### PR TITLE
Explicitly enable IPv4 forwarding

### DIFF
--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/kernelconfig/component.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/kernelconfig/component.go
@@ -64,6 +64,9 @@ net.core.netdev_max_backlog = 5000
 net.core.rmem_max = 16777216
 # Default Socket Send Buffer
 net.core.wmem_max = 16777216
+# explicitly enable IPv4 forwarding for all interfaces by default if not enabled by the OS image already
+net.ipv4.conf.all.forwarding = 1
+net.ipv4.conf.default.forwarding = 1
 # enable martian packets
 net.ipv4.conf.default.log_martians = 1
 # Increase the maximum total buffer-space allocatable

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/kernelconfig/component_test.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/kernelconfig/component_test.go
@@ -73,6 +73,9 @@ net.core.netdev_max_backlog = 5000
 net.core.rmem_max = 16777216
 # Default Socket Send Buffer
 net.core.wmem_max = 16777216
+# explicitly enable IPv4 forwarding for all interfaces by default if not enabled by the OS image already
+net.ipv4.conf.all.forwarding = 1
+net.ipv4.conf.default.forwarding = 1
 # enable martian packets
 net.ipv4.conf.default.log_martians = 1
 # Increase the maximum total buffer-space allocatable


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area os
/kind technical-debt

**What this PR does / why we need it**:

Currently, gardener implicitly expects the selected OS image for shoot workers to enable IPv4 forwarding by default.
Make this explicit by configuring worker nodes with `net.ipv4.conf.{all,default}.forwarding = 1`.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

/cc @ScheererJ @MrBatschner

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Gardener explicitly configures the shoot worker nodes' kernels with `net.ipv4.conf.{all,default}.forwarding = 1`.
```
