### PR TITLE
Allow providing separate ETCD TLS secrets for Gardener `controlplane` chart

### DIFF
--- a/charts/gardener/controlplane/charts/runtime/templates/apiserver/deployment.yaml
+++ b/charts/gardener/controlplane/charts/runtime/templates/apiserver/deployment.yaml
@@ -207,7 +207,11 @@ spec:
         - --etcd-cafile=/etc/gardener-apiserver/srv/etcd/ca.crt
         - --etcd-certfile=/etc/gardener-apiserver/srv/etcd/tls.crt
         - --etcd-keyfile=/etc/gardener-apiserver/srv/etcd/tls.key
-        {{- else}}
+        {{- else if and .Values.global.apiserver.etcd.caBundleSecretName .Values.global.apiserver.etcd.clientCertSecretName }}
+        - --etcd-cafile=/etc/gardener-apiserver/srv/etcd/ca/bundle.crt
+        - --etcd-certfile=/etc/gardener-apiserver/srv/etcd/client/tls.crt
+        - --etcd-keyfile=/etc/gardener-apiserver/srv/etcd/client/tls.key
+        {{- else }}
         {{- if .Values.global.apiserver.etcd.caBundle }}
         - --etcd-cafile=/etc/gardener-apiserver/srv/etcd-client-ca.crt
         {{- end }}
@@ -314,6 +318,16 @@ spec:
           mountPath: /etc/gardener-apiserver/srv/etcd/
           readOnly: true
         {{- end }}
+        {{- if .Values.global.apiserver.etcd.caBundleSecretName }}
+        - name: gardener-etcd-ca-bundle
+          mountPath: /etc/gardener-apiserver/srv/etcd/ca/
+          readOnly: true
+        {{- end }}
+        {{- if .Values.global.apiserver.etcd.clientCertSecretName }}
+        - name: gardener-etcd-client-cert
+          mountPath: /etc/gardener-apiserver/srv/etcd/client/
+          readOnly: true
+        {{- end }}
         {{- if .Values.global.apiserver.kubeconfig }}
         - name: gardener-apiserver-kubeconfig
           mountPath: /etc/gardener-apiserver/kubeconfig
@@ -401,6 +415,16 @@ spec:
       - name: gardener-etcd-client-tls
         secret:
           secretName: {{ .Values.global.apiserver.etcd.tlsSecretName }}
+      {{- end }}
+      {{- if .Values.global.apiserver.etcd.caBundleSecretName }}
+      - name: gardener-etcd-ca-bundle
+        secret:
+          secretName: {{ .Values.global.apiserver.etcd.caBundleSecretName }}
+      {{- end }}
+      {{- if .Values.global.apiserver.etcd.clientCertSecretName }}
+      - name: gardener-etcd-client-cert
+        secret:
+          secretName: {{ .Values.global.apiserver.etcd.clientCertSecretName }}
       {{- end }}
       {{- if .Values.global.apiserver.kubeconfig }}
       - name: gardener-apiserver-kubeconfig

--- a/charts/gardener/controlplane/values.yaml
+++ b/charts/gardener/controlplane/values.yaml
@@ -51,20 +51,25 @@ global:
     etcd:
       useSidecar: false # only meant for development purposes. if this is set to true, other etcd config values are ignored
       servers: https://etcd:2379
-      tlsSecretName:
-      # caBundle: |
-      #   -----BEGIN CERTIFICATE-----
-      #   ...
-      #   -----END CERTIFICATE-----
-      # tls:
-      #   crt: |
-      #     -----BEGIN CERTIFICATE-----
-      #     ...
-      #     -----END CERTIFICATE-----
-      #   key: |
-      #     -----BEGIN RSA PRIVATE KEY-----
-      #     ...
-      #     -----END RSA PRIVATE KEY-----
+  #   BEGIN etcd TLS configuration (CA and client certificate)
+  #   - either specify 'tlsSecretName' or ('caBundleSecretName' and 'clientCertSecretName') or ('caBundle' and 'tls')
+  #   tlsSecretName: etcd-tls-secrets # must contain 'ca.crt', 'tls.crt', 'tls.key' keys
+  #   caBundleSecretName: etcd-ca-bundle # must contain 'bundle.crt' key
+  #   clientCertSecretName: etcd-client-cert # must contain 'tls.crt', 'tls.key' keys
+  #   caBundle: |
+  #     -----BEGIN CERTIFICATE-----
+  #     ...
+  #     -----END CERTIFICATE-----
+  #   tls:
+  #     crt: |
+  #       -----BEGIN CERTIFICATE-----
+  #       ...
+  #       -----END CERTIFICATE-----
+  #     key: |
+  #       -----BEGIN RSA PRIVATE KEY-----
+  #       ...
+  #       -----END RSA PRIVATE KEY-----
+  #   END etcd TLS configuration (CA and client certificate)
     insecureSkipTLSVerify: false
     groupPriorityMinimum: 10000
     versionPriority: 20

--- a/charts/gardener/controlplane/values.yaml
+++ b/charts/gardener/controlplane/values.yaml
@@ -73,11 +73,13 @@ global:
     insecureSkipTLSVerify: false
     groupPriorityMinimum: 10000
     versionPriority: 20
-    tlsSecretName:
+  # BEGIN gardener-apiserver TLS configuration (CA and server certificate)
+  # - specify 'caBundle' and ('tlsSecretName' or 'tls')
     caBundle: |
       -----BEGIN CERTIFICATE-----
       ...
       -----END CERTIFICATE-----
+  # tlsSecretName: gardener-apiserver-tls-secrets # must contain 'tls.crt', 'tls.key' keys
     tls:
       crt: |
         -----BEGIN CERTIFICATE-----
@@ -87,6 +89,7 @@ global:
         -----BEGIN RSA PRIVATE KEY-----
         ...
         -----END RSA PRIVATE KEY-----
+  # END gardener-apiserver TLS configuration (CA and server certificate)
     featureGates: {}
   # enableAdmissionPlugins: [] # List of admission plugins to be enabled in addition to default enabled ones.
   # disableAdmissionPlugins: [] # List of admission plugins that should be disabled although they are in the default enabled plugins list.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity
/kind enhancement

**What this PR does / why we need it**:
Earlier, it was only possible to provide `global.apiserver.etcd.tlsSecretName` which needed to contain `ca.crt`, `tls.crt` and `tls.key`.
With this PR, it is possible to specify separate secrets for the ETCD CA bundle (via `global.apiserver.etcd.caBundleSecretName` which must contain `bundle.crt`) and the ETCD client cert (via `global.apiserver.etcd.clientCertSecretName` which must contain `tls.crt` and `tls.key`).

**Special notes for your reviewer**:
On the way, I improved the explanation for the TLS configuration for the `gardener-apiserver`.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
It is now possible to provide separate secrets for the ETCD CA/client certificate configuration for the `gardener-apiserver` when using the Gardener `controlplane` Helm chart.
```
