### PR TITLE
Updated Service Account Manager documentation

### DIFF
--- a/docs/concepts/controller-manager.md
+++ b/docs/concepts/controller-manager.md
@@ -98,7 +98,7 @@ In order to activate it, provide the following configuration:
 * `concurrentSyncs`: The amount of goroutines scheduled for reconciling events.
 * `ttlNonShootEvents`: When an event reaches this time-to-live it gets deleted unless it is a Shoot-related event (defaults to `1h`, equivalent to the `event-ttl` default).
 
-> :warning: In addition, you should also configure the `--event-ttl` for the kube-apiserver to define an upper-limit of how long Shoot-related events should be stored.
+> :warning: In addition, you should also configure the `--event-ttl` for the kube-apiserver to define an upper-limit of how long Shoot-related events should be stored. The `--event-ttl` should be larger than the `ttlNonShootEvents` or this controller will have no effect.
 
 ### [`ExposureClass` Controller](../../pkg/controllermanager/controller/exposureclass)
 

--- a/docs/concepts/controller-manager.md
+++ b/docs/concepts/controller-manager.md
@@ -98,8 +98,10 @@ In order to activate it, provide the following configuration:
 * `concurrentSyncs`: The amount of goroutines scheduled for reconciling events.
 * `ttlNonShootEvents`: When an event reaches this time-to-live it gets deleted unless it is a Shoot-related event (defaults to `1h`, equivalent to the `event-ttl` default).
 
-> :warning: In addition, you should also configure the `--event-ttl` for the kube-apiserver to define an upper-limit of how long Shoot-related events should be stored.
+{{% alert color="warning"  title="Warning" %}}
+In addition, you should also configure the `--event-ttl` for the kube-apiserver to define an upper-limit of how long Shoot-related events should be stored.
 The `--event-ttl` should be larger than the `ttlNonShootEvents` or this controller will have no effect.
+{{% /alert %}}
 
 ### [`ExposureClass` Controller](../../pkg/controllermanager/controller/exposureclass)
 
@@ -133,7 +135,9 @@ Gardener administrators and extension developers can define their own roles, see
 In addition, operators can configure the Project controller to maintain a default [ResourceQuota](https://kubernetes.io/docs/concepts/policy/resource-quotas/) for project namespaces.
 Quotas can especially limit the creation of user facing resources, e.g. `Shoots`, `SecretBindings`, `Secrets` and thus protect the Garden cluster from massive resource exhaustion but also enable operators to align quotas with respective enterprise policies.
 
-> :warning: **Gardener itself is not exempted from configured quotas**. For example, Gardener creates `Secrets` for every shoot cluster in the project namespace and at the same time increases the available quota count. Please mind this additional resource consumption.
+{{% alert color="warning"  title="Warning" %}}
+**Gardener itself is not exempted from configured quotas**. For example, Gardener creates `Secrets` for every shoot cluster in the project namespace and at the same time increases the available quota count. Please mind this additional resource consumption.
+{{% /alert %}}
 
 The controller configuration provides a template section `controllers.project.quotas` where such a ResourceQuota (see example below) can be deposited.
 
@@ -191,7 +195,9 @@ The component configuration of the `gardener-controller-manager` offers to confi
 * `staleGracePeriodDays`: Don't compute auto-delete timestamps for stale `Project`s that are unused for only less than `staleGracePeriodDays`. This is to not unnecessarily make people/end-users nervous "just because" they haven't actively used their `Project` for a given amount of time. When you change this value then already assigned auto-delete timestamps may be removed again if the new grace period is not yet exceeded.
 * `staleExpirationTimeDays`: Expiration time after which stale `Project`s are finally auto-deleted (after `.status.staleSinceTimestamp`). If this value is changed and an auto-delete timestamp got already assigned to the projects then the new value will only take effect if it's increased. Hence, decreasing the `staleExpirationTimeDays` will not decrease already assigned auto-delete timestamps.
 
-> Gardener administrators/operators can exclude specific `Project`s from the stale check by annotating the related `Namespace` resource with `project.gardener.cloud/skip-stale-check=true`.
+{{% alert color="info"  title="Note" %}}
+Gardener administrators/operators can exclude specific `Project`s from the stale check by annotating the related `Namespace` resource with `project.gardener.cloud/skip-stale-check=true`.
+{{% /alert %}}
 
 #### "Activity" Reconciler
 

--- a/docs/concepts/controller-manager.md
+++ b/docs/concepts/controller-manager.md
@@ -98,10 +98,7 @@ In order to activate it, provide the following configuration:
 * `concurrentSyncs`: The amount of goroutines scheduled for reconciling events.
 * `ttlNonShootEvents`: When an event reaches this time-to-live it gets deleted unless it is a Shoot-related event (defaults to `1h`, equivalent to the `event-ttl` default).
 
-{{% alert color="warning"  title="Warning" %}}
-In addition, you should also configure the `--event-ttl` for the kube-apiserver to define an upper-limit of how long Shoot-related events should be stored.
-The `--event-ttl` should be larger than the `ttlNonShootEvents` or this controller will have no effect.
-{{% /alert %}}
+> :warning: In addition, you should also configure the `--event-ttl` for the kube-apiserver to define an upper-limit of how long Shoot-related events should be stored.
 
 ### [`ExposureClass` Controller](../../pkg/controllermanager/controller/exposureclass)
 
@@ -135,9 +132,7 @@ Gardener administrators and extension developers can define their own roles, see
 In addition, operators can configure the Project controller to maintain a default [ResourceQuota](https://kubernetes.io/docs/concepts/policy/resource-quotas/) for project namespaces.
 Quotas can especially limit the creation of user facing resources, e.g. `Shoots`, `SecretBindings`, `Secrets` and thus protect the Garden cluster from massive resource exhaustion but also enable operators to align quotas with respective enterprise policies.
 
-{{% alert color="warning"  title="Warning" %}}
-**Gardener itself is not exempted from configured quotas**. For example, Gardener creates `Secrets` for every shoot cluster in the project namespace and at the same time increases the available quota count. Please mind this additional resource consumption.
-{{% /alert %}}
+> :warning: **Gardener itself is not exempted from configured quotas**. For example, Gardener creates `Secrets` for every shoot cluster in the project namespace and at the same time increases the available quota count. Please mind this additional resource consumption.
 
 The controller configuration provides a template section `controllers.project.quotas` where such a ResourceQuota (see example below) can be deposited.
 
@@ -195,9 +190,7 @@ The component configuration of the `gardener-controller-manager` offers to confi
 * `staleGracePeriodDays`: Don't compute auto-delete timestamps for stale `Project`s that are unused for only less than `staleGracePeriodDays`. This is to not unnecessarily make people/end-users nervous "just because" they haven't actively used their `Project` for a given amount of time. When you change this value then already assigned auto-delete timestamps may be removed again if the new grace period is not yet exceeded.
 * `staleExpirationTimeDays`: Expiration time after which stale `Project`s are finally auto-deleted (after `.status.staleSinceTimestamp`). If this value is changed and an auto-delete timestamp got already assigned to the projects then the new value will only take effect if it's increased. Hence, decreasing the `staleExpirationTimeDays` will not decrease already assigned auto-delete timestamps.
 
-{{% alert color="info"  title="Note" %}}
-Gardener administrators/operators can exclude specific `Project`s from the stale check by annotating the related `Namespace` resource with `project.gardener.cloud/skip-stale-check=true`.
-{{% /alert %}}
+> Gardener administrators/operators can exclude specific `Project`s from the stale check by annotating the related `Namespace` resource with `project.gardener.cloud/skip-stale-check=true`.
 
 #### "Activity" Reconciler
 

--- a/docs/development/logging.md
+++ b/docs/development/logging.md
@@ -19,9 +19,11 @@ Instead, it needs to be backed by a logging implementation like [zapr](https://g
 controller-runtime already provides a [set of helpers](https://github.com/kubernetes-sigs/controller-runtime/tree/v0.11.0/pkg/log/zap) for constructing zapr loggers, i.e., logr loggers backed by [zap](https://github.com/uber-go/zap), which is a popular logging library in the go community.
 Hence, we are migrating our component logging from logrus to logr (backed by zap) as part of [gardener/gardener#4251](https://github.com/gardener/gardener/issues/4251).
 
-> ⚠️ `logger.Logger` (logrus logger) is deprecated in Gardener and shall not be used in new code – use logr loggers when writing new code! (also see [Migration from logrus to logr](#migration-from-logrus-to-logr))
-> 
-> ℹ️ Don't use zap loggers directly, always use the logr interface in order to avoid tight coupling to a specific logging implementation.
+{{% alert color="warning"  title="Warning" %}}
+`logger.Logger` (logrus logger) is deprecated in Gardener and shall not be used in new code – use logr loggers when writing new code! (also see [Migration from logrus to logr](#migration-from-logrus-to-logr))
+
+Don't use zap loggers directly, always use the logr interface in order to avoid tight coupling to a specific logging implementation.
+{{% /alert %}}
 
 gardener-apiserver differs from the other components as it is based on the [apiserver library](https://github.com/kubernetes/apiserver) and therefore uses [klog](https://github.com/kubernetes/klog) – just like kube-apiserver.
 As gardener-apiserver writes (almost) no logs in our coding (outside the apiserver library), there is currently no plan for switching the logging implementation.
@@ -73,9 +75,6 @@ Gardener components can be configured to either log in `json` (default) or `text
 
 Components can be set to one of the following log levels (with increasing verbosity): `error`, `info` (default), `debug`.
 
-> ℹ️ Note: some Gardener components don't feature a configurable log level and format yet.
-> In this case, they log at `info` in `json` format.
-> We might add configuration options via command line flags that can be used in all components in the future though (see [gardener/gardener#5191](https://github.com/gardener/gardener/issues/5191)).
 
 ## Log Levels
 
@@ -138,7 +137,9 @@ results in
 
 The logger is injected by controller-runtime's `Controller` implementation and our `controllerutils.CreateWorker` alike (if a logger is passed using `controllerutils.WithLogger`). The logger returned by `logf.FromContext` is never `nil`. If the context doesn't carry a logger, it falls back to the global logger (`logf.Log`), which might discard logs if not configured, but is also never `nil`.
 
-> ⚠️ Make sure that you don't overwrite the `name` or `namespace` value keys for such loggers, otherwise you will lose information about the reconciled object.
+{{% alert color="warning"  title="Warning" %}}
+Make sure that you don't overwrite the `name` or `namespace` value keys for such loggers, otherwise you will lose information about the reconciled object.
+{{% /alert %}} 
 
 The controller implementation (controller-runtime / `CreateWorker`) itself takes care of logging the error returned by reconcilers.
 Hence, don't log an error that you are returning.

--- a/docs/development/logging.md
+++ b/docs/development/logging.md
@@ -135,9 +135,7 @@ results in
 
 The logger is injected by controller-runtime's `Controller` implementation and our `controllerutils.CreateWorker` alike (if a logger is passed using `controllerutils.WithLogger`). The logger returned by `logf.FromContext` is never `nil`. If the context doesn't carry a logger, it falls back to the global logger (`logf.Log`), which might discard logs if not configured, but is also never `nil`.
 
-
 > ⚠️ Make sure that you don't overwrite the `name` or `namespace` value keys for such loggers, otherwise you will lose information about the reconciled object.
-
 
 The controller implementation (controller-runtime / `CreateWorker`) itself takes care of logging the error returned by reconcilers.
 Hence, don't log an error that you are returning.

--- a/docs/development/logging.md
+++ b/docs/development/logging.md
@@ -19,11 +19,9 @@ Instead, it needs to be backed by a logging implementation like [zapr](https://g
 controller-runtime already provides a [set of helpers](https://github.com/kubernetes-sigs/controller-runtime/tree/v0.11.0/pkg/log/zap) for constructing zapr loggers, i.e., logr loggers backed by [zap](https://github.com/uber-go/zap), which is a popular logging library in the go community.
 Hence, we are migrating our component logging from logrus to logr (backed by zap) as part of [gardener/gardener#4251](https://github.com/gardener/gardener/issues/4251).
 
-{{% alert color="warning"  title="Warning" %}}
-`logger.Logger` (logrus logger) is deprecated in Gardener and shall not be used in new code – use logr loggers when writing new code! (also see [Migration from logrus to logr](#migration-from-logrus-to-logr))
-
-Don't use zap loggers directly, always use the logr interface in order to avoid tight coupling to a specific logging implementation.
-{{% /alert %}}
+> ⚠️ `logger.Logger` (logrus logger) is deprecated in Gardener and shall not be used in new code – use logr loggers when writing new code! (also see [Migration from logrus to logr](#migration-from-logrus-to-logr))
+>
+> ℹ️ Don't use zap loggers directly, always use the logr interface in order to avoid tight coupling to a specific logging implementation.
 
 gardener-apiserver differs from the other components as it is based on the [apiserver library](https://github.com/kubernetes/apiserver) and therefore uses [klog](https://github.com/kubernetes/klog) – just like kube-apiserver.
 As gardener-apiserver writes (almost) no logs in our coding (outside the apiserver library), there is currently no plan for switching the logging implementation.
@@ -137,9 +135,9 @@ results in
 
 The logger is injected by controller-runtime's `Controller` implementation and our `controllerutils.CreateWorker` alike (if a logger is passed using `controllerutils.WithLogger`). The logger returned by `logf.FromContext` is never `nil`. If the context doesn't carry a logger, it falls back to the global logger (`logf.Log`), which might discard logs if not configured, but is also never `nil`.
 
-{{% alert color="warning"  title="Warning" %}}
-Make sure that you don't overwrite the `name` or `namespace` value keys for such loggers, otherwise you will lose information about the reconciled object.
-{{% /alert %}} 
+
+> ⚠️ Make sure that you don't overwrite the `name` or `namespace` value keys for such loggers, otherwise you will lose information about the reconciled object.
+
 
 The controller implementation (controller-runtime / `CreateWorker`) itself takes care of logging the error returned by reconcilers.
 Hence, don't log an error that you are returning.

--- a/docs/extensions/heartbeat.md
+++ b/docs/extensions/heartbeat.md
@@ -1,6 +1,6 @@
 # Heartbeat Controller
 
-The heartbeat controller renews a dedicated `Lease` object named `gardener-extension-heartbeat` at regular 30 second intervals by default. This `Lease` is used for heartbeats similar to how `gardenlet` uses `Lease` objects for seed heartbeats (see [gardenlet heartbeats](../concepts/gardenlet#heartbeats)).
+The heartbeat controller renews a dedicated `Lease` object named `gardener-extension-heartbeat` at regular 30 second intervals by default. This `Lease` is used for heartbeats similar to how `gardenlet` uses `Lease` objects for seed heartbeats (see [gardenlet heartbeats](../concepts/gardenlet.md#heartbeats)).
 
 The `gardener-extension-heartbeat` `Lease` can be checked by other controllers to verify that the corresponding extension controller is still running. Currently, `gardenlet` checks this `Lease` when performing shoot health checks and expects to find the `Lease` inside the namespace where the extension controller is deployed by the corresponding `ControllerInstallation`. For each extension resource deployed in the Shoot control plane, `gardenlet` finds the corresponding `gardener-extension-heartbeat` `Lease` resource and checks whether the `Lease`'s `.spec.renewTime` is older than the allowed threshold for stale extension health checks - in this case, `gardenlet` considers the health check report for an extension resource as "outdated" and reflects this in the `Shoot` status.
 

--- a/docs/usage/projects.md
+++ b/docs/usage/projects.md
@@ -57,11 +57,11 @@ The list of members (again a list in `.spec.members[]` using the `rbac.authoriza
 Each project member must have at least one role (currently described in `.spec.members[].role`, additional roles can be added to `.spec.members[].roles[]`). The following roles exist:
 
 * `admin`: This allows to fully manage resources inside the project (e.g., secrets, shoots, configmaps, and similar). Mind that the `admin` role has readonly access to service accounts.
-* `serviceaccountmanager`: This allows to fully manage service accounts inside the project namespace and request tokens for them. The permissions of the created service accounts are instead managed by the `admin` role. Please refer to [this document](./project_namespace_access.md).
+* `serviceaccountmanager`: This allows to fully manage service accounts inside the project namespace and request tokens for them. The permissions of the created service accounts are instead managed by the `admin` role. Please refer to [Service Account Manager](./service-account-manager.md).
 * `uam`: This allows to add/modify/remove human users or groups to/from the project member list.
 * `viewer`: This allows to read all resources inside the project except secrets.
 * `owner`: This combines the `admin`, `uam` and `serviceaccountmanager` roles.
-* Extension roles (prefixed with `extension:`): Please refer to [this document](../extensions/project-roles.md).
+* Extension roles (prefixed with `extension:`): Please refer to [Extending Project Roles](../extensions/project-roles.md).
 
 The [project controller](../concepts/controller-manager.md#project-controller) inside the Gardener Controller Manager is managing RBAC resources that grant the described privileges to the respective members.
 
@@ -94,4 +94,4 @@ The project owner can gradually remove these roles if desired.
 
 ## Stale Projects
 
-When a project is not actively used for some period of time the project is marked as "stale". This is done by controller called "Stale Projects Reconciler". Once the project is marked as stale there is a time frame in which if not used it will be deleted by that controller. More detailed information can be found [here](../concepts/controller-manager.md#stale-projects-reconciler).
+When a project is not actively used for some period of time, it is marked as "stale". This is done by a controller called ["Stale Projects Reconciler"](../concepts/controller-manager.md#stale-projects-reconciler). Once the project is marked as stale there is a time frame in which if not used it will be deleted by that controller.

--- a/docs/usage/service-account-manager.md
+++ b/docs/usage/service-account-manager.md
@@ -5,7 +5,7 @@ With Gardener `v1.47` a new role called `serviceaccountmanager` was introduced. 
 
 ## Actions
 
-Once given the `serviceaccountmanager` role, a user can create/update/delete `ServiceAccount`s in the project namespace.
+Once assigned the `serviceaccountmanager` role, a user can create/update/delete `ServiceAccount`s in the project namespace.
 
 ### Create a Service Account
  In order to create a `ServiceAccount` named "robot-user", run the following `kubectl` command:

--- a/docs/usage/service-account-manager.md
+++ b/docs/usage/service-account-manager.md
@@ -1,16 +1,20 @@
-# Project Namespace Access
+# Service Account Manager
 
-## Service Account Manager
+## Overview
 With Gardener `v1.47` a new role called `serviceaccountmanager` was introduced. This role allows to fully manage `ServiceAccount`'s in the project namespace and request tokens for them. This is the preferred way of managing the access to a project namespace as it aims to replace the usage of the default `ServiceAccount` secrets that will no longer be generated automatically with Kubernetes `v1.24+`.
 
+## Actions
+
+Once given the `serviceaccountmanager` role, a user can create/update/delete `ServiceAccount`s in the project namespace.
+
 ### Create a Service Account
-Once given the `serviceaccountmanager` role a user can create/update/delete `ServiceAccount`s in the project namespace. In order to create a `ServiceAccount` named "robot-user" run the following `kubectl` command:
+ In order to create a `ServiceAccount` named "robot-user", run the following `kubectl` command:
 
 ```code
 kubectl -n project-abc create sa robot-user
 ```
 
-### Request a token for a Service Account
+### Request a Token for a Service Account
 A token for the "robot-user" `ServiceAccount` can be requested via the [TokenRequest API](https://kubernetes.io/docs/reference/kubernetes-api/authentication-resources/token-request-v1/) in several ways:
 
 - using `kubectl` >= v1.24
@@ -45,10 +49,10 @@ curl -X POST https://api.gardener/api/v1/namespaces/project-abc/serviceaccounts/
       }'
 ```
 
-Mind that the returned token is not stored within the Kubernetes cluster, will be valid for `3600` seconds and will be invalidated if the "robot-user" `ServiceAccount` is deleted. Although `expirationSeconds` can be modified depending on the needs, the returned token's validity will not exceed the configured `service-account-max-token-expiration` duration for the garden cluster. It is advised that the actual `expirationTimestamp` is verified so that expectations are met. This can be done by asserting the `expirationTimestamp` in the `TokenRequestStatus` or the `exp` claim in the token itself.
+Mind that the returned token is not stored within the Kubernetes cluster, will be valid for `3600` seconds, and will be invalidated if the "robot-user" `ServiceAccount` is deleted. Although `expirationSeconds` can be modified depending on the needs, the returned token's validity will not exceed the configured `service-account-max-token-expiration` duration for the garden cluster. It is advised that the actual `expirationTimestamp` is verified so that expectations are met. This can be done by asserting the `expirationTimestamp` in the `TokenRequestStatus` or the `exp` claim in the token itself.
 
 ### Delete a Service Account
-In order to delete the `ServiceAccount` named "robot-user" run the following `kubectl` command:
+In order to delete the `ServiceAccount` named "robot-user", run the following `kubectl` command:
 
 ```code
 kubectl -n project-abc delete sa robot-user

--- a/docs/usage/shoot_access.md
+++ b/docs/usage/shoot_access.md
@@ -49,9 +49,7 @@ Here, the `kubeconfig-request.json` has the following content:
 }
 ```
 
-{{% alert color="info"  title="Note" %}}
-The [`gardenctl-v2`](https://github.com/gardener/gardenctl-v2/) tool makes it easy to target shoot clusters and automatically renews such `kubeconfig` when required.
-{{% /alert %}}
+> The [`gardenctl-v2`](https://github.com/gardener/gardenctl-v2/) tool makes it easy to target shoot clusters and automatically renews such `kubeconfig` when required.
 
 ## OpenID Connect
 

--- a/docs/usage/shoot_access.md
+++ b/docs/usage/shoot_access.md
@@ -49,7 +49,9 @@ Here, the `kubeconfig-request.json` has the following content:
 }
 ```
 
-> The [`gardenctl-v2`](https://github.com/gardener/gardenctl-v2/) tool makes it easy to target shoot clusters and automatically renews such `kubeconfig` when required.
+{{% alert color="info"  title="Note" %}}
+The [`gardenctl-v2`](https://github.com/gardener/gardenctl-v2/) tool makes it easy to target shoot clusters and automatically renews such `kubeconfig` when required.
+{{% /alert %}}
 
 ## OpenID Connect
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area documentation
/kind enhancement

**What this PR does / why we need it**:
This PR:
- updates notes in various topics
- renames Project Namespace Access to Service Account Manager for clarity
- fixes broken links

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```doc developer
NONE
```
