### PR TITLE
Remove GA-ed `Shoot{C,S}ARotation` feature gates

### DIFF
--- a/docs/deployment/feature_gates.md
+++ b/docs/deployment/feature_gates.md
@@ -100,10 +100,12 @@ The following tables are a summary of the feature gates that you can set on diff
 | SeedKubeScheduler                            | `false` | `Deprecated` | `1.55` |        |
 | ShootCARotation                              | `false` | `Alpha`      | `1.42` | `1.50` |
 | ShootCARotation                              | `true`  | `Beta`       | `1.51` | `1.56` |
-| ShootCARotation                              | `true`  | `GA`         | `1.57` |        |
+| ShootCARotation                              | `true`  | `GA`         | `1.57` | `1.59` |
+| ShootCARotation                              |         | `Removed`    | `1.60` |        |
 | ShootSARotation                              | `false` | `Alpha`      | `1.48` | `1.50` |
 | ShootSARotation                              | `true`  | `Beta`       | `1.51` | `1.56` |
-| ShootSARotation                              | `true`  | `GA`         | `1.57` |        |
+| ShootSARotation                              | `true`  | `GA`         | `1.57` | `1.59` |
+| ShootSARotation                              |         | `Removed`    | `1.60` |        |
 
 ## Using a feature
 
@@ -154,9 +156,6 @@ A *General Availability* (GA) feature is also referred to as a *stable* feature.
 | SecretBindingProviderValidation            | `gardener-apiserver`                                             | Enables validations on Gardener API server that:<br>- requires the provider type of a SecretBinding to be set (on SecretBinding creation)<br>- requires the SecretBinding provider type to match the Shoot provider type (on Shoot creation)<br>- enforces immutability on the provider type of a SecretBinding |
 | ForceRestore                               | `gardenlet`                                                      | Enables forcing the shoot's restoration to the destination seed during control plane migration if the preparation for migration in the source seed is not finished after a certain grace period and is considered unlikely to succeed (falling back to the [control plane migration "bad case" scenario](../proposals/17-shoot-control-plane-migration-bad-case.md)). If you enable this feature gate, make sure to also enable `CopyEtcdBackupsDuringControlPlaneMigration`. |
 | DisableDNSProviderManagement               | `gardenlet`                                                      | Disables management of `dns.gardener.cloud/v1alpha1.DNSProvider` resources. In this case, the `shoot-dns-service` extension will take this over if it is installed. |
-| ShootCARotation                            | `gardener-apiserver`, `gardenlet`                                | Enables the feature to trigger automated CA rotation for shoot clusters. |
-| ShootSARotation                            | `gardener-apiserver`, `gardenlet`                                | Enables the feature to trigger automated service account signing key rotation for shoot clusters. |
 | HAControlPlanes                            | `gardener-apiserver`                                             | HAControlPlanes allows shoot control planes to be run in high availability mode. |
-| WorkerPoolKubernetesVersion                | `gardener-apiserver`                                             | Allows to overwrite the Kubernetes version used for shoot clusters per worker pool (see [this document](../usage/worker_pool_k8s_versions.md)) |
 | DefaultSeccompProfile                      | `gardenlet`                                                      | Enables the defaulting of the seccomp profile for Gardener managed workload in the seed to RuntimeDefault. |
 | CoreDNSQueryRewriting                      | `gardenlet`                                                      | Enables automatic DNS query rewriting in shoot cluster's CoreDNS to shortcut name resolution of fully qualified in-cluster and out-of-cluster names, which follow a user-defined pattern. Details can be found in [DNS Search Path Optimization](../usage/dns-search-path-optimization.md). |

--- a/docs/usage/shoot_credentials_rotation.md
+++ b/docs/usage/shoot_credentials_rotation.md
@@ -102,8 +102,6 @@ This is the same certificate that is also contained in the `kubeconfig`'s `certi
 All of the certificates are valid for 10 years.
 Since it requires adaptation for the consumers of the `Shoot`, there is no automatic rotation and **it is the responsibility of the end-user to regularly rotate the CA certificates.**
 
-> Note that the CA rotation can only be triggered if the `ShootCARotation` feature gate is enabled.
-
 The rotation happens in three stages (see also [GEP-18](../proposals/18-shoot-CA-rotation.md) for the full details):
 
 - In stage one, new CAs are created and added to the bundle (together with the old CAs). Client certificates are re-issued immediately.
@@ -243,8 +241,6 @@ This also includes system components running in the `kube-system` namespace.
 
 The token signing key has no expiration date.
 Since it might require adaptation for the consumers of the `Shoot`, there is no automatic rotation and **it is the responsibility of the end-user to regularly rotate the signing key.**
-
-> Note that the signing key rotation can only be triggered if the `ShootSARotation` feature gate is enabled.
 
 The rotation happens in three stages, similar to how the [CA certificates](#certificate-authorities) are rotated:
 

--- a/example/20-componentconfig-gardenlet.yaml
+++ b/example/20-componentconfig-gardenlet.yaml
@@ -121,8 +121,6 @@ featureGates:
   ReversedVPN: true
   CopyEtcdBackupsDuringControlPlaneMigration: true
   ForceRestore: false
-  ShootCARotation: true
-  ShootSARotation: true
   DefaultSeccompProfile: true
   CoreDNSQueryRewriting: true
 # seedConfig:

--- a/example/gardener-local/controlplane/values.yaml
+++ b/example/gardener-local/controlplane/values.yaml
@@ -159,8 +159,6 @@ global:
         policy: ""
     featureGates:
       SeedChange: true
-      ShootCARotation: true
-      ShootSARotation: true
     resources: {}
 
   # Gardener admission controller configuration values

--- a/example/gardener-local/gardenlet/values.yaml
+++ b/example/gardener-local/gardenlet/values.yaml
@@ -33,8 +33,6 @@ config:
     ManagedIstio: true
     APIServerSNI: true
     ReversedVPN: true
-    ShootCARotation: true
-    ShootSARotation: true
     CopyEtcdBackupsDuringControlPlaneMigration: true
     DefaultSeccompProfile: true
     CoreDNSQueryRewriting: true

--- a/hack/local-development/start-apiserver
+++ b/hack/local-development/start-apiserver
@@ -59,8 +59,6 @@ apiserver_flags="
   --tls-private-key-file $TLS_KEY_FILE \
   --feature-gates HAControlPlanes=true \
   --feature-gates SeedChange=true \
-  --feature-gates ShootCARotation=true \
-  --feature-gates ShootSARotation=true \
   --shoot-admin-kubeconfig-max-expiration=1h \
   --enable-admission-plugins=ShootVPAEnabledByDefault \
   --v 2"

--- a/pkg/apiserver/features/features.go
+++ b/pkg/apiserver/features/features.go
@@ -26,7 +26,5 @@ func RegisterFeatureGates() {
 	utilruntime.Must(utilfeature.DefaultMutableFeatureGate.Add(features.GetFeatures(
 		features.HAControlPlanes,
 		features.SeedChange,
-		features.ShootCARotation,
-		features.ShootSARotation,
 	)))
 }

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -103,20 +103,6 @@ const (
 	// GA: v1.52.0
 	DisableDNSProviderManagement featuregate.Feature = "DisableDNSProviderManagement"
 
-	// ShootCARotation enables the automated rotation of the shoot CA certificates.
-	// owner: @rfranzke
-	// alpha: v1.42.0
-	// beta: v1.51.0
-	// GA: v1.57.0
-	ShootCARotation featuregate.Feature = "ShootCARotation"
-
-	// ShootSARotation enables the automated rotation of the shoot service account signing key.
-	// owner: @rfranzke
-	// alpha: v1.48.0
-	// beta: v1.51.0
-	// GA: v1.57.0
-	ShootSARotation featuregate.Feature = "ShootSARotation"
-
 	// HAControlPlanes allows shoot control planes to be run in high availability mode.
 	// owner: @shreyas-s-rao @timuthy
 	// alpha: v1.49.0
@@ -145,8 +131,6 @@ var allFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	CopyEtcdBackupsDuringControlPlaneMigration: {Default: true, PreRelease: featuregate.Beta},
 	ForceRestore:                 {Default: false, PreRelease: featuregate.Alpha},
 	DisableDNSProviderManagement: {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
-	ShootCARotation:              {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
-	ShootSARotation:              {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
 	HAControlPlanes:              {Default: false, PreRelease: featuregate.Alpha},
 	DefaultSeccompProfile:        {Default: false, PreRelease: featuregate.Alpha},
 	CoreDNSQueryRewriting:        {Default: false, PreRelease: featuregate.Alpha},

--- a/pkg/gardenlet/features/features.go
+++ b/pkg/gardenlet/features/features.go
@@ -36,8 +36,6 @@ func RegisterFeatureGates() {
 		features.CopyEtcdBackupsDuringControlPlaneMigration,
 		features.ForceRestore,
 		features.DisableDNSProviderManagement,
-		features.ShootCARotation,
-		features.ShootSARotation,
 		features.DefaultSeccompProfile,
 		features.CoreDNSQueryRewriting,
 	)))


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security open-source
/kind enhancement

**What this PR does / why we need it**:
This PR removes the GA-ed  `Shoot{C,S}ARotation` feature gates (promoted to GA with #6734).

**Which issue(s) this PR fixes**:
Part of #3292

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The GA-ed `Shoot{C,S}ARotation` feature gates are now removed.
```
