### PR TITLE
Specify `NetworkPolicy` in kind sorter

### DIFF
--- a/pkg/chartrenderer/sorter.go
+++ b/pkg/chartrenderer/sorter.go
@@ -37,6 +37,7 @@ var InstallOrder SortOrder = []string{
 	"LimitRange",
 	"PodSecurityPolicy",
 	"PodDisruptionBudget",
+	"NetworkPolicy",
 	"Secret",
 	"ConfigMap",
 	"StorageClass",


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind enhancement

**What this PR does / why we need it**:
- Without this PR, `NetworkPolicy`s have the same "priority" than other non-specified resources, for example `EnvoyFilter`s.
- #6857 added a new `NetworkPolicy` which was important to allow the seed kube-apiserver to reach the webhook server of istiod.
- Now we could still see GRM fail with
   ```
   {"level":"error","ts":"2022-10-20T20:52:32.609Z","msg":"Reconciler error","controller":"resource","object":{"name":"istio","namespace":"istio-system"},"namespace":"istio-system","name":"istio","reconcileID":"8953c61f-64c6-4e7f-98a6-5e413468ba4c","error":"could not apply all new resources: error during apply of object \"networking.istio.io/v1alpha3/EnvoyFilter/istio-ingress/http-connect-listener\": Internal error occurred: failed calling webhook \"validation.istio.io\": failed to call webhook: Post \"[https://istiod.istio-system.svc:443/validate?timeout=10s](https://istiod.istio-system.svc/validate?timeout=10s)\": context deadline exceeded","stacktrace":"sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\t/go/src/github.com/gardener/gardener/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:326\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/go/src/github.com/gardener/gardener/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:273\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2\n\t/go/src/github.com/gardener/gardener/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:234"}
   ```
   because it has chosen to deploy the `EnvoyFilter` before the `NetworkPolicy` introduced in #6857 since both have same "priority" and lexicographic ordering applies.
- Generally and independent of this particular example, it makes sense to deploy `NetworkPolicy`s quite early before other resources.

**Special notes for your reviewer**:
/milestone v1.58
/cc @plkokanov 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
