### PR TITLE
Add missing e2e domain names to be added to /etc/hosts for local setup.

### DIFF
--- a/docs/deployment/content/remote-local-setup.yaml
+++ b/docs/deployment/content/remote-local-setup.yaml
@@ -32,7 +32,7 @@ spec:
           echo kubectl           && curl -sL  "https://dl.k8s.io/release/$(curl -sL https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" -o /usr/local/bin/kubectl && chmod +x /usr/local/bin/kubectl
           echo tmux-completion   && curl -sL  "https://raw.githubusercontent.com/imomaliev/tmux-bash-completion/master/completions/tmux" -o /usr/share/bash-completion/completions/tmux
           echo docker-completion && curl -sL  "https://raw.githubusercontent.com/docker/docker-ce/master/components/cli/contrib/completion/bash/docker" -o /usr/share/bash-completion/completions/docker
-          bash -c "echo api.{e2e-managedseed.garden,{local,e2e-{hibernated,unpriv,wake-up,migrate,rotate,default}}.local}.{internal,external}.local.gardener.cloud \
+          bash -c "echo api.{e2e-managedseed.garden,{local,e2e-{managedseed,hibernated,unpriv,wake-up,migrate,rotate,default,upgrade-node,upgrade-zone}}.local}.{internal,external}.local.gardener.cloud \
                    | sed 's/ /\n/g' | sed 's/^/127.0.0.1 /' | sort >> /etc/hosts"
           echo 'source ~/.bashrc' > ~/.bash_profile
           cat > ~/.bashrc <<"EOF"

--- a/docs/deployment/getting_started_locally.md
+++ b/docs/deployment/getting_started_locally.md
@@ -121,6 +121,10 @@ cat <<EOF | sudo tee -a /etc/hosts
 127.0.0.1 api.e2e-rotate.local.internal.local.gardener.cloud
 127.0.0.1 api.e2e-default.local.external.local.gardener.cloud
 127.0.0.1 api.e2e-default.local.internal.local.gardener.cloud
+127.0.0.1 api.e2e-upgrade-node.local.external.local.gardener.cloud
+127.0.0.1 api.e2e-upgrade-node.local.internal.local.gardener.cloud
+127.0.0.1 api.e2e-upgrade-zone.local.external.local.gardener.cloud
+127.0.0.1 api.e2e-upgrade-zone.local.internal.local.gardener.cloud
 EOF
 ```
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area documentation
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
Add missing e2e domain names to be added to /etc/hosts for local setup.

Some e2e tests were missing in the documentation and the deployment automation for the remote local setup. This can be confusing as the names can most likely not be resolved by any dns server.

**Which issue(s) this PR fixes**:
None.

**Special notes for your reviewer**:
Running the corresponding e2e tests without having these name mappings in place will most likely result in failures.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
