### PR TITLE
Deflake `BackupBucket` controller integration tests

### DIFF
--- a/test/integration/gardenlet/backupbucket/backupbucket_suite_test.go
+++ b/test/integration/gardenlet/backupbucket/backupbucket_suite_test.go
@@ -90,7 +90,7 @@ var _ = BeforeSuite(func() {
 			ErrorIfCRDPathMissing: true,
 		},
 		GardenerAPIServer: &gardenerenvtest.GardenerAPIServer{
-			Args: []string{"--disable-admission-plugins=DeletionConfirmation,ResourceReferenceManager,ExtensionValidator"},
+			Args: []string{"--disable-admission-plugins=DeletionConfirmation,ExtensionLabels,ExtensionValidator,ResourceReferenceManager"},
 		},
 	}
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind flake

**What this PR does / why we need it**:
In the `ExtensionLabels` admission plugin, we were checking for the BackupBucket referred by the BackupEntry to add the label. https://github.com/gardener/gardener/blob/3ed9a0e91762a1184bfc30218c01969565aa4263/plugin/pkg/global/extensionlabels/admission.go#L191
Sometimes, the apiserver is late to observe the created `BackupBucket` and the creation call for `BackupEntry` fails.
This PR disables this plugin in the tests.

**Which issue(s) this PR fixes**:
Fixes #7010 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
