### PR TITLE
[release-v1.58] Automated cherry pick of #6979: Fix gardenlet metrics scraping by seed-prometheus

### DIFF
--- a/charts/gardener/gardenlet/charts/runtime/templates/deployment.yaml
+++ b/charts/gardener/gardenlet/charts/runtime/templates/deployment.yaml
@@ -46,6 +46,7 @@ spec:
     metadata:
       annotations:
         prometheus.io/scrape: 'true'
+        prometheus.io/scheme: 'http'
         prometheus.io/port: {{ required ".Values.global.gardenlet.config.server.metrics.port is required" .Values.global.gardenlet.config.server.metrics.port | quote }}
         {{- if .Values.global.gardenlet.config.gardenClientConnection.bootstrapKubeconfig }}
         {{- if not .Values.global.gardenlet.config.gardenClientConnection.bootstrapKubeconfig.secretRef }}


### PR DESCRIPTION
/kind/bug
/area/monitoring

Cherry pick of #6979 on release-v1.58.

#6979: Fix gardenlet metrics scraping by seed-prometheus

**Release Notes:**
```bugfix operator
`gardenlet` is scraped again by `seed-prometheus`.
```