### PR TITLE
Do not destroy etcd-druid/HVPA on seed deletion when seed is garden at the same time

### DIFF
--- a/pkg/gardenlet/controller/seed/seed/reconciler_delete.go
+++ b/pkg/gardenlet/controller/seed/seed/reconciler_delete.go
@@ -181,10 +181,8 @@ func (r *Reconciler) runDeleteSeedFlow(
 	var (
 		dnsRecord          = getManagedIngressDNSRecord(log, seedClient, r.GardenNamespace, seed.GetInfo().Spec.DNS, secretData, seed.GetIngressFQDN("*"), "")
 		autoscaler         = clusterautoscaler.NewBootstrapper(seedClient, r.GardenNamespace)
-		hvpa               = hvpa.New(seedClient, r.GardenNamespace, hvpa.Values{})
 		kubeStateMetrics   = kubestatemetrics.New(seedClient, r.GardenNamespace, nil, kubestatemetrics.Values{ClusterType: component.ClusterTypeSeed})
 		nginxIngress       = nginxingress.New(seedClient, r.GardenNamespace, nginxingress.Values{})
-		etcdDruid          = etcd.NewBootstrapper(seedClient, r.GardenNamespace, nil, r.Config.ETCDConfig, "", nil, "")
 		networkPolicies    = networkpolicies.NewBootstrapper(seedClient, r.GardenNamespace, networkpolicies.GlobalValues{})
 		clusterIdentity    = clusteridentity.NewForSeed(seedClient, r.GardenNamespace, "")
 		dwdEndpoint        = dependencywatchdog.NewBootstrapper(seedClient, r.GardenNamespace, dependencywatchdog.BootstrapperValues{Role: dependencywatchdog.RoleEndpoint})
@@ -217,14 +215,6 @@ func (r *Reconciler) runDeleteSeedFlow(
 			Fn:           ensureNoControllerInstallations(r.GardenClient, seed.GetInfo().Name),
 			Dependencies: flow.NewTaskIDs(destroyDNSRecord),
 		})
-		destroyEtcdDruid = g.Add(flow.Task{
-			Name: "Destroying etcd druid",
-			Fn:   component.OpDestroyAndWait(etcdDruid).Destroy,
-			// only destroy Etcd CRD once all extension controllers are gone, otherwise they might not be able to start up
-			// again (e.g. after being evicted by VPA)
-			// see https://github.com/gardener/gardener/issues/6487#issuecomment-1220597217
-			Dependencies: flow.NewTaskIDs(noControllerInstallations),
-		})
 		destroyClusterIdentity = g.Add(flow.Task{
 			Name: "Destroying cluster-identity",
 			Fn:   component.OpDestroyAndWait(clusterIdentity).Destroy,
@@ -248,10 +238,6 @@ func (r *Reconciler) runDeleteSeedFlow(
 		destroyDWDProbe = g.Add(flow.Task{
 			Name: "Destroy dependency-watchdog-probe",
 			Fn:   component.OpDestroyAndWait(dwdProbe).Destroy,
-		})
-		destroyHVPA = g.Add(flow.Task{
-			Name: "Destroy HVPA controller",
-			Fn:   component.OpDestroyAndWait(hvpa).Destroy,
 		})
 		destroyKubeStateMetrics = g.Add(flow.Task{
 			Name: "Destroy kube-state-metrics",
@@ -280,13 +266,11 @@ func (r *Reconciler) runDeleteSeedFlow(
 		})
 		syncPointCleanedUp = flow.NewTaskIDs(
 			destroyNginxIngress,
-			destroyEtcdDruid,
 			destroyClusterIdentity,
 			destroyClusterAutoscaler,
 			destroyNetworkPolicies,
 			destroyDWDEndpoint,
 			destroyDWDProbe,
-			destroyHVPA,
 			destroyKubeStateMetrics,
 			destroyVPNAuthzServer,
 			destroyIstio,
@@ -304,36 +288,56 @@ func (r *Reconciler) runDeleteSeedFlow(
 	// When the seed is the garden cluster then these components are reconciled by the gardener-operator.
 	if !seedIsGarden {
 		var (
+			etcdDruid             = etcd.NewBootstrapper(seedClient, r.GardenNamespace, nil, r.Config.ETCDConfig, "", nil, "")
+			hvpa                  = hvpa.New(seedClient, r.GardenNamespace, hvpa.Values{})
 			verticalPodAutoscaler = vpa.New(seedClient, r.GardenNamespace, nil, vpa.Values{ClusterType: component.ClusterTypeSeed, RuntimeKubernetesVersion: kubernetesVersion})
 			resourceManager       = resourcemanager.New(seedClient, r.GardenNamespace, nil, resourcemanager.Values{Version: kubernetesVersion})
+
+			destroyEtcdDruid = g.Add(flow.Task{
+				Name: "Destroying etcd druid",
+				Fn:   component.OpDestroyAndWait(etcdDruid).Destroy,
+				// only destroy Etcd CRD once all extension controllers are gone, otherwise they might not be able to start up
+				// again (e.g. after being evicted by VPA)
+				// see https://github.com/gardener/gardener/issues/6487#issuecomment-1220597217
+				Dependencies: flow.NewTaskIDs(noControllerInstallations),
+			})
+			destroyVPA = g.Add(flow.Task{
+				Name: "Destroy Kubernetes vertical pod autoscaler",
+				Fn:   component.OpDestroyAndWait(verticalPodAutoscaler).Destroy,
+			})
+			destroyHVPA = g.Add(flow.Task{
+				Name: "Destroy HVPA controller",
+				Fn:   component.OpDestroyAndWait(hvpa).Destroy,
+			})
 		)
 
-		destroyVPA := g.Add(flow.Task{
-			Name: "Destroy Kubernetes vertical pod autoscaler",
-			Fn:   component.OpDestroyAndWait(verticalPodAutoscaler).Destroy,
-		})
-		syncPointCleanedUp.Insert(destroyVPA)
+		syncPointCleanedUp.Insert(
+			destroyEtcdDruid,
+			destroyHVPA,
+			destroyVPA,
+		)
 
-		ensureNoManagedResourcesExist := g.Add(flow.Task{
-			Name: "Ensuring all ManagedResources are gone",
-			Fn: func(ctx context.Context) error {
-				managedResourcesStillExist, err := managedresources.CheckIfManagedResourcesExist(ctx, r.SeedClientSet.Client(), pointer.String(v1beta1constants.SeedResourceManagerClass))
-				if err != nil {
-					return err
-				}
-				if managedResourcesStillExist {
-					return fmt.Errorf("at least one ManagedResource still exists, cannot delete gardener-resource-manager")
-				}
-				return nil
-			},
-			Dependencies: flow.NewTaskIDs(destroySystemResources),
-		})
-
-		_ = g.Add(flow.Task{
-			Name:         "Destroying gardener-resource-manager",
-			Fn:           resourceManager.Destroy,
-			Dependencies: flow.NewTaskIDs(ensureNoManagedResourcesExist),
-		})
+		var (
+			ensureNoManagedResourcesExist = g.Add(flow.Task{
+				Name: "Ensuring all ManagedResources are gone",
+				Fn: func(ctx context.Context) error {
+					managedResourcesStillExist, err := managedresources.CheckIfManagedResourcesExist(ctx, r.SeedClientSet.Client(), pointer.String(v1beta1constants.SeedResourceManagerClass))
+					if err != nil {
+						return err
+					}
+					if managedResourcesStillExist {
+						return fmt.Errorf("at least one ManagedResource still exists, cannot delete gardener-resource-manager")
+					}
+					return nil
+				},
+				Dependencies: flow.NewTaskIDs(destroySystemResources),
+			})
+			_ = g.Add(flow.Task{
+				Name:         "Destroying gardener-resource-manager",
+				Fn:           resourceManager.Destroy,
+				Dependencies: flow.NewTaskIDs(ensureNoManagedResourcesExist),
+			})
+		)
 	}
 
 	if err := g.Compile().Run(ctx, flow.Opts{Log: log}); err != nil {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind bug

**What this PR does / why we need it**:
When a seed cluster is the garden at the same time and it gets deleted then `gardenlet` also deletes `etcd-druid` and `hvpa-controller` which are actually supposed to be managed by `gardener-operator`.
This PR fixes this issue.

**Which issue(s) this PR fixes**:
Introduced with #7048 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
An issue has been fixed which caused `etcd-druid` and `hvpa-controller` to be deleted on `Seed` deletion when the seed is the garden at the same time.
```
