### PR TITLE
Fix flaky shoot conditions integration test

### DIFF
--- a/test/integration/controllermanager/shoot/conditions/conditions_suite_test.go
+++ b/test/integration/controllermanager/shoot/conditions/conditions_suite_test.go
@@ -55,6 +55,7 @@ var (
 	restConfig *rest.Config
 	testEnv    *gardenerenvtest.GardenerTestEnvironment
 	testClient client.Client
+	mgrClient  client.Client
 
 	testNamespace *corev1.Namespace
 	testRunID     string
@@ -107,6 +108,7 @@ var _ = BeforeSuite(func() {
 		}),
 	})
 	Expect(err).NotTo(HaveOccurred())
+	mgrClient = mgr.GetClient()
 
 	By("setting up field indexes")
 	Expect(indexer.AddManagedSeedShootName(ctx, mgr.GetFieldIndexer())).To(Succeed())


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind flake

**What this PR does / why we need it**:
This PR improves the flakiness reported in #6931.

<details> 
<summary>Test results:</summary>
<pre>
> stress -p 16 ./test/integration/controllermanager/shoot/conditions/conditions.test
5s: 0 runs so far, 0 failures
10s: 10 runs so far, 0 failures
15s: 16 runs so far, 0 failures
20s: 30 runs so far, 0 failures
25s: 32 runs so far, 0 failures
30s: 48 runs so far, 0 failures
35s: 54 runs so far, 0 failures
40s: 64 runs so far, 0 failures
45s: 75 runs so far, 0 failures
50s: 82 runs so far, 0 failures
55s: 94 runs so far, 0 failures
1m0s: 102 runs so far, 0 failures
1m5s: 112 runs so far, 0 failures
1m10s: 120 runs so far, 0 failures
1m15s: 132 runs so far, 0 failures
1m20s: 140 runs so far, 0 failures
1m25s: 150 runs so far, 0 failures
1m30s: 162 runs so far, 0 failures
1m35s: 168 runs so far, 0 failures
1m40s: 181 runs so far, 0 failures
1m45s: 189 runs so far, 0 failures
1m50s: 200 runs so far, 0 failures
1m55s: 208 runs so far, 0 failures
2m0s: 219 runs so far, 0 failures
2m5s: 229 runs so far, 0 failures
2m10s: 237 runs so far, 0 failures
2m15s: 248 runs so far, 0 failures
2m20s: 256 runs so far, 0 failures
2m25s: 268 runs so far, 0 failures
2m30s: 277 runs so far, 0 failures
2m35s: 287 runs so far, 0 failures
2m40s: 295 runs so far, 0 failures
2m45s: 307 runs so far, 0 failures
2m50s: 317 runs so far, 0 failures
2m55s: 326 runs so far, 0 failures
3m0s: 335 runs so far, 0 failures
3m5s: 345 runs so far, 0 failures
3m10s: 355 runs so far, 0 failures
3m15s: 366 runs so far, 0 failures
3m20s: 375 runs so far, 0 failures
3m25s: 384 runs so far, 0 failures
3m30s: 393 runs so far, 0 failures
3m35s: 403 runs so far, 0 failures
3m40s: 414 runs so far, 0 failures
3m45s: 422 runs so far, 0 failures
3m50s: 432 runs so far, 0 failures
3m55s: 442 runs so far, 0 failures
4m0s: 453 runs so far, 0 failures
4m5s: 462 runs so far, 0 failures
4m10s: 471 runs so far, 0 failures
4m15s: 481 runs so far, 0 failures
4m20s: 492 runs so far, 0 failures
4m25s: 502 runs so far, 0 failures
4m30s: 511 runs so far, 0 failures
4m35s: 521 runs so far, 0 failures
4m40s: 531 runs so far, 0 failures
4m45s: 542 runs so far, 0 failures
4m50s: 551 runs so far, 0 failures
4m55s: 561 runs so far, 0 failures
5m0s: 570 runs so far, 0 failures
5m5s: 579 runs so far, 0 failures
5m10s: 589 runs so far, 0 failures
5m15s: 599 runs so far, 0 failures
5m20s: 608 runs so far, 0 failures
5m25s: 616 runs so far, 0 failures
5m30s: 626 runs so far, 0 failures
5m35s: 636 runs so far, 0 failures
5m40s: 647 runs so far, 0 failures
5m45s: 655 runs so far, 0 failures
5m50s: 664 runs so far, 0 failures
5m55s: 674 runs so far, 0 failures
6m0s: 684 runs so far, 0 failures
6m5s: 694 runs so far, 0 failures
6m10s: 704 runs so far, 0 failures
6m15s: 712 runs so far, 0 failures
6m20s: 723 runs so far, 0 failures
6m25s: 733 runs so far, 0 failures
6m30s: 742 runs so far, 0 failures
6m35s: 754 runs so far, 0 failures
6m40s: 761 runs so far, 0 failures
6m45s: 772 runs so far, 0 failures
6m50s: 781 runs so far, 0 failures
6m55s: 791 runs so far, 0 failures
7m0s: 802 runs so far, 0 failures
7m5s: 810 runs so far, 0 failures
7m10s: 820 runs so far, 0 failures
7m15s: 829 runs so far, 0 failures
7m20s: 839 runs so far, 0 failures
7m25s: 850 runs so far, 0 failures
7m30s: 857 runs so far, 0 failures
7m35s: 868 runs so far, 0 failures
7m40s: 878 runs so far, 0 failures
7m45s: 888 runs so far, 0 failures
7m50s: 898 runs so far, 0 failures
7m55s: 907 runs so far, 0 failures
8m0s: 916 runs so far, 0 failures
</pre>
</details>

**Which issue(s) this PR fixes**:
Fixes #6931

**Special notes for your reviewer**:
The [logs](https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/batch/pull-gardener-integration/1583444048444657664) from the flaky test run say:

```
   Begin Captured GinkgoWriter Output >>
    STEP: Create Shoot 10/21/22 13:05:59.375
    {"level":"debug","ts":"2022-10-21T13:05:59.380Z","msg":"Updating shoot conditions","controller":"shoot-conditions","controllerGroup":"core.gardener.cloud","controllerKind":"Shoot","Shoot":{"name":"test-476ss","namespace":"garden"},"namespace":"garden","name":"test-476ss","reconcileID":"a22bb773-ac22-443d-8614-68af292ab3c6"}
    {"level":"info","ts":"2022-10-21T13:05:59.381Z","logger":"conditions-controller-test","msg":"Created shoot for test","shoot":{"namespace":"garden","name":"test-476ss"}}
    {"level":"info","ts":"2022-10-21T13:05:59.388Z","logger":"conditions-controller-test","msg":"Created ManagedSeed for test","managedSeed":{"namespace":"garden","name":"test-476ss"}}
    {"level":"info","ts":"2022-10-21T13:05:59.393Z","logger":"conditions-controller-test","msg":"Created Seed for test","seed":{"name":"test-476ss"}}
    STEP: Delete Seed 10/21/22 13:06:04.403
    {"level":"debug","ts":"2022-10-21T13:06:04.415Z","msg":"Updating shoot conditions","controller":"shoot-conditions","controllerGroup":"core.gardener.cloud","controllerKind":"Shoot","Shoot":{"name":"test-476ss","namespace":"garden"},"namespace":"garden","name":"test-476ss","reconcileID":"90529b67-4503-41ff-b876-8f945bafa060"}
    STEP: Delete ManagedSeed 10/21/22 13:06:04.416
    STEP: Delete Shoot 10/21/22 13:06:04.421
```

- `13:06:04.415` "msg":"Updating shoot conditions" --> updated the shoot conditions
- `13:06:04.416` STEP: Delete ManagedSeed --> already tears down the env through `DeferCleanup`, initialized by the test failure

Both events happen almost simultaneously which is why I think it was an unfortunate timing. The change in this PR buys us a little bit more time but if the test system is running short on resources, then the error might happen again.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
