### PR TITLE
Split graph "Number of Nodes in Worker Group(s)" by workerpool to align with other charts

### DIFF
--- a/charts/seed-monitoring/charts/grafana/dashboards/owners/node-pool-dashboard.json
+++ b/charts/seed-monitoring/charts/grafana/dashboards/owners/node-pool-dashboard.json
@@ -455,17 +455,35 @@
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
-      "seriesOverrides": [],
+      "seriesOverrides": [
+        {
+          "$$hashKey": "object:122",
+          "alias": "Sum of selected groups",
+          "color": "#C4162A",
+          "fill": 1,
+          "fillGradient": 3
+        }
+      ],
       "spaceLength": 10,
       "stack": false,
       "steppedLine": false,
       "targets": [
         {
-          "expr": "count(kube_node_labels{label_worker_gardener_cloud_pool=~\"$worker_group\"})",
+          "exemplar": true,
+          "expr": "count(kube_node_labels{label_worker_gardener_cloud_pool=~\"$worker_group\"}) by (label_worker_gardener_cloud_pool)",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 1,
-          "legendFormat": "nodes",
+          "legendFormat": "{{label_worker_gardener_cloud_pool}}",
           "refId": "A"
+        },
+        {
+          "exemplar": true,
+          "expr": "count(kube_node_labels{label_worker_gardener_cloud_pool=~\"$worker_group\"})",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Sum of selected groups",
+          "refId": "B"
         }
       ],
       "thresholds": [],


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind enhancement

**What this PR does / why we need it**:
Most charts in dashboard "Node/Worker Pool Overview" split their graphs by selected worker groups, except for the graph "Number of Nodes in Worker Group(s)":
<img width="875" alt="image" src="https://user-images.githubusercontent.com/30311254/204281270-e9f5c3ea-744c-4437-9dc7-d1575cc499d9.png">

For convenience (when analyzing clusters I often want to see the distribution of nodes upon worker groups) this PR adds splitting by worker groups to the aforementioned chart so that it looks like this:
<img width="664" alt="image" src="https://user-images.githubusercontent.com/30311254/204281611-267dd2ef-4cf4-403e-a0cb-bf1b6f02a38f.png">


cc @istvanballok 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
