### PR TITLE
Remove journald path from the fluent-bit and promtail configuration.

### DIFF
--- a/charts/seed-bootstrap/charts/fluent-bit/templates/_fluent-bit-config.tpl
+++ b/charts/seed-bootstrap/charts/fluent-bit/templates/_fluent-bit-config.tpl
@@ -50,49 +50,42 @@
   [INPUT]
       Name            systemd
       Tag             journald.docker
-      Path            %%JOURNALD_PATH%%
       Read_From_Tail  True
       Systemd_Filter  _SYSTEMD_UNIT=docker.service
 
   [INPUT]
       Name            systemd
       Tag             journald.kubelet
-      Path            %%JOURNALD_PATH%%
       Read_From_Tail  True
       Systemd_Filter  _SYSTEMD_UNIT=kubelet.service
 
   [INPUT]
       Name            systemd
       Tag             journald.containerd
-      Path            %%JOURNALD_PATH%%
       Read_From_Tail  True
       Systemd_Filter  _SYSTEMD_UNIT=containerd.service
 
   [INPUT]
       Name            systemd
       Tag             journald.cloud-config-downloader
-      Path            %%JOURNALD_PATH%%
       Read_From_Tail  True
       Systemd_Filter  _SYSTEMD_UNIT=cloud-config-downloader.service
 
   [INPUT]
       Name            systemd
       Tag             journald.docker-monitor
-      Path            %%JOURNALD_PATH%%
       Read_From_Tail  True
       Systemd_Filter  _SYSTEMD_UNIT=docker-monitor.service
 
   [INPUT]
       Name            systemd
       Tag             journald.containerd-monitor
-      Path            %%JOURNALD_PATH%%
       Read_From_Tail  True
       Systemd_Filter  _SYSTEMD_UNIT=containerd-monitor.service
 
   [INPUT]
       Name            systemd
       Tag             journald.kubelet-monitor
-      Path            %%JOURNALD_PATH%%
       Read_From_Tail  True
       Systemd_Filter  _SYSTEMD_UNIT=kubelet-monitor.service
 {{ end }}

--- a/charts/seed-bootstrap/charts/fluent-bit/templates/fluent-bit-daemonset.yaml
+++ b/charts/seed-bootstrap/charts/fluent-bit/templates/fluent-bit-daemonset.yaml
@@ -35,25 +35,6 @@ spec:
         volumeMounts:
         - name: plugins
           mountPath: "/plugins"
-      - name: journald-config
-        image: {{ index .Values.global.images "alpine" }}
-        command:
-        - sh
-        - "-c"
-        - |
-          JOURNALD_PATH="/var/log/journal"
-          if [ ! -d ${JOURNALD_PATH} ]; then
-              JOURNALD_PATH="/run/log/journal"
-          fi
-          cp -rL /template-config/* /fluent-bit-config/
-          sed -i "s|%%JOURNALD_PATH%%|${JOURNALD_PATH}|g" /fluent-bit-config/input.conf
-        volumeMounts:
-        - name: template-config
-          mountPath: /template-config
-        - name: config-dir
-          mountPath: /fluent-bit-config
-        - name: varlog
-          mountPath: /var/log
       priorityClassName: gardener-system-600
       containers:
       - name: fluent-bit
@@ -114,11 +95,9 @@ spec:
       - key: node-role.kubernetes.io/control-plane
         effect: NoSchedule
       volumes:
-      - name: template-config
+      - name: config-dir
         configMap:
           name: {{ include "fluent-bit.config.name" . }}
-      - name: config-dir
-        emptyDir: {}
       - name: varlog
         hostPath:
           path: /var/log

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/promtail/component.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/promtail/component.go
@@ -32,8 +32,6 @@ const (
 
 	// PathDirectory is the path for the promtail's directory.
 	PathDirectory = "/var/lib/promtail"
-	// PathSetActiveJournalFileScript is the path for the active journal file script.
-	PathSetActiveJournalFileScript = PathDirectory + "/scripts/set_active_journal_file.sh"
 	// PathFetchTokenScript is the path to a script which fetches promtail's token for communication with the Loki
 	// sidecar proxy.
 	PathFetchTokenScript = PathDirectory + "/scripts/fetch-token.sh"
@@ -71,7 +69,6 @@ func (component) Config(ctx components.Context) ([]extensionsv1alpha1.Unit, []ex
 		return []extensionsv1alpha1.Unit{
 			getPromtailUnit(
 				"/bin/systemctl disable "+UnitName,
-				`/bin/sh -c "echo 'service does not have configuration'"`,
 				fmt.Sprintf(`/bin/sh -c "echo service %s is removed!; while true; do sleep 86400; done"`, UnitName),
 			),
 			getFetchTokenScriptUnit(
@@ -94,7 +91,6 @@ func (component) Config(ctx components.Context) ([]extensionsv1alpha1.Unit, []ex
 	return []extensionsv1alpha1.Unit{
 			getPromtailUnit(
 				execStartPreCopyBinaryFromContainer("promtail", ctx.Images[images.ImageNamePromtail]),
-				"/bin/sh "+PathSetActiveJournalFileScript,
 				v1beta1constants.OperatingSystemConfigFilePathBinaries+`/promtail -config.file=`+PathConfig,
 			),
 			getFetchTokenScriptUnit(
@@ -106,6 +102,5 @@ func (component) Config(ctx components.Context) ([]extensionsv1alpha1.Unit, []ex
 			promtailConfigFile,
 			fetchTokenScriptFile,
 			getPromtailCAFile(ctx),
-			setActiveJournalFile(),
 		}, nil
 }

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/promtail/config.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/promtail/config.go
@@ -63,15 +63,6 @@ func init() {
 	}
 }
 
-const setActiveJournalFileScript = `#!/bin/bash
-PERSISTANT_JOURNAL_FILE=/var/log/journal
-TEMP_JOURNAL_FILE=/run/log/journal
-if [ ! -d "$PERSISTANT_JOURNAL_FILE" ] && [ -d "$TEMP_JOURNAL_FILE" ]; then
-	sed -i -e "s|$PERSISTANT_JOURNAL_FILE|$TEMP_JOURNAL_FILE|g" ` + PathConfig + `
-elif  [ ! -d "$TEMP_JOURNAL_FILE" ] && [ -d "$PERSISTANT_JOURNAL_FILE" ]; then
-	sed -i -e "s|$TEMP_JOURNAL_FILE$|$PERSISTANT_JOURNAL_FILE|g" ` + PathConfig + `
-fi`
-
 func getPromtailConfigurationFile(ctx components.Context) (extensionsv1alpha1.File, error) {
 	var config bytes.Buffer
 
@@ -124,20 +115,7 @@ func getPromtailCAFile(ctx components.Context) extensionsv1alpha1.File {
 	}
 }
 
-func setActiveJournalFile() extensionsv1alpha1.File {
-	return extensionsv1alpha1.File{
-		Path:        PathSetActiveJournalFileScript,
-		Permissions: pointer.Int32(0644),
-		Content: extensionsv1alpha1.FileContent{
-			Inline: &extensionsv1alpha1.FileContentInline{
-				Encoding: "b64",
-				Data:     utils.EncodeBase64([]byte(setActiveJournalFileScript)),
-			},
-		},
-	}
-}
-
-func getPromtailUnit(execStartPre, execStartPreConfig, execStart string) extensionsv1alpha1.Unit {
+func getPromtailUnit(execStartPre, execStart string) extensionsv1alpha1.Unit {
 	return extensionsv1alpha1.Unit{
 		Name:    UnitName,
 		Command: pointer.String("start"),
@@ -162,7 +140,6 @@ RestartSec=5
 EnvironmentFile=/etc/environment
 ExecStartPre=/bin/sh -c "systemctl set-environment HOSTNAME=$(hostname)"
 ExecStartPre=` + execStartPre + `
-ExecStartPre=` + execStartPreConfig + `
 ExecStart=` + execStart),
 	}
 }

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/promtail/config_test.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/promtail/config_test.go
@@ -83,7 +83,6 @@ RestartSec=5
 EnvironmentFile=/etc/environment
 ExecStartPre=/bin/sh -c "systemctl set-environment HOSTNAME=$(hostname)"
 ExecStartPre=/usr/bin/docker run --rm -v /opt/bin:/opt/bin:rw --entrypoint /bin/sh ` + promtailRepository + ":" + promtailImageTag + " -c " + "\"cp /usr/bin/promtail /opt/bin\"" + `
-ExecStartPre=/bin/sh ` + PathSetActiveJournalFileScript + `
 ExecStart=/opt/bin/promtail -config.file=` + PathConfig),
 				},
 				extensionsv1alpha1.Unit{
@@ -133,7 +132,6 @@ scrape_configs:
       job: systemd-journal
       origin: systemd-journal
     max_age: 12h
-    path: /var/log/journal
   relabel_configs:
   - action: drop
     regex: ^localhost$
@@ -157,7 +155,6 @@ scrape_configs:
       job: systemd-combine-journal
       origin: systemd-journal
     max_age: 12h
-    path: /var/log/journal
   relabel_configs:
   - action: drop
     regex: ^localhost$
@@ -294,16 +291,6 @@ exit $?
 						},
 					},
 				},
-				extensionsv1alpha1.File{
-					Path:        "/var/lib/promtail/scripts/set_active_journal_file.sh",
-					Permissions: pointer.Int32(0644),
-					Content: extensionsv1alpha1.FileContent{
-						Inline: &extensionsv1alpha1.FileContentInline{
-							Encoding: "b64",
-							Data:     utils.EncodeBase64([]byte(setActiveJournalFileScript)),
-						},
-					},
-				},
 			))
 		})
 
@@ -346,7 +333,6 @@ RestartSec=5
 EnvironmentFile=/etc/environment
 ExecStartPre=/bin/sh -c "systemctl set-environment HOSTNAME=$(hostname)"
 ExecStartPre=/bin/systemctl disable promtail.service
-ExecStartPre=/bin/sh -c "echo 'service does not have configuration'"
 ExecStart=/bin/sh -c "echo service promtail.service is removed!; while true; do sleep 86400; done"`),
 				},
 				extensionsv1alpha1.Unit{

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/promtail/templates/promtail-config.tpl.yaml
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/promtail/templates/promtail-config.tpl.yaml
@@ -20,7 +20,6 @@ scrape_configs:
       job: systemd-journal
       origin: systemd-journal
     max_age: 12h
-    path: /var/log/journal
   relabel_configs:
   - action: drop
     regex: ^localhost$
@@ -44,7 +43,6 @@ scrape_configs:
       job: systemd-combine-journal
       origin: systemd-journal
     max_age: 12h
-    path: /var/log/journal
   relabel_configs:
   - action: drop
     regex: ^localhost$


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area logging
/kind enhancement

**What this PR does / why we need it**:
It looks like `Fluent-Bit` and `Promtail` have an efficient mechanism to detect in which directory `journald` logs. By removing the explicit path both log processor manage to choose between `/var/log/journal` and `/run/log/journal`.

**Which issue(s) this PR fixes**:
Fixes [#6965](https://github.com/gardener/gardener/issues/6965)

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Gardener correctly identifies the logging directory for `systemd-journald` and does not rely on a directory existence check.
```
