### PR TITLE
Adds timeouts for reconciler contexts

### DIFF
--- a/pkg/controllermanager/apis/config/types.go
+++ b/pkg/controllermanager/apis/config/types.go
@@ -78,7 +78,7 @@ type ControllerManagerControllerConfiguration struct {
 	// ShootMaintenance defines the configuration of the ShootMaintenance controller.
 	ShootMaintenance ShootMaintenanceControllerConfiguration
 	// ShootQuota defines the configuration of the ShootQuota controller.
-	ShootQuota ShootQuotaControllerConfiguration
+	ShootQuota *ShootQuotaControllerConfiguration
 	// ShootHibernation defines the configuration of the ShootHibernation controller.
 	ShootHibernation ShootHibernationControllerConfiguration
 	// ShootReference defines the configuration of the ShootReference controller. If unspecified, it is defaulted with `concurrentSyncs=5`.
@@ -262,7 +262,7 @@ type ShootQuotaControllerConfiguration struct {
 	ConcurrentSyncs *int
 	// SyncPeriod is the duration how often the existing resources are reconciled
 	// (how often Shoots referenced Quota is checked).
-	SyncPeriod metav1.Duration
+	SyncPeriod *metav1.Duration
 }
 
 // ShootHibernationControllerConfiguration defines the configuration of the

--- a/pkg/controllermanager/apis/config/v1alpha1/defaults.go
+++ b/pkg/controllermanager/apis/config/v1alpha1/defaults.go
@@ -138,9 +138,17 @@ func SetDefaults_ControllerManagerConfiguration(obj *ControllerManagerConfigurat
 		obj.Controllers.ShootMaintenance.ConcurrentSyncs = &v
 	}
 
+	if obj.Controllers.ShootQuota == nil {
+		obj.Controllers.ShootQuota = &ShootQuotaControllerConfiguration{}
+	}
 	if obj.Controllers.ShootQuota.ConcurrentSyncs == nil {
 		v := DefaultControllerConcurrentSyncs
 		obj.Controllers.ShootQuota.ConcurrentSyncs = &v
+	}
+	if obj.Controllers.ShootQuota.SyncPeriod == nil {
+		obj.Controllers.ShootQuota.SyncPeriod = &metav1.Duration{
+			Duration: 60 * time.Minute,
+		}
 	}
 
 	if obj.Controllers.ShootReference == nil {

--- a/pkg/controllermanager/apis/config/v1alpha1/defaults.go
+++ b/pkg/controllermanager/apis/config/v1alpha1/defaults.go
@@ -138,11 +138,6 @@ func SetDefaults_ControllerManagerConfiguration(obj *ControllerManagerConfigurat
 		obj.Controllers.ShootMaintenance.ConcurrentSyncs = &v
 	}
 
-	if obj.Controllers.ShootQuota.ConcurrentSyncs == nil {
-		v := DefaultControllerConcurrentSyncs
-		obj.Controllers.ShootQuota.ConcurrentSyncs = &v
-	}
-
 	if obj.Controllers.ShootReference == nil {
 		obj.Controllers.ShootReference = &ShootReferenceControllerConfiguration{}
 	}
@@ -269,6 +264,15 @@ func SetDefaults_ManagedSeedSetControllerConfiguration(obj *ManagedSeedSetContro
 		v := 3
 		obj.MaxShootRetries = &v
 	}
+}
+
+// SetDefaults_ShootQuotaControllerConfiguration sets defaults for the given ShootQuotaControllerConfiguration.
+func SetDefaults_ShootQuotaControllerConfiguration(obj *ShootQuotaControllerConfiguration) {
+	if obj.ConcurrentSyncs == nil {
+		v := DefaultControllerConcurrentSyncs
+		obj.ConcurrentSyncs = &v
+	}
+	obj.SyncPeriod = metav1.Duration{Duration: 30 * time.Second}
 }
 
 // SetDefaults_ShootHibernationControllerConfiguration sets defaults for the given ShootHibernationControllerConfiguration.

--- a/pkg/controllermanager/apis/config/v1alpha1/defaults.go
+++ b/pkg/controllermanager/apis/config/v1alpha1/defaults.go
@@ -138,6 +138,11 @@ func SetDefaults_ControllerManagerConfiguration(obj *ControllerManagerConfigurat
 		obj.Controllers.ShootMaintenance.ConcurrentSyncs = &v
 	}
 
+	if obj.Controllers.ShootQuota.ConcurrentSyncs == nil {
+		v := DefaultControllerConcurrentSyncs
+		obj.Controllers.ShootQuota.ConcurrentSyncs = &v
+	}
+
 	if obj.Controllers.ShootReference == nil {
 		obj.Controllers.ShootReference = &ShootReferenceControllerConfiguration{}
 	}
@@ -264,15 +269,6 @@ func SetDefaults_ManagedSeedSetControllerConfiguration(obj *ManagedSeedSetContro
 		v := 3
 		obj.MaxShootRetries = &v
 	}
-}
-
-// SetDefaults_ShootQuotaControllerConfiguration sets defaults for the given ShootQuotaControllerConfiguration.
-func SetDefaults_ShootQuotaControllerConfiguration(obj *ShootQuotaControllerConfiguration) {
-	if obj.ConcurrentSyncs == nil {
-		v := DefaultControllerConcurrentSyncs
-		obj.ConcurrentSyncs = &v
-	}
-	obj.SyncPeriod = metav1.Duration{Duration: 30 * time.Second}
 }
 
 // SetDefaults_ShootHibernationControllerConfiguration sets defaults for the given ShootHibernationControllerConfiguration.

--- a/pkg/controllermanager/apis/config/v1alpha1/defaults_test.go
+++ b/pkg/controllermanager/apis/config/v1alpha1/defaults_test.go
@@ -86,8 +86,11 @@ var _ = Describe("Defaults", func() {
 			Expect(obj.Controllers.ShootMaintenance.ConcurrentSyncs).NotTo(BeNil())
 			Expect(obj.Controllers.ShootMaintenance.ConcurrentSyncs).To(PointTo(Equal(5)))
 
+			Expect(obj.Controllers.ShootQuota).NotTo(BeNil())
 			Expect(obj.Controllers.ShootQuota.ConcurrentSyncs).NotTo(BeNil())
 			Expect(obj.Controllers.ShootQuota.ConcurrentSyncs).To(PointTo(Equal(5)))
+			Expect(obj.Controllers.ShootQuota.SyncPeriod).NotTo(BeNil())
+			Expect(obj.Controllers.ShootQuota.SyncPeriod).To(PointTo(Equal(metav1.Duration{Duration: 60 * time.Minute})))
 
 			Expect(obj.Controllers.ShootReference).NotTo(BeNil())
 			Expect(obj.Controllers.ShootReference.ConcurrentSyncs).NotTo(BeNil())

--- a/pkg/controllermanager/apis/config/v1alpha1/defaults_test.go
+++ b/pkg/controllermanager/apis/config/v1alpha1/defaults_test.go
@@ -86,9 +86,6 @@ var _ = Describe("Defaults", func() {
 			Expect(obj.Controllers.ShootMaintenance.ConcurrentSyncs).NotTo(BeNil())
 			Expect(obj.Controllers.ShootMaintenance.ConcurrentSyncs).To(PointTo(Equal(5)))
 
-			Expect(obj.Controllers.ShootQuota.ConcurrentSyncs).NotTo(BeNil())
-			Expect(obj.Controllers.ShootQuota.ConcurrentSyncs).To(PointTo(Equal(5)))
-
 			Expect(obj.Controllers.ShootReference).NotTo(BeNil())
 			Expect(obj.Controllers.ShootReference.ConcurrentSyncs).NotTo(BeNil())
 			Expect(obj.Controllers.ShootReference.ConcurrentSyncs).To(PointTo(Equal(5)))
@@ -210,6 +207,16 @@ var _ = Describe("Defaults", func() {
 
 			SetDefaults_ManagedSeedSetControllerConfiguration(obj)
 			Expect(obj.MaxShootRetries).To(PointTo(Equal(3)))
+		})
+	})
+
+	Describe("#SetDefaults_ShootQuotaControllerConfiguration", func() {
+		It("should correctly default the ShootHibernation Controller configuration", func() {
+			obj := &ShootQuotaControllerConfiguration{}
+
+			SetDefaults_ShootQuotaControllerConfiguration(obj)
+			Expect(obj.ConcurrentSyncs).To(PointTo(Equal(5)))
+			Expect(obj.SyncPeriod).To(Equal(metav1.Duration{Duration: 30 * time.Second}))
 		})
 	})
 

--- a/pkg/controllermanager/apis/config/v1alpha1/defaults_test.go
+++ b/pkg/controllermanager/apis/config/v1alpha1/defaults_test.go
@@ -86,6 +86,9 @@ var _ = Describe("Defaults", func() {
 			Expect(obj.Controllers.ShootMaintenance.ConcurrentSyncs).NotTo(BeNil())
 			Expect(obj.Controllers.ShootMaintenance.ConcurrentSyncs).To(PointTo(Equal(5)))
 
+			Expect(obj.Controllers.ShootQuota.ConcurrentSyncs).NotTo(BeNil())
+			Expect(obj.Controllers.ShootQuota.ConcurrentSyncs).To(PointTo(Equal(5)))
+
 			Expect(obj.Controllers.ShootReference).NotTo(BeNil())
 			Expect(obj.Controllers.ShootReference.ConcurrentSyncs).NotTo(BeNil())
 			Expect(obj.Controllers.ShootReference.ConcurrentSyncs).To(PointTo(Equal(5)))
@@ -207,16 +210,6 @@ var _ = Describe("Defaults", func() {
 
 			SetDefaults_ManagedSeedSetControllerConfiguration(obj)
 			Expect(obj.MaxShootRetries).To(PointTo(Equal(3)))
-		})
-	})
-
-	Describe("#SetDefaults_ShootQuotaControllerConfiguration", func() {
-		It("should correctly default the ShootHibernation Controller configuration", func() {
-			obj := &ShootQuotaControllerConfiguration{}
-
-			SetDefaults_ShootQuotaControllerConfiguration(obj)
-			Expect(obj.ConcurrentSyncs).To(PointTo(Equal(5)))
-			Expect(obj.SyncPeriod).To(Equal(metav1.Duration{Duration: 30 * time.Second}))
 		})
 	})
 

--- a/pkg/controllermanager/apis/config/v1alpha1/types.go
+++ b/pkg/controllermanager/apis/config/v1alpha1/types.go
@@ -94,7 +94,8 @@ type ControllerManagerControllerConfiguration struct {
 	// ShootMaintenance defines the configuration of the ShootMaintenance controller.
 	ShootMaintenance ShootMaintenanceControllerConfiguration `json:"shootMaintenance"`
 	// ShootQuota defines the configuration of the ShootQuota controller.
-	ShootQuota ShootQuotaControllerConfiguration `json:"shootQuota"`
+	// +optional
+	ShootQuota *ShootQuotaControllerConfiguration `json:"shootQuota,omitempty"`
 	// ShootHibernation defines the configuration of the ShootHibernation controller.
 	ShootHibernation ShootHibernationControllerConfiguration `json:"shootHibernation"`
 	// ShootReference defines the configuration of the ShootReference controller. If unspecified, it is defaulted with `concurrentSyncs=5`.
@@ -315,7 +316,8 @@ type ShootQuotaControllerConfiguration struct {
 	ConcurrentSyncs *int `json:"concurrentSyncs,omitempty"`
 	// SyncPeriod is the duration how often the existing resources are reconciled
 	// (how often Shoots referenced Quota is checked).
-	SyncPeriod metav1.Duration `json:"syncPeriod"`
+	// +optional
+	SyncPeriod *metav1.Duration `json:"syncPeriod,omitempty"`
 }
 
 // ShootHibernationControllerConfiguration defines the configuration of the

--- a/pkg/controllermanager/apis/config/v1alpha1/zz_generated.conversion.go
+++ b/pkg/controllermanager/apis/config/v1alpha1/zz_generated.conversion.go
@@ -519,9 +519,7 @@ func autoConvert_v1alpha1_ControllerManagerControllerConfiguration_To_config_Con
 	if err := Convert_v1alpha1_ShootMaintenanceControllerConfiguration_To_config_ShootMaintenanceControllerConfiguration(&in.ShootMaintenance, &out.ShootMaintenance, s); err != nil {
 		return err
 	}
-	if err := Convert_v1alpha1_ShootQuotaControllerConfiguration_To_config_ShootQuotaControllerConfiguration(&in.ShootQuota, &out.ShootQuota, s); err != nil {
-		return err
-	}
+	out.ShootQuota = (*config.ShootQuotaControllerConfiguration)(unsafe.Pointer(in.ShootQuota))
 	if err := Convert_v1alpha1_ShootHibernationControllerConfiguration_To_config_ShootHibernationControllerConfiguration(&in.ShootHibernation, &out.ShootHibernation, s); err != nil {
 		return err
 	}
@@ -563,9 +561,7 @@ func autoConvert_config_ControllerManagerControllerConfiguration_To_v1alpha1_Con
 	if err := Convert_config_ShootMaintenanceControllerConfiguration_To_v1alpha1_ShootMaintenanceControllerConfiguration(&in.ShootMaintenance, &out.ShootMaintenance, s); err != nil {
 		return err
 	}
-	if err := Convert_config_ShootQuotaControllerConfiguration_To_v1alpha1_ShootQuotaControllerConfiguration(&in.ShootQuota, &out.ShootQuota, s); err != nil {
-		return err
-	}
+	out.ShootQuota = (*ShootQuotaControllerConfiguration)(unsafe.Pointer(in.ShootQuota))
 	if err := Convert_config_ShootHibernationControllerConfiguration_To_v1alpha1_ShootHibernationControllerConfiguration(&in.ShootHibernation, &out.ShootHibernation, s); err != nil {
 		return err
 	}
@@ -965,7 +961,7 @@ func Convert_config_ShootMaintenanceControllerConfiguration_To_v1alpha1_ShootMai
 
 func autoConvert_v1alpha1_ShootQuotaControllerConfiguration_To_config_ShootQuotaControllerConfiguration(in *ShootQuotaControllerConfiguration, out *config.ShootQuotaControllerConfiguration, s conversion.Scope) error {
 	out.ConcurrentSyncs = (*int)(unsafe.Pointer(in.ConcurrentSyncs))
-	out.SyncPeriod = in.SyncPeriod
+	out.SyncPeriod = (*v1.Duration)(unsafe.Pointer(in.SyncPeriod))
 	return nil
 }
 
@@ -976,7 +972,7 @@ func Convert_v1alpha1_ShootQuotaControllerConfiguration_To_config_ShootQuotaCont
 
 func autoConvert_config_ShootQuotaControllerConfiguration_To_v1alpha1_ShootQuotaControllerConfiguration(in *config.ShootQuotaControllerConfiguration, out *ShootQuotaControllerConfiguration, s conversion.Scope) error {
 	out.ConcurrentSyncs = (*int)(unsafe.Pointer(in.ConcurrentSyncs))
-	out.SyncPeriod = in.SyncPeriod
+	out.SyncPeriod = (*v1.Duration)(unsafe.Pointer(in.SyncPeriod))
 	return nil
 }
 

--- a/pkg/controllermanager/apis/config/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/controllermanager/apis/config/v1alpha1/zz_generated.deepcopy.go
@@ -247,7 +247,11 @@ func (in *ControllerManagerControllerConfiguration) DeepCopyInto(out *Controller
 		(*in).DeepCopyInto(*out)
 	}
 	in.ShootMaintenance.DeepCopyInto(&out.ShootMaintenance)
-	in.ShootQuota.DeepCopyInto(&out.ShootQuota)
+	if in.ShootQuota != nil {
+		in, out := &in.ShootQuota, &out.ShootQuota
+		*out = new(ShootQuotaControllerConfiguration)
+		(*in).DeepCopyInto(*out)
+	}
 	in.ShootHibernation.DeepCopyInto(&out.ShootHibernation)
 	if in.ShootReference != nil {
 		in, out := &in.ShootReference, &out.ShootReference
@@ -720,7 +724,11 @@ func (in *ShootQuotaControllerConfiguration) DeepCopyInto(out *ShootQuotaControl
 		*out = new(int)
 		**out = **in
 	}
-	out.SyncPeriod = in.SyncPeriod
+	if in.SyncPeriod != nil {
+		in, out := &in.SyncPeriod, &out.SyncPeriod
+		*out = new(v1.Duration)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/controllermanager/apis/config/v1alpha1/zz_generated.defaults.go
+++ b/pkg/controllermanager/apis/config/v1alpha1/zz_generated.defaults.go
@@ -53,6 +53,7 @@ func SetObjectDefaults_ControllerManagerConfiguration(in *ControllerManagerConfi
 	if in.Controllers.SeedBackupBucketsCheck != nil {
 		SetDefaults_SeedBackupBucketsCheckControllerConfiguration(in.Controllers.SeedBackupBucketsCheck)
 	}
+	SetDefaults_ShootQuotaControllerConfiguration(&in.Controllers.ShootQuota)
 	SetDefaults_ShootHibernationControllerConfiguration(&in.Controllers.ShootHibernation)
 	if in.Controllers.ShootRetry != nil {
 		SetDefaults_ShootRetryControllerConfiguration(in.Controllers.ShootRetry)

--- a/pkg/controllermanager/apis/config/v1alpha1/zz_generated.defaults.go
+++ b/pkg/controllermanager/apis/config/v1alpha1/zz_generated.defaults.go
@@ -53,7 +53,6 @@ func SetObjectDefaults_ControllerManagerConfiguration(in *ControllerManagerConfi
 	if in.Controllers.SeedBackupBucketsCheck != nil {
 		SetDefaults_SeedBackupBucketsCheckControllerConfiguration(in.Controllers.SeedBackupBucketsCheck)
 	}
-	SetDefaults_ShootQuotaControllerConfiguration(&in.Controllers.ShootQuota)
 	SetDefaults_ShootHibernationControllerConfiguration(&in.Controllers.ShootHibernation)
 	if in.Controllers.ShootRetry != nil {
 		SetDefaults_ShootRetryControllerConfiguration(in.Controllers.ShootRetry)

--- a/pkg/controllermanager/apis/config/validation/validation.go
+++ b/pkg/controllermanager/apis/config/validation/validation.go
@@ -203,7 +203,7 @@ func validateShootMaintenanceControllerConfiguration(conf config.ShootMaintenanc
 	return allErrs
 }
 
-func validateShootQuotaControllerConfiguration(conf config.ShootQuotaControllerConfiguration, fldPath *field.Path) field.ErrorList {
+func validateShootQuotaControllerConfiguration(conf *config.ShootQuotaControllerConfiguration, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 	return allErrs
 }

--- a/pkg/controllermanager/apis/config/zz_generated.deepcopy.go
+++ b/pkg/controllermanager/apis/config/zz_generated.deepcopy.go
@@ -247,7 +247,11 @@ func (in *ControllerManagerControllerConfiguration) DeepCopyInto(out *Controller
 		(*in).DeepCopyInto(*out)
 	}
 	in.ShootMaintenance.DeepCopyInto(&out.ShootMaintenance)
-	in.ShootQuota.DeepCopyInto(&out.ShootQuota)
+	if in.ShootQuota != nil {
+		in, out := &in.ShootQuota, &out.ShootQuota
+		*out = new(ShootQuotaControllerConfiguration)
+		(*in).DeepCopyInto(*out)
+	}
 	in.ShootHibernation.DeepCopyInto(&out.ShootHibernation)
 	if in.ShootReference != nil {
 		in, out := &in.ShootReference, &out.ShootReference
@@ -722,7 +726,11 @@ func (in *ShootQuotaControllerConfiguration) DeepCopyInto(out *ShootQuotaControl
 		*out = new(int)
 		**out = **in
 	}
-	out.SyncPeriod = in.SyncPeriod
+	if in.SyncPeriod != nil {
+		in, out := &in.SyncPeriod, &out.SyncPeriod
+		*out = new(v1.Duration)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/controllermanager/controller/bastion/reconciler.go
+++ b/pkg/controllermanager/controller/bastion/reconciler.go
@@ -28,6 +28,7 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	operationsv1alpha1 "github.com/gardener/gardener/pkg/apis/operations/v1alpha1"
 	"github.com/gardener/gardener/pkg/controllermanager/apis/config"
+	"github.com/gardener/gardener/pkg/controllerutils"
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 )
 
@@ -41,6 +42,9 @@ type Reconciler struct {
 // Reconcile reacts to updates on Bastion resources and cleans up expired Bastions.
 func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 	log := logf.FromContext(ctx)
+
+	ctx, cancel := context.WithTimeout(ctx, controllerutils.DefaultReconciliationTimeout)
+	defer cancel()
 
 	bastion := &operationsv1alpha1.Bastion{}
 	if err := r.Client.Get(ctx, request.NamespacedName, bastion); err != nil {

--- a/pkg/controllermanager/controller/bastion/reconciler.go
+++ b/pkg/controllermanager/controller/bastion/reconciler.go
@@ -43,7 +43,7 @@ type Reconciler struct {
 func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 	log := logf.FromContext(ctx)
 
-	ctx, cancel := context.WithTimeout(ctx, controllerutils.DefaultReconciliationTimeout)
+	ctx, cancel := controllerutils.GetMainReconciliationContext(ctx, controllerutils.DefaultReconciliationTimeout)
 	defer cancel()
 
 	bastion := &operationsv1alpha1.Bastion{}

--- a/pkg/controllermanager/controller/bastion/reconciler_test.go
+++ b/pkg/controllermanager/controller/bastion/reconciler_test.go
@@ -69,7 +69,7 @@ var _ = Describe("Controller", func() {
 
 	Describe("Reconciler", func() {
 		It("should return nil because object not found", func() {
-			mockClient.EXPECT().Get(ctx, kubernetesutils.Key(namespace, bastionName), gomock.AssignableToTypeOf(&operationsv1alpha1.Bastion{})).Return(apierrors.NewNotFound(schema.GroupResource{}, ""))
+			mockClient.EXPECT().Get(gomock.Any(), kubernetesutils.Key(namespace, bastionName), gomock.AssignableToTypeOf(&operationsv1alpha1.Bastion{})).Return(apierrors.NewNotFound(schema.GroupResource{}, ""))
 
 			result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: kubernetesutils.Key(namespace, bastionName)})
 			Expect(result).To(Equal(reconcile.Result{}))
@@ -80,12 +80,12 @@ var _ = Describe("Controller", func() {
 			created := time.Now().Add(-maxLifetime / 2)
 			requeueAfter := time.Until(created.Add(maxLifetime))
 
-			mockClient.EXPECT().Get(ctx, kubernetesutils.Key(namespace, shootName), gomock.AssignableToTypeOf(&gardencorev1beta1.Shoot{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.Shoot, _ ...client.GetOption) error {
+			mockClient.EXPECT().Get(gomock.Any(), kubernetesutils.Key(namespace, shootName), gomock.AssignableToTypeOf(&gardencorev1beta1.Shoot{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.Shoot, _ ...client.GetOption) error {
 				*obj = newShoot(namespace, shootName, &seedName)
 				return nil
 			})
 
-			mockClient.EXPECT().Get(ctx, kubernetesutils.Key(namespace, bastionName), gomock.AssignableToTypeOf(&operationsv1alpha1.Bastion{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *operationsv1alpha1.Bastion, _ ...client.GetOption) error {
+			mockClient.EXPECT().Get(gomock.Any(), kubernetesutils.Key(namespace, bastionName), gomock.AssignableToTypeOf(&operationsv1alpha1.Bastion{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *operationsv1alpha1.Bastion, _ ...client.GetOption) error {
 				*obj = newBastion(namespace, bastionName, shootName, &seedName, &created, nil)
 				return nil
 			})
@@ -100,12 +100,12 @@ var _ = Describe("Controller", func() {
 			remaining := 30 * time.Second
 			expires := now.Add(remaining)
 
-			mockClient.EXPECT().Get(ctx, kubernetesutils.Key(namespace, shootName), gomock.AssignableToTypeOf(&gardencorev1beta1.Shoot{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.Shoot, _ ...client.GetOption) error {
+			mockClient.EXPECT().Get(gomock.Any(), kubernetesutils.Key(namespace, shootName), gomock.AssignableToTypeOf(&gardencorev1beta1.Shoot{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.Shoot, _ ...client.GetOption) error {
 				*obj = newShoot(namespace, shootName, &seedName)
 				return nil
 			})
 
-			mockClient.EXPECT().Get(ctx, kubernetesutils.Key(namespace, bastionName), gomock.AssignableToTypeOf(&operationsv1alpha1.Bastion{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *operationsv1alpha1.Bastion, _ ...client.GetOption) error {
+			mockClient.EXPECT().Get(gomock.Any(), kubernetesutils.Key(namespace, bastionName), gomock.AssignableToTypeOf(&operationsv1alpha1.Bastion{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *operationsv1alpha1.Bastion, _ ...client.GetOption) error {
 				*obj = newBastion(namespace, bastionName, shootName, &seedName, &now, &expires)
 				return nil
 			})
@@ -116,12 +116,12 @@ var _ = Describe("Controller", func() {
 		})
 
 		It("should requeue soon-to-reach-max-lifetime Bastions", func() {
-			mockClient.EXPECT().Get(ctx, kubernetesutils.Key(namespace, shootName), gomock.AssignableToTypeOf(&gardencorev1beta1.Shoot{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.Shoot, _ ...client.GetOption) error {
+			mockClient.EXPECT().Get(gomock.Any(), kubernetesutils.Key(namespace, shootName), gomock.AssignableToTypeOf(&gardencorev1beta1.Shoot{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.Shoot, _ ...client.GetOption) error {
 				*obj = newShoot(namespace, shootName, &seedName)
 				return nil
 			})
 
-			mockClient.EXPECT().Get(ctx, kubernetesutils.Key(namespace, bastionName), gomock.AssignableToTypeOf(&operationsv1alpha1.Bastion{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *operationsv1alpha1.Bastion, _ ...client.GetOption) error {
+			mockClient.EXPECT().Get(gomock.Any(), kubernetesutils.Key(namespace, bastionName), gomock.AssignableToTypeOf(&operationsv1alpha1.Bastion{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *operationsv1alpha1.Bastion, _ ...client.GetOption) error {
 				now := time.Now()
 				created := now.Add(-maxLifetime).Add(10 * time.Minute) // reaches end-of-life in 10 minutes
 				expires := now.Add(30 * time.Minute)                   // expires in 30 minutes
@@ -136,16 +136,16 @@ var _ = Describe("Controller", func() {
 		})
 
 		It("should delete Bastions with missing shoots", func() {
-			mockClient.EXPECT().Get(ctx, kubernetesutils.Key(namespace, shootName), gomock.AssignableToTypeOf(&gardencorev1beta1.Shoot{})).Return(apierrors.NewNotFound(schema.GroupResource{}, ""))
+			mockClient.EXPECT().Get(gomock.Any(), kubernetesutils.Key(namespace, shootName), gomock.AssignableToTypeOf(&gardencorev1beta1.Shoot{})).Return(apierrors.NewNotFound(schema.GroupResource{}, ""))
 
-			mockClient.EXPECT().Get(ctx, kubernetesutils.Key(namespace, bastionName), gomock.AssignableToTypeOf(&operationsv1alpha1.Bastion{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *operationsv1alpha1.Bastion, _ ...client.GetOption) error {
+			mockClient.EXPECT().Get(gomock.Any(), kubernetesutils.Key(namespace, bastionName), gomock.AssignableToTypeOf(&operationsv1alpha1.Bastion{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *operationsv1alpha1.Bastion, _ ...client.GetOption) error {
 				created := time.Now().Add(-maxLifetime / 2)
 
 				*obj = newBastion(namespace, bastionName, shootName, &seedName, &created, nil)
 				return nil
 			})
 
-			mockClient.EXPECT().Delete(ctx, gomock.AssignableToTypeOf(&operationsv1alpha1.Bastion{}))
+			mockClient.EXPECT().Delete(gomock.Any(), gomock.AssignableToTypeOf(&operationsv1alpha1.Bastion{}))
 
 			result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: kubernetesutils.Key(namespace, bastionName)})
 			Expect(result).To(Equal(reconcile.Result{}))
@@ -153,7 +153,7 @@ var _ = Describe("Controller", func() {
 		})
 
 		It("should delete Bastions with shoots in deletion", func() {
-			mockClient.EXPECT().Get(ctx, kubernetesutils.Key(namespace, shootName), gomock.AssignableToTypeOf(&gardencorev1beta1.Shoot{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.Shoot, _ ...client.GetOption) error {
+			mockClient.EXPECT().Get(gomock.Any(), kubernetesutils.Key(namespace, shootName), gomock.AssignableToTypeOf(&gardencorev1beta1.Shoot{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.Shoot, _ ...client.GetOption) error {
 				shoot := newShoot(namespace, shootName, &seedName)
 				now := metav1.Now()
 				shoot.DeletionTimestamp = &now
@@ -161,14 +161,14 @@ var _ = Describe("Controller", func() {
 				return nil
 			})
 
-			mockClient.EXPECT().Get(ctx, kubernetesutils.Key(namespace, bastionName), gomock.AssignableToTypeOf(&operationsv1alpha1.Bastion{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *operationsv1alpha1.Bastion, _ ...client.GetOption) error {
+			mockClient.EXPECT().Get(gomock.Any(), kubernetesutils.Key(namespace, bastionName), gomock.AssignableToTypeOf(&operationsv1alpha1.Bastion{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *operationsv1alpha1.Bastion, _ ...client.GetOption) error {
 				created := time.Now().Add(-maxLifetime / 2)
 
 				*obj = newBastion(namespace, bastionName, shootName, &seedName, &created, nil)
 				return nil
 			})
 
-			mockClient.EXPECT().Delete(ctx, gomock.AssignableToTypeOf(&operationsv1alpha1.Bastion{}))
+			mockClient.EXPECT().Delete(gomock.Any(), gomock.AssignableToTypeOf(&operationsv1alpha1.Bastion{}))
 
 			result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: kubernetesutils.Key(namespace, bastionName)})
 			Expect(result).To(Equal(reconcile.Result{}))
@@ -176,12 +176,12 @@ var _ = Describe("Controller", func() {
 		})
 
 		It("should delete expired Bastions", func() {
-			mockClient.EXPECT().Get(ctx, kubernetesutils.Key(namespace, shootName), gomock.AssignableToTypeOf(&gardencorev1beta1.Shoot{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.Shoot, _ ...client.GetOption) error {
+			mockClient.EXPECT().Get(gomock.Any(), kubernetesutils.Key(namespace, shootName), gomock.AssignableToTypeOf(&gardencorev1beta1.Shoot{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.Shoot, _ ...client.GetOption) error {
 				*obj = newShoot(namespace, shootName, &seedName)
 				return nil
 			})
 
-			mockClient.EXPECT().Get(ctx, kubernetesutils.Key(namespace, bastionName), gomock.AssignableToTypeOf(&operationsv1alpha1.Bastion{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *operationsv1alpha1.Bastion, _ ...client.GetOption) error {
+			mockClient.EXPECT().Get(gomock.Any(), kubernetesutils.Key(namespace, bastionName), gomock.AssignableToTypeOf(&operationsv1alpha1.Bastion{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *operationsv1alpha1.Bastion, _ ...client.GetOption) error {
 				created := time.Now().Add(-maxLifetime / 2)
 				expires := time.Now().Add(-5 * time.Second)
 
@@ -189,7 +189,7 @@ var _ = Describe("Controller", func() {
 				return nil
 			})
 
-			mockClient.EXPECT().Delete(ctx, gomock.AssignableToTypeOf(&operationsv1alpha1.Bastion{}))
+			mockClient.EXPECT().Delete(gomock.Any(), gomock.AssignableToTypeOf(&operationsv1alpha1.Bastion{}))
 
 			result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: kubernetesutils.Key(namespace, bastionName)})
 			Expect(result).To(Equal(reconcile.Result{}))
@@ -197,19 +197,19 @@ var _ = Describe("Controller", func() {
 		})
 
 		It("should delete Bastions that have reached their TTL", func() {
-			mockClient.EXPECT().Get(ctx, kubernetesutils.Key(namespace, shootName), gomock.AssignableToTypeOf(&gardencorev1beta1.Shoot{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.Shoot, _ ...client.GetOption) error {
+			mockClient.EXPECT().Get(gomock.Any(), kubernetesutils.Key(namespace, shootName), gomock.AssignableToTypeOf(&gardencorev1beta1.Shoot{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.Shoot, _ ...client.GetOption) error {
 				*obj = newShoot(namespace, shootName, &seedName)
 				return nil
 			})
 
-			mockClient.EXPECT().Get(ctx, kubernetesutils.Key(namespace, bastionName), gomock.AssignableToTypeOf(&operationsv1alpha1.Bastion{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *operationsv1alpha1.Bastion, _ ...client.GetOption) error {
+			mockClient.EXPECT().Get(gomock.Any(), kubernetesutils.Key(namespace, bastionName), gomock.AssignableToTypeOf(&operationsv1alpha1.Bastion{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *operationsv1alpha1.Bastion, _ ...client.GetOption) error {
 				created := time.Now().Add(-maxLifetime * 2)
 
 				*obj = newBastion(namespace, bastionName, shootName, &seedName, &created, nil)
 				return nil
 			})
 
-			mockClient.EXPECT().Delete(ctx, gomock.AssignableToTypeOf(&operationsv1alpha1.Bastion{}))
+			mockClient.EXPECT().Delete(gomock.Any(), gomock.AssignableToTypeOf(&operationsv1alpha1.Bastion{}))
 
 			result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: kubernetesutils.Key(namespace, bastionName)})
 			Expect(result).To(Equal(reconcile.Result{}))
@@ -219,12 +219,12 @@ var _ = Describe("Controller", func() {
 		It("should delete Bastions with outdated seed information", func() {
 			newSeedName := "new-seed-after-migration"
 
-			mockClient.EXPECT().Get(ctx, kubernetesutils.Key(namespace, shootName), gomock.AssignableToTypeOf(&gardencorev1beta1.Shoot{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.Shoot, _ ...client.GetOption) error {
+			mockClient.EXPECT().Get(gomock.Any(), kubernetesutils.Key(namespace, shootName), gomock.AssignableToTypeOf(&gardencorev1beta1.Shoot{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.Shoot, _ ...client.GetOption) error {
 				*obj = newShoot(namespace, shootName, &newSeedName)
 				return nil
 			})
 
-			mockClient.EXPECT().Get(ctx, kubernetesutils.Key(namespace, bastionName), gomock.AssignableToTypeOf(&operationsv1alpha1.Bastion{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *operationsv1alpha1.Bastion, _ ...client.GetOption) error {
+			mockClient.EXPECT().Get(gomock.Any(), kubernetesutils.Key(namespace, bastionName), gomock.AssignableToTypeOf(&operationsv1alpha1.Bastion{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *operationsv1alpha1.Bastion, _ ...client.GetOption) error {
 				created := time.Now().Add(-maxLifetime / 2)
 				expires := time.Now().Add(1 * time.Minute)
 
@@ -232,7 +232,7 @@ var _ = Describe("Controller", func() {
 				return nil
 			})
 
-			mockClient.EXPECT().Delete(ctx, gomock.AssignableToTypeOf(&operationsv1alpha1.Bastion{}))
+			mockClient.EXPECT().Delete(gomock.Any(), gomock.AssignableToTypeOf(&operationsv1alpha1.Bastion{}))
 
 			result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: kubernetesutils.Key(namespace, bastionName)})
 			Expect(result).To(Equal(reconcile.Result{}))
@@ -240,12 +240,12 @@ var _ = Describe("Controller", func() {
 		})
 
 		It("should delete Bastions with outdated seed information 2", func() {
-			mockClient.EXPECT().Get(ctx, kubernetesutils.Key(namespace, shootName), gomock.AssignableToTypeOf(&gardencorev1beta1.Shoot{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.Shoot, _ ...client.GetOption) error {
+			mockClient.EXPECT().Get(gomock.Any(), kubernetesutils.Key(namespace, shootName), gomock.AssignableToTypeOf(&gardencorev1beta1.Shoot{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.Shoot, _ ...client.GetOption) error {
 				*obj = newShoot(namespace, shootName, nil) // shoot was removed from original seed and since then hasn't found a new seed
 				return nil
 			})
 
-			mockClient.EXPECT().Get(ctx, kubernetesutils.Key(namespace, bastionName), gomock.AssignableToTypeOf(&operationsv1alpha1.Bastion{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *operationsv1alpha1.Bastion, _ ...client.GetOption) error {
+			mockClient.EXPECT().Get(gomock.Any(), kubernetesutils.Key(namespace, bastionName), gomock.AssignableToTypeOf(&operationsv1alpha1.Bastion{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *operationsv1alpha1.Bastion, _ ...client.GetOption) error {
 				created := time.Now().Add(-maxLifetime / 2)
 				expires := time.Now().Add(1 * time.Minute)
 
@@ -253,7 +253,7 @@ var _ = Describe("Controller", func() {
 				return nil
 			})
 
-			mockClient.EXPECT().Delete(ctx, gomock.AssignableToTypeOf(&operationsv1alpha1.Bastion{}))
+			mockClient.EXPECT().Delete(gomock.Any(), gomock.AssignableToTypeOf(&operationsv1alpha1.Bastion{}))
 
 			result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: kubernetesutils.Key(namespace, bastionName)})
 			Expect(result).To(Equal(reconcile.Result{}))

--- a/pkg/controllermanager/controller/certificatesigningrequest/reconciler.go
+++ b/pkg/controllermanager/controller/certificatesigningrequest/reconciler.go
@@ -36,6 +36,7 @@ import (
 
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/controllermanager/apis/config"
+	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/utils"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 )
@@ -56,6 +57,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		finalState     string
 		extra          = make(map[string]authorizationv1.ExtraValue)
 	)
+
+	ctx, cancel := context.WithTimeout(ctx, controllerutils.DefaultReconciliationTimeout)
+	defer cancel()
 
 	csr := &certificatesv1.CertificateSigningRequest{}
 	if err := r.Client.Get(ctx, request.NamespacedName, csr); err != nil {

--- a/pkg/controllermanager/controller/certificatesigningrequest/reconciler.go
+++ b/pkg/controllermanager/controller/certificatesigningrequest/reconciler.go
@@ -58,7 +58,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		extra          = make(map[string]authorizationv1.ExtraValue)
 	)
 
-	ctx, cancel := context.WithTimeout(ctx, controllerutils.DefaultReconciliationTimeout)
+	ctx, cancel := controllerutils.GetMainReconciliationContext(ctx, controllerutils.DefaultReconciliationTimeout)
 	defer cancel()
 
 	csr := &certificatesv1.CertificateSigningRequest{}

--- a/pkg/controllermanager/controller/certificatesigningrequest/reconciler_test.go
+++ b/pkg/controllermanager/controller/certificatesigningrequest/reconciler_test.go
@@ -41,7 +41,7 @@ import (
 
 var _ = Describe("Reconciler", func() {
 	var (
-		ctx                    context.Context
+		ctx                    = context.TODO()
 		ctrl                   *gomock.Controller
 		c                      *mockclient.MockClient
 		fakeCertificatesClient certificatesclientv1.CertificateSigningRequestInterface
@@ -93,7 +93,7 @@ var _ = Describe("Reconciler", func() {
 	})
 
 	It("should return nil because object not found", func() {
-		c.EXPECT().Get(ctx, client.ObjectKeyFromObject(csr), &certificatesv1.CertificateSigningRequest{}).Return(errNotFound)
+		c.EXPECT().Get(gomock.Any(), client.ObjectKeyFromObject(csr), &certificatesv1.CertificateSigningRequest{}).Return(errNotFound)
 
 		result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: csr.Name}})
 		Expect(result).To(Equal(reconcile.Result{}))
@@ -102,7 +102,7 @@ var _ = Describe("Reconciler", func() {
 
 	Context("when csr is in final state", func() {
 		It("should ignore it because certificate is present in the status field", func() {
-			c.EXPECT().Get(ctx, client.ObjectKeyFromObject(csr), gomock.AssignableToTypeOf(&certificatesv1.CertificateSigningRequest{})).DoAndReturn(
+			c.EXPECT().Get(gomock.Any(), client.ObjectKeyFromObject(csr), gomock.AssignableToTypeOf(&certificatesv1.CertificateSigningRequest{})).DoAndReturn(
 				func(_ context.Context, _ client.ObjectKey, obj *certificatesv1.CertificateSigningRequest, _ ...client.GetOption) error {
 					csr.Status.Certificate = []byte("test-certificate")
 					csr.DeepCopyInto(obj)
@@ -115,7 +115,7 @@ var _ = Describe("Reconciler", func() {
 		})
 
 		It("should ignore it because csr is Approved", func() {
-			c.EXPECT().Get(ctx, client.ObjectKeyFromObject(csr), gomock.AssignableToTypeOf(&certificatesv1.CertificateSigningRequest{})).DoAndReturn(
+			c.EXPECT().Get(gomock.Any(), client.ObjectKeyFromObject(csr), gomock.AssignableToTypeOf(&certificatesv1.CertificateSigningRequest{})).DoAndReturn(
 				func(_ context.Context, _ client.ObjectKey, obj *certificatesv1.CertificateSigningRequest, _ ...client.GetOption) error {
 					csr.Status.Conditions = append(csr.Status.Conditions, certificatesv1.CertificateSigningRequestCondition{
 						Type: certificatesv1.CertificateApproved,
@@ -139,7 +139,7 @@ var _ = Describe("Reconciler", func() {
 			Expect(err).NotTo(HaveOccurred())
 			csr.Spec.Request = csrData
 
-			c.EXPECT().Get(ctx, client.ObjectKeyFromObject(csr), gomock.AssignableToTypeOf(&certificatesv1.CertificateSigningRequest{})).DoAndReturn(
+			c.EXPECT().Get(gomock.Any(), client.ObjectKeyFromObject(csr), gomock.AssignableToTypeOf(&certificatesv1.CertificateSigningRequest{})).DoAndReturn(
 				func(_ context.Context, _ client.ObjectKey, obj *certificatesv1.CertificateSigningRequest, _ ...client.GetOption) error {
 					csr.DeepCopyInto(obj)
 					return nil
@@ -163,7 +163,7 @@ var _ = Describe("Reconciler", func() {
 			Expect(err).NotTo(HaveOccurred())
 			csr.Spec.Request = csrData
 
-			c.EXPECT().Create(ctx, gomock.AssignableToTypeOf(&authorizationv1.SubjectAccessReview{})).DoAndReturn(func(_ context.Context, obj *authorizationv1.SubjectAccessReview, _ ...client.CreateOption) error {
+			c.EXPECT().Create(gomock.Any(), gomock.AssignableToTypeOf(&authorizationv1.SubjectAccessReview{})).DoAndReturn(func(_ context.Context, obj *authorizationv1.SubjectAccessReview, _ ...client.CreateOption) error {
 				// For the simplicity of test, we are assuming SubjectAccessReview will be allowed if user is admin and not allowed for other users.
 				if obj.Spec.User == "admin" {
 					sar.Status = authorizationv1.SubjectAccessReviewStatus{
@@ -182,7 +182,7 @@ var _ = Describe("Reconciler", func() {
 		})
 
 		It("should result an error when user does not has authorization for seedclient subresource (sar.Status.Allowed is false)", func() {
-			c.EXPECT().Get(ctx, client.ObjectKeyFromObject(csr), gomock.AssignableToTypeOf(&certificatesv1.CertificateSigningRequest{})).DoAndReturn(
+			c.EXPECT().Get(gomock.Any(), client.ObjectKeyFromObject(csr), gomock.AssignableToTypeOf(&certificatesv1.CertificateSigningRequest{})).DoAndReturn(
 				func(_ context.Context, _ client.ObjectKey, obj *certificatesv1.CertificateSigningRequest, _ ...client.GetOption) error {
 					csr.Spec.Username = "foo"
 					csr.DeepCopyInto(obj)
@@ -196,7 +196,7 @@ var _ = Describe("Reconciler", func() {
 		It("should approve the csr when user has authorization for seedclient subresource (sar.Status.Allowed is true)", func() {
 			_, err := fakeCertificatesClient.Create(ctx, csr, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
-			c.EXPECT().Get(ctx, client.ObjectKeyFromObject(csr), gomock.AssignableToTypeOf(&certificatesv1.CertificateSigningRequest{})).DoAndReturn(
+			c.EXPECT().Get(gomock.Any(), client.ObjectKeyFromObject(csr), gomock.AssignableToTypeOf(&certificatesv1.CertificateSigningRequest{})).DoAndReturn(
 				func(_ context.Context, _ client.ObjectKey, obj *certificatesv1.CertificateSigningRequest, _ ...client.GetOption) error {
 					csr.Spec.Username = "admin"
 					csr.DeepCopyInto(obj)

--- a/pkg/controllermanager/controller/cloudprofile/reconciler.go
+++ b/pkg/controllermanager/controller/cloudprofile/reconciler.go
@@ -44,7 +44,7 @@ type Reconciler struct {
 func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 	log := logf.FromContext(ctx)
 
-	ctx, cancel := context.WithTimeout(ctx, controllerutils.DefaultReconciliationTimeout)
+	ctx, cancel := controllerutils.GetMainReconciliationContext(ctx, controllerutils.DefaultReconciliationTimeout)
 	defer cancel()
 
 	cloudProfile := &gardencorev1beta1.CloudProfile{}

--- a/pkg/controllermanager/controller/cloudprofile/reconciler.go
+++ b/pkg/controllermanager/controller/cloudprofile/reconciler.go
@@ -44,6 +44,9 @@ type Reconciler struct {
 func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 	log := logf.FromContext(ctx)
 
+	ctx, cancel := context.WithTimeout(ctx, controllerutils.DefaultReconciliationTimeout)
+	defer cancel()
+
 	cloudProfile := &gardencorev1beta1.CloudProfile{}
 	if err := r.Client.Get(ctx, request.NamespacedName, cloudProfile); err != nil {
 		if apierrors.IsNotFound(err) {

--- a/pkg/controllermanager/controller/cloudprofile/reconciler_test.go
+++ b/pkg/controllermanager/controller/cloudprofile/reconciler_test.go
@@ -68,7 +68,7 @@ var _ = Describe("Reconciler", func() {
 	})
 
 	It("should return nil because object not found", func() {
-		c.EXPECT().Get(ctx, kubernetesutils.Key(cloudProfileName), gomock.AssignableToTypeOf(&gardencorev1beta1.CloudProfile{})).Return(apierrors.NewNotFound(schema.GroupResource{}, ""))
+		c.EXPECT().Get(gomock.Any(), kubernetesutils.Key(cloudProfileName), gomock.AssignableToTypeOf(&gardencorev1beta1.CloudProfile{})).Return(apierrors.NewNotFound(schema.GroupResource{}, ""))
 
 		result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: cloudProfileName}})
 		Expect(result).To(Equal(reconcile.Result{}))
@@ -76,7 +76,7 @@ var _ = Describe("Reconciler", func() {
 	})
 
 	It("should return err because object reading failed", func() {
-		c.EXPECT().Get(ctx, kubernetesutils.Key(cloudProfileName), gomock.AssignableToTypeOf(&gardencorev1beta1.CloudProfile{})).Return(fakeErr)
+		c.EXPECT().Get(gomock.Any(), kubernetesutils.Key(cloudProfileName), gomock.AssignableToTypeOf(&gardencorev1beta1.CloudProfile{})).Return(fakeErr)
 
 		result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: cloudProfileName}})
 		Expect(result).To(Equal(reconcile.Result{}))
@@ -85,7 +85,7 @@ var _ = Describe("Reconciler", func() {
 
 	Context("when deletion timestamp not set", func() {
 		BeforeEach(func() {
-			c.EXPECT().Get(ctx, kubernetesutils.Key(cloudProfileName), gomock.AssignableToTypeOf(&gardencorev1beta1.CloudProfile{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.CloudProfile, _ ...client.GetOption) error {
+			c.EXPECT().Get(gomock.Any(), kubernetesutils.Key(cloudProfileName), gomock.AssignableToTypeOf(&gardencorev1beta1.CloudProfile{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.CloudProfile, _ ...client.GetOption) error {
 				*obj = *cloudProfile
 				return nil
 			})
@@ -94,7 +94,7 @@ var _ = Describe("Reconciler", func() {
 		It("should ensure the finalizer (error)", func() {
 			errToReturn := apierrors.NewNotFound(schema.GroupResource{}, cloudProfileName)
 
-			c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&gardencorev1beta1.CloudProfile{}), gomock.Any()).DoAndReturn(func(_ context.Context, o client.Object, patch client.Patch, opts ...client.PatchOption) error {
+			c.EXPECT().Patch(gomock.Any(), gomock.AssignableToTypeOf(&gardencorev1beta1.CloudProfile{}), gomock.Any()).DoAndReturn(func(_ context.Context, o client.Object, patch client.Patch, opts ...client.PatchOption) error {
 				Expect(patch.Data(o)).To(BeEquivalentTo(fmt.Sprintf(`{"metadata":{"finalizers":["%s"],"resourceVersion":"42"}}`, finalizerName)))
 				return errToReturn
 			})
@@ -105,7 +105,7 @@ var _ = Describe("Reconciler", func() {
 		})
 
 		It("should ensure the finalizer (no error)", func() {
-			c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&gardencorev1beta1.CloudProfile{}), gomock.Any()).DoAndReturn(func(_ context.Context, o client.Object, patch client.Patch, opts ...client.PatchOption) error {
+			c.EXPECT().Patch(gomock.Any(), gomock.AssignableToTypeOf(&gardencorev1beta1.CloudProfile{}), gomock.Any()).DoAndReturn(func(_ context.Context, o client.Object, patch client.Patch, opts ...client.PatchOption) error {
 				Expect(patch.Data(o)).To(BeEquivalentTo(fmt.Sprintf(`{"metadata":{"finalizers":["%s"],"resourceVersion":"42"}}`, finalizerName)))
 				return nil
 			})
@@ -122,7 +122,7 @@ var _ = Describe("Reconciler", func() {
 			cloudProfile.DeletionTimestamp = &now
 			cloudProfile.Finalizers = []string{finalizerName}
 
-			c.EXPECT().Get(ctx, kubernetesutils.Key(cloudProfileName), gomock.AssignableToTypeOf(&gardencorev1beta1.CloudProfile{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.CloudProfile, _ ...client.GetOption) error {
+			c.EXPECT().Get(gomock.Any(), kubernetesutils.Key(cloudProfileName), gomock.AssignableToTypeOf(&gardencorev1beta1.CloudProfile{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.CloudProfile, _ ...client.GetOption) error {
 				*obj = *cloudProfile
 				return nil
 			})
@@ -137,7 +137,7 @@ var _ = Describe("Reconciler", func() {
 		})
 
 		It("should return an error because Shoot referencing CloudProfile exists", func() {
-			c.EXPECT().List(ctx, gomock.AssignableToTypeOf(&gardencorev1beta1.ShootList{})).DoAndReturn(func(_ context.Context, obj *gardencorev1beta1.ShootList, _ ...client.ListOption) error {
+			c.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&gardencorev1beta1.ShootList{})).DoAndReturn(func(_ context.Context, obj *gardencorev1beta1.ShootList, _ ...client.ListOption) error {
 				(&gardencorev1beta1.ShootList{Items: []gardencorev1beta1.Shoot{
 					{
 						ObjectMeta: metav1.ObjectMeta{Name: "test-shoot", Namespace: "test-namespace"},
@@ -155,12 +155,12 @@ var _ = Describe("Reconciler", func() {
 		})
 
 		It("should remove the finalizer (error)", func() {
-			c.EXPECT().List(ctx, gomock.AssignableToTypeOf(&gardencorev1beta1.ShootList{})).DoAndReturn(func(_ context.Context, obj *gardencorev1beta1.ShootList, _ ...client.ListOption) error {
+			c.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&gardencorev1beta1.ShootList{})).DoAndReturn(func(_ context.Context, obj *gardencorev1beta1.ShootList, _ ...client.ListOption) error {
 				(&gardencorev1beta1.ShootList{}).DeepCopyInto(obj)
 				return nil
 			})
 
-			c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&gardencorev1beta1.CloudProfile{}), gomock.Any()).DoAndReturn(func(_ context.Context, o client.Object, patch client.Patch, opts ...client.PatchOption) error {
+			c.EXPECT().Patch(gomock.Any(), gomock.AssignableToTypeOf(&gardencorev1beta1.CloudProfile{}), gomock.Any()).DoAndReturn(func(_ context.Context, o client.Object, patch client.Patch, opts ...client.PatchOption) error {
 				Expect(patch.Data(o)).To(BeEquivalentTo(`{"metadata":{"finalizers":null,"resourceVersion":"42"}}`))
 				return fakeErr
 			})
@@ -171,12 +171,12 @@ var _ = Describe("Reconciler", func() {
 		})
 
 		It("should remove the finalizer (no error)", func() {
-			c.EXPECT().List(ctx, gomock.AssignableToTypeOf(&gardencorev1beta1.ShootList{})).DoAndReturn(func(_ context.Context, obj *gardencorev1beta1.ShootList, _ ...client.ListOption) error {
+			c.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&gardencorev1beta1.ShootList{})).DoAndReturn(func(_ context.Context, obj *gardencorev1beta1.ShootList, _ ...client.ListOption) error {
 				(&gardencorev1beta1.ShootList{}).DeepCopyInto(obj)
 				return nil
 			})
 
-			c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&gardencorev1beta1.CloudProfile{}), gomock.Any()).DoAndReturn(func(_ context.Context, o client.Object, patch client.Patch, opts ...client.PatchOption) error {
+			c.EXPECT().Patch(gomock.Any(), gomock.AssignableToTypeOf(&gardencorev1beta1.CloudProfile{}), gomock.Any()).DoAndReturn(func(_ context.Context, o client.Object, patch client.Patch, opts ...client.PatchOption) error {
 				Expect(patch.Data(o)).To(BeEquivalentTo(`{"metadata":{"finalizers":null,"resourceVersion":"42"}}`))
 				return nil
 			})

--- a/pkg/controllermanager/controller/controllerdeployment/reconciler.go
+++ b/pkg/controllermanager/controller/controllerdeployment/reconciler.go
@@ -44,6 +44,9 @@ type Reconciler struct {
 func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
 	log := logf.FromContext(ctx)
 
+	ctx, cancel := context.WithTimeout(ctx, controllerutils.DefaultReconciliationTimeout)
+	defer cancel()
+
 	controllerDeployment := &gardencorev1beta1.ControllerDeployment{}
 	if err := r.Client.Get(ctx, kubernetesutils.Key(req.Name), controllerDeployment); err != nil {
 		if apierrors.IsNotFound(err) {

--- a/pkg/controllermanager/controller/controllerdeployment/reconciler.go
+++ b/pkg/controllermanager/controller/controllerdeployment/reconciler.go
@@ -44,7 +44,7 @@ type Reconciler struct {
 func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
 	log := logf.FromContext(ctx)
 
-	ctx, cancel := context.WithTimeout(ctx, controllerutils.DefaultReconciliationTimeout)
+	ctx, cancel := controllerutils.GetMainReconciliationContext(ctx, controllerutils.DefaultReconciliationTimeout)
 	defer cancel()
 
 	controllerDeployment := &gardencorev1beta1.ControllerDeployment{}

--- a/pkg/controllermanager/controller/controllerregistration/controllerregistrationfinalizer/reconciler.go
+++ b/pkg/controllermanager/controller/controllerregistration/controllerregistrationfinalizer/reconciler.go
@@ -43,6 +43,9 @@ type Reconciler struct {
 func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 	log := logf.FromContext(ctx)
 
+	ctx, cancel := context.WithTimeout(ctx, controllerutils.DefaultReconciliationTimeout)
+	defer cancel()
+
 	controllerRegistration := &gardencorev1beta1.ControllerRegistration{}
 	if err := r.Client.Get(ctx, request.NamespacedName, controllerRegistration); err != nil {
 		if apierrors.IsNotFound(err) {

--- a/pkg/controllermanager/controller/controllerregistration/controllerregistrationfinalizer/reconciler.go
+++ b/pkg/controllermanager/controller/controllerregistration/controllerregistrationfinalizer/reconciler.go
@@ -43,7 +43,7 @@ type Reconciler struct {
 func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 	log := logf.FromContext(ctx)
 
-	ctx, cancel := context.WithTimeout(ctx, controllerutils.DefaultReconciliationTimeout)
+	ctx, cancel := controllerutils.GetMainReconciliationContext(ctx, controllerutils.DefaultReconciliationTimeout)
 	defer cancel()
 
 	controllerRegistration := &gardencorev1beta1.ControllerRegistration{}

--- a/pkg/controllermanager/controller/controllerregistration/controllerregistrationfinalizer/reconciler_test.go
+++ b/pkg/controllermanager/controller/controllerregistration/controllerregistrationfinalizer/reconciler_test.go
@@ -74,7 +74,7 @@ var _ = Describe("ControllerRegistration", func() {
 		})
 
 		It("should return nil because object not found", func() {
-			c.EXPECT().Get(ctx, kubernetesutils.Key(controllerRegistrationName), gomock.AssignableToTypeOf(&gardencorev1beta1.ControllerRegistration{})).Return(apierrors.NewNotFound(schema.GroupResource{}, ""))
+			c.EXPECT().Get(gomock.Any(), kubernetesutils.Key(controllerRegistrationName), gomock.AssignableToTypeOf(&gardencorev1beta1.ControllerRegistration{})).Return(apierrors.NewNotFound(schema.GroupResource{}, ""))
 
 			result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: controllerRegistrationName}})
 			Expect(result).To(Equal(reconcile.Result{}))
@@ -82,7 +82,7 @@ var _ = Describe("ControllerRegistration", func() {
 		})
 
 		It("should return err because object reading failed", func() {
-			c.EXPECT().Get(ctx, kubernetesutils.Key(controllerRegistrationName), gomock.AssignableToTypeOf(&gardencorev1beta1.ControllerRegistration{})).Return(fakeErr)
+			c.EXPECT().Get(gomock.Any(), kubernetesutils.Key(controllerRegistrationName), gomock.AssignableToTypeOf(&gardencorev1beta1.ControllerRegistration{})).Return(fakeErr)
 
 			result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: controllerRegistrationName}})
 			Expect(result).To(Equal(reconcile.Result{}))
@@ -91,7 +91,7 @@ var _ = Describe("ControllerRegistration", func() {
 
 		Context("deletion timestamp not set", func() {
 			BeforeEach(func() {
-				c.EXPECT().Get(ctx, kubernetesutils.Key(controllerRegistrationName), gomock.AssignableToTypeOf(&gardencorev1beta1.ControllerRegistration{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.ControllerRegistration, _ ...client.GetOption) error {
+				c.EXPECT().Get(gomock.Any(), kubernetesutils.Key(controllerRegistrationName), gomock.AssignableToTypeOf(&gardencorev1beta1.ControllerRegistration{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.ControllerRegistration, _ ...client.GetOption) error {
 					*obj = *controllerRegistration
 					return nil
 				})
@@ -100,7 +100,7 @@ var _ = Describe("ControllerRegistration", func() {
 			It("should ensure the finalizer (error)", func() {
 				errToReturn := apierrors.NewNotFound(schema.GroupResource{}, controllerRegistrationName)
 
-				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&gardencorev1beta1.ControllerRegistration{}), gomock.Any()).DoAndReturn(func(_ context.Context, o client.Object, patch client.Patch, opts ...client.PatchOption) error {
+				c.EXPECT().Patch(gomock.Any(), gomock.AssignableToTypeOf(&gardencorev1beta1.ControllerRegistration{}), gomock.Any()).DoAndReturn(func(_ context.Context, o client.Object, patch client.Patch, opts ...client.PatchOption) error {
 					Expect(patch.Data(o)).To(BeEquivalentTo(fmt.Sprintf(`{"metadata":{"finalizers":["%s"],"resourceVersion":"42"}}`, finalizerName)))
 					return errToReturn
 				})
@@ -111,7 +111,7 @@ var _ = Describe("ControllerRegistration", func() {
 			})
 
 			It("should ensure the finalizer (no error)", func() {
-				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&gardencorev1beta1.ControllerRegistration{}), gomock.Any()).DoAndReturn(func(_ context.Context, o client.Object, patch client.Patch, opts ...client.PatchOption) error {
+				c.EXPECT().Patch(gomock.Any(), gomock.AssignableToTypeOf(&gardencorev1beta1.ControllerRegistration{}), gomock.Any()).DoAndReturn(func(_ context.Context, o client.Object, patch client.Patch, opts ...client.PatchOption) error {
 					Expect(patch.Data(o)).To(BeEquivalentTo(fmt.Sprintf(`{"metadata":{"finalizers":["%s"],"resourceVersion":"42"}}`, finalizerName)))
 					return nil
 				})
@@ -128,7 +128,7 @@ var _ = Describe("ControllerRegistration", func() {
 				controllerRegistration.DeletionTimestamp = &now
 				controllerRegistration.Finalizers = []string{FinalizerName}
 
-				c.EXPECT().Get(ctx, kubernetesutils.Key(controllerRegistrationName), gomock.AssignableToTypeOf(&gardencorev1beta1.ControllerRegistration{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.ControllerRegistration, _ ...client.GetOption) error {
+				c.EXPECT().Get(gomock.Any(), kubernetesutils.Key(controllerRegistrationName), gomock.AssignableToTypeOf(&gardencorev1beta1.ControllerRegistration{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.ControllerRegistration, _ ...client.GetOption) error {
 					*obj = *controllerRegistration
 					return nil
 				})
@@ -143,7 +143,7 @@ var _ = Describe("ControllerRegistration", func() {
 			})
 
 			It("should return an error because installation list failed", func() {
-				c.EXPECT().List(ctx, gomock.AssignableToTypeOf(&gardencorev1beta1.ControllerInstallationList{})).Return(fakeErr)
+				c.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&gardencorev1beta1.ControllerInstallationList{})).Return(fakeErr)
 
 				result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: controllerRegistrationName}})
 				Expect(result).To(Equal(reconcile.Result{}))
@@ -151,7 +151,7 @@ var _ = Describe("ControllerRegistration", func() {
 			})
 
 			It("should return an error because installation referencing controllerRegistration exists", func() {
-				c.EXPECT().List(ctx, gomock.AssignableToTypeOf(&gardencorev1beta1.ControllerInstallationList{})).DoAndReturn(func(_ context.Context, obj *gardencorev1beta1.ControllerInstallationList, _ ...client.ListOption) error {
+				c.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&gardencorev1beta1.ControllerInstallationList{})).DoAndReturn(func(_ context.Context, obj *gardencorev1beta1.ControllerInstallationList, _ ...client.ListOption) error {
 					(&gardencorev1beta1.ControllerInstallationList{Items: []gardencorev1beta1.ControllerInstallation{
 						{
 							Spec: gardencorev1beta1.ControllerInstallationSpec{
@@ -170,12 +170,12 @@ var _ = Describe("ControllerRegistration", func() {
 			})
 
 			It("should remove the finalizer (error)", func() {
-				c.EXPECT().List(ctx, gomock.AssignableToTypeOf(&gardencorev1beta1.ControllerInstallationList{})).DoAndReturn(func(_ context.Context, obj *gardencorev1beta1.ControllerInstallationList, _ ...client.ListOption) error {
+				c.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&gardencorev1beta1.ControllerInstallationList{})).DoAndReturn(func(_ context.Context, obj *gardencorev1beta1.ControllerInstallationList, _ ...client.ListOption) error {
 					(&gardencorev1beta1.ControllerInstallationList{}).DeepCopyInto(obj)
 					return nil
 				})
 
-				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&gardencorev1beta1.ControllerRegistration{}), gomock.Any()).DoAndReturn(func(_ context.Context, o client.Object, patch client.Patch, opts ...client.PatchOption) error {
+				c.EXPECT().Patch(gomock.Any(), gomock.AssignableToTypeOf(&gardencorev1beta1.ControllerRegistration{}), gomock.Any()).DoAndReturn(func(_ context.Context, o client.Object, patch client.Patch, opts ...client.PatchOption) error {
 					Expect(patch.Data(o)).To(BeEquivalentTo(`{"metadata":{"finalizers":null,"resourceVersion":"42"}}`))
 					return fakeErr
 				})
@@ -186,12 +186,12 @@ var _ = Describe("ControllerRegistration", func() {
 			})
 
 			It("should remove the finalizer (no error)", func() {
-				c.EXPECT().List(ctx, gomock.AssignableToTypeOf(&gardencorev1beta1.ControllerInstallationList{})).DoAndReturn(func(_ context.Context, obj *gardencorev1beta1.ControllerInstallationList, _ ...client.ListOption) error {
+				c.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&gardencorev1beta1.ControllerInstallationList{})).DoAndReturn(func(_ context.Context, obj *gardencorev1beta1.ControllerInstallationList, _ ...client.ListOption) error {
 					(&gardencorev1beta1.ControllerInstallationList{}).DeepCopyInto(obj)
 					return nil
 				})
 
-				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&gardencorev1beta1.ControllerRegistration{}), gomock.Any()).DoAndReturn(func(_ context.Context, o client.Object, patch client.Patch, opts ...client.PatchOption) error {
+				c.EXPECT().Patch(gomock.Any(), gomock.AssignableToTypeOf(&gardencorev1beta1.ControllerRegistration{}), gomock.Any()).DoAndReturn(func(_ context.Context, o client.Object, patch client.Patch, opts ...client.PatchOption) error {
 					Expect(patch.Data(o)).To(BeEquivalentTo(`{"metadata":{"finalizers":null,"resourceVersion":"42"}}`))
 					return nil
 				})

--- a/pkg/controllermanager/controller/controllerregistration/seed/reconciler.go
+++ b/pkg/controllermanager/controller/controllerregistration/seed/reconciler.go
@@ -65,6 +65,9 @@ type Reconciler struct {
 func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 	log := logf.FromContext(ctx)
 
+	ctx, cancel := context.WithTimeout(ctx, controllerutils.DefaultReconciliationTimeout)
+	defer cancel()
+
 	seed := &gardencorev1beta1.Seed{}
 	if err := r.Client.Get(ctx, request.NamespacedName, seed); err != nil {
 		if apierrors.IsNotFound(err) {

--- a/pkg/controllermanager/controller/controllerregistration/seed/reconciler.go
+++ b/pkg/controllermanager/controller/controllerregistration/seed/reconciler.go
@@ -65,7 +65,7 @@ type Reconciler struct {
 func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 	log := logf.FromContext(ctx)
 
-	ctx, cancel := context.WithTimeout(ctx, controllerutils.DefaultReconciliationTimeout)
+	ctx, cancel := controllerutils.GetMainReconciliationContext(ctx, controllerutils.DefaultReconciliationTimeout)
 	defer cancel()
 
 	seed := &gardencorev1beta1.Seed{}

--- a/pkg/controllermanager/controller/controllerregistration/seedfinalizer/reconciler.go
+++ b/pkg/controllermanager/controller/controllerregistration/seedfinalizer/reconciler.go
@@ -43,6 +43,9 @@ type Reconciler struct {
 func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 	log := logf.FromContext(ctx)
 
+	ctx, cancel := context.WithTimeout(ctx, controllerutils.DefaultReconciliationTimeout)
+	defer cancel()
+
 	seed := &gardencorev1beta1.Seed{}
 	if err := r.Client.Get(ctx, request.NamespacedName, seed); err != nil {
 		if apierrors.IsNotFound(err) {

--- a/pkg/controllermanager/controller/controllerregistration/seedfinalizer/reconciler.go
+++ b/pkg/controllermanager/controller/controllerregistration/seedfinalizer/reconciler.go
@@ -43,7 +43,7 @@ type Reconciler struct {
 func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 	log := logf.FromContext(ctx)
 
-	ctx, cancel := context.WithTimeout(ctx, controllerutils.DefaultReconciliationTimeout)
+	ctx, cancel := controllerutils.GetMainReconciliationContext(ctx, controllerutils.DefaultReconciliationTimeout)
 	defer cancel()
 
 	seed := &gardencorev1beta1.Seed{}

--- a/pkg/controllermanager/controller/controllerregistration/seedfinalizer/reconciler_test.go
+++ b/pkg/controllermanager/controller/controllerregistration/seedfinalizer/reconciler_test.go
@@ -69,7 +69,7 @@ var _ = Describe("Reconciler", func() {
 
 	Describe("#Reconcile", func() {
 		It("should return nil because object not found", func() {
-			c.EXPECT().Get(ctx, kubernetesutils.Key(seedName), gomock.AssignableToTypeOf(&gardencorev1beta1.Seed{})).Return(apierrors.NewNotFound(schema.GroupResource{}, ""))
+			c.EXPECT().Get(gomock.Any(), kubernetesutils.Key(seedName), gomock.AssignableToTypeOf(&gardencorev1beta1.Seed{})).Return(apierrors.NewNotFound(schema.GroupResource{}, ""))
 
 			result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: seedName}})
 			Expect(result).To(Equal(reconcile.Result{}))
@@ -77,7 +77,7 @@ var _ = Describe("Reconciler", func() {
 		})
 
 		It("should return err because object reading failed", func() {
-			c.EXPECT().Get(ctx, kubernetesutils.Key(seedName), gomock.AssignableToTypeOf(&gardencorev1beta1.Seed{})).Return(fakeErr)
+			c.EXPECT().Get(gomock.Any(), kubernetesutils.Key(seedName), gomock.AssignableToTypeOf(&gardencorev1beta1.Seed{})).Return(fakeErr)
 
 			result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: seedName}})
 			Expect(result).To(Equal(reconcile.Result{}))
@@ -86,7 +86,7 @@ var _ = Describe("Reconciler", func() {
 
 		Context("deletion timestamp not set", func() {
 			BeforeEach(func() {
-				c.EXPECT().Get(ctx, kubernetesutils.Key(seedName), gomock.AssignableToTypeOf(&gardencorev1beta1.Seed{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.Seed, _ ...client.GetOption) error {
+				c.EXPECT().Get(gomock.Any(), kubernetesutils.Key(seedName), gomock.AssignableToTypeOf(&gardencorev1beta1.Seed{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.Seed, _ ...client.GetOption) error {
 					*obj = *seed
 					return nil
 				})
@@ -95,7 +95,7 @@ var _ = Describe("Reconciler", func() {
 			It("should ensure the finalizer (error)", func() {
 				errToReturn := apierrors.NewNotFound(schema.GroupResource{}, seedName)
 
-				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&gardencorev1beta1.Seed{}), gomock.Any()).DoAndReturn(func(_ context.Context, o client.Object, patch client.Patch, opts ...client.PatchOption) error {
+				c.EXPECT().Patch(gomock.Any(), gomock.AssignableToTypeOf(&gardencorev1beta1.Seed{}), gomock.Any()).DoAndReturn(func(_ context.Context, o client.Object, patch client.Patch, opts ...client.PatchOption) error {
 					Expect(patch.Data(o)).To(BeEquivalentTo(fmt.Sprintf(`{"metadata":{"finalizers":["%s"],"resourceVersion":"42"}}`, finalizerName)))
 					return errToReturn
 				})
@@ -106,7 +106,7 @@ var _ = Describe("Reconciler", func() {
 			})
 
 			It("should ensure the finalizer (no error)", func() {
-				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&gardencorev1beta1.Seed{}), gomock.Any()).DoAndReturn(func(_ context.Context, o client.Object, patch client.Patch, opts ...client.PatchOption) error {
+				c.EXPECT().Patch(gomock.Any(), gomock.AssignableToTypeOf(&gardencorev1beta1.Seed{}), gomock.Any()).DoAndReturn(func(_ context.Context, o client.Object, patch client.Patch, opts ...client.PatchOption) error {
 					Expect(patch.Data(o)).To(BeEquivalentTo(fmt.Sprintf(`{"metadata":{"finalizers":["%s"],"resourceVersion":"42"}}`, finalizerName)))
 					return nil
 				})
@@ -123,7 +123,7 @@ var _ = Describe("Reconciler", func() {
 				seed.DeletionTimestamp = &now
 				seed.Finalizers = []string{FinalizerName}
 
-				c.EXPECT().Get(ctx, kubernetesutils.Key(seedName), gomock.AssignableToTypeOf(&gardencorev1beta1.Seed{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.Seed, _ ...client.GetOption) error {
+				c.EXPECT().Get(gomock.Any(), kubernetesutils.Key(seedName), gomock.AssignableToTypeOf(&gardencorev1beta1.Seed{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.Seed, _ ...client.GetOption) error {
 					*obj = *seed
 					return nil
 				})
@@ -138,7 +138,7 @@ var _ = Describe("Reconciler", func() {
 			})
 
 			It("should return an error because installation list failed", func() {
-				c.EXPECT().List(ctx, gomock.AssignableToTypeOf(&gardencorev1beta1.ControllerInstallationList{})).Return(fakeErr)
+				c.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&gardencorev1beta1.ControllerInstallationList{})).Return(fakeErr)
 
 				result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: seedName}})
 				Expect(result).To(Equal(reconcile.Result{}))
@@ -146,7 +146,7 @@ var _ = Describe("Reconciler", func() {
 			})
 
 			It("should return an error because installation referencing seed exists", func() {
-				c.EXPECT().List(ctx, gomock.AssignableToTypeOf(&gardencorev1beta1.ControllerInstallationList{})).DoAndReturn(func(_ context.Context, obj *gardencorev1beta1.ControllerInstallationList, _ ...client.ListOption) error {
+				c.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&gardencorev1beta1.ControllerInstallationList{})).DoAndReturn(func(_ context.Context, obj *gardencorev1beta1.ControllerInstallationList, _ ...client.ListOption) error {
 					(&gardencorev1beta1.ControllerInstallationList{Items: []gardencorev1beta1.ControllerInstallation{
 						{
 							Spec: gardencorev1beta1.ControllerInstallationSpec{
@@ -165,12 +165,12 @@ var _ = Describe("Reconciler", func() {
 			})
 
 			It("should remove the finalizer (error)", func() {
-				c.EXPECT().List(ctx, gomock.AssignableToTypeOf(&gardencorev1beta1.ControllerInstallationList{})).DoAndReturn(func(_ context.Context, obj *gardencorev1beta1.ControllerInstallationList, _ ...client.ListOption) error {
+				c.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&gardencorev1beta1.ControllerInstallationList{})).DoAndReturn(func(_ context.Context, obj *gardencorev1beta1.ControllerInstallationList, _ ...client.ListOption) error {
 					(&gardencorev1beta1.ControllerInstallationList{}).DeepCopyInto(obj)
 					return nil
 				})
 
-				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&gardencorev1beta1.Seed{}), gomock.Any()).DoAndReturn(func(_ context.Context, o client.Object, patch client.Patch, opts ...client.PatchOption) error {
+				c.EXPECT().Patch(gomock.Any(), gomock.AssignableToTypeOf(&gardencorev1beta1.Seed{}), gomock.Any()).DoAndReturn(func(_ context.Context, o client.Object, patch client.Patch, opts ...client.PatchOption) error {
 					Expect(patch.Data(o)).To(BeEquivalentTo(`{"metadata":{"finalizers":null,"resourceVersion":"42"}}`))
 					return fakeErr
 				})
@@ -181,12 +181,12 @@ var _ = Describe("Reconciler", func() {
 			})
 
 			It("should remove the finalizer (no error)", func() {
-				c.EXPECT().List(ctx, gomock.AssignableToTypeOf(&gardencorev1beta1.ControllerInstallationList{})).DoAndReturn(func(_ context.Context, obj *gardencorev1beta1.ControllerInstallationList, _ ...client.ListOption) error {
+				c.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&gardencorev1beta1.ControllerInstallationList{})).DoAndReturn(func(_ context.Context, obj *gardencorev1beta1.ControllerInstallationList, _ ...client.ListOption) error {
 					(&gardencorev1beta1.ControllerInstallationList{}).DeepCopyInto(obj)
 					return nil
 				})
 
-				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&gardencorev1beta1.Seed{}), gomock.Any()).DoAndReturn(func(_ context.Context, o client.Object, patch client.Patch, opts ...client.PatchOption) error {
+				c.EXPECT().Patch(gomock.Any(), gomock.AssignableToTypeOf(&gardencorev1beta1.Seed{}), gomock.Any()).DoAndReturn(func(_ context.Context, o client.Object, patch client.Patch, opts ...client.PatchOption) error {
 					Expect(patch.Data(o)).To(BeEquivalentTo(`{"metadata":{"finalizers":null,"resourceVersion":"42"}}`))
 					return nil
 				})

--- a/pkg/controllermanager/controller/event/reconciler.go
+++ b/pkg/controllermanager/controller/event/reconciler.go
@@ -28,6 +28,7 @@ import (
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	"github.com/gardener/gardener/pkg/controllermanager/apis/config"
+	"github.com/gardener/gardener/pkg/controllerutils"
 )
 
 // Reconciler reconciles Event.
@@ -40,6 +41,9 @@ type Reconciler struct {
 // Reconcile performs the main reconciliation logic.
 func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
 	log := logf.FromContext(ctx)
+
+	ctx, cancel := context.WithTimeout(ctx, controllerutils.DefaultReconciliationTimeout)
+	defer cancel()
 
 	event := &corev1.Event{}
 	if err := r.Client.Get(ctx, req.NamespacedName, event); err != nil {

--- a/pkg/controllermanager/controller/event/reconciler.go
+++ b/pkg/controllermanager/controller/event/reconciler.go
@@ -42,7 +42,7 @@ type Reconciler struct {
 func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
 	log := logf.FromContext(ctx)
 
-	ctx, cancel := context.WithTimeout(ctx, controllerutils.DefaultReconciliationTimeout)
+	ctx, cancel := controllerutils.GetMainReconciliationContext(ctx, controllerutils.DefaultReconciliationTimeout)
 	defer cancel()
 
 	event := &corev1.Event{}

--- a/pkg/controllermanager/controller/exposureclass/reconciler.go
+++ b/pkg/controllermanager/controller/exposureclass/reconciler.go
@@ -48,7 +48,7 @@ type Reconciler struct {
 func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 	log := logf.FromContext(ctx)
 
-	ctx, cancel := context.WithTimeout(ctx, controllerutils.DefaultReconciliationTimeout)
+	ctx, cancel := controllerutils.GetMainReconciliationContext(ctx, controllerutils.DefaultReconciliationTimeout)
 	defer cancel()
 
 	exposureClass := &gardencorev1beta1.ExposureClass{}

--- a/pkg/controllermanager/controller/exposureclass/reconciler.go
+++ b/pkg/controllermanager/controller/exposureclass/reconciler.go
@@ -28,7 +28,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/ratelimiter"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/controllermanager/apis/config"
@@ -49,6 +48,9 @@ type Reconciler struct {
 func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 	log := logf.FromContext(ctx)
 
+	ctx, cancel := context.WithTimeout(ctx, controllerutils.DefaultReconciliationTimeout)
+	defer cancel()
+
 	exposureClass := &gardencorev1beta1.ExposureClass{}
 	if err := r.Client.Get(ctx, request.NamespacedName, exposureClass); err != nil {
 		if apierrors.IsNotFound(err) {
@@ -60,7 +62,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 
 	if exposureClass.DeletionTimestamp != nil {
 		// Ignore the exposure class if it has no gardener finalizer.
-		if !sets.New[string](exposureClass.Finalizers...).Has(gardencorev1alpha1.GardenerName) {
+		if !sets.New[string](exposureClass.Finalizers...).Has(gardencorev1beta1.GardenerName) {
 			return reconcile.Result{}, nil
 		}
 
@@ -91,7 +93,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 
 	if !controllerutil.ContainsFinalizer(exposureClass, gardencorev1beta1.GardenerName) {
 		log.Info("Adding finalizer")
-		if err := controllerutils.AddFinalizers(ctx, r.Client, exposureClass, gardencorev1alpha1.GardenerName); err != nil {
+		if err := controllerutils.AddFinalizers(ctx, r.Client, exposureClass, gardencorev1beta1.GardenerName); err != nil {
 			return reconcile.Result{}, fmt.Errorf("could not add finalizer: %w", err)
 		}
 	}

--- a/pkg/controllermanager/controller/managedseedset/reconciler.go
+++ b/pkg/controllermanager/controller/managedseedset/reconciler.go
@@ -43,6 +43,9 @@ type Reconciler struct {
 func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 	log := logf.FromContext(ctx)
 
+	ctx, cancel := context.WithTimeout(ctx, r.Config.SyncPeriod.Duration)
+	defer cancel()
+
 	managedSeedSet := &seedmanagementv1alpha1.ManagedSeedSet{}
 	if err := r.Client.Get(ctx, request.NamespacedName, managedSeedSet); err != nil {
 		if apierrors.IsNotFound(err) {

--- a/pkg/controllermanager/controller/managedseedset/reconciler.go
+++ b/pkg/controllermanager/controller/managedseedset/reconciler.go
@@ -43,7 +43,7 @@ type Reconciler struct {
 func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 	log := logf.FromContext(ctx)
 
-	ctx, cancel := context.WithTimeout(ctx, r.Config.SyncPeriod.Duration)
+	ctx, cancel := controllerutils.GetMainReconciliationContext(ctx, r.Config.SyncPeriod.Duration)
 	defer cancel()
 
 	managedSeedSet := &seedmanagementv1alpha1.ManagedSeedSet{}

--- a/pkg/controllermanager/controller/managedseedset/reconciler_test.go
+++ b/pkg/controllermanager/controller/managedseedset/reconciler_test.go
@@ -93,7 +93,7 @@ var _ = Describe("reconciler", func() {
 
 	var (
 		expectGetManagedSeedSet = func() {
-			c.EXPECT().Get(ctx, kubernetesutils.Key(namespace, name), gomock.AssignableToTypeOf(&seedmanagementv1alpha1.ManagedSeedSet{})).DoAndReturn(
+			c.EXPECT().Get(gomock.Any(), kubernetesutils.Key(namespace, name), gomock.AssignableToTypeOf(&seedmanagementv1alpha1.ManagedSeedSet{})).DoAndReturn(
 				func(_ context.Context, _ client.ObjectKey, mss *seedmanagementv1alpha1.ManagedSeedSet, _ ...client.GetOption) error {
 					*mss = *managedSeedSet
 					return nil
@@ -101,7 +101,7 @@ var _ = Describe("reconciler", func() {
 			)
 		}
 		expectPatchManagedSeedSet = func(expect func(*seedmanagementv1alpha1.ManagedSeedSet)) {
-			c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&seedmanagementv1alpha1.ManagedSeedSet{}), gomock.Any()).DoAndReturn(
+			c.EXPECT().Patch(gomock.Any(), gomock.AssignableToTypeOf(&seedmanagementv1alpha1.ManagedSeedSet{}), gomock.Any()).DoAndReturn(
 				func(_ context.Context, mss *seedmanagementv1alpha1.ManagedSeedSet, _ client.Patch, _ ...client.PatchOption) error {
 					expect(mss)
 					*managedSeedSet = *mss
@@ -110,7 +110,7 @@ var _ = Describe("reconciler", func() {
 			)
 		}
 		expectPatchManagedSeedSetStatus = func(expect func(*seedmanagementv1alpha1.ManagedSeedSet)) {
-			sw.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&seedmanagementv1alpha1.ManagedSeedSet{}), gomock.Any()).DoAndReturn(
+			sw.EXPECT().Patch(gomock.Any(), gomock.AssignableToTypeOf(&seedmanagementv1alpha1.ManagedSeedSet{}), gomock.Any()).DoAndReturn(
 				func(_ context.Context, mss *seedmanagementv1alpha1.ManagedSeedSet, _ client.Patch, _ ...client.PatchOption) error {
 					expect(mss)
 					*managedSeedSet = *mss
@@ -127,7 +127,7 @@ var _ = Describe("reconciler", func() {
 				expectPatchManagedSeedSet(func(mss *seedmanagementv1alpha1.ManagedSeedSet) {
 					Expect(mss.Finalizers).To(Equal([]string{gardencorev1beta1.GardenerName}))
 				})
-				actuator.EXPECT().Reconcile(ctx, gomock.Any(), managedSeedSet).Return(status, false, nil)
+				actuator.EXPECT().Reconcile(gomock.Any(), gomock.Any(), managedSeedSet).Return(status, false, nil)
 				expectPatchManagedSeedSetStatus(func(mss *seedmanagementv1alpha1.ManagedSeedSet) {
 					Expect(&mss.Status).To(Equal(status))
 				})
@@ -140,7 +140,7 @@ var _ = Describe("reconciler", func() {
 			It("should reconcile the ManagedSeedSet creation or update, and update the status", func() {
 				expectGetManagedSeedSet()
 				managedSeedSet.Finalizers = []string{gardencorev1beta1.GardenerName}
-				actuator.EXPECT().Reconcile(ctx, gomock.Any(), managedSeedSet).Return(status, false, nil)
+				actuator.EXPECT().Reconcile(gomock.Any(), gomock.Any(), managedSeedSet).Return(status, false, nil)
 				expectPatchManagedSeedSetStatus(func(mss *seedmanagementv1alpha1.ManagedSeedSet) {
 					Expect(&mss.Status).To(Equal(status))
 				})
@@ -160,7 +160,7 @@ var _ = Describe("reconciler", func() {
 
 			It("should reconcile the ManagedSeedSet deletion and update the status", func() {
 				expectGetManagedSeedSet()
-				actuator.EXPECT().Reconcile(ctx, gomock.Any(), managedSeedSet).Return(status, false, nil)
+				actuator.EXPECT().Reconcile(gomock.Any(), gomock.Any(), managedSeedSet).Return(status, false, nil)
 				expectPatchManagedSeedSetStatus(func(mss *seedmanagementv1alpha1.ManagedSeedSet) {
 					Expect(&mss.Status).To(Equal(status))
 				})
@@ -172,7 +172,7 @@ var _ = Describe("reconciler", func() {
 
 			It("should reconcile the ManagedSeedSet deletion, remove the finalizer, and not update the status", func() {
 				expectGetManagedSeedSet()
-				actuator.EXPECT().Reconcile(ctx, gomock.Any(), managedSeedSet).Return(status, true, nil)
+				actuator.EXPECT().Reconcile(gomock.Any(), gomock.Any(), managedSeedSet).Return(status, true, nil)
 				expectPatchManagedSeedSet(func(mss *seedmanagementv1alpha1.ManagedSeedSet) {
 					Expect(mss.Finalizers).To(BeEmpty())
 				})

--- a/pkg/controllermanager/controller/project/activity/reconciler.go
+++ b/pkg/controllermanager/controller/project/activity/reconciler.go
@@ -41,7 +41,7 @@ type Reconciler struct {
 func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 	log := logf.FromContext(ctx)
 
-	ctx, cancel := context.WithTimeout(ctx, controllerutils.DefaultReconciliationTimeout)
+	ctx, cancel := controllerutils.GetMainReconciliationContext(ctx, controllerutils.DefaultReconciliationTimeout)
 	defer cancel()
 
 	project := &gardencorev1beta1.Project{}

--- a/pkg/controllermanager/controller/project/activity/reconciler.go
+++ b/pkg/controllermanager/controller/project/activity/reconciler.go
@@ -27,6 +27,7 @@ import (
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	"github.com/gardener/gardener/pkg/controllermanager/apis/config"
+	"github.com/gardener/gardener/pkg/controllerutils"
 )
 
 // Reconciler reconciles Projects and updates the lastActivityTimestamp in the status.
@@ -39,6 +40,9 @@ type Reconciler struct {
 // Reconcile reconciles Projects and updates the lastActivityTimestamp in the status.
 func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 	log := logf.FromContext(ctx)
+
+	ctx, cancel := context.WithTimeout(ctx, controllerutils.DefaultReconciliationTimeout)
+	defer cancel()
 
 	project := &gardencorev1beta1.Project{}
 	if err := r.Client.Get(ctx, request.NamespacedName, project); err != nil {

--- a/pkg/controllermanager/controller/project/activity/reconciler_test.go
+++ b/pkg/controllermanager/controller/project/activity/reconciler_test.go
@@ -87,7 +87,7 @@ var _ = Describe("Project Activity", func() {
 			}
 
 			k8sGardenRuntimeClient.EXPECT().Get(
-				ctx,
+				gomock.Any(),
 				gomock.Any(),
 				gomock.AssignableToTypeOf(&gardencorev1beta1.Project{}),
 			).DoAndReturn(func(_ context.Context, namespacedName client.ObjectKey, obj *gardencorev1beta1.Project, _ ...client.GetOption) error {
@@ -100,7 +100,7 @@ var _ = Describe("Project Activity", func() {
 
 			k8sGardenRuntimeClient.EXPECT().Status().Return(mockStatusWriter).AnyTimes()
 
-			mockStatusWriter.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&gardencorev1beta1.Project{}), gomock.Any()).DoAndReturn(
+			mockStatusWriter.EXPECT().Patch(gomock.Any(), gomock.AssignableToTypeOf(&gardencorev1beta1.Project{}), gomock.Any()).DoAndReturn(
 				func(_ context.Context, prj *gardencorev1beta1.Project, _ client.Patch, _ ...client.PatchOption) error {
 					*project = *prj
 					return nil

--- a/pkg/controllermanager/controller/project/project/reconciler.go
+++ b/pkg/controllermanager/controller/project/project/reconciler.go
@@ -60,6 +60,9 @@ type Reconciler struct {
 func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 	log := logf.FromContext(ctx)
 
+	ctx, cancel := context.WithTimeout(ctx, controllerutils.DefaultReconciliationTimeout)
+	defer cancel()
+
 	project := &gardencorev1beta1.Project{}
 	if err := r.Client.Get(ctx, request.NamespacedName, project); err != nil {
 		if apierrors.IsNotFound(err) {

--- a/pkg/controllermanager/controller/project/project/reconciler.go
+++ b/pkg/controllermanager/controller/project/project/reconciler.go
@@ -60,7 +60,7 @@ type Reconciler struct {
 func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 	log := logf.FromContext(ctx)
 
-	ctx, cancel := context.WithTimeout(ctx, controllerutils.DefaultReconciliationTimeout)
+	ctx, cancel := controllerutils.GetMainReconciliationContext(ctx, controllerutils.DefaultReconciliationTimeout)
 	defer cancel()
 
 	project := &gardencorev1beta1.Project{}

--- a/pkg/controllermanager/controller/project/project/reconciler_test.go
+++ b/pkg/controllermanager/controller/project/project/reconciler_test.go
@@ -209,7 +209,7 @@ var _ = Describe("Default Resource Quota", func() {
 				Config: resourceQuota,
 			}
 
-			c.EXPECT().Get(ctx, kubernetesutils.Key(namespace, ResourceQuotaName), gomock.AssignableToTypeOf(&corev1.ResourceQuota{})).
+			c.EXPECT().Get(gomock.Any(), kubernetesutils.Key(namespace, ResourceQuotaName), gomock.AssignableToTypeOf(&corev1.ResourceQuota{})).
 				Return(apierrors.NewNotFound(corev1.Resource("resourcequota"), "resourcequota"))
 
 			expectedResourceQuota := resourceQuota.DeepCopy()
@@ -219,7 +219,7 @@ var _ = Describe("Default Resource Quota", func() {
 			expectedResourceQuota.SetName(ResourceQuotaName)
 			expectedResourceQuota.SetNamespace(namespace)
 
-			c.EXPECT().Create(ctx, expectedResourceQuota).Return(nil)
+			c.EXPECT().Create(gomock.Any(), expectedResourceQuota).Return(nil)
 
 			Expect(createOrUpdateResourceQuota(ctx, c, namespace, ownerRef, config)).To(Succeed())
 		})
@@ -243,7 +243,7 @@ var _ = Describe("Default Resource Quota", func() {
 				},
 			}
 
-			c.EXPECT().Get(ctx, kubernetesutils.Key(namespace, ResourceQuotaName), gomock.AssignableToTypeOf(&corev1.ResourceQuota{})).
+			c.EXPECT().Get(gomock.Any(), kubernetesutils.Key(namespace, ResourceQuotaName), gomock.AssignableToTypeOf(&corev1.ResourceQuota{})).
 				DoAndReturn(func(_ context.Context, _ client.ObjectKey, resourceQuota *corev1.ResourceQuota, _ ...client.GetOption) error {
 					*resourceQuota = *existingResourceQuota
 					return nil
@@ -255,7 +255,7 @@ var _ = Describe("Default Resource Quota", func() {
 			expectedResourceQuota.ObjectMeta.Annotations = map[string]string{"foo": "bar"}
 			expectedResourceQuota.Spec.Hard[secrets] = quantity
 
-			c.EXPECT().Patch(ctx, expectedResourceQuota, gomock.Any()).Return(nil)
+			c.EXPECT().Patch(gomock.Any(), expectedResourceQuota, gomock.Any()).Return(nil)
 
 			Expect(createOrUpdateResourceQuota(ctx, c, namespace, ownerRef, config)).To(Succeed())
 		})

--- a/pkg/controllermanager/controller/project/stale/reconciler.go
+++ b/pkg/controllermanager/controller/project/stale/reconciler.go
@@ -48,6 +48,9 @@ type Reconciler struct {
 func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 	log := logf.FromContext(ctx)
 
+	ctx, cancel := context.WithTimeout(ctx, r.Config.StaleSyncPeriod.Duration)
+	defer cancel()
+
 	project := &gardencorev1beta1.Project{}
 	if err := r.Client.Get(ctx, request.NamespacedName, project); err != nil {
 		if apierrors.IsNotFound(err) {

--- a/pkg/controllermanager/controller/project/stale/reconciler.go
+++ b/pkg/controllermanager/controller/project/stale/reconciler.go
@@ -33,6 +33,7 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/controllermanager/apis/config"
+	"github.com/gardener/gardener/pkg/controllerutils"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 )
@@ -48,7 +49,7 @@ type Reconciler struct {
 func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 	log := logf.FromContext(ctx)
 
-	ctx, cancel := context.WithTimeout(ctx, r.Config.StaleSyncPeriod.Duration)
+	ctx, cancel := controllerutils.GetMainReconciliationContext(ctx, r.Config.StaleSyncPeriod.Duration)
 	defer cancel()
 
 	project := &gardencorev1beta1.Project{}

--- a/pkg/controllermanager/controller/project/stale/reconciler_test.go
+++ b/pkg/controllermanager/controller/project/stale/reconciler_test.go
@@ -120,7 +120,7 @@ var _ = Describe("Reconciler", func() {
 			Clock:  fakeClock,
 		}
 
-		k8sGardenRuntimeClient.EXPECT().Get(ctx, kubernetesutils.Key(project.Name), gomock.AssignableToTypeOf(&gardencorev1beta1.Project{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.Project, _ ...client.GetOption) error {
+		k8sGardenRuntimeClient.EXPECT().Get(gomock.Any(), kubernetesutils.Key(project.Name), gomock.AssignableToTypeOf(&gardencorev1beta1.Project{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.Project, _ ...client.GetOption) error {
 			*obj = *project
 			return nil
 		})
@@ -137,7 +137,7 @@ var _ = Describe("Reconciler", func() {
 		})
 
 		BeforeEach(func() {
-			k8sGardenRuntimeClient.EXPECT().Get(ctx, kubernetesutils.Key(namespaceName), gomock.AssignableToTypeOf(&corev1.Namespace{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *corev1.Namespace, _ ...client.GetOption) error {
+			k8sGardenRuntimeClient.EXPECT().Get(gomock.Any(), kubernetesutils.Key(namespaceName), gomock.AssignableToTypeOf(&corev1.Namespace{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *corev1.Namespace, _ ...client.GetOption) error {
 				*obj = *namespace
 				return nil
 			}).AnyTimes()
@@ -184,7 +184,7 @@ var _ = Describe("Reconciler", func() {
 
 			Describe("project should be marked as not stale", func() {
 				It("has shoots", func() {
-					k8sGardenRuntimeClient.EXPECT().List(ctx, partialShootMetaList, client.InNamespace(namespaceName), client.Limit(1)).DoAndReturn(func(ctx context.Context, list *metav1.PartialObjectMetadataList, opts ...client.ListOption) error {
+					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialShootMetaList, client.InNamespace(namespaceName), client.Limit(1)).DoAndReturn(func(ctx context.Context, list *metav1.PartialObjectMetadataList, opts ...client.ListOption) error {
 						(&metav1.PartialObjectMetadataList{Items: []metav1.PartialObjectMetadata{*partialObjectMetadata}}).DeepCopyInto(list)
 						return nil
 					})
@@ -196,8 +196,8 @@ var _ = Describe("Reconciler", func() {
 				})
 
 				It("has backupentries", func() {
-					k8sGardenRuntimeClient.EXPECT().List(ctx, partialShootMetaList, client.InNamespace(namespaceName), client.Limit(1))
-					k8sGardenRuntimeClient.EXPECT().List(ctx, partialBackupEntryMetaList, client.InNamespace(namespaceName), client.Limit(1)).DoAndReturn(func(ctx context.Context, list *metav1.PartialObjectMetadataList, opts ...client.ListOption) error {
+					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialShootMetaList, client.InNamespace(namespaceName), client.Limit(1))
+					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialBackupEntryMetaList, client.InNamespace(namespaceName), client.Limit(1)).DoAndReturn(func(ctx context.Context, list *metav1.PartialObjectMetadataList, opts ...client.ListOption) error {
 						(&metav1.PartialObjectMetadataList{Items: []metav1.PartialObjectMetadata{*partialObjectMetadata}}).DeepCopyInto(list)
 						return nil
 					})
@@ -209,17 +209,17 @@ var _ = Describe("Reconciler", func() {
 				})
 
 				It("has secrets that are used by shoots in the same namespace", func() {
-					k8sGardenRuntimeClient.EXPECT().List(ctx, partialShootMetaList, client.InNamespace(namespaceName), client.Limit(1))
-					k8sGardenRuntimeClient.EXPECT().List(ctx, partialBackupEntryMetaList, client.InNamespace(namespaceName), client.Limit(1))
-					k8sGardenRuntimeClient.EXPECT().List(ctx, gomock.AssignableToTypeOf(&corev1.SecretList{}), client.InNamespace(namespaceName)).DoAndReturn(func(ctx context.Context, list *corev1.SecretList, opts ...client.ListOption) error {
+					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialShootMetaList, client.InNamespace(namespaceName), client.Limit(1))
+					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialBackupEntryMetaList, client.InNamespace(namespaceName), client.Limit(1))
+					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&corev1.SecretList{}), client.InNamespace(namespaceName)).DoAndReturn(func(ctx context.Context, list *corev1.SecretList, opts ...client.ListOption) error {
 						(&corev1.SecretList{Items: []corev1.Secret{*secret}}).DeepCopyInto(list)
 						return nil
 					})
-					k8sGardenRuntimeClient.EXPECT().List(ctx, gomock.AssignableToTypeOf(&gardencorev1beta1.SecretBindingList{})).DoAndReturn(func(ctx context.Context, list *gardencorev1beta1.SecretBindingList, opts ...client.ListOption) error {
+					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&gardencorev1beta1.SecretBindingList{})).DoAndReturn(func(ctx context.Context, list *gardencorev1beta1.SecretBindingList, opts ...client.ListOption) error {
 						(&gardencorev1beta1.SecretBindingList{Items: []gardencorev1beta1.SecretBinding{*secretBinding}}).DeepCopyInto(list)
 						return nil
 					})
-					k8sGardenRuntimeClient.EXPECT().List(ctx, gomock.AssignableToTypeOf(&gardencorev1beta1.ShootList{}), client.InNamespace(namespaceName)).DoAndReturn(func(ctx context.Context, list *gardencorev1beta1.ShootList, opts ...client.ListOption) error {
+					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&gardencorev1beta1.ShootList{}), client.InNamespace(namespaceName)).DoAndReturn(func(ctx context.Context, list *gardencorev1beta1.ShootList, opts ...client.ListOption) error {
 						(&gardencorev1beta1.ShootList{Items: []gardencorev1beta1.Shoot{*shoot}}).DeepCopyInto(list)
 						return nil
 					})
@@ -235,17 +235,17 @@ var _ = Describe("Reconciler", func() {
 					secretBinding.Namespace = otherNamespace
 					shoot.Namespace = otherNamespace
 
-					k8sGardenRuntimeClient.EXPECT().List(ctx, partialShootMetaList, client.InNamespace(namespaceName), client.Limit(1))
-					k8sGardenRuntimeClient.EXPECT().List(ctx, partialBackupEntryMetaList, client.InNamespace(namespaceName), client.Limit(1))
-					k8sGardenRuntimeClient.EXPECT().List(ctx, gomock.AssignableToTypeOf(&corev1.SecretList{}), client.InNamespace(namespaceName)).DoAndReturn(func(ctx context.Context, list *corev1.SecretList, opts ...client.ListOption) error {
+					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialShootMetaList, client.InNamespace(namespaceName), client.Limit(1))
+					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialBackupEntryMetaList, client.InNamespace(namespaceName), client.Limit(1))
+					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&corev1.SecretList{}), client.InNamespace(namespaceName)).DoAndReturn(func(ctx context.Context, list *corev1.SecretList, opts ...client.ListOption) error {
 						(&corev1.SecretList{Items: []corev1.Secret{*secret}}).DeepCopyInto(list)
 						return nil
 					})
-					k8sGardenRuntimeClient.EXPECT().List(ctx, gomock.AssignableToTypeOf(&gardencorev1beta1.SecretBindingList{})).DoAndReturn(func(ctx context.Context, list *gardencorev1beta1.SecretBindingList, opts ...client.ListOption) error {
+					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&gardencorev1beta1.SecretBindingList{})).DoAndReturn(func(ctx context.Context, list *gardencorev1beta1.SecretBindingList, opts ...client.ListOption) error {
 						(&gardencorev1beta1.SecretBindingList{Items: []gardencorev1beta1.SecretBinding{*secretBinding}}).DeepCopyInto(list)
 						return nil
 					})
-					k8sGardenRuntimeClient.EXPECT().List(ctx, gomock.AssignableToTypeOf(&gardencorev1beta1.ShootList{}), client.InNamespace(otherNamespace)).DoAndReturn(func(ctx context.Context, list *gardencorev1beta1.ShootList, opts ...client.ListOption) error {
+					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&gardencorev1beta1.ShootList{}), client.InNamespace(otherNamespace)).DoAndReturn(func(ctx context.Context, list *gardencorev1beta1.ShootList, opts ...client.ListOption) error {
 						(&gardencorev1beta1.ShootList{Items: []gardencorev1beta1.Shoot{*shoot}}).DeepCopyInto(list)
 						return nil
 					})
@@ -257,18 +257,18 @@ var _ = Describe("Reconciler", func() {
 				})
 
 				It("has quotas that are used by shoots in the same namespace", func() {
-					k8sGardenRuntimeClient.EXPECT().List(ctx, partialShootMetaList, client.InNamespace(namespaceName), client.Limit(1))
-					k8sGardenRuntimeClient.EXPECT().List(ctx, partialBackupEntryMetaList, client.InNamespace(namespaceName), client.Limit(1))
-					k8sGardenRuntimeClient.EXPECT().List(ctx, gomock.AssignableToTypeOf(&corev1.SecretList{}), client.InNamespace(namespaceName))
-					k8sGardenRuntimeClient.EXPECT().List(ctx, partialQuotaMetaList, client.InNamespace(namespaceName)).DoAndReturn(func(ctx context.Context, list *metav1.PartialObjectMetadataList, opts ...client.ListOption) error {
+					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialShootMetaList, client.InNamespace(namespaceName), client.Limit(1))
+					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialBackupEntryMetaList, client.InNamespace(namespaceName), client.Limit(1))
+					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&corev1.SecretList{}), client.InNamespace(namespaceName))
+					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialQuotaMetaList, client.InNamespace(namespaceName)).DoAndReturn(func(ctx context.Context, list *metav1.PartialObjectMetadataList, opts ...client.ListOption) error {
 						(&metav1.PartialObjectMetadataList{Items: []metav1.PartialObjectMetadata{*quotaMeta}}).DeepCopyInto(list)
 						return nil
 					})
-					k8sGardenRuntimeClient.EXPECT().List(ctx, gomock.AssignableToTypeOf(&gardencorev1beta1.SecretBindingList{})).DoAndReturn(func(ctx context.Context, list *gardencorev1beta1.SecretBindingList, opts ...client.ListOption) error {
+					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&gardencorev1beta1.SecretBindingList{})).DoAndReturn(func(ctx context.Context, list *gardencorev1beta1.SecretBindingList, opts ...client.ListOption) error {
 						(&gardencorev1beta1.SecretBindingList{Items: []gardencorev1beta1.SecretBinding{*secretBinding}}).DeepCopyInto(list)
 						return nil
 					})
-					k8sGardenRuntimeClient.EXPECT().List(ctx, gomock.AssignableToTypeOf(&gardencorev1beta1.ShootList{}), client.InNamespace(namespaceName)).DoAndReturn(func(ctx context.Context, list *gardencorev1beta1.ShootList, opts ...client.ListOption) error {
+					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&gardencorev1beta1.ShootList{}), client.InNamespace(namespaceName)).DoAndReturn(func(ctx context.Context, list *gardencorev1beta1.ShootList, opts ...client.ListOption) error {
 						(&gardencorev1beta1.ShootList{Items: []gardencorev1beta1.Shoot{*shoot}}).DeepCopyInto(list)
 						return nil
 					})
@@ -284,18 +284,18 @@ var _ = Describe("Reconciler", func() {
 					secretBinding.Namespace = otherNamespace
 					shoot.Namespace = otherNamespace
 
-					k8sGardenRuntimeClient.EXPECT().List(ctx, partialShootMetaList, client.InNamespace(namespaceName), client.Limit(1))
-					k8sGardenRuntimeClient.EXPECT().List(ctx, partialBackupEntryMetaList, client.InNamespace(namespaceName), client.Limit(1))
-					k8sGardenRuntimeClient.EXPECT().List(ctx, gomock.AssignableToTypeOf(&corev1.SecretList{}), client.InNamespace(namespaceName))
-					k8sGardenRuntimeClient.EXPECT().List(ctx, partialQuotaMetaList, client.InNamespace(namespaceName)).DoAndReturn(func(ctx context.Context, list *metav1.PartialObjectMetadataList, opts ...client.ListOption) error {
+					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialShootMetaList, client.InNamespace(namespaceName), client.Limit(1))
+					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialBackupEntryMetaList, client.InNamespace(namespaceName), client.Limit(1))
+					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&corev1.SecretList{}), client.InNamespace(namespaceName))
+					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialQuotaMetaList, client.InNamespace(namespaceName)).DoAndReturn(func(ctx context.Context, list *metav1.PartialObjectMetadataList, opts ...client.ListOption) error {
 						(&metav1.PartialObjectMetadataList{Items: []metav1.PartialObjectMetadata{*quotaMeta}}).DeepCopyInto(list)
 						return nil
 					})
-					k8sGardenRuntimeClient.EXPECT().List(ctx, gomock.AssignableToTypeOf(&gardencorev1beta1.SecretBindingList{})).DoAndReturn(func(ctx context.Context, list *gardencorev1beta1.SecretBindingList, opts ...client.ListOption) error {
+					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&gardencorev1beta1.SecretBindingList{})).DoAndReturn(func(ctx context.Context, list *gardencorev1beta1.SecretBindingList, opts ...client.ListOption) error {
 						(&gardencorev1beta1.SecretBindingList{Items: []gardencorev1beta1.SecretBinding{*secretBinding}}).DeepCopyInto(list)
 						return nil
 					})
-					k8sGardenRuntimeClient.EXPECT().List(ctx, gomock.AssignableToTypeOf(&gardencorev1beta1.ShootList{}), client.InNamespace(otherNamespace)).DoAndReturn(func(ctx context.Context, list *gardencorev1beta1.ShootList, opts ...client.ListOption) error {
+					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&gardencorev1beta1.ShootList{}), client.InNamespace(otherNamespace)).DoAndReturn(func(ctx context.Context, list *gardencorev1beta1.ShootList, opts ...client.ListOption) error {
 						(&gardencorev1beta1.ShootList{Items: []gardencorev1beta1.Shoot{*shoot}}).DeepCopyInto(list)
 						return nil
 					})
@@ -310,18 +310,18 @@ var _ = Describe("Reconciler", func() {
 
 			Describe("project should be marked as stale", func() {
 				It("has secrets that are unused", func() {
-					k8sGardenRuntimeClient.EXPECT().List(ctx, partialShootMetaList, client.InNamespace(namespaceName), client.Limit(1))
-					k8sGardenRuntimeClient.EXPECT().List(ctx, partialBackupEntryMetaList, client.InNamespace(namespaceName), client.Limit(1))
-					k8sGardenRuntimeClient.EXPECT().List(ctx, gomock.AssignableToTypeOf(&corev1.SecretList{}), client.InNamespace(namespaceName)).DoAndReturn(func(ctx context.Context, list *corev1.SecretList, opts ...client.ListOption) error {
+					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialShootMetaList, client.InNamespace(namespaceName), client.Limit(1))
+					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialBackupEntryMetaList, client.InNamespace(namespaceName), client.Limit(1))
+					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&corev1.SecretList{}), client.InNamespace(namespaceName)).DoAndReturn(func(ctx context.Context, list *corev1.SecretList, opts ...client.ListOption) error {
 						(&corev1.SecretList{Items: []corev1.Secret{*secret}}).DeepCopyInto(list)
 						return nil
 					})
-					k8sGardenRuntimeClient.EXPECT().List(ctx, gomock.AssignableToTypeOf(&gardencorev1beta1.SecretBindingList{})).DoAndReturn(func(ctx context.Context, list *gardencorev1beta1.SecretBindingList, opts ...client.ListOption) error {
+					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&gardencorev1beta1.SecretBindingList{})).DoAndReturn(func(ctx context.Context, list *gardencorev1beta1.SecretBindingList, opts ...client.ListOption) error {
 						(&gardencorev1beta1.SecretBindingList{Items: []gardencorev1beta1.SecretBinding{*secretBinding}}).DeepCopyInto(list)
 						return nil
 					})
-					k8sGardenRuntimeClient.EXPECT().List(ctx, gomock.AssignableToTypeOf(&gardencorev1beta1.ShootList{}), client.InNamespace(namespaceName))
-					k8sGardenRuntimeClient.EXPECT().List(ctx, partialQuotaMetaList, client.InNamespace(namespaceName))
+					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&gardencorev1beta1.ShootList{}), client.InNamespace(namespaceName))
+					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialQuotaMetaList, client.InNamespace(namespaceName))
 
 					expectStaleMarking(k8sGardenRuntimeClient, mockStatusWriter, project, nil, nil, fakeClock)
 
@@ -342,21 +342,21 @@ var _ = Describe("Reconciler", func() {
 						},
 					}
 
-					k8sGardenRuntimeClient.EXPECT().List(ctx, partialShootMetaList, client.InNamespace(namespaceName), client.Limit(1))
-					k8sGardenRuntimeClient.EXPECT().List(ctx, partialBackupEntryMetaList, client.InNamespace(namespaceName), client.Limit(1))
-					k8sGardenRuntimeClient.EXPECT().List(ctx, gomock.AssignableToTypeOf(&corev1.SecretList{}), client.InNamespace(namespaceName)).DoAndReturn(func(ctx context.Context, list *corev1.SecretList, opts ...client.ListOption) error {
+					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialShootMetaList, client.InNamespace(namespaceName), client.Limit(1))
+					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialBackupEntryMetaList, client.InNamespace(namespaceName), client.Limit(1))
+					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&corev1.SecretList{}), client.InNamespace(namespaceName)).DoAndReturn(func(ctx context.Context, list *corev1.SecretList, opts ...client.ListOption) error {
 						(&corev1.SecretList{Items: []corev1.Secret{*secretWithOwnerRef}}).DeepCopyInto(list)
 						return nil
 					})
-					k8sGardenRuntimeClient.EXPECT().List(ctx, gomock.AssignableToTypeOf(&gardencorev1beta1.SecretBindingList{})).DoAndReturn(func(ctx context.Context, list *gardencorev1beta1.SecretBindingList, opts ...client.ListOption) error {
+					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&gardencorev1beta1.SecretBindingList{})).DoAndReturn(func(ctx context.Context, list *gardencorev1beta1.SecretBindingList, opts ...client.ListOption) error {
 						(&gardencorev1beta1.SecretBindingList{Items: []gardencorev1beta1.SecretBinding{*secretBinding}}).DeepCopyInto(list)
 						return nil
 					}).AnyTimes()
-					k8sGardenRuntimeClient.EXPECT().List(ctx, gomock.AssignableToTypeOf(&gardencorev1beta1.ShootList{}), client.InNamespace(otherNamespace)).DoAndReturn(func(ctx context.Context, list *gardencorev1beta1.ShootList, opts ...client.ListOption) error {
+					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&gardencorev1beta1.ShootList{}), client.InNamespace(otherNamespace)).DoAndReturn(func(ctx context.Context, list *gardencorev1beta1.ShootList, opts ...client.ListOption) error {
 						(&gardencorev1beta1.ShootList{Items: []gardencorev1beta1.Shoot{*shoot}}).DeepCopyInto(list)
 						return nil
 					}).AnyTimes()
-					k8sGardenRuntimeClient.EXPECT().List(ctx, partialQuotaMetaList, client.InNamespace(namespaceName))
+					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialQuotaMetaList, client.InNamespace(namespaceName))
 
 					expectStaleMarking(k8sGardenRuntimeClient, mockStatusWriter, project, nil, nil, fakeClock)
 
@@ -365,18 +365,18 @@ var _ = Describe("Reconciler", func() {
 				})
 
 				It("has quotas that are unused", func() {
-					k8sGardenRuntimeClient.EXPECT().List(ctx, partialShootMetaList, client.InNamespace(namespaceName), client.Limit(1))
-					k8sGardenRuntimeClient.EXPECT().List(ctx, partialBackupEntryMetaList, client.InNamespace(namespaceName), client.Limit(1))
-					k8sGardenRuntimeClient.EXPECT().List(ctx, gomock.AssignableToTypeOf(&corev1.SecretList{}), client.InNamespace(namespaceName))
-					k8sGardenRuntimeClient.EXPECT().List(ctx, partialQuotaMetaList, client.InNamespace(namespaceName)).DoAndReturn(func(ctx context.Context, list *metav1.PartialObjectMetadataList, opts ...client.ListOption) error {
+					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialShootMetaList, client.InNamespace(namespaceName), client.Limit(1))
+					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialBackupEntryMetaList, client.InNamespace(namespaceName), client.Limit(1))
+					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&corev1.SecretList{}), client.InNamespace(namespaceName))
+					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialQuotaMetaList, client.InNamespace(namespaceName)).DoAndReturn(func(ctx context.Context, list *metav1.PartialObjectMetadataList, opts ...client.ListOption) error {
 						(&metav1.PartialObjectMetadataList{Items: []metav1.PartialObjectMetadata{*quotaMeta}}).DeepCopyInto(list)
 						return nil
 					})
-					k8sGardenRuntimeClient.EXPECT().List(ctx, gomock.AssignableToTypeOf(&gardencorev1beta1.SecretBindingList{})).DoAndReturn(func(ctx context.Context, list *gardencorev1beta1.SecretBindingList, opts ...client.ListOption) error {
+					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&gardencorev1beta1.SecretBindingList{})).DoAndReturn(func(ctx context.Context, list *gardencorev1beta1.SecretBindingList, opts ...client.ListOption) error {
 						(&gardencorev1beta1.SecretBindingList{Items: []gardencorev1beta1.SecretBinding{*secretBinding}}).DeepCopyInto(list)
 						return nil
 					})
-					k8sGardenRuntimeClient.EXPECT().List(ctx, gomock.AssignableToTypeOf(&gardencorev1beta1.ShootList{}), client.InNamespace(namespaceName))
+					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&gardencorev1beta1.ShootList{}), client.InNamespace(namespaceName))
 
 					expectStaleMarking(k8sGardenRuntimeClient, mockStatusWriter, project, nil, nil, fakeClock)
 
@@ -385,10 +385,10 @@ var _ = Describe("Reconciler", func() {
 				})
 
 				It("it is not used", func() {
-					k8sGardenRuntimeClient.EXPECT().List(ctx, partialShootMetaList, client.InNamespace(namespaceName), client.Limit(1))
-					k8sGardenRuntimeClient.EXPECT().List(ctx, partialBackupEntryMetaList, client.InNamespace(namespaceName), client.Limit(1))
-					k8sGardenRuntimeClient.EXPECT().List(ctx, gomock.AssignableToTypeOf(&corev1.SecretList{}), client.InNamespace(namespaceName))
-					k8sGardenRuntimeClient.EXPECT().List(ctx, partialQuotaMetaList, client.InNamespace(namespaceName))
+					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialShootMetaList, client.InNamespace(namespaceName), client.Limit(1))
+					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialBackupEntryMetaList, client.InNamespace(namespaceName), client.Limit(1))
+					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&corev1.SecretList{}), client.InNamespace(namespaceName))
+					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialQuotaMetaList, client.InNamespace(namespaceName))
 
 					expectStaleMarking(k8sGardenRuntimeClient, mockStatusWriter, project, nil, nil, fakeClock)
 
@@ -400,10 +400,10 @@ var _ = Describe("Reconciler", func() {
 					staleSinceTimestamp := metav1.Time{Time: fakeClock.Now().Add(-24*time.Hour*time.Duration(staleGracePeriodDays) + time.Hour)}
 					project.Status.StaleSinceTimestamp = &staleSinceTimestamp
 
-					k8sGardenRuntimeClient.EXPECT().List(ctx, partialShootMetaList, client.InNamespace(namespaceName), client.Limit(1))
-					k8sGardenRuntimeClient.EXPECT().List(ctx, partialBackupEntryMetaList, client.InNamespace(namespaceName), client.Limit(1))
-					k8sGardenRuntimeClient.EXPECT().List(ctx, gomock.AssignableToTypeOf(&corev1.SecretList{}), client.InNamespace(namespaceName))
-					k8sGardenRuntimeClient.EXPECT().List(ctx, partialQuotaMetaList, client.InNamespace(namespaceName))
+					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialShootMetaList, client.InNamespace(namespaceName), client.Limit(1))
+					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialBackupEntryMetaList, client.InNamespace(namespaceName), client.Limit(1))
+					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&corev1.SecretList{}), client.InNamespace(namespaceName))
+					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialQuotaMetaList, client.InNamespace(namespaceName))
 
 					expectStaleMarking(k8sGardenRuntimeClient, mockStatusWriter, project, &staleSinceTimestamp, nil, fakeClock)
 
@@ -418,10 +418,10 @@ var _ = Describe("Reconciler", func() {
 					)
 					project.Status.StaleSinceTimestamp = &staleSinceTimestamp
 
-					k8sGardenRuntimeClient.EXPECT().List(ctx, partialShootMetaList, client.InNamespace(namespaceName), client.Limit(1))
-					k8sGardenRuntimeClient.EXPECT().List(ctx, partialBackupEntryMetaList, client.InNamespace(namespaceName), client.Limit(1))
-					k8sGardenRuntimeClient.EXPECT().List(ctx, gomock.AssignableToTypeOf(&corev1.SecretList{}), client.InNamespace(namespaceName))
-					k8sGardenRuntimeClient.EXPECT().List(ctx, partialQuotaMetaList, client.InNamespace(namespaceName))
+					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialShootMetaList, client.InNamespace(namespaceName), client.Limit(1))
+					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialBackupEntryMetaList, client.InNamespace(namespaceName), client.Limit(1))
+					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&corev1.SecretList{}), client.InNamespace(namespaceName))
+					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialQuotaMetaList, client.InNamespace(namespaceName))
 
 					expectStaleMarking(k8sGardenRuntimeClient, mockStatusWriter, project, &staleSinceTimestamp, &staleAutoDeleteTimestamp, fakeClock)
 
@@ -438,10 +438,10 @@ var _ = Describe("Reconciler", func() {
 					project.Status.StaleSinceTimestamp = &staleSinceTimestamp
 					project.Status.StaleAutoDeleteTimestamp = &staleAutoDeleteTimestamp
 
-					k8sGardenRuntimeClient.EXPECT().List(ctx, partialShootMetaList, client.InNamespace(namespaceName), client.Limit(1))
-					k8sGardenRuntimeClient.EXPECT().List(ctx, partialBackupEntryMetaList, client.InNamespace(namespaceName), client.Limit(1))
-					k8sGardenRuntimeClient.EXPECT().List(ctx, gomock.AssignableToTypeOf(&corev1.SecretList{}), client.InNamespace(namespaceName))
-					k8sGardenRuntimeClient.EXPECT().List(ctx, partialQuotaMetaList, client.InNamespace(namespaceName))
+					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialShootMetaList, client.InNamespace(namespaceName), client.Limit(1))
+					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialBackupEntryMetaList, client.InNamespace(namespaceName), client.Limit(1))
+					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&corev1.SecretList{}), client.InNamespace(namespaceName))
+					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialQuotaMetaList, client.InNamespace(namespaceName))
 
 					expectStaleMarking(k8sGardenRuntimeClient, mockStatusWriter, project, &staleSinceTimestamp, &staleAutoDeleteTimestamp, fakeClock)
 
@@ -454,8 +454,8 @@ var _ = Describe("Reconciler", func() {
 						gardenerutils.ConfirmationDeletion: "true",
 						v1beta1constants.GardenerTimestamp: gardenerutils.TimeNow().UTC().String(),
 					}
-					k8sGardenRuntimeClient.EXPECT().Patch(ctx, projectCopy, gomock.Any())
-					k8sGardenRuntimeClient.EXPECT().Delete(ctx, projectCopy)
+					k8sGardenRuntimeClient.EXPECT().Patch(gomock.Any(), projectCopy, gomock.Any())
+					k8sGardenRuntimeClient.EXPECT().Delete(gomock.Any(), projectCopy)
 
 					_, result := reconciler.Reconcile(ctx, request)
 					Expect(result).To(Succeed())
@@ -472,7 +472,7 @@ func expectNonStaleMarking(k8sGardenRuntimeClient *mockclient.MockClient, mockSt
 	projectPatched.Status.StaleSinceTimestamp = nil
 	projectPatched.Status.StaleAutoDeleteTimestamp = nil
 
-	test.EXPECTStatusPatch(context.TODO(), mockStatusWriter, projectPatched, project, types.MergePatchType)
+	test.EXPECTStatusPatch(gomock.Any(), mockStatusWriter, projectPatched, project, types.MergePatchType)
 }
 
 func expectStaleMarking(k8sGardenRuntimeClient *mockclient.MockClient, mockStatusWriter *mockclient.MockStatusWriter, project *gardencorev1beta1.Project, staleSinceTimestamp, staleAutoDeleteTimestamp *metav1.Time, fakeClock *testing.FakeClock) {
@@ -486,5 +486,5 @@ func expectStaleMarking(k8sGardenRuntimeClient *mockclient.MockClient, mockStatu
 	}
 	projectPatched.Status.StaleAutoDeleteTimestamp = staleAutoDeleteTimestamp
 
-	test.EXPECTStatusPatch(context.TODO(), mockStatusWriter, projectPatched, project, types.MergePatchType)
+	test.EXPECTStatusPatch(gomock.Any(), mockStatusWriter, projectPatched, project, types.MergePatchType)
 }

--- a/pkg/controllermanager/controller/quota/reconciler.go
+++ b/pkg/controllermanager/controller/quota/reconciler.go
@@ -44,6 +44,9 @@ type Reconciler struct {
 func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 	log := logf.FromContext(ctx)
 
+	ctx, cancel := context.WithTimeout(ctx, controllerutils.DefaultReconciliationTimeout)
+	defer cancel()
+
 	quota := &gardencorev1beta1.Quota{}
 	if err := r.Client.Get(ctx, request.NamespacedName, quota); err != nil {
 		if apierrors.IsNotFound(err) {

--- a/pkg/controllermanager/controller/quota/reconciler.go
+++ b/pkg/controllermanager/controller/quota/reconciler.go
@@ -44,7 +44,7 @@ type Reconciler struct {
 func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 	log := logf.FromContext(ctx)
 
-	ctx, cancel := context.WithTimeout(ctx, controllerutils.DefaultReconciliationTimeout)
+	ctx, cancel := controllerutils.GetMainReconciliationContext(ctx, controllerutils.DefaultReconciliationTimeout)
 	defer cancel()
 
 	quota := &gardencorev1beta1.Quota{}

--- a/pkg/controllermanager/controller/secretbinding/reconciler.go
+++ b/pkg/controllermanager/controller/secretbinding/reconciler.go
@@ -46,7 +46,7 @@ type Reconciler struct {
 func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 	log := logf.FromContext(ctx)
 
-	ctx, cancel := context.WithTimeout(ctx, controllerutils.DefaultReconciliationTimeout)
+	ctx, cancel := controllerutils.GetMainReconciliationContext(ctx, controllerutils.DefaultReconciliationTimeout)
 	defer cancel()
 
 	secretBinding := &gardencorev1beta1.SecretBinding{}

--- a/pkg/controllermanager/controller/secretbinding/reconciler.go
+++ b/pkg/controllermanager/controller/secretbinding/reconciler.go
@@ -46,6 +46,9 @@ type Reconciler struct {
 func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 	log := logf.FromContext(ctx)
 
+	ctx, cancel := context.WithTimeout(ctx, controllerutils.DefaultReconciliationTimeout)
+	defer cancel()
+
 	secretBinding := &gardencorev1beta1.SecretBinding{}
 	if err := r.Client.Get(ctx, request.NamespacedName, secretBinding); err != nil {
 		if apierrors.IsNotFound(err) {

--- a/pkg/controllermanager/controller/secretbinding/reconciler_test.go
+++ b/pkg/controllermanager/controller/secretbinding/reconciler_test.go
@@ -165,24 +165,24 @@ var _ = Describe("SecretBindingControl", func() {
 			reconciler = &Reconciler{Client: c}
 			request = reconcile.Request{NamespacedName: types.NamespacedName{Namespace: secretBindingNamespace, Name: secretBindingName}}
 
-			c.EXPECT().Get(ctx, gomock.Any(), gomock.AssignableToTypeOf(&gardencorev1beta1.SecretBinding{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.SecretBinding, _ ...client.GetOption) error {
+			c.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.AssignableToTypeOf(&gardencorev1beta1.SecretBinding{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.SecretBinding, _ ...client.GetOption) error {
 				secretBinding.DeepCopyInto(obj)
 				return nil
 			})
 
-			c.EXPECT().Get(ctx, gomock.Any(), gomock.AssignableToTypeOf(&corev1.Secret{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *corev1.Secret, _ ...client.GetOption) error {
+			c.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.AssignableToTypeOf(&corev1.Secret{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *corev1.Secret, _ ...client.GetOption) error {
 				secret.DeepCopyInto(obj)
 				return nil
 			})
 
-			c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&gardencorev1beta1.SecretBinding{}), gomock.Any()).DoAndReturn(
+			c.EXPECT().Patch(gomock.Any(), gomock.AssignableToTypeOf(&gardencorev1beta1.SecretBinding{}), gomock.Any()).DoAndReturn(
 				func(_ context.Context, sb *gardencorev1beta1.SecretBinding, _ client.Patch, _ ...client.PatchOption) error {
 					*secretBinding = *sb
 					return nil
 				},
 			).AnyTimes()
 
-			c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&corev1.Secret{}), gomock.Any()).DoAndReturn(
+			c.EXPECT().Patch(gomock.Any(), gomock.AssignableToTypeOf(&corev1.Secret{}), gomock.Any()).DoAndReturn(
 				func(_ context.Context, s *corev1.Secret, _ client.Patch, _ ...client.PatchOption) error {
 					*secret = *s
 					return nil
@@ -204,12 +204,12 @@ var _ = Describe("SecretBindingControl", func() {
 		It("should remove the label from the secret when there are no secretbindings referring it", func() {
 			secretBinding.DeletionTimestamp = &metav1.Time{Time: time.Date(1, 1, 1, 1, 1, 1, 1, time.UTC)}
 
-			c.EXPECT().List(ctx, gomock.AssignableToTypeOf(&gardencorev1beta1.SecretBindingList{})).DoAndReturn(func(_ context.Context, list *gardencorev1beta1.SecretBindingList, _ ...client.ListOption) error {
+			c.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&gardencorev1beta1.SecretBindingList{})).DoAndReturn(func(_ context.Context, list *gardencorev1beta1.SecretBindingList, _ ...client.ListOption) error {
 				(&gardencorev1beta1.SecretBindingList{Items: []gardencorev1beta1.SecretBinding{*secretBinding}}).DeepCopyInto(list)
 				return nil
 			}).AnyTimes()
 
-			c.EXPECT().List(ctx, gomock.AssignableToTypeOf(&gardencorev1beta1.ShootList{})).DoAndReturn(func(_ context.Context, list *gardencorev1beta1.ShootList, _ ...client.ListOption) error {
+			c.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&gardencorev1beta1.ShootList{})).DoAndReturn(func(_ context.Context, list *gardencorev1beta1.ShootList, _ ...client.ListOption) error {
 				(&gardencorev1beta1.ShootList{}).DeepCopyInto(list)
 				return nil
 			})
@@ -281,12 +281,12 @@ var _ = Describe("SecretBindingControl", func() {
 		BeforeEach(func() {
 			reconciler = &Reconciler{Client: c}
 
-			c.EXPECT().List(ctx, gomock.AssignableToTypeOf(&gardencorev1beta1.SecretBindingList{}), gomock.Any()).DoAndReturn(func(_ context.Context, list *gardencorev1beta1.SecretBindingList, _ ...client.ListOption) error {
+			c.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&gardencorev1beta1.SecretBindingList{}), gomock.Any()).DoAndReturn(func(_ context.Context, list *gardencorev1beta1.SecretBindingList, _ ...client.ListOption) error {
 				(&gardencorev1beta1.SecretBindingList{Items: []gardencorev1beta1.SecretBinding{*secretBinding1, *secretBinding2}}).DeepCopyInto(list)
 				return nil
 			}).AnyTimes()
 
-			c.EXPECT().Get(ctx, gomock.Any(), gomock.AssignableToTypeOf(&gardencorev1beta1.SecretBinding{})).DoAndReturn(func(_ context.Context, namespacedName client.ObjectKey, obj *gardencorev1beta1.SecretBinding, _ ...client.GetOption) error {
+			c.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.AssignableToTypeOf(&gardencorev1beta1.SecretBinding{})).DoAndReturn(func(_ context.Context, namespacedName client.ObjectKey, obj *gardencorev1beta1.SecretBinding, _ ...client.GetOption) error {
 				for _, sb := range []gardencorev1beta1.SecretBinding{*secretBinding1, *secretBinding2} {
 					if reflect.DeepEqual(namespacedName.Name, sb.Name) && reflect.DeepEqual(namespacedName.Namespace, sb.Namespace) {
 						sb.DeepCopyInto(obj)
@@ -296,7 +296,7 @@ var _ = Describe("SecretBindingControl", func() {
 				return nil
 			}).AnyTimes()
 
-			c.EXPECT().Get(ctx, gomock.Any(), gomock.AssignableToTypeOf(&gardencorev1beta1.Quota{})).DoAndReturn(func(_ context.Context, namespacedName client.ObjectKey, obj *gardencorev1beta1.Quota, _ ...client.GetOption) error {
+			c.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.AssignableToTypeOf(&gardencorev1beta1.Quota{})).DoAndReturn(func(_ context.Context, namespacedName client.ObjectKey, obj *gardencorev1beta1.Quota, _ ...client.GetOption) error {
 				for _, q := range []gardencorev1beta1.Quota{*quota1, *quota2} {
 					if reflect.DeepEqual(namespacedName.Name, q.Name) && reflect.DeepEqual(namespacedName.Namespace, q.Namespace) {
 						q.DeepCopyInto(obj)
@@ -306,7 +306,7 @@ var _ = Describe("SecretBindingControl", func() {
 				return nil
 			}).AnyTimes()
 
-			c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&gardencorev1beta1.SecretBinding{}), gomock.Any()).DoAndReturn(
+			c.EXPECT().Patch(gomock.Any(), gomock.AssignableToTypeOf(&gardencorev1beta1.SecretBinding{}), gomock.Any()).DoAndReturn(
 				func(_ context.Context, sb *gardencorev1beta1.SecretBinding, _ client.Patch, _ ...client.PatchOption) error {
 					if sb.Name == secretBindingName1 {
 						*secretBinding1 = *sb
@@ -317,7 +317,7 @@ var _ = Describe("SecretBindingControl", func() {
 				},
 			).AnyTimes()
 
-			c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&gardencorev1beta1.Quota{}), gomock.Any()).DoAndReturn(
+			c.EXPECT().Patch(gomock.Any(), gomock.AssignableToTypeOf(&gardencorev1beta1.Quota{}), gomock.Any()).DoAndReturn(
 				func(_ context.Context, q *gardencorev1beta1.Quota, _ client.Patch, _ ...client.PatchOption) error {
 					if q.Name == quotaName1 {
 						*quota1 = *q
@@ -328,7 +328,7 @@ var _ = Describe("SecretBindingControl", func() {
 				},
 			).AnyTimes()
 
-			c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&corev1.Secret{}), gomock.Any()).DoAndReturn(
+			c.EXPECT().Patch(gomock.Any(), gomock.AssignableToTypeOf(&corev1.Secret{}), gomock.Any()).DoAndReturn(
 				func(_ context.Context, s *corev1.Secret, _ client.Patch, _ ...client.PatchOption) error {
 					return nil
 				},
@@ -336,7 +336,7 @@ var _ = Describe("SecretBindingControl", func() {
 		})
 
 		It("should add the label to the quota referred by the secretbinding", func() {
-			c.EXPECT().Get(ctx, gomock.Any(), gomock.AssignableToTypeOf(&corev1.Secret{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *corev1.Secret, _ ...client.GetOption) error {
+			c.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.AssignableToTypeOf(&corev1.Secret{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *corev1.Secret, _ ...client.GetOption) error {
 				(&corev1.Secret{}).DeepCopyInto(obj)
 				return nil
 			})
@@ -357,7 +357,7 @@ var _ = Describe("SecretBindingControl", func() {
 		It("should remove the label from the quota when there are no secretbindings referring it", func() {
 			secretBinding1.DeletionTimestamp = &metav1.Time{Time: time.Date(1, 1, 1, 1, 1, 1, 1, time.UTC)}
 
-			c.EXPECT().List(ctx, gomock.AssignableToTypeOf(&gardencorev1beta1.ShootList{})).DoAndReturn(func(_ context.Context, list *gardencorev1beta1.ShootList, _ ...client.ListOption) error {
+			c.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&gardencorev1beta1.ShootList{})).DoAndReturn(func(_ context.Context, list *gardencorev1beta1.ShootList, _ ...client.ListOption) error {
 				(&gardencorev1beta1.ShootList{}).DeepCopyInto(list)
 				return nil
 			})

--- a/pkg/controllermanager/controller/seed/backupbucketscheck/reconciler.go
+++ b/pkg/controllermanager/controller/seed/backupbucketscheck/reconciler.go
@@ -29,6 +29,7 @@ import (
 	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	"github.com/gardener/gardener/pkg/controllermanager/apis/config"
 	"github.com/gardener/gardener/pkg/controllermanager/controller/seed/utils"
+	"github.com/gardener/gardener/pkg/controllerutils"
 )
 
 // Reconciler reconciles Seeds and maintains the BackupBucketsReady condition according to the observed status of the
@@ -44,7 +45,7 @@ type Reconciler struct {
 func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
 	log := logf.FromContext(ctx)
 
-	ctx, cancel := context.WithTimeout(ctx, r.Config.SyncPeriod.Duration)
+	ctx, cancel := controllerutils.GetMainReconciliationContext(ctx, r.Config.SyncPeriod.Duration)
 	defer cancel()
 
 	seed := &gardencorev1beta1.Seed{}

--- a/pkg/controllermanager/controller/seed/backupbucketscheck/reconciler.go
+++ b/pkg/controllermanager/controller/seed/backupbucketscheck/reconciler.go
@@ -44,6 +44,9 @@ type Reconciler struct {
 func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
 	log := logf.FromContext(ctx)
 
+	ctx, cancel := context.WithTimeout(ctx, r.Config.SyncPeriod.Duration)
+	defer cancel()
+
 	seed := &gardencorev1beta1.Seed{}
 	if err := r.Client.Get(ctx, req.NamespacedName, seed); err != nil {
 		if apierrors.IsNotFound(err) {

--- a/pkg/controllermanager/controller/seed/backupbucketscheck/reconciler_test.go
+++ b/pkg/controllermanager/controller/seed/backupbucketscheck/reconciler_test.go
@@ -43,7 +43,7 @@ var _ = Describe("Reconciler", func() {
 	const syncPeriod = 1 * time.Second
 
 	var (
-		ctx context.Context
+		ctx = context.TODO()
 		c   client.Client
 
 		conf      config.SeedBackupBucketsCheckControllerConfiguration

--- a/pkg/controllermanager/controller/seed/extensionscheck/reconciler.go
+++ b/pkg/controllermanager/controller/seed/extensionscheck/reconciler.go
@@ -29,6 +29,7 @@ import (
 	"github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	"github.com/gardener/gardener/pkg/controllermanager/apis/config"
 	"github.com/gardener/gardener/pkg/controllermanager/controller/seed/utils"
+	"github.com/gardener/gardener/pkg/controllerutils"
 )
 
 var conditionsToCheck = []gardencorev1beta1.ConditionType{
@@ -51,7 +52,7 @@ type Reconciler struct {
 func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 	log := logf.FromContext(ctx)
 
-	ctx, cancel := context.WithTimeout(ctx, r.Config.SyncPeriod.Duration)
+	ctx, cancel := controllerutils.GetMainReconciliationContext(ctx, r.Config.SyncPeriod.Duration)
 	defer cancel()
 
 	seed := &gardencorev1beta1.Seed{}

--- a/pkg/controllermanager/controller/seed/extensionscheck/reconciler.go
+++ b/pkg/controllermanager/controller/seed/extensionscheck/reconciler.go
@@ -51,6 +51,9 @@ type Reconciler struct {
 func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 	log := logf.FromContext(ctx)
 
+	ctx, cancel := context.WithTimeout(ctx, r.Config.SyncPeriod.Duration)
+	defer cancel()
+
 	seed := &gardencorev1beta1.Seed{}
 	if err := r.Client.Get(ctx, request.NamespacedName, seed); err != nil {
 		if apierrors.IsNotFound(err) {

--- a/pkg/controllermanager/controller/seed/lifecycle/reconciler.go
+++ b/pkg/controllermanager/controller/seed/lifecycle/reconciler.go
@@ -51,6 +51,9 @@ type Reconciler struct {
 func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
 	log := logf.FromContext(ctx)
 
+	ctx, cancel := context.WithTimeout(ctx, r.Config.SyncPeriod.Duration)
+	defer cancel()
+
 	seed := &gardencorev1beta1.Seed{}
 	if err := r.Client.Get(ctx, req.NamespacedName, seed); err != nil {
 		if apierrors.IsNotFound(err) {

--- a/pkg/controllermanager/controller/seed/lifecycle/reconciler.go
+++ b/pkg/controllermanager/controller/seed/lifecycle/reconciler.go
@@ -31,6 +31,7 @@ import (
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	"github.com/gardener/gardener/pkg/controllermanager/apis/config"
+	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/utils/flow"
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 )
@@ -51,7 +52,7 @@ type Reconciler struct {
 func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
 	log := logf.FromContext(ctx)
 
-	ctx, cancel := context.WithTimeout(ctx, r.Config.SyncPeriod.Duration)
+	ctx, cancel := controllerutils.GetMainReconciliationContext(ctx, r.Config.SyncPeriod.Duration)
 	defer cancel()
 
 	seed := &gardencorev1beta1.Seed{}

--- a/pkg/controllermanager/controller/seed/secrets/reconciler.go
+++ b/pkg/controllermanager/controller/seed/secrets/reconciler.go
@@ -44,7 +44,7 @@ type Reconciler struct {
 func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
 	log := logf.FromContext(ctx)
 
-	ctx, cancel := context.WithTimeout(ctx, controllerutils.DefaultReconciliationTimeout)
+	ctx, cancel := controllerutils.GetMainReconciliationContext(ctx, controllerutils.DefaultReconciliationTimeout)
 	defer cancel()
 
 	seed := &gardencorev1beta1.Seed{}

--- a/pkg/controllermanager/controller/seed/secrets/reconciler.go
+++ b/pkg/controllermanager/controller/seed/secrets/reconciler.go
@@ -44,6 +44,9 @@ type Reconciler struct {
 func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
 	log := logf.FromContext(ctx)
 
+	ctx, cancel := context.WithTimeout(ctx, controllerutils.DefaultReconciliationTimeout)
+	defer cancel()
+
 	seed := &gardencorev1beta1.Seed{}
 	if err := r.Client.Get(ctx, req.NamespacedName, seed); err != nil {
 		if apierrors.IsNotFound(err) {

--- a/pkg/controllermanager/controller/shoot/add.go
+++ b/pkg/controllermanager/controller/shoot/add.go
@@ -50,7 +50,7 @@ func AddToManager(mgr manager.Manager, cfg config.ControllerManagerConfiguration
 	}
 
 	if err := (&quota.Reconciler{
-		Config: cfg.Controllers.ShootQuota,
+		Config: *cfg.Controllers.ShootQuota,
 	}).AddToManager(mgr); err != nil {
 		return fmt.Errorf("failed adding quota reconciler: %w", err)
 	}

--- a/pkg/controllermanager/controller/shoot/conditions/reconciler.go
+++ b/pkg/controllermanager/controller/shoot/conditions/reconciler.go
@@ -26,6 +26,7 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	"github.com/gardener/gardener/pkg/controllermanager/apis/config"
+	"github.com/gardener/gardener/pkg/controllerutils"
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 )
 
@@ -38,6 +39,9 @@ type Reconciler struct {
 // Reconcile reconciles Shoots registered as Seeds and copies the Seed conditions to the Shoot object.
 func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 	log := logf.FromContext(ctx)
+
+	ctx, cancel := context.WithTimeout(ctx, controllerutils.DefaultReconciliationTimeout)
+	defer cancel()
 
 	shoot := &gardencorev1beta1.Shoot{}
 	if err := r.Client.Get(ctx, request.NamespacedName, shoot); err != nil {

--- a/pkg/controllermanager/controller/shoot/conditions/reconciler.go
+++ b/pkg/controllermanager/controller/shoot/conditions/reconciler.go
@@ -40,7 +40,7 @@ type Reconciler struct {
 func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 	log := logf.FromContext(ctx)
 
-	ctx, cancel := context.WithTimeout(ctx, controllerutils.DefaultReconciliationTimeout)
+	ctx, cancel := controllerutils.GetMainReconciliationContext(ctx, controllerutils.DefaultReconciliationTimeout)
 	defer cancel()
 
 	shoot := &gardencorev1beta1.Shoot{}

--- a/pkg/controllermanager/controller/shoot/hibernation/reconciler.go
+++ b/pkg/controllermanager/controller/shoot/hibernation/reconciler.go
@@ -90,7 +90,7 @@ type Reconciler struct {
 func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 	log := logf.FromContext(ctx)
 
-	ctx, cancel := context.WithTimeout(ctx, controllerutils.DefaultReconciliationTimeout)
+	ctx, cancel := controllerutils.GetMainReconciliationContext(ctx, controllerutils.DefaultReconciliationTimeout)
 	defer cancel()
 
 	shoot := &gardencorev1beta1.Shoot{}

--- a/pkg/controllermanager/controller/shoot/hibernation/reconciler.go
+++ b/pkg/controllermanager/controller/shoot/hibernation/reconciler.go
@@ -33,6 +33,7 @@ import (
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	"github.com/gardener/gardener/pkg/controllermanager/apis/config"
+	"github.com/gardener/gardener/pkg/controllerutils"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 )
 
@@ -88,6 +89,9 @@ type Reconciler struct {
 // Reconcile reconciles Shoots and hibernates or wakes them up according to their hibernation schedules.
 func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 	log := logf.FromContext(ctx)
+
+	ctx, cancel := context.WithTimeout(ctx, controllerutils.DefaultReconciliationTimeout)
+	defer cancel()
 
 	shoot := &gardencorev1beta1.Shoot{}
 	if err := r.Client.Get(ctx, request.NamespacedName, shoot); err != nil {

--- a/pkg/controllermanager/controller/shoot/maintenance/reconciler.go
+++ b/pkg/controllermanager/controller/shoot/maintenance/reconciler.go
@@ -55,6 +55,9 @@ type Reconciler struct {
 func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 	log := logf.FromContext(ctx)
 
+	ctx, cancel := context.WithTimeout(ctx, controllerutils.DefaultReconciliationTimeout)
+	defer cancel()
+
 	shoot := &gardencorev1beta1.Shoot{}
 	if err := r.Client.Get(ctx, request.NamespacedName, shoot); err != nil {
 		if apierrors.IsNotFound(err) {

--- a/pkg/controllermanager/controller/shoot/maintenance/reconciler.go
+++ b/pkg/controllermanager/controller/shoot/maintenance/reconciler.go
@@ -55,7 +55,7 @@ type Reconciler struct {
 func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 	log := logf.FromContext(ctx)
 
-	ctx, cancel := context.WithTimeout(ctx, controllerutils.DefaultReconciliationTimeout)
+	ctx, cancel := controllerutils.GetMainReconciliationContext(ctx, controllerutils.DefaultReconciliationTimeout)
 	defer cancel()
 
 	shoot := &gardencorev1beta1.Shoot{}

--- a/pkg/controllermanager/controller/shoot/quota/reconciler.go
+++ b/pkg/controllermanager/controller/shoot/quota/reconciler.go
@@ -29,6 +29,7 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/controllermanager/apis/config"
+	"github.com/gardener/gardener/pkg/controllerutils"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 )
@@ -44,7 +45,7 @@ type Reconciler struct {
 func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 	log := logf.FromContext(ctx)
 
-	ctx, cancel := context.WithTimeout(ctx, r.Config.SyncPeriod.Duration)
+	ctx, cancel := context.WithTimeout(ctx, controllerutils.DefaultReconciliationTimeout)
 	defer cancel()
 
 	shoot := &gardencorev1beta1.Shoot{}

--- a/pkg/controllermanager/controller/shoot/quota/reconciler.go
+++ b/pkg/controllermanager/controller/shoot/quota/reconciler.go
@@ -29,6 +29,7 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/controllermanager/apis/config"
+	"github.com/gardener/gardener/pkg/controllerutils"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 )
@@ -44,7 +45,7 @@ type Reconciler struct {
 func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 	log := logf.FromContext(ctx)
 
-	ctx, cancel := context.WithTimeout(ctx, r.Config.SyncPeriod.Duration)
+	ctx, cancel := controllerutils.GetMainReconciliationContext(ctx, r.Config.SyncPeriod.Duration)
 	defer cancel()
 
 	shoot := &gardencorev1beta1.Shoot{}

--- a/pkg/controllermanager/controller/shoot/quota/reconciler.go
+++ b/pkg/controllermanager/controller/shoot/quota/reconciler.go
@@ -29,7 +29,6 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/controllermanager/apis/config"
-	"github.com/gardener/gardener/pkg/controllerutils"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 )
@@ -45,7 +44,7 @@ type Reconciler struct {
 func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 	log := logf.FromContext(ctx)
 
-	ctx, cancel := context.WithTimeout(ctx, controllerutils.DefaultReconciliationTimeout)
+	ctx, cancel := context.WithTimeout(ctx, r.Config.SyncPeriod.Duration)
 	defer cancel()
 
 	shoot := &gardencorev1beta1.Shoot{}

--- a/pkg/controllermanager/controller/shoot/quota/reconciler.go
+++ b/pkg/controllermanager/controller/shoot/quota/reconciler.go
@@ -44,6 +44,9 @@ type Reconciler struct {
 func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 	log := logf.FromContext(ctx)
 
+	ctx, cancel := context.WithTimeout(ctx, r.Config.SyncPeriod.Duration)
+	defer cancel()
+
 	shoot := &gardencorev1beta1.Shoot{}
 	if err := r.Client.Get(ctx, request.NamespacedName, shoot); err != nil {
 		if apierrors.IsNotFound(err) {

--- a/pkg/controllermanager/controller/shoot/reference/reconciler.go
+++ b/pkg/controllermanager/controller/shoot/reference/reconciler.go
@@ -54,7 +54,7 @@ type Reconciler struct {
 func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 	log := logf.FromContext(ctx)
 
-	ctx, cancel := context.WithTimeout(ctx, controllerutils.DefaultReconciliationTimeout)
+	ctx, cancel := controllerutils.GetMainReconciliationContext(ctx, controllerutils.DefaultReconciliationTimeout)
 	defer cancel()
 
 	shoot := &gardencorev1beta1.Shoot{}

--- a/pkg/controllermanager/controller/shoot/reference/reconciler.go
+++ b/pkg/controllermanager/controller/shoot/reference/reconciler.go
@@ -54,6 +54,9 @@ type Reconciler struct {
 func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 	log := logf.FromContext(ctx)
 
+	ctx, cancel := context.WithTimeout(ctx, controllerutils.DefaultReconciliationTimeout)
+	defer cancel()
+
 	shoot := &gardencorev1beta1.Shoot{}
 	if err := r.Client.Get(ctx, request.NamespacedName, shoot); err != nil {
 		if apierrors.IsNotFound(err) {

--- a/pkg/controllermanager/controller/shoot/retry/reconciler.go
+++ b/pkg/controllermanager/controller/shoot/retry/reconciler.go
@@ -42,7 +42,7 @@ type Reconciler struct {
 func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 	log := logf.FromContext(ctx)
 
-	ctx, cancel := context.WithTimeout(ctx, controllerutils.DefaultReconciliationTimeout)
+	ctx, cancel := controllerutils.GetMainReconciliationContext(ctx, controllerutils.DefaultReconciliationTimeout)
 	defer cancel()
 
 	shoot := &gardencorev1beta1.Shoot{}

--- a/pkg/controllermanager/controller/shoot/retry/reconciler.go
+++ b/pkg/controllermanager/controller/shoot/retry/reconciler.go
@@ -28,6 +28,7 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/controllermanager/apis/config"
+	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/utils"
 )
 
@@ -40,6 +41,9 @@ type Reconciler struct {
 // Reconcile reconciles failed Shoots and retries them.
 func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 	log := logf.FromContext(ctx)
+
+	ctx, cancel := context.WithTimeout(ctx, controllerutils.DefaultReconciliationTimeout)
+	defer cancel()
 
 	shoot := &gardencorev1beta1.Shoot{}
 	if err := r.Client.Get(ctx, request.NamespacedName, shoot); err != nil {

--- a/pkg/controllermanager/controller/shoot/statuslabel/reconciler.go
+++ b/pkg/controllermanager/controller/shoot/statuslabel/reconciler.go
@@ -41,7 +41,7 @@ type Reconciler struct {
 func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 	log := logf.FromContext(ctx)
 
-	ctx, cancel := context.WithTimeout(ctx, controllerutils.DefaultReconciliationTimeout)
+	ctx, cancel := controllerutils.GetMainReconciliationContext(ctx, controllerutils.DefaultReconciliationTimeout)
 	defer cancel()
 
 	shoot := &gardencorev1beta1.Shoot{}

--- a/pkg/controllermanager/controller/shoot/statuslabel/reconciler.go
+++ b/pkg/controllermanager/controller/shoot/statuslabel/reconciler.go
@@ -27,6 +27,7 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/controllermanager/apis/config"
+	"github.com/gardener/gardener/pkg/controllerutils"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 )
 
@@ -39,6 +40,9 @@ type Reconciler struct {
 // Reconcile reconciles Shoots and updates their status label.
 func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 	log := logf.FromContext(ctx)
+
+	ctx, cancel := context.WithTimeout(ctx, controllerutils.DefaultReconciliationTimeout)
+	defer cancel()
 
 	shoot := &gardencorev1beta1.Shoot{}
 	if err := r.Client.Get(ctx, request.NamespacedName, shoot); err != nil {

--- a/pkg/controllerutils/miscellaneous.go
+++ b/pkg/controllerutils/miscellaneous.go
@@ -15,6 +15,7 @@
 package controllerutils
 
 import (
+	"context"
 	"strings"
 	"time"
 
@@ -126,4 +127,26 @@ func ReconcileOncePer24hDuration(clock clock.Clock, objectMeta metav1.ObjectMeta
 	}
 
 	return 0
+}
+
+// GetMainReconciliationContext returns context with timeout for main client. Timeout should be equal to timeout passed in the argument but
+// not more than the DefaultReconciliationTimeout.
+func GetMainReconciliationContext(ctx context.Context, timeout time.Duration) (context.Context, context.CancelFunc) {
+	t := timeout
+	if timeout > DefaultReconciliationTimeout {
+		t = DefaultReconciliationTimeout
+	}
+
+	return context.WithTimeout(ctx, t)
+}
+
+// GetChildReconciliationContext returns context with timeout for the secondary client. Timeout should should be set to half of the main
+// timeout.
+func GetChildReconciliationContext(ctx context.Context, timeout time.Duration) (context.Context, context.CancelFunc) {
+	t := timeout
+	if timeout > DefaultReconciliationTimeout {
+		t = DefaultReconciliationTimeout
+	}
+
+	return context.WithTimeout(ctx, t/2)
 }

--- a/pkg/controllerutils/miscellaneous.go
+++ b/pkg/controllerutils/miscellaneous.go
@@ -27,6 +27,9 @@ import (
 	"github.com/gardener/gardener/pkg/utils"
 )
 
+// DefaultReconciliationTimeout is the default timeout for the context of reconciliation functions.
+const DefaultReconciliationTimeout = 1 * time.Minute
+
 const separator = ","
 
 // GetTasks returns the list of tasks in the ShootTasks annotation.

--- a/pkg/controllerutils/miscellaneous.go
+++ b/pkg/controllerutils/miscellaneous.go
@@ -129,8 +129,8 @@ func ReconcileOncePer24hDuration(clock clock.Clock, objectMeta metav1.ObjectMeta
 	return 0
 }
 
-// GetMainReconciliationContext returns context with timeout for main client. Timeout should be equal to timeout passed in the argument but
-// not more than the DefaultReconciliationTimeout.
+// GetMainReconciliationContext returns a context with timeout for the controller's main client. The resulting context has a timeout equal to the timeout passed in the argument but
+// not more than DefaultReconciliationTimeout.
 func GetMainReconciliationContext(ctx context.Context, timeout time.Duration) (context.Context, context.CancelFunc) {
 	t := timeout
 	if timeout > DefaultReconciliationTimeout {
@@ -140,8 +140,8 @@ func GetMainReconciliationContext(ctx context.Context, timeout time.Duration) (c
 	return context.WithTimeout(ctx, t)
 }
 
-// GetChildReconciliationContext returns context with timeout for the secondary client. Timeout should should be set to half of the main
-// timeout.
+// GetChildReconciliationContext returns context with timeout for the controller's secondary client. The resulting context has a timeout equal to half of the timeout
+// for the controller's main client.
 func GetChildReconciliationContext(ctx context.Context, timeout time.Duration) (context.Context, context.CancelFunc) {
 	t := timeout
 	if timeout > DefaultReconciliationTimeout {

--- a/pkg/gardenlet/controller/backupbucket/reconciler.go
+++ b/pkg/gardenlet/controller/backupbucket/reconciler.go
@@ -69,9 +69,9 @@ type Reconciler struct {
 func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 	log := logf.FromContext(ctx)
 
-	gardenCtx, cancel := context.WithTimeout(ctx, controllerutils.DefaultReconciliationTimeout)
+	gardenCtx, cancel := context.WithTimeout(ctx, 2*controllerutils.DefaultReconciliationTimeout)
 	defer cancel()
-	seedCtx, cancel := context.WithTimeout(ctx, controllerutils.DefaultReconciliationTimeout/2)
+	seedCtx, cancel := context.WithTimeout(ctx, controllerutils.DefaultReconciliationTimeout)
 	defer cancel()
 
 	backupBucket := &gardencorev1beta1.BackupBucket{}

--- a/pkg/gardenlet/controller/backupbucket/reconciler.go
+++ b/pkg/gardenlet/controller/backupbucket/reconciler.go
@@ -69,6 +69,9 @@ type Reconciler struct {
 func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 	log := logf.FromContext(ctx)
 
+	ctx, cancel := context.WithTimeout(ctx, controllerutils.DefaultReconciliationTimeout)
+	defer cancel()
+
 	backupBucket := &gardencorev1beta1.BackupBucket{}
 	if err := r.GardenClient.Get(ctx, request.NamespacedName, backupBucket); err != nil {
 		if apierrors.IsNotFound(err) {

--- a/pkg/gardenlet/controller/backupbucket/reconciler.go
+++ b/pkg/gardenlet/controller/backupbucket/reconciler.go
@@ -69,9 +69,9 @@ type Reconciler struct {
 func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 	log := logf.FromContext(ctx)
 
-	gardenCtx, cancel := context.WithTimeout(ctx, 2*controllerutils.DefaultReconciliationTimeout)
+	gardenCtx, cancel := context.WithTimeout(ctx, controllerutils.DefaultReconciliationTimeout)
 	defer cancel()
-	seedCtx, cancel := context.WithTimeout(ctx, controllerutils.DefaultReconciliationTimeout)
+	seedCtx, cancel := context.WithTimeout(ctx, controllerutils.DefaultReconciliationTimeout/2)
 	defer cancel()
 
 	backupBucket := &gardencorev1beta1.BackupBucket{}

--- a/pkg/gardenlet/controller/backupbucket/reconciler.go
+++ b/pkg/gardenlet/controller/backupbucket/reconciler.go
@@ -69,9 +69,9 @@ type Reconciler struct {
 func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 	log := logf.FromContext(ctx)
 
-	gardenCtx, cancel := context.WithTimeout(ctx, controllerutils.DefaultReconciliationTimeout)
+	gardenCtx, cancel := controllerutils.GetMainReconciliationContext(ctx, controllerutils.DefaultReconciliationTimeout)
 	defer cancel()
-	seedCtx, cancel := context.WithTimeout(ctx, controllerutils.DefaultReconciliationTimeout/2)
+	seedCtx, cancel := controllerutils.GetChildReconciliationContext(ctx, controllerutils.DefaultReconciliationTimeout)
 	defer cancel()
 
 	backupBucket := &gardencorev1beta1.BackupBucket{}

--- a/pkg/gardenlet/controller/backupentry/reconciler.go
+++ b/pkg/gardenlet/controller/backupentry/reconciler.go
@@ -80,9 +80,9 @@ type Reconciler struct {
 func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 	log := logf.FromContext(ctx)
 
-	gardenCtx, cancel := context.WithTimeout(ctx, 11*time.Minute)
+	gardenCtx, cancel := context.WithTimeout(ctx, controllerutils.DefaultReconciliationTimeout)
 	defer cancel()
-	seedCtx, cancel := context.WithTimeout(ctx, 10*time.Minute)
+	seedCtx, cancel := context.WithTimeout(ctx, controllerutils.DefaultReconciliationTimeout/2)
 	defer cancel()
 
 	backupEntry := &gardencorev1beta1.BackupEntry{}

--- a/pkg/gardenlet/controller/backupentry/reconciler.go
+++ b/pkg/gardenlet/controller/backupentry/reconciler.go
@@ -80,6 +80,9 @@ type Reconciler struct {
 func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 	log := logf.FromContext(ctx)
 
+	ctx, cancel := context.WithTimeout(ctx, controllerutils.DefaultReconciliationTimeout)
+	defer cancel()
+
 	backupEntry := &gardencorev1beta1.BackupEntry{}
 	if err := r.GardenClient.Get(ctx, request.NamespacedName, backupEntry); err != nil {
 		if apierrors.IsNotFound(err) {

--- a/pkg/gardenlet/controller/backupentry/reconciler.go
+++ b/pkg/gardenlet/controller/backupentry/reconciler.go
@@ -80,9 +80,9 @@ type Reconciler struct {
 func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 	log := logf.FromContext(ctx)
 
-	gardenCtx, cancel := context.WithTimeout(ctx, controllerutils.DefaultReconciliationTimeout)
+	gardenCtx, cancel := context.WithTimeout(ctx, 11*time.Minute)
 	defer cancel()
-	seedCtx, cancel := context.WithTimeout(ctx, controllerutils.DefaultReconciliationTimeout/2)
+	seedCtx, cancel := context.WithTimeout(ctx, 10*time.Minute)
 	defer cancel()
 
 	backupEntry := &gardencorev1beta1.BackupEntry{}

--- a/pkg/gardenlet/controller/backupentry/reconciler.go
+++ b/pkg/gardenlet/controller/backupentry/reconciler.go
@@ -80,7 +80,9 @@ type Reconciler struct {
 func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 	log := logf.FromContext(ctx)
 
-	ctx, cancel := context.WithTimeout(ctx, controllerutils.DefaultReconciliationTimeout)
+	gardenCtx, cancel := context.WithTimeout(ctx, controllerutils.DefaultReconciliationTimeout)
+	defer cancel()
+	seedCtx, cancel := context.WithTimeout(ctx, controllerutils.DefaultReconciliationTimeout/2)
 	defer cancel()
 
 	backupEntry := &gardencorev1beta1.BackupEntry{}
@@ -98,18 +100,19 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	}
 
 	if backupEntry.DeletionTimestamp != nil {
-		return r.deleteBackupEntry(ctx, log, backupEntry)
+		return r.deleteBackupEntry(gardenCtx, seedCtx, log, backupEntry)
 	}
 
 	if shouldMigrateBackupEntry(backupEntry) {
-		return r.migrateBackupEntry(ctx, log, backupEntry)
+		return r.migrateBackupEntry(gardenCtx, seedCtx, log, backupEntry)
 	}
 
-	return r.reconcileBackupEntry(ctx, log, backupEntry)
+	return r.reconcileBackupEntry(gardenCtx, seedCtx, log, backupEntry)
 }
 
 func (r *Reconciler) reconcileBackupEntry(
-	ctx context.Context,
+	gardenCtx context.Context,
+	seedCtx context.Context,
 	log logr.Logger,
 	backupEntry *gardencorev1beta1.BackupEntry,
 ) (
@@ -118,13 +121,13 @@ func (r *Reconciler) reconcileBackupEntry(
 ) {
 	if !controllerutil.ContainsFinalizer(backupEntry, gardencorev1beta1.GardenerName) {
 		log.Info("Adding finalizer")
-		if err := controllerutils.AddFinalizers(ctx, r.GardenClient, backupEntry, gardencorev1beta1.GardenerName); err != nil {
+		if err := controllerutils.AddFinalizers(gardenCtx, r.GardenClient, backupEntry, gardencorev1beta1.GardenerName); err != nil {
 			return reconcile.Result{}, fmt.Errorf("failed to add finalizer: %w", err)
 		}
 	}
 
 	operationType := v1beta1helper.ComputeOperationType(backupEntry.ObjectMeta, backupEntry.Status.LastOperation)
-	if updateErr := r.updateBackupEntryStatusOperationStart(ctx, backupEntry, operationType); updateErr != nil {
+	if updateErr := r.updateBackupEntryStatusOperationStart(gardenCtx, backupEntry, operationType); updateErr != nil {
 		return reconcile.Result{}, fmt.Errorf("could not update status after reconciliation start: %w", updateErr)
 	}
 
@@ -150,16 +153,16 @@ func (r *Reconciler) reconcileBackupEntry(
 		}
 	)
 
-	if err := r.waitUntilBackupBucketReconciled(ctx, log, backupBucket); err != nil {
+	if err := r.waitUntilBackupBucketReconciled(gardenCtx, log, backupBucket); err != nil {
 		return reconcile.Result{}, fmt.Errorf("associated BackupBucket %q is not ready yet with err: %w", backupEntry.Spec.BucketName, err)
 	}
 
-	gardenSecret, err := r.getGardenSecret(ctx, backupBucket)
+	gardenSecret, err := r.getGardenSecret(gardenCtx, backupBucket)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
 
-	if err := r.SeedClient.Get(ctx, client.ObjectKeyFromObject(extensionSecret), extensionSecret); err != nil {
+	if err := r.SeedClient.Get(seedCtx, client.ObjectKeyFromObject(extensionSecret), extensionSecret); err != nil {
 		if !apierrors.IsNotFound(err) {
 			return reconcile.Result{}, err
 		}
@@ -178,7 +181,7 @@ func (r *Reconciler) reconcileBackupEntry(
 	}
 
 	if mustReconcileExtensionSecret {
-		if err := r.reconcileBackupEntryExtensionSecret(ctx, extensionSecret, gardenSecret); err != nil {
+		if err := r.reconcileBackupEntryExtensionSecret(seedCtx, extensionSecret, gardenSecret); err != nil {
 			return reconcile.Result{}, err
 		}
 	}
@@ -202,7 +205,7 @@ func (r *Reconciler) reconcileBackupEntry(
 		return reconcile.Result{}, err
 	}
 
-	if err := r.SeedClient.Get(ctx, client.ObjectKeyFromObject(extensionBackupEntry), extensionBackupEntry); err != nil {
+	if err := r.SeedClient.Get(seedCtx, client.ObjectKeyFromObject(extensionBackupEntry), extensionBackupEntry); err != nil {
 		if !apierrors.IsNotFound(err) {
 			return reconcile.Result{}, err
 		}
@@ -240,13 +243,13 @@ func (r *Reconciler) reconcileBackupEntry(
 
 		r.Recorder.Event(backupEntry, corev1.EventTypeWarning, gardencorev1beta1.EventReconcileError, reconcileErr.Description)
 
-		if updateErr := r.updateBackupEntryStatusError(ctx, backupEntry, operationType, reconcileErr.Description, reconcileErr); updateErr != nil {
+		if updateErr := r.updateBackupEntryStatusError(gardenCtx, backupEntry, operationType, reconcileErr.Description, reconcileErr); updateErr != nil {
 			return reconcile.Result{}, fmt.Errorf("could not update status after reconciliation error: %w", updateErr)
 		}
 	}
 
 	if mustReconcileExtensionBackupEntry {
-		if err := r.reconcileBackupEntryExtension(ctx, backupBucket, backupEntry, component); err != nil {
+		if err := r.reconcileBackupEntryExtension(gardenCtx, seedCtx, backupBucket, backupEntry, component); err != nil {
 			return reconcile.Result{}, err
 		}
 		// return early here, the BackupEntry status will be updated by the reconciliation caused by the extension BackupEntry status update.
@@ -254,12 +257,12 @@ func (r *Reconciler) reconcileBackupEntry(
 	}
 
 	if extensionBackupEntry.Status.LastOperation != nil && extensionBackupEntry.Status.LastOperation.State == gardencorev1beta1.LastOperationStateSucceeded {
-		if updateErr := r.updateBackupEntryStatusSucceeded(ctx, backupEntry, operationType); updateErr != nil {
+		if updateErr := r.updateBackupEntryStatusSucceeded(gardenCtx, backupEntry, operationType); updateErr != nil {
 			return reconcile.Result{}, fmt.Errorf("could not update status after reconciliation success: %w", updateErr)
 		}
 
 		if kubernetesutils.HasMetaDataAnnotation(&backupEntry.ObjectMeta, v1beta1constants.GardenerOperation, v1beta1constants.GardenerOperationRestore) {
-			if updateErr := removeGardenerOperationAnnotation(ctx, r.GardenClient, backupEntry); updateErr != nil {
+			if updateErr := removeGardenerOperationAnnotation(gardenCtx, r.GardenClient, backupEntry); updateErr != nil {
 				return reconcile.Result{}, fmt.Errorf("could not remove %q annotation: %w", v1beta1constants.GardenerOperation, updateErr)
 			}
 		}
@@ -268,7 +271,8 @@ func (r *Reconciler) reconcileBackupEntry(
 }
 
 func (r *Reconciler) deleteBackupEntry(
-	ctx context.Context,
+	gardenCtx context.Context,
+	seedCtx context.Context,
 	log logr.Logger,
 	backupEntry *gardencorev1beta1.BackupEntry,
 ) (
@@ -284,7 +288,7 @@ func (r *Reconciler) deleteBackupEntry(
 	present, _ := strconv.ParseBool(backupEntry.ObjectMeta.Annotations[gardencorev1beta1.BackupEntryForceDeletion])
 	if present || r.Clock.Since(backupEntry.DeletionTimestamp.Local()) > gracePeriod {
 		operationType := v1beta1helper.ComputeOperationType(backupEntry.ObjectMeta, backupEntry.Status.LastOperation)
-		if updateErr := r.updateBackupEntryStatusOperationStart(ctx, backupEntry, operationType); updateErr != nil {
+		if updateErr := r.updateBackupEntryStatusOperationStart(gardenCtx, backupEntry, operationType); updateErr != nil {
 			return reconcile.Result{}, fmt.Errorf("could not update status after deletion start: %w", updateErr)
 		}
 
@@ -295,21 +299,21 @@ func (r *Reconciler) deleteBackupEntry(
 			},
 		}
 
-		if err := r.waitUntilBackupBucketReconciled(ctx, log, backupBucket); err != nil {
+		if err := r.waitUntilBackupBucketReconciled(gardenCtx, log, backupBucket); err != nil {
 			return reconcile.Result{}, fmt.Errorf("associated BackupBucket %q is not ready yet with err: %w", backupEntry.Spec.BucketName, err)
 		}
 
-		gardenSecret, err := r.getGardenSecret(ctx, backupBucket)
+		gardenSecret, err := r.getGardenSecret(gardenCtx, backupBucket)
 		if err != nil {
 			return reconcile.Result{}, err
 		}
 
-		if err := r.reconcileBackupEntryExtensionSecret(ctx, extensionSecret, gardenSecret); err != nil {
+		if err := r.reconcileBackupEntryExtensionSecret(seedCtx, extensionSecret, gardenSecret); err != nil {
 			return reconcile.Result{}, err
 		}
 
 		component := r.newExtensionComponent(log, backupEntry)
-		if err := component.Destroy(ctx); err != nil {
+		if err := component.Destroy(seedCtx); err != nil {
 			return reconcile.Result{}, err
 		}
 
@@ -319,7 +323,7 @@ func (r *Reconciler) deleteBackupEntry(
 			},
 		}
 
-		if err := r.SeedClient.Get(ctx, client.ObjectKeyFromObject(extensionBackupEntry), extensionBackupEntry); err != nil {
+		if err := r.SeedClient.Get(seedCtx, client.ObjectKeyFromObject(extensionBackupEntry), extensionBackupEntry); err != nil {
 			if !apierrors.IsNotFound(err) {
 				return reconcile.Result{}, err
 			}
@@ -327,7 +331,7 @@ func (r *Reconciler) deleteBackupEntry(
 			if lastError := extensionBackupEntry.Status.LastError; lastError != nil {
 				r.Recorder.Event(backupEntry, corev1.EventTypeWarning, gardencorev1beta1.EventDeleteError, lastError.Description)
 
-				if updateErr := r.updateBackupEntryStatusError(ctx, backupEntry, operationType, lastError.Description, lastError); updateErr != nil {
+				if updateErr := r.updateBackupEntryStatusError(gardenCtx, backupEntry, operationType, lastError.Description, lastError); updateErr != nil {
 					return reconcile.Result{}, fmt.Errorf("could not update status after deletion error: %w", updateErr)
 				}
 				return reconcile.Result{}, errors.New(lastError.Description)
@@ -336,11 +340,11 @@ func (r *Reconciler) deleteBackupEntry(
 			return reconcile.Result{RequeueAfter: RequeueDurationWhenResourceDeletionStillPresent}, nil
 		}
 
-		if err := client.IgnoreNotFound(r.SeedClient.Delete(ctx, extensionSecret)); err != nil {
+		if err := client.IgnoreNotFound(r.SeedClient.Delete(seedCtx, extensionSecret)); err != nil {
 			return reconcile.Result{}, nil
 		}
 
-		if updateErr := r.updateBackupEntryStatusSucceeded(ctx, backupEntry, operationType); updateErr != nil {
+		if updateErr := r.updateBackupEntryStatusSucceeded(gardenCtx, backupEntry, operationType); updateErr != nil {
 			return reconcile.Result{}, fmt.Errorf("could not update status after deletion success: %w", updateErr)
 		}
 
@@ -348,7 +352,7 @@ func (r *Reconciler) deleteBackupEntry(
 
 		if controllerutil.ContainsFinalizer(backupEntry, gardencorev1beta1.GardenerName) {
 			log.Info("Removing finalizer")
-			if err := controllerutils.RemoveFinalizers(ctx, r.GardenClient, backupEntry, gardencorev1beta1.GardenerName); err != nil {
+			if err := controllerutils.RemoveFinalizers(gardenCtx, r.GardenClient, backupEntry, gardencorev1beta1.GardenerName); err != nil {
 				return reconcile.Result{}, fmt.Errorf("failed to remove finalizer: %w", err)
 			}
 		}
@@ -356,7 +360,7 @@ func (r *Reconciler) deleteBackupEntry(
 		return reconcile.Result{}, nil
 	}
 
-	if updateErr := r.updateBackupEntryStatusPending(ctx, backupEntry, fmt.Sprintf("Deletion of backup entry is scheduled for %s", backupEntry.DeletionTimestamp.Time.Add(gracePeriod))); updateErr != nil {
+	if updateErr := r.updateBackupEntryStatusPending(gardenCtx, backupEntry, fmt.Sprintf("Deletion of backup entry is scheduled for %s", backupEntry.DeletionTimestamp.Time.Add(gracePeriod))); updateErr != nil {
 		return reconcile.Result{}, fmt.Errorf("could not update status after deletion success: %w", updateErr)
 	}
 
@@ -368,7 +372,8 @@ func (r *Reconciler) deleteBackupEntry(
 }
 
 func (r *Reconciler) migrateBackupEntry(
-	ctx context.Context,
+	gardenCtx context.Context,
+	seedCtx context.Context,
 	log logr.Logger,
 	backupEntry *gardencorev1beta1.BackupEntry,
 ) (
@@ -380,7 +385,7 @@ func (r *Reconciler) migrateBackupEntry(
 		return reconcile.Result{}, nil
 	}
 
-	if updateErr := r.updateBackupEntryStatusOperationStart(ctx, backupEntry, gardencorev1beta1.LastOperationTypeMigrate); updateErr != nil {
+	if updateErr := r.updateBackupEntryStatusOperationStart(gardenCtx, backupEntry, gardencorev1beta1.LastOperationTypeMigrate); updateErr != nil {
 		return reconcile.Result{}, fmt.Errorf("could not update status after migration start: %w", updateErr)
 	}
 
@@ -395,7 +400,7 @@ func (r *Reconciler) migrateBackupEntry(
 		}
 	)
 
-	if err := r.SeedClient.Get(ctx, client.ObjectKeyFromObject(extensionBackupEntry), extensionBackupEntry); err != nil {
+	if err := r.SeedClient.Get(seedCtx, client.ObjectKeyFromObject(extensionBackupEntry), extensionBackupEntry); err != nil {
 		if !apierrors.IsNotFound(err) {
 			return reconcile.Result{}, err
 		}
@@ -423,7 +428,7 @@ func (r *Reconciler) migrateBackupEntry(
 				r.Recorder.Event(backupEntry, corev1.EventTypeWarning, gardencorev1beta1.EventReconcileError, migrateError.Description)
 
 				description := migrateError.Description
-				if updateErr := r.updateBackupEntryStatusError(ctx, backupEntry, gardencorev1beta1.LastOperationTypeMigrate, description, migrateError); updateErr != nil {
+				if updateErr := r.updateBackupEntryStatusError(gardenCtx, backupEntry, gardencorev1beta1.LastOperationTypeMigrate, description, migrateError); updateErr != nil {
 					return reconcile.Result{}, fmt.Errorf("could not update status after migration error: %w", updateErr)
 				}
 
@@ -432,7 +437,7 @@ func (r *Reconciler) migrateBackupEntry(
 				}
 				return reconcile.Result{}, nil
 			} else if lastOperation.State == gardencorev1beta1.LastOperationStateSucceeded {
-				if err := component.Destroy(ctx); err != nil {
+				if err := component.Destroy(seedCtx); err != nil {
 					return reconcile.Result{}, err
 				}
 				return reconcile.Result{RequeueAfter: RequeueDurationWhenResourceDeletionStillPresent}, nil
@@ -441,7 +446,7 @@ func (r *Reconciler) migrateBackupEntry(
 			if lastError := extensionBackupEntry.Status.LastError; lastError != nil {
 				r.Recorder.Event(backupEntry, corev1.EventTypeWarning, gardencorev1beta1.EventDeleteError, lastError.Description)
 
-				if updateErr := r.updateBackupEntryStatusError(ctx, backupEntry, gardencorev1beta1.LastOperationTypeDelete, lastError.Description, lastError); updateErr != nil {
+				if updateErr := r.updateBackupEntryStatusError(gardenCtx, backupEntry, gardencorev1beta1.LastOperationTypeDelete, lastError.Description, lastError); updateErr != nil {
 					return reconcile.Result{}, fmt.Errorf("could not update status after deletion error: %w", updateErr)
 				}
 				return reconcile.Result{}, errors.New(lastError.Description)
@@ -449,15 +454,15 @@ func (r *Reconciler) migrateBackupEntry(
 			log.Info("Extension BackupEntry not yet deleted", "extensionBackupEntry", client.ObjectKeyFromObject(extensionBackupEntry))
 			return reconcile.Result{RequeueAfter: RequeueDurationWhenResourceDeletionStillPresent}, nil
 		default:
-			return reconcile.Result{}, component.Migrate(ctx)
+			return reconcile.Result{}, component.Migrate(seedCtx)
 		}
 	}
 
-	if err := client.IgnoreNotFound(r.SeedClient.Delete(ctx, extensionSecret)); err != nil {
+	if err := client.IgnoreNotFound(r.SeedClient.Delete(seedCtx, extensionSecret)); err != nil {
 		return reconcile.Result{}, err
 	}
 
-	if updateErr := r.updateBackupEntryStatusSucceeded(ctx, backupEntry, gardencorev1beta1.LastOperationTypeMigrate); updateErr != nil {
+	if updateErr := r.updateBackupEntryStatusSucceeded(gardenCtx, backupEntry, gardencorev1beta1.LastOperationTypeMigrate); updateErr != nil {
 		return reconcile.Result{}, fmt.Errorf("could not update status after migration success: %w", updateErr)
 	}
 
@@ -632,22 +637,22 @@ func (r *Reconciler) reconcileBackupEntryExtensionSecret(ctx context.Context, ex
 }
 
 // reconcileBackupEntryExtension deploys the BackupEntry extension resource in Seed with the required secret.
-func (r *Reconciler) reconcileBackupEntryExtension(ctx context.Context, backupBucket *gardencorev1beta1.BackupBucket, backupEntry *gardencorev1beta1.BackupEntry, component extensionsbackupentry.Interface) error {
+func (r *Reconciler) reconcileBackupEntryExtension(gardenCtx context.Context, seedCtx context.Context, backupBucket *gardencorev1beta1.BackupBucket, backupEntry *gardencorev1beta1.BackupEntry, component extensionsbackupentry.Interface) error {
 	component.SetType(backupBucket.Spec.Provider.Type)
 	component.SetProviderConfig(backupBucket.Spec.ProviderConfig)
 	component.SetRegion(backupBucket.Spec.Provider.Region)
 	component.SetBackupBucketProviderStatus(backupBucket.Status.ProviderStatus)
 
 	if !isRestorePhase(backupEntry) {
-		return component.Deploy(ctx)
+		return component.Deploy(seedCtx)
 	}
 
 	shootName := gardenerutils.GetShootNameFromOwnerReferences(backupEntry)
 	shootState := &gardencorev1beta1.ShootState{}
-	if err := r.GardenClient.Get(ctx, kubernetesutils.Key(backupEntry.Namespace, shootName), shootState); err != nil {
+	if err := r.GardenClient.Get(gardenCtx, kubernetesutils.Key(backupEntry.Namespace, shootName), shootState); err != nil {
 		return err
 	}
-	return component.Restore(ctx, shootState)
+	return component.Restore(seedCtx, shootState)
 }
 
 func shouldMigrateBackupEntry(be *gardencorev1beta1.BackupEntry) bool {

--- a/pkg/gardenlet/controller/backupentry/reconciler.go
+++ b/pkg/gardenlet/controller/backupentry/reconciler.go
@@ -80,9 +80,9 @@ type Reconciler struct {
 func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 	log := logf.FromContext(ctx)
 
-	gardenCtx, cancel := context.WithTimeout(ctx, controllerutils.DefaultReconciliationTimeout)
+	gardenCtx, cancel := controllerutils.GetMainReconciliationContext(ctx, controllerutils.DefaultReconciliationTimeout)
 	defer cancel()
-	seedCtx, cancel := context.WithTimeout(ctx, controllerutils.DefaultReconciliationTimeout/2)
+	seedCtx, cancel := controllerutils.GetChildReconciliationContext(ctx, controllerutils.DefaultReconciliationTimeout)
 	defer cancel()
 
 	backupEntry := &gardencorev1beta1.BackupEntry{}

--- a/pkg/gardenlet/controller/bastion/reconciler.go
+++ b/pkg/gardenlet/controller/bastion/reconciler.go
@@ -69,6 +69,9 @@ type Reconciler struct {
 func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 	log := logf.FromContext(ctx)
 
+	ctx, cancel := context.WithTimeout(ctx, controllerutils.DefaultReconciliationTimeout)
+	defer cancel()
+
 	bastion := &operationsv1alpha1.Bastion{}
 	if err := r.GardenClient.Get(ctx, request.NamespacedName, bastion); err != nil {
 		if apierrors.IsNotFound(err) {

--- a/pkg/gardenlet/controller/bastion/reconciler.go
+++ b/pkg/gardenlet/controller/bastion/reconciler.go
@@ -69,11 +69,13 @@ type Reconciler struct {
 func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 	log := logf.FromContext(ctx)
 
-	ctx, cancel := context.WithTimeout(ctx, controllerutils.DefaultReconciliationTimeout)
+	gardenCtx, cancel := context.WithTimeout(ctx, controllerutils.DefaultReconciliationTimeout)
+	defer cancel()
+	seedCtx, cancel := context.WithTimeout(ctx, controllerutils.DefaultReconciliationTimeout/2)
 	defer cancel()
 
 	bastion := &operationsv1alpha1.Bastion{}
-	if err := r.GardenClient.Get(ctx, request.NamespacedName, bastion); err != nil {
+	if err := r.GardenClient.Get(gardenCtx, request.NamespacedName, bastion); err != nil {
 		if apierrors.IsNotFound(err) {
 			log.V(1).Info("Object is gone, stop reconciling")
 			return reconcile.Result{}, nil
@@ -84,15 +86,15 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	// get Shoot for the bastion
 	shoot := gardencorev1beta1.Shoot{}
 	shootKey := kubernetesutils.Key(bastion.Namespace, bastion.Spec.ShootRef.Name)
-	if err := r.GardenClient.Get(ctx, shootKey, &shoot); err != nil {
+	if err := r.GardenClient.Get(gardenCtx, shootKey, &shoot); err != nil {
 		return reconcile.Result{}, fmt.Errorf("could not get shoot %v: %w", shootKey, err)
 	}
 
 	var err error
 	if bastion.DeletionTimestamp != nil {
-		err = r.cleanupBastion(ctx, log, bastion, &shoot)
+		err = r.cleanupBastion(gardenCtx, seedCtx, log, bastion, &shoot)
 	} else {
-		err = r.reconcileBastion(ctx, log, bastion, &shoot)
+		err = r.reconcileBastion(gardenCtx, seedCtx, log, bastion, &shoot)
 	}
 
 	if cause := reconcilerutils.ReconcileErrCause(err); cause != nil {
@@ -103,14 +105,15 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 }
 
 func (r *Reconciler) reconcileBastion(
-	ctx context.Context,
+	gardenCtx context.Context,
+	seedCtx context.Context,
 	log logr.Logger,
 	bastion *operationsv1alpha1.Bastion,
 	shoot *gardencorev1beta1.Shoot,
 ) error {
 	if !controllerutil.ContainsFinalizer(bastion, finalizerName) {
 		log.Info("Adding finalizer")
-		if err := controllerutils.AddFinalizers(ctx, r.GardenClient, bastion, finalizerName); err != nil {
+		if err := controllerutils.AddFinalizers(gardenCtx, r.GardenClient, bastion, finalizerName); err != nil {
 			return fmt.Errorf("failed to add finalizer: %w", err)
 		}
 	}
@@ -135,7 +138,7 @@ func (r *Reconciler) reconcileBastion(
 		}
 	)
 
-	if err := r.SeedClient.Get(ctx, client.ObjectKeyFromObject(extensionBastion), extensionBastion); err != nil {
+	if err := r.SeedClient.Get(seedCtx, client.ObjectKeyFromObject(extensionBastion), extensionBastion); err != nil {
 		if !apierrors.IsNotFound(err) {
 			return err
 		}
@@ -167,20 +170,20 @@ func (r *Reconciler) reconcileBastion(
 		message := fmt.Sprintf("Error while waiting for %s %s/%s to become ready", extensionsv1alpha1.BastionResource, extensionBastion.Namespace, extensionBastion.Name)
 		err := fmt.Errorf("%s: %w", message, lastObservedError)
 
-		if patchErr := patchReadyCondition(ctx, r.GardenClient, bastion, gardencorev1alpha1.ConditionFalse, "FailedReconciling", err.Error()); patchErr != nil {
+		if patchErr := patchReadyCondition(gardenCtx, r.GardenClient, bastion, gardencorev1alpha1.ConditionFalse, "FailedReconciling", err.Error()); patchErr != nil {
 			log.Error(patchErr, "Failed patching ready condition")
 		}
 	}
 
 	if mustReconcileExtensionBastion {
-		if _, err := controllerutils.GetAndCreateOrMergePatch(ctx, r.SeedClient, extensionBastion, func() error {
+		if _, err := controllerutils.GetAndCreateOrMergePatch(seedCtx, r.SeedClient, extensionBastion, func() error {
 			metav1.SetMetaDataAnnotation(&extensionBastion.ObjectMeta, v1beta1constants.GardenerOperation, v1beta1constants.GardenerOperationReconcile)
 			metav1.SetMetaDataAnnotation(&extensionBastion.ObjectMeta, v1beta1constants.GardenerTimestamp, r.Clock.Now().UTC().String())
 
 			extensionBastion.Spec = extensionBastionSpec
 			return nil
 		}); err != nil {
-			if patchErr := patchReadyCondition(ctx, r.GardenClient, bastion, gardencorev1alpha1.ConditionFalse, "FailedReconciling", err.Error()); patchErr != nil {
+			if patchErr := patchReadyCondition(seedCtx, r.GardenClient, bastion, gardencorev1alpha1.ConditionFalse, "FailedReconciling", err.Error()); patchErr != nil {
 				log.Error(patchErr, "Failed patching ready condition")
 			}
 			return fmt.Errorf("failed to ensure bastion extension resource: %w", err)
@@ -195,7 +198,7 @@ func (r *Reconciler) reconcileBastion(
 		setReadyCondition(bastion, gardencorev1alpha1.ConditionTrue, "SuccessfullyReconciled", "The bastion has been reconciled successfully.")
 		bastion.Status.Ingress = extensionBastion.Status.Ingress.DeepCopy()
 		bastion.Status.ObservedGeneration = &bastion.Generation
-		if err := r.GardenClient.Status().Patch(ctx, bastion, patch); err != nil {
+		if err := r.GardenClient.Status().Patch(gardenCtx, bastion, patch); err != nil {
 			return fmt.Errorf("failed patching ready condition of Bastion: %w", err)
 		}
 	}
@@ -204,7 +207,8 @@ func (r *Reconciler) reconcileBastion(
 }
 
 func (r *Reconciler) cleanupBastion(
-	ctx context.Context,
+	gardenCtx context.Context,
+	seedCtx context.Context,
 	log logr.Logger,
 	bastion *operationsv1alpha1.Bastion,
 	shoot *gardencorev1beta1.Shoot,
@@ -213,19 +217,19 @@ func (r *Reconciler) cleanupBastion(
 		return nil
 	}
 
-	if err := patchReadyCondition(ctx, r.GardenClient, bastion, gardencorev1alpha1.ConditionFalse, "DeletionInProgress", "The bastion is being deleted."); err != nil {
+	if err := patchReadyCondition(gardenCtx, r.GardenClient, bastion, gardencorev1alpha1.ConditionFalse, "DeletionInProgress", "The bastion is being deleted."); err != nil {
 		return fmt.Errorf("failed patching ready condition of Bastion: %w", err)
 	}
 
 	// delete bastion extension resource in seed cluster
 	extensionBastion := newBastionExtension(bastion, shoot)
-	if err := r.SeedClient.Delete(ctx, extensionBastion); err != nil {
+	if err := r.SeedClient.Delete(seedCtx, extensionBastion); err != nil {
 		if apierrors.IsNotFound(err) {
 			log.Info("Successfully deleted")
 
 			if controllerutil.ContainsFinalizer(bastion, finalizerName) {
 				log.Info("Removing finalizer")
-				if err := controllerutils.RemoveFinalizers(ctx, r.GardenClient, bastion, finalizerName); err != nil {
+				if err := controllerutils.RemoveFinalizers(gardenCtx, r.GardenClient, bastion, finalizerName); err != nil {
 					return fmt.Errorf("failed to remove finalizer: %w", err)
 				}
 			}

--- a/pkg/gardenlet/controller/bastion/reconciler.go
+++ b/pkg/gardenlet/controller/bastion/reconciler.go
@@ -69,9 +69,9 @@ type Reconciler struct {
 func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 	log := logf.FromContext(ctx)
 
-	gardenCtx, cancel := context.WithTimeout(ctx, controllerutils.DefaultReconciliationTimeout)
+	gardenCtx, cancel := controllerutils.GetMainReconciliationContext(ctx, controllerutils.DefaultReconciliationTimeout)
 	defer cancel()
-	seedCtx, cancel := context.WithTimeout(ctx, controllerutils.DefaultReconciliationTimeout/2)
+	seedCtx, cancel := controllerutils.GetChildReconciliationContext(ctx, controllerutils.DefaultReconciliationTimeout)
 	defer cancel()
 
 	bastion := &operationsv1alpha1.Bastion{}

--- a/pkg/gardenlet/controller/bastion/reconciler.go
+++ b/pkg/gardenlet/controller/bastion/reconciler.go
@@ -183,7 +183,7 @@ func (r *Reconciler) reconcileBastion(
 			extensionBastion.Spec = extensionBastionSpec
 			return nil
 		}); err != nil {
-			if patchErr := patchReadyCondition(seedCtx, r.GardenClient, bastion, gardencorev1alpha1.ConditionFalse, "FailedReconciling", err.Error()); patchErr != nil {
+			if patchErr := patchReadyCondition(gardenCtx, r.GardenClient, bastion, gardencorev1alpha1.ConditionFalse, "FailedReconciling", err.Error()); patchErr != nil {
 				log.Error(patchErr, "Failed patching ready condition")
 			}
 			return fmt.Errorf("failed to ensure bastion extension resource: %w", err)

--- a/pkg/gardenlet/controller/controllerinstallation/care/reconciler.go
+++ b/pkg/gardenlet/controller/controllerinstallation/care/reconciler.go
@@ -46,6 +46,9 @@ type Reconciler struct {
 func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 	log := logf.FromContext(ctx)
 
+	ctx, cancel := context.WithTimeout(ctx, r.Config.SyncPeriod.Duration)
+	defer cancel()
+
 	controllerInstallation := &gardencorev1beta1.ControllerInstallation{}
 	if err := r.GardenClient.Get(ctx, request.NamespacedName, controllerInstallation); err != nil {
 		if apierrors.IsNotFound(err) {

--- a/pkg/gardenlet/controller/controllerinstallation/care/reconciler.go
+++ b/pkg/gardenlet/controller/controllerinstallation/care/reconciler.go
@@ -29,6 +29,7 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
+	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/gardenlet/apis/config"
 	"github.com/gardener/gardener/pkg/utils/kubernetes/health"
 )
@@ -46,9 +47,9 @@ type Reconciler struct {
 func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 	log := logf.FromContext(ctx)
 
-	gardenCtx, cancel := context.WithTimeout(ctx, r.Config.SyncPeriod.Duration)
+	gardenCtx, cancel := controllerutils.GetMainReconciliationContext(ctx, r.Config.SyncPeriod.Duration)
 	defer cancel()
-	seedCtx, cancel := context.WithTimeout(ctx, r.Config.SyncPeriod.Duration/2)
+	seedCtx, cancel := controllerutils.GetChildReconciliationContext(ctx, r.Config.SyncPeriod.Duration)
 	defer cancel()
 
 	controllerInstallation := &gardencorev1beta1.ControllerInstallation{}

--- a/pkg/gardenlet/controller/controllerinstallation/controllerinstallation/reconciler.go
+++ b/pkg/gardenlet/controller/controllerinstallation/controllerinstallation/reconciler.go
@@ -70,6 +70,9 @@ type Reconciler struct {
 func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 	log := logf.FromContext(ctx)
 
+	ctx, cancel := context.WithTimeout(ctx, controllerutils.DefaultReconciliationTimeout)
+	defer cancel()
+
 	controllerInstallation := &gardencorev1beta1.ControllerInstallation{}
 	if err := r.GardenClient.Get(ctx, request.NamespacedName, controllerInstallation); err != nil {
 		if apierrors.IsNotFound(err) {

--- a/pkg/gardenlet/controller/controllerinstallation/controllerinstallation/reconciler.go
+++ b/pkg/gardenlet/controller/controllerinstallation/controllerinstallation/reconciler.go
@@ -70,9 +70,9 @@ type Reconciler struct {
 func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 	log := logf.FromContext(ctx)
 
-	gardenCtx, cancel := context.WithTimeout(ctx, controllerutils.DefaultReconciliationTimeout)
+	gardenCtx, cancel := controllerutils.GetMainReconciliationContext(ctx, controllerutils.DefaultReconciliationTimeout)
 	defer cancel()
-	seedCtx, cancel := context.WithTimeout(ctx, controllerutils.DefaultReconciliationTimeout/2)
+	seedCtx, cancel := controllerutils.GetChildReconciliationContext(ctx, controllerutils.DefaultReconciliationTimeout)
 	defer cancel()
 
 	controllerInstallation := &gardencorev1beta1.ControllerInstallation{}
@@ -170,7 +170,7 @@ func (r *Reconciler) reconcile(
 	}
 
 	// TODO(timuthy, rfranzke): Drop this code when the FullNetworkPoliciesInRuntimeCluster feature gate gets promoted to GA.
-	if err := r.reconcileNetworkPoliciesInSeed(ctx, namespace.Name); err != nil {
+	if err := r.reconcileNetworkPoliciesInSeed(seedCtx, namespace.Name); err != nil {
 		return reconcile.Result{}, err
 	}
 

--- a/pkg/gardenlet/controller/controllerinstallation/controllerinstallation/reconciler.go
+++ b/pkg/gardenlet/controller/controllerinstallation/controllerinstallation/reconciler.go
@@ -70,11 +70,13 @@ type Reconciler struct {
 func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 	log := logf.FromContext(ctx)
 
-	ctx, cancel := context.WithTimeout(ctx, controllerutils.DefaultReconciliationTimeout)
+	gardenCtx, cancel := context.WithTimeout(ctx, controllerutils.DefaultReconciliationTimeout)
+	defer cancel()
+	seedCtx, cancel := context.WithTimeout(ctx, controllerutils.DefaultReconciliationTimeout/2)
 	defer cancel()
 
 	controllerInstallation := &gardencorev1beta1.ControllerInstallation{}
-	if err := r.GardenClient.Get(ctx, request.NamespacedName, controllerInstallation); err != nil {
+	if err := r.GardenClient.Get(gardenCtx, request.NamespacedName, controllerInstallation); err != nil {
 		if apierrors.IsNotFound(err) {
 			log.V(1).Info("Object is gone, stop reconciling")
 			return reconcile.Result{}, nil
@@ -83,13 +85,14 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	}
 
 	if controllerInstallation.DeletionTimestamp != nil {
-		return r.delete(ctx, log, controllerInstallation)
+		return r.delete(gardenCtx, seedCtx, log, controllerInstallation)
 	}
-	return r.reconcile(ctx, log, controllerInstallation)
+	return r.reconcile(gardenCtx, seedCtx, log, controllerInstallation)
 }
 
 func (r *Reconciler) reconcile(
-	ctx context.Context,
+	gardenCtx context.Context,
+	seedCtx context.Context,
 	log logr.Logger,
 	controllerInstallation *gardencorev1beta1.ControllerInstallation,
 ) (
@@ -98,7 +101,7 @@ func (r *Reconciler) reconcile(
 ) {
 	if !controllerutil.ContainsFinalizer(controllerInstallation, finalizerName) {
 		log.Info("Adding finalizer")
-		if err := controllerutils.AddFinalizers(ctx, r.GardenClient, controllerInstallation, finalizerName); err != nil {
+		if err := controllerutils.AddFinalizers(gardenCtx, r.GardenClient, controllerInstallation, finalizerName); err != nil {
 			return reconcile.Result{}, fmt.Errorf("failed to add finalizer: %w", err)
 		}
 	}
@@ -109,13 +112,13 @@ func (r *Reconciler) reconcile(
 	)
 
 	defer func() {
-		if err := patchConditions(ctx, r.GardenClient, controllerInstallation, conditionValid, conditionInstalled); err != nil {
+		if err := patchConditions(gardenCtx, r.GardenClient, controllerInstallation, conditionValid, conditionInstalled); err != nil {
 			log.Error(err, "Failed to patch conditions")
 		}
 	}()
 
 	controllerRegistration := &gardencorev1beta1.ControllerRegistration{}
-	if err := r.GardenClient.Get(ctx, client.ObjectKey{Name: controllerInstallation.Spec.RegistrationRef.Name}, controllerRegistration); err != nil {
+	if err := r.GardenClient.Get(gardenCtx, client.ObjectKey{Name: controllerInstallation.Spec.RegistrationRef.Name}, controllerRegistration); err != nil {
 		if apierrors.IsNotFound(err) {
 			conditionValid = v1beta1helper.UpdatedConditionWithClock(r.Clock, conditionValid, gardencorev1beta1.ConditionFalse, "RegistrationNotFound", fmt.Sprintf("Referenced ControllerRegistration does not exist: %+v", err))
 		} else {
@@ -125,7 +128,7 @@ func (r *Reconciler) reconcile(
 	}
 
 	seed := &gardencorev1beta1.Seed{}
-	if err := r.GardenClient.Get(ctx, client.ObjectKey{Name: controllerInstallation.Spec.SeedRef.Name}, seed); err != nil {
+	if err := r.GardenClient.Get(gardenCtx, client.ObjectKey{Name: controllerInstallation.Spec.SeedRef.Name}, seed); err != nil {
 		if apierrors.IsNotFound(err) {
 			conditionValid = v1beta1helper.UpdatedConditionWithClock(r.Clock, conditionValid, gardencorev1beta1.ConditionFalse, "SeedNotFound", fmt.Sprintf("Referenced Seed does not exist: %+v", err))
 		} else {
@@ -137,7 +140,7 @@ func (r *Reconciler) reconcile(
 	var providerConfig *runtime.RawExtension
 	if deploymentRef := controllerInstallation.Spec.DeploymentRef; deploymentRef != nil {
 		controllerDeployment := &gardencorev1beta1.ControllerDeployment{}
-		if err := r.GardenClient.Get(ctx, kubernetesutils.Key(deploymentRef.Name), controllerDeployment); err != nil {
+		if err := r.GardenClient.Get(gardenCtx, kubernetesutils.Key(deploymentRef.Name), controllerDeployment); err != nil {
 			return reconcile.Result{}, err
 		}
 		providerConfig = &controllerDeployment.ProviderConfig
@@ -156,7 +159,7 @@ func (r *Reconciler) reconcile(
 	}
 
 	namespace := getNamespaceForControllerInstallation(controllerInstallation)
-	if _, err := controllerutils.GetAndCreateOrMergePatch(ctx, r.SeedClientSet.Client(), namespace, func() error {
+	if _, err := controllerutils.GetAndCreateOrMergePatch(seedCtx, r.SeedClientSet.Client(), namespace, func() error {
 		metav1.SetMetaDataLabel(&namespace.ObjectMeta, v1beta1constants.GardenRole, v1beta1constants.GardenRoleExtension)
 		metav1.SetMetaDataLabel(&namespace.ObjectMeta, v1beta1constants.LabelControllerRegistrationName, controllerRegistration.Name)
 		metav1.SetMetaDataLabel(&namespace.ObjectMeta, resourcesv1alpha1.HighAvailabilityConfigConsider, "true")
@@ -225,7 +228,7 @@ func (r *Reconciler) reconcile(
 	conditionValid = v1beta1helper.UpdatedConditionWithClock(r.Clock, conditionValid, gardencorev1beta1.ConditionTrue, "RegistrationValid", "chart could be rendered successfully.")
 
 	if err := managedresources.Create(
-		ctx,
+		seedCtx,
 		r.SeedClientSet.Client(),
 		v1beta1constants.GardenNamespace,
 		controllerInstallation.Name,
@@ -251,7 +254,8 @@ func (r *Reconciler) reconcile(
 }
 
 func (r *Reconciler) delete(
-	ctx context.Context,
+	gardenCtx context.Context,
+	seedCtx context.Context,
 	log logr.Logger,
 	controllerInstallation *gardencorev1beta1.ControllerInstallation,
 ) (
@@ -265,13 +269,13 @@ func (r *Reconciler) delete(
 	)
 
 	defer func() {
-		if err := patchConditions(ctx, r.GardenClient, controllerInstallation, conditionValid, conditionInstalled); client.IgnoreNotFound(err) != nil {
+		if err := patchConditions(gardenCtx, r.GardenClient, controllerInstallation, conditionValid, conditionInstalled); client.IgnoreNotFound(err) != nil {
 			log.Error(err, "Failed to patch conditions")
 		}
 	}()
 
 	seed := &gardencorev1beta1.Seed{}
-	if err := r.GardenClient.Get(ctx, client.ObjectKey{Name: controllerInstallation.Spec.SeedRef.Name}, seed); err != nil {
+	if err := r.GardenClient.Get(gardenCtx, client.ObjectKey{Name: controllerInstallation.Spec.SeedRef.Name}, seed); err != nil {
 		if apierrors.IsNotFound(err) {
 			conditionValid = v1beta1helper.UpdatedConditionWithClock(r.Clock, conditionValid, gardencorev1beta1.ConditionFalse, "SeedNotFound", fmt.Sprintf("Referenced Seed does not exist: %+v", err))
 		} else {
@@ -286,7 +290,7 @@ func (r *Reconciler) delete(
 			Namespace: v1beta1constants.GardenNamespace,
 		},
 	}
-	if err := r.SeedClientSet.Client().Delete(ctx, mr); err == nil {
+	if err := r.SeedClientSet.Client().Delete(seedCtx, mr); err == nil {
 		log.Info("Deletion of ManagedResource is still pending", "managedResource", client.ObjectKeyFromObject(mr))
 
 		msg := fmt.Sprintf("Deletion of ManagedResource %q is still pending.", controllerInstallation.Name)
@@ -303,12 +307,12 @@ func (r *Reconciler) delete(
 			Namespace: v1beta1constants.GardenNamespace,
 		},
 	}
-	if err := r.SeedClientSet.Client().Delete(ctx, secret); client.IgnoreNotFound(err) != nil {
+	if err := r.SeedClientSet.Client().Delete(seedCtx, secret); client.IgnoreNotFound(err) != nil {
 		conditionInstalled = v1beta1helper.UpdatedConditionWithClock(r.Clock, conditionInstalled, gardencorev1beta1.ConditionFalse, "DeletionFailed", fmt.Sprintf("Deletion of ManagedResource secret %q failed: %+v", controllerInstallation.Name, err))
 	}
 
 	namespace := getNamespaceForControllerInstallation(controllerInstallation)
-	if err := r.SeedClientSet.Client().Delete(ctx, namespace); err == nil || apierrors.IsConflict(err) {
+	if err := r.SeedClientSet.Client().Delete(seedCtx, namespace); err == nil || apierrors.IsConflict(err) {
 		log.Info("Deletion of Namespace is still pending", "namespace", client.ObjectKeyFromObject(namespace))
 
 		msg := fmt.Sprintf("Deletion of Namespace %q is still pending.", namespace.Name)
@@ -323,7 +327,7 @@ func (r *Reconciler) delete(
 
 	if controllerutil.ContainsFinalizer(controllerInstallation, finalizerName) {
 		log.Info("Removing finalizer")
-		if err := controllerutils.RemoveFinalizers(ctx, r.GardenClient, controllerInstallation, finalizerName); err != nil {
+		if err := controllerutils.RemoveFinalizers(gardenCtx, r.GardenClient, controllerInstallation, finalizerName); err != nil {
 			return reconcile.Result{}, fmt.Errorf("failed to remove finalizer: %w", err)
 		}
 	}

--- a/pkg/gardenlet/controller/controllerinstallation/required/reconciler.go
+++ b/pkg/gardenlet/controller/controllerinstallation/required/reconciler.go
@@ -51,7 +51,7 @@ type Reconciler struct {
 func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 	log := logf.FromContext(ctx)
 
-	ctx, cancel := context.WithTimeout(ctx, controllerutils.DefaultReconciliationTimeout)
+	ctx, cancel := controllerutils.GetMainReconciliationContext(ctx, controllerutils.DefaultReconciliationTimeout)
 	defer cancel()
 
 	controllerInstallation := &gardencorev1beta1.ControllerInstallation{}

--- a/pkg/gardenlet/controller/controllerinstallation/required/reconciler.go
+++ b/pkg/gardenlet/controller/controllerinstallation/required/reconciler.go
@@ -29,6 +29,7 @@ import (
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
+	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/gardenlet/apis/config"
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 )
@@ -49,6 +50,9 @@ type Reconciler struct {
 // Reconcile performs the main reconciliation logic.
 func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 	log := logf.FromContext(ctx)
+
+	ctx, cancel := context.WithTimeout(ctx, controllerutils.DefaultReconciliationTimeout)
+	defer cancel()
 
 	controllerInstallation := &gardencorev1beta1.ControllerInstallation{}
 	if err := r.GardenClient.Get(ctx, request.NamespacedName, controllerInstallation); err != nil {

--- a/pkg/gardenlet/controller/managedseed/reconciler.go
+++ b/pkg/gardenlet/controller/managedseed/reconciler.go
@@ -52,7 +52,7 @@ type Reconciler struct {
 func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 	log := logf.FromContext(ctx)
 
-	ctx, cancel := context.WithTimeout(ctx, r.Config.Controllers.ManagedSeed.SyncPeriod.Duration)
+	ctx, cancel := context.WithTimeout(ctx, controllerutils.DefaultReconciliationTimeout)
 	defer cancel()
 
 	ms := &seedmanagementv1alpha1.ManagedSeed{}

--- a/pkg/gardenlet/controller/managedseed/reconciler.go
+++ b/pkg/gardenlet/controller/managedseed/reconciler.go
@@ -52,6 +52,9 @@ type Reconciler struct {
 func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 	log := logf.FromContext(ctx)
 
+	ctx, cancel := context.WithTimeout(ctx, r.Config.Controllers.ManagedSeed.SyncPeriod.Duration)
+	defer cancel()
+
 	ms := &seedmanagementv1alpha1.ManagedSeed{}
 	if err := r.GardenClient.Get(ctx, request.NamespacedName, ms); err != nil {
 		if apierrors.IsNotFound(err) {

--- a/pkg/gardenlet/controller/managedseed/reconciler.go
+++ b/pkg/gardenlet/controller/managedseed/reconciler.go
@@ -52,7 +52,7 @@ type Reconciler struct {
 func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 	log := logf.FromContext(ctx)
 
-	ctx, cancel := controllerutils.GetMainReconciliationContext(ctx, controllerutils.DefaultReconciliationTimeout)
+	ctx, cancel := controllerutils.GetMainReconciliationContext(ctx, r.Config.Controllers.ManagedSeed.SyncPeriod.Duration)
 	defer cancel()
 
 	ms := &seedmanagementv1alpha1.ManagedSeed{}

--- a/pkg/gardenlet/controller/managedseed/reconciler.go
+++ b/pkg/gardenlet/controller/managedseed/reconciler.go
@@ -52,7 +52,7 @@ type Reconciler struct {
 func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 	log := logf.FromContext(ctx)
 
-	ctx, cancel := context.WithTimeout(ctx, controllerutils.DefaultReconciliationTimeout)
+	ctx, cancel := controllerutils.GetMainReconciliationContext(ctx, controllerutils.DefaultReconciliationTimeout)
 	defer cancel()
 
 	ms := &seedmanagementv1alpha1.ManagedSeed{}

--- a/pkg/gardenlet/controller/managedseed/reconciler_test.go
+++ b/pkg/gardenlet/controller/managedseed/reconciler_test.go
@@ -107,7 +107,7 @@ var _ = Describe("Reconciler", func() {
 
 	var (
 		expectGetManagedSeed = func() {
-			gardenClient.EXPECT().Get(ctx, kubernetesutils.Key(namespace, name), gomock.AssignableToTypeOf(&seedmanagementv1alpha1.ManagedSeed{})).DoAndReturn(
+			gardenClient.EXPECT().Get(gomock.Any(), kubernetesutils.Key(namespace, name), gomock.AssignableToTypeOf(&seedmanagementv1alpha1.ManagedSeed{})).DoAndReturn(
 				func(_ context.Context, _ client.ObjectKey, ms *seedmanagementv1alpha1.ManagedSeed, _ ...client.GetOption) error {
 					*ms = *managedSeed
 					return nil
@@ -115,7 +115,7 @@ var _ = Describe("Reconciler", func() {
 			)
 		}
 		expectPatchManagedSeed = func(expect func(*seedmanagementv1alpha1.ManagedSeed)) {
-			gardenClient.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&seedmanagementv1alpha1.ManagedSeed{}), gomock.Any()).DoAndReturn(
+			gardenClient.EXPECT().Patch(gomock.Any(), gomock.AssignableToTypeOf(&seedmanagementv1alpha1.ManagedSeed{}), gomock.Any()).DoAndReturn(
 				func(_ context.Context, ms *seedmanagementv1alpha1.ManagedSeed, _ client.Patch, _ ...client.PatchOption) error {
 					expect(ms)
 					*managedSeed = *ms
@@ -124,7 +124,7 @@ var _ = Describe("Reconciler", func() {
 			)
 		}
 		expectPatchManagedSeedStatus = func(expect func(*seedmanagementv1alpha1.ManagedSeed)) {
-			gardenStatusWriter.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&seedmanagementv1alpha1.ManagedSeed{}), gomock.Any()).DoAndReturn(
+			gardenStatusWriter.EXPECT().Patch(gomock.Any(), gomock.AssignableToTypeOf(&seedmanagementv1alpha1.ManagedSeed{}), gomock.Any()).DoAndReturn(
 				func(_ context.Context, ms *seedmanagementv1alpha1.ManagedSeed, _ client.Patch, _ ...client.PatchOption) error {
 					expect(ms)
 					*managedSeed = *ms
@@ -141,7 +141,7 @@ var _ = Describe("Reconciler", func() {
 				expectPatchManagedSeed(func(ms *seedmanagementv1alpha1.ManagedSeed) {
 					Expect(ms.Finalizers).To(Equal([]string{gardencorev1beta1.GardenerName}))
 				})
-				actuator.EXPECT().Reconcile(ctx, gomock.AssignableToTypeOf(logr.Logger{}), managedSeed).Return(status, false, nil)
+				actuator.EXPECT().Reconcile(gomock.Any(), gomock.AssignableToTypeOf(logr.Logger{}), managedSeed).Return(status, false, nil)
 				expectPatchManagedSeedStatus(func(ms *seedmanagementv1alpha1.ManagedSeed) {
 					Expect(&ms.Status).To(Equal(status))
 				})
@@ -154,7 +154,7 @@ var _ = Describe("Reconciler", func() {
 			It("should reconcile the ManagedSeed creation or update, and update the status (no wait)", func() {
 				expectGetManagedSeed()
 				managedSeed.Finalizers = []string{gardencorev1beta1.GardenerName}
-				actuator.EXPECT().Reconcile(ctx, gomock.AssignableToTypeOf(logr.Logger{}), managedSeed).Return(status, false, nil)
+				actuator.EXPECT().Reconcile(gomock.Any(), gomock.AssignableToTypeOf(logr.Logger{}), managedSeed).Return(status, false, nil)
 				expectPatchManagedSeedStatus(func(ms *seedmanagementv1alpha1.ManagedSeed) {
 					Expect(&ms.Status).To(Equal(status))
 				})
@@ -167,7 +167,7 @@ var _ = Describe("Reconciler", func() {
 			It("should reconcile the ManagedSeed creation or update, and update the status (wait)", func() {
 				expectGetManagedSeed()
 				managedSeed.Finalizers = []string{gardencorev1beta1.GardenerName}
-				actuator.EXPECT().Reconcile(ctx, gomock.AssignableToTypeOf(logr.Logger{}), managedSeed).Return(status, true, nil)
+				actuator.EXPECT().Reconcile(gomock.Any(), gomock.AssignableToTypeOf(logr.Logger{}), managedSeed).Return(status, true, nil)
 				expectPatchManagedSeedStatus(func(ms *seedmanagementv1alpha1.ManagedSeed) {
 					Expect(&ms.Status).To(Equal(status))
 				})
@@ -187,7 +187,7 @@ var _ = Describe("Reconciler", func() {
 
 			It("should reconcile the ManagedSeed deletion and update the status (no wait)", func() {
 				expectGetManagedSeed()
-				actuator.EXPECT().Delete(ctx, gomock.AssignableToTypeOf(logr.Logger{}), managedSeed).Return(status, false, false, nil)
+				actuator.EXPECT().Delete(gomock.Any(), gomock.AssignableToTypeOf(logr.Logger{}), managedSeed).Return(status, false, false, nil)
 				expectPatchManagedSeedStatus(func(ms *seedmanagementv1alpha1.ManagedSeed) {
 					Expect(&ms.Status).To(Equal(status))
 				})
@@ -199,7 +199,7 @@ var _ = Describe("Reconciler", func() {
 
 			It("should reconcile the ManagedSeed deletion and update the status (wait)", func() {
 				expectGetManagedSeed()
-				actuator.EXPECT().Delete(ctx, gomock.AssignableToTypeOf(logr.Logger{}), managedSeed).Return(status, true, false, nil)
+				actuator.EXPECT().Delete(gomock.Any(), gomock.AssignableToTypeOf(logr.Logger{}), managedSeed).Return(status, true, false, nil)
 				expectPatchManagedSeedStatus(func(ms *seedmanagementv1alpha1.ManagedSeed) {
 					Expect(&ms.Status).To(Equal(status))
 				})
@@ -211,7 +211,7 @@ var _ = Describe("Reconciler", func() {
 
 			It("should reconcile the ManagedSeed deletion, remove the finalizer, and not update the status", func() {
 				expectGetManagedSeed()
-				actuator.EXPECT().Delete(ctx, gomock.AssignableToTypeOf(logr.Logger{}), managedSeed).Return(status, false, true, nil)
+				actuator.EXPECT().Delete(gomock.Any(), gomock.AssignableToTypeOf(logr.Logger{}), managedSeed).Return(status, false, true, nil)
 				expectPatchManagedSeed(func(ms *seedmanagementv1alpha1.ManagedSeed) {
 					Expect(ms.Finalizers).To(BeEmpty())
 				})

--- a/pkg/gardenlet/controller/networkpolicy/reconciler.go
+++ b/pkg/gardenlet/controller/networkpolicy/reconciler.go
@@ -64,7 +64,7 @@ type Reconciler struct {
 func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 	log := logf.FromContext(ctx)
 
-	ctx, cancel := context.WithTimeout(ctx, controllerutils.DefaultReconciliationTimeout)
+	ctx, cancel := controllerutils.GetMainReconciliationContext(ctx, controllerutils.DefaultReconciliationTimeout)
 	defer cancel()
 
 	namespace := &corev1.Namespace{}

--- a/pkg/gardenlet/controller/networkpolicy/reconciler.go
+++ b/pkg/gardenlet/controller/networkpolicy/reconciler.go
@@ -64,6 +64,9 @@ type Reconciler struct {
 func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 	log := logf.FromContext(ctx)
 
+	ctx, cancel := context.WithTimeout(ctx, controllerutils.DefaultReconciliationTimeout)
+	defer cancel()
+
 	namespace := &corev1.Namespace{}
 	if err := r.RuntimeClient.Get(ctx, request.NamespacedName, namespace); err != nil {
 		if apierrors.IsNotFound(err) {

--- a/pkg/gardenlet/controller/seed/care/reconciler.go
+++ b/pkg/gardenlet/controller/seed/care/reconciler.go
@@ -51,6 +51,11 @@ type Reconciler struct {
 func (r *Reconciler) Reconcile(reconcileCtx context.Context, req reconcile.Request) (reconcile.Result, error) {
 	log := logf.FromContext(reconcileCtx)
 
+	// Timeout for all calls (e.g. status updates), give status updates a bit of headroom if health checks
+	// themselves run into timeouts, so that we will still update the status with that timeout error.
+	reconcileCtx, cancel := context.WithTimeout(reconcileCtx, 2*r.Config.SyncPeriod.Duration)
+	defer cancel()
+
 	seed := &gardencorev1beta1.Seed{}
 	if err := r.GardenClient.Get(reconcileCtx, req.NamespacedName, seed); err != nil {
 		if apierrors.IsNotFound(err) {

--- a/pkg/gardenlet/controller/seed/care/reconciler.go
+++ b/pkg/gardenlet/controller/seed/care/reconciler.go
@@ -53,7 +53,7 @@ func (r *Reconciler) Reconcile(reconcileCtx context.Context, req reconcile.Reque
 
 	// Timeout for all calls (e.g. status updates), give status updates a bit of headroom if health checks
 	// themselves run into timeouts, so that we will still update the status with that timeout error.
-	reconcileCtx, cancel := context.WithTimeout(reconcileCtx, 2*r.Config.SyncPeriod.Duration)
+	reconcileCtx, cancel := context.WithTimeout(reconcileCtx, r.Config.SyncPeriod.Duration)
 	defer cancel()
 
 	seed := &gardencorev1beta1.Seed{}
@@ -65,7 +65,7 @@ func (r *Reconciler) Reconcile(reconcileCtx context.Context, req reconcile.Reque
 		return reconcile.Result{}, fmt.Errorf("error retrieving object from store: %w", err)
 	}
 
-	ctx, cancel := context.WithTimeout(reconcileCtx, r.Config.SyncPeriod.Duration)
+	ctx, cancel := context.WithTimeout(reconcileCtx, r.Config.SyncPeriod.Duration/2)
 	defer cancel()
 
 	log.V(1).Info("Starting seed care")

--- a/pkg/gardenlet/controller/seed/care/reconciler.go
+++ b/pkg/gardenlet/controller/seed/care/reconciler.go
@@ -27,6 +27,7 @@ import (
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
+	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/gardenlet/apis/config"
 )
 
@@ -53,7 +54,7 @@ func (r *Reconciler) Reconcile(reconcileCtx context.Context, req reconcile.Reque
 
 	// Timeout for all calls (e.g. status updates), give status updates a bit of headroom if health checks
 	// themselves run into timeouts, so that we will still update the status with that timeout error.
-	reconcileCtx, cancel := context.WithTimeout(reconcileCtx, r.Config.SyncPeriod.Duration)
+	reconcileCtx, cancel := controllerutils.GetMainReconciliationContext(reconcileCtx, r.Config.SyncPeriod.Duration)
 	defer cancel()
 
 	seed := &gardencorev1beta1.Seed{}
@@ -65,7 +66,7 @@ func (r *Reconciler) Reconcile(reconcileCtx context.Context, req reconcile.Reque
 		return reconcile.Result{}, fmt.Errorf("error retrieving object from store: %w", err)
 	}
 
-	ctx, cancel := context.WithTimeout(reconcileCtx, r.Config.SyncPeriod.Duration/2)
+	ctx, cancel := controllerutils.GetChildReconciliationContext(reconcileCtx, r.Config.SyncPeriod.Duration)
 	defer cancel()
 
 	log.V(1).Info("Starting seed care")

--- a/pkg/gardenlet/controller/seed/lease/reconciler.go
+++ b/pkg/gardenlet/controller/seed/lease/reconciler.go
@@ -54,7 +54,7 @@ type Reconciler struct {
 func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 	log := logf.FromContext(ctx)
 
-	ctx, cancel := context.WithTimeout(ctx, time.Duration(*r.Config.LeaseResyncSeconds)*time.Second)
+	ctx, cancel := controllerutils.GetMainReconciliationContext(ctx, time.Duration(*r.Config.LeaseResyncSeconds)*time.Second)
 	defer cancel()
 
 	seed := &gardencorev1beta1.Seed{}

--- a/pkg/gardenlet/controller/seed/lease/reconciler.go
+++ b/pkg/gardenlet/controller/seed/lease/reconciler.go
@@ -54,6 +54,9 @@ type Reconciler struct {
 func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 	log := logf.FromContext(ctx)
 
+	ctx, cancel := context.WithTimeout(ctx, time.Duration(*r.Config.LeaseResyncSeconds)*time.Second)
+	defer cancel()
+
 	seed := &gardencorev1beta1.Seed{}
 	if err := r.GardenClient.Get(ctx, request.NamespacedName, seed); err != nil {
 		if apierrors.IsNotFound(err) {

--- a/pkg/gardenlet/controller/seed/seed/reconciler.go
+++ b/pkg/gardenlet/controller/seed/seed/reconciler.go
@@ -33,6 +33,7 @@ import (
 	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	operatorv1alpha1 "github.com/gardener/gardener/pkg/apis/operator/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
+	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/gardenlet/apis/config"
 	"github.com/gardener/gardener/pkg/operation/botanist/component"
 	seedpkg "github.com/gardener/gardener/pkg/operation/seed"
@@ -60,9 +61,9 @@ type Reconciler struct {
 func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 	log := logf.FromContext(ctx)
 
-	gardenCtx, cancel := context.WithTimeout(ctx, r.Config.Controllers.Seed.SyncPeriod.Duration)
+	gardenCtx, cancel := controllerutils.GetMainReconciliationContext(ctx, r.Config.Controllers.Seed.SyncPeriod.Duration)
 	defer cancel()
-	seedCtx, cancel := context.WithTimeout(ctx, r.Config.Controllers.Seed.SyncPeriod.Duration/2)
+	seedCtx, cancel := controllerutils.GetChildReconciliationContext(ctx, r.Config.Controllers.Seed.SyncPeriod.Duration)
 	defer cancel()
 
 	seed := &gardencorev1beta1.Seed{}

--- a/pkg/gardenlet/controller/seed/seed/reconciler.go
+++ b/pkg/gardenlet/controller/seed/seed/reconciler.go
@@ -33,7 +33,6 @@ import (
 	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	operatorv1alpha1 "github.com/gardener/gardener/pkg/apis/operator/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
-	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/gardenlet/apis/config"
 	"github.com/gardener/gardener/pkg/operation/botanist/component"
 	seedpkg "github.com/gardener/gardener/pkg/operation/seed"
@@ -61,13 +60,8 @@ type Reconciler struct {
 func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 	log := logf.FromContext(ctx)
 
-	gardenCtx, cancel := controllerutils.GetMainReconciliationContext(ctx, r.Config.Controllers.Seed.SyncPeriod.Duration)
-	defer cancel()
-	seedCtx, cancel := controllerutils.GetChildReconciliationContext(ctx, r.Config.Controllers.Seed.SyncPeriod.Duration)
-	defer cancel()
-
 	seed := &gardencorev1beta1.Seed{}
-	if err := r.GardenClient.Get(gardenCtx, request.NamespacedName, seed); err != nil {
+	if err := r.GardenClient.Get(ctx, request.NamespacedName, seed); err != nil {
 		if apierrors.IsNotFound(err) {
 			log.V(1).Info("Object is gone, stop reconciling")
 			return reconcile.Result{}, nil
@@ -76,35 +70,35 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	}
 
 	// Check if seed namespace is already available.
-	if err := r.GardenClient.Get(gardenCtx, client.ObjectKey{Name: gardenerutils.ComputeGardenNamespace(seed.Name)}, &corev1.Namespace{}); err != nil {
+	if err := r.GardenClient.Get(ctx, client.ObjectKey{Name: gardenerutils.ComputeGardenNamespace(seed.Name)}, &corev1.Namespace{}); err != nil {
 		return reconcile.Result{}, fmt.Errorf("failed to get seed namespace in garden cluster: %w", err)
 	}
 
-	seedObj, err := seedpkg.NewBuilder().WithSeedObject(seed).Build(gardenCtx)
+	seedObj, err := seedpkg.NewBuilder().WithSeedObject(seed).Build(ctx)
 	if err != nil {
 		log.Error(err, "Failed to create a Seed object")
 		conditionSeedBootstrapped := v1beta1helper.GetOrInitConditionWithClock(r.Clock, seed.Status.Conditions, gardencorev1beta1.SeedBootstrapped)
 		conditionSeedBootstrapped = v1beta1helper.UpdatedConditionWithClock(r.Clock, conditionSeedBootstrapped, gardencorev1beta1.ConditionUnknown, gardencorev1beta1.ConditionCheckError, fmt.Sprintf("Failed to create a Seed object (%s).", err.Error()))
-		if err := r.patchSeedStatus(gardenCtx, r.GardenClient, seed, "<unknown>", nil, nil, conditionSeedBootstrapped); err != nil {
+		if err := r.patchSeedStatus(ctx, r.GardenClient, seed, "<unknown>", nil, nil, conditionSeedBootstrapped); err != nil {
 			return reconcile.Result{}, fmt.Errorf("could not patch seed status after failed creation of Seed object: %w", err)
 		}
 		return reconcile.Result{}, err
 	}
 
 	if seed.Status.ClusterIdentity == nil {
-		seedClusterIdentity, err := determineClusterIdentity(seedCtx, r.SeedClientSet.Client())
+		seedClusterIdentity, err := determineClusterIdentity(ctx, r.SeedClientSet.Client())
 		if err != nil {
 			return reconcile.Result{}, err
 		}
 
 		log.Info("Setting cluster identity", "identity", seedClusterIdentity)
 		seed.Status.ClusterIdentity = &seedClusterIdentity
-		if err := r.GardenClient.Status().Update(seedCtx, seed); err != nil {
+		if err := r.GardenClient.Status().Update(ctx, seed); err != nil {
 			return reconcile.Result{}, err
 		}
 	}
 
-	seedIsGarden, err := kubernetesutils.ResourcesExist(seedCtx, r.SeedClientSet.Client(), operatorv1alpha1.SchemeGroupVersion.WithKind("GardenList"))
+	seedIsGarden, err := kubernetesutils.ResourcesExist(ctx, r.SeedClientSet.Client(), operatorv1alpha1.SchemeGroupVersion.WithKind("GardenList"))
 	if err != nil {
 		if !meta.IsNoMatchError(err) {
 			return reconcile.Result{}, err
@@ -113,10 +107,10 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	}
 
 	if seed.DeletionTimestamp != nil {
-		return r.delete(gardenCtx, seedCtx, log, seedObj, seedIsGarden)
+		return r.delete(ctx, log, seedObj, seedIsGarden)
 	}
 
-	return r.reconcile(gardenCtx, seedCtx, log, seedObj, seedIsGarden)
+	return r.reconcile(ctx, log, seedObj, seedIsGarden)
 }
 
 func (r *Reconciler) patchSeedStatus(

--- a/pkg/gardenlet/controller/seed/seed/reconciler_delete.go
+++ b/pkg/gardenlet/controller/seed/seed/reconciler_delete.go
@@ -61,8 +61,7 @@ import (
 )
 
 func (r *Reconciler) delete(
-	gardenCtx context.Context,
-	seedCtx context.Context,
+	ctx context.Context,
 	log logr.Logger,
 	seedObj *seedpkg.Seed,
 	seedIsGarden bool,
@@ -80,7 +79,7 @@ func (r *Reconciler) delete(
 	// When this happens the controller will remove the finalizers from the Seed so that it can be garbage collected.
 	parentLogMessage := "Can't delete Seed, because the following objects are still referencing it:"
 
-	associatedShoots, err := controllerutils.DetermineShootsAssociatedTo(gardenCtx, r.GardenClient, seed)
+	associatedShoots, err := controllerutils.DetermineShootsAssociatedTo(ctx, r.GardenClient, seed)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
@@ -95,12 +94,12 @@ func (r *Reconciler) delete(
 	if seed.Spec.Backup != nil {
 		backupBucket := &gardencorev1beta1.BackupBucket{ObjectMeta: metav1.ObjectMeta{Name: string(seed.UID)}}
 
-		if err := r.GardenClient.Delete(gardenCtx, backupBucket); client.IgnoreNotFound(err) != nil {
+		if err := r.GardenClient.Delete(ctx, backupBucket); client.IgnoreNotFound(err) != nil {
 			return reconcile.Result{}, err
 		}
 	}
 
-	associatedBackupBuckets, err := controllerutils.DetermineBackupBucketAssociations(gardenCtx, r.GardenClient, seed.Name)
+	associatedBackupBuckets, err := controllerutils.DetermineBackupBucketAssociations(ctx, r.GardenClient, seed.Name)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
@@ -114,10 +113,10 @@ func (r *Reconciler) delete(
 
 	log.Info("No Shoots or BackupBuckets are referencing the Seed, deletion accepted")
 
-	if err := r.runDeleteSeedFlow(seedCtx, log, seedObj, seedIsGarden); err != nil {
+	if err := r.runDeleteSeedFlow(ctx, log, seedObj, seedIsGarden); err != nil {
 		conditionSeedBootstrapped := v1beta1helper.GetOrInitConditionWithClock(r.Clock, seedObj.GetInfo().Status.Conditions, gardencorev1beta1.SeedBootstrapped)
 		conditionSeedBootstrapped = v1beta1helper.UpdatedConditionWithClock(r.Clock, conditionSeedBootstrapped, gardencorev1beta1.ConditionFalse, "DebootstrapFailed", fmt.Sprintf("Failed to delete Seed Cluster (%s).", err.Error()))
-		if err := r.patchSeedStatus(seedCtx, r.GardenClient, seed, "<unknown>", nil, nil, conditionSeedBootstrapped); err != nil {
+		if err := r.patchSeedStatus(ctx, r.GardenClient, seed, "<unknown>", nil, nil, conditionSeedBootstrapped); err != nil {
 			return reconcile.Result{}, fmt.Errorf("could not patch seed status after deletion flow failed: %w", err)
 		}
 		return reconcile.Result{}, err
@@ -126,10 +125,10 @@ func (r *Reconciler) delete(
 	// Remove finalizer from referenced secret
 	if seed.Spec.SecretRef != nil {
 		secret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: seed.Spec.SecretRef.Name, Namespace: seed.Spec.SecretRef.Namespace}}
-		if err := r.GardenClient.Get(gardenCtx, client.ObjectKeyFromObject(secret), secret); err == nil {
+		if err := r.GardenClient.Get(ctx, client.ObjectKeyFromObject(secret), secret); err == nil {
 			if controllerutil.ContainsFinalizer(secret, gardencorev1beta1.ExternalGardenerName) {
 				log.Info("Removing finalizer from secret", "secret", client.ObjectKeyFromObject(secret))
-				if err := controllerutils.RemoveFinalizers(gardenCtx, r.GardenClient, secret, gardencorev1beta1.ExternalGardenerName); err != nil {
+				if err := controllerutils.RemoveFinalizers(ctx, r.GardenClient, secret, gardencorev1beta1.ExternalGardenerName); err != nil {
 					return reconcile.Result{}, fmt.Errorf("failed to remove finalizer from secret: %w", err)
 				}
 			}
@@ -141,7 +140,7 @@ func (r *Reconciler) delete(
 	// Remove finalizer from Seed
 	if controllerutil.ContainsFinalizer(seed, gardencorev1beta1.GardenerName) {
 		log.Info("Removing finalizer")
-		if err := controllerutils.RemoveFinalizers(gardenCtx, r.GardenClient, seed, gardencorev1beta1.GardenerName); err != nil {
+		if err := controllerutils.RemoveFinalizers(ctx, r.GardenClient, seed, gardencorev1beta1.GardenerName); err != nil {
 			return reconcile.Result{}, fmt.Errorf("failed to remove finalizer: %w", err)
 		}
 	}

--- a/pkg/gardenlet/controller/seed/seed/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/seed/seed/reconciler_reconcile.go
@@ -96,7 +96,8 @@ import (
 )
 
 func (r *Reconciler) reconcile(
-	ctx context.Context,
+	gardenCtx context.Context,
+	seedCtx context.Context,
 	log logr.Logger,
 	seedObj *seedpkg.Seed,
 	seedIsGarden bool,
@@ -129,7 +130,7 @@ func (r *Reconciler) reconcile(
 
 	if !controllerutil.ContainsFinalizer(seed, gardencorev1beta1.GardenerName) {
 		log.Info("Adding finalizer")
-		if err := controllerutils.AddFinalizers(ctx, r.GardenClient, seed, gardencorev1beta1.GardenerName); err != nil {
+		if err := controllerutils.AddFinalizers(gardenCtx, r.GardenClient, seed, gardencorev1beta1.GardenerName); err != nil {
 			return reconcile.Result{}, err
 		}
 	}
@@ -137,14 +138,14 @@ func (r *Reconciler) reconcile(
 	// Add the Gardener finalizer to the referenced Seed secret to protect it from deletion as long as the Seed resource
 	// does exist.
 	if seed.Spec.SecretRef != nil {
-		secret, err := kubernetesutils.GetSecretByReference(ctx, r.GardenClient, seed.Spec.SecretRef)
+		secret, err := kubernetesutils.GetSecretByReference(gardenCtx, r.GardenClient, seed.Spec.SecretRef)
 		if err != nil {
 			return reconcile.Result{}, err
 		}
 
 		if !controllerutil.ContainsFinalizer(secret, gardencorev1beta1.ExternalGardenerName) {
 			log.Info("Adding finalizer to referenced secret", "secret", client.ObjectKeyFromObject(secret))
-			if err := controllerutils.AddFinalizers(ctx, r.GardenClient, secret, gardencorev1beta1.ExternalGardenerName); err != nil {
+			if err := controllerutils.AddFinalizers(gardenCtx, r.GardenClient, secret, gardencorev1beta1.ExternalGardenerName); err != nil {
 				return reconcile.Result{}, err
 			}
 		}
@@ -154,30 +155,30 @@ func (r *Reconciler) reconcile(
 	seedKubernetesVersion, err := r.checkMinimumK8SVersion(r.SeedClientSet.Version())
 	if err != nil {
 		conditionSeedBootstrapped = v1beta1helper.UpdatedConditionWithClock(r.Clock, conditionSeedBootstrapped, gardencorev1beta1.ConditionFalse, "K8SVersionTooOld", err.Error())
-		if err := r.patchSeedStatus(ctx, r.GardenClient, seed, "<unknown>", capacity, allocatable, conditionSeedBootstrapped); err != nil {
+		if err := r.patchSeedStatus(gardenCtx, r.GardenClient, seed, "<unknown>", capacity, allocatable, conditionSeedBootstrapped); err != nil {
 			return reconcile.Result{}, fmt.Errorf("could not patch seed status after check for minimum Kubernetes version failed: %w", err)
 		}
 		return reconcile.Result{}, err
 	}
 
-	gardenSecrets, err := gardenerutils.ReadGardenSecrets(ctx, log, r.GardenClient, gardenerutils.ComputeGardenNamespace(seed.Name), true)
+	gardenSecrets, err := gardenerutils.ReadGardenSecrets(gardenCtx, log, r.GardenClient, gardenerutils.ComputeGardenNamespace(seed.Name), true)
 	if err != nil {
 		conditionSeedBootstrapped = v1beta1helper.UpdatedConditionWithClock(r.Clock, conditionSeedBootstrapped, gardencorev1beta1.ConditionFalse, "GardenSecretsError", err.Error())
-		if err := r.patchSeedStatus(ctx, r.GardenClient, seed, "<unknown>", capacity, allocatable, conditionSeedBootstrapped); err != nil {
+		if err := r.patchSeedStatus(gardenCtx, r.GardenClient, seed, "<unknown>", capacity, allocatable, conditionSeedBootstrapped); err != nil {
 			return reconcile.Result{}, fmt.Errorf("could not patch seed status after reading garden secrets failed: %w", err)
 		}
 		return reconcile.Result{}, err
 	}
 
 	conditionSeedBootstrapped = v1beta1helper.UpdatedConditionWithClock(r.Clock, conditionSeedBootstrapped, gardencorev1beta1.ConditionProgressing, "BootstrapProgressing", "Seed cluster is currently being bootstrapped.")
-	if err = r.patchSeedStatus(ctx, r.GardenClient, seed, seedKubernetesVersion, capacity, allocatable, conditionSeedBootstrapped); err != nil {
+	if err = r.patchSeedStatus(gardenCtx, r.GardenClient, seed, seedKubernetesVersion, capacity, allocatable, conditionSeedBootstrapped); err != nil {
 		return reconcile.Result{}, fmt.Errorf("could not update status of %s condition to %s: %w", conditionSeedBootstrapped.Type, gardencorev1beta1.ConditionProgressing, err)
 	}
 
 	// Bootstrap the Seed cluster.
-	if err := r.runReconcileSeedFlow(ctx, log, seedObj, seedIsGarden, gardenSecrets); err != nil {
+	if err := r.runReconcileSeedFlow(seedCtx, log, seedObj, seedIsGarden, gardenSecrets); err != nil {
 		conditionSeedBootstrapped = v1beta1helper.UpdatedConditionWithClock(r.Clock, conditionSeedBootstrapped, gardencorev1beta1.ConditionFalse, "BootstrappingFailed", err.Error())
-		if err := r.patchSeedStatus(ctx, r.GardenClient, seed, "<unknown>", capacity, allocatable, conditionSeedBootstrapped); err != nil {
+		if err := r.patchSeedStatus(seedCtx, r.GardenClient, seed, "<unknown>", capacity, allocatable, conditionSeedBootstrapped); err != nil {
 			return reconcile.Result{}, fmt.Errorf("could not patch seed status after reconciliation flow failed: %w", err)
 		}
 		return reconcile.Result{}, err
@@ -190,14 +191,14 @@ func (r *Reconciler) reconcile(
 	conditionSeedSystemComponentsHealthy := v1beta1helper.GetOrInitConditionWithClock(r.Clock, seed.Status.Conditions, gardencorev1beta1.SeedSystemComponentsHealthy)
 	conditionSeedSystemComponentsHealthy = v1beta1helper.UpdatedConditionWithClock(r.Clock, conditionSeedSystemComponentsHealthy, gardencorev1beta1.ConditionProgressing, "SystemComponentsCheckProgressing", "Pending health check of system components after successful bootstrap of seed cluster.")
 	conditionSeedBootstrapped = v1beta1helper.UpdatedConditionWithClock(r.Clock, conditionSeedBootstrapped, gardencorev1beta1.ConditionTrue, "BootstrappingSucceeded", "Seed cluster has been bootstrapped successfully.")
-	if err = r.patchSeedStatus(ctx, r.GardenClient, seed, seedKubernetesVersion, capacity, allocatable, conditionSeedBootstrapped, conditionSeedSystemComponentsHealthy); err != nil {
+	if err = r.patchSeedStatus(gardenCtx, r.GardenClient, seed, seedKubernetesVersion, capacity, allocatable, conditionSeedBootstrapped, conditionSeedSystemComponentsHealthy); err != nil {
 		return reconcile.Result{}, fmt.Errorf("could not update status of %s condition to %s and %s conditions to %s: %w", conditionSeedBootstrapped.Type, gardencorev1beta1.ConditionTrue, conditionSeedSystemComponentsHealthy.Type, gardencorev1beta1.ConditionProgressing, err)
 	}
 
 	if seed.Spec.Backup != nil {
 		// This should be post updating the seed is available. Since, scheduler will then mostly use
 		// same seed for deploying the backupBucket extension.
-		if err := deployBackupBucketInGarden(ctx, r.GardenClient, seed); err != nil {
+		if err := deployBackupBucketInGarden(gardenCtx, r.GardenClient, seed); err != nil {
 			return reconcile.Result{}, err
 		}
 	}

--- a/pkg/gardenlet/controller/shoot/care/reconciler.go
+++ b/pkg/gardenlet/controller/shoot/care/reconciler.go
@@ -72,6 +72,11 @@ type Reconciler struct {
 func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
 	log := logf.FromContext(ctx)
 
+	// Timeout for all calls (e.g. status updates), give status updates a bit of headroom if health checks
+	// themselves run into timeouts, so that we will still update the status with that timeout error.
+	ctx, cancel := context.WithTimeout(ctx, 2*r.Config.Controllers.ShootCare.SyncPeriod.Duration)
+	defer cancel()
+
 	shoot := &gardencorev1beta1.Shoot{}
 	if err := r.GardenClient.Get(ctx, req.NamespacedName, shoot); err != nil {
 		if apierrors.IsNotFound(err) {

--- a/pkg/gardenlet/controller/shoot/care/reconciler.go
+++ b/pkg/gardenlet/controller/shoot/care/reconciler.go
@@ -32,6 +32,7 @@ import (
 	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap"
+	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/gardenlet/apis/config"
 	gardenlethelper "github.com/gardener/gardener/pkg/gardenlet/apis/config/helper"
 	"github.com/gardener/gardener/pkg/operation"
@@ -74,7 +75,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 
 	// Timeout for all calls (e.g. status updates), give status updates a bit of headroom if health checks
 	// themselves run into timeouts, so that we will still update the status with that timeout error.
-	ctx, cancel := context.WithTimeout(ctx, r.Config.Controllers.ShootCare.SyncPeriod.Duration)
+	ctx, cancel := controllerutils.GetMainReconciliationContext(ctx, r.Config.Controllers.ShootCare.SyncPeriod.Duration)
 	defer cancel()
 
 	shoot := &gardencorev1beta1.Shoot{}
@@ -98,7 +99,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		return reconcile.Result{}, nil
 	}
 
-	careCtx, cancel := context.WithTimeout(ctx, r.Config.Controllers.ShootCare.SyncPeriod.Duration/2)
+	careCtx, cancel := controllerutils.GetChildReconciliationContext(ctx, r.Config.Controllers.ShootCare.SyncPeriod.Duration)
 	defer cancel()
 
 	// Initialize conditions based on the current status.

--- a/pkg/gardenlet/controller/shoot/care/reconciler.go
+++ b/pkg/gardenlet/controller/shoot/care/reconciler.go
@@ -74,7 +74,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 
 	// Timeout for all calls (e.g. status updates), give status updates a bit of headroom if health checks
 	// themselves run into timeouts, so that we will still update the status with that timeout error.
-	ctx, cancel := context.WithTimeout(ctx, 2*r.Config.Controllers.ShootCare.SyncPeriod.Duration)
+	ctx, cancel := context.WithTimeout(ctx, r.Config.Controllers.ShootCare.SyncPeriod.Duration)
 	defer cancel()
 
 	shoot := &gardencorev1beta1.Shoot{}
@@ -98,7 +98,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		return reconcile.Result{}, nil
 	}
 
-	careCtx, cancel := context.WithTimeout(ctx, r.Config.Controllers.ShootCare.SyncPeriod.Duration)
+	careCtx, cancel := context.WithTimeout(ctx, r.Config.Controllers.ShootCare.SyncPeriod.Duration/2)
 	defer cancel()
 
 	// Initialize conditions based on the current status.

--- a/pkg/gardenlet/controller/shoot/shoot/reconciler.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler.go
@@ -82,6 +82,11 @@ type Reconciler struct {
 func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 	log := logf.FromContext(ctx)
 
+	gardenCtx, cancel := context.WithTimeout(ctx, r.Config.Controllers.Shoot.SyncPeriod.Duration)
+	defer cancel()
+	seedCtx, cancel := context.WithTimeout(ctx, r.Config.Controllers.Shoot.SyncPeriod.Duration/2)
+	defer cancel()
+
 	shoot := &gardencorev1beta1.Shoot{}
 	if err := r.GardenClient.Get(ctx, request.NamespacedName, shoot); err != nil {
 		if apierrors.IsNotFound(err) {
@@ -97,17 +102,17 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	}
 
 	if shoot.DeletionTimestamp != nil {
-		return r.deleteShoot(ctx, log, shoot)
+		return r.deleteShoot(gardenCtx, seedCtx, log, shoot)
 	}
 
 	if helper.ShouldPrepareShootForMigration(shoot) {
-		return r.migrateShoot(ctx, log, shoot)
+		return r.migrateShoot(gardenCtx, seedCtx, log, shoot)
 	}
 
-	return r.reconcileShoot(ctx, log, shoot)
+	return r.reconcileShoot(gardenCtx, seedCtx, log, shoot)
 }
 
-func (r *Reconciler) reconcileShoot(ctx context.Context, log logr.Logger, shoot *gardencorev1beta1.Shoot) (reconcile.Result, error) {
+func (r *Reconciler) reconcileShoot(gardenCtx context.Context, seedCtx context.Context, log logr.Logger, shoot *gardencorev1beta1.Shoot) (reconcile.Result, error) {
 	var (
 		operationType = helper.ComputeOperationType(shoot)
 		isRestoring   = operationType == gardencorev1beta1.LastOperationTypeRestore
@@ -116,31 +121,31 @@ func (r *Reconciler) reconcileShoot(ctx context.Context, log logr.Logger, shoot 
 
 	if !controllerutil.ContainsFinalizer(shoot, gardencorev1beta1.GardenerName) {
 		log.Info("Adding finalizer")
-		if err := controllerutils.AddFinalizers(ctx, r.GardenClient, shoot, gardencorev1beta1.GardenerName); err != nil {
+		if err := controllerutils.AddFinalizers(gardenCtx, r.GardenClient, shoot, gardencorev1beta1.GardenerName); err != nil {
 			return reconcile.Result{}, fmt.Errorf("failed to add finalizer: %w", err)
 		}
 	}
 
-	o, result, err := r.prepareOperation(ctx, log, shoot)
+	o, result, err := r.prepareOperation(gardenCtx, seedCtx, log, shoot)
 	if err != nil || o == nil {
 		return result, err
 	}
 
 	r.Recorder.Event(shoot, corev1.EventTypeNormal, gardencorev1beta1.EventReconciling, fmt.Sprintf("%s Shoot cluster", utils.IifString(isRestoring, "Restoring", "Reconciling")))
-	if flowErr := r.runReconcileShootFlow(ctx, o, operationType); flowErr != nil {
+	if flowErr := r.runReconcileShootFlow(gardenCtx, o, operationType); flowErr != nil {
 		r.Recorder.Event(shoot, corev1.EventTypeWarning, gardencorev1beta1.EventReconcileError, flowErr.Description)
-		updateErr := r.patchShootStatusOperationError(ctx, shoot, flowErr.Description, operationType, flowErr.LastErrors...)
+		updateErr := r.patchShootStatusOperationError(gardenCtx, shoot, flowErr.Description, operationType, flowErr.LastErrors...)
 		return reconcile.Result{}, errorsutils.WithSuppressed(errors.New(flowErr.Description), updateErr)
 	}
 
 	r.Recorder.Event(shoot, corev1.EventTypeNormal, gardencorev1beta1.EventReconciled, fmt.Sprintf("%s Shoot cluster", utils.IifString(isRestoring, "Restored", "Reconciled")))
-	if err := r.patchShootStatusOperationSuccess(ctx, shoot, o.Shoot.SeedNamespace, &o.Seed.GetInfo().Name, operationType); err != nil {
+	if err := r.patchShootStatusOperationSuccess(gardenCtx, shoot, o.Shoot.SeedNamespace, &o.Seed.GetInfo().Name, operationType); err != nil {
 		return reconcile.Result{}, err
 	}
 
-	if syncErr := r.syncClusterResourceToSeed(ctx, shoot, o.Garden.Project, o.Shoot.CloudProfile, o.Seed.GetInfo()); syncErr != nil {
+	if syncErr := r.syncClusterResourceToSeed(seedCtx, shoot, o.Garden.Project, o.Shoot.CloudProfile, o.Seed.GetInfo()); syncErr != nil {
 		log.Error(syncErr, "Cluster resource sync to seed failed")
-		updateErr := r.patchShootStatusOperationError(ctx, shoot, syncErr.Error(), operationType, shoot.Status.LastErrors...)
+		updateErr := r.patchShootStatusOperationError(seedCtx, shoot, syncErr.Error(), operationType, shoot.Status.LastErrors...)
 		return reconcile.Result{}, errorsutils.WithSuppressed(syncErr, updateErr)
 	}
 
@@ -152,11 +157,11 @@ func (r *Reconciler) reconcileShoot(ctx context.Context, log logr.Logger, shoot 
 	return result, nil
 }
 
-func (r *Reconciler) migrateShoot(ctx context.Context, log logr.Logger, shoot *gardencorev1beta1.Shoot) (reconcile.Result, error) {
+func (r *Reconciler) migrateShoot(gardenCtx context.Context, seedCtx context.Context, log logr.Logger, shoot *gardencorev1beta1.Shoot) (reconcile.Result, error) {
 	log = log.WithValues("operation", "migrate")
 
 	destinationSeed := &gardencorev1beta1.Seed{}
-	if err := r.GardenClient.Get(ctx, client.ObjectKey{Name: *shoot.Spec.SeedName}, destinationSeed); err != nil {
+	if err := r.GardenClient.Get(gardenCtx, client.ObjectKey{Name: *shoot.Spec.SeedName}, destinationSeed); err != nil {
 		return reconcile.Result{}, err
 	}
 
@@ -164,32 +169,32 @@ func (r *Reconciler) migrateShoot(ctx context.Context, log logr.Logger, shoot *g
 		return reconcile.Result{}, fmt.Errorf("destination Seed is not available to host the control plane of Shoot %s: %w", shoot.GetName(), err)
 	}
 
-	hasBastions, err := r.shootHasBastions(ctx, shoot)
+	hasBastions, err := r.shootHasBastions(gardenCtx, shoot)
 	if err != nil {
 		return reconcile.Result{}, fmt.Errorf("failed to check for related Bastions: %w", err)
 	}
 	if hasBastions {
 		hasBastionErr := errors.New("shoot has still Bastions")
-		updateErr := r.patchShootStatusOperationError(ctx, shoot, hasBastionErr.Error(), gardencorev1beta1.LastOperationTypeMigrate, shoot.Status.LastErrors...)
+		updateErr := r.patchShootStatusOperationError(gardenCtx, shoot, hasBastionErr.Error(), gardencorev1beta1.LastOperationTypeMigrate, shoot.Status.LastErrors...)
 		return reconcile.Result{}, errorsutils.WithSuppressed(hasBastionErr, updateErr)
 	}
 
-	o, result, err := r.prepareOperation(ctx, log, shoot)
+	o, result, err := r.prepareOperation(gardenCtx, seedCtx, log, shoot)
 	if err != nil || o == nil {
 		return result, err
 	}
 
 	r.Recorder.Event(shoot, corev1.EventTypeNormal, gardencorev1beta1.EventPrepareMigration, "Preparing Shoot cluster for migration")
-	if flowErr := r.runMigrateShootFlow(ctx, o); flowErr != nil {
+	if flowErr := r.runMigrateShootFlow(seedCtx, o); flowErr != nil {
 		r.Recorder.Event(shoot, corev1.EventTypeWarning, gardencorev1beta1.EventMigrationPreparationFailed, flowErr.Description)
-		updateErr := r.patchShootStatusOperationError(ctx, shoot, flowErr.Description, gardencorev1beta1.LastOperationTypeMigrate, flowErr.LastErrors...)
+		updateErr := r.patchShootStatusOperationError(seedCtx, shoot, flowErr.Description, gardencorev1beta1.LastOperationTypeMigrate, flowErr.LastErrors...)
 		return reconcile.Result{}, errorsutils.WithSuppressed(errors.New(flowErr.Description), updateErr)
 	}
 
-	return r.finalizeShootMigration(ctx, shoot, o)
+	return r.finalizeShootMigration(seedCtx, shoot, o)
 }
 
-func (r *Reconciler) deleteShoot(ctx context.Context, log logr.Logger, shoot *gardencorev1beta1.Shoot) (reconcile.Result, error) {
+func (r *Reconciler) deleteShoot(gardenCtx context.Context, seedCtx context.Context, log logr.Logger, shoot *gardencorev1beta1.Shoot) (reconcile.Result, error) {
 	if !controllerutil.ContainsFinalizer(shoot, gardencorev1beta1.GardenerName) {
 		return reconcile.Result{}, nil
 	}
@@ -201,46 +206,46 @@ func (r *Reconciler) deleteShoot(ctx context.Context, log logr.Logger, shoot *ga
 	// We accept the deletion.
 	if len(shoot.Status.UID) == 0 {
 		log.Info("The `.status.uid` is empty, assuming Shoot cluster did never exist, deletion accepted")
-		return r.finalizeShootDeletion(ctx, log, shoot)
+		return r.finalizeShootDeletion(seedCtx, log, shoot)
 	}
 
 	operationType := v1beta1helper.ComputeOperationType(shoot.ObjectMeta, shoot.Status.LastOperation)
 
-	hasBastions, err := r.shootHasBastions(ctx, shoot)
+	hasBastions, err := r.shootHasBastions(gardenCtx, shoot)
 	if err != nil {
 		return reconcile.Result{}, fmt.Errorf("failed to check for related Bastions: %w", err)
 	}
 	if hasBastions {
 		hasBastionErr := errors.New("shoot has still Bastions")
-		updateErr := r.patchShootStatusOperationError(ctx, shoot, hasBastionErr.Error(), operationType, shoot.Status.LastErrors...)
+		updateErr := r.patchShootStatusOperationError(gardenCtx, shoot, hasBastionErr.Error(), operationType, shoot.Status.LastErrors...)
 		return reconcile.Result{}, errorsutils.WithSuppressed(hasBastionErr, updateErr)
 	}
 
 	// If the .status.lastOperation already indicates that the deletion is successful then we finalize it immediately.
 	if shoot.Status.LastOperation != nil && shoot.Status.LastOperation.Type == gardencorev1beta1.LastOperationTypeDelete && shoot.Status.LastOperation.State == gardencorev1beta1.LastOperationStateSucceeded {
 		log.Info("The `.status.lastOperation` indicates a successful deletion, deletion accepted")
-		return r.finalizeShootDeletion(ctx, log, shoot)
+		return r.finalizeShootDeletion(seedCtx, log, shoot)
 	}
 
-	o, result, err := r.prepareOperation(ctx, log, shoot)
+	o, result, err := r.prepareOperation(gardenCtx, seedCtx, log, shoot)
 	if err != nil || o == nil {
 		return result, err
 	}
 
 	r.Recorder.Event(shoot, corev1.EventTypeNormal, gardencorev1beta1.EventDeleting, "Deleting Shoot cluster")
-	if flowErr := r.runDeleteShootFlow(ctx, o); flowErr != nil {
+	if flowErr := r.runDeleteShootFlow(gardenCtx, o); flowErr != nil {
 		r.Recorder.Event(shoot, corev1.EventTypeWarning, gardencorev1beta1.EventDeleteError, flowErr.Description)
-		updateErr := r.patchShootStatusOperationError(ctx, shoot, flowErr.Description, operationType, flowErr.LastErrors...)
+		updateErr := r.patchShootStatusOperationError(gardenCtx, shoot, flowErr.Description, operationType, flowErr.LastErrors...)
 		return reconcile.Result{}, errorsutils.WithSuppressed(errors.New(flowErr.Description), updateErr)
 	}
 
 	r.Recorder.Event(shoot, corev1.EventTypeNormal, gardencorev1beta1.EventDeleted, "Deleted Shoot cluster")
-	return r.finalizeShootDeletion(ctx, log, shoot)
+	return r.finalizeShootDeletion(seedCtx, log, shoot)
 }
 
-func (r *Reconciler) prepareOperation(ctx context.Context, log logr.Logger, shoot *gardencorev1beta1.Shoot) (*operation.Operation, reconcile.Result, error) {
+func (r *Reconciler) prepareOperation(gardenCtx context.Context, seedCtx context.Context, log logr.Logger, shoot *gardencorev1beta1.Shoot) (*operation.Operation, reconcile.Result, error) {
 	// fetch related objects required for shoot operation
-	project, _, err := gardenerutils.ProjectAndNamespaceFromReader(ctx, r.GardenClient, shoot.Namespace)
+	project, _, err := gardenerutils.ProjectAndNamespaceFromReader(gardenCtx, r.GardenClient, shoot.Namespace)
 	if err != nil {
 		return nil, reconcile.Result{}, err
 	}
@@ -249,14 +254,14 @@ func (r *Reconciler) prepareOperation(ctx context.Context, log logr.Logger, shoo
 	}
 
 	cloudProfile := &gardencorev1beta1.CloudProfile{}
-	if err := r.GardenClient.Get(ctx, kubernetesutils.Key(shoot.Spec.CloudProfileName), cloudProfile); err != nil {
+	if err := r.GardenClient.Get(gardenCtx, kubernetesutils.Key(shoot.Spec.CloudProfileName), cloudProfile); err != nil {
 		return nil, reconcile.Result{}, err
 	}
 
 	seed := &gardencorev1beta1.Seed{}
 	// always fetch the seed that this gardenlet is responsible for (instead of using spec.seedName),
 	// it is never acting on a foreign seed (e.g., during control plane migration)
-	if err := r.GardenClient.Get(ctx, client.ObjectKey{Name: r.Config.SeedConfig.Name}, seed); err != nil {
+	if err := r.GardenClient.Get(gardenCtx, client.ObjectKey{Name: r.Config.SeedConfig.Name}, seed); err != nil {
 		return nil, reconcile.Result{}, err
 	}
 
@@ -267,9 +272,9 @@ func (r *Reconciler) prepareOperation(ctx context.Context, log logr.Logger, shoo
 		log.Info("Skipping shoot because it should not be reconciled right now")
 
 		if i.ShouldOnlySyncClusterResource {
-			if syncErr := r.syncClusterResourceToSeed(ctx, shoot, project, cloudProfile, seed); syncErr != nil {
+			if syncErr := r.syncClusterResourceToSeed(seedCtx, shoot, project, cloudProfile, seed); syncErr != nil {
 				log.Error(syncErr, "Failed syncing Cluster resource to Seed while Shoot should not be reconciled")
-				updateErr := r.patchShootStatusOperationError(ctx, shoot, syncErr.Error(), i.OperationType, shoot.Status.LastErrors...)
+				updateErr := r.patchShootStatusOperationError(seedCtx, shoot, syncErr.Error(), i.OperationType, shoot.Status.LastErrors...)
 				return nil, reconcile.Result{}, errorsutils.WithSuppressed(syncErr, updateErr)
 			}
 			return nil, reconcile.Result{}, nil
@@ -279,23 +284,23 @@ func (r *Reconciler) prepareOperation(ctx context.Context, log logr.Logger, shoo
 	}
 
 	shootNamespace := shootpkg.ComputeTechnicalID(project.Name, shoot)
-	if err := r.updateShootStatusOperationStart(ctx, shoot, shootNamespace, i.OperationType); err != nil {
+	if err := r.updateShootStatusOperationStart(gardenCtx, shoot, shootNamespace, i.OperationType); err != nil {
 		return nil, reconcile.Result{}, err
 	}
 
-	o, operationErr := r.initializeOperation(ctx, log, shoot, project, cloudProfile, seed)
+	o, operationErr := r.initializeOperation(gardenCtx, log, shoot, project, cloudProfile, seed)
 	if operationErr != nil {
-		updateErr := r.patchShootStatusOperationError(ctx, shoot, fmt.Sprintf("Could not initialize a new operation for Shoot cluster: %s", operationErr.Error()), i.OperationType, lastErrorsOperationInitializationFailure(shoot.Status.LastErrors, operationErr)...)
+		updateErr := r.patchShootStatusOperationError(gardenCtx, shoot, fmt.Sprintf("Could not initialize a new operation for Shoot cluster: %s", operationErr.Error()), i.OperationType, lastErrorsOperationInitializationFailure(shoot.Status.LastErrors, operationErr)...)
 		return nil, reconcile.Result{}, errorsutils.WithSuppressed(operationErr, updateErr)
 	}
 
-	if err := r.checkSeedAndSyncClusterResource(ctx, shoot, project, cloudProfile, seed); err != nil {
+	if err := r.checkSeedAndSyncClusterResource(seedCtx, shoot, project, cloudProfile, seed); err != nil {
 		log.Error(err, "Shoot cannot be synced with seed")
 
 		patch := client.MergeFrom(shoot.DeepCopy())
 		shoot.Status.LastOperation.Description = fmt.Sprintf("Shoot cannot be synced with Seed: %v", err)
 		shoot.Status.LastOperation.LastUpdateTime = metav1.NewTime(r.Clock.Now().UTC())
-		if patchErr := r.GardenClient.Status().Patch(ctx, shoot, patch); patchErr != nil {
+		if patchErr := r.GardenClient.Status().Patch(seedCtx, shoot, patch); patchErr != nil {
 			return nil, reconcile.Result{}, errorsutils.WithSuppressed(err, patchErr)
 		}
 

--- a/pkg/gardenlet/controller/shootstate/extensions/reconciler.go
+++ b/pkg/gardenlet/controller/shootstate/extensions/reconciler.go
@@ -29,6 +29,7 @@ import (
 	apiextensions "github.com/gardener/gardener/pkg/api/extensions"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
+	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/extensions"
 	"github.com/gardener/gardener/pkg/gardenlet/apis/config"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
@@ -48,6 +49,9 @@ type Reconciler struct {
 // Reconcile performs the main reconciliation logic.
 func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 	log := logf.FromContext(ctx)
+
+	ctx, cancel := context.WithTimeout(ctx, controllerutils.DefaultReconciliationTimeout)
+	defer cancel()
 
 	obj := r.NewObjectFunc()
 	if err := r.SeedClient.Get(ctx, request.NamespacedName, obj); err != nil {

--- a/pkg/gardenlet/controller/shootstate/extensions/reconciler.go
+++ b/pkg/gardenlet/controller/shootstate/extensions/reconciler.go
@@ -50,7 +50,7 @@ type Reconciler struct {
 func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 	log := logf.FromContext(ctx)
 
-	ctx, cancel := context.WithTimeout(ctx, controllerutils.DefaultReconciliationTimeout)
+	ctx, cancel := controllerutils.GetMainReconciliationContext(ctx, controllerutils.DefaultReconciliationTimeout)
 	defer cancel()
 
 	obj := r.NewObjectFunc()

--- a/pkg/gardenlet/controller/shootstate/extensions/reconciler_test.go
+++ b/pkg/gardenlet/controller/shootstate/extensions/reconciler_test.go
@@ -282,9 +282,9 @@ var _ = Describe("Reconciler", func() {
 			reconciler.SeedClient = mockClient
 
 			gomock.InOrder(
-				mockClient.EXPECT().Get(ctx, client.ObjectKeyFromObject(extension), gomock.AssignableToTypeOf(&extensionsv1alpha1.Extension{})),
-				mockClient.EXPECT().Get(ctx, client.ObjectKeyFromObject(cluster), gomock.AssignableToTypeOf(&extensionsv1alpha1.Cluster{})).SetArg(2, *cluster),
-				mockClient.EXPECT().Get(ctx, client.ObjectKeyFromObject(shootState), gomock.AssignableToTypeOf(&gardencorev1beta1.ShootState{})),
+				mockClient.EXPECT().Get(gomock.Any(), client.ObjectKeyFromObject(extension), gomock.AssignableToTypeOf(&extensionsv1alpha1.Extension{})),
+				mockClient.EXPECT().Get(gomock.Any(), client.ObjectKeyFromObject(cluster), gomock.AssignableToTypeOf(&extensionsv1alpha1.Cluster{})).SetArg(2, *cluster),
+				mockClient.EXPECT().Get(gomock.Any(), client.ObjectKeyFromObject(shootState), gomock.AssignableToTypeOf(&gardencorev1beta1.ShootState{})),
 			)
 
 			_, err := reconciler.Reconcile(ctx, reconcileRequest)

--- a/pkg/gardenlet/controller/shootstate/secret/reconciler.go
+++ b/pkg/gardenlet/controller/shootstate/secret/reconciler.go
@@ -54,7 +54,7 @@ type Reconciler struct {
 func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 	log := logf.FromContext(ctx)
 
-	ctx, cancel := context.WithTimeout(ctx, controllerutils.DefaultReconciliationTimeout)
+	ctx, cancel := controllerutils.GetMainReconciliationContext(ctx, controllerutils.DefaultReconciliationTimeout)
 	defer cancel()
 
 	secret := &corev1.Secret{}

--- a/pkg/gardenlet/controller/shootstate/secret/reconciler.go
+++ b/pkg/gardenlet/controller/shootstate/secret/reconciler.go
@@ -54,6 +54,9 @@ type Reconciler struct {
 func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 	log := logf.FromContext(ctx)
 
+	ctx, cancel := context.WithTimeout(ctx, controllerutils.DefaultReconciliationTimeout)
+	defer cancel()
+
 	secret := &corev1.Secret{}
 	if err := r.SeedClient.Get(ctx, request.NamespacedName, secret); err != nil {
 		if apierrors.IsNotFound(err) {

--- a/pkg/resourcemanager/controller/csrapprover/reconciler.go
+++ b/pkg/resourcemanager/controller/csrapprover/reconciler.go
@@ -32,6 +32,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/gardener/gardener/pkg/client/kubernetes"
+	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/resourcemanager/apis/config"
 	"github.com/gardener/gardener/pkg/utils"
 )
@@ -48,6 +49,9 @@ type Reconciler struct {
 // Reconcile performs the main reconciliation logic.
 func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 	log := logf.FromContext(ctx)
+
+	ctx, cancel := controllerutils.GetMainReconciliationContext(ctx, controllerutils.DefaultReconciliationTimeout)
+	defer cancel()
 
 	csr := &certificatesv1.CertificateSigningRequest{}
 	if err := r.TargetClient.Get(ctx, request.NamespacedName, csr); err != nil {

--- a/pkg/resourcemanager/controller/garbagecollector/reconciler.go
+++ b/pkg/resourcemanager/controller/garbagecollector/reconciler.go
@@ -32,6 +32,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/resourcemanager/apis/config"
 	"github.com/gardener/gardener/pkg/resourcemanager/controller/garbagecollector/references"
 	errorsutils "github.com/gardener/gardener/pkg/utils/errors"
@@ -52,7 +53,7 @@ type Reconciler struct {
 func (r *Reconciler) Reconcile(reconcileCtx context.Context, _ reconcile.Request) (reconcile.Result, error) {
 	log := logf.FromContext(reconcileCtx)
 
-	ctx, cancel := context.WithTimeout(reconcileCtx, time.Minute)
+	ctx, cancel := controllerutils.GetMainReconciliationContext(reconcileCtx, time.Minute)
 	defer cancel()
 
 	log.Info("Starting garbage collection")

--- a/pkg/resourcemanager/controller/garbagecollector/reconciler.go
+++ b/pkg/resourcemanager/controller/garbagecollector/reconciler.go
@@ -53,7 +53,7 @@ type Reconciler struct {
 func (r *Reconciler) Reconcile(reconcileCtx context.Context, _ reconcile.Request) (reconcile.Result, error) {
 	log := logf.FromContext(reconcileCtx)
 
-	ctx, cancel := controllerutils.GetMainReconciliationContext(reconcileCtx, time.Minute)
+	ctx, cancel := controllerutils.GetMainReconciliationContext(reconcileCtx, r.Config.SyncPeriod.Duration)
 	defer cancel()
 
 	log.Info("Starting garbage collection")

--- a/pkg/resourcemanager/controller/health/health/reconciler.go
+++ b/pkg/resourcemanager/controller/health/health/reconciler.go
@@ -17,7 +17,6 @@ package health
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/go-logr/logr"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
@@ -61,7 +60,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	// timeout for all calls (e.g. status updates), give status updates a bit of headroom if health checks
 	// themselves run into timeouts, so that we will still update the status with that timeout error
 	var cancel context.CancelFunc
-	ctx, cancel = controllerutils.GetMainReconciliationContext(ctx, time.Minute)
+	ctx, cancel = controllerutils.GetMainReconciliationContext(ctx, r.Config.SyncPeriod.Duration)
 	defer cancel()
 
 	mr := &resourcesv1alpha1.ManagedResource{}
@@ -103,7 +102,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 func (r *Reconciler) executeHealthChecks(ctx context.Context, log logr.Logger, mr *resourcesv1alpha1.ManagedResource) (reconcile.Result, error) {
 	log.Info("Starting ManagedResource health checks")
 	// don't block workers if calls timeout for some reason
-	healthCheckCtx, cancel := controllerutils.GetChildReconciliationContext(ctx, time.Minute)
+	healthCheckCtx, cancel := controllerutils.GetChildReconciliationContext(ctx, r.Config.SyncPeriod.Duration)
 	defer cancel()
 
 	var (

--- a/pkg/resourcemanager/controller/health/health/reconciler.go
+++ b/pkg/resourcemanager/controller/health/health/reconciler.go
@@ -34,6 +34,7 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
+	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/resourcemanager/apis/config"
 	"github.com/gardener/gardener/pkg/resourcemanager/controller/health/utils"
 	resourcemanagerpredicate "github.com/gardener/gardener/pkg/resourcemanager/predicate"
@@ -60,7 +61,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	// timeout for all calls (e.g. status updates), give status updates a bit of headroom if health checks
 	// themselves run into timeouts, so that we will still update the status with that timeout error
 	var cancel context.CancelFunc
-	ctx, cancel = context.WithTimeout(ctx, 2*time.Minute)
+	ctx, cancel = controllerutils.GetMainReconciliationContext(ctx, time.Minute)
 	defer cancel()
 
 	mr := &resourcesv1alpha1.ManagedResource{}
@@ -102,7 +103,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 func (r *Reconciler) executeHealthChecks(ctx context.Context, log logr.Logger, mr *resourcesv1alpha1.ManagedResource) (reconcile.Result, error) {
 	log.Info("Starting ManagedResource health checks")
 	// don't block workers if calls timeout for some reason
-	healthCheckCtx, cancel := context.WithTimeout(ctx, time.Minute)
+	healthCheckCtx, cancel := controllerutils.GetChildReconciliationContext(ctx, time.Minute)
 	defer cancel()
 
 	var (

--- a/pkg/resourcemanager/controller/health/progressing/reconciler.go
+++ b/pkg/resourcemanager/controller/health/progressing/reconciler.go
@@ -17,7 +17,6 @@ package progressing
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
@@ -53,7 +52,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	// timeout for all calls (e.g. status updates), give status updates a bit of headroom if checks
 	// themselves run into timeouts, so that we will still update the status with that timeout error
 	var cancel context.CancelFunc
-	ctx, cancel = controllerutils.GetMainReconciliationContext(ctx, time.Minute)
+	ctx, cancel = controllerutils.GetMainReconciliationContext(ctx, r.Config.SyncPeriod.Duration)
 	defer cancel()
 
 	mr := &resourcesv1alpha1.ManagedResource{}
@@ -96,7 +95,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 func (r *Reconciler) reconcile(ctx context.Context, log logr.Logger, mr *resourcesv1alpha1.ManagedResource) (reconcile.Result, error) {
 	log.V(1).Info("Starting ManagedResource progressing checks")
 	// don't block workers if calls timeout for some reason
-	checkCtx, cancel := controllerutils.GetChildReconciliationContext(ctx, time.Minute)
+	checkCtx, cancel := controllerutils.GetChildReconciliationContext(ctx, r.Config.SyncPeriod.Duration)
 	defer cancel()
 
 	conditionResourcesProgressing := v1beta1helper.GetOrInitConditionWithClock(r.Clock, mr.Status.Conditions, resourcesv1alpha1.ResourcesProgressing)

--- a/pkg/resourcemanager/controller/health/progressing/reconciler.go
+++ b/pkg/resourcemanager/controller/health/progressing/reconciler.go
@@ -30,6 +30,7 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
+	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/resourcemanager/apis/config"
 	"github.com/gardener/gardener/pkg/resourcemanager/controller/health/utils"
 	resourcemanagerpredicate "github.com/gardener/gardener/pkg/resourcemanager/predicate"
@@ -52,7 +53,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	// timeout for all calls (e.g. status updates), give status updates a bit of headroom if checks
 	// themselves run into timeouts, so that we will still update the status with that timeout error
 	var cancel context.CancelFunc
-	ctx, cancel = context.WithTimeout(ctx, 2*time.Minute)
+	ctx, cancel = controllerutils.GetMainReconciliationContext(ctx, time.Minute)
 	defer cancel()
 
 	mr := &resourcesv1alpha1.ManagedResource{}
@@ -95,7 +96,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 func (r *Reconciler) reconcile(ctx context.Context, log logr.Logger, mr *resourcesv1alpha1.ManagedResource) (reconcile.Result, error) {
 	log.V(1).Info("Starting ManagedResource progressing checks")
 	// don't block workers if calls timeout for some reason
-	checkCtx, cancel := context.WithTimeout(ctx, time.Minute)
+	checkCtx, cancel := controllerutils.GetChildReconciliationContext(ctx, time.Minute)
 	defer cancel()
 
 	conditionResourcesProgressing := v1beta1helper.GetOrInitConditionWithClock(r.Clock, mr.Status.Conditions, resourcesv1alpha1.ResourcesProgressing)

--- a/pkg/resourcemanager/controller/managedresource/reconciler.go
+++ b/pkg/resourcemanager/controller/managedresource/reconciler.go
@@ -158,7 +158,7 @@ func (r *Reconciler) reconcile(ctx context.Context, log logr.Logger, mr *resourc
 		forceOverwriteAnnotations = *v
 	}
 
-	reconcileCtx, cancel := controllerutils.GetMainReconciliationContext(ctx, time.Minute)
+	reconcileCtx, cancel := controllerutils.GetMainReconciliationContext(ctx, r.Config.SyncPeriod.Duration)
 	defer cancel()
 
 	// Initialize condition based on the current status.
@@ -377,7 +377,7 @@ func (r *Reconciler) reconcile(ctx context.Context, log logr.Logger, mr *resourc
 func (r *Reconciler) delete(ctx context.Context, log logr.Logger, mr *resourcesv1alpha1.ManagedResource) (reconcile.Result, error) {
 	log.Info("Starting to delete ManagedResource")
 
-	deleteCtx, cancel := controllerutils.GetMainReconciliationContext(ctx, time.Minute)
+	deleteCtx, cancel := controllerutils.GetMainReconciliationContext(ctx, r.Config.SyncPeriod.Duration)
 	defer cancel()
 
 	if err := r.updateConditionsForDeletion(ctx, mr); err != nil {

--- a/pkg/resourcemanager/controller/managedresource/reconciler.go
+++ b/pkg/resourcemanager/controller/managedresource/reconciler.go
@@ -158,7 +158,7 @@ func (r *Reconciler) reconcile(ctx context.Context, log logr.Logger, mr *resourc
 		forceOverwriteAnnotations = *v
 	}
 
-	reconcileCtx, cancel := context.WithTimeout(ctx, time.Minute)
+	reconcileCtx, cancel := controllerutils.GetMainReconciliationContext(ctx, time.Minute)
 	defer cancel()
 
 	// Initialize condition based on the current status.
@@ -377,7 +377,7 @@ func (r *Reconciler) reconcile(ctx context.Context, log logr.Logger, mr *resourc
 func (r *Reconciler) delete(ctx context.Context, log logr.Logger, mr *resourcesv1alpha1.ManagedResource) (reconcile.Result, error) {
 	log.Info("Starting to delete ManagedResource")
 
-	deleteCtx, cancel := context.WithTimeout(ctx, time.Minute)
+	deleteCtx, cancel := controllerutils.GetMainReconciliationContext(ctx, time.Minute)
 	defer cancel()
 
 	if err := r.updateConditionsForDeletion(ctx, mr); err != nil {

--- a/pkg/resourcemanager/controller/networkpolicy/reconciler.go
+++ b/pkg/resourcemanager/controller/networkpolicy/reconciler.go
@@ -50,6 +50,9 @@ type Reconciler struct {
 func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 	log := logf.FromContext(ctx)
 
+	ctx, cancel := controllerutils.GetMainReconciliationContext(ctx, controllerutils.DefaultReconciliationTimeout)
+	defer cancel()
+
 	networkPolicyList := &metav1.PartialObjectMetadataList{}
 	networkPolicyList.SetGroupVersionKind(networkingv1.SchemeGroupVersion.WithKind("NetworkPolicyList"))
 	if err := r.TargetClient.List(ctx, networkPolicyList, client.MatchingLabels{

--- a/pkg/resourcemanager/controller/node/reconciler.go
+++ b/pkg/resourcemanager/controller/node/reconciler.go
@@ -37,6 +37,7 @@ import (
 	"github.com/gardener/gardener/pkg/api/indexer"
 	"github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/resourcemanager/apis/config"
 	"github.com/gardener/gardener/pkg/resourcemanager/controller/node/helper"
 	"github.com/gardener/gardener/pkg/utils/kubernetes/health"
@@ -54,7 +55,7 @@ type Reconciler struct {
 func (r *Reconciler) Reconcile(reconcileCtx context.Context, req reconcile.Request) (reconcile.Result, error) {
 	log := logf.FromContext(reconcileCtx)
 
-	ctx, cancel := context.WithTimeout(reconcileCtx, time.Minute)
+	ctx, cancel := controllerutils.GetMainReconciliationContext(reconcileCtx, time.Minute)
 	defer cancel()
 
 	node := &corev1.Node{}

--- a/pkg/resourcemanager/controller/node/reconciler.go
+++ b/pkg/resourcemanager/controller/node/reconciler.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 	"strings"
-	"time"
 
 	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
@@ -55,7 +54,7 @@ type Reconciler struct {
 func (r *Reconciler) Reconcile(reconcileCtx context.Context, req reconcile.Request) (reconcile.Result, error) {
 	log := logf.FromContext(reconcileCtx)
 
-	ctx, cancel := controllerutils.GetMainReconciliationContext(reconcileCtx, time.Minute)
+	ctx, cancel := controllerutils.GetMainReconciliationContext(reconcileCtx, controllerutils.DefaultReconciliationTimeout)
 	defer cancel()
 
 	node := &corev1.Node{}

--- a/pkg/resourcemanager/controller/secret/reconciler.go
+++ b/pkg/resourcemanager/controller/secret/reconciler.go
@@ -17,7 +17,6 @@ package secret
 import (
 	"context"
 	"fmt"
-	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -43,7 +42,7 @@ type Reconciler struct {
 func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
 	log := logf.FromContext(ctx)
 
-	ctx, cancel := controllerutils.GetMainReconciliationContext(ctx, time.Minute)
+	ctx, cancel := controllerutils.GetMainReconciliationContext(ctx, controllerutils.DefaultReconciliationTimeout)
 	defer cancel()
 
 	secret := &corev1.Secret{}

--- a/pkg/resourcemanager/controller/secret/reconciler.go
+++ b/pkg/resourcemanager/controller/secret/reconciler.go
@@ -43,7 +43,7 @@ type Reconciler struct {
 func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
 	log := logf.FromContext(ctx)
 
-	ctx, cancel := context.WithTimeout(ctx, time.Minute)
+	ctx, cancel := controllerutils.GetMainReconciliationContext(ctx, time.Minute)
 	defer cancel()
 
 	secret := &corev1.Secret{}

--- a/pkg/resourcemanager/controller/tokeninvalidator/reconciler.go
+++ b/pkg/resourcemanager/controller/tokeninvalidator/reconciler.go
@@ -27,6 +27,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
+	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/resourcemanager/apis/config"
 )
 
@@ -43,6 +44,9 @@ type Reconciler struct {
 // Reconcile labels secrets whose tokens should be invalidated.
 func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 	log := logf.FromContext(ctx)
+
+	ctx, cancel := controllerutils.GetMainReconciliationContext(ctx, controllerutils.DefaultReconciliationTimeout)
+	defer cancel()
 
 	secret := &metav1.PartialObjectMetadata{}
 	secret.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("Secret"))

--- a/pkg/resourcemanager/controller/tokenrequestor/reconciler.go
+++ b/pkg/resourcemanager/controller/tokenrequestor/reconciler.go
@@ -37,6 +37,7 @@ import (
 
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
+	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/resourcemanager/apis/config"
 )
 
@@ -59,7 +60,7 @@ type Reconciler struct {
 func (r *Reconciler) Reconcile(reconcileCtx context.Context, req reconcile.Request) (reconcile.Result, error) {
 	log := logf.FromContext(reconcileCtx)
 
-	ctx, cancel := context.WithTimeout(reconcileCtx, time.Minute)
+	ctx, cancel := controllerutils.GetMainReconciliationContext(reconcileCtx, time.Minute)
 	defer cancel()
 
 	secret := &corev1.Secret{}

--- a/pkg/resourcemanager/controller/tokenrequestor/reconciler.go
+++ b/pkg/resourcemanager/controller/tokenrequestor/reconciler.go
@@ -60,7 +60,7 @@ type Reconciler struct {
 func (r *Reconciler) Reconcile(reconcileCtx context.Context, req reconcile.Request) (reconcile.Result, error) {
 	log := logf.FromContext(reconcileCtx)
 
-	ctx, cancel := controllerutils.GetMainReconciliationContext(reconcileCtx, time.Minute)
+	ctx, cancel := controllerutils.GetMainReconciliationContext(reconcileCtx, controllerutils.DefaultReconciliationTimeout)
 	defer cancel()
 
 	secret := &corev1.Secret{}

--- a/pkg/scheduler/controller/shoot/reconciler.go
+++ b/pkg/scheduler/controller/shoot/reconciler.go
@@ -48,7 +48,7 @@ type Reconciler struct {
 func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 	log := logf.FromContext(ctx)
 
-	ctx, cancel := context.WithTimeout(ctx, controllerutils.DefaultReconciliationTimeout)
+	ctx, cancel := controllerutils.GetMainReconciliationContext(ctx, controllerutils.DefaultReconciliationTimeout)
 	defer cancel()
 
 	shoot := &gardencorev1beta1.Shoot{}

--- a/pkg/scheduler/controller/shoot/reconciler.go
+++ b/pkg/scheduler/controller/shoot/reconciler.go
@@ -31,6 +31,7 @@ import (
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
+	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/scheduler/apis/config"
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	cidrvalidation "github.com/gardener/gardener/pkg/utils/validation/cidr"
@@ -46,6 +47,9 @@ type Reconciler struct {
 // Reconcile schedules shoots to seeds.
 func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 	log := logf.FromContext(ctx)
+
+	ctx, cancel := context.WithTimeout(ctx, controllerutils.DefaultReconciliationTimeout)
+	defer cancel()
 
 	shoot := &gardencorev1beta1.Shoot{}
 	if err := r.Client.Get(ctx, request.NamespacedName, shoot); err != nil {

--- a/test/integration/controllermanager/shoot/quota/quota_suite_test.go
+++ b/test/integration/controllermanager/shoot/quota/quota_suite_test.go
@@ -117,7 +117,7 @@ var _ = BeforeSuite(func() {
 	Expect((&quota.Reconciler{
 		Config: config.ShootQuotaControllerConfiguration{
 			ConcurrentSyncs: pointer.Int(5),
-			SyncPeriod:      metav1.Duration{Duration: 500 * time.Millisecond},
+			SyncPeriod:      &metav1.Duration{Duration: 500 * time.Millisecond},
 		},
 		Clock: fakeClock,
 	}).AddToManager(mgr)).To(Succeed())

--- a/test/integration/gardenlet/managedseed/managedseed_suite_test.go
+++ b/test/integration/gardenlet/managedseed/managedseed_suite_test.go
@@ -216,7 +216,10 @@ var _ = BeforeSuite(func() {
 	cfg := config.GardenletConfiguration{
 		Controllers: &config.GardenletControllerConfiguration{
 			ManagedSeed: &config.ManagedSeedControllerConfiguration{
-				WaitSyncPeriod:   &metav1.Duration{Duration: 5 * time.Millisecond},
+				WaitSyncPeriod: &metav1.Duration{Duration: 5 * time.Millisecond},
+				// Set the SyncPeriod to 1 second because it is also used as a timeout for the context used in the
+				// reconciler.
+				SyncPeriod:       &metav1.Duration{Duration: 1 * time.Second},
 				ConcurrentSyncs:  pointer.Int(5),
 				SyncJitterPeriod: &metav1.Duration{Duration: 50 * time.Millisecond},
 				// This controller is pretty heavy-weight, so use a higher duration.

--- a/test/integration/gardenlet/managedseed/managedseed_suite_test.go
+++ b/test/integration/gardenlet/managedseed/managedseed_suite_test.go
@@ -216,10 +216,7 @@ var _ = BeforeSuite(func() {
 	cfg := config.GardenletConfiguration{
 		Controllers: &config.GardenletControllerConfiguration{
 			ManagedSeed: &config.ManagedSeedControllerConfiguration{
-				WaitSyncPeriod: &metav1.Duration{Duration: 5 * time.Millisecond},
-				// Set the SyncPeriod to 1 second because it is also used as a timeout for the context used in the
-				// reconciler.
-				SyncPeriod:       &metav1.Duration{Duration: 1 * time.Second},
+				WaitSyncPeriod:   &metav1.Duration{Duration: 5 * time.Millisecond},
 				ConcurrentSyncs:  pointer.Int(5),
 				SyncJitterPeriod: &metav1.Duration{Duration: 50 * time.Millisecond},
 				// This controller is pretty heavy-weight, so use a higher duration.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area scalability
/kind enhancement

**What this PR does / why we need it**:
This PR introduces a timeout for contexts used by reconciler functions.

**Which issue(s) this PR fixes**:
Part of #4251 

**Special notes for your reviewer**:
As the issue also mentions adding waits for cache syncs - this comes out of the box when using controller runtime with a default timeout of 2 minutes. 
The shoot and seed care controllers were already using contexts that timeout for the health check functions: https://github.com/gardener/gardener/blob/a60a42fb33ec790a17105215e25ca208f31e7a74/pkg/gardenlet/controller/shoot/shoot_care_control.go#L233-L234
and
https://github.com/gardener/gardener/blob/a60a42fb33ec790a17105215e25ca208f31e7a74/pkg/gardenlet/controller/seed/care/reconciler.go#L61-L62
I was not sure whether we should keep those as they are, or unify them so that only one time context is used.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
The `controllermanager` and `gardenlet` controller reconciliations are now limited to a `1m` timeout. Additionally, there is a 1m limit on predicate functions that use contexts.
```
