### PR TITLE
Add `Project` information to `Cluster` resource

### DIFF
--- a/docs/api-reference/extensions.md
+++ b/docs/api-reference/extensions.md
@@ -516,6 +516,20 @@ k8s.io/apimachinery/pkg/runtime.RawExtension
 <p>Shoot is a raw extension field that contains the shoot resource that has to be reconciled.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>project</code></br>
+<em>
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/runtime#RawExtension">
+k8s.io/apimachinery/pkg/runtime.RawExtension
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Project is a raw extension field that contains the project resource that has to be reconciled.</p>
+</td>
+</tr>
 </table>
 </td>
 </tr>
@@ -2132,6 +2146,20 @@ k8s.io/apimachinery/pkg/runtime.RawExtension
 </td>
 <td>
 <p>Shoot is a raw extension field that contains the shoot resource that has to be reconciled.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>project</code></br>
+<em>
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/runtime#RawExtension">
+k8s.io/apimachinery/pkg/runtime.RawExtension
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Project is a raw extension field that contains the project resource that has to be reconciled.</p>
 </td>
 </tr>
 </tbody>

--- a/docs/extensions/cluster.md
+++ b/docs/extensions/cluster.md
@@ -12,7 +12,7 @@ The problem is that Gardener does not know which extension requires which inform
 In order to deal with this problem we have introduced the `Cluster` extension resource.
 This CRD is written into the seeds, however, it does not contain a `status`, so it is not expected that something acts upon it.
 Instead, you can treat it like a `ConfigMap` which contains data that might be interesting for you.
-In the context of Gardener, seeds and shoots, and extensibility the `Cluster` resource contains the `CloudProfile`, `Seed`, and `Shoot` manifest.
+In the context of Gardener, seeds and shoots, and extensibility the `Cluster` resource contains the `CloudProfile`, `Seed`, `Shoot` and `Project` manifest.
 Extension controllers can take whatever information they want out of it that might help completing their individual tasks.
 
 ```yaml
@@ -34,6 +34,10 @@ spec:
   shoot:
     apiVersion: core.gardener.cloud/v1beta1
     kind: Shoot
+    ...
+  project:
+    apiVersion: core.gardener.cloud/v1beta1
+    kind: Project
     ...
 ```
 

--- a/example/seed-crds/10-crd-extensions.gardener.cloud_clusters.yaml
+++ b/example/seed-crds/10-crd-extensions.gardener.cloud_clusters.yaml
@@ -45,6 +45,11 @@ spec:
                   cloudprofile resource referenced by the shoot that has to be reconciled.
                 type: object
                 x-kubernetes-preserve-unknown-fields: true
+              project:
+                description: Project is a raw extension field that contains the project
+                  resource that has to be reconciled.
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
               seed:
                 description: Seed is a raw extension field that contains the seed
                   resource referenced by the shoot that has to be reconciled.

--- a/pkg/apis/extensions/v1alpha1/types_cluster.go
+++ b/pkg/apis/extensions/v1alpha1/types_cluster.go
@@ -64,4 +64,9 @@ type ClusterSpec struct {
 	// +kubebuilder:validation:XPreserveUnknownFields
 	// +kubebuilder:pruning:PreserveUnknownFields
 	Shoot runtime.RawExtension `json:"shoot"`
+	// Project is a raw extension field that contains the project resource that has to be reconciled.
+	// +kubebuilder:validation:XPreserveUnknownFields
+	// +kubebuilder:pruning:PreserveUnknownFields
+	// +optional
+	Project runtime.RawExtension `json:"project,omitempty"`
 }

--- a/pkg/apis/extensions/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/extensions/v1alpha1/zz_generated.deepcopy.go
@@ -457,6 +457,7 @@ func (in *ClusterSpec) DeepCopyInto(out *ClusterSpec) {
 	in.CloudProfile.DeepCopyInto(&out.CloudProfile)
 	in.Seed.DeepCopyInto(&out.Seed)
 	in.Shoot.DeepCopyInto(&out.Shoot)
+	in.Project.DeepCopyInto(&out.Project)
 	return
 }
 

--- a/pkg/extensions/cluster.go
+++ b/pkg/extensions/cluster.go
@@ -92,7 +92,7 @@ func SyncClusterResourceToSeed(
 			APIVersion: gardencorev1beta1.SchemeGroupVersion.String(),
 			Kind:       "Project",
 		}
-		shootObj.ManagedFields = nil
+		projectObj.ManagedFields = nil
 	}
 
 	_, err := controllerutils.GetAndCreateOrMergePatch(ctx, c, cluster, func() error {

--- a/pkg/gardenlet/controller/shoot/shoot_control.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control.go
@@ -165,7 +165,7 @@ func (r *shootReconciler) syncClusterResourceToSeed(ctx context.Context, shoot *
 	}
 
 	clusterName := shootpkg.ComputeTechnicalID(project.Name, shoot)
-	return gardenerextensions.SyncClusterResourceToSeed(ctx, r.seedClientSet.Client(), clusterName, shoot, cloudProfile, seed)
+	return gardenerextensions.SyncClusterResourceToSeed(ctx, r.seedClientSet.Client(), clusterName, shoot, cloudProfile, seed, project)
 }
 
 func (r *shootReconciler) checkSeedAndSyncClusterResource(ctx context.Context, shoot *gardencorev1beta1.Shoot, project *gardencorev1beta1.Project, cloudProfile *gardencorev1beta1.CloudProfile, seed *gardencorev1beta1.Seed) error {

--- a/pkg/operation/botanist/clusteridentity.go
+++ b/pkg/operation/botanist/clusteridentity.go
@@ -36,7 +36,7 @@ func (b *Botanist) EnsureShootClusterIdentity(ctx context.Context) error {
 			return err
 		}
 
-		if err := extensions.SyncClusterResourceToSeed(ctx, b.SeedClientSet.Client(), b.Shoot.SeedNamespace, b.Shoot.GetInfo(), nil, nil); err != nil {
+		if err := extensions.SyncClusterResourceToSeed(ctx, b.SeedClientSet.Client(), b.Shoot.SeedNamespace, b.Shoot.GetInfo(), nil, nil, nil); err != nil {
 			return err
 		}
 	}

--- a/pkg/operation/botanist/component/extensions/crds/assets/crd-extensions.gardener.cloud_clusters.yaml
+++ b/pkg/operation/botanist/component/extensions/crds/assets/crd-extensions.gardener.cloud_clusters.yaml
@@ -45,6 +45,11 @@ spec:
                   cloudprofile resource referenced by the shoot that has to be reconciled.
                 type: object
                 x-kubernetes-preserve-unknown-fields: true
+              project:
+                description: Project is a raw extension field that contains the project
+                  resource that has to be reconciled.
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
               seed:
                 description: Seed is a raw extension field that contains the seed
                   resource referenced by the shoot that has to be reconciled.

--- a/pkg/operation/botanist/infrastructure.go
+++ b/pkg/operation/botanist/infrastructure.go
@@ -76,7 +76,7 @@ func (b *Botanist) WaitForInfrastructure(ctx context.Context) error {
 			return err
 		}
 
-		if err := extensions.SyncClusterResourceToSeed(ctx, b.SeedClientSet.Client(), b.Shoot.SeedNamespace, b.Shoot.GetInfo(), nil, nil); err != nil {
+		if err := extensions.SyncClusterResourceToSeed(ctx, b.SeedClientSet.Client(), b.Shoot.SeedNamespace, b.Shoot.GetInfo(), nil, nil, nil); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind enhancement

**What this PR does / why we need it**:

The `extensionsv1alpha1.Cluster` type is already very useful for obtaining relevant data concerning `Seed`, `Shoot` and `Infrastructure`. For our use cases, it would be really handy to also have the `Project` resource present in the `Cluster` extension. As the project data was already available where the `Cluster` resource is created, this is a rather small change - but greatly improves developer experience for us.

Background: We would like to use `Project`-specific data in an extension on seeds.

**Release note**:

```feature developer
Project data is available in the Cluster extension on seeds.
```
