### PR TITLE
Fix flaky `ShootState` Extensions Controller Integration Test Suite

### DIFF
--- a/test/integration/gardenlet/shootstate/extensions/extensions_suite_test.go
+++ b/test/integration/gardenlet/shootstate/extensions/extensions_suite_test.go
@@ -59,6 +59,7 @@ var (
 	restConfig *rest.Config
 	testEnv    *gardenerenvtest.GardenerTestEnvironment
 	testClient client.Client
+	mgrClient  client.Client
 
 	testNamespace *corev1.Namespace
 	testRunID     string
@@ -131,6 +132,7 @@ var _ = BeforeSuite(func() {
 		}),
 	})
 	Expect(err).NotTo(HaveOccurred())
+	mgrClient = mgr.GetClient()
 
 	By("registering controller")
 	Expect((&extensions.Reconciler{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind flake

**What this PR does / why we need it**:
The reconciler exits early when it doesn't find the related `Cluster` resource: https://github.com/gardener/gardener/blob/0f08132b736b76a57c45576ad3e07f11c962b822/pkg/gardenlet/controller/shootstate/extensions/reconciler.go#L81-L87

With this PR, we ensure that the manager cache observes the frequently created/deleted `Cluster` resources before proceeding with our actual test logic.

Without this change:

```
$ stress -ignore "unable to grab random port" -p 32 ./extensions.test
0 runs so far, 0 failures
0 runs so far, 0 failures
0 runs so far, 0 failures
0 runs so far, 0 failures
5 runs so far, 0 failures
8 runs so far, 0 failures
19 runs so far, 0 failures
29 runs so far, 1 failures
31 runs so far, 1 failures
31 runs so far, 1 failures
31 runs so far, 1 failures
32 runs so far, 1 failures
38 runs so far, 1 failures
```

With this change:

```
$ stress -ignore "unable to grab random port" -p 32 ./extensions.test
0 runs so far, 0 failures
0 runs so far, 0 failures
0 runs so far, 0 failures
1 runs so far, 0 failures
2 runs so far, 0 failures
4 runs so far, 0 failures
29 runs so far, 0 failures
32 runs so far, 0 failures
32 runs so far, 0 failures
32 runs so far, 0 failures
35 runs so far, 0 failures
38 runs so far, 0 failures
46 runs so far, 0 failures
59 runs so far, 0 failures
63 runs so far, 0 failures
64 runs so far, 0 failures
64 runs so far, 0 failures
67 runs so far, 0 failures
71 runs so far, 0 failures
79 runs so far, 0 failures
90 runs so far, 0 failures
95 runs so far, 0 failures
96 runs so far, 0 failures
97 runs so far, 0 failures
100 runs so far, 0 failures
106 runs so far, 0 failures
111 runs so far, 0 failures
122 runs so far, 0 failures
126 runs so far, 0 failures
128 runs so far, 0 failures
129 runs so far, 0 failures
133 runs so far, 0 failures
140 runs so far, 0 failures
144 runs so far, 0 failures
152 runs so far, 0 failures
155 runs so far, 0 failures
157 runs so far, 0 failures
160 runs so far, 0 failures
163 runs so far, 0 failures
168 runs so far, 0 failures
174 runs so far, 0 failures
181 runs so far, 0 failures
185 runs so far, 0 failures
187 runs so far, 0 failures
190 runs so far, 0 failures
193 runs so far, 0 failures
198 runs so far, 0 failures
202 runs so far, 0 failures
210 runs so far, 0 failures
216 runs so far, 0 failures
218 runs so far, 0 failures
220 runs so far, 0 failures
224 runs so far, 0 failures
229 runs so far, 0 failures
234 runs so far, 0 failures
238 runs so far, 0 failures
245 runs so far, 0 failures
248 runs so far, 0 failures
251 runs so far, 0 failures
255 runs so far, 0 failures
257 runs so far, 0 failures
261 runs so far, 0 failures
267 runs so far, 0 failures
272 runs so far, 0 failures
277 runs so far, 0 failures
279 runs so far, 0 failures
281 runs so far, 0 failures
287 runs so far, 0 failures
293 runs so far, 0 failures
298 runs so far, 0 failures
302 runs so far, 0 failures
307 runs so far, 0 failures
308 runs so far, 0 failures
312 runs so far, 0 failures
313 runs so far, 0 failures
319 runs so far, 0 failures
323 runs so far, 0 failures
330 runs so far, 0 failures
333 runs so far, 0 failures
```

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener/issues/6923

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
