### PR TITLE
Add short names for machine resources

### DIFF
--- a/extensions/pkg/controller/worker/templates/machineclasses.tpl.yaml
+++ b/extensions/pkg/controller/worker/templates/machineclasses.tpl.yaml
@@ -15,7 +15,7 @@ spec:
     plural: machineclasses
     singular: machineclass
     shortNames:
-      - machcls
+      - machclass
   scope: Namespaced
   versions:
   - additionalPrinterColumns:

--- a/extensions/pkg/controller/worker/templates/machineclasses.tpl.yaml
+++ b/extensions/pkg/controller/worker/templates/machineclasses.tpl.yaml
@@ -13,9 +13,9 @@ spec:
     kind: MachineClass
     listKind: MachineClassList
     plural: machineclasses
-    singular: machineclass
     shortNames:
     - mcc
+    singular: machineclass
   scope: Namespaced
   versions:
   - additionalPrinterColumns:

--- a/extensions/pkg/controller/worker/templates/machineclasses.tpl.yaml
+++ b/extensions/pkg/controller/worker/templates/machineclasses.tpl.yaml
@@ -14,6 +14,8 @@ spec:
     listKind: MachineClassList
     plural: machineclasses
     singular: machineclass
+    shortNames:
+      - machcls
   scope: Namespaced
   versions:
   - additionalPrinterColumns:

--- a/extensions/pkg/controller/worker/templates/machineclasses.tpl.yaml
+++ b/extensions/pkg/controller/worker/templates/machineclasses.tpl.yaml
@@ -15,7 +15,7 @@ spec:
     plural: machineclasses
     singular: machineclass
     shortNames:
-      - machclass
+    - mcc
   scope: Namespaced
   versions:
   - additionalPrinterColumns:

--- a/extensions/pkg/controller/worker/templates/machinedeployments.tpl.yaml
+++ b/extensions/pkg/controller/worker/templates/machinedeployments.tpl.yaml
@@ -13,9 +13,9 @@ spec:
     kind: MachineDeployment
     listKind: MachineDeploymentList
     plural: machinedeployments
-    singular: machinedeployment
     shortNames:
     - mcd
+    singular: machinedeployment
   scope: Namespaced
   versions:
   - additionalPrinterColumns:

--- a/extensions/pkg/controller/worker/templates/machinedeployments.tpl.yaml
+++ b/extensions/pkg/controller/worker/templates/machinedeployments.tpl.yaml
@@ -14,6 +14,8 @@ spec:
     listKind: MachineDeploymentList
     plural: machinedeployments
     singular: machinedeployment
+    shortNames:
+      - machdeploy
   scope: Namespaced
   versions:
   - additionalPrinterColumns:

--- a/extensions/pkg/controller/worker/templates/machinedeployments.tpl.yaml
+++ b/extensions/pkg/controller/worker/templates/machinedeployments.tpl.yaml
@@ -15,7 +15,7 @@ spec:
     plural: machinedeployments
     singular: machinedeployment
     shortNames:
-      - machdeploy
+    - mcd
   scope: Namespaced
   versions:
   - additionalPrinterColumns:

--- a/extensions/pkg/controller/worker/templates/machines.tpl.yaml
+++ b/extensions/pkg/controller/worker/templates/machines.tpl.yaml
@@ -13,9 +13,9 @@ spec:
     kind: Machine
     listKind: MachineList
     plural: machines
-    singular: machine
     shortNames:
     - mc
+    singular: machine
   scope: Namespaced
   versions:
   - additionalPrinterColumns:

--- a/extensions/pkg/controller/worker/templates/machines.tpl.yaml
+++ b/extensions/pkg/controller/worker/templates/machines.tpl.yaml
@@ -15,7 +15,7 @@ spec:
     plural: machines
     singular: machine
     shortNames:
-      - mach
+    - mc
   scope: Namespaced
   versions:
   - additionalPrinterColumns:

--- a/extensions/pkg/controller/worker/templates/machines.tpl.yaml
+++ b/extensions/pkg/controller/worker/templates/machines.tpl.yaml
@@ -14,6 +14,8 @@ spec:
     listKind: MachineList
     plural: machines
     singular: machine
+    shortNames:
+      - mach
   scope: Namespaced
   versions:
   - additionalPrinterColumns:

--- a/extensions/pkg/controller/worker/templates/machinesets.tpl.yaml
+++ b/extensions/pkg/controller/worker/templates/machinesets.tpl.yaml
@@ -14,6 +14,8 @@ spec:
     listKind: MachineSetList
     plural: machinesets
     singular: machineset
+    shortNames:
+      - machset
   scope: Namespaced
   versions:
   - additionalPrinterColumns:

--- a/extensions/pkg/controller/worker/templates/machinesets.tpl.yaml
+++ b/extensions/pkg/controller/worker/templates/machinesets.tpl.yaml
@@ -13,9 +13,9 @@ spec:
     kind: MachineSet
     listKind: MachineSetList
     plural: machinesets
-    singular: machineset
     shortNames:
     - mcs
+    singular: machineset
   scope: Namespaced
   versions:
   - additionalPrinterColumns:

--- a/extensions/pkg/controller/worker/templates/machinesets.tpl.yaml
+++ b/extensions/pkg/controller/worker/templates/machinesets.tpl.yaml
@@ -15,7 +15,7 @@ spec:
     plural: machinesets
     singular: machineset
     shortNames:
-      - machset
+    - mcs
   scope: Namespaced
   versions:
   - additionalPrinterColumns:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind enhancement

**What this PR does / why we need it**:
This PR adds short names for machine resources which were removed when support for `K8S 1.22` was added. The names are as follows:

- `mc` for `machines`
- `mcc` for `machineclass`
- `mcd` for `machinedeployment`
- `mcs` for `machineset`

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
The testing was done on a local kind setup of gardener and the outcome is as follows:
<img width="831" alt="Screenshot 2022-10-11 at 8 30 10 PM" src="https://user-images.githubusercontent.com/66425093/195128827-009a207f-60bd-419b-acf8-8f41e9a42acf.png">
<img width="443" alt="Screenshot 2022-10-11 at 8 30 17 PM" src="https://user-images.githubusercontent.com/66425093/195128856-5636791b-fae5-4cd8-9149-cb53e77d5470.png">
<img width="627" alt="Screenshot 2022-10-11 at 8 30 25 PM" src="https://user-images.githubusercontent.com/66425093/195128950-f3731f73-dd79-451c-971d-4b413f7840c5.png">
<img width="555" alt="Screenshot 2022-10-11 at 8 30 33 PM" src="https://user-images.githubusercontent.com/66425093/195128992-3d6e8a97-74ea-4b58-8610-2a3020e73574.png">


**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Short names for machine (mc), machineclass (mcc), machinedeployment (mcd), and machineset (mcs) resources are now added. 
```
