### PR TITLE
Remove misleading ExpectWithOffset in e2e test

### DIFF
--- a/test/utils/shoots/update/highavailability/upgrade.go
+++ b/test/utils/shoots/update/highavailability/upgrade.go
@@ -125,7 +125,7 @@ func verifyEtcdAffinity(ctx context.Context, seedClient kubernetes.Interface, sh
 }
 
 // DeployZeroDownTimeValidatorJob deploys a Job into the cluster which ensures
-// zero down time by continuously checking the kube-apiserver's health.
+// zero downtime by continuously checking the kube-apiserver's health.
 // This job fails once a health check fails. Its associated pod results in error status.
 func DeployZeroDownTimeValidatorJob(ctx context.Context, c client.Client, testName, namespace, token string) (*batchv1.Job, error) {
 	job := batchv1.Job{

--- a/test/utils/shoots/update/update.go
+++ b/test/utils/shoots/update/update.go
@@ -170,15 +170,14 @@ func RunTest(
 
 	if gardencorev1beta1helper.IsHAControlPlaneConfigured(f.Shoot) {
 		By("ensuring there was no downtime while upgrading shoot")
-		ExpectWithOffset(1, f.SeedClient.Client().Get(ctx, client.ObjectKeyFromObject(job), job)).To(Succeed())
-		ExpectWithOffset(1, job.Status.Failed).Should(BeZero())
-		ExpectWithOffset(1,
-			client.IgnoreNotFound(
-				f.SeedClient.Client().Delete(ctx,
-					job,
-					client.PropagationPolicy(metav1.DeletePropagationForeground),
-				),
+		Expect(f.SeedClient.Client().Get(ctx, client.ObjectKeyFromObject(job), job)).To(Succeed())
+		Expect(job.Status.Failed).Should(BeZero())
+		Expect(client.IgnoreNotFound(
+			f.SeedClient.Client().Delete(ctx,
+				job,
+				client.PropagationPolicy(metav1.DeletePropagationForeground),
 			),
+		),
 		).To(Succeed())
 	}
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind test

**What this PR does / why we need it**:
See changes in HA e2e-test. An actual error should directly point to the line where the expectation is made which helps to efficiently narrow down the cause.

Current output:
```
     STEP: re-creating shoot client 11/24/22 11:39:50.528
    STEP: verifying the Kubernetes version for all existing nodes matches with the versions defined in the Shoot spec [after update] 11/24/22 11:39:50.667
    STEP: ensuring there was no downtime while upgrading shoot 11/24/22 11:39:50.681
    [AfterEach] Shoot Tests
      /home/prow/go/src/github.com/gardener/gardener/test/framework/gingko_utils.go:41
    [AfterEach] Shoot Tests
      /home/prow/go/src/github.com/gardener/gardener/test/framework/gingko_utils.go:41
  << End Captured GinkgoWriter Output
  Expected
      <int32>: 1
  to be zero-valued
  In [It] at: /home/prow/go/src/github.com/gardener/gardener/test/e2e/gardener/shoot/create_update_delete.go:73 
```

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
