### PR TITLE
Exclude the attach subresource when considering high latency of the API Server

### DIFF
--- a/charts/seed-monitoring/charts/grafana/dashboards/owners/apiserver-overview.json
+++ b/charts/seed-monitoring/charts/grafana/dashboards/owners/apiserver-overview.json
@@ -1055,7 +1055,7 @@
       "targets": [
         {
           "exemplar": false,
-          "expr": "max by(verb, quantile) (apiserver_latency_seconds:quantile{pod=~\"$apiserver\", verb=~\"$verb\",quantile=~\"$quantile\",subresource!~\"log|portforward|exec|proxy\"})",
+          "expr": "max by(verb, quantile) (apiserver_latency_seconds:quantile{pod=~\"$apiserver\", verb=~\"$verb\",quantile=~\"$quantile\",subresource!~\"log|portforward|exec|proxy|attach\"})",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,

--- a/pkg/operation/botanist/component/kubeapiserver/monitoring.go
+++ b/pkg/operation/botanist/component/kubeapiserver/monitoring.go
@@ -117,7 +117,7 @@ const (
   # Some verbs excluded because they are expected to be long-lasting:
   # WATCHLIST is long-poll, CONNECT is "kubectl exec".
   - alert: KubeApiServerLatency
-    expr: histogram_quantile(0.99, sum without (instance,resource) (rate(` + monitoringMetricApiserverRequestDurationSecondsBucket + `{subresource!~"log|portforward|exec|proxy",verb!~"CONNECT|WATCHLIST|WATCH|PROXY proxy"}[5m]))) > 3
+    expr: histogram_quantile(0.99, sum without (instance,resource,subresource) (rate(` + monitoringMetricApiserverRequestDurationSecondsBucket + `{subresource!~"log|portforward|exec|proxy|attach",verb!~"CONNECT|WATCHLIST|WATCH|PROXY proxy"}[5m]))) > 3
     for: 30m
     labels:
       service: ` + v1beta1constants.DeploymentNameKubeAPIServer + `

--- a/pkg/operation/botanist/component/kubeapiserver/monitoring_test.go
+++ b/pkg/operation/botanist/component/kubeapiserver/monitoring_test.go
@@ -124,7 +124,7 @@ metric_relabel_configs:
   # Some verbs excluded because they are expected to be long-lasting:
   # WATCHLIST is long-poll, CONNECT is "kubectl exec".
   - alert: KubeApiServerLatency
-    expr: histogram_quantile(0.99, sum without (instance,resource) (rate(apiserver_request_duration_seconds_bucket{subresource!~"log|portforward|exec|proxy",verb!~"CONNECT|WATCHLIST|WATCH|PROXY proxy"}[5m]))) > 3
+    expr: histogram_quantile(0.99, sum without (instance,resource,subresource) (rate(apiserver_request_duration_seconds_bucket{subresource!~"log|portforward|exec|proxy|attach",verb!~"CONNECT|WATCHLIST|WATCH|PROXY proxy"}[5m]))) > 3
     for: 30m
     labels:
       service: kube-apiserver


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind enhancement

**What this PR does / why we need it**:

Exclude the `attach` subresource when considering high latency of the API Server

The reported latency of the `attach` subresource request depends on the
latency of the underlying request (e.g. when attaching to a pod)
hence it need not be considered for the KubeApiServerLatency alert
or should not raise concerns on the request latency panel of the API Server dashboard.

See #6445

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

/cc @wyb1 @rickardsjp 

- Adjust the "Request Latency" panel on the "API Server" dashboard to exclude the "attach" subresource

- Adjust the KubeApiServerLatency alert to exclude the "attach" subresource. The resource label was already aggregated away in the alert definition so with this change the subresource label is also aggregated away for consistency. The main remaining dimension for the alert is the verb (GET, POST, ...)

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Latency metrics of the attach subresource are not considered for the KubeApiServerLatency alert and API Server / Request Latency dashboard panel.
```
