### PR TITLE
Update machines crd

### DIFF
--- a/extensions/pkg/controller/worker/templates/alicloudmachineclasses.tpl.yaml
+++ b/extensions/pkg/controller/worker/templates/alicloudmachineclasses.tpl.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.2
+    controller-gen.kubebuilder.io/version: v0.9.2
   labels:
 {{ toYaml .labels | indent 4 }}
   name: alicloudmachineclasses.machine.sapcloud.io

--- a/extensions/pkg/controller/worker/templates/awsmachineclasses.tpl.yaml
+++ b/extensions/pkg/controller/worker/templates/awsmachineclasses.tpl.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.2
+    controller-gen.kubebuilder.io/version: v0.9.2
   labels:
 {{ toYaml .labels | indent 4 }}
   name: awsmachineclasses.machine.sapcloud.io

--- a/extensions/pkg/controller/worker/templates/azuremachineclasses.tpl.yaml
+++ b/extensions/pkg/controller/worker/templates/azuremachineclasses.tpl.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.2
+    controller-gen.kubebuilder.io/version: v0.9.2
   labels:
 {{ toYaml .labels | indent 4 }}
   name: azuremachineclasses.machine.sapcloud.io

--- a/extensions/pkg/controller/worker/templates/gcpmachineclasses.tpl.yaml
+++ b/extensions/pkg/controller/worker/templates/gcpmachineclasses.tpl.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.2
+    controller-gen.kubebuilder.io/version: v0.9.2
   labels:
 {{ toYaml .labels | indent 4 }}
   name: gcpmachineclasses.machine.sapcloud.io

--- a/extensions/pkg/controller/worker/templates/machineclasses.tpl.yaml
+++ b/extensions/pkg/controller/worker/templates/machineclasses.tpl.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.2
+    controller-gen.kubebuilder.io/version: v0.9.2
   labels:
 {{ toYaml .labels | indent 4 }}
   name: machineclasses.machine.sapcloud.io

--- a/extensions/pkg/controller/worker/templates/machinedeployments.tpl.yaml
+++ b/extensions/pkg/controller/worker/templates/machinedeployments.tpl.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.2
+    controller-gen.kubebuilder.io/version: v0.9.2
   labels:
 {{ toYaml .labels | indent 4 }}
   name: machinedeployments.machine.sapcloud.io

--- a/extensions/pkg/controller/worker/templates/machines.tpl.yaml
+++ b/extensions/pkg/controller/worker/templates/machines.tpl.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.2
+    controller-gen.kubebuilder.io/version: v0.9.2
   labels:
 {{ toYaml .labels | indent 4 }}
   name: machines.machine.sapcloud.io
@@ -27,6 +27,15 @@ spec:
       jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    - description: Node backing the machine object
+      jsonPath: .metadata.labels.node
+      name: Node
+      type: string
+    - description: ProviderID of the infra instance backing the machine object
+      jsonPath: .spec.providerID
+      name: ProviderID
+      priority: 1
+      type: string
     name: v1alpha1
     schema:
       openAPIV3Schema:
@@ -93,9 +102,10 @@ spec:
                       created with.
                     properties:
                       configSource:
-                        description: If specified, the source to get node configuration
-                          from The DynamicKubeletConfig feature gate must be enabled
-                          for the Kubelet to use this field
+                        description: 'Deprecated. If specified, the source of the
+                              node''s configuration. The DynamicKubeletConfig feature
+                              gate must be enabled for the Kubelet to use this field.
+                              This field is deprecated as of 1.22: https://git.k8s.io/enhancements/keps/sig-node/281-dynamic-kubelet-configuration'
                         properties:
                           configMap:
                             description: ConfigMap is a reference to a Node's ConfigMap

--- a/extensions/pkg/controller/worker/templates/machinesets.tpl.yaml
+++ b/extensions/pkg/controller/worker/templates/machinesets.tpl.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.2
+    controller-gen.kubebuilder.io/version: v0.9.2
   labels:
 {{ toYaml .labels | indent 4 }}
   name: machinesets.machine.sapcloud.io

--- a/extensions/pkg/controller/worker/templates/openstackmachineclasses.tpl.yaml
+++ b/extensions/pkg/controller/worker/templates/openstackmachineclasses.tpl.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.2
+    controller-gen.kubebuilder.io/version: v0.9.2
   labels:
 {{ toYaml .labels | indent 4 }}
   name: openstackmachineclasses.machine.sapcloud.io

--- a/extensions/pkg/controller/worker/templates/packetmachineclasses.tpl.yaml
+++ b/extensions/pkg/controller/worker/templates/packetmachineclasses.tpl.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.2
+    controller-gen.kubebuilder.io/version: v0.9.2
   labels:
 {{ toYaml .labels | indent 4 }}
   name: packetmachineclasses.machine.sapcloud.io


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind enhancement

**What this PR does / why we need it**:
This PR is about the issue raised on mcm which can be seen [here](https://github.com/gardener/machine-controller-manager/issues/737). This will update gardener to use the latest machine crd, allowing the display of node name and providerID when listing machines. The output is as follows:
<img width="1254" alt="Screenshot 2022-10-05 at 6 49 10 PM" src="https://user-images.githubusercontent.com/66425093/194219406-f646d588-7271-4376-95fe-1ea57d67b87a.png">


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
The testing was done using the local kind setup of gardener.
**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Updated machine CRD, allowing the display of node name and providerID(using -owide flag) when listing machines in the control plane of the shoot
```