### PR TITLE
Added checks for non-gardener managed seed clusters to ensure correct seed configurations.

### DIFF
--- a/cmd/gardenlet/app/bootstrappers/seed_config.go
+++ b/cmd/gardenlet/app/bootstrappers/seed_config.go
@@ -69,67 +69,65 @@ func (s *SeedConfigChecker) Start(ctx context.Context) error {
 	return nil
 }
 
-// CheckSeedConfigHeuristically validates the networking configuration of the seed configuration heuristically against the actual cluster
+// checkSeedConfigHeuristically validates the networking configuration of the seed configuration heuristically against the actual cluster.
 func checkSeedConfigHeuristically(ctx context.Context, seedClient client.Client, seedConfig *config.SeedConfig) error {
-	if seedConfig == nil {
-		// Nothing to check
-		return nil
-	}
-
 	// Restrict the heuristic to a maximum of 100 entries to prevent initialization delays for big clusters
 	limit := &client.ListOptions{Limit: 100}
 
 	if seedConfig.Spec.Networks.Nodes != nil {
-		nodes := &corev1.NodeList{}
-		if err := seedClient.List(ctx, nodes, limit); client.IgnoreNotFound(err) != nil {
+		nodeList := &corev1.NodeList{}
+		if err := seedClient.List(ctx, nodeList, limit); err != nil {
 			return err
 		}
+
 		_, seedConfigNodes, err := net.ParseCIDR(*seedConfig.Spec.Networks.Nodes)
 		if err != nil {
 			return err
 		}
-		for _, n := range nodes.Items {
-			for _, address := range n.Status.Addresses {
+
+		for _, node := range nodeList.Items {
+			for _, address := range node.Status.Addresses {
 				if address.Type == corev1.NodeInternalIP {
-					nodeIP := net.ParseIP(address.Address)
-					if nodeIP != nil && !seedConfigNodes.Contains(nodeIP) {
-						return fmt.Errorf("incorrect node network specified in seed configuration (cluster node=%q vs. config=%q)", nodeIP, *seedConfig.Spec.Networks.Nodes)
+					if ip := net.ParseIP(address.Address); ip != nil && !seedConfigNodes.Contains(ip) {
+						return fmt.Errorf("incorrect node network specified in seed configuration (cluster node=%q vs. config=%q)", ip, *seedConfig.Spec.Networks.Nodes)
 					}
 				}
 			}
 		}
 	}
 
-	pods := &corev1.PodList{}
-	if err := seedClient.List(ctx, pods, limit); client.IgnoreNotFound(err) != nil {
+	podList := &corev1.PodList{}
+	if err := seedClient.List(ctx, podList, limit); err != nil {
 		return err
 	}
+
 	_, seedConfigPods, err := net.ParseCIDR(seedConfig.Spec.Networks.Pods)
 	if err != nil {
 		return err
 	}
-	for _, p := range pods.Items {
-		if !p.Spec.HostNetwork && p.Status.PodIP != "" {
-			podIP := net.ParseIP(p.Status.PodIP)
-			if podIP != nil && !seedConfigPods.Contains(podIP) {
-				return fmt.Errorf("incorrect pod network specified in seed configuration (cluster pod=%q vs. config=%q)", podIP, seedConfig.Spec.Networks.Pods)
+
+	for _, pod := range podList.Items {
+		if !pod.Spec.HostNetwork && pod.Status.PodIP != "" {
+			if ip := net.ParseIP(pod.Status.PodIP); ip != nil && !seedConfigPods.Contains(ip) {
+				return fmt.Errorf("incorrect pod network specified in seed configuration (cluster pod=%q vs. config=%q)", ip, seedConfig.Spec.Networks.Pods)
 			}
 		}
 	}
 
-	services := &corev1.ServiceList{}
-	if err := seedClient.List(ctx, services, limit); client.IgnoreNotFound(err) != nil {
+	serviceList := &corev1.ServiceList{}
+	if err := seedClient.List(ctx, serviceList, limit); err != nil {
 		return err
 	}
+
 	_, seedConfigServices, err := net.ParseCIDR(seedConfig.Spec.Networks.Services)
 	if err != nil {
 		return err
 	}
-	for _, s := range services.Items {
-		if s.Spec.Type == corev1.ServiceTypeClusterIP && s.Spec.ClusterIP != "" && s.Spec.ClusterIP != corev1.ClusterIPNone {
-			serviceIP := net.ParseIP(s.Spec.ClusterIP)
-			if serviceIP != nil && !seedConfigServices.Contains(serviceIP) {
-				return fmt.Errorf("incorrect service network specified in seed configuration (cluster service=%q vs. config=%q)", serviceIP, seedConfig.Spec.Networks.Services)
+
+	for _, service := range serviceList.Items {
+		if service.Spec.Type == corev1.ServiceTypeClusterIP && service.Spec.ClusterIP != "" && service.Spec.ClusterIP != corev1.ClusterIPNone {
+			if ip := net.ParseIP(service.Spec.ClusterIP); ip != nil && !seedConfigServices.Contains(ip) {
+				return fmt.Errorf("incorrect service network specified in seed configuration (cluster service=%q vs. config=%q)", ip, seedConfig.Spec.Networks.Services)
 			}
 		}
 	}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/area quality
/kind technical-debt

**What this PR does / why we need it**:
Added checks for non-gardener managed seed clusters to ensure correct seed configurations.

Clusters managed by gardener embed information about the node, pod and service networks inside the cluster as a config map. Other kubernetes clusters do not offer this information in a standard way.
To ensure that the seed configuration fits to the reality of the seed cluster this change introduces a heuristic check that the configured node network is valid for the nodes seen in the cluster. The same applies to the pods and services. (The amount of entities being checked is limited so that large clusters do not delay the gardenlet start-up too much.)

**Which issue(s) this PR fixes**:
None.

**Special notes for your reviewer**:
Having the seed configuration diverge from the seed cluster reality can lead to hard to track down issues with network policies as some of the ranges are taken from the seed configuration.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Gardenlet will not start in case the seed configuration is incorrect, i.e. if the node, pod or service network specified in the Seed resource do not match to the cluster reality.
```
