### PR TITLE
Remove step to install openvpn in local setup guide

### DIFF
--- a/docs/development/local_setup.md
+++ b/docs/development/local_setup.md
@@ -71,19 +71,6 @@ brew install helm
 
 For other OS please check the [Helm installation documentation](https://helm.sh/docs/intro/install/).
 
-## Installing openvpn
-
-We use `OpenVPN` to establish network connectivity from the control plane running in the Seed cluster to the Shoot's worker nodes running in private networks.
-To harden the security we need to generate another secret to encrypt the network traffic ([details](https://openvpn.net/index.php/open-source/documentation/howto.html#security)).
-Please install the `openvpn` binary. On macOS run
-
-```bash
-brew install openvpn
-export PATH=$(brew --prefix openvpn)/sbin:$PATH
-```
-
-For other OS, please check the [OpenVPN downloads page](https://openvpn.net/index.php/open-source/downloads.html).
-
 ## Installing Docker
 
 You need to have docker installed and running. On macOS run


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area documentation
/kind cleanup

**What this PR does / why we need it**:

After https://github.com/gardener/gardener/pull/6641, the `openvpn` binary should not be required to run Gardener locally.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
