### PR TITLE
Deprecate seedTemplate field from ManagedSeed API

### DIFF
--- a/docs/api-reference/seedmanagement.md
+++ b/docs/api-reference/seedmanagement.md
@@ -103,7 +103,8 @@ github.com/gardener/gardener/pkg/apis/core/v1beta1.SeedTemplate
 <em>(Optional)</em>
 <p>SeedTemplate is a template for a Seed object, that should be used to register a given cluster as a Seed.
 Either SeedTemplate or Gardenlet must be specified. When Seed is specified, the ManagedSeed controller will not deploy a gardenlet into the cluster
-and an existing gardenlet reconciling the new Seed is required.</p>
+and an existing gardenlet reconciling the new Seed is required.
+Deprecated: This field is deprecated and will be removed in a future version of Gardener. Define seed via <code>.spec.gardenlet.config</code> instead.</p>
 </td>
 </tr>
 <tr>
@@ -913,7 +914,8 @@ github.com/gardener/gardener/pkg/apis/core/v1beta1.SeedTemplate
 <em>(Optional)</em>
 <p>SeedTemplate is a template for a Seed object, that should be used to register a given cluster as a Seed.
 Either SeedTemplate or Gardenlet must be specified. When Seed is specified, the ManagedSeed controller will not deploy a gardenlet into the cluster
-and an existing gardenlet reconciling the new Seed is required.</p>
+and an existing gardenlet reconciling the new Seed is required.
+Deprecated: This field is deprecated and will be removed in a future version of Gardener. Define seed via <code>.spec.gardenlet.config</code> instead.</p>
 </td>
 </tr>
 <tr>
@@ -1054,7 +1056,8 @@ github.com/gardener/gardener/pkg/apis/core/v1beta1.SeedTemplate
 <em>(Optional)</em>
 <p>SeedTemplate is a template for a Seed object, that should be used to register a given cluster as a Seed.
 Either SeedTemplate or Gardenlet must be specified. When Seed is specified, the ManagedSeed controller will not deploy a gardenlet into the cluster
-and an existing gardenlet reconciling the new Seed is required.</p>
+and an existing gardenlet reconciling the new Seed is required.
+Deprecated: This field is deprecated and will be removed in a future version of Gardener. Define seed via <code>.spec.gardenlet.config</code> instead.</p>
 </td>
 </tr>
 <tr>

--- a/docs/concepts/gardenlet.md
+++ b/docs/concepts/gardenlet.md
@@ -355,11 +355,6 @@ creates a clone of itself with the same version and the same configuration
 that it currently has.
 Then it deploys the gardenlet clone into the managed seed cluster.
 
-If you want to prevent the automatic gardenlet deployment,
-specify the `seedTemplate` section in the `ManagedSeed` resource, and don't specify
-the `gardenlet` section.
-In this case, you have to deploy the gardenlet on your own into the seed cluster.
-
 More information: [Register Shoot as Seed](../usage/managed_seed.md)
 
 ## Migrating from Previous Gardener Versions

--- a/docs/deployment/gardenlet_api_access.md
+++ b/docs/deployment/gardenlet_api_access.md
@@ -60,7 +60,6 @@ Today, the following rules are implemented:
 [1] If you use `ManagedSeed` resources then the gardenlet reconciling them ("parent gardenlet") may be allowed to submit certain requests for the `Seed` resources resulting out of such `ManagedSeed` reconciliations (even if the "parent gardenlet" is not responsible for them):
 
 - ℹ️ It is allowed to delete the `Seed` resources if the corresponding `ManagedSeed` objects already have a `deletionTimestamp` (this is secure as gardenlets themselves don't have permissions for deleting `ManagedSeed`s).
-- ⚠ It is allowed to create or update `Seed` resources if the corresponding `ManagedSeed` objects use a seed template, i.e., `.spec.seedTemplate != nil`. In this case, there is at least one gardenlet in your system which is responsible for two or more `Seed`s. Please keep in mind that this use case is not recommended for production scenarios (you should only have one dedicated gardenlet per seed cluster), hence, the security improvements discussed in this document might be limited.
 
 ## `SeedAuthorizer` Authorization Webhook Enablement
 

--- a/docs/usage/managed_seed.md
+++ b/docs/usage/managed_seed.md
@@ -3,24 +3,22 @@
 An existing shoot can be registered as a seed by creating a `ManagedSeed` resource. This resource contains:
 
 * The name of the shoot that should be registered as seed.
-* An optional `seedTemplate` section that contains the `Seed` spec and parts of its metadata, such as labels and annotations.
-* An optional `gardenlet` section that contains:
+* An `gardenlet` section that contains:
     * `gardenlet` deployment parameters, such as the number of replicas, the image, etc.
     * The `GardenletConfiguration` resource that contains controllers configuration, feature gates, and a `seedConfig` section that contains the `Seed` spec and parts of its metadata.
     * Additional configuration parameters, such as the garden connection bootstrap mechanism (see [TLS Bootstrapping](../concepts/gardenlet.md#tls-bootstrapping)), and whether to merge the provided configuration with the configuration of the parent `gardenlet`.
 
-Either the `seedTemplate` or the `gardenlet` section must be specified, but not both:
+`gardenlet` is deployed to the shoot, and it registers a new seed upon startup based on the `seedConfig` section.
 
-* If the `seedTemplate` section is specified, `gardenlet` is not deployed to the shoot, and a new `Seed` resource is created based on the template.
-* If the `gardenlet` section is specified, `gardenlet` is deployed to the shoot, and it registers a new seed upon startup based on the `seedConfig` section of the `GardenletConfiguration` resource.
+> Note: Earlier Gardener allowed specifying a `seedTemplate` directly in the `ManagedSeed` resource. This feature is discontinued, any seed configuration must be via the `GardenletConfiguration`.
 
 Note the following important aspects:
 
 * Unlike the `Seed` resource, the `ManagedSeed` resource is namespaced. Currently, managed seeds are restricted to the `garden` namespace.
-* The newly created `Seed` resource always has the same name as the `ManagedSeed` resource. Attempting to specify a different name in `seedTemplate` or `seedConfig` will fail.
+* The newly created `Seed` resource always has the same name as the `ManagedSeed` resource. Attempting to specify a different name in `seedConfig` will fail.
 * The `ManagedSeed` resource must always refer to an existing shoot. Attempting to create a `ManagedSeed` referring to a non-existing shoot will fail.
 * A shoot that is being referred to by a `ManagedSeed` cannot be deleted. Attempting to delete such a shoot will fail.
-* You can omit practically everything from the `seedTemplate` or `gardenlet` section, including all or most of the `Seed` spec fields. Proper defaults will be supplied in all cases, based either on the most common use cases or the information already available in the `Shoot` resource.
+* You can omit practically everything from the `gardenlet` section, including all or most of the `Seed` spec fields. Proper defaults will be supplied in all cases, based either on the most common use cases or the information already available in the `Shoot` resource.
 * Also, if your seed is configured to host HA shoot control planes, then `gardenlet` will be deployed with multiple replicas across nodes or availability zones by default.
 * Some `Seed` spec fields, for example the provider type and region, networking CIDRs for pods, services, and nodes, etc., must be the same as the corresponding `Shoot` spec fields of the shoot that is being registered as seed. Attempting to use different values (except empty ones, so that they are supplied by the defaulting mechanims) will fail.
 
@@ -47,33 +45,6 @@ For an example that uses non-default configuration, see [55-managed-seed-gardenl
 In order to making the `ManagedSeed` controller renew the gardenlet's kubeconfig secret, annotate the `ManagedSeed` with `gardener.cloud/operation=renew-kubeconfig`. This will trigger a reconciliation during which the kubeconfig secret is deleted and the bootstrapping is performed again (during which gardenlet obtains a new client certificate).
 
 It is also possible to trigger the renewal on the secret directly, see [here](../concepts/gardenlet.md#rotate-certificates-using-bootstrap-kubeconfig).
-
-## Creating a Seed from a Template
-
-To register a shoot as a seed from a template without deploying `gardenlet` to the shoot using a default configuration, create a `ManagedSeed` resource similar to the following:
-
-```yaml
-apiVersion: seedmanagement.gardener.cloud/v1alpha1
-kind: ManagedSeed
-metadata:
-  name: my-managed-seed
-  namespace: garden
-spec:
-  shoot:
-    name: crazy-botany
-  seedTemplate:
-    spec:
-      dns:
-        ingressDomain: ""
-      networks:
-        pods: ""
-        services: ""
-      provider:
-        type: ""
-        region: ""
-```
-
-For an example that uses non-default configuration, see [55-managed-seed-seedtemplate.yaml](../../example/55-managedseed-seedtemplate.yaml)
 
 ### Specifying `apiServer` `replicas` and `autoscaler` options
 

--- a/example/57-managedseedset.yaml
+++ b/example/57-managedseedset.yaml
@@ -9,7 +9,7 @@ spec:
     matchLabels:
       name: my-managed-seed-set
   template:
-    # <See `55-managedseed-gardenlet.yaml` and `55-managedseed-seedtemplate.yaml` for more details>
+    # <See `55-managedseed-gardenlet.yaml` for more details>
     metadata:
       labels:
         name: my-managed-seed-set

--- a/pkg/apis/seedmanagement/types_managedseed.go
+++ b/pkg/apis/seedmanagement/types_managedseed.go
@@ -63,6 +63,7 @@ type ManagedSeedSpec struct {
 	// SeedTemplate is a template for a Seed object, that should be used to register a given cluster as a Seed.
 	// Either SeedTemplate or Gardenlet must be specified. When Seed is specified, the ManagedSeed controller will not deploy a gardenlet into the cluster
 	// and an existing gardenlet reconciling the new Seed is required.
+	// Deprecated: This field is deprecated and will be removed in a future version of Gardener. Define seed via `.spec.gardenlet.config` instead.
 	SeedTemplate *gardencore.SeedTemplate
 	// Gardenlet specifies that the ManagedSeed controller should deploy a gardenlet into the cluster
 	// with the given deployment parameters and GardenletConfiguration.

--- a/pkg/apis/seedmanagement/v1alpha1/generated.proto
+++ b/pkg/apis/seedmanagement/v1alpha1/generated.proto
@@ -256,6 +256,7 @@ message ManagedSeedSpec {
   // SeedTemplate is a template for a Seed object, that should be used to register a given cluster as a Seed.
   // Either SeedTemplate or Gardenlet must be specified. When Seed is specified, the ManagedSeed controller will not deploy a gardenlet into the cluster
   // and an existing gardenlet reconciling the new Seed is required.
+  // Deprecated: This field is deprecated and will be removed in a future version of Gardener. Define seed via `.spec.gardenlet.config` instead.
   // +optional
   optional github.com.gardener.gardener.pkg.apis.core.v1beta1.SeedTemplate seedTemplate = 2;
 

--- a/pkg/apis/seedmanagement/v1alpha1/types_managedseed.go
+++ b/pkg/apis/seedmanagement/v1alpha1/types_managedseed.go
@@ -70,6 +70,7 @@ type ManagedSeedSpec struct {
 	// SeedTemplate is a template for a Seed object, that should be used to register a given cluster as a Seed.
 	// Either SeedTemplate or Gardenlet must be specified. When Seed is specified, the ManagedSeed controller will not deploy a gardenlet into the cluster
 	// and an existing gardenlet reconciling the new Seed is required.
+	// Deprecated: This field is deprecated and will be removed in a future version of Gardener. Define seed via `.spec.gardenlet.config` instead.
 	// +optional
 	SeedTemplate *gardencorev1beta1.SeedTemplate `json:"seedTemplate,omitempty" protobuf:"bytes,2,opt,name=seedTemplate"`
 	// Gardenlet specifies that the ManagedSeed controller should deploy a gardenlet into the cluster

--- a/pkg/apis/seedmanagement/validation/managedseedset_test.go
+++ b/pkg/apis/seedmanagement/validation/managedseedset_test.go
@@ -373,19 +373,13 @@ var _ = Describe("ManagedSeedSet Validation Tests", func() {
 			))
 		})
 
-		It("should forbid changes to immutable fields in template", func() {
+		It("should allow changing from seedTemplate to Gardenlet", func() {
 			newManagedSeedSet.Spec.Template.Spec.SeedTemplate = nil
 			newManagedSeedSet.Spec.Template.Spec.Gardenlet = &seedmanagement.Gardenlet{}
 
 			errorList := ValidateManagedSeedSetUpdate(newManagedSeedSet, managedSeedSet)
 
-			Expect(errorList).To(ConsistOf(
-				PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":   Equal(field.ErrorTypeInvalid),
-					"Field":  Equal("spec.template.spec"),
-					"Detail": Equal("changing from seed template to gardenlet and vice versa is not allowed"),
-				})),
-			))
+			Expect(errorList).To(BeEmpty())
 		})
 
 		It("should forbid changes to immutable fields in shootTemplate", func() {

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -16002,7 +16002,7 @@ func schema_pkg_apis_seedmanagement_v1alpha1_ManagedSeedSpec(ref common.Referenc
 					},
 					"seedTemplate": {
 						SchemaProps: spec.SchemaProps{
-							Description: "SeedTemplate is a template for a Seed object, that should be used to register a given cluster as a Seed. Either SeedTemplate or Gardenlet must be specified. When Seed is specified, the ManagedSeed controller will not deploy a gardenlet into the cluster and an existing gardenlet reconciling the new Seed is required.",
+							Description: "SeedTemplate is a template for a Seed object, that should be used to register a given cluster as a Seed. Either SeedTemplate or Gardenlet must be specified. When Seed is specified, the ManagedSeed controller will not deploy a gardenlet into the cluster and an existing gardenlet reconciling the new Seed is required. Deprecated: This field is deprecated and will be removed in a future version of Gardener. Define seed via `.spec.gardenlet.config` instead.",
 							Ref:         ref("github.com/gardener/gardener/pkg/apis/core/v1beta1.SeedTemplate"),
 						},
 					},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind api-change

**What this PR does / why we need it**:
This PR deprecates managedSeed.spec.seedTemplate. At the same time it allows operators to switch from `seedTemplate` to `gardenlet.config`, so that we can remove the seedTemplate field in one of the next Gardener releases.

**Which issue(s) this PR fixes**:
Part of #6898

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
The field `managedSeed.spec.seedTemplate` has been deprecated and will be removed very soon in a future release of Gardener. Please adapt your ManagedSeedSet or ManagedSeed objects and transfer any seed configuration to `managedSeed.spec.gardenlet.config` (see example `example/55-managedseed-gardenlet.yaml`).
Please note that as a consequence, Gardenlet will be deployed and managed automatically (see `docs/usage/managed_seed.md` for more information).
```
