### PR TITLE
Bind address of kube-controller-manager to pod ip

### DIFF
--- a/pkg/operation/botanist/component/kubecontrollermanager/kube_controller_manager.go
+++ b/pkg/operation/botanist/component/kubecontrollermanager/kube_controller_manager.go
@@ -290,6 +290,17 @@ func (k *kubeControllerManager) Deploy(ctx context.Context) error {
 								Protocol:      corev1.ProtocolTCP,
 							},
 						},
+						Env: []corev1.EnvVar{
+							{
+								Name: "POD_IP",
+								ValueFrom: &corev1.EnvVarSource{
+									FieldRef: &corev1.ObjectFieldSelector{
+										APIVersion: "v1",
+										FieldPath:  "status.podIP",
+									},
+								},
+							},
+						},
 						Resources: resourceRequirements,
 						VolumeMounts: []corev1.VolumeMount{
 							{
@@ -514,6 +525,7 @@ func (k *kubeControllerManager) computeCommand(port int32) []string {
 		"--authentication-kubeconfig="+gutil.PathGenericKubeconfig,
 		"--authorization-kubeconfig="+gutil.PathGenericKubeconfig,
 		"--kubeconfig="+gutil.PathGenericKubeconfig,
+		"--bind-address=$(POD_IP)",
 	)
 
 	if k.config.NodeCIDRMaskSize != nil {

--- a/pkg/operation/botanist/component/kubecontrollermanager/kube_controller_manager_test.go
+++ b/pkg/operation/botanist/component/kubecontrollermanager/kube_controller_manager_test.go
@@ -477,6 +477,17 @@ var _ = Describe("KubeControllerManager", func() {
 													Protocol:      corev1.ProtocolTCP,
 												},
 											},
+											Env: []corev1.EnvVar{
+												{
+													Name: "POD_IP",
+													ValueFrom: &corev1.EnvVarSource{
+														FieldRef: &corev1.ObjectFieldSelector{
+															APIVersion: "v1",
+															FieldPath:  "status.podIP",
+														},
+													},
+												},
+											},
 											Resources: corev1.ResourceRequirements{
 												Requests: corev1.ResourceList{
 													corev1.ResourceCPU:    resource.MustParse("100m"),
@@ -857,6 +868,7 @@ func commandForKubernetesVersion(
 		"--authentication-kubeconfig=/var/run/secrets/gardener.cloud/shoot/generic-kubeconfig/kubeconfig",
 		"--authorization-kubeconfig=/var/run/secrets/gardener.cloud/shoot/generic-kubeconfig/kubeconfig",
 		"--kubeconfig=/var/run/secrets/gardener.cloud/shoot/generic-kubeconfig/kubeconfig",
+		"--bind-address=$(POD_IP)",
 	)
 
 	if nodeCIDRMaskSize != nil {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind enhancement

**What this PR does / why we need it**:
`kube-controller-manager` now binds to its own pod IP address instead of `0.0.0.0`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
`kube-controller-manager` now binds to its own pod IP address instead of `0.0.0.0`.
```
