### PR TITLE
Improve validations for `BackupBucket`s and `BackupEntry`s

### DIFF
--- a/pkg/controllerutils/associations.go
+++ b/pkg/controllerutils/associations.go
@@ -92,6 +92,12 @@ func DetermineBackupBucketAssociations(ctx context.Context, c client.Client, see
 	return determineAssociations(ctx, c, &gardencorev1beta1.BackupBucketList{}, client.MatchingFields{core.BackupBucketSeedName: seedName})
 }
 
+// DetermineBackupEntryAssociations determine the BackupEntry resources which are associated
+// to BackupBucket with name <bucketName>
+func DetermineBackupEntryAssociations(ctx context.Context, c client.Client, bucketName string) ([]string, error) {
+	return determineAssociations(ctx, c, &gardencorev1beta1.BackupEntryList{}, client.MatchingFields{core.BackupEntryBucketName: bucketName})
+}
+
 // DetermineControllerInstallationAssociations determine the ControllerInstallation resources which are associated
 // to seed with name <seedName>
 func DetermineControllerInstallationAssociations(ctx context.Context, c client.Client, seedName string) ([]string, error) {

--- a/pkg/controllerutils/associations.go
+++ b/pkg/controllerutils/associations.go
@@ -92,12 +92,6 @@ func DetermineBackupBucketAssociations(ctx context.Context, c client.Client, see
 	return determineAssociations(ctx, c, &gardencorev1beta1.BackupBucketList{}, client.MatchingFields{core.BackupBucketSeedName: seedName})
 }
 
-// DetermineBackupEntryAssociations determine the BackupEntry resources which are associated
-// to BackupBucket with name <bucketName>
-func DetermineBackupEntryAssociations(ctx context.Context, c client.Client, bucketName string) ([]string, error) {
-	return determineAssociations(ctx, c, &gardencorev1beta1.BackupEntryList{}, client.MatchingFields{core.BackupEntryBucketName: bucketName})
-}
-
 // DetermineControllerInstallationAssociations determine the ControllerInstallation resources which are associated
 // to seed with name <seedName>
 func DetermineControllerInstallationAssociations(ctx context.Context, c client.Client, seedName string) ([]string, error) {

--- a/pkg/gardenlet/controller/backupbucket/reconciler.go
+++ b/pkg/gardenlet/controller/backupbucket/reconciler.go
@@ -244,19 +244,6 @@ func (r *Reconciler) deleteBackupBucket(
 		return reconcile.Result{}, nil
 	}
 
-	associatedBackupEntries, err := controllerutils.DetermineBackupEntryAssociations(ctx, r.GardenClient, backupBucket.Name)
-	if err != nil {
-		return reconcile.Result{}, err
-	}
-
-	if len(associatedBackupEntries) > 0 {
-		log.Info("Cannot delete BackupBucket because BackupEntries are still referencing it", "backupEntryNames", associatedBackupEntries)
-		r.Recorder.Eventf(backupBucket, corev1.EventTypeNormal, v1beta1constants.EventResourceReferenced, "cannot delete BackupBucket because the following BackupEntries are still referencing it: %+v", associatedBackupEntries)
-		return reconcile.Result{}, fmt.Errorf("BackupBucket %s still has references", backupBucket.Name)
-	}
-
-	log.Info("No BackupEntries are referencing this BackupBucket, accepting deletion")
-
 	operationType := v1beta1helper.ComputeOperationType(backupBucket.ObjectMeta, backupBucket.Status.LastOperation)
 	if updateErr := r.updateBackupBucketStatusOperationStart(ctx, backupBucket, operationType); updateErr != nil {
 		return reconcile.Result{}, fmt.Errorf("could not update status after deletion start: %w", updateErr)

--- a/pkg/gardenlet/controller/seed/seed/reconciler_delete.go
+++ b/pkg/gardenlet/controller/seed/seed/reconciler_delete.go
@@ -82,15 +82,6 @@ func (r *Reconciler) delete(
 
 	if seed.Spec.Backup != nil {
 		backupBucket := &gardencorev1beta1.BackupBucket{ObjectMeta: metav1.ObjectMeta{Name: string(seed.UID)}}
-		associatedBackupEntries, err := controllerutils.DetermineBackupEntryAssociations(ctx, r.GardenClient, backupBucket.Name)
-		if err != nil {
-			return reconcile.Result{}, err
-		}
-		if len(associatedBackupEntries) > 0 {
-			log.Info("Cannot delete Seed's BackupBucket because BackupEntries are still referencing it", "backupEntryNames", associatedBackupEntries)
-			r.Recorder.Eventf(backupBucket, corev1.EventTypeNormal, v1beta1constants.EventResourceReferenced, "cannot delete BackupBucket because the following BackupEntries are still referencing it: %+v", associatedBackupEntries)
-			return reconcile.Result{}, fmt.Errorf("BackupBucket %s still has references", backupBucket.Name)
-		}
 
 		if err := r.GardenClient.Delete(ctx, backupBucket); client.IgnoreNotFound(err) != nil {
 			return reconcile.Result{}, err

--- a/pkg/gardenlet/controller/seed/seed/reconciler_delete.go
+++ b/pkg/gardenlet/controller/seed/seed/reconciler_delete.go
@@ -75,9 +75,18 @@ func (r *Reconciler) delete(
 
 	// Before deletion, it has to be ensured that no Shoots nor BackupBuckets depend on the Seed anymore.
 	// When this happens the controller will remove the finalizers from the Seed so that it can be garbage collected.
+	parentLogMessage := "Can't delete Seed, because the following objects are still referencing it:"
+
 	associatedShoots, err := controllerutils.DetermineShootsAssociatedTo(ctx, r.GardenClient, seed)
 	if err != nil {
 		return reconcile.Result{}, err
+	}
+
+	if len(associatedShoots) > 0 {
+		log.Info("Cannot delete Seed because the following Shoots are still referencing it", "shoots", associatedShoots)
+		r.Recorder.Event(seed, corev1.EventTypeNormal, v1beta1constants.EventResourceReferenced, fmt.Sprintf("%s Shoots=%v", parentLogMessage, associatedShoots))
+
+		return reconcile.Result{}, errors.New("seed still has references")
 	}
 
 	if seed.Spec.Backup != nil {
@@ -93,18 +102,9 @@ func (r *Reconciler) delete(
 		return reconcile.Result{}, err
 	}
 
-	if len(associatedShoots) > 0 || len(associatedBackupBuckets) > 0 {
-		parentLogMessage := "Can't delete Seed, because the following objects are still referencing it:"
-
-		if len(associatedShoots) != 0 {
-			log.Info("Cannot delete Seed because the following Shoots are still referencing it", "shoots", associatedShoots)
-			r.Recorder.Event(seed, corev1.EventTypeNormal, v1beta1constants.EventResourceReferenced, fmt.Sprintf("%s Shoots=%v", parentLogMessage, associatedShoots))
-		}
-
-		if len(associatedBackupBuckets) != 0 {
-			log.Info("Cannot delete Seed because the following BackupBuckets are still referencing it", "backupBuckets", associatedBackupBuckets)
-			r.Recorder.Event(seed, corev1.EventTypeNormal, v1beta1constants.EventResourceReferenced, fmt.Sprintf("%s BackupBuckets=%v", parentLogMessage, associatedBackupBuckets))
-		}
+	if len(associatedBackupBuckets) > 0 {
+		log.Info("Cannot delete Seed because the following BackupBuckets are still referencing it", "backupBuckets", associatedBackupBuckets)
+		r.Recorder.Event(seed, corev1.EventTypeNormal, v1beta1constants.EventResourceReferenced, fmt.Sprintf("%s BackupBuckets=%v", parentLogMessage, associatedBackupBuckets))
 
 		return reconcile.Result{}, errors.New("seed still has references")
 	}

--- a/plugin/pkg/global/resourcereferencemanager/admission.go
+++ b/plugin/pkg/global/resourcereferencemanager/admission.go
@@ -40,6 +40,7 @@ import (
 	kubeinformers "k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	kubecorev1listers "k8s.io/client-go/listers/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/gardener/gardener/pkg/apis/core"
 	"github.com/gardener/gardener/pkg/apis/core/helper"
@@ -53,7 +54,6 @@ import (
 	corev1alphalisters "github.com/gardener/gardener/pkg/client/core/listers/core/v1alpha1"
 	clientkubernetes "github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/plugin/pkg/utils"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
@@ -416,7 +416,7 @@ func (r *ReferenceManager) Admit(ctx context.Context, a admission.Attributes, o 
 			if a.GetName() == "" {
 				return r.validateBackupBucketDeleteCollection(ctx, a)
 			} else {
-				return r.validateBackupBucketDelete(ctx, a)
+				return r.validateBackupBucketDeletion(ctx, a)
 			}
 		} else {
 			backupBucket, ok := a.GetObject().(*core.BackupBucket)
@@ -785,7 +785,7 @@ func (r *ReferenceManager) validateBackupBucketDeleteCollection(ctx context.Cont
 	}
 
 	for _, backupBucket := range backupBucketList.Items {
-		if err := r.validateBackupBucketDelete(ctx, utils.NewAttributesWithName(a, backupBucket.Name)); err != nil {
+		if err := r.validateBackupBucketDeletion(ctx, utils.NewAttributesWithName(a, backupBucket.Name)); err != nil {
 			return err
 		}
 	}
@@ -793,7 +793,7 @@ func (r *ReferenceManager) validateBackupBucketDeleteCollection(ctx context.Cont
 	return nil
 }
 
-func (r *ReferenceManager) validateBackupBucketDelete(ctx context.Context, a admission.Attributes) error {
+func (r *ReferenceManager) validateBackupBucketDeletion(ctx context.Context, a admission.Attributes) error {
 	backupEntryList, err := r.gardenCoreClient.Core().BackupEntries("").List(ctx, metav1.ListOptions{
 		FieldSelector: fields.SelectorFromSet(fields.Set{core.BackupEntryBucketName: a.GetName()}).String(),
 	})

--- a/plugin/pkg/global/resourcereferencemanager/admission.go
+++ b/plugin/pkg/global/resourcereferencemanager/admission.go
@@ -403,6 +403,7 @@ func (r *ReferenceManager) Admit(ctx context.Context, a admission.Attributes, o 
 				})
 			}
 		}
+
 	case core.Kind("BackupBucket"):
 		if operation == admission.Delete {
 			// The "delete endpoint" handler of the k8s.io/apiserver library calls the admission controllers
@@ -425,6 +426,7 @@ func (r *ReferenceManager) Admit(ctx context.Context, a admission.Attributes, o 
 
 			err = r.ensureBackupBucketReferences(ctx, oldBackupBucket, backupBucket, operation)
 		}
+
 	case core.Kind("BackupEntry"):
 		backupEntry, ok := a.GetObject().(*core.BackupEntry)
 		if !ok {
@@ -438,6 +440,7 @@ func (r *ReferenceManager) Admit(ctx context.Context, a admission.Attributes, o 
 			}
 		}
 		err = r.ensureBackupEntryReferences(ctx, oldBackupEntry, backupEntry)
+
 	case core.Kind("CloudProfile"):
 		cloudProfile, ok := a.GetObject().(*core.CloudProfile)
 		if !ok {
@@ -531,6 +534,7 @@ func (r *ReferenceManager) Admit(ctx context.Context, a admission.Attributes, o 
 				}
 			}
 		}
+
 	case core.Kind("ControllerRegistration"):
 		controllerRegistration, ok := a.GetObject().(*core.ControllerRegistration)
 		if !ok {

--- a/plugin/pkg/global/resourcereferencemanager/admission_test.go
+++ b/plugin/pkg/global/resourcereferencemanager/admission_test.go
@@ -16,16 +16,9 @@ package resourcereferencemanager_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
-
-	"github.com/gardener/gardener/pkg/apis/core"
-	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
-	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
-	corefake "github.com/gardener/gardener/pkg/client/core/clientset/internalversion/fake"
-	externalcoreinformers "github.com/gardener/gardener/pkg/client/core/informers/externalversions"
-	coreinformers "github.com/gardener/gardener/pkg/client/core/informers/internalversion"
-	. "github.com/gardener/gardener/plugin/pkg/global/resourcereferencemanager"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -43,6 +36,17 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/testing"
 	"k8s.io/utils/pointer"
+
+	"github.com/gardener/gardener/pkg/apis/core"
+	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	internalclientset "github.com/gardener/gardener/pkg/client/core/clientset/internalversion/fake"
+	externalclientset "github.com/gardener/gardener/pkg/client/core/clientset/versioned/fake"
+	externalcoreinformers "github.com/gardener/gardener/pkg/client/core/informers/externalversions"
+	coreinformers "github.com/gardener/gardener/pkg/client/core/informers/internalversion"
+	. "github.com/gardener/gardener/pkg/utils/test/matchers"
+	. "github.com/gardener/gardener/plugin/pkg/global/resourcereferencemanager"
 )
 
 type fakeAuthorizerType struct{}
@@ -63,14 +67,17 @@ var _ = Describe("resourcereferencemanager", func() {
 			admissionHandler                  *ReferenceManager
 			kubeInformerFactory               kubeinformers.SharedInformerFactory
 			kubeClient                        *fake.Clientset
-			gardenCoreClient                  *corefake.Clientset
+			gardenCoreClient                  *internalclientset.Clientset
+			gardenExternalCoreClient          *externalclientset.Clientset
 			gardenCoreInformerFactory         coreinformers.SharedInformerFactory
 			gardenCoreExternalInformerFactory externalcoreinformers.SharedInformerFactory
 			fakeAuthorizer                    fakeAuthorizerType
 			scheme                            *runtime.Scheme
 			dynamicClient                     *dynamicfake.FakeDynamicClient
 
-			shoot core.Shoot
+			backupBucket core.BackupBucket
+			backupEntry  core.BackupEntry
+			shoot        core.Shoot
 
 			namespace                  = "default"
 			cloudProfileName           = "profile-1"
@@ -216,6 +223,30 @@ var _ = Describe("resourcereferencemanager", func() {
 				},
 			}
 
+			backupBucketBase = core.BackupBucket{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "bucket",
+				},
+				Spec: core.BackupBucketSpec{
+					SeedName: &seedName,
+					SecretRef: corev1.SecretReference{
+						Name:      secretName,
+						Namespace: namespace,
+					},
+				},
+			}
+
+			backupEntryBase = core.BackupEntry{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "entry",
+					Namespace: namespace,
+				},
+				Spec: core.BackupEntrySpec{
+					BucketName: backupBucketBase.Name,
+					SeedName:   &seedName,
+				},
+			}
+
 			discoveryClientResources = []*metav1.APIResourceList{
 				{
 					GroupVersion: "v1",
@@ -258,9 +289,12 @@ var _ = Describe("resourcereferencemanager", func() {
 			kubeClient.Fake = testing.Fake{Resources: discoveryClientResources}
 			admissionHandler.SetKubeClientset(kubeClient)
 
-			gardenCoreClient = corefake.NewSimpleClientset()
+			gardenCoreClient = internalclientset.NewSimpleClientset()
 			gardenCoreClient.Fake = testing.Fake{Resources: discoveryGardenClientResources}
 			admissionHandler.SetInternalCoreClientset(gardenCoreClient)
+
+			gardenExternalCoreClient = &externalclientset.Clientset{}
+			admissionHandler.SetExternalCoreClientset(gardenExternalCoreClient)
 
 			gardenCoreInformerFactory = coreinformers.NewSharedInformerFactory(nil, 0)
 			admissionHandler.SetInternalCoreInformerFactory(gardenCoreInformerFactory)
@@ -281,6 +315,22 @@ var _ = Describe("resourcereferencemanager", func() {
 
 			project = projectBase
 			shoot = shootBase
+			backupBucket = backupBucketBase
+			backupEntry = backupEntryBase
+		})
+
+		It("should return nil because the resource is not BackupBucket and operation is delete", func() {
+			attrs := admission.NewAttributesRecord(&controllerRegistration, nil, core.Kind("ControllerRegistration").WithVersion("version"), "", controllerRegistration.Name, core.Resource("controllerregistrations").WithVersion("version"), "", admission.Delete, &metav1.DeleteOptions{}, false, nil)
+
+			err := admissionHandler.Admit(context.TODO(), attrs, nil)
+
+			Expect(err).NotTo(HaveOccurred())
+
+			attrs = admission.NewAttributesRecord(&shoot, nil, core.Kind("Shoot").WithVersion("version"), "", controllerRegistration.Name, core.Resource("shoots").WithVersion("version"), "", admission.Delete, &metav1.DeleteOptions{}, false, nil)
+
+			err = admissionHandler.Admit(context.TODO(), attrs, nil)
+
+			Expect(err).NotTo(HaveOccurred())
 		})
 
 		Context("tests for ControllerRegistration objects", func() {
@@ -923,6 +973,151 @@ var _ = Describe("resourcereferencemanager", func() {
 			})
 		})
 
+		Context("tests for BackupBucket objects", func() {
+			It("should reject if the referred Seed is not found", func() {
+				attrs := admission.NewAttributesRecord(&backupBucket, nil, core.Kind("BackupBucket").WithVersion("version"), backupBucket.Namespace, backupBucket.Name, core.Resource("backupBuckets").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, defaultUserInfo)
+
+				err := admissionHandler.Admit(context.TODO(), attrs, nil)
+
+				Expect(err).To(BeForbiddenError())
+				Expect(err).To(MatchError(ContainSubstring("backupBuckets.core.gardener.cloud %q is forbidden: seed.core.gardener.cloud %q not found", backupBucket.Name, seed.Name)))
+			})
+
+			It("should reject if the referred Secret is not found", func() {
+				kubeClient.AddReactor("get", "secrets", func(action testing.Action) (bool, runtime.Object, error) {
+					return true, nil, fmt.Errorf("secret not found")
+				})
+				Expect(gardenCoreInformerFactory.Core().InternalVersion().Seeds().Informer().GetStore().Add(&seed)).To(Succeed())
+
+				attrs := admission.NewAttributesRecord(&backupBucket, nil, core.Kind("BackupBucket").WithVersion("version"), backupBucket.Namespace, backupBucket.Name, core.Resource("backupBuckets").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, defaultUserInfo)
+
+				err := admissionHandler.Admit(context.TODO(), attrs, nil)
+
+				Expect(err).To(BeForbiddenError())
+				Expect(err).To(MatchError(ContainSubstring("secret not found")))
+			})
+
+			It("should accept (secret looked up live)", func() {
+				kubeClient.AddReactor("get", "secrets", func(action testing.Action) (bool, runtime.Object, error) {
+					return true, &corev1.Secret{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: secret.Namespace,
+							Name:      secret.Name,
+						},
+					}, nil
+				})
+				Expect(gardenCoreInformerFactory.Core().InternalVersion().Seeds().Informer().GetStore().Add(&seed)).To(Succeed())
+
+				attrs := admission.NewAttributesRecord(&backupBucket, nil, core.Kind("BackupBucket").WithVersion("version"), backupBucket.Namespace, backupBucket.Name, core.Resource("backupBuckets").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, defaultUserInfo)
+
+				err := admissionHandler.Admit(context.TODO(), attrs, nil)
+
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("should accept (secret found in cache)", func() {
+				Expect(kubeInformerFactory.Core().V1().Secrets().Informer().GetStore().Add(&secret)).To(Succeed())
+				Expect(gardenCoreInformerFactory.Core().InternalVersion().Seeds().Informer().GetStore().Add(&seed)).To(Succeed())
+
+				attrs := admission.NewAttributesRecord(&backupBucket, nil, core.Kind("BackupBucket").WithVersion("version"), backupBucket.Namespace, backupBucket.Name, core.Resource("backupBuckets").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, defaultUserInfo)
+
+				err := admissionHandler.Admit(context.TODO(), attrs, nil)
+
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("should accept deletion if no backupEntries are referencing it", func() {
+				Expect(kubeInformerFactory.Core().V1().Secrets().Informer().GetStore().Add(&secret)).To(Succeed())
+				Expect(gardenCoreInformerFactory.Core().InternalVersion().Seeds().Informer().GetStore().Add(&seed)).To(Succeed())
+
+				gardenExternalCoreClient.AddReactor("list", "backupentries", func(action testing.Action) (bool, runtime.Object, error) {
+					return true, &gardencorev1beta1.BackupEntryList{Items: []gardencorev1beta1.BackupEntry{}}, nil
+				})
+
+				attrs := admission.NewAttributesRecord(&backupBucket, nil, core.Kind("BackupBucket").WithVersion("version"), backupBucket.Namespace, backupBucket.Name, core.Resource("backupBuckets").WithVersion("version"), "", admission.Delete, &metav1.DeleteOptions{}, false, defaultUserInfo)
+
+				err := admissionHandler.Admit(context.TODO(), attrs, nil)
+
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("should reject deletion if there are backupEntries referencing it", func() {
+				Expect(kubeInformerFactory.Core().V1().Secrets().Informer().GetStore().Add(&secret)).To(Succeed())
+				Expect(gardenCoreInformerFactory.Core().InternalVersion().Seeds().Informer().GetStore().Add(&seed)).To(Succeed())
+
+				backupEntry1 := &gardencorev1beta1.BackupEntry{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "entry",
+						Namespace: namespace,
+					},
+					Spec: gardencorev1beta1.BackupEntrySpec{
+						BucketName: backupBucket.Name,
+						SeedName:   &seedName,
+					},
+				}
+				backupEntry2 := backupEntry1.DeepCopy()
+				backupEntry2.Name = "another-name"
+				backupEntry2.Namespace = "another-namespace"
+
+				gardenExternalCoreClient.AddReactor("list", "backupentries", func(action testing.Action) (bool, runtime.Object, error) {
+					return true, &gardencorev1beta1.BackupEntryList{Items: []gardencorev1beta1.BackupEntry{*backupEntry1, *backupEntry2}}, nil
+				})
+
+				attrs := admission.NewAttributesRecord(&backupBucket, nil, core.Kind("BackupBucket").WithVersion("version"), backupBucket.Namespace, backupBucket.Name, core.Resource("backupBuckets").WithVersion("version"), "", admission.Delete, &metav1.DeleteOptions{}, false, defaultUserInfo)
+
+				err := admissionHandler.Admit(context.TODO(), attrs, nil)
+
+				Expect(err).To(BeForbiddenError())
+				Expect(err).To(MatchError(ContainSubstring("backupBuckets.core.gardener.cloud %q is forbidden: cannot delete BackupBucket because BackupEntries are still referencing it, backupEntryNames: %s/%s,%s/%s", backupBucket.Name, backupEntry1.Namespace, backupEntry1.Name, backupEntry2.Namespace, backupEntry2.Name)))
+			})
+
+			It("should reject deletion if the listing fails", func() {
+				Expect(kubeInformerFactory.Core().V1().Secrets().Informer().GetStore().Add(&secret)).To(Succeed())
+				Expect(gardenCoreInformerFactory.Core().InternalVersion().Seeds().Informer().GetStore().Add(&seed)).To(Succeed())
+
+				gardenExternalCoreClient.AddReactor("list", "backupentries", func(action testing.Action) (bool, runtime.Object, error) {
+					return true, nil, errors.New("error")
+				})
+
+				attrs := admission.NewAttributesRecord(&backupBucket, nil, core.Kind("BackupBucket").WithVersion("version"), backupBucket.Namespace, backupBucket.Name, core.Resource("backupBuckets").WithVersion("version"), "", admission.Delete, &metav1.DeleteOptions{}, false, defaultUserInfo)
+
+				err := admissionHandler.Admit(context.TODO(), attrs, nil)
+
+				Expect(err).To(HaveOccurred())
+			})
+		})
+
+		Context("tests for BackupEntry objects", func() {
+			It("should reject if the referred Seed is not found", func() {
+				attrs := admission.NewAttributesRecord(&backupEntry, nil, core.Kind("BackupEntry").WithVersion("version"), backupEntry.Namespace, backupEntry.Name, core.Resource("backupEntries").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, defaultUserInfo)
+
+				err := admissionHandler.Admit(context.TODO(), attrs, nil)
+
+				Expect(err).To(BeForbiddenError())
+				Expect(err).To(MatchError(ContainSubstring("backupEntries.core.gardener.cloud %q is forbidden: seed.core.gardener.cloud %q not found", backupEntry.Name, seed.Name)))
+			})
+
+			It("should reject if the referred BackupBucket is not found", func() {
+				Expect(gardenCoreInformerFactory.Core().InternalVersion().Seeds().Informer().GetStore().Add(&seed)).To(Succeed())
+				attrs := admission.NewAttributesRecord(&backupEntry, nil, core.Kind("BackupEntry").WithVersion("version"), backupEntry.Namespace, backupEntry.Name, core.Resource("backupEntries").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, defaultUserInfo)
+
+				err := admissionHandler.Admit(context.TODO(), attrs, nil)
+
+				Expect(err).To(BeForbiddenError())
+				Expect(err).To(MatchError(ContainSubstring("backupEntries.core.gardener.cloud %q is forbidden: backupbucket.core.gardener.cloud %q not found", backupEntry.Name, backupBucket.Name)))
+			})
+
+			It("should accept if the referred resources exist", func() {
+				Expect(gardenCoreInformerFactory.Core().InternalVersion().Seeds().Informer().GetStore().Add(&seed)).To(Succeed())
+				Expect(gardenCoreInformerFactory.Core().InternalVersion().BackupBuckets().Informer().GetStore().Add(&backupBucket)).To(Succeed())
+				attrs := admission.NewAttributesRecord(&backupEntry, nil, core.Kind("BackupEntry").WithVersion("version"), backupEntry.Namespace, backupEntry.Name, core.Resource("backupEntries").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, defaultUserInfo)
+
+				err := admissionHandler.Admit(context.TODO(), attrs, nil)
+
+				Expect(err).NotTo(HaveOccurred())
+			})
+		})
+
 		Context("tests for Project objects", func() {
 			It("should set the created-by field", func() {
 				Expect(gardenCoreInformerFactory.Core().InternalVersion().Projects().Informer().GetStore().Add(&project)).To(Succeed())
@@ -1545,6 +1740,53 @@ var _ = Describe("resourcereferencemanager", func() {
 				Expect(err.Error()).To(ContainSubstring(shootTwo.Spec.Provider.Workers[0].Name))
 				Expect(err.Error()).To(ContainSubstring(shootTwo.Spec.Provider.Workers[1].Name))
 			})
+		})
+	})
+
+	Describe("#Register", func() {
+		It("should register the plugin", func() {
+			plugins := admission.NewPlugins()
+			Register(plugins)
+
+			registered := plugins.Registered()
+			Expect(registered).To(HaveLen(1))
+			Expect(registered).To(ContainElement(PluginName))
+		})
+	})
+
+	Describe("#New", func() {
+		It("should only handle CREATE, UPDATE and DELETE operations", func() {
+			rm, err := New()
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(rm.Handles(admission.Create)).To(BeTrue())
+			Expect(rm.Handles(admission.Update)).To(BeTrue())
+			Expect(rm.Handles(admission.Connect)).NotTo(BeTrue())
+			Expect(rm.Handles(admission.Delete)).To(BeTrue())
+		})
+	})
+
+	Describe("#ValidateInitialization", func() {
+		It("should not return error if everything is set", func() {
+			rm, _ := New()
+
+			internalGardenClient := &internalclientset.Clientset{}
+			externalGardenClient := &externalclientset.Clientset{}
+			rm.SetInternalCoreClientset(internalGardenClient)
+			rm.SetExternalCoreClientset(externalGardenClient)
+
+			rm.SetInternalCoreInformerFactory(coreinformers.NewSharedInformerFactory(nil, 0))
+			rm.SetExternalCoreInformerFactory(externalcoreinformers.NewSharedInformerFactory(nil, 0))
+
+			fakeAuthorizer := fakeAuthorizerType{}
+			rm.SetAuthorizer(fakeAuthorizer)
+
+			kubeInformerFactory := kubeinformers.NewSharedInformerFactory(nil, 0)
+			rm.SetKubeInformerFactory(kubeInformerFactory)
+
+			err := rm.ValidateInitialization()
+
+			Expect(err).NotTo(HaveOccurred())
 		})
 	})
 })

--- a/plugin/pkg/shoot/managedseed/admission.go
+++ b/plugin/pkg/shoot/managedseed/admission.go
@@ -173,7 +173,7 @@ func (v *ManagedSeed) validateDeleteCollection(ctx context.Context, a admission.
 		return err
 	}
 	for _, shoot := range shoots {
-		if err := v.validateDelete(ctx, newAttributesWithName(a, shoot.Name)); err != nil {
+		if err := v.validateDelete(ctx, utils.NewAttributesWithName(a, shoot.Name)); err != nil {
 			return err
 		}
 	}
@@ -191,20 +191,6 @@ func (v *ManagedSeed) validateDelete(ctx context.Context, a admission.Attributes
 	}
 
 	return admission.NewForbidden(a, fmt.Errorf("cannot delete shoot %s/%s since it is still referenced by a managed seed", a.GetNamespace(), a.GetName()))
-}
-
-func newAttributesWithName(a admission.Attributes, name string) admission.Attributes {
-	return admission.NewAttributesRecord(a.GetObject(),
-		a.GetOldObject(),
-		a.GetKind(),
-		a.GetNamespace(),
-		name,
-		a.GetResource(),
-		a.GetSubresource(),
-		a.GetOperation(),
-		a.GetOperationOptions(),
-		a.IsDryRun(),
-		a.GetUserInfo())
 }
 
 func (v *ManagedSeed) getShoots(ctx context.Context, selector labels.Selector) ([]core.Shoot, error) {

--- a/plugin/pkg/utils/miscellaneous.go
+++ b/plugin/pkg/utils/miscellaneous.go
@@ -58,3 +58,18 @@ func GetFilteredShootList(shootLister corelisters.ShootLister, predicateFn func(
 	}
 	return matchingShoots, nil
 }
+
+// NewAttributesWithName returns admission.Attributes with the given name and all other attributes kept same.
+func NewAttributesWithName(a admission.Attributes, name string) admission.Attributes {
+	return admission.NewAttributesRecord(a.GetObject(),
+		a.GetOldObject(),
+		a.GetKind(),
+		a.GetNamespace(),
+		name,
+		a.GetResource(),
+		a.GetSubresource(),
+		a.GetOperation(),
+		a.GetOperationOptions(),
+		a.IsDryRun(),
+		a.GetUserInfo())
+}

--- a/plugin/pkg/utils/miscellaneous_test.go
+++ b/plugin/pkg/utils/miscellaneous_test.go
@@ -88,4 +88,15 @@ var _ = Describe("Miscellaneous", func() {
 		Entry("is used by shoot in migration", "seed2", true),
 		Entry("is unused", "seed3", false),
 	)
+
+	Describe("#NewAttributesWithName", func() {
+		It("should return admission.Attributes with the given name", func() {
+			name := "name"
+			attrs := admission.NewAttributesRecord(&shoot1, nil, core.Kind("Shoot").WithVersion("version"), shoot1.Namespace, "", core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, nil)
+
+			newAttrs := NewAttributesWithName(attrs, name)
+
+			Expect(newAttrs.GetName()).To(Equal(name))
+		})
+	})
 })

--- a/test/integration/gardenlet/backupbucket/backupbucket_suite_test.go
+++ b/test/integration/gardenlet/backupbucket/backupbucket_suite_test.go
@@ -84,8 +84,7 @@ var _ = BeforeSuite(func() {
 	testEnv = &gardenerenvtest.GardenerTestEnvironment{
 		Environment: &envtest.Environment{
 			CRDInstallOptions: envtest.CRDInstallOptions{
-				Paths: []string{filepath.Join("..", "..", "..", "..", "example", "seed-crds", "10-crd-extensions.gardener.cloud_backupbuckets.yaml"),
-					filepath.Join("..", "..", "..", "..", "example", "seed-crds", "10-crd-extensions.gardener.cloud_backupentries.yaml")},
+				Paths: []string{filepath.Join("..", "..", "..", "..", "example", "seed-crds", "10-crd-extensions.gardener.cloud_backupbuckets.yaml")},
 			},
 			ErrorIfCRDPathMissing: true,
 		},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind bug

**What this PR does / why we need it**:
This PR introduces a check before deleting the Seed's `BackupBucket` to check if there are any `BackupEntry`s referencing it.
For the issue description please read #7064 

**Which issue(s) this PR fixes**:
Fixes #7064 

**Special notes for your reviewer**:
/cc @plkokanov @rfranzke 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
The `ResourceReferenceManager` admission plugin in the gardener-apiserver now validates the `BackupBuckets` and `BackupEntries` for their resource references. Also, the deletion of `BackupBucket` is rejected if there are existing `BackupEntries` referencing it.
```
