### PR TITLE
Revert "Drop Priority class gardener-shoot-controlplane"

### DIFF
--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -755,4 +755,7 @@ const (
 	// PriorityClassNameShootControlPlane100 is the name of a PriorityClass for Shoot control plane components.
 	// Please consider the documentation in https://github.com/gardener/gardener/blob/master/docs/development/priority-classes.md
 	PriorityClassNameShootControlPlane100 = "gardener-system-100"
+	// PriorityClassNameShootControlPlane is the name of a PriorityClass for Shoot control plane components.
+	// Deprecated: this PriorityClass will be removed in a future version, use the fine-granular PriorityClasses above instead.
+	PriorityClassNameShootControlPlane = "gardener-shoot-controlplane"
 )

--- a/pkg/operation/botanist/component/seedsystem/seedsystem.go
+++ b/pkg/operation/botanist/component/seedsystem/seedsystem.go
@@ -176,6 +176,8 @@ var gardenletManagedPriorityClasses = []struct {
 	{v1beta1constants.PriorityClassNameShootControlPlane300, 999998300, "PriorityClass for Shoot control plane components"},
 	{v1beta1constants.PriorityClassNameShootControlPlane200, 999998200, "PriorityClass for Shoot control plane components"},
 	{v1beta1constants.PriorityClassNameShootControlPlane100, 999998100, "PriorityClass for Shoot control plane components"},
+	// TODO: remove this in a future release once all components have been migrated to the other fine-granular PriorityClasses.
+	{v1beta1constants.PriorityClassNameShootControlPlane, 100, "DEPRECATED PriorityClass for Shoot control plane components"},
 }
 
 func addPriorityClasses(registry *managedresources.Registry) error {

--- a/pkg/operation/botanist/component/seedsystem/seedsystem_test.go
+++ b/pkg/operation/botanist/component/seedsystem/seedsystem_test.go
@@ -151,7 +151,7 @@ status: {}
 		})
 
 		It("should successfully deploy the resources", func() {
-			Expect(managedResourceSecret.Data).To(HaveLen(11))
+			Expect(managedResourceSecret.Data).To(HaveLen(12))
 			Expect(string(managedResourceSecret.Data["deployment__"+namespace+"__reserve-excess-capacity.yaml"])).To(Equal(deploymentYAML))
 			expectPriorityClasses(managedResourceSecret.Data)
 		})
@@ -275,6 +275,7 @@ func expectPriorityClasses(data map[string][]byte) {
 		{"gardener-system-300", 999998300, "PriorityClass for Shoot control plane components"},
 		{"gardener-system-200", 999998200, "PriorityClass for Shoot control plane components"},
 		{"gardener-system-100", 999998100, "PriorityClass for Shoot control plane components"},
+		{"gardener-shoot-controlplane", 100, "DEPRECATED PriorityClass for Shoot control plane components"},
 	}
 
 	for _, pc := range expected {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug

**What this PR does / why we need it**:
This PR reverts https://github.com/gardener/gardener/commit/d2dddea9b0368519a6ae19d0687f7d2cc6c3d5d8. See the motivation in https://github.com/gardener/gardener/issues/6798.

**Which issue(s) this PR fixes**:
Fix https://github.com/gardener/gardener/issues/6798

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
An issue causing the `gardener-shoot-controlplane` PriorityClass to be deleted too early when there are still Deployments (`vpn-seed-server`) that reference it is now mitigated.
```
