### PR TITLE
Revert "The blackbox-exporter need not tolerate the NoSchedule/NoExecute taints"

### DIFF
--- a/charts/shoot-core/components/charts/monitoring/charts/blackbox-exporter/templates/deployment.yaml
+++ b/charts/shoot-core/components/charts/monitoring/charts/blackbox-exporter/templates/deployment.yaml
@@ -35,7 +35,11 @@ spec:
     spec:
       serviceAccountName: blackbox-exporter
       tolerations:
+      - effect: NoSchedule
+        operator: Exists
       - key: CriticalAddonsOnly
+        operator: Exists
+      - effect: NoExecute
         operator: Exists
       priorityClassName: system-cluster-critical
       nodeSelector:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind enhancement

**What this PR does / why we need it**:

Reverts gardener/gardener#7002.

The blackbox-exporter should tolerate the NoSchedule/NoExecute taints.

Shoot owners can taint their nodes to control scheduling and execution of the workload. If the system components did not tolerate these taints, it can happen that they can not be scheduled at all.

Note that there is a `systemComponents.allow=true` configuration option on the worker pools which can be used to prevent scheduling system components to specific worker pools. (See #2480)

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

/cc @rickardsjp @hendrikKahl @rfranzke 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The blackbox-exporter tolerates the NoSchedule/NoExecute taints
```
