### PR TITLE
Enhance test framework to handle upgrades to Kubernetes v1.25

### DIFF
--- a/example/provider-local/garden/base/cloudprofile.yaml
+++ b/example/provider-local/garden/base/cloudprofile.yaml
@@ -8,8 +8,8 @@ spec:
   - name: local
   kubernetes:
     versions:
-    - version: 1.25.0
-    - version: 1.24.0
+    - version: 1.25.4
+    - version: 1.24.8
     - version: 1.23.6
     - version: 1.22.0
     - version: 1.21.0

--- a/example/provider-local/shoot.yaml
+++ b/example/provider-local/shoot.yaml
@@ -32,7 +32,7 @@ spec:
       maxSurge: 1
       maxUnavailable: 0
   kubernetes:
-    version: 1.25.0
+    version: 1.25.4
     kubelet:
       seccompDefault: true
       serializeImagePulls: false

--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -74,7 +74,7 @@ func DefaultShoot(name string) *gardencorev1beta1.Shoot {
 			SecretBindingName: "local",
 			CloudProfileName:  "local",
 			Kubernetes: gardencorev1beta1.Kubernetes{
-				Version:                     "1.25.0",
+				Version:                     "1.25.4",
 				EnableStaticTokenKubeconfig: pointer.Bool(true),
 				Kubelet: &gardencorev1beta1.KubeletConfig{
 					SerializeImagePulls: pointer.Bool(false),

--- a/test/e2e/managedseed/create_rotate_delete.go
+++ b/test/e2e/managedseed/create_rotate_delete.go
@@ -55,8 +55,8 @@ var _ = Describe("ManagedSeed Tests", Label("ManagedSeed", "default"), func() {
 		GardenerConfig: e2e.DefaultGardenConfig("garden"),
 	})
 	f.Shoot = e2e.DefaultShoot("e2e-managedseed")
-	// TODO(shafeeqes): Remove this once v1.25.0 seeds are supported
-	f.Shoot.Spec.Kubernetes.Version = "1.24.0"
+	// TODO(shafeeqes): Remove this once v1.25 seeds are supported
+	f.Shoot.Spec.Kubernetes.Version = "1.24.8"
 
 	It("Create Shoot, Create ManagedSeed, Delete ManagedSeed, Delete Shoot", func() {
 		By("Create Shoot")

--- a/test/e2e/shoot/create_and_delete_unprivileged.go
+++ b/test/e2e/shoot/create_and_delete_unprivileged.go
@@ -36,7 +36,7 @@ var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
 
 	f.Shoot = e2e.DefaultShoot("e2e-unpriv")
 	// This version is pinned here, because we have removed support for this field for shoots with k8s v1.25+
-	f.Shoot.Spec.Kubernetes.Version = "1.24.0"
+	f.Shoot.Spec.Kubernetes.Version = "1.24.8"
 	f.Shoot.Spec.Kubernetes.AllowPrivilegedContainers = pointer.Bool(false)
 	f.Shoot.Spec.Kubernetes.KubeAPIServer = &gardencorev1beta1.KubeAPIServerConfig{
 		AdmissionPlugins: []gardencorev1beta1.AdmissionPlugin{

--- a/test/e2e/shoot/create_update_delete.go
+++ b/test/e2e/shoot/create_update_delete.go
@@ -39,7 +39,7 @@ var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
 
 	// explicitly use one version below the latest supported minor version so that Kubernetes version update test can be
 	// performed
-	f.Shoot.Spec.Kubernetes.Version = "1.24.0"
+	f.Shoot.Spec.Kubernetes.Version = "1.24.8"
 
 	// Disable PodSecurityPolicy in the Shoot spec
 	f.Shoot.Spec.Kubernetes.KubeAPIServer = &gardencorev1beta1.KubeAPIServerConfig{

--- a/test/framework/shoot_utils.go
+++ b/test/framework/shoot_utils.go
@@ -26,6 +26,7 @@ import (
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/utils"
 	"github.com/gardener/gardener/pkg/utils/retry"
+	versionutils "github.com/gardener/gardener/pkg/utils/version"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -260,9 +261,14 @@ func setShootGeneralSettings(shoot *gardencorev1beta1.Shoot, cfg *ShootCreationC
 		shoot.Spec.Hibernation.Enabled = &cfg.startHibernated
 	}
 
-	// allow privileged containers defaults to true
-	if cfg.allowPrivilegedContainers != nil {
-		shoot.Spec.Kubernetes.AllowPrivilegedContainers = cfg.allowPrivilegedContainers
+	// Errors are ignored here because we cannot do anything meaningful with them - variables will default to `false`.
+	k8sLessEqual125, _ := versionutils.CheckVersionMeetsConstraint(shoot.Spec.Kubernetes.Version, "< 1.25")
+	// This field should not be set for kubernetes version >= 1.25
+	if k8sLessEqual125 {
+		// allow privileged containers defaults to true
+		if cfg.allowPrivilegedContainers != nil {
+			shoot.Spec.Kubernetes.AllowPrivilegedContainers = cfg.allowPrivilegedContainers
+		}
 	}
 
 	if clearExtensions {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind enhancement

**What this PR does / why we need it**:
This PR enhances the testmachinery tests to handle upgrades to Kubernetes v1.25.
- `.spec.kubernetes.allowPrivilegedContainers` is not set if the cluster version is >= 1.25
- If the cluster version is >= 1.23, PSP admission plugin is disabled and allowPrivilegedContainers field is set to nil and we wait for a successful reconciliation, verify no PSPs exist and the continue with the upgrade.

**Which issue(s) this PR fixes**:
Part of #6567 
xRef #5250 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
