### PR TITLE
Enable heartbeat controller in the common app package

### DIFF
--- a/extensions/pkg/controller/operatingsystemconfig/oscommon/cmd/options.go
+++ b/extensions/pkg/controller/operatingsystemconfig/oscommon/cmd/options.go
@@ -16,6 +16,7 @@ package cmd
 
 import (
 	"github.com/gardener/gardener/extensions/pkg/controller/cmd"
+	extensionsheartbeatcontroller "github.com/gardener/gardener/extensions/pkg/controller/heartbeat"
 	"github.com/gardener/gardener/extensions/pkg/controller/operatingsystemconfig"
 	"github.com/gardener/gardener/extensions/pkg/controller/operatingsystemconfig/oscommon"
 	"github.com/gardener/gardener/extensions/pkg/controller/operatingsystemconfig/oscommon/generator"
@@ -29,5 +30,6 @@ func SwitchOptions(ctrlName string, osTypes []string, generator generator.Genera
 		cmd.Switch(operatingsystemconfig.ControllerName, func(mgr manager.Manager) error {
 			return oscommon.AddToManager(mgr, ctrlName, osTypes, generator)
 		}),
+		cmd.Switch(extensionsheartbeatcontroller.ControllerName, extensionsheartbeatcontroller.AddToManager),
 	)
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area open-source
/kind enhancement

**What this PR does / why we need it**:
This PR enables heartbeat controller in the common app package for os extensions.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/4798

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Added heartbeat controller to the common app package for os extensions.
```
