### PR TITLE
Clean up the stale `kube-addon-manager-vpa` VPA

### DIFF
--- a/pkg/operation/botanist/resource_manager.go
+++ b/pkg/operation/botanist/resource_manager.go
@@ -43,6 +43,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apiserver/pkg/authentication/user"
+	vpaautoscalingv1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
 	"k8s.io/component-base/version"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -153,7 +154,12 @@ func (b *Botanist) DeployGardenerResourceManager(ctx context.Context) error {
 	secrets.BootstrapKubeconfig = nil
 	b.Shoot.Components.ControlPlane.ResourceManager.SetSecrets(secrets)
 
-	return b.Shoot.Components.ControlPlane.ResourceManager.Deploy(ctx)
+	if err := b.Shoot.Components.ControlPlane.ResourceManager.Deploy(ctx); err != nil {
+		return err
+	}
+
+	// TODO(ialidzhikov): Remove in 1.63.
+	return kutil.DeleteObject(ctx, b.SeedClientSet.Client(), &vpaautoscalingv1.VerticalPodAutoscaler{ObjectMeta: metav1.ObjectMeta{Namespace: b.Shoot.SeedNamespace, Name: "kube-addon-manager-vpa"}})
 }
 
 // ScaleGardenerResourceManagerToOne scales the gardener-resource-manager deployment

--- a/pkg/operation/botanist/resource_manager_test.go
+++ b/pkg/operation/botanist/resource_manager_test.go
@@ -43,6 +43,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	vpaautoscalingv1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -145,6 +146,12 @@ var _ = Describe("ResourceManager", func() {
 
 						// set secrets
 						resourceManager.EXPECT().SetSecrets(secrets),
+
+						c.EXPECT().Delete(ctx, gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{})).DoAndReturn(func(_ context.Context, obj *vpaautoscalingv1.VerticalPodAutoscaler, opts ...client.DeleteOption) error {
+							Expect(obj.Name).To(Equal("kube-addon-manager-vpa"))
+							Expect(obj.Namespace).To(Equal(seedNamespace))
+							return nil
+						}),
 					)
 
 					resourceManager.EXPECT().Deploy(ctx)
@@ -258,6 +265,12 @@ var _ = Describe("ResourceManager", func() {
 				})
 
 				It("should set the secrets and deploy", func() {
+					c.EXPECT().Delete(ctx, gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{})).DoAndReturn(func(_ context.Context, obj *vpaautoscalingv1.VerticalPodAutoscaler, opts ...client.DeleteOption) error {
+						Expect(obj.Name).To(Equal("kube-addon-manager-vpa"))
+						Expect(obj.Namespace).To(Equal(seedNamespace))
+						return nil
+					})
+
 					resourceManager.EXPECT().Deploy(ctx)
 					Expect(botanist.DeployGardenerResourceManager(ctx)).To(Succeed())
 				})
@@ -311,6 +324,12 @@ var _ = Describe("ResourceManager", func() {
 						// set secrets and deploy with shoot access token
 						resourceManager.EXPECT().SetSecrets(secrets),
 						resourceManager.EXPECT().Deploy(ctx),
+
+						c.EXPECT().Delete(ctx, gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{})).DoAndReturn(func(_ context.Context, obj *vpaautoscalingv1.VerticalPodAutoscaler, opts ...client.DeleteOption) error {
+							Expect(obj.Name).To(Equal("kube-addon-manager-vpa"))
+							Expect(obj.Namespace).To(Equal(seedNamespace))
+							return nil
+						}),
 					)
 
 					Expect(botanist.DeployGardenerResourceManager(ctx)).To(Succeed())


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity
/kind cleanup

**What this PR does / why we need it**:
We missed to explicitly delete the `kube-addon-manager-vpa` VPA in https://github.com/gardener/gardener/pull/1114.
On a soil cluster:
```
$ k get vpa -A --field-selector=metadata.name=kube-addon-manager-vpa
NAMESPACE                 NAME                     MODE   CPU   MEM        PROVIDED   AGE
shoot--garden--alicloud   kube-addon-manager-vpa   Off    45m   10500k     True       3y203d
shoot-garden-aws          kube-addon-manager-vpa   Off    45m   85491088   True       3y204d
shoot-garden-az           kube-addon-manager-vpa   Off    45m   85491088   True       3y204d
shoot-garden-gcp          kube-addon-manager-vpa   Off    45m   85491088   True       3y204d
```

On a Seed:
```
$ k get vpa -A --field-selector=metadata.name=kube-addon-manager-vpa
NAMESPACE                        NAME                     MODE   CPU   MEM         PROVIDED   AGE
<omitted>                        kube-addon-manager-vpa   Off    11m   78221997    True       3y178d
<omitted>                        kube-addon-manager-vpa   Off    63m   109814751   True       3y157d
<omitted>                        kube-addon-manager-vpa   Off    49m   109814751   True       3y178d
```

This is causing the following logs in the vpa-recommender:
```
E1115 14:56:03.982622       1 cluster_feeder.go:554] Cannot get target selector from VPA's targetRef. Reason: Deployment <omitted>/kube-addon-manager does not exist
E1115 14:56:04.019836       1 cluster_feeder.go:554] Cannot get target selector from VPA's targetRef. Reason: Deployment <omitted>/kube-addon-manager does not exist
E1115 14:56:04.025976       1 cluster_feeder.go:554] Cannot get target selector from VPA's targetRef. Reason: Deployment <omitted>/kube-addon-manager does not exist
```

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
