### PR TITLE
Fix section filtering of check-apidiff

### DIFF
--- a/hack/check-apidiff.sh
+++ b/hack/check-apidiff.sh
@@ -57,7 +57,7 @@ exported_pkg=(
 
 # check the changes only for the package that is in the exported_pkg list
 while IFS= read -r line; do
-    if [[ $line =~ "gardener/gardener" ]]; then
+    if [[ $line =~ ^"github.com/gardener/gardener" ]]; then
         temp=0
         for x in ${exported_pkg[*]}; do
             if [[ $line =~ $x ]]; then


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area open-source
/kind bug

**What this PR does / why we need it**:
The script check-apidiff outputs lines containing `gardener/gardener`, e.g. in function parameter types.
The regex should look for `github.com/gardener/gardener` instead.


**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
