### PR TITLE
Fix prometheus alerts for multi-node etcd

### DIFF
--- a/pkg/operation/botanist/component/etcd/monitoring.go
+++ b/pkg/operation/botanist/component/etcd/monitoring.go
@@ -176,7 +176,7 @@ const (
   {{- if .backupEnabled }}
   # etcd backup failure alerts
   - alert: KubeEtcdDeltaBackupFailed
-    expr: (time() - ` + monitoringMetricBackupRestoreSnapshotLatestTimestamp + `{job="` + monitoringPrometheusJobBackupRestoreNamePrefix + `-{{ .role }}",kind="Incr"} > bool 900) + (etcdbr_snapshot_required{job="` + monitoringPrometheusJobBackupRestoreNamePrefix + `-{{ .role }}", kind="Incr"} >= bool 1) == 2
+    expr: ((time() - ` + monitoringMetricBackupRestoreSnapshotLatestTimestamp + `{job="` + monitoringPrometheusJobBackupRestoreNamePrefix + `-{{ .role }}",kind="Incr"} > bool 900) + (etcdbr_snapshot_required{job="` + monitoringPrometheusJobBackupRestoreNamePrefix + `-{{ .role }}", kind="Incr"} >= bool 1) == 2) + on(pod,role) 0 * (` + monitoringMetricEtcdServerIsLeader + `{job="` + monitoringPrometheusJobEtcdNamePrefix + `-{{ .role }}" == 1 )
     for: 15m
     labels:
       service: etcd
@@ -184,10 +184,10 @@ const (
       type: seed
       visibility: operator
     annotations:
-      description: No delta snapshot for the past at least 30 minutes.
+      description: No delta snapshot for the past at least 30 minutes taken by backup-restore leader.
       summary: Etcd delta snapshot failure.
   - alert: KubeEtcdFullBackupFailed
-    expr: (time() - ` + monitoringMetricBackupRestoreSnapshotLatestTimestamp + `{job="` + monitoringPrometheusJobBackupRestoreNamePrefix + `-{{ .role }}",kind="Full"} > bool 86400) + (etcdbr_snapshot_required{job="` + monitoringPrometheusJobBackupRestoreNamePrefix + `-{{ .role }}", kind="Full"} >= bool 1) == 2
+    expr: ((time() - ` + monitoringMetricBackupRestoreSnapshotLatestTimestamp + `{job="` + monitoringPrometheusJobBackupRestoreNamePrefix + `-{{ .role }}",kind="Full"} > bool 86400) + (etcdbr_snapshot_required{job="` + monitoringPrometheusJobBackupRestoreNamePrefix + `-{{ .role }}", kind="Full"} >= bool 1) == 2) + on(pod,role) 0 * (` + monitoringMetricEtcdServerIsLeader + `{job="` + monitoringPrometheusJobEtcdNamePrefix + `-{{ .role }}" == 1 )
     for: 15m
     labels:
       service: etcd
@@ -195,7 +195,7 @@ const (
       type: seed
       visibility: operator
     annotations:
-      description: No full snapshot taken in the past day.
+      description: No full snapshot taken in the past day taken by backup-restore leader.
       summary: Etcd full snapshot failure.
 
   # etcd data restoration failure alert

--- a/pkg/operation/botanist/component/etcd/monitoring.go
+++ b/pkg/operation/botanist/component/etcd/monitoring.go
@@ -176,7 +176,7 @@ const (
   {{- if .backupEnabled }}
   # etcd backup failure alerts
   - alert: KubeEtcdDeltaBackupFailed
-    expr: ((time() - ` + monitoringMetricBackupRestoreSnapshotLatestTimestamp + `{job="` + monitoringPrometheusJobBackupRestoreNamePrefix + `-{{ .role }}",kind="Incr"} > bool 900) + (etcdbr_snapshot_required{job="` + monitoringPrometheusJobBackupRestoreNamePrefix + `-{{ .role }}", kind="Incr"} >= bool 1) == 2) + on(pod,role) 0 * (` + monitoringMetricEtcdServerIsLeader + `{job="` + monitoringPrometheusJobEtcdNamePrefix + `-{{ .role }}"} == 1 )
+    expr: ((time() - ` + monitoringMetricBackupRestoreSnapshotLatestTimestamp + `{job="` + monitoringPrometheusJobBackupRestoreNamePrefix + `-{{ .role }}",kind="Incr"} > bool 900) + (etcdbr_snapshot_required{job="` + monitoringPrometheusJobBackupRestoreNamePrefix + `-{{ .role }}", kind="Incr"} >= bool 1) == 2) + on(pod,role) group_left 0 * (` + monitoringMetricEtcdServerIsLeader + `{job="` + monitoringPrometheusJobEtcdNamePrefix + `-{{ .role }}"} == 1 )
     for: 15m
     labels:
       service: etcd
@@ -187,7 +187,7 @@ const (
       description: No delta snapshot for the past at least 30 minutes taken by backup-restore leader.
       summary: Etcd delta snapshot failure.
   - alert: KubeEtcdFullBackupFailed
-    expr: ((time() - ` + monitoringMetricBackupRestoreSnapshotLatestTimestamp + `{job="` + monitoringPrometheusJobBackupRestoreNamePrefix + `-{{ .role }}",kind="Full"} > bool 86400) + (etcdbr_snapshot_required{job="` + monitoringPrometheusJobBackupRestoreNamePrefix + `-{{ .role }}", kind="Full"} >= bool 1) == 2) + on(pod,role) 0 * (` + monitoringMetricEtcdServerIsLeader + `{job="` + monitoringPrometheusJobEtcdNamePrefix + `-{{ .role }}"} == 1 )
+    expr: ((time() - ` + monitoringMetricBackupRestoreSnapshotLatestTimestamp + `{job="` + monitoringPrometheusJobBackupRestoreNamePrefix + `-{{ .role }}",kind="Full"} > bool 86400) + (etcdbr_snapshot_required{job="` + monitoringPrometheusJobBackupRestoreNamePrefix + `-{{ .role }}", kind="Full"} >= bool 1) == 2) + on(pod,role) group_left 0 * (` + monitoringMetricEtcdServerIsLeader + `{job="` + monitoringPrometheusJobEtcdNamePrefix + `-{{ .role }}"} == 1 )
     for: 15m
     labels:
       service: etcd

--- a/pkg/operation/botanist/component/etcd/monitoring.go
+++ b/pkg/operation/botanist/component/etcd/monitoring.go
@@ -176,7 +176,7 @@ const (
   {{- if .backupEnabled }}
   # etcd backup failure alerts
   - alert: KubeEtcdDeltaBackupFailed
-    expr: ((time() - ` + monitoringMetricBackupRestoreSnapshotLatestTimestamp + `{job="` + monitoringPrometheusJobBackupRestoreNamePrefix + `-{{ .role }}",kind="Incr"} > bool 900) + (etcdbr_snapshot_required{job="` + monitoringPrometheusJobBackupRestoreNamePrefix + `-{{ .role }}", kind="Incr"} >= bool 1) == 2) + on(pod,role) 0 * (` + monitoringMetricEtcdServerIsLeader + `{job="` + monitoringPrometheusJobEtcdNamePrefix + `-{{ .role }}" == 1 )
+    expr: ((time() - ` + monitoringMetricBackupRestoreSnapshotLatestTimestamp + `{job="` + monitoringPrometheusJobBackupRestoreNamePrefix + `-{{ .role }}",kind="Incr"} > bool 900) + (etcdbr_snapshot_required{job="` + monitoringPrometheusJobBackupRestoreNamePrefix + `-{{ .role }}", kind="Incr"} >= bool 1) == 2) + on(pod,role) 0 * (` + monitoringMetricEtcdServerIsLeader + `{job="` + monitoringPrometheusJobEtcdNamePrefix + `-{{ .role }}"} == 1 )
     for: 15m
     labels:
       service: etcd
@@ -187,7 +187,7 @@ const (
       description: No delta snapshot for the past at least 30 minutes taken by backup-restore leader.
       summary: Etcd delta snapshot failure.
   - alert: KubeEtcdFullBackupFailed
-    expr: ((time() - ` + monitoringMetricBackupRestoreSnapshotLatestTimestamp + `{job="` + monitoringPrometheusJobBackupRestoreNamePrefix + `-{{ .role }}",kind="Full"} > bool 86400) + (etcdbr_snapshot_required{job="` + monitoringPrometheusJobBackupRestoreNamePrefix + `-{{ .role }}", kind="Full"} >= bool 1) == 2) + on(pod,role) 0 * (` + monitoringMetricEtcdServerIsLeader + `{job="` + monitoringPrometheusJobEtcdNamePrefix + `-{{ .role }}" == 1 )
+    expr: ((time() - ` + monitoringMetricBackupRestoreSnapshotLatestTimestamp + `{job="` + monitoringPrometheusJobBackupRestoreNamePrefix + `-{{ .role }}",kind="Full"} > bool 86400) + (etcdbr_snapshot_required{job="` + monitoringPrometheusJobBackupRestoreNamePrefix + `-{{ .role }}", kind="Full"} >= bool 1) == 2) + on(pod,role) 0 * (` + monitoringMetricEtcdServerIsLeader + `{job="` + monitoringPrometheusJobEtcdNamePrefix + `-{{ .role }}"} == 1 )
     for: 15m
     labels:
       service: etcd

--- a/pkg/operation/botanist/component/etcd/monitoring_test.go
+++ b/pkg/operation/botanist/component/etcd/monitoring_test.go
@@ -373,7 +373,7 @@ metric_relabel_configs:
 
 	alertingRulesBackup = `  # etcd backup failure alerts
   - alert: KubeEtcdDeltaBackupFailed
-    expr: ((time() - etcdbr_snapshot_latest_timestamp{job="kube-etcd3-backup-restore-` + testRole + `",kind="Incr"} > bool 900) + (etcdbr_snapshot_required{job="kube-etcd3-backup-restore-` + testRole + `", kind="Incr"} >= bool 1) == 2) + on(pod,role) 0 * (etcd_server_is_leader{job="kube-etcd3-` + testRole + `" == 1 )
+    expr: ((time() - etcdbr_snapshot_latest_timestamp{job="kube-etcd3-backup-restore-` + testRole + `",kind="Incr"} > bool 900) + (etcdbr_snapshot_required{job="kube-etcd3-backup-restore-` + testRole + `", kind="Incr"} >= bool 1) == 2) + on(pod,role) group_left 0 * (etcd_server_is_leader{job="kube-etcd3-` + testRole + `"} == 1 )
     for: 15m
     labels:
       service: etcd
@@ -384,7 +384,7 @@ metric_relabel_configs:
       description: No delta snapshot for the past at least 30 minutes taken by backup-restore leader.
       summary: Etcd delta snapshot failure.
   - alert: KubeEtcdFullBackupFailed
-    expr: ((time() - etcdbr_snapshot_latest_timestamp{job="kube-etcd3-backup-restore-` + testRole + `",kind="Full"} > bool 86400) + (etcdbr_snapshot_required{job="kube-etcd3-backup-restore-` + testRole + `", kind="Full"} >= bool 1) == 2) + on(pod,role) 0 * (etcd_server_is_leader{job="kube-etcd3-` + testRole + `" == 1 )
+    expr: ((time() - etcdbr_snapshot_latest_timestamp{job="kube-etcd3-backup-restore-` + testRole + `",kind="Full"} > bool 86400) + (etcdbr_snapshot_required{job="kube-etcd3-backup-restore-` + testRole + `", kind="Full"} >= bool 1) == 2) + on(pod,role) group_left 0 * (etcd_server_is_leader{job="kube-etcd3-` + testRole + `"} == 1 )
     for: 15m
     labels:
       service: etcd

--- a/pkg/operation/botanist/component/etcd/monitoring_test.go
+++ b/pkg/operation/botanist/component/etcd/monitoring_test.go
@@ -373,7 +373,7 @@ metric_relabel_configs:
 
 	alertingRulesBackup = `  # etcd backup failure alerts
   - alert: KubeEtcdDeltaBackupFailed
-    expr: (time() - etcdbr_snapshot_latest_timestamp{job="kube-etcd3-backup-restore-` + testRole + `",kind="Incr"} > bool 900) + (etcdbr_snapshot_required{job="kube-etcd3-backup-restore-` + testRole + `", kind="Incr"} >= bool 1) == 2
+    expr: ((time() - etcdbr_snapshot_latest_timestamp{job="kube-etcd3-backup-restore-` + testRole + `",kind="Incr"} > bool 900) + (etcdbr_snapshot_required{job="kube-etcd3-backup-restore-` + testRole + `", kind="Incr"} >= bool 1) == 2) + on(pod,role) 0 * (etcd_server_is_leader{job="kube-etcd3-` + testRole + `" == 1 )
     for: 15m
     labels:
       service: etcd
@@ -381,10 +381,10 @@ metric_relabel_configs:
       type: seed
       visibility: operator
     annotations:
-      description: No delta snapshot for the past at least 30 minutes.
+      description: No delta snapshot for the past at least 30 minutes taken by backup-restore leader.
       summary: Etcd delta snapshot failure.
   - alert: KubeEtcdFullBackupFailed
-    expr: (time() - etcdbr_snapshot_latest_timestamp{job="kube-etcd3-backup-restore-` + testRole + `",kind="Full"} > bool 86400) + (etcdbr_snapshot_required{job="kube-etcd3-backup-restore-` + testRole + `", kind="Full"} >= bool 1) == 2
+    expr: ((time() - etcdbr_snapshot_latest_timestamp{job="kube-etcd3-backup-restore-` + testRole + `",kind="Full"} > bool 86400) + (etcdbr_snapshot_required{job="kube-etcd3-backup-restore-` + testRole + `", kind="Full"} >= bool 1) == 2) + on(pod,role) 0 * (etcd_server_is_leader{job="kube-etcd3-` + testRole + `" == 1 )
     for: 15m
     labels:
       service: etcd
@@ -392,7 +392,7 @@ metric_relabel_configs:
       type: seed
       visibility: operator
     annotations:
-      description: No full snapshot taken in the past day.
+      description: No full snapshot taken in the past day taken by backup-restore leader.
       summary: Etcd full snapshot failure.
 
   # etcd data restoration failure alert

--- a/pkg/operation/botanist/component/etcd/testdata/monitoring_alertingrules_important_multinode_with_backup.yaml
+++ b/pkg/operation/botanist/component/etcd/testdata/monitoring_alertingrules_important_multinode_with_backup.yaml
@@ -32,7 +32,7 @@ tests:
   - series: 'etcdbr_snapshot_required{job="kube-etcd3-backup-restore-test",kind="Full",pod="etcd",role="test"}'
     values: '1+0x2912'
   - series: 'etcd_server_is_leader{job="kube-etcd3-test",pod="etcd",role="test"}'
-    values: '1+0x100'
+    values: '1+0x2912'
   # KubeEtcdRestorationFailed
   - series: 'etcdbr_restoration_duration_seconds_count{job="kube-etcd3-backup-restore-test",succeeded="false"}'
     values: '0+0x7 1 2 2'
@@ -100,6 +100,8 @@ tests:
     alertname: KubeEtcdDeltaBackupFailed
     exp_alerts:
     - exp_labels:
+        pod: etcd
+        role: test
         job: kube-etcd3-backup-restore-test
         kind: Incr
         service: etcd
@@ -113,6 +115,8 @@ tests:
     alertname: KubeEtcdFullBackupFailed
     exp_alerts:
     - exp_labels:
+        pod: etcd
+        role: test
         job: kube-etcd3-backup-restore-test
         kind: Full
         service: etcd

--- a/pkg/operation/botanist/component/etcd/testdata/monitoring_alertingrules_important_multinode_with_backup.yaml
+++ b/pkg/operation/botanist/component/etcd/testdata/monitoring_alertingrules_important_multinode_with_backup.yaml
@@ -20,15 +20,19 @@ tests:
   - series: 'etcd_mvcc_db_total_size_in_bytes{job="kube-etcd3-test"}'
     values: '7194070000+107374182x20' # 6.7GB 6.8GB 6.9GB .. 7.7GB
   # KubeEtcdDeltaBackupFailed
-  - series: 'etcdbr_snapshot_latest_timestamp{job="kube-etcd3-backup-restore-test",kind="Incr"}'
+  - series: 'etcdbr_snapshot_latest_timestamp{job="kube-etcd3-backup-restore-test",kind="Incr",pod="etcd",role="test"}'
     values: '0+0x62'
-  - series: 'etcdbr_snapshot_required{job="kube-etcd3-backup-restore-test",kind="Incr"}'
+  - series: 'etcdbr_snapshot_required{job="kube-etcd3-backup-restore-test",kind="Incr",pod="etcd",role="test"}'
     values: '1+0x62'
+  - series: 'etcd_server_is_leader{job="kube-etcd3-test", pod="etcd",role="test"}'
+    values: '1+0x100'
   # KubeEtcdFullBackupFailed
-  - series: 'etcdbr_snapshot_latest_timestamp{job="kube-etcd3-backup-restore-test",kind="Full"}'
+  - series: 'etcdbr_snapshot_latest_timestamp{job="kube-etcd3-backup-restore-test",kind="Full",pod="etcd",role="test"}'
     values: '0+0x2912'
-  - series: 'etcdbr_snapshot_required{job="kube-etcd3-backup-restore-test",kind="Full"}'
+  - series: 'etcdbr_snapshot_required{job="kube-etcd3-backup-restore-test",kind="Full",pod="etcd",role="test"}'
     values: '1+0x2912'
+  - series: 'etcd_server_is_leader{job="kube-etcd3-test",pod="etcd",role="test"}'
+    values: '1+0x100'
   # KubeEtcdRestorationFailed
   - series: 'etcdbr_restoration_duration_seconds_count{job="kube-etcd3-backup-restore-test",succeeded="false"}'
     values: '0+0x7 1 2 2'
@@ -103,7 +107,7 @@ tests:
         type: seed
         visibility: operator
       exp_annotations:
-        description: No delta snapshot for the past at least 30 minutes.
+        description: No delta snapshot for the past at least 30 minutes taken by backup-restore leader.
         summary: Etcd delta snapshot failure.
   - eval_time: 1456m
     alertname: KubeEtcdFullBackupFailed
@@ -116,7 +120,7 @@ tests:
         type: seed
         visibility: operator
       exp_annotations:
-        description: No full snapshot taken in the past day.
+        description: No full snapshot taken in the past day taken by backup-restore leader.
         summary: Etcd full snapshot failure.
   - eval_time: 5m
     alertname: KubeEtcdRestorationFailed

--- a/pkg/operation/botanist/component/etcd/testdata/monitoring_alertingrules_important_singlenode_with_backup.yaml
+++ b/pkg/operation/botanist/component/etcd/testdata/monitoring_alertingrules_important_singlenode_with_backup.yaml
@@ -25,11 +25,13 @@ tests:
   - series: 'etcdbr_snapshot_required{job="kube-etcd3-backup-restore-test",kind="Incr", pod="etcd", role="test"}'
     values: '1+0x62'
   - series: 'etcd_server_is_leader{job="kube-etcd3-test", pod="etcd", role="test"}'
-    values: '1+0x30'
+    values: '1+0x62'
   # KubeEtcdFullBackupFailed
-  - series: 'etcdbr_snapshot_latest_timestamp{job="kube-etcd3-backup-restore-test",kind="Full"}'
+  - series: 'etcdbr_snapshot_latest_timestamp{job="kube-etcd3-backup-restore-test",kind="Full", pod="etcd", role="test"}'
     values: '0+0x2912'
-  - series: 'etcdbr_snapshot_required{job="kube-etcd3-backup-restore-test",kind="Full"}'
+  - series: 'etcdbr_snapshot_required{job="kube-etcd3-backup-restore-test",kind="Full", pod="etcd", role="test"}'
+    values: '1+0x2912'
+  - series: 'etcd_server_is_leader{job="kube-etcd3-test", pod="etcd", role="test"}'
     values: '1+0x2912'
   # KubeEtcdRestorationFailed
   - series: 'etcdbr_restoration_duration_seconds_count{job="kube-etcd3-backup-restore-test",succeeded="false"}'
@@ -98,6 +100,8 @@ tests:
     alertname: KubeEtcdDeltaBackupFailed
     exp_alerts:
     - exp_labels:
+        pod: etcd
+        role: test
         job: kube-etcd3-backup-restore-test
         kind: Incr
         service: etcd
@@ -105,12 +109,14 @@ tests:
         type: seed
         visibility: operator
       exp_annotations:
-        description: No delta snapshot for the past at least 30 minutes.
+        description: No delta snapshot for the past at least 30 minutes taken by backup-restore leader.
         summary: Etcd delta snapshot failure.
   - eval_time: 1456m
     alertname: KubeEtcdFullBackupFailed
     exp_alerts:
     - exp_labels:
+        pod: etcd
+        role: test
         job: kube-etcd3-backup-restore-test
         kind: Full
         service: etcd
@@ -118,7 +124,7 @@ tests:
         type: seed
         visibility: operator
       exp_annotations:
-        description: No full snapshot taken in the past day.
+        description: No full snapshot taken in the past day taken by backup-restore leader.
         summary: Etcd full snapshot failure.
   - eval_time: 5m
     alertname: KubeEtcdRestorationFailed

--- a/pkg/operation/botanist/component/etcd/testdata/monitoring_alertingrules_important_singlenode_with_backup.yaml
+++ b/pkg/operation/botanist/component/etcd/testdata/monitoring_alertingrules_important_singlenode_with_backup.yaml
@@ -20,10 +20,12 @@ tests:
   - series: 'etcd_mvcc_db_total_size_in_bytes{job="kube-etcd3-test"}'
     values: '7194070000+107374182x20' # 6.7GB 6.8GB 6.9GB .. 7.7GB
   # KubeEtcdDeltaBackupFailed
-  - series: 'etcdbr_snapshot_latest_timestamp{job="kube-etcd3-backup-restore-test",kind="Incr"}'
+  - series: 'etcdbr_snapshot_latest_timestamp{job="kube-etcd3-backup-restore-test",kind="Incr", pod="etcd", role="test"}'
     values: '0+0x62'
-  - series: 'etcdbr_snapshot_required{job="kube-etcd3-backup-restore-test",kind="Incr"}'
+  - series: 'etcdbr_snapshot_required{job="kube-etcd3-backup-restore-test",kind="Incr", pod="etcd", role="test"}'
     values: '1+0x62'
+  - series: 'etcd_server_is_leader{job="kube-etcd3-test", pod="etcd", role="test"}'
+    values: '1+0x30'
   # KubeEtcdFullBackupFailed
   - series: 'etcdbr_snapshot_latest_timestamp{job="kube-etcd3-backup-restore-test",kind="Full"}'
     values: '0+0x2912'

--- a/pkg/operation/botanist/component/etcd/testdata/monitoring_alertingrules_normal_multinode_with_backup.yaml
+++ b/pkg/operation/botanist/component/etcd/testdata/monitoring_alertingrules_normal_multinode_with_backup.yaml
@@ -21,15 +21,19 @@ tests:
   - series: 'etcd_mvcc_db_total_size_in_bytes{job="kube-etcd3-test"}'
     values: '7194070000+107374182x20' # 6.7GB 6.8GB 6.9GB .. 7.7GB
   # KubeEtcdDeltaBackupFailed
-  - series: 'etcdbr_snapshot_latest_timestamp{job="kube-etcd3-backup-restore-test",kind="Incr"}'
+  - series: 'etcdbr_snapshot_latest_timestamp{job="kube-etcd3-backup-restore-test",kind="Incr", pod="etcd", role="test"}'
     values: '0+0x62'
-  - series: 'etcdbr_snapshot_required{job="kube-etcd3-backup-restore-test",kind="Incr"}'
+  - series: 'etcdbr_snapshot_required{job="kube-etcd3-backup-restore-test",kind="Incr", pod="etcd", role="test"}'
     values: '1+0x62'
+  - series: 'etcd_server_is_leader{job="kube-etcd3-test", pod="etcd", role="test"}'
+    values: '1+0x70'
   # KubeEtcdFullBackupFailed
-  - series: 'etcdbr_snapshot_latest_timestamp{job="kube-etcd3-backup-restore-test",kind="Full"}'
+  - series: 'etcdbr_snapshot_latest_timestamp{job="kube-etcd3-backup-restore-test",kind="Full", pod="etcd", role="test"}'
     values: '0+0x2912'
-  - series: 'etcdbr_snapshot_required{job="kube-etcd3-backup-restore-test",kind="Full"}'
+  - series: 'etcdbr_snapshot_required{job="kube-etcd3-backup-restore-test",kind="Full", pod="etcd", role="test"}'
     values: '1+0x2912'
+  - series: 'etcd_server_is_leader{job="kube-etcd3-test", pod="etcd", role="test"}'
+    values: '1+0x70'
   # KubeEtcdRestorationFailed
   - series: 'etcdbr_restoration_duration_seconds_count{job="kube-etcd3-backup-restore-test",succeeded="false"}'
     values: '0+0x7 1 2 2'
@@ -109,7 +113,7 @@ tests:
         type: seed
         visibility: operator
       exp_annotations:
-        description: No delta snapshot for the past at least 30 minutes.
+        description: No delta snapshot for the past at least 30 minutes by backup-restore leader.
         summary: Etcd delta snapshot failure.
   - eval_time: 1456m
     alertname: KubeEtcdFullBackupFailed
@@ -122,7 +126,7 @@ tests:
         type: seed
         visibility: operator
       exp_annotations:
-        description: No full snapshot taken in the past day.
+        description: No full snapshot taken in the past day by backup-restore leader.
         summary: Etcd full snapshot failure.
   - eval_time: 5m
     alertname: KubeEtcdRestorationFailed

--- a/pkg/operation/botanist/component/etcd/testdata/monitoring_alertingrules_normal_multinode_with_backup.yaml
+++ b/pkg/operation/botanist/component/etcd/testdata/monitoring_alertingrules_normal_multinode_with_backup.yaml
@@ -33,7 +33,7 @@ tests:
   - series: 'etcdbr_snapshot_required{job="kube-etcd3-backup-restore-test",kind="Full", pod="etcd", role="test"}'
     values: '1+0x2912'
   - series: 'etcd_server_is_leader{job="kube-etcd3-test", pod="etcd", role="test"}'
-    values: '1+0x70'
+    values: '1+0x2912'
   # KubeEtcdRestorationFailed
   - series: 'etcdbr_restoration_duration_seconds_count{job="kube-etcd3-backup-restore-test",succeeded="false"}'
     values: '0+0x7 1 2 2'
@@ -106,6 +106,8 @@ tests:
     alertname: KubeEtcdDeltaBackupFailed
     exp_alerts:
     - exp_labels:
+        pod: etcd
+        role: test
         job: kube-etcd3-backup-restore-test
         kind: Incr
         service: etcd
@@ -113,12 +115,14 @@ tests:
         type: seed
         visibility: operator
       exp_annotations:
-        description: No delta snapshot for the past at least 30 minutes by backup-restore leader.
+        description: No delta snapshot for the past at least 30 minutes taken by backup-restore leader.
         summary: Etcd delta snapshot failure.
   - eval_time: 1456m
     alertname: KubeEtcdFullBackupFailed
     exp_alerts:
     - exp_labels:
+        pod: etcd
+        role: test
         job: kube-etcd3-backup-restore-test
         kind: Full
         service: etcd
@@ -126,7 +130,7 @@ tests:
         type: seed
         visibility: operator
       exp_annotations:
-        description: No full snapshot taken in the past day by backup-restore leader.
+        description: No full snapshot taken in the past day taken by backup-restore leader.
         summary: Etcd full snapshot failure.
   - eval_time: 5m
     alertname: KubeEtcdRestorationFailed

--- a/pkg/operation/botanist/component/etcd/testdata/monitoring_alertingrules_normal_singlenode_with_backup.yaml
+++ b/pkg/operation/botanist/component/etcd/testdata/monitoring_alertingrules_normal_singlenode_with_backup.yaml
@@ -26,14 +26,14 @@ tests:
   - series: 'etcdbr_snapshot_required{job="kube-etcd3-backup-restore-test",kind="Incr", pod="etcd", role="test"}'
     values: '1+0x62'
   - series: 'etcd_server_is_leader{job="kube-etcd3-test", pod="etcd", role="test"}'
-    values: '1+0x30'
+    values: '1+0x62'
   # KubeEtcdFullBackupFailed
   - series: 'etcdbr_snapshot_latest_timestamp{job="kube-etcd3-backup-restore-test",kind="Full", pod="etcd", role="test"}'
     values: '0+0x2912'
   - series: 'etcdbr_snapshot_required{job="kube-etcd3-backup-restore-test",kind="Full", pod="etcd", role="test"}'
     values: '1+0x2912'
   - series: 'etcd_server_is_leader{job="kube-etcd3-test", pod="etcd", role="test"}'
-    values: '1+0x30'
+    values: '1+0x2912'
   # KubeEtcdRestorationFailed
   - series: 'etcdbr_restoration_duration_seconds_count{job="kube-etcd3-backup-restore-test",succeeded="false"}'
     values: '0+0x7 1 2 2'
@@ -106,6 +106,8 @@ tests:
     alertname: KubeEtcdDeltaBackupFailed
     exp_alerts:
     - exp_labels:
+        pod: etcd
+        role: test
         job: kube-etcd3-backup-restore-test
         kind: Incr
         service: etcd
@@ -113,12 +115,14 @@ tests:
         type: seed
         visibility: operator
       exp_annotations:
-        description: No delta snapshot for the past at least 30 minutes.
+        description: No delta snapshot for the past at least 30 minutes taken by backup-restore leader.
         summary: Etcd delta snapshot failure.
   - eval_time: 1456m
     alertname: KubeEtcdFullBackupFailed
     exp_alerts:
     - exp_labels:
+        pod: etcd
+        role: test
         job: kube-etcd3-backup-restore-test
         kind: Full
         service: etcd
@@ -126,7 +130,7 @@ tests:
         type: seed
         visibility: operator
       exp_annotations:
-        description: No full snapshot taken in the past day.
+        description: No full snapshot taken in the past day taken by backup-restore leader.
         summary: Etcd full snapshot failure.
   - eval_time: 5m
     alertname: KubeEtcdRestorationFailed

--- a/pkg/operation/botanist/component/etcd/testdata/monitoring_alertingrules_normal_singlenode_with_backup.yaml
+++ b/pkg/operation/botanist/component/etcd/testdata/monitoring_alertingrules_normal_singlenode_with_backup.yaml
@@ -21,15 +21,19 @@ tests:
   - series: 'etcd_mvcc_db_total_size_in_bytes{job="kube-etcd3-test"}'
     values: '7194070000+107374182x20' # 6.7GB 6.8GB 6.9GB .. 7.7GB
   # KubeEtcdDeltaBackupFailed
-  - series: 'etcdbr_snapshot_latest_timestamp{job="kube-etcd3-backup-restore-test",kind="Incr"}'
+  - series: 'etcdbr_snapshot_latest_timestamp{job="kube-etcd3-backup-restore-test",kind="Incr", pod="etcd", role="test"}'
     values: '0+0x62'
-  - series: 'etcdbr_snapshot_required{job="kube-etcd3-backup-restore-test",kind="Incr"}'
+  - series: 'etcdbr_snapshot_required{job="kube-etcd3-backup-restore-test",kind="Incr", pod="etcd", role="test"}'
     values: '1+0x62'
+  - series: 'etcd_server_is_leader{job="kube-etcd3-test", pod="etcd", role="test"}'
+    values: '1+0x30'
   # KubeEtcdFullBackupFailed
-  - series: 'etcdbr_snapshot_latest_timestamp{job="kube-etcd3-backup-restore-test",kind="Full"}'
+  - series: 'etcdbr_snapshot_latest_timestamp{job="kube-etcd3-backup-restore-test",kind="Full", pod="etcd", role="test"}'
     values: '0+0x2912'
-  - series: 'etcdbr_snapshot_required{job="kube-etcd3-backup-restore-test",kind="Full"}'
+  - series: 'etcdbr_snapshot_required{job="kube-etcd3-backup-restore-test",kind="Full", pod="etcd", role="test"}'
     values: '1+0x2912'
+  - series: 'etcd_server_is_leader{job="kube-etcd3-test", pod="etcd", role="test"}'
+    values: '1+0x30'
   # KubeEtcdRestorationFailed
   - series: 'etcdbr_restoration_duration_seconds_count{job="kube-etcd3-backup-restore-test",succeeded="false"}'
     values: '0+0x7 1 2 2'


### PR DESCRIPTION
**How to categorize this PR?**
/area monitoring
/kind enhancement

**What this PR does / why we need it**:
In etcd cluster, only backup-restore leader is allowed to take delta/full snapshots but it has been observed that prometheus alerts are also active for backup-restore followers and as they are not taking any backups since they are followers, this leads to false prometheus alerts of backup not taken.
This PR enhance the prometheus alerts: `KubeEtcdDeltaBackupFailed` and `KubeEtcdFullBackupFailed` , so it should be only active for the backup-restore leader. 
 
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
cc @istvanballok @shreyas-s-rao 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
