### PR TITLE
Do not put `gardenlet` under time pressure during start-up

### DIFF
--- a/cmd/gardenlet/app/app.go
+++ b/cmd/gardenlet/app/app.go
@@ -175,6 +175,7 @@ func run(ctx context.Context, cancel context.CancelFunc, log logr.Logger, cfg *c
 	log.Info("Setting up periodic health manager")
 	healthGracePeriod := time.Duration((*cfg.Controllers.Seed.LeaseResyncSeconds)*(*cfg.Controllers.Seed.LeaseResyncMissThreshold)) * time.Second
 	healthManager := gardenerhealthz.NewPeriodicHealthz(clock.RealClock{}, healthGracePeriod)
+	healthManager.Set(true)
 
 	log.Info("Setting up health check endpoints")
 	if err := mgr.AddHealthzCheck("periodic-health", gardenerhealthz.CheckerFunc(healthManager)); err != nil {

--- a/pkg/healthz/default.go
+++ b/pkg/healthz/default.go
@@ -68,5 +68,5 @@ func (d *defaultHealthz) Get() bool {
 func (d *defaultHealthz) Set(health bool) {
 	d.mutex.Lock()
 	defer d.mutex.Unlock()
-	d.health = health && d.started
+	d.health = health
 }

--- a/pkg/healthz/default_test.go
+++ b/pkg/healthz/default_test.go
@@ -64,19 +64,19 @@ var _ = Describe("Default", func() {
 				Expect(d.health).To(BeFalse())
 			})
 
-			It("should not set the status to true (HealthManager not started)", func() {
+			It("should set the status to true (HealthManager not started)", func() {
 				d.Set(true)
-				Expect(d.health).To(BeFalse())
+				Expect(d.health).To(BeTrue())
 			})
 
-			It("should not set the status to true (HealthManager already stopped)", func() {
+			It("should set the status to true (HealthManager already stopped)", func() {
 				Expect(d.Start(ctx)).To(Succeed())
 				Expect(d.health).To(BeTrue())
 				d.Stop()
 				Expect(d.health).To(BeFalse())
 
 				d.Set(true)
-				Expect(d.health).To(BeFalse())
+				Expect(d.health).To(BeTrue())
 			})
 		})
 

--- a/pkg/healthz/periodic.go
+++ b/pkg/healthz/periodic.go
@@ -97,11 +97,12 @@ func (p *periodicHealthz) Get() bool {
 	return p.health
 }
 
-// Set sets the current health status. When the health status is 'true' then the timer is reset.
+// Set sets the current health status. When the health status is 'true' and the manager is started then the timer is
+// reset.
 func (p *periodicHealthz) Set(health bool) {
 	p.mutex.Lock()
 	defer p.mutex.Unlock()
-	p.health = health && p.started
+	p.health = health
 
 	if health && p.started {
 		p.timer.Reset(p.resetDuration)

--- a/pkg/healthz/periodic_test.go
+++ b/pkg/healthz/periodic_test.go
@@ -101,19 +101,19 @@ var _ = Describe("Periodic", func() {
 				Expect(p.Get()).To(BeFalse())
 			})
 
-			It("should not set the status to true (HealthManager not started)", func() {
+			It("should set the status to true (HealthManager not started)", func() {
 				p.Set(true)
-				Expect(p.Get()).To(BeFalse())
+				Expect(p.Get()).To(BeTrue())
 			})
 
-			It("should not set the status to true (HealthManager already stopped)", func() {
+			It("should set the status to true (HealthManager already stopped)", func() {
 				Expect(p.Start(ctx)).To(Succeed())
 				Expect(p.Get()).To(BeTrue())
 				p.Stop()
 				Expect(p.Get()).To(BeFalse())
 
 				p.Set(true)
-				Expect(p.Get()).To(BeFalse())
+				Expect(p.Get()).To(BeTrue())
 			})
 
 			It("should correctly set the status to false after the reset duration", func() {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind enhancement

**What this PR does / why we need it**:
Before this PR, the `gardenlet`'s `/healthz` endpoint was always returning "unhealthy" right after the `gardenlet` started up. This put it unnecessarily under pressure because if it didn't start-up fast enough then the `kubelet` would terminate the pod according to the `gardenlet`'s pod `livenessProbe` settings.

After #6688, the problem became worse/more visible because
- the bootstrapping process is now using a cached client which starts a WATCH for `Secret`s which can take a while in large seed clusters (earlier, it was using an uncached client and made direct calls to the `kube-apiserver`, effectively postponing the WATCH for `Secret`s).
- the bootstrapping process is now only performed by the leader (earlier, it was always performed right away which only worked because we never ran multiple `gardenlet` replicas, but it actually was the wrong approach).

With this change, we initialize the health manager with status "healthy" right from the beginning. This makes the start-up procedure more smooth since the `gardenlet` does now have more time for leader election and the bootstrapping procedure (including setting up the WATCHes). Once it has finished bootstrapping, the [health manager is started](https://github.com/gardener/gardener/blob/9c6789844109351f4512871d8b1de25f9d91bd3c/cmd/gardenlet/app/app.go#L387) which internally starts a timer that would set the status to "unhealthy" after some time unless the [seed lease reconciler prevents it](https://github.com/gardener/gardener/blob/9c6789844109351f4512871d8b1de25f9d91bd3c/pkg/gardenlet/controller/seed/lease_control.go#L105).

Apart from making the start-up procedure more smooth by removing the time pressure, this PR also allows to run multiple `gardenlet` replicas. Without this PR, non-leader replicas would have always been killed because their liveness probes always failed (they never became "healthy" unless they became the leader).

**Special notes for your reviewer**:
/cc @ialidzhikov
FYI @BeckerMax @timuthy 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
The `gardenlet` is no longer put under time pressure during its start-up procedure by preventing its liveness probe from falsely failing.
```
