### PR TITLE
Revert "[ci:component:github.com/gardener/etcd-druid:v0.13.3->v0.14.0]"

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -30,7 +30,7 @@ images:
 - name: etcd-druid
   sourceRepository: github.com/gardener/etcd-druid
   repository: eu.gcr.io/gardener-project/gardener/etcd-druid
-  tag: "v0.14.0"
+  tag: "v0.13.3"
 - name: dependency-watchdog
   sourceRepository: github.com/gardener/dependency-watchdog
   repository: eu.gcr.io/gardener-project/gardener/dependency-watchdog


### PR DESCRIPTION
Reverts gardener/gardener#6955

HA tests are [failing](https://prow.gardener.cloud/view/gs/gardener-prow/logs/ci-gardener-e2e-kind-ha-single-zone/1589982663094046720) (tests are introduced by this PR https://github.com/gardener/gardener/pull/6910 ), due to  ETCD became unhealthy after upgrading from non-HA shoot to HA  `zone`/`node`.

Tests are passing in previous `etcd-druid` version.