### PR TITLE
Inject annotations for GRMs unique `ConfigMap`

### DIFF
--- a/pkg/operation/botanist/component/resourcemanager/resource_manager.go
+++ b/pkg/operation/botanist/component/resourcemanager/resource_manager.go
@@ -51,6 +51,7 @@ import (
 	"github.com/gardener/gardener/pkg/operation/botanist/component"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/kubescheduler"
 	resourcemanagerconfigv1alpha1 "github.com/gardener/gardener/pkg/resourcemanager/apis/config/v1alpha1"
+	"github.com/gardener/gardener/pkg/resourcemanager/controller/garbagecollector/references"
 	"github.com/gardener/gardener/pkg/resourcemanager/webhook/podschedulername"
 	"github.com/gardener/gardener/pkg/resourcemanager/webhook/podtopologyspreadconstraints"
 	"github.com/gardener/gardener/pkg/resourcemanager/webhook/projectedtokenmount"
@@ -855,6 +856,8 @@ func (r *resourceManager) ensureDeployment(ctx context.Context, configMap *corev
 				utilruntime.Must(gutil.InjectGenericKubeconfig(deployment, genericTokenKubeconfigSecret.Name, r.secrets.shootAccess.Secret.Name))
 			}
 		}
+
+		utilruntime.Must(references.InjectAnnotations(deployment))
 
 		// Due to a checksum calculation, handling Topology Spread Constraints must happen last.
 		r.handleTopologySpreadConstraints(deployment)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind bug

**What this PR does / why we need it**:
After #6865, the GRM has a unique `ConfigMap`. However, without this PR, its own garbage collector deletes it since the `Deployment` is missing the reference annotation (hence, garbage collector thinks `ConfigMap` is not in-use). This PR fixes this.

```
2022-11-04 03:17:31 {"log":{"controller":"garbage-collector","level":"info","msg":"Garbage collection finished","name":"","namespace":"","object":{"name":""},"reconcileID":"1cc0fdec-34a1-4f88-9dc8-8737eb1b37a0","ts":"2022-11-04T03:17:31.754Z"}}
2022-11-04 03:17:31 {"log":{"controller":"garbage-collector","kind":"configmap","level":"info","msg":"Delete resource","name":"gardener-resource-manager-b4bc54ca","namespace":"garden","object":{"name":""},"reconcileID":"1cc0fdec-34a1-4f88-9dc8-8737eb1b37a0","ts":"2022-11-04T03:17:31.734Z"}}
2022-11-04 03:17:31 {"log":{"controller":"garbage-collector","kind":"configmap","level":"info","msg":"Delete resource","name":"gardener-resource-manager-e16db5f8","namespace":"shoot--foo--bar","object":{"name":""},"reconcileID":"1cc0fdec-34a1-4f88-9dc8-8737eb1b37a0","ts":"2022-11-04T03:17:31.734Z"}}
2022-11-04 03:17:30 {"log":{"controller":"garbage-collector","level":"info","msg":"Starting garbage collection","name":"","namespace":"","object":{"name":""},"reconcileID":"1cc0fdec-34a1-4f88-9dc8-8737eb1b37a0","ts":"2022-11-04T03:17:30.969Z"}}
```

/milestone v1.59

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
