### PR TITLE
`CreateForShoot` and `NewForShoot` now accept additional `origin` parameter

### DIFF
--- a/docs/extensions/conventions.md
+++ b/docs/extensions/conventions.md
@@ -35,7 +35,7 @@ Some extensions might not only create resources in the seed cluster itself but a
 However, there are no credentials for the shoot for every extension.
 
 Extensions are supposed to use [`ManagedResources`](../concepts/resource-manager.md#ManagedResource-controller) to manage resources in shoot clusters.
-gardenlet deploys gardener-resource-manager instances into all shoot control planes, that will reconcile `ManagedResources` without a specified class (`spec.class=null`) in shoot clusters.
+gardenlet deploys gardener-resource-manager instances into all shoot control planes, that will reconcile `ManagedResources` without a specified class (`spec.class=null`) in shoot clusters. Mind that Gardener acts on `ManagedResources` with the `origin=gardener` label. In order to prevent unwanted behavior extensions should omit the `origin` label or provide their own unique value for it when creating such resources.
 
 If you need to deploy a non-DaemonSet resource you need to ensure that it only runs on nodes that are allowed to host system components and extensions.
 To do that you need to configure a `nodeSelector` as following:

--- a/pkg/operation/botanist/addons.go
+++ b/pkg/operation/botanist/addons.go
@@ -174,7 +174,7 @@ func (b *Botanist) DeployManagedResourceForAddons(ctx context.Context) error {
 			return fmt.Errorf("error rendering %q chart: %+v", name, err)
 		}
 
-		if err := managedresources.CreateForShoot(ctx, b.SeedClientSet.Client(), b.Shoot.SeedNamespace, name, false, renderedChart.AsSecretData()); err != nil {
+		if err := managedresources.CreateForShoot(ctx, b.SeedClientSet.Client(), b.Shoot.SeedNamespace, name, managedresources.LabelValueGardener, false, renderedChart.AsSecretData()); err != nil {
 			return err
 		}
 	}

--- a/pkg/operation/botanist/component/clusterautoscaler/cluster_autoscaler.go
+++ b/pkg/operation/botanist/component/clusterautoscaler/cluster_autoscaler.go
@@ -292,7 +292,7 @@ func (c *clusterAutoscaler) Deploy(ctx context.Context) error {
 		return err
 	}
 
-	if err := managedresources.CreateForShoot(ctx, c.client, c.namespace, managedResourceTargetName, false, data); err != nil {
+	if err := managedresources.CreateForShoot(ctx, c.client, c.namespace, managedResourceTargetName, managedresources.LabelValueGardener, false, data); err != nil {
 		return err
 	}
 

--- a/pkg/operation/botanist/component/coredns/coredns.go
+++ b/pkg/operation/botanist/component/coredns/coredns.go
@@ -143,7 +143,7 @@ func (c *coreDNS) Deploy(ctx context.Context) error {
 		return err
 	}
 
-	return managedresources.CreateForShoot(ctx, c.client, c.namespace, ManagedResourceName, false, data)
+	return managedresources.CreateForShoot(ctx, c.client, c.namespace, ManagedResourceName, managedresources.LabelValueGardener, false, data)
 }
 
 func (c *coreDNS) Destroy(ctx context.Context) error {

--- a/pkg/operation/botanist/component/gardeneraccess/access.go
+++ b/pkg/operation/botanist/component/gardeneraccess/access.go
@@ -106,7 +106,7 @@ func (g *gardener) Deploy(ctx context.Context) error {
 		return err
 	}
 
-	return managedresources.CreateForShoot(ctx, g.client, g.namespace, managedResourceName, true, data)
+	return managedresources.CreateForShoot(ctx, g.client, g.namespace, managedResourceName, managedresources.LabelValueGardener, true, data)
 }
 
 func (g *gardener) Destroy(ctx context.Context) error {

--- a/pkg/operation/botanist/component/kubeapiserver/kube_apiserver.go
+++ b/pkg/operation/botanist/component/kubeapiserver/kube_apiserver.go
@@ -477,7 +477,7 @@ func (k *kubeAPIServer) Deploy(ctx context.Context) error {
 		return err
 	}
 
-	return managedresources.CreateForShoot(ctx, k.client.Client(), k.namespace, ManagedResourceName, false, data)
+	return managedresources.CreateForShoot(ctx, k.client.Client(), k.namespace, ManagedResourceName, managedresources.LabelValueGardener, false, data)
 }
 
 func (k *kubeAPIServer) Destroy(ctx context.Context) error {

--- a/pkg/operation/botanist/component/kubecontrollermanager/shoot_resources.go
+++ b/pkg/operation/botanist/component/kubecontrollermanager/shoot_resources.go
@@ -50,5 +50,5 @@ func (k *kubeControllerManager) reconcileShootResources(ctx context.Context, ser
 		return err
 	}
 
-	return managedresources.CreateForShoot(ctx, k.seedClient.Client(), k.namespace, managedResourceName, true, data)
+	return managedresources.CreateForShoot(ctx, k.seedClient.Client(), k.namespace, managedResourceName, managedresources.LabelValueGardener, true, data)
 }

--- a/pkg/operation/botanist/component/kubeproxy/kube_proxy.go
+++ b/pkg/operation/botanist/component/kubeproxy/kube_proxy.go
@@ -140,7 +140,7 @@ func (k *kubeProxy) reconcileManagedResource(ctx context.Context, data map[strin
 	var (
 		mrName             = managedResourceName(pool)
 		secretName, secret = managedresources.NewSecret(k.client, k.namespace, mrName, data, true)
-		managedResource    = managedresources.NewForShoot(k.client, k.namespace, mrName, false).WithSecretRef(secretName)
+		managedResource    = managedresources.NewForShoot(k.client, k.namespace, mrName, managedresources.LabelValueGardener, false).WithSecretRef(secretName)
 	)
 
 	secret = secret.WithLabels(getManagedResourceLabels(pool))

--- a/pkg/operation/botanist/component/kubescheduler/kube_scheduler.go
+++ b/pkg/operation/botanist/component/kubescheduler/kube_scheduler.go
@@ -480,7 +480,7 @@ func (k *kubeScheduler) reconcileShootResources(ctx context.Context, serviceAcco
 		return err
 	}
 
-	return managedresources.CreateForShoot(ctx, k.client, k.namespace, managedResourceName, false, data)
+	return managedresources.CreateForShoot(ctx, k.client, k.namespace, managedResourceName, managedresources.LabelValueGardener, false, data)
 }
 
 func (k *kubeScheduler) computeEnvironmentVariables() []corev1.EnvVar {

--- a/pkg/operation/botanist/component/logging/eventlogger/event_logger.go
+++ b/pkg/operation/botanist/component/logging/eventlogger/event_logger.go
@@ -202,7 +202,7 @@ func (l *eventLogger) reconcileRBACForShoot(ctx context.Context) error {
 		return err
 	}
 
-	return managedresources.CreateForShoot(ctx, l.client, l.namespace, managedResourceName, false, resources)
+	return managedresources.CreateForShoot(ctx, l.client, l.namespace, managedResourceName, managedresources.LabelValueGardener, false, resources)
 }
 
 func (l *eventLogger) reconcileRBACForSeed(ctx context.Context) error {

--- a/pkg/operation/botanist/component/logging/kuberbacproxy/kube_rbac_proxy.go
+++ b/pkg/operation/botanist/component/logging/kuberbacproxy/kube_rbac_proxy.go
@@ -154,7 +154,7 @@ func (k *kubeRBACProxy) Deploy(ctx context.Context) error {
 		return err
 	}
 
-	return managedresources.CreateForShoot(ctx, k.client, k.namespace, managedResourceName, false, resources)
+	return managedresources.CreateForShoot(ctx, k.client, k.namespace, managedResourceName, managedresources.LabelValueGardener, false, resources)
 }
 
 func (k *kubeRBACProxy) Destroy(ctx context.Context) error {

--- a/pkg/operation/botanist/component/metricsserver/metrics_server.go
+++ b/pkg/operation/botanist/component/metricsserver/metrics_server.go
@@ -118,7 +118,7 @@ func (m *metricsServer) Deploy(ctx context.Context) error {
 		return err
 	}
 
-	return managedresources.CreateForShoot(ctx, m.client, m.namespace, managedResourceName, false, data)
+	return managedresources.CreateForShoot(ctx, m.client, m.namespace, managedResourceName, managedresources.LabelValueGardener, false, data)
 }
 
 func (m *metricsServer) Destroy(ctx context.Context) error {

--- a/pkg/operation/botanist/component/namespaces/namespaces.go
+++ b/pkg/operation/botanist/component/namespaces/namespaces.go
@@ -60,7 +60,7 @@ func (n *namespaces) Deploy(ctx context.Context) error {
 		return err
 	}
 
-	return managedresources.CreateForShoot(ctx, n.client, n.namespace, managedResourceName, true, data)
+	return managedresources.CreateForShoot(ctx, n.client, n.namespace, managedResourceName, managedresources.LabelValueGardener, true, data)
 }
 
 func (n *namespaces) Destroy(ctx context.Context) error {

--- a/pkg/operation/botanist/component/nodelocaldns/nodelocaldns.go
+++ b/pkg/operation/botanist/component/nodelocaldns/nodelocaldns.go
@@ -117,7 +117,7 @@ func (c *nodeLocalDNS) Deploy(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	return managedresources.CreateForShoot(ctx, c.client, c.namespace, ManagedResourceName, false, data)
+	return managedresources.CreateForShoot(ctx, c.client, c.namespace, ManagedResourceName, managedresources.LabelValueGardener, false, data)
 }
 
 func (c *nodeLocalDNS) Destroy(ctx context.Context) error {

--- a/pkg/operation/botanist/component/nodeproblemdetector/node_problem_detector.go
+++ b/pkg/operation/botanist/component/nodeproblemdetector/node_problem_detector.go
@@ -96,7 +96,7 @@ func (c *nodeProblemDetector) Deploy(ctx context.Context) error {
 		return err
 	}
 
-	return managedresources.CreateForShoot(ctx, c.client, c.namespace, ManagedResourceName, false, data)
+	return managedresources.CreateForShoot(ctx, c.client, c.namespace, ManagedResourceName, managedresources.LabelValueGardener, false, data)
 }
 
 func (c *nodeProblemDetector) Destroy(ctx context.Context) error {

--- a/pkg/operation/botanist/component/resourceconfig.go
+++ b/pkg/operation/botanist/component/resourceconfig.go
@@ -140,7 +140,7 @@ func DeployResourceConfigs(
 		}
 	}
 
-	return managedresources.CreateForShoot(ctx, c, namespace, managedResourceName, false, registry.SerializedObjects())
+	return managedresources.CreateForShoot(ctx, c, namespace, managedResourceName, managedresources.LabelValueGardener, false, registry.SerializedObjects())
 }
 
 // DestroyResourceConfigs destroys the provided ResourceConfigs <allResources> based on the ClusterType.

--- a/pkg/operation/botanist/component/resourcemanager/resource_manager.go
+++ b/pkg/operation/botanist/component/resourcemanager/resource_manager.go
@@ -1119,7 +1119,7 @@ func (r *resourceManager) ensureShootResources(ctx context.Context) error {
 		return err
 	}
 
-	return managedresources.CreateForShoot(ctx, r.client, r.namespace, ManagedResourceName, false, data)
+	return managedresources.CreateForShoot(ctx, r.client, r.namespace, ManagedResourceName, managedresources.LabelValueGardener, false, data)
 }
 
 func (r *resourceManager) ensureNetworkPolicy(ctx context.Context) error {

--- a/pkg/operation/botanist/component/shootsystem/shootsystem.go
+++ b/pkg/operation/botanist/component/shootsystem/shootsystem.go
@@ -71,7 +71,7 @@ func (s *shootSystem) Deploy(ctx context.Context) error {
 		return err
 	}
 
-	return managedresources.CreateForShoot(ctx, s.client, s.namespace, ManagedResourceName, false, data)
+	return managedresources.CreateForShoot(ctx, s.client, s.namespace, ManagedResourceName, managedresources.LabelValueGardener, false, data)
 }
 
 func (s *shootSystem) Destroy(ctx context.Context) error {

--- a/pkg/operation/botanist/component/vpnshoot/vpnshoot.go
+++ b/pkg/operation/botanist/component/vpnshoot/vpnshoot.go
@@ -226,7 +226,7 @@ func (v *vpnShoot) Deploy(ctx context.Context) error {
 		return err
 	}
 
-	return managedresources.CreateForShoot(ctx, v.client, v.namespace, managedResourceName, false, data)
+	return managedresources.CreateForShoot(ctx, v.client, v.namespace, managedResourceName, managedresources.LabelValueGardener, false, data)
 }
 
 func (v *vpnShoot) Destroy(ctx context.Context) error {

--- a/pkg/operation/botanist/operatingsystemconfig.go
+++ b/pkg/operation/botanist/operatingsystemconfig.go
@@ -152,7 +152,7 @@ var (
 // 2. A secret containing some shared RBAC policies for downloading the cloud config execution script
 func (b *Botanist) DeployManagedResourceForCloudConfigExecutor(ctx context.Context) error {
 	var (
-		managedResource                  = managedresources.NewForShoot(b.SeedClientSet.Client(), b.Shoot.SeedNamespace, CloudConfigExecutionManagedResourceName, false)
+		managedResource                  = managedresources.NewForShoot(b.SeedClientSet.Client(), b.Shoot.SeedNamespace, CloudConfigExecutionManagedResourceName, managedresources.LabelValueGardener, false)
 		managedResourceSecretsCount      = len(b.Shoot.GetInfo().Spec.Provider.Workers) + 1
 		managedResourceSecretLabels      = map[string]string{SecretLabelKeyManagedResource: CloudConfigExecutionManagedResourceName}
 		managedResourceSecretNamesWanted = sets.NewString()

--- a/pkg/utils/managedresources/managedresources_test.go
+++ b/pkg/utils/managedresources/managedresources_test.go
@@ -78,7 +78,7 @@ var _ = Describe("managedresources", func() {
 				c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&corev1.Secret{})).Return(fakeErr),
 			)
 
-			Expect(CreateForShoot(ctx, c, namespace, name, keepObjects, data)).To(MatchError(fakeErr))
+			Expect(CreateForShoot(ctx, c, namespace, name, LabelValueGardener, keepObjects, data)).To(MatchError(fakeErr))
 		})
 
 		It("should return the error of the managed resource reconciliation", func() {
@@ -89,7 +89,7 @@ var _ = Describe("managedresources", func() {
 				c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})).Return(fakeErr),
 			)
 
-			Expect(CreateForShoot(ctx, c, namespace, name, keepObjects, data)).To(MatchError(fakeErr))
+			Expect(CreateForShoot(ctx, c, namespace, name, LabelValueGardener, keepObjects, data)).To(MatchError(fakeErr))
 		})
 
 		It("should successfully create secret and managed resource", func() {
@@ -118,7 +118,7 @@ var _ = Describe("managedresources", func() {
 				}),
 			)
 
-			Expect(CreateForShoot(ctx, c, namespace, name, keepObjects, data)).To(Succeed())
+			Expect(CreateForShoot(ctx, c, namespace, name, LabelValueGardener, keepObjects, data)).To(Succeed())
 		})
 	})
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind bug

**What this PR does / why we need it**:
This PR changes the signatures of `CreateForShoot` and `NewForShoot` functions and adds an additional `origin` parameter. If an extension controller deploys a `managedresource` via these functions then Gardener acts on it (because it being labeled with `origin=gardener`) which is unwanted and implicit behavior. This PR tries to prevent side effects that may be caused by the usage of these functions in external components.

I also got some insights on this issue from @ialidzhikov in a private discussion.
@ialidzhikov feel free to review and give any additional feedback! 

**Which issue(s) this PR fixes**:
Fixes #7141

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking developer
Functions CreateForShoot() and NewForShoot() in `pkg/utils/managedresources` had their signatures changed. They both now accept an additional parameter called `origin`. Gardener acts on resources with "origin=gardener" label. External callers of these functions should provide their own unique origin value when creating `managedresources` in order to prevent unwanted actions on these resources.
```
