### PR TITLE
Fix test to use TokenRequest API for garden clusters >=1.24

### DIFF
--- a/test/testmachinery/gardener/security/rbac.go
+++ b/test/testmachinery/gardener/security/rbac.go
@@ -43,7 +43,6 @@ import (
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
-	"github.com/gardener/gardener/pkg/utils/retry"
 )
 
 const (
@@ -83,19 +82,6 @@ var _ = ginkgo.Describe("RBAC testing", func() {
 		defer func() {
 			framework.ExpectNoError(f.GardenClient.Client().Delete(ctx, serviceAccount))
 		}()
-
-		err = retry.UntilTimeout(ctx, 10*time.Second, serviceAccountPermissionTimeout, func(ctx context.Context) (bool, error) {
-			newServiceAccount := &corev1.ServiceAccount{}
-			if err := f.GardenClient.Client().Get(ctx, client.ObjectKey{Namespace: serviceAccount.Namespace, Name: serviceAccount.Name}, newServiceAccount); err != nil {
-				return retry.MinorError(err)
-			}
-			serviceAccount = newServiceAccount
-			if len(serviceAccount.Secrets) != 0 {
-				return retry.Ok()
-			}
-			return retry.NotOk()
-		})
-		framework.ExpectNoError(err)
 
 		saClient, err := framework.NewClientFromServiceAccount(ctx, f.GardenClient, serviceAccount)
 		framework.ExpectNoError(err)

--- a/test/testmachinery/gardener/security/rbac.go
+++ b/test/testmachinery/gardener/security/rbac.go
@@ -50,6 +50,10 @@ const (
 	serviceAccountPermissionTimeout = 60 * time.Second
 )
 
+var (
+	labels = map[string]string{"testmachinery.gardener.cloud/name": "rbac"}
+)
+
 var _ = ginkgo.Describe("RBAC testing", func() {
 
 	f := framework.NewGardenerFramework(nil)
@@ -74,14 +78,12 @@ var _ = ginkgo.Describe("RBAC testing", func() {
 			ObjectMeta: v1.ObjectMeta{
 				GenerateName: "test-",
 				Namespace:    f.ProjectNamespace,
+				Labels:       labels,
 			},
 		}
 
 		err := f.GardenClient.Client().Create(ctx, serviceAccount)
 		framework.ExpectNoError(err)
-		defer func() {
-			framework.ExpectNoError(f.GardenClient.Client().Delete(ctx, serviceAccount))
-		}()
 
 		saClient, err := framework.NewClientFromServiceAccount(ctx, f.GardenClient, serviceAccount)
 		framework.ExpectNoError(err)
@@ -90,6 +92,13 @@ var _ = ginkgo.Describe("RBAC testing", func() {
 		err = saClient.Client().List(ctx, shoots, client.InNamespace(v1beta1constants.GardenNamespace))
 		g.Expect(err).To(g.HaveOccurred())
 		g.Expect(errors.IsForbidden(err)).To(g.BeTrue())
-	}, serviceAccountPermissionTimeout)
+	}, serviceAccountPermissionTimeout, framework.WithCAfterTest(func(ctx context.Context) {
+		framework.ExpectNoError(f.GardenClient.Client().DeleteAllOf(
+			ctx,
+			&corev1.ServiceAccount{},
+			client.InNamespace(f.ProjectNamespace),
+			client.MatchingLabels(labels)),
+		)
+	}, serviceAccountPermissionTimeout))
 
 })


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind bug

**What this PR does / why we need it**:
Fix testmachinery test to always use TokenRequest API and to properly clean up created service account

**Which issue(s) this PR fixes**:
Fixes #6975 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fix garden RBAC test to use `TokenRequest` API.
```
