### PR TITLE
Rename `validate-namespace-deletion` VWC to `gardener-admission-controller`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -347,7 +347,7 @@ gardener-down: $(SKAFFOLD) $(HELM) $(KUBECTL)
 	$(KUBECTL) delete seed local-ha --ignore-not-found --wait --timeout 5m
 	$(KUBECTL) delete seed local2 --ignore-not-found --wait --timeout 5m
 	$(SKAFFOLD) delete -m provider-local,gardenlet
-	$(KUBECTL) delete validatingwebhookconfiguration/validate-namespace-deletion --ignore-not-found
+	$(KUBECTL) delete validatingwebhookconfiguration/gardener-admission-controller --ignore-not-found
 	$(KUBECTL) annotate project local garden confirmation.gardener.cloud/deletion=true
 	$(SKAFFOLD) delete -m local-env
 	$(SKAFFOLD) delete -m etcd,controlplane

--- a/charts/gardener/controlplane/charts/application/templates/validatingwebhook-admission-controller.yaml
+++ b/charts/gardener/controlplane/charts/application/templates/validatingwebhook-admission-controller.yaml
@@ -2,7 +2,7 @@
 apiVersion: {{ include "webhookadmissionregistration" . }}
 kind: ValidatingWebhookConfiguration
 metadata:
-  name: validate-namespace-deletion
+  name: gardener-admission-controller
 webhooks:
 - name: validate-namespace-deletion.gardener.cloud
   admissionReviewVersions: ["v1", "v1beta1"]


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind cleanup

**What this PR does / why we need it**:
This PR renames the `validate-namespace-deletion` ValidatingWebhookConfiguration to `gardener-admission-controller` to prevent confusion when people search for the gardener-admission-controller's ValidatingWebhookConfiguration.

**Which issue(s) this PR fixes**:
Fixes #6858

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
The `validate-namespace-deletion` `ValidatingWebhookConfiguration` is renamed to `gardener-admission-controller`. You might need to cleanup the existing `validate-namespace-deletion` `ValidatingWebhookConfiguration`.
```
