### PR TITLE
Fix a "many-to-many matching" error case in a recording rule

### DIFF
--- a/charts/seed-bootstrap/prometheus-rules/metering.rules.yaml
+++ b/charts/seed-bootstrap/prometheus-rules/metering.rules.yaml
@@ -160,7 +160,7 @@ groups:
 
   - record: metering:persistent_volume_usage:sum_by_namespace
     expr: |2
-            sum by (namespace) (kubelet_volume_stats_used_bytes)
+            sum by (namespace) (max by(namespace, persistentvolumeclaim) (kubelet_volume_stats_used_bytes))
           + on (namespace) group_right
             _namespace_to_shoot_uid_and_date
         or
@@ -255,7 +255,7 @@ groups:
   - record: metering:persistent_volume_usage:sum_by_namespace_owner
     expr: |2
         sum by (namespace, owner) (
-                kubelet_volume_stats_used_bytes
+                max by (namespace, persistentvolumeclaim) (kubelet_volume_stats_used_bytes)
               + on (namespace, persistentvolumeclaim) group_right
                 kube_pod_spec_volumes_persistentvolumeclaims_info * 0
           + on (namespace, pod) group_left (owner)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind enhancement

**What this PR does / why we need it**:

In 826af63e8e5 Calculate the monthly average resource usage of the shoot control planes

recording rules were added to calculate the resource usage of the shoot control planes and we noticed that the recording rule which calculates the persistent disk usage by owner can throw an error:

```
  metering:persistent_volume_usage:sum_by_namespace_owner:
    ...
    many-to-many matching not allowed: matching labels must be unique on one side
```

when a statfulset's pod with a persistent volume is rescheduled to a different node.

During that transition it can happen that the kubelet metrics about the disk usage are reported (or at least returned by the PromQL queries) for both the old and the new nodes. This means that for a single persistent volume we get 2 usage metrics instead of 1 and hence the many-to-many vector matching error is reported during this transition period, typically for a single evaluation iteration.

To avoid this temporary error condition we can take the maximum of the duplicate metrics, i.e. the maximum for each conceptually unique namespace, persistent volume claim combination. By taking the maximum, we make sure to have only a single time series for any namespace, persistent volume claim combination and hence we can avoid the many-to-many matching error above.

The same underlying behavior could also impact the calculation of the metering:persistent_volume_usage:sum_by_namespace recording rule by adding up the duplicated disk usage metrics and hence double counting the disk usage of a single disk. By taking the maximum first, we can avoid that temporary glitch.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

/cc @rickardsjp 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Fix a "many-to-many matching" error case in a recording rule related to the monthly average resource usage calculation of the shoot control planes
```
