### PR TITLE
Explicitly set seccomp profile for nginx-ingress-controller

### DIFF
--- a/charts/shoot-addons/charts/nginx-ingress/templates/controller-deployment.yaml
+++ b/charts/shoot-addons/charts/nginx-ingress/templates/controller-deployment.yaml
@@ -66,6 +66,10 @@ spec:
           - --{{ $key }}={{ $value }}
           {{- end }}
           securityContext:
+{{- if semverCompare ">= 1.19-0" .Capabilities.KubeVersion.GitVersion }}
+            seccompProfile:
+              type: Unconfined
+{{- end }}
             capabilities:
                 drop:
                 - ALL

--- a/pkg/operation/botanist/component/nginxingress/nginxingress.go
+++ b/pkg/operation/botanist/component/nginxingress/nginxingress.go
@@ -148,10 +148,6 @@ func (n *nginxIngress) computeResourcesData() (map[string][]byte, error) {
 
 	utilruntime.Must(kutil.MakeUnique(configMap))
 
-	k8sVersionGreaterEqual119, err := version.CompareVersions(n.values.KubernetesVersion, ">=", "1.19")
-	if err != nil {
-		return nil, err
-	}
 	k8sVersionGreaterEqual121, err := version.CompareVersions(n.values.KubernetesVersion, ">=", "1.21")
 	if err != nil {
 		return nil, err
@@ -583,9 +579,7 @@ func (n *nginxIngress) computeResourcesData() (map[string][]byte, error) {
 	// Skipped until https://github.com/kubernetes/ingress-nginx/issues/8640 is resolved
 	// and special seccomp profile is implemented for the nginx-ingress
 	deploymentController.Spec.Template.Labels[resourcesv1alpha1.SeccompProfileSkip] = "true"
-	if k8sVersionGreaterEqual119 {
-		deploymentController.Spec.Template.Spec.Containers[0].SecurityContext.SeccompProfile = &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeUnconfined}
-	}
+	deploymentController.Spec.Template.Spec.Containers[0].SecurityContext.SeccompProfile = &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeUnconfined}
 
 	if k8sVersionGreaterEqual122 {
 		ingressClass = &networkingv1.IngressClass{

--- a/pkg/operation/botanist/component/nginxingress/nginxingress.go
+++ b/pkg/operation/botanist/component/nginxingress/nginxingress.go
@@ -437,6 +437,7 @@ func (n *nginxIngress) computeResourcesData() (map[string][]byte, error) {
 								},
 								RunAsUser:                pointer.Int64(101),
 								AllowPrivilegeEscalation: pointer.Bool(true),
+								SeccompProfile:           &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeUnconfined},
 							},
 							Env: []corev1.EnvVar{
 								{
@@ -579,7 +580,6 @@ func (n *nginxIngress) computeResourcesData() (map[string][]byte, error) {
 	// Skipped until https://github.com/kubernetes/ingress-nginx/issues/8640 is resolved
 	// and special seccomp profile is implemented for the nginx-ingress
 	deploymentController.Spec.Template.Labels[resourcesv1alpha1.SeccompProfileSkip] = "true"
-	deploymentController.Spec.Template.Spec.Containers[0].SecurityContext.SeccompProfile = &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeUnconfined}
 
 	if k8sVersionGreaterEqual122 {
 		ingressClass = &networkingv1.IngressClass{

--- a/pkg/operation/botanist/component/nginxingress/nginxingress.go
+++ b/pkg/operation/botanist/component/nginxingress/nginxingress.go
@@ -148,6 +148,10 @@ func (n *nginxIngress) computeResourcesData() (map[string][]byte, error) {
 
 	utilruntime.Must(kutil.MakeUnique(configMap))
 
+	k8sVersionGreaterEqual119, err := version.CompareVersions(n.values.KubernetesVersion, ">=", "1.19")
+	if err != nil {
+		return nil, err
+	}
 	k8sVersionGreaterEqual121, err := version.CompareVersions(n.values.KubernetesVersion, ">=", "1.21")
 	if err != nil {
 		return nil, err
@@ -579,6 +583,9 @@ func (n *nginxIngress) computeResourcesData() (map[string][]byte, error) {
 	// Skipped until https://github.com/kubernetes/ingress-nginx/issues/8640 is resolved
 	// and special seccomp profile is implemented for the nginx-ingress
 	deploymentController.Spec.Template.Labels[resourcesv1alpha1.SeccompProfileSkip] = "true"
+	if k8sVersionGreaterEqual119 {
+		deploymentController.Spec.Template.Spec.Containers[0].SecurityContext.SeccompProfile = &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeUnconfined}
+	}
 
 	if k8sVersionGreaterEqual122 {
 		ingressClass = &networkingv1.IngressClass{

--- a/pkg/operation/botanist/component/nginxingress/nginxingress_test.go
+++ b/pkg/operation/botanist/component/nginxingress/nginxingress_test.go
@@ -423,7 +423,7 @@ spec:
       terminationGracePeriodSeconds: 60
 status: {}
 `
-			deploymentControllerYAMLFor = func(k8sVersionGreaterEqual122 bool) string {
+			deploymentControllerYAMLFor = func(k8sVersionGreaterEqual119, k8sVersionGreaterEqual122 bool) string {
 				out := `apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -546,7 +546,15 @@ spec:
 				out += `
             drop:
             - ALL
-          runAsUser: 101
+          runAsUser: 101`
+
+				if k8sVersionGreaterEqual119 {
+					out += `
+          seccompProfile:
+            type: Unconfined`
+				}
+
+				out += `
       priorityClassName: gardener-system-600
       serviceAccountName: nginx-ingress
       terminationGracePeriodSeconds: 60
@@ -607,7 +615,7 @@ status: {}
 			})
 
 			It("should successfully deploy all resources", func() {
-				Expect(string(managedResourceSecret.Data["deployment__"+namespace+"__nginx-ingress-controller.yaml"])).To(Equal(deploymentControllerYAMLFor(true)))
+				Expect(string(managedResourceSecret.Data["deployment__"+namespace+"__nginx-ingress-controller.yaml"])).To(Equal(deploymentControllerYAMLFor(true, true)))
 				Expect(string(managedResourceSecret.Data["ingressclass____"+v1beta1constants.SeedNginxIngressClass122+".yaml"])).To(Equal(ingressClassYAML))
 				Expect(string(managedResourceSecret.Data["poddisruptionbudget__"+namespace+"__nginx-ingress-controller.yaml"])).To(Equal(podDisruptionBudgetYAMLFor(true)))
 			})
@@ -620,7 +628,7 @@ status: {}
 			})
 
 			It("should successfully deploy all resources", func() {
-				Expect(string(managedResourceSecret.Data["deployment__"+namespace+"__nginx-ingress-controller.yaml"])).To(Equal(deploymentControllerYAMLFor(false)))
+				Expect(string(managedResourceSecret.Data["deployment__"+namespace+"__nginx-ingress-controller.yaml"])).To(Equal(deploymentControllerYAMLFor(false, false)))
 				Expect(string(managedResourceSecret.Data["poddisruptionbudget__"+namespace+"__nginx-ingress-controller.yaml"])).To(Equal(podDisruptionBudgetYAMLFor(false)))
 			})
 		})


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area open-source security
/kind bug

**What this PR does / why we need it**:
After https://github.com/gardener/gardener/pull/6741 it is possible to enable cluster-wide seccomp defaulting. Also there is the [seccomp defaulting webhook](https://github.com/gardener/gardener/pull/6450/files). These do not play well with the `nginx-ingress-controller`. The `nginx-ingress-controller` needs a customized seccomp profile which is not well documented (see [ref](https://github.com/kubernetes/ingress-nginx/issues/8640)). Also customized seccomp profiles are not trivial to distribute. Some options will be a daemonset or a security profiles [operator](https://github.com/kubernetes-sigs/security-profiles-operator). Adding the `CAP_SYS_ADMIN` capability [ref](https://github.com/torvalds/linux/blob/master/include/uapi/linux/capability.h) can make it work, but this actually alters the provided seccomp profile by enabling additional syscalls. This is not ideal because the container also gains the capabilities of `SYS_ADMIN`. Read more on seccomp vs linux capabilities [here](https://security.stackexchange.com/questions/210400/difference-between-linux-capabities-and-seccomp).

This PR explicitly sets the seccomp profile for the `nginx-ingress-controller` to Unconfined. This is the also what the current default seccomp profile is in kubernetes.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
An issue causing the `nginx-ingress-controller` installed via the shoot's `nginx-ingress` addon to fail to start when cluster-wide seccomp defaulting is enabled is now fixed.
```
