### PR TITLE
Add helper functions to parse error code from error

### DIFF
--- a/extensions/pkg/util/errors.go
+++ b/extensions/pkg/util/errors.go
@@ -1,0 +1,80 @@
+// Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"errors"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+// DetermineError determines the Gardener error codes for the given error and returns an ErrorWithCodes with the error and codes.
+func DetermineError(err error, knownCodes map[gardencorev1beta1.ErrorCode]func(string) bool) error {
+	if err == nil {
+		return nil
+	}
+
+	// try to re-use codes from error
+	var coder gardencorev1beta1helper.Coder
+	if errors.As(err, &coder) {
+		return err
+	}
+
+	codes := DetermineErrorCodes(err, knownCodes)
+	if len(codes) == 0 {
+		return err
+	}
+
+	return gardencorev1beta1helper.NewErrorWithCodes(err, codes...)
+}
+
+// DetermineErrorCodes determines error codes based on the given error.
+func DetermineErrorCodes(err error, knownCodes map[gardencorev1beta1.ErrorCode]func(string) bool) []gardencorev1beta1.ErrorCode {
+	var (
+		coder   gardencorev1beta1helper.Coder
+		message = err.Error()
+		codes   = sets.NewString()
+	)
+
+	if err == nil {
+		return nil
+	}
+
+	// try to re-use codes from error
+	if errors.As(err, &coder) {
+		for _, code := range coder.Codes() {
+			codes.Insert(string(code))
+			// found codes don't need to be checked any more
+			delete(knownCodes, code)
+		}
+	}
+
+	// determine error codes
+	for code, matchFn := range knownCodes {
+		if !codes.Has(string(code)) && matchFn(message) {
+			codes.Insert(string(code))
+		}
+	}
+
+	// compute error code list based on code string set
+	var out []gardencorev1beta1.ErrorCode
+	for _, c := range codes.List() {
+		out = append(out, gardencorev1beta1.ErrorCode(c))
+	}
+	return out
+}

--- a/extensions/pkg/util/errors.go
+++ b/extensions/pkg/util/errors.go
@@ -59,8 +59,6 @@ func DetermineErrorCodes(err error, knownCodes map[gardencorev1beta1.ErrorCode]f
 	if errors.As(err, &coder) {
 		for _, code := range coder.Codes() {
 			codes.Insert(string(code))
-			// found codes don't need to be checked any more
-			delete(knownCodes, code)
 		}
 	}
 

--- a/extensions/pkg/util/errors_test.go
+++ b/extensions/pkg/util/errors_test.go
@@ -1,0 +1,181 @@
+// Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util_test
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+
+	. "github.com/gardener/gardener/extensions/pkg/util"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("errors", func() {
+	var (
+		unauthenticatedRegexp               = regexp.MustCompile(`(?i)(InvalidAuthenticationTokenTenant|Authentication failed)`)
+		unauthorizedRegexp                  = regexp.MustCompile(`(?i)(Unauthorized|AuthorizationFailed|AccessDenied|OperationNotAllowed)`)
+		quotaExceededRegexp                 = regexp.MustCompile(`(?i)((?:^|[^t]|(?:[^s]|^)t|(?:[^e]|^)st|(?:[^u]|^)est|(?:[^q]|^)uest|(?:[^e]|^)quest|(?:[^r]|^)equest)LimitExceeded)`)
+		rateLimitsExceededRegexp            = regexp.MustCompile(`(?i)(RequestLimitExceeded|Throttling)`)
+		dependenciesRegexp                  = regexp.MustCompile(`(?i)(PendingVerification)`)
+		retryableDependenciesRegexp         = regexp.MustCompile(`(?i)(RetryableError)`)
+		resourcesDepletedRegexp             = regexp.MustCompile(`(?i)(not available in the current hardware cluster)`)
+		configurationProblemRegexp          = regexp.MustCompile(`(?i)(InvalidParameter)`)
+		retryableConfigurationProblemRegexp = regexp.MustCompile(`(?i)(is misconfigured and requires zero voluntary evictions)`)
+
+		knownCodes = map[gardencorev1beta1.ErrorCode]func(string) bool{
+			gardencorev1beta1.ErrorInfraUnauthenticated:          unauthenticatedRegexp.MatchString,
+			gardencorev1beta1.ErrorInfraUnauthorized:             unauthorizedRegexp.MatchString,
+			gardencorev1beta1.ErrorInfraQuotaExceeded:            quotaExceededRegexp.MatchString,
+			gardencorev1beta1.ErrorInfraRateLimitsExceeded:       rateLimitsExceededRegexp.MatchString,
+			gardencorev1beta1.ErrorInfraDependencies:             dependenciesRegexp.MatchString,
+			gardencorev1beta1.ErrorRetryableInfraDependencies:    retryableDependenciesRegexp.MatchString,
+			gardencorev1beta1.ErrorInfraResourcesDepleted:        resourcesDepletedRegexp.MatchString,
+			gardencorev1beta1.ErrorConfigurationProblem:          configurationProblemRegexp.MatchString,
+			gardencorev1beta1.ErrorRetryableConfigurationProblem: retryableConfigurationProblemRegexp.MatchString,
+		}
+	)
+
+	Describe("#DetermineError", func() {
+		It("should return nil for empty error", func() {
+			Expect(DetermineError(nil, knownCodes)).To(BeNil())
+		})
+	})
+	DescribeTable("#DetermineError",
+		func(err error, expectedErr error) {
+			Expect(DetermineError(err, knownCodes)).To(Equal(expectedErr))
+		},
+
+		Entry("no wrapped error",
+			fmt.Errorf("foo"),
+			errors.New("foo"),
+		),
+		Entry("no code to extract",
+			errors.New("foo"),
+			errors.New("foo"),
+		),
+		Entry("unauthenticated",
+			errors.New("authentication failed"),
+			gardencorev1beta1helper.NewErrorWithCodes(errors.New("authentication failed"), gardencorev1beta1.ErrorInfraUnauthenticated),
+		),
+		Entry("unauthenticated",
+			errors.New("invalidauthenticationtokentenant"),
+			gardencorev1beta1helper.NewErrorWithCodes(errors.New("invalidauthenticationtokentenant"), gardencorev1beta1.ErrorInfraUnauthenticated),
+		),
+		Entry("wrapped unauthenticated error with coder",
+			fmt.Errorf("%w", gardencorev1beta1helper.NewErrorWithCodes(errors.New("unauthenticated"), gardencorev1beta1.ErrorInfraUnauthenticated)),
+			fmt.Errorf("%w", gardencorev1beta1helper.NewErrorWithCodes(errors.New("unauthenticated"), gardencorev1beta1.ErrorInfraUnauthenticated)),
+		),
+		Entry("unauthorized",
+			errors.New("unauthorized"),
+			gardencorev1beta1helper.NewErrorWithCodes(errors.New("unauthorized"), gardencorev1beta1.ErrorInfraUnauthorized),
+		),
+		Entry("unauthorized with coder",
+			gardencorev1beta1helper.NewErrorWithCodes(errors.New("operation not allowed"), gardencorev1beta1.ErrorInfraUnauthorized),
+			gardencorev1beta1helper.NewErrorWithCodes(errors.New("operation not allowed"), gardencorev1beta1.ErrorInfraUnauthorized),
+		),
+		Entry("wrapped unauthorized error",
+			fmt.Errorf("no sufficient permissions: %w", errors.New("AuthorizationFailed")),
+			gardencorev1beta1helper.NewErrorWithCodes(fmt.Errorf("no sufficient permissions: %w", errors.New("AuthorizationFailed")), gardencorev1beta1.ErrorInfraUnauthorized),
+		),
+		Entry("wrapped unauthorized error with coder",
+			fmt.Errorf("%w", gardencorev1beta1helper.NewErrorWithCodes(errors.New("unauthorized"), gardencorev1beta1.ErrorInfraUnauthorized)),
+			fmt.Errorf("%w", gardencorev1beta1helper.NewErrorWithCodes(errors.New("unauthorized"), gardencorev1beta1.ErrorInfraUnauthorized)),
+		),
+		Entry("insufficient privileges",
+			errors.New("accessdenied"),
+			gardencorev1beta1helper.NewErrorWithCodes(errors.New("accessdenied"), gardencorev1beta1.ErrorInfraUnauthorized),
+		),
+		Entry("insufficient privileges with coder",
+			gardencorev1beta1helper.NewErrorWithCodes(errors.New("accessdenied"), gardencorev1beta1.ErrorInfraUnauthorized),
+			gardencorev1beta1helper.NewErrorWithCodes(errors.New("accessdenied"), gardencorev1beta1.ErrorInfraUnauthorized),
+		),
+		Entry("quota exceeded",
+			errors.New("limitexceeded"),
+			gardencorev1beta1helper.NewErrorWithCodes(errors.New("limitexceeded"), gardencorev1beta1.ErrorInfraQuotaExceeded),
+		),
+		Entry("quota exceeded",
+			errors.New("foolimitexceeded"),
+			gardencorev1beta1helper.NewErrorWithCodes(errors.New("foolimitexceeded"), gardencorev1beta1.ErrorInfraQuotaExceeded),
+		),
+		Entry("quota exceeded",
+			errors.New("equestlimitexceeded"),
+			gardencorev1beta1helper.NewErrorWithCodes(errors.New("equestlimitexceeded"), gardencorev1beta1.ErrorInfraQuotaExceeded),
+		),
+		Entry("quota exceeded",
+			errors.New("subnetlimitexceeded"),
+			gardencorev1beta1helper.NewErrorWithCodes(errors.New("subnetlimitexceeded"), gardencorev1beta1.ErrorInfraQuotaExceeded),
+		),
+		Entry("quota exceeded with coder",
+			gardencorev1beta1helper.NewErrorWithCodes(errors.New("limitexceeded"), gardencorev1beta1.ErrorInfraQuotaExceeded),
+			gardencorev1beta1helper.NewErrorWithCodes(errors.New("limitexceeded"), gardencorev1beta1.ErrorInfraQuotaExceeded),
+		),
+		Entry("request throttling",
+			errors.New("message=cannot get hosted zones: Throttling"),
+			gardencorev1beta1helper.NewErrorWithCodes(errors.New("message=cannot get hosted zones: Throttling"), gardencorev1beta1.ErrorInfraRateLimitsExceeded),
+		),
+		Entry("request throttling",
+			errors.New("requestlimitexceeded"),
+			gardencorev1beta1helper.NewErrorWithCodes(errors.New("requestlimitexceeded"), gardencorev1beta1.ErrorInfraRateLimitsExceeded),
+		),
+		Entry("request throttling with coder",
+			gardencorev1beta1helper.NewErrorWithCodes(errors.New("message=cannot get hosted zones: Throttling"), gardencorev1beta1.ErrorInfraRateLimitsExceeded),
+			gardencorev1beta1helper.NewErrorWithCodes(errors.New("message=cannot get hosted zones: Throttling"), gardencorev1beta1.ErrorInfraRateLimitsExceeded),
+		),
+		Entry("infrastructure dependencies",
+			errors.New("pendingverification"),
+			gardencorev1beta1helper.NewErrorWithCodes(errors.New("pendingverification"), gardencorev1beta1.ErrorInfraDependencies),
+		),
+		Entry("infrastructure dependencies with coder",
+			fmt.Errorf("error occurred: %w", gardencorev1beta1helper.NewErrorWithCodes(errors.New("pendingverification"), gardencorev1beta1.ErrorInfraDependencies)),
+			fmt.Errorf("error occurred: %w", gardencorev1beta1helper.NewErrorWithCodes(errors.New("pendingverification"), gardencorev1beta1.ErrorInfraDependencies)),
+		),
+		Entry("resources depleted",
+			fmt.Errorf("error occurred: not available in the current hardware cluster"),
+			gardencorev1beta1helper.NewErrorWithCodes(errors.New("error occurred: not available in the current hardware cluster"), gardencorev1beta1.ErrorInfraResourcesDepleted),
+		),
+		Entry("resources depleted with coder",
+			fmt.Errorf("error occurred: %w", gardencorev1beta1helper.NewErrorWithCodes(errors.New("not available in the current hardware cluster"), gardencorev1beta1.ErrorInfraResourcesDepleted)),
+			fmt.Errorf("error occurred: %w", gardencorev1beta1helper.NewErrorWithCodes(errors.New("not available in the current hardware cluster"), gardencorev1beta1.ErrorInfraResourcesDepleted)),
+		),
+		Entry("configuration problem",
+			fmt.Errorf("error occurred: %w", errors.New("InvalidParameterValue")),
+			gardencorev1beta1helper.NewErrorWithCodes(fmt.Errorf("error occurred: %w", errors.New("InvalidParameterValue")), gardencorev1beta1.ErrorConfigurationProblem),
+		),
+		Entry("configuration problem with coder",
+			fmt.Errorf("error occurred: %w", gardencorev1beta1helper.NewErrorWithCodes(errors.New("InvalidParameterValue"), gardencorev1beta1.ErrorConfigurationProblem)),
+			fmt.Errorf("error occurred: %w", gardencorev1beta1helper.NewErrorWithCodes(errors.New("InvalidParameterValue"), gardencorev1beta1.ErrorConfigurationProblem)),
+		),
+		Entry("retryable configuration problem",
+			errors.New("pod disruption budget default/pdb is misconfigured and requires zero voluntary evictions"),
+			gardencorev1beta1helper.NewErrorWithCodes(errors.New("pod disruption budget default/pdb is misconfigured and requires zero voluntary evictions"), gardencorev1beta1.ErrorRetryableConfigurationProblem),
+		),
+		Entry("retryable configuration problem with coder",
+			gardencorev1beta1helper.NewErrorWithCodes(errors.New("pod disruption budget default/pdb is misconfigured and requires zero voluntary evictions"), gardencorev1beta1.ErrorRetryableConfigurationProblem),
+			gardencorev1beta1helper.NewErrorWithCodes(errors.New("pod disruption budget default/pdb is misconfigured and requires zero voluntary evictions"), gardencorev1beta1.ErrorRetryableConfigurationProblem),
+		),
+		Entry("retryable infrastructure dependencies",
+			errors.New("Code=\"RetryableError\" Message=\"A retryable error occurred"),
+			gardencorev1beta1helper.NewErrorWithCodes(errors.New("Code=\"RetryableError\" Message=\"A retryable error occurred"), gardencorev1beta1.ErrorRetryableInfraDependencies),
+		),
+		Entry("retryable infrastructure dependencies with coder",
+			gardencorev1beta1helper.NewErrorWithCodes(errors.New("Code=\"RetryableError\" Message=\"A retryable error occurred"), gardencorev1beta1.ErrorRetryableInfraDependencies),
+			gardencorev1beta1helper.NewErrorWithCodes(errors.New("Code=\"RetryableError\" Message=\"A retryable error occurred"), gardencorev1beta1.ErrorRetryableInfraDependencies)),
+	)
+})


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity quality
/kind enhancement

**What this PR does / why we need it**:
This PR adds helper functions so the extension can use provider-specific regex to parse error code from error.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/5444

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature dependency
Extensions can now use the `extensions/pkg/util.{DetermineError,DetermineErrorCodes}` functions for conveniently handling errors with codes.
```
