### PR TITLE
Skip `podtopologyspreadconstraints` webhook for `gardenlet`

### DIFF
--- a/charts/gardener/gardenlet/templates/deployment.yaml
+++ b/charts/gardener/gardenlet/templates/deployment.yaml
@@ -62,6 +62,7 @@ spec:
 {{ include "gardenlet.deployment.labels" . | indent 8 }}
         projected-token-mount.resources.gardener.cloud/skip: "true"
         seccompprofile.resources.gardener.cloud/skip: "true"
+        topology-spread-constraints.resources.gardener.cloud/skip: "true"
         {{- if .Values.podLabels }}
 {{ toYaml .Values.podLabels | indent 8 }}
         {{- end }}

--- a/pkg/gardenlet/controller/managedseed/charttest/gardenlet_chart_test.go
+++ b/pkg/gardenlet/controller/managedseed/charttest/gardenlet_chart_test.go
@@ -65,8 +65,9 @@ var (
 		"resources.gardener.cloud/garbage-collectable-reference": "true",
 	})
 	expectedLabelsWithSkippedWebhooks = utils.MergeStringMaps(expectedLabels, map[string]string{
-		"projected-token-mount.resources.gardener.cloud/skip": "true",
-		"seccompprofile.resources.gardener.cloud/skip":        "true",
+		"projected-token-mount.resources.gardener.cloud/skip":       "true",
+		"seccompprofile.resources.gardener.cloud/skip":              "true",
+		"topology-spread-constraints.resources.gardener.cloud/skip": "true",
 	})
 )
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness quality
/kind bug

**What this PR does / why we need it**:
Similar to https://github.com/gardener/gardener/pull/6175

A bug has been fixed which could prevent gardenlet pods from coming up in case the pod-topology-spread-constraints webhook served by gardener-resource-manager is unavailable or broken. This is easily reproducible if a seed is hibernated and then woken up.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @timuthy 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
A bug has been fixed which could prevent `gardenlet` pods from coming up in case the `podtopologyspreadconstraints` webhook served by `gardener-resource-manager` is unavailable or broken.
```
