### PR TITLE
Add `kubernetes.io/arch` label in worker

### DIFF
--- a/pkg/operation/botanist/component/extensions/worker/worker.go
+++ b/pkg/operation/botanist/component/extensions/worker/worker.go
@@ -173,6 +173,7 @@ func (w *worker) deploy(ctx context.Context, operation string) (extensionsv1alph
 			labels = map[string]string{}
 		}
 		labels["node.kubernetes.io/role"] = "node"
+		labels["kubernetes.io/arch"] = *workerPool.Machine.Architecture
 
 		labels[v1beta1constants.LabelNodeLocalDNS] = strconv.FormatBool(w.values.NodeLocalDNSENabled)
 

--- a/pkg/operation/botanist/component/extensions/worker/worker_test.go
+++ b/pkg/operation/botanist/component/extensions/worker/worker_test.go
@@ -274,6 +274,7 @@ var _ = Describe("Worker", func() {
 					Annotations:    worker1Annotations,
 					Labels: utils.MergeStringMaps(worker1Labels, map[string]string{
 						"node.kubernetes.io/role":         "node",
+						"kubernetes.io/arch":              *worker1Arch,
 						"worker.gardener.cloud/pool":      worker1Name,
 						"worker.garden.sapcloud.io/group": worker1Name,
 						"worker.gardener.cloud/cri-name":  string(worker1CRIName),
@@ -317,6 +318,7 @@ var _ = Describe("Worker", func() {
 					MaxUnavailable: worker2MaxUnavailable,
 					Labels: map[string]string{
 						"node.kubernetes.io/role":                          "node",
+						"kubernetes.io/arch":                               *worker2Arch,
 						"worker.gardener.cloud/system-components":          "true",
 						"worker.gardener.cloud/pool":                       worker2Name,
 						"worker.garden.sapcloud.io/group":                  worker2Name,


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement

**What this PR does / why we need it**:
This PR adds `kubernetes.io/arch` label in worker pool labels. Doing so will add this label in machinedeployment node-template so it can be used to scale the worker pool from zero.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
I am not adding `kubernetes.io/os` label as there will be no benefit for it, cause as of now only supported os is `linux`.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
`kubernetes.io/arch` label can now be used for scaling the worker pools from `0` based on CPU architecture.
```
