### PR TITLE
Deflake `Seed` controller integration test

### DIFF
--- a/hack/test-integration.sh
+++ b/hack/test-integration.sh
@@ -29,6 +29,8 @@ fi
 export KUBEBUILDER_ASSETS="$(setup-envtest use -p path ${ENVTEST_K8S_VERSION})"
 echo "using envtest tools installed at '$KUBEBUILDER_ASSETS'"
 
+export LD_FLAGS="$($(dirname "$0")/get-build-ld-flags.sh)"
+
 echo "> Integration Tests"
 
 source "$(dirname "$0")/test-integration.env"
@@ -42,4 +44,4 @@ if [ -n "${CI:-}" -a -n "${ARTIFACTS:-}" ] ; then
   test_flags="--ginkgo.junit-report=junit.xml"
 fi
 
-GO111MODULE=on go test -timeout=5m -mod=vendor $@ $test_flags | grep -v 'no test files'
+GO111MODULE=on go test -timeout=5m -mod=vendor -ldflags "$LD_FLAGS" $@ $test_flags | grep -v 'no test files'

--- a/hack/test-integration.sh
+++ b/hack/test-integration.sh
@@ -29,8 +29,6 @@ fi
 export KUBEBUILDER_ASSETS="$(setup-envtest use -p path ${ENVTEST_K8S_VERSION})"
 echo "using envtest tools installed at '$KUBEBUILDER_ASSETS'"
 
-export LD_FLAGS="$($(dirname "$0")/get-build-ld-flags.sh)"
-
 echo "> Integration Tests"
 
 source "$(dirname "$0")/test-integration.env"
@@ -44,4 +42,4 @@ if [ -n "${CI:-}" -a -n "${ARTIFACTS:-}" ] ; then
   test_flags="--ginkgo.junit-report=junit.xml"
 fi
 
-GO111MODULE=on go test -timeout=5m -mod=vendor -ldflags "$LD_FLAGS" $@ $test_flags | grep -v 'no test files'
+GO111MODULE=on go test -timeout=5m -mod=vendor $@ $test_flags | grep -v 'no test files'

--- a/pkg/operation/botanist/component/resourcemanager/resource_manager.go
+++ b/pkg/operation/botanist/component/resourcemanager/resource_manager.go
@@ -1772,6 +1772,8 @@ var (
 	// TimeoutWaitForDeployment is the timeout used while waiting for the Deployments to become healthy
 	// or deleted.
 	TimeoutWaitForDeployment = 5 * time.Minute
+	// WaitForDeployment is an alias for retry.Until. Exposed for tests.
+	WaitForDeployment = retry.Until
 )
 
 // Wait signals whether a deployment is ready or needs more time to be deployed.
@@ -1779,7 +1781,7 @@ func (r *resourceManager) Wait(ctx context.Context) error {
 	timeoutCtx, cancel := context.WithTimeout(ctx, TimeoutWaitForDeployment)
 	defer cancel()
 
-	return retry.Until(timeoutCtx, IntervalWaitForDeployment, func(ctx context.Context) (done bool, err error) {
+	return WaitForDeployment(timeoutCtx, IntervalWaitForDeployment, func(ctx context.Context) (done bool, err error) {
 		deployment := r.emptyDeployment()
 		if err := r.client.Get(ctx, client.ObjectKeyFromObject(deployment), deployment); err != nil {
 			return retry.SevereError(err)

--- a/pkg/operation/botanist/component/resourcemanager/resource_manager.go
+++ b/pkg/operation/botanist/component/resourcemanager/resource_manager.go
@@ -1772,8 +1772,8 @@ var (
 	// TimeoutWaitForDeployment is the timeout used while waiting for the Deployments to become healthy
 	// or deleted.
 	TimeoutWaitForDeployment = 5 * time.Minute
-	// WaitForDeployment is an alias for retry.Until. Exposed for tests.
-	WaitForDeployment = retry.Until
+	// Until is an alias for retry.Until. Exposed for tests.
+	Until = retry.Until
 )
 
 // Wait signals whether a deployment is ready or needs more time to be deployed.
@@ -1781,7 +1781,7 @@ func (r *resourceManager) Wait(ctx context.Context) error {
 	timeoutCtx, cancel := context.WithTimeout(ctx, TimeoutWaitForDeployment)
 	defer cancel()
 
-	return WaitForDeployment(timeoutCtx, IntervalWaitForDeployment, func(ctx context.Context) (done bool, err error) {
+	return Until(timeoutCtx, IntervalWaitForDeployment, func(ctx context.Context) (done bool, err error) {
 		deployment := r.emptyDeployment()
 		if err := r.client.Get(ctx, client.ObjectKeyFromObject(deployment), deployment); err != nil {
 			return retry.SevereError(err)

--- a/test/integration/gardenlet/seed/seed/seed_suite_test.go
+++ b/test/integration/gardenlet/seed/seed/seed_suite_test.go
@@ -171,7 +171,7 @@ var _ = BeforeSuite(func() {
 		Config: config.GardenletConfiguration{
 			Controllers: &config.GardenletControllerConfiguration{
 				Seed: &config.SeedControllerConfiguration{
-					SyncPeriod: &metav1.Duration{Duration: time.Minute},
+					SyncPeriod: &metav1.Duration{Duration: 500 * time.Millisecond},
 				},
 			},
 			SNI: &config.SNI{

--- a/test/integration/gardenlet/seed/seed/seed_suite_test.go
+++ b/test/integration/gardenlet/seed/seed/seed_suite_test.go
@@ -19,7 +19,6 @@ import (
 	_ "embed"
 	"path/filepath"
 	"testing"
-	"time"
 
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
@@ -44,6 +43,7 @@ import (
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	gardenerenvtest "github.com/gardener/gardener/pkg/envtest"
 	"github.com/gardener/gardener/pkg/gardenlet/apis/config"
+	gardenletconfigv1alpha1 "github.com/gardener/gardener/pkg/gardenlet/apis/config/v1alpha1"
 	"github.com/gardener/gardener/pkg/gardenlet/controller/seed/seed"
 	"github.com/gardener/gardener/pkg/gardenlet/features"
 	"github.com/gardener/gardener/pkg/logger"
@@ -175,7 +175,8 @@ var _ = BeforeSuite(func() {
 		Config: config.GardenletConfiguration{
 			Controllers: &config.GardenletControllerConfiguration{
 				Seed: &config.SeedControllerConfiguration{
-					SyncPeriod: &metav1.Duration{Duration: 500 * time.Millisecond},
+					// This controller is pretty heavy-weight, so use DefaultControllerSyncPeriod
+					SyncPeriod: &gardenletconfigv1alpha1.DefaultControllerSyncPeriod,
 				},
 			},
 			SNI: &config.SNI{

--- a/test/integration/gardenlet/seed/seed/seed_suite_test.go
+++ b/test/integration/gardenlet/seed/seed/seed_suite_test.go
@@ -19,6 +19,7 @@ import (
 	_ "embed"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
@@ -43,7 +44,6 @@ import (
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	gardenerenvtest "github.com/gardener/gardener/pkg/envtest"
 	"github.com/gardener/gardener/pkg/gardenlet/apis/config"
-	gardenletconfigv1alpha1 "github.com/gardener/gardener/pkg/gardenlet/apis/config/v1alpha1"
 	"github.com/gardener/gardener/pkg/gardenlet/controller/seed/seed"
 	"github.com/gardener/gardener/pkg/gardenlet/features"
 	"github.com/gardener/gardener/pkg/logger"
@@ -175,8 +175,8 @@ var _ = BeforeSuite(func() {
 		Config: config.GardenletConfiguration{
 			Controllers: &config.GardenletControllerConfiguration{
 				Seed: &config.SeedControllerConfiguration{
-					// This controller is pretty heavy-weight, so use DefaultControllerSyncPeriod
-					SyncPeriod: &gardenletconfigv1alpha1.DefaultControllerSyncPeriod,
+					// This controller is pretty heavy-weight, so use a higher duration.
+					SyncPeriod: &metav1.Duration{Duration: time.Minute},
 				},
 			},
 			SNI: &config.SNI{

--- a/test/integration/gardenlet/seed/seed/seed_suite_test.go
+++ b/test/integration/gardenlet/seed/seed/seed_suite_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/gardener/gardener/pkg/api/indexer"
 	gardencore "github.com/gardener/gardener/pkg/apis/core"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	operatorv1alpha1 "github.com/gardener/gardener/pkg/apis/operator/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	gardenerenvtest "github.com/gardener/gardener/pkg/envtest"
 	"github.com/gardener/gardener/pkg/gardenlet/apis/config"
@@ -136,6 +137,9 @@ var _ = BeforeSuite(func() {
 		NewCache: cache.BuilderWithOptions(cache.Options{
 			SelectorsByObject: map[client.Object]cache.ObjectSelector{
 				&gardencorev1beta1.Seed{}: {
+					Label: labels.SelectorFromSet(labels.Set{testID: testRunID}),
+				},
+				&operatorv1alpha1.Garden{}: {
 					Label: labels.SelectorFromSet(labels.Set{testID: testRunID}),
 				},
 			},

--- a/test/integration/gardenlet/seed/seed/seed_test.go
+++ b/test/integration/gardenlet/seed/seed/seed_test.go
@@ -226,16 +226,6 @@ var _ = Describe("Seed controller tests", func() {
 				})
 
 				test := func(seedIsGarden bool) {
-					// Make sure there are no garden resources present before proceeding to the test, since the controller takes the
-					// decision whether the seed is garden or not based on this.
-					if !seedIsGarden {
-						Eventually(func(g Gomega) []operatorv1alpha1.Garden {
-							gardenList := &operatorv1alpha1.GardenList{}
-							g.Expect(mgrClient.List(ctx, gardenList)).To(Succeed())
-							return gardenList.Items
-						}).Should(BeEmpty())
-					}
-
 					By("Wait for Seed to have finalizer")
 					Eventually(func(g Gomega) []string {
 						g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(seed), seed)).To(Succeed())
@@ -370,19 +360,17 @@ var _ = Describe("Seed controller tests", func() {
 					Expect(testClient.Delete(ctx, seed)).To(Succeed())
 
 					if seedIsGarden {
-						// The CRDs are cleaned up by the Destroy function of GRM, in case the seed is not garden. So It might happen that, before we fetch the
-						// ManagedResourceList is empty, the CRDs are already gone. Since the gardener-resource-manager is deleted only after all the managedresources
-						// are gone, we don't need to assert it seperately. In case the seed is garden, the Destroy is called by the gardener-operator and since it's
-						// not running in this test, we can safely assert the below-mentioned.
+						// The CRDs are cleaned up by the Destroy function of GRM. In case the seed is garden, the Destroy is called by the gardener-operator and since it's
+						// not running in this test, we can safely assert the below-mentioned. But if the seed is not garden, it might so happen that, before we fetch the
+						// ManagedResourceList and expect it to be empty, the CRDs are already gone. Since the gardener-resource-manager is deleted only after all the
+						// managedresources are gone, we don't need to assert it separately.
 						By("Verify that the seed system components have been deleted")
 						Eventually(func(g Gomega) []resourcesv1alpha1.ManagedResource {
 							managedResourceList := &resourcesv1alpha1.ManagedResourceList{}
 							g.Expect(testClient.List(ctx, managedResourceList, client.InNamespace(testNamespace.Name))).To(Succeed())
 							return managedResourceList.Items
 						}).Should(BeEmpty())
-					}
-
-					if !seedIsGarden {
+					} else {
 						By("Verify that gardener-resource-manager has been deleted")
 						Eventually(func(g Gomega) error {
 							deployment := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "gardener-resource-manager", Namespace: testNamespace.Name}}
@@ -422,6 +410,11 @@ var _ = Describe("Seed controller tests", func() {
 						DeferCleanup(func() {
 							By("Delete Garden")
 							Expect(client.IgnoreNotFound(testClient.Delete(ctx, garden))).To(Succeed())
+
+							By("Wait until the manager cache observes garden deletion")
+							Eventually(func() error {
+								return mgrClient.Get(ctx, client.ObjectKeyFromObject(garden), &operatorv1alpha1.Garden{})
+							}).Should(BeNotFoundError())
 						})
 					})
 

--- a/test/integration/gardenlet/seed/seed/seed_test.go
+++ b/test/integration/gardenlet/seed/seed/seed_test.go
@@ -157,6 +157,11 @@ var _ = Describe("Seed controller tests", func() {
 				}}
 				Expect(testClient.Create(ctx, internalDomainSecret)).To(Succeed())
 
+				By("Wait until the manager cache observes the internal domain secret")
+				Eventually(func() error {
+					return mgrClient.Get(ctx, client.ObjectKeyFromObject(internalDomainSecret), internalDomainSecret)
+				}).Should(Succeed())
+
 				DeferCleanup(func() {
 					Expect(testClient.Delete(ctx, internalDomainSecret)).To(Succeed())
 				})
@@ -195,6 +200,11 @@ var _ = Describe("Seed controller tests", func() {
 						Data: map[string][]byte{"foo": []byte("bar")},
 					}
 					Expect(testClient.Create(ctx, globalMonitoringSecret)).To(Succeed())
+
+					By("Wait until the manager cache observes the global monitoring secret")
+					Eventually(func() error {
+						return mgrClient.Get(ctx, client.ObjectKeyFromObject(globalMonitoringSecret), globalMonitoringSecret)
+					}).Should(Succeed())
 
 					DeferCleanup(func() {
 						Expect(testClient.Delete(ctx, globalMonitoringSecret)).To(Succeed())

--- a/test/integration/gardenlet/seed/seed/seed_test.go
+++ b/test/integration/gardenlet/seed/seed/seed_test.go
@@ -49,7 +49,7 @@ var _ = Describe("Seed controller tests", func() {
 		seed *gardencorev1beta1.Seed
 	)
 
-	BeforeEach(func() {
+	JustBeforeEach(func() {
 		DeferCleanup(test.WithVar(&secretutils.GenerateKey, secretutils.FakeGenerateKey))
 		DeferCleanup(test.WithFeatureGate(gardenletfeatures.FeatureGate, features.HVPA, true))
 
@@ -113,7 +113,7 @@ var _ = Describe("Seed controller tests", func() {
 		// Typically, GCM creates the seed-specific namespace, but it doesn't run in this test, hence we have to do it.
 		var seedNamespace *corev1.Namespace
 
-		BeforeEach(func() {
+		JustBeforeEach(func() {
 			By("Create seed namespace in garden")
 			seedNamespace = &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: gutil.ComputeGardenNamespace(seed.Name)}}
 			Expect(testClient.Create(ctx, seedNamespace)).To(Succeed())
@@ -149,7 +149,7 @@ var _ = Describe("Seed controller tests", func() {
 		})
 
 		Context("when internal domain secret exists", func() {
-			BeforeEach(func() {
+			JustBeforeEach(func() {
 				By("Create internal domain secret in seed namespace")
 				internalDomainSecret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
 					GenerateName: "secret-",
@@ -194,7 +194,7 @@ var _ = Describe("Seed controller tests", func() {
 				// Typically, GCM creates the global monitoring secret, but it doesn't run in this test, hence we have to do it.
 				var globalMonitoringSecret *corev1.Secret
 
-				BeforeEach(func() {
+				JustBeforeEach(func() {
 					DeferCleanup(
 						test.WithVars(
 							&resourcemanager.Until, untilInTest,


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind flake

**What this PR does / why we need it**:
The test errors with,
```
  Reason: "GardenSecretsError",
              Message: "need an internal domain secret but found none",
              Codes: nil,
```
This PR adds a check to wait until the manager cache has observed the created secrets.
I hope this will solve the flake.

**Which issue(s) this PR fixes**:
Fixes #6933
Fixes #7124

**Special notes for your reviewer**:
I was unable to reproduce this locally, because running against an actual cluster, the tests won't pass at all because the deployment controller is running and it doesn't allow manually patching the deployment.

I tried to wait for the pod to get ready, but the image tag from the component-base version ([ref](https://github.com/gardener/gardener/blob/b4df8668a47e3c68be00a55a9692b60242ab7fbb/pkg/gardenlet/controller/seed/seed/components.go#L179)),was not proper because we don't set the ldflags in the integration tests. Added ba7b8fc4cda24ccedf7a11a652c4e456b394bded to solve this, still the timeouts were too low, so the test never succeeded. But thought there is no harm in keeping this change.


**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
