### PR TITLE
Fix flaky `ControllerInstallation` controller integration test suite

### DIFF
--- a/test/integration/gardenlet/controllerinstallation/controllerinstallation/controllerinstallation_suite_test.go
+++ b/test/integration/gardenlet/controllerinstallation/controllerinstallation/controllerinstallation_suite_test.go
@@ -26,7 +26,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/client-go/rest"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
@@ -106,7 +105,10 @@ var _ = BeforeSuite(func() {
 	testClient, err = client.New(restConfig, client.Options{Scheme: kubernetes.GardenScheme})
 	Expect(err).NotTo(HaveOccurred())
 
-	testRunID = utils.ComputeSHA256Hex([]byte(uuid.NewUUID()))[:8]
+	// Prevent testRunID from being able to be interpreted as number, see https://github.com/gardener/gardener/issues/6786
+	// for more details about the reasoning.
+	testRunID, err = utils.GenerateRandomStringFromCharset(12, "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
+	Expect(err).NotTo(HaveOccurred())
 	log.Info("Using test run ID for test", "testRunID", testRunID)
 
 	By("creating seed")


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind flake

**What this PR does / why we need it**:
Fix flaky `ControllerInstallation` controller integration test suite by preventing the `testRunID` from becoming a number.

Before:

```
stress -ignore "unable to grab random port" -p 32 ./controllerinstallation.test
...
32 runs so far, 1 failures
```

Now:

```
stress -ignore "unable to grab random port" -p 32 ./controllerinstallation.test
...
248 runs so far, 0 failures
```

**Which issue(s) this PR fixes**:
Fixes #6786

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
