### PR TITLE
Increase replicas of nginx ingress controller to 2

### DIFF
--- a/pkg/operation/botanist/component/nginxingress/nginxingress.go
+++ b/pkg/operation/botanist/component/nginxingress/nginxingress.go
@@ -396,7 +396,7 @@ func (n *nginxIngress) computeResourcesData() (map[string][]byte, error) {
 				},
 			},
 			Spec: appsv1.DeploymentSpec{
-				Replicas:             pointer.Int32(1),
+				Replicas:             pointer.Int32(2),
 				RevisionHistoryLimit: pointer.Int32(2),
 				Selector: &metav1.LabelSelector{
 					MatchLabels: getLabels(labelValueController, labelValueAddons),

--- a/pkg/operation/botanist/component/nginxingress/nginxingress_test.go
+++ b/pkg/operation/botanist/component/nginxingress/nginxingress_test.go
@@ -436,7 +436,7 @@ metadata:
   name: nginx-ingress-controller
   namespace: ` + namespace + `
 spec:
-  replicas: 1
+  replicas: 2
   revisionHistoryLimit: 2
   selector:
     matchLabels:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind bug

**What this PR does / why we need it**:
This PR increases the replicas of `nginx-ingress-controller` to 2 to prevent it from blocking rolling seed nodes.
Its pod disruption budget is configured with a minimum availability of 1 which is not compatible with one replica.

**Which issue(s) this PR fixes**:
Fixes #7041 
Introduced with https://github.com/gardener/gardener/pull/6982

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
`nginx-ingress-controller` now runs with 2 replicas to make it compatible with its pod disruption budget.
```
