### PR TITLE
Improve the logging in the `WaitUntilPodIsRunning` func

### DIFF
--- a/test/framework/k8s_utils.go
+++ b/test/framework/k8s_utils.go
@@ -429,18 +429,18 @@ func NewClientFromServiceAccount(ctx context.Context, k8sClient kubernetes.Inter
 func WaitUntilPodIsRunning(ctx context.Context, log logr.Logger, name, namespace string, c kubernetes.Interface) error {
 	return retry.Until(ctx, defaultPollInterval, func(ctx context.Context) (done bool, err error) {
 		pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name}}
-		log = log.WithValues("pod", client.ObjectKeyFromObject(pod))
+		podLog := log.WithValues("pod", client.ObjectKeyFromObject(pod))
 
 		if err := c.Client().Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, pod); err != nil {
 			return retry.SevereError(err)
 		}
 
 		if !health.IsPodReady(pod) {
-			log.Info("Waiting for Pod to be ready")
+			podLog.Info("Waiting for Pod to be ready")
 			return retry.MinorError(fmt.Errorf(`pod "%s/%s" is not ready: %v`, namespace, name, err))
 		}
 
-		log.Info("Pod is ready now")
+		podLog.Info("Pod is ready now")
 		return retry.Ok()
 	})
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind bug

**What this PR does / why we need it**:
Similar to https://github.com/gardener/gardener/pull/6714

Currently the logging in a test using the `WaitUntilPodIsRunning` func:
```
2022-11-30T09:17:49.191653708Z stdout F {"level":"info","ts":"2022-11-30T09:17:49.191Z","logger":"test","msg":"Waiting for Pod to be ready","pod":"default/gvisorgt7w5"}
2022-11-30T09:17:54.200376106Z stdout F {"level":"info","ts":"2022-11-30T09:17:54.200Z","logger":"test","msg":"Waiting for Pod to be ready","pod":"default/gvisorgt7w5","pod":"default/gvisorgt7w5"}
2022-11-30T09:17:59.204597147Z stdout F {"level":"info","ts":"2022-11-30T09:17:59.204Z","logger":"test","msg":"Waiting for Pod to be ready","pod":"default/gvisorgt7w5","pod":"default/gvisorgt7w5","pod":"default/gvisorgt7w5"}
2022-11-30T09:18:04.209369788Z stdout F {"level":"info","ts":"2022-11-30T09:18:04.209Z","logger":"test","msg":"Waiting for Pod to be ready","pod":"default/gvisorgt7w5","pod":"default/gvisorgt7w5","pod":"default/gvisorgt7w5","pod":"default/gvisorgt7w5"}
2022-11-30T09:18:09.217220272Z stdout F {"level":"info","ts":"2022-11-30T09:18:09.216Z","logger":"test","msg":"Waiting for Pod to be ready","pod":"default/gvisorgt7w5","pod":"default/gvisorgt7w5","pod":"default/gvisorgt7w5","pod":"default/gvisorgt7w5","pod":"default/gvisorgt7w5"}
2022-11-30T09:18:14.224996688Z stdout F {"level":"info","ts":"2022-11-30T09:18:14.224Z","logger":"test","msg":"Waiting for Pod to be ready","pod":"default/gvisorgt7w5","pod":"default/gvisorgt7w5","pod":"default/gvisorgt7w5","pod":"default/gvisorgt7w5","pod":"default/gvisorgt7w5","pod":"default/gvisorgt7w5"}
```

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
