### PR TITLE
Modifies timeout of EtcdCopyBackupsTask

### DIFF
--- a/pkg/operation/botanist/component/etcdcopybackupstask/etcdcopybackupstask.go
+++ b/pkg/operation/botanist/component/etcdcopybackupstask/etcdcopybackupstask.go
@@ -38,9 +38,6 @@ const (
 	// DefaultTimeout is the default timeout and defines how long Gardener should wait
 	// for a successful reconciliation of an EtcdCopyBackupsTasks resource.
 	DefaultTimeout = 5 * time.Minute
-
-	// DefaultWaitForFinalSnapshotTimeout is the default timeout for waiting for a final full snapshot.
-	DefaultWaitForFinalSnapshotTimeout = 30 * time.Minute
 )
 
 // Interface contains functions to manage EtcdCopyBackupsTasks.

--- a/pkg/operation/botanist/etcdcopybackupstask.go
+++ b/pkg/operation/botanist/etcdcopybackupstask.go
@@ -41,7 +41,7 @@ func (b *Botanist) DefaultEtcdCopyBackupsTask() etcdcopybackupstask.Interface {
 			Namespace: b.Shoot.SeedNamespace,
 			WaitForFinalSnapshot: &druidv1alpha1.WaitForFinalSnapshotSpec{
 				Enabled: true,
-				Timeout: &metav1.Duration{Duration: etcdcopybackupstask.DefaultWaitForFinalSnapshotTimeout},
+				Timeout: &metav1.Duration{Duration: etcdcopybackupstask.DefaultTimeout},
 			},
 		},
 		etcdcopybackupstask.DefaultInterval,

--- a/pkg/operation/botanist/etcdcopybackupstask_test.go
+++ b/pkg/operation/botanist/etcdcopybackupstask_test.go
@@ -111,7 +111,7 @@ var _ = Describe("EtcdCopyBackupsTask", func() {
 					Namespace: botanist.Shoot.SeedNamespace,
 					WaitForFinalSnapshot: &druidv1alpha1.WaitForFinalSnapshotSpec{
 						Enabled: true,
-						Timeout: &metav1.Duration{Duration: etcdcopybackupstask.DefaultWaitForFinalSnapshotTimeout},
+						Timeout: &metav1.Duration{Duration: etcdcopybackupstask.DefaultTimeout},
 					},
 				}),
 				expectedWaitInterval:       Equal(etcdcopybackupstask.DefaultInterval),


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane-migration
/kind bug

**What this PR does / why we need it**:
This PR reduces the timeout that the `EtcdCopyBackupsTask` will wait for a final snapshot of the `ETCD` backups to be made before initiating the copy of backups from the source `Seed` to the destination `Seed` during controll plane migration.
The timeout was previously 30 minutes which was way higher than the 5 minutes timeout of the `Deploy` method that actually creates the `EtcdCopyBackupsTask`. This meant that during forced control plane migration (when the `shoot.gardener.cloud/force-restore=true` is used on the `Shoot`) the shoot would always get stuck on the `DeployEtcdCopyBackupsTask` step, because the `EtcdCopyBackupsTask` is always recreated on each reconciliation (this recreation is intended)
With #6302 we have agreed that loss of data during bad case control plane migration is acceptable so there is no reason to wait for the full 30 minutes.
This change does not affect the good case control plane migration.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Reduced the timeout that `EtcdCopyBackupsTask` waits until a final snapshot of the `ETCD` backups is made before copying backups from the source `Seed` to the destination `Seed` during control plane migration to 5 minutes.
```
