### PR TITLE
Remove seed zone admission checks

### DIFF
--- a/plugin/pkg/seed/validator/admission_test.go
+++ b/plugin/pkg/seed/validator/admission_test.go
@@ -127,31 +127,6 @@ var _ = Describe("validator", func() {
 				Expect(err).ToNot(HaveOccurred())
 			})
 		})
-
-		Context("Seed Update", func() {
-			var oldSeed, newSeed *core.Seed
-
-			BeforeEach(func() {
-				oldSeed = seedBase.DeepCopy()
-				newSeed = seedBase.DeepCopy()
-
-				oldSeed.Spec.Provider.Zones = []string{"1", "2"}
-				newSeed.Spec.Provider.Zones = []string{"2"}
-			})
-
-			It("should allow zone removal there are no shoots", func() {
-				attrs := admission.NewAttributesRecord(newSeed, oldSeed, core.Kind("Seed").WithVersion("version"), "", seed.Name, core.Resource("seeds").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, nil)
-
-				Expect(admissionHandler.Validate(context.TODO(), attrs, nil)).To(Succeed())
-			})
-
-			It("should forbid zone removal when there are shoots", func() {
-				Expect(coreInformerFactory.Core().InternalVersion().Shoots().Informer().GetStore().Add(&shoot)).To(Succeed())
-				attrs := admission.NewAttributesRecord(newSeed, oldSeed, core.Kind("Seed").WithVersion("version"), "", seed.Name, core.Resource("seeds").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, nil)
-
-				Expect(admissionHandler.Validate(context.TODO(), attrs, nil)).To(BeForbiddenError())
-			})
-		})
 	})
 
 	Describe("#Register", func() {

--- a/plugin/pkg/utils/miscellaneous.go
+++ b/plugin/pkg/utils/miscellaneous.go
@@ -20,9 +20,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apiserver/pkg/admission"
-	"k8s.io/utils/pointer"
 
 	"github.com/gardener/gardener/pkg/apis/core"
 	corelisters "github.com/gardener/gardener/pkg/client/core/listers/core/internalversion"
@@ -59,23 +57,4 @@ func GetFilteredShootList(shootLister corelisters.ShootLister, predicateFn func(
 		}
 	}
 	return matchingShoots, nil
-}
-
-// ValidateZoneRemovalFromSeeds returns an error when zones are removed from the old seed while it is still in use by
-// shoots.
-func ValidateZoneRemovalFromSeeds(oldSeedSpec, newSeedSpec *core.SeedSpec, seedName string, shootLister corelisters.ShootLister, kind string) error {
-	if removedZones := sets.NewString(oldSeedSpec.Provider.Zones...).Difference(sets.NewString(newSeedSpec.Provider.Zones...)); removedZones.Len() > 0 {
-		shootList, err := GetFilteredShootList(shootLister, func(shoot *core.Shoot) bool {
-			return pointer.StringDeref(shoot.Spec.SeedName, "") == seedName
-		})
-		if err != nil {
-			return err
-		}
-
-		if len(shootList) > 0 {
-			return apierrors.NewForbidden(core.Resource(kind), seedName, fmt.Errorf("cannot remove zones %v from %s %s as there are %d Shoots scheduled to this Seed", removedZones.List(), kind, seedName, len(shootList)))
-		}
-	}
-
-	return nil
 }

--- a/plugin/pkg/utils/miscellaneous_test.go
+++ b/plugin/pkg/utils/miscellaneous_test.go
@@ -22,8 +22,6 @@ import (
 	"k8s.io/utils/pointer"
 
 	"github.com/gardener/gardener/pkg/apis/core"
-	coreinformers "github.com/gardener/gardener/pkg/client/core/informers/internalversion"
-	corelisters "github.com/gardener/gardener/pkg/client/core/listers/core/internalversion"
 	. "github.com/gardener/gardener/plugin/pkg/utils"
 )
 
@@ -90,65 +88,4 @@ var _ = Describe("Miscellaneous", func() {
 		Entry("is used by shoot in migration", "seed2", true),
 		Entry("is unused", "seed3", false),
 	)
-
-	Describe("#ValidateZoneRemovalFromSeeds", func() {
-		var (
-			seedName = "foo"
-			kind     = "foo"
-
-			coreInformerFactory coreinformers.SharedInformerFactory
-			shootLister         corelisters.ShootLister
-
-			oldSeedSpec, newSeedSpec *core.SeedSpec
-			shoot                    *core.Shoot
-		)
-
-		BeforeEach(func() {
-			coreInformerFactory = coreinformers.NewSharedInformerFactory(nil, 0)
-			shootLister = coreInformerFactory.Core().InternalVersion().Shoots().Lister()
-
-			oldSeedSpec = &core.SeedSpec{
-				Provider: core.SeedProvider{
-					Zones: []string{"1", "2"},
-				},
-			}
-			newSeedSpec = oldSeedSpec.DeepCopy()
-
-			shoot = &core.Shoot{
-				Spec: core.ShootSpec{
-					SeedName: &seedName,
-				},
-			}
-		})
-
-		It("should do nothing because a new zone was added", func() {
-			newSeedSpec.Provider.Zones = append(newSeedSpec.Provider.Zones, "3")
-
-			Expect(ValidateZoneRemovalFromSeeds(oldSeedSpec, newSeedSpec, seedName, shootLister, kind)).To(Succeed())
-		})
-
-		It("should do nothing because no zone was removed and no shoots exist", func() {
-			Expect(ValidateZoneRemovalFromSeeds(oldSeedSpec, newSeedSpec, seedName, shootLister, kind)).To(Succeed())
-		})
-
-		It("should do nothing because no zone was removed even though shoots exist", func() {
-			Expect(coreInformerFactory.Core().InternalVersion().Shoots().Informer().GetStore().Add(shoot)).To(Succeed())
-
-			Expect(ValidateZoneRemovalFromSeeds(oldSeedSpec, newSeedSpec, seedName, shootLister, kind)).To(Succeed())
-		})
-
-		It("should do nothing because zone was removed and no shoots exist", func() {
-			newSeedSpec.Provider.Zones = []string{"2"}
-
-			Expect(ValidateZoneRemovalFromSeeds(oldSeedSpec, newSeedSpec, seedName, shootLister, kind)).To(Succeed())
-		})
-
-		It("should return an error because zone was removed even though shoots exist", func() {
-			newSeedSpec.Provider.Zones = []string{"2"}
-			Expect(coreInformerFactory.Core().InternalVersion().Shoots().Informer().GetStore().Add(shoot)).To(Succeed())
-
-			Expect(ValidateZoneRemovalFromSeeds(oldSeedSpec, newSeedSpec, seedName, shootLister, kind)).To(MatchError(ContainSubstring("cannot remove zones")))
-		})
-
-	})
 })


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area high-availability
/kind technical-debt

**What this PR does / why we need it**:
This PR removes `.provider.zones` checks for `Seed`s and `ManagedSeed`s so that:
- zone names can be different from how they are defined in `shoot.spec.workers[].zones`
- zones can be modified when shoots are already scheduled to the seed

Some IaaS providers have inconsistent naming conventions for their zones, e.g. when zone is named `1` their CCM would add `topology.kubernetes.io/zone=europe-1` to `Node`s.

In the future, Gardener extensions should iron out this difference via webhooks so that we can introduce the removed checks again.

Part of https://github.com/gardener/gardener/issues/6529

**Special notes for your reviewer**:
/cc @rfranzke @acumino 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
