### PR TITLE
Fixed `gardener-e2e-kind-ha-single-zone` failing tests.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -344,6 +344,7 @@ gardener-up: $(SKAFFOLD) $(HELM) $(KUBECTL)
 gardener-down: $(SKAFFOLD) $(HELM) $(KUBECTL)
 	@# delete stuff gradually in the right order, otherwise several dependencies will prevent the cleanup from succeeding
 	$(KUBECTL) delete seed local --ignore-not-found --wait --timeout 5m
+	$(KUBECTL) delete seed local-ha --ignore-not-found --wait --timeout 5m
 	$(KUBECTL) delete seed local2 --ignore-not-found --wait --timeout 5m
 	$(SKAFFOLD) delete -m provider-local,gardenlet
 	$(KUBECTL) delete validatingwebhookconfiguration/validate-namespace-deletion --ignore-not-found
@@ -351,7 +352,7 @@ gardener-down: $(SKAFFOLD) $(HELM) $(KUBECTL)
 	$(SKAFFOLD) delete -m local-env
 	$(SKAFFOLD) delete -m etcd,controlplane
 	@# workaround for https://github.com/gardener/gardener/issues/5164
-	$(KUBECTL) delete ns seed-local --ignore-not-found
+	$(KUBECTL) delete ns seed-local seed-local-ha --ignore-not-found
 	@# cleanup namespaces that don't get deleted automatically
 	$(KUBECTL) delete ns gardener-system-seed-lease istio-ingress istio-system --ignore-not-found
 

--- a/hack/test-e2e-local.sh
+++ b/hack/test-e2e-local.sh
@@ -10,6 +10,11 @@ source "$(dirname "$0")/test-e2e-local.env"
 
 ginkgo_flags=
 
+seed_name="local";
+if [[ "${HA_MODE:-}" == "single-zone" ||  "${HA_MODE:-}" == "multi-zone" ]] ; then
+  seed_name="local-ha"; 
+fi
+
 shoot_names=(
   e2e-managedseed.garden
   e2e-hibernated.local
@@ -30,7 +35,7 @@ if [ -n "${CI:-}" -a -n "${ARTIFACTS:-}" ]; then
   for shoot in "${shoot_names[@]}" ; do
     printf "\n127.0.0.1 api.%s.external.local.gardener.cloud\n127.0.0.1 api.%s.internal.local.gardener.cloud\n" $shoot $shoot >>/etc/hosts
   done
-  printf "\n127.0.0.1 gu-local--e2e-rotate.ingress.local.seed.local.gardener.cloud\n" >>/etc/hosts
+  printf "\n127.0.0.1 gu-local--e2e-rotate.ingress.$seed_name.seed.local.gardener.cloud\n" >>/etc/hosts
   printf "\n127.0.0.1 api.e2e-managedseed.garden.external.local.gardener.cloud\n127.0.0.1 api.e2e-managedseed.garden.internal.local.gardener.cloud\n" >>/etc/hosts
 else
   for shoot in "${shoot_names[@]}" ; do
@@ -46,4 +51,4 @@ for ((i = 2; i <= "$#"; i++)); do
   fi
 done
 
-GO111MODULE=on ginkgo run --timeout=1h $ginkgo_flags "${@:1:$((i - 1))}" --v --progress ./test/e2e/... "${@:$i}"
+GO111MODULE=on ginkgo run --timeout=1h $ginkgo_flags "${@:1:$((i - 1))}" --v --progress ./test/e2e/... "${@:$i}" 

--- a/hack/test-e2e-local.sh
+++ b/hack/test-e2e-local.sh
@@ -51,4 +51,4 @@ for ((i = 2; i <= "$#"; i++)); do
   fi
 done
 
-GO111MODULE=on ginkgo run --timeout=1h $ginkgo_flags "${@:1:$((i - 1))}" --v --progress ./test/e2e/... "${@:$i}" 
+GO111MODULE=on ginkgo run --timeout=1h $ginkgo_flags "${@:1:$((i - 1))}" --v --progress ./test/e2e/... "${@:$i}"

--- a/pkg/provider-local/webhook/controlplane/ensurer.go
+++ b/pkg/provider-local/webhook/controlplane/ensurer.go
@@ -47,14 +47,16 @@ func (e *ensurer) EnsureKubeletConfiguration(_ context.Context, _ gcontext.Garde
 
 // EnsureAdditionalFiles ensures that additional required system files are added.
 func (e *ensurer) EnsureAdditionalFiles(ctx context.Context, gc gcontext.GardenContext, new, _ *[]extensionsv1alpha1.File) error {
-	clusterName := "gardener-local-control-plane"
 	cluster, err := gc.GetCluster(ctx)
 	if err != nil {
 		return err
 	}
+	
+	kindClusterName := "gardener-local-control-plane"
 	if gardencorev1beta1helper.IsHAControlPlaneConfigured(cluster.Shoot) {
-		clusterName = "gardener-local-ha-control-plane"
+		kindClusterName = "gardener-local-ha-control-plane"
 	}
+
 	appendUniqueFile(new, extensionsv1alpha1.File{
 		Path:        "/etc/containerd/conf.d/50-provider-local-registry.toml",
 		Permissions: pointer.Int32(0644),

--- a/pkg/provider-local/webhook/controlplane/ensurer.go
+++ b/pkg/provider-local/webhook/controlplane/ensurer.go
@@ -49,10 +49,11 @@ func (e *ensurer) EnsureKubeletConfiguration(_ context.Context, _ gcontext.Garde
 func (e *ensurer) EnsureAdditionalFiles(ctx context.Context, gc gcontext.GardenContext, new, _ *[]extensionsv1alpha1.File) error {
 	clusterName := "gardener-local-control-plane"
 	cluster, err := gc.GetCluster(ctx)
-	if err == nil {
-		if gardencorev1beta1helper.IsHAControlPlaneConfigured(cluster.Shoot) {
-			clusterName = "gardener-local-ha-control-plane"
-		}
+	if err != nil {
+		return err
+	}
+	if gardencorev1beta1helper.IsHAControlPlaneConfigured(cluster.Shoot) {
+		clusterName = "gardener-local-ha-control-plane"
 	}
 	appendUniqueFile(new, extensionsv1alpha1.File{
 		Path:        "/etc/containerd/conf.d/50-provider-local-registry.toml",

--- a/pkg/provider-local/webhook/controlplane/ensurer.go
+++ b/pkg/provider-local/webhook/controlplane/ensurer.go
@@ -19,6 +19,7 @@ import (
 
 	gcontext "github.com/gardener/gardener/extensions/pkg/webhook/context"
 	"github.com/gardener/gardener/extensions/pkg/webhook/controlplane/genericmutator"
+	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 
 	"github.com/Masterminds/semver"
@@ -45,7 +46,14 @@ func (e *ensurer) EnsureKubeletConfiguration(_ context.Context, _ gcontext.Garde
 }
 
 // EnsureAdditionalFiles ensures that additional required system files are added.
-func (e *ensurer) EnsureAdditionalFiles(_ context.Context, _ gcontext.GardenContext, new, _ *[]extensionsv1alpha1.File) error {
+func (e *ensurer) EnsureAdditionalFiles(ctx context.Context, gc gcontext.GardenContext, new, _ *[]extensionsv1alpha1.File) error {
+	clusterName := "gardener-local-control-plane"
+	cluster, err := gc.GetCluster(ctx)
+	if err == nil {
+		if gardencorev1beta1helper.IsHAControlPlaneConfigured(cluster.Shoot) {
+			clusterName = "gardener-local-ha-control-plane"
+		}
+	}
 	appendUniqueFile(new, extensionsv1alpha1.File{
 		Path:        "/etc/containerd/conf.d/50-provider-local-registry.toml",
 		Permissions: pointer.Int32(0644),
@@ -53,19 +61,19 @@ func (e *ensurer) EnsureAdditionalFiles(_ context.Context, _ gcontext.GardenCont
 			Inline: &extensionsv1alpha1.FileContentInline{
 				Encoding: "",
 				Data: `[plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:5001"]
-  endpoint = ["http://gardener-local-control-plane:5001"]
+  endpoint = ["http://` + clusterName + `:5001"]
 [plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]
-  endpoint = ["http://gardener-local-control-plane:5002"]
+  endpoint = ["http://` + clusterName + `:5002"]
 [plugins."io.containerd.grpc.v1.cri".registry.mirrors."gcr.io"]
-  endpoint = ["http://gardener-local-control-plane:5003"]
+  endpoint = ["http://` + clusterName + `:5003"]
 [plugins."io.containerd.grpc.v1.cri".registry.mirrors."eu.gcr.io"]
-  endpoint = ["http://gardener-local-control-plane:5004"]
+  endpoint = ["http://` + clusterName + `:5004"]
 [plugins."io.containerd.grpc.v1.cri".registry.mirrors."ghcr.io"]
-  endpoint = ["http://gardener-local-control-plane:5005"]
+  endpoint = ["http://` + clusterName + `:5005"]
 [plugins."io.containerd.grpc.v1.cri".registry.mirrors."registry.k8s.io"]
-  endpoint = ["http://gardener-local-control-plane:5006"]
+  endpoint = ["http://` + clusterName + `:5006"]
 [plugins."io.containerd.grpc.v1.cri".registry.mirrors."quay.io"]
-  endpoint = ["http://gardener-local-control-plane:5007"]
+  endpoint = ["http://` + clusterName + `:5007"]
 `,
 			},
 		},

--- a/pkg/provider-local/webhook/controlplane/ensurer.go
+++ b/pkg/provider-local/webhook/controlplane/ensurer.go
@@ -51,7 +51,7 @@ func (e *ensurer) EnsureAdditionalFiles(ctx context.Context, gc gcontext.GardenC
 	if err != nil {
 		return err
 	}
-	
+
 	kindClusterName := "gardener-local-control-plane"
 	if gardencorev1beta1helper.IsHAControlPlaneConfigured(cluster.Shoot) {
 		kindClusterName = "gardener-local-ha-control-plane"
@@ -64,19 +64,19 @@ func (e *ensurer) EnsureAdditionalFiles(ctx context.Context, gc gcontext.GardenC
 			Inline: &extensionsv1alpha1.FileContentInline{
 				Encoding: "",
 				Data: `[plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:5001"]
-  endpoint = ["http://` + clusterName + `:5001"]
+  endpoint = ["http://` + kindClusterName + `:5001"]
 [plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]
-  endpoint = ["http://` + clusterName + `:5002"]
+  endpoint = ["http://` + kindClusterName + `:5002"]
 [plugins."io.containerd.grpc.v1.cri".registry.mirrors."gcr.io"]
-  endpoint = ["http://` + clusterName + `:5003"]
+  endpoint = ["http://` + kindClusterName + `:5003"]
 [plugins."io.containerd.grpc.v1.cri".registry.mirrors."eu.gcr.io"]
-  endpoint = ["http://` + clusterName + `:5004"]
+  endpoint = ["http://` + kindClusterName + `:5004"]
 [plugins."io.containerd.grpc.v1.cri".registry.mirrors."ghcr.io"]
-  endpoint = ["http://` + clusterName + `:5005"]
+  endpoint = ["http://` + kindClusterName + `:5005"]
 [plugins."io.containerd.grpc.v1.cri".registry.mirrors."registry.k8s.io"]
-  endpoint = ["http://` + clusterName + `:5006"]
+  endpoint = ["http://` + kindClusterName + `:5006"]
 [plugins."io.containerd.grpc.v1.cri".registry.mirrors."quay.io"]
-  endpoint = ["http://` + clusterName + `:5007"]
+  endpoint = ["http://` + kindClusterName + `:5007"]
 `,
 			},
 		},


### PR DESCRIPTION
**How to categorize this PR?**
/area testing
/kind test
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->


**What this PR does / why we need it**:
This PR fixes [ci-gardener-e2e-kind-ha-single-zone prow job ](https://prow.gardener.cloud/view/gs/gardener-prow/logs/ci-gardener-e2e-kind-ha-single-zone/1579834505412218880) two failing tests. 
Recently this [PR](https://github.com/gardener/gardener/pull/6719) introduced e2e test to support HA test `ci-gardener-e2e-kind-ha-single-zone` 
1. `Shoot Tests Create Shoot, Rotate Credentials and Delete Shoot [Shoot, default, credentials-rotation]` test is failing, due to host not resolved.
``` log
Get \"https://gu-local--e2e-rotate.ingress.local-ha.seed.local.gardener.cloud:8448/\": dial tcp: lookup gu-local--e2e-rotate.ingress.local-ha.seed.local.gardener.cloud on 100.64.0.10:53: no such host\noccurred",
```
**Fix** : Based  on `HA_MODE`, using appropriate  seed name to update `ingress` host to `/etcd/hosts` file.
    
2. E2e ManagedSeed test is failing, local registry host are not resolved and referred wrong cluster name `gardener-local-control-plane` instead of `gardener-local-ha-control-plane`.   

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
