### PR TITLE
Removes setting owner checks on `Etcd` resources

### DIFF
--- a/pkg/operation/botanist/component/etcd/etcd.go
+++ b/pkg/operation/botanist/component/etcd/etcd.go
@@ -115,8 +115,6 @@ type Interface interface {
 	SetHVPAConfig(config *HVPAConfig)
 	// Get retrieves the Etcd resource
 	Get(context.Context) (*druidv1alpha1.Etcd, error)
-	// SetOwnerCheckConfig sets the owner check configuration.
-	SetOwnerCheckConfig(config *OwnerCheckConfig)
 	// Scale scales the etcd resource to the given replica count.
 	Scale(context.Context, int32) error
 	// RolloutPeerCA gets the peer CA and patches the
@@ -184,7 +182,6 @@ type etcd struct {
 	etcd                    *druidv1alpha1.Etcd
 	backupConfig            *BackupConfig
 	hvpaConfig              *HVPAConfig
-	ownerCheckConfig        *OwnerCheckConfig
 }
 
 func (e *etcd) hasHAControlPlane() bool {
@@ -564,16 +561,6 @@ func (e *etcd) Deploy(ctx context.Context) error {
 			}
 		}
 
-		if e.ownerCheckConfig != nil {
-			e.etcd.Spec.Backup.OwnerCheck = &druidv1alpha1.OwnerCheckSpec{
-				Name:        e.ownerCheckConfig.Name,
-				ID:          e.ownerCheckConfig.ID,
-				Interval:    &metav1.Duration{Duration: 30 * time.Second},
-				Timeout:     &metav1.Duration{Duration: 2 * time.Minute},
-				DNSCacheTTL: &metav1.Duration{Duration: 1 * time.Minute},
-			}
-		}
-
 		e.etcd.Spec.StorageCapacity = &storageCapacity
 		e.etcd.Spec.VolumeClaimTemplate = &volumeClaimTemplate
 		return nil
@@ -836,9 +823,6 @@ func (e *etcd) Get(ctx context.Context) (*druidv1alpha1.Etcd, error) {
 
 func (e *etcd) SetBackupConfig(backupConfig *BackupConfig) { e.backupConfig = backupConfig }
 func (e *etcd) SetHVPAConfig(hvpaConfig *HVPAConfig)       { e.hvpaConfig = hvpaConfig }
-func (e *etcd) SetOwnerCheckConfig(ownerCheckConfig *OwnerCheckConfig) {
-	e.ownerCheckConfig = ownerCheckConfig
-}
 
 func (e *etcd) Scale(ctx context.Context, replicas int32) error {
 	etcdObj := &druidv1alpha1.Etcd{}
@@ -1041,13 +1025,4 @@ type HVPAConfig struct {
 	MaintenanceTimeWindow gardencorev1beta1.MaintenanceTimeWindow
 	// The update mode to use for scale down.
 	ScaleDownUpdateMode *string
-}
-
-// OwnerCheckConfig contains parameters related to checking if the seed is an owner
-// of the shoot. The ownership can change during control plane migration.
-type OwnerCheckConfig struct {
-	// Name is the domain name of the owner DNS record.
-	Name string
-	// ID is the seed ID value that is expected to be found in the owner DNS record.
-	ID string
 }

--- a/pkg/operation/botanist/component/etcd/mock/mocks.go
+++ b/pkg/operation/botanist/component/etcd/mock/mocks.go
@@ -162,18 +162,6 @@ func (mr *MockInterfaceMockRecorder) SetHVPAConfig(arg0 interface{}) *gomock.Cal
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetHVPAConfig", reflect.TypeOf((*MockInterface)(nil).SetHVPAConfig), arg0)
 }
 
-// SetOwnerCheckConfig mocks base method.
-func (m *MockInterface) SetOwnerCheckConfig(arg0 *etcd.OwnerCheckConfig) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "SetOwnerCheckConfig", arg0)
-}
-
-// SetOwnerCheckConfig indicates an expected call of SetOwnerCheckConfig.
-func (mr *MockInterfaceMockRecorder) SetOwnerCheckConfig(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetOwnerCheckConfig", reflect.TypeOf((*MockInterface)(nil).SetOwnerCheckConfig), arg0)
-}
-
 // Snapshot mocks base method.
 func (m *MockInterface) Snapshot(arg0 context.Context, arg1 kubernetes.PodExecutor) error {
 	m.ctrl.T.Helper()

--- a/pkg/operation/botanist/etcd.go
+++ b/pkg/operation/botanist/etcd.go
@@ -30,7 +30,6 @@ import (
 	"github.com/gardener/gardener/pkg/operation/botanist/component/etcd"
 	"github.com/gardener/gardener/pkg/operation/shoot"
 	"github.com/gardener/gardener/pkg/utils/flow"
-	gutil "github.com/gardener/gardener/pkg/utils/gardener"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/timewindow"
 
@@ -122,16 +121,6 @@ func (b *Botanist) DeployEtcd(ctx context.Context) error {
 			FullSnapshotSchedule: snapshotSchedule,
 			LeaderElection:       backupLeaderElection,
 		})
-
-		// Owner checks are only enabled if the `etcd-main` resource is deployed with 1 replica.
-		// They must not be used for clustered etcd. Ref: https://github.com/gardener/gardener/issues/6302
-		if gardencorev1beta1helper.SeedSettingOwnerChecksEnabled(b.Seed.GetInfo().Spec.Settings) &&
-			getEtcdReplicas(b.Shoot.GetInfo()) == 1 {
-			b.Shoot.Components.ControlPlane.EtcdMain.SetOwnerCheckConfig(&etcd.OwnerCheckConfig{
-				Name: gutil.GetOwnerDomain(b.Shoot.InternalClusterDomain),
-				ID:   *b.Seed.GetInfo().Status.ClusterIdentity,
-			})
-		}
 	}
 
 	// Roll out the new peer CA first so that every member in the cluster trusts the old and the new CA.

--- a/pkg/operation/botanist/etcd_test.go
+++ b/pkg/operation/botanist/etcd_test.go
@@ -353,12 +353,6 @@ var _ = Describe("Etcd", func() {
 						LeaderElection:       backupLeaderElectionConfig,
 					})
 				}
-				expectSetOwnerCheckConfig = func() {
-					etcdMain.EXPECT().SetOwnerCheckConfig(&etcd.OwnerCheckConfig{
-						Name: "owner.internal.example.com",
-						ID:   "seed-identity",
-					})
-				}
 			)
 
 			BeforeEach(func() {
@@ -372,37 +366,12 @@ var _ = Describe("Etcd", func() {
 				}
 			})
 
-			It("should set the secrets and deploy with owner checks", func() {
-				expectGetBackupSecret()
-				expectSetBackupConfig()
-				expectSetOwnerCheckConfig()
-				etcdMain.EXPECT().Deploy(ctx)
-				etcdEvents.EXPECT().Deploy(ctx)
-
-				Expect(botanist.DeployEtcd(ctx)).To(Succeed())
-			})
-
-			It("should set secrets and deploy without owner checks if high-availability is set on the shoot", func() {
+			It("should set secrets and deploy", func() {
 				botanist.Shoot.GetInfo().Spec.ControlPlane = &gardencorev1beta1.ControlPlane{
 					HighAvailability: &gardencorev1beta1.HighAvailability{
 						FailureTolerance: gardencorev1beta1.FailureTolerance{
 							Type: gardencorev1beta1.FailureToleranceTypeNode,
 						},
-					},
-				}
-
-				expectGetBackupSecret()
-				expectSetBackupConfig()
-				etcdMain.EXPECT().Deploy(ctx)
-				etcdEvents.EXPECT().Deploy(ctx)
-
-				Expect(botanist.DeployEtcd(ctx)).To(Succeed())
-			})
-
-			It("should set the secrets and deploy without owner checks if they are disabled", func() {
-				botanist.Seed.GetInfo().Spec.Settings = &gardencorev1beta1.SeedSettings{
-					OwnerChecks: &gardencorev1beta1.SeedSettingOwnerChecks{
-						Enabled: false,
 					},
 				}
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane-migration
/kind cleanup

**What this PR does / why we need it**:
Owner check settings are no longer set on `Etcd` resources in all cases. Previously they were only set if the replica of `etcd-main` statefulset was 1.

**Which issue(s) this PR fixes**:
Part of #6302

**Special notes for your reviewer**:
This PR will restart the `etcd-main` pods for shoot clusters that use only a single replica for them, as the settings will be changed.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Owner check settings are no longer configured for `Etcd` resources in all cases. Previously they were only configured for the `etcd-main` `Etcd` resource when the corresponding `StatefulSet` was deployed with 1 replica.
```
