### PR TITLE
Fix logging integration test

### DIFF
--- a/test/testmachinery/shoots/logging/seed_logging_stack.go
+++ b/test/testmachinery/shoots/logging/seed_logging_stack.go
@@ -54,7 +54,7 @@ const (
 	loggerDeploymentCleanupTimeout = 5 * time.Minute
 
 	fluentBitName                 = "fluent-bit"
-	fluentBitConfingDiskName      = "template-config"
+	fluentBitConfigVolumeName     = "config-dir"
 	lokiName                      = "loki"
 	lokiConfigDiskName            = "config"
 	garden                        = "garden"
@@ -106,7 +106,7 @@ var _ = ginkgo.Describe("Seed logging testing", func() {
 		}))
 		framework.ExpectNoError(err)
 		framework.ExpectNoError(f.SeedClient.Client().Get(ctx, types.NamespacedName{Namespace: v1beta1constants.GardenNamespace, Name: fluentBitName}, fluentBit))
-		framework.ExpectNoError(f.SeedClient.Client().Get(ctx, types.NamespacedName{Namespace: v1beta1constants.GardenNamespace, Name: getConfigMapName(fluentBit.Spec.Template.Spec.Volumes, fluentBitConfingDiskName)}, fluentBitConfMap))
+		framework.ExpectNoError(f.SeedClient.Client().Get(ctx, types.NamespacedName{Namespace: v1beta1constants.GardenNamespace, Name: getConfigMapName(fluentBit.Spec.Template.Spec.Volumes, fluentBitConfigVolumeName)}, fluentBitConfMap))
 		framework.ExpectNoError(f.SeedClient.Client().Get(ctx, types.NamespacedName{Namespace: v1beta1constants.GardenNamespace, Name: fluentBitName}, fluentBitService))
 		framework.ExpectNoError(f.SeedClient.Client().Get(ctx, types.NamespacedName{Namespace: v1beta1constants.GardenNamespace, Name: fluentBitClusterRoleName}, fluentBitClusterRole))
 		framework.ExpectNoError(f.SeedClient.Client().Get(ctx, types.NamespacedName{Namespace: v1beta1constants.GardenNamespace, Name: fluentBitClusterRoleName}, fluentBitClusterRoleBinding))


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind bug

**What this PR does / why we need it**:
https://github.com/gardener/gardener/pull/6980 changes the volume name of the volume that holds the fluent-bit ConfigMap.
Hence, current executions of the beta tests all fail with:
```
  Unexpected error:
      <*errors.errorString | 0xc000960af0>: {
          s: "resource name may not be empty",
      }
      resource name may not be empty
  occurred
  In [BeforeEach] at: 
  /go/src/github.com/gardener/gardener/test/testmachinery/shoots/logging/seed_logging_stack.go:109
```

![Screenshot 2022-11-30 at 12 38 46](https://user-images.githubusercontent.com/9372594/204774598-073bf3c8-c5f5-46c3-a95d-a4f37267881d.png)

**Which issue(s) this PR fixes**:
See above

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
An issue causing the Seed logging integration test to always fail is now fixed.
```
