### PR TITLE
Make HOSTNAME env to lowercase for promtail service

### DIFF
--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/promtail/config.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/promtail/config.go
@@ -138,7 +138,7 @@ MemorySwapMax=0
 Restart=always
 RestartSec=5
 EnvironmentFile=/etc/environment
-ExecStartPre=/bin/sh -c "systemctl set-environment HOSTNAME=$(hostname)"
+ExecStartPre=/bin/sh -c "systemctl set-environment HOSTNAME=$(hostname | tr [:upper:] [:lower:])"
 ExecStartPre=` + execStartPre + `
 ExecStart=` + execStart),
 	}

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/promtail/config_test.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/promtail/config_test.go
@@ -81,7 +81,7 @@ MemorySwapMax=0
 Restart=always
 RestartSec=5
 EnvironmentFile=/etc/environment
-ExecStartPre=/bin/sh -c "systemctl set-environment HOSTNAME=$(hostname)"
+ExecStartPre=/bin/sh -c "systemctl set-environment HOSTNAME=$(hostname | tr [:upper:] [:lower:])"
 ExecStartPre=/usr/bin/docker run --rm -v /opt/bin:/opt/bin:rw --entrypoint /bin/sh ` + promtailRepository + ":" + promtailImageTag + " -c " + "\"cp /usr/bin/promtail /opt/bin\"" + `
 ExecStart=/opt/bin/promtail -config.file=` + PathConfig),
 				},
@@ -331,7 +331,7 @@ MemorySwapMax=0
 Restart=always
 RestartSec=5
 EnvironmentFile=/etc/environment
-ExecStartPre=/bin/sh -c "systemctl set-environment HOSTNAME=$(hostname)"
+ExecStartPre=/bin/sh -c "systemctl set-environment HOSTNAME=$(hostname | tr [:upper:] [:lower:])"
 ExecStartPre=/bin/systemctl disable promtail.service
 ExecStart=/bin/sh -c "echo service promtail.service is removed!; while true; do sleep 86400; done"`),
 				},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area logging
/kind enhancement

**What this PR does / why we need it**:
The name of a K8s Node object must be a valid [DNS subdomain name](https://kubernetes.io/docs/concepts/overview/working-with-objects/names#dns-subdomain-names). But Promtail uses the `HOSTNAME` env variable to search for pods running on its hostname and on Alicloud the node can consist of capital letters. Since the search is case-sensitive Promtail fails to get the pods running on the node. So the logs from `kube-system` are missing for all clusters on Alicloud. With this PR the `HOSTNAME` variable is transformed to lowercase.

**Which issue(s) this PR fixes**:
Fixes [#7114](https://github.com/gardener/gardener/issues/7114)

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Promtail installed on each shoot node now scrapes log from pods when `HOSTNAME` contains capital letters
```
