### PR TITLE
Fix replicas on hibernation for vpn-seed-server

### DIFF
--- a/pkg/operation/botanist/component/vpnseedserver/mock/mocks.go
+++ b/pkg/operation/botanist/component/vpnseedserver/mock/mocks.go
@@ -80,6 +80,20 @@ func (mr *MockInterfaceMockRecorder) Destroy(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Destroy", reflect.TypeOf((*MockInterface)(nil).Destroy), arg0)
 }
 
+// GetValues mocks base method.
+func (m *MockInterface) GetValues() vpnseedserver.Values {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetValues")
+	ret0, _ := ret[0].(vpnseedserver.Values)
+	return ret0
+}
+
+// GetValues indicates an expected call of GetValues.
+func (mr *MockInterfaceMockRecorder) GetValues() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetValues", reflect.TypeOf((*MockInterface)(nil).GetValues))
+}
+
 // ScrapeConfigs mocks base method.
 func (m *MockInterface) ScrapeConfigs() ([]string, error) {
 	m.ctrl.T.Helper()

--- a/pkg/operation/botanist/component/vpnseedserver/vpn_seed_server.go
+++ b/pkg/operation/botanist/component/vpnseedserver/vpn_seed_server.go
@@ -104,6 +104,9 @@ type Interface interface {
 
 	// SetSNIConfig set the sni config.
 	SetSNIConfig(*config.SNI)
+
+	// GetValues returns the current configuration values of the deployer.
+	GetValues() Values
 }
 
 // Secrets is collection of secrets for the vpn-seed-server.
@@ -176,6 +179,10 @@ type vpnSeedServer struct {
 	exposureClassHandlerName *string
 	sniConfig                *config.SNI
 	secrets                  Secrets
+}
+
+func (v *vpnSeedServer) GetValues() Values {
+	return v.values
 }
 
 func (v *vpnSeedServer) Deploy(ctx context.Context) error {

--- a/pkg/operation/botanist/vpnseedserver.go
+++ b/pkg/operation/botanist/vpnseedserver.go
@@ -80,7 +80,7 @@ func (b *Botanist) DefaultVPNSeedServer() (vpnseedserver.Interface, error) {
 			ServiceCIDR: b.Shoot.Networks.Services.String(),
 			NodeCIDR:    pointer.StringDeref(b.Shoot.GetInfo().Spec.Networking.Nodes, ""),
 		},
-		Replicas:                             1,
+		Replicas:                             b.Shoot.GetReplicas(1),
 		HighAvailabilityEnabled:              b.Shoot.VPNHighAvailabilityEnabled,
 		HighAvailabilityNumberOfSeedServers:  b.Shoot.VPNHighAvailabilityNumberOfSeedServers,
 		HighAvailabilityNumberOfShootClients: b.Shoot.VPNHighAvailabilityNumberOfShootClients,
@@ -96,7 +96,7 @@ func (b *Botanist) DefaultVPNSeedServer() (vpnseedserver.Interface, error) {
 	}
 
 	if b.Shoot.VPNHighAvailabilityEnabled {
-		values.Replicas = int32(b.Shoot.VPNHighAvailabilityNumberOfSeedServers)
+		values.Replicas = b.Shoot.GetReplicas(int32(b.Shoot.VPNHighAvailabilityNumberOfSeedServers))
 	}
 
 	return vpnseedserver.New(

--- a/test/e2e/gardener/shoot/create_and_delete_hibernated.go
+++ b/test/e2e/gardener/shoot/create_and_delete_hibernated.go
@@ -20,10 +20,13 @@ import (
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	e2e "github.com/gardener/gardener/test/e2e/gardener"
+	"github.com/gardener/gardener/test/framework"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
@@ -40,9 +43,17 @@ var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
 		Expect(f.CreateShootAndWaitForCreation(ctx, false)).To(Succeed())
 		f.Verify()
 
+		verifyNoPodsRunning(f)
+
 		By("Delete Shoot")
 		ctx, cancel = context.WithTimeout(parentCtx, 15*time.Minute)
 		defer cancel()
 		Expect(f.DeleteShootAndWaitForDeletion(ctx, f.Shoot)).To(Succeed())
 	})
 })
+
+func verifyNoPodsRunning(f *framework.ShootCreationFramework) {
+	list := &corev1.PodList{}
+	Expect(f.ShootFramework.SeedClient.Client().List(context.Background(), list, client.InNamespace(f.Shoot.Status.TechnicalID))).To(Succeed())
+	Expect(list.Items).To(BeEmpty())
+}

--- a/test/e2e/gardener/shoot/create_and_delete_hibernated.go
+++ b/test/e2e/gardener/shoot/create_and_delete_hibernated.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 	e2e "github.com/gardener/gardener/test/e2e/gardener"
 	"github.com/gardener/gardener/test/framework"
 
@@ -43,7 +44,7 @@ var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
 		Expect(f.CreateShootAndWaitForCreation(ctx, false)).To(Succeed())
 		f.Verify()
 
-		verifyNoPodsRunning(f)
+		verifyNoPodsRunning(ctx, f)
 
 		By("Delete Shoot")
 		ctx, cancel = context.WithTimeout(parentCtx, 15*time.Minute)
@@ -52,8 +53,8 @@ var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
 	})
 })
 
-func verifyNoPodsRunning(f *framework.ShootCreationFramework) {
-	list := &corev1.PodList{}
-	Expect(f.ShootFramework.SeedClient.Client().List(context.Background(), list, client.InNamespace(f.Shoot.Status.TechnicalID))).To(Succeed())
-	Expect(list.Items).To(BeEmpty())
+func verifyNoPodsRunning(ctx context.Context, f *framework.ShootCreationFramework) {
+	podsAreExisting, err := kutil.ResourcesExist(ctx, f.ShootFramework.SeedClient.Client(), corev1.SchemeGroupVersion.WithKind("PodList"), client.InNamespace(f.Shoot.Status.TechnicalID))
+	Expect(err).To(Succeed())
+	Expect(podsAreExisting).To(BeFalse())
 }

--- a/test/e2e/gardener/shoot/create_hibernate_wakeup_delete.go
+++ b/test/e2e/gardener/shoot/create_hibernate_wakeup_delete.go
@@ -40,7 +40,7 @@ var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
 		defer cancel()
 		Expect(f.HibernateShoot(ctx, f.Shoot)).To(Succeed())
 
-		verifyNoPodsRunning(f)
+		verifyNoPodsRunning(ctx, f)
 
 		By("Wake up Shoot")
 		ctx, cancel = context.WithTimeout(parentCtx, 15*time.Minute)

--- a/test/e2e/gardener/shoot/create_hibernate_wakeup_delete.go
+++ b/test/e2e/gardener/shoot/create_hibernate_wakeup_delete.go
@@ -40,6 +40,8 @@ var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
 		defer cancel()
 		Expect(f.HibernateShoot(ctx, f.Shoot)).To(Succeed())
 
+		verifyNoPodsRunning(f)
+
 		By("Wake up Shoot")
 		ctx, cancel = context.WithTimeout(parentCtx, 15*time.Minute)
 		defer cancel()


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug

**What this PR does / why we need it**:
`vpn-seed-server`deployment is not scaled-down on hibernation. The bug was introduced with #6978

**Which issue(s) this PR fixes**:
Fixes #7187

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fix replicas on hibernation for `vpn-seed-server` deployment.
```
