### PR TITLE
Remove preStop hook from gardener-apiserver

### DIFF
--- a/charts/gardener/controlplane/charts/runtime/templates/apiserver/deployment.yaml
+++ b/charts/gardener/controlplane/charts/runtime/templates/apiserver/deployment.yaml
@@ -264,13 +264,6 @@ spec:
         {{- end }}
         {{- include "gardener-apiserver.watchCacheSizes" . | indent 8 }}
         - --v=2
-        lifecycle:
-          preStop:
-            exec:
-              command:
-              - sh
-              - -c
-              - sleep 5
         livenessProbe:
           httpGet:
             scheme: HTTPS

--- a/charts/gardener/controlplane/values.yaml
+++ b/charts/gardener/controlplane/values.yaml
@@ -172,9 +172,9 @@ global:
           value: "1G"
           percentage: 70
 
+    shutdownDelayDuration: 15s
  #  goAwayChance: 0.1
  #  http2MaxStreamsPerConnection: 1000
- #  shutdownDelayDuration: 20s
  #  requests:
  #    maxNonMutatingInflight: 400
  #    maxMutatingInflight: 200


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind bug

**What this PR does / why we need it**:
Since #6159 the OCI image for gardener apiserver no longer have shell or `sleep` command, so the preStop hook fails with
```
garden 21m Warning FailedPreStopHook pod/gardener-apiserver-66696f74b-cxjt4 Exec lifecycle hook ([sh -c sleep 5]) for Container "gardener-apiserver" in Pod "gardener-apiserver-66696f74b-cxjt4_garden(eebdbc49-6344-4aaa-bf37-005e5c611387)" failed - error: rpc error: code = Unknown desc = failed to exec in container: failed to start exec "148275b2daa0f1799c10d3b643b3a465846c20c0d55ea5443803d5269645c9b0": OCI runtime exec failed: exec failed: unable to start container process: exec: "sh": executable file not found in $PATH: unknown, message: ""
```

So, similarly to #3295, the preStop hook is removed and the `--shutdown-delay-duration` flag by default is using value < 20s.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
cc @dimityrmirchev 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
The broken `preStop` hook from Gardener API Server deployment has been removed.
```
