### PR TITLE
Improve rotation of `ServiceAccount` token signing key

### DIFF
--- a/pkg/operation/botanist/secrets.go
+++ b/pkg/operation/botanist/secrets.go
@@ -32,12 +32,14 @@ import (
 	"github.com/gardener/gardener/pkg/utils/flow"
 	gutil "github.com/gardener/gardener/pkg/utils/gardener"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
+	"github.com/gardener/gardener/pkg/utils/retry"
 	secretutils "github.com/gardener/gardener/pkg/utils/secrets"
 	secretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager"
 
 	"golang.org/x/time/rate"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
@@ -453,17 +455,29 @@ func (b *Botanist) CreateNewServiceAccountSecrets(ctx context.Context) error {
 				return err
 			}
 
-			// Make sure we have the most recent version of the service account when we reach this point (which might
-			// take a while given the above limiter.Wait call - in the meantime, the object might have been changed).
-			if err := b.ShootClientSet.Client().Get(ctx, client.ObjectKeyFromObject(&serviceAccount), &serviceAccount); err != nil {
-				return err
-			}
+			timeoutCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+			defer cancel()
 
-			patch := client.MergeFromWithOptions(serviceAccount.DeepCopy(), client.MergeFromWithOptimisticLock{})
-			metav1.SetMetaDataLabel(&serviceAccount.ObjectMeta, labelKeyRotationKeyName, serviceAccountKeySecret.Name)
-			serviceAccount.Secrets = append([]corev1.ObjectReference{{Name: secret.Name}}, serviceAccount.Secrets...)
+			return retry.Until(timeoutCtx, time.Second, func(ctx context.Context) (bool, error) {
+				// Make sure we have the most recent version of the service account when we reach this point (which might
+				// take a while given the above limiter.Wait call - in the meantime, the object might have been changed).
+				if err := b.ShootClientSet.Client().Get(ctx, client.ObjectKeyFromObject(&serviceAccount), &serviceAccount); err != nil {
+					return retry.SevereError(err)
+				}
 
-			return b.ShootClientSet.Client().Patch(ctx, &serviceAccount, patch)
+				patch := client.MergeFromWithOptions(serviceAccount.DeepCopy(), client.MergeFromWithOptimisticLock{})
+				metav1.SetMetaDataLabel(&serviceAccount.ObjectMeta, labelKeyRotationKeyName, serviceAccountKeySecret.Name)
+				serviceAccount.Secrets = append([]corev1.ObjectReference{{Name: secret.Name}}, serviceAccount.Secrets...)
+
+				if err := b.ShootClientSet.Client().Patch(ctx, &serviceAccount, patch); err != nil {
+					if apierrors.IsConflict(err) {
+						return retry.MinorError(err)
+					}
+					return retry.SevereError(err)
+				}
+
+				return retry.Ok()
+			})
 		})
 	}
 
@@ -512,19 +526,31 @@ func (b *Botanist) DeleteOldServiceAccountSecrets(ctx context.Context) error {
 				return err
 			}
 
-			// Make sure we have the most recent version of the service account when we reach this point (which might
-			// take a while given the above limiter.Wait call - in the meantime, the object might have been changed).
-			// Also, when deleting above secrets, kube-controller-manager might already remove them from the service
-			// account which definitely changes the object.
-			if err := b.ShootClientSet.Client().Get(ctx, client.ObjectKeyFromObject(&serviceAccount), &serviceAccount); err != nil {
-				return err
-			}
+			timeoutCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+			defer cancel()
 
-			patch := client.MergeFromWithOptions(serviceAccount.DeepCopy(), client.MergeFromWithOptimisticLock{})
-			delete(serviceAccount.Labels, labelKeyRotationKeyName)
-			serviceAccount.Secrets = []corev1.ObjectReference{serviceAccount.Secrets[0]}
+			return retry.Until(timeoutCtx, time.Second, func(ctx context.Context) (bool, error) {
+				// Make sure we have the most recent version of the service account when we reach this point (which might
+				// take a while given the above limiter.Wait call - in the meantime, the object might have been changed).
+				// Also, when deleting above secrets, kube-controller-manager might already remove them from the service
+				// account which definitely changes the object.
+				if err := b.ShootClientSet.Client().Get(ctx, client.ObjectKeyFromObject(&serviceAccount), &serviceAccount); err != nil {
+					return retry.SevereError(err)
+				}
 
-			return b.ShootClientSet.Client().Patch(ctx, &serviceAccount, patch)
+				patch := client.MergeFromWithOptions(serviceAccount.DeepCopy(), client.MergeFromWithOptimisticLock{})
+				delete(serviceAccount.Labels, labelKeyRotationKeyName)
+				serviceAccount.Secrets = []corev1.ObjectReference{serviceAccount.Secrets[0]}
+
+				if err := b.ShootClientSet.Client().Patch(ctx, &serviceAccount, patch); err != nil {
+					if apierrors.IsConflict(err) {
+						return retry.MinorError(err)
+					}
+					return retry.SevereError(err)
+				}
+
+				return retry.Ok()
+			})
 		})
 	}
 

--- a/pkg/operation/botanist/secrets.go
+++ b/pkg/operation/botanist/secrets.go
@@ -443,10 +443,6 @@ func (b *Botanist) CreateNewServiceAccountSecrets(ctx context.Context) error {
 				}
 			}
 
-			patch := client.MergeFromWithOptions(serviceAccount.DeepCopy(), client.MergeFromWithOptimisticLock{})
-			metav1.SetMetaDataLabel(&serviceAccount.ObjectMeta, labelKeyRotationKeyName, serviceAccountKeySecret.Name)
-			serviceAccount.Secrets = append([]corev1.ObjectReference{{Name: secret.Name}}, serviceAccount.Secrets...)
-
 			// Wait until we are allowed by the limiter to not overload the kube-apiserver with too many requests.
 			if err := limiter.Wait(ctx); err != nil {
 				return err
@@ -456,6 +452,16 @@ func (b *Botanist) CreateNewServiceAccountSecrets(ctx context.Context) error {
 				log.Error(err, "Error creating new ServiceAccount secret")
 				return err
 			}
+
+			// Make sure we have the most recent version of the service account when we reach this point (which might
+			// take a while given the above limiter.Wait call - in the meantime, the object might have been changed).
+			if err := b.ShootClientSet.Client().Get(ctx, client.ObjectKeyFromObject(&serviceAccount), &serviceAccount); err != nil {
+				return err
+			}
+
+			patch := client.MergeFromWithOptions(serviceAccount.DeepCopy(), client.MergeFromWithOptimisticLock{})
+			metav1.SetMetaDataLabel(&serviceAccount.ObjectMeta, labelKeyRotationKeyName, serviceAccountKeySecret.Name)
+			serviceAccount.Secrets = append([]corev1.ObjectReference{{Name: secret.Name}}, serviceAccount.Secrets...)
 
 			return b.ShootClientSet.Client().Patch(ctx, &serviceAccount, patch)
 		})
@@ -496,10 +502,6 @@ func (b *Botanist) DeleteOldServiceAccountSecrets(ctx context.Context) error {
 				secretsToDelete = append(secretsToDelete, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: secretReference.Name, Namespace: serviceAccount.Namespace}})
 			}
 
-			patch := client.MergeFromWithOptions(serviceAccount.DeepCopy(), client.MergeFromWithOptimisticLock{})
-			delete(serviceAccount.Labels, labelKeyRotationKeyName)
-			serviceAccount.Secrets = []corev1.ObjectReference{serviceAccount.Secrets[0]}
-
 			// Wait until we are allowed by the limiter to not overload the kube-apiserver with too many requests.
 			if err := limiter.Wait(ctx); err != nil {
 				return err
@@ -509,6 +511,18 @@ func (b *Botanist) DeleteOldServiceAccountSecrets(ctx context.Context) error {
 				log.Error(err, "Error deleting old ServiceAccount secrets")
 				return err
 			}
+
+			// Make sure we have the most recent version of the service account when we reach this point (which might
+			// take a while given the above limiter.Wait call - in the meantime, the object might have been changed).
+			// Also, when deleting above secrets, kube-controller-manager might already remove them from the service
+			// account which definitely changes the object.
+			if err := b.ShootClientSet.Client().Get(ctx, client.ObjectKeyFromObject(&serviceAccount), &serviceAccount); err != nil {
+				return err
+			}
+
+			patch := client.MergeFromWithOptions(serviceAccount.DeepCopy(), client.MergeFromWithOptimisticLock{})
+			delete(serviceAccount.Labels, labelKeyRotationKeyName)
+			serviceAccount.Secrets = []corev1.ObjectReference{serviceAccount.Secrets[0]}
 
 			return b.ShootClientSet.Client().Patch(ctx, &serviceAccount, patch)
 		})

--- a/pkg/operation/botanist/secrets.go
+++ b/pkg/operation/botanist/secrets.go
@@ -443,7 +443,7 @@ func (b *Botanist) CreateNewServiceAccountSecrets(ctx context.Context) error {
 				}
 			}
 
-			patch := client.StrategicMergeFrom(serviceAccount.DeepCopy(), client.MergeFromWithOptimisticLock{})
+			patch := client.MergeFromWithOptions(serviceAccount.DeepCopy(), client.MergeFromWithOptimisticLock{})
 			metav1.SetMetaDataLabel(&serviceAccount.ObjectMeta, labelKeyRotationKeyName, serviceAccountKeySecret.Name)
 			serviceAccount.Secrets = append([]corev1.ObjectReference{{Name: secret.Name}}, serviceAccount.Secrets...)
 
@@ -496,7 +496,7 @@ func (b *Botanist) DeleteOldServiceAccountSecrets(ctx context.Context) error {
 				secretsToDelete = append(secretsToDelete, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: secretReference.Name, Namespace: serviceAccount.Namespace}})
 			}
 
-			patch := client.StrategicMergeFrom(serviceAccount.DeepCopy(), client.MergeFromWithOptimisticLock{})
+			patch := client.MergeFromWithOptions(serviceAccount.DeepCopy(), client.MergeFromWithOptimisticLock{})
 			delete(serviceAccount.Labels, labelKeyRotationKeyName)
 			serviceAccount.Secrets = []corev1.ObjectReference{serviceAccount.Secrets[0]}
 

--- a/pkg/operation/botanist/secrets_test.go
+++ b/pkg/operation/botanist/secrets_test.go
@@ -373,6 +373,7 @@ var _ = Describe("Secrets", func() {
 				Expect(sa2.Secrets).To(ConsistOf(corev1.ObjectReference{Name: "sa2-token" + suffix}))
 				Expect(sa3.Labels).NotTo(HaveKey("credentials.gardener.cloud/key-name"))
 				Expect(sa3.Secrets).To(ConsistOf(corev1.ObjectReference{Name: "new-sa-secret"}))
+				Expect(shootClient.Get(ctx, client.ObjectKeyFromObject(sa3OldSecret), &corev1.Secret{})).To(BeNotFoundError())
 			})
 		})
 	})


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security robustness
/kind enhancement

**What this PR does / why we need it**:
This PR improves the rotation of the `ServiceAccount` token signing key by

- using "merge" patch instead of "strategic merge" patch (the `secrets[]` list in `ServiceAccount`s has `patchStrategy=merge`, hence a strategic merge always merges the list. However, we are only interested in completely replacing it with our desired state.)
- reading the `ServiceAccount` again before patching (especially when deleting `ServiceAccount` secrets, `kube-controller-manager` might simultaneously change the `ServiceAccount` and remove them from the `.secrets[]` list. This changes the object's resource version which makes our `Patch` w/ optimistic lock fail.)
- retrying on conflict (since we might be outdated at the time the limiter allows us to work on a `ServiceAccount`).

**Which issue(s) this PR fixes**:
Part of #3292

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other user
The rotation procedure of the `ServiceAccount` token signing key has been improved.
```
