### PR TITLE
Wait for all shoot `ManagedResource`s to be deleted before deleting `kube-apiserver`

### DIFF
--- a/pkg/gardenlet/controller/shoot/shoot_control_delete.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control_delete.go
@@ -500,7 +500,7 @@ func (r *shootReconciler) runDeleteShootFlow(ctx context.Context, o *operation.O
 		deleteKubeAPIServer = g.Add(flow.Task{
 			Name:         "Deleting Kubernetes API server",
 			Fn:           flow.TaskFn(botanist.DeleteKubeAPIServer).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			Dependencies: flow.NewTaskIDs(syncPointCleaned, waitUntilControlPlaneDeleted).InsertIf(cleanupShootResources, waitUntilShootManagedResourcesDeleted),
+			Dependencies: flow.NewTaskIDs(syncPointCleaned, waitUntilControlPlaneDeleted, waitUntilShootManagedResourcesDeleted),
 		})
 		destroyKubeAPIServerSNI = g.Add(flow.Task{
 			Name:         "Destroying Kubernetes API server service SNI",

--- a/pkg/gardenlet/controller/shoot/shoot_control_migrate.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control_migrate.go
@@ -294,7 +294,7 @@ func (r *shootReconciler) runPrepareShootForMigrationFlow(ctx context.Context, o
 		deleteKubeAPIServer = g.Add(flow.Task{
 			Name:         "Deleting kube-apiserver deployment",
 			Fn:           flow.TaskFn(botanist.DeleteKubeAPIServer).SkipIf(!kubeAPIServerDeploymentFound),
-			Dependencies: flow.NewTaskIDs(waitForManagedResourcesDeletion, waitUntilEtcdReady, waitUntilControlPlaneDeleted).InsertIf(cleanupShootResources, waitUntilShootManagedResourcesDeleted),
+			Dependencies: flow.NewTaskIDs(waitForManagedResourcesDeletion, waitUntilEtcdReady, waitUntilControlPlaneDeleted, waitUntilShootManagedResourcesDeleted),
 		})
 		waitUntilKubeAPIServerDeleted = g.Add(flow.Task{
 			Name:         "Waiting until kube-apiserver has been deleted",

--- a/pkg/operation/botanist/managedresources_test.go
+++ b/pkg/operation/botanist/managedresources_test.go
@@ -1,0 +1,108 @@
+// Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package botanist_test
+
+import (
+	"context"
+	"time"
+
+	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	fakekubernetes "github.com/gardener/gardener/pkg/client/kubernetes/fake"
+	"github.com/gardener/gardener/pkg/operation"
+	. "github.com/gardener/gardener/pkg/operation/botanist"
+	shootpkg "github.com/gardener/gardener/pkg/operation/shoot"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+var _ = Describe("ManagedResources", func() {
+	var (
+		fakeClient                                                                    client.Client
+		botanist                                                                      *Botanist
+		namespace                                                                     *corev1.Namespace
+		ctx                                                                           = context.TODO()
+		seedManagedResource, shootManagedResouceZeroClass, shootManagedResouceNoClass *resourcesv1alpha1.ManagedResource
+
+		deleteManagedResoucesWithDelay = func(ctx context.Context, delay time.Duration, managedResources ...*resourcesv1alpha1.ManagedResource) {
+			time.Sleep(delay)
+			for _, mr := range managedResources {
+				Expect(fakeClient.Delete(ctx, mr)).To(Succeed())
+			}
+		}
+	)
+
+	BeforeEach(func() {
+		fakeClient = fakeclient.NewClientBuilder().WithScheme(kubernetes.SeedScheme).Build()
+		botanist = &Botanist{Operation: &operation.Operation{}}
+		k8sSeedClient := fakekubernetes.NewClientSetBuilder().WithClient(fakeClient).Build()
+		namespace = &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "test"}}
+		botanist.SeedClientSet = k8sSeedClient
+		botanist.Shoot = &shootpkg.Shoot{
+			SeedNamespace: namespace.Name,
+		}
+		seedManagedResource = &resourcesv1alpha1.ManagedResource{
+			ObjectMeta: metav1.ObjectMeta{Name: "seed", Namespace: namespace.Name},
+			Spec:       resourcesv1alpha1.ManagedResourceSpec{Class: pointer.String("seed")},
+		}
+		shootManagedResouceZeroClass = &resourcesv1alpha1.ManagedResource{
+			ObjectMeta: metav1.ObjectMeta{Name: "shoot-zero-class", Namespace: namespace.Name},
+			Spec:       resourcesv1alpha1.ManagedResourceSpec{Class: pointer.String("")},
+		}
+		shootManagedResouceNoClass = &resourcesv1alpha1.ManagedResource{
+			ObjectMeta: metav1.ObjectMeta{Name: "shoot-no-class", Namespace: namespace.Name},
+		}
+	})
+
+	Describe("#WaitUntilShootManagedResourcesDeleted", func() {
+		It("should wait for all managed resources referring the shoot to be deleted", func() {
+			Expect(fakeClient.Create(ctx, namespace)).To(Succeed())
+			Expect(fakeClient.Create(ctx, shootManagedResouceZeroClass)).To(Succeed())
+			Expect(fakeClient.Create(ctx, shootManagedResouceNoClass)).To(Succeed())
+			Expect(fakeClient.Create(ctx, seedManagedResource)).To(Succeed())
+
+			go deleteManagedResoucesWithDelay(ctx, time.Second*3, shootManagedResouceZeroClass, shootManagedResouceNoClass)
+
+			timeoutContext, cancel := context.WithTimeout(ctx, time.Second*30)
+			defer cancel()
+			Expect(botanist.WaitUntilShootManagedResourcesDeleted(timeoutContext)).To(Succeed())
+			mrList := &metav1.PartialObjectMetadataList{}
+			mrList.SetGroupVersionKind(resourcesv1alpha1.SchemeGroupVersion.WithKind("ManagedResourceList"))
+			Expect(fakeClient.List(ctx, mrList, client.InNamespace(namespace.Name))).To(Succeed())
+			Expect(len(mrList.Items)).To(Equal(1))
+		})
+
+		It("should timeout because not all managed resources referring the shoot are deleted", func() {
+			Expect(fakeClient.Create(ctx, namespace)).To(Succeed())
+			Expect(fakeClient.Create(ctx, shootManagedResouceZeroClass)).To(Succeed())
+			Expect(fakeClient.Create(ctx, shootManagedResouceNoClass)).To(Succeed())
+			Expect(fakeClient.Create(ctx, seedManagedResource)).To(Succeed())
+
+			go deleteManagedResoucesWithDelay(ctx, time.Second*1, shootManagedResouceNoClass)
+
+			timeoutContext, cancel := context.WithTimeout(ctx, time.Second*6)
+			defer cancel()
+			err := botanist.WaitUntilShootManagedResourcesDeleted(timeoutContext)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("managed resources that refer the shoot still exist"))
+		})
+	})
+})

--- a/pkg/operation/botanist/managedresources_test.go
+++ b/pkg/operation/botanist/managedresources_test.go
@@ -47,6 +47,7 @@ var _ = Describe("ManagedResources", func() {
 		seedManagedResource, shootManagedResouceZeroClass, shootManagedResouceNoClass *resourcesv1alpha1.ManagedResource
 
 		deleteManagedResoucesWithDelay = func(ctx context.Context, delay time.Duration, managedResources ...*resourcesv1alpha1.ManagedResource) {
+			defer GinkgoRecover()
 			time.Sleep(delay)
 			for _, mr := range managedResources {
 				Expect(fakeClient.Delete(ctx, mr)).To(Succeed())


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness quality
/kind enhancement

**What this PR does / why we need it**:
Right now Gardener waits only the managed resources labeled with `origin=gardener` to be deleted before deleting the shoot's `kube-apiserver`. This does not guarantee that all managed resources referring the shoot are cleaned up.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
cc @plkokanov @rfranzke 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The `gardenlet` now waits for all managed resources referring the shoot to be deleted before continuing with the deletion of the shoot's `kube-apiserver` during shoot deletion or controlplane migration.
```
