### PR TITLE
added certificate-list.md file which contains the list of certificate…

### DIFF
--- a/docs/development/certificate-list.md
+++ b/docs/development/certificate-list.md
@@ -1,49 +1,61 @@
-# List of certificates use in Gardener and its location.
-|Serial No.|    Certificates        | Cluster         |Cluster (Base/virtual)|Storage location|  Description               |
-| ---------|----------------| --------------- |----------------------|----------------|-----------------------------|
-|1.        | kubeApiServer            | SHOOT Master  |Both                  |/etc/kubernetes/pki| use for secure communication between kube-apiserver and kubelet |
-|2.        | kubelet                  | SHOOT Worker  |Both                  |/etc/kubernetes/pki| used for signing client certificates for talking to kubelet API, e.g. kube-apiserver-kubelet |
-|3.        |etcd CA                  | SHOOT master  |Both                  |/etc/kubernetes/pki/etcd| CA (used for signing etcd serving certificates and client certificates |
-|4.        | front-proxy CA           | SHOOT master  |Both                  |/etc/kubernetes/pki| used for signing client certificates that kube-aggregator (part of kube-apiserver) uses to talk to extension API servers, filled into extension-apiserver-authentication ConfigMap and read by extension API servers to verify incoming kube-aggregator requests) |
-|5.        |metrics-server            | SHOOT master |Both                  |/etc/kubernetes/pki| used for signing serving certificates, filled into APIService caBundle field and read by kube-aggregator to verify the presented serving certificate |
-|6.        | ReversedVPN CA            | SHOOT master |Both                  |/etc/kubernetes/pki| used for signing vpn-seed-server serving certificate and vpn-shoot client certificate|
-|7.        |vpn-seed-server          | shoot         |Base                   |/etc/envoy         | This is used by the Shoot API Server and the prometheus pods to communicate over VPN/proxy with pods in the Shoot cluster. **Note: only if rversed vpn disable**|
-|8.        |shoot-cluste-autoscaler  | shoot         |                      |/var/run/secrets/gardener.cloud/shoot/generic-kubeconfig/kubeconfig|To establish a secure communication between HPA/VPA and metrics server |
-|9.        |ca-provider-vsphere-controlplane| shoot  |Both                  |                     |Gardener Extension need to communicate with vsphere provider, for Gardener to leverage vSphere clusters for machine provisioning|
-|10.        |ca-provider-vsphere-controlplane-bundle|shoot| Both             |                     |                       |
-|11.        |Cluster CA               |             |                       |                     |used for signing kube-apiserver serving certificates and client certificates | 
-|12.        |gardenLet CA             |garden       |                       |                     |Used for communication between gardnerlet and gardner API server|
-|13.        |ca-seed                  |garden       |Both                   |                     |certificate generated for a seed cluster|
-|14.        |ca-seed-bundle           |garden       |Both                   |                     |contains ROOT and intermediate certificates| 
-|15.        |garden-etcd-events-ca    |Garden       |Base                   |/var/etcd/ssl/client,server| Secure communication between garden API server and etcd, etcd-events store that contains all Event objects (events.k8s.io) of a cluster|
-|16.        |garden-etcd-main-ca      |Garden       |Base                   |/var/etcd/ssl/client,server| Secure communication between garden API server and etcd, etcd main store contains all “cluster critical” or “long-term” objects. for backup|
-|17.        |garden-kube-aggregator-ca|Garden       |Base                   |/var/etcd/ssl/client,server| Secure communication between garden API server and kube aggregator|
-|18.        |garden-kube-apiserver-ca |Garden       |Base                   |/var/etcd/ssl/client,server| Secure communication between gardenlet and kube apiServer |
-|19.        |identity-ca              |garden       |Base                   |                       | identity provider using OIDC|
-|20.        |Istio-ca                 |istio-system |                       |/var/run/secrets/tokens    | multiple kube-apiservers behind a single LoadBalancer, an intermediate proxy must be placed between the Cloud-Provider’s LoadBalancer and kube-apiservers|
-|21.        |cert-manager-webhook     |Cert-manager |Base                   |                           |                     |
-|22.        |managedresource-cluster  |garden       |Both                   |                           |                     |
-|23.        |networking-calico  |garden       |Base                   |                           |                     |
-|24.        |istio-ca-secret          |             |Both                   |                           |Istio secret         |
+# List of certificates in gardener
 
-### Pod processes identity using service account
-|Serial No.|    secret                          |       type                           | Cluster(Base/virtual)| Description   |
-|----------|--------------------------|--------------------------------------|----------------------|---------------|
-|1.        |cert-manager-cainjector-token       |kubernetes.io/service-account-token|Base                  |               |
-|2.        | default-token                       |kubernetes.io/service-account-token|Both                  |               |
-|3.        | gardener-extension-networking-calico|kubernetes.io/service-account-token|Both                  |               |
-|4.        | calico-kube-controllers-token       |kubernetes.io/service-account-token|Both                  |               |                     
-|5.        | calico-node-cpva-token              |kubernetes.io/service-account-token|Virtual               |               |                                                                                                  
-|6.        | calico-node-token                   |kubernetes.io/service-account-token|Both                  |               |                                                                                                   
-|7.        | calico-typha-token                  |kubernetes.io/service-account-token|Virtual               |               |                                                                                                   
-|8.        | certificate-controller              |kubernetes.io/service-account-token|Both                  |Kubernetes service accounts are Kubernetes resources, created and managed using the Kubernetes API|
-|9.        | cluster-autoscaler-token            |kubernetes.io/service-account-token|Both                  |               |                                                                                                   
-|10.        | horizontal-pod-autoscaler-token    |kubernetes.io/service-account-token|Both                  |               |                                                                                                   
-|11.        | replicaset-controller-token        |kubernetes.io/service-account-token|Both                  |               |                                                                                                   
-|12.        | replication-controller-token       |kubernetes.io/service-account-token|Both                  |               |                                                                                                   
-|13.        | root-ca-cert-publisher-token       |kubernetes.io/service-account-token|Both                  |               |                                                                                                   
-|14.        | cluster-autoscaler-token           |kubernetes.io/service-account-token|Both                  |               |
-### Certificate required to secure a domain
-* **Domain CA:** stores in source cluster
-* **Ingress CA:** stores in source cluster
-* **Service CA:** stores in source cluster
+|Serial No.| Component                                   | Certificates                               |
+|----------|---------------------------------------------|--------------------------------------------|
+|1. |Cross-charging                                      |cross-charging-webhooks-ca                  |             
+|2. |Cross-charging                                      |cross-charging-webhooks-ca-csr              |             
+|3. |Cross-charging                                      |cross-charging-webhooks-cert                |             
+|4. |garden auditlog                                     |auditlog-proxy-ca                           |             
+|5. |garden auditlog                                     |auditlog-proxy-ca-csr                       |             
+|6. |garden auditlog                                     |auditlog-proxy-server-cert                  |             
+|7. |garden                                              |apiserver-oidc-webhook-authenticator-operator-ca|         
+|8. |garden                                              |apiserver-oidc-webhook-authenticator-operator-cert|       
+|9. |garden                                              |apiservers-metrics-scraper-cert                   |       
+|10.|garden                                              |etcd-ca                                     |              
+|11.|garden                                              |etcd-ca-csr                                 |              
+|12.|garden                                              |etcd-client-cert                            |              
+|13.|garden                                              |etcd-server-cert                            |              
+|14.|garden                                              |kube-aggregator-ca-csr                      |              
+|15.|garden                                              |kube-aggregator-client-cert                 |              
+|16.|garden                                              |kube-apiserver-client-cert                  |              
+|17.|garden                                              |kube-apiserver-ca-csr                       |              
+|18.|garden                                              |kube-apiserver-client-admin-cert            |              
+|19.|garden                                              |kube-apiserver-client-kube-controller-manager-cert|        
+|20.|gardener-extension-admission-calico                 |gardener-extension-admission-calico-ca      |              
+|21.|gardener-extension-admission-calico                 |gardener-extension-admission-calico-ca-csr  |              
+|22.|gardener-extension-admission-calico                 |gardener-extension-admission-calico-cert    |              
+|23.|gardener-extension-admission-cilium                 |gardener-extension-admission-cilium-ca      |              
+|24.|gardener-extension-admission-cilium                 |gardener-extension-admission-cilium-ca-csr  |              
+|25.|gardener-extension-admission-cilium                 |gardener-extension-admission-cilium-cert    |              
+|26.|gardener-extension-admission-shoot-dns-service      |gardener-extension-admission-shoot-dns-service-ca|         
+|27.|gardener-extension-admission-shoot-dns-service      |gardener-extension-admission-shoot-dns-service-ca-csr|     
+|28.|gardener-extension-admission-shoot-dns-service      |gardener-extension-admission-shoot-dns-service-cert|       
+|29.|gardener-extension-admission-alicloud               |gardener-extension-admission-alicloud-ca           |       
+|30.|gardener-extension-admission-alicloud               |gardener-extension-admission-alicloud-ca-csr       |       
+|31.|gardener-extension-admission-alicloud               |gardener-extension-admission-alicloud-cert         |       
+|32.|gardener-extension-admission-aws                    |gardener-extension-admission-aws-ca                |       
+|33.|gardener-extension-admission-aws                    |gardener-extension-admission-aws-ca-csr            |       
+|34.|gardener-extension-admission-aws                    |gardener-extension-admission-aws-cert              |       
+|35.|gardener-extension-admission-azure                  |gardener-extension-admission-azure-ca              |       
+|36.|gardener-extension-admission-azure                  |gardener-extension-admission-azure-ca-csr          |       
+|37.|gardener-extension-admission-azure                  |gardener-extension-admission-azure-cert            |       
+|38.|gardener-extension-admission-gcp                    |gardener-extension-admission-gcp-ca                |       
+|39.|gardener-extension-admission-gcp                    |gardener-extension-admission-gcp-ca-csr            |       
+|40.|gardener-extension-admission-gcp                    |gardener-extension-admission-gcp-cert              |       
+|41.|gardener-extension-admission-openstack              |gardener-extension-admission-openstack-ca          |       
+|42.|gardener-extension-admission-openstack              |gardener-extension-admission-openstack-ca-csr      |       
+|43.|gardener-extension-admission-openstack              |gardener-extension-admission-openstack-cert        |       
+|44.|gardener-extension-admission-vsphere                |gardener-extension-admission-vsphere-ca            |       
+|45.|gardener-extension-admission-vsphere                |gardener-extension-admission-vsphere-ca-csr        |       
+|46.|gardener-extension-admission-azure                  |gardener-extension-admission-azure-cert            |       
+|47.|Gardener                                            |gardener-ca                                        |
+|48.|Gardener                                            |gardener-ca-csr                                    |
+|49.|Gardener                                            |gardener-admission-controller-cert                 |
+|50.|Gardener                                            |gardener-apiserver-cert                            |
+|51.|Gardener                                            |gardener-controller-manager-cert                   |
+|52.|oidc-webhook-authenticator                          |oidc-webhook-authenticator                         |
+|53.|oidc-webhook-authenticator                          |oidc-webhook-authenticator-ca-csr                  |
+|54.|oidc-webhook-authenticator                          |oidc-webhook-authenticator-cert                    |
+|55.|terminal                                            |terminal-ca                                        |                           
+|56.|terminal                                            |terminal-ca-csr                                    |
+|57.|terminal                                            |terminal-controller-manager-cert                   |

--- a/docs/development/certificate-list.md
+++ b/docs/development/certificate-list.md
@@ -1,0 +1,49 @@
+# List of certificates use in Gardener and its location.
+|Serial No.|    Certificates        | Cluster         |Cluster (Base/virtual)|Storage location|  Description               |
+| ---------|----------------| --------------- |----------------------|----------------|-----------------------------|
+|1.        | kubeApiServer            | SHOOT Master  |Both                  |/etc/kubernetes/pki| use for secure communication between kube-apiserver and kubelet |
+|2.        | kubelet                  | SHOOT Worker  |Both                  |/etc/kubernetes/pki| used for signing client certificates for talking to kubelet API, e.g. kube-apiserver-kubelet |
+|3.        |etcd CA                  | SHOOT master  |Both                  |/etc/kubernetes/pki/etcd| CA (used for signing etcd serving certificates and client certificates |
+|4.        | front-proxy CA           | SHOOT master  |Both                  |/etc/kubernetes/pki| used for signing client certificates that kube-aggregator (part of kube-apiserver) uses to talk to extension API servers, filled into extension-apiserver-authentication ConfigMap and read by extension API servers to verify incoming kube-aggregator requests) |
+|5.        |metrics-server            | SHOOT master |Both                  |/etc/kubernetes/pki| used for signing serving certificates, filled into APIService caBundle field and read by kube-aggregator to verify the presented serving certificate |
+|6.        | ReversedVPN CA            | SHOOT master |Both                  |/etc/kubernetes/pki| used for signing vpn-seed-server serving certificate and vpn-shoot client certificate|
+|7.        |vpn-seed-server          | shoot         |Base                   |/etc/envoy         | This is used by the Shoot API Server and the prometheus pods to communicate over VPN/proxy with pods in the Shoot cluster. **Note: only if rversed vpn disable**|
+|8.        |shoot-cluste-autoscaler  | shoot         |                      |/var/run/secrets/gardener.cloud/shoot/generic-kubeconfig/kubeconfig|To establish a secure communication between HPA/VPA and metrics server |
+|9.        |ca-provider-vsphere-controlplane| shoot  |Both                  |                     |Gardener Extension need to communicate with vsphere provider, for Gardener to leverage vSphere clusters for machine provisioning|
+|10.        |ca-provider-vsphere-controlplane-bundle|shoot| Both             |                     |                       |
+|11.        |Cluster CA               |             |                       |                     |used for signing kube-apiserver serving certificates and client certificates | 
+|12.        |gardenLet CA             |garden       |                       |                     |Used for communication between gardnerlet and gardner API server|
+|13.        |ca-seed                  |garden       |Both                   |                     |certificate generated for a seed cluster|
+|14.        |ca-seed-bundle           |garden       |Both                   |                     |contains ROOT and intermediate certificates| 
+|15.        |garden-etcd-events-ca    |Garden       |Base                   |/var/etcd/ssl/client,server| Secure communication between garden API server and etcd, etcd-events store that contains all Event objects (events.k8s.io) of a cluster|
+|16.        |garden-etcd-main-ca      |Garden       |Base                   |/var/etcd/ssl/client,server| Secure communication between garden API server and etcd, etcd main store contains all “cluster critical” or “long-term” objects. for backup|
+|17.        |garden-kube-aggregator-ca|Garden       |Base                   |/var/etcd/ssl/client,server| Secure communication between garden API server and kube aggregator|
+|18.        |garden-kube-apiserver-ca |Garden       |Base                   |/var/etcd/ssl/client,server| Secure communication between gardenlet and kube apiServer |
+|19.        |identity-ca              |garden       |Base                   |                       | identity provider using OIDC|
+|20.        |Istio-ca                 |istio-system |                       |/var/run/secrets/tokens    | multiple kube-apiservers behind a single LoadBalancer, an intermediate proxy must be placed between the Cloud-Provider’s LoadBalancer and kube-apiservers|
+|21.        |cert-manager-webhook     |Cert-manager |Base                   |                           |                     |
+|22.        |managedresource-cluster  |garden       |Both                   |                           |                     |
+|23.        |networking-calico  |garden       |Base                   |                           |                     |
+|24.        |istio-ca-secret          |             |Both                   |                           |Istio secret         |
+
+### Pod processes identity using service account
+|Serial No.|    secret                          |       type                           | Cluster(Base/virtual)| Description   |
+|----------|--------------------------|--------------------------------------|----------------------|---------------|
+|1.        |cert-manager-cainjector-token       |kubernetes.io/service-account-token|Base                  |               |
+|2.        | default-token                       |kubernetes.io/service-account-token|Both                  |               |
+|3.        | gardener-extension-networking-calico|kubernetes.io/service-account-token|Both                  |               |
+|4.        | calico-kube-controllers-token       |kubernetes.io/service-account-token|Both                  |               |                     
+|5.        | calico-node-cpva-token              |kubernetes.io/service-account-token|Virtual               |               |                                                                                                  
+|6.        | calico-node-token                   |kubernetes.io/service-account-token|Both                  |               |                                                                                                   
+|7.        | calico-typha-token                  |kubernetes.io/service-account-token|Virtual               |               |                                                                                                   
+|8.        | certificate-controller              |kubernetes.io/service-account-token|Both                  |Kubernetes service accounts are Kubernetes resources, created and managed using the Kubernetes API|
+|9.        | cluster-autoscaler-token            |kubernetes.io/service-account-token|Both                  |               |                                                                                                   
+|10.        | horizontal-pod-autoscaler-token    |kubernetes.io/service-account-token|Both                  |               |                                                                                                   
+|11.        | replicaset-controller-token        |kubernetes.io/service-account-token|Both                  |               |                                                                                                   
+|12.        | replication-controller-token       |kubernetes.io/service-account-token|Both                  |               |                                                                                                   
+|13.        | root-ca-cert-publisher-token       |kubernetes.io/service-account-token|Both                  |               |                                                                                                   
+|14.        | cluster-autoscaler-token           |kubernetes.io/service-account-token|Both                  |               |
+### Certificate required to secure a domain
+* **Domain CA:** stores in source cluster
+* **Ingress CA:** stores in source cluster
+* **Service CA:** stores in source cluster


### PR DESCRIPTION
… use in gardener

**How to categorize this PR?**

<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area TODO
Certificate
/kind TODO
Document

**What this PR does / why we need it**:
This PR contains list of certificate use in gardener. 
If user wants to use his own certificate in gardener he will have the list of certificate and purpose of each certificate.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
