### PR TITLE
`gardener-resource-manager`s `secret` controller watches the right cluster

### DIFF
--- a/pkg/resourcemanager/controller/add.go
+++ b/pkg/resourcemanager/controller/add.go
@@ -97,7 +97,7 @@ func AddToManager(mgr manager.Manager, sourceCluster, targetCluster cluster.Clus
 	if err := (&secret.Reconciler{
 		Config:      cfg.Controllers.Secret,
 		ClassFilter: managerpredicate.NewClassFilter(*cfg.Controllers.ResourceClass),
-	}).AddToManager(mgr, targetCluster); err != nil {
+	}).AddToManager(mgr, sourceCluster); err != nil {
 		return fmt.Errorf("failed adding secret controller: %w", err)
 	}
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind regression bug

**What this PR does / why we need it**:
This PR fixes a bug that prevents `Shoot` deletion for clusters that were created prior `v1.59`. On deletion, GRM is redeployed but its `secret` controller watches the wrong cluster (`target` instead of `source`). Hence, it does not cleanup the finalizers.
For `Shoot`s created with `v1.59` the deletion works because the `secret` controller was never adding the finalizer in the first place.

**Which issue(s) this PR fixes**:
Introduced with #6865 
Fixes #6961

**Special notes for your reviewer**:
This regression was not discovered earlier because
- integration tests only have one cluster (source=target)
- e2e/TestMachinery tests don't cover this case (ref https://github.com/gardener/gardener/issues/2692)


**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
A bug has been fixed which caused stuck `Shoot` on deletion because their `Namespace`s in the seed cluster were not cleaned up properly. It only affected clusters created prior `gardener/gardener@v1.59`.
```
