### PR TITLE
Deflake `Pod Scheduler Name Webhook Handler` test

### DIFF
--- a/test/integration/seedadmissioncontroller/podschedulername/podschedulername_suite_test.go
+++ b/test/integration/seedadmissioncontroller/podschedulername/podschedulername_suite_test.go
@@ -16,15 +16,15 @@ package podschedulername_test
 
 import (
 	"context"
+	"net/http"
 	"testing"
-
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -128,6 +128,12 @@ var _ = BeforeSuite(func() {
 		defer GinkgoRecover()
 		Expect(mgr.Start(mgrContext)).To(Succeed())
 	}()
+
+	// Wait for the webhook server to start
+	Eventually(func() error {
+		checker := mgr.GetWebhookServer().StartedChecker()
+		return checker(&http.Request{})
+	}).Should(BeNil())
 
 	DeferCleanup(func() {
 		By("stopping manager")

--- a/test/integration/seedadmissioncontroller/podschedulername/podschedulername_test.go
+++ b/test/integration/seedadmissioncontroller/podschedulername/podschedulername_test.go
@@ -56,8 +56,9 @@ var _ = Describe("Pod Scheduler Name Webhook Handler", func() {
 			expected := &corev1.Pod{}
 			Expect(testClient.Get(ctx, client.ObjectKeyFromObject(pod), expected)).To(Succeed())
 			Expect(testClient.Update(ctx, pod)).To(Succeed())
-			Expect(pod).To(Equal(expected))
+			Expect(pod.Spec).To(Equal(expected.Spec))
 		})
+
 		It("Delete does nothing", func() {
 			Expect(testClient.Delete(ctx, pod)).To(Succeed())
 		})


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind flake

**What this PR does / why we need it**:
See https://github.com/gardener/gardener/issues/6709

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener/issues/6709

On HEAD (512619b8f52c8bb34103612ece2b98359eeb7514):
```
$ stress -ignore "unable to grab random port" -p 16 ./test/integration/seedadmissioncontroller/podschedulername/podschedulername.test

55s: 82 runs so far, 27 failures (32.93%)
```

With this PR:
```
$ stress -ignore "unable to grab random port" -p 16 ./test/integration/seedadmissioncontroller/podschedulername/podschedulername.test

4m15s: 443 runs so far, 0 failures
```

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
