### PR TITLE
Configure shoot worker pool labels via `--node-labels`

### DIFF
--- a/docs/extensions/worker.md
+++ b/docs/extensions/worker.md
@@ -76,6 +76,11 @@ spec:
         cpu: 2
         gpu: 0
         memory: 8Gi
+    labels:
+      node.kubernetes.io/role: node
+      worker.gardener.cloud/cri-name: containerd
+      worker.gardener.cloud/pool: cpu-worker
+      worker.gardener.cloud/system-components: "true"
     userData: c29tZSBkYXRhIHRvIGJvb3RzdHJhcCB0aGUgVk0K
     volume:
       size: 20Gi
@@ -100,6 +105,12 @@ Also, as you can see, Gardener copies the output of the infrastructure creation 
 In the `.spec.pools[]` field the desired worker pools are listed.
 In the above example, one pool with machine type `m4.large` and `min=3`, `max=5` machines shall be spread over two availability zones (`eu-west-1b`, `eu-west-1c`).
 This information together with the infrastructure status must be used to determine the proper configuration for the machine classes.
+
+The `spec.pools[].labels` map contains all labels that should be added to all nodes of the corresponding worker pool.
+Gardener configures kubelet's `--node-labels` flag to contain all labels mentioned here.
+This makes sure that kubelet adds all user-specified and gardener-managed labels to the new `Node` object when registering a new machine with the API server.
+Nevertheless, this is only effective when bootstrapping new nodes.
+The provider extension (respectively, machine-controller-manager) is still responsible for updating the labels of existing `Nodes` when the worker specification changes.
 
 The `spec.pools[].nodeTemplate.capacity` field contains the resource information of the machine like `cpu`, `gpu` and `memory`. This info is used by Cluster Autoscaler to generate `nodeTemplate` during scaling the `nodeGroup` from zero.
 

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/operatingsystemconfig.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/operatingsystemconfig.go
@@ -124,8 +124,8 @@ type OriginalValues struct {
 	PromtailEnabled bool
 	// LokiIngressHostName is the ingress host name of the shoot's Loki.
 	LokiIngressHostName string
-	// NodeLocalDNSENabled indicates whether node local dns is enabled or not.
-	NodeLocalDNSENabled bool
+	// NodeLocalDNSEnabled indicates whether node local dns is enabled or not.
+	NodeLocalDNSEnabled bool
 }
 
 // New creates a new instance of Interface.
@@ -517,7 +517,7 @@ func (o *operatingSystemConfig) newDeployer(osc *extensionsv1alpha1.OperatingSys
 		sshPublicKeys:           o.values.SSHPublicKeys,
 		lokiIngressHostName:     o.values.LokiIngressHostName,
 		promtailEnabled:         o.values.PromtailEnabled,
-		nodeLocalDNSENabled:     o.values.NodeLocalDNSENabled,
+		nodeLocalDNSEnabled:     o.values.NodeLocalDNSEnabled,
 	}, nil
 }
 
@@ -577,7 +577,7 @@ type deployer struct {
 	sshPublicKeys           []string
 	lokiIngressHostName     string
 	promtailEnabled         bool
-	nodeLocalDNSENabled     bool
+	nodeLocalDNSEnabled     bool
 }
 
 // exposed for testing
@@ -617,7 +617,7 @@ func (d *deployer) deploy(ctx context.Context, operation string) (extensionsv1al
 			ClusterDomain:           d.clusterDomain,
 			CRIName:                 d.criName,
 			Images:                  d.images,
-			NodeLabels:              gutil.NodeLabelsForWorkerPool(d.worker, d.nodeLocalDNSENabled),
+			NodeLabels:              gutil.NodeLabelsForWorkerPool(d.worker, d.nodeLocalDNSEnabled),
 			KubeletCABundle:         d.kubeletCABundle,
 			KubeletConfigParameters: d.kubeletConfigParameters,
 			KubeletCLIFlags:         d.kubeletCLIFlags,

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/operatingsystemconfig.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/operatingsystemconfig.go
@@ -124,6 +124,8 @@ type OriginalValues struct {
 	PromtailEnabled bool
 	// LokiIngressHostName is the ingress host name of the shoot's Loki.
 	LokiIngressHostName string
+	// NodeLocalDNSENabled indicates whether node local dns is enabled or not.
+	NodeLocalDNSENabled bool
 }
 
 // New creates a new instance of Interface.
@@ -515,6 +517,7 @@ func (o *operatingSystemConfig) newDeployer(osc *extensionsv1alpha1.OperatingSys
 		sshPublicKeys:           o.values.SSHPublicKeys,
 		lokiIngressHostName:     o.values.LokiIngressHostName,
 		promtailEnabled:         o.values.PromtailEnabled,
+		nodeLocalDNSENabled:     o.values.NodeLocalDNSENabled,
 	}, nil
 }
 
@@ -574,6 +577,7 @@ type deployer struct {
 	sshPublicKeys           []string
 	lokiIngressHostName     string
 	promtailEnabled         bool
+	nodeLocalDNSENabled     bool
 }
 
 // exposed for testing
@@ -613,6 +617,7 @@ func (d *deployer) deploy(ctx context.Context, operation string) (extensionsv1al
 			ClusterDomain:           d.clusterDomain,
 			CRIName:                 d.criName,
 			Images:                  d.images,
+			NodeLabels:              gutil.NodeLabelsForWorkerPool(d.worker, d.nodeLocalDNSENabled),
 			KubeletCABundle:         d.kubeletCABundle,
 			KubeletConfigParameters: d.kubeletConfigParameters,
 			KubeletCLIFlags:         d.kubeletCLIFlags,

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/operatingsystemconfig_test.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/operatingsystemconfig_test.go
@@ -138,6 +138,7 @@ var _ = Describe("OperatingSystemConfig", func() {
 				{
 					Name: worker1Name,
 					Machine: gardencorev1beta1.Machine{
+						Architecture: pointer.String(v1beta1constants.ArchitectureAMD64),
 						Image: &gardencorev1beta1.ShootMachineImage{
 							Name:           "type1",
 							ProviderConfig: &runtime.RawExtension{Raw: []byte(`{"foo":"bar"}`)},
@@ -148,6 +149,7 @@ var _ = Describe("OperatingSystemConfig", func() {
 				{
 					Name: worker2Name,
 					Machine: gardencorev1beta1.Machine{
+						Architecture: pointer.String(v1beta1constants.ArchitectureAMD64),
 						Image: &gardencorev1beta1.ShootMachineImage{
 							Name: "type2",
 						},

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/components.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/components.go
@@ -36,6 +36,7 @@ type Context struct {
 	ClusterDomain           string
 	CRIName                 extensionsv1alpha1.CRIName
 	Images                  map[string]*imagevector.Image
+	NodeLabels              map[string]string
 	KubeletCABundle         []byte
 	KubeletCLIFlags         ConfigurableKubeletCLIFlags
 	KubeletConfigParameters ConfigurableKubeletConfigParameters

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/kubelet/cliflags.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/kubelet/cliflags.go
@@ -43,6 +43,7 @@ func CLIFlags(kubernetesVersion *semver.Version, nodeLabels map[string]string, c
 	)
 
 	// maps are unsorted in go, make sure to output node labels in the exact same order every time
+	// this ensures deterministic behavior so that tests are stable and the OSC doesn't change on every reconciliation
 	labelKeys := make([]string, 0, len(nodeLabels))
 	for key := range nodeLabels {
 		labelKeys = append(labelKeys, key)

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/kubelet/cliflags_test.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/kubelet/cliflags_test.go
@@ -41,7 +41,8 @@ var _ = Describe("CLIFlags", func() {
 		func(kubernetesVersion string, criName extensionsv1alpha1.CRIName, image *imagevector.Image, cliFlags components.ConfigurableKubeletCLIFlags, matcher gomegatypes.GomegaMatcher) {
 			v := semver.MustParse(kubernetesVersion)
 			nodeLabels := map[string]string{
-				"test": "foo",
+				"test":  "foo",
+				"test2": "bar",
 			}
 			Expect(kubelet.CLIFlags(v, nodeLabels, criName, image, cliFlags)).To(matcher)
 		},
@@ -61,6 +62,7 @@ var _ = Describe("CLIFlags", func() {
 				"--kubeconfig=/var/lib/kubelet/kubeconfig-real",
 				"--node-labels=worker.gardener.cloud/kubernetes-version=1.20.1",
 				"--node-labels=test=foo",
+				"--node-labels=test2=bar",
 				"--network-plugin=cni",
 				"--pod-infra-container-image=foo.io/hyperkube:version",
 				"--v=2",
@@ -78,6 +80,7 @@ var _ = Describe("CLIFlags", func() {
 				"--kubeconfig=/var/lib/kubelet/kubeconfig-real",
 				"--node-labels=worker.gardener.cloud/kubernetes-version=1.20.1",
 				"--node-labels=test=foo",
+				"--node-labels=test2=bar",
 				"--container-runtime=remote",
 				"--container-runtime-endpoint=unix:///run/containerd/containerd.sock",
 				"--runtime-cgroups=/system.slice/containerd.service",
@@ -100,6 +103,7 @@ var _ = Describe("CLIFlags", func() {
 				"--kubeconfig=/var/lib/kubelet/kubeconfig-real",
 				"--node-labels=worker.gardener.cloud/kubernetes-version=1.21.1",
 				"--node-labels=test=foo",
+				"--node-labels=test2=bar",
 				"--network-plugin=cni",
 				"--pod-infra-container-image=foo.io/hyperkube:version",
 				"--v=2",
@@ -117,6 +121,7 @@ var _ = Describe("CLIFlags", func() {
 				"--kubeconfig=/var/lib/kubelet/kubeconfig-real",
 				"--node-labels=worker.gardener.cloud/kubernetes-version=1.21.1",
 				"--node-labels=test=foo",
+				"--node-labels=test2=bar",
 				"--container-runtime=remote",
 				"--container-runtime-endpoint=unix:///run/containerd/containerd.sock",
 				"--runtime-cgroups=/system.slice/containerd.service",
@@ -139,6 +144,7 @@ var _ = Describe("CLIFlags", func() {
 				"--kubeconfig=/var/lib/kubelet/kubeconfig-real",
 				"--node-labels=worker.gardener.cloud/kubernetes-version=1.22.1",
 				"--node-labels=test=foo",
+				"--node-labels=test2=bar",
 				"--network-plugin=cni",
 				"--pod-infra-container-image=foo.io/hyperkube:version",
 				"--v=2",
@@ -156,6 +162,7 @@ var _ = Describe("CLIFlags", func() {
 				"--kubeconfig=/var/lib/kubelet/kubeconfig-real",
 				"--node-labels=worker.gardener.cloud/kubernetes-version=1.22.1",
 				"--node-labels=test=foo",
+				"--node-labels=test2=bar",
 				"--container-runtime=remote",
 				"--container-runtime-endpoint=unix:///run/containerd/containerd.sock",
 				"--runtime-cgroups=/system.slice/containerd.service",

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/kubelet/cliflags_test.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/kubelet/cliflags_test.go
@@ -40,7 +40,10 @@ var _ = Describe("CLIFlags", func() {
 	DescribeTable("#CLIFlags",
 		func(kubernetesVersion string, criName extensionsv1alpha1.CRIName, image *imagevector.Image, cliFlags components.ConfigurableKubeletCLIFlags, matcher gomegatypes.GomegaMatcher) {
 			v := semver.MustParse(kubernetesVersion)
-			Expect(kubelet.CLIFlags(v, criName, image, cliFlags)).To(matcher)
+			nodeLabels := map[string]string{
+				"test": "foo",
+			}
+			Expect(kubelet.CLIFlags(v, nodeLabels, criName, image, cliFlags)).To(matcher)
 		},
 
 		Entry(
@@ -57,6 +60,7 @@ var _ = Describe("CLIFlags", func() {
 				"--image-pull-progress-deadline=2m0s",
 				"--kubeconfig=/var/lib/kubelet/kubeconfig-real",
 				"--node-labels=worker.gardener.cloud/kubernetes-version=1.20.1",
+				"--node-labels=test=foo",
 				"--network-plugin=cni",
 				"--pod-infra-container-image=foo.io/hyperkube:version",
 				"--v=2",
@@ -73,6 +77,7 @@ var _ = Describe("CLIFlags", func() {
 				"--config=/var/lib/kubelet/config/kubelet",
 				"--kubeconfig=/var/lib/kubelet/kubeconfig-real",
 				"--node-labels=worker.gardener.cloud/kubernetes-version=1.20.1",
+				"--node-labels=test=foo",
 				"--container-runtime=remote",
 				"--container-runtime-endpoint=unix:///run/containerd/containerd.sock",
 				"--runtime-cgroups=/system.slice/containerd.service",
@@ -94,6 +99,7 @@ var _ = Describe("CLIFlags", func() {
 				"--image-pull-progress-deadline=2m0s",
 				"--kubeconfig=/var/lib/kubelet/kubeconfig-real",
 				"--node-labels=worker.gardener.cloud/kubernetes-version=1.21.1",
+				"--node-labels=test=foo",
 				"--network-plugin=cni",
 				"--pod-infra-container-image=foo.io/hyperkube:version",
 				"--v=2",
@@ -110,6 +116,7 @@ var _ = Describe("CLIFlags", func() {
 				"--config=/var/lib/kubelet/config/kubelet",
 				"--kubeconfig=/var/lib/kubelet/kubeconfig-real",
 				"--node-labels=worker.gardener.cloud/kubernetes-version=1.21.1",
+				"--node-labels=test=foo",
 				"--container-runtime=remote",
 				"--container-runtime-endpoint=unix:///run/containerd/containerd.sock",
 				"--runtime-cgroups=/system.slice/containerd.service",
@@ -131,6 +138,7 @@ var _ = Describe("CLIFlags", func() {
 				"--image-pull-progress-deadline=2m0s",
 				"--kubeconfig=/var/lib/kubelet/kubeconfig-real",
 				"--node-labels=worker.gardener.cloud/kubernetes-version=1.22.1",
+				"--node-labels=test=foo",
 				"--network-plugin=cni",
 				"--pod-infra-container-image=foo.io/hyperkube:version",
 				"--v=2",
@@ -147,6 +155,7 @@ var _ = Describe("CLIFlags", func() {
 				"--config=/var/lib/kubelet/config/kubelet",
 				"--kubeconfig=/var/lib/kubelet/kubeconfig-real",
 				"--node-labels=worker.gardener.cloud/kubernetes-version=1.22.1",
+				"--node-labels=test=foo",
 				"--container-runtime=remote",
 				"--container-runtime-endpoint=unix:///run/containerd/containerd.sock",
 				"--runtime-cgroups=/system.slice/containerd.service",

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/kubelet/component.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/kubelet/component.go
@@ -104,7 +104,7 @@ func (component) Config(ctx components.Context) ([]extensionsv1alpha1.Unit, []ex
 		return nil, nil, err
 	}
 
-	cliFlags := CLIFlags(ctx.KubernetesVersion, ctx.CRIName, ctx.Images[images.ImageNamePauseContainer], ctx.KubeletCLIFlags)
+	cliFlags := CLIFlags(ctx.KubernetesVersion, ctx.NodeLabels, ctx.CRIName, ctx.Images[images.ImageNamePauseContainer], ctx.KubeletCLIFlags)
 
 	return []extensionsv1alpha1.Unit{
 			{

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/kubelet/component_test.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/kubelet/component_test.go
@@ -62,7 +62,12 @@ var _ = Describe("Component", func() {
 					Tag:        pointer.String(pauseContainerImageTag),
 				},
 			}
-			cliFlags := CLIFlags(ctx.KubernetesVersion, ctx.CRIName, ctx.Images[images.ImageNamePauseContainer], ctx.KubeletCLIFlags)
+			ctx.NodeLabels = map[string]string{
+				"test": "foo",
+				"blub": "bar",
+			}
+
+			cliFlags := CLIFlags(ctx.KubernetesVersion, ctx.NodeLabels, ctx.CRIName, ctx.Images[images.ImageNamePauseContainer], ctx.KubeletCLIFlags)
 			units, files, err := component.Config(ctx)
 
 			Expect(err).NotTo(HaveOccurred())

--- a/pkg/operation/botanist/component/extensions/worker/worker.go
+++ b/pkg/operation/botanist/component/extensions/worker/worker.go
@@ -16,9 +16,15 @@ package worker
 
 import (
 	"context"
-	"fmt"
-	"strconv"
 	"time"
+
+	"github.com/Masterminds/semver"
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
@@ -29,15 +35,7 @@ import (
 	"github.com/gardener/gardener/pkg/extensions"
 	"github.com/gardener/gardener/pkg/operation/botanist/component"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/extensions/operatingsystemconfig"
-	"github.com/gardener/gardener/pkg/utils"
-
-	"github.com/Masterminds/semver"
-	"github.com/go-logr/logr"
-	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	gutil "github.com/gardener/gardener/pkg/utils/gardener"
 )
 
 const (
@@ -167,35 +165,6 @@ func (w *worker) deploy(ctx context.Context, operation string) (extensionsv1alph
 			}
 		}
 
-		// copy labels map
-		labels := utils.MergeStringMaps(workerPool.Labels)
-		if labels == nil {
-			labels = map[string]string{}
-		}
-		labels["node.kubernetes.io/role"] = "node"
-		labels["kubernetes.io/arch"] = *workerPool.Machine.Architecture
-
-		labels[v1beta1constants.LabelNodeLocalDNS] = strconv.FormatBool(w.values.NodeLocalDNSENabled)
-
-		if gardencorev1beta1helper.SystemComponentsAllowed(&workerPool) {
-			labels[v1beta1constants.LabelWorkerPoolSystemComponents] = "true"
-		}
-
-		// worker pool name labels
-		labels[v1beta1constants.LabelWorkerPool] = workerPool.Name
-		labels[v1beta1constants.LabelWorkerPoolDeprecated] = workerPool.Name
-
-		// add CRI labels selected by the RuntimeClass
-		if workerPool.CRI != nil {
-			labels[extensionsv1alpha1.CRINameWorkerLabel] = string(workerPool.CRI.Name)
-			if len(workerPool.CRI.ContainerRuntimes) > 0 {
-				for _, cr := range workerPool.CRI.ContainerRuntimes {
-					key := fmt.Sprintf(extensionsv1alpha1.ContainerRuntimeNameWorkerLabel, cr.Type)
-					labels[key] = "true"
-				}
-			}
-		}
-
 		var pConfig *runtime.RawExtension
 		if workerPool.ProviderConfig != nil {
 			pConfig = &runtime.RawExtension{
@@ -237,7 +206,7 @@ func (w *worker) deploy(ctx context.Context, operation string) (extensionsv1alph
 			MaxSurge:       *workerPool.MaxSurge,
 			MaxUnavailable: *workerPool.MaxUnavailable,
 			Annotations:    workerPool.Annotations,
-			Labels:         labels,
+			Labels:         gutil.NodeLabelsForWorkerPool(workerPool, w.values.NodeLocalDNSENabled),
 			Taints:         workerPool.Taints,
 			MachineType:    workerPool.Machine.Type,
 			MachineImage: extensionsv1alpha1.MachineImage{

--- a/pkg/operation/botanist/component/extensions/worker/worker.go
+++ b/pkg/operation/botanist/component/extensions/worker/worker.go
@@ -84,8 +84,8 @@ type Values struct {
 	InfrastructureProviderStatus *runtime.RawExtension
 	// WorkerNameToOperatingSystemConfigsMap contains the operating system configurations for the worker pools.
 	WorkerNameToOperatingSystemConfigsMap map[string]*operatingsystemconfig.OperatingSystemConfigs
-	// NodeLocalDNSENabled indicates whether node local dns is enabled or not.
-	NodeLocalDNSENabled bool
+	// NodeLocalDNSEnabled indicates whether node local dns is enabled or not.
+	NodeLocalDNSEnabled bool
 }
 
 // New creates a new instance of Interface.
@@ -206,7 +206,7 @@ func (w *worker) deploy(ctx context.Context, operation string) (extensionsv1alph
 			MaxSurge:       *workerPool.MaxSurge,
 			MaxUnavailable: *workerPool.MaxUnavailable,
 			Annotations:    workerPool.Annotations,
-			Labels:         gutil.NodeLabelsForWorkerPool(workerPool, w.values.NodeLocalDNSENabled),
+			Labels:         gutil.NodeLabelsForWorkerPool(workerPool, w.values.NodeLocalDNSEnabled),
 			Taints:         workerPool.Taints,
 			MachineType:    workerPool.Machine.Type,
 			MachineImage: extensionsv1alpha1.MachineImage{

--- a/pkg/operation/botanist/operatingsystemconfig.go
+++ b/pkg/operation/botanist/operatingsystemconfig.go
@@ -78,7 +78,7 @@ func (b *Botanist) DefaultOperatingSystemConfig() (operatingsystemconfig.Interfa
 				MachineTypes:        b.Shoot.CloudProfile.Spec.MachineTypes,
 				PromtailEnabled:     promtailEnabled,
 				LokiIngressHostName: lokiIngressHost,
-				NodeLocalDNSENabled: v1beta1helper.IsNodeLocalDNSEnabled(b.Shoot.GetInfo().Spec.SystemComponents, b.Shoot.GetInfo().Annotations),
+				NodeLocalDNSEnabled: v1beta1helper.IsNodeLocalDNSEnabled(b.Shoot.GetInfo().Spec.SystemComponents, b.Shoot.GetInfo().Annotations),
 			},
 		},
 		operatingsystemconfig.DefaultInterval,

--- a/pkg/operation/botanist/operatingsystemconfig.go
+++ b/pkg/operation/botanist/operatingsystemconfig.go
@@ -78,6 +78,7 @@ func (b *Botanist) DefaultOperatingSystemConfig() (operatingsystemconfig.Interfa
 				MachineTypes:        b.Shoot.CloudProfile.Spec.MachineTypes,
 				PromtailEnabled:     promtailEnabled,
 				LokiIngressHostName: lokiIngressHost,
+				NodeLocalDNSENabled: v1beta1helper.IsNodeLocalDNSEnabled(b.Shoot.GetInfo().Spec.SystemComponents, b.Shoot.GetInfo().Annotations),
 			},
 		},
 		operatingsystemconfig.DefaultInterval,

--- a/pkg/operation/botanist/worker.go
+++ b/pkg/operation/botanist/worker.go
@@ -52,7 +52,7 @@ func (b *Botanist) DefaultWorker() worker.Interface {
 			Workers:             b.Shoot.GetInfo().Spec.Provider.Workers,
 			KubernetesVersion:   b.Shoot.KubernetesVersion,
 			MachineTypes:        b.Shoot.CloudProfile.Spec.MachineTypes,
-			NodeLocalDNSENabled: v1beta1helper.IsNodeLocalDNSEnabled(b.Shoot.GetInfo().Spec.SystemComponents, b.Shoot.GetInfo().Annotations),
+			NodeLocalDNSEnabled: v1beta1helper.IsNodeLocalDNSEnabled(b.Shoot.GetInfo().Spec.SystemComponents, b.Shoot.GetInfo().Annotations),
 		},
 		worker.DefaultInterval,
 		worker.DefaultSevereThreshold,

--- a/pkg/utils/gardener/shoot.go
+++ b/pkg/utils/gardener/shoot.go
@@ -167,7 +167,7 @@ func GetShootNameFromOwnerReferences(objectMeta metav1.Object) string {
 }
 
 // NodeLabelsForWorkerPool returns a combined map of all user-specified and gardener-managed node labels.
-func NodeLabelsForWorkerPool(workerPool gardencorev1beta1.Worker, nodeLocalDNSENabled bool) map[string]string {
+func NodeLabelsForWorkerPool(workerPool gardencorev1beta1.Worker, nodeLocalDNSEnabled bool) map[string]string {
 	// copy worker pool labels map
 	labels := utils.MergeStringMaps(workerPool.Labels)
 	if labels == nil {
@@ -176,7 +176,7 @@ func NodeLabelsForWorkerPool(workerPool gardencorev1beta1.Worker, nodeLocalDNSEN
 	labels["node.kubernetes.io/role"] = "node"
 	labels["kubernetes.io/arch"] = *workerPool.Machine.Architecture
 
-	labels[v1beta1constants.LabelNodeLocalDNS] = strconv.FormatBool(nodeLocalDNSENabled)
+	labels[v1beta1constants.LabelNodeLocalDNS] = strconv.FormatBool(nodeLocalDNSEnabled)
 
 	if gardencorev1beta1helper.SystemComponentsAllowed(&workerPool) {
 		labels[v1beta1constants.LabelWorkerPoolSystemComponents] = "true"

--- a/pkg/utils/gardener/shoot.go
+++ b/pkg/utils/gardener/shoot.go
@@ -37,6 +37,8 @@ import (
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/utils"
@@ -162,6 +164,40 @@ func GetShootNameFromOwnerReferences(objectMeta metav1.Object) string {
 		}
 	}
 	return ""
+}
+
+// NodeLabelsForWorkerPool returns a combined map of all user-specified and gardener-managed node labels.
+func NodeLabelsForWorkerPool(workerPool gardencorev1beta1.Worker, nodeLocalDNSENabled bool) map[string]string {
+	// copy worker pool labels map
+	labels := utils.MergeStringMaps(workerPool.Labels)
+	if labels == nil {
+		labels = map[string]string{}
+	}
+	labels["node.kubernetes.io/role"] = "node"
+	labels["kubernetes.io/arch"] = *workerPool.Machine.Architecture
+
+	labels[v1beta1constants.LabelNodeLocalDNS] = strconv.FormatBool(nodeLocalDNSENabled)
+
+	if gardencorev1beta1helper.SystemComponentsAllowed(&workerPool) {
+		labels[v1beta1constants.LabelWorkerPoolSystemComponents] = "true"
+	}
+
+	// worker pool name labels
+	labels[v1beta1constants.LabelWorkerPool] = workerPool.Name
+	labels[v1beta1constants.LabelWorkerPoolDeprecated] = workerPool.Name
+
+	// add CRI labels selected by the RuntimeClass
+	if workerPool.CRI != nil {
+		labels[extensionsv1alpha1.CRINameWorkerLabel] = string(workerPool.CRI.Name)
+		if len(workerPool.CRI.ContainerRuntimes) > 0 {
+			for _, cr := range workerPool.CRI.ContainerRuntimes {
+				key := fmt.Sprintf(extensionsv1alpha1.ContainerRuntimeNameWorkerLabel, cr.Type)
+				labels[key] = "true"
+			}
+		}
+	}
+
+	return labels
 }
 
 const (

--- a/test/e2e/gardener/common.go
+++ b/test/e2e/gardener/common.go
@@ -97,6 +97,9 @@ func DefaultShoot(name string) *gardencorev1beta1.Shoot {
 					CRI: &gardencorev1beta1.CRI{
 						Name: gardencorev1beta1.CRINameContainerD,
 					},
+					Labels: map[string]string{
+						"foo": "bar",
+					},
 					Minimum: 1,
 					Maximum: 1,
 				}},

--- a/test/e2e/gardener/shoot/create_update_delete.go
+++ b/test/e2e/gardener/shoot/create_update_delete.go
@@ -31,7 +31,7 @@ import (
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/utils/pointer"
-	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
@@ -89,10 +89,10 @@ var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
 				expectedNodeLabels["worker.gardener.cloud/kubernetes-version"] = kubernetesVersion
 
 				nodeList := &corev1.NodeList{}
-				g.Expect(shootClient.Client().List(ctx, nodeList, runtimeclient.MatchingLabels{
+				g.Expect(shootClient.Client().List(ctx, nodeList, client.MatchingLabels{
 					"worker.gardener.cloud/pool": workerPool.Name,
 				})).To(Succeed())
-				g.Expect(nodeList.Items).To(HaveLen(1), "worker pool %s should have exactly three Nodes", workerPool.Name)
+				g.Expect(nodeList.Items).To(HaveLen(1), "worker pool %s should have exactly one Node", workerPool.Name)
 
 				for key, value := range expectedNodeLabels {
 					g.Expect(nodeList.Items[0].Labels).To(HaveKeyWithValue(key, value), "worker pool %s should have expected labels", workerPool.Name)

--- a/test/e2e/gardener/shoot/create_update_delete.go
+++ b/test/e2e/gardener/shoot/create_update_delete.go
@@ -16,10 +16,12 @@ package shoot
 
 import (
 	"context"
+	"strconv"
 	"time"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
+	"github.com/gardener/gardener/pkg/utils"
 	e2e "github.com/gardener/gardener/test/e2e/gardener"
 	"github.com/gardener/gardener/test/framework"
 	"github.com/gardener/gardener/test/utils/shoots/access"
@@ -29,6 +31,7 @@ import (
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/utils/pointer"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
@@ -65,6 +68,36 @@ var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
 			g.Expect(err).NotTo(HaveOccurred())
 
 			g.Expect(shootClient.Client().List(ctx, &corev1.NamespaceList{})).To(Succeed())
+		}).Should(Succeed())
+
+		By("Verify worker node labels")
+		commonNodeLabels := utils.MergeStringMaps(f.Shoot.Spec.Provider.Workers[0].Labels)
+		commonNodeLabels["networking.gardener.cloud/node-local-dns-enabled"] = "false"
+		commonNodeLabels["node.kubernetes.io/role"] = "node"
+
+		Eventually(func(g Gomega) {
+			for _, workerPool := range f.Shoot.Spec.Provider.Workers {
+				expectedNodeLabels := utils.MergeStringMaps(commonNodeLabels)
+				expectedNodeLabels["worker.gardener.cloud/pool"] = workerPool.Name
+				expectedNodeLabels["worker.gardener.cloud/cri-name"] = string(workerPool.CRI.Name)
+				expectedNodeLabels["worker.gardener.cloud/system-components"] = strconv.FormatBool(workerPool.SystemComponents.Allow)
+
+				kubernetesVersion := f.Shoot.Spec.Kubernetes.Version
+				if workerPool.Kubernetes != nil && workerPool.Kubernetes.Version != nil {
+					kubernetesVersion = *workerPool.Kubernetes.Version
+				}
+				expectedNodeLabels["worker.gardener.cloud/kubernetes-version"] = kubernetesVersion
+
+				nodeList := &corev1.NodeList{}
+				g.Expect(shootClient.Client().List(ctx, nodeList, runtimeclient.MatchingLabels{
+					"worker.gardener.cloud/pool": workerPool.Name,
+				})).To(Succeed())
+				g.Expect(nodeList.Items).To(HaveLen(1), "worker pool %s should have exactly three Nodes", workerPool.Name)
+
+				for key, value := range expectedNodeLabels {
+					g.Expect(nodeList.Items[0].Labels).To(HaveKeyWithValue(key, value), "worker pool %s should have expected labels", workerPool.Name)
+				}
+			}
 		}).Should(Succeed())
 
 		By("Update Shoot")


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind enhancement

**What this PR does / why we need it**:

With this PR, gardenlet passes all worker node labels to kubelet's `--node-label` flag instead of relying on machine-controller-manager to add labels asynchronously.
Passing all worker pool labels to `--node-labels` makes sure, the `Node` objects immediately contain the specified labels on registration.
machine-controller-manager is still responsible for updating `Node` labels after registration according to specification changes.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/7117

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other user
User-specified and gardener-managed `Node` labels are added immediately on registration of new `Nodes`.
```
