### PR TITLE
Fix `ControllerInstallation` integration test flakiness

### DIFF
--- a/test/integration/gardenlet/controllerinstallation/controllerinstallation/controllerinstallation_suite_test.go
+++ b/test/integration/gardenlet/controllerinstallation/controllerinstallation/controllerinstallation_suite_test.go
@@ -71,6 +71,7 @@ var (
 	testEnv       *gardenerenvtest.GardenerTestEnvironment
 	testClient    client.Client
 	testClientSet kubernetes.Interface
+	mgrClient     client.Client
 
 	seed                  *gardencorev1beta1.Seed
 	gardenNamespace       *corev1.Namespace
@@ -181,6 +182,7 @@ var _ = BeforeSuite(func() {
 		}),
 	})
 	Expect(err).NotTo(HaveOccurred())
+	mgrClient = mgr.GetClient()
 
 	Expect(resourcesv1alpha1.AddToScheme(mgr.GetScheme())).To(Succeed())
 

--- a/test/integration/gardenlet/controllerinstallation/controllerinstallation/controllerinstallation_test.go
+++ b/test/integration/gardenlet/controllerinstallation/controllerinstallation/controllerinstallation_test.go
@@ -63,7 +63,7 @@ var _ = Describe("ControllerInstallation controller tests", func() {
 		}
 		controllerInstallation = &gardencorev1beta1.ControllerInstallation{
 			ObjectMeta: metav1.ObjectMeta{
-				GenerateName: "deploy-",
+				GenerateName: "installation-",
 				Labels:       map[string]string{testID: testRunID},
 			},
 		}
@@ -74,9 +74,19 @@ var _ = Describe("ControllerInstallation controller tests", func() {
 		Expect(testClient.Create(ctx, controllerRegistration)).To(Succeed())
 		log.Info("Created ControllerRegistration", "controllerRegistration", client.ObjectKeyFromObject(controllerRegistration))
 
+		By("Wait until manager has observed ControllerRegistration")
+		Eventually(func() error {
+			return mgrClient.Get(ctx, client.ObjectKeyFromObject(controllerRegistration), controllerRegistration)
+		}).Should(Succeed())
+
 		By("Create ControllerDeployment")
 		Expect(testClient.Create(ctx, controllerDeployment)).To(Succeed())
 		log.Info("Created ControllerDeployment", "controllerDeployment", client.ObjectKeyFromObject(controllerDeployment))
+
+		By("Wait until manager has observed ControllerDeployment")
+		Eventually(func() error {
+			return mgrClient.Get(ctx, client.ObjectKeyFromObject(controllerDeployment), controllerDeployment)
+		}).Should(Succeed())
 
 		By("Create ControllerInstallation")
 		controllerInstallation.Spec.SeedRef = corev1.ObjectReference{Name: seed.Name}
@@ -84,6 +94,11 @@ var _ = Describe("ControllerInstallation controller tests", func() {
 		controllerInstallation.Spec.DeploymentRef = &corev1.ObjectReference{Name: controllerDeployment.Name}
 		Expect(testClient.Create(ctx, controllerInstallation)).To(Succeed())
 		log.Info("Created ControllerInstallation", "controllerInstallation", client.ObjectKeyFromObject(controllerInstallation))
+
+		By("Wait until manager has observed ControllerInstallation")
+		Eventually(func() error {
+			return mgrClient.Get(ctx, client.ObjectKeyFromObject(controllerInstallation), controllerInstallation)
+		}).Should(Succeed())
 
 		DeferCleanup(func() {
 			By("Delete ControllerInstallation")


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind flake

**What this PR does / why we need it**:
This PR fixes flaky behaviour of the `ControllerInstallation` integration test suite by waiting until the manager has observed the created objects.

**Which issue(s) this PR fixes**:
See https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/6820/pull-gardener-integration/1580183781677993984

**Special notes for your reviewer**:
In above failure, I think the test failed because the manager was not having the `ControllerDeployment` in its cache, hence the [`HelmTypePredicate`](https://github.com/gardener/gardener/blob/bbe19d1c11c59b7a595decfde227947725f4d7f4/pkg/gardenlet/controller/controllerinstallation/controllerinstallation/add.go#L117-L132) returned `false`.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
