### PR TITLE
[GEP-20] Adjust Control Plane Status Dashboard

### DIFF
--- a/charts/seed-monitoring/charts/grafana/dashboards/owners/kubernetes-control-plane-status-dashboard.json
+++ b/charts/seed-monitoring/charts/grafana/dashboards/owners/kubernetes-control-plane-status-dashboard.json
@@ -1428,21 +1428,21 @@
               "expr": "rate(container_cpu_usage_seconds_total{pod=~\"kube-controller-manager-(.+)\"}[$__rate_interval])",
               "format": "time_series",
               "intervalFactor": 1,
-              "legendFormat": "current",
+              "legendFormat": "{{pod}}-current",
               "refId": "A"
             },
             {
               "expr": "kube_pod_container_resource_limits{resource=\"cpu\", unit=\"core\", pod=~\"kube-controller-manager-(.+)\"}",
               "format": "time_series",
               "intervalFactor": 1,
-              "legendFormat": "limits",
+              "legendFormat": "{{pod}}-limits",
               "refId": "C"
             },
             {
               "expr": "kube_pod_container_resource_requests{resource=\"cpu\", unit=\"core\", pod=~\"kube-controller-manager-(.+)\"}",
               "format": "time_series",
               "intervalFactor": 1,
-              "legendFormat": "requests",
+              "legendFormat": "{{pod}}-requests",
               "refId": "B"
             }
           ],
@@ -1529,21 +1529,21 @@
               "expr": "container_memory_working_set_bytes{pod=~\"kube-controller-manager-(.+)\"}",
               "format": "time_series",
               "intervalFactor": 1,
-              "legendFormat": "current",
+              "legendFormat": "{{pod}}-current",
               "refId": "A"
             },
             {
               "expr": "kube_pod_container_resource_limits{resource=\"memory\", unit=\"byte\", pod=~\"kube-controller-manager-(.+)\"}",
               "format": "time_series",
               "intervalFactor": 1,
-              "legendFormat": "limits",
+              "legendFormat": "{{pod}}-limits",
               "refId": "B"
             },
             {
               "expr": "kube_pod_container_resource_requests{resource=\"memory\", unit=\"byte\", pod=~\"kube-controller-manager-(.+)\"}",
               "format": "time_series",
               "intervalFactor": 1,
-              "legendFormat": "requests",
+              "legendFormat": "{{pod}}-requests",
               "refId": "C"
             }
           ],
@@ -1732,21 +1732,21 @@
               "expr": "rate(container_cpu_usage_seconds_total{pod=~\"kube-scheduler-(.+)\"}[$__rate_interval])",
               "format": "time_series",
               "intervalFactor": 1,
-              "legendFormat": "current",
+              "legendFormat": "{{pod}}-current",
               "refId": "A"
             },
             {
               "expr": "kube_pod_container_resource_limits{resource=\"cpu\", unit=\"core\", pod=~\"kube-scheduler-(.+)\"}",
               "format": "time_series",
               "intervalFactor": 1,
-              "legendFormat": "limits",
+              "legendFormat": "{{pod}}-limits",
               "refId": "C"
             },
             {
               "expr": "kube_pod_container_resource_requests{resource=\"cpu\", unit=\"core\", pod=~\"kube-scheduler-(.+)\"}",
               "format": "time_series",
               "intervalFactor": 1,
-              "legendFormat": "requests",
+              "legendFormat": "{{pod}}-requests",
               "refId": "B"
             }
           ],
@@ -1833,21 +1833,21 @@
               "expr": "container_memory_working_set_bytes{pod=~\"kube-scheduler-(.+)\"}",
               "format": "time_series",
               "intervalFactor": 1,
-              "legendFormat": "current",
+              "legendFormat": "{{pod}}-current",
               "refId": "A"
             },
             {
               "expr": "kube_pod_container_resource_limits{resource=\"memory\", unit=\"byte\", pod=~\"kube-scheduler-(.+)\"}",
               "format": "time_series",
               "intervalFactor": 1,
-              "legendFormat": "limits",
+              "legendFormat": "{{pod}}-limits",
               "refId": "B"
             },
             {
               "expr": "kube_pod_container_resource_requests{resource=\"memory\", unit=\"byte\", pod=~\"kube-scheduler-(.+)\"}",
               "format": "time_series",
               "intervalFactor": 1,
-              "legendFormat": "requests",
+              "legendFormat": "{{pod}}-requests",
               "refId": "C"
             }
           ],


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/area high-availability
/kind enhancement

**What this PR does / why we need it**:
This PR adjust the `Kubenetes Control Plane Status` dashboard to correctly show CPU and Memory usage for `kube-controller-manager` and `kube-scheduler` if they are deployed with multiple replicas.

**Which issue(s) this PR fixes**:
Fixes partly #6529

**Special notes for your reviewer**:
I also checked the dashboard for other components that will run with multiple replicas in the future, the configuration should already be sufficient.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The `Kubernetes Control Plane Status` dashboard has been updated to show correct values for `kube-controller-manager` and `kube-scheduler` once they are deployed with multiple replicas for HA shoots.
```
