### PR TITLE
Fix calculation of overlapping CIDR ranges.

### DIFF
--- a/pkg/operation/botanist/component/networkpolicies/peers.go
+++ b/pkg/operation/botanist/component/networkpolicies/peers.go
@@ -101,7 +101,7 @@ func excludeBlock(parentBlock *net.IPNet, cidrs ...string) ([]string, error) {
 		parentBlockMaskLength, _ := parentBlock.Mask.Size()
 		ipNetMaskLength, _ := ipNet.Mask.Size()
 
-		if parentBlock.Contains(ip) && (parentBlockMaskLength < ipNetMaskLength) {
+		if parentBlock.Contains(ip) && parentBlockMaskLength < ipNetMaskLength {
 			matchedCIDRs = append(matchedCIDRs, cidr)
 		}
 	}

--- a/pkg/operation/botanist/component/networkpolicies/peers.go
+++ b/pkg/operation/botanist/component/networkpolicies/peers.go
@@ -98,8 +98,10 @@ func excludeBlock(parentBlock *net.IPNet, cidrs ...string) ([]string, error) {
 		if err != nil {
 			return matchedCIDRs, err
 		}
+		parentBlockMaskLength, _ := parentBlock.Mask.Size()
+		ipNetMaskLength, _ := ipNet.Mask.Size()
 
-		if parentBlock.Contains(ip) && !ipNet.Contains(parentBlock.IP) {
+		if parentBlock.Contains(ip) && (parentBlockMaskLength < ipNetMaskLength) {
 			matchedCIDRs = append(matchedCIDRs, cidr)
 		}
 	}

--- a/pkg/operation/botanist/component/networkpolicies/peers_test.go
+++ b/pkg/operation/botanist/component/networkpolicies/peers_test.go
@@ -108,6 +108,7 @@ var _ = Describe("networkpolicies", func() {
 				"192.168.0.0/16",
 				"10.10.0.0/24",
 				"10.0.0.0/8",
+				"10.0.0.0/12",
 				"100.64.0.0/10",
 				"172.16.0.0/12",
 			)
@@ -117,7 +118,7 @@ var _ = Describe("networkpolicies", func() {
 				{
 					IPBlock: &networkingv1.IPBlock{
 						CIDR:   "10.0.0.0/8",
-						Except: []string{"10.10.0.0/24"},
+						Except: []string{"10.10.0.0/24", "10.0.0.0/12"},
 					},
 				},
 				{

--- a/pkg/operation/botanist/networkpolicies_test.go
+++ b/pkg/operation/botanist/networkpolicies_test.go
@@ -57,7 +57,10 @@ var _ = Describe("Networkpolicies", func() {
 				Except: []string{podCIDRSeed},
 			}},
 			networkingv1.NetworkPolicyPeer{IPBlock: &networkingv1.IPBlock{CIDR: "172.16.0.0/12"}},
-			networkingv1.NetworkPolicyPeer{IPBlock: &networkingv1.IPBlock{CIDR: "192.168.0.0/16"}},
+			networkingv1.NetworkPolicyPeer{IPBlock: &networkingv1.IPBlock{
+				CIDR:   "192.168.0.0/16",
+				Except: []string{serviceCIDRSeed},
+			}},
 			networkingv1.NetworkPolicyPeer{IPBlock: &networkingv1.IPBlock{CIDR: "100.64.0.0/10"}},
 		}
 	)
@@ -149,7 +152,10 @@ var _ = Describe("Networkpolicies", func() {
 						Except: append([]string{podCIDRSeed, nodeCIDRSeed}, blockCIDRs...),
 					}},
 					networkingv1.NetworkPolicyPeer{IPBlock: &networkingv1.IPBlock{CIDR: "172.16.0.0/12"}},
-					networkingv1.NetworkPolicyPeer{IPBlock: &networkingv1.IPBlock{CIDR: "192.168.0.0/16"}},
+					networkingv1.NetworkPolicyPeer{IPBlock: &networkingv1.IPBlock{
+						CIDR:   "192.168.0.0/16",
+						Except: []string{serviceCIDRSeed},
+					}},
 					networkingv1.NetworkPolicyPeer{IPBlock: &networkingv1.IPBlock{
 						CIDR:   "100.64.0.0/10",
 						Except: nil,
@@ -186,8 +192,14 @@ var _ = Describe("Networkpolicies", func() {
 						CIDR:   "10.0.0.0/8",
 						Except: append(append([]string{podCIDRSeed, nodeCIDRSeed}, blockCIDRs...), nodeCIDRShoot),
 					}},
-					networkingv1.NetworkPolicyPeer{IPBlock: &networkingv1.IPBlock{CIDR: "172.16.0.0/12"}},
-					networkingv1.NetworkPolicyPeer{IPBlock: &networkingv1.IPBlock{CIDR: "192.168.0.0/16"}},
+					networkingv1.NetworkPolicyPeer{IPBlock: &networkingv1.IPBlock{
+						CIDR:   "172.16.0.0/12",
+						Except: []string{serviceCIDRShoot},
+					}},
+					networkingv1.NetworkPolicyPeer{IPBlock: &networkingv1.IPBlock{
+						CIDR:   "192.168.0.0/16",
+						Except: []string{serviceCIDRSeed},
+					}},
 					networkingv1.NetworkPolicyPeer{IPBlock: &networkingv1.IPBlock{
 						CIDR:   "100.64.0.0/10",
 						Except: []string{podCIDRShoot},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind bug

**What this PR does / why we need it**:
Due to the wrong overlap test, NetworkPolicy `allow-private-networks` doesn't contain a `except` clauses for networks that are includes in the subnet but have the same start address. 

**Which issue(s) this PR fixes**:
Fixes #7110

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fixed a bug where service, pod or node CIDRs that are private network (RFC1918) or carrier-grade NAT (RFC6598) IPv4 blocks would not be added as except clause to `allow-to-private-networks` networkpolicy.
```
