### PR TITLE
Wait for webhook server to start in `Extension CRDs Webhook` test

### DIFF
--- a/test/integration/seedadmissioncontroller/extensioncrds/extensioncrds_suite_test.go
+++ b/test/integration/seedadmissioncontroller/extensioncrds/extensioncrds_suite_test.go
@@ -16,6 +16,7 @@ package extensioncrds_test
 
 import (
 	"context"
+	"net/http"
 	"strings"
 	"testing"
 
@@ -128,6 +129,12 @@ var _ = BeforeSuite(func() {
 		defer GinkgoRecover()
 		Expect(mgr.Start(mgrContext)).To(Succeed())
 	}()
+
+	// Wait for the webhook server to start
+	Eventually(func() error {
+		checker := mgr.GetWebhookServer().StartedChecker()
+		return checker(&http.Request{})
+	}).Should(BeNil())
 
 	DeferCleanup(func() {
 		By("stopping manager")


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind flake

**What this PR does / why we need it**:
Similar to https://github.com/gardener/gardener/pull/6783. I was not able to produce a flake for the `Extension CRDs Webhook` test but theoretically it makes sense to wait for the webhook server to be started in the BeforeSuite before running the tests.
I should have amended this small change to https://github.com/gardener/gardener/pull/6783 but I didn't noticed that this test is also missing the wait.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
