### PR TITLE
`kubelet` requests server certificate via `CertificateSigningRequest` API

### DIFF
--- a/cmd/gardener-resource-manager/app/app.go
+++ b/cmd/gardener-resource-manager/app/app.go
@@ -23,6 +23,7 @@ import (
 	"github.com/gardener/gardener/pkg/controllerutils/routes"
 	gardenerhealthz "github.com/gardener/gardener/pkg/healthz"
 	resourcemanagercmd "github.com/gardener/gardener/pkg/resourcemanager/cmd"
+	csrapprovercontroller "github.com/gardener/gardener/pkg/resourcemanager/controller/csrapprover"
 	garbagecollectorcontroller "github.com/gardener/gardener/pkg/resourcemanager/controller/garbagecollector"
 	healthcontroller "github.com/gardener/gardener/pkg/resourcemanager/controller/health"
 	resourcecontroller "github.com/gardener/gardener/pkg/resourcemanager/controller/managedresource"
@@ -64,6 +65,7 @@ func NewResourceManagerCommand() *cobra.Command {
 		tokenInvalidatorControllerOpts          = &tokeninvalidatorcontroller.ControllerOptions{}
 		tokenRequestorControllerOpts            = &tokenrequestorcontroller.ControllerOptions{}
 		rootCAControllerOpts                    = &rootcacontroller.ControllerOptions{}
+		csrApproverControllerOpts               = &csrapprovercontroller.ControllerOptions{}
 		projectedTokenMountWebhookOpts          = &projectedtokenmountwebhook.WebhookOptions{}
 		podSchedulerNameWebhookOpts             = &podschedulernamewebhook.WebhookOptions{}
 		podZoneAffinityWebhookOpts              = &podzoneaffinity.WebhookOptions{}
@@ -95,6 +97,7 @@ func NewResourceManagerCommand() *cobra.Command {
 					tokenInvalidatorControllerOpts,
 					tokenRequestorControllerOpts,
 					rootCAControllerOpts,
+					csrApproverControllerOpts,
 					projectedTokenMountWebhookOpts,
 					podSchedulerNameWebhookOpts,
 					podTopologySpreadConstraintsWebhookOpts,
@@ -124,6 +127,8 @@ func NewResourceManagerCommand() *cobra.Command {
 				tokenInvalidatorControllerOpts.Completed().TargetCluster = targetClusterOpts.Completed().Cluster
 				tokenRequestorControllerOpts.Completed().TargetCluster = targetClusterOpts.Completed().Cluster
 				rootCAControllerOpts.Completed().TargetCluster = targetClusterOpts.Completed().Cluster
+				csrApproverControllerOpts.Completed().TargetCluster = targetClusterOpts.Completed().Cluster
+				csrApproverControllerOpts.Completed().Namespace = managerOptions.Namespace
 				projectedTokenMountWebhookOpts.Completed().TargetCluster = targetClusterOpts.Completed().Cluster
 
 				// setup manager
@@ -168,6 +173,7 @@ func NewResourceManagerCommand() *cobra.Command {
 					tokeninvalidatorcontroller.AddToManager,
 					tokenrequestorcontroller.AddToManager,
 					rootcacontroller.AddToManager,
+					csrapprovercontroller.AddToManager,
 					// health endpoints
 					resourcemanagerhealthz.AddToManager,
 					// webhooks
@@ -243,6 +249,7 @@ func NewResourceManagerCommand() *cobra.Command {
 		tokenInvalidatorControllerOpts,
 		tokenRequestorControllerOpts,
 		rootCAControllerOpts,
+		csrApproverControllerOpts,
 		projectedTokenMountWebhookOpts,
 		podSchedulerNameWebhookOpts,
 		podTopologySpreadConstraintsWebhookOpts,

--- a/docs/concepts/resource-manager.md
+++ b/docs/concepts/resource-manager.md
@@ -473,6 +473,34 @@ Please see the graphic below:
 
 ![image](images/resource-manager-projected-token-controlplane-to-shoot-apiserver.jpg)
 
+### Kubelet Server `CertificateSigningRequest` Approver
+
+Gardener configures the kubelets such that they request two certificates via the `CertificateSigningRequest` API:
+
+1. client certificate for communicating with the `kube-apiserver`
+2. server certificate for serving its HTTPS server
+
+For client certificates, the `kubernetes.io/kube-apiserver-client-kubelet` signer is used (see [this document](https://kubernetes.io/docs/reference/access-authn-authz/certificate-signing-requests/#kubernetes-signers) for more details).
+The `kube-controller-manager`'s `csrapprover` controller is responsible for auto-approving such `CertificateSigningRequest`s so that the respective certificates can be issued.
+
+For server certificates, the `kubernetes.io/kubelet-serving` signer is used.
+Unfortunately, the `kube-controller-manager` is not able to auto-approve such `CertificateSigningRequest`s (see [kubernetes/kubernetes#73356](https://github.com/kubernetes/kubernetes/issues/73356) for details).
+
+That's the motivation for having this controller as part of `gardener-resource-manager`.
+It watches `CertificateSigningRequest`s with the `kubernetes.io/kubelet-serving` signer and auto-approves them when all the following conditions are met:
+
+- The `.spec.username` is prefixed with `system:node:`.
+- There must be at least one DNS name of IP address as part of the certificate SANs.
+- The common name in the CSR must match the `.spec.username`.
+- The organization in the CSR must only contain `system:nodes`.
+- There must be a `Node` object with the same name in the shoot cluster.
+- There must be exactly one `Machine` for the node in the seed cluster.
+- The DNS names part of the SANs must be equal to all `.status.addresses[]` of type `Hostname` in the `Node`.
+- The IP addresses part of the SANs must be equal to all `.status.addresses[]` of type `InternalIP` in the `Node`.
+
+If one of these requirements is violated the `CertificateSigningRequest` will be denied.
+Otherwise, once approved the `kube-controller-manager`'s `csrsigner` controller will issue the requested certificate. 
+
 ## Webhooks
 
 ### Auto-Mounting Projected `ServiceAccount` Tokens

--- a/docs/concepts/resource-manager.md
+++ b/docs/concepts/resource-manager.md
@@ -490,7 +490,7 @@ That's the motivation for having this controller as part of `gardener-resource-m
 It watches `CertificateSigningRequest`s with the `kubernetes.io/kubelet-serving` signer and auto-approves them when all the following conditions are met:
 
 - The `.spec.username` is prefixed with `system:node:`.
-- There must be at least one DNS name of IP address as part of the certificate SANs.
+- There must be at least one DNS name or IP address as part of the certificate SANs.
 - The common name in the CSR must match the `.spec.username`.
 - The organization in the CSR must only contain `system:nodes`.
 - There must be a `Node` object with the same name in the shoot cluster.

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/kubelet/component_test.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/kubelet/component_test.go
@@ -455,6 +455,7 @@ rotateCertificates: true`
 	out += `
 runtimeRequestTimeout: 2m0s
 serializeImagePulls: true
+serverTLSBootstrap: true
 shutdownGracePeriod: 0s
 shutdownGracePeriodCriticalPods: 0s
 streamingConnectionIdleTimeout: 0s

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/kubelet/config.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/kubelet/config.go
@@ -93,6 +93,7 @@ func Config(kubernetesVersion *semver.Version, clusterDNSAddress, clusterDomain 
 		RuntimeRequestTimeout:            metav1.Duration{Duration: 2 * time.Minute},
 		SeccompDefault:                   params.SeccompDefault,
 		SerializeImagePulls:              params.SerializeImagePulls,
+		ServerTLSBootstrap:               true,
 		RegistryPullQPS:                  params.RegistryPullQPS,
 		RegistryBurst:                    pointer.Int32Deref(params.RegistryBurst, 0),
 		SyncFrequency:                    metav1.Duration{Duration: time.Minute},

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/kubelet/config_test.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/kubelet/config_test.go
@@ -142,6 +142,7 @@ var _ = Describe("Config", func() {
 			ResolverConfig:            pointer.String("/etc/resolv.conf"),
 			RuntimeRequestTimeout:     metav1.Duration{Duration: 2 * time.Minute},
 			SerializeImagePulls:       pointer.Bool(true),
+			ServerTLSBootstrap:        true,
 			SyncFrequency:             metav1.Duration{Duration: time.Minute},
 			VolumeStatsAggPeriod:      metav1.Duration{Duration: time.Minute},
 		}
@@ -229,6 +230,7 @@ var _ = Describe("Config", func() {
 			RuntimeRequestTimeout:            metav1.Duration{Duration: 2 * time.Minute},
 			SerializeImagePulls:              params.SerializeImagePulls,
 			SeccompDefault:                   params.SeccompDefault,
+			ServerTLSBootstrap:               true,
 			SyncFrequency:                    metav1.Duration{Duration: time.Minute},
 			SystemReserved:                   params.SystemReserved,
 			VolumeStatsAggPeriod:             metav1.Duration{Duration: time.Minute},

--- a/pkg/operation/botanist/component/kubecontrollermanager/kube_controller_manager.go
+++ b/pkg/operation/botanist/component/kubecontrollermanager/kube_controller_manager.go
@@ -534,6 +534,8 @@ func (k *kubeControllerManager) computeCommand(port int32) []string {
 		fmt.Sprintf("--cluster-signing-kubelet-client-key-file=%s/%s", volumeMountPathCAClient, secrets.DataKeyPrivateKeyCA),
 		fmt.Sprintf("--cluster-signing-kubelet-serving-cert-file=%s/%s", volumeMountPathCAKubelet, secrets.DataKeyCertificateCA),
 		fmt.Sprintf("--cluster-signing-kubelet-serving-key-file=%s/%s", volumeMountPathCAKubelet, secrets.DataKeyPrivateKeyCA),
+		fmt.Sprintf("--cluster-signing-legacy-unknown-cert-file=%s/%s", volumeMountPathCAClient, secrets.DataKeyCertificateCA),
+		fmt.Sprintf("--cluster-signing-legacy-unknown-key-file=%s/%s", volumeMountPathCAClient, secrets.DataKeyPrivateKeyCA),
 	)
 
 	if version.ConstraintK8sGreaterEqual119.Check(k.version) {

--- a/pkg/operation/botanist/component/kubecontrollermanager/kube_controller_manager_test.go
+++ b/pkg/operation/botanist/component/kubecontrollermanager/kube_controller_manager_test.go
@@ -895,6 +895,8 @@ func commandForKubernetesVersion(
 		"--cluster-signing-kubelet-client-key-file=/srv/kubernetes/ca-client/ca.key",
 		"--cluster-signing-kubelet-serving-cert-file=/srv/kubernetes/ca-kubelet/ca.crt",
 		"--cluster-signing-kubelet-serving-key-file=/srv/kubernetes/ca-kubelet/ca.key",
+		"--cluster-signing-legacy-unknown-cert-file=/srv/kubernetes/ca-client/ca.crt",
+		"--cluster-signing-legacy-unknown-key-file=/srv/kubernetes/ca-client/ca.key",
 	)
 
 	if k8sVersionGreaterEqual119, _ := versionutils.CompareVersions(version, ">=", "1.19"); k8sVersionGreaterEqual119 {

--- a/pkg/operation/botanist/component/kubecontrollermanager/kube_controller_manager_test.go
+++ b/pkg/operation/botanist/component/kubecontrollermanager/kube_controller_manager_test.go
@@ -118,6 +118,7 @@ var _ = Describe("KubeControllerManager", func() {
 		Expect(fakeClient.Create(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "ca", Namespace: namespace}})).To(Succeed())
 		Expect(fakeClient.Create(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "generic-token-kubeconfig", Namespace: namespace}})).To(Succeed())
 		Expect(fakeClient.Create(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "ca-client-current", Namespace: namespace}})).To(Succeed())
+		Expect(fakeClient.Create(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "ca-kubelet-current", Namespace: namespace}})).To(Succeed())
 		Expect(fakeClient.Create(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "service-account-key-current", Namespace: namespace}})).To(Succeed())
 	})
 
@@ -513,6 +514,10 @@ var _ = Describe("KubeControllerManager", func() {
 													MountPath: "/srv/kubernetes/ca-client",
 												},
 												{
+													Name:      "ca-kubelet",
+													MountPath: "/srv/kubernetes/ca-kubelet",
+												},
+												{
 													Name:      "service-account-key",
 													MountPath: "/srv/kubernetes/service-account-key",
 												},
@@ -537,6 +542,14 @@ var _ = Describe("KubeControllerManager", func() {
 											VolumeSource: corev1.VolumeSource{
 												Secret: &corev1.SecretVolumeSource{
 													SecretName: "ca-client-current",
+												},
+											},
+										},
+										{
+											Name: "ca-kubelet",
+											VolumeSource: corev1.VolumeSource{
+												Secret: &corev1.SecretVolumeSource{
+													SecretName: "ca-kubelet-current",
 												},
 											},
 										},
@@ -876,8 +889,12 @@ func commandForKubernetesVersion(
 	command = append(command,
 		fmt.Sprintf("--cluster-cidr=%s", podNetwork.String()),
 		fmt.Sprintf("--cluster-name=%s", clusterName),
-		"--cluster-signing-cert-file=/srv/kubernetes/ca-client/ca.crt",
-		"--cluster-signing-key-file=/srv/kubernetes/ca-client/ca.key",
+		"--cluster-signing-kube-apiserver-client-cert-file=/srv/kubernetes/ca-client/ca.crt",
+		"--cluster-signing-kube-apiserver-client-key-file=/srv/kubernetes/ca-client/ca.key",
+		"--cluster-signing-kubelet-client-cert-file=/srv/kubernetes/ca-client/ca.crt",
+		"--cluster-signing-kubelet-client-key-file=/srv/kubernetes/ca-client/ca.key",
+		"--cluster-signing-kubelet-serving-cert-file=/srv/kubernetes/ca-kubelet/ca.crt",
+		"--cluster-signing-kubelet-serving-key-file=/srv/kubernetes/ca-kubelet/ca.key",
 	)
 
 	if k8sVersionGreaterEqual119, _ := versionutils.CompareVersions(version, ">=", "1.19"); k8sVersionGreaterEqual119 {

--- a/pkg/operation/botanist/resource_manager.go
+++ b/pkg/operation/botanist/resource_manager.go
@@ -69,6 +69,7 @@ func (b *Botanist) DefaultResourceManager() (resourcemanager.Interface, error) {
 		MaxConcurrentTokenInvalidatorWorkers: pointer.Int32(5),
 		MaxConcurrentTokenRequestorWorkers:   pointer.Int32(5),
 		MaxConcurrentRootCAPublisherWorkers:  pointer.Int32(5),
+		MaxConcurrentCSRApproverWorkers:      pointer.Int32(5),
 		SecretNameServerCA:                   v1beta1constants.SecretNameCACluster,
 		SyncPeriod:                           pointer.Duration(time.Minute),
 		TargetDiffersFromSourceCluster:       true,

--- a/pkg/resourcemanager/cmd/source.go
+++ b/pkg/resourcemanager/cmd/source.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"time"
 
+	machinev1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
 	"github.com/spf13/pflag"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -35,6 +36,7 @@ var (
 	sourceSchemeBuilder = runtime.NewSchemeBuilder(
 		kubernetesscheme.AddToScheme,
 		resourcesv1alpha1.AddToScheme,
+		machinev1alpha1.AddToScheme,
 	)
 
 	// AddToSourceScheme registers all API types in the given scheme that resource-manager expects to be in the source

--- a/pkg/resourcemanager/controller/csrapprover/add.go
+++ b/pkg/resourcemanager/controller/csrapprover/add.go
@@ -1,0 +1,111 @@
+// Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package csrapprover
+
+import (
+	"fmt"
+
+	"github.com/spf13/pflag"
+	certificatesv1 "k8s.io/api/certificates/v1"
+	kubernetesclientset "k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/cluster"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	predicateutils "github.com/gardener/gardener/pkg/controllerutils/predicate"
+)
+
+// ControllerName is the name of the controller.
+const ControllerName = "kubelet-csr-approver"
+
+// defaultControllerConfig is the default config for the controller.
+var defaultControllerConfig ControllerConfig
+
+// ControllerOptions are options for adding the controller to a Manager.
+type ControllerOptions struct {
+	maxConcurrentWorkers int
+}
+
+// ControllerConfig is the completed configuration for the controller.
+type ControllerConfig struct {
+	MaxConcurrentWorkers int
+	TargetCluster        cluster.Cluster
+	Namespace            string
+}
+
+// AddToManagerWithOptions adds the controller to a Manager with the given config.
+func AddToManagerWithOptions(mgr manager.Manager, conf ControllerConfig) error {
+	if conf.MaxConcurrentWorkers == 0 {
+		return nil
+	}
+
+	kubernetesClient, err := kubernetesclientset.NewForConfig(conf.TargetCluster.GetConfig())
+	if err != nil {
+		return fmt.Errorf("failed creating Kubernetes client: %w", err)
+	}
+
+	c, err := controller.New(ControllerName, mgr,
+		controller.Options{
+			MaxConcurrentReconciles: conf.MaxConcurrentWorkers,
+			Reconciler: &Reconciler{
+				SourceClient:       mgr.GetClient(),
+				TargetClient:       conf.TargetCluster.GetClient(),
+				CertificatesClient: kubernetesClient.CertificatesV1().CertificateSigningRequests(),
+				Namespace:          conf.Namespace,
+			},
+			RecoverPanic: true,
+		},
+	)
+	if err != nil {
+		return err
+	}
+
+	return c.Watch(
+		source.NewKindWithCache(&certificatesv1.CertificateSigningRequest{}, conf.TargetCluster.GetCache()),
+		&handler.EnqueueRequestForObject{},
+		predicateutils.ForEventTypes(predicateutils.Create, predicateutils.Update),
+		predicate.NewPredicateFuncs(func(obj client.Object) bool {
+			csr, ok := obj.(*certificatesv1.CertificateSigningRequest)
+			return ok && csr.Spec.SignerName == certificatesv1.KubeletServingSignerName
+		}),
+	)
+}
+
+// AddToManager adds the controller to a Manager using the default config.
+func AddToManager(mgr manager.Manager) error {
+	return AddToManagerWithOptions(mgr, defaultControllerConfig)
+}
+
+// AddFlags adds the needed command line flags to the given FlagSet.
+func (o *ControllerOptions) AddFlags(fs *pflag.FlagSet) {
+	fs.IntVar(&o.maxConcurrentWorkers, "kubelet-csr-approver-max-concurrent-workers", 0, "number of worker threads for concurrent kubelet csr approval reconciliations (default: 0)")
+}
+
+// Complete completes the given command line flags and set the defaultControllerConfig accordingly.
+func (o *ControllerOptions) Complete() error {
+	defaultControllerConfig = ControllerConfig{
+		MaxConcurrentWorkers: o.maxConcurrentWorkers,
+	}
+	return nil
+}
+
+// Completed returns the completed ControllerConfig.
+func (o *ControllerOptions) Completed() *ControllerConfig {
+	return &defaultControllerConfig
+}

--- a/pkg/resourcemanager/controller/csrapprover/reconciler.go
+++ b/pkg/resourcemanager/controller/csrapprover/reconciler.go
@@ -111,7 +111,7 @@ func (r *Reconciler) mustApprove(ctx context.Context, csr *certificatesv1.Certif
 	}
 
 	if len(x509cr.DNSNames)+len(x509cr.IPAddresses) == 0 {
-		return "no DNS names or IP addresses in the SANS found", false, nil
+		return "no DNS names or IP addresses in the SANs found", false, nil
 	}
 
 	if x509cr.Subject.CommonName != csr.Spec.Username {

--- a/pkg/resourcemanager/controller/csrapprover/reconciler.go
+++ b/pkg/resourcemanager/controller/csrapprover/reconciler.go
@@ -1,0 +1,172 @@
+// Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package csrapprover
+
+import (
+	"context"
+	"crypto/x509"
+	"fmt"
+	"strings"
+
+	machinev1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
+	certificatesv1 "k8s.io/api/certificates/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apiserver/pkg/authentication/user"
+	certificatesclientv1 "k8s.io/client-go/kubernetes/typed/certificates/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	"github.com/gardener/gardener/pkg/utils"
+)
+
+// Reconciler reconciles CertificateSigningRequest objects.
+type Reconciler struct {
+	SourceClient       client.Client
+	TargetClient       client.Client
+	CertificatesClient certificatesclientv1.CertificateSigningRequestInterface
+	Namespace          string
+}
+
+// Reconcile performs the main reconciliation logic.
+func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
+	log := logf.FromContext(ctx)
+
+	csr := &certificatesv1.CertificateSigningRequest{}
+	if err := r.TargetClient.Get(ctx, request.NamespacedName, csr); err != nil {
+		if apierrors.IsNotFound(err) {
+			log.V(1).Info("Object is gone, stop reconciling")
+			return reconcile.Result{}, nil
+		}
+		return reconcile.Result{}, fmt.Errorf("error retrieving object from store: %w", err)
+	}
+
+	var (
+		isInFinalState bool
+		finalState     string
+	)
+
+	for _, c := range csr.Status.Conditions {
+		if c.Type == certificatesv1.CertificateApproved || c.Type == certificatesv1.CertificateDenied {
+			isInFinalState = true
+			finalState = string(c.Type)
+		}
+	}
+
+	if len(csr.Status.Certificate) != 0 || isInFinalState {
+		log.Info("Ignoring CSR, as it is in final state", "finalState", finalState)
+		return reconcile.Result{}, nil
+	}
+
+	x509cr, err := utils.DecodeCertificateRequest(csr.Spec.Request)
+	if err != nil {
+		return reconcile.Result{}, fmt.Errorf("unable to parse csr: %w", err)
+	}
+
+	reason, allowed, err := r.mustApprove(ctx, csr, x509cr)
+	if err != nil {
+		return reconcile.Result{}, fmt.Errorf("failed when checking for approval conditions: %w", err)
+	}
+
+	if allowed {
+		log.Info("Auto-approving CSR", "reason", reason)
+		csr.Status.Conditions = append(csr.Status.Conditions, certificatesv1.CertificateSigningRequestCondition{
+			Type:    certificatesv1.CertificateApproved,
+			Status:  corev1.ConditionTrue,
+			Reason:  "RequestApproved",
+			Message: fmt.Sprintf("Approving kubelet server certificate CSR (%s)", reason),
+		})
+	} else {
+		log.Info("Denying CSR", "reason", reason)
+		csr.Status.Conditions = append(csr.Status.Conditions, certificatesv1.CertificateSigningRequestCondition{
+			Type:    certificatesv1.CertificateDenied,
+			Status:  corev1.ConditionTrue,
+			Reason:  "RequestDenied",
+			Message: fmt.Sprintf("Denying kubelet server certificate CSR (%s)", reason),
+		})
+	}
+
+	_, err = r.CertificatesClient.UpdateApproval(ctx, csr.Name, csr, kubernetes.DefaultUpdateOptions())
+	return reconcile.Result{}, err
+}
+
+func (r *Reconciler) mustApprove(ctx context.Context, csr *certificatesv1.CertificateSigningRequest, x509cr *x509.CertificateRequest) (string, bool, error) {
+	if prefix := "system:node:"; !strings.HasPrefix(csr.Spec.Username, prefix) {
+		return fmt.Sprintf("username %q is not prefixed with %q", csr.Spec.Username, prefix), false, nil
+	}
+
+	if len(x509cr.DNSNames)+len(x509cr.IPAddresses) == 0 {
+		return "no DNS names or IP addresses in the SANS found", false, nil
+	}
+
+	if x509cr.Subject.CommonName != csr.Spec.Username {
+		return "common name in CSR does not match username", false, nil
+	}
+
+	if len(x509cr.Subject.Organization) != 1 || !utils.ValueExists(user.NodesGroup, x509cr.Subject.Organization) {
+		return "organization in CSR does not match nodes group", false, nil
+	}
+
+	nodeName := strings.TrimPrefix(x509cr.Subject.CommonName, "system:node:")
+
+	node := &corev1.Node{}
+	if err := r.TargetClient.Get(ctx, client.ObjectKey{Name: nodeName}, node); err != nil {
+		if apierrors.IsNotFound(err) {
+			return fmt.Sprintf("could not find node object with name %q", node.Name), false, nil
+		}
+		return "", false, err
+	}
+
+	machineList := &machinev1alpha1.MachineList{}
+	if err := r.SourceClient.List(ctx, machineList, client.InNamespace(r.Namespace), client.MatchingLabels{"node": node.Name}); err != nil {
+		return "", false, err
+	}
+
+	if length := len(machineList.Items); length != 1 {
+		return fmt.Sprintf("Expected exactly one machine in namespace %q for node %q but found %d", r.Namespace, node.Name, length), false, nil
+	}
+
+	var (
+		hostNames   []string
+		ipAddresses []string
+	)
+
+	for _, address := range node.Status.Addresses {
+		if address.Type == corev1.NodeHostName {
+			hostNames = append(hostNames, address.Address)
+		}
+		if address.Type == corev1.NodeInternalIP {
+			ipAddresses = append(ipAddresses, address.Address)
+		}
+	}
+
+	if !sets.NewString(hostNames...).Equal(sets.NewString(x509cr.DNSNames...)) {
+		return "DNS names in CSR do not match Hostname addresses in node object", false, nil
+	}
+
+	var ipAddressesInCSR []string
+	for _, ip := range x509cr.IPAddresses {
+		ipAddressesInCSR = append(ipAddressesInCSR, ip.String())
+	}
+
+	if !sets.NewString(ipAddresses...).Equal(sets.NewString(ipAddressesInCSR...)) {
+		return "IP addresses in CSR do not match InternalIP addresses in node object", false, nil
+	}
+
+	return "all checks passed", true, nil
+}

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -963,6 +963,7 @@ build:
         - pkg/healthz
         - pkg/logger
         - pkg/resourcemanager/cmd
+        - pkg/resourcemanager/controller/csrapprover
         - pkg/resourcemanager/controller/garbagecollector
         - pkg/resourcemanager/controller/garbagecollector/references
         - pkg/resourcemanager/controller/health

--- a/test/integration/resourcemanager/csrapprover/csrapprover_suite_test.go
+++ b/test/integration/resourcemanager/csrapprover/csrapprover_suite_test.go
@@ -1,0 +1,164 @@
+// Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package csrapprover_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	machinev1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	userpkg "k8s.io/apiserver/pkg/authentication/user"
+	kubernetesscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	"github.com/gardener/gardener/pkg/logger"
+	resourcemanagercmd "github.com/gardener/gardener/pkg/resourcemanager/cmd"
+	"github.com/gardener/gardener/pkg/resourcemanager/controller/csrapprover"
+	. "github.com/gardener/gardener/pkg/utils/test/matchers"
+)
+
+func TestKubeletCSRApproverController(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Kubelet Server CertificateSigningRequest Approver Controller Integration Test Suite")
+}
+
+const (
+	// testID is used for generating test namespace names and other IDs
+	testID = "kubelet-csr-autoapprove-controller-test"
+
+	nodeName = "my-node"
+	userName = "system:node:" + nodeName
+)
+
+var (
+	ctx = context.Background()
+	log logr.Logger
+
+	restConfig *rest.Config
+	scheme     *runtime.Scheme
+	testEnv    *envtest.Environment
+	testClient client.Client
+
+	testNamespace *corev1.Namespace
+	testRunID     string
+)
+
+var _ = BeforeSuite(func() {
+	logf.SetLogger(logger.MustNewZapLogger(logger.DebugLevel, logger.FormatJSON, zap.WriteTo(GinkgoWriter)))
+	log = logf.Log.WithName(testID)
+
+	By("starting test environment")
+	testEnv = &envtest.Environment{
+		CRDInstallOptions: envtest.CRDInstallOptions{
+			Paths: []string{filepath.Join("testdata", "crd-machines.yaml")},
+		},
+		ErrorIfCRDPathMissing: true,
+	}
+
+	var err error
+	restConfig, err = testEnv.Start()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(restConfig).NotTo(BeNil())
+
+	DeferCleanup(func() {
+		By("stopping test environment")
+		Expect(testEnv.Stop()).To(Succeed())
+	})
+
+	By("creating test clients")
+	scheme = runtime.NewScheme()
+	Expect(kubernetesscheme.AddToScheme(scheme)).NotTo(HaveOccurred())
+	Expect(machinev1alpha1.AddToScheme(scheme)).NotTo(HaveOccurred())
+
+	// We have to "fake" that our test client is the kubelet user because the .spec.username field in CSRs will also be
+	// overwritten by the kube-apiserver to the user who created it. This would always fail the constraints of this
+	// controller.
+	user, err := testEnv.AddUser(
+		envtest.User{Name: userName, Groups: []string{userpkg.SystemPrivilegedGroup}},
+		&rest.Config{QPS: 1000.0, Burst: 2000.0},
+	)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(user).NotTo(BeNil())
+
+	testClient, err = client.New(user.Config(), client.Options{Scheme: scheme})
+	Expect(err).NotTo(HaveOccurred())
+
+	By("creating test namespace")
+	testNamespace = &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			// create dedicated namespace for each test run, so that we can run multiple tests concurrently for stress tests
+			GenerateName: testID + "-",
+		},
+	}
+	Expect(testClient.Create(ctx, testNamespace)).To(Succeed())
+	log.Info("Created Namespace for test", "namespaceName", testNamespace.Name)
+	testRunID = testNamespace.Name
+
+	DeferCleanup(func() {
+		By("deleting test namespace")
+		Expect(testClient.Delete(ctx, testNamespace)).To(Or(Succeed(), BeNotFoundError()))
+	})
+
+	By("setting up manager")
+	mgr, err := manager.New(restConfig, manager.Options{
+		Scheme:             scheme,
+		MetricsBindAddress: "0",
+		Namespace:          testNamespace.Name,
+		NewCache: cache.BuilderWithOptions(cache.Options{
+			DefaultSelector: cache.ObjectSelector{
+				Label: labels.SelectorFromSet(labels.Set{testID: testRunID}),
+			},
+		}),
+	})
+	Expect(err).NotTo(HaveOccurred())
+
+	By("registering controller")
+	targetClusterOpts := &resourcemanagercmd.TargetClusterOptions{Namespace: testNamespace.Name, RESTConfig: restConfig}
+	Expect(targetClusterOpts.Complete()).To(Succeed())
+	Expect(mgr.Add(targetClusterOpts.Completed().Cluster)).To(Succeed())
+
+	Expect(csrapprover.AddToManagerWithOptions(mgr, csrapprover.ControllerConfig{
+		MaxConcurrentWorkers: 5,
+		TargetCluster:        targetClusterOpts.Completed().Cluster,
+		Namespace:            testNamespace.Name,
+	})).To(Succeed())
+
+	By("starting manager")
+	mgrContext, mgrCancel := context.WithCancel(ctx)
+
+	go func() {
+		defer GinkgoRecover()
+		Expect(mgr.Start(mgrContext)).To(Succeed())
+	}()
+
+	DeferCleanup(func() {
+		By("stopping manager")
+		mgrCancel()
+	})
+})

--- a/test/integration/resourcemanager/csrapprover/csrapprover_test.go
+++ b/test/integration/resourcemanager/csrapprover/csrapprover_test.go
@@ -195,12 +195,12 @@ var _ = Describe("Kubelet Server CertificateSigningRequest Approver Controller t
 				runTest("is not prefixed with")
 			})
 
-			Context("SANS don't contain any DNS names or IP addresses", func() {
+			Context("SANs don't contain any DNS names or IP addresses", func() {
 				BeforeEach(func() {
 					dnsNames, ips = nil, nil
 				})
 
-				runTest("no DNS names or IP addresses in the SANS found")
+				runTest("no DNS names or IP addresses in the SANs found")
 			})
 
 			Context("common name does not match username", func() {

--- a/test/integration/resourcemanager/csrapprover/csrapprover_test.go
+++ b/test/integration/resourcemanager/csrapprover/csrapprover_test.go
@@ -1,0 +1,403 @@
+// Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package csrapprover_test
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509/pkix"
+	"net"
+
+	machinev1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	certificatesv1 "k8s.io/api/certificates/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apiserver/pkg/authentication/user"
+	certutil "k8s.io/client-go/util/cert"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	secretutils "github.com/gardener/gardener/pkg/utils/secrets"
+	"github.com/gardener/gardener/pkg/utils/test"
+)
+
+var _ = Describe("Kubelet Server CertificateSigningRequest Approver Controller tests", func() {
+	var (
+		privateKey         *rsa.PrivateKey
+		certificateSubject *pkix.Name
+
+		ip1      = "1.2.3.4"
+		ip2      = "5.6.7.8"
+		ips      []net.IP
+		dnsName1 = "foo.bar"
+		dnsName2 = "bar.baz"
+		dnsNames []string
+
+		csr *certificatesv1.CertificateSigningRequest
+	)
+
+	BeforeEach(func() {
+		privateKey, _ = secretutils.FakeGenerateKey(rand.Reader, 4096)
+		certificateSubject = &pkix.Name{
+			CommonName:   userName,
+			Organization: []string{user.NodesGroup},
+		}
+
+		ips = []net.IP{net.ParseIP(ip1), net.ParseIP(ip2)}
+		dnsNames = []string{dnsName1, dnsName2}
+
+		csr = &certificatesv1.CertificateSigningRequest{
+			// Username, UID, Groups will be injected by API server.
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: testID + "-",
+				Labels:       map[string]string{testID: testRunID},
+			},
+			Spec: certificatesv1.CertificateSigningRequestSpec{
+				Usages: []certificatesv1.KeyUsage{
+					certificatesv1.UsageDigitalSignature,
+					certificatesv1.UsageKeyEncipherment,
+					certificatesv1.UsageClientAuth,
+				},
+				SignerName: certificatesv1.KubeletServingSignerName,
+			},
+		}
+	})
+
+	JustBeforeEach(func() {
+		By("Generate CSR data")
+		csrData, err := certutil.MakeCSR(privateKey, certificateSubject, dnsNames, ips)
+		Expect(err).NotTo(HaveOccurred())
+		csr.Spec.Request = csrData
+
+		By("Create CertificateSigningRequest")
+		Expect(testClient.Create(ctx, csr)).To(Succeed())
+		log.Info("Created CertificateSigningRequest for test", "certificateSigningRequest", client.ObjectKeyFromObject(csr))
+
+		DeferCleanup(func() {
+			By("Delete CertificateSigningRequest")
+			Expect(client.IgnoreNotFound(testClient.Delete(ctx, csr))).To(Succeed())
+		})
+	})
+
+	Context("non kubelet server certificate", func() {
+		BeforeEach(func() {
+			csr.Spec.SignerName = certificatesv1.KubeAPIServerClientSignerName
+		})
+
+		It("should ignore the CSR and do nothing", func() {
+			Consistently(func(g Gomega) {
+				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(csr), csr)).To(Succeed())
+				g.Expect(csr.Status.Conditions).To(BeEmpty())
+			}).Should(Succeed())
+		})
+	})
+
+	Context("kubelet server certificate", func() {
+		Context("constraints fulfilled", func() {
+			BeforeEach(func() {
+				By("Create Node")
+				node := &corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:   nodeName,
+						Labels: map[string]string{testID: testRunID},
+					},
+				}
+				Expect(testClient.Create(ctx, node)).To(Succeed())
+				log.Info("Created Node for test", "node", client.ObjectKeyFromObject(node))
+
+				DeferCleanup(func() {
+					By("Delete Node")
+					Expect(client.IgnoreNotFound(testClient.Delete(ctx, node))).To(Succeed())
+				})
+
+				By("Create Machine")
+				machine := &machinev1alpha1.Machine{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "machine",
+						Namespace: testNamespace.Name,
+						Labels: map[string]string{
+							testID: testRunID,
+							"node": node.Name,
+						},
+					},
+				}
+				Expect(testClient.Create(ctx, machine)).To(Succeed())
+				log.Info("Created Machine for test", "machine", client.ObjectKeyFromObject(machine))
+
+				DeferCleanup(func() {
+					By("Delete Machine")
+					Expect(client.IgnoreNotFound(testClient.Delete(ctx, machine))).To(Succeed())
+				})
+
+				By("Patch node's addresses in status")
+				patch := client.MergeFrom(node.DeepCopy())
+				node.Status.Addresses = []corev1.NodeAddress{
+					{Type: corev1.NodeHostName, Address: dnsName1},
+					{Type: corev1.NodeHostName, Address: dnsName2},
+					{Type: corev1.NodeInternalIP, Address: ip1},
+					{Type: corev1.NodeInternalIP, Address: ip2},
+				}
+				Expect(testClient.Status().Patch(ctx, node, patch)).To(Succeed())
+			})
+
+			It("should approve the CSR", func() {
+				Eventually(func(g Gomega) {
+					g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(csr), csr)).To(Succeed())
+					g.Expect(csr.Status.Conditions).To(ContainElement(And(
+						HaveField("Type", certificatesv1.CertificateApproved),
+						HaveField("Reason", "RequestApproved"),
+						HaveField("Message", "Approving kubelet server certificate CSR (all checks passed)"),
+					)))
+				}).Should(Succeed())
+			})
+		})
+
+		Context("constraints violated", func() {
+			runTest := func(expectedReason string) {
+				It("should deny the CSR", func() {
+					Eventually(func(g Gomega) {
+						g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(csr), csr)).To(Succeed())
+						g.Expect(csr.Status.Conditions).To(ContainElement(And(
+							HaveField("Type", certificatesv1.CertificateDenied),
+							HaveField("Reason", "RequestDenied"),
+							HaveField("Message", And(
+								ContainSubstring("Denying kubelet server certificate CSR"),
+								ContainSubstring(expectedReason),
+							)),
+						)))
+					}).Should(Succeed())
+				})
+			}
+
+			Context("username not prefixed with system:node:", func() {
+				BeforeEach(func() {
+					clientWithAdminUsername, err := client.New(restConfig, client.Options{Scheme: scheme})
+					Expect(err).NotTo(HaveOccurred())
+
+					DeferCleanup(test.WithVar(
+						&testClient, clientWithAdminUsername,
+					))
+				})
+
+				runTest("is not prefixed with")
+			})
+
+			Context("SANS don't contain any DNS names or IP addresses", func() {
+				BeforeEach(func() {
+					dnsNames, ips = nil, nil
+				})
+
+				runTest("no DNS names or IP addresses in the SANS found")
+			})
+
+			Context("common name does not match username", func() {
+				BeforeEach(func() {
+					certificateSubject.CommonName = "some-other-name"
+				})
+
+				runTest("common name in CSR does not match username")
+			})
+
+			Context("organization is empty", func() {
+				BeforeEach(func() {
+					certificateSubject.Organization = nil
+				})
+
+				runTest("organization in CSR does not match nodes group")
+			})
+
+			Context("organization contains too many items", func() {
+				BeforeEach(func() {
+					certificateSubject.Organization = []string{"foo", "bar"}
+				})
+
+				runTest("organization in CSR does not match nodes group")
+			})
+
+			Context("organization does not contain nodes group", func() {
+				BeforeEach(func() {
+					certificateSubject.Organization = []string{"foo"}
+				})
+
+				runTest("organization in CSR does not match nodes group")
+			})
+
+			Context("node object not found", func() {
+				runTest("could not find node object with name")
+			})
+
+			Context("machine object not found", func() {
+				BeforeEach(func() {
+					By("Create Node")
+					node := &corev1.Node{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:   nodeName,
+							Labels: map[string]string{testID: testRunID},
+						},
+					}
+					Expect(testClient.Create(ctx, node)).To(Succeed())
+					log.Info("Created Node for test", "node", client.ObjectKeyFromObject(node))
+
+					DeferCleanup(func() {
+						By("Delete Node")
+						Expect(client.IgnoreNotFound(testClient.Delete(ctx, node))).To(Succeed())
+					})
+				})
+
+				runTest("Expected exactly one machine in namespace")
+			})
+
+			Context("too many machine objects found", func() {
+				BeforeEach(func() {
+					By("Create Node")
+					node := &corev1.Node{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:   nodeName,
+							Labels: map[string]string{testID: testRunID},
+						},
+					}
+					Expect(testClient.Create(ctx, node)).To(Succeed())
+					log.Info("Created Node for test", "node", client.ObjectKeyFromObject(node))
+
+					DeferCleanup(func() {
+						By("Delete Node")
+						Expect(client.IgnoreNotFound(testClient.Delete(ctx, node))).To(Succeed())
+					})
+
+					machine := &machinev1alpha1.Machine{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "machine",
+							Namespace: testNamespace.Name,
+							Labels: map[string]string{
+								testID: testRunID,
+								"node": node.Name,
+							},
+						},
+					}
+					machine2 := machine.DeepCopy()
+					machine2.Name = "machine2"
+
+					By("Create Machine1")
+					Expect(testClient.Create(ctx, machine)).To(Succeed())
+					log.Info("Created Machine for test", "machine", client.ObjectKeyFromObject(machine))
+
+					By("Create Machine2")
+					Expect(testClient.Create(ctx, machine2)).To(Succeed())
+					log.Info("Created Machine for test", "machine", client.ObjectKeyFromObject(machine2))
+
+					DeferCleanup(func() {
+						By("Delete Machine1")
+						Expect(client.IgnoreNotFound(testClient.Delete(ctx, machine))).To(Succeed())
+						By("Delete Machine2")
+						Expect(client.IgnoreNotFound(testClient.Delete(ctx, machine2))).To(Succeed())
+					})
+				})
+
+				runTest("Expected exactly one machine in namespace")
+			})
+
+			Context("DNS names do not match Hostname addresses", func() {
+				BeforeEach(func() {
+					By("Create Node")
+					node := &corev1.Node{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:   nodeName,
+							Labels: map[string]string{testID: testRunID},
+						},
+					}
+					Expect(testClient.Create(ctx, node)).To(Succeed())
+					log.Info("Created Node for test", "node", client.ObjectKeyFromObject(node))
+
+					DeferCleanup(func() {
+						By("Delete Node")
+						Expect(client.IgnoreNotFound(testClient.Delete(ctx, node))).To(Succeed())
+					})
+
+					machine := &machinev1alpha1.Machine{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "machine",
+							Namespace: testNamespace.Name,
+							Labels: map[string]string{
+								testID: testRunID,
+								"node": node.Name,
+							},
+						},
+					}
+
+					By("Create Machine")
+					Expect(testClient.Create(ctx, machine)).To(Succeed())
+					log.Info("Created Machine for test", "machine", client.ObjectKeyFromObject(machine))
+
+					DeferCleanup(func() {
+						By("Delete Machine")
+						Expect(client.IgnoreNotFound(testClient.Delete(ctx, machine))).To(Succeed())
+					})
+				})
+
+				runTest("DNS names in CSR do not match Hostname addresses in node object")
+			})
+
+			Context("DNS names do not match Hostname addresses", func() {
+				BeforeEach(func() {
+					By("Create Node")
+					node := &corev1.Node{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:   nodeName,
+							Labels: map[string]string{testID: testRunID},
+						},
+					}
+					Expect(testClient.Create(ctx, node)).To(Succeed())
+					log.Info("Created Node for test", "node", client.ObjectKeyFromObject(node))
+
+					DeferCleanup(func() {
+						By("Delete Node")
+						Expect(client.IgnoreNotFound(testClient.Delete(ctx, node))).To(Succeed())
+					})
+
+					machine := &machinev1alpha1.Machine{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "machine",
+							Namespace: testNamespace.Name,
+							Labels: map[string]string{
+								testID: testRunID,
+								"node": node.Name,
+							},
+						},
+					}
+
+					By("Create Machine")
+					Expect(testClient.Create(ctx, machine)).To(Succeed())
+					log.Info("Created Machine for test", "machine", client.ObjectKeyFromObject(machine))
+
+					DeferCleanup(func() {
+						By("Delete Machine")
+						Expect(client.IgnoreNotFound(testClient.Delete(ctx, machine))).To(Succeed())
+					})
+
+					By("Patch node's addresses in status")
+					patch := client.MergeFrom(node.DeepCopy())
+					node.Status.Addresses = []corev1.NodeAddress{
+						{Type: corev1.NodeHostName, Address: dnsName1},
+						{Type: corev1.NodeHostName, Address: dnsName2},
+					}
+					Expect(testClient.Status().Patch(ctx, node, patch)).To(Succeed())
+				})
+
+				runTest("IP addresses in CSR do not match InternalIP addresses in node object")
+			})
+		})
+	})
+})

--- a/test/integration/resourcemanager/csrapprover/testdata/crd-machines.yaml
+++ b/test/integration/resourcemanager/csrapprover/testdata/crd-machines.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: machines.machine.sapcloud.io
+spec:
+  scope: Namespaced
+  names:
+    kind: Machine
+    listKind: MachineList
+    plural: machines
+    singular: machine
+  group: machine.sapcloud.io
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        type: object
+        x-kubernetes-preserve-unknown-fields: true


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind enhancement

**What this PR does / why we need it**:
- Previously, the `kubelet` was creating a self-signed CA and server certificate for `1y` when starting up. The `kube-apiserver` was not verifying the certificate when talking to the `kubelet` via HTTPS since it does not know about this CA.
- This approach has two problems: (1) long validity of server certificate, (2) no client-side certificate validation in `kube-apiserver`
- Now, the `kubelet` uses the `CertificateSigningRequest` API to request the server certificate. It will be signed by the existing `ca-kubelet`. The whole mechanism works similar to what it does for requesting its client certificate.
- The `gardener-resource-manager` serves a controller watching such CSRs and auto-approves them if several constraints are met (there is no auto-approval in `kube-controller-manager` for kubelet server certs).
- The `kube-apiserver` still does not validate the server certificate for backwards-compatibility (if it did, it would fail until all `kubelet`s were updated/reconciled). This will be added in a future Gardener release.

**Which issue(s) this PR fixes**:
Part of #3292 

**Special notes for your reviewer**:
PoC co-authored by @mwennrich and @Kumm-Kai
cc @vlerenc 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
The `kubelet`s running on shoot worker nodes are now requesting server certificates via the `CertificateSigningRequest` API. They have the default validity of `30d` and are auto-rotated when `80%` of their lifetime expires.
```
