### PR TITLE
Add PATCH as allowed VERB for Gardenlet leases in the Garden cluster

### DIFF
--- a/pkg/admissioncontroller/webhook/auth/seed/authorizer.go
+++ b/pkg/admissioncontroller/webhook/auth/seed/authorizer.go
@@ -252,7 +252,7 @@ func (a *authorizer) authorizeLease(log logr.Logger, seedName string, attrs auth
 	}
 
 	return a.authorize(log, seedName, graph.VertexTypeLease, attrs,
-		[]string{"get", "update"},
+		[]string{"get", "update", "patch"},
 		[]string{"create"},
 		nil,
 	)

--- a/pkg/admissioncontroller/webhook/auth/seed/authorizer_test.go
+++ b/pkg/admissioncontroller/webhook/auth/seed/authorizer_test.go
@@ -1266,13 +1266,12 @@ var _ = Describe("Seed", func() {
 					decision, reason, err := authorizer.Authorize(ctx, attrs)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(decision).To(Equal(auth.DecisionNoOpinion))
-					Expect(reason).To(ContainSubstring("only the following verbs are allowed for this resource type: [create get update]"))
+					Expect(reason).To(ContainSubstring("only the following verbs are allowed for this resource type: [create get update patch]"))
 
 				},
 
 				Entry("list", "list"),
 				Entry("watch", "watch"),
-				Entry("patch", "patch"),
 				Entry("delete", "delete"),
 				Entry("deletecollection", "deletecollection"),
 			)
@@ -1305,6 +1304,7 @@ var _ = Describe("Seed", func() {
 
 				Entry("get", "get"),
 				Entry("update", "update"),
+				Entry("patch", "patch"),
 			)
 		})
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind bug

**What this PR does / why we need it**:

[The recent Gardenlet Seed Lease controller refactoring ](https://github.com/gardener/gardener/commit/98ce217fd6bc916e9f08fb0d63d6480ab13ea7ab)seems to have introduced a regression. The controller-runtime client now uses PATCH to update the gardenlet's lease in Garden cluster, but the Gardener Authorization Webhook has not been updated.
This leads to failed Seed bootstrapping.

cc @rfranzke 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
