### PR TITLE
Deflake `Project` controller integration tests

### DIFF
--- a/test/integration/controllermanager/project/activity/activity_suite_test.go
+++ b/test/integration/controllermanager/project/activity/activity_suite_test.go
@@ -59,6 +59,7 @@ var (
 	restConfig *rest.Config
 	testEnv    *gardenerenvtest.GardenerTestEnvironment
 	testClient client.Client
+	mgrClient  client.Client
 
 	testNamespace *corev1.Namespace
 	testRunID     string
@@ -120,6 +121,7 @@ var _ = BeforeSuite(func() {
 		}),
 	})
 	Expect(err).NotTo(HaveOccurred())
+	mgrClient = mgr.GetClient()
 
 	By("setting up field indexes")
 	Expect(indexer.AddProjectNamespace(ctx, mgr.GetFieldIndexer())).To(Succeed())

--- a/test/integration/controllermanager/project/activity/activity_test.go
+++ b/test/integration/controllermanager/project/activity/activity_test.go
@@ -101,13 +101,11 @@ var _ = Describe("Project Activity controller tests", func() {
 			log.Info("Updated object", "kind", kind, "object", client.ObjectKeyFromObject(obj))
 
 			By("Wait until manager has observed updated" + kind)
-			updatedObjMeta := &metav1.PartialObjectMetadata{}
-			updatedObjMeta.SetGroupVersionKind(obj.GetObjectKind().GroupVersionKind())
-
+			objResourceVersion := obj.GetResourceVersion()
 			Eventually(func(g Gomega) string {
-				g.Expect(mgrClient.Get(ctx, client.ObjectKeyFromObject(obj), updatedObjMeta)).To(Succeed())
-				return updatedObjMeta.GetResourceVersion()
-			}).Should(Equal(obj.GetResourceVersion()))
+				g.Expect(mgrClient.Get(ctx, client.ObjectKeyFromObject(obj), obj)).To(Succeed())
+				return obj.GetResourceVersion()
+			}).Should(Equal(objResourceVersion))
 
 			By("Ensure lastActivityTimestamp was updated after object update")
 			lastActivityTimestamp = assertLastActivityTimestampUpdated(ctx, project, lastActivityTimestamp)

--- a/test/integration/controllermanager/project/project/project_test.go
+++ b/test/integration/controllermanager/project/project/project_test.go
@@ -167,6 +167,11 @@ var _ = Describe("Project controller tests", func() {
 		Expect(testClient.Create(ctx, shoot)).To(Succeed())
 		log.Info("Created Shoot for test", "shoot", client.ObjectKeyFromObject(shoot))
 
+		By("Wait until manager has observed Shoot creation")
+		Eventually(func() error {
+			return mgrClient.Get(ctx, client.ObjectKeyFromObject(shoot), shoot)
+		}).Should(Succeed())
+
 		DeferCleanup(func() {
 			By("Cleanup Shoot")
 			Expect(client.IgnoreNotFound(testClient.Delete(ctx, shoot))).To(Succeed())


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind flake

**What this PR does / why we need it**:
This PR fixes the flake in the Project main reconciler and Project activity reconciler by waiting until the manager cache observes creation and updation.

Activity reconciler:
Before:
```
$ stress -ignore "unable to grab random port" -p 32 ./test/integration/controllermanager/project/activity/activity.test
...
13m25s: 416 runs so far, 32 failures (7.69%)
13m30s: 416 runs so far, 32 failures (7.69%)
13m35s: 416 runs so far, 32 failures (7.69%)
13m40s: 416 runs so far, 32 failures (7.69%)
13m45s: 416 runs so far, 32 failures (7.69%)
```
After:
```
$ stress -ignore "unable to grab random port" -p 32 ./test/integration/controllermanager/project/activity/activity.test
...
20m40s: 672 runs so far, 0 failures
20m45s: 677 runs so far, 0 failures
20m50s: 688 runs so far, 0 failures
20m55s: 701 runs so far, 0 failures
21m0s: 704 runs so far, 0 failures
```


**Which issue(s) this PR fixes**:
Fixes #6928 

**Special notes for your reviewer**:
/cc @oliver-goetz 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
