### PR TITLE
Add docs about field removal

### DIFF
--- a/docs/development/changing-the-api.md
+++ b/docs/development/changing-the-api.md
@@ -15,7 +15,8 @@ We are following the same approaches.
 
 The Gardener API is defined in `pkg/apis/{core,extensions,settings}` directories and is the main point of interaction with the system.
 It must be ensured that the API is always backwards-compatible.
-If fields shall be removed permanently from the API then a proper deprecation period must be adhered to so that end-users have enough time adapt their clients.
+
+#### Changing the API
 
 **Checklist** when changing the API:
 
@@ -29,6 +30,25 @@ If fields shall be removed permanently from the API then a proper deprecation pe
 1. If necessary then adapt the exemplary YAML manifests of the Gardener resources defined in `example/*.yaml`.
 1. In most cases it makes sense to add/adapt the documentation for administrators/operators and/or end-users in the `docs` folder to provide information on purpose and usage of the added/changed fields.
 1. When opening the pull request then always add a release note so that end-users are becoming aware of the changes.
+
+#### Removing a field
+
+If fields shall be removed permanently from the API then a proper deprecation period must be adhered to so that end-users have enough time adapt their clients. The followed process for removing a field is:
+1. The field in the external version(s) has to be commented out with appropriate doc string that the protobuf number of the corresponding field is reserved. Example:
+
+   ```diff
+   -	SeedTemplate *gardencorev1beta1.SeedTemplate `json:"seedTemplate,omitempty" protobuf:"bytes,2,opt,name=seedTemplate"`
+
+   +	// SeedTemplate is tombstoned to show why 2 is reserved protobuf tag.
+   +	// SeedTemplate *gardencorev1beta1.SeedTemplate `json:"seedTemplate,omitempty" protobuf:"bytes,2,opt,name=seedTemplate"`
+   ```
+
+   The reasoning behind this is to prevent the same protobuf number to be used by a new field. Introducing a new field with the same protobuf number would be a breaking change for clients still using the old protobuf definitions that have the old field for the given protobuf number.
+   The field in the internal version can be removed.
+
+2. Unit test has to be added to make sure that a new field does not reuse the already reserved protobuf tag.
+
+Example of field removal can be found in https://github.com/gardener/gardener/pull/6972.
 
 ## Component configuration APIs
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
This PR proposes the process for removing a field. Inspired by upstream changes for field removal such as https://github.com/kubernetes/kubernetes/pull/102412.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
I am creating the PR in draft state as the referenced PR (https://github.com/gardener/gardener/pull/6972) as example is not yet merged.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
