### PR TITLE
Remove GA-ed `DisableDNSProviderManagement` feature gate

### DIFF
--- a/docs/deployment/feature_gates.md
+++ b/docs/deployment/feature_gates.md
@@ -91,7 +91,8 @@ The following tables are a summary of the feature gates that you can set on diff
 | WorkerPoolKubernetesVersion                  |         | `Removed`    | `1.52` |        |
 | DisableDNSProviderManagement                 | `false` | `Alpha`      | `1.41` | `1.49` |
 | DisableDNSProviderManagement                 | `true`  | `Beta`       | `1.50` | `1.51` |
-| DisableDNSProviderManagement                 | `true`  | `GA`         | `1.52` |        |
+| DisableDNSProviderManagement                 | `true`  | `GA`         | `1.52` | `1.59` |
+| DisableDNSProviderManagement                 |         | `Removed`    | `1.60` |        |
 | SecretBindingProviderValidation              | `false` | `Alpha`      | `1.38` | `1.50` |
 | SecretBindingProviderValidation              | `true`  | `Beta`       | `1.51` | `1.52` |
 | SecretBindingProviderValidation              | `true`  | `GA`         | `1.53` | `1.54` |
@@ -155,7 +156,6 @@ A *General Availability* (GA) feature is also referred to as a *stable* feature.
 | CopyEtcdBackupsDuringControlPlaneMigration | `gardenlet`                                                      | Enables the copy of etcd backups from the object store of the source seed to the object store of the destination seed during control plane migration. |
 | SecretBindingProviderValidation            | `gardener-apiserver`                                             | Enables validations on Gardener API server that:<br>- requires the provider type of a SecretBinding to be set (on SecretBinding creation)<br>- requires the SecretBinding provider type to match the Shoot provider type (on Shoot creation)<br>- enforces immutability on the provider type of a SecretBinding |
 | ForceRestore                               | `gardenlet`                                                      | Enables forcing the shoot's restoration to the destination seed during control plane migration if the preparation for migration in the source seed is not finished after a certain grace period and is considered unlikely to succeed (falling back to the [control plane migration "bad case" scenario](../proposals/17-shoot-control-plane-migration-bad-case.md)). If you enable this feature gate, make sure to also enable `CopyEtcdBackupsDuringControlPlaneMigration`. |
-| DisableDNSProviderManagement               | `gardenlet`                                                      | Disables management of `dns.gardener.cloud/v1alpha1.DNSProvider` resources. In this case, the `shoot-dns-service` extension will take this over if it is installed. |
 | HAControlPlanes                            | `gardener-apiserver`                                             | HAControlPlanes allows shoot control planes to be run in high availability mode. |
 | DefaultSeccompProfile                      | `gardenlet`                                                      | Enables the defaulting of the seccomp profile for Gardener managed workload in the seed to RuntimeDefault. |
 | CoreDNSQueryRewriting                      | `gardenlet`                                                      | Enables automatic DNS query rewriting in shoot cluster's CoreDNS to shortcut name resolution of fully qualified in-cluster and out-of-cluster names, which follow a user-defined pattern. Details can be found in [DNS Search Path Optimization](../usage/dns-search-path-optimization.md). |

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -91,18 +91,6 @@ const (
 	// alpha: v1.39.0
 	ForceRestore featuregate.Feature = "ForceRestore"
 
-	// DisableDNSProviderManagement disables management of `dns.gardener.cloud/v1alpha1.DNSProvider` resources.
-	// In this case, the `shoot-dns-service` extension can take this over if it is installed and following prerequisites
-	// are given:
-	// - The `shoot-dns-service` extension must be installed in a version >= `v1.20.0`.
-	// - The controller deployment of the `shoot-dns-service` sets `providerConfig.values.dnsProviderManagement.enabled=true`
-	// - Its admission controller (`gardener-extension-admission-shoot-dns-service`) is deployed on the garden cluster
-	// owner: @MartinWeindel @timuthy
-	// alpha: v1.41
-	// beta: v1.50
-	// GA: v1.52.0
-	DisableDNSProviderManagement featuregate.Feature = "DisableDNSProviderManagement"
-
 	// HAControlPlanes allows shoot control planes to be run in high availability mode.
 	// owner: @shreyas-s-rao @timuthy
 	// alpha: v1.49.0
@@ -129,11 +117,10 @@ var allFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	SeedKubeScheduler:  {Default: false, PreRelease: featuregate.Deprecated},
 	ReversedVPN:        {Default: true, PreRelease: featuregate.Beta},
 	CopyEtcdBackupsDuringControlPlaneMigration: {Default: true, PreRelease: featuregate.Beta},
-	ForceRestore:                 {Default: false, PreRelease: featuregate.Alpha},
-	DisableDNSProviderManagement: {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
-	HAControlPlanes:              {Default: false, PreRelease: featuregate.Alpha},
-	DefaultSeccompProfile:        {Default: false, PreRelease: featuregate.Alpha},
-	CoreDNSQueryRewriting:        {Default: false, PreRelease: featuregate.Alpha},
+	ForceRestore:          {Default: false, PreRelease: featuregate.Alpha},
+	HAControlPlanes:       {Default: false, PreRelease: featuregate.Alpha},
+	DefaultSeccompProfile: {Default: false, PreRelease: featuregate.Alpha},
+	CoreDNSQueryRewriting: {Default: false, PreRelease: featuregate.Alpha},
 }
 
 // GetFeatures returns a feature gate map with the respective specifications. Non-existing feature gates are ignored.

--- a/pkg/gardenlet/features/features.go
+++ b/pkg/gardenlet/features/features.go
@@ -35,7 +35,6 @@ func RegisterFeatureGates() {
 		features.ReversedVPN,
 		features.CopyEtcdBackupsDuringControlPlaneMigration,
 		features.ForceRestore,
-		features.DisableDNSProviderManagement,
 		features.DefaultSeccompProfile,
 		features.CoreDNSQueryRewriting,
 	)))


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind cleanup

**What this PR does / why we need it**:
Taken over from #6940.

The `DisableDNSProviderManagement` feature gate is locked to default and no-op since v1.52. I believe we can clean it up now.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/5270

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The GA-ed `DisableDNSProviderManagement` feature gate is now removed.
```
