### PR TITLE
Update apiserver-proxy-pod-webhook image version

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -338,4 +338,4 @@ images:
 - name: apiserver-proxy-pod-webhook
   sourceRepository: github.com/gardener/apiserver-proxy
   repository: eu.gcr.io/gardener-project/gardener/apiserver-proxy-pod-webhook
-  tag: "v0.6.0"
+  tag: "v0.7.0"


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement

**What this PR does / why we need it**:
https://github.com/gardener/gardener/pull/6698 was reverted with https://github.com/gardener/gardener/pull/6720 due to CI/CD instabilities. `apiserver-proxy-pod-webhook@v0.7.0` seems to be fine from my point of view.
https://github.com/gardener/apiserver-proxy/compare/v0.6.0..v0.7.0: for the `apiserver-proxy-pod-webhook`:
- the builder image is updated
- and in general bazel related versions are updated

If there is potential issue causing troubles, it is likely to be in apiserver-proxy-sidecar (which is not updated with this PR).

**Which issue(s) this PR fixes**:
Needed for https://github.com/gardener/gardener/issues/6818 to allow updating the `apiserver-proxy-pod-webhook` version.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The following image is updated:
- eu.gcr.io/gardener-project/gardener/apiserver-proxy-pod-webhook: v0.6.0 -> v0.7.0
```
