### PR TITLE
Set force-deletion annotation on source BackupEntry

### DIFF
--- a/pkg/operation/botanist/backupentry.go
+++ b/pkg/operation/botanist/backupentry.go
@@ -102,5 +102,9 @@ func (b *Botanist) DestroySourceBackupEntry(ctx context.Context) error {
 		return nil
 	}
 
+	if err := b.Shoot.Components.SourceBackupEntry.SetForceDeletionAnnotation(ctx); err != nil {
+		return err
+	}
+
 	return b.Shoot.Components.SourceBackupEntry.Destroy(ctx)
 }

--- a/pkg/operation/botanist/backupentry_test.go
+++ b/pkg/operation/botanist/backupentry_test.go
@@ -87,7 +87,6 @@ var _ = Describe("BackupEntry", func() {
 	})
 
 	Describe("#DestroySourceBackupEntry", func() {
-
 		It("shouldn't destroy the SourceBackupEntry component when CopyEtcdBackupsDuringControlPlaneMigration=false", func() {
 			defer test.WithFeatureGate(gardenletfeatures.FeatureGate, features.CopyEtcdBackupsDuringControlPlaneMigration, false)()
 
@@ -128,9 +127,10 @@ var _ = Describe("BackupEntry", func() {
 			Expect(botanist.DestroySourceBackupEntry(ctx)).To(Succeed())
 		})
 
-		It("should destroy the SourceBackupEntry component", func() {
+		It("should set force-deletion annotation and destroy the SourceBackupEntry component", func() {
 			defer test.WithFeatureGate(gardenletfeatures.FeatureGate, features.CopyEtcdBackupsDuringControlPlaneMigration, true)()
 
+			sourceBackupEntry.EXPECT().SetForceDeletionAnnotation(ctx)
 			sourceBackupEntry.EXPECT().Destroy(ctx)
 
 			Expect(botanist.DestroySourceBackupEntry(ctx)).To(Succeed())

--- a/pkg/operation/botanist/component/backupentry/backupentry_test.go
+++ b/pkg/operation/botanist/component/backupentry/backupentry_test.go
@@ -313,12 +313,27 @@ var _ = Describe("BackupEntry", func() {
 			Expect(err).To(HaveOccurred())
 		})
 
-		It("should return the retrived backupentry and save it locally", func() {
+		It("should return the retrieved backupentry and save it locally", func() {
 			Expect(c.Create(ctx, expected)).To(Succeed())
 			backupEntry, err := defaultDepWaiter.Get(ctx)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(backupEntry).To(Equal(expected))
 			Expect(defaultDepWaiter.GetActualBucketName()).To(Equal(expected.Spec.BucketName))
+		})
+	})
+
+	Describe("#SetForceDeletionAnnotation", func() {
+		It("should not do anything if backupentry does not exist", func() {
+			Expect(defaultDepWaiter.SetForceDeletionAnnotation(ctx)).To(Succeed())
+		})
+
+		It("should set the force-deletion annotation on the backupentry", func() {
+			modified := expected.DeepCopy()
+
+			Expect(c.Create(ctx, expected)).To(Succeed())
+			Expect(defaultDepWaiter.SetForceDeletionAnnotation(ctx)).To(Succeed())
+			Expect(c.Get(ctx, kutil.Key(modified.Namespace, modified.Name), modified)).To(Succeed())
+			Expect(modified.Annotations["backupentry.core.gardener.cloud/force-deletion"]).To(Equal("true"))
 		})
 	})
 })

--- a/pkg/operation/botanist/component/backupentry/mock/mocks.go
+++ b/pkg/operation/botanist/component/backupentry/mock/mocks.go
@@ -133,6 +133,20 @@ func (mr *MockInterfaceMockRecorder) SetBucketName(arg0 interface{}) *gomock.Cal
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetBucketName", reflect.TypeOf((*MockInterface)(nil).SetBucketName), arg0)
 }
 
+// SetForceDeletionAnnotation mocks base method.
+func (m *MockInterface) SetForceDeletionAnnotation(arg0 context.Context) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetForceDeletionAnnotation", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SetForceDeletionAnnotation indicates an expected call of SetForceDeletionAnnotation.
+func (mr *MockInterfaceMockRecorder) SetForceDeletionAnnotation(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetForceDeletionAnnotation", reflect.TypeOf((*MockInterface)(nil).SetForceDeletionAnnotation), arg0)
+}
+
 // Wait mocks base method.
 func (m *MockInterface) Wait(arg0 context.Context) error {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane-migration
/kind bug

**What this PR does / why we need it**:
This PR fixes an issue that would cause the restoration phase of control plane migration to get stuck with the following error:
```
task "Waiting until the source backup entry has been reconciled" failed: Error while waiting for BackupEntry garden-mhtest/source-shoot--mhtest--i0711345e9--91eb2fe5-66b8-4daf-9826-8778a703fc18 to become ready: extension state is not succeeded but Pending
```
This could happen if the `gardenlet` configration specifies `controllers.backupEntry.deletionGracePeriodHours` larger than 0 and the `Shoot`'s control plane is migrated twice within that timeframe. In that case the source `BackupEntry` will become `Pending` while the respective controller waits for the deletion grace period to expire and have the following status:
```
Status:
  Last Operation:
    Description:        Deletion of backup entry is scheduled for 2022-12-03 11:44:13 +0000 UTC
    Last Update Time:   2022-11-29T15:21:57Z
    Progress:           0
    State:              Pending
    Type:               Delete
```
With this PR the `backupentry.core.gardener.cloud/force-deletion` annotation is set on the source `BackupEntry` which will make it so that it is removed immediately.

**Which issue(s) this PR fixes**:
Fixes #7111 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fixed an issue where the restoration phase of control plane can get stuck while waiting for the source `BackupEntry` to become ready. The issue could occur if the `gardenlet` configration specifies `controllers.backupEntry.deletionGracePeriodHours` larger than 0 and the `Shoot`'s control plane is migrated twice within that timeframe.
```
