### PR TITLE
Drop the `gardener-shoot-controlplane` PriorityClass

### DIFF
--- a/docs/development/priority-classes.md
+++ b/docs/development/priority-classes.md
@@ -46,7 +46,3 @@ The listed well-known `PriorityClasses` follow this rough concept:
 | `gardener-system-300` | 999998300 | `cloud-controller-manager`, `cluster-autoscaler`, `csi-driver-controller`, `kube-controller-manager`, `kube-scheduler`, `machine-controller-manager`, `terraformer`, `vpn-seed-server` |
 | `gardener-system-200` | 999998200 | `csi-snapshot-controller`, `csi-snapshot-validation`, `cert-controller-manager`, `shoot-dns-service`, `vpa-admission-controller`, `vpa-recommender`, `vpa-updater`                     |
 | `gardener-system-100` | 999998100 | `alertmanager`, `grafana-operators`, `grafana-users`, `kube-state-metrics`, `prometheus`, `loki`, `event-logger`                                                                       |
-
-There is also a legacy `PriorityClass` called `gardener-shoot-controlplane` with value `100`.
-This `PriorityClass` is deprecated and will be removed in a future release.
-Make sure to migrate all your components to the above listed fine-granular `PriorityClasses`.

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -757,9 +757,6 @@ const (
 	// PriorityClassNameShootControlPlane100 is the name of a PriorityClass for Shoot control plane components.
 	// Please consider the documentation in https://github.com/gardener/gardener/blob/master/docs/development/priority-classes.md
 	PriorityClassNameShootControlPlane100 = "gardener-system-100"
-	// PriorityClassNameShootControlPlane is the name of a PriorityClass for Shoot control plane components.
-	// Deprecated: this PriorityClass will be removed in a future version, use the fine-granular PriorityClasses above instead.
-	PriorityClassNameShootControlPlane = "gardener-shoot-controlplane"
 
 	// TechnicalIDPrefix is a prefix used for a shoot's technical id.
 	TechnicalIDPrefix = "shoot--"

--- a/pkg/operation/botanist/component/seedsystem/seedsystem.go
+++ b/pkg/operation/botanist/component/seedsystem/seedsystem.go
@@ -176,8 +176,6 @@ var gardenletManagedPriorityClasses = []struct {
 	{v1beta1constants.PriorityClassNameShootControlPlane300, 999998300, "PriorityClass for Shoot control plane components"},
 	{v1beta1constants.PriorityClassNameShootControlPlane200, 999998200, "PriorityClass for Shoot control plane components"},
 	{v1beta1constants.PriorityClassNameShootControlPlane100, 999998100, "PriorityClass for Shoot control plane components"},
-	// TODO: remove this in a future release once all components have been migrated to the other fine-granular PriorityClasses.
-	{v1beta1constants.PriorityClassNameShootControlPlane, 100, "DEPRECATED PriorityClass for Shoot control plane components"},
 }
 
 func addPriorityClasses(registry *managedresources.Registry) error {

--- a/pkg/operation/botanist/component/seedsystem/seedsystem_test.go
+++ b/pkg/operation/botanist/component/seedsystem/seedsystem_test.go
@@ -152,7 +152,7 @@ status: {}
 		})
 
 		It("should successfully deploy the resources", func() {
-			Expect(managedResourceSecret.Data).To(HaveLen(12))
+			Expect(managedResourceSecret.Data).To(HaveLen(11))
 			Expect(string(managedResourceSecret.Data["deployment__"+namespace+"__reserve-excess-capacity.yaml"])).To(Equal(deploymentYAML))
 			expectPriorityClasses(managedResourceSecret.Data)
 		})
@@ -276,7 +276,6 @@ func expectPriorityClasses(data map[string][]byte) {
 		{"gardener-system-300", 999998300, "PriorityClass for Shoot control plane components"},
 		{"gardener-system-200", 999998200, "PriorityClass for Shoot control plane components"},
 		{"gardener-system-100", 999998100, "PriorityClass for Shoot control plane components"},
-		{"gardener-shoot-controlplane", 100, "DEPRECATED PriorityClass for Shoot control plane components"},
 	}
 
 	for _, pc := range expected {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind cleanup

**What this PR does / why we need it**:
This PR is similar to https://github.com/gardener/gardener/commit/d2dddea9b0368519a6ae19d0687f7d2cc6c3d5d8 (part of https://github.com/gardener/gardener/pull/6738). Back then we had to revert this commit with https://github.com/gardener/gardener/pull/6799 due to https://github.com/gardener/gardener/issues/6798. This revert was done in v1.58.0 and cherry-picked to v1.57.1. Now in v1.59.0 it should be safe to delete this `gardener-shoot-controlplane` PriorityClass as components like vpn-seed-server should have been already reconciled with gardenlet >= 1.57.1 and no longer use the `gardener-shoot-controlplane` PriorityClass.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/5634

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
The `gardener-shoot-controlplane` `PriorityClass` is now deleted by `gardenlet`. Before updating to this version of Gardener, make sure that there are no extensions or external components still using this `PriorityClass`. Refer to [this documentation](https://github.com/gardener/gardener/blob/v1.58.0/docs/development/priority-classes.md) to find out which `PriorityClass` should be used instead.
```
