### PR TITLE
Adapt cluster-proportional autoscaling of coredns to new high-availability handling.

### DIFF
--- a/pkg/operation/botanist/component/coredns/coredns.go
+++ b/pkg/operation/botanist/component/coredns/coredns.go
@@ -772,6 +772,9 @@ import custom/*.server
 		if c.values.WantsVerticalPodAutoscaler {
 			managedObjects = append(managedObjects, clusterProportionalDNSAutoscalerVPA)
 		}
+		// Replicas are managed by the cluster-proportional autoscaler and not the high-availability webhook
+		delete(deployment.Labels, resourcesv1alpha1.HighAvailabilityConfigType)
+		deployment.Spec.Replicas = nil
 	} else {
 		managedObjects = append(managedObjects, horizontalPodAutoscaler)
 	}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/area high-availability
/kind regression

**What this PR does / why we need it**:
Adapt cluster-proportional autoscaling of coredns to new high-availability handling.

With PR #6989 high-availability handling was introduced to coredns and other components. While it works nicely with the default scenario with horizontal pod autoscaler, it fails in combination with the cluster-proportional autoscaling approach. In the latter case the autoscaler and the gardener-resource-manager race towards changing the replica count of the coredns deployment. As a result, pods are created/terminated constantly. With this change, the replica mutation of the high-availability handling is disabled in case coredns uses the cluster-proportional autoscaling approach.

**Which issue(s) this PR fixes**:
None.

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Cluster-proportional autoscaling of coredns now works with the high-availability handling.
```

/invite @timuthy @rfranzke 
/cc @timuthy @rfranzke 