### PR TITLE
Fix flaky `shoot conditions` integration test

### DIFF
--- a/test/integration/controllermanager/shoot/conditions/conditions_test.go
+++ b/test/integration/controllermanager/shoot/conditions/conditions_test.go
@@ -160,6 +160,11 @@ var _ = Describe("Shoot Conditions controller tests", func() {
 			Expect(testClient.Create(ctx, managedSeed)).To(Succeed())
 			log.Info("Created ManagedSeed for test", "managedSeed", client.ObjectKeyFromObject(managedSeed))
 
+			By("Wait until manager cache has observed ManagedSeed")
+			Eventually(func() error {
+				return mgrClient.Get(ctx, client.ObjectKeyFromObject(managedSeed), managedSeed)
+			}).Should(Succeed())
+
 			Expect(testClient.Create(ctx, seed)).To(Succeed())
 			log.Info("Created Seed for test", "seed", client.ObjectKeyFromObject(seed))
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind flake

**What this PR does / why we need it**:
This PR fixes the Shoot Conditions integration test flake.

While trying to reproduce the flake, the occurrence which failed was due to client was not able to detect the managed seed, even though it was created. There this PR waits for manager client to observe MangedSeed.

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener/issues/6931

**Special notes for your reviewer**:
Stress test result:
Before:
```
stress -ignore "unable to grab random port" -p 32 ./test/integration/controllermanager/shoot/conditions/conditions.test -ginkgo.v -ginkgo.progress
5s: 0 runs so far, 0 failures
.
.
4m20s: 349 runs so far, 1 failures (0.29%)
4m25s: 354 runs so far, 1 failures (0.28%)
```
After:
```
stress -ignore "unable to grab random port" -p 32 ./test/integration/controllermanager/shoot/conditions/conditions.test -ginkgo.v -ginkgo.progress
5s: 0 runs so far, 0 failures
.
.
9m30s: 692 runs so far, 0 failures
9m35s: 700 runs so far, 0 failures
.
15m55s: 1227 runs so far, 0 failures
16m0s: 1238 runs so far, 0 failures
```

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
