### PR TITLE
Fix `NeedsSecretBindingReferenceLabelPredicate` for Project activity reconciler

### DIFF
--- a/pkg/controllermanager/controller/project/activity/add.go
+++ b/pkg/controllermanager/controller/project/activity/add.go
@@ -139,7 +139,7 @@ func (r *Reconciler) NeedsSecretBindingReferenceLabelPredicate() predicate.Predi
 			_, oldObjHasLabel := oldObjMeta.GetLabels()[v1beta1constants.LabelSecretBindingReference]
 			_, newObjHasLabel := objMeta.GetLabels()[v1beta1constants.LabelSecretBindingReference]
 
-			return oldObjHasLabel && newObjHasLabel
+			return oldObjHasLabel || newObjHasLabel
 		},
 		DeleteFunc: func(e event.DeleteEvent) bool {
 			objMeta, err := meta.Accessor(e.Object)

--- a/pkg/controllermanager/controller/project/activity/add_test.go
+++ b/pkg/controllermanager/controller/project/activity/add_test.go
@@ -123,16 +123,16 @@ var _ = Describe("Add", func() {
 				Expect(p.Update(event.UpdateEvent{ObjectOld: secret, ObjectNew: secret})).To(BeTrue())
 			})
 
-			It("should return false when only new object has the label", func() {
+			It("should return true when only new object has the label", func() {
 				oldSecret := secret.DeepCopy()
 				oldSecret.Labels = nil
-				Expect(p.Update(event.UpdateEvent{ObjectOld: oldSecret, ObjectNew: secret})).To(BeFalse())
+				Expect(p.Update(event.UpdateEvent{ObjectOld: oldSecret, ObjectNew: secret})).To(BeTrue())
 			})
 
-			It("should return false when only old object has the label", func() {
+			It("should return true when only old object has the label", func() {
 				oldSecret := secret.DeepCopy()
 				secret.Labels = nil
-				Expect(p.Update(event.UpdateEvent{ObjectOld: oldSecret, ObjectNew: secret})).To(BeFalse())
+				Expect(p.Update(event.UpdateEvent{ObjectOld: oldSecret, ObjectNew: secret})).To(BeTrue())
 			})
 
 			It("should return false when neither object has the label", func() {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind bug

**What this PR does / why we need it**:
The `NeedsSecretBindingReferenceLabelPredicate` added in #6667 
https://github.com/gardener/gardener/blob/cfe4e102ef96380e09eae4d00fff5896e291bc56/pkg/controllermanager/controller/project/activity/add.go#L128-L143
doesn't match the previous behavior.
Previously,
https://github.com/gardener/gardener/blob/958fec3e428d6bcc9b115b0423fd5ba51981b06d/pkg/controllermanager/controller/project/project_activity_control.go#L103-L123
If either of the old or new object had the "referred" label, it was queued.
The old object not having the label and new object having it is the case when the secret is referred for the first time.
The old object having the label and new object not having it is the case when the very last secretbinding referring this secret is deleted.
We want to consider both of this as "activity" and update the `lastActivityTimestamp` of the project.
This PR fixes this predicate.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @rfranzke 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
