### PR TITLE
Adapt high-availability configuration of shoot control plane components

### DIFF
--- a/pkg/operation/botanist/clusterautoscaler.go
+++ b/pkg/operation/botanist/clusterautoscaler.go
@@ -36,6 +36,7 @@ func (b *Botanist) DefaultClusterAutoscaler() (clusterautoscaler.Interface, erro
 		image.String(),
 		b.Shoot.GetReplicas(1),
 		b.Shoot.GetInfo().Spec.Kubernetes.ClusterAutoscaler,
+		b.Seed.KubernetesVersion,
 	), nil
 }
 

--- a/pkg/operation/botanist/clusterautoscaler_test.go
+++ b/pkg/operation/botanist/clusterautoscaler_test.go
@@ -18,6 +18,14 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/Masterminds/semver"
+	"github.com/golang/mock/gomock"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	mockkubernetes "github.com/gardener/gardener/pkg/client/kubernetes/mock"
@@ -25,15 +33,9 @@ import (
 	. "github.com/gardener/gardener/pkg/operation/botanist"
 	mockclusterautoscaler "github.com/gardener/gardener/pkg/operation/botanist/component/clusterautoscaler/mock"
 	mockworker "github.com/gardener/gardener/pkg/operation/botanist/component/extensions/worker/mock"
+	seedpkg "github.com/gardener/gardener/pkg/operation/seed"
 	shootpkg "github.com/gardener/gardener/pkg/operation/shoot"
 	"github.com/gardener/gardener/pkg/utils/imagevector"
-
-	"github.com/golang/mock/gomock"
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 )
 
 var _ = Describe("ClusterAutoscaler", func() {
@@ -45,6 +47,9 @@ var _ = Describe("ClusterAutoscaler", func() {
 	BeforeEach(func() {
 		ctrl = gomock.NewController(GinkgoT())
 		botanist = &Botanist{Operation: &operation.Operation{}}
+		botanist.Seed = &seedpkg.Seed{
+			KubernetesVersion: semver.MustParse("1.25.0"),
+		}
 	})
 
 	AfterEach(func() {

--- a/pkg/operation/botanist/component/clusterautoscaler/monitoring_test.go
+++ b/pkg/operation/botanist/component/clusterautoscaler/monitoring_test.go
@@ -15,6 +15,7 @@
 package clusterautoscaler_test
 
 import (
+	"github.com/Masterminds/semver"
 	. "github.com/onsi/ginkgo/v2"
 
 	. "github.com/gardener/gardener/pkg/operation/botanist/component/clusterautoscaler"
@@ -22,7 +23,7 @@ import (
 )
 
 var _ = Describe("Monitoring", func() {
-	clusterAutoscaler := New(nil, "", nil, "", 0, nil)
+	clusterAutoscaler := New(nil, "", nil, "", 0, nil, semver.MustParse("1.25.0"))
 
 	Describe("#ScrapeConfig", func() {
 		It("should successfully test the scrape configuration", func() {

--- a/pkg/operation/botanist/component/etcd/etcd_test.go
+++ b/pkg/operation/botanist/component/etcd/etcd_test.go
@@ -404,45 +404,6 @@ var _ = Describe("Etcd", func() {
 						DataKey: pointer.String(secretutils.DataKeyCertificateBundle),
 					},
 				}
-
-				switch *failureToleranceType {
-				case gardencorev1beta1.FailureToleranceTypeNode:
-					obj.Spec.SchedulingConstraints = druidv1alpha1.SchedulingConstraints{
-						Affinity: &corev1.Affinity{
-							PodAntiAffinity: &corev1.PodAntiAffinity{
-								RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
-									{
-										TopologyKey: corev1.LabelHostname,
-										LabelSelector: &metav1.LabelSelector{
-											MatchLabels: map[string]string{
-												"gardener.cloud/role": "controlplane",
-												"role":                testRole,
-											},
-										},
-									},
-								},
-							},
-						},
-					}
-				case gardencorev1beta1.FailureToleranceTypeZone:
-					obj.Spec.SchedulingConstraints = druidv1alpha1.SchedulingConstraints{
-						Affinity: &corev1.Affinity{
-							PodAntiAffinity: &corev1.PodAntiAffinity{
-								RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
-									{
-										TopologyKey: corev1.LabelTopologyZone,
-										LabelSelector: &metav1.LabelSelector{
-											MatchLabels: map[string]string{
-												"gardener.cloud/role": "controlplane",
-												"role":                testRole,
-											},
-										},
-									},
-								},
-							},
-						},
-					}
-				}
 			}
 
 			if pointer.StringDeref(peerServerSecretName, "") != "" {

--- a/pkg/operation/botanist/component/kubeapiserver/deployment.go
+++ b/pkg/operation/botanist/component/kubeapiserver/deployment.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/etcd"
 	"github.com/gardener/gardener/pkg/resourcemanager/controller/garbagecollector/references"
@@ -190,7 +191,9 @@ func (k *kubeAPIServer) reconcileDeployment(
 	}
 
 	_, err := controllerutils.GetAndCreateOrMergePatch(ctx, k.client.Client(), deployment, func() error {
-		deployment.Labels = GetLabels()
+		deployment.Labels = utils.MergeStringMaps(GetLabels(), map[string]string{
+			resourcesv1alpha1.HighAvailabilityConfigType: resourcesv1alpha1.HighAvailabilityConfigTypeServer,
+		})
 		deployment.Spec = appsv1.DeploymentSpec{
 			MinReadySeconds:      30,
 			RevisionHistoryLimit: pointer.Int32(2),

--- a/pkg/operation/botanist/component/kubeapiserver/kube_apiserver_test.go
+++ b/pkg/operation/botanist/component/kubeapiserver/kube_apiserver_test.go
@@ -1577,6 +1577,7 @@ rules:
 					"gardener.cloud/role": "controlplane",
 					"app":                 "kubernetes",
 					"role":                "apiserver",
+					"high-availability-config.resources.gardener.cloud/type": "server",
 				}))
 			})
 
@@ -1585,10 +1586,11 @@ rules:
 				deployAndRead()
 
 				Expect(deployment.Labels).To(Equal(map[string]string{
-					"gardener.cloud/role":                    "controlplane",
-					"app":                                    "kubernetes",
-					"role":                                   "apiserver",
-					"core.gardener.cloud/apiserver-exposure": "gardener-managed",
+					"gardener.cloud/role": "controlplane",
+					"app":                 "kubernetes",
+					"role":                "apiserver",
+					"high-availability-config.resources.gardener.cloud/type": "server",
+					"core.gardener.cloud/apiserver-exposure":                 "gardener-managed",
 				}))
 			})
 

--- a/pkg/operation/botanist/component/kubecontrollermanager/monitoring_test.go
+++ b/pkg/operation/botanist/component/kubecontrollermanager/monitoring_test.go
@@ -31,7 +31,7 @@ var _ = Describe("Monitoring", func() {
 		func(version, expectedScrapeConfig string) {
 			semverVersion, err := semver.NewVersion(version)
 			Expect(err).NotTo(HaveOccurred())
-			kubeControllerManager := New(logr.Discard(), nil, "", nil, semverVersion, "", nil, nil, nil, nil)
+			kubeControllerManager := New(logr.Discard(), nil, "", nil, semverVersion, "", nil, nil, nil, nil, semver.MustParse("1.25.0"))
 			test.ScrapeConfigs(kubeControllerManager, expectedScrapeConfig)
 		},
 
@@ -46,7 +46,7 @@ var _ = Describe("Monitoring", func() {
 	It("should successfully test the alerting rules", func() {
 		semverVersion, err := semver.NewVersion("1.18.4")
 		Expect(err).NotTo(HaveOccurred())
-		kubeControllerManager := New(logr.Discard(), nil, "", nil, semverVersion, "", nil, nil, nil, nil)
+		kubeControllerManager := New(logr.Discard(), nil, "", nil, semverVersion, "", nil, nil, nil, nil, semver.MustParse("1.25.0"))
 
 		test.AlertingRulesWithPromtool(
 			kubeControllerManager,

--- a/pkg/operation/botanist/component/kubecontrollermanager/waiter.go
+++ b/pkg/operation/botanist/component/kubecontrollermanager/waiter.go
@@ -77,7 +77,7 @@ func (k *kubeControllerManager) WaitForControllerToBeActive(ctx context.Context)
 
 		// Check that one replica of the controller exists.
 		if len(podList.Items) < 1 {
-			k.log.Info("Waiting for kube-controller-manager to have exactly one replica")
+			k.log.Info("Waiting for kube-controller-manager to have at least one replica")
 			return retry.MinorError(fmt.Errorf("controller %s is not active", v1beta1constants.DeploymentNameKubeControllerManager))
 		}
 

--- a/pkg/operation/botanist/component/kubecontrollermanager/waiter.go
+++ b/pkg/operation/botanist/component/kubecontrollermanager/waiter.go
@@ -76,15 +76,17 @@ func (k *kubeControllerManager) WaitForControllerToBeActive(ctx context.Context)
 		}
 
 		// Check that one replica of the controller exists.
-		if len(podList.Items) != 1 {
+		if len(podList.Items) < 1 {
 			k.log.Info("Waiting for kube-controller-manager to have exactly one replica")
 			return retry.MinorError(fmt.Errorf("controller %s is not active", v1beta1constants.DeploymentNameKubeControllerManager))
 		}
 
-		// Check that the existing replica is not getting deleted.
-		if podList.Items[0].DeletionTimestamp != nil {
-			k.log.Info("Waiting for a new replica of kube-controller-manager")
-			return retry.MinorError(fmt.Errorf("controller %s is not active", v1beta1constants.DeploymentNameKubeControllerManager))
+		// Check that the existing replicas are not getting deleted.
+		for _, pod := range podList.Items {
+			if pod.DeletionTimestamp != nil {
+				k.log.Info("Waiting for a new replica of kube-controller-manager")
+				return retry.MinorError(fmt.Errorf("controller %s is not active", v1beta1constants.DeploymentNameKubeControllerManager))
+			}
 		}
 
 		// Check if the controller is active by reading its leader election record.

--- a/pkg/operation/botanist/component/kubescheduler/monitoring_test.go
+++ b/pkg/operation/botanist/component/kubescheduler/monitoring_test.go
@@ -30,7 +30,7 @@ var _ = Describe("Monitoring", func() {
 		func(version, expectedScrapeConfig string) {
 			semverVersion, err := semver.NewVersion(version)
 			Expect(err).NotTo(HaveOccurred())
-			kubeScheduler := New(nil, "", nil, semverVersion, "", 0, nil)
+			kubeScheduler := New(nil, "", nil, semverVersion, "", 0, nil, semver.MustParse("1.25.0"))
 
 			test.ScrapeConfigs(kubeScheduler, expectedScrapeConfig)
 		},
@@ -46,7 +46,7 @@ var _ = Describe("Monitoring", func() {
 	It("should successfully test the alerting rules", func() {
 		semverVersion, err := semver.NewVersion("1.18.4")
 		Expect(err).NotTo(HaveOccurred())
-		kubeScheduler := New(nil, "", nil, semverVersion, "", 0, nil)
+		kubeScheduler := New(nil, "", nil, semverVersion, "", 0, nil, semver.MustParse("1.25.0"))
 
 		test.AlertingRulesWithPromtool(
 			kubeScheduler,

--- a/pkg/operation/botanist/kubecontrollermanager.go
+++ b/pkg/operation/botanist/kubecontrollermanager.go
@@ -61,6 +61,7 @@ func (b *Botanist) DefaultKubeControllerManager() (kubecontrollermanager.Interfa
 			Enabled:             hvpaEnabled,
 			ScaleDownUpdateMode: &scaleDownUpdateMode,
 		},
+		b.Seed.KubernetesVersion,
 	), nil
 }
 

--- a/pkg/operation/botanist/kubecontrollermanager_test.go
+++ b/pkg/operation/botanist/kubecontrollermanager_test.go
@@ -18,17 +18,7 @@ import (
 	"context"
 	"fmt"
 
-	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
-	mockkubernetes "github.com/gardener/gardener/pkg/client/kubernetes/mock"
-	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
-	"github.com/gardener/gardener/pkg/operation"
-	. "github.com/gardener/gardener/pkg/operation/botanist"
-	mockkubeapiserver "github.com/gardener/gardener/pkg/operation/botanist/component/kubeapiserver/mock"
-	mockkubecontrollermanager "github.com/gardener/gardener/pkg/operation/botanist/component/kubecontrollermanager/mock"
-	shootpkg "github.com/gardener/gardener/pkg/operation/shoot"
-	"github.com/gardener/gardener/pkg/utils/imagevector"
-	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
-
+	"github.com/Masterminds/semver"
 	"github.com/go-logr/logr"
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo/v2"
@@ -38,6 +28,18 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	mockkubernetes "github.com/gardener/gardener/pkg/client/kubernetes/mock"
+	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
+	"github.com/gardener/gardener/pkg/operation"
+	. "github.com/gardener/gardener/pkg/operation/botanist"
+	mockkubeapiserver "github.com/gardener/gardener/pkg/operation/botanist/component/kubeapiserver/mock"
+	mockkubecontrollermanager "github.com/gardener/gardener/pkg/operation/botanist/component/kubecontrollermanager/mock"
+	seedpkg "github.com/gardener/gardener/pkg/operation/seed"
+	shootpkg "github.com/gardener/gardener/pkg/operation/shoot"
+	"github.com/gardener/gardener/pkg/utils/imagevector"
+	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 )
 
 var _ = Describe("KubeControllerManager", func() {
@@ -69,6 +71,9 @@ var _ = Describe("KubeControllerManager", func() {
 
 			botanist.Logger = logr.Discard()
 			botanist.SeedClientSet = kubernetesClient
+			botanist.Seed = &seedpkg.Seed{
+				KubernetesVersion: semver.MustParse("1.25.0"),
+			}
 			botanist.Shoot = &shootpkg.Shoot{
 				Networks: &shootpkg.Networks{},
 			}

--- a/pkg/operation/botanist/kubescheduler.go
+++ b/pkg/operation/botanist/kubescheduler.go
@@ -35,5 +35,6 @@ func (b *Botanist) DefaultKubeScheduler() (kubescheduler.Interface, error) {
 		image.String(),
 		b.Shoot.GetReplicas(1),
 		b.Shoot.GetInfo().Spec.Kubernetes.KubeScheduler,
+		b.Seed.KubernetesVersion,
 	), nil
 }

--- a/pkg/operation/botanist/kubescheduler_test.go
+++ b/pkg/operation/botanist/kubescheduler_test.go
@@ -15,16 +15,18 @@
 package botanist_test
 
 import (
+	"github.com/Masterminds/semver"
+	"github.com/golang/mock/gomock"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	mockkubernetes "github.com/gardener/gardener/pkg/client/kubernetes/mock"
 	"github.com/gardener/gardener/pkg/operation"
 	. "github.com/gardener/gardener/pkg/operation/botanist"
+	seedpkg "github.com/gardener/gardener/pkg/operation/seed"
 	shootpkg "github.com/gardener/gardener/pkg/operation/shoot"
 	"github.com/gardener/gardener/pkg/utils/imagevector"
-
-	"github.com/golang/mock/gomock"
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("KubeScheduler", func() {
@@ -36,6 +38,9 @@ var _ = Describe("KubeScheduler", func() {
 	BeforeEach(func() {
 		ctrl = gomock.NewController(GinkgoT())
 		botanist = &Botanist{Operation: &operation.Operation{}}
+		botanist.Seed = &seedpkg.Seed{
+			KubernetesVersion: semver.MustParse("1.25.0"),
+		}
 	})
 
 	AfterEach(func() {

--- a/pkg/operation/operation.go
+++ b/pkg/operation/operation.go
@@ -47,7 +47,7 @@ import (
 	gutil "github.com/gardener/gardener/pkg/utils/gardener"
 	"github.com/gardener/gardener/pkg/utils/imagevector"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
-	"github.com/gardener/gardener/pkg/utils/version"
+	versionutils "github.com/gardener/gardener/pkg/utils/version"
 )
 
 // NewBuilder returns a new Builder.
@@ -276,7 +276,7 @@ func (b *Builder) Build(
 	}
 	operation.Seed = seed
 
-	seedVersion, err := semver.NewVersion(seedClientSet.Version())
+	seedVersion, err := semver.NewVersion(versionutils.Normalize(seedClientSet.Version()))
 	if err != nil {
 		return nil, err
 	}
@@ -357,7 +357,7 @@ func (o *Operation) initShootClients(ctx context.Context, versionMatchRequired b
 			kubeVersion        = o.Shoot.GetInfo().Spec.Kubernetes.Version
 		)
 
-		ok, err := version.CompareVersions(shootClientVersion, "=", kubeVersion)
+		ok, err := versionutils.CompareVersions(shootClientVersion, "=", kubeVersion)
 		if err != nil {
 			return err
 		}

--- a/pkg/operation/seed/types.go
+++ b/pkg/operation/seed/types.go
@@ -19,6 +19,8 @@ import (
 	"sync"
 	"sync/atomic"
 
+	"github.com/Masterminds/semver"
+
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 )
 
@@ -32,5 +34,6 @@ type Seed struct {
 	info      atomic.Value
 	infoMutex sync.Mutex
 
+	KubernetesVersion              *semver.Version
 	LoadBalancerServiceAnnotations map[string]string
 }

--- a/pkg/utils/version/version.go
+++ b/pkg/utils/version/version.go
@@ -120,14 +120,15 @@ func init() {
 // if needed.
 func CompareVersions(version1, operator, version2 string) (bool, error) {
 	var (
-		v1 = normalizeVersion(version1)
-		v2 = normalizeVersion(version2)
+		v1 = Normalize(version1)
+		v2 = Normalize(version2)
 	)
 
 	return CheckVersionMeetsConstraint(v1, fmt.Sprintf("%s %s", operator, v2))
 }
 
-func normalizeVersion(version string) string {
+// Normalize normalizes the version by cutting prefixes and suffixes.
+func Normalize(version string) string {
 	v := strings.Replace(version, "v", "", -1)
 	idx := strings.IndexAny(v, "-+")
 	if idx != -1 {
@@ -143,7 +144,7 @@ func CheckVersionMeetsConstraint(version, constraint string) (bool, error) {
 		return false, err
 	}
 
-	v, err := semver.NewVersion(normalizeVersion(version))
+	v, err := semver.NewVersion(Normalize(version))
 	if err != nil {
 		return false, err
 	}

--- a/pkg/utils/version/version_suite_test.go
+++ b/pkg/utils/version/version_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package version_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestVersion(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Utils Version Suite")
+}

--- a/pkg/utils/version/version_test.go
+++ b/pkg/utils/version/version_test.go
@@ -1,0 +1,37 @@
+// Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package version_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	. "github.com/gardener/gardener/pkg/utils/version"
+)
+
+var _ = Describe("Version", func() {
+	DescribeTable("#Normalize",
+		func(input, output string) {
+			Expect(Normalize(input)).To(Equal(output))
+		},
+
+		Entry("version w/ 'v'-prefix w/o suffixes", "v1.2.3", "1.2.3"),
+		Entry("version w/ 'v'-prefix w suffixes starting with '-'", "v1.2.3-foo.bar", "1.2.3"),
+		Entry("version w/ 'v'-prefix w suffixes starting with '+'", "v1.2.3+foo.bar", "1.2.3"),
+		Entry("version w/o 'v'-prefix w/o suffixes", "1.2.3", "1.2.3"),
+		Entry("version w/o 'v'-prefix w suffixes starting with '-'", "1.2.3-foo.bar", "1.2.3"),
+		Entry("version w/o 'v'-prefix w suffixes starting with '+'", "1.2.3+foo.bar", "1.2.3"),
+	)
+})

--- a/test/utils/shoots/update/highavailability/upgrade.go
+++ b/test/utils/shoots/update/highavailability/upgrade.go
@@ -99,9 +99,9 @@ func verifyEtcdAffinity(ctx context.Context, seedClient kubernetes.Interface, sh
 		v1beta1constants.ETCDRoleEvents,
 		v1beta1constants.ETCDRoleMain,
 	} {
-		topologyKey, numberOfZones := corev1.LabelHostname, 1
+		numberOfZones := 1
 		if gardencorev1beta1helper.IsMultiZonalShootControlPlane(shoot) {
-			topologyKey, numberOfZones = corev1.LabelTopologyZone, 3
+			numberOfZones = 3
 		}
 
 		sts := &appsv1.StatefulSet{ObjectMeta: metav1.ObjectMeta{
@@ -120,19 +120,7 @@ func verifyEtcdAffinity(ctx context.Context, seedClient kubernetes.Interface, sh
 			"Operator": Equal(corev1.NodeSelectorOpIn),
 			"Values":   HaveLen(numberOfZones),
 		}), "for component "+sts.Name)
-		Expect(sts.Spec.Template.Spec.Affinity.PodAntiAffinity).To(Equal(&corev1.PodAntiAffinity{
-			RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
-				{
-					TopologyKey: topologyKey,
-					LabelSelector: &metav1.LabelSelector{
-						MatchLabels: map[string]string{
-							v1beta1constants.GardenRole: v1beta1constants.GardenRoleControlPlane,
-							v1beta1constants.LabelRole:  componentName,
-						},
-					},
-				},
-			},
-		}), "for component "+sts.Name)
+		Expect(sts.Spec.Template.Spec.Affinity.PodAntiAffinity).To(BeNil(), "for component "+sts.Name)
 	}
 }
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area high-availability
/kind enhancement

**What this PR does / why we need it**:
This PR adapts the HA configuration of the non-observability-related shoot control plane components.
Concretely, the components are labeled according to their type and custom replica/affinity changes have been dropped.
The webhook introduced with https://github.com/gardener/gardener/pull/6967 will take care to properly inject the required HA configuration.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/6529
Similar to https://github.com/gardener/gardener/pull/6982 and https://github.com/gardener/gardener/pull/6989

**Special notes for your reviewer**:
✅ ~Depends on https://github.com/gardener/gardener/pull/6967 which needs to be merged first.~

/cc @timuthy 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
All non-observability-related shoot control plane components are now running with configuration for high-availability according to [the conventions](https://github.com/gardener/gardener/blob/master/docs/development/high-availability.md).
```
