### PR TITLE
Add CVE re-scoring configuration to VPA images

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -249,11 +249,11 @@ images:
   labels:
     - name: 'gardener.cloud/cve-categorisation'
       value:
-        network_exposure: 'protected'
+        network_exposure: 'private'
         authentication_enforced: false
         user_interaction: 'gardener-operator'
         confidentiality_requirement: 'low'
-        integrity_requirement: 'none'
+        integrity_requirement: 'high'
         availability_requirement: 'high'
 - name: vpa-admission-controller
   sourceRepository: github.com/kubernetes/autoscaler
@@ -263,11 +263,11 @@ images:
   labels:
     - name: 'gardener.cloud/cve-categorisation'
       value:
-        network_exposure: 'protected'
+        network_exposure: 'private'
         authentication_enforced: false
         user_interaction: 'gardener-operator'
         confidentiality_requirement: 'low'
-        integrity_requirement: 'none'
+        integrity_requirement: 'high'
         availability_requirement: 'high'
 - name: vpa-recommender
   sourceRepository: github.com/kubernetes/autoscaler
@@ -277,11 +277,11 @@ images:
   labels:
     - name: 'gardener.cloud/cve-categorisation'
       value:
-        network_exposure: 'protected'
+        network_exposure: 'private'
         authentication_enforced: false
         user_interaction: 'gardener-operator'
         confidentiality_requirement: 'low'
-        integrity_requirement: 'low'
+        integrity_requirement: 'high'
         availability_requirement: 'high'
 - name: vpa-recommender
   sourceRepository: github.com/kubernetes/autoscaler
@@ -291,11 +291,11 @@ images:
   labels:
     - name: 'gardener.cloud/cve-categorisation'
       value:
-        network_exposure: 'protected'
+        network_exposure: 'private'
         authentication_enforced: false
         user_interaction: 'gardener-operator'
         confidentiality_requirement: 'low'
-        integrity_requirement: 'low'
+        integrity_requirement: 'high'
         availability_requirement: 'high'
 - name: vpa-updater
   sourceRepository: github.com/kubernetes/autoscaler
@@ -305,11 +305,11 @@ images:
   labels:
     - name: 'gardener.cloud/cve-categorisation'
       value:
-        network_exposure: 'protected'
+        network_exposure: 'private'
         authentication_enforced: false
         user_interaction: 'gardener-operator'
         confidentiality_requirement: 'low'
-        integrity_requirement: 'none'
+        integrity_requirement: 'high'
         availability_requirement: 'high'
 - name: vpa-updater
   sourceRepository: github.com/kubernetes/autoscaler
@@ -319,11 +319,11 @@ images:
   labels:
     - name: 'gardener.cloud/cve-categorisation'
       value:
-        network_exposure: 'protected'
+        network_exposure: 'private'
         authentication_enforced: false
         user_interaction: 'gardener-operator'
         confidentiality_requirement: 'low'
-        integrity_requirement: 'none'
+        integrity_requirement: 'high'
         availability_requirement: 'high'
 
 # HVPA

--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -246,31 +246,85 @@ images:
   repository: registry.k8s.io/autoscaling/vpa-admission-controller
   tag: "0.11.0"
   targetVersion: "< 1.21"
+  labels:
+    - name: 'gardener.cloud/cve-categorisation'
+      value:
+        network_exposure: 'protected'
+        authentication_enforced: false
+        user_interaction: 'gardener-operator'
+        confidentiality_requirement: 'low'
+        integrity_requirement: 'none'
+        availability_requirement: 'high'
 - name: vpa-admission-controller
   sourceRepository: github.com/kubernetes/autoscaler
   repository: registry.k8s.io/autoscaling/vpa-admission-controller
   tag: "0.12.0"
   targetVersion: ">= 1.21"
+  labels:
+    - name: 'gardener.cloud/cve-categorisation'
+      value:
+        network_exposure: 'protected'
+        authentication_enforced: false
+        user_interaction: 'gardener-operator'
+        confidentiality_requirement: 'low'
+        integrity_requirement: 'none'
+        availability_requirement: 'high'
 - name: vpa-recommender
   sourceRepository: github.com/kubernetes/autoscaler
   repository: registry.k8s.io/autoscaling/vpa-recommender
   tag: "0.11.0"
   targetVersion: "< 1.21"
+  labels:
+    - name: 'gardener.cloud/cve-categorisation'
+      value:
+        network_exposure: 'protected'
+        authentication_enforced: false
+        user_interaction: 'gardener-operator'
+        confidentiality_requirement: 'low'
+        integrity_requirement: 'low'
+        availability_requirement: 'high'
 - name: vpa-recommender
   sourceRepository: github.com/kubernetes/autoscaler
   repository: registry.k8s.io/autoscaling/vpa-recommender
   tag: "0.12.0"
   targetVersion: ">= 1.21"
+  labels:
+    - name: 'gardener.cloud/cve-categorisation'
+      value:
+        network_exposure: 'protected'
+        authentication_enforced: false
+        user_interaction: 'gardener-operator'
+        confidentiality_requirement: 'low'
+        integrity_requirement: 'low'
+        availability_requirement: 'high'
 - name: vpa-updater
   sourceRepository: github.com/kubernetes/autoscaler
   repository: registry.k8s.io/autoscaling/vpa-updater
   tag: "0.11.0"
   targetVersion: "< 1.21"
+  labels:
+    - name: 'gardener.cloud/cve-categorisation'
+      value:
+        network_exposure: 'protected'
+        authentication_enforced: false
+        user_interaction: 'gardener-operator'
+        confidentiality_requirement: 'low'
+        integrity_requirement: 'none'
+        availability_requirement: 'high'
 - name: vpa-updater
   sourceRepository: github.com/kubernetes/autoscaler
   repository: registry.k8s.io/autoscaling/vpa-updater
   tag: "0.12.0"
   targetVersion: ">= 1.21"
+  labels:
+    - name: 'gardener.cloud/cve-categorisation'
+      value:
+        network_exposure: 'protected'
+        authentication_enforced: false
+        user_interaction: 'gardener-operator'
+        confidentiality_requirement: 'low'
+        integrity_requirement: 'none'
+        availability_requirement: 'high'
 
 # HVPA
 - name: hvpa-controller


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area auto-scaling
/kind enhancement

**What this PR does / why we need it**:
Add CVE re-scoring configuration to VPA images, so we can automatically re-compute CVE scores for VPA vulnerabilities.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
