### PR TITLE
Fix gardenlet metrics scraping by seed-prometheus

### DIFF
--- a/charts/gardener/gardenlet/templates/deployment.yaml
+++ b/charts/gardener/gardenlet/templates/deployment.yaml
@@ -46,6 +46,7 @@ spec:
     metadata:
       annotations:
         prometheus.io/scrape: 'true'
+        prometheus.io/scheme: 'http'
         prometheus.io/port: {{ required ".Values.config.server.metrics.port is required" .Values.config.server.metrics.port | quote }}
         {{- if .Values.config.gardenClientConnection.bootstrapKubeconfig }}
         {{- if not .Values.config.gardenClientConnection.bootstrapKubeconfig.secretRef }}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind bug

**What this PR does / why we need it**:

Currently, seed-prometheus fails to scrape gardenlet with:
```
Get "https://10.1.130.202:2729/metrics": http: server gave HTTP response to HTTPS client
```

Broken by https://github.com/gardener/gardener/pull/6688
Part of https://github.com/gardener/gardener/issues/4251

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
`gardenlet` is scraped again by `seed-prometheus`.
```
