### PR TITLE
Handle `batch/v1` CronJobs and Update `envtest` to use `1.25`

### DIFF
--- a/hack/test-integration.sh
+++ b/hack/test-integration.sh
@@ -18,7 +18,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-ENVTEST_K8S_VERSION=${ENVTEST_K8S_VERSION:-"1.23"}
+ENVTEST_K8S_VERSION=${ENVTEST_K8S_VERSION:-"1.25"}
 
 echo "> Installing envtest tools@${ENVTEST_K8S_VERSION} with setup-envtest if necessary"
 if ! command -v setup-envtest &> /dev/null ; then
@@ -26,15 +26,7 @@ if ! command -v setup-envtest &> /dev/null ; then
   exit 1
 fi
 
-ARCH=
-# if using M1 macbook, use amd64 architecture build, as suggested in
-# https://github.com/kubernetes-sigs/controller-runtime/issues/1657#issuecomment-988484517
-if [[ $(uname) == 'Darwin' && $(uname -m) == 'arm64' ]]; then
-  ARCH='--arch=amd64'
-fi
-
-# --use-env allows overwriting the envtest tools path via the KUBEBUILDER_ASSETS env var just like it was before
-export KUBEBUILDER_ASSETS="$(setup-envtest ${ARCH} use --use-env -p path ${ENVTEST_K8S_VERSION})"
+export KUBEBUILDER_ASSETS="$(setup-envtest use -p path ${ENVTEST_K8S_VERSION})"
 echo "using envtest tools installed at '$KUBEBUILDER_ASSETS'"
 
 echo "> Integration Tests"

--- a/pkg/operation/botanist/cleanup.go
+++ b/pkg/operation/botanist/cleanup.go
@@ -249,13 +249,20 @@ func (b *Botanist) CleanKubernetesResources(ctx context.Context) error {
 		)(ctx)
 	}
 
-	var ingressList client.ObjectList = &networkingv1.IngressList{}
+	var (
+		ingressList client.ObjectList = &networkingv1.IngressList{}
+		cronJobList client.ObjectList = &batchv1beta1.CronJobList{}
+	)
+
 	if version.ConstraintK8sLess119.Check(b.Shoot.KubernetesVersion) {
 		ingressList = &extensionsv1beta1.IngressList{}
 	}
+	if version.ConstraintK8sGreaterEqual121.Check(b.Shoot.KubernetesVersion) {
+		cronJobList = &batchv1.CronJobList{}
+	}
 
 	return flow.Parallel(
-		cleanResourceFn(ops, c, &batchv1beta1.CronJobList{}, CronJobCleanOption, cleanOptions),
+		cleanResourceFn(ops, c, cronJobList, CronJobCleanOption, cleanOptions),
 		cleanResourceFn(ops, c, &appsv1.DaemonSetList{}, DaemonSetCleanOption, cleanOptions),
 		cleanResourceFn(ops, c, &appsv1.DeploymentList{}, DeploymentCleanOption, cleanOptions),
 		cleanResourceFn(ops, c, ingressList, IngressCleanOption, cleanOptions),

--- a/pkg/resourcemanager/controller/add.go
+++ b/pkg/resourcemanager/controller/add.go
@@ -17,7 +17,6 @@ package controller
 import (
 	"fmt"
 
-	"github.com/Masterminds/semver"
 	"k8s.io/apimachinery/pkg/util/wait"
 	kubernetesclientset "k8s.io/client-go/kubernetes"
 	"k8s.io/utils/clock"
@@ -49,11 +48,6 @@ func AddToManager(mgr manager.Manager, sourceCluster, targetCluster cluster.Clus
 		return err
 	}
 
-	targetKubernetesVersion, err := semver.NewVersion(targetServerVersion.GitVersion)
-	if err != nil {
-		return err
-	}
-
 	var targetCacheDisabled bool
 	if cfg.TargetClientConnection != nil {
 		targetCacheDisabled = pointer.BoolDeref(cfg.TargetClientConnection.DisableCachedClient, false)
@@ -73,7 +67,7 @@ func AddToManager(mgr manager.Manager, sourceCluster, targetCluster cluster.Clus
 		if err := (&garbagecollector.Reconciler{
 			Config:                  cfg.Controllers.GarbageCollector,
 			Clock:                   clock.RealClock{},
-			TargetKubernetesVersion: targetKubernetesVersion,
+			TargetKubernetesVersion: targetServerVersion.GitVersion,
 		}).AddToManager(mgr, targetCluster); err != nil {
 			return fmt.Errorf("failed adding garbage collector controller: %w", err)
 		}

--- a/pkg/resourcemanager/controller/garbagecollector/reconciler.go
+++ b/pkg/resourcemanager/controller/garbagecollector/reconciler.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/Masterminds/semver"
 	"github.com/hashicorp/go-multierror"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
@@ -42,7 +41,7 @@ import (
 type Reconciler struct {
 	TargetReader            client.Reader
 	TargetWriter            client.Writer
-	TargetKubernetesVersion *semver.Version
+	TargetKubernetesVersion string
 	Config                  config.GarbageCollectorControllerConfig
 	Clock                   clock.Clock
 	MinimumObjectLifetime   *time.Duration
@@ -97,18 +96,18 @@ func (r *Reconciler) Reconcile(reconcileCtx context.Context, _ reconcile.Request
 		}
 	)
 
-	k8sGreater121, err := versionutils.CheckVersionMeetsConstraint(r.TargetKubernetesVersion.String(), ">= 1.21")
+	k8sGreater121, err := versionutils.CheckVersionMeetsConstraint(r.TargetKubernetesVersion, ">= 1.21")
 	if err != nil {
 		return reconcile.Result{}, err
 	}
-	k8sLesser125, err := versionutils.CheckVersionMeetsConstraint(r.TargetKubernetesVersion.String(), "< 1.25")
+	k8sLess125, err := versionutils.CheckVersionMeetsConstraint(r.TargetKubernetesVersion, "< 1.25")
 	if err != nil {
 		return reconcile.Result{}, err
 	}
 	if k8sGreater121 {
 		groupVersionKinds = append(groupVersionKinds, batchv1.SchemeGroupVersion.WithKind("CronJobList"))
 	}
-	if k8sLesser125 {
+	if k8sLess125 {
 		groupVersionKinds = append(groupVersionKinds, batchv1beta1.SchemeGroupVersion.WithKind("CronJobList"))
 	}
 

--- a/test/integration/resourcemanager/garbagecollector/garbagecollector_suite_test.go
+++ b/test/integration/resourcemanager/garbagecollector/garbagecollector_suite_test.go
@@ -19,7 +19,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Masterminds/semver"
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -111,7 +110,7 @@ var _ = BeforeSuite(func() {
 		Clock:                 clock.RealClock{},
 		MinimumObjectLifetime: pointer.Duration(0),
 		// Use the same version as the envtest package
-		TargetKubernetesVersion: semver.MustParse("1.25.0"),
+		TargetKubernetesVersion: "1.25.0",
 	}).AddToManager(mgr, mgr)).To(Succeed())
 
 	By("starting manager")

--- a/test/integration/resourcemanager/garbagecollector/garbagecollector_suite_test.go
+++ b/test/integration/resourcemanager/garbagecollector/garbagecollector_suite_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Masterminds/semver"
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -109,6 +110,8 @@ var _ = BeforeSuite(func() {
 		},
 		Clock:                 clock.RealClock{},
 		MinimumObjectLifetime: pointer.Duration(0),
+		// Use the same version as the envtest package
+		TargetKubernetesVersion: semver.MustParse("1.25.0"),
 	}).AddToManager(mgr, mgr)).To(Succeed())
 
 	By("starting manager")

--- a/test/integration/resourcemanager/garbagecollector/garbagecollector_test.go
+++ b/test/integration/resourcemanager/garbagecollector/garbagecollector_test.go
@@ -25,7 +25,6 @@ import (
 	gomegatypes "github.com/onsi/gomega/types"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
-	batchv1beta1 "k8s.io/api/batch/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -130,7 +129,7 @@ var _ = Describe("Garbage collector tests", func() {
 				},
 			},
 
-			&batchv1beta1.CronJob{
+			&batchv1.CronJob{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      resourceName,
 					Namespace: testNamespace.Name,
@@ -139,9 +138,9 @@ var _ = Describe("Garbage collector tests", func() {
 						"reference.resources.gardener.cloud/configmap-foo": resourceName + "-configmap2",
 					},
 				},
-				Spec: batchv1beta1.CronJobSpec{
+				Spec: batchv1.CronJobSpec{
 					Schedule: "5 4 * * *",
-					JobTemplate: batchv1beta1.JobTemplateSpec{
+					JobTemplate: batchv1.JobTemplateSpec{
 						Spec: batchv1.JobSpec{
 							Template: podTemplateSpec(corev1.RestartPolicyNever),
 						},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind task

**What this PR does / why we need it**:
The garbage collector in the GRM was trying to list batch/v1beta1 CronJobs which are not present in Kubernetes v1.25.  This PR adds handling for this.

Also this PR updates envtest to use version 1.25.0.
The workaround for `arm64` architecture introduced in https://github.com/gardener/gardener/pull/6027 is no longer needed, because now we have releases for arm64 as well, see 
https://github.com/kubernetes-sigs/kubebuilder/issues/2664 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @shreyas-s-rao 


**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
