### PR TITLE
Fix flaky `Extensions Webhook Certificates` integration tests

### DIFF
--- a/test/integration/extensions/webhook/certificates/certificates_test.go
+++ b/test/integration/extensions/webhook/certificates/certificates_test.go
@@ -217,6 +217,12 @@ var _ = Describe("Certificates tests", func() {
 				Expect(mgr.Start(mgrContext)).To(Succeed())
 			}()
 
+			// Wait for the webhook server to start
+			Eventually(func() error {
+				checker := mgr.GetWebhookServer().StartedChecker()
+				return checker(&http.Request{})
+			}).Should(BeNil())
+
 			DeferCleanup(func() {
 				By("stopping manager")
 				mgrCancel()
@@ -378,6 +384,12 @@ var _ = Describe("Certificates tests", func() {
 				defer GinkgoRecover()
 				Expect(mgr.Start(mgrContext)).To(Succeed())
 			}()
+
+			// Wait for the webhook server to start
+			Eventually(func() error {
+				checker := mgr.GetWebhookServer().StartedChecker()
+				return checker(&http.Request{})
+			}).Should(BeNil())
 
 			DeferCleanup(func() {
 				By("stopping manager")

--- a/test/integration/extensions/webhook/certificates/certificates_test.go
+++ b/test/integration/extensions/webhook/certificates/certificates_test.go
@@ -199,13 +199,15 @@ var _ = Describe("Certificates tests", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("verifying certificates exist on disk")
-			serverCert, err := os.ReadFile(filepath.Join(mgr.GetWebhookServer().CertDir, "tls.crt"))
-			Expect(err).NotTo(HaveOccurred())
-			Expect(serverCert).NotTo(BeEmpty())
+			Eventually(func(g Gomega) {
+				serverCert, err := os.ReadFile(filepath.Join(mgr.GetWebhookServer().CertDir, "tls.crt"))
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(serverCert).NotTo(BeEmpty())
 
-			serverKey, err := os.ReadFile(filepath.Join(mgr.GetWebhookServer().CertDir, "tls.key"))
-			Expect(err).NotTo(HaveOccurred())
-			Expect(serverKey).NotTo(BeEmpty())
+				serverKey, err := os.ReadFile(filepath.Join(mgr.GetWebhookServer().CertDir, "tls.key"))
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(serverKey).NotTo(BeEmpty())
+			}).Should(Succeed())
 
 			By("starting manager")
 			mgrContext, mgrCancel := context.WithCancel(ctx)
@@ -357,13 +359,15 @@ var _ = Describe("Certificates tests", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("verifying certificates exist on disk")
-			serverCert, err := os.ReadFile(filepath.Join(mgr.GetWebhookServer().CertDir, "tls.crt"))
-			Expect(err).NotTo(HaveOccurred())
-			Expect(serverCert).NotTo(BeEmpty())
+			Eventually(func(g Gomega) {
+				serverCert, err := os.ReadFile(filepath.Join(mgr.GetWebhookServer().CertDir, "tls.crt"))
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(serverCert).NotTo(BeEmpty())
 
-			serverKey, err := os.ReadFile(filepath.Join(mgr.GetWebhookServer().CertDir, "tls.key"))
-			Expect(err).NotTo(HaveOccurred())
-			Expect(serverKey).NotTo(BeEmpty())
+				serverKey, err := os.ReadFile(filepath.Join(mgr.GetWebhookServer().CertDir, "tls.key"))
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(serverKey).NotTo(BeEmpty())
+			}).Should(Succeed())
 
 			By("starting manager")
 			mgrContext, mgrCancel := context.WithCancel(ctx)

--- a/test/integration/extensions/webhook/certificates/certificates_test.go
+++ b/test/integration/extensions/webhook/certificates/certificates_test.go
@@ -36,6 +36,7 @@ import (
 	secretutils "github.com/gardener/gardener/pkg/utils/secrets"
 	"github.com/gardener/gardener/pkg/utils/test"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
+	"k8s.io/apimachinery/pkg/util/uuid"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -56,7 +57,6 @@ import (
 const (
 	servicePort = 12345
 
-	extensionName                   = "provider-test"
 	extensionType                   = "test"
 	shootWebhookManagedResourceName = "extension-provider-test-shoot-webhooks"
 
@@ -73,6 +73,7 @@ var _ = Describe("Certificates tests", func() {
 		codec     = newCodec(kubernetes.SeedScheme, kubernetes.SeedCodec, kubernetes.SeedSerializer)
 		fakeClock *testclock.FakeClock
 
+		extensionName      string
 		extensionNamespace *corev1.Namespace
 		shootNamespace     *corev1.Namespace
 		cluster            *extensionsv1alpha1.Cluster
@@ -125,6 +126,9 @@ var _ = Describe("Certificates tests", func() {
 	})
 
 	BeforeEach(func() {
+		// use unique extension name for each test,for unique webhook config name
+		extensionName = "provider-test-" + utils.ComputeSHA256Hex([]byte(uuid.NewUUID()))[:8]
+
 		fakeClock = testclock.NewFakeClock(time.Now())
 
 		cluster = &extensionsv1alpha1.Cluster{
@@ -292,7 +296,7 @@ var _ = Describe("Certificates tests", func() {
 	Context("run with seed webhook", func() {
 		BeforeEach(func() {
 			seedWebhook = admissionregistrationv1.MutatingWebhook{
-				Name: fmt.Sprintf("%s.%s.extensions.gardener.cloud", seedWebhookName, extensionType),
+				Name: fmt.Sprintf("%s.%s.extensions.gardener.cloud", seedWebhookName, strings.TrimPrefix(extensionName, "provider-")),
 				ClientConfig: admissionregistrationv1.WebhookClientConfig{
 					Service: &admissionregistrationv1.ServiceReference{
 						Name:      "gardener-extension-" + extensionName,

--- a/test/integration/extensions/webhook/certificates/certificates_test.go
+++ b/test/integration/extensions/webhook/certificates/certificates_test.go
@@ -314,13 +314,15 @@ var _ = Describe("Certificates tests", func() {
 					},
 				},
 				AdmissionReviewVersions: []string{"v1", "v1beta1"},
-				FailurePolicy:           &failurePolicyFail,
-				MatchPolicy:             &matchPolicyExact,
-				SideEffects:             &sideEffectsNone,
-				TimeoutSeconds:          &timeoutSeconds,
-				ReinvocationPolicy:      &reinvocationPolicy,
-				NamespaceSelector:       &metav1.LabelSelector{},
-				ObjectSelector:          &metav1.LabelSelector{},
+				// here variable failurePolicyFail can't be used as it can be overwritten to
+				// `Ignore` by previous tests
+				FailurePolicy:      (*admissionregistrationv1.FailurePolicyType)(pointer.String("Fail")),
+				MatchPolicy:        &matchPolicyExact,
+				SideEffects:        &sideEffectsNone,
+				TimeoutSeconds:     &timeoutSeconds,
+				ReinvocationPolicy: &reinvocationPolicy,
+				NamespaceSelector:  &metav1.LabelSelector{},
+				ObjectSelector:     &metav1.LabelSelector{},
 			}
 
 			seedWebhookConfig = &admissionregistrationv1.MutatingWebhookConfiguration{

--- a/test/integration/extensions/webhook/certificates/certificates_test.go
+++ b/test/integration/extensions/webhook/certificates/certificates_test.go
@@ -246,14 +246,14 @@ var _ = Describe("Certificates tests", func() {
 			})
 
 			It("should rotate the certificates and update the webhook configs", func() {
-				var caBundle1, caBundle2, serverCert1 []byte
+				var serverCert1 []byte
 
 				By("retrieving CA bundle (before first reconciliation)")
 
 				Eventually(func(g Gomega) []byte {
 					g.Expect(getShootWebhookConfig(codec, shootWebhookConfig, shootNamespace.Name)).To(Succeed())
 					return shootWebhookConfig.Webhooks[0].ClientConfig.CABundle
-				}).Should(Equal(caBundle1))
+				}).Should(Not(BeEmpty()))
 
 				By("reading generated server certificate from disk")
 				Eventually(func(g Gomega) []byte {
@@ -274,7 +274,7 @@ var _ = Describe("Certificates tests", func() {
 				Eventually(func(g Gomega) []byte {
 					g.Expect(getShootWebhookConfig(codec, shootWebhookConfig, shootNamespace.Name)).To(Succeed())
 					return shootWebhookConfig.Webhooks[0].ClientConfig.CABundle
-				}).Should(Equal(caBundle2))
+				}).Should(Not(BeEmpty()))
 
 				By("reading re-generated server certificate from disk")
 				Eventually(func(g Gomega) []byte {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind flake

**What this PR does / why we need it**:
This PR fixes flakes of `Extensions Webhook Certificates` integration test.

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener/issues/6932

**Special notes for your reviewer**:
> `stress -ignore "unable to grab random port | bind: address already in use" -p 8 ./test/integration/extensions/webhook/certificates/certificates.test`

`bind: address already in use` is ignored so the test failing because of port already being used is not counted.
also I am using this config to prevent it 
```
WebhookServer: &webhook.Server{
       Port: rand.Intn(1000) + 9000,
},
```

Result on master for:

```
.
.
2m45s: 158 runs so far, 6 failures (3.80%)
2m50s: 163 runs so far, 6 failures (3.68%)
```
After the changes:
```
4m45s: 266 runs so far, 0 failures
4m50s: 271 runs so far, 0 failures
4m55s: 277 runs so far, 0 failures
.
.
8m25s: 473 runs so far, 0 failures
```

Also, only 8 test is being run in the parallel cause when running more tests some times secret manager fails to restart cause informers failed to sync.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
