### PR TITLE
Remove legacy VPN solution

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -94,10 +94,6 @@ images:
   repository: eu.gcr.io/gardener-project/gardener/autoscaler/cluster-autoscaler
   tag: "v1.20.3"
   targetVersion: "< 1.21"
-- name: vpn-seed
-  sourceRepository: github.com/gardener/vpn
-  repository: eu.gcr.io/gardener-project/gardener/vpn-seed
-  tag: "0.20.0"
 - name: vpn-seed-server
   sourceRepository: github.com/gardener/vpn2
   repository: eu.gcr.io/gardener-project/gardener/vpn-seed-server
@@ -138,10 +134,6 @@ images:
   tag: v0.6.2
 
 # Shoot core addons
-- name: vpn-shoot
-  sourceRepository: github.com/gardener/vpn
-  repository: eu.gcr.io/gardener-project/gardener/vpn-shoot
-  tag: "0.20.0"
 - name: vpn-shoot-client
   sourceRepository: github.com/gardener/vpn2
   repository: eu.gcr.io/gardener-project/gardener/vpn-shoot-client

--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -198,10 +198,6 @@ images:
 - name: alpine
   repository: alpine
   tag: "3.15.4"
-- name: alpine-iptables
-  sourceRepository: github.com/gardener/alpine-iptables
-  repository: eu.gcr.io/gardener-project/gardener/alpine-iptables
-  tag: "3.16.3"
 
 # Logging
 - name: fluent-bit

--- a/charts/seed-monitoring/charts/core/charts/prometheus/templates/prometheus.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/templates/prometheus.yaml
@@ -59,9 +59,6 @@ spec:
         role: monitoring
         networking.gardener.cloud/to-dns: allowed
         networking.gardener.cloud/to-public-networks: allowed
-{{- if not .Values.reversedVPN.enabled }}
-        networking.gardener.cloud/to-shoot-networks: allowed
-{{- end }}
         networking.gardener.cloud/to-shoot-apiserver: allowed
         networking.gardener.cloud/to-seed-apiserver: allowed
     spec:

--- a/charts/seed-monitoring/charts/core/charts/prometheus/values.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/values.yaml
@@ -24,9 +24,6 @@ secretNameClusterCA: ca
 secretNameEtcdCA: ca-etcd
 secretNameEtcdClientCert: etcd-client-tls
 
-reversedVPN:
-  enabled: false
-
 namespace:
   uid: 100c3bb5-48b9-4f88-96ef-48ed557d4212
 

--- a/cmd/gardenlet/app/app.go
+++ b/cmd/gardenlet/app/app.go
@@ -57,7 +57,6 @@ import (
 	clientmapbuilder "github.com/gardener/gardener/pkg/client/kubernetes/clientmap/builder"
 	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/controllerutils/routes"
-	"github.com/gardener/gardener/pkg/features"
 	"github.com/gardener/gardener/pkg/gardenlet/apis/config"
 	confighelper "github.com/gardener/gardener/pkg/gardenlet/apis/config/helper"
 	"github.com/gardener/gardener/pkg/gardenlet/bootstrap"
@@ -129,11 +128,6 @@ func run(ctx context.Context, cancel context.CancelFunc, log logr.Logger, cfg *c
 		return err
 	}
 	log.Info("Feature Gates", "featureGates", gardenletfeatures.FeatureGate.String())
-
-	if gardenletfeatures.FeatureGate.Enabled(features.ReversedVPN) && !gardenletfeatures.FeatureGate.Enabled(features.APIServerSNI) {
-		return fmt.Errorf("inconsistent feature gate: APIServerSNI is required for ReversedVPN (APIServerSNI: %t, ReversedVPN: %t)",
-			gardenletfeatures.FeatureGate.Enabled(features.APIServerSNI), gardenletfeatures.FeatureGate.Enabled(features.ReversedVPN))
-	}
 
 	if kubeconfig := os.Getenv("GARDEN_KUBECONFIG"); kubeconfig != "" {
 		cfg.GardenClientConnection.Kubeconfig = kubeconfig

--- a/docs/deployment/feature_gates.md
+++ b/docs/deployment/feature_gates.md
@@ -107,8 +107,8 @@ The following tables are a summary of the feature gates that you can set on diff
 | ShootSARotation                              | `true`  | `GA`         | `1.57` | `1.59` |
 | ShootSARotation                              |         | `Removed`    | `1.60` |        |
 | ReversedVPN                                  | `false` | `Alpha`      | `1.22` | `1.41` |
-| ReversedVPN                                  | `true`  | `Beta`       | `1.42` | `1.61` |
-| ReversedVPN                                  | `true`  | `GA`         | `1.61` |        |
+| ReversedVPN                                  | `true`  | `Beta`       | `1.42` | `1.62` |
+| ReversedVPN                                  | `true`  | `GA`         | `1.63` |        |
 
 ## Using a feature
 

--- a/docs/deployment/feature_gates.md
+++ b/docs/deployment/feature_gates.md
@@ -30,8 +30,6 @@ The following tables are a summary of the feature gates that you can set on diff
 | APIServerSNI (deprecated)                    | `true`  | `Beta`  | `1.48` |        |
 | SeedChange                                   | `false` | `Alpha` | `1.12` | `1.52` |
 | SeedChange                                   | `true`  | `Beta`  | `1.53` |        |
-| ReversedVPN                                  | `false` | `Alpha` | `1.22` | `1.41` |
-| ReversedVPN                                  | `true`  | `Beta`  | `1.42` |        |
 | CopyEtcdBackupsDuringControlPlaneMigration   | `false` | `Alpha` | `1.37` | `1.52` |
 | CopyEtcdBackupsDuringControlPlaneMigration   | `true`  | `Beta`  | `1.53` |        |
 | ForceRestore                                 | `false` | `Alpha` | `1.39` |        |
@@ -108,6 +106,9 @@ The following tables are a summary of the feature gates that you can set on diff
 | ShootSARotation                              | `true`  | `Beta`       | `1.51` | `1.56` |
 | ShootSARotation                              | `true`  | `GA`         | `1.57` | `1.59` |
 | ShootSARotation                              |         | `Removed`    | `1.60` |        |
+| ReversedVPN                                  | `false` | `Alpha`      | `1.22` | `1.41` |
+| ReversedVPN                                  | `true`  | `Beta`       | `1.42` | `1.61` |
+| ReversedVPN                                  | `true`  | `Deprecated` | `1.61` |        |
 
 ## Using a feature
 

--- a/docs/deployment/feature_gates.md
+++ b/docs/deployment/feature_gates.md
@@ -108,7 +108,7 @@ The following tables are a summary of the feature gates that you can set on diff
 | ShootSARotation                              |         | `Removed`    | `1.60` |        |
 | ReversedVPN                                  | `false` | `Alpha`      | `1.22` | `1.41` |
 | ReversedVPN                                  | `true`  | `Beta`       | `1.42` | `1.61` |
-| ReversedVPN                                  | `true`  | `Deprecated` | `1.61` |        |
+| ReversedVPN                                  | `true`  | `GA`         | `1.61` |        |
 
 ## Using a feature
 

--- a/docs/development/local_setup.md
+++ b/docs/development/local_setup.md
@@ -260,7 +260,7 @@ If your remote Garden cluster is a Gardener shoot, and you can access the seed o
 hack/local-development/remote-garden/enable-seed-authorizer <seed kubeconfig> <namespace>
 ```
 
-> Note: This script is not working anymore, as the `ReversedVPN` feature can't be disabled. The annotation `alpha.featuregates.shoot.gardener.cloud/reversed-vpn` on `Shoot`s is no longer respected .
+> Note: This script is not working anymore, as the `ReversedVPN` feature can't be disabled. The annotation `alpha.featuregates.shoot.gardener.cloud/reversed-vpn` on `Shoot`s is no longer respected.
 
 To prevent Gardener from reconciling the shoot and overwriting your changes, add the annotation `shoot.gardener.cloud/ignore: 'true'` to the remote Garden shoot. Note that this annotation takes effect only if it is enabled via the `constollers.shoot.respectSyncPeriodOverwrite: true` option in the `gardenlet` configuration.
 

--- a/docs/development/local_setup.md
+++ b/docs/development/local_setup.md
@@ -260,7 +260,7 @@ If your remote Garden cluster is a Gardener shoot, and you can access the seed o
 hack/local-development/remote-garden/enable-seed-authorizer <seed kubeconfig> <namespace>
 ```
 
-> Note: The configuration changes introduced by this script result in a working `SeedAuthorization` feature only on shoots for which the `ReversedVPN` feature is not enabled. If the corresponding feature gate is enabled in `gardenlet`, add the annotation `alpha.featuregates.shoot.gardener.cloud/reversed-vpn: 'false'` to the remote Garden shoot to disable it for that particular shoot.
+> Note: This script is not working anymore, as the `ReversedVPN` feature can't be disabled. The annotation `alpha.featuregates.shoot.gardener.cloud/reversed-vpn` on `Shoot`s is no longer respected .
 
 To prevent Gardener from reconciling the shoot and overwriting your changes, add the annotation `shoot.gardener.cloud/ignore: 'true'` to the remote Garden shoot. Note that this annotation takes effect only if it is enabled via the `constollers.shoot.respectSyncPeriodOverwrite: true` option in the `gardenlet` configuration.
 

--- a/docs/extensions/provider-local.md
+++ b/docs/extensions/provider-local.md
@@ -26,14 +26,6 @@ Please note that all of them are no technical limitations/blockers but simply ad
 
    _In order to realize DNS (see [Implementation Details](#implementation-details) section below), the `/etc/hosts` file is manipulated. This does not work for TXT records. In the future, we could look into using [CoreDNS](https://coredns.io/) instead._
 
-3. No load balancers for Shoot clusters.
-
-   _We have not yet developed a `cloud-controller-manager` which could reconcile load balancer `Service`s in the shoot cluster. Hence, when the gardenlet's `ReversedVPN` feature gate is disabled then the `kube-system/vpn-shoot` `Service` must be manually patched (with `{"status": {"loadBalancer": {"ingress": [{"hostname": "vpn-shoot"}]}}}`) to make the reconciliation work._
-
-4. Only one shoot cluster possible when gardenlet's `APIServerSNI` feature gate is disabled.
-
-   _When [`APIServerSNI`](../proposals/08-shoot-apiserver-via-sni.md) is disabled then gardenlet uses load balancer `Service`s in order to expose the shoot clusters' `kube-apiserver`s. Typically, local Kubernetes clusters don't support this. In this case, the local extension uses the host IP to expose the `kube-apiserver`, however, this can only be done once._\
-   _However, given that the `APIServerSNI` feature gate is deprecated and will be removed in the future (see [gardener/gardener#6007](https://github.com/gardener/gardener/pull/6007)), we will probably not invest into this._
 
 5. In case a seed cluster with multiple availability zones, i.e. multiple entries in `.spec.provider.zones`, is used in conjunction with a single-zone shoot control plane, i.e. a shoot cluster without `.spec.controlPlane.highAvailability` or with `.spec.controlPlane.highAvailability.failureTolerance.type` set to `node`, the local address of the API server endpoint needs to be determined manually or via the in cluster `coredns`.
 
@@ -113,9 +105,6 @@ data:
 #### `Infrastructure`
 
 This controller generates a `NetworkPolicy` which allows the control plane pods (like `kube-apiserver`) to communicate with the worker machine pods (see [`Worker` section](#worker))).
-
-In addition, it creates a `Service` named `vpn-shoot` which is only used in case the gardenlet's `ReversedVPN` feature gate is disabled.
-This `Service` enables the `vpn-seed` containers in the `kube-apiserver` pods in the seed cluster to communicate with the `vpn-shoot` pod running in the shoot cluster.
 
 #### `Network`
 

--- a/docs/extensions/provider-local.md
+++ b/docs/extensions/provider-local.md
@@ -26,6 +26,9 @@ Please note that all of them are no technical limitations/blockers but simply ad
 
    _In order to realize DNS (see [Implementation Details](#implementation-details) section below), the `/etc/hosts` file is manipulated. This does not work for TXT records. In the future, we could look into using [CoreDNS](https://coredns.io/) instead._
 
+3. No load balancers for Shoot clusters.
+
+   _We have not yet developed a `cloud-controller-manager` which could reconcile load balancer `Service`s in the shoot cluster.
 
 5. In case a seed cluster with multiple availability zones, i.e. multiple entries in `.spec.provider.zones`, is used in conjunction with a single-zone shoot control plane, i.e. a shoot cluster without `.spec.controlPlane.highAvailability` or with `.spec.controlPlane.highAvailability.failureTolerance.type` set to `node`, the local address of the API server endpoint needs to be determined manually or via the in cluster `coredns`.
 

--- a/docs/proposals/14-reversed-cluster-vpn.md
+++ b/docs/proposals/14-reversed-cluster-vpn.md
@@ -152,6 +152,8 @@ The OpenVPN client- and server pods are singleton pods in this approach and ther
 
 We have introduced a gardenlet feature gate `ReversedVPN`. If `APIServerSNI` and `ReversedVPN` are enabled the proposed solution is automatically enabled for all shoot clusters hosted by the seed. If `ReversedVPN` is enabled but `APIServerSNI` is not the gardenlet will panic during startup as this is an invalid configuration. All existing shoot clusters will automatically be migrated during the next reconciliation. We assume that the `ReversedVPN` feature will work with Gardener as well as operator managed Istio.
 
+We have also added a shoot annotation `alpha.featuregates.shoot.gardener.cloud/reversed-vpn` which can override the feature gate to enable or disable the solution for individual clusters. This is only respected if `APIServerSNI` is enabled, otherwise it is ignored.
+
 ### Security Review
 
 The change in the VPN solution will potentially open up new attack vectors. We will perform a thorough analysis outside of this document.

--- a/docs/proposals/14-reversed-cluster-vpn.md
+++ b/docs/proposals/14-reversed-cluster-vpn.md
@@ -152,8 +152,6 @@ The OpenVPN client- and server pods are singleton pods in this approach and ther
 
 We have introduced a gardenlet feature gate `ReversedVPN`. If `APIServerSNI` and `ReversedVPN` are enabled the proposed solution is automatically enabled for all shoot clusters hosted by the seed. If `ReversedVPN` is enabled but `APIServerSNI` is not the gardenlet will panic during startup as this is an invalid configuration. All existing shoot clusters will automatically be migrated during the next reconciliation. We assume that the `ReversedVPN` feature will work with Gardener as well as operator managed Istio.
 
-We have also added a shoot annotation `alpha.featuregates.shoot.gardener.cloud/reversed-vpn` which can override the feature gate to enable or disable the solution for individual clusters. This is only respected if `APIServerSNI` is enabled, otherwise it is ignored.
-
 ### Security Review
 
 The change in the VPN solution will potentially open up new attack vectors. We will perform a thorough analysis outside of this document.

--- a/docs/proposals/18-shoot-CA-rotation.md
+++ b/docs/proposals/18-shoot-CA-rotation.md
@@ -42,6 +42,7 @@ Out of scope for now:
 - `kubelet` serving CA is self-generated (valid for `1y`) and self-signed by `kubelet` on startup
   - `kube-apiserver` does not seem to verify the presented serving certificate
   - `kubelet` can be configured to request serving certificate via CSR that can be verified by `kube-apiserver`, though, we consider this as a separate improvement outside of this GEP
+- Legacy VPN solution uses the cluster CA for both serving and client certificates. As the solution is soon to be dropped in favor of the new `ReversedVPN` solution, we don't intend to introduce a dedicated CA for this component. If `ReversedVPN` is disabled and the CA rotation is triggered, we make sure to propagate the cluster CA to the relevant places in the legacy VPN solution.
 
 Naturally, not all certificates used for communication with the `kube-apiserver` are under control of Gardener. An example for a Gardener-controlled certificate is the kubelet client certificate used to communicate with the api server. An example for credentials not controlled by gardener are kubeconfigs or client certificates requested via `CertificateSigningRequest`s by the shoot owner.
 

--- a/docs/proposals/18-shoot-CA-rotation.md
+++ b/docs/proposals/18-shoot-CA-rotation.md
@@ -42,7 +42,6 @@ Out of scope for now:
 - `kubelet` serving CA is self-generated (valid for `1y`) and self-signed by `kubelet` on startup
   - `kube-apiserver` does not seem to verify the presented serving certificate
   - `kubelet` can be configured to request serving certificate via CSR that can be verified by `kube-apiserver`, though, we consider this as a separate improvement outside of this GEP
-- Legacy VPN solution uses the cluster CA for both serving and client certificates. As the solution is soon to be dropped in favor of the new `ReversedVPN` solution, we don't intend to introduce a dedicated CA for this component. If `ReversedVPN` is disabled and the CA rotation is triggered, we make sure to propagate the cluster CA to the relevant places in the legacy VPN solution.
 
 Naturally, not all certificates used for communication with the `kube-apiserver` are under control of Gardener. An example for a Gardener-controlled certificate is the kubelet client certificate used to communicate with the api server. An example for credentials not controlled by gardener are kubeconfigs or client certificates requested via `CertificateSigningRequest`s by the shoot owner.
 

--- a/docs/usage/reversed-vpn-tunnel.md
+++ b/docs/usage/reversed-vpn-tunnel.md
@@ -5,7 +5,8 @@ title: Reversed VPN Tunnel
 # Reversed VPN Tunnel Setup and Configuration 
 
 The Reversed VPN Tunnel is enabled by default.
-A high availability VPN connection is automatically deployed in all shoots that configure an HA control-plane.
+A highly available VPN connection is automatically deployed in all shoots that configure an HA control-plane.
+
 ## Reversed VPN Tunnel
 
 In the first VPN solution, connection establishment was initiated by a VPN client in the seed cluster.
@@ -19,7 +20,7 @@ Connection establishment with a reversed tunnel:
 `APIServer --> Envoy-Proxy | VPN-Seed-Server <-- Istio/Envoy-Proxy <-- SNI API Server Endpoint <-- LB (one for all clusters of a seed) <--- internet <--- VPN-Shoot-Client --> Pods | Nodes | Services`
 
 The reversed VPN tunnel is always deployed.
-The feature gate `ReversedVPN` is GA and will be removed in a future release
+The feature gate `ReversedVPN` is GA and will be removed in a future release.
 
 ## High Availability for Reversed VPN Tunnel
 

--- a/docs/usage/reversed-vpn-tunnel.md
+++ b/docs/usage/reversed-vpn-tunnel.md
@@ -4,52 +4,22 @@ title: Reversed VPN Tunnel
 
 # Reversed VPN Tunnel Setup and Configuration 
 
-This is a short guide describing how to enable tunneling traffic from shoot cluster to seed cluster instead of the default "seed to shoot" direction. 
+The Reversed VPN Tunnel is enabled by default.
+A high availability VPN connection is automatically deployed in all shoots that configure an HA control-plane.
+## Reversed VPN Tunnel
 
-## The OpenVPN Default
+In the first VPN solution, connection establishment was initiated by a VPN client in the seed cluster.
+Due to several issues with this solution, the tunnel establishment direction has been reverted.
+The client is deployed in the shoot and initiates the connection from there. This way, there is no need to deploy a special purpose
+loadbalancer for the sake of addressing the data-plane, in addition to saving costs, this is considered the more secure alternative.
+For more information on how this is achieved, please have a look at the following [GEP](../proposals/14-reversed-cluster-vpn.md).
 
-By default, Gardener makes use of OpenVPN to connect the shoot controlplane running on the seed cluster to the dataplane 
-running on the shoot worker nodes, usually in isolated networks. This is achieved by having a sidecar to certain control plane components such as the `kube-apiserver` and `prometheus`. 
-
-With a sidecar, all traffic directed to the cluster is intercepted by iptables rules and redirected 
-to the tunnel endpoint in the shoot cluster deployed behind a cloud loadbalancer. This has the following disadvantages: 
-
-- Every shoot would require an additional loadbalancer, this accounts for additional overhead in terms of both costs and troubleshooting efforts.
-- Private access use-cases would not be possible without having a seed residing in the same private domain as a hard requirement. For example, have a look at [this issue](https://github.com/gardener/gardener-extension-provider-gcp/issues/56)
-- Providing a public endpoint to access components in the shoot poses a security risk.
-
-This is how it looks like today with the OpenVPN solution:
-
-`APIServer | VPN-seed ---> internet ---> LB --> VPN-Shoot (4314) --> Pods | Nodes | Services`
-
-
-## Reversing the Tunnel
-
-To address the above issues, the tunnel can establishment direction can be reverted, i.e. instead of having the client reside in the seed, 
-we deploy the client in the shoot and initiate the connection from there. This way, there is no need to deploy a special purpose 
-loadbalancer for the sake of addressing the dataplane, in addition to saving costs, this is considered the more secure alternative. 
-For more information on how this is achieved, please have a look at the following [GEP](../proposals/14-reversed-cluster-vpn.md). 
-
-How it should look like at the end:
+Connection establishment with a reversed tunnel:
 
 `APIServer --> Envoy-Proxy | VPN-Seed-Server <-- Istio/Envoy-Proxy <-- SNI API Server Endpoint <-- LB (one for all clusters of a seed) <--- internet <--- VPN-Shoot-Client --> Pods | Nodes | Services`
 
-### How to Configure
-
-To enable the usage of the reversed vpn tunnel feature, either the Gardenlet `ReversedVPN` feature-gate must be set to `true` as shown below or the shoot must be annotated with `"alpha.featuregates.shoot.gardener.cloud/reversed-vpn: true"`.
-
-```yaml
-featureGates:
-  ReversedVPN: true
-``` 
-Please refer to the examples [here](https://github.com/gardener/gardener/blob/master/example/20-componentconfig-gardenlet.yaml) for more information.
-
-To disable the feature-gate the shoot must be annotated with `"alpha.featuregates.shoot.gardener.cloud/reversed-vpn: false"`
-
-Once the feature-gate is enabled, a `vpn-seed-server` deployment will be added to the controlplane. The `kube-apiserver` will be configured to connect to resources in the dataplane such as pods, services and nodes though the `vpn-seed-service` via http proxy/connect protocol.
-In the dataplane of the cluster, the `vpn-shoot` will establish the connection to the `vpn-seed-server` indirectly using the SNI API Server endpoint as a http proxy. After the connection has been established requests from the `kube-apiserver` will be handled by the tunnel.
-
-> Please note this feature is still in Beta, so you might see instabilities every now and then.
+The reversed VPN tunnel is always deployed.
+The feature gate `ReversedVPN` is GA and will be removed in a future release
 
 ## High Availability for Reversed VPN Tunnel
 

--- a/example/20-componentconfig-gardenlet.yaml
+++ b/example/20-componentconfig-gardenlet.yaml
@@ -118,7 +118,6 @@ featureGates:
   HVPAForShootedSeed: true
   ManagedIstio: true
   APIServerSNI: true
-  ReversedVPN: true
   CopyEtcdBackupsDuringControlPlaneMigration: true
   ForceRestore: false
   DefaultSeccompProfile: true

--- a/example/gardener-local/gardenlet/values.yaml
+++ b/example/gardener-local/gardenlet/values.yaml
@@ -33,7 +33,6 @@ config:
     HVPAForShootedSeed: true
     ManagedIstio: true
     APIServerSNI: true
-    ReversedVPN: true
     CopyEtcdBackupsDuringControlPlaneMigration: true
     DefaultSeccompProfile: true
     CoreDNSQueryRewriting: true

--- a/extensions/pkg/webhook/controlplane/genericmutator/mutator.go
+++ b/extensions/pkg/webhook/controlplane/genericmutator/mutator.go
@@ -63,8 +63,7 @@ type Ensurer interface {
 	// "old" might be "nil" and must always be checked.
 	EnsureETCD(ctx context.Context, gctx gcontext.GardenContext, new, old *druidv1alpha1.Etcd) error
 	// EnsureVPNSeedServerDeployment ensures that the vpn-seed-server deployment conforms to the provider requirements.
-	// "old" might be "nil" and must always be checked. Please note that the vpn-seed-server deployment will only exist
-	// if the gardenlet's ReversedVPN feature gate is enabeld.
+	// "old" might be "nil" and must always be checked.
 	EnsureVPNSeedServerDeployment(ctx context.Context, gctx gcontext.GardenContext, new, old *appsv1.Deployment) error
 	// EnsureKubeletServiceUnitOptions ensures that the kubelet.service unit options conform to the provider requirements.
 	EnsureKubeletServiceUnitOptions(ctx context.Context, gctx gcontext.GardenContext, kubeletVersion *semver.Version, new, old []*unit.UnitOption) ([]*unit.UnitOption, error)

--- a/hack/.ci/set_dependency_version
+++ b/hack/.ci/set_dependency_version
@@ -116,8 +116,6 @@ if name in injectedSpecialCases:
     names = injectedSpecialCases[name]
 elif name == 'autoscaler':
     names = ['cluster-autoscaler']
-elif name == 'vpn':
-    names = ['vpn-seed', 'vpn-shoot']
 elif name == 'vpn2':
     names = ['vpn-seed-server', 'vpn-shoot-client']
 elif name == 'external-dns-management':

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -557,8 +557,6 @@ const (
 	AnnotationShootCloudConfigExecutionMaxDelaySeconds = "shoot.gardener.cloud/cloud-config-execution-max-delay-seconds"
 	// AnnotationShootForceRestore is a key for an annotation on a Shoot or BackupEntry resource to trigger a forceful restoration to a different seed.
 	AnnotationShootForceRestore = "shoot.gardener.cloud/force-restore"
-	// AnnotationReversedVPN moves the vpn-server to the seed.
-	AnnotationReversedVPN = "alpha.featuregates.shoot.gardener.cloud/reversed-vpn"
 	// AnnotationNodeLocalDNS enables a per node dns cache on the shoot cluster.
 	AnnotationNodeLocalDNS = "alpha.featuregates.shoot.gardener.cloud/node-local-dns"
 	// AnnotationNodeLocalDNSForceTcpToClusterDns enforces upgrade to tcp connections for communication between node local and cluster dns.

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -105,7 +105,7 @@ var allFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	HVPA:               {Default: false, PreRelease: featuregate.Alpha},
 	HVPAForShootedSeed: {Default: false, PreRelease: featuregate.Alpha},
 	ManagedIstio:       {Default: true, PreRelease: featuregate.Deprecated, LockToDefault: true},
-	APIServerSNI:       {Default: true, PreRelease: featuregate.Deprecated, LockToDefault: true},
+	APIServerSNI:       {Default: true, PreRelease: featuregate.Deprecated},
 	SeedChange:         {Default: true, PreRelease: featuregate.Beta},
 	ReversedVPN:        {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
 	CopyEtcdBackupsDuringControlPlaneMigration: {Default: true, PreRelease: featuregate.Beta},

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -67,7 +67,7 @@ const (
 	// owner: @ScheererJ @DockToFuture
 	// alpha: v1.22.0
 	// beta: v1.42.0
-	// deprecated: v1.61.0
+	// GA: v1.63.0
 	ReversedVPN featuregate.Feature = "ReversedVPN"
 
 	// CopyEtcdBackupsDuringControlPlaneMigration enables the copy of etcd backups from the object store of the source seed

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -67,6 +67,7 @@ const (
 	// owner: @ScheererJ @DockToFuture
 	// alpha: v1.22.0
 	// beta: v1.42.0
+	// deprecated: v1.61.0
 	ReversedVPN featuregate.Feature = "ReversedVPN"
 
 	// CopyEtcdBackupsDuringControlPlaneMigration enables the copy of etcd backups from the object store of the source seed
@@ -106,7 +107,7 @@ var allFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	ManagedIstio:       {Default: true, PreRelease: featuregate.Deprecated},
 	APIServerSNI:       {Default: true, PreRelease: featuregate.Deprecated},
 	SeedChange:         {Default: true, PreRelease: featuregate.Beta},
-	ReversedVPN:        {Default: true, PreRelease: featuregate.Beta},
+	ReversedVPN:        {Default: true, PreRelease: featuregate.Deprecated},
 	CopyEtcdBackupsDuringControlPlaneMigration: {Default: true, PreRelease: featuregate.Beta},
 	ForceRestore:          {Default: false, PreRelease: featuregate.Alpha},
 	HAControlPlanes:       {Default: false, PreRelease: featuregate.Alpha},

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -107,7 +107,7 @@ var allFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	ManagedIstio:       {Default: true, PreRelease: featuregate.Deprecated},
 	APIServerSNI:       {Default: true, PreRelease: featuregate.Deprecated},
 	SeedChange:         {Default: true, PreRelease: featuregate.Beta},
-	ReversedVPN:        {Default: true, PreRelease: featuregate.Deprecated},
+	ReversedVPN:        {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
 	CopyEtcdBackupsDuringControlPlaneMigration: {Default: true, PreRelease: featuregate.Beta},
 	ForceRestore:          {Default: false, PreRelease: featuregate.Alpha},
 	HAControlPlanes:       {Default: false, PreRelease: featuregate.Alpha},

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -105,7 +105,7 @@ var allFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	HVPA:               {Default: false, PreRelease: featuregate.Alpha},
 	HVPAForShootedSeed: {Default: false, PreRelease: featuregate.Alpha},
 	ManagedIstio:       {Default: true, PreRelease: featuregate.Deprecated, LockToDefault: true},
-	APIServerSNI:       {Default: true, PreRelease: featuregate.Deprecated},
+	APIServerSNI:       {Default: true, PreRelease: featuregate.Deprecated, LockToDefault: true},
 	SeedChange:         {Default: true, PreRelease: featuregate.Beta},
 	ReversedVPN:        {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
 	CopyEtcdBackupsDuringControlPlaneMigration: {Default: true, PreRelease: featuregate.Beta},

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -104,8 +104,8 @@ const (
 var allFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	HVPA:               {Default: false, PreRelease: featuregate.Alpha},
 	HVPAForShootedSeed: {Default: false, PreRelease: featuregate.Alpha},
-	ManagedIstio:       {Default: true, PreRelease: featuregate.Deprecated},
-	APIServerSNI:       {Default: true, PreRelease: featuregate.Deprecated},
+	ManagedIstio:       {Default: true, PreRelease: featuregate.Deprecated, LockToDefault: true},
+	APIServerSNI:       {Default: true, PreRelease: featuregate.Deprecated, LockToDefault: true},
 	SeedChange:         {Default: true, PreRelease: featuregate.Beta},
 	ReversedVPN:        {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
 	CopyEtcdBackupsDuringControlPlaneMigration: {Default: true, PreRelease: featuregate.Beta},

--- a/pkg/gardenlet/controller/managedseed/valueshelper_test.go
+++ b/pkg/gardenlet/controller/managedseed/valueshelper_test.go
@@ -105,8 +105,7 @@ var _ = Describe("ValuesHelper", func() {
 				},
 			},
 			FeatureGates: map[string]bool{
-				string(features.ReversedVPN): true,
-				string(features.HVPA):        true,
+				string(features.HVPA): true,
 			},
 			Logging: &config.Logging{
 				Enabled: pointer.Bool(true),
@@ -145,9 +144,7 @@ var _ = Describe("ValuesHelper", func() {
 				APIVersion: configv1alpha1.SchemeGroupVersion.String(),
 				Kind:       "GardenletConfiguration",
 			},
-			FeatureGates: map[string]bool{
-				string(features.ReversedVPN): false,
-			},
+			FeatureGates: map[string]bool{},
 		}
 		shoot = &gardencorev1beta1.Shoot{
 			ObjectMeta: metav1.ObjectMeta{
@@ -224,8 +221,7 @@ var _ = Describe("ValuesHelper", func() {
 					},
 				},
 				FeatureGates: map[string]bool{
-					string(features.ReversedVPN): false,
-					string(features.HVPA):        true,
+					string(features.HVPA): true,
 				},
 				Logging: &configv1alpha1.Logging{
 					Enabled: pointer.Bool(true),
@@ -281,8 +277,7 @@ var _ = Describe("ValuesHelper", func() {
 						},
 					},
 					"featureGates": map[string]interface{}{
-						"ReversedVPN": false,
-						"HVPA":        true,
+						"HVPA": true,
 					},
 					"logging": map[string]interface{}{
 						"enabled": true,

--- a/pkg/gardenlet/controller/managedseed/valueshelper_test.go
+++ b/pkg/gardenlet/controller/managedseed/valueshelper_test.go
@@ -145,7 +145,9 @@ var _ = Describe("ValuesHelper", func() {
 				APIVersion: configv1alpha1.SchemeGroupVersion.String(),
 				Kind:       "GardenletConfiguration",
 			},
-			FeatureGates: map[string]bool{},
+			FeatureGates: map[string]bool{
+				"FooFeature": false,
+			},
 		}
 		shoot = &gardencorev1beta1.Shoot{
 			ObjectMeta: metav1.ObjectMeta{
@@ -222,7 +224,7 @@ var _ = Describe("ValuesHelper", func() {
 					},
 				},
 				FeatureGates: map[string]bool{
-					string("FooFeature"): true,
+					string("FooFeature"): false,
 					string("BarFeature"): true,
 				},
 				Logging: &configv1alpha1.Logging{
@@ -279,7 +281,7 @@ var _ = Describe("ValuesHelper", func() {
 						},
 					},
 					"featureGates": map[string]interface{}{
-						"FooFeature": true,
+						"FooFeature": false,
 						"BarFeature": true,
 					},
 					"logging": map[string]interface{}{

--- a/pkg/gardenlet/controller/managedseed/valueshelper_test.go
+++ b/pkg/gardenlet/controller/managedseed/valueshelper_test.go
@@ -105,7 +105,8 @@ var _ = Describe("ValuesHelper", func() {
 				},
 			},
 			FeatureGates: map[string]bool{
-				string(features.HVPA): true,
+				string("FooFeature"): true,
+				string("BarFeature"): true,
 			},
 			Logging: &config.Logging{
 				Enabled: pointer.Bool(true),
@@ -221,7 +222,8 @@ var _ = Describe("ValuesHelper", func() {
 					},
 				},
 				FeatureGates: map[string]bool{
-					string(features.HVPA): true,
+					string("FooFeature"): true,
+					string("BarFeature"): true,
 				},
 				Logging: &configv1alpha1.Logging{
 					Enabled: pointer.Bool(true),
@@ -277,7 +279,8 @@ var _ = Describe("ValuesHelper", func() {
 						},
 					},
 					"featureGates": map[string]interface{}{
-						"HVPA": true,
+						"FooFeature": true,
+						"BarFeature": true,
 					},
 					"logging": map[string]interface{}{
 						"enabled": true,

--- a/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
@@ -592,15 +592,15 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 			Fn:           flow.TaskFn(botanist.CleanupOrphanedDNSRecordSecrets).DoIf(!o.Shoot.HibernationEnabled),
 			Dependencies: flow.NewTaskIDs(deployInternalDomainDNSRecord, deployExternalDomainDNSRecord, deployOwnerDomainDNSRecord, deployIngressDomainDNSRecord),
 		})
-		vpnLBReady = g.Add(flow.Task{
-			Name:         "Waiting until vpn-shoot LoadBalancer is ready",
-			Fn:           flow.TaskFn(botanist.WaitUntilVpnShootServiceIsReady).SkipIf(o.Shoot.HibernationEnabled || o.Shoot.ReversedVPNEnabled),
-			Dependencies: flow.NewTaskIDs(syncPointAllSystemComponentsDeployed, waitUntilNetworkIsReady, waitUntilWorkerReady),
-		})
+		// vpnLBReady = g.Add(flow.Task{
+		// 	Name:         "Waiting until vpn-shoot LoadBalancer is ready",
+		// 	Fn:           flow.TaskFn(botanist.WaitUntilVpnShootServiceIsReady).SkipIf(o.Shoot.HibernationEnabled || o.Shoot.ReversedVPNEnabled),
+		// 	Dependencies: flow.NewTaskIDs(syncPointAllSystemComponentsDeployed, waitUntilNetworkIsReady, waitUntilWorkerReady),
+		// })
 		waitUntilTunnelConnectionExists = g.Add(flow.Task{
 			Name:         "Waiting until the Kubernetes API server can connect to the Shoot workers",
 			Fn:           flow.TaskFn(botanist.WaitUntilTunnelConnectionExists).SkipIf(o.Shoot.HibernationEnabled),
-			Dependencies: flow.NewTaskIDs(syncPointAllSystemComponentsDeployed, waitUntilNetworkIsReady, waitUntilWorkerReady, vpnLBReady),
+			Dependencies: flow.NewTaskIDs(syncPointAllSystemComponentsDeployed, waitUntilNetworkIsReady, waitUntilWorkerReady),
 		})
 		_ = g.Add(flow.Task{
 			Name:         "Waiting until all shoot worker nodes have updated the cloud config user data",

--- a/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
@@ -511,7 +511,7 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 		})
 		deployVPNShoot = g.Add(flow.Task{
 			Name:         "Deploying vpn-shoot system component",
-			Fn:           flow.TaskFn(botanist.DeployVPNShoot).RetryUntilTimeout(defaultInterval, defaultTimeout).SkipIf(o.Shoot.HibernationEnabled),
+			Fn:           flow.TaskFn(botanist.Shoot.Components.SystemComponents.VPNShoot.Deploy).RetryUntilTimeout(defaultInterval, defaultTimeout).SkipIf(o.Shoot.HibernationEnabled),
 			Dependencies: flow.NewTaskIDs(deployGardenerResourceManager, deployKubeScheduler, deployVPNSeedServer, waitUntilShootNamespacesReady),
 		})
 		deployNodeProblemDetector = g.Add(flow.Task{

--- a/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
@@ -592,11 +592,6 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 			Fn:           flow.TaskFn(botanist.CleanupOrphanedDNSRecordSecrets).DoIf(!o.Shoot.HibernationEnabled),
 			Dependencies: flow.NewTaskIDs(deployInternalDomainDNSRecord, deployExternalDomainDNSRecord, deployOwnerDomainDNSRecord, deployIngressDomainDNSRecord),
 		})
-		// vpnLBReady = g.Add(flow.Task{
-		// 	Name:         "Waiting until vpn-shoot LoadBalancer is ready",
-		// 	Fn:           flow.TaskFn(botanist.WaitUntilVpnShootServiceIsReady).SkipIf(o.Shoot.HibernationEnabled || o.Shoot.ReversedVPNEnabled),
-		// 	Dependencies: flow.NewTaskIDs(syncPointAllSystemComponentsDeployed, waitUntilNetworkIsReady, waitUntilWorkerReady),
-		// })
 		waitUntilTunnelConnectionExists = g.Add(flow.Task{
 			Name:         "Waiting until the Kubernetes API server can connect to the Shoot workers",
 			Fn:           flow.TaskFn(botanist.WaitUntilTunnelConnectionExists).SkipIf(o.Shoot.HibernationEnabled),

--- a/pkg/operation/botanist/component/kubeapiserver/configmaps.go
+++ b/pkg/operation/botanist/component/kubeapiserver/configmaps.go
@@ -101,7 +101,7 @@ func (k *kubeAPIServer) reconcileConfigMapAuditPolicy(ctx context.Context, confi
 }
 
 func (k *kubeAPIServer) reconcileConfigMapEgressSelector(ctx context.Context, configMap *corev1.ConfigMap) error {
-	if !k.values.VPN.ReversedVPNEnabled || k.values.VPN.HighAvailabilityEnabled {
+	if k.values.VPN.HighAvailabilityEnabled {
 		// We don't delete the confimap here as we don't know its name (as it's unique). Instead, we rely on the usual
 		// garbage collection for unique secrets/configmaps.
 		return nil

--- a/pkg/operation/botanist/component/kubeapiserver/deployment.go
+++ b/pkg/operation/botanist/component/kubeapiserver/deployment.go
@@ -42,9 +42,6 @@ import (
 )
 
 const (
-	// SecretNameVPNSeedTLSAuth is the name of the secret containing the TLS auth for the vpn-seed.
-	SecretNameVPNSeedTLSAuth  = "vpn-seed-tlsauth"
-	secretNameLegacyVPNSeed   = "vpn-seed"
 	secretNameHAVPNSeedClient = "vpn-seed-client"
 
 	secretNameServer                 = "kube-apiserver"
@@ -54,7 +51,6 @@ const (
 
 	// ContainerNameKubeAPIServer is the name of the kube-apiserver container.
 	ContainerNameKubeAPIServer            = "kube-apiserver"
-	containerNameVPNSeed                  = "vpn-seed"
 	containerNameVPNSeedClient            = "vpn-client"
 	containerNameAPIServerProxyPodMutator = "apiserver-proxy-pod-mutator"
 
@@ -72,14 +68,12 @@ const (
 	volumeNameHTTPProxy                            = "http-proxy"
 	volumeNameKubeAPIServerToKubelet               = "kubelet-client"
 	volumeNameKubeAggregator                       = "kube-aggregator"
-	volumeNameLibModules                           = "modules"
 	volumeNameOIDCCABundle                         = "oidc-cabundle"
 	volumeNameServer                               = "kube-apiserver-server"
 	volumeNameServiceAccountKey                    = "service-account-key"
 	volumeNameServiceAccountKeyBundle              = "service-account-key-bundle"
 	volumeNameUserProvidedServiceAccountSigningKey = "service-account-signing-key"
 	volumeNameStaticToken                          = "static-token"
-	volumeNameVPNSeed                              = "vpn-seed"
 	volumeNameVPNSeedClient                        = "vpn-seed-client"
 	volumeNameAPIServerAccess                      = "kube-api-access-gardener"
 	volumeNameVPNSeedTLSAuth                       = "vpn-seed-tlsauth"
@@ -110,7 +104,6 @@ const (
 	volumeMountPathServiceAccountKeyBundle              = "/srv/kubernetes/service-account-key-bundle"
 	volumeMountPathUserProvidedServiceAccountSigningKey = "/srv/kubernetes/service-account-signing-key"
 	volumeMountPathStaticToken                          = "/srv/kubernetes/token"
-	volumeMountPathVPNSeed                              = "/srv/secrets/vpn-seed"
 	volumeMountPathVPNSeedClient                        = "/srv/secrets/vpn-client"
 	volumeMountPathAPIServerAccess                      = "/var/run/secrets/kubernetes.io/serviceaccount"
 	volumeMountPathVPNSeedTLSAuth                       = "/srv/secrets/tlsauth"

--- a/pkg/operation/botanist/component/kubeapiserver/deployment.go
+++ b/pkg/operation/botanist/component/kubeapiserver/deployment.go
@@ -475,7 +475,7 @@ func (k *kubeAPIServer) reconcileDeployment(
 		k.handleHostCertVolumes(deployment)
 		k.handleSNISettings(deployment)
 		k.handlePodMutatorSettings(deployment)
-		k.handleVPNSettings(deployment, configMapEgressSelector, secretCAVPN, secretHTTPProxy, secretCAClient, secretHAVPNSeedClient, secretHAVPNSeedClientSeedTLSAuth)
+		k.handleVPNSettings(deployment, configMapEgressSelector, secretCAVPN, secretHTTPProxy, secretHAVPNSeedClient, secretHAVPNSeedClientSeedTLSAuth)
 		k.handleOIDCSettings(deployment, secretOIDCCABundle)
 		k.handleServiceAccountSigningKeySettings(deployment, secretUserProvidedServiceAccountSigningKey)
 
@@ -714,7 +714,6 @@ func (k *kubeAPIServer) handleVPNSettings(
 	configMapEgressSelector *corev1.ConfigMap,
 	secretCAVPN *corev1.Secret,
 	secretHTTPProxy *corev1.Secret,
-	secretLegacyVPNCAClient *corev1.Secret,
 	secretHAVPNSeedClient *corev1.Secret,
 	secretHAVPNSeedClientSeedTLSAuth *corev1.Secret,
 ) {

--- a/pkg/operation/botanist/component/kubeapiserver/hvpa.go
+++ b/pkg/operation/botanist/component/kubeapiserver/hvpa.go
@@ -72,11 +72,6 @@ func (k *kubeAPIServer) reconcileHVPA(ctx context.Context, hvpa *hvpav1alpha1.Hv
 				},
 				ControlledValues: &controlledValues,
 			},
-			{
-				ContainerName:    containerNameVPNSeed,
-				Mode:             &containerPolicyOff,
-				ControlledValues: &controlledValues,
-			},
 		}
 		weightBasedScalingIntervals = []hvpav1alpha1.WeightBasedScalingInterval{
 			{

--- a/pkg/operation/botanist/component/kubeapiserver/kube_apiserver.go
+++ b/pkg/operation/botanist/component/kubeapiserver/kube_apiserver.go
@@ -82,8 +82,6 @@ const (
 	SecretNameUserKubeconfig = "user-kubeconfig"
 	// ServicePortName is the name of the port in the service.
 	ServicePortName = "kube-apiserver"
-	// UserNameVPNSeed is the user name for the vpn-seed components (used as common name in its client certificate)
-	UserNameVPNSeed = "vpn-seed"
 	// UserNameVPNSeedClient is the user name for the HA vpn-seed-client components (used as common name in its client certificate)
 	UserNameVPNSeedClient = "vpn-seed-client"
 
@@ -214,8 +212,6 @@ type Images struct {
 	APIServerProxyPodWebhook string
 	// KubeAPIServer is the container image for the kube-apiserver.
 	KubeAPIServer string
-	// VPNSeed is the container image for the vpn-seed.
-	VPNSeed string
 	// VPNClient is the container image for the vpn-seed-client.
 	VPNClient string
 }

--- a/pkg/operation/botanist/component/kubeapiserver/kube_apiserver.go
+++ b/pkg/operation/botanist/component/kubeapiserver/kube_apiserver.go
@@ -222,8 +222,6 @@ type Images struct {
 
 // VPNConfig contains information for configuring the VPN settings for the kube-apiserver.
 type VPNConfig struct {
-	// ReversedVPNEnabled states whether the 'ReversedVPN' feature gate is enabled.
-	ReversedVPNEnabled bool
 	// PodNetworkCIDR is the CIDR of the pod network.
 	PodNetworkCIDR string
 	// ServiceNetworkCIDR is the CIDR of the service network.
@@ -394,16 +392,6 @@ func (k *kubeAPIServer) Deploy(ctx context.Context) error {
 		return err
 	}
 
-	secretLegacyVPNSeed, err := k.reconcileSecretLegacyVPNSeed(ctx)
-	if err != nil {
-		return err
-	}
-
-	secretLegacyVPNSeedTLSAuth, err := k.reconcileSecretLegacyVPNSeedTLSAuth(ctx)
-	if err != nil {
-		return err
-	}
-
 	secretHAVPNSeedClient, err := k.reconcileSecretHAVPNSeedClient(ctx)
 	if err != nil {
 		return err
@@ -450,8 +438,6 @@ func (k *kubeAPIServer) Deploy(ctx context.Context) error {
 		secretKubeletClient,
 		secretKubeAggregator,
 		secretHTTPProxy,
-		secretLegacyVPNSeed,
-		secretLegacyVPNSeedTLSAuth,
 		secretHAVPNSeedClient,
 		secretHAVPNClientSeedTLSAuth,
 	); err != nil {

--- a/pkg/operation/botanist/component/kubeapiserver/kube_apiserver.go
+++ b/pkg/operation/botanist/component/kubeapiserver/kube_apiserver.go
@@ -206,8 +206,6 @@ type ETCDEncryptionConfig struct {
 
 // Images is a set of container images used for the containers of the kube-apiserver pods.
 type Images struct {
-	// AlpineIPTables is the container image for alpine-iptables.
-	AlpineIPTables string
 	// APIServerProxyPodWebhook is the container image for the apiserver-proxy-pod-webhook.
 	APIServerProxyPodWebhook string
 	// KubeAPIServer is the container image for the kube-apiserver.

--- a/pkg/operation/botanist/component/kubeapiserver/kube_apiserver.go
+++ b/pkg/operation/botanist/component/kubeapiserver/kube_apiserver.go
@@ -228,7 +228,7 @@ type VPNConfig struct {
 	ServiceNetworkCIDR string
 	// NodeNetworkCIDR is the CIDR of the node network.
 	NodeNetworkCIDR *string
-	// HighAvailabilityEnabled states if VPN uses HA configuration (only works together with ReversedVPNEnabled=true)
+	// HighAvailabilityEnabled states if VPN uses HA configuration.
 	HighAvailabilityEnabled bool
 	// HighAvailabilityNumberOfSeedServers is the number of VPN seed servers used for HA
 	HighAvailabilityNumberOfSeedServers int

--- a/pkg/operation/botanist/component/kubeapiserver/kube_apiserver_test.go
+++ b/pkg/operation/botanist/component/kubeapiserver/kube_apiserver_test.go
@@ -458,11 +458,6 @@ var _ = Describe("KubeAPIServer", func() {
 						},
 						ControlledValues: &controlledValues,
 					},
-					{
-						ContainerName:    "vpn-seed",
-						Mode:             &containerPolicyOff,
-						ControlledValues: &controlledValues,
-					},
 				}
 				defaultExpectedWeightBasedScalingIntervals = []hvpav1alpha1.WeightBasedScalingInterval{
 					{
@@ -677,11 +672,6 @@ var _ = Describe("KubeAPIServer", func() {
 								"cpu":    resource.MustParse("8"),
 								"memory": resource.MustParse("25G"),
 							},
-							ControlledValues: &controlledValues,
-						},
-						{
-							ContainerName:    "vpn-seed",
-							Mode:             &containerPolicyOff,
 							ControlledValues: &controlledValues,
 						},
 						{
@@ -1599,7 +1589,7 @@ rules:
 				Expect(deployment.Spec.Template.Spec.InitContainers).To(BeEmpty())
 			})
 
-			It("should have no init container and three vpn-seed-client sidecar containers when vpn high availability are enabled", func() {
+			It("should have one init container and three vpn-seed-client sidecar containers when vpn high availability are enabled", func() {
 				values := Values{
 					Images: Images{VPNClient: "vpn-client-image:really-latest"},
 					VPN: VPNConfig{

--- a/pkg/operation/botanist/component/kubeapiserver/logging.go
+++ b/pkg/operation/botanist/component/kubeapiserver/logging.go
@@ -38,22 +38,6 @@ const (
     Reserve_Data        True
 `
 
-	loggingParserNameVPNSeed = "vpnSeedParser"
-	loggingParserVPNSeed     = `[PARSER]
-    Name        ` + loggingParserNameVPNSeed + `
-    Format      regex
-    Regex       ^(?<time>[^0-9]*\d{1,2}\s+[^\s]+\s+\d{4})\s+(?<log>.*)
-    Time_Key    time
-    Time_Format %a %b%t%d %H:%M:%S %Y
-`
-	loggingFilterVPNSeed = `[FILTER]
-    Name                parser
-    Match               kubernetes.*` + v1beta1constants.DeploymentNameKubeAPIServer + `*` + containerNameVPNSeed + `*
-    Key_Name            log
-    Parser              ` + loggingParserNameVPNSeed + `
-    Reserve_Data        True
-`
-
 	loggingParserNameAPIProxyMutator = "apiProxyMutatorParser"
 	loggingParserAPIProxyMutator     = `[PARSER]
     Name        ` + loggingParserNameAPIProxyMutator + `
@@ -77,8 +61,8 @@ const (
 // CentralLoggingConfiguration returns a fluent-bit parser and filter for the kube-apiserver logs.
 func CentralLoggingConfiguration() (component.CentralLoggingConfig, error) {
 	return component.CentralLoggingConfig{
-		Filters:     fmt.Sprintf("%s\n%s\n%s\n%s", loggingFilterAPIServer, loggingFilterVPNSeed, loggingFilterAPIProxyMutator, loggingModifyFilterAPIProxyMutator),
-		Parsers:     fmt.Sprintf("%s\n%s\n%s", loggingParserAPIServer, loggingParserVPNSeed, loggingParserAPIProxyMutator),
+		Filters:     fmt.Sprintf("%s\n%s\n%s", loggingFilterAPIServer, loggingFilterAPIProxyMutator, loggingModifyFilterAPIProxyMutator),
+		Parsers:     fmt.Sprintf("%s\n%s", loggingParserAPIServer, loggingParserAPIProxyMutator),
 		UserExposed: true,
 		PodPrefixes: []string{v1beta1constants.DeploymentNameKubeAPIServer},
 	}, nil

--- a/pkg/operation/botanist/component/kubeapiserver/logging_test.go
+++ b/pkg/operation/botanist/component/kubeapiserver/logging_test.go
@@ -35,13 +35,6 @@ var _ = Describe("Logging", func() {
     Time_Format %m%d %H:%M:%S.%L
 
 [PARSER]
-    Name        vpnSeedParser
-    Format      regex
-    Regex       ^(?<time>[^0-9]*\d{1,2}\s+[^\s]+\s+\d{4})\s+(?<log>.*)
-    Time_Key    time
-    Time_Format %a %b%t%d %H:%M:%S %Y
-
-[PARSER]
     Name        apiProxyMutatorParser
     Format      json
     Time_Key    ts
@@ -52,13 +45,6 @@ var _ = Describe("Logging", func() {
     Match               kubernetes.*kube-apiserver*kube-apiserver*
     Key_Name            log
     Parser              kubeAPIServerParser
-    Reserve_Data        True
-
-[FILTER]
-    Name                parser
-    Match               kubernetes.*kube-apiserver*vpn-seed*
-    Key_Name            log
-    Parser              vpnSeedParser
     Reserve_Data        True
 
 [FILTER]

--- a/pkg/operation/botanist/component/kubeapiserver/networkpolicies.go
+++ b/pkg/operation/botanist/component/kubeapiserver/networkpolicies.go
@@ -170,23 +170,21 @@ func (k *kubeAPIServer) reconcileNetworkPolicyAllowKubeAPIServer(ctx context.Con
 			PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress, networkingv1.PolicyTypeEgress},
 		}
 
-		if k.values.VPN.ReversedVPNEnabled {
-			port := &portVPNSeedServerNonHA
-			if k.values.VPN.HighAvailabilityEnabled {
-				port = &portVPNSeedServerHA
-			}
-			networkPolicy.Spec.Egress = append(networkPolicy.Spec.Egress, networkingv1.NetworkPolicyEgressRule{
-				To: []networkingv1.NetworkPolicyPeer{{
-					PodSelector: &metav1.LabelSelector{
-						MatchLabels: vpnseedserver.GetLabels(),
-					},
-				}},
-				Ports: []networkingv1.NetworkPolicyPort{{
-					Protocol: &protocol,
-					Port:     port,
-				}},
-			})
+		port := &portVPNSeedServerNonHA
+		if k.values.VPN.HighAvailabilityEnabled {
+			port = &portVPNSeedServerHA
 		}
+		networkPolicy.Spec.Egress = append(networkPolicy.Spec.Egress, networkingv1.NetworkPolicyEgressRule{
+			To: []networkingv1.NetworkPolicyPeer{{
+				PodSelector: &metav1.LabelSelector{
+					MatchLabels: vpnseedserver.GetLabels(),
+				},
+			}},
+			Ports: []networkingv1.NetworkPolicyPort{{
+				Protocol: &protocol,
+				Port:     port,
+			}},
+		})
 
 		return nil
 	})

--- a/pkg/operation/botanist/component/kubeapiserver/networkpolicies.go
+++ b/pkg/operation/botanist/component/kubeapiserver/networkpolicies.go
@@ -129,18 +129,19 @@ func (k *kubeAPIServer) reconcileNetworkPolicyAllowKubeAPIServer(ctx context.Con
 			PodSelector: metav1.LabelSelector{
 				MatchLabels: GetLabels(),
 			},
-			Egress: []networkingv1.NetworkPolicyEgressRule{{
-				// Allow connection to shoot's etcd instances.
-				To: []networkingv1.NetworkPolicyPeer{{
-					PodSelector: &metav1.LabelSelector{
-						MatchLabels: etcd.GetLabels(),
-					},
-				}},
-				Ports: []networkingv1.NetworkPolicyPort{{
-					Protocol: &protocol,
-					Port:     &portEtcd,
-				}},
-			},
+			Egress: []networkingv1.NetworkPolicyEgressRule{
+				{
+					// Allow connection to shoot's etcd instances.
+					To: []networkingv1.NetworkPolicyPeer{{
+						PodSelector: &metav1.LabelSelector{
+							MatchLabels: etcd.GetLabels(),
+						},
+					}},
+					Ports: []networkingv1.NetworkPolicyPort{{
+						Protocol: &protocol,
+						Port:     &portEtcd,
+					}},
+				},
 				{
 					To: []networkingv1.NetworkPolicyPeer{{
 						PodSelector: &metav1.LabelSelector{
@@ -186,7 +187,6 @@ func (k *kubeAPIServer) reconcileNetworkPolicyAllowKubeAPIServer(ctx context.Con
 			},
 			PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress, networkingv1.PolicyTypeEgress},
 		}
-
 		return nil
 	})
 	return err

--- a/pkg/operation/botanist/component/kubeapiserver/secrets.go
+++ b/pkg/operation/botanist/component/kubeapiserver/secrets.go
@@ -313,7 +313,7 @@ func (k *kubeAPIServer) reconcileSecretKubeAggregator(ctx context.Context) (*cor
 }
 
 func (k *kubeAPIServer) reconcileSecretHTTPProxy(ctx context.Context) (*corev1.Secret, error) {
-	if !k.values.VPN.ReversedVPNEnabled || k.values.VPN.HighAvailabilityEnabled {
+	if k.values.VPN.HighAvailabilityEnabled {
 		return nil, nil
 	}
 
@@ -323,24 +323,6 @@ func (k *kubeAPIServer) reconcileSecretHTTPProxy(ctx context.Context) (*corev1.S
 		CertType:                    secretutils.ClientCert,
 		SkipPublishingCACertificate: true,
 	}, secretsmanager.SignedByCA(v1beta1constants.SecretNameCAVPN), secretsmanager.Rotate(secretsmanager.InPlace))
-	if err != nil {
-		return nil, err
-	}
-
-	return secret, nil
-}
-
-func (k *kubeAPIServer) reconcileSecretLegacyVPNSeed(ctx context.Context) (*corev1.Secret, error) {
-	if k.values.VPN.ReversedVPNEnabled {
-		return nil, nil
-	}
-
-	secret, err := k.secretsManager.Generate(ctx, &secretutils.CertificateSecretConfig{
-		Name:                        secretNameLegacyVPNSeed,
-		CommonName:                  UserNameVPNSeed,
-		CertType:                    secretutils.ClientCert,
-		SkipPublishingCACertificate: true,
-	}, secretsmanager.SignedByCA(v1beta1constants.SecretNameCAClient), secretsmanager.Rotate(secretsmanager.InPlace))
 	if err != nil {
 		return nil, err
 	}
@@ -359,21 +341,6 @@ func (k *kubeAPIServer) reconcileSecretHAVPNSeedClient(ctx context.Context) (*co
 		CertType:                    secretutils.ClientCert,
 		SkipPublishingCACertificate: true,
 	}, secretsmanager.SignedByCA(v1beta1constants.SecretNameCAVPN), secretsmanager.Rotate(secretsmanager.InPlace))
-	if err != nil {
-		return nil, err
-	}
-
-	return secret, nil
-}
-
-func (k *kubeAPIServer) reconcileSecretLegacyVPNSeedTLSAuth(ctx context.Context) (*corev1.Secret, error) {
-	if k.values.VPN.ReversedVPNEnabled {
-		return nil, nil
-	}
-
-	secret, err := k.secretsManager.Generate(ctx, &secretutils.VPNTLSAuthConfig{
-		Name: SecretNameVPNSeedTLSAuth,
-	}, secretsmanager.Rotate(secretsmanager.InPlace))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/operation/botanist/component/vpnshoot/mock/mocks.go
+++ b/pkg/operation/botanist/component/vpnshoot/mock/mocks.go
@@ -8,7 +8,6 @@ import (
 	context "context"
 	reflect "reflect"
 
-	vpnshoot "github.com/gardener/gardener/pkg/operation/botanist/component/vpnshoot"
 	gomock "github.com/golang/mock/gomock"
 )
 
@@ -91,18 +90,6 @@ func (m *MockInterface) ScrapeConfigs() ([]string, error) {
 func (mr *MockInterfaceMockRecorder) ScrapeConfigs() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ScrapeConfigs", reflect.TypeOf((*MockInterface)(nil).ScrapeConfigs))
-}
-
-// SetSecrets mocks base method.
-func (m *MockInterface) SetSecrets(arg0 vpnshoot.Secrets) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "SetSecrets", arg0)
-}
-
-// SetSecrets indicates an expected call of SetSecrets.
-func (mr *MockInterfaceMockRecorder) SetSecrets(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetSecrets", reflect.TypeOf((*MockInterface)(nil).SetSecrets), arg0)
 }
 
 // Wait mocks base method.

--- a/pkg/operation/botanist/component/vpnshoot/vpnshoot.go
+++ b/pkg/operation/botanist/component/vpnshoot/vpnshoot.go
@@ -424,7 +424,7 @@ func (v *vpnShoot) computeResourcesData(secretCAVPN *corev1.Secret, secretsVPNSh
 			kind = "StatefulSet"
 		}
 		containerNames := []string{containerName}
-		if v.values.VPNHighAvailabilityEnabled {
+		if v.values.HighAvailabilityEnabled {
 			containerNames = nil
 			for i := 0; i < v.values.HighAvailabilityNumberOfSeedServers; i++ {
 				containerNames = append(containerNames, fmt.Sprintf("%s-s%d", containerName, i))

--- a/pkg/operation/botanist/component/vpnshoot/vpnshoot.go
+++ b/pkg/operation/botanist/component/vpnshoot/vpnshoot.go
@@ -238,17 +238,13 @@ func (v *vpnShoot) WaitCleanup(ctx context.Context) error {
 
 func (v *vpnShoot) computeResourcesData(secretCAVPN *corev1.Secret, secretsVPNShoot []vpnSecret) (map[string][]byte, error) {
 	var (
-		secretNameTLSAuth string
-
 		secretVPNSeedServerTLSAuth *corev1.Secret
 		found                      bool
 	)
 
-	secretNameTLSAuth = vpnseedserver.SecretNameTLSAuth
-
-	secretVPNSeedServerTLSAuth, found = v.secretsManager.Get(secretNameTLSAuth)
+	secretVPNSeedServerTLSAuth, found = v.secretsManager.Get(vpnseedserver.SecretNameTLSAuth)
 	if !found {
-		return nil, fmt.Errorf("secret %q not found", secretNameTLSAuth)
+		return nil, fmt.Errorf("secret %q not found", vpnseedserver.SecretNameTLSAuth)
 	}
 
 	var (

--- a/pkg/operation/botanist/component/vpnshoot/vpnshoot.go
+++ b/pkg/operation/botanist/component/vpnshoot/vpnshoot.go
@@ -54,16 +54,11 @@ const (
 	// LabelValue is used as value for LabeApp.
 	LabelValue = "vpn-shoot"
 
-	servicePort   int32 = 4314
-	containerPort int32 = 1194
-
 	managedResourceName = "shoot-core-vpn-shoot"
 	deploymentName      = "vpn-shoot"
 	containerName       = "vpn-shoot"
 	initContainerName   = "vpn-shoot-init"
 	serviceName         = "vpn-shoot"
-
-	secretNameDH = "vpn-shoot-dh"
 
 	volumeName          = "vpn-shoot"
 	volumeNameTLSAuth   = "vpn-shoot-tlsauth"

--- a/pkg/operation/botanist/component/vpnshoot/vpnshoot.go
+++ b/pkg/operation/botanist/component/vpnshoot/vpnshoot.go
@@ -90,16 +90,6 @@ type ReversedVPNValues struct {
 	OpenVPNPort int32
 }
 
-// NetworkValues contains the configuration values for the network.
-type NetworkValues struct {
-	// PodCIDR is the CIDR of the pod network.
-	PodCIDR string
-	// ServiceCIDR is the CIDR of the service network.
-	ServiceCIDR string
-	// NodeCIDR is the CIDR of the node network.
-	NodeCIDR string
-}
-
 // Values is a set of configuration values for the VPNShoot component.
 type Values struct {
 	// Image is the container image used for vpnShoot.
@@ -110,8 +100,6 @@ type Values struct {
 	VPAEnabled bool
 	// ReversedVPN contains the configuration values for the ReversedVPN.
 	ReversedVPN ReversedVPNValues
-	// Network contains the configuration values for the network.
-	Network NetworkValues
 	// HighAvailabilityEnabled marks whether HA is enabled for VPN.
 	HighAvailabilityEnabled bool
 	// HighAvailabilityNumberOfSeedServers is the number of VPN seed servers used for HA

--- a/pkg/operation/botanist/component/vpnshoot/vpnshoot.go
+++ b/pkg/operation/botanist/component/vpnshoot/vpnshoot.go
@@ -67,14 +67,11 @@ const (
 
 	volumeName          = "vpn-shoot"
 	volumeNameTLSAuth   = "vpn-shoot-tlsauth"
-	volumeNameDH        = "vpn-shoot-dh"
 	volumeNameDevNetTun = "dev-net-tun"
 
-	volumeMountPathSecretShoot = "/srv/secrets/vpn-shoot"
-	volumeMountPathSecret      = "/srv/secrets/vpn-client"
-	volumeMountPathSecretTLS   = "/srv/secrets/tlsauth"
-	volumeMountPathSecretDH    = "/srv/secrets/dh"
-	volumeMountPathDevNetTun   = "/dev/net/tun"
+	volumeMountPathSecret    = "/srv/secrets/vpn-client"
+	volumeMountPathSecretTLS = "/srv/secrets/tlsauth"
+	volumeMountPathDevNetTun = "/dev/net/tun"
 )
 
 // Interface contains functions for a VPNShoot Deployer

--- a/pkg/operation/botanist/component/vpnshoot/vpnshoot.go
+++ b/pkg/operation/botanist/component/vpnshoot/vpnshoot.go
@@ -81,8 +81,6 @@ const (
 type Interface interface {
 	component.DeployWaiter
 	component.MonitoringComponent
-	// SetSecrets sets the secrets.
-	SetSecrets(Secrets)
 }
 
 // ReversedVPNValues contains the configuration values for the ReversedVPN.
@@ -181,12 +179,11 @@ func (v *vpnShoot) Deploy(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
-		mountPath := volumeMountPathSecret
 
 		secrets = append(secrets, vpnSecret{
 			name:       config.Name,
 			volumeName: volumeName,
-			mountPath:  mountPath,
+			mountPath:  volumeMountPathSecret,
 			secret:     secret,
 		})
 	} else {

--- a/pkg/operation/botanist/component/vpnshoot/vpnshoot_test.go
+++ b/pkg/operation/botanist/component/vpnshoot/vpnshoot_test.go
@@ -729,7 +729,6 @@ status: {}
 						secretNameTLSAuth = expectTLSAuthSecret(managedResourceSecret.Data)
 					)
 
-					_ = secretNameClient1 // TODO
 					statefulSet := &appsv1.StatefulSet{}
 					Expect(runtime.DecodeInto(newCodec(), managedResourceSecret.Data["statefulset__kube-system__vpn-shoot.yaml"], statefulSet)).To(Succeed())
 					expected := statefulSetFor(3, 2, []string{secretNameClient0, secretNameClient1}, secretNameCA, secretNameTLSAuth, values.VPAEnabled)

--- a/pkg/operation/botanist/component/vpnshoot/vpnshoot_test.go
+++ b/pkg/operation/botanist/component/vpnshoot/vpnshoot_test.go
@@ -23,10 +23,8 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
-	"github.com/gardener/gardener/pkg/operation/botanist/component"
 	. "github.com/gardener/gardener/pkg/operation/botanist/component/vpnshoot"
 	"github.com/gardener/gardener/pkg/resourcemanager/controller/garbagecollector/references"
-	"github.com/gardener/gardener/pkg/utils"
 	"github.com/gardener/gardener/pkg/utils/retry"
 	retryfake "github.com/gardener/gardener/pkg/utils/retry/fake"
 	secretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager"
@@ -65,21 +63,10 @@ var _ = Describe("VPNShoot", func() {
 		managedResource       *resourcesv1alpha1.ManagedResource
 		managedResourceSecret *corev1.Secret
 
-		serviceNetwork = "10.0.0.0/24"
-		podNetwork     = "192.168.0.0/16"
-		nodeNetwork    = "172.16.0.0/20"
-
 		endPoint                        = "10.0.0.1"
 		openVPNPort               int32 = 8132
 		reversedVPNHeader               = "outbound|1194||vpn-seed-server.shoot--project--shoot-name.svc.cluster.local"
 		reversedVPNHeaderTemplate       = "outbound|1194||vpn-seed-server-%d.shoot--project--shoot-name.svc.cluster.local"
-
-		secretNameDH     = "vpn-shoot-dh"
-		secretChecksumDH = "5678"
-		secretDataDH     = map[string][]byte{"foo": []byte("dash")}
-		secretNameDHTest = "vpn-shoot-dh-" + utils.ComputeSecretChecksum(secretDataDH)[:8]
-
-		secretNameTLSAuthLegacyVPN = "vpn-shoot-tlsauth-03c727cf"
 
 		secrets = Secrets{}
 
@@ -120,32 +107,6 @@ var _ = Describe("VPNShoot", func() {
 
 	Describe("#Deploy", func() {
 		var (
-			secretDHYAML = `apiVersion: v1
-data:
-  foo: ZGFzaA==
-immutable: true
-kind: Secret
-metadata:
-  creationTimestamp: null
-  labels:
-    resources.gardener.cloud/garbage-collectable-reference: "true"
-  name: ` + secretNameDHTest + `
-  namespace: kube-system
-type: Opaque
-`
-			secretTLSAuthYAML = `apiVersion: v1
-data:
-  data-for: dnBuLXNlZWQtdGxzYXV0aA==
-immutable: true
-kind: Secret
-metadata:
-  creationTimestamp: null
-  labels:
-    resources.gardener.cloud/garbage-collectable-reference: "true"
-  name: ` + secretNameTLSAuthLegacyVPN + `
-  namespace: kube-system
-type: Opaque
-`
 			networkPolicyYAML = `apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -293,7 +254,7 @@ spec:
     updateMode: Auto
 status: {}
 `
-			containerFor = func(clients int, index *int, reversedVPNEnabled, vpaEnabled, highAvailable bool) *corev1.Container {
+			containerFor = func(clients int, index *int, vpaEnabled, highAvailable bool) *corev1.Container {
 				var (
 					limits = corev1.ResourceList{
 						corev1.ResourceMemory: resource.MustParse("120Mi"),
@@ -311,9 +272,6 @@ status: {}
 
 				if !highAvailable {
 					mountPath := "/srv/secrets/vpn-client"
-					if !reversedVPNEnabled {
-						mountPath = "/srv/secrets/vpn-shoot"
-					}
 					volumeMounts = []corev1.VolumeMount{
 						{
 							Name:      "vpn-shoot",
@@ -334,56 +292,37 @@ status: {}
 					MountPath: "/srv/secrets/tlsauth",
 				})
 
-				if reversedVPNEnabled {
-					env = append(env,
-						corev1.EnvVar{
-							Name:  "ENDPOINT",
-							Value: endPoint,
-						},
-						corev1.EnvVar{
-							Name:  "OPENVPN_PORT",
-							Value: strconv.Itoa(int(openVPNPort)),
-						},
-						corev1.EnvVar{
-							Name:  "REVERSED_VPN_HEADER",
-							Value: header,
-						},
-						corev1.EnvVar{
-							Name:  "DO_NOT_CONFIGURE_KERNEL_SETTINGS",
-							Value: "true",
-						},
-						corev1.EnvVar{
-							Name:  "IS_SHOOT_CLIENT",
-							Value: "true",
-						},
-					)
 
-					volumeMounts = append(volumeMounts,
-						corev1.VolumeMount{
-							Name:      "dev-net-tun",
-							MountPath: "/dev/net/tun",
-						},
-					)
-				} else {
-					env = append(env, []corev1.EnvVar{
-						{
-							Name:  "SERVICE_NETWORK",
-							Value: serviceNetwork,
-						},
-						{
-							Name:  "POD_NETWORK",
-							Value: podNetwork,
-						},
-						{
-							Name:  "NODE_NETWORK",
-							Value: nodeNetwork,
-						},
-					}...)
-					volumeMounts = append(volumeMounts, corev1.VolumeMount{
-						Name:      "vpn-shoot-dh",
-						MountPath: "/srv/secrets/dh",
-					})
-				}
+				env = append(env,
+					corev1.EnvVar{
+						Name:  "ENDPOINT",
+						Value: endPoint,
+					},
+					corev1.EnvVar{
+						Name:  "OPENVPN_PORT",
+						Value: strconv.Itoa(int(openVPNPort)),
+					},
+					corev1.EnvVar{
+						Name:  "REVERSED_VPN_HEADER",
+						Value: header,
+					},
+					corev1.EnvVar{
+						Name:  "DO_NOT_CONFIGURE_KERNEL_SETTINGS",
+						Value: "true",
+					},
+					corev1.EnvVar{
+						Name:  "IS_SHOOT_CLIENT",
+						Value: "true",
+					},
+				)
+
+				volumeMounts = append(volumeMounts,
+					corev1.VolumeMount{
+						Name:      "dev-net-tun",
+						MountPath: "/dev/net/tun",
+					},
+				)
+
 
 				if vpaEnabled {
 					limits = corev1.ResourceList{
@@ -418,7 +357,7 @@ status: {}
 					ImagePullPolicy: corev1.PullIfNotPresent,
 					Env:             env,
 					SecurityContext: &corev1.SecurityContext{
-						Privileged: pointer.Bool(!reversedVPNEnabled),
+						Privileged: pointer.Bool(false),
 						Capabilities: &corev1.Capabilities{
 							Add: []corev1.Capability{"NET_ADMIN"},
 						},
@@ -492,7 +431,7 @@ status: {}
 				return volumes
 			}
 
-			templateForEx = func(servers int, secretNameClients []string, secretNameCA, secretNameTLSAuth string, reversedVPNEnabled, vpaEnabled, highAvailable bool) *corev1.PodTemplateSpec {
+			templateForEx = func(servers int, secretNameClients []string, secretNameCA, secretNameTLSAuth string, vpaEnabled, highAvailable bool) *corev1.PodTemplateSpec {
 				var (
 					annotations = map[string]string{
 						references.AnnotationKey(references.KindSecret, secretNameCA): secretNameCA,
@@ -543,35 +482,21 @@ status: {}
 					annotations[references.AnnotationKey(references.KindSecret, item)] = item
 				}
 
-				if reversedVPNEnabled {
-					annotations[references.AnnotationKey(references.KindSecret, secretNameTLSAuth)] = secretNameTLSAuth
 
-					hostPathCharDev := corev1.HostPathCharDev
-					volumes = append(volumes,
-						corev1.Volume{
-							Name: "dev-net-tun",
-							VolumeSource: corev1.VolumeSource{
-								HostPath: &corev1.HostPathVolumeSource{
-									Path: "/dev/net/tun",
-									Type: &hostPathCharDev,
-								},
-							},
-						},
-					)
-				} else {
-					annotations[references.AnnotationKey(references.KindSecret, secretNameTLSAuthLegacyVPN)] = secretNameTLSAuthLegacyVPN
-					annotations[references.AnnotationKey(references.KindSecret, secretNameDHTest)] = secretNameDHTest
+				annotations[references.AnnotationKey(references.KindSecret, secretNameTLSAuth)] = secretNameTLSAuth
 
-					volumes = append(volumes, corev1.Volume{
-						Name: "vpn-shoot-dh",
+				hostPathCharDev := corev1.HostPathCharDev
+				volumes = append(volumes,
+					corev1.Volume{
+						Name: "dev-net-tun",
 						VolumeSource: corev1.VolumeSource{
-							Secret: &corev1.SecretVolumeSource{
-								SecretName:  secretNameDHTest,
-								DefaultMode: pointer.Int32(0400),
+							HostPath: &corev1.HostPathVolumeSource{
+								Path: "/dev/net/tun",
+								Type: &hostPathCharDev,
 							},
 						},
-					})
-				}
+					},
+				)
 
 				obj := &corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{
@@ -603,41 +528,41 @@ status: {}
 				}
 
 				if !highAvailable {
-					obj.Spec.Containers = append(obj.Spec.Containers, *containerFor(1, nil, reversedVPNEnabled, vpaEnabled, highAvailable))
+					obj.Spec.Containers = append(obj.Spec.Containers, *containerFor(1, nil, vpaEnabled, highAvailable))
 				} else {
 					for i := 0; i < servers; i++ {
-						obj.Spec.Containers = append(obj.Spec.Containers, *containerFor(len(secretNameClients), &i, reversedVPNEnabled, vpaEnabled, highAvailable))
+						obj.Spec.Containers = append(obj.Spec.Containers, *containerFor(len(secretNameClients), &i, vpaEnabled, highAvailable))
 					}
 				}
 
-				if reversedVPNEnabled {
-					if highAvailable {
-						reversedVPNInitContainers[0].Env = append(reversedVPNInitContainers[0].Env, []corev1.EnvVar{
-							{
-								Name:  "CONFIGURE_BONDING",
-								Value: "true",
-							},
-							{
-								Name:  "HA_VPN_SERVERS",
-								Value: "3",
-							},
-							{
-								Name:  "HA_VPN_CLIENTS",
-								Value: "2",
-							},
-						}...)
-					}
-					obj.Spec.InitContainers = reversedVPNInitContainers
+
+				if highAvailable {
+					reversedVPNInitContainers[0].Env = append(reversedVPNInitContainers[0].Env, []corev1.EnvVar{
+						{
+							Name:  "CONFIGURE_BONDING",
+							Value: "true",
+						},
+						{
+							Name:  "HA_VPN_SERVERS",
+							Value: "3",
+						},
+						{
+							Name:  "HA_VPN_CLIENTS",
+							Value: "2",
+						},
+					}...)
 				}
+				obj.Spec.InitContainers = reversedVPNInitContainers
+			
 
 				return obj
 			}
 
-			templateFor = func(secretNameCA, secretNameClient, secretNameTLSAuth string, reversedVPNEnabled, vpaEnabled bool) *corev1.PodTemplateSpec {
-				return templateForEx(1, []string{secretNameClient}, secretNameCA, secretNameTLSAuth, reversedVPNEnabled, vpaEnabled, false)
+			templateFor = func(secretNameCA, secretNameClient, secretNameTLSAuth string, vpaEnabled bool) *corev1.PodTemplateSpec {
+				return templateForEx(1, []string{secretNameClient}, secretNameCA, secretNameTLSAuth, vpaEnabled, false)
 			}
 
-			objectMetaForEx = func(secretNameClients []string, secretNameCA, secretNameTLSAuth string, reversedVPNEnabled bool) *metav1.ObjectMeta {
+			objectMetaForEx = func(secretNameClients []string, secretNameCA, secretNameTLSAuth string) *metav1.ObjectMeta {
 				annotations := map[string]string{
 					references.AnnotationKey(references.KindSecret, secretNameCA): secretNameCA,
 				}
@@ -645,12 +570,7 @@ status: {}
 					annotations[references.AnnotationKey(references.KindSecret, item)] = item
 				}
 
-				if reversedVPNEnabled {
-					annotations[references.AnnotationKey(references.KindSecret, secretNameTLSAuth)] = secretNameTLSAuth
-				} else {
-					annotations[references.AnnotationKey(references.KindSecret, secretNameTLSAuthLegacyVPN)] = secretNameTLSAuthLegacyVPN
-					annotations[references.AnnotationKey(references.KindSecret, secretNameDHTest)] = secretNameDHTest
-				}
+				annotations[references.AnnotationKey(references.KindSecret, secretNameTLSAuth)] = secretNameTLSAuth
 
 				return &metav1.ObjectMeta{
 					Name:        "vpn-shoot",
@@ -664,11 +584,11 @@ status: {}
 				}
 			}
 
-			objectMetaFor = func(secretNameCA, secretNameClient, secretNameTLSAuth string, reversedVPNEnabled bool) *metav1.ObjectMeta {
-				return objectMetaForEx([]string{secretNameClient}, secretNameCA, secretNameTLSAuth, reversedVPNEnabled)
+			objectMetaFor = func(secretNameCA, secretNameClient, secretNameTLSAuth string) *metav1.ObjectMeta {
+				return objectMetaForEx([]string{secretNameClient}, secretNameCA, secretNameTLSAuth)
 			}
 
-			deploymentFor = func(secretNameCA, secretNameClient, secretNameTLSAuth string, reversedVPNEnabled, vpaEnabled bool) *appsv1.Deployment {
+			deploymentFor = func(secretNameCA, secretNameClient, secretNameTLSAuth string, vpaEnabled bool) *appsv1.Deployment {
 				var (
 					intStrMax, intStrZero = intstr.FromString("100%"), intstr.FromString("0%")
 				)
@@ -678,7 +598,7 @@ status: {}
 						APIVersion: "apps/v1",
 						Kind:       "Deployment",
 					},
-					ObjectMeta: *objectMetaFor(secretNameCA, secretNameClient, secretNameTLSAuth, reversedVPNEnabled),
+					ObjectMeta: *objectMetaFor(secretNameCA, secretNameClient, secretNameTLSAuth),
 					Spec: appsv1.DeploymentSpec{
 						RevisionHistoryLimit: pointer.Int32(2),
 						Replicas:             pointer.Int32(1),
@@ -694,18 +614,18 @@ status: {}
 								"app": "vpn-shoot",
 							},
 						},
-						Template: *templateFor(secretNameCA, secretNameClient, secretNameTLSAuth, reversedVPNEnabled, vpaEnabled),
+						Template: *templateFor(secretNameCA, secretNameClient, secretNameTLSAuth, vpaEnabled),
 					},
 				}
 			}
 
-			statefulSetFor = func(servers, replicas int, secretNameClients []string, secretNameCA, secretNameTLSAuth string, reversedVPNEnabled, vpaEnabled bool) *appsv1.StatefulSet {
+			statefulSetFor = func(servers, replicas int, secretNameClients []string, secretNameCA, secretNameTLSAuth string, vpaEnabled bool) *appsv1.StatefulSet {
 				return &appsv1.StatefulSet{
 					TypeMeta: metav1.TypeMeta{
 						APIVersion: "apps/v1",
 						Kind:       "StatefulSet",
 					},
-					ObjectMeta: *objectMetaForEx(secretNameClients, secretNameCA, secretNameTLSAuth, reversedVPNEnabled),
+					ObjectMeta: *objectMetaForEx(secretNameClients, secretNameCA, secretNameTLSAuth),
 					Spec: appsv1.StatefulSetSpec{
 						PodManagementPolicy:  appsv1.ParallelPodManagement,
 						RevisionHistoryLimit: pointer.Int32(2),
@@ -718,61 +638,10 @@ status: {}
 								"app": "vpn-shoot",
 							},
 						},
-						Template: *templateForEx(servers, secretNameClients, secretNameCA, secretNameTLSAuth, reversedVPNEnabled, vpaEnabled, true),
+						Template: *templateForEx(servers, secretNameClients, secretNameCA, secretNameTLSAuth, vpaEnabled, true),
 					},
 				}
 			}
-
-			clusterRoleYAML = `apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  creationTimestamp: null
-  name: system:gardener.cloud:vpn-seed
-rules:
-- apiGroups:
-  - ""
-  resourceNames:
-  - vpn-shoot
-  resources:
-  - services
-  verbs:
-  - get
-`
-			clusterRoleBindingYAML = `apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  annotations:
-    resources.gardener.cloud/delete-on-invalid-update: "true"
-  creationTimestamp: null
-  name: system:gardener.cloud:vpn-seed
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: system:gardener.cloud:vpn-seed
-subjects:
-- kind: User
-  name: vpn-seed
-`
-			serviceYAML = `apiVersion: v1
-kind: Service
-metadata:
-  creationTimestamp: null
-  labels:
-    app: vpn-shoot
-  name: vpn-shoot
-  namespace: kube-system
-spec:
-  ports:
-  - name: openvpn
-    port: 4314
-    protocol: TCP
-    targetPort: 1194
-  selector:
-    app: vpn-shoot
-  type: LoadBalancer
-status:
-  loadBalancer: {}
-`
 		)
 
 		JustBeforeEach(func() {
@@ -810,66 +679,9 @@ status:
 			Expect(string(managedResourceSecret.Data["networkpolicy__kube-system__gardener.cloud--allow-vpn.yaml"])).To(Equal(networkPolicyYAML))
 			Expect(string(managedResourceSecret.Data["serviceaccount__kube-system__vpn-shoot.yaml"])).To(Equal(serviceAccountYAML))
 
-			if !values.ReversedVPN.Enabled {
-				Expect(string(managedResourceSecret.Data["secret__kube-system__"+secretNameTLSAuthLegacyVPN+".yaml"])).To(Equal(secretTLSAuthYAML))
-			}
-		})
-
-		Context("VPNShoot with ReversedVPN not enabled", func() {
-			BeforeEach(func() {
-				values.ReversedVPN.Enabled = false
-				values.Network = NetworkValues{
-					ServiceCIDR: serviceNetwork,
-					PodCIDR:     podNetwork,
-					NodeCIDR:    nodeNetwork,
-				}
-				secrets.DH = &component.Secret{Name: secretNameDH, Checksum: secretChecksumDH, Data: secretDataDH}
-			})
-
-			JustBeforeEach(func() {
-				Expect(string(managedResourceSecret.Data["clusterrole____system_gardener.cloud_vpn-seed.yaml"])).To(Equal(clusterRoleYAML))
-				Expect(string(managedResourceSecret.Data["clusterrolebinding____system_gardener.cloud_vpn-seed.yaml"])).To(Equal(clusterRoleBindingYAML))
-				Expect(string(managedResourceSecret.Data["service__kube-system__vpn-shoot.yaml"])).To(Equal(serviceYAML))
-				Expect(string(managedResourceSecret.Data["secret__kube-system__"+secretNameDHTest+".yaml"])).To(Equal(secretDHYAML))
-			})
-
-			Context("w/o VPA", func() {
-				BeforeEach(func() {
-					values.VPAEnabled = false
-				})
-
-				It("should successfully deploy all resources", func() {
-					secretNameClient := expectVPNShootSecret(managedResourceSecret.Data, values.ReversedVPN.Enabled)
-					secretNameCA := expectCASecret(managedResourceSecret.Data)
-
-					deployment := &appsv1.Deployment{}
-					Expect(runtime.DecodeInto(newCodec(), managedResourceSecret.Data["deployment__kube-system__vpn-shoot.yaml"], deployment)).To(Succeed())
-					Expect(deployment).To(DeepEqual(deploymentFor(secretNameCA, secretNameClient, secretNameTLSAuthLegacyVPN, values.ReversedVPN.Enabled, values.VPAEnabled)))
-				})
-			})
-
-			Context("w/ VPA", func() {
-				BeforeEach(func() {
-					values.VPAEnabled = true
-				})
-
-				It("should successfully deploy all resources", func() {
-					Expect(string(managedResourceSecret.Data["verticalpodautoscaler__kube-system__vpn-shoot.yaml"])).To(Equal(vpaYAML))
-
-					secretNameClient := expectVPNShootSecret(managedResourceSecret.Data, values.ReversedVPN.Enabled)
-					secretNameCA := expectCASecret(managedResourceSecret.Data)
-
-					deployment := &appsv1.Deployment{}
-					Expect(runtime.DecodeInto(newCodec(), managedResourceSecret.Data["deployment__kube-system__vpn-shoot.yaml"], deployment)).To(Succeed())
-					Expect(deployment).To(DeepEqual(deploymentFor(secretNameCA, secretNameClient, secretNameTLSAuthLegacyVPN, values.ReversedVPN.Enabled, values.VPAEnabled)))
-				})
-			})
 		})
 
 		Context("VPNShoot with ReversedVPN enabled", func() {
-			BeforeEach(func() {
-				values.ReversedVPN.Enabled = true
-			})
 
 			Context("w/o VPA", func() {
 				BeforeEach(func() {
@@ -878,14 +690,14 @@ status:
 
 				It("should successfully deploy all resources", func() {
 					var (
-						secretNameClient  = expectVPNShootSecret(managedResourceSecret.Data, values.ReversedVPN.Enabled)
+						secretNameClient  = expectVPNShootSecret(managedResourceSecret.Data)
 						secretNameCA      = expectCASecret(managedResourceSecret.Data)
 						secretNameTLSAuth = expectTLSAuthSecret(managedResourceSecret.Data)
 					)
 
 					deployment := &appsv1.Deployment{}
 					Expect(runtime.DecodeInto(newCodec(), managedResourceSecret.Data["deployment__kube-system__vpn-shoot.yaml"], deployment)).To(Succeed())
-					Expect(deployment).To(DeepEqual(deploymentFor(secretNameCA, secretNameClient, secretNameTLSAuth, values.ReversedVPN.Enabled, values.VPAEnabled)))
+					Expect(deployment).To(DeepEqual(deploymentFor(secretNameCA, secretNameClient, secretNameTLSAuth, values.VPAEnabled)))
 				})
 			})
 
@@ -898,14 +710,14 @@ status:
 					Expect(string(managedResourceSecret.Data["verticalpodautoscaler__kube-system__vpn-shoot.yaml"])).To(Equal(vpaYAML))
 
 					var (
-						secretNameClient  = expectVPNShootSecret(managedResourceSecret.Data, values.ReversedVPN.Enabled)
+						secretNameClient  = expectVPNShootSecret(managedResourceSecret.Data)
 						secretNameCA      = expectCASecret(managedResourceSecret.Data)
 						secretNameTLSAuth = expectTLSAuthSecret(managedResourceSecret.Data)
 					)
 
 					deployment := &appsv1.Deployment{}
 					Expect(runtime.DecodeInto(newCodec(), managedResourceSecret.Data["deployment__kube-system__vpn-shoot.yaml"], deployment)).To(Succeed())
-					Expect(deployment).To(DeepEqual(deploymentFor(secretNameCA, secretNameClient, secretNameTLSAuth, values.ReversedVPN.Enabled, values.VPAEnabled)))
+					Expect(deployment).To(DeepEqual(deploymentFor(secretNameCA, secretNameClient, secretNameTLSAuth, values.VPAEnabled)))
 				})
 			})
 
@@ -921,8 +733,8 @@ status:
 					Expect(string(managedResourceSecret.Data["verticalpodautoscaler__kube-system__vpn-shoot.yaml"])).To(Equal(vpaHAYAML))
 
 					var (
-						secretNameClient0 = expectVPNShootSecret(managedResourceSecret.Data, values.ReversedVPN.Enabled, "-0")
-						secretNameClient1 = expectVPNShootSecret(managedResourceSecret.Data, values.ReversedVPN.Enabled, "-1")
+						secretNameClient0 = expectVPNShootSecret(managedResourceSecret.Data, "-0")
+						secretNameClient1 = expectVPNShootSecret(managedResourceSecret.Data, "-1")
 						secretNameCA      = expectCASecret(managedResourceSecret.Data)
 						secretNameTLSAuth = expectTLSAuthSecret(managedResourceSecret.Data)
 					)
@@ -930,7 +742,7 @@ status:
 					_ = secretNameClient1 // TODO
 					statefulSet := &appsv1.StatefulSet{}
 					Expect(runtime.DecodeInto(newCodec(), managedResourceSecret.Data["statefulset__kube-system__vpn-shoot.yaml"], statefulSet)).To(Succeed())
-					expected := statefulSetFor(3, 2, []string{secretNameClient0, secretNameClient1}, secretNameCA, secretNameTLSAuth, values.ReversedVPN.Enabled, values.VPAEnabled)
+					expected := statefulSetFor(3, 2, []string{secretNameClient0, secretNameClient1}, secretNameCA, secretNameTLSAuth, values.VPAEnabled)
 					Expect(statefulSet).To(DeepEqual(expected))
 				})
 
@@ -942,7 +754,6 @@ status:
 
 		Context("PodSecurityPolicy", func() {
 			BeforeEach(func() {
-				values.ReversedVPN.Enabled = true
 				values.VPAEnabled = true
 			})
 
@@ -954,14 +765,14 @@ status:
 					Expect(string(managedResourceSecret.Data["verticalpodautoscaler__kube-system__vpn-shoot.yaml"])).To(Equal(vpaYAML))
 
 					var (
-						secretNameClient  = expectVPNShootSecret(managedResourceSecret.Data, values.ReversedVPN.Enabled)
+						secretNameClient  = expectVPNShootSecret(managedResourceSecret.Data)
 						secretNameCA      = expectCASecret(managedResourceSecret.Data)
 						secretNameTLSAuth = expectTLSAuthSecret(managedResourceSecret.Data)
 					)
 
 					deployment := &appsv1.Deployment{}
 					Expect(runtime.DecodeInto(newCodec(), managedResourceSecret.Data["deployment__kube-system__vpn-shoot.yaml"], deployment)).To(Succeed())
-					Expect(deployment).To(DeepEqual(deploymentFor(secretNameCA, secretNameClient, secretNameTLSAuth, values.ReversedVPN.Enabled, values.VPAEnabled)))
+					Expect(deployment).To(DeepEqual(deploymentFor(secretNameCA, secretNameClient, secretNameTLSAuth, values.VPAEnabled)))
 				})
 
 				It("should successfully deploy all resources", func() {
@@ -1113,11 +924,8 @@ status:
 	})
 })
 
-func expectVPNShootSecret(data map[string][]byte, reversedVPNEnabled bool, haSuffix ...string) string {
+func expectVPNShootSecret(data map[string][]byte, haSuffix ...string) string {
 	suffix := "client"
-	if !reversedVPNEnabled {
-		suffix = "server"
-	}
 
 	if len(haSuffix) > 0 {
 		suffix += haSuffix[0]

--- a/pkg/operation/botanist/component/vpnshoot/vpnshoot_test.go
+++ b/pkg/operation/botanist/component/vpnshoot/vpnshoot_test.go
@@ -292,7 +292,6 @@ status: {}
 					MountPath: "/srv/secrets/tlsauth",
 				})
 
-
 				env = append(env,
 					corev1.EnvVar{
 						Name:  "ENDPOINT",
@@ -322,7 +321,6 @@ status: {}
 						MountPath: "/dev/net/tun",
 					},
 				)
-
 
 				if vpaEnabled {
 					limits = corev1.ResourceList{
@@ -482,7 +480,6 @@ status: {}
 					annotations[references.AnnotationKey(references.KindSecret, item)] = item
 				}
 
-
 				annotations[references.AnnotationKey(references.KindSecret, secretNameTLSAuth)] = secretNameTLSAuth
 
 				hostPathCharDev := corev1.HostPathCharDev
@@ -535,7 +532,6 @@ status: {}
 					}
 				}
 
-
 				if highAvailable {
 					reversedVPNInitContainers[0].Env = append(reversedVPNInitContainers[0].Env, []corev1.EnvVar{
 						{
@@ -553,7 +549,6 @@ status: {}
 					}...)
 				}
 				obj.Spec.InitContainers = reversedVPNInitContainers
-			
 
 				return obj
 			}

--- a/pkg/operation/botanist/component/vpnshoot/vpnshoot_test.go
+++ b/pkg/operation/botanist/component/vpnshoot/vpnshoot_test.go
@@ -68,8 +68,6 @@ var _ = Describe("VPNShoot", func() {
 		reversedVPNHeader               = "outbound|1194||vpn-seed-server.shoot--project--shoot-name.svc.cluster.local"
 		reversedVPNHeaderTemplate       = "outbound|1194||vpn-seed-server-%d.shoot--project--shoot-name.svc.cluster.local"
 
-		secrets = Secrets{}
-
 		values = Values{
 			Image: image,
 			ReversedVPN: ReversedVPNValues{
@@ -644,10 +642,7 @@ status: {}
 
 			Expect(c.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)).To(MatchError(apierrors.NewNotFound(schema.GroupResource{Group: resourcesv1alpha1.SchemeGroupVersion.Group, Resource: "managedresources"}, managedResource.Name)))
 			Expect(c.Get(ctx, client.ObjectKeyFromObject(managedResourceSecret), managedResourceSecret)).To(MatchError(apierrors.NewNotFound(schema.GroupResource{Group: corev1.SchemeGroupVersion.Group, Resource: "secrets"}, managedResourceSecret.Name)))
-
-			vpnShoot.SetSecrets(secrets)
 			Expect(vpnShoot.Deploy(ctx)).To(Succeed())
-
 			Expect(c.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)).To(Succeed())
 
 			Expect(managedResource).To(DeepEqual(&resourcesv1alpha1.ManagedResource{

--- a/pkg/operation/botanist/coredns_test.go
+++ b/pkg/operation/botanist/coredns_test.go
@@ -77,10 +77,11 @@ var _ = Describe("CoreDNS", func() {
 				CoreDNS: net.ParseIP("18.19.20.21"),
 				Pods:    &net.IPNet{IP: net.ParseIP("22.23.24.25")},
 			}
+			botanist.Garden = &garden.Garden{}
 		})
 
 		It("should successfully create a coredns interface", func() {
-			defer test.WithFeatureGate(gardenletfeatures.FeatureGate, features.APIServerSNI, false)()
+			defer test.WithFeatureGate(gardenletfeatures.FeatureGate, features.APIServerSNI, true)()
 
 			kubernetesClient.EXPECT().Client()
 			botanist.ImageVector = imagevector.ImageVector{{Name: "coredns"}}
@@ -117,7 +118,7 @@ var _ = Describe("CoreDNS", func() {
 			})
 
 			It("should successfully create a coredns interface with cluster-proportional autoscaling enabled", func() {
-				defer test.WithFeatureGate(gardenletfeatures.FeatureGate, features.APIServerSNI, false)()
+				defer test.WithFeatureGate(gardenletfeatures.FeatureGate, features.APIServerSNI, true)()
 
 				kubernetesClient.EXPECT().Client()
 				botanist.ImageVector = imagevector.ImageVector{{Name: "coredns"}, {Name: "cluster-proportional-autoscaler"}}
@@ -130,7 +131,6 @@ var _ = Describe("CoreDNS", func() {
 			It("should return an error because the cluster-proportional autoscaler image cannot be found", func() {
 				botanist.ImageVector = imagevector.ImageVector{{Name: "coredns"}}
 				botanist.APIServerAddress = "coredns-test"
-				botanist.Garden = &garden.Garden{}
 
 				coreDNS, err := botanist.DefaultCoreDNS()
 				Expect(coreDNS).To(BeNil())

--- a/pkg/operation/botanist/dns_test.go
+++ b/pkg/operation/botanist/dns_test.go
@@ -188,12 +188,6 @@ var _ = Describe("dns", func() {
 			gardenletfeatures.RegisterFeatureGates()
 		})
 
-		It("returns false when feature gate is disabled", func() {
-			Expect(gardenletfeatures.FeatureGate.Set("APIServerSNI=false")).ToNot(HaveOccurred())
-
-			Expect(b.APIServerSNIEnabled()).To(BeFalse())
-		})
-
 		It("returns true when feature gate is enabled", func() {
 			Expect(gardenletfeatures.FeatureGate.Set("APIServerSNI=true")).ToNot(HaveOccurred())
 			b.Garden.InternalDomain = &garden.Domain{Provider: "some-provider"}
@@ -208,12 +202,6 @@ var _ = Describe("dns", func() {
 	Context("APIServerSNIPodMutatorEnabled", func() {
 		BeforeEach(func() {
 			gardenletfeatures.RegisterFeatureGates()
-		})
-
-		It("returns false when the feature gate is disabled", func() {
-			Expect(gardenletfeatures.FeatureGate.Set("APIServerSNI=false")).ToNot(HaveOccurred())
-
-			Expect(b.APIServerSNIPodMutatorEnabled()).To(BeFalse())
 		})
 
 		Context("APIServerSNI feature gate is enabled", func() {

--- a/pkg/operation/botanist/kubeapiserver.go
+++ b/pkg/operation/botanist/kubeapiserver.go
@@ -157,7 +157,6 @@ func (b *Botanist) DefaultKubeAPIServer(ctx context.Context) (kubeapiserver.Inte
 			StaticTokenKubeconfigEnabled:   b.Shoot.GetInfo().Spec.Kubernetes.EnableStaticTokenKubeconfig,
 			Version:                        b.Shoot.KubernetesVersion,
 			VPN: kubeapiserver.VPNConfig{
-				ReversedVPNEnabled:                   true,
 				PodNetworkCIDR:                       b.Shoot.Networks.Pods.String(),
 				ServiceNetworkCIDR:                   b.Shoot.Networks.Services.String(),
 				NodeNetworkCIDR:                      b.Shoot.GetInfo().Spec.Networking.Nodes,

--- a/pkg/operation/botanist/kubeapiserver.go
+++ b/pkg/operation/botanist/kubeapiserver.go
@@ -157,7 +157,7 @@ func (b *Botanist) DefaultKubeAPIServer(ctx context.Context) (kubeapiserver.Inte
 			StaticTokenKubeconfigEnabled:   b.Shoot.GetInfo().Spec.Kubernetes.EnableStaticTokenKubeconfig,
 			Version:                        b.Shoot.KubernetesVersion,
 			VPN: kubeapiserver.VPNConfig{
-				ReversedVPNEnabled:                   b.Shoot.ReversedVPNEnabled,
+				ReversedVPNEnabled:                   true,
 				PodNetworkCIDR:                       b.Shoot.Networks.Pods.String(),
 				ServiceNetworkCIDR:                   b.Shoot.Networks.Services.String(),
 				NodeNetworkCIDR:                      b.Shoot.GetInfo().Spec.Networking.Nodes,

--- a/pkg/operation/botanist/kubeapiserver.go
+++ b/pkg/operation/botanist/kubeapiserver.go
@@ -418,11 +418,6 @@ func (b *Botanist) computeKubeAPIServerImages() (kubeapiserver.Images, error) {
 		return kubeapiserver.Images{}, err
 	}
 
-	imageVPNSeed, err := b.ImageVector.FindImage(images.ImageNameVpnSeed, imagevector.RuntimeVersion(b.SeedVersion()), imagevector.TargetVersion(b.ShootVersion()))
-	if err != nil {
-		return kubeapiserver.Images{}, err
-	}
-
 	vpnClient := ""
 	if b.Shoot.VPNHighAvailabilityEnabled {
 		imageVPNClient, err := b.ImageVector.FindImage(images.ImageNameVpnShootClient, imagevector.RuntimeVersion(b.SeedVersion()), imagevector.TargetVersion(b.ShootVersion()))
@@ -436,7 +431,6 @@ func (b *Botanist) computeKubeAPIServerImages() (kubeapiserver.Images, error) {
 		AlpineIPTables:           imageAlpineIPTables.String(),
 		APIServerProxyPodWebhook: imageApiserverProxyPodWebhook.String(),
 		KubeAPIServer:            imageKubeAPIServer.String(),
-		VPNSeed:                  imageVPNSeed.String(),
 		VPNClient:                vpnClient,
 	}, nil
 }

--- a/pkg/operation/botanist/kubeapiserver.go
+++ b/pkg/operation/botanist/kubeapiserver.go
@@ -403,11 +403,6 @@ func resourcesRequirementsForKubeAPIServer(nodeCount int32, scalingClass string)
 }
 
 func (b *Botanist) computeKubeAPIServerImages() (kubeapiserver.Images, error) {
-	imageAlpineIPTables, err := b.ImageVector.FindImage(images.ImageNameAlpineIptables, imagevector.RuntimeVersion(b.SeedVersion()), imagevector.TargetVersion(b.ShootVersion()))
-	if err != nil {
-		return kubeapiserver.Images{}, err
-	}
-
 	imageApiserverProxyPodWebhook, err := b.ImageVector.FindImage(images.ImageNameApiserverProxyPodWebhook, imagevector.RuntimeVersion(b.SeedVersion()), imagevector.TargetVersion(b.ShootVersion()))
 	if err != nil {
 		return kubeapiserver.Images{}, err
@@ -428,7 +423,6 @@ func (b *Botanist) computeKubeAPIServerImages() (kubeapiserver.Images, error) {
 	}
 
 	return kubeapiserver.Images{
-		AlpineIPTables:           imageAlpineIPTables.String(),
 		APIServerProxyPodWebhook: imageApiserverProxyPodWebhook.String(),
 		KubeAPIServer:            imageKubeAPIServer.String(),
 		VPNClient:                vpnClient,

--- a/pkg/operation/botanist/kubeapiserver_test.go
+++ b/pkg/operation/botanist/kubeapiserver_test.go
@@ -1110,19 +1110,8 @@ usernames: ["admin"]
 					Expect(kubeAPIServer.GetValues().VPN).To(Equal(expectedConfig))
 				},
 
-				Entry("ReversedVPN disabled",
-					nil,
-					kubeapiserver.VPNConfig{
-						ReversedVPNEnabled: false,
-						PodNetworkCIDR:     podNetworkCIDR,
-						ServiceNetworkCIDR: serviceNetworkCIDR,
-						NodeNetworkCIDR:    &nodeNetworkCIDR,
-					},
-				),
 				Entry("ReversedVPN enabled",
-					func() {
-						botanist.Shoot.ReversedVPNEnabled = true
-					},
+					nil,
 					kubeapiserver.VPNConfig{
 						ReversedVPNEnabled: true,
 						PodNetworkCIDR:     podNetworkCIDR,
@@ -1137,7 +1126,7 @@ usernames: ["admin"]
 						botanist.Shoot.SetInfo(shootCopy)
 					},
 					kubeapiserver.VPNConfig{
-						ReversedVPNEnabled: false,
+						ReversedVPNEnabled: true,
 						PodNetworkCIDR:     podNetworkCIDR,
 						ServiceNetworkCIDR: serviceNetworkCIDR,
 					},

--- a/pkg/operation/botanist/kubeapiserver_test.go
+++ b/pkg/operation/botanist/kubeapiserver_test.go
@@ -134,10 +134,8 @@ var _ = Describe("KubeAPIServer", func() {
 					KubernetesVersion: semver.MustParse("1.22.1"),
 				},
 				ImageVector: imagevector.ImageVector{
-					{Name: "alpine-iptables"},
 					{Name: "apiserver-proxy-pod-webhook"},
 					{Name: "kube-apiserver"},
-					{Name: "vpn-seed"},
 					{Name: "vpn-shoot-client"},
 				},
 				APIServerAddress:   apiServerAddress,
@@ -182,16 +180,8 @@ var _ = Describe("KubeAPIServer", func() {
 	})
 
 	Describe("#DefaultKubeAPIServer", func() {
-		It("should return an error because the alpine-iptables image cannot be found", func() {
+		It("should return an error because the apiserver-proxy-pod-webhook image cannot be found", func() {
 			botanist.ImageVector = imagevector.ImageVector{}
-
-			kubeAPIServer, err := botanist.DefaultKubeAPIServer(ctx)
-			Expect(kubeAPIServer).To(BeNil())
-			Expect(err).To(MatchError(ContainSubstring("could not find image \"alpine-iptables\"")))
-		})
-
-		It("should return an error because the apiserver-proxy-pod-webhook cannot be found", func() {
-			botanist.ImageVector = imagevector.ImageVector{{Name: "alpine-iptables"}}
 
 			kubeAPIServer, err := botanist.DefaultKubeAPIServer(ctx)
 			Expect(kubeAPIServer).To(BeNil())
@@ -199,7 +189,7 @@ var _ = Describe("KubeAPIServer", func() {
 		})
 
 		It("should return an error because the kube-apiserver cannot be found", func() {
-			botanist.ImageVector = imagevector.ImageVector{{Name: "alpine-iptables"}, {Name: "apiserver-proxy-pod-webhook"}}
+			botanist.ImageVector = imagevector.ImageVector{{Name: "apiserver-proxy-pod-webhook"}}
 
 			kubeAPIServer, err := botanist.DefaultKubeAPIServer(ctx)
 			Expect(kubeAPIServer).To(BeNil())

--- a/pkg/operation/botanist/kubeapiserver_test.go
+++ b/pkg/operation/botanist/kubeapiserver_test.go
@@ -1113,7 +1113,6 @@ usernames: ["admin"]
 				Entry("ReversedVPN enabled",
 					nil,
 					kubeapiserver.VPNConfig{
-						ReversedVPNEnabled: true,
 						PodNetworkCIDR:     podNetworkCIDR,
 						ServiceNetworkCIDR: serviceNetworkCIDR,
 						NodeNetworkCIDR:    &nodeNetworkCIDR,
@@ -1126,7 +1125,6 @@ usernames: ["admin"]
 						botanist.Shoot.SetInfo(shootCopy)
 					},
 					kubeapiserver.VPNConfig{
-						ReversedVPNEnabled: true,
 						PodNetworkCIDR:     podNetworkCIDR,
 						ServiceNetworkCIDR: serviceNetworkCIDR,
 					},

--- a/pkg/operation/botanist/kubeapiserverexposure_test.go
+++ b/pkg/operation/botanist/kubeapiserverexposure_test.go
@@ -139,42 +139,5 @@ var _ = Describe("KubeAPIServerExposure", func() {
 				Entry("NodePort", corev1.ServiceTypeNodePort),
 			)
 		})
-
-		Context("sni disabled", func() {
-			BeforeEach(func() {
-				Expect(gardenletfeatures.FeatureGate.Set("APIServerSNI=false")).ToNot(HaveOccurred())
-			})
-
-			It("returns Disabled for not existing services", func() {
-				phase, err := botanist.SNIPhase(ctx)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(phase).To(Equal(component.PhaseDisabled))
-			})
-
-			It("returns Disabling for service of type ClusterIP", func() {
-				svc.Spec.Type = corev1.ServiceTypeClusterIP
-				Expect(client.Create(ctx, svc)).NotTo(HaveOccurred())
-
-				phase, err := botanist.SNIPhase(ctx)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(phase).To(Equal(component.PhaseDisabling))
-			})
-
-			DescribeTable(
-				"return Disabled for service of type",
-				func(svcType corev1.ServiceType) {
-					svc.Spec.Type = svcType
-					Expect(client.Create(ctx, svc)).NotTo(HaveOccurred())
-
-					phase, err := botanist.SNIPhase(ctx)
-					Expect(err).NotTo(HaveOccurred())
-					Expect(phase).To(Equal(component.PhaseDisabled))
-				},
-
-				Entry("ExternalName", corev1.ServiceTypeExternalName),
-				Entry("LoadBalancer", corev1.ServiceTypeLoadBalancer),
-				Entry("NodePort", corev1.ServiceTypeNodePort),
-			)
-		})
 	})
 })

--- a/pkg/operation/botanist/monitoring.go
+++ b/pkg/operation/botanist/monitoring.go
@@ -97,13 +97,12 @@ func (b *Botanist) DeploySeedMonitoring(ctx context.Context) error {
 		b.Shoot.Components.SystemComponents.CoreDNS,
 		b.Shoot.Components.SystemComponents.KubeProxy,
 		b.Shoot.Components.SystemComponents.VPNShoot,
+		b.Shoot.Components.ControlPlane.VPNSeedServer,
 	}
 
 	if b.Shoot.NodeLocalDNSEnabled {
 		monitoringComponents = append(monitoringComponents, b.Shoot.Components.SystemComponents.NodeLocalDNS)
 	}
-
-	monitoringComponents = append(monitoringComponents, b.Shoot.Components.ControlPlane.VPNSeedServer)
 
 	if b.Shoot.WantsClusterAutoscaler {
 		monitoringComponents = append(monitoringComponents, b.Shoot.Components.ControlPlane.ClusterAutoscaler)

--- a/pkg/operation/botanist/monitoring.go
+++ b/pkg/operation/botanist/monitoring.go
@@ -103,9 +103,9 @@ func (b *Botanist) DeploySeedMonitoring(ctx context.Context) error {
 		monitoringComponents = append(monitoringComponents, b.Shoot.Components.SystemComponents.NodeLocalDNS)
 	}
 
-	if b.Shoot.ReversedVPNEnabled {
-		monitoringComponents = append(monitoringComponents, b.Shoot.Components.ControlPlane.VPNSeedServer)
-	}
+	//if b.Shoot.ReversedVPNEnabled {
+	monitoringComponents = append(monitoringComponents, b.Shoot.Components.ControlPlane.VPNSeedServer)
+	//}
 
 	if b.Shoot.WantsClusterAutoscaler {
 		monitoringComponents = append(monitoringComponents, b.Shoot.Components.ControlPlane.ClusterAutoscaler)
@@ -213,7 +213,7 @@ func (b *Botanist) DeploySeedMonitoring(ctx context.Context) error {
 				"enabled": b.Shoot.NodeLocalDNSEnabled,
 			},
 			"reversedVPN": map[string]interface{}{
-				"enabled": b.Shoot.ReversedVPNEnabled,
+				"enabled": true,
 			},
 			"ingress": map[string]interface{}{
 				"class":          ingressClass,

--- a/pkg/operation/botanist/monitoring.go
+++ b/pkg/operation/botanist/monitoring.go
@@ -210,9 +210,6 @@ func (b *Botanist) DeploySeedMonitoring(ctx context.Context) error {
 			"nodeLocalDNS": map[string]interface{}{
 				"enabled": b.Shoot.NodeLocalDNSEnabled,
 			},
-			"reversedVPN": map[string]interface{}{
-				"enabled": true,
-			},
 			"ingress": map[string]interface{}{
 				"class":          ingressClass,
 				"authSecretName": credentialsSecret.Name,

--- a/pkg/operation/botanist/monitoring.go
+++ b/pkg/operation/botanist/monitoring.go
@@ -103,9 +103,7 @@ func (b *Botanist) DeploySeedMonitoring(ctx context.Context) error {
 		monitoringComponents = append(monitoringComponents, b.Shoot.Components.SystemComponents.NodeLocalDNS)
 	}
 
-	//if b.Shoot.ReversedVPNEnabled {
 	monitoringComponents = append(monitoringComponents, b.Shoot.Components.ControlPlane.VPNSeedServer)
-	//}
 
 	if b.Shoot.WantsClusterAutoscaler {
 		monitoringComponents = append(monitoringComponents, b.Shoot.Components.ControlPlane.ClusterAutoscaler)

--- a/pkg/operation/botanist/monitoring_test.go
+++ b/pkg/operation/botanist/monitoring_test.go
@@ -166,7 +166,7 @@ var _ = Describe("Monitoring", func() {
 						},
 						HVPA: mockHVPA,
 					},
-					ReversedVPNEnabled: true,
+					//ReversedVPNEnabled: true,
 				},
 				ImageVector: imagevector.ImageVector{
 					{Name: "grafana"},

--- a/pkg/operation/botanist/monitoring_test.go
+++ b/pkg/operation/botanist/monitoring_test.go
@@ -166,7 +166,6 @@ var _ = Describe("Monitoring", func() {
 						},
 						HVPA: mockHVPA,
 					},
-					//ReversedVPNEnabled: true,
 				},
 				ImageVector: imagevector.ImageVector{
 					{Name: "grafana"},

--- a/pkg/operation/botanist/networkpolicies.go
+++ b/pkg/operation/botanist/networkpolicies.go
@@ -54,9 +54,6 @@ func (b *Botanist) DefaultNetworkPolicies(sniPhase component.Phase) (component.D
 	}
 
 	allCIDRNetworks := append(seedCIDRNetworks, b.Seed.GetInfo().Spec.Networks.BlockCIDRs...)
-	if !b.Shoot.ReversedVPNEnabled {
-		allCIDRNetworks = append(allCIDRNetworks, shootCIDRNetworks...)
-	}
 
 	privateNetworkPeers, err := networkpolicies.ToNetworkPolicyPeersWithExceptions(networkpolicies.AllPrivateNetworkBlocks(), allCIDRNetworks...)
 	if err != nil {

--- a/pkg/operation/botanist/networkpolicies_test.go
+++ b/pkg/operation/botanist/networkpolicies_test.go
@@ -125,48 +125,6 @@ var _ = Describe("Networkpolicies", func() {
 		),
 
 		Entry(
-			"w/ network CIDRs with reversed vpn",
-			component.PhaseUnknown,
-			func() {
-				botanist.Shoot.GetInfo().Spec.Networking.Pods = &podCIDRShoot
-				botanist.Shoot.GetInfo().Spec.Networking.Services = &serviceCIDRShoot
-				botanist.Shoot.GetInfo().Spec.Networking.Nodes = &nodeCIDRShoot
-				botanist.Seed.GetInfo().Spec.Networks.Nodes = &nodeCIDRSeed
-				botanist.Seed.GetInfo().Spec.Networks.BlockCIDRs = blockCIDRs
-				botanist.Shoot.ReversedVPNEnabled = true
-			},
-			func(client client.Client, namespace string, values networkpolicies.Values) {
-				Expect(client).To(Equal(c))
-				Expect(namespace).To(Equal(seedNamespace))
-				Expect(values.SNIEnabled).To(BeFalse())
-				Expect(values.BlockedAddresses).To(Equal(blockCIDRs))
-				Expect(values.DenyAllTraffic).To(BeTrue())
-				Expect(values.ShootNetworkPeers).To(ConsistOf(
-					networkingv1.NetworkPolicyPeer{IPBlock: &networkingv1.IPBlock{CIDR: nodeCIDRShoot, Except: blockCIDRs}},
-					networkingv1.NetworkPolicyPeer{IPBlock: &networkingv1.IPBlock{CIDR: podCIDRShoot}},
-					networkingv1.NetworkPolicyPeer{IPBlock: &networkingv1.IPBlock{CIDR: "172.16.0.0/14"}},
-				))
-				Expect(values.PrivateNetworkPeers).To(ConsistOf(
-					networkingv1.NetworkPolicyPeer{IPBlock: &networkingv1.IPBlock{
-						CIDR:   "10.0.0.0/8",
-						Except: append([]string{podCIDRSeed, nodeCIDRSeed}, blockCIDRs...),
-					}},
-					networkingv1.NetworkPolicyPeer{IPBlock: &networkingv1.IPBlock{CIDR: "172.16.0.0/12"}},
-					networkingv1.NetworkPolicyPeer{IPBlock: &networkingv1.IPBlock{
-						CIDR:   "192.168.0.0/16",
-						Except: []string{serviceCIDRSeed},
-					}},
-					networkingv1.NetworkPolicyPeer{IPBlock: &networkingv1.IPBlock{
-						CIDR:   "100.64.0.0/10",
-						Except: nil,
-					}},
-				))
-				Expect(values.NodeLocalIPVSAddress).To(PointTo(Equal("169.254.20.10")))
-				Expect(values.DNSServerAddress).To(PointTo(Equal("192.168.0.10")))
-			},
-		),
-
-		Entry(
 			"w/ network CIDRs",
 			component.PhaseUnknown,
 			func() {
@@ -192,10 +150,7 @@ var _ = Describe("Networkpolicies", func() {
 						CIDR:   "10.0.0.0/8",
 						Except: append([]string{podCIDRSeed, nodeCIDRSeed}, blockCIDRs...),
 					}},
-					networkingv1.NetworkPolicyPeer{IPBlock: &networkingv1.IPBlock{
-						CIDR:   "172.16.0.0/12",
-						Except: []string{serviceCIDRShoot},
-					}},
+					networkingv1.NetworkPolicyPeer{IPBlock: &networkingv1.IPBlock{CIDR: "172.16.0.0/12"}},
 					networkingv1.NetworkPolicyPeer{IPBlock: &networkingv1.IPBlock{
 						CIDR:   "192.168.0.0/16",
 						Except: []string{serviceCIDRSeed},

--- a/pkg/operation/botanist/networkpolicies_test.go
+++ b/pkg/operation/botanist/networkpolicies_test.go
@@ -190,7 +190,7 @@ var _ = Describe("Networkpolicies", func() {
 				Expect(values.PrivateNetworkPeers).To(ConsistOf(
 					networkingv1.NetworkPolicyPeer{IPBlock: &networkingv1.IPBlock{
 						CIDR:   "10.0.0.0/8",
-						Except: append(append([]string{podCIDRSeed, nodeCIDRSeed}, blockCIDRs...), nodeCIDRShoot),
+						Except: append([]string{podCIDRSeed, nodeCIDRSeed}, blockCIDRs...),
 					}},
 					networkingv1.NetworkPolicyPeer{IPBlock: &networkingv1.IPBlock{
 						CIDR:   "172.16.0.0/12",
@@ -202,7 +202,7 @@ var _ = Describe("Networkpolicies", func() {
 					}},
 					networkingv1.NetworkPolicyPeer{IPBlock: &networkingv1.IPBlock{
 						CIDR:   "100.64.0.0/10",
-						Except: []string{podCIDRShoot},
+						Except: nil,
 					}},
 				))
 				Expect(values.NodeLocalIPVSAddress).To(PointTo(Equal("169.254.20.10")))

--- a/pkg/operation/botanist/nodeproblemdetector_test.go
+++ b/pkg/operation/botanist/nodeproblemdetector_test.go
@@ -21,6 +21,7 @@ import (
 	gardenletfeatures "github.com/gardener/gardener/pkg/gardenlet/features"
 	"github.com/gardener/gardener/pkg/operation"
 	. "github.com/gardener/gardener/pkg/operation/botanist"
+	"github.com/gardener/gardener/pkg/operation/garden"
 	shootpkg "github.com/gardener/gardener/pkg/operation/shoot"
 	"github.com/gardener/gardener/pkg/utils/imagevector"
 	"github.com/gardener/gardener/pkg/utils/test"
@@ -47,6 +48,7 @@ var _ = Describe("NodeProblemDetector", func() {
 				},
 			},
 		})
+		botanist.Garden = &garden.Garden{}
 	})
 
 	AfterEach(func() {
@@ -63,7 +65,7 @@ var _ = Describe("NodeProblemDetector", func() {
 		})
 
 		It("should successfully create a nodeproblemdetector interface", func() {
-			defer test.WithFeatureGate(gardenletfeatures.FeatureGate, features.APIServerSNI, false)()
+			defer test.WithFeatureGate(gardenletfeatures.FeatureGate, features.APIServerSNI, true)()
 			kubernetesClient.EXPECT().Client()
 			botanist.ImageVector = imagevector.ImageVector{{Name: "node-problem-detector"}}
 

--- a/pkg/operation/botanist/vpnseedserver.go
+++ b/pkg/operation/botanist/vpnseedserver.go
@@ -107,9 +107,6 @@ func (b *Botanist) DefaultVPNSeedServer() (vpnseedserver.Interface, error) {
 
 // DeployVPNServer deploys the vpn-seed-server.
 func (b *Botanist) DeployVPNServer(ctx context.Context) error {
-	if !b.Shoot.ReversedVPNEnabled {
-		return b.Shoot.Components.ControlPlane.VPNSeedServer.Destroy(ctx)
-	}
 
 	b.Shoot.Components.ControlPlane.VPNSeedServer.SetSecrets(vpnseedserver.Secrets{DiffieHellmanKey: b.getDiffieHellmanSecret()})
 	b.Shoot.Components.ControlPlane.VPNSeedServer.SetSeedNamespaceObjectUID(b.SeedNamespaceObject.UID)

--- a/pkg/operation/botanist/vpnseedserver_test.go
+++ b/pkg/operation/botanist/vpnseedserver_test.go
@@ -165,7 +165,6 @@ var _ = Describe("VPNSeedServer", func() {
 						VPNSeedServer: vpnSeedServer,
 					},
 				},
-				ReversedVPNEnabled: true,
 			}
 			botanist.Config = &config.GardenletConfiguration{
 				SNI: &config.SNI{

--- a/pkg/operation/botanist/vpnshoot.go
+++ b/pkg/operation/botanist/vpnshoot.go
@@ -26,17 +26,10 @@ import (
 
 // DefaultVPNShoot returns a deployer for the VPNShoot
 func (b *Botanist) DefaultVPNShoot() (vpnshoot.Interface, error) {
-	var (
-		imageName         = images.ImageNameVpnShoot
-		reversedVPNValues = vpnshoot.ReversedVPNValues{
-			Enabled: false,
-		}
-	)
 
-	imageName = images.ImageNameVpnShootClient
+	imageName := images.ImageNameVpnShootClient
 
-	reversedVPNValues = vpnshoot.ReversedVPNValues{
-		Enabled:     true,
+	reversedVPNValues := vpnshoot.ReversedVPNValues{
 		Header:      "outbound|1194||" + vpnseedserver.ServiceName + "." + b.Shoot.SeedNamespace + ".svc.cluster.local",
 		Endpoint:    b.outOfClusterAPIServerFQDN(),
 		OpenVPNPort: 8132,

--- a/pkg/operation/botanist/vpnshoot.go
+++ b/pkg/operation/botanist/vpnshoot.go
@@ -33,16 +33,14 @@ func (b *Botanist) DefaultVPNShoot() (vpnshoot.Interface, error) {
 		}
 	)
 
-	if b.Shoot.ReversedVPNEnabled {
-		imageName = images.ImageNameVpnShootClient
+	imageName = images.ImageNameVpnShootClient
 
-		reversedVPNValues = vpnshoot.ReversedVPNValues{
-			Enabled:     true,
-			Header:      "outbound|1194||" + vpnseedserver.ServiceName + "." + b.Shoot.SeedNamespace + ".svc.cluster.local",
-			Endpoint:    b.outOfClusterAPIServerFQDN(),
-			OpenVPNPort: 8132,
+	reversedVPNValues = vpnshoot.ReversedVPNValues{
+		Enabled:     true,
+		Header:      "outbound|1194||" + vpnseedserver.ServiceName + "." + b.Shoot.SeedNamespace + ".svc.cluster.local",
+		Endpoint:    b.outOfClusterAPIServerFQDN(),
+		OpenVPNPort: 8132,
 		}
-	}
 
 	image, err := b.ImageVector.FindImage(imageName, imagevector.RuntimeVersion(b.ShootVersion()), imagevector.TargetVersion(b.ShootVersion()))
 	if err != nil {
@@ -76,11 +74,6 @@ func (b *Botanist) DefaultVPNShoot() (vpnshoot.Interface, error) {
 // DeployVPNShoot deploys the VPNShoot system component.
 func (b *Botanist) DeployVPNShoot(ctx context.Context) error {
 	secrets := vpnshoot.Secrets{}
-
-	if !b.Shoot.ReversedVPNEnabled {
-		dhSecret := b.getDiffieHellmanSecret()
-		secrets.DH = &dhSecret
-	}
 
 	b.Shoot.Components.SystemComponents.VPNShoot.SetSecrets(secrets)
 

--- a/pkg/operation/botanist/vpnshoot.go
+++ b/pkg/operation/botanist/vpnshoot.go
@@ -33,7 +33,7 @@ func (b *Botanist) DefaultVPNShoot() (vpnshoot.Interface, error) {
 		Header:      "outbound|1194||" + vpnseedserver.ServiceName + "." + b.Shoot.SeedNamespace + ".svc.cluster.local",
 		Endpoint:    b.outOfClusterAPIServerFQDN(),
 		OpenVPNPort: 8132,
-		}
+	}
 
 	image, err := b.ImageVector.FindImage(imageName, imagevector.RuntimeVersion(b.ShootVersion()), imagevector.TargetVersion(b.ShootVersion()))
 	if err != nil {

--- a/pkg/operation/botanist/vpnshoot.go
+++ b/pkg/operation/botanist/vpnshoot.go
@@ -19,7 +19,6 @@ import (
 	"github.com/gardener/gardener/pkg/operation/botanist/component/vpnshoot"
 	"github.com/gardener/gardener/pkg/utils/images"
 	"github.com/gardener/gardener/pkg/utils/imagevector"
-	"k8s.io/utils/pointer"
 )
 
 // DefaultVPNShoot returns a deployer for the VPNShoot
@@ -37,11 +36,6 @@ func (b *Botanist) DefaultVPNShoot() (vpnshoot.Interface, error) {
 			Header:      "outbound|1194||" + vpnseedserver.ServiceName + "." + b.Shoot.SeedNamespace + ".svc.cluster.local",
 			Endpoint:    b.outOfClusterAPIServerFQDN(),
 			OpenVPNPort: 8132,
-		},
-		Network: vpnshoot.NetworkValues{
-			PodCIDR:     b.Shoot.Networks.Pods.String(),
-			ServiceCIDR: b.Shoot.Networks.Services.String(),
-			NodeCIDR:    pointer.StringDeref(b.Shoot.GetInfo().Spec.Networking.Nodes, ""),
 		},
 		HighAvailabilityEnabled:              b.Shoot.VPNHighAvailabilityEnabled,
 		HighAvailabilityNumberOfSeedServers:  b.Shoot.VPNHighAvailabilityNumberOfSeedServers,

--- a/pkg/operation/botanist/vpnshoot_test.go
+++ b/pkg/operation/botanist/vpnshoot_test.go
@@ -65,20 +65,9 @@ var _ = Describe("VPNShoot", func() {
 			})
 		})
 
-		It("should successfully create a vpnShoot interface for ReversedVPN not enabled case", func() {
-			kubernetesClient.EXPECT().Client()
-			botanist.ImageVector = imagevector.ImageVector{{Name: images.ImageNameVpnShoot}}
-			botanist.Shoot.ReversedVPNEnabled = false
-
-			vpnShoot, err := botanist.DefaultVPNShoot()
-			Expect(vpnShoot).NotTo(BeNil())
-			Expect(err).NotTo(HaveOccurred())
-		})
-
-		It("should successfully create a vpnShoot interface for ReversedVPN enabled case", func() {
+		It("should successfully create a vpnShoot interface for ReversedVPN", func() {
 			kubernetesClient.EXPECT().Client()
 			botanist.ImageVector = imagevector.ImageVector{{Name: images.ImageNameVpnShootClient}}
-			botanist.Shoot.ReversedVPNEnabled = true
 
 			vpnShoot, err := botanist.DefaultVPNShoot()
 			Expect(vpnShoot).NotTo(BeNil())

--- a/pkg/operation/botanist/waiter.go
+++ b/pkg/operation/botanist/waiter.go
@@ -59,34 +59,6 @@ func (b *Botanist) WaitUntilTunnelConnectionExists(ctx context.Context) error {
 	if err := retry.UntilTimeout(ctx, 5*time.Second, timeout, func(ctx context.Context) (bool, error) {
 		return CheckTunnelConnection(ctx, b.Logger, b.ShootClientSet, common.VPNTunnel)
 	}); err != nil {
-		// If the classic VPN solution is used for the shoot cluster then let's try to fetch
-		// the last events of the vpn-shoot service (potentially indicating an error with the load balancer service).
-		if !b.Shoot.ReversedVPNEnabled {
-			b.Logger.Error(err, "Error occurred while checking the tunnel connection")
-
-			service := &corev1.Service{
-				TypeMeta: metav1.TypeMeta{
-					APIVersion: corev1.SchemeGroupVersion.String(),
-					Kind:       "Service",
-				},
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "vpn-shoot",
-					Namespace: metav1.NamespaceSystem,
-				},
-			}
-
-			eventsErrorMessage, err2 := kutil.FetchEventMessages(ctx, b.ShootClientSet.Client().Scheme(), b.ShootClientSet.Client(), service, corev1.EventTypeWarning, 2)
-			if err2 != nil {
-				return fmt.Errorf("'%v' occurred but could not fetch events for more information: %w", err, err2)
-			}
-
-			if eventsErrorMessage != "" {
-				return fmt.Errorf("%s\n\n%s", err.Error(), eventsErrorMessage)
-			}
-
-			return err
-		}
-
 		return err
 	}
 

--- a/pkg/operation/botanist/waiter.go
+++ b/pkg/operation/botanist/waiter.go
@@ -43,14 +43,6 @@ func (b *Botanist) WaitUntilNginxIngressServiceIsReady(ctx context.Context) erro
 	return nil
 }
 
-// WaitUntilVpnShootServiceIsReady waits until the external load balancer of the VPN has been created.
-func (b *Botanist) WaitUntilVpnShootServiceIsReady(ctx context.Context) error {
-	const timeout = 10 * time.Minute
-
-	_, err := kutil.WaitUntilLoadBalancerIsReady(ctx, b.Logger, b.ShootClientSet.Client(), metav1.NamespaceSystem, "vpn-shoot", timeout)
-	return err
-}
-
 // WaitUntilTunnelConnectionExists waits until a port forward connection to the tunnel pod (vpn-shoot) in the kube-system
 // namespace of the Shoot cluster can be established.
 func (b *Botanist) WaitUntilTunnelConnectionExists(ctx context.Context) error {

--- a/pkg/operation/shoot/types.go
+++ b/pkg/operation/shoot/types.go
@@ -85,7 +85,6 @@ type Shoot struct {
 	WantsAlertmanager                       bool
 	IgnoreAlerts                            bool
 	HibernationEnabled                      bool
-	ReversedVPNEnabled                      bool
 	VPNHighAvailabilityEnabled              bool
 	VPNHighAvailabilityNumberOfSeedServers  int
 	VPNHighAvailabilityNumberOfShootClients int

--- a/pkg/utils/images/images.go
+++ b/pkg/utils/images/images.go
@@ -115,12 +115,8 @@ const (
 	ImageNameVpaRecommender = "vpa-recommender"
 	// ImageNameVpaUpdater is a constant for an image in the image vector with name 'vpa-updater'.
 	ImageNameVpaUpdater = "vpa-updater"
-	// ImageNameVpnSeed is a constant for an image in the image vector with name 'vpn-seed'.
-	ImageNameVpnSeed = "vpn-seed"
 	// ImageNameVpnSeedServer is a constant for an image in the image vector with name 'vpn-seed-server'.
 	ImageNameVpnSeedServer = "vpn-seed-server"
-	// ImageNameVpnShoot is a constant for an image in the image vector with name 'vpn-shoot'.
-	ImageNameVpnShoot = "vpn-shoot"
 	// ImageNameVpnShootClient is a constant for an image in the image vector with name 'vpn-shoot-client'.
 	ImageNameVpnShootClient = "vpn-shoot-client"
 )

--- a/pkg/utils/images/images.go
+++ b/pkg/utils/images/images.go
@@ -23,8 +23,6 @@ const (
 	ImageNameAlertmanager = "alertmanager"
 	// ImageNameAlpine is a constant for an image in the image vector with name 'alpine'.
 	ImageNameAlpine = "alpine"
-	// ImageNameAlpineIptables is a constant for an image in the image vector with name 'alpine-iptables'.
-	ImageNameAlpineIptables = "alpine-iptables"
 	// ImageNameApiserverProxy is a constant for an image in the image vector with name 'apiserver-proxy'.
 	ImageNameApiserverProxy = "apiserver-proxy"
 	// ImageNameApiserverProxyPodWebhook is a constant for an image in the image vector with name 'apiserver-proxy-pod-webhook'.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind cleanup

**What this PR does / why we need it**:
Remove code for legacy VPN solution.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
The legacy VPN solution has been removed. The feature gates `ReversedVPN`, `ManagedIstio` and `APIServerSNI` are unconditionally enabled (locked to their default values) now.
```
```breaking user
The annotation `alpha.featuregates.shoot.gardener.cloud/reversed-vpn` on `Shoot`s is no longer respected and should be removed from all resources.
```
