### PR TITLE
Remove status port 15021 from service `istio-ingressgateway`.

### DIFF
--- a/pkg/operation/botanist/component/istio/charts/istio/istio-ingress/templates/deployment.yaml
+++ b/pkg/operation/botanist/component/istio/charts/istio/istio-ingress/templates/deployment.yaml
@@ -53,7 +53,6 @@ spec:
           runAsGroup: 1337
           runAsNonRoot: true
         ports:
-        - containerPort: 15021
         {{- range .Values.ports }}
         - containerPort: {{ .targetPort }}
           protocol: TCP

--- a/pkg/operation/botanist/component/istio/charts/istio/istio-ingress/templates/service.yaml
+++ b/pkg/operation/botanist/component/istio/charts/istio/istio-ingress/templates/service.yaml
@@ -17,10 +17,6 @@ spec:
   selector:
 {{ .Values.labels  | toYaml | indent 4 }}
   ports:
-  - name: {{ .Values.portsNames.status }}
-    port: 15021
-    targetPort: 15021
-    protocol: TCP
 {{- if .Values.ports }}
 {{ toYaml .Values.ports | indent 2 }}
 {{- end }}

--- a/pkg/operation/botanist/component/istio/istiod_test.go
+++ b/pkg/operation/botanist/component/istio/istiod_test.go
@@ -1498,10 +1498,6 @@ spec:
     foo: bar
     
   ports:
-  - name: status-port
-    port: 15021
-    targetPort: 15021
-    protocol: TCP
   - name: foo
     port: 999
     targetPort: 999
@@ -1576,7 +1572,6 @@ spec:
           runAsGroup: 1337
           runAsNonRoot: true
         ports:
-        - containerPort: 15021
         - containerPort: 999
           protocol: TCP
         args:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement

**What this PR does / why we need it**:
Currently the status port 15021 of the istio ingress gateway is exposed via a service.
The port is only used for the readiness probe.

**Which issue(s) this PR fixes**:
Fixes # None

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Remove status port 15021 from service istio-ingressgateway.
```
