### PR TITLE
Use Ginkgo timeout in Prow

### DIFF
--- a/hack/test-integration.sh
+++ b/hack/test-integration.sh
@@ -34,12 +34,17 @@ echo "> Integration Tests"
 source "$(dirname "$0")/test-integration.env"
 
 test_flags=
-# If running in prow, we want to generate a machine-readable output file under the location specified via $ARTIFACTS.
+# If running in Prow, we want to generate a machine-readable output file under the location specified via $ARTIFACTS.
 # This will add a JUnit view above the build log that shows an overview over successful and failed test cases.
 if [ -n "${CI:-}" -a -n "${ARTIFACTS:-}" ] ; then
   mkdir -p "$ARTIFACTS"
   trap "report-collector \"$ARTIFACTS/junit.xml\"" EXIT
   test_flags="--ginkgo.junit-report=junit.xml"
+  # Use Ginkgo timeout in Prow to print everything that is buffered in GinkgoWriter.
+  test_flags+=" --ginkgo.timeout=5m"
+else
+  # We don't want Ginkgo's timeout flag locally because it causes skipping the test cache.
+  timeout_flag=-timeout=5m
 fi
 
-GO111MODULE=on go test -timeout=5m -mod=vendor $@ $test_flags | grep -v 'no test files'
+GO111MODULE=on go test ${timeout_flag:-} -mod=vendor $@ $test_flags | grep -v 'no test files'

--- a/hack/test.sh
+++ b/hack/test.sh
@@ -21,7 +21,7 @@ set -o pipefail
 echo "> Test"
 
 test_flags=
-# If running in prow, we want to generate a machine-readable output file under the location specified via $ARTIFACTS.
+# If running in Prow, we want to generate a machine-readable output file under the location specified via $ARTIFACTS.
 # This will add a JUnit view above the build log that shows an overview over successful and failed test cases.
 if [ -n "${CI:-}" -a -n "${ARTIFACTS:-}" ] ; then
   if which report-collector &>/dev/null; then
@@ -31,6 +31,11 @@ if [ -n "${CI:-}" -a -n "${ARTIFACTS:-}" ] ; then
   else
     echo "report-collector not found in PATH, not generating machine-readable test report"
   fi
+  # Use Ginkgo timeout in Prow to print everything that is buffered in GinkgoWriter.
+  test_flags+=" --ginkgo.timeout=2m"
+else
+  # We don't want Ginkgo's timeout flag locally because it causes skipping the test cache.
+  timeout_flag=-timeout=2m
 fi
 
-GO111MODULE=on go test -race -timeout=2m -mod=vendor $@ $test_flags | grep -v 'no test files'
+GO111MODULE=on go test -race ${timeout_flag:-} -mod=vendor $@ $test_flags | grep -v 'no test files'


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/area testing
/kind enhancement

**What this PR does / why we need it**:
This PR changes the test execution in Prow to use `--ginkgo.timeout`. Without this flag, Ginkgo is not able to emit what's been written to `GinkgoWriter` which makes it especially hard to analyze failing or flaky tests.

**Special notes for your reviewer**:
/cc @timebertt 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
