### PR TITLE
Update apiserver-proxy sidecar image version

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -334,7 +334,7 @@ images:
 - name: apiserver-proxy-sidecar
   sourceRepository: github.com/gardener/apiserver-proxy
   repository: eu.gcr.io/gardener-project/gardener/apiserver-proxy
-  tag: "v0.6.0"
+  tag: "v0.7.0"
 - name: apiserver-proxy-pod-webhook
   sourceRepository: github.com/gardener/apiserver-proxy
   repository: eu.gcr.io/gardener-project/gardener/apiserver-proxy-pod-webhook


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement

**What this PR does / why we need it**:
Similar to https://github.com/gardener/gardener/pull/6828 - this PR updates the apiserver-proxy sidecar image. Around my changes in the apiserver-proxy, I executed the release tests and the default tests in my local setup against apiserver-proxy images that are based on revisions after v0.7.0. During the testing there was no test failure or I was not able to notice abnormal thing.
That's why I rather assume that the reason for the flakes back then was another one. 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The following image is updated:
- eu.gcr.io/gardener-project/gardener/apiserver-proxy: v0.6.0 -> v0.7.0
```
