### PR TITLE
Adapt static telegraf in the Loki pod

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -240,7 +240,7 @@ images:
 - name: fluent-bit-plugin-installer
   sourceRepository: github.com/gardener/logging
   repository: eu.gcr.io/gardener-project/gardener/fluent-bit-to-loki
-  tag: "v0.45.0"
+  tag: "v0.46.0"
 - name: loki
   sourceRepository: github.com/grafana/loki
   repository: grafana/loki
@@ -248,7 +248,7 @@ images:
 - name: loki-curator
   sourceRepository: github.com/gardener/logging
   repository: eu.gcr.io/gardener-project/gardener/loki-curator
-  tag: "v0.45.0"
+  tag: "v0.46.0"
 - name: kube-rbac-proxy
   sourceRepository: github.com/brancz/kube-rbac-proxy
   repository: quay.io/brancz/kube-rbac-proxy
@@ -260,11 +260,11 @@ images:
 - name: telegraf
   sourceRepository: github.com/gardener/logging
   repository: eu.gcr.io/gardener-project/gardener/telegraf-iptables
-  tag: "v0.45.0"
+  tag: "v0.46.0"
 - name: event-logger
   sourceRepository: github.com/gardener/logging
   repository: eu.gcr.io/gardener-project/gardener/event-logger
-  tag: "v0.45.0"
+  tag: "v0.46.0"
 
 # VPA
 - name: vpa-admission-controller

--- a/charts/seed-bootstrap/charts/loki/templates/_helpers.tpl
+++ b/charts/seed-bootstrap/charts/loki/templates/_helpers.tpl
@@ -78,7 +78,6 @@ telegraf.conf: |+
 start.sh: |+
   #/bin/bash
 
-  touch /run/xtables.lock
   iptables -A INPUT -p tcp --dport {{ .Values.kubeRBACProxy.port }}  -j ACCEPT -m comment --comment "promtail"
   /usr/bin/telegraf --config /etc/telegraf/telegraf.conf
 {{- end -}}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area logging
/kind enhancement

**What this PR does / why we need it**:
With this PR the `Telegraf` in the Loki pod is changed to use a static binary image.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator github.com/gardener/logging #158 @vlvasilev 
The Telegraf image used by Loki pod is built from scratch with static binary.
```
