### PR TITLE
Configurable log level/format for gardener apiserver

### DIFF
--- a/charts/gardener/controlplane/charts/runtime/templates/apiserver/deployment.yaml
+++ b/charts/gardener/controlplane/charts/runtime/templates/apiserver/deployment.yaml
@@ -263,7 +263,9 @@ spec:
         - --tls-private-key-file=/etc/gardener-apiserver/srv/gardener-apiserver.key
         {{- end }}
         {{- include "gardener-apiserver.watchCacheSizes" . | indent 8 }}
-        - --v=2
+        - --log-level={{ .Values.global.apiserver.logLevel | default "info"  }}
+        - --log-format={{ .Values.global.apiserver.logFormat | default "json"  }}
+        - --v={{ .Values.global.apiserver.logVerbosity | default "2"  }}
         livenessProbe:
           httpGet:
             scheme: HTTPS

--- a/charts/gardener/controlplane/values.yaml
+++ b/charts/gardener/controlplane/values.yaml
@@ -6,6 +6,9 @@ global:
     replicaCount: 1
     securePort: 8443
     serviceAccountName: gardener-apiserver
+    logLevel: info
+    logFormat: json
+    logVerbosity: "2"
     image:
       repository: eu.gcr.io/gardener-project/gardener/apiserver
       tag: latest

--- a/cmd/gardener-apiserver/app/gardener_apiserver.go
+++ b/cmd/gardener-apiserver/app/gardener_apiserver.go
@@ -262,7 +262,7 @@ func (o *Options) config(kubeAPIServerConfig *rest.Config, kubeClient *kubernete
 
 // Run runs gardener-apiserver with the given Options.
 func (o *Options) Run(ctx context.Context) error {
-	log, err := logger.NewZapLogger(logger.InfoLevel, logger.FormatJSON)
+	log, err := logger.NewZapLogger(o.ExtraOptions.LogLevel, o.ExtraOptions.LogFormat)
 	if err != nil {
 		return fmt.Errorf("error instantiating zap logger: %w", err)
 	}

--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -94,6 +94,9 @@ type ExtraOptions struct {
 	ClusterIdentity              string
 	AdminKubeconfigMaxExpiration time.Duration
 	CredentialsRotationInterval  time.Duration
+
+	LogLevel  string
+	LogFormat string
 }
 
 // Validate checks if the required flags are set
@@ -121,6 +124,9 @@ func (o *ExtraOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&o.ClusterIdentity, "cluster-identity", o.ClusterIdentity, "This flag is used for specifying the identity of the Garden cluster")
 	fs.DurationVar(&o.AdminKubeconfigMaxExpiration, "shoot-admin-kubeconfig-max-expiration", time.Hour*24, "The maximum validity duration of a credential requested to a Shoot by an AdminKubeconfigRequest. If an otherwise valid AdminKubeconfigRequest with a validity duration larger than this value is requested, a credential will be issued with a validity duration of this value.")
 	fs.DurationVar(&o.CredentialsRotationInterval, "shoot-credentials-rotation-interval", time.Hour*24*90, "The duration after the initial shoot creation or the last credentials rotation when a client warning for the next credentials rotation is issued.")
+
+	fs.StringVar(&o.LogLevel, "log-level", "info", "The level/severity for the logs. Must be one of [info,debug,error]")
+	fs.StringVar(&o.LogFormat, "log-format", "json", "The format for the logs. Must be one of [json,text]")
 }
 
 // ApplyTo applies the extra options to the API Server config.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement

**What this PR does / why we need it**:
This PR creates cli parameters `--log-level=<debug/info/error>` and `log-format=<json/text>` in gardener-apiserver and enables their configuration in gardener control plane helm chart.
Additionally, parameter `--v=<number>` which was existing before is now configurable too.

**Which issue(s) this PR fixes**:
Part of #5191 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
log-level, log-format and verbosity of gardener-apiserver can now be configured.
```
