### PR TITLE
use dedicated lock for container logrotate service

### DIFF
--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/containerd/component_test.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/containerd/component_test.go
@@ -58,7 +58,7 @@ ExecStart=/opt/bin/health-monitor-containerd`),
 					Content: pointer.String(`[Unit]
 Description=Rotate and Compress System Logs
 [Service]
-ExecStart=/usr/sbin/logrotate /etc/systemd/containerd.conf
+ExecStart=/usr/sbin/logrotate -s /var/lib/containerd-logrotate.status /etc/systemd/containerd.conf
 [Install]
 WantedBy=multi-user.target`),
 				},
@@ -126,7 +126,7 @@ containerd_monitoring
 
 	logRotateData = `/var/log/pods/*/*/*.log {
     rotate 14
-	copytruncate
+    copytruncate
     missingok
     notifempty
     compress

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/containerd/logrotate/logrotate.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/containerd/logrotate/logrotate.go
@@ -38,7 +38,7 @@ func Config(pathConfig, pathLogFiles, prefix string) ([]extensionsv1alpha1.Unit,
 			Content: pointer.String(`[Unit]
 Description=Rotate and Compress System Logs
 [Service]
-ExecStart=/usr/sbin/logrotate ` + pathConfig + `
+ExecStart=/usr/sbin/logrotate -s /var/lib/` + prefix + `-logrotate.status ` + pathConfig + `
 [Install]
 WantedBy=multi-user.target`),
 		},
@@ -65,7 +65,7 @@ WantedBy=multi-user.target`),
 				Inline: &extensionsv1alpha1.FileContentInline{
 					Data: pathLogFiles + ` {
     rotate 14
-	copytruncate
+    copytruncate
     missingok
     notifempty
     compress

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/containerd/logrotate/logrotate_test.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/containerd/logrotate/logrotate_test.go
@@ -49,7 +49,7 @@ var _ = Describe("Logrotate", func() {
 						Content: pointer.String(`[Unit]
 Description=Rotate and Compress System Logs
 [Service]
-ExecStart=/usr/sbin/logrotate ` + pathConfig + `
+ExecStart=/usr/sbin/logrotate -s /var/lib/` + prefix + `-logrotate.status ` + pathConfig + `
 [Install]
 WantedBy=multi-user.target`),
 					},
@@ -76,7 +76,7 @@ WantedBy=multi-user.target`),
 							Inline: &extensionsv1alpha1.FileContentInline{
 								Data: pathLogFiles.String() + ` {
     rotate 14
-	copytruncate
+    copytruncate
     missingok
     notifempty
     compress

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/docker/component_test.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/docker/component_test.go
@@ -58,7 +58,7 @@ ExecStart=/opt/bin/health-monitor-docker`),
 					Content: pointer.String(`[Unit]
 Description=Rotate and Compress System Logs
 [Service]
-ExecStart=/usr/sbin/logrotate /etc/systemd/docker.conf
+ExecStart=/usr/sbin/logrotate -s /var/lib/docker-logrotate.status /etc/systemd/docker.conf
 [Install]
 WantedBy=multi-user.target`),
 				},

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/docker/logrotate/logrotate.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/docker/logrotate/logrotate.go
@@ -43,7 +43,7 @@ func Config(pathConfig, pathLogFiles, prefix string) ([]extensionsv1alpha1.Unit,
 			Content: pointer.String(`[Unit]
 Description=Rotate and Compress System Logs
 [Service]
-ExecStart=/usr/sbin/logrotate ` + pathConfig + `
+ExecStart=/usr/sbin/logrotate -s /var/lib/` + prefix + `-logrotate.status ` + pathConfig + `
 [Install]
 WantedBy=multi-user.target`),
 		},

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/docker/logrotate/logrotate_test.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/docker/logrotate/logrotate_test.go
@@ -49,7 +49,7 @@ var _ = Describe("Logrotate", func() {
 						Content: pointer.String(`[Unit]
 Description=Rotate and Compress System Logs
 [Service]
-ExecStart=/usr/sbin/logrotate ` + pathConfig + `
+ExecStart=/usr/sbin/logrotate -s /var/lib/` + prefix + `-logrotate.status ` + pathConfig + `
 [Install]
 WantedBy=multi-user.target`),
 					},


### PR DESCRIPTION
/kind bug
/area os

**What this PR does / why we need it**:
This PR sets dedicated lock file for gardener provisioned logrotate service avoiding collision with OS supplied logrotate service

**Release note**:
```bug operator
Gardener provisioned logrotate service now uses a dedicated state lock file. The purpose is to avoid race conditions with OS logrotate service. 
```
