### PR TITLE
Fix zone pinning for existing clusters

### DIFF
--- a/pkg/operation/botanist/namespaces.go
+++ b/pkg/operation/botanist/namespaces.go
@@ -99,14 +99,16 @@ func (b *Botanist) DeploySeedNamespace(ctx context.Context) error {
 
 			if zones, ok := namespace.Annotations[resourcesv1alpha1.HighAvailabilityConfigZones]; ok {
 				chosenZones.Insert(strings.Split(zones, ",")...)
-			} else {
-				// The zones annotation is used to add a node affinity to pods and pin them to exactly those zones part of
-				// the annotation's value. However, existing clusters might already run in multiple zones. In particular,
-				// if they have created their volumes in multiple zones already, we cannot change this unless we delete and
-				// recreate the disks. This is nothing we want to do automatically, so let's find the existing volumes and
-				// use their zones from now on.
-				// As a consequence, even shoots w/o failure tolerance type 'zone' might be pinned to multiple zones.
-				// TODO(rfranzke): Clean up this else-block in a future release.
+			}
+
+			// The zones annotation is used to add a node affinity to pods and pin them to exactly those zones part of
+			// the annotation's value. However, existing clusters might already run in multiple zones. In particular,
+			// if they have created their volumes in multiple zones already, we cannot change this unless we delete and
+			// recreate the disks. This is nothing we want to do automatically, so let's find the existing volumes and
+			// use their zones from now on.
+			// As a consequence, even shoots w/o failure tolerance type 'zone' might be pinned to multiple zones.
+			// TODO(rfranzke): Clean up this block in a future release.
+			{
 				pvcList := &corev1.PersistentVolumeClaimList{}
 				if err := b.SeedClientSet.Client().List(ctx, pvcList, client.InNamespace(b.Shoot.SeedNamespace)); err != nil {
 					return fmt.Errorf("failed listing PVCs: %w", err)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area high-availability
/kind bug

**What this PR does / why we need it**:
This PR fixes the zone pinning for existing clusters by reading the zone information from the `NodeAffinity` of Persistent Volumes.
Earlier the `topology.kubernetes.io/zone` or `failure-domain.beta.kubernetes.io/zone` label was used which is however not always set, esp. when using CSI ([ref](https://github.com/kubernetes/kubernetes/issues/103403#issuecomment-878864702)).

**Special notes for your reviewer**:
/cc @rfranzke @ialidzhikov @dguendisch

Thanks @ialidzhikov for noticing and the reference!

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
An issue has been fixed that caused Pods being stuck in `Pending` state when scheduled on seed clusters with multiple zones.
```
