### PR TITLE
Add multinode etcd dashboard, adapt etcd dashboard and alerts

### DIFF
--- a/charts/seed-monitoring/charts/grafana/dashboards/operators/etcd-backup-dashboard.json
+++ b/charts/seed-monitoring/charts/grafana/dashboards/operators/etcd-backup-dashboard.json
@@ -320,7 +320,7 @@
         "current": false,
         "max": false,
         "min": false,
-        "show": false,
+        "show": true,
         "total": false,
         "values": false
       },
@@ -345,7 +345,7 @@
           "expr": "etcdbr_snapshot_duration_seconds_count{role=\"main\",kind=\"Full\",succeeded=\"true\"}",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "Succeeded",
+          "legendFormat": "{{pod}} Succeeded",
           "metric": "etcdbr_snapshot_duration_seconds_count",
           "refId": "A",
           "step": 2
@@ -354,7 +354,7 @@
           "expr": "etcdbr_snapshot_duration_seconds_count{role=\"main\",kind=\"Full\",succeeded=\"false\"}",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "Failed",
+          "legendFormat": "{{pod}} Failed",
           "metric": "etcdbr_snapshot_duration_seconds_count",
           "refId": "B",
           "step": 2
@@ -431,7 +431,7 @@
         "current": false,
         "max": false,
         "min": false,
-        "show": false,
+        "show": true,
         "total": false,
         "values": false
       },
@@ -456,7 +456,7 @@
           "expr": "etcdbr_snapshot_duration_seconds_count{role=\"main\",kind=\"Incr\",succeeded=\"true\"}",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "Succeeded",
+          "legendFormat": "{{pod}} Succeeded",
           "metric": "etcdbr_snapshot_duration_seconds_count",
           "refId": "A",
           "step": 2
@@ -465,7 +465,7 @@
           "expr": "etcdbr_snapshot_duration_seconds_count{role=\"main\",kind=\"Incr\",succeeded=\"false\"}",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "Failed",
+          "legendFormat": "{{pod}} Failed",
           "metric": "etcdbr_snapshot_duration_seconds_count",
           "refId": "B",
           "step": 2
@@ -542,7 +542,7 @@
         "current": false,
         "max": false,
         "min": false,
-        "show": false,
+        "show": true,
         "total": false,
         "values": false
       },
@@ -648,7 +648,7 @@
         "current": false,
         "max": false,
         "min": false,
-        "show": false,
+        "show": true,
         "total": false,
         "values": false
       },
@@ -673,7 +673,7 @@
           "expr": "etcdbr_defragmentation_duration_seconds_count{role=\"main\",succeeded=\"true\"}",
           "instant": false,
           "intervalFactor": 1,
-          "legendFormat": "Succeeded",
+          "legendFormat": "{{pod}} Succeeded",
           "metric": "etcdbr_defragmentation_duration_seconds_count",
           "refId": "A",
           "step": 4
@@ -681,7 +681,7 @@
         {
           "expr": "etcdbr_defragmentation_duration_seconds_count{role=\"main\",succeeded=\"false\"}",
           "instant": false,
-          "legendFormat": "Failed",
+          "legendFormat": "{{pod}} Failed",
           "refId": "B"
         }
       ],
@@ -863,7 +863,7 @@
         "current": false,
         "max": false,
         "min": false,
-        "show": false,
+        "show": true,
         "total": false,
         "values": false
       },
@@ -888,7 +888,7 @@
           "expr": "etcdbr_validation_duration_seconds_count{role=\"main\",succeeded=\"true\"}",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "Succeeded",
+          "legendFormat": "{{pod}} Succeeded",
           "metric": "etcdbr_validation_duration_seconds_count",
           "refId": "A",
           "step": 2
@@ -898,7 +898,7 @@
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
-          "legendFormat": "Failed",
+          "legendFormat": "{{pod}} Failed",
           "metric": "etcdbr_validation_duration_seconds_count",
           "refId": "B",
           "step": 2
@@ -975,7 +975,7 @@
         "current": false,
         "max": false,
         "min": false,
-        "show": false,
+        "show": true,
         "total": false,
         "values": false
       },
@@ -1000,7 +1000,7 @@
           "expr": "etcdbr_restoration_duration_seconds_count{role=\"main\",succeeded=\"true\"}",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "Succeeded",
+          "legendFormat": "{{pod}} {{restore}} Succeeded",
           "metric": "etcdbr_restoration_duration_seconds_count",
           "refId": "A",
           "step": 2
@@ -1010,7 +1010,7 @@
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
-          "legendFormat": "Failed",
+          "legendFormat": "{{pod}} {{restore}} Failed",
           "metric": "etcdbr_restoration_duration_seconds_count",
           "refId": "B",
           "step": 2
@@ -1098,7 +1098,7 @@
         "current": false,
         "max": false,
         "min": false,
-        "show": false,
+        "show": true,
         "total": false,
         "values": false
       },
@@ -1123,7 +1123,7 @@
           "expr": "process_resident_memory_bytes{job=\"kube-etcd3-backup-restore-main\"}",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "Memory",
+          "legendFormat": "{{pod}} Memory",
           "metric": "process_resident_memory_bytes",
           "refId": "A",
           "step": 2
@@ -1197,7 +1197,7 @@
         "current": false,
         "max": false,
         "min": false,
-        "show": false,
+        "show": true,
         "total": false,
         "values": false
       },
@@ -1222,7 +1222,7 @@
           "expr": "rate(process_cpu_seconds_total{job=\"kube-etcd3-backup-restore-main\"}[$__rate_interval]) * 100",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "CPU",
+          "legendFormat": "{{pod}} CPU",
           "metric": "process_cpu_seconds_total",
           "refId": "A",
           "step": 2

--- a/charts/seed-monitoring/charts/grafana/dashboards/operators/etcd-cluster-details-dashboard.json
+++ b/charts/seed-monitoring/charts/grafana/dashboards/operators/etcd-cluster-details-dashboard.json
@@ -451,7 +451,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "changes(etcd_server_leader_changes_seen_total{job=\"kube-etcd3-$cluster\"}[1d])",
+          "expr": "increase(etcd_server_leader_changes_seen_total{job=\"kube-etcd3-$cluster\"}[1d])",
           "interval": "",
           "legendFormat": "{{pod}}",
           "refId": "A"

--- a/charts/seed-monitoring/charts/grafana/dashboards/operators/etcd-cluster-details-dashboard.json
+++ b/charts/seed-monitoring/charts/grafana/dashboards/operators/etcd-cluster-details-dashboard.json
@@ -1162,7 +1162,7 @@
       "yaxes": [
         {
           "$$hashKey": "object:1401",
-          "format": "short",
+          "format": "s",
           "label": null,
           "logBase": 1,
           "max": null,
@@ -1171,7 +1171,7 @@
         },
         {
           "$$hashKey": "object:1402",
-          "format": "short",
+          "format": "s",
           "label": null,
           "logBase": 1,
           "max": null,
@@ -1259,7 +1259,7 @@
       "yaxes": [
         {
           "$$hashKey": "object:1401",
-          "format": "short",
+          "format": "binBps",
           "label": null,
           "logBase": 1,
           "max": null,
@@ -1268,7 +1268,7 @@
         },
         {
           "$$hashKey": "object:1402",
-          "format": "short",
+          "format": "binBps",
           "label": null,
           "logBase": 1,
           "max": null,
@@ -1356,7 +1356,7 @@
       "yaxes": [
         {
           "$$hashKey": "object:1401",
-          "format": "short",
+          "format": "binBps",
           "label": null,
           "logBase": 1,
           "max": null,
@@ -1365,7 +1365,7 @@
         },
         {
           "$$hashKey": "object:1402",
-          "format": "short",
+          "format": "binBps",
           "label": null,
           "logBase": 1,
           "max": null,

--- a/charts/seed-monitoring/charts/grafana/dashboards/operators/etcd-cluster-details-dashboard.json
+++ b/charts/seed-monitoring/charts/grafana/dashboards/operators/etcd-cluster-details-dashboard.json
@@ -59,7 +59,7 @@
         "orientation": "auto",
         "reduceOptions": {
           "calcs": [
-            "lastNotNull"
+            "last"
           ],
           "fields": "",
           "values": false
@@ -120,7 +120,7 @@
         "orientation": "auto",
         "reduceOptions": {
           "calcs": [
-            "lastNotNull"
+            "last"
           ],
           "fields": "",
           "values": false
@@ -180,7 +180,7 @@
         "orientation": "auto",
         "reduceOptions": {
           "calcs": [
-            "lastNotNull"
+            "last"
           ],
           "fields": "",
           "values": false
@@ -273,7 +273,7 @@
         "orientation": "auto",
         "reduceOptions": {
           "calcs": [
-            "lastNotNull"
+            "last"
           ],
           "fields": "",
           "values": false
@@ -355,7 +355,7 @@
         "orientation": "auto",
         "reduceOptions": {
           "calcs": [
-            "lastNotNull"
+            "last"
           ],
           "fields": "",
           "values": false
@@ -1026,7 +1026,6 @@
             "mode": "thresholds"
           },
           "mappings": [],
-          "noValue": "0",
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -1065,7 +1064,7 @@
         "orientation": "auto",
         "reduceOptions": {
           "calcs": [
-            "lastNotNull"
+            "last"
           ],
           "fields": "",
           "values": false

--- a/charts/seed-monitoring/charts/grafana/dashboards/operators/etcd-cluster-details-dashboard.json
+++ b/charts/seed-monitoring/charts/grafana/dashboards/operators/etcd-cluster-details-dashboard.json
@@ -627,7 +627,7 @@
         "current": false,
         "max": false,
         "min": false,
-        "show": false,
+        "show": true,
         "total": false,
         "values": false
       },
@@ -660,7 +660,7 @@
         {
           "expr": "sum(etcd_server_proposals_pending{role=~\"$cluster\"})",
           "intervalFactor": 2,
-          "legendFormat": "Proposal Pending Total",
+          "legendFormat": "Proposal Pending",
           "metric": "etcd_server_proposals_pending",
           "refId": "B",
           "step": 2

--- a/charts/seed-monitoring/charts/grafana/dashboards/operators/etcd-cluster-details-dashboard.json
+++ b/charts/seed-monitoring/charts/grafana/dashboards/operators/etcd-cluster-details-dashboard.json
@@ -1,8 +1,19 @@
 {
   "annotations": {
-    "list": []
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
   },
   "editable": true,
+  "gnetId": null,
   "graphTooltip": 0,
   "id": 9,
   "iteration": 1542111230310,
@@ -10,6 +21,7 @@
   "panels": [
     {
       "collapsed": false,
+      "datasource": null,
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -1586,7 +1598,7 @@
       }
     }
   ],
-  "schemaVersion": 16,
+  "schemaVersion": 27,
   "style": "dark",
   "tags": [
     "controlplane",
@@ -1595,12 +1607,16 @@
   "templating": {
     "list": [
       {
+        "allValue": null,
         "current": {
           "tags": [],
           "text": "main",
           "value": "main"
         },
+        "description": null,
+        "error": null,
         "hide": 0,
+        "includeAll": false,
         "label": null,
         "multi": false,
         "name": "cluster",
@@ -1621,12 +1637,16 @@
         "type": "custom"
       },
       {
+        "allValue": null,
         "current": {
-          "tags": [],
+          "selected": true,
           "text": "0",
           "value": "0"
         },
+        "description": null,
+        "error": null,
         "hide": 0,
+        "includeAll": false,
         "label": null,
         "multi": false,
         "name": "member",
@@ -1648,6 +1668,7 @@
           }
         ],
         "query": "0, 1, 2",
+        "queryValue": "",
         "skipUrlSync": false,
         "type": "custom"
       }

--- a/charts/seed-monitoring/charts/grafana/dashboards/operators/etcd-cluster-details-dashboard.json
+++ b/charts/seed-monitoring/charts/grafana/dashboards/operators/etcd-cluster-details-dashboard.json
@@ -1451,7 +1451,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "rate(etcd_server_slow_apply_total{job=\"kube-etcd3-$cluster\"}[5m])",
+          "expr": "rate(etcd_server_slow_apply_total{job=\"kube-etcd3-$cluster\"}[$__rate_interval])",
           "interval": "",
           "legendFormat": "{{pod}}",
           "refId": "A"
@@ -1548,7 +1548,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "rate(etcd_server_slow_read_indexes_total{job=\"kube-etcd3-$cluster\"}[5m])",
+          "expr": "rate(etcd_server_slow_read_indexes_total{job=\"kube-etcd3-$cluster\"}[$__rate_interval])",
           "interval": "",
           "legendFormat": "{{pod}}",
           "refId": "A"

--- a/charts/seed-monitoring/charts/grafana/dashboards/operators/etcd-cluster-details-dashboard.json
+++ b/charts/seed-monitoring/charts/grafana/dashboards/operators/etcd-cluster-details-dashboard.json
@@ -548,7 +548,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "etcd_server_heartbeat_send_failures_total{job=\"kube-etcd3-$cluster\"}",
+          "expr": "rate(etcd_server_heartbeat_send_failures_total{job=\"kube-etcd3-$cluster\"}[$__rate_interval])",
           "instant": false,
           "interval": "",
           "legendFormat": "{{pod}}",

--- a/charts/seed-monitoring/charts/grafana/dashboards/operators/etcd-cluster-details-dashboard.json
+++ b/charts/seed-monitoring/charts/grafana/dashboards/operators/etcd-cluster-details-dashboard.json
@@ -1,0 +1,1689 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "graphTooltip": 0,
+  "id": 9,
+  "iteration": 1542111230310,
+  "links": [],
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 61,
+      "title": "Cluster Status",
+      "type": "row"
+    },
+    {
+      "datasource": "prometheus",
+      "description": "Observed size of the etcd cluster",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 0,
+        "y": 1
+      },
+      "id": 47,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.5.17",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "etcdbr_cluster_size{job=\"kube-etcd3-backup-restore-$cluster\",pod=~\".*$cluster-$member\"}",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "Cluster Size",
+      "type": "stat"
+    },
+    {
+      "datasource": "prometheus",
+      "description": "Total number of etcd members that are running, that may or may not be part of the same cluster (due to possible network partition or cluster formation errors)",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 4,
+        "y": 1
+      },
+      "id": 49,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.5.17",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum(up{job=\"kube-etcd3-backup-restore-$cluster\"})",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "Running Members",
+      "type": "stat"
+    },
+    {
+      "datasource": "prometheus",
+      "description": "Total number of etcd members that have quorum.\nEtcd cluster is considered healthy if this value matches the \"Cluster Size\" value",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 8,
+        "y": 1
+      },
+      "id": 51,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.5.17",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum(etcd_server_has_leader{job=\"kube-etcd3-$cluster\"})",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "Quorate Members",
+      "type": "stat"
+    },
+    {
+      "datasource": "prometheus",
+      "description": "Shows whether the selected etcd member is a \"Leader\", \"Follower\" or a \"Learner\"",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "from": "",
+              "id": 1,
+              "text": "Follower",
+              "to": "",
+              "type": 1,
+              "value": "0"
+            },
+            {
+              "from": "",
+              "id": 2,
+              "text": "Learner",
+              "to": "",
+              "type": 1,
+              "value": "1"
+            },
+            {
+              "from": "",
+              "id": 3,
+              "text": "Leader",
+              "to": "",
+              "type": 1,
+              "value": "2"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 0
+              },
+              {
+                "color": "yellow",
+                "value": 1
+              },
+              {
+                "color": "green",
+                "value": 2
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 12,
+        "y": 1
+      },
+      "id": 63,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.5.17",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "etcd_server_is_leader{job=\"kube-etcd3-$cluster\",pod=~\".*$cluster-$member\"}*2 + etcd_server_is_learner{job=\"kube-etcd3-$cluster\",pod=~\".*$cluster-$member\"}",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "\"etcd-$cluster-$member\" Membership Status",
+      "type": "stat"
+    },
+    {
+      "datasource": "prometheus",
+      "description": "Shows whether the selected etcd member is healthy or not",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "from": "",
+              "id": 1,
+              "text": "Unhealthy",
+              "to": "",
+              "type": 1,
+              "value": "0"
+            },
+            {
+              "from": "",
+              "id": 2,
+              "text": "Healthy",
+              "to": "",
+              "type": 1,
+              "value": "1"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 0
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 8,
+        "x": 16,
+        "y": 1
+      },
+      "id": 67,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.5.17",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "etcd_server_has_leader{job=\"kube-etcd3-$cluster\",pod=~\".*$cluster-$member\"}",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "\"etcd-$cluster-$member\" Member Health Status",
+      "type": "stat"
+    },
+    {
+      "datasource": "prometheus",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 6
+      },
+      "id": 57,
+      "title": "Cluster Operations",
+      "type": "row"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "prometheus",
+      "description": "Total number of leader changes seen per day in the cluster",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 0,
+        "y": 7
+      },
+      "hiddenSeries": false,
+      "id": 69,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.17",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "changes(etcd_server_leader_changes_seen_total{job=\"kube-etcd3-$cluster\"}[1d])",
+          "interval": "",
+          "legendFormat": "{{pod}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Total Leader Elections Per Day",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:717",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:718",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "prometheus",
+      "description": "Total number of heartbeat send failures per etcd member",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 8,
+        "y": 7
+      },
+      "hiddenSeries": false,
+      "id": 77,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.17",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "etcd_server_heartbeat_send_failures_total{job=\"kube-etcd3-$cluster\"}",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "{{pod}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Heartbeat Send Failures",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:1146",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:1147",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "prometheus",
+      "description": "Raft proposal details for the etcd cluster",
+      "editable": true,
+      "error": false,
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "fill": 0,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 16,
+        "y": 7
+      },
+      "hiddenSeries": false,
+      "id": 22,
+      "isNew": true,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": false,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 2,
+      "links": [],
+      "nullPointMode": "connected",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.17",
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "span": 6,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(rate(etcd_server_proposals_failed_total{role=~\"$cluster\"}[$__rate_interval]))",
+          "intervalFactor": 2,
+          "legendFormat": "Proposal Failure Rate",
+          "metric": "etcd_server_proposals_failed_total",
+          "refId": "A",
+          "step": 2
+        },
+        {
+          "expr": "sum(etcd_server_proposals_pending{role=~\"$cluster\"})",
+          "intervalFactor": 2,
+          "legendFormat": "Proposal Pending Total",
+          "metric": "etcd_server_proposals_pending",
+          "refId": "B",
+          "step": 2
+        },
+        {
+          "expr": "sum(rate(etcd_server_proposals_committed_total{role=~\"$cluster\"}[$__rate_interval]))",
+          "intervalFactor": 2,
+          "legendFormat": "Proposal Commit Rate",
+          "metric": "etcd_server_proposals_committed_total",
+          "refId": "C",
+          "step": 2
+        },
+        {
+          "expr": "sum(rate(etcd_server_proposals_applied_total{role=~\"$cluster\"}[$__rate_interval]))",
+          "intervalFactor": 2,
+          "legendFormat": "Proposal Apply Rate",
+          "refId": "D",
+          "step": 2
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Raft Proposals",
+      "tooltip": {
+        "msResolution": false,
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": "",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "prometheus",
+      "description": "Time taken by etcd-backup-restore to add learner to the cluster",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 0,
+        "y": 14
+      },
+      "hiddenSeries": false,
+      "id": 73,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.17",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "histogram_quantile(0.99, sum(rate(etcdbr_add_learner_duration_seconds_bucket{job=\"kube-etcd3-backup-restore-$cluster\"}[$__rate_interval])) by (le))",
+          "interval": "",
+          "legendFormat": "etcd-$cluster",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Add Learner Duration",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:972",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:973",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "prometheus",
+      "description": "Total number of successful promotions from learner to voting member in the cluster",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 8,
+        "y": 14
+      },
+      "hiddenSeries": false,
+      "id": 71,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.17",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "etcd_server_learner_promote_successes{job=\"kube-etcd3-$cluster\"}",
+          "interval": "",
+          "legendFormat": "{{pod}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Successful Learner Promotions",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:885",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:886",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "prometheus",
+      "description": "Time taken by etcd-backup-restore to remove member from the cluster",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 16,
+        "y": 14
+      },
+      "hiddenSeries": false,
+      "id": 75,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.17",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "histogram_quantile(0.99, sum(rate(etcdbr_member_remove_duration_seconds_bucket{job=\"kube-etcd3-backup-restore-$cluster\"}[$__rate_interval])) by (le))",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "etcd-$cluster",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Member Remove Duration",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:1059",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:1060",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "collapsed": false,
+      "datasource": "prometheus",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 21
+      },
+      "id": 55,
+      "panels": [],
+      "title": "Peer Networking",
+      "type": "row"
+    },
+    {
+      "datasource": "prometheus",
+      "description": "Total number of active peers in the cluster for the selected member",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 0
+              },
+              {
+                "color": "#EAB839",
+                "value": 1
+              },
+              {
+                "color": "green",
+                "value": 2
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 0,
+        "y": 22
+      },
+      "id": 79,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.5.17",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum(etcd_network_active_peers{job=\"kube-etcd3-$cluster\",pod=~\".*$cluster-$member\"})",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "\"etcd-$cluster-$member\" Active Peers",
+      "type": "stat"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "prometheus",
+      "description": "Round trip time taken for etcd peer communication",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 4,
+        "y": 22
+      },
+      "hiddenSeries": false,
+      "id": 81,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.17",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "histogram_quantile(0.99, sum(rate(etcd_network_peer_round_trip_time_seconds_bucket{job=\"kube-etcd3-$cluster\"}[$__rate_interval])) by (le))",
+          "interval": "",
+          "legendFormat": "etcd-$cluster",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Peer RTT",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:1401",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:1402",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "prometheus",
+      "description": "Network rate for data sent from selected member to other members in the cluster",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 5,
+        "w": 7,
+        "x": 10,
+        "y": 22
+      },
+      "hiddenSeries": false,
+      "id": 82,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.17",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "rate(etcd_network_peer_sent_bytes_total{job=\"kube-etcd3-$cluster\",pod=~\".*$cluster-$member\"}[5m])",
+          "interval": "",
+          "legendFormat": "{{To}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Peer Sent Bytes",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:1401",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:1402",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "prometheus",
+      "description": "Network rate for data received by selected member from other members in the cluster",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 5,
+        "w": 7,
+        "x": 17,
+        "y": 22
+      },
+      "hiddenSeries": false,
+      "id": 83,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.17",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "rate(etcd_network_peer_received_bytes_total{job=\"kube-etcd3-$cluster\",pod=~\".*$cluster-$member\"}[5m])",
+          "interval": "",
+          "legendFormat": "{{From}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Peer Received Bytes",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:1401",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:1402",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "collapsed": false,
+      "datasource": "prometheus",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 27
+      },
+      "id": 53,
+      "panels": [],
+      "title": "Cluster Latency",
+      "type": "row"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "prometheus",
+      "description": "Shows the slow applies on the etcd cluster",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 5,
+        "w": 7,
+        "x": 0,
+        "y": 28
+      },
+      "hiddenSeries": false,
+      "id": 84,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.17",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "rate(etcd_server_slow_apply_total{job=\"kube-etcd3-$cluster\"}[5m])",
+          "interval": "",
+          "legendFormat": "{{pod}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Total Slow Applies",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:1401",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:1402",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "prometheus",
+      "description": "Shows the slow index reads for the etcd cluster",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 5,
+        "w": 7,
+        "x": 7,
+        "y": 28
+      },
+      "hiddenSeries": false,
+      "id": 85,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.17",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "rate(etcd_server_slow_read_indexes_total{job=\"kube-etcd3-$cluster\"}[5m])",
+          "interval": "",
+          "legendFormat": "{{pod}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Total Slow Read Indexes",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:1401",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:1402",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    }
+  ],
+  "schemaVersion": 16,
+  "style": "dark",
+  "tags": [
+    "controlplane",
+    "seed"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "tags": [],
+          "text": "main",
+          "value": "main"
+        },
+        "hide": 0,
+        "label": null,
+        "multi": false,
+        "name": "cluster",
+        "options": [
+          {
+            "selected": true,
+            "text": "main",
+            "value": "main"
+          },
+          {
+            "selected": false,
+            "text": "events",
+            "value": "events"
+          }
+        ],
+        "query": "main, events",
+        "skipUrlSync": false,
+        "type": "custom"
+      },
+      {
+        "current": {
+          "tags": [],
+          "text": "0",
+          "value": "0"
+        },
+        "hide": 0,
+        "label": null,
+        "multi": false,
+        "name": "member",
+        "options": [
+          {
+            "selected": true,
+            "text": "0",
+            "value": "0"
+          },
+          {
+            "selected": false,
+            "text": "1",
+            "value": "1"
+          },
+          {
+            "selected": false,
+            "text": "2",
+            "value": "2"
+          }
+        ],
+        "query": "0, 1, 2",
+        "skipUrlSync": false,
+        "type": "custom"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-30m",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "3h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "14d"
+    ]
+  },
+  "timezone": "utc",
+  "title": "ETCD Cluster Details",
+  "uid": "etcd-cluster-details",
+  "version": 1
+}

--- a/charts/seed-monitoring/charts/grafana/dashboards/operators/etcd-dashboard.json
+++ b/charts/seed-monitoring/charts/grafana/dashboards/operators/etcd-dashboard.json
@@ -130,7 +130,7 @@
         "current": false,
         "max": false,
         "min": false,
-        "show": false,
+        "show": true,
         "total": false,
         "values": false
       },
@@ -230,7 +230,7 @@
         "current": false,
         "max": false,
         "min": false,
-        "show": false,
+        "show": true,
         "total": false,
         "values": false
       },
@@ -330,7 +330,7 @@
         "current": false,
         "max": false,
         "min": false,
-        "show": false,
+        "show": true,
         "total": false,
         "values": false
       },
@@ -421,7 +421,7 @@
         "current": false,
         "max": false,
         "min": false,
-        "show": false,
+        "show": true,
         "total": false,
         "values": false
       },
@@ -511,7 +511,7 @@
         "current": false,
         "max": false,
         "min": false,
-        "show": false,
+        "show": true,
         "total": false,
         "values": false
       },
@@ -608,7 +608,7 @@
         "current": false,
         "max": false,
         "min": false,
-        "show": false,
+        "show": true,
         "total": false,
         "values": false
       },
@@ -698,7 +698,7 @@
         "current": false,
         "max": false,
         "min": false,
-        "show": false,
+        "show": true,
         "total": false,
         "values": false
       },
@@ -799,7 +799,7 @@
         "current": false,
         "max": false,
         "min": false,
-        "show": false,
+        "show": true,
         "total": false,
         "values": false
       },
@@ -883,7 +883,7 @@
         "current": false,
         "max": false,
         "min": false,
-        "show": false,
+        "show": true,
         "total": false,
         "values": false
       },

--- a/charts/seed-monitoring/charts/grafana/dashboards/operators/etcd-dashboard.json
+++ b/charts/seed-monitoring/charts/grafana/dashboards/operators/etcd-dashboard.json
@@ -351,7 +351,7 @@
         {
           "expr": "process_resident_memory_bytes{job=\"kube-etcd3-$cluster\"}",
           "intervalFactor": 2,
-          "legendFormat": "{{instance}} Resident Memory",
+          "legendFormat": "{{pod}} Resident Memory",
           "metric": "process_resident_memory_bytes",
           "refId": "A",
           "step": 4
@@ -444,7 +444,7 @@
           "hide": false,
           "interval": "",
           "intervalFactor": 2,
-          "legendFormat": "{{instance}} DB Size",
+          "legendFormat": "{{pod}} DB Size",
           "metric": "",
           "refId": "A",
           "step": 4
@@ -533,7 +533,7 @@
           "expr": "histogram_quantile(0.99, sum(rate(etcd_disk_wal_fsync_duration_seconds_bucket{role=~\"$cluster\"}[$__rate_interval])) by (instance, le))",
           "hide": false,
           "intervalFactor": 2,
-          "legendFormat": "{{instance}} WAL fsync",
+          "legendFormat": "{{pod}} WAL fsync",
           "metric": "etcd_disk_wal_fsync_duration_seconds_bucket",
           "refId": "A",
           "step": 4
@@ -541,7 +541,7 @@
         {
           "expr": "histogram_quantile(0.99, sum(rate(etcd_disk_backend_commit_duration_seconds_bucket{role=~\"$cluster\"}[$__rate_interval])) by (instance, le))",
           "intervalFactor": 2,
-          "legendFormat": "{{instance}} DB fsync",
+          "legendFormat": "{{pod}} DB fsync",
           "metric": "etcd_disk_backend_commit_duration_seconds_bucket",
           "refId": "B",
           "step": 4
@@ -629,7 +629,7 @@
         {
           "expr": "rate(etcd_network_client_grpc_received_bytes_total{role=~\"$cluster\"}[$__rate_interval])",
           "intervalFactor": 2,
-          "legendFormat": "{{instance}} Client Traffic In",
+          "legendFormat": "{{pod}} Client Traffic In",
           "metric": "etcd_network_client_grpc_received_bytes_total",
           "refId": "A",
           "step": 4
@@ -719,7 +719,7 @@
         {
           "expr": "rate(etcd_network_client_grpc_sent_bytes_total{role=~\"$cluster\"}[$__rate_interval])",
           "intervalFactor": 2,
-          "legendFormat": "{{instance}} Client Traffic Out",
+          "legendFormat": "{{pod}} Client Traffic Out",
           "metric": "etcd_network_client_grpc_sent_bytes_total",
           "refId": "A",
           "step": 4
@@ -946,408 +946,6 @@
         "align": false,
         "alignLevel": null
       }
-    },
-    {
-      "collapsed": true,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 23
-      },
-      "id": 28,
-      "panels": [
-        {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "prometheus",
-          "decimals": 0,
-          "editable": true,
-          "error": false,
-          "fill": 0,
-          "gridPos": {
-            "h": 3,
-            "w": 6,
-            "x": 0,
-            "y": 18
-          },
-          "id": 24,
-          "isNew": true,
-          "legend": {
-            "alignAsTable": false,
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "rightSide": false,
-            "show": false,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 2,
-          "links": [],
-          "nullPointMode": "connected",
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "span": 6,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "expr": "changes(etcd_server_leader_changes_seen_total{role=~\"$cluster\"}[1d])",
-              "format": "time_series",
-              "intervalFactor": 2,
-              "legendFormat": "{{instance}} Total Leader Elections Per Day",
-              "metric": "etcd_server_leader_changes_seen_total",
-              "refId": "A",
-              "step": 2
-            }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "Total Leader Elections Per Day",
-          "tooltip": {
-            "msResolution": false,
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            },
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false,
-            "alignLevel": null
-          }
-        },
-        {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "prometheus",
-          "editable": true,
-          "error": false,
-          "fill": 0,
-          "gridPos": {
-            "h": 3,
-            "w": 6,
-            "x": 6,
-            "y": 18
-          },
-          "id": 18,
-          "isNew": true,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": false,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 2,
-          "links": [],
-          "nullPointMode": "connected",
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "span": 3,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "expr": "sum(rate(etcd_network_peer_received_bytes_total{role=~\"$cluster\"}[$__rate_interval])) by (instance)",
-              "intervalFactor": 2,
-              "legendFormat": "{{instance}} Peer Traffic In",
-              "metric": "etcd_network_peer_received_bytes_total",
-              "refId": "A",
-              "step": 4
-            }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "Peer Traffic In",
-          "tooltip": {
-            "msResolution": false,
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "Bps",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            },
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false,
-            "alignLevel": null
-          }
-        },
-        {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "prometheus",
-          "decimals": null,
-          "editable": true,
-          "error": false,
-          "fill": 0,
-          "grid": {},
-          "gridPos": {
-            "h": 3,
-            "w": 6,
-            "x": 12,
-            "y": 18
-          },
-          "id": 20,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": false,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 2,
-          "links": [],
-          "nullPointMode": "connected",
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "span": 3,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "expr": "sum(rate(etcd_network_peer_sent_bytes_total{role=~\"$cluster\"}[$__rate_interval])) by (instance)",
-              "hide": false,
-              "interval": "",
-              "intervalFactor": 2,
-              "legendFormat": "{{instance}} Peer Traffic Out",
-              "metric": "etcd_network_peer_sent_bytes_total",
-              "refId": "A",
-              "step": 4
-            }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "Peer Traffic Out",
-          "tooltip": {
-            "msResolution": false,
-            "shared": true,
-            "sort": 0,
-            "value_type": "cumulative"
-          },
-          "type": "graph",
-          "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "Bps",
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            },
-            {
-              "format": "short",
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false,
-            "alignLevel": null
-          }
-        },
-        {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "prometheus",
-          "editable": true,
-          "error": false,
-          "fill": 0,
-          "gridPos": {
-            "h": 3,
-            "w": 6,
-            "x": 18,
-            "y": 18
-          },
-          "id": 22,
-          "isNew": true,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": false,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 2,
-          "links": [],
-          "nullPointMode": "connected",
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "span": 6,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "expr": "sum(rate(etcd_server_proposals_failed_total{role=~\"$cluster\"}[$__rate_interval]))",
-              "intervalFactor": 2,
-              "legendFormat": "Proposal Failure Rate",
-              "metric": "etcd_server_proposals_failed_total",
-              "refId": "A",
-              "step": 2
-            },
-            {
-              "expr": "sum(etcd_server_proposals_pending{role=~\"$cluster\"})",
-              "intervalFactor": 2,
-              "legendFormat": "Proposal Pending Total",
-              "metric": "etcd_server_proposals_pending",
-              "refId": "B",
-              "step": 2
-            },
-            {
-              "expr": "sum(rate(etcd_server_proposals_committed_total{role=~\"$cluster\"}[$__rate_interval]))",
-              "intervalFactor": 2,
-              "legendFormat": "Proposal Commit Rate",
-              "metric": "etcd_server_proposals_committed_total",
-              "refId": "C",
-              "step": 2
-            },
-            {
-              "expr": "sum(rate(etcd_server_proposals_applied_total{role=~\"$cluster\"}[$__rate_interval]))",
-              "intervalFactor": 2,
-              "legendFormat": "Proposal Apply Rate",
-              "refId": "D",
-              "step": 2
-            }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "Raft Proposals",
-          "tooltip": {
-            "msResolution": false,
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "short",
-              "label": "",
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            },
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false,
-            "alignLevel": null
-          }
-        }
-      ],
-      "title": "Cluster",
-      "type": "row"
     }
   ],
   "schemaVersion": 16,

--- a/pkg/operation/botanist/component/etcd/testdata/monitoring_alertingrules_important_multinode_with_backup.yaml
+++ b/pkg/operation/botanist/component/etcd/testdata/monitoring_alertingrules_important_multinode_with_backup.yaml
@@ -8,13 +8,13 @@ tests:
   input_series:
   # KubeEtcdTestDown
   - series: 'up{job="kube-etcd3-test"}'
-    values: '0+0x20'
+    values: '1+0x20'
   # KubeEtcd3TestNoLeader
   - series: 'etcd_server_has_leader{job="kube-etcd3-test"}'
     values: '0+0x20'
   # KubeEtcd3HighNumberOfFailedProposals
   - series: 'etcd_server_proposals_failed_total{job="kube-etcd3-test", pod="etcd"}'
-    values: '0+2x60 121+0x60'
+    values: '0+1x6 6+0x115'
   # KubeEtcd3DbSizeLimitApproaching
   # KubeEtcd3DbSizeLimitCrossed
   - series: 'etcd_mvcc_db_total_size_in_bytes{job="kube-etcd3-test"}'
@@ -42,7 +42,7 @@ tests:
         type: seed
         visibility: operator
       exp_annotations:
-        description: Etcd3 cluster test is unavailable or cannot be scraped. As long as etcd3 test is down the cluster is unreachable.
+        description: Etcd3 cluster test is unavailable (due to possible quorum loss) or cannot be scraped. As long as etcd3 test is down, the cluster is unreachable.
         summary: Etcd3 test cluster down.
   - eval_time: 15m
     alertname: KubeEtcd3TestNoLeader
@@ -53,7 +53,7 @@ tests:
         type: seed
         visibility: operator
       exp_annotations:
-        description: Etcd3 test has no leader. No communication with etcd test possible. Apiserver is read only.
+        description: Etcd3 test has no leader. Possible network partition in the etcd cluster.
         summary: Etcd3 test has no leader.
   - eval_time: 1h
     alertname: KubeEtcd3HighNumberOfFailedProposals
@@ -66,7 +66,7 @@ tests:
         pod: etcd
         job: kube-etcd3-test
       exp_annotations:
-        description: Etcd3 test pod etcd has seen 121 proposal failures within the last hour.
+        description: Etcd3 test pod etcd has seen 6 proposal failures within the last hour.
         summary: High number of failed etcd proposals
   - eval_time: 5m
     alertname: KubeEtcd3DbSizeLimitApproaching

--- a/pkg/operation/botanist/component/etcd/testdata/monitoring_alertingrules_important_multinode_without_backup.yaml
+++ b/pkg/operation/botanist/component/etcd/testdata/monitoring_alertingrules_important_multinode_without_backup.yaml
@@ -1,0 +1,81 @@
+rule_files:
+- kube-etcd3-test.rules.yaml
+
+evaluation_interval: 30s
+
+tests:
+- interval: 30s
+  input_series:
+  # KubeEtcdTestDown
+  - series: 'up{job="kube-etcd3-test"}'
+    values: '1+0x20'
+  # KubeEtcd3TestNoLeader
+  - series: 'etcd_server_has_leader{job="kube-etcd3-test"}'
+    values: '0+0x20'
+  # KubeEtcd3HighNumberOfFailedProposals
+  - series: 'etcd_server_proposals_failed_total{job="kube-etcd3-test", pod="etcd"}'
+    values: '0+1x6 6+0x115'
+  # KubeEtcd3DbSizeLimitApproaching
+  # KubeEtcd3DbSizeLimitCrossed
+  - series: 'etcd_mvcc_db_total_size_in_bytes{job="kube-etcd3-test"}'
+    values: '7194070000+107374182x20' # 6.7GB 6.8GB 6.9GB .. 7.7GB
+  alert_rule_test:
+  - eval_time: 5m
+    alertname: KubeEtcdTestDown
+    exp_alerts:
+    - exp_labels:
+        service: etcd
+        severity: blocker
+        type: seed
+        visibility: operator
+      exp_annotations:
+        description: Etcd3 cluster test is unavailable (due to possible quorum loss) or cannot be scraped. As long as etcd3 test is down, the cluster is unreachable.
+        summary: Etcd3 test cluster down.
+  - eval_time: 15m
+    alertname: KubeEtcd3TestNoLeader
+    exp_alerts:
+    - exp_labels:
+        service: etcd
+        severity: critical
+        type: seed
+        visibility: operator
+      exp_annotations:
+        description: Etcd3 test has no leader. Possible network partition in the etcd cluster.
+        summary: Etcd3 test has no leader.
+  - eval_time: 1h
+    alertname: KubeEtcd3HighNumberOfFailedProposals
+    exp_alerts:
+    - exp_labels:
+        service: etcd
+        severity: warning
+        type: seed
+        visibility: operator
+        pod: etcd
+        job: kube-etcd3-test
+      exp_annotations:
+        description: Etcd3 test pod etcd has seen 6 proposal failures within the last hour.
+        summary: High number of failed etcd proposals
+  - eval_time: 5m
+    alertname: KubeEtcd3DbSizeLimitApproaching
+    exp_alerts:
+    - exp_labels:
+        job: kube-etcd3-test
+        service: etcd
+        severity: warning
+        type: seed
+        visibility: all
+      exp_annotations:
+        description: Etcd3 test DB size is approaching its current practical limit of 8GB. Etcd quota might need to be increased.
+        summary: Etcd3 test DB size is approaching its current practical limit.
+  - eval_time: 10m
+    alertname: KubeEtcd3DbSizeLimitCrossed
+    exp_alerts:
+    - exp_labels:
+        job: kube-etcd3-test
+        service: etcd
+        severity: critical
+        type: seed
+        visibility: all
+      exp_annotations:
+        description: Etcd3 test DB size has crossed its current practical limit of 8GB. Etcd quota must be increased to allow updates.
+        summary: Etcd3 test DB size has crossed its current practical limit.

--- a/pkg/operation/botanist/component/etcd/testdata/monitoring_alertingrules_important_singlenode_with_backup.yaml
+++ b/pkg/operation/botanist/component/etcd/testdata/monitoring_alertingrules_important_singlenode_with_backup.yaml
@@ -8,28 +8,41 @@ tests:
   input_series:
   # KubeEtcdTestDown
   - series: 'up{job="kube-etcd3-test"}'
-    values: '0+0x30'
+    values: '0+0x20'
   # KubeEtcd3TestNoLeader
   - series: 'etcd_server_has_leader{job="kube-etcd3-test"}'
-    values: '0+0x30'
+    values: '0+0x20'
   # KubeEtcd3HighNumberOfFailedProposals
   - series: 'etcd_server_proposals_failed_total{job="kube-etcd3-test", pod="etcd"}'
-    values: '0+2x60 121+0x60'
+    values: '0+1x6 6+0x115'
   # KubeEtcd3DbSizeLimitApproaching
   # KubeEtcd3DbSizeLimitCrossed
   - series: 'etcd_mvcc_db_total_size_in_bytes{job="kube-etcd3-test"}'
     values: '7194070000+107374182x20' # 6.7GB 6.8GB 6.9GB .. 7.7GB
+  # KubeEtcdDeltaBackupFailed
+  - series: 'etcdbr_snapshot_latest_timestamp{job="kube-etcd3-backup-restore-test",kind="Incr"}'
+    values: '0+0x62'
+  - series: 'etcdbr_snapshot_required{job="kube-etcd3-backup-restore-test",kind="Incr"}'
+    values: '1+0x62'
+  # KubeEtcdFullBackupFailed
+  - series: 'etcdbr_snapshot_latest_timestamp{job="kube-etcd3-backup-restore-test",kind="Full"}'
+    values: '0+0x2912'
+  - series: 'etcdbr_snapshot_required{job="kube-etcd3-backup-restore-test",kind="Full"}'
+    values: '1+0x2912'
+  # KubeEtcdRestorationFailed
+  - series: 'etcdbr_restoration_duration_seconds_count{job="kube-etcd3-backup-restore-test",succeeded="false"}'
+    values: '0+0x7 1 2 2'
   alert_rule_test:
-  - eval_time: 15m
+  - eval_time: 5m
     alertname: KubeEtcdTestDown
     exp_alerts:
     - exp_labels:
         service: etcd
-        severity: critical
+        severity: blocker
         type: seed
         visibility: operator
       exp_annotations:
-        description: Etcd3 cluster test is unavailable or cannot be scraped. As long as etcd3 test is down the cluster is unreachable.
+        description: Etcd3 cluster test is unavailable or cannot be scraped. As long as etcd3 test is down, the cluster is unreachable.
         summary: Etcd3 test cluster down.
   - eval_time: 15m
     alertname: KubeEtcd3TestNoLeader
@@ -40,7 +53,7 @@ tests:
         type: seed
         visibility: operator
       exp_annotations:
-        description: Etcd3 test has no leader. No communication with etcd test possible. Apiserver is read only.
+        description: Etcd3 test has no leader.
         summary: Etcd3 test has no leader.
   - eval_time: 1h
     alertname: KubeEtcd3HighNumberOfFailedProposals
@@ -53,7 +66,7 @@ tests:
         pod: etcd
         job: kube-etcd3-test
       exp_annotations:
-        description: Etcd3 test pod etcd has seen 121 proposal failures within the last hour.
+        description: Etcd3 test pod etcd has seen 6 proposal failures within the last hour.
         summary: High number of failed etcd proposals
   - eval_time: 5m
     alertname: KubeEtcd3DbSizeLimitApproaching
@@ -79,3 +92,42 @@ tests:
       exp_annotations:
         description: Etcd3 test DB size has crossed its current practical limit of 8GB. Etcd quota must be increased to allow updates.
         summary: Etcd3 test DB size has crossed its current practical limit.
+  - eval_time: 31m
+    alertname: KubeEtcdDeltaBackupFailed
+    exp_alerts:
+    - exp_labels:
+        job: kube-etcd3-backup-restore-test
+        kind: Incr
+        service: etcd
+        severity: critical
+        type: seed
+        visibility: operator
+      exp_annotations:
+        description: No delta snapshot for the past at least 30 minutes.
+        summary: Etcd delta snapshot failure.
+  - eval_time: 1456m
+    alertname: KubeEtcdFullBackupFailed
+    exp_alerts:
+    - exp_labels:
+        job: kube-etcd3-backup-restore-test
+        kind: Full
+        service: etcd
+        severity: critical
+        type: seed
+        visibility: operator
+      exp_annotations:
+        description: No full snapshot taken in the past day.
+        summary: Etcd full snapshot failure.
+  - eval_time: 5m
+    alertname: KubeEtcdRestorationFailed
+    exp_alerts:
+    - exp_labels:
+        job: kube-etcd3-backup-restore-test
+        succeeded: false
+        service: etcd
+        severity: critical
+        type: seed
+        visibility: operator
+      exp_annotations:
+        description: Etcd data restoration was triggered, but has failed.
+        summary: Etcd data restoration failure.

--- a/pkg/operation/botanist/component/etcd/testdata/monitoring_alertingrules_important_singlenode_without_backup.yaml
+++ b/pkg/operation/botanist/component/etcd/testdata/monitoring_alertingrules_important_singlenode_without_backup.yaml
@@ -14,7 +14,7 @@ tests:
     values: '0+0x20'
   # KubeEtcd3HighNumberOfFailedProposals
   - series: 'etcd_server_proposals_failed_total{job="kube-etcd3-test", pod="etcd"}'
-    values: '0+2x60 121+0x60'
+    values: '0+1x6 6+0x115'
   # KubeEtcd3DbSizeLimitApproaching
   # KubeEtcd3DbSizeLimitCrossed
   - series: 'etcd_mvcc_db_total_size_in_bytes{job="kube-etcd3-test"}'
@@ -29,7 +29,7 @@ tests:
         type: seed
         visibility: operator
       exp_annotations:
-        description: Etcd3 cluster test is unavailable or cannot be scraped. As long as etcd3 test is down the cluster is unreachable.
+        description: Etcd3 cluster test is unavailable or cannot be scraped. As long as etcd3 test is down, the cluster is unreachable.
         summary: Etcd3 test cluster down.
   - eval_time: 15m
     alertname: KubeEtcd3TestNoLeader
@@ -40,7 +40,7 @@ tests:
         type: seed
         visibility: operator
       exp_annotations:
-        description: Etcd3 test has no leader. No communication with etcd test possible. Apiserver is read only.
+        description: Etcd3 test has no leader.
         summary: Etcd3 test has no leader.
   - eval_time: 1h
     alertname: KubeEtcd3HighNumberOfFailedProposals
@@ -53,7 +53,7 @@ tests:
         pod: etcd
         job: kube-etcd3-test
       exp_annotations:
-        description: Etcd3 test pod etcd has seen 121 proposal failures within the last hour.
+        description: Etcd3 test pod etcd has seen 6 proposal failures within the last hour.
         summary: High number of failed etcd proposals
   - eval_time: 5m
     alertname: KubeEtcd3DbSizeLimitApproaching

--- a/pkg/operation/botanist/component/etcd/testdata/monitoring_alertingrules_normal_multinode_with_backup.yaml
+++ b/pkg/operation/botanist/component/etcd/testdata/monitoring_alertingrules_normal_multinode_with_backup.yaml
@@ -9,13 +9,13 @@ tests:
   # KubeEtcdTestDown
   # KubeEtcdBackupRestoreTestDown
   - series: 'up{job="kube-etcd3-test"}'
-    values: '0+0x30 1+0x40'
+    values: '1+0x70'
   # KubeEtcd3TestNoLeader
   - series: 'etcd_server_has_leader{job="kube-etcd3-test"}'
     values: '0+0x30'
   # KubeEtcd3HighNumberOfFailedProposals
   - series: 'etcd_server_proposals_failed_total{job="kube-etcd3-test", pod="etcd"}'
-    values: '0+2x60 121+0x60'
+    values: '0+1x6 6+0x115'
   # KubeEtcd3DbSizeLimitApproaching
   # KubeEtcd3DbSizeLimitCrossed
   - series: 'etcd_mvcc_db_total_size_in_bytes{job="kube-etcd3-test"}'
@@ -35,7 +35,7 @@ tests:
     values: '0+0x7 1 2 2'
   # KubeEtcdBackupRestoreTestDown
   - series: 'up{job="kube-etcd3-backup-restore-test"}'
-    values: '0+0x60 1+0x10'
+    values: '0+0x70'
   - series: 'etcdbr_snapshotter_failure{job="kube-etcd3-backup-restore-test"}'
     values: '1+1x30 1+0x40'
   alert_rule_test:
@@ -48,7 +48,7 @@ tests:
         type: seed
         visibility: operator
       exp_annotations:
-        description: Etcd3 cluster test is unavailable or cannot be scraped. As long as etcd3 test is down the cluster is unreachable.
+        description: Etcd3 cluster test is unavailable (due to possible quorum loss) or cannot be scraped. As long as etcd3 test is down, the cluster is unreachable.
         summary: Etcd3 test cluster down.
   - eval_time: 15m
     alertname: KubeEtcd3TestNoLeader
@@ -59,7 +59,7 @@ tests:
         type: seed
         visibility: operator
       exp_annotations:
-        description: Etcd3 test has no leader. No communication with etcd test possible. Apiserver is read only.
+        description: Etcd3 test has no leader. Possible network partition in the etcd cluster.
         summary: Etcd3 test has no leader.
   - eval_time: 1h
     alertname: KubeEtcd3HighNumberOfFailedProposals
@@ -72,7 +72,7 @@ tests:
         pod: etcd
         job: kube-etcd3-test
       exp_annotations:
-        description: Etcd3 test pod etcd has seen 121 proposal failures within the last hour.
+        description: Etcd3 test pod etcd has seen 6 proposal failures within the last hour.
         summary: High number of failed etcd proposals
   - eval_time: 5m
     alertname: KubeEtcd3DbSizeLimitApproaching
@@ -137,18 +137,6 @@ tests:
       exp_annotations:
         description: Etcd data restoration was triggered, but has failed.
         summary: Etcd data restoration failure.
-  - eval_time: 16m
-    alertname: KubeEtcdBackupRestoreTestDown
-    exp_alerts:
-    - exp_labels:
-        job: kube-etcd3-backup-restore-test
-        service: etcd
-        severity: critical
-        type: seed
-        visibility: operator
-      exp_annotations:
-        description: Etcd backup restore test process down or snapshotter failed with error. Backups will not be triggered unless backup restore is brought back up. This is unsafe behaviour and may cause data loss.
-        summary: Etcd backup restore test process down or snapshotter failed with error
   - eval_time: 30m
     alertname: KubeEtcdBackupRestoreTestDown
     exp_alerts:
@@ -160,6 +148,3 @@ tests:
       exp_annotations:
         description: Etcd backup restore test process down or snapshotter failed with error. Backups will not be triggered unless backup restore is brought back up. This is unsafe behaviour and may cause data loss.
         summary: Etcd backup restore test process down or snapshotter failed with error
-  - eval_time: 35m
-    alertname: KubeEtcdBackupRestoreTestDown
-    exp_alerts:

--- a/pkg/operation/botanist/component/etcd/testdata/monitoring_alertingrules_normal_multinode_without_backup.yaml
+++ b/pkg/operation/botanist/component/etcd/testdata/monitoring_alertingrules_normal_multinode_without_backup.yaml
@@ -1,0 +1,81 @@
+rule_files:
+- kube-etcd3-test.rules.yaml
+
+evaluation_interval: 30s
+
+tests:
+- interval: 30s
+  input_series:
+  # KubeEtcdTestDown
+  - series: 'up{job="kube-etcd3-test"}'
+    values: '1+0x30'
+  # KubeEtcd3TestNoLeader
+  - series: 'etcd_server_has_leader{job="kube-etcd3-test"}'
+    values: '0+0x30'
+  # KubeEtcd3HighNumberOfFailedProposals
+  - series: 'etcd_server_proposals_failed_total{job="kube-etcd3-test", pod="etcd"}'
+    values: '0+1x6 6+0x115'
+  # KubeEtcd3DbSizeLimitApproaching
+  # KubeEtcd3DbSizeLimitCrossed
+  - series: 'etcd_mvcc_db_total_size_in_bytes{job="kube-etcd3-test"}'
+    values: '7194070000+107374182x20' # 6.7GB 6.8GB 6.9GB .. 7.7GB
+  alert_rule_test:
+  - eval_time: 15m
+    alertname: KubeEtcdTestDown
+    exp_alerts:
+    - exp_labels:
+        service: etcd
+        severity: critical
+        type: seed
+        visibility: operator
+      exp_annotations:
+        description: Etcd3 cluster test is unavailable (due to possible quorum loss) or cannot be scraped. As long as etcd3 test is down, the cluster is unreachable.
+        summary: Etcd3 test cluster down.
+  - eval_time: 15m
+    alertname: KubeEtcd3TestNoLeader
+    exp_alerts:
+    - exp_labels:
+        service: etcd
+        severity: critical
+        type: seed
+        visibility: operator
+      exp_annotations:
+        description: Etcd3 test has no leader. Possible network partition in the etcd cluster.
+        summary: Etcd3 test has no leader.
+  - eval_time: 1h
+    alertname: KubeEtcd3HighNumberOfFailedProposals
+    exp_alerts:
+    - exp_labels:
+        service: etcd
+        severity: warning
+        type: seed
+        visibility: operator
+        pod: etcd
+        job: kube-etcd3-test
+      exp_annotations:
+        description: Etcd3 test pod etcd has seen 6 proposal failures within the last hour.
+        summary: High number of failed etcd proposals
+  - eval_time: 5m
+    alertname: KubeEtcd3DbSizeLimitApproaching
+    exp_alerts:
+    - exp_labels:
+        job: kube-etcd3-test
+        service: etcd
+        severity: warning
+        type: seed
+        visibility: all
+      exp_annotations:
+        description: Etcd3 test DB size is approaching its current practical limit of 8GB. Etcd quota might need to be increased.
+        summary: Etcd3 test DB size is approaching its current practical limit.
+  - eval_time: 10m
+    alertname: KubeEtcd3DbSizeLimitCrossed
+    exp_alerts:
+    - exp_labels:
+        job: kube-etcd3-test
+        service: etcd
+        severity: critical
+        type: seed
+        visibility: all
+      exp_annotations:
+        description: Etcd3 test DB size has crossed its current practical limit of 8GB. Etcd quota must be increased to allow updates.
+        summary: Etcd3 test DB size has crossed its current practical limit.

--- a/pkg/operation/botanist/component/etcd/testdata/monitoring_alertingrules_normal_singlenode_with_backup.yaml
+++ b/pkg/operation/botanist/component/etcd/testdata/monitoring_alertingrules_normal_singlenode_with_backup.yaml
@@ -1,0 +1,165 @@
+rule_files:
+- kube-etcd3-test.rules.yaml
+
+evaluation_interval: 30s
+
+tests:
+- interval: 30s
+  input_series:
+  # KubeEtcdTestDown
+  # KubeEtcdBackupRestoreTestDown
+  - series: 'up{job="kube-etcd3-test"}'
+    values: '0+0x30 1+0x40'
+  # KubeEtcd3TestNoLeader
+  - series: 'etcd_server_has_leader{job="kube-etcd3-test"}'
+    values: '0+0x30'
+  # KubeEtcd3HighNumberOfFailedProposals
+  - series: 'etcd_server_proposals_failed_total{job="kube-etcd3-test", pod="etcd"}'
+    values: '0+1x6 6+0x115'
+  # KubeEtcd3DbSizeLimitApproaching
+  # KubeEtcd3DbSizeLimitCrossed
+  - series: 'etcd_mvcc_db_total_size_in_bytes{job="kube-etcd3-test"}'
+    values: '7194070000+107374182x20' # 6.7GB 6.8GB 6.9GB .. 7.7GB
+  # KubeEtcdDeltaBackupFailed
+  - series: 'etcdbr_snapshot_latest_timestamp{job="kube-etcd3-backup-restore-test",kind="Incr"}'
+    values: '0+0x62'
+  - series: 'etcdbr_snapshot_required{job="kube-etcd3-backup-restore-test",kind="Incr"}'
+    values: '1+0x62'
+  # KubeEtcdFullBackupFailed
+  - series: 'etcdbr_snapshot_latest_timestamp{job="kube-etcd3-backup-restore-test",kind="Full"}'
+    values: '0+0x2912'
+  - series: 'etcdbr_snapshot_required{job="kube-etcd3-backup-restore-test",kind="Full"}'
+    values: '1+0x2912'
+  # KubeEtcdRestorationFailed
+  - series: 'etcdbr_restoration_duration_seconds_count{job="kube-etcd3-backup-restore-test",succeeded="false"}'
+    values: '0+0x7 1 2 2'
+  # KubeEtcdBackupRestoreTestDown
+  - series: 'up{job="kube-etcd3-backup-restore-test"}'
+    values: '0+0x60 1+0x10'
+  - series: 'etcdbr_snapshotter_failure{job="kube-etcd3-backup-restore-test"}'
+    values: '1+1x30 1+0x40'
+  alert_rule_test:
+  - eval_time: 15m
+    alertname: KubeEtcdTestDown
+    exp_alerts:
+    - exp_labels:
+        service: etcd
+        severity: critical
+        type: seed
+        visibility: operator
+      exp_annotations:
+        description: Etcd3 cluster test is unavailable or cannot be scraped. As long as etcd3 test is down, the cluster is unreachable.
+        summary: Etcd3 test cluster down.
+  - eval_time: 15m
+    alertname: KubeEtcd3TestNoLeader
+    exp_alerts:
+    - exp_labels:
+        service: etcd
+        severity: critical
+        type: seed
+        visibility: operator
+      exp_annotations:
+        description: Etcd3 test has no leader.
+        summary: Etcd3 test has no leader.
+  - eval_time: 1h
+    alertname: KubeEtcd3HighNumberOfFailedProposals
+    exp_alerts:
+    - exp_labels:
+        service: etcd
+        severity: warning
+        type: seed
+        visibility: operator
+        pod: etcd
+        job: kube-etcd3-test
+      exp_annotations:
+        description: Etcd3 test pod etcd has seen 6 proposal failures within the last hour.
+        summary: High number of failed etcd proposals
+  - eval_time: 5m
+    alertname: KubeEtcd3DbSizeLimitApproaching
+    exp_alerts:
+    - exp_labels:
+        job: kube-etcd3-test
+        service: etcd
+        severity: warning
+        type: seed
+        visibility: all
+      exp_annotations:
+        description: Etcd3 test DB size is approaching its current practical limit of 8GB. Etcd quota might need to be increased.
+        summary: Etcd3 test DB size is approaching its current practical limit.
+  - eval_time: 10m
+    alertname: KubeEtcd3DbSizeLimitCrossed
+    exp_alerts:
+    - exp_labels:
+        job: kube-etcd3-test
+        service: etcd
+        severity: critical
+        type: seed
+        visibility: all
+      exp_annotations:
+        description: Etcd3 test DB size has crossed its current practical limit of 8GB. Etcd quota must be increased to allow updates.
+        summary: Etcd3 test DB size has crossed its current practical limit.
+  - eval_time: 31m
+    alertname: KubeEtcdDeltaBackupFailed
+    exp_alerts:
+    - exp_labels:
+        job: kube-etcd3-backup-restore-test
+        kind: Incr
+        service: etcd
+        severity: critical
+        type: seed
+        visibility: operator
+      exp_annotations:
+        description: No delta snapshot for the past at least 30 minutes.
+        summary: Etcd delta snapshot failure.
+  - eval_time: 1456m
+    alertname: KubeEtcdFullBackupFailed
+    exp_alerts:
+    - exp_labels:
+        job: kube-etcd3-backup-restore-test
+        kind: Full
+        service: etcd
+        severity: critical
+        type: seed
+        visibility: operator
+      exp_annotations:
+        description: No full snapshot taken in the past day.
+        summary: Etcd full snapshot failure.
+  - eval_time: 5m
+    alertname: KubeEtcdRestorationFailed
+    exp_alerts:
+    - exp_labels:
+        job: kube-etcd3-backup-restore-test
+        succeeded: false
+        service: etcd
+        severity: critical
+        type: seed
+        visibility: operator
+      exp_annotations:
+        description: Etcd data restoration was triggered, but has failed.
+        summary: Etcd data restoration failure.
+  - eval_time: 16m
+    alertname: KubeEtcdBackupRestoreTestDown
+    exp_alerts:
+    - exp_labels:
+        job: kube-etcd3-backup-restore-test
+        service: etcd
+        severity: critical
+        type: seed
+        visibility: operator
+      exp_annotations:
+        description: Etcd backup restore test process down or snapshotter failed with error. Backups will not be triggered unless backup restore is brought back up. This is unsafe behaviour and may cause data loss.
+        summary: Etcd backup restore test process down or snapshotter failed with error
+  - eval_time: 30m
+    alertname: KubeEtcdBackupRestoreTestDown
+    exp_alerts:
+    - exp_labels:
+        service: etcd
+        severity: critical
+        type: seed
+        visibility: operator
+      exp_annotations:
+        description: Etcd backup restore test process down or snapshotter failed with error. Backups will not be triggered unless backup restore is brought back up. This is unsafe behaviour and may cause data loss.
+        summary: Etcd backup restore test process down or snapshotter failed with error
+  - eval_time: 35m
+    alertname: KubeEtcdBackupRestoreTestDown
+    exp_alerts:

--- a/pkg/operation/botanist/component/etcd/testdata/monitoring_alertingrules_normal_singlenode_without_backup.yaml
+++ b/pkg/operation/botanist/component/etcd/testdata/monitoring_alertingrules_normal_singlenode_without_backup.yaml
@@ -1,0 +1,81 @@
+rule_files:
+- kube-etcd3-test.rules.yaml
+
+evaluation_interval: 30s
+
+tests:
+- interval: 30s
+  input_series:
+  # KubeEtcdTestDown
+  - series: 'up{job="kube-etcd3-test"}'
+    values: '0+0x30'
+  # KubeEtcd3TestNoLeader
+  - series: 'etcd_server_has_leader{job="kube-etcd3-test"}'
+    values: '0+0x30'
+  # KubeEtcd3HighNumberOfFailedProposals
+  - series: 'etcd_server_proposals_failed_total{job="kube-etcd3-test", pod="etcd"}'
+    values: '0+1x6 6+0x115'
+  # KubeEtcd3DbSizeLimitApproaching
+  # KubeEtcd3DbSizeLimitCrossed
+  - series: 'etcd_mvcc_db_total_size_in_bytes{job="kube-etcd3-test"}'
+    values: '7194070000+107374182x20' # 6.7GB 6.8GB 6.9GB .. 7.7GB
+  alert_rule_test:
+  - eval_time: 15m
+    alertname: KubeEtcdTestDown
+    exp_alerts:
+    - exp_labels:
+        service: etcd
+        severity: critical
+        type: seed
+        visibility: operator
+      exp_annotations:
+        description: Etcd3 cluster test is unavailable or cannot be scraped. As long as etcd3 test is down, the cluster is unreachable.
+        summary: Etcd3 test cluster down.
+  - eval_time: 15m
+    alertname: KubeEtcd3TestNoLeader
+    exp_alerts:
+    - exp_labels:
+        service: etcd
+        severity: critical
+        type: seed
+        visibility: operator
+      exp_annotations:
+        description: Etcd3 test has no leader.
+        summary: Etcd3 test has no leader.
+  - eval_time: 1h
+    alertname: KubeEtcd3HighNumberOfFailedProposals
+    exp_alerts:
+    - exp_labels:
+        service: etcd
+        severity: warning
+        type: seed
+        visibility: operator
+        pod: etcd
+        job: kube-etcd3-test
+      exp_annotations:
+        description: Etcd3 test pod etcd has seen 6 proposal failures within the last hour.
+        summary: High number of failed etcd proposals
+  - eval_time: 5m
+    alertname: KubeEtcd3DbSizeLimitApproaching
+    exp_alerts:
+    - exp_labels:
+        job: kube-etcd3-test
+        service: etcd
+        severity: warning
+        type: seed
+        visibility: all
+      exp_annotations:
+        description: Etcd3 test DB size is approaching its current practical limit of 8GB. Etcd quota might need to be increased.
+        summary: Etcd3 test DB size is approaching its current practical limit.
+  - eval_time: 10m
+    alertname: KubeEtcd3DbSizeLimitCrossed
+    exp_alerts:
+    - exp_labels:
+        job: kube-etcd3-test
+        service: etcd
+        severity: critical
+        type: seed
+        visibility: all
+      exp_annotations:
+        description: Etcd3 test DB size has crossed its current practical limit of 8GB. Etcd quota must be increased to allow updates.
+        summary: Etcd3 test DB size has crossed its current practical limit.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area backup
/area monitoring
/area high-availability
/kind enhancement

**What this PR does / why we need it**:
This PR adds a new grafana dashboard for multinode etcd, called `Etcd Cluster Details`. It also adapts the existing etcd dashboard to work for multinode etcd clusters, and also adapts the prometheus alerting rules.
Also revert the `failedProposals` threshold value alert to original value of 5. More details in https://github.com/gardener/gardener/pull/1036.

The new dashboard provides cluster-specific details like cluster health, cluster operation details, peer networking details and latency information.
![Screenshot](https://user-images.githubusercontent.com/42259948/202266366-23307cde-25f8-4be6-ae0d-7e6d876ed8ab.png)


**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/etcd-druid/issues/221

**Special notes for your reviewer**:
/cc @istvanballok @rickardsjp @timuthy 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Add grafana dashboard and adapt prometheus alerts for monitoring multinode etcd clusters backing shoot clusters.
```
