### PR TITLE
Enhance `PodSecurity` documentation

### DIFF
--- a/docs/usage/pod-security.md
+++ b/docs/usage/pod-security.md
@@ -50,7 +50,7 @@ admissionPlugins:
       namespaces: []
 ```
 
-⚠️ Note that `pod-security.admission.config.k8s.io/v1` configuration requires v1.25+. For v1.23 and v1.24, use `pod-security.admission.config.k8s.io/v1beta1`. For v1.22, use `pod-security.admission.config.k8s.io/v1alpha1`.
+⚠️ Note that `pod-security.admission.config.k8s.io/v1` configuration requires `v1.25`+. For `v1.23` and `v1.24`, use `pod-security.admission.config.k8s.io/v1beta1`. For `v1.22`, use `pod-security.admission.config.k8s.io/v1alpha1`.
 
 Also note that in `v1.22` the feature gate `PodSecurity` is not enabled by default. You have to add:
 

--- a/docs/usage/pod-security.md
+++ b/docs/usage/pod-security.md
@@ -1,6 +1,6 @@
 # Migrating From `PodSecurityPolicy`s To PodSecurity Admission Controller
 
-Kubernetes has deprecated the `PodSecurityPolicy` API in v1.21 and it will be removed in v1.25. With v1.23, a new feature called [`PodSecurity`](https://kubernetes.io/docs/concepts/security/pod-security-admission/) was promoted to beta. From `v1.25` onwards, there will be no API serving `PodSecurityPolicy`s, so you have to cleanup all the existing PSPs before upgrading your cluster. Detailed migration steps are described [here](https://kubernetes.io/docs/tasks/configure-pod-container/migrate-from-psp/).
+Kubernetes has deprecated the `PodSecurityPolicy` API in `v1.21` and it will be removed in `v1.25`. With `v1.23`, a new feature called [`PodSecurity`](https://kubernetes.io/docs/concepts/security/pod-security-admission/) was promoted to beta. From `v1.25` onwards, there will be no API serving `PodSecurityPolicy`s, so you have to cleanup all the existing PSPs before upgrading your cluster. Detailed migration steps are described [here](https://kubernetes.io/docs/tasks/configure-pod-container/migrate-from-psp/).
 
 After migration, you should disable the `PodSecurityPolicy` admission plugin. To do so, you have to add: 
 ```yaml
@@ -22,7 +22,7 @@ If you wish to add your custom configuration for the `PodSecurity` plugin and yo
 admissionPlugins:
 - name: PodSecurity
   config:
-    apiVersion: pod-security.admission.config.k8s.io/v1beta1
+    apiVersion: pod-security.admission.config.k8s.io/v1
     kind: PodSecurityConfiguration
     # Defaults applied when a mode label is not set.
     #
@@ -33,7 +33,7 @@ admissionPlugins:
     #
     # Version label values must be one of:
     # - "latest" (default) 
-    # - specific version like "v1.24"
+    # - specific version like "v1.25"
     defaults:
       enforce: "privileged"
       enforce-version: "latest"
@@ -50,8 +50,9 @@ admissionPlugins:
       namespaces: []
 ```
 
-If your cluster version is `v1.22`, use `apiVersion: pod-security.admission.config.k8s.io/v1alpha1`.
-Please note that in `v1.22` the feature gate `PodSecurity` is not enabled by default. You have to add:
+⚠️ Note that `pod-security.admission.config.k8s.io/v1` configuration requires v1.25+. For v1.23 and v1.24, use `pod-security.admission.config.k8s.io/v1beta1`. For v1.22, use `pod-security.admission.config.k8s.io/v1alpha1`.
+
+Also note that in `v1.22` the feature gate `PodSecurity` is not enabled by default. You have to add:
 
 ```yaml
 featureGates:
@@ -59,6 +60,7 @@ featureGates:
 ```
 
 under `.spec.kubernetes.kubeAPIServer`.
+
 For proper functioning of Gardener, `kube-system` namespace will also be automatically added to the `exemptions.namespaces` list.
 
 ## `.spec.kubernetes.allowPrivilegedContainers` in the Shoot spec

--- a/test/e2e/gardener/common.go
+++ b/test/e2e/gardener/common.go
@@ -81,6 +81,7 @@ func DefaultShoot(name string) *gardencorev1beta1.Shoot {
 					RegistryPullQPS:     pointer.Int32(10),
 					RegistryBurst:       pointer.Int32(20),
 				},
+				KubeAPIServer: &gardencorev1beta1.KubeAPIServerConfig{},
 			},
 			Networking: gardencorev1beta1.Networking{
 				Type:           "calico",

--- a/test/e2e/gardener/shoot/create_and_delete_unprivileged.go
+++ b/test/e2e/gardener/shoot/create_and_delete_unprivileged.go
@@ -38,12 +38,11 @@ var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
 	// This version is pinned here, because we have removed support for this field for shoots with k8s v1.25+
 	f.Shoot.Spec.Kubernetes.Version = "1.24.8"
 	f.Shoot.Spec.Kubernetes.AllowPrivilegedContainers = pointer.Bool(false)
-	f.Shoot.Spec.Kubernetes.KubeAPIServer = &gardencorev1beta1.KubeAPIServerConfig{
-		AdmissionPlugins: []gardencorev1beta1.AdmissionPlugin{
-			{
-				Name: "PodSecurity",
-				Config: &runtime.RawExtension{
-					Raw: []byte(`{
+	f.Shoot.Spec.Kubernetes.KubeAPIServer.AdmissionPlugins = []gardencorev1beta1.AdmissionPlugin{
+		{
+			Name: "PodSecurity",
+			Config: &runtime.RawExtension{
+				Raw: []byte(`{
 						"apiVersion": "pod-security.admission.config.k8s.io/v1beta1",
 						"kind": "PodSecurityConfiguration",
 						"defaults": {
@@ -51,7 +50,6 @@ var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
 						  "enforce-version": "latest"
 						}
 					  }`),
-				},
 			},
 		},
 	}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area documentation
/kind enhancement

**What this PR does / why we need it**:
Different Kubernetes versions from `v1.22` to `v1.25` use different admission config versions for `PodSecurity` admission plugin. This PR enhances the documentation with the above-mentioned.

This PR also includes one minor change in the e2e tests.

**Which issue(s) this PR fixes**:
Part of #5250 

**Special notes for your reviewer**:
/cc @rfranzke 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
