### PR TITLE
Fix flaky `Project` controller tests

### DIFF
--- a/test/integration/controllermanager/project/activity/activity_test.go
+++ b/test/integration/controllermanager/project/activity/activity_test.go
@@ -30,7 +30,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-var _ = Describe("Project Activity controller tests", func() {
+var _ = Describe("Project Activity controller tests", Ordered, func() {
 	var project *gardencorev1beta1.Project
 
 	BeforeEach(func() {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind flake

**What this PR does / why we need it**:
This PR (hopefully) fixes the flaky `Project` controller tests. I was not able to reproduce it locally.

However, I found some places in the `project_test.go` which might have violated ginkgo's [Don't Initialize Variables in Container Nodes](https://onsi.github.io/ginkgo/#avoid-spec-pollution-dont-initialize-variables-in-container-nodes) rule and fixed that. `triggerAndWaitForReconciliation` and `waitForProjectPhase` now receive the `project` via their interface and do not use the project pointer of the Ginkgo container anymore.

`activity_test.go` uses a global fake clock which is assigned to the `Reconciler`. As different tests are manipulating this fake clock, they could influence each other when running in parallel. In order to avoid these side effects, the `Describe` container of this test is now `Ordered`.

**Which issue(s) this PR fixes**:
Fixes #6928 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
