### PR TITLE
Allow all traffic to `istiod` webhook server port

### DIFF
--- a/pkg/operation/botanist/component/istio/istiod.go
+++ b/pkg/operation/botanist/component/istio/istiod.go
@@ -20,20 +20,19 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/gardener/gardener/pkg/chartrenderer"
-	"github.com/gardener/gardener/pkg/features"
-	gardenletfeatures "github.com/gardener/gardener/pkg/gardenlet/features"
-	"github.com/gardener/gardener/pkg/operation/botanist/component"
-	"github.com/gardener/gardener/pkg/utils/managedresources"
-
 	networkingv1alpha3 "istio.io/client-go/pkg/apis/networking/v1alpha3"
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/gardener/gardener/pkg/chartrenderer"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
-	networkingv1 "k8s.io/api/networking/v1"
+	"github.com/gardener/gardener/pkg/features"
+	gardenletfeatures "github.com/gardener/gardener/pkg/gardenlet/features"
+	"github.com/gardener/gardener/pkg/operation/botanist/component"
+	"github.com/gardener/gardener/pkg/utils/managedresources"
 )
 
 const (
@@ -42,6 +41,7 @@ const (
 
 	istiodServiceName            = "istiod"
 	istiodServicePortNameMetrics = "metrics"
+	portWebhookServer            = 10250
 )
 
 var (
@@ -257,7 +257,7 @@ func (i *istiod) generateIstiodChart() (*chartrenderer.RenderedChart, error) {
 		"deployNamespace":   false,
 		"priorityClassName": "istiod",
 		"ports": map[string]interface{}{
-			"https": 10250,
+			"https": portWebhookServer,
 		},
 		"portsNames": map[string]interface{}{
 			"metrics": istiodServicePortNameMetrics,

--- a/pkg/operation/botanist/component/istio/istiod_test.go
+++ b/pkg/operation/botanist/component/istio/istiod_test.go
@@ -1946,6 +1946,30 @@ spec:
   - Ingress
 status: {}
 `
+		istioSystemNetworkPolicyAllowToIstiodWebhookServerPort = `apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  annotations:
+    gardener.cloud/description: Allows Ingress from all sources to the webhook server
+      port of istiod
+  creationTimestamp: null
+  name: allow-to-istiod-webhook-server-port
+  namespace: ` + deployNS + `
+spec:
+  ingress:
+  - from:
+    - ipBlock:
+        cidr: 0.0.0.0/0
+    ports:
+    - port: 10250
+      protocol: TCP
+  podSelector:
+    matchLabels:
+      app: istiod
+  policyTypes:
+  - Ingress
+status: {}
+`
 		istioSystemNetworkPolicyAllowFromIstioIngress = `apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -2410,7 +2434,7 @@ spec:
 
 			Expect(c.Get(ctx, client.ObjectKeyFromObject(managedResourceSecret), managedResourceSecret)).To(Succeed())
 			Expect(managedResourceSecret.Type).To(Equal(corev1.SecretTypeOpaque))
-			Expect(managedResourceSecret.Data).To(HaveLen(40))
+			Expect(managedResourceSecret.Data).To(HaveLen(41))
 
 			By("checking istio-istiod resources")
 			Expect(string(managedResourceSecret.Data["istio-istiod_templates_configmap.yaml"])).To(Equal(istiodConfigMap))
@@ -2453,6 +2477,7 @@ spec:
 			Expect(string(managedResourceSecret.Data["networkpolicy__test__allow-from-istio-ingress.yaml"])).To(Equal(istioSystemNetworkPolicyAllowFromIstioIngress))
 			Expect(string(managedResourceSecret.Data["networkpolicy__test__allow-from-shoot-vpn.yaml"])).To(Equal(istioSystemNetworkPolicyAllowFromShootVpn))
 			Expect(string(managedResourceSecret.Data["networkpolicy__test__allow-to-dns.yaml"])).To(Equal(istioSystemNetworkPolicyAllowToDns))
+			Expect(string(managedResourceSecret.Data["networkpolicy__test__allow-to-istiod-webhook-server-port.yaml"])).To(Equal(istioSystemNetworkPolicyAllowToIstiodWebhookServerPort))
 			Expect(string(managedResourceSecret.Data["networkpolicy__test__deny-all.yaml"])).To(Equal(istioSystemNetworkPolicyDenyAll))
 
 			By("checking istio-proxy-protocol resources")
@@ -2478,7 +2503,7 @@ spec:
 			It("should succesfully deploy pdb with correct apiVersion ", func() {
 				Expect(c.Get(ctx, client.ObjectKeyFromObject(managedResourceSecret), managedResourceSecret)).To(Succeed())
 				Expect(managedResourceSecret.Type).To(Equal(corev1.SecretTypeOpaque))
-				Expect(managedResourceSecret.Data).To(HaveLen(40))
+				Expect(managedResourceSecret.Data).To(HaveLen(41))
 
 				Expect(string(managedResourceSecret.Data["istio-istiod_templates_poddisruptionbudget.yaml"])).To(Equal(istiodPodDisruptionBudgetFor(false)))
 				Expect(string(managedResourceSecret.Data["istio-ingress_templates_poddisruptionbudget_test-ingress.yaml"])).To(Equal(istioIngressPodDisruptionBudgetFor(false)))

--- a/pkg/operation/botanist/component/istio/networkpolicies.go
+++ b/pkg/operation/botanist/component/istio/networkpolicies.go
@@ -81,7 +81,6 @@ func getIstioSystemNetworkPolicyTransformers(values IstioNetworkPolicyValues) []
 								v1beta1constants.LabelApp: istiodAppLabelValue,
 							},
 						},
-
 						Egress: []networkingv1.NetworkPolicyEgressRule{{
 							To: []networkingv1.NetworkPolicyPeer{
 								{
@@ -139,6 +138,38 @@ func getIstioSystemNetworkPolicyTransformers(values IstioNetworkPolicyValues) []
 								CIDR: fmt.Sprintf("%s/32", *values.NodeLocalIPVSAddress),
 							},
 						})
+					}
+
+					return nil
+				}
+			},
+		},
+		{
+			name: "allow-to-istiod-webhook-server-port",
+			transform: func(obj *networkingv1.NetworkPolicy) func() error {
+				return func() error {
+					obj.Annotations = map[string]string{
+						v1beta1constants.GardenerDescription: "Allows Ingress from all sources to the webhook server port of istiod",
+					}
+					obj.Spec = networkingv1.NetworkPolicySpec{
+						PodSelector: metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								v1beta1constants.LabelApp: istiodAppLabelValue,
+							},
+						},
+						Ingress: []networkingv1.NetworkPolicyIngressRule{{
+							From: []networkingv1.NetworkPolicyPeer{
+								{
+									IPBlock: &networkingv1.IPBlock{
+										CIDR: "0.0.0.0/0",
+									},
+								},
+							},
+							Ports: []networkingv1.NetworkPolicyPort{
+								{Protocol: protocolPtr(corev1.ProtocolTCP), Port: intStrPtr(portWebhookServer)},
+							},
+						}},
+						PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
 					}
 
 					return nil


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security networking
/kind bug

**What this PR does / why we need it**:
After #6826, there is a race condition when a new seed is bootstrapped: The `NetworkPolicy`s in the `istio-system` namespace do not allow the seed's API server to talk to the webhook server port of `istiod`. Hence, when a new seed is bootstrapped, depending on the order of the deployment, sometimes the `ValidatingWebhook` for `EnvoyFilter` and other istio-related resources cannot be reached. This effectively makes the `kube-apiserver`s inaccessible.

**Special notes for your reviewer**:
/cc @ScheererJ @axel7born 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
