### PR TITLE
Let the metrics-server tolerate the NoSchedule/NoExecute taints

### DIFF
--- a/pkg/operation/botanist/component/metricsserver/metrics_server.go
+++ b/pkg/operation/botanist/component/metricsserver/metrics_server.go
@@ -292,6 +292,12 @@ func (m *metricsServer) computeResourcesData(serverSecret, caSecret *corev1.Secr
 						Tolerations: []corev1.Toleration{{
 							Key:      "CriticalAddonsOnly",
 							Operator: corev1.TolerationOpExists,
+						}, {
+							Effect:   corev1.TaintEffectNoSchedule,
+							Operator: corev1.TolerationOpExists,
+						}, {
+							Effect:   corev1.TaintEffectNoExecute,
+							Operator: corev1.TolerationOpExists,
 						}},
 						PriorityClassName: "system-cluster-critical",
 						NodeSelector: map[string]string{

--- a/pkg/operation/botanist/component/metricsserver/metrics_server_test.go
+++ b/pkg/operation/botanist/component/metricsserver/metrics_server_test.go
@@ -292,6 +292,10 @@ spec:
       tolerations:
       - key: CriticalAddonsOnly
         operator: Exists
+      - effect: NoSchedule
+        operator: Exists
+      - effect: NoExecute
+        operator: Exists
       volumes:
       - name: metrics-server
         secret:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind enhancement

**What this PR does / why we need it**:

Let the metrics-server tolerate the NoSchedule/NoExecute taints

Motivation: Shoot owners can taint their nodes to control scheduling and execution of the workload. If the system components did not tolerate these taints, it can happen that they can not be scheduled at all.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

/cc @rickardsjp @hendrikKahl 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The metrics-server tolerates the NoSchedule/NoExecute taints
```
