### PR TITLE
Fix flaky `ShootValidator` integration test

### DIFF
--- a/test/integration/apiserver/admissionplugins/shootvalidator/shootvalidator_suite_test.go
+++ b/test/integration/apiserver/admissionplugins/shootvalidator/shootvalidator_suite_test.go
@@ -73,7 +73,7 @@ var _ = BeforeSuite(func() {
 	testEnv = &gardenerenvtest.GardenerTestEnvironment{
 		GardenerAPIServer: &gardenerenvtest.GardenerAPIServer{
 			Args: []string{
-				"--disable-admission-plugins=DeletionConfirmation,ResourceReferenceManager,ExtensionValidator,ShootDNS",
+				"--disable-admission-plugins=DeletionConfirmation,ResourceReferenceManager,ExtensionValidator,ShootDNS,SeedValidator",
 			},
 		},
 	}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind flake

**What this PR does / why we need it**:
We are already waiting till the `shoot` gets deleted,
ref: 
https://github.com/gardener/gardener/blob/d1d365fdbcdab52680aca6d82626e15b747fe752/test/integration/apiserver/admissionplugins/shootvalidator/shootvalidator_test.go#L139-L141
in the integration test, but still it flakes with,
```
              Status: "Failure",
              Message: "seeds.core.gardener.cloud \"shootvalidator-test-57nh4\" is forbidden: cannot delete seed shootvalidator-test-57nh4 since it is still used by shoot(s)",
              Reason: "Forbidden",
```
This PR disables the `SeedValidator` plugin for this test as it's anyway not relevant to the test.


**Which issue(s) this PR fixes**:
Fixes #6642

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
