### PR TITLE
Configurable log level/format for gardener-seed-admission-controller

### DIFF
--- a/cmd/gardener-seed-admission-controller/app/app.go
+++ b/cmd/gardener-seed-admission-controller/app/app.go
@@ -61,7 +61,7 @@ func NewCommand() *cobra.Command {
 				return err
 			}
 
-			log, err := logger.NewZapLogger(logger.InfoLevel, logger.FormatJSON)
+			log, err := logger.NewZapLogger(opts.logLevel, opts.logFormat)
 			if err != nil {
 				return fmt.Errorf("error instantiating zap logger: %w", err)
 			}

--- a/cmd/gardener-seed-admission-controller/app/options.go
+++ b/cmd/gardener-seed-admission-controller/app/options.go
@@ -18,6 +18,9 @@ import (
 	"fmt"
 
 	"github.com/spf13/pflag"
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	"github.com/gardener/gardener/pkg/logger"
 )
 
 type options struct {
@@ -36,6 +39,10 @@ type options struct {
 	enableProfiling bool
 	// enableContentionProfiling enables lock contention profiling, if enableProfiling is true.
 	enableContentionProfiling bool
+	// logLevel defines the level/severity for the logs. Must be one of [info,debug,error]
+	logLevel string
+	// logFormat defines the format for the logs. Must be one of [json,text]
+	logFormat string
 }
 
 func (o *options) addFlags(fs *pflag.FlagSet) {
@@ -46,6 +53,8 @@ func (o *options) addFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&o.healthBindAddress, "health-bind-address", ":8081", "Bind address for the health server")
 	fs.BoolVar(&o.enableProfiling, "profiling", false, "Enable profiling via web interface host:port/debug/pprof/")
 	fs.BoolVar(&o.enableContentionProfiling, "contention-profiling", false, "Enable lock contention profiling, if profiling is enabled")
+	fs.StringVar(&o.logLevel, "log-level", "info", "The level/severity for the logs. Must be one of [info,debug,error]")
+	fs.StringVar(&o.logFormat, "log-format", "json", "The format for the logs. Must be one of [json,text]")
 }
 
 func (o *options) complete() error {
@@ -63,6 +72,14 @@ func (o *options) validate() error {
 
 	if len(o.serverCertDir) == 0 {
 		return fmt.Errorf("missing server tls cert path")
+	}
+
+	if !sets.NewString(logger.AllLogLevels...).Has(o.logLevel) {
+		return fmt.Errorf("invalid --log-level: %s", o.logLevel)
+	}
+
+	if !sets.NewString(logger.AllLogFormats...).Has(o.logFormat) {
+		return fmt.Errorf("invalid --log-format: %s", o.logFormat)
 	}
 
 	return nil

--- a/pkg/operation/botanist/component/seedadmissioncontroller/seedadmissioncontroller_test.go
+++ b/pkg/operation/botanist/component/seedadmissioncontroller/seedadmissioncontroller_test.go
@@ -52,6 +52,7 @@ var _ = Describe("SeedAdmission", func() {
 		c          *mockclient.MockClient
 		fakeClient client.Client
 		sm         secretsmanager.Interface
+		v          Values
 
 		seedAdmission component.DeployWaiter
 
@@ -163,6 +164,8 @@ spec:
         - --tls-cert-dir=/srv/gardener-seed-admission-controller
         - --metrics-bind-address=:8080
         - --health-bind-address=:8081
+        - --log-level=info
+        - --log-format=json
         image: ` + image + `
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -406,8 +409,14 @@ status: {}
 		c = mockclient.NewMockClient(ctrl)
 		fakeClient = fakeclient.NewClientBuilder().WithScheme(kubernetesscheme.Scheme).Build()
 		sm = fakesecretsmanager.New(fakeClient, namespace)
+		v = Values{
+			Image:             image,
+			KubernetesVersion: version,
+			LogLevel:          "info",
+			LogFormat:         "json",
+		}
 
-		seedAdmission = New(c, namespace, sm, image, version)
+		seedAdmission = New(c, namespace, sm, v)
 
 		By("creating secrets managed outside of this package for whose secretsmanager.Get() will be called")
 		Expect(fakeClient.Create(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "ca-seed", Namespace: namespace}})).To(Succeed())

--- a/pkg/operation/seed/components.go
+++ b/pkg/operation/seed/components.go
@@ -105,7 +105,7 @@ func defaultKubeScheduler(c client.Client, imageVector imagevector.ImageVector, 
 	return gardenerkubescheduler.Bootstrap(c, secretsManager, v1beta1constants.GardenNamespace, image, seedVersion)
 }
 
-func defaultGardenerSeedAdmissionController(c client.Client, imageVector imagevector.ImageVector, secretsManager secretsmanager.Interface, seedVersion *semver.Version) (component.DeployWaiter, error) {
+func defaultGardenerSeedAdmissionController(c client.Client, imageVector imagevector.ImageVector, secretsManager secretsmanager.Interface, seedVersion *semver.Version, conf *config.GardenletConfiguration) (component.DeployWaiter, error) {
 	image, err := imageVector.FindImage(images.ImageNameGardenerSeedAdmissionController)
 	if err != nil {
 		return nil, err
@@ -117,7 +117,14 @@ func defaultGardenerSeedAdmissionController(c client.Client, imageVector imageve
 	}
 	image = &imagevector.Image{Repository: repository, Tag: &tag}
 
-	return seedadmissioncontroller.New(c, v1beta1constants.GardenNamespace, secretsManager, image.String(), seedVersion), nil
+	values := seedadmissioncontroller.Values{
+		Image:             image.String(),
+		KubernetesVersion: seedVersion,
+		LogLevel:          conf.LogLevel,
+		LogFormat:         conf.LogFormat,
+	}
+
+	return seedadmissioncontroller.New(c, v1beta1constants.GardenNamespace, secretsManager, values), nil
 }
 
 func defaultGardenerResourceManager(c client.Client, seedVersion *semver.Version, imageVector imagevector.ImageVector, secretsManager secretsmanager.Interface) (component.DeployWaiter, error) {

--- a/pkg/operation/seed/seed.go
+++ b/pkg/operation/seed/seed.go
@@ -891,7 +891,7 @@ func runCreateSeedFlow(
 	if err != nil {
 		return err
 	}
-	gardenerSeedAdmissionController, err := defaultGardenerSeedAdmissionController(seedClient, imageVector, secretsManager, kubernetesVersion)
+	gardenerSeedAdmissionController, err := defaultGardenerSeedAdmissionController(seedClient, imageVector, secretsManager, kubernetesVersion, conf)
 	if err != nil {
 		return err
 	}
@@ -1070,7 +1070,7 @@ func RunDeleteSeedFlow(
 	// setup for flow graph
 	var (
 		autoscaler       = clusterautoscaler.NewBootstrapper(seedClient, v1beta1constants.GardenNamespace)
-		gsac             = seedadmissioncontroller.New(seedClient, v1beta1constants.GardenNamespace, nil, "", nil)
+		gsac             = seedadmissioncontroller.New(seedClient, v1beta1constants.GardenNamespace, nil, seedadmissioncontroller.Values{})
 		hvpa             = hvpa.New(seedClient, v1beta1constants.GardenNamespace, hvpa.Values{})
 		kubeStateMetrics = kubestatemetrics.New(seedClient, v1beta1constants.GardenNamespace, nil, kubestatemetrics.Values{ClusterType: component.ClusterTypeSeed})
 		resourceManager  = resourcemanager.New(seedClient, v1beta1constants.GardenNamespace, nil, "", resourcemanager.Values{Version: kubernetesVersion})


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement

**What this PR does / why we need it**:
This PR creates cli parameters `--log-level=<debug/info/error>` and `--log-format=<json/text>` in gardener-seed-admission-controller and enables its configuration in botanist package.
There is no dedicated configuration for gardener-seed-admission-controller and this PR does not create one for this purpose only. Thus, log-level and log-format settings of gardenlet are used for gardener-seed-admission-controller too.

Additionally, different log-levels/format could be set by changing the deployment while ignoring the corresponding managed resource during reconciliation.

**Which issue(s) this PR fixes**:
Part of #5191

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
log-level and log-format of gardener-seed-admission-controller can now be configured.
```
