### PR TITLE
Parameterize `hack/kind-up.sh`

### DIFF
--- a/hack/kind-up.sh
+++ b/hack/kind-up.sh
@@ -9,10 +9,14 @@ PATH_CLUSTER_VALUES=""
 PATH_KUBECONFIG=""
 ENVIRONMENT="skaffold"
 DEPLOY_REGISTRY=true
+CHART=$(dirname "$0")/../example/gardener-local/kind/cluster
 
 parse_flags() {
   while test $# -gt 0; do
     case "$1" in
+    --chart)
+      shift; CHART="$1"
+      ;;
     --cluster-name)
       shift; CLUSTER_NAME="$1"
       ;;
@@ -42,7 +46,7 @@ mkdir -m 0755 -p \
 
 kind create cluster \
   --name "$CLUSTER_NAME" \
-  --config <(helm template $(dirname "$0")/../example/gardener-local/kind/cluster --values "$PATH_CLUSTER_VALUES" --set "environment=$ENVIRONMENT")
+  --config <(helm template $CHART --values "$PATH_CLUSTER_VALUES" --set "environment=$ENVIRONMENT")
 
 # workaround https://kind.sigs.k8s.io/docs/user/known-issues/#pod-errors-due-to-too-many-open-files
 kubectl get nodes -o name |\


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
Parameterize the chart passed to `hack/kind-up.sh` such that the script can be used by extensions. This is necessary because vendored g/g does not include the `example` subtree. Access to that content means it must be duplicated into the tree of an extension that needs to use it, so it is no longer on a relative parent path to the `hack` directory.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
