### PR TITLE
Deflake `BackupEntry` controller integration test and Minor controller improvements

### DIFF
--- a/pkg/gardenlet/controller/backupentry/backupentry/reconciler.go
+++ b/pkg/gardenlet/controller/backupentry/backupentry/reconciler.go
@@ -346,7 +346,11 @@ func (r *Reconciler) deleteBackupEntry(
 		return reconcile.Result{}, fmt.Errorf("could not update status after deletion success: %w", updateErr)
 	}
 
-	return reconcile.Result{}, nil
+	requeueAfter := backupEntry.DeletionTimestamp.Time.Add(gracePeriod).Sub(r.Clock.Now())
+	if requeueAfter < 0 {
+		return reconcile.Result{}, fmt.Errorf("the backupentry should have been deleted by now")
+	}
+	return reconcile.Result{RequeueAfter: requeueAfter}, nil
 }
 
 func (r *Reconciler) migrateBackupEntry(

--- a/pkg/gardenlet/controller/backupentry/backupentry/reconciler.go
+++ b/pkg/gardenlet/controller/backupentry/backupentry/reconciler.go
@@ -52,7 +52,7 @@ import (
 )
 
 var (
-	// DefaultTimeout defines how long the controller should wait until the extension resource is ready or is succesfully deleted. Exposed for tests.
+	// DefaultTimeout defines how long the controller should wait until the BackupBucket resource is ready or is succesfully deleted. Exposed for tests.
 	DefaultTimeout = 30 * time.Second
 	// DefaultSevereThreshold is the default threshold until an error reported by the component is treated as 'severe'. Exposed for tests.
 	DefaultSevereThreshold = 15 * time.Second

--- a/test/integration/gardenlet/backupentry/backupentry/backupentry_suite_test.go
+++ b/test/integration/gardenlet/backupentry/backupentry/backupentry_suite_test.go
@@ -93,7 +93,7 @@ var _ = BeforeSuite(func() {
 			ErrorIfCRDPathMissing: true,
 		},
 		GardenerAPIServer: &gardenerenvtest.GardenerAPIServer{
-			Args: []string{"--disable-admission-plugins=DeletionConfirmation,ExtensionLabels,ExtensionValidator,ResourceReferenceManager"},
+			Args: []string{"--disable-admission-plugins=DeletionConfirmation,Bastion,ResourceReferenceManager,ExtensionValidator,ShootDNS,ShootQuotaValidator,ShootTolerationRestriction,ShootValidator"},
 		},
 	}
 

--- a/test/integration/gardenlet/backupentry/backupentry/backupentry_test.go
+++ b/test/integration/gardenlet/backupentry/backupentry/backupentry_test.go
@@ -519,7 +519,7 @@ var _ = Describe("BackupEntry controller tests", func() {
 			}).Should(Succeed())
 
 			By("stepping the clock to pass the grace period")
-			fakeClock.Step((time.Duration(deletionGracePeriodHours)*time.Hour + time.Second))
+			fakeClock.Step((time.Duration(deletionGracePeriodHours)*time.Hour + time.Minute))
 			Expect(testClient.Get(ctx, client.ObjectKeyFromObject(backupEntry), backupEntry)).To(Succeed())
 			patch := client.MergeFrom(backupEntry.DeepCopy())
 			metav1.SetMetaDataAnnotation(&backupEntry.ObjectMeta, v1beta1constants.GardenerOperation, v1beta1constants.GardenerOperationReconcile)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind flake

**What this PR does / why we need it**:
This PR increases the duration stepped by the fakeClock.
This is similar to #6498 , where the decision for deletion is taken by comparing the deletionTimestamp of the object and the current `clock.Now()`. It can so happen that the deletionTimestamp set is already 1 or 2s after we set the fakeClock time to `time.Now()`, so stepping the time for 1s doesn't yield the expected result. 

This PR also requeues the backupEntry in case the gracePeriod for deletion is not passed. (/cc @plkokanov )

**Which issue(s) this PR fixes**:
Fixes 
https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/7048/pull-gardener-integration/1595522667966894080
https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/batch/pull-gardener-integration/1597590783429447680

**Special notes for your reviewer**:
```
stress -ignore "unable to grab random port | resource quota evaluation timed out" -p 32 ./test/integration/gardenlet/backupentry/backupentry/backupentry.test --ginkgo.v --ginkgo.progress
...
9m40s: 1063 runs so far, 0 failures
9m45s: 1070 runs so far, 0 failures
9m50s: 1072 runs so far, 0 failures
9m55s: 1089 runs so far, 0 failures
10m0s: 1099 runs so far, 0 failures
10m5s: 1104 runs so far, 0 failures
```

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
