### PR TITLE
HA config webhook extends node selector requirements instead of node selector terms

### DIFF
--- a/pkg/utils/kubernetes/highavailability.go
+++ b/pkg/utils/kubernetes/highavailability.go
@@ -38,20 +38,21 @@ func GetReplicaCount(failureToleranceType *gardencorev1beta1.FailureToleranceTyp
 	return pointer.Int32(2)
 }
 
-// GetNodeAffinitySelectorTermsForZones adds a node affinity to ensure all pods are scheduled only on nodes in the provided zones. If
-// no zones are provided then nothing is done.
-func GetNodeAffinitySelectorTermsForZones(failureToleranceType *gardencorev1beta1.FailureToleranceType, zones []string) []corev1.NodeSelectorTerm {
+// GetNodeSelectorRequirementForZones returns a node selector requirement to ensure all pods are scheduled only on
+// nodes in the provided zones. If no zones are provided then nothing is done.
+// Note that the returned requirement should be added to all existing node selector terms in the
+// spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms field of pods because
+// the various node selector terms are evaluated with the OR operator.
+func GetNodeSelectorRequirementForZones(failureToleranceType *gardencorev1beta1.FailureToleranceType, zones []string) *corev1.NodeSelectorRequirement {
 	if len(zones) == 0 || failureToleranceType == nil {
 		return nil
 	}
 
-	return []corev1.NodeSelectorTerm{{
-		MatchExpressions: []corev1.NodeSelectorRequirement{{
-			Key:      corev1.LabelTopologyZone,
-			Operator: corev1.NodeSelectorOpIn,
-			Values:   zones,
-		}},
-	}}
+	return &corev1.NodeSelectorRequirement{
+		Key:      corev1.LabelTopologyZone,
+		Operator: corev1.NodeSelectorOpIn,
+		Values:   zones,
+	}
 }
 
 // GetTopologySpreadConstraints adds topology spread constraints based on the passed `failureToleranceType`. This is

--- a/pkg/utils/kubernetes/highavailability_test.go
+++ b/pkg/utils/kubernetes/highavailability_test.go
@@ -43,14 +43,14 @@ var _ = Describe("HighAvailability", func() {
 
 	zones := []string{"a", "b", "c"}
 
-	DescribeTable("#GetNodeAffinitySelectorTermsForZones",
+	DescribeTable("#GetNodeSelectorRequirementForZones",
 		func(failureToleranceType *gardencorev1beta1.FailureToleranceType, zones []string, matcher gomegatypes.GomegaMatcher) {
-			Expect(GetNodeAffinitySelectorTermsForZones(failureToleranceType, zones)).To(matcher)
+			Expect(GetNodeSelectorRequirementForZones(failureToleranceType, zones)).To(matcher)
 		},
 
 		Entry("no zones", nil, nil, BeNil()),
 		Entry("no failure-tolerance-type", nil, zones, BeNil()),
-		Entry("zones and failure-tolerance-type set", failureToleranceTypePtr(""), zones, ConsistOf(corev1.NodeSelectorTerm{MatchExpressions: []corev1.NodeSelectorRequirement{{Key: corev1.LabelTopologyZone, Operator: corev1.NodeSelectorOpIn, Values: zones}}})),
+		Entry("zones and failure-tolerance-type set", failureToleranceTypePtr(""), zones, Equal(&corev1.NodeSelectorRequirement{Key: corev1.LabelTopologyZone, Operator: corev1.NodeSelectorOpIn, Values: zones})),
 	)
 
 	labelSelector := metav1.LabelSelector{MatchLabels: map[string]string{"foo": "bar"}}

--- a/test/integration/resourcemanager/highavailabilityconfig/highavailabilityconfig_test.go
+++ b/test/integration/resourcemanager/highavailabilityconfig/highavailabilityconfig_test.go
@@ -408,6 +408,13 @@ var _ = Describe("HighAvailabilityConfig tests", func() {
 														Values:   []string{"some", "other", "zones"},
 													}},
 												},
+												{
+													MatchExpressions: []corev1.NodeSelectorRequirement{{
+														Key:      "foo",
+														Operator: corev1.NodeSelectorOpNotIn,
+														Values:   []string{"bar"},
+													}},
+												},
 											},
 										},
 									},
@@ -421,17 +428,31 @@ var _ = Describe("HighAvailabilityConfig tests", func() {
 									RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
 										NodeSelectorTerms: []corev1.NodeSelectorTerm{
 											{
-												MatchExpressions: []corev1.NodeSelectorRequirement{{
-													Key:      corev1.LabelHostname,
-													Operator: corev1.NodeSelectorOpExists,
-												}},
+												MatchExpressions: []corev1.NodeSelectorRequirement{
+													{
+														Key:      corev1.LabelHostname,
+														Operator: corev1.NodeSelectorOpExists,
+													},
+													{
+														Key:      corev1.LabelTopologyZone,
+														Operator: corev1.NodeSelectorOpIn,
+														Values:   zones,
+													},
+												},
 											},
 											{
-												MatchExpressions: []corev1.NodeSelectorRequirement{{
-													Key:      corev1.LabelTopologyZone,
-													Operator: corev1.NodeSelectorOpIn,
-													Values:   zones,
-												}},
+												MatchExpressions: []corev1.NodeSelectorRequirement{
+													{
+														Key:      "foo",
+														Operator: corev1.NodeSelectorOpNotIn,
+														Values:   []string{"bar"},
+													},
+													{
+														Key:      corev1.LabelTopologyZone,
+														Operator: corev1.NodeSelectorOpIn,
+														Values:   zones,
+													},
+												},
 											},
 										},
 									},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind bug

**What this PR does / why we need it**:



**Which issue(s) this PR fixes**:
Introduced with #6967, the HA config webhook part of `gardener-resource-manager` can perform zone-pinning by injecting a node affinity. Earlier, its result for a `Pod` which already had an existing node affinity looked like this:

```yaml
spec:
  affinity:
    nodeAffinity:
      requiredDuringSchedulingIgnoredDuringExecution:
        nodeSelectorTerms:
        - matchExpressions:
          - key: foo
            operator: In
            values:
            - bar
        - matchExpressions:
          - key: topology.kubernetes.io/zone
            operator: In
            values:
            - europe-1a
```

However, the `nodeSelectorTerms` are evaluated with the `OR`-operator. As a result, the pods might only respect one of the constraints.

With this PR, the result of the webhook will look like this:

```yaml
spec:
  affinity:
    nodeAffinity:
      requiredDuringSchedulingIgnoredDuringExecution:
        nodeSelectorTerms:
        - matchExpressions:
          - key: foo
            operator: In
            values:
            - bar
          - key: topology.kubernetes.io/zone
            operator: In
            values:
            - europe-1a
```

Also, if there are multiple already existing node selector terms then second node selector requirement for the zone-pinning is injected into each of them to ensure it is always respected.

**Special notes for your reviewer**:
/cc @ialidzhikov 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
The `HighAvailabilityConfig` webhook part of `gardener-resource-manager` now ensures that the zone-pinning affinity is always respected.
```
