### PR TITLE
Revert "remove dnsprovider from supported extension kinds" temporarily

### DIFF
--- a/pkg/apis/core/validation/controllerregistration.go
+++ b/pkg/apis/core/validation/controllerregistration.go
@@ -57,7 +57,7 @@ var SupportedExtensionKinds = sets.NewString(
 	extensionsv1alpha1.NetworkResource,
 	extensionsv1alpha1.OperatingSystemConfigResource,
 	extensionsv1alpha1.WorkerResource,
-	// TODO: drop this with v1.55 or later to still support removal of any controller registrations specifying resources of kind DNSProvider, see https://github.com/gardener/gardener/issues/5270
+	// TODO: drop this with v1.60 or later to still support removal of any controller registrations specifying resources of kind DNSProvider, see https://github.com/gardener/gardener/issues/5270
 	"DNSProvider",
 )
 

--- a/pkg/apis/core/validation/controllerregistration.go
+++ b/pkg/apis/core/validation/controllerregistration.go
@@ -57,6 +57,8 @@ var SupportedExtensionKinds = sets.NewString(
 	extensionsv1alpha1.NetworkResource,
 	extensionsv1alpha1.OperatingSystemConfigResource,
 	extensionsv1alpha1.WorkerResource,
+	// TODO: drop this with v1.55 or later to still support removal of any controller registrations specifying resources of kind DNSProvider, see https://github.com/gardener/gardener/issues/5270
+	"DNSProvider",
 )
 
 // ValidateControllerRegistrationSpec validates the specification of a ControllerRegistration object.


### PR DESCRIPTION


**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind cleanup

**What this PR does / why we need it**:
This PR reverts the PR #6840 "Remove DNSProvider from supported extension kinds" temporarily, as it prevents removing the `dns-external` extension if it was not removed before updating to Gardener `v1.58.0`.
It should be reapplied for `v1.60.0` or later.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
This reverts commit c18cd01b5bf17f4d8fe1abf622b25b8064b5df95.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Revert removal `DNSProvider` from supported extension kinds until `v1.60.0` or later.
```
