### PR TITLE
Adapt high-availability configuration of shoot system components

### DIFF
--- a/charts/shoot-core/components/charts/monitoring/charts/blackbox-exporter/templates/deployment.yaml
+++ b/charts/shoot-core/components/charts/monitoring/charts/blackbox-exporter/templates/deployment.yaml
@@ -11,11 +11,12 @@ metadata:
     gardener.cloud/role: monitoring
     component: blackbox-exporter
     origin: gardener
+    high-availability-config.resources.gardener.cloud/type: server
   annotations:
 {{ include "blackbox-exporter.deployment.annotations" . | indent 4 }}
 spec:
-  revisionHistoryLimit: 1
-  replicas: 2
+  replicas: 1
+  revisionHistoryLimit: 2
   selector:
     matchLabels:
       component: blackbox-exporter

--- a/charts/shoot-core/components/charts/monitoring/charts/blackbox-exporter/templates/pdb.yaml
+++ b/charts/shoot-core/components/charts/monitoring/charts/blackbox-exporter/templates/pdb.yaml
@@ -3,6 +3,9 @@ kind: PodDisruptionBudget
 metadata:
   name: blackbox-exporter
   namespace: kube-system
+  labels:
+    gardener.cloud/role: monitoring
+    component: blackbox-exporter
 spec:
   maxUnavailable: 1
   selector:

--- a/pkg/operation/botanist/component/coredns/coredns_test.go
+++ b/pkg/operation/botanist/component/coredns/coredns_test.go
@@ -253,12 +253,14 @@ metadata:
   creationTimestamp: null
   labels:
     gardener.cloud/role: system-component
+    high-availability-config.resources.gardener.cloud/type: server
     k8s-app: kube-dns
     origin: gardener
   name: coredns
   namespace: kube-system
 spec:
-  revisionHistoryLimit: 1
+  replicas: 2
+  revisionHistoryLimit: 2
   selector:
     matchLabels:
       k8s-app: kube-dns
@@ -286,27 +288,6 @@ spec:
         k8s-app: kube-dns
         origin: gardener
     spec:
-      affinity:
-        podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - podAffinityTerm:
-              labelSelector:
-                matchExpressions:
-                - key: k8s-app
-                  operator: In
-                  values:
-                  - kube-dns
-              topologyKey: topology.kubernetes.io/zone
-            weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchExpressions:
-                - key: k8s-app
-                  operator: In
-                  values:
-                  - kube-dns
-              topologyKey: kubernetes.io/hostname
-            weight: 95
       containers:
       - args:
         - -conf
@@ -387,25 +368,6 @@ spec:
       tolerations:
       - key: CriticalAddonsOnly
         operator: Exists
-      topologySpreadConstraints:
-      - labelSelector:
-          matchExpressions:
-          - key: k8s-app
-            operator: In
-            values:
-            - kube-dns
-        maxSkew: 2
-        topologyKey: topology.kubernetes.io/zone
-        whenUnsatisfiable: ScheduleAnyway
-      - labelSelector:
-          matchExpressions:
-          - key: k8s-app
-            operator: In
-            values:
-            - kube-dns
-        maxSkew: 2
-        topologyKey: kubernetes.io/hostname
-        whenUnsatisfiable: ScheduleAnyway
       volumes:
       - configMap:
           items:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area high-availability
/kind enhancement

**What this PR does / why we need it**:
This PR adapts the HA configuration of the non-observability-related shoot system components.
Concretely, the components are labeled according to their type and custom replica/affinity changes have been dropped.
The webhook introduced with https://github.com/gardener/gardener/pull/6967 will take care to properly inject the required HA configuration.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/6529
Similar to https://github.com/gardener/gardener/pull/6982 and https://github.com/gardener/gardener/pull/6992

**Special notes for your reviewer**:
✅ ~Depends on https://github.com/gardener/gardener/pull/6967 which needs to be merged first.~

/cc @timuthy 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
All non-observability-related shoot system components are now running with configuration for high-availability according to [the conventions](https://github.com/gardener/gardener/blob/master/docs/development/high-availability.md).
```
