### PR TITLE
[GEP-20] Added validation for HA configuration in `ManagedSeed`

### DIFF
--- a/pkg/apis/core/helper/helpers.go
+++ b/pkg/apis/core/helper/helpers.go
@@ -497,15 +497,15 @@ func IsHASeedConfigured(seed *core.Seed) bool {
 	return metav1.HasLabel(seed.ObjectMeta, v1beta1constants.LabelSeedMultiZonal) || seed.Spec.HighAvailability != nil
 }
 
-// ValidateBooleanValue validates the value of label `v1beta1constants.LabelSeedMultiZonal`.
-func ValidateBooleanValue(val string, fldPath *field.Path) field.ErrorList {
+// ValidateMultiZoneSeedLabelValue validates the value of label `v1beta1constants.LabelSeedMultiZonal`.
+func ValidateMultiZoneSeedLabelValue(val string, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	if len(val) == 0 {
 		return allErrs
 	}
 	if _, err := strconv.ParseBool(val); err != nil {
-		allErrs = append(allErrs, field.Invalid(fldPath, val, "invalid boolean value"))
+		allErrs = append(allErrs, field.Invalid(fldPath, val, fmt.Sprintf("managed seed label %s has an invalid value.", v1beta1constants.LabelSeedMultiZonal)))
 	}
 
 	return allErrs

--- a/pkg/apis/core/helper/helpers.go
+++ b/pkg/apis/core/helper/helpers.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/utils/pointer"
 
 	"github.com/gardener/gardener/pkg/apis/core"
@@ -494,4 +495,18 @@ func IsMultiZonalSeed(seed *core.Seed) bool {
 // IsHASeedConfigured returns true if HA configuration for the seed system components has been set either via label or spec.
 func IsHASeedConfigured(seed *core.Seed) bool {
 	return metav1.HasLabel(seed.ObjectMeta, v1beta1constants.LabelSeedMultiZonal) || seed.Spec.HighAvailability != nil
+}
+
+// ValidateBooleanValue validates the value of label `v1beta1constants.LabelSeedMultiZonal`.
+func ValidateBooleanValue(val string, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	if len(val) == 0 {
+		return allErrs
+	}
+	if _, err := strconv.ParseBool(val); err != nil {
+		allErrs = append(allErrs, field.Invalid(fldPath, val, "invalid boolean value"))
+	}
+
+	return allErrs
 }

--- a/pkg/apis/core/helper/helpers_test.go
+++ b/pkg/apis/core/helper/helpers_test.go
@@ -874,26 +874,26 @@ var _ = Describe("helper", func() {
 		})
 	})
 
-	Describe("#ValidateBooleanValue", func() {
+	Describe("#ValidateMultiZoneSeedLabelValue", func() {
 		var (
 			multiZonalSeedLabelVal string
 			fldPath                = field.NewPath("metadata", "labels").Key(v1beta1constants.LabelSeedMultiZonal)
 		)
 
 		It("should allow empty value", func() {
-			errList := ValidateBooleanValue(multiZonalSeedLabelVal, fldPath)
+			errList := ValidateMultiZoneSeedLabelValue(multiZonalSeedLabelVal, fldPath)
 			Expect(errList).To(HaveLen(0))
 		})
 
 		It("should allow valid boolean value", func() {
 			multiZonalSeedLabelVal = "true"
-			errList := ValidateBooleanValue(multiZonalSeedLabelVal, fldPath)
+			errList := ValidateMultiZoneSeedLabelValue(multiZonalSeedLabelVal, fldPath)
 			Expect(errList).To(HaveLen(0))
 		})
 
 		It("should forbid invalid boolean value", func() {
 			multiZonalSeedLabelVal = "allowed"
-			errList := ValidateBooleanValue(multiZonalSeedLabelVal, fldPath)
+			errList := ValidateMultiZoneSeedLabelValue(multiZonalSeedLabelVal, fldPath)
 			Expect(errList).To(ConsistOf(
 				PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":     Equal(field.ErrorTypeInvalid),

--- a/pkg/apis/core/helper/helpers_test.go
+++ b/pkg/apis/core/helper/helpers_test.go
@@ -21,6 +21,7 @@ import (
 	. "github.com/gardener/gardener/pkg/apis/core/helper"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	"github.com/Masterminds/semver"
 	. "github.com/onsi/ginkgo/v2"
@@ -873,4 +874,32 @@ var _ = Describe("helper", func() {
 		})
 	})
 
+	Describe("#ValidateBooleanValue", func() {
+		var (
+			multiZonalSeedLabelVal string
+			fldPath                = field.NewPath("metadata", "labels").Key(v1beta1constants.LabelSeedMultiZonal)
+		)
+
+		It("should allow empty value", func() {
+			errList := ValidateBooleanValue(multiZonalSeedLabelVal, fldPath)
+			Expect(errList).To(HaveLen(0))
+		})
+
+		It("should allow valid boolean value", func() {
+			multiZonalSeedLabelVal = "true"
+			errList := ValidateBooleanValue(multiZonalSeedLabelVal, fldPath)
+			Expect(errList).To(HaveLen(0))
+		})
+
+		It("should forbid invalid boolean value", func() {
+			multiZonalSeedLabelVal = "allowed"
+			errList := ValidateBooleanValue(multiZonalSeedLabelVal, fldPath)
+			Expect(errList).To(ConsistOf(
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":     Equal(field.ErrorTypeInvalid),
+					"Field":    Equal(fldPath.String()),
+					"BadValue": Equal(multiZonalSeedLabelVal),
+				}))))
+		})
+	})
 })

--- a/pkg/apis/core/validation/seed.go
+++ b/pkg/apis/core/validation/seed.go
@@ -281,7 +281,7 @@ func ValidateSeedHAConfig(seed *core.Seed) field.ErrorList {
 
 	// validate the value of label if present.
 	if multiZoneLabelVal, ok := seed.Labels[v1beta1constants.LabelSeedMultiZonal]; ok {
-		allErrs = append(allErrs, helper.ValidateBooleanValue(multiZoneLabelVal, multiZonalSeedLabelPath)...)
+		allErrs = append(allErrs, helper.ValidateMultiZoneSeedLabelValue(multiZoneLabelVal, multiZonalSeedLabelPath)...)
 	}
 
 	// validate the value of .spec.highAvailability.failureTolerance.type if present.

--- a/pkg/apis/core/validation/seed.go
+++ b/pkg/apis/core/validation/seed.go
@@ -16,9 +16,9 @@ package validation
 
 import (
 	"fmt"
-	"strconv"
 
 	"github.com/gardener/gardener/pkg/apis/core"
+	"github.com/gardener/gardener/pkg/apis/core/helper"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/utils"
 	cidrvalidation "github.com/gardener/gardener/pkg/utils/validation/cidr"
@@ -281,25 +281,13 @@ func ValidateSeedHAConfig(seed *core.Seed) field.ErrorList {
 
 	// validate the value of label if present.
 	if multiZoneLabelVal, ok := seed.Labels[v1beta1constants.LabelSeedMultiZonal]; ok {
-		allErrs = append(allErrs, validateMultiZoneSeedLabelValue(multiZoneLabelVal, multiZonalSeedLabelPath)...)
+		allErrs = append(allErrs, helper.ValidateBooleanValue(multiZoneLabelVal, multiZonalSeedLabelPath)...)
 	}
 
 	// validate the value of .spec.highAvailability.failureTolerance.type if present.
 	if seed.Spec.HighAvailability != nil {
 		allErrs = append(allErrs, ValidateFailureToleranceTypeValue(seed.Spec.HighAvailability.FailureTolerance.Type, field.NewPath("spec", "highAvailability", "failureTolerance", "type"))...)
 	}
-	return allErrs
-}
-
-func validateMultiZoneSeedLabelValue(val string, fldPath *field.Path) field.ErrorList {
-	allErrs := field.ErrorList{}
-
-	if len(val) > 0 {
-		if _, err := strconv.ParseBool(val); err != nil {
-			allErrs = append(allErrs, field.Invalid(fldPath, val, fmt.Sprintf("seed label %s has an invalid boolean value %s", v1beta1constants.LabelSeedMultiZonal, val)))
-		}
-	}
-
 	return allErrs
 }
 

--- a/pkg/apis/seedmanagement/helper/helper_test.go
+++ b/pkg/apis/seedmanagement/helper/helper_test.go
@@ -24,6 +24,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
 var _ = Describe("Helper", func() {
@@ -64,7 +65,7 @@ var _ = Describe("Helper", func() {
 			}
 		})
 
-		Context("#ExtractSeedSpec", func() {
+		Context("#ExtractSeedTemplate", func() {
 			It("seedTemplate is defined", func() {
 				managedSeed.Spec.SeedTemplate = &gardencore.SeedTemplate{
 					Spec: gardencore.SeedSpec{
@@ -77,9 +78,11 @@ var _ = Describe("Helper", func() {
 						HighAvailability: &haConfig,
 					},
 				}
-				spec, err := ExtractSeedSpec(managedSeed)
+				seedTemplate, fldPath, err := ExtractSeedTemplate(managedSeed)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(*spec.HighAvailability).To(Equal(haConfig))
+				Expect(seedTemplate).ToNot(BeNil())
+				Expect(fldPath).To(Equal(field.NewPath("spec", "seedTemplate")))
+				Expect(*seedTemplate.Spec.HighAvailability).To(Equal(haConfig))
 			})
 
 			It("gardenlet is defined", func() {
@@ -98,13 +101,15 @@ var _ = Describe("Helper", func() {
 						},
 					},
 				}
-				spec, err := ExtractSeedSpec(managedSeed)
+				seedTemplate, fldPath, err := ExtractSeedTemplate(managedSeed)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(spec).ToNot(BeNil())
+				Expect(seedTemplate).ToNot(BeNil())
+				Expect(fldPath).To(Equal(field.NewPath("spec", "gardenlet", "config", "seedConfig")))
+				Expect(seedTemplate.Spec).ToNot(BeNil())
 			})
 
 			It("neither seedTemplate nor gardenlet is defined", func() {
-				_, err := ExtractSeedSpec(managedSeed)
+				_, _, err := ExtractSeedTemplate(managedSeed)
 				Expect(err).To(HaveOccurred())
 			})
 		})

--- a/pkg/apis/seedmanagement/helper/helper_test.go
+++ b/pkg/apis/seedmanagement/helper/helper_test.go
@@ -163,10 +163,28 @@ var _ = Describe("Helper", func() {
 				Expect(isMultiZonalSeed).To(BeTrue())
 			})
 
-			It(" should return error if alpha seed label for multi-zone is used for managedseed which is not supported", func() {
-				managedSeed.Labels = map[string]string{v1beta1constants.LabelSeedMultiZonal: ""}
-				_, err := IsMultiZonalManagedSeed(managedSeed)
-				Expect(err).To(HaveOccurred())
+			It("should return true for multi-zonal seed identified via seed multi-zonal seed label", func() {
+				managedSeed.Spec.Gardenlet = &seedmanagement.Gardenlet{
+					Config: &configv1alpha1.GardenletConfiguration{
+						TypeMeta: metav1.TypeMeta{
+							APIVersion: configv1alpha1.SchemeGroupVersion.String(),
+							Kind:       "GardenletConfiguration",
+						},
+						SeedConfig: &configv1alpha1.SeedConfig{
+							SeedTemplate: gardencorev1beta1.SeedTemplate{
+								Spec: gardencorev1beta1.SeedSpec{
+									Backup: &gardencorev1beta1.SeedBackup{},
+								},
+								ObjectMeta: metav1.ObjectMeta{
+									Labels: map[string]string{v1beta1constants.LabelSeedMultiZonal: ""},
+								},
+							},
+						},
+					},
+				}
+				isMultiZonalSeed, err := IsMultiZonalManagedSeed(managedSeed)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(isMultiZonalSeed).To(BeTrue())
 			})
 
 			It("should return error if no seed spec set", func() {

--- a/pkg/apis/seedmanagement/validation/managedseed.go
+++ b/pkg/apis/seedmanagement/validation/managedseed.go
@@ -68,7 +68,7 @@ func ValidateHAConfig(managedSeed *seedmanagement.ManagedSeed) field.ErrorList {
 	allErrs = append(allErrs, validateManagedSeedShouldNotHaveBothMultiZoneLabelAndHASpec(seedTemplate.ObjectMeta, &seedTemplate.Spec, multiZonalSeedLabelPath, seedSpecHAPath)...)
 
 	// validate the value of label if present.
-	if multiZoneLabelVal, ok := seedTemplate.ObjectMeta.Labels[v1beta1constants.LabelSeedMultiZonal]; ok {
+	if multiZoneLabelVal := seedTemplate.ObjectMeta.Labels[v1beta1constants.LabelSeedMultiZonal]; multiZoneLabelVal != "" {
 		allErrs = append(allErrs, gardencorehelper.ValidateMultiZoneSeedLabelValue(multiZoneLabelVal, multiZonalSeedLabelPath)...)
 	}
 
@@ -80,10 +80,10 @@ func ValidateHAConfig(managedSeed *seedmanagement.ManagedSeed) field.ErrorList {
 	return allErrs
 }
 
-func validateManagedSeedShouldNotHaveBothMultiZoneLabelAndHASpec(msObjectMeta metav1.ObjectMeta, seedSpec *gardencore.SeedSpec, multiZonalSeedLabelPath *field.Path, seedSpecHAPath *field.Path) field.ErrorList {
+func validateManagedSeedShouldNotHaveBothMultiZoneLabelAndHASpec(seedObjectMeta metav1.ObjectMeta, seedSpec *gardencore.SeedSpec, multiZonalSeedLabelPath *field.Path, seedSpecHAPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
-	if metav1.HasLabel(msObjectMeta, v1beta1constants.LabelSeedMultiZonal) && seedSpec.HighAvailability != nil {
+	if metav1.HasLabel(seedObjectMeta, v1beta1constants.LabelSeedMultiZonal) && seedSpec.HighAvailability != nil {
 		allErrs = append(allErrs,
 			field.Forbidden(multiZonalSeedLabelPath,
 				fmt.Sprintf("both %s label and %s have been set. HA configuration for the managedseed should only be set via .spec.highAvailability", v1beta1constants.LabelSeedMultiZonal, seedSpecHAPath.String())))

--- a/pkg/apis/seedmanagement/validation/managedseed.go
+++ b/pkg/apis/seedmanagement/validation/managedseed.go
@@ -69,7 +69,7 @@ func ValidateHAConfig(managedSeed *seedmanagement.ManagedSeed) field.ErrorList {
 
 	// validate the value of label if present.
 	if multiZoneLabelVal, ok := seedTemplate.ObjectMeta.Labels[v1beta1constants.LabelSeedMultiZonal]; ok {
-		allErrs = append(allErrs, gardencorehelper.ValidateBooleanValue(multiZoneLabelVal, multiZonalSeedLabelPath)...)
+		allErrs = append(allErrs, gardencorehelper.ValidateMultiZoneSeedLabelValue(multiZoneLabelVal, multiZonalSeedLabelPath)...)
 	}
 
 	// validate the value of .seedSpec.highAvailability.failureTolerance.type if present.
@@ -86,7 +86,7 @@ func validateManagedSeedShouldNotHaveBothMultiZoneLabelAndHASpec(msObjectMeta me
 	if metav1.HasLabel(msObjectMeta, v1beta1constants.LabelSeedMultiZonal) && seedSpec.HighAvailability != nil {
 		allErrs = append(allErrs,
 			field.Forbidden(multiZonalSeedLabelPath,
-				fmt.Sprintf("both %s and %s have been set. HA configuration for the managedseed should only be set via .spec.highAvailability", v1beta1constants.LabelSeedMultiZonal, seedSpecHAPath.String())))
+				fmt.Sprintf("both %s label and %s have been set. HA configuration for the managedseed should only be set via .spec.highAvailability", v1beta1constants.LabelSeedMultiZonal, seedSpecHAPath.String())))
 	}
 
 	return allErrs


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement

**What this PR does / why we need it**:
As part of PR #6723 Seed and ManagedSeed API changes were introduced. Validations that are applicable on the Seed are also applicable when a ManagedSeed is created. This PR bridges that gap and introduces this API validations which provides fail fast semantics to ManagedSeed creation.

**Which issue(s) this PR fixes**:
We recently noticed that HA seed creation via landscape setup tool was throwing the following errors:
```
{"level":"info","ts":"2022-10-13T14:08:07.513Z","msg":"Wait completed, proceeding to shutdown the manager"}
panic: could not register seed "aws-ha": Seed.core.gardener.cloud "aws-ha" is invalid: metadata.labels[seed.gardener.cloud/multi-zonal]: Forbidden: both seed.gardener.cloud/multi-zonal and .spec.highAvailability have been set. HA configuration for the seed should only be set via .spec.highAvailability

goroutine 1 [running]:
main.main()
	/go/src/github.com/gardener/gardener/cmd/gardenlet/main.go:30 +0x92
```
A ManagedSeed with GardenletConfig is used in gardener context today. With 1.58.x of gardener a check has been added which prohibits adding both a multi-zonal label and spec.highAvailability to a Seed. However this is missing in ManagedSeed. As a consequence the ManagedSeed creation never errors out and it is only later when a Seed is created and labels and spec.highAvailability is set on the Seed will it fail.

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
API validation for ManagedSeed is enhanced. Additional check which validates HA configuration for a ManagedSeed is added.
```
