### PR TITLE
Fix flaky `ControllerInstallation` Required Controller Integration Test Suite

### DIFF
--- a/test/integration/gardenlet/controllerinstallation/required/required_suite_test.go
+++ b/test/integration/gardenlet/controllerinstallation/required/required_suite_test.go
@@ -58,6 +58,7 @@ var (
 	restConfig *rest.Config
 	testEnv    *gardenerenvtest.GardenerTestEnvironment
 	testClient client.Client
+	mgrClient  client.Client
 
 	testNamespace *corev1.Namespace
 	testRunID     string
@@ -139,6 +140,7 @@ var _ = BeforeSuite(func() {
 		}),
 	})
 	Expect(err).NotTo(HaveOccurred())
+	mgrClient = mgr.GetClient()
 
 	By("setting up field indexes")
 	Expect(indexer.AddControllerInstallationSeedRefName(ctx, mgr.GetFieldIndexer())).To(Succeed())

--- a/test/integration/gardenlet/controllerinstallation/required/required_test.go
+++ b/test/integration/gardenlet/controllerinstallation/required/required_test.go
@@ -58,6 +58,14 @@ var _ = Describe("ControllerInstallation Required controller tests", func() {
 			Expect(testClient.Delete(ctx, controllerRegistration)).To(Succeed())
 		})
 
+		By("Wait until manager has observed ControllerRegistration")
+		// Use the manager's cache to ensure it has observed the ControllerRegistration. Otherwise, the controller might
+		// simply not enqueue the ControllerInstallation when extension resources get created later.
+		// See https://github.com/gardener/gardener/issues/6927
+		Eventually(func() error {
+			return mgrClient.Get(ctx, client.ObjectKeyFromObject(controllerRegistration), controllerRegistration)
+		}).Should(Succeed())
+
 		By("Create ControllerInstallation")
 		controllerInstallation = &gardencorev1beta1.ControllerInstallation{
 			ObjectMeta: metav1.ObjectMeta{
@@ -84,6 +92,14 @@ var _ = Describe("ControllerInstallation Required controller tests", func() {
 			Expect(testClient.Delete(ctx, controllerInstallation)).To(Succeed())
 		})
 
+		By("Wait until manager has observed ControllerInstallation")
+		// Use the manager's cache to ensure it has observed the ControllerInstallation. Otherwise, the controller might
+		// simply not enqueue the ControllerInstallation when extension resources get created later.
+		// See https://github.com/gardener/gardener/issues/6927
+		Eventually(func() error {
+			return mgrClient.Get(ctx, client.ObjectKeyFromObject(controllerInstallation), controllerInstallation)
+		}).Should(Succeed())
+
 		infrastructure = &extensionsv1alpha1.Infrastructure{
 			ObjectMeta: metav1.ObjectMeta{
 				GenerateName: "infra1-",
@@ -109,6 +125,7 @@ var _ = Describe("ControllerInstallation Required controller tests", func() {
 
 	Context("when extension resources exist", func() {
 		It("should set the Required condition to True", func() {
+			By("Create Infrastructure")
 			Expect(testClient.Create(ctx, infrastructure)).To(Succeed())
 			log.Info("Created Infrastructure for test", "infrastructure", client.ObjectKeyFromObject(infrastructure))
 
@@ -124,6 +141,7 @@ var _ = Describe("ControllerInstallation Required controller tests", func() {
 		})
 
 		It("should set the Required condition to False when all extension resources get deleted", func() {
+			By("Create Infrastructure")
 			Expect(testClient.Create(ctx, infrastructure)).To(Succeed())
 			log.Info("Created Infrastructure for test", "infrastructure", client.ObjectKeyFromObject(infrastructure))
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind flake

**What this PR does / why we need it**:
The reconciler does nothing when it doesn't find any `ControllerRegistration`s https://github.com/gardener/gardener/blob/73c9272bcf13e5ab610955c38334321a589c2213/pkg/gardenlet/controller/controllerinstallation/required/add.go#L194-L208 or any `ControllerInstallation`s https://github.com/gardener/gardener/blob/73c9272bcf13e5ab610955c38334321a589c2213/pkg/gardenlet/controller/controllerinstallation/required/add.go#L214-L228

With this PR, we ensure that the manager cache observes the frequently created/deleted `Controller{Registration,Installation}` resources before proceeding with our actual test logic.

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener/issues/6927
Similar to https://github.com/gardener/gardener/pull/7012

**Special notes for your reviewer**:
I was not able to reproduce the flake locally, so I can't share the `stress` results.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
