### PR TITLE
[gardener-local] Run 2 replicas of admission-controller

### DIFF
--- a/example/gardener-local/controlplane/values.yaml
+++ b/example/gardener-local/controlplane/values.yaml
@@ -248,7 +248,7 @@ global:
               2gdfX1KfoWJn/MxI5UKf5RZ2ygmNCTqdLFK/5v7zr4aMw5fSxc9Hf0WuKA8EGzfw
               8dNU6RXARJRSWWKk7wAxSoiNZT/L9VdB0DxZNgZiPBNzdSN6ovgG
               -----END RSA PRIVATE KEY-----
-    replicaCount: 1
+    replicaCount: 2
     resources: {}
 
   # Gardener controller manager configuration values


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind bug

**What this PR does / why we need it**:

Without this PR, subsequent invocations of `make gardener-up` might fail with
```
Error: UPGRADE FAILED: update: failed to update: Internal error occurred: failed calling webhook "validate-kubeconfig-secrets.gardener.cloud": failed to call webhook: Post "https://gardener-admission-controller.garden.svc:443/webhooks/validate-kubeconfig-secrets?timeout=10s": dial tcp 10.2.2.10:443: connect: connection refused
deploying "gardener-controlplane": install: exit status 1
```

