### PR TITLE
`ManagedResource` controller only considers `ConfigMap`s/`Secret`s as garbage-collectable resources

### DIFF
--- a/pkg/resourcemanager/controller/managedresource/reconciler.go
+++ b/pkg/resourcemanager/controller/managedresource/reconciler.go
@@ -632,8 +632,9 @@ func keepObject(meta metav1.Object) bool {
 	return keyExistsAndValueTrue(meta.GetAnnotations(), resourcesv1alpha1.KeepObject)
 }
 
-func isGarbageCollectableResource(meta metav1.Object) bool {
-	return keyExistsAndValueTrue(meta.GetLabels(), references.LabelKeyGarbageCollectable)
+func isGarbageCollectableResource(obj *unstructured.Unstructured) bool {
+	return keyExistsAndValueTrue(obj.GetLabels(), references.LabelKeyGarbageCollectable) &&
+		obj.GetAPIVersion() == "v1" && sets.NewString("ConfigMap", "Secret").Has(obj.GetKind())
 }
 
 func keyExistsAndValueTrue(kv map[string]string, key string) bool {

--- a/test/integration/resourcemanager/managedresource/resource_suite_test.go
+++ b/test/integration/resourcemanager/managedresource/resource_suite_test.go
@@ -125,6 +125,7 @@ var _ = BeforeSuite(func() {
 		},
 		ClassFilter:                   filter,
 		RequeueAfterOnDeletionPending: pointer.Duration(50 * time.Millisecond),
+		GarbageCollectorActivated:     true,
 	}).AddToManager(mgr, mgr, mgr)).To(Succeed())
 
 	By("starting manager")

--- a/test/integration/resourcemanager/managedresource/resource_test.go
+++ b/test/integration/resourcemanager/managedresource/resource_test.go
@@ -429,9 +429,9 @@ var _ = Describe("ManagedResource controller tests", func() {
 					ContainCondition(OfType(resourcesv1alpha1.ResourcesApplied), WithStatus(gardencorev1beta1.ConditionTrue), WithReason(resourcesv1alpha1.ConditionApplySucceeded)),
 				)
 
-				Consistently(func(g Gomega) {
-					g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(configMap), configMap)).To(BeNotFoundError())
-				}).Should(Succeed())
+				Consistently(func() error {
+					return testClient.Get(ctx, client.ObjectKeyFromObject(configMap), configMap)
+				}).Should(BeNotFoundError())
 			})
 		})
 
@@ -520,8 +520,8 @@ var _ = Describe("ManagedResource controller tests", func() {
 					ContainCondition(OfType(resourcesv1alpha1.ResourcesApplied), WithStatus(gardencorev1beta1.ConditionTrue), WithReason(resourcesv1alpha1.ConditionApplySucceeded)),
 				)
 
-				Consistently(func(g Gomega) {
-					g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(configMap), configMap)).To(Succeed())
+				Consistently(func() error {
+					return testClient.Get(ctx, client.ObjectKeyFromObject(configMap), configMap)
 				}).Should(Succeed())
 			})
 
@@ -529,9 +529,9 @@ var _ = Describe("ManagedResource controller tests", func() {
 				By("deleting ManagedResource")
 				Expect(testClient.Delete(ctx, managedResource)).To(Or(Succeed(), BeNotFoundError()))
 
-				Eventually(func(g Gomega) {
-					g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)).To(BeNotFoundError())
-				}).Should(Succeed())
+				Eventually(func() error {
+					return testClient.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)
+				}).Should(BeNotFoundError())
 
 				Expect(testClient.Get(ctx, client.ObjectKeyFromObject(configMap), configMap)).To(Succeed())
 			})
@@ -583,22 +583,22 @@ var _ = Describe("ManagedResource controller tests", func() {
 					ContainCondition(OfType(resourcesv1alpha1.ResourcesApplied), WithStatus(gardencorev1beta1.ConditionTrue), WithReason(resourcesv1alpha1.ConditionApplySucceeded)),
 				)
 
-				Consistently(func(g Gomega) {
-					g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(configMap), configMap)).To(Succeed())
+				Consistently(func() error {
+					return testClient.Get(ctx, client.ObjectKeyFromObject(configMap), configMap)
 				}).Should(Succeed())
 
-				Eventually(func(g Gomega) {
-					g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(node), node)).To(BeNotFoundError())
-				}).Should(Succeed())
+				Eventually(func() error {
+					return testClient.Get(ctx, client.ObjectKeyFromObject(node), node)
+				}).Should(BeNotFoundError())
 			})
 
 			It("should keep the garbage-collectable objects even after deletion of ManagedResource", func() {
 				By("deleting ManagedResource")
 				Expect(testClient.Delete(ctx, managedResource)).To(Or(Succeed(), BeNotFoundError()))
 
-				Eventually(func(g Gomega) {
-					g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)).To(BeNotFoundError())
-				}).Should(Succeed())
+				Eventually(func() error {
+					return testClient.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)
+				}).Should(BeNotFoundError())
 
 				Expect(testClient.Get(ctx, client.ObjectKeyFromObject(configMap), configMap)).To(Succeed())
 				Expect(testClient.Get(ctx, client.ObjectKeyFromObject(node), node)).To(BeNotFoundError())


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind bug

**What this PR does / why we need it**:
`gardener-resource-manager` now only considers `ConfigMap`s/`Secret`s as garbage-collectable resources (i.e., other resources with the "garbage-collectable" label will not be kept even if removed from the `ManagedResource` or when it is deleted).

**Which issue(s) this PR fixes**:
Fixes #7156

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
`gardener-resource-manager` now only considers `ConfigMap`s/`Secret`s as garbage-collectable resources (i.e., other resources with the "garbage-collectable" label will not be kept even if removed from the `ManagedResource` or when it is deleted).
```
