### PR TITLE
The blackbox-exporter need not tolerate the NoSchedule/NoExecute taints

### DIFF
--- a/charts/shoot-core/components/charts/monitoring/charts/blackbox-exporter/templates/deployment.yaml
+++ b/charts/shoot-core/components/charts/monitoring/charts/blackbox-exporter/templates/deployment.yaml
@@ -34,11 +34,7 @@ spec:
     spec:
       serviceAccountName: blackbox-exporter
       tolerations:
-      - effect: NoSchedule
-        operator: Exists
       - key: CriticalAddonsOnly
-        operator: Exists
-      - effect: NoExecute
         operator: Exists
       priorityClassName: system-cluster-critical
       nodeSelector:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind enhancement

**What this PR does / why we need it**:

The blackbox-exporter need not tolerate the NoSchedule/NoExecute taints

In #888
```
0eb37d5f7 Tweaked control-plane and system components. (2019-04-01)
```

the blackbox-exporter deployment which is deployed in the kube-system namespace in the shoot was configured to tolerate nodes with the NoSchedule or NoExecute taints, i.e. even cordoned nodes.

It is not necessary, the blackbox exporter instances could respect these taints.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

/cc @rickardsjp 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The blackbox-exporter respects the previously unnecessarily tolerated NoSchedule/NoExecute taints
```
