### PR TITLE
Fix monitoring alert for failed audit logs

### DIFF
--- a/charts/seed-monitoring/charts/grafana/dashboards/operators/cluster-overview-dashboard.json
+++ b/charts/seed-monitoring/charts/grafana/dashboards/operators/cluster-overview-dashboard.json
@@ -981,7 +981,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(rate (apiserver_audit_error_total{plugin=\"webhook\"} [$__rate_interval])) by (app ,role) / ignoring(plugin) sum(rate(apiserver_audit_event_total [$__rate_interval])) by (app, role)",
+          "expr": "sum(rate (apiserver_audit_error_total{plugin!=\"log\"} [$__rate_interval])) by (app ,role) / ignoring(plugin) sum(rate(apiserver_audit_event_total [$__rate_interval])) by (app, role)",
           "format": "time_series",
           "instant": false,
           "interval": "",

--- a/pkg/operation/botanist/component/kubeapiserver/monitoring.go
+++ b/pkg/operation/botanist/component/kubeapiserver/monitoring.go
@@ -154,7 +154,7 @@ const (
       quantile: "0.9"
   ### API auditlog ###
   - alert: KubeApiServerTooManyAuditlogFailures
-    expr: sum(rate (` + monitoringMetricApiserverAuditErrorTotal + `{plugin="webhook",job="` + monitoringPrometheusJobName + `"}[5m])) / sum(rate(` + monitoringMetricApiserverAuditEventTotal + `{job="` + monitoringPrometheusJobName + `"}[5m])) > bool 0.02 == 1
+    expr: sum(rate (` + monitoringMetricApiserverAuditErrorTotal + `{plugin!="log",job="` + monitoringPrometheusJobName + `"}[5m])) / sum(rate(` + monitoringMetricApiserverAuditEventTotal + `{job="` + monitoringPrometheusJobName + `"}[5m])) > bool 0.02 == 1
     for: 15m
     labels:
       service: auditlog
@@ -167,7 +167,7 @@ const (
   - record: shoot:` + monitoringMetricApiserverAuditEventTotal + `:sum
     expr: sum(rate(` + monitoringMetricApiserverAuditEventTotal + `{job="` + monitoringPrometheusJobName + `"}[5m]))
   - record: shoot:` + monitoringMetricApiserverAuditErrorTotal + `:sum
-    expr: sum(rate(` + monitoringMetricApiserverAuditErrorTotal + `{plugin="webhook",job="` + monitoringPrometheusJobName + `"}[5m]))
+    expr: sum(rate(` + monitoringMetricApiserverAuditErrorTotal + `{plugin!="log",job="` + monitoringPrometheusJobName + `"}[5m]))
   ### API latency ###
   - record: ` + monitoringMetricApiserverLatencySeconds + `:quantile
     expr: histogram_quantile(0.99, sum without (instance, pod) (rate(` + monitoringMetricApiserverRequestDurationSecondsBucket + `[5m])))

--- a/pkg/operation/botanist/component/kubeapiserver/monitoring_test.go
+++ b/pkg/operation/botanist/component/kubeapiserver/monitoring_test.go
@@ -161,7 +161,7 @@ metric_relabel_configs:
       quantile: "0.9"
   ### API auditlog ###
   - alert: KubeApiServerTooManyAuditlogFailures
-    expr: sum(rate (apiserver_audit_error_total{plugin="webhook",job="kube-apiserver"}[5m])) / sum(rate(apiserver_audit_event_total{job="kube-apiserver"}[5m])) > bool 0.02 == 1
+    expr: sum(rate (apiserver_audit_error_total{plugin!="log",job="kube-apiserver"}[5m])) / sum(rate(apiserver_audit_event_total{job="kube-apiserver"}[5m])) > bool 0.02 == 1
     for: 15m
     labels:
       service: auditlog
@@ -174,7 +174,7 @@ metric_relabel_configs:
   - record: shoot:apiserver_audit_event_total:sum
     expr: sum(rate(apiserver_audit_event_total{job="kube-apiserver"}[5m]))
   - record: shoot:apiserver_audit_error_total:sum
-    expr: sum(rate(apiserver_audit_error_total{plugin="webhook",job="kube-apiserver"}[5m]))
+    expr: sum(rate(apiserver_audit_error_total{plugin!="log",job="kube-apiserver"}[5m]))
   ### API latency ###
   - record: apiserver_latency_seconds:quantile
     expr: histogram_quantile(0.99, sum without (instance, pod) (rate(apiserver_request_duration_seconds_bucket[5m])))

--- a/pkg/operation/botanist/component/kubeapiserver/testdata/monitoring_alertingrules.yaml
+++ b/pkg/operation/botanist/component/kubeapiserver/testdata/monitoring_alertingrules.yaml
@@ -26,7 +26,7 @@ tests:
   - series: 'apiserver_request_duration_seconds_bucket{verb="POST", le="3"}'
     values: '0+0x62'
   # KubeApiServerTooManyAuditlogFailures
-  - series: 'apiserver_audit_error_total{plugin="webhook", job="kube-apiserver"}'
+  - series: 'apiserver_audit_error_total{plugin!="log", job="kube-apiserver"}'
     values: '1+1x31'
   - series: 'apiserver_audit_event_total{job="kube-apiserver"}'
     values: '0+30x31'

--- a/pkg/operation/botanist/component/kubeapiserver/testdata/monitoring_alertingrules.yaml
+++ b/pkg/operation/botanist/component/kubeapiserver/testdata/monitoring_alertingrules.yaml
@@ -26,7 +26,7 @@ tests:
   - series: 'apiserver_request_duration_seconds_bucket{verb="POST", le="3"}'
     values: '0+0x62'
   # KubeApiServerTooManyAuditlogFailures
-  - series: 'apiserver_audit_error_total{plugin!="log", job="kube-apiserver"}'
+  - series: 'apiserver_audit_error_total{plugin="webhook", job="kube-apiserver"}'
     values: '1+1x31'
   - series: 'apiserver_audit_event_total{job="kube-apiserver"}'
     values: '0+30x31'


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area audit-logging monitoring
/kind bug

**What this PR does / why we need it**:
Fix monitoring alert for failed audit logs.
The `apiserver_audit_error_total` metric have a label `plugin` which values except `webhook` can be `buffered`, `log` and `truncate` and for the alert all metrics except those from the `log` plugin are relevant. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
The `KubeApiServerTooManyAuditlogFailures` alert is now fixed to fire also when the audit plugins `buffered` and `truncate` are failing to process an audit event.
```
