### PR TITLE
Minor improvements for the metering dashboards

### DIFF
--- a/charts/seed-bootstrap/dashboards/gardener-resource-usage-by-container.json
+++ b/charts/seed-bootstrap/dashboards/gardener-resource-usage-by-container.json
@@ -79,13 +79,7 @@
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
-      "seriesOverrides": [
-        {
-          "$$hashKey": "object:1160",
-          "alias": "/Total/",
-          "dashes": true
-        }
-      ],
+      "seriesOverrides": [],
       "spaceLength": 10,
       "stack": false,
       "steppedLine": false,
@@ -195,13 +189,7 @@
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
-      "seriesOverrides": [
-        {
-          "$$hashKey": "object:1349",
-          "alias": "/Total/",
-          "dashes": true
-        }
-      ],
+      "seriesOverrides": [],
       "spaceLength": 10,
       "stack": false,
       "steppedLine": false,
@@ -324,13 +312,7 @@
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
-      "seriesOverrides": [
-        {
-          "$$hashKey": "object:1115",
-          "alias": "/Total/",
-          "dashes": true
-        }
-      ],
+      "seriesOverrides": [],
       "spaceLength": 10,
       "stack": false,
       "steppedLine": false,
@@ -439,13 +421,7 @@
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
-      "seriesOverrides": [
-        {
-          "$$hashKey": "object:1115",
-          "alias": "/Total/",
-          "dashes": true
-        }
-      ],
+      "seriesOverrides": [],
       "spaceLength": 10,
       "stack": false,
       "steppedLine": false,
@@ -554,13 +530,7 @@
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
-      "seriesOverrides": [
-        {
-          "$$hashKey": "object:1115",
-          "alias": "/Total/",
-          "dashes": true
-        }
-      ],
+      "seriesOverrides": [],
       "spaceLength": 10,
       "stack": false,
       "steppedLine": false,
@@ -683,13 +653,7 @@
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
-      "seriesOverrides": [
-        {
-          "$$hashKey": "object:1115",
-          "alias": "/Total/",
-          "dashes": true
-        }
-      ],
+      "seriesOverrides": [],
       "spaceLength": 10,
       "stack": false,
       "steppedLine": false,
@@ -799,13 +763,7 @@
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
-      "seriesOverrides": [
-        {
-          "$$hashKey": "object:1115",
-          "alias": "/Total/",
-          "dashes": true
-        }
-      ],
+      "seriesOverrides": [],
       "spaceLength": 10,
       "stack": false,
       "steppedLine": false,
@@ -928,13 +886,7 @@
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
-      "seriesOverrides": [
-        {
-          "$$hashKey": "object:1115",
-          "alias": "/Total/",
-          "dashes": true
-        }
-      ],
+      "seriesOverrides": [],
       "spaceLength": 10,
       "stack": false,
       "steppedLine": false,
@@ -1044,13 +996,7 @@
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
-      "seriesOverrides": [
-        {
-          "$$hashKey": "object:1115",
-          "alias": "/Total/",
-          "dashes": true
-        }
-      ],
+      "seriesOverrides": [],
       "spaceLength": 10,
       "stack": false,
       "steppedLine": false,

--- a/charts/seed-bootstrap/dashboards/shoot-control-plane-resource-usage-by-owner-container.json
+++ b/charts/seed-bootstrap/dashboards/shoot-control-plane-resource-usage-by-owner-container.json
@@ -349,7 +349,7 @@
         },
         {
           "exemplar": true,
-          "expr": "metering:network_receive:sum_by_namespace{shoot_uid!=\"\",namespace=~\"$namespace\"} + metering:network_transmit:sum_by_namespace{shoot_uid!=\"\",namespace=~\"$namespace\"}",
+          "expr": "metering:network_receive:sum_by_namespace:avg_over_time{shoot_uid!=\"\",namespace=~\"$namespace\"} + metering:network_transmit:sum_by_namespace:avg_over_time{shoot_uid!=\"\",namespace=~\"$namespace\"}",
           "hide": false,
           "instant": true,
           "interval": "",
@@ -624,13 +624,7 @@
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
-      "seriesOverrides": [
-        {
-          "$$hashKey": "object:1160",
-          "alias": "/Total/",
-          "dashes": true
-        }
-      ],
+      "seriesOverrides": [],
       "spaceLength": 10,
       "stack": false,
       "steppedLine": false,
@@ -740,13 +734,7 @@
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
-      "seriesOverrides": [
-        {
-          "$$hashKey": "object:1349",
-          "alias": "/Total/",
-          "dashes": true
-        }
-      ],
+      "seriesOverrides": [],
       "spaceLength": 10,
       "stack": false,
       "steppedLine": false,
@@ -869,13 +857,7 @@
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
-      "seriesOverrides": [
-        {
-          "$$hashKey": "object:1115",
-          "alias": "/Total/",
-          "dashes": true
-        }
-      ],
+      "seriesOverrides": [],
       "spaceLength": 10,
       "stack": false,
       "steppedLine": false,
@@ -984,13 +966,7 @@
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
-      "seriesOverrides": [
-        {
-          "$$hashKey": "object:1115",
-          "alias": "/Total/",
-          "dashes": true
-        }
-      ],
+      "seriesOverrides": [],
       "spaceLength": 10,
       "stack": false,
       "steppedLine": false,
@@ -1099,13 +1075,7 @@
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
-      "seriesOverrides": [
-        {
-          "$$hashKey": "object:1115",
-          "alias": "/Total/",
-          "dashes": true
-        }
-      ],
+      "seriesOverrides": [],
       "spaceLength": 10,
       "stack": false,
       "steppedLine": false,
@@ -1228,13 +1198,7 @@
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
-      "seriesOverrides": [
-        {
-          "$$hashKey": "object:1115",
-          "alias": "/Total/",
-          "dashes": true
-        }
-      ],
+      "seriesOverrides": [],
       "spaceLength": 10,
       "stack": false,
       "steppedLine": false,
@@ -1344,13 +1308,7 @@
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
-      "seriesOverrides": [
-        {
-          "$$hashKey": "object:1115",
-          "alias": "/Total/",
-          "dashes": true
-        }
-      ],
+      "seriesOverrides": [],
       "spaceLength": 10,
       "stack": false,
       "steppedLine": false,
@@ -1473,13 +1431,7 @@
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
-      "seriesOverrides": [
-        {
-          "$$hashKey": "object:1115",
-          "alias": "/Total/",
-          "dashes": true
-        }
-      ],
+      "seriesOverrides": [],
       "spaceLength": 10,
       "stack": false,
       "steppedLine": false,
@@ -1589,13 +1541,7 @@
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
-      "seriesOverrides": [
-        {
-          "$$hashKey": "object:1115",
-          "alias": "/Total/",
-          "dashes": true
-        }
-      ],
+      "seriesOverrides": [],
       "spaceLength": 10,
       "stack": false,
       "steppedLine": false,

--- a/charts/seed-bootstrap/dashboards/shoot-control-plane-resource-usage-overview.json
+++ b/charts/seed-bootstrap/dashboards/shoot-control-plane-resource-usage-overview.json
@@ -34,10 +34,6 @@
               {
                 "color": "green",
                 "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
               }
             ]
           }
@@ -140,7 +136,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "min(metering:cpu_usage:sum_by_namespace:avg_over_time:this_month{shoot_uid!=\"\"})",
+          "expr": "min(\n    (metering:cpu_usage:sum_by_namespace:avg_over_time:this_month{shoot_uid!=\"\"} > 0)\n  +\n    0 * (metering:memory_usage_seconds:this_month > 300)\n)",
           "hide": false,
           "instant": true,
           "interval": "",
@@ -149,7 +145,7 @@
         },
         {
           "exemplar": true,
-          "expr": "quantile(0.5, metering:cpu_usage:sum_by_namespace:avg_over_time:this_month{shoot_uid!=\"\"})",
+          "expr": "quantile(0.5,\n    (metering:cpu_usage:sum_by_namespace:avg_over_time:this_month{shoot_uid!=\"\"} > 0)\n  +\n    0 * (metering:memory_usage_seconds:this_month > 300)\n)",
           "hide": false,
           "instant": true,
           "interval": "",
@@ -158,7 +154,7 @@
         },
         {
           "exemplar": true,
-          "expr": "max(metering:cpu_usage:sum_by_namespace:avg_over_time:this_month{shoot_uid!=\"\"})",
+          "expr": "max(\n    (metering:cpu_usage:sum_by_namespace:avg_over_time:this_month{shoot_uid!=\"\"} > 0)\n  +\n    0 * (metering:memory_usage_seconds:this_month > 300)\n)",
           "instant": true,
           "interval": "",
           "legendFormat": "Maximum",
@@ -166,7 +162,7 @@
         },
         {
           "exemplar": true,
-          "expr": "avg(metering:cpu_usage:sum_by_namespace:avg_over_time:this_month{shoot_uid!=\"\"})",
+          "expr": "avg(\n    (metering:cpu_usage:sum_by_namespace:avg_over_time:this_month{shoot_uid!=\"\"} > 0)\n  +\n    0 * (metering:memory_usage_seconds:this_month > 300)\n)",
           "hide": false,
           "instant": true,
           "interval": "",
@@ -224,7 +220,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "min(metering:memory_usage:sum_by_namespace:avg_over_time:this_month{shoot_uid!=\"\"})",
+          "expr": "min(\n    (metering:memory_usage:sum_by_namespace:avg_over_time:this_month{shoot_uid!=\"\"} > 0)\n  +\n    0 * (metering:memory_usage_seconds:this_month > 300)\n)",
           "hide": false,
           "instant": true,
           "interval": "",
@@ -233,7 +229,7 @@
         },
         {
           "exemplar": true,
-          "expr": "quantile(0.5, metering:memory_usage:sum_by_namespace:avg_over_time:this_month{shoot_uid!=\"\"})",
+          "expr": "quantile(0.5,\n    (metering:memory_usage:sum_by_namespace:avg_over_time:this_month{shoot_uid!=\"\"} > 0)\n  +\n    0 * (metering:memory_usage_seconds:this_month > 300)\n)",
           "hide": false,
           "instant": true,
           "interval": "",
@@ -242,7 +238,7 @@
         },
         {
           "exemplar": true,
-          "expr": "max(metering:memory_usage:sum_by_namespace:avg_over_time:this_month{shoot_uid!=\"\"})",
+          "expr": "max(\n    (metering:memory_usage:sum_by_namespace:avg_over_time:this_month{shoot_uid!=\"\"} > 0)\n  +\n    0 * (metering:memory_usage_seconds:this_month > 300)\n)",
           "instant": true,
           "interval": "",
           "legendFormat": "Maximum",
@@ -250,7 +246,7 @@
         },
         {
           "exemplar": true,
-          "expr": "avg(metering:memory_usage:sum_by_namespace:avg_over_time:this_month{shoot_uid!=\"\"})",
+          "expr": "avg(\n    (metering:memory_usage:sum_by_namespace:avg_over_time:this_month{shoot_uid!=\"\"} > 0)\n  +\n    0 * (metering:memory_usage_seconds:this_month > 300)\n)",
           "hide": false,
           "instant": true,
           "interval": "",
@@ -308,7 +304,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "min(metering:network_receive:sum_by_namespace:avg_over_time:this_month{shoot_uid!=\"\"}+metering:network_transmit:sum_by_namespace:avg_over_time:this_month{shoot_uid!=\"\"})",
+          "expr": "min(\n    (metering:network_receive:sum_by_namespace:avg_over_time:this_month{shoot_uid!=\"\"}\n     +\n     metering:network_transmit:sum_by_namespace:avg_over_time:this_month{shoot_uid!=\"\"} > 0)\n  +\n    0 * (metering:memory_usage_seconds:this_month > 300)\n)",
           "hide": false,
           "instant": true,
           "interval": "",
@@ -317,7 +313,7 @@
         },
         {
           "exemplar": true,
-          "expr": "quantile(0.5, metering:network_receive:sum_by_namespace:avg_over_time:this_month{shoot_uid!=\"\"}+metering:network_transmit:sum_by_namespace:avg_over_time:this_month{shoot_uid!=\"\"})",
+          "expr": "quantile(0.5,\n    (metering:network_receive:sum_by_namespace:avg_over_time:this_month{shoot_uid!=\"\"}\n     +\n     metering:network_transmit:sum_by_namespace:avg_over_time:this_month{shoot_uid!=\"\"} > 0)\n  +\n    0 * (metering:memory_usage_seconds:this_month > 300)\n)",
           "hide": false,
           "instant": true,
           "interval": "",
@@ -326,7 +322,7 @@
         },
         {
           "exemplar": true,
-          "expr": "max(metering:network_receive:sum_by_namespace:avg_over_time:this_month{shoot_uid!=\"\"}+metering:network_transmit:sum_by_namespace:avg_over_time:this_month{shoot_uid!=\"\"})",
+          "expr": "max(\n    (metering:network_receive:sum_by_namespace:avg_over_time:this_month{shoot_uid!=\"\"}\n     +\n     metering:network_transmit:sum_by_namespace:avg_over_time:this_month{shoot_uid!=\"\"} > 0)\n  +\n    0 * (metering:memory_usage_seconds:this_month > 300)\n)",
           "instant": true,
           "interval": "",
           "legendFormat": "Maximum",
@@ -334,7 +330,7 @@
         },
         {
           "exemplar": true,
-          "expr": "avg(metering:network_receive:sum_by_namespace:avg_over_time:this_month{shoot_uid!=\"\"}+metering:network_transmit:sum_by_namespace:avg_over_time:this_month{shoot_uid!=\"\"})",
+          "expr": "avg(\n    (metering:network_receive:sum_by_namespace:avg_over_time:this_month{shoot_uid!=\"\"}\n     +\n     metering:network_transmit:sum_by_namespace:avg_over_time:this_month{shoot_uid!=\"\"} > 0)\n  +\n    0 * (metering:memory_usage_seconds:this_month > 300)\n)",
           "hide": false,
           "instant": true,
           "interval": "",
@@ -392,7 +388,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "min(metering:working_set_memory:sum_by_namespace:avg_over_time:this_month{shoot_uid!=\"\"})",
+          "expr": "min(\n    (metering:working_set_memory:sum_by_namespace:avg_over_time:this_month{shoot_uid!=\"\"} > 0)\n  +\n    0 * (metering:memory_usage_seconds:this_month > 300)\n)",
           "hide": false,
           "instant": true,
           "interval": "",
@@ -401,7 +397,7 @@
         },
         {
           "exemplar": true,
-          "expr": "quantile(0.5, metering:working_set_memory:sum_by_namespace:avg_over_time:this_month{shoot_uid!=\"\"})",
+          "expr": "quantile(0.5,\n    (metering:working_set_memory:sum_by_namespace:avg_over_time:this_month{shoot_uid!=\"\"} > 0)\n  +\n    0 * (metering:memory_usage_seconds:this_month > 300)\n)",
           "hide": false,
           "instant": true,
           "interval": "",
@@ -410,7 +406,7 @@
         },
         {
           "exemplar": true,
-          "expr": "max(metering:working_set_memory:sum_by_namespace:avg_over_time:this_month{shoot_uid!=\"\"})",
+          "expr": "max(\n    (metering:working_set_memory:sum_by_namespace:avg_over_time:this_month{shoot_uid!=\"\"} > 0)\n  +\n    0 * (metering:memory_usage_seconds:this_month > 300)\n)",
           "instant": true,
           "interval": "",
           "legendFormat": "Maximum",
@@ -418,7 +414,7 @@
         },
         {
           "exemplar": true,
-          "expr": "avg(metering:working_set_memory:sum_by_namespace:avg_over_time:this_month{shoot_uid!=\"\"})",
+          "expr": "avg(\n    (metering:working_set_memory:sum_by_namespace:avg_over_time:this_month{shoot_uid!=\"\"} > 0)\n  +\n    0 * (metering:memory_usage_seconds:this_month > 300)\n)",
           "hide": false,
           "instant": true,
           "interval": "",
@@ -1090,7 +1086,6 @@
         "allValue": ".*",
         "current": {
           "selected": true,
-          "tags": [],
           "text": [
             "All"
           ],


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind enhancement

**What this PR does / why we need it**:

Minor improvements for the metering dashboards that were introduced in

- #6944

Improvements:

- avoid using dashed lines: they look similar as if data was missing
- fix promql query for the average network usage
- for the overview, don't consider the unhealthy clusters: consider only cluster that have been running for at least 5 minutes and are not stuck in creation, i.e. use at least some resources

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

/cc @rickardsjp 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
