### PR TITLE
Also respect "exotic" node address types when auto-approving kubelet server CSRs

### DIFF
--- a/pkg/resourcemanager/controller/csrapprover/reconciler.go
+++ b/pkg/resourcemanager/controller/csrapprover/reconciler.go
@@ -149,16 +149,16 @@ func (r *Reconciler) mustApprove(ctx context.Context, csr *certificatesv1.Certif
 	)
 
 	for _, address := range node.Status.Addresses {
-		if address.Type == corev1.NodeHostName {
+		if address.Type == corev1.NodeHostName || address.Type == corev1.NodeInternalDNS || address.Type == corev1.NodeExternalDNS {
 			hostNames = append(hostNames, address.Address)
 		}
-		if address.Type == corev1.NodeInternalIP {
+		if address.Type == corev1.NodeInternalIP || address.Type == corev1.NodeExternalIP {
 			ipAddresses = append(ipAddresses, address.Address)
 		}
 	}
 
 	if !sets.NewString(hostNames...).Equal(sets.NewString(x509cr.DNSNames...)) {
-		return "DNS names in CSR do not match Hostname addresses in node object", false, nil
+		return "DNS names in CSR do not match addresses of type 'Hostname' or 'InternalDNS' or 'ExternalDNS' in node object", false, nil
 	}
 
 	var ipAddressesInCSR []string
@@ -167,7 +167,7 @@ func (r *Reconciler) mustApprove(ctx context.Context, csr *certificatesv1.Certif
 	}
 
 	if !sets.NewString(ipAddresses...).Equal(sets.NewString(ipAddressesInCSR...)) {
-		return "IP addresses in CSR do not match InternalIP addresses in node object", false, nil
+		return "IP addresses in CSR do not match addresses of type 'InternalIP' or 'ExternalIP' in node object", false, nil
 	}
 
 	return "all checks passed", true, nil


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind bug

**What this PR does / why we need it**:
The `CertificateSigningRequest`s created by `kubelet`s for their server certificates are now also auto-approved when their `Node` object contains addresses of type `InternalDNS`, `ExternalDNS`, or `ExternalIP`.

**Which issue(s) this PR fixes**:
Introduced with #6784 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
The `CertificateSigningRequest`s created by `kubelet`s for their server certificates are now also auto-approved when their `Node` object contains addresses of type `InternalDNS`, `ExternalDNS`, or `ExternalIP`.
```
