### PR TITLE
Configurable log level/format for gardener-resource-manager

### DIFF
--- a/charts/gardener/gardener-resource-manager/templates/deployment.yaml
+++ b/charts/gardener/gardener-resource-manager/templates/deployment.yaml
@@ -76,6 +76,8 @@ spec:
         {{- if .Values.controllers.rootCAController.rootCAPath }}
         - --root-ca-file="{{ .Values.controllers.rootCAController.rootCAPath }}"
         {{- end }}
+        - --log-level={{ .Values.logLevel | default "info"  }}
+        - --log-format={{ .Values.logFormat | default "json"  }}
         resources:
 {{ toYaml .Values.resources | nindent 12 }}
         livenessProbe:

--- a/charts/gardener/gardener-resource-manager/values.yaml
+++ b/charts/gardener/gardener-resource-manager/values.yaml
@@ -10,6 +10,9 @@ serverPort: 10250
 metricsPort: 8080
 healthPort: 8081
 
+logLevel: info
+logFormat: json
+
 serverCertificate: |
   some-tls-certificate
 serverPrivateKey: |

--- a/cmd/gardener-resource-manager/app/options.go
+++ b/cmd/gardener-resource-manager/app/options.go
@@ -1,0 +1,53 @@
+// Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package app
+
+import (
+	"fmt"
+
+	"github.com/spf13/pflag"
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	"github.com/gardener/gardener/pkg/logger"
+)
+
+type options struct {
+	// logLevel defines the level/severity for the logs. Must be one of [info,debug,error]
+	logLevel string
+	// logFormat defines the format for the logs. Must be one of [json,text]
+	logFormat string
+}
+
+func (o *options) addFlags(fs *pflag.FlagSet) {
+	fs.StringVar(&o.logLevel, "log-level", "info", "The level/severity for the logs. Must be one of [info,debug,error]")
+	fs.StringVar(&o.logFormat, "log-format", "json", "The format for the logs. Must be one of [json,text]")
+}
+
+func (o *options) complete() error {
+	return nil
+}
+
+func (o *options) validate() error {
+
+	if !sets.NewString(logger.AllLogLevels...).Has(o.logLevel) {
+		return fmt.Errorf("invalid --log-level: %s", o.logLevel)
+	}
+
+	if !sets.NewString(logger.AllLogFormats...).Has(o.logFormat) {
+		return fmt.Errorf("invalid --log-format: %s", o.logFormat)
+	}
+
+	return nil
+}

--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -18,12 +18,14 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/gardener/gardener/pkg/logger"
 	corerest "github.com/gardener/gardener/pkg/registry/core/rest"
 	operationsrest "github.com/gardener/gardener/pkg/registry/operations/rest"
 	seedmanagementrest "github.com/gardener/gardener/pkg/registry/seedmanagement/rest"
 	settingsrest "github.com/gardener/gardener/pkg/registry/settings/rest"
 
 	"github.com/spf13/pflag"
+	"k8s.io/apimachinery/pkg/util/sets"
 	genericapiserver "k8s.io/apiserver/pkg/server"
 )
 
@@ -114,6 +116,14 @@ func (o *ExtraOptions) Validate() []error {
 	if o.CredentialsRotationInterval < 24*time.Hour ||
 		o.CredentialsRotationInterval > time.Duration(1<<32)*time.Second {
 		allErrors = append(allErrors, fmt.Errorf("--shoot-credentials-rotation-interval must be between 24 hours and 2^32 seconds"))
+	}
+
+	if !sets.NewString(logger.AllLogLevels...).Has(o.LogLevel) {
+		allErrors = append(allErrors, fmt.Errorf("invalid --log-level: %s", o.LogLevel))
+	}
+
+	if !sets.NewString(logger.AllLogFormats...).Has(o.LogFormat) {
+		allErrors = append(allErrors, fmt.Errorf("invalid --log-format: %s", o.LogFormat))
 	}
 
 	return allErrors

--- a/pkg/operation/botanist/component/resourcemanager/monitoring_test.go
+++ b/pkg/operation/botanist/component/resourcemanager/monitoring_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 var _ = Describe("Monitoring", func() {
-	resourceManager := New(nil, "shoot--foo--bar", nil, "", Values{})
+	resourceManager := New(nil, "shoot--foo--bar", nil, Values{})
 
 	Describe("#ScrapeConfig", func() {
 		It("should successfully test the scrape configuration", func() {

--- a/pkg/operation/botanist/resource_manager.go
+++ b/pkg/operation/botanist/resource_manager.go
@@ -25,6 +25,7 @@ import (
 	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
+	"github.com/gardener/gardener/pkg/logger"
 	"github.com/gardener/gardener/pkg/operation/botanist/component"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/resourcemanager"
 	gutil "github.com/gardener/gardener/pkg/utils/gardener"
@@ -65,6 +66,7 @@ func (b *Botanist) DefaultResourceManager() (resourcemanager.Interface, error) {
 		ClusterIdentity:                      b.Seed.GetInfo().Status.ClusterIdentity,
 		ConcurrentSyncs:                      pointer.Int32(20),
 		HealthSyncPeriod:                     pointer.Duration(time.Minute),
+		Image:                                image.String(),
 		MaxConcurrentHealthWorkers:           pointer.Int32(10),
 		MaxConcurrentTokenInvalidatorWorkers: pointer.Int32(5),
 		MaxConcurrentTokenRequestorWorkers:   pointer.Int32(5),
@@ -84,13 +86,14 @@ func (b *Botanist) DefaultResourceManager() (resourcemanager.Interface, error) {
 		},
 		SchedulingProfile:    v1beta1helper.ShootSchedulingProfile(b.Shoot.GetInfo()),
 		FailureToleranceType: b.GetFailureToleranceType(),
+		LogLevel:             logger.InfoLevel,
+		LogFormat:            logger.FormatJSON,
 	}
 
 	return resourcemanager.New(
 		b.SeedClientSet.Client(),
 		b.Shoot.SeedNamespace,
 		b.SecretsManager,
-		image.String(),
 		cfg,
 	), nil
 }

--- a/pkg/operation/seed/seed.go
+++ b/pkg/operation/seed/seed.go
@@ -387,7 +387,7 @@ func RunReconcileSeedFlow(
 
 	// Deploy gardener-resource-manager first since it serves central functionality (e.g., projected token mount webhook)
 	// which is required for all other components to start-up.
-	gardenerResourceManager, err := defaultGardenerResourceManager(seedClient, kubernetesVersion, imageVector, secretsManager)
+	gardenerResourceManager, err := defaultGardenerResourceManager(seedClient, kubernetesVersion, imageVector, secretsManager, conf)
 	if err != nil {
 		return err
 	}
@@ -1073,7 +1073,7 @@ func RunDeleteSeedFlow(
 		gsac             = seedadmissioncontroller.New(seedClient, v1beta1constants.GardenNamespace, nil, "", nil)
 		hvpa             = hvpa.New(seedClient, v1beta1constants.GardenNamespace, hvpa.Values{})
 		kubeStateMetrics = kubestatemetrics.New(seedClient, v1beta1constants.GardenNamespace, nil, kubestatemetrics.Values{ClusterType: component.ClusterTypeSeed})
-		resourceManager  = resourcemanager.New(seedClient, v1beta1constants.GardenNamespace, nil, "", resourcemanager.Values{Version: kubernetesVersion})
+		resourceManager  = resourcemanager.New(seedClient, v1beta1constants.GardenNamespace, nil, resourcemanager.Values{Version: kubernetesVersion})
 		nginxIngress     = nginxingress.New(seedClient, v1beta1constants.GardenNamespace, nginxingress.Values{})
 		etcdDruid        = etcd.NewBootstrapper(seedClient, v1beta1constants.GardenNamespace, conf, "", nil)
 		networkPolicies  = networkpolicies.NewBootstrapper(seedClient, v1beta1constants.GardenNamespace, networkpolicies.GlobalValues{})


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement

**What this PR does / why we need it**:
This PR creates cli parameters `--log-level=<debug/info/error>` and `--log-format=<json/text>` in gardener-resource-manager and enables their configuration in gardener-control-plane helm chart and `botanist` package.
The later does not include a dedicated configuration for gardener-resource-manager and this PR does not create one for this purpose only. This is the log-level/format configurations:

When running on Seed clusters:
log-level and log-format settings of gardenlet are used for gardener-controller-manager too

When running on Shoot clusters:
There are default values only `--log-level=info` `--log-format=json`

In both scenarios different log-levels/format could be set by changing their deployments while ignoring the corresponding managed resource during reconciliation.

**Which issue(s) this PR fixes**:
Part of #5191

**Special notes for your reviewer**:
This PR adds a verification of log-levels and log-format for gardener-apiserver which was forgotten in https://github.com/gardener/gardener/pull/6817

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
log-level and log-format of gardener-resource-manager can now be configured.
```
