### PR TITLE
Reduce the nginx-ingress-k8s-backend replicas to 1

### DIFF
--- a/pkg/operation/botanist/component/nginxingress/nginxingress.go
+++ b/pkg/operation/botanist/component/nginxingress/nginxingress.go
@@ -336,7 +336,7 @@ func (n *nginxIngress) computeResourcesData() (map[string][]byte, error) {
 				Labels:    map[string]string{v1beta1constants.LabelApp: labelAppValue},
 			},
 			Spec: appsv1.DeploymentSpec{
-				Replicas:             pointer.Int32(2),
+				Replicas:             pointer.Int32(1),
 				RevisionHistoryLimit: pointer.Int32(2),
 				Selector: &metav1.LabelSelector{
 					MatchLabels: getLabels(labelValueBackend, labelValueAddons),

--- a/pkg/operation/botanist/component/nginxingress/nginxingress_test.go
+++ b/pkg/operation/botanist/component/nginxingress/nginxingress_test.go
@@ -380,7 +380,7 @@ metadata:
   name: nginx-ingress-k8s-backend
   namespace: ` + namespace + `
 spec:
-  replicas: 2
+  replicas: 1
   revisionHistoryLimit: 2
   selector:
     matchLabels:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind cleanup

**What this PR does / why we need it**:
https://github.com/gardener/gardener/pull/6982 increases the `nginx-ingress-k8s-backend` replicas from 1 to 2. However the default backend is not that important component and if it is not available, nginx-ingress won't show a custom error page. This PR reduces the `nginx-ingress-k8s-backend` replicas from 1 (as before).

**Which issue(s) this PR fixes**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
