### PR TITLE
[GEP-21] IPv6 Single-Stack Support in Local Gardener

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -104,6 +104,7 @@
 * [GEP-18: Automated Shoot CA Rotation](proposals/18-shoot-CA-rotation.md)
 * [GEP-19: Monitoring Stack - Migrating to the prometheus-operator](proposals/19-migrating-to-prometheus-operator.md)
 * [GEP-20: Highly Available Shoot Control Planes](proposals/20-ha-control-planes.md)
+* [GEP-21: IPv6 Single-Stack Support in Local Gardener](proposals/21-ipv6-singlestack-local.md)
 
 ## Development
 

--- a/docs/proposals/21-ipv6-singlestack-local.md
+++ b/docs/proposals/21-ipv6-singlestack-local.md
@@ -7,7 +7,8 @@ authors:
 - "@einfachnuralex"
 - "@timebertt"
 reviewers:
-- "TBD"
+- "@ScheererJ"
+- "@rfranzke"
 ---
 
 # GEP-21: IPv6 Single-Stack Support in Local Gardener

--- a/docs/proposals/21-ipv6-singlestack-local.md
+++ b/docs/proposals/21-ipv6-singlestack-local.md
@@ -79,13 +79,11 @@ Once this enhancement has been implemented and IPv6 single-stack networking in l
 - support changing the networking setup of shoots from IPv4 to IPv6 single-stack or vice-versa
 - host IPv6 single-stack shoots on IPv4 single-stack seeds or vice-versa
 - propose changes API types defined outside of gardener/gardener and their implementations, e.g., the `NetworkConfig` APIs (`providerConfig`) of networking extensions
-- support the legacy VPN tunnel (`ReversedVPN` feature gate is disabled)
 
 ## Proposal
 
 A new feature gate `IPv6SingleStack` is added to gardener-apiserver.
 The IPv6-related fields and values can only be used if the feature gate is enabled.
-The feature gate cannot be enabled if the `ReversedVPN` feature gate is disabled (the legacy VPN tunnel solution is [not supported by provider-local](https://github.com/gardener/gardener/blob/83de074f1bc1c009f92e97a08289340591377af6/docs/extensions/provider-local.md#current-limitations) anyway).
 
 The feature gate serves the purpose of disabling the feature in productive Gardener installations and prevents users from configuring IPv6 networking for their shoot clusters, while it is still under development and not supported on cloud infrastructure.
 As part of this enhancement, the feature gate is supposed to be enabled only in the local environment.

--- a/docs/proposals/21-ipv6-singlestack-local.md
+++ b/docs/proposals/21-ipv6-singlestack-local.md
@@ -181,8 +181,7 @@ This includes the kind cluster configuration itself as well as its calico config
 Developers will need to perform some configuration of their machine and Docker installation.
 Corresponding instructions are made available for macOS and Linux machines.
 
-provider-local is configured to use IPv6 addresses for patching the status of LoadBalancer services.
-This is auto-detected if provider-local runs on the seed itself and configured explicitly if running on the host machine (which might have both IPv4 and IPv6 addresses).
+provider-local is configured to use an IPv6 address (`::1`) instead of `127.0.0.1` for patching the status of LoadBalancer services.
 
 #### Scheduling
 

--- a/docs/proposals/21-ipv6-singlestack-local.md
+++ b/docs/proposals/21-ipv6-singlestack-local.md
@@ -78,7 +78,7 @@ Once this enhancement has been implemented and IPv6 single-stack networking in l
 - use IPv6 prefixes assigned by provider for pod CIDR similar to [provider-assigned node CIDR](https://github.com/gardener/gardener/blob/219d828fcdea81fb3edf13de2736daf81e137923/pkg/operation/botanist/infrastructure.go#L73)
 - support changing the networking setup of shoots from IPv4 to IPv6 single-stack or vice-versa
 - host IPv6 single-stack shoots on IPv4 single-stack seeds or vice-versa
-- propose changes API types defined outside of gardener/gardener and their implementations, e.g., the `NetworkConfig` APIs (`providerConfig`) of networking extensions
+- propose changes to API types defined outside of gardener/gardener and their implementations, e.g., the `NetworkConfig` APIs (`providerConfig`) of networking extensions
 
 ## Proposal
 
@@ -109,7 +109,8 @@ spec:
 
 `ipFamilies` is the central setting for specifying the IP families used for shoot networking.
 This field is inspired by the `Service.spec.ipFamilies` field in Kubernetes ([doc](https://kubernetes.io/docs/concepts/services-networking/dual-stack/#services)).
-The default value is `["IPv4"]` (IPv4 single-stack).
+The field is defaulted to `["IPv4"]` (IPv4 single-stack) if not set.
+With this, this field is set to its implicit value for all existing shoots to provide backward-compatibility.
 If the `IPv6SingleStack` feature gate is enabled, `["IPv6"]` can be specified to switch to IPv6 single-stack.
 
 Later on, `["IPv4","IPv6"]` or `["IPv6","IPv4"]` can be supported for dual-stack networking.
@@ -132,6 +133,7 @@ For supporting dual-stack networking setups in the future, the `Shoot` API must 
 Similar to the [`Service` API](https://kubernetes.io/docs/concepts/services-networking/dual-stack/#services), the `Shoot` API may be extended with list equivalents of `Shoot.spec.networking.{pods,services,nodes}`.
 In this case, the existing CIDR fields may specify the respective CIDR of the primary IP family while the list fields contain CIDRs of both IP families.
 The primary IP family may be determined by the first element of the `ipFamilies` field.
+Similar to the `Service.spec.clusterIPs` field, API validation may enforce that the list only contains two entries with the primary IP family being the first one.
 
 ```yaml
 apiVersion: core.gardener.cloud/v1beta1


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement

**What this PR does / why we need it**:

Adds a GEP for implementing IPv6 Single-Stack Support in Local Gardener.

Co-Authored-By: @einfachnuralex

Part of https://github.com/gardener/gardener/issues/7051

**Special notes for your reviewer**:

/cc @ScheererJ @majst01 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
