### PR TITLE
Support running "make generate" in the (dev) "remote-local-setup"

### DIFF
--- a/docs/development/content/remote-local-setup.yaml
+++ b/docs/development/content/remote-local-setup.yaml
@@ -21,7 +21,7 @@ spec:
         - |
           set -ex
           cd
-          apk add bash bash-completion curl fzf git jq less lsof make mandoc mc procps tmux tmux-doc yq vim
+          apk add bash bash-completion curl fzf gcompat git jq less lsof make mandoc mc parallel procps sed strace tar tmux tmux-doc yq vim
           apk add --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main mount
           echo golang            && curl -sLO "https://go.dev/dl/$(curl -sL https://golang.org/VERSION?m=text).linux-amd64.tar.gz" && tar -C /usr/local -xzf go1.*.linux-amd64.tar.gz
           echo helm              && curl -sLO "https://get.helm.sh/helm-$(curl -sL https://api.github.com/repos/helm/helm/releases/latest | jq .tag_name -r)-linux-amd64.tar.gz" && tar -xzf helm-*-linux-amd64.tar.gz && mv linux-amd64/helm /usr/local/bin/helm
@@ -32,9 +32,11 @@ spec:
           echo kubectl           && curl -sL  "https://dl.k8s.io/release/$(curl -sL https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" -o /usr/local/bin/kubectl && chmod +x /usr/local/bin/kubectl
           echo tmux-completion   && curl -sL  "https://raw.githubusercontent.com/imomaliev/tmux-bash-completion/master/completions/tmux" -o /usr/share/bash-completion/completions/tmux
           echo docker-completion && curl -sL  "https://raw.githubusercontent.com/docker/docker-ce/master/components/cli/contrib/completion/bash/docker" -o /usr/share/bash-completion/completions/docker
+          echo yaml2json         && curl -sL  "https://github.com/bronze1man/yaml2json/releases/download/$(curl -sL https://api.github.com/repos/bronze1man/yaml2json/releases/latest | jq .tag_name -r)/yaml2json_linux_amd64" -o /usr/local/bin/yaml2json && chmod +x /usr/local/bin/yaml2json
           echo '127.0.0.1 api.local.local.external.local.gardener.cloud' >> /etc/hosts
           echo 'source ~/.bashrc' > ~/.bash_profile
           cat > ~/.bashrc <<"EOF"
+            export GOPATH=~/go
             export PATH=$PATH:/usr/local/go/bin
             export KUBECONFIG=~/gardener/example/gardener-local/kind/kubeconfig:/tmp/kubeconfig-shoot-local.yaml
             source <(kubectl completion bash)
@@ -53,6 +55,9 @@ spec:
           EOF
           git clone -q https://github.com/gardener/gardener.git
           cd gardener
+          mkdir -p ~/go/src/github.com/gardener
+          ln -s ~/gardener ~/go/src/github.com/gardener/gardener
+          ln -s ~/gardener/hack/tools/bin/protoc-gen-gogo ~/gardener/protoc-gen-gogo
           # TODO 'host.docker.internal' can not be resolved on docker for Linux (https://github.com/docker/for-linux/issues/264, https://stackoverflow.com/questions/48546124/what-is-linux-equivalent-of-host-docker-internal)
           #      maybe there is a better way than using the IP address of the docker0 device: 172.17.0.1
           #      ip addr show docker0 | awk '/inet .* docker0/{print substr($2,0, index($2,"/")-1)}'
@@ -84,8 +89,8 @@ spec:
           read
         stdin: true
         resources:
-          requests: {cpu: 8, memory: 8G}
-          limits:   {cpu: 8, memory: 8G}
+          requests: {cpu: 8, memory: 16G}
+          limits:   {cpu: 8, memory: 16G}
         securityContext:
           privileged: true
         volumeMounts:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:

Gardener developers need to execute `make generate` if the source code changes require adjusting the versioned generated code.

This step is very CPU intensive and somewhat time consuming (5+ minutes).

This commit adjusts the development version of the remote-local-setup so that `make generate` can be executed in the remote pod in the cloud, saving some CPU cycles for the local machine.

The gcompat package is the GNU C Library compatibility layer for musl, which is needed for this alpine based docker image.

`parallel` and `tar` are needed by `make generate`. The simpler BusyBox version of `tar` is lacking some features.

`strace` is generally useful for debugging purposes.

code generation currently needs the old style Go setup: hence `GOPATH` is set to `~/go` and the gardener git repository is symlinked to `~/go/src/github.com/gardener/gardener`.

The repository is symlinked only: the default working directory is still `~/gardener`, it is preferred for its shorter path.

The symbolic link

    ln -s ~/gardener/hack/tools/bin/protoc-gen-gogo ~/gardener/protoc-gen-gogo

is needed when executing `make generate`: `protoc` tries to execute `protoc-gen-gogo` in the current directory which is the repository root, and does not seem to search the `PATH`. (`strace -f` was useful to figure that out).
Hence a symbolic link for `protoc-gen-gogo` is added to the repository root.

Note that I'm not sure why this is not an issue when `make generate` is executed on the laptop but I did not attempt to debug that on the Mac.

Note also that the 8GB memory limit was not sufficient for the parallel code generation: a few Go compile processes were OOM killed, so the memory requests and limits are doubled now.

With this change `make generate` can be executed in the `~/go/src/github.com/gardener/gardener` folder and takes about 5 minutes with 8 cores in the cloud:

```
cd ~/go/src/github.com/gardener/gardener
time nice make generate
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

/cc @rickardsjp @wyb1 @rfranzke @ialidzhikov 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
