### PR TITLE
Remove scale subresource from etcd CRD

### DIFF
--- a/pkg/operation/botanist/component/etcd/crds/templates/crd-druid.gardener.cloud_etcds.yaml
+++ b/pkg/operation/botanist/component/etcd/crds/templates/crd-druid.gardener.cloud_etcds.yaml
@@ -1712,8 +1712,7 @@ spec:
     served: true
     storage: true
     subresources:
-      scale:
-        labelSelectorPath: .status.labelSelector
-        specReplicasPath: .spec.replicas
-        statusReplicasPath: .status.replicas
+      # /scale subresource is intentionally removed from this CRD, although it is specified
+      # in the original CRD from etcd-druid, due to adverse interaction with VPA.
+      # See https://github.com/gardener/gardener/pull/6850 for details.
       status: {}


### PR DESCRIPTION
Signed-off-by: Shreyas Rao <shreyas.sriganesh.rao@sap.com>

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area auto-scaling
/kind bug

**What this PR does / why we need it**:
This PR removes scale subresource from the `etcd` CRD to allow VPA to provide recommendations to the etcd pods.

The issue was observed after etcd-druid started mandatorily setting `ownerRef` on the etcd statefulset since g/g `v1.53.0`. Due to this, VPA recommender stopped providing recommendations to the etcd pods, since the statefulset had an owner that defined a scale subresource. The root problem is with VPA opting to not provide recommendations in such situations, even if `updateMode` is set to `Off`.

This is a temporary fix for gardener, in order to allow vertical scaling of etcd pods once again.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/invite @istvanballok @andrerun @unmarshall 
/cc @aaronfern @plkokanov 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Remove `/scale` subresource from etcd CRD.
```
