### PR TITLE
Deflake `Bastion` controller integration test

### DIFF
--- a/pkg/controllermanager/controller/bastion/reconciler.go
+++ b/pkg/controllermanager/controller/bastion/reconciler.go
@@ -112,6 +112,10 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		}
 	}
 
+	if requeueAfter < 0 {
+		requeueAfter = 0
+	}
+
 	log.V(1).Info("Requeuing Bastion", "requeueAfter", requeueAfter)
 	return reconcile.Result{RequeueAfter: requeueAfter}, nil
 }

--- a/pkg/controllermanager/controller/bastion/reconciler.go
+++ b/pkg/controllermanager/controller/bastion/reconciler.go
@@ -113,7 +113,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	}
 
 	if requeueAfter < 0 {
-		requeueAfter = 0
+		return reconcile.Result{}, fmt.Errorf("the bastion should already have been deleted")
 	}
 
 	log.V(1).Info("Requeuing Bastion", "requeueAfter", requeueAfter)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind flake

**What this PR does / why we need it**:
This PR introduces few minor improvements to solve few flakes:
Set the fakeClock time to `creationTimestamp.Time`. And also set the heartbeatTimestamp using `fakeClock.Now()` instead of `time.Now()`.
  The calculations inside the reconciler are made based on the `creationTimestamp`, the object is created a bit after we set fakeClock to `time.Now()`, and we set the `heartBeatTimestamp` ([and thus the expirationTimestamp](https://github.com/gardener/gardener/blob/5b3456739b23d2009b69e65b642892c507842a6a/pkg/registry/operations/bastion/strategy.go#L154)) using `time.Now()`, this causes the Bastion to be deleted immediately.
See: https://prow.gardener.cloud/view/gs/gardener-prow/logs/ci-gardener-integration/1594977484552540160#1:build-log.txt%3A49-55

Also during stress testing:
```
    [It] should delete Bastion if it's older than maxLifetime
      /Users/I545724/go/src/github.com/gardener/gardener/test/integration/controllermanager/bastion/bastion_test.go:242
    {"level":"debug","ts":"2022-11-25T14:33:58.698+0530","msg":"Requeuing Bastion","controller":"bastion","controllerGroup":"operations.gardener.cloud","controllerKind":"Bastion","Bastion":{"name":"test-5f324995","namespace":"bastion-controller-test-xmm92"},"namespace":"bastion-controller-test-xmm92","name":"test-5f324995","reconcileID":"c2e51e90-2a60-4560-9faa-8d972b647bd0","shoot":"bastion-controller-test-xmm92/test-5f324995","requeueAfter":"1.164058s"}
    {"level":"debug","ts":"2022-11-25T14:33:59.863+0530","msg":"Requeuing Bastion","controller":"bastion","controllerGroup":"operations.gardener.cloud","controllerKind":"Bastion","Bastion":{"name":"test-5f324995","namespace":"bastion-controller-test-xmm92"},"namespace":"bastion-controller-test-xmm92","name":"test-5f324995","reconcileID":"efbd39e7-d4a3-42d1-b5ec-dfabbf66cadd","shoot":"bastion-controller-test-xmm92/test-5f324995","requeueAfter":"1.164058s"}
    {"level":"debug","ts":"2022-11-25T14:34:01.028+0530","msg":"Requeuing Bastion","controller":"bastion","controllerGroup":"operations.gardener.cloud","controllerKind":"Bastion","Bastion":{"name":"test-5f324995","namespace":"bastion-controller-test-xmm92"},"namespace":"bastion-controller-test-xmm92","name":"test-5f324995","reconcileID":"aaac0148-88cb-42d2-9fb7-fa5d0f6b07db","shoot":"bastion-controller-test-xmm92/test-5f324995","requeueAfter":"1.164058s"}
    {"level":"debug","ts":"2022-11-25T14:34:02.194+0530","msg":"Requeuing Bastion","controller":"bastion","controllerGroup":"operations.gardener.cloud","controllerKind":"Bastion","Bastion":{"name":"test-5f324995","namespace":"bastion-controller-test-xmm92"},"namespace":"bastion-controller-test-xmm92","name":"test-5f324995","reconcileID":"dda7f9f8-49e3-4035-8007-b6c53c3288a7","shoot":"bastion-controller-test-xmm92/test-5f324995","requeueAfter":"1.164058s"}
    {"level":"debug","ts":"2022-11-25T14:34:03.359+0530","msg":"Requeuing Bastion","controller":"bastion","controllerGroup":"operations.gardener.cloud","controllerKind":"Bastion","Bastion":{"name":"test-5f324995","namespace":"bastion-controller-test-xmm92"},"namespace":"bastion-controller-test-xmm92","name":"test-5f324995","reconcileID":"22841b65-74fb-4a2d-9a20-b1488090483e","shoot":"bastion-controller-test-xmm92/test-5f324995","requeueAfter":"1.164058s"}
```
The creationTimestamp is again >1s than the fakeClock time, so even after stepping a second, the bastion is not deleted.

Also I am stepping 2 seconds more than the maxLifeTime, to prevent cases like the requeueAfter is some milliseconds.
```
      {"level":"debug","ts":"2022-11-25T14:36:10.387+0530","msg":"Requeuing Bastion","controller":"bastion","controllerGroup":"operations.gardener.cloud","controllerKind":"Bastion","Bastion":{"name":"test-5f324995","namespace":"bastion-controller-test-l85dc"},"namespace":"bastion-controller-test-l85dc","name":"test-5f324995","reconcileID":"ab73e9ce-644c-4702-b298-fa61cd17c253","shoot":"bastion-controller-test-l85dc/test-5f324995","requeueAfter":"377.093ms"}
      {"level":"debug","ts":"2022-11-25T14:36:10.765+0530","msg":"Requeuing Bastion","controller":"bastion","controllerGroup":"operations.gardener.cloud","controllerKind":"Bastion","Bastion":{"name":"test-5f324995","namespace":"bastion-controller-test-l85dc"},"namespace":"bastion-controller-test-l85dc","name":"test-5f324995","reconcileID":"7fac2c66-8743-45ec-aec4-2845a4956b65","shoot":"bastion-controller-test-l85dc/test-5f324995","requeueAfter":"377.093ms"}
      {"level":"debug","ts":"2022-11-25T14:36:11.143+0530","msg":"Requeuing Bastion","controller":"bastion","controllerGroup":"operations.gardener.cloud","controllerKind":"Bastion","Bastion":{"name":"test-5f324995","namespace":"bastion-controller-test-l85dc"},"namespace":"bastion-controller-test-l85dc","name":"test-5f324995","reconcileID":"e6dd04b0-ec13-43ad-8176-fb44901b5c38","shoot":"bastion-controller-test-l85dc/test-5f324995","requeueAfter":"377.093ms"}
      {"level":"debug","ts":"2022-11-25T14:36:11.522+0530","msg":"Requeuing Bastion","controller":"bastion","controllerGroup":"operations.gardener.cloud","controllerKind":"Bastion","Bastion":{"name":"test-5f324995","namespace":"bastion-controller-test-l85dc"},"namespace":"bastion-controller-test-l85dc","name":"test-5f324995","reconcileID":"ed8e16c8-fb8b-4191-80e0-429faf21ec55","shoot":"bastion-controller-test-l85dc/test-5f324995","requeueAfter":"377.093ms"}
      {"level":"debug","ts":"2022-11-25T14:36:11.900+0530","msg":"Requeuing Bastion","controller":"bastion","controllerGroup":"operations.gardener.cloud","controllerKind":"Bastion","Bastion":{"name":"test-5f324995","namespace":"bastion-controller-test-l85dc"},"namespace":"bastion-controller-test-l85dc","name":"test-5f324995","reconcileID":"566d2328-213a-4d80-9e0c-603c0512f3c1","shoot":"bastion-controller-test-l85dc/test-5f324995","requeueAfter":"377.093ms"}

  Waiting for:
      Deleting bastion because it reached its maximum lifetime
  In [It] at: /gardener/gardener/test/integration/controllermanager/bastion/bastion_test.go:248
```

Before:
```
$ stress -ignore "unable to grab random port | resource quota evaluation timed out" -p 64 ./test/integration/controllermanager/bastion/bastion.test
4m20s: 624 runs so far, 12 failures (1.92%)
4m25s: 646 runs so far, 12 failures (1.86%)
4m30s: 652 runs so far, 12 failures (1.84%)
4m35s: 668 runs so far, 12 failures (1.80%)
4m40s: 685 runs so far, 12 failures (1.75%)
4m45s: 710 runs so far, 12 failures (1.69%)
```

After:
```
$ stress -ignore "unable to grab random port | resource quota evaluation timed out" -p 64 ./test/integration/controllermanager/bastion/bastion.test
28m55s: 5054 runs so far, 0 failures
29m0s: 5072 runs so far, 0 failures
29m5s: 5085 runs so far, 0 failures
29m10s: 5100 runs so far, 0 failures
29m15s: 5116 runs so far, 0 failures
```

**Which issue(s) this PR fixes**:
Fixes https://prow.gardener.cloud/view/gs/gardener-prow/logs/ci-gardener-integration/1594977484552540160#1:build-log.txt%3A49-55

**Special notes for your reviewer**:
/cc @rfranzke 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
3. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
