### PR TITLE
Finally drop deprecated `garden.sapcloud.io/role` label

### DIFF
--- a/docs/development/high-availability.md
+++ b/docs/development/high-availability.md
@@ -43,7 +43,7 @@ Concretely, all seed system components should respect the following conventions:
   Apart from the above, there might be special cases where these rules do not apply, for example:
 
   - `istio-ingressgateway` is scaled horizontally, hence the above numbers are the minimum values.
-  - `nginx-ingress-controller` in the seed cluster is only used to advertise observability endpoints, hence it also only runs with `1` replica at all times. In the future, this component might disappear in favor of the `istio-ingressgateway` anyways.
+  - `nginx-ingress-controller` in the seed cluster is used to advertise all shoot observability endpoints, so due to performance reasons it runs with `2` replicas at all times. In the future, this component might disappear in favor of the `istio-ingressgateway` anyways.
 
 - **Topology Spread Constraints**
 

--- a/docs/development/seed_network_policies.md
+++ b/docs/development/seed_network_policies.md
@@ -52,7 +52,7 @@ allow-to-private-networks         networking.gardener.cloud/to-private-networks=
 allow-to-public-networks          networking.gardener.cloud/to-public-networks=allowed
 
 # allows Ingress to etcd pods from the Shoot's Kubernetes API Server
-allow-etcd                        app=etcd-statefulset,garden.sapcloud.io/role=controlplane
+allow-etcd                        app=etcd-statefulset,gardener.cloud/role=controlplane
 
 # used by the Shoot API server to allows ingress from pods labeled
 # with'networking.gardener.cloud/to-shoot-apiserver=allowed', from Prometheus, and allows Egress to etcd pods

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -200,10 +200,6 @@ const (
 	// GardenerOperationRenewKubeconfig is a constant for the value of the operation annotation to renew the gardenlet's kubeconfig secret.
 	GardenerOperationRenewKubeconfig = "renew-kubeconfig"
 
-	// DeprecatedGardenRole is the key for an annotation on a Kubernetes object indicating what it is used for.
-	//
-	// Deprecated: Use `GardenRole` instead.
-	DeprecatedGardenRole = "garden.sapcloud.io/role"
 	// GardenRole is a constant for a label that describes a role.
 	GardenRole = "gardener.cloud/role"
 	// GardenRoleExtension is a constant for a label that describes the 'extensions' role.

--- a/pkg/operation/botanist/component/etcd/etcd.go
+++ b/pkg/operation/botanist/component/etcd/etcd.go
@@ -422,7 +422,7 @@ func (e *etcd) Deploy(ctx context.Context) error {
 		e.etcd.Spec.Replicas = replicas
 		e.etcd.Spec.PriorityClassName = pointer.String(v1beta1constants.PriorityClassNameShootControlPlane500)
 		e.etcd.Spec.Annotations = annotations
-		e.etcd.Spec.Labels = utils.MergeStringMaps(e.getRoleLabels(), e.getDeprecatedRoleLabels(), map[string]string{
+		e.etcd.Spec.Labels = utils.MergeStringMaps(e.getRoleLabels(), map[string]string{
 			v1beta1constants.LabelApp:                            LabelAppValue,
 			v1beta1constants.LabelNetworkPolicyToDNS:             v1beta1constants.LabelNetworkPolicyAllowed,
 			v1beta1constants.LabelNetworkPolicyToPublicNetworks:  v1beta1constants.LabelNetworkPolicyAllowed,
@@ -430,7 +430,7 @@ func (e *etcd) Deploy(ctx context.Context) error {
 			v1beta1constants.LabelNetworkPolicyToSeedAPIServer:   v1beta1constants.LabelNetworkPolicyAllowed,
 		})
 		e.etcd.Spec.Selector = &metav1.LabelSelector{
-			MatchLabels: utils.MergeStringMaps(e.getDeprecatedRoleLabels(), map[string]string{
+			MatchLabels: utils.MergeStringMaps(e.getRoleLabels(), map[string]string{
 				v1beta1constants.LabelApp: LabelAppValue,
 			}),
 		}
@@ -702,15 +702,6 @@ func (e *etcd) Destroy(ctx context.Context) error {
 	}
 
 	return nil
-}
-
-// TODO(timuthy): remove this function in a future release. Instead we can use `getRoleLabels` as soon as new labels
-// have been added to all etcd StatefulSets.
-func (e *etcd) getDeprecatedRoleLabels() map[string]string {
-	return map[string]string{
-		v1beta1constants.DeprecatedGardenRole: v1beta1constants.GardenRoleControlPlane,
-		v1beta1constants.LabelRole:            e.role,
-	}
 }
 
 func (e *etcd) getRoleLabels() map[string]string {

--- a/pkg/operation/botanist/component/etcd/etcd_test.go
+++ b/pkg/operation/botanist/component/etcd/etcd_test.go
@@ -315,7 +315,6 @@ var _ = Describe("Etcd", func() {
 					PriorityClassName: pointer.String("gardener-system-500"),
 					Labels: map[string]string{
 						"gardener.cloud/role":              "controlplane",
-						"garden.sapcloud.io/role":          "controlplane",
 						"role":                             testRole,
 						"app":                              "etcd-statefulset",
 						"networking.gardener.cloud/to-dns": "allowed",
@@ -325,9 +324,9 @@ var _ = Describe("Etcd", func() {
 					},
 					Selector: &metav1.LabelSelector{
 						MatchLabels: map[string]string{
-							"garden.sapcloud.io/role": "controlplane",
-							"role":                    testRole,
-							"app":                     "etcd-statefulset",
+							"gardener.cloud/role": "controlplane",
+							"role":                testRole,
+							"app":                 "etcd-statefulset",
 						},
 					},
 					Etcd: druidv1alpha1.EtcdConfig{

--- a/pkg/utils/kubernetes/health/etcd.go
+++ b/pkg/utils/kubernetes/health/etcd.go
@@ -33,7 +33,7 @@ func CheckEtcd(etcd *druidv1alpha1.Etcd) error {
 			continue
 		}
 
-		// TODO(timuthy): Check for cond.Status != druidv1alpha1.ConditionTrue as soon as https://github.com/gardener/etcd-druid/issues/413 is resolved.
+		// TODO(timuthy): Check for cond.Status != druidv1alpha1.ConditionTrue as soon as https://github.com/gardener/etcd-druid/pull/469 is released.
 		if cond.Status == druidv1alpha1.ConditionFalse {
 			return fmt.Errorf("backup for etcd %q is reported as unready: %s", etcd.Name, cond.Message)
 		}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind cleanup technical-debt

**What this PR does / why we need it**:
This PR mainly and finally abandons the deprecated `garden.sapcloud.io/role` label 🥳 

It revises two more aspects along the way:
- HA doc
- Ref to `etcd-druid` PR that I filed when I was trying to solve the related TODO 😞 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
The deprecated label `garden.sapcloud.io/role` was finally removed from all Gardener components and from the API constants.
```
