### PR TITLE
Set priority class for `kube-scheduler` and `cluster-autoscaler`

### DIFF
--- a/pkg/operation/botanist/component/clusterautoscaler/cluster_autoscaler.go
+++ b/pkg/operation/botanist/component/clusterautoscaler/cluster_autoscaler.go
@@ -187,8 +187,6 @@ func (c *clusterAutoscaler) Deploy(ctx context.Context) error {
 				}),
 			},
 			Spec: corev1.PodSpec{
-				ServiceAccountName:            serviceAccount.Name,
-				TerminationGracePeriodSeconds: pointer.Int64(5),
 				Containers: []corev1.Container{
 					{
 						Name:            containerName,
@@ -220,6 +218,9 @@ func (c *clusterAutoscaler) Deploy(ctx context.Context) error {
 						},
 					},
 				},
+				PriorityClassName:             v1beta1constants.PriorityClassNameShootControlPlane300,
+				ServiceAccountName:            serviceAccount.Name,
+				TerminationGracePeriodSeconds: pointer.Int64(5),
 			},
 		}
 

--- a/pkg/operation/botanist/component/clusterautoscaler/cluster_autoscaler_test.go
+++ b/pkg/operation/botanist/component/clusterautoscaler/cluster_autoscaler_test.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
@@ -282,8 +283,6 @@ var _ = Describe("ClusterAutoscaler", func() {
 							},
 						},
 						Spec: corev1.PodSpec{
-							ServiceAccountName:            serviceAccountName,
-							TerminationGracePeriodSeconds: pointer.Int64(5),
 							Containers: []corev1.Container{
 								{
 									Name:            "cluster-autoscaler",
@@ -315,6 +314,9 @@ var _ = Describe("ClusterAutoscaler", func() {
 									},
 								},
 							},
+							PriorityClassName:             v1beta1constants.PriorityClassNameShootControlPlane300,
+							ServiceAccountName:            serviceAccountName,
+							TerminationGracePeriodSeconds: pointer.Int64(5),
 						},
 					},
 				},

--- a/pkg/operation/botanist/component/kubescheduler/kube_scheduler.go
+++ b/pkg/operation/botanist/component/kubescheduler/kube_scheduler.go
@@ -289,6 +289,7 @@ func (k *kubeScheduler) Deploy(ctx context.Context) error {
 						},
 					},
 				},
+				PriorityClassName: v1beta1constants.PriorityClassNameShootControlPlane300,
 				Volumes: []corev1.Volume{
 					{
 						Name: volumeNameClientCA,

--- a/pkg/operation/botanist/component/kubescheduler/kube_scheduler_test.go
+++ b/pkg/operation/botanist/component/kubescheduler/kube_scheduler_test.go
@@ -22,6 +22,7 @@ import (
 	"text/template"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
 	. "github.com/gardener/gardener/pkg/operation/botanist/component/kubescheduler"
@@ -266,6 +267,7 @@ var _ = Describe("KubeScheduler", func() {
 									},
 								},
 							},
+							PriorityClassName: v1beta1constants.PriorityClassNameShootControlPlane300,
 							Volumes: []corev1.Volume{
 								{
 									Name: "client-ca",


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug

**What this PR does / why we need it**:
See https://github.com/gardener/gardener/issues/5634#issuecomment-1279953592

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/5634

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
`kube-scheduler` and `cluster-autoscaler` Pods now run with the appropriate priority set according to the following [document](https://github.com/gardener/gardener/blob/v1.57.1/docs/development/priority-classes.md). Previously these Pods were running without a priority class set and were preempted in favour of less important Pods.
```
