### PR TITLE
Allow all authenticated users to create tokenreviews and selfsubjectaccessreviews

### DIFF
--- a/charts/gardener/controlplane/charts/application/templates/rbac-user.yaml
+++ b/charts/gardener/controlplane/charts/application/templates/rbac-user.yaml
@@ -247,6 +247,49 @@ subjects:
   kind: Group
   name: system:authenticated
 
+# Cluster role with cluster role binding allowing all authenticated users create tokenreviews and selfsubjectaccessreviews
+---
+apiVersion: {{ include "rbacversion" . }}
+kind: ClusterRole
+metadata:
+  name: gardener.cloud:system:user-auth
+  labels:
+    app: gardener
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+rules:
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - selfsubjectaccessreviews
+  verbs:
+  - create
+---
+apiVersion: {{ include "rbacversion" . }}
+kind: ClusterRoleBinding
+metadata:
+  name: gardener.cloud:system:user-auth
+  labels:
+    app: gardener
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: gardener.cloud:system:user-auth
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:authenticated
+
 # Cluster role for allowing creation of projects.
 # IMPORTANT: You need to define a corresponding ClusterRoleBinding binding specific users/
 #            groups/serviceaccounts to this ClusterRole on your own.


### PR DESCRIPTION
**How to categorize this PR?**

/area dev-productivity ops-productivity user-management
/kind enhancement

**What this PR does / why we need it**:
This PR introduces the new `ClusterRole` and `ClusterRoleBinding` with the name `gardener.cloud:system:user-auth` that allows all authenticated users to [create a TokenReview](https://kubernetes.io/docs/reference/kubernetes-api/authentication-resources/token-review-v1/#create-create-a-tokenreview) and to [create a SelfSubjectAccessReview](https://kubernetes.io/docs/reference/kubernetes-api/authorization-resources/self-subject-access-review-v1/#create-create-a-selfsubjectaccessreview).

The authorization to create TokenReviews is required for users of `gardenctl` if they use tab completion for the new `ssh-patch` command. In order to display the list of bastion resources of the respective user, its name must be determined. In the case of token authentication a tokenReview is necessary. We decided to also add the `SelfSubjectAccessReview` authorization to the new `ClusterRole` for consistency reasons.

**Which issue(s) this PR fixes**:

Related PR: https://github.com/gardener/gardenctl-v2/pull/180

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Allow all authenticated users to create `TokenReview`s and `SelfSubjectaAccessReview`s. This is a required for the new `gardenctl ssh-patch` command.
```
