### PR TITLE
Fix `MCM` replica count during shoot hibernation

### DIFF
--- a/extensions/pkg/controller/worker/genericactuator/actuator_reconcile.go
+++ b/extensions/pkg/controller/worker/genericactuator/actuator_reconcile.go
@@ -69,7 +69,10 @@ func (a *genericActuator) Reconcile(ctx context.Context, log logr.Logger, worker
 			return 0
 		// If the cluster is created with hibernation enabled, then desired replicas for MCM is 0 if there are no existing machine deployments with positive replica count
 		case extensionscontroller.IsHibernationEnabled(cluster) && extensionscontroller.IsCreationInProcess(cluster):
-			return isExistingMachineDeploymentWithPositiveReplicaCountPresent(existingMachineDeployments)
+			if isExistingMachineDeploymentWithPositiveReplicaCountPresent(existingMachineDeployments) {
+				return 1
+			}
+			return 0
 		// If shoot is either waking up or in the process of hibernation then, MCM is required and therefore its desired replicas is 1
 		case extensionscontroller.IsHibernatingOrWakingUp(cluster):
 			return 1
@@ -528,13 +531,13 @@ func getExistingMachineDeployment(existingMachineDeployments *machinev1alpha1.Ma
 	return nil
 }
 
-func isExistingMachineDeploymentWithPositiveReplicaCountPresent(existingMachineDeployments *machinev1alpha1.MachineDeploymentList) int32 {
+func isExistingMachineDeploymentWithPositiveReplicaCountPresent(existingMachineDeployments *machinev1alpha1.MachineDeploymentList) bool {
 	for _, machineDeployment := range existingMachineDeployments.Items {
 		if machineDeployment.Status.Replicas > 0 {
-			return 1
+			return true
 		}
 	}
-	return 0
+	return false
 }
 
 // ReadMachineConfiguration reads the configuration from worker-pool and returns the corresponding configuration of machine-deployment.

--- a/extensions/pkg/controller/worker/genericactuator/actuator_reconcile.go
+++ b/extensions/pkg/controller/worker/genericactuator/actuator_reconcile.go
@@ -55,15 +55,21 @@ func (a *genericActuator) Reconcile(ctx context.Context, log logr.Logger, worker
 		return fmt.Errorf("pre worker reconciliation hook failed: %w", err)
 	}
 
+	// Get the list of all existing machine deployments.
+	existingMachineDeployments := &machinev1alpha1.MachineDeploymentList{}
+	if err := a.client.List(ctx, existingMachineDeployments, client.InNamespace(worker.Namespace)); err != nil {
+		return err
+	}
+
 	// mcmReplicaFunc returns the desired replicas for machine controller manager
 	var mcmReplicaFunc = func() int32 {
 		switch {
 		// If the cluster is hibernated then there is no further need of MCM and therefore its desired replicas is 0
 		case extensionscontroller.IsHibernated(cluster):
 			return 0
-		// If the cluster is created with hibernation enabled, then desired replicas for MCM is 0
+		// If the cluster is created with hibernation enabled, then desired replicas for MCM is 0 if there are no existing machine deployments with positive replica count
 		case extensionscontroller.IsHibernationEnabled(cluster) && extensionscontroller.IsCreationInProcess(cluster):
-			return 0
+			return isExistingMachineDeploymentWithPositiveReplicaCountPresent(existingMachineDeployments)
 		// If shoot is either waking up or in the process of hibernation then, MCM is required and therefore its desired replicas is 1
 		case extensionscontroller.IsHibernatingOrWakingUp(cluster):
 			return 1
@@ -128,12 +134,6 @@ func (a *genericActuator) Reconcile(ctx context.Context, log logr.Logger, worker
 	// Update the machine images in the worker provider status.
 	if err := workerDelegate.UpdateMachineImagesStatus(ctx); err != nil {
 		return fmt.Errorf("failed to update the machine image status: %w", err)
-	}
-
-	// Get the list of all existing machine deployments.
-	existingMachineDeployments := &machinev1alpha1.MachineDeploymentList{}
-	if err := a.client.List(ctx, existingMachineDeployments, client.InNamespace(worker.Namespace)); err != nil {
-		return err
 	}
 
 	existingMachineDeploymentNames := sets.String{}
@@ -526,6 +526,15 @@ func getExistingMachineDeployment(existingMachineDeployments *machinev1alpha1.Ma
 		}
 	}
 	return nil
+}
+
+func isExistingMachineDeploymentWithPositiveReplicaCountPresent(existingMachineDeployments *machinev1alpha1.MachineDeploymentList) int32 {
+	for _, machineDeployment := range existingMachineDeployments.Items {
+		if machineDeployment.Status.Replicas > 0 {
+			return 1
+		}
+	}
+	return 0
 }
 
 // ReadMachineConfiguration reads the configuration from worker-pool and returns the corresponding configuration of machine-deployment.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/area robustness
/kind enhancement

**What this PR does / why we need it**:
This PR fixes the `MCM` replica count function to scale up `MCM` when hibernation is enabled during creation, and machines are present in the cluster.

**Which issue(s) this PR fixes**:
Fixes #7151 

**Special notes for your reviewer**:
The testing for this was done using the local gardener kind cluster setup.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The generic Worker actuator will scale up machine-controller-manager Deployment when Shoot hibernates with `.status.lastOperationType=Create` or `.status.lastOperationType=nil` and a machine deployment exists with `.status.Replicas` > 0.
```
