### PR TITLE
Update `kindest/node` image to v1.24.7

### DIFF
--- a/example/gardener-local/kind-ha/cluster-local.yaml
+++ b/example/gardener-local/kind-ha/cluster-local.yaml
@@ -3,7 +3,7 @@ kind: Cluster
 nodes:
 - role: control-plane
   topology.kubernetes.io/zone: "0"
-  image: kindest/node:v1.24.0
+  image: kindest/node:v1.24.7
   extraPortMappings:
   # istio-ingressgateway
   - containerPort: 30443
@@ -52,7 +52,7 @@ nodes:
 - role: worker
   labels:
     topology.kubernetes.io/zone: "1"
-  image: kindest/node:v1.24.0
+  image: kindest/node:v1.24.7
   extraMounts:
   - hostPath: example/gardener-local/controlplane
     containerPath: /etc/gardener/controlplane
@@ -64,7 +64,7 @@ nodes:
 - role: worker
   labels:
     topology.kubernetes.io/zone: "2"
-  image: kindest/node:v1.24.0
+  image: kindest/node:v1.24.7
   extraMounts:
   - hostPath: example/gardener-local/controlplane
     containerPath: /etc/gardener/controlplane

--- a/example/gardener-local/kind-ha/cluster-skaffold.yaml
+++ b/example/gardener-local/kind-ha/cluster-skaffold.yaml
@@ -2,7 +2,7 @@ apiVersion: kind.x-k8s.io/v1alpha4
 kind: Cluster
 nodes:
 - role: control-plane
-  image: kindest/node:v1.24.0
+  image: kindest/node:v1.24.7
   labels:
     topology.kubernetes.io/zone: "0"
   extraPortMappings:
@@ -52,7 +52,7 @@ nodes:
 - role: worker
   labels:
     topology.kubernetes.io/zone: "1"
-  image: kindest/node:v1.24.0
+  image: kindest/node:v1.24.7
   extraMounts:
   - hostPath: example/gardener-local/controlplane
     containerPath: /etc/gardener/controlplane
@@ -64,7 +64,7 @@ nodes:
 - role: worker
   labels:
     topology.kubernetes.io/zone: "2"
-  image: kindest/node:v1.24.0
+  image: kindest/node:v1.24.7
   extraMounts:
   - hostPath: example/gardener-local/controlplane
     containerPath: /etc/gardener/controlplane

--- a/example/gardener-local/kind/cluster-local.yaml
+++ b/example/gardener-local/kind/cluster-local.yaml
@@ -2,7 +2,7 @@ apiVersion: kind.x-k8s.io/v1alpha4
 kind: Cluster
 nodes:
 - role: control-plane
-  image: kindest/node:v1.24.0
+  image: kindest/node:v1.24.7
   extraPortMappings:
   # istio-ingressgateway
   - containerPort: 30443

--- a/example/gardener-local/kind/cluster-skaffold.yaml
+++ b/example/gardener-local/kind/cluster-skaffold.yaml
@@ -2,7 +2,7 @@ apiVersion: kind.x-k8s.io/v1alpha4
 kind: Cluster
 nodes:
 - role: control-plane
-  image: kindest/node:v1.24.0
+  image: kindest/node:v1.24.7
   extraPortMappings:
   # istio-ingressgateway
   - containerPort: 30443

--- a/example/gardener-local/kind2/cluster-local.yaml
+++ b/example/gardener-local/kind2/cluster-local.yaml
@@ -2,7 +2,7 @@ apiVersion: kind.x-k8s.io/v1alpha4
 kind: Cluster
 nodes:
 - role: control-plane
-  image: kindest/node:v1.24.0
+  image: kindest/node:v1.24.7
   extraPortMappings:
   # istio-ingressgateway
   - containerPort: 30443

--- a/example/gardener-local/kind2/cluster-skaffold.yaml
+++ b/example/gardener-local/kind2/cluster-skaffold.yaml
@@ -2,7 +2,7 @@ apiVersion: kind.x-k8s.io/v1alpha4
 kind: Cluster
 nodes:
 - role: control-plane
-  image: kindest/node:v1.24.0
+  image: kindest/node:v1.24.7
   extraPortMappings:
   # istio-ingressgateway
   # TODO (plkokanov): when using skaffold to deploy, 127.0.0.2 is not used as listenAddress (unlike the local deployment)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind cleanup

**What this PR does / why we need it**:
While looking into test failure reasons, in the kind's kube-apiserver logs I noticed the following logs:
```
2022-10-25T12:40:14.755270505Z stderr F W1025 12:40:14.755061       1 merge.go:121] Should not happen: OpenAPI V3 merge schema conflict on io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
2022-10-25T12:40:14.755300989Z stderr F W1025 12:40:14.755093       1 merge.go:121] Should not happen: OpenAPI V3 merge schema conflict on io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta
...
```

This is a known issue fixed in v1.24.1 - ref https://github.com/kubernetes/kubernetes/issues/109871.
To prevent having test failures that are potentially caused by already fixed upstream issues, I guess it makes sense to update the `kindest/node` image to the latest available patch release.

**Which issue(s) this PR fixes**:
Does not fix a particular issue

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
