### PR TITLE
Fix imageVectorOverwrite for HA e2e tests

### DIFF
--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -1185,52 +1185,16 @@ profiles:
   activation:
   - env: HA_MODE=single-zone
   patches:
-  - op: replace
-    path: /deploy/helm/releases/0/setValueTemplates
+  - op: add
+    path: /deploy/helm/releases/0/setValues
     value:
-      global:
-        gardenlet:
-          imageVectorOverwrite: |
-            images:
-            - name: gardenlet
-              repository: localhost:5001/eu_gcr_io_gardener-project_gardener_gardenlet
-              tag: "{{.IMAGE_TAG6}}"
-            - name: gardener-resource-manager
-              repository: localhost:5001/eu_gcr_io_gardener-project_gardener_resource-manager
-              tag: "{{.IMAGE_TAG7}}"
-            - name: gardener-seed-admission-controller
-              repository: localhost:5001/eu_gcr_io_gardener-project_gardener_seed-admission-controller
-              tag: "{{.IMAGE_TAG8}}"
-          config:
-            seedConfig:
-              spec:
-                highAvailability:
-                  failureTolerance:
-                    type: node
+      global.gardenlet.config.seedConfig.spec.highAvailability.failureTolerance.type: node
 
 - name: ha-multi-zone
   activation:
   - env: HA_MODE=multi-zone
   patches:
-  - op: replace
-    path: /deploy/helm/releases/0/setValueTemplates
+  - op: add
+    path: /deploy/helm/releases/0/setValues
     value:
-      global:
-        gardenlet:
-          imageVectorOverwrite: |
-            images:
-            - name: gardenlet
-              repository: localhost:5001/eu_gcr_io_gardener-project_gardener_gardenlet
-              tag: "{{.IMAGE_TAG6}}"
-            - name: gardener-resource-manager
-              repository: localhost:5001/eu_gcr_io_gardener-project_gardener_resource-manager
-              tag: "{{.IMAGE_TAG7}}"
-            - name: gardener-seed-admission-controller
-              repository: localhost:5001/eu_gcr_io_gardener-project_gardener_seed-admission-controller
-              tag: "{{.IMAGE_TAG8}}"
-          config:
-            seedConfig:
-              spec:
-                highAvailability:
-                  failureTolerance:
-                    type: zone
+      global.gardenlet.config.seedConfig.spec.highAvailability.failureTolerance.type: zone

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -1190,6 +1190,17 @@ profiles:
     value:
       global:
         gardenlet:
+          imageVectorOverwrite: |
+            images:
+            - name: gardenlet
+              repository: localhost:5001/eu_gcr_io_gardener-project_gardener_gardenlet
+              tag: "{{.IMAGE_TAG6}}"
+            - name: gardener-resource-manager
+              repository: localhost:5001/eu_gcr_io_gardener-project_gardener_resource-manager
+              tag: "{{.IMAGE_TAG7}}"
+            - name: gardener-seed-admission-controller
+              repository: localhost:5001/eu_gcr_io_gardener-project_gardener_seed-admission-controller
+              tag: "{{.IMAGE_TAG8}}"
           config:
             seedConfig:
               spec:
@@ -1206,6 +1217,17 @@ profiles:
     value:
       global:
         gardenlet:
+          imageVectorOverwrite: |
+            images:
+            - name: gardenlet
+              repository: localhost:5001/eu_gcr_io_gardener-project_gardener_gardenlet
+              tag: "{{.IMAGE_TAG6}}"
+            - name: gardener-resource-manager
+              repository: localhost:5001/eu_gcr_io_gardener-project_gardener_resource-manager
+              tag: "{{.IMAGE_TAG7}}"
+            - name: gardener-seed-admission-controller
+              repository: localhost:5001/eu_gcr_io_gardener-project_gardener_seed-admission-controller
+              tag: "{{.IMAGE_TAG8}}"
           config:
             seedConfig:
               spec:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind bug

**What this PR does / why we need it**:
This PR sets image vectors to the locally built images in HA e2e tests.
It turned out In PRs #6830 and #6831, that they were pointing to the latest dev image on eu.gcro.io instead (see image of `eu.gcr.io/gardener-project/gardener/resource-manager` in [images.log](https://storage.googleapis.com/gardener-prow/pr-logs/pull/gardener_gardener/6830/pull-gardener-e2e-kind-ha-single-zone/1580620626316496896/artifacts/gardener-local-ha-control-plane/images.log) of this [failing test](https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/6830/pull-gardener-e2e-kind-ha-single-zone/1580620626316496896))

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
