### PR TITLE
Deflake `Shoot` quota controller integration test suite

### DIFF
--- a/pkg/controllermanager/controller/shoot/quota/reconciler.go
+++ b/pkg/controllermanager/controller/shoot/quota/reconciler.go
@@ -90,8 +90,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		return reconcile.Result{RequeueAfter: r.Config.SyncPeriod.Duration}, nil
 	}
 
-	expirationTime, exits := shoot.Annotations[v1beta1constants.ShootExpirationTimestamp]
-	if !exits {
+	expirationTime, exist := shoot.Annotations[v1beta1constants.ShootExpirationTimestamp]
+	if !exist {
 		expirationTime = shoot.CreationTimestamp.Add(time.Duration(*clusterLifeTime*24) * time.Hour).Format(time.RFC3339)
 		log.Info("Setting expiration timestamp annotation", "expirationTime", expirationTime)
 

--- a/test/integration/controllermanager/shoot/quota/quota_suite_test.go
+++ b/test/integration/controllermanager/shoot/quota/quota_suite_test.go
@@ -69,7 +69,7 @@ var _ = BeforeSuite(func() {
 	By("starting test environment")
 	testEnv = &gardenerenvtest.GardenerTestEnvironment{
 		GardenerAPIServer: &gardenerenvtest.GardenerAPIServer{
-			Args: []string{"--disable-admission-plugins=ResourceReferenceManager,ExtensionValidator,ShootQuotaValidator,ShootValidator,ShootTolerationRestriction,ManagedSeedShoot,ManagedSeed,ShootManagedSeed,ShootDNS"},
+			Args: []string{"--disable-admission-plugins=DeletionConfirmation,ResourceReferenceManager,ExtensionValidator,ShootQuotaValidator,ShootValidator,ShootTolerationRestriction,ManagedSeedShoot,ManagedSeed,ShootManagedSeed,ShootDNS"},
 		},
 	}
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind flake

**What this PR does / why we need it**:
This PR deflakes the `Shoot` quota controller integration test suite by verifying the manager has observed the updated `Shoot` before stepping the clock. Otherwise, it might happen that the manager is not yet aware of the new `expiration-timestamp` annotation and deletes the `Shoot` because now the expiration timestamp has passed.

Before:
```
$ stress -ignore "unable to grab random port" -p 64 ./test/integration/controllermanager/shoot/quota/quota.test
...
8m25s: 1391 runs so far, 47 failures (3.38%)
8m30s: 1407 runs so far, 47 failures (3.34%)
8m35s: 1415 runs so far, 47 failures (3.32%)
```
After:
```
$ stress -ignore "unable to grab random port" -p 64 ./test/integration/controllermanager/shoot/quota/quota.test
...
15m10s: 2368 runs so far, 0 failures
15m15s: 2371 runs so far, 0 failures
15m20s: 2389 runs so far, 0 failures
15m25s: 2407 runs so far, 0 failures
15m30s: 2428 runs so far, 0 failures
```

**Which issue(s) this PR fixes**:
Fixes #6707 

**Special notes for your reviewer**:
Similar to https://github.com/gardener/gardener/pull/6717

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
