### PR TITLE
Remove vpa for vpa-recommender on seeds. Avoids VPA self-scaling…

### DIFF
--- a/pkg/operation/botanist/component/vpa/vpa_test.go
+++ b/pkg/operation/botanist/component/vpa/vpa_test.go
@@ -562,8 +562,15 @@ var _ = Describe("VPA", func() {
 			}
 
 			priorityClassName := v1beta1constants.PriorityClassNameSeedSystem700
+			var cpuRequest string
+			var memoryRequest string
 			if clusterType == component.ClusterTypeShoot {
 				priorityClassName = v1beta1constants.PriorityClassNameShootControlPlane200
+				cpuRequest = "30m"
+				memoryRequest = "200Mi"
+			} else {
+				cpuRequest = "200m"
+				memoryRequest = "800M"
 			}
 
 			obj := &appsv1.Deployment{
@@ -627,8 +634,8 @@ var _ = Describe("VPA", func() {
 								},
 								Resources: corev1.ResourceRequirements{
 									Requests: corev1.ResourceList{
-										corev1.ResourceCPU:    resource.MustParse("30m"),
-										corev1.ResourceMemory: resource.MustParse("200Mi"),
+										corev1.ResourceCPU:    resource.MustParse(cpuRequest),
+										corev1.ResourceMemory: resource.MustParse(memoryRequest),
 									},
 									Limits: corev1.ResourceList{
 										corev1.ResourceMemory: resource.MustParse("4Gi"),
@@ -1297,7 +1304,7 @@ var _ = Describe("VPA", func() {
 
 				Expect(c.Get(ctx, client.ObjectKeyFromObject(managedResourceSecret), managedResourceSecret)).To(Succeed())
 				Expect(managedResourceSecret.Type).To(Equal(corev1.SecretTypeOpaque))
-				Expect(managedResourceSecret.Data).To(HaveLen(23))
+				Expect(managedResourceSecret.Data).To(HaveLen(22))
 
 				By("checking vpa-updater resources")
 				clusterRoleUpdater.Name = replaceTargetSubstrings(clusterRoleUpdater.Name)
@@ -1330,7 +1337,7 @@ var _ = Describe("VPA", func() {
 				Expect(string(managedResourceSecret.Data["clusterrole____gardener.cloud_vpa_source_checkpoint-actor.yaml"])).To(Equal(componenttest.Serialize(clusterRoleRecommenderCheckpointActor)))
 				Expect(string(managedResourceSecret.Data["clusterrolebinding____gardener.cloud_vpa_source_checkpoint-actor.yaml"])).To(Equal(componenttest.Serialize(clusterRoleBindingRecommenderCheckpointActor)))
 				Expect(string(managedResourceSecret.Data["deployment__"+namespace+"__vpa-recommender.yaml"])).To(Equal(componenttest.Serialize(deploymentRecommender)))
-				Expect(string(managedResourceSecret.Data["verticalpodautoscaler__"+namespace+"__vpa-recommender.yaml"])).To(Equal(componenttest.Serialize(vpaRecommender)))
+				Expect(managedResourceSecret.Data).NotTo(HaveKey("verticalpodautoscaler__" + namespace + "__vpa-recommender.yaml"))
 
 				By("checking vpa-admission-controller resources")
 				clusterRoleAdmissionController.Name = replaceTargetSubstrings(clusterRoleAdmissionController.Name)


### PR DESCRIPTION
… on soils.

**How to categorize this PR?**
/area auto-scaling
/kind bug

**What this PR does / why we need it**:
No longer deploy a vpa resource for seed recommender, since that would cause the recommender to act on said vpa resource, and attempt to autoscale its own deployment. Self-scaling is not supported by VPA. In place of VPA, use higher fixed request values for the garden/vpa-recommender deployment.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
A the seed vpa-recommender is no longer scaled by VPA. Instead, fixed resource request values are used.
```