### PR TITLE
Document restrictions with regards to custom dns configuration and node local dns.

### DIFF
--- a/docs/usage/custom-dns-config.md
+++ b/docs/usage/custom-dns-config.md
@@ -61,6 +61,14 @@ simply applying a configuration can break DNS).
 If incompatible changes are applied by mistake, simply delete the content of the `ConfigMap` and re-apply.
 This should bring the cluster DNS back to functioning state.
 
+## Known Issues
+
+The custom DNS configuration may not work as expected in conjunction with [`NodeLocalDNS`](node-local-dns.md).
+With `NodeLocalDNS`, ordinary dns queries targetted at the upstream DNS servers, i.e. non-kubernetes domains,
+will not end up at CoreDNS, but will instead be directly sent to the upstream DNS server. Therefore, configuration
+applying to non-kubernetes entities, e.g. the `istio.server` block in the example above, may not have any effect
+with `NodeLocalDNS` enabled. If this kind of custom configuration is required `NodeLocalDNS` needs to be disabled.
+
 ## References
 
 [1] [Import plugin](https://github.com/coredns/coredns/tree/master/plugin/import)

--- a/docs/usage/node-local-dns.md
+++ b/docs/usage/node-local-dns.md
@@ -47,3 +47,12 @@ It is worth noting that:
 - Switching node-local-dns off by removing the annotation can be a rather destructive operation that will result in pods without a working dns configuration.
 
 For more information about `node-local-dns` please refer to the [KEP](https://github.com/kubernetes/enhancements/blob/master/keps/sig-network/1024-nodelocal-cache-dns/README.md) or to the [usage documentation](https://kubernetes.io/docs/tasks/administer-cluster/nodelocaldns/). 
+
+## Known Issues
+
+The [custom DNS configuration](custom-dns-config.md) may not work as expected in conjunction with `NodeLocalDNS`.
+With `NodeLocalDNS`, ordinary dns queries targetted at the upstream DNS servers, i.e. non-kubernetes domains,
+will not end up at CoreDNS, but will instead be directly sent to the upstream DNS server. Therefore, configuration
+applying to non-kubernetes entities, e.g. the `istio.server` block in the
+[custom DNS configuration](custom-dns-config.md) example, may not have any effect with `NodeLocalDNS` enabled.
+If this kind of custom configuration is required `NodeLocalDNS` needs to be disabled.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/area documentation
/kind enhancement

**What this PR does / why we need it**:
Document restrictions with regards to custom dns configuration and node local dns.

At the moment, certain custom dns configuration is not possible in conjunction with node local dns. The documentation has been updated accordingly.

**Which issue(s) this PR fixes**:
None.

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
