### PR TITLE
Add documentation for supported architectures in shoot

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -68,6 +68,7 @@
 * [Trusted TLS certificate for shoot control planes](usage/trusted-tls-for-control-planes.md)
 * [Controlling the Kubernetes versions for specific worker pools](usage/worker_pool_k8s_versions.md)
 * [Migrating from `PodSecurityPolicy`s to PodSecurity admission controller](usage/pod-security.md)
+* [Supported CPU Architectures for Shoot Worker Nodes](usage/shoot_supported_architectures.md)
 
 ## [API Reference](api-reference/README.md)
 

--- a/docs/usage/shoot_supported_architectures.md
+++ b/docs/usage/shoot_supported_architectures.md
@@ -1,6 +1,6 @@
 # Supported CPU Architectures for Shoot Worker Nodes
 
-Users can create shoot clusters with worker groups having virtual machines of different architectures. CPU architecture of each worker pool can be specified in the `Shoot` specification as follows:-
+Users can create shoot clusters with worker groups having virtual machines of different architectures. CPU architecture of each worker pool can be specified in the `Shoot` specification as follows:
 
 ## Example Usage in a `Shoot`
 
@@ -10,12 +10,31 @@ spec:
     workers:
     - name: cpu-worker
       machine:
-        architecture: <some-cpu-architecture>
+        architecture: <some-cpu-architecture> # optional
 ```
 
-If no value is specified for the architecture field, it defaults to `amd64`. For a valid shoot object, a machine should be present in the respective CloudProfile with the same CPU architecture as specified in the `Shoot` yaml.
+If no value is specified for the architecture field, it defaults to `amd64`. For a valid shoot object, a machine type should be present in the respective `CloudProfile` with the same CPU architecture as specified in the `Shoot` yaml. Also, a valid machine image should be present in the `CloudProfile` that supports the required architecture specified in the `Shoot` worker pool.
 
-Currently, Gardener supports two most widely used CPU architectures:-
+## Example Usage in a `CloudProfile`
+
+```yaml
+spec:
+  machineImages:
+  - name: test-image
+    versions:
+    - architectures: # optional
+      - <architecture-1>
+      - <architecture-2>
+      version: 1.2.3
+  machineTypes:
+  - architecture: <some-cpu-architecture>
+    cpu: "2"
+    gpu: "0"
+    memory: 8Gi
+    name: test-machine
+```
+
+Currently, Gardener supports two most widely used CPU architectures:
 
 * `amd64`
 * `arm64`

--- a/docs/usage/shoot_supported_architectures.md
+++ b/docs/usage/shoot_supported_architectures.md
@@ -13,7 +13,7 @@ spec:
         architecture: <some-cpu-architecture>
 ```
 
-If no value is specified for the architecture field it defaults to `amd64`. For a valid shoot object, a machine should be present in the respective CloudProfile with the same CPU architecture as specified in Shoot yaml.
+If no value is specified for the architecture field, it defaults to `amd64`. For a valid shoot object, a machine should be present in the respective CloudProfile with the same CPU architecture as specified in the `Shoot` yaml.
 
 Currently, Gardener supports two most widely used CPU architectures:-
 

--- a/docs/usage/shoot_supported_architectures.md
+++ b/docs/usage/shoot_supported_architectures.md
@@ -1,0 +1,21 @@
+# Shoot Supported Architectures
+
+Users can create shoot with worker groups having virtual machines of different architectures. CPU architecture of each worker pool can be specified in shoot yaml as follows:-
+
+## Example Usage in a `Shoot`
+
+```yaml
+spec:
+  provider:
+    workers:
+    - name: cpu-worker
+      machine:
+        architecture: <some-cpu-architecture>
+```
+
+If there is no value specified for architecture it defaults to `amd64`.
+
+Currently, Gardener supports two most widely used CPU architectures:-
+
+* `amd64`
+* `arm64`

--- a/docs/usage/shoot_supported_architectures.md
+++ b/docs/usage/shoot_supported_architectures.md
@@ -1,6 +1,6 @@
-# Shoot Supported Architectures
+# Supported CPU Architectures for Shoot Worker Nodes
 
-Users can create shoot with worker groups having virtual machines of different architectures. CPU architecture of each worker pool can be specified in shoot yaml as follows:-
+Users can create shoot clusters with worker groups having virtual machines of different architectures. CPU architecture of each worker pool can be specified in the `Shoot` specification as follows:-
 
 ## Example Usage in a `Shoot`
 
@@ -13,7 +13,7 @@ spec:
         architecture: <some-cpu-architecture>
 ```
 
-If there is no value specified for architecture it defaults to `amd64`.
+If no value is specified for the architecture field it defaults to `amd64`. For a valid shoot object, a machine should be present in the respective CloudProfile with the same CPU architecture as specified in Shoot yaml.
 
 Currently, Gardener supports two most widely used CPU architectures:-
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area documentation
/kind task

**What this PR does / why we need it**:
This PR adds documentation for supported architecture in shoot worker pool.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/backlog/issues/19

/cc @rfranzke 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
