### PR TITLE
Upgrade go-apidiff version

### DIFF
--- a/hack/check-apidiff.sh
+++ b/hack/check-apidiff.sh
@@ -74,7 +74,7 @@ while IFS= read -r line; do
 done < "${tmpDir}/output.txt"
 
 if [[ $retval -eq 1 ]]; then
-    echo >&2 "FAIL: contains incompatible changes:"
+    echo >&2 "FAIL: contains compatible/incompatible changes:"
     cat ${tmpDir}/result.txt
 fi
 

--- a/hack/tools.mk
+++ b/hack/tools.mk
@@ -57,7 +57,7 @@ YQ                         := $(TOOLS_BIN_DIR)/yq
 # default tool versions
 DOCFORGE_VERSION ?= v0.32.0
 GOLANGCI_LINT_VERSION ?= v1.50.1
-GO_APIDIFF_VERSION ?= v0.4.0
+GO_APIDIFF_VERSION ?= v0.5.0
 GO_VULN_CHECK_VERSION ?= latest
 HELM_VERSION ?= v3.6.3
 KIND_VERSION ?= v0.14.0


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area open-source
/kind enhancement

**What this PR does / why we need it**:
Upgrade go-apidiff version to fix panicking in the test.

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener/issues/6917

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
