### PR TITLE
Clarify the role that is used to manage permissions of service accounts

### DIFF
--- a/docs/usage/projects.md
+++ b/docs/usage/projects.md
@@ -56,7 +56,7 @@ Please note that the `.spec.owner` field is deprecated and will be removed in fu
 The list of members (again a list in `.spec.members[]` using the `rbac.authorization.k8s.io/v1.Subject` type) contains all the people that are associated with the project in any way.
 Each project member must have at least one role (currently described in `.spec.members[].role`, additional roles can be added to `.spec.members[].roles[]`). The following roles exist:
 
-* `admin`: This allows to fully manage resources inside the project (e.g., secrets, shoots, configmaps, and similar).
+* `admin`: This allows to fully manage resources inside the project (e.g., secrets, shoots, configmaps, and similar). Mind that the `admin` role has readonly access to service accounts.
 * `serviceaccountmanager`: This allows to fully manage service accounts inside the project namespace and request tokens for them. The permissions of the created service accounts are instead managed by the `admin` role. Please refer to [this document](./project_namespace_access.md).
 * `uam`: This allows to add/modify/remove human users or groups to/from the project member list.
 * `viewer`: This allows to read all resources inside the project except secrets.

--- a/docs/usage/projects.md
+++ b/docs/usage/projects.md
@@ -57,8 +57,8 @@ The list of members (again a list in `.spec.members[]` using the `rbac.authoriza
 Each project member must have at least one role (currently described in `.spec.members[].role`, additional roles can be added to `.spec.members[].roles[]`). The following roles exist:
 
 * `admin`: This allows to fully manage resources inside the project (e.g., secrets, shoots, configmaps, and similar).
-* `serviceaccountmanager`: This allows to fully manage service accounts inside the project namespace and request tokens for them. Please refer to [this document](./project_namespace_access.md).
-* `uam`: This allows to add/modify/remove human users or groups to/from the project member list. Technical users (service accounts) can be managed by all admins.
+* `serviceaccountmanager`: This allows to fully manage service accounts inside the project namespace and request tokens for them. The permissions of the created service accounts are instead managed by the `admin` role. Please refer to [this document](./project_namespace_access.md).
+* `uam`: This allows to add/modify/remove human users or groups to/from the project member list.
 * `viewer`: This allows to read all resources inside the project except secrets.
 * `owner`: This combines the `admin`, `uam` and `serviceaccountmanager` roles.
 * Extension roles (prefixed with `extension:`): Please refer to [this document](../extensions/project-roles.md).


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area documentation
/kind cleanup

**What this PR does / why we need it**:
This PR clarifies which role should be used to manage permissions of service accounts.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
I am not sure if we should add a note that the `admin` role has readonly permissions for `serviceaccounts`. WDYT?

cc @donistz @n-boshnakov 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
