### PR TITLE
Always validate `Seed` selection for multi zonal `Shoot`s

### DIFF
--- a/plugin/pkg/shoot/validator/admission.go
+++ b/plugin/pkg/shoot/validator/admission.go
@@ -494,10 +494,8 @@ func (c *validationContext) validateScheduling(ctx context.Context, a admission.
 	}
 
 	if c.seed != nil {
-		if mustCheckSchedulingConstraints {
-			if err := c.validateSeedSelectionForMultiZonalShoot(); err != nil {
-				return admission.NewForbidden(a, err)
-			}
+		if err := c.validateSeedSelectionForMultiZonalShoot(); err != nil {
+			return admission.NewForbidden(a, err)
 		}
 
 		if c.seed.DeletionTimestamp != nil {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area high-availability
/kind bug

**What this PR does / why we need it**:
At the moment the `Seed` selection for multizonal `Shoot`s is carried out only when the shoot is scheduled or rescheduled. This does not cover the case, when a shoot should be updated to a HA configuration with `failureTolerance` `type` `zone` while remaining scheduled on the same seed.
This PR removes the condition for the validation, that it runs on any update of the shoot.

**Which issue(s) this PR fixes**:
Fixes #7190

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Prevent updating `Shoot`s which are scheduled to a `Seed` with less then 3 zones to `spec.controlPlane.failureTolerance.type: zone` 
```
