### PR TITLE
Allow `gardenlet`s to list `Garden`s

### DIFF
--- a/charts/gardener/gardenlet/templates/clusterrole-gardenlet.yaml
+++ b/charts/gardener/gardenlet/templates/clusterrole-gardenlet.yaml
@@ -13,6 +13,14 @@ metadata:
     heritage: "{{ .Release.Service }}"
 rules:
 - apiGroups:
+  - operator.gardener.cloud
+  resources:
+  - gardens
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - ""
   resources:
   - endpoints

--- a/pkg/gardenlet/controller/managedseed/charttest/charttest.go
+++ b/pkg/gardenlet/controller/managedseed/charttest/charttest.go
@@ -184,6 +184,11 @@ func getGardenletClusterRole(labels map[string]string) *rbacv1.ClusterRole {
 		},
 		Rules: []rbacv1.PolicyRule{
 			{
+				APIGroups: []string{"operator.gardener.cloud"},
+				Resources: []string{"gardens"},
+				Verbs:     []string{"get", "list", "watch"},
+			},
+			{
 				APIGroups: []string{""},
 				Resources: []string{"endpoints", "persistentvolumes"},
 				Verbs:     []string{"get", "list", "watch"},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind bug

**What this PR does / why we need it**:
Allow `gardenlet`s to list `Garden`s, otherwise they might fail with

```
{"level":"error","ts":"2022-12-06T09:05:19.075Z","msg":"sigs.k8s.io/controller-runtime/pkg/cache/internal/informers_map.go:262: Failed to watch *v1.PartialObjectMetadata: failed to list *v1.PartialObjectMetadata: gardens.operator.gardener.cloud is forbidden: User \"system:serviceaccount:garden:gardenlet\" cannot list resource \"gardens\" in API group \"operator.gardener.cloud\" at the cluster scope\n","stacktrace":"k8s.io/client-go/tools/cache.DefaultWatchErrorHandler\n\t/go/src/github.com/gardener/gardener/vendor/k8s.io/client-go/tools/cache/reflector.go:140\nk8s.io/client-go/tools/cache.(*Reflector).Run.func1\n\t/go/src/github.com/gardener/gardener/vendor/k8s.io/client-go/tools/cache/reflector.go:224\nk8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1\n\t/go/src/github.com/gardener/gardener/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:157\nk8s.io/apimachinery/pkg/util/wait.BackoffUntil\n\t/go/src/github.com/gardener/gardener/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:158\nk8s.io/client-go/tools/cache.(*Reflector).Run\n\t/go/src/github.com/gardener/gardener/vendor/k8s.io/client-go/tools/cache/reflector.go:222\nk8s.io/apimachinery/pkg/util/wait.(*Group).StartWithChannel.func1\n\t/go/src/github.com/gardener/gardener/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:58\nk8s.io/apimachinery/pkg/util/wait.(*Group).Start.func1\n\t/go/src/github.com/gardener/gardener/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:75"}
```

if the seed cluster is a garden at the same time.

**Which issue(s) this PR fixes**:
Left-over from #7009 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
A bug has been fixed which prevented `gardenlet` from reconciling its `Seed` in case the seed cluster is the garden cluster at the same time.
```
