### PR TITLE
Use prow-friendly label commands in `cherry-pick-pull.sh`

### DIFF
--- a/hack/cherry-pick-pull.sh
+++ b/hack/cherry-pick-pull.sh
@@ -210,7 +210,7 @@ for pull in "${PULLS[@]}"; do
   pr_info=$(curl "https://api.github.com/repos/${MAIN_REPO_ORG}/${MAIN_REPO_NAME}/pulls/${pull}" -sS)
   subject=$(echo ${pr_info} | jq -cr '.title')
   SUBJECTS+=("#${pull}: ${subject}")
-  labels=$(echo ${pr_info} | jq '.labels[].name' -cr | grep -P '^(area|kind)' | sed 's|^|/|g')
+  labels=$(echo ${pr_info} | jq '.labels[].name' -cr | grep -P '^(area|kind)' | sed -e 's|/| |' -e 's|^|/|g')
   LABELS+=("${labels}")
 
   # remove the patch file from /tmp


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind bug

**What this PR does / why we need it**:

`hack/cherry-pick-pull.sh` adds labels in a command format that is not accepted by prow, e.g.:
```
/kind/bug
/area/monitoring
```

This PR fixes this and switches to the following format:
```
/kind bug
/area monitoring
```

**Which issue(s) this PR fixes**:
Example PR: https://github.com/gardener/gardener/pull/6984
