### PR TITLE
Recommend to debug integration tests in KIND_ENV=local mode

### DIFF
--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -227,7 +227,7 @@ This can be helpful for debugging integration tests, because you can easily insp
 Run an `envtest` suite (not using `gardener-apiserver`) against an existing cluster:
 
 ```bash
-make kind-up
+make kind-up KIND_ENV=local
 export KUBECONFIG=$PWD/example/gardener-local/kind/local/kubeconfig
 export USE_EXISTING_CLUSTER=true
 
@@ -241,7 +241,7 @@ k get managedresource -A -w
 Run a `gardenerenvtest` suite (using `gardener-apiserver`) against an existing gardener setup:
 
 ```bash
-make kind-up
+make kind-up KIND_ENV=local
 export KUBECONFIG=$PWD/example/gardener-local/kind/local/kubeconfig
 make dev-setup
 # you might need to disable some admission plugins in hack/local-development/start-apiserver
@@ -267,7 +267,7 @@ Stress-test an `envtest` suite (not using `gardener-apiserver`):
 ginkgo build ./test/integration/resourcemanager/health
 
 # prepare a cluster to run the test against
-make kind-up
+make kind-up KIND_ENV=local
 export KUBECONFIG=$PWD/example/gardener-local/kind/local/kubeconfig
 export USE_EXISTING_CLUSTER=true
 
@@ -286,7 +286,7 @@ Stress-test a `gardenerenvtest` suite (using `gardener-apiserver`):
 ginkgo build ./test/integration/controllermanager/bastion
 
 # prepare a cluster including gardener-apiserver to run the test against
-make kind-up
+make kind-up KIND_ENV=local
 export KUBECONFIG=$PWD/example/gardener-local/kind/local/kubeconfig
 make dev-setup
 # you might need to disable some admission plugins in hack/local-development/start-apiserver


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area documentation
/kind enhancement

**What this PR does / why we need it**:
This PR includes a tiny change of the testing documentation which suggests to run the kind cluster in `KIND_ENV=local` mode when debugging integration tests.
In the default skaffold mode you might get into trouble if you try to start other local programs like gardener-admission-controller.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
