### PR TITLE
Validate audit policy api version on shoot update request

### DIFF
--- a/example/95-configmap-custom-audit-policy.yaml
+++ b/example/95-configmap-custom-audit-policy.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: garden-dev
 data:
   policy: |-
-    apiVersion: audit.k8s.io/v1beta1
+    apiVersion: audit.k8s.io/v1
     kind: Policy
     rules:
       - level: Metadata

--- a/pkg/admissioncontroller/webhook/admission/auditpolicy/handler_test.go
+++ b/pkg/admissioncontroller/webhook/admission/auditpolicy/handler_test.go
@@ -32,7 +32,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	admissionv1 "k8s.io/api/admission/v1"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -70,7 +70,7 @@ var _ = Describe("handler", func() {
 		shootName      = "fake-shoot-name"
 		shootNamespace = cmNamespace
 
-		cm                  *v1.ConfigMap
+		cm                  *corev1.ConfigMap
 		shootv1beta1        *gardencorev1beta1.Shoot
 		shootv1alpha1       *gardencorev1alpha1.Shoot
 		shootv1beta1K8sV124 *gardencorev1beta1.Shoot
@@ -189,7 +189,7 @@ rules:
 					KubeAPIServer: &gardencorev1beta1.KubeAPIServerConfig{
 						AuditConfig: &gardencorev1beta1.AuditConfig{
 							AuditPolicy: &gardencorev1beta1.AuditPolicy{
-								ConfigMapRef: &v1.ObjectReference{
+								ConfigMapRef: &corev1.ObjectReference{
 									Name: cmName,
 								},
 							},
@@ -212,7 +212,7 @@ rules:
 					KubeAPIServer: &gardencorev1alpha1.KubeAPIServerConfig{
 						AuditConfig: &gardencorev1alpha1.AuditConfig{
 							AuditPolicy: &gardencorev1alpha1.AuditPolicy{
-								ConfigMapRef: &v1.ObjectReference{
+								ConfigMapRef: &corev1.ObjectReference{
 									Name: cmName,
 								},
 							},
@@ -236,7 +236,7 @@ rules:
 					KubeAPIServer: &gardencorev1beta1.KubeAPIServerConfig{
 						AuditConfig: &gardencorev1beta1.AuditConfig{
 							AuditPolicy: &gardencorev1beta1.AuditPolicy{
-								ConfigMapRef: &v1.ObjectReference{
+								ConfigMapRef: &corev1.ObjectReference{
 									Name: cmName,
 								},
 							},
@@ -261,7 +261,7 @@ rules:
 					KubeAPIServer: &gardencorev1beta1.KubeAPIServerConfig{
 						AuditConfig: &gardencorev1beta1.AuditConfig{
 							AuditPolicy: &gardencorev1beta1.AuditPolicy{
-								ConfigMapRef: &v1.ObjectReference{
+								ConfigMapRef: &corev1.ObjectReference{
 									Name: cmName,
 								},
 							},
@@ -327,12 +327,12 @@ rules:
 			})
 
 			It("references a valid auditPolicy (CREATE)", func() {
-				returnedCm := v1.ConfigMap{
+				returnedCm := corev1.ConfigMap{
 					TypeMeta:   metav1.TypeMeta{},
 					ObjectMeta: metav1.ObjectMeta{ResourceVersion: "1"},
 					Data:       map[string]string{"policy": validAuditPolicy},
 				}
-				mockReader.EXPECT().Get(gomock.Any(), kutil.Key(shootNamespace, cmName), gomock.AssignableToTypeOf(&v1.ConfigMap{})).DoAndReturn(func(_ context.Context, key client.ObjectKey, cm *v1.ConfigMap, _ ...client.GetOption) error {
+				mockReader.EXPECT().Get(gomock.Any(), kutil.Key(shootNamespace, cmName), gomock.AssignableToTypeOf(&corev1.ConfigMap{})).DoAndReturn(func(_ context.Context, key client.ObjectKey, cm *corev1.ConfigMap, _ ...client.GetOption) error {
 					*cm = returnedCm
 					return nil
 				})
@@ -340,12 +340,12 @@ rules:
 			})
 
 			It("references a valid auditPolicy (CREATE/v1alpha1)", func() {
-				returnedCm := v1.ConfigMap{
+				returnedCm := corev1.ConfigMap{
 					TypeMeta:   metav1.TypeMeta{},
 					ObjectMeta: metav1.ObjectMeta{ResourceVersion: "1"},
 					Data:       map[string]string{"policy": validAuditPolicy},
 				}
-				mockReader.EXPECT().Get(gomock.Any(), kutil.Key(shootNamespace, cmName), gomock.AssignableToTypeOf(&v1.ConfigMap{})).DoAndReturn(func(_ context.Context, key client.ObjectKey, cm *v1.ConfigMap, _ ...client.GetOption) error {
+				mockReader.EXPECT().Get(gomock.Any(), kutil.Key(shootNamespace, cmName), gomock.AssignableToTypeOf(&corev1.ConfigMap{})).DoAndReturn(func(_ context.Context, key client.ObjectKey, cm *corev1.ConfigMap, _ ...client.GetOption) error {
 					*cm = returnedCm
 					return nil
 				})
@@ -353,12 +353,12 @@ rules:
 			})
 
 			It("references a valid auditPolicy/v1alpha1 (CREATE k8s < 1.24.0)", func() {
-				returnedCm := v1.ConfigMap{
+				returnedCm := corev1.ConfigMap{
 					TypeMeta:   metav1.TypeMeta{},
 					ObjectMeta: metav1.ObjectMeta{ResourceVersion: "1"},
 					Data:       map[string]string{"policy": validAuditPolicyV1alpha1},
 				}
-				mockReader.EXPECT().Get(gomock.Any(), kutil.Key(shootNamespace, cmName), gomock.AssignableToTypeOf(&v1.ConfigMap{})).DoAndReturn(func(_ context.Context, key client.ObjectKey, cm *v1.ConfigMap, _ ...client.GetOption) error {
+				mockReader.EXPECT().Get(gomock.Any(), kutil.Key(shootNamespace, cmName), gomock.AssignableToTypeOf(&corev1.ConfigMap{})).DoAndReturn(func(_ context.Context, key client.ObjectKey, cm *corev1.ConfigMap, _ ...client.GetOption) error {
 					*cm = returnedCm
 					return nil
 				})
@@ -366,12 +366,12 @@ rules:
 			})
 
 			It("references a valid auditPolicy/v1beta1 (CREATE k8s < 1.24.0)", func() {
-				returnedCm := v1.ConfigMap{
+				returnedCm := corev1.ConfigMap{
 					TypeMeta:   metav1.TypeMeta{},
 					ObjectMeta: metav1.ObjectMeta{ResourceVersion: "1"},
 					Data:       map[string]string{"policy": validAuditPolicyV1beta1},
 				}
-				mockReader.EXPECT().Get(gomock.Any(), kutil.Key(shootNamespace, cmName), gomock.AssignableToTypeOf(&v1.ConfigMap{})).DoAndReturn(func(_ context.Context, key client.ObjectKey, cm *v1.ConfigMap, _ ...client.GetOption) error {
+				mockReader.EXPECT().Get(gomock.Any(), kutil.Key(shootNamespace, cmName), gomock.AssignableToTypeOf(&corev1.ConfigMap{})).DoAndReturn(func(_ context.Context, key client.ObjectKey, cm *corev1.ConfigMap, _ ...client.GetOption) error {
 					*cm = returnedCm
 					return nil
 				})
@@ -391,14 +391,14 @@ rules:
 			})
 
 			It("auditPolicy name was added (UPDATE)", func() {
-				returnedCm := v1.ConfigMap{
+				returnedCm := corev1.ConfigMap{
 					Data: map[string]string{"policy": validAuditPolicy},
 				}
 				apiServerConfig := shootv1beta1.Spec.Kubernetes.KubeAPIServer.DeepCopy()
 				shootv1beta1.Spec.Kubernetes.KubeAPIServer = nil
 				newShoot := shootv1beta1.DeepCopy()
 				newShoot.Spec.Kubernetes.KubeAPIServer = apiServerConfig
-				mockReader.EXPECT().Get(gomock.Any(), kutil.Key(shootNamespace, cmName), gomock.AssignableToTypeOf(&v1.ConfigMap{})).DoAndReturn(func(_ context.Context, key client.ObjectKey, cm *v1.ConfigMap, _ ...client.GetOption) error {
+				mockReader.EXPECT().Get(gomock.Any(), kutil.Key(shootNamespace, cmName), gomock.AssignableToTypeOf(&corev1.ConfigMap{})).DoAndReturn(func(_ context.Context, key client.ObjectKey, cm *corev1.ConfigMap, _ ...client.GetOption) error {
 					*cm = returnedCm
 					return nil
 				})
@@ -406,14 +406,14 @@ rules:
 			})
 
 			It("auditPolicy name was added (UPDATE/v1alpha1)", func() {
-				returnedCm := v1.ConfigMap{
+				returnedCm := corev1.ConfigMap{
 					Data: map[string]string{"policy": validAuditPolicy},
 				}
 				apiServerConfig := shootv1alpha1.Spec.Kubernetes.KubeAPIServer.DeepCopy()
 				shootv1alpha1.Spec.Kubernetes.KubeAPIServer = nil
 				newShoot := shootv1alpha1.DeepCopy()
 				newShoot.Spec.Kubernetes.KubeAPIServer = apiServerConfig
-				mockReader.EXPECT().Get(gomock.Any(), kutil.Key(shootNamespace, cmName), gomock.AssignableToTypeOf(&v1.ConfigMap{})).DoAndReturn(func(_ context.Context, key client.ObjectKey, cm *v1.ConfigMap, _ ...client.GetOption) error {
+				mockReader.EXPECT().Get(gomock.Any(), kutil.Key(shootNamespace, cmName), gomock.AssignableToTypeOf(&corev1.ConfigMap{})).DoAndReturn(func(_ context.Context, key client.ObjectKey, cm *corev1.ConfigMap, _ ...client.GetOption) error {
 					*cm = returnedCm
 					return nil
 				})
@@ -421,12 +421,12 @@ rules:
 			})
 
 			It("referenced auditPolicy name was changed (UPDATE)", func() {
-				returnedCm := v1.ConfigMap{
+				returnedCm := corev1.ConfigMap{
 					Data: map[string]string{"policy": validAuditPolicy},
 				}
 				newShoot := shootv1beta1.DeepCopy()
 				newShoot.Spec.Kubernetes.KubeAPIServer.AuditConfig.AuditPolicy.ConfigMapRef.Name = cmNameOther
-				mockReader.EXPECT().Get(gomock.Any(), kutil.Key(shootNamespace, cmNameOther), gomock.AssignableToTypeOf(&v1.ConfigMap{})).DoAndReturn(func(_ context.Context, key client.ObjectKey, cm *v1.ConfigMap, _ ...client.GetOption) error {
+				mockReader.EXPECT().Get(gomock.Any(), kutil.Key(shootNamespace, cmNameOther), gomock.AssignableToTypeOf(&corev1.ConfigMap{})).DoAndReturn(func(_ context.Context, key client.ObjectKey, cm *corev1.ConfigMap, _ ...client.GetOption) error {
 					*cm = returnedCm
 					return nil
 				})
@@ -434,12 +434,12 @@ rules:
 			})
 
 			It("referenced auditPolicy name was changed (UPDATE/v1alpha1)", func() {
-				returnedCm := v1.ConfigMap{
+				returnedCm := corev1.ConfigMap{
 					Data: map[string]string{"policy": validAuditPolicy},
 				}
 				newShoot := shootv1alpha1.DeepCopy()
 				newShoot.Spec.Kubernetes.KubeAPIServer.AuditConfig.AuditPolicy.ConfigMapRef.Name = cmNameOther
-				mockReader.EXPECT().Get(gomock.Any(), kutil.Key(shootNamespace, cmNameOther), gomock.AssignableToTypeOf(&v1.ConfigMap{})).DoAndReturn(func(_ context.Context, key client.ObjectKey, cm *v1.ConfigMap, _ ...client.GetOption) error {
+				mockReader.EXPECT().Get(gomock.Any(), kutil.Key(shootNamespace, cmNameOther), gomock.AssignableToTypeOf(&corev1.ConfigMap{})).DoAndReturn(func(_ context.Context, key client.ObjectKey, cm *corev1.ConfigMap, _ ...client.GetOption) error {
 					*cm = returnedCm
 					return nil
 				})
@@ -479,22 +479,22 @@ rules:
 
 		Context("Deny", func() {
 			It("references a configmap that does not exist", func() {
-				mockReader.EXPECT().Get(gomock.Any(), kutil.Key(shootNamespace, cmName), &v1.ConfigMap{}).DoAndReturn(func(_ context.Context, key client.ObjectKey, cm *v1.ConfigMap, _ ...client.GetOption) error {
+				mockReader.EXPECT().Get(gomock.Any(), kutil.Key(shootNamespace, cmName), &corev1.ConfigMap{}).DoAndReturn(func(_ context.Context, key client.ObjectKey, cm *corev1.ConfigMap, _ ...client.GetOption) error {
 					return apierrors.NewNotFound(schema.GroupResource{Resource: "configmaps"}, cmName)
 				})
 				test(admissionv1.Create, nil, shootv1beta1, false, statusCodeInvalid, "referenced audit policy does not exist", "")
 			})
 
 			It("fails getting cm", func() {
-				mockReader.EXPECT().Get(gomock.Any(), kutil.Key(shootNamespace, cmName), &v1.ConfigMap{}).DoAndReturn(func(_ context.Context, key client.ObjectKey, cm *v1.ConfigMap, _ ...client.GetOption) error {
+				mockReader.EXPECT().Get(gomock.Any(), kutil.Key(shootNamespace, cmName), &corev1.ConfigMap{}).DoAndReturn(func(_ context.Context, key client.ObjectKey, cm *corev1.ConfigMap, _ ...client.GetOption) error {
 					return fmt.Errorf("fake")
 				})
 				test(admissionv1.Create, nil, shootv1beta1, false, statusCodeInternalError, "could not retrieve config map: fake", "")
 			})
 
 			It("references configmap without a policy key", func() {
-				mockReader.EXPECT().Get(gomock.Any(), kutil.Key(shootNamespace, cmName), &v1.ConfigMap{}).DoAndReturn(func(_ context.Context, key client.ObjectKey, cm *v1.ConfigMap, _ ...client.GetOption) error {
-					*cm = v1.ConfigMap{
+				mockReader.EXPECT().Get(gomock.Any(), kutil.Key(shootNamespace, cmName), &corev1.ConfigMap{}).DoAndReturn(func(_ context.Context, key client.ObjectKey, cm *corev1.ConfigMap, _ ...client.GetOption) error {
+					*cm = corev1.ConfigMap{
 						Data: nil,
 					}
 					return nil
@@ -503,12 +503,12 @@ rules:
 			})
 
 			It("references audit policy which breaks validation rules", func() {
-				returnedCm := v1.ConfigMap{
+				returnedCm := corev1.ConfigMap{
 					TypeMeta:   metav1.TypeMeta{},
 					ObjectMeta: metav1.ObjectMeta{ResourceVersion: "2"},
 					Data:       map[string]string{"policy": invalidAuditPolicy},
 				}
-				mockReader.EXPECT().Get(gomock.Any(), kutil.Key(shootNamespace, cmName), gomock.AssignableToTypeOf(&v1.ConfigMap{})).DoAndReturn(func(_ context.Context, key client.ObjectKey, cm *v1.ConfigMap, _ ...client.GetOption) error {
+				mockReader.EXPECT().Get(gomock.Any(), kutil.Key(shootNamespace, cmName), gomock.AssignableToTypeOf(&corev1.ConfigMap{})).DoAndReturn(func(_ context.Context, key client.ObjectKey, cm *corev1.ConfigMap, _ ...client.GetOption) error {
 					*cm = returnedCm
 					return nil
 				})
@@ -516,12 +516,12 @@ rules:
 			})
 
 			It("references audit policy with invalid structure", func() {
-				returnedCm := v1.ConfigMap{
+				returnedCm := corev1.ConfigMap{
 					TypeMeta:   metav1.TypeMeta{},
 					ObjectMeta: metav1.ObjectMeta{ResourceVersion: "2"},
 					Data:       map[string]string{"policy": missingKeyAuditPolicy},
 				}
-				mockReader.EXPECT().Get(gomock.Any(), kutil.Key(shootNamespace, cmName), gomock.AssignableToTypeOf(&v1.ConfigMap{})).DoAndReturn(func(_ context.Context, key client.ObjectKey, cm *v1.ConfigMap, _ ...client.GetOption) error {
+				mockReader.EXPECT().Get(gomock.Any(), kutil.Key(shootNamespace, cmName), gomock.AssignableToTypeOf(&corev1.ConfigMap{})).DoAndReturn(func(_ context.Context, key client.ObjectKey, cm *corev1.ConfigMap, _ ...client.GetOption) error {
 					*cm = returnedCm
 					return nil
 				})
@@ -529,12 +529,12 @@ rules:
 			})
 
 			It("references a valid auditPolicy/v1alpha1 (CREATE k8s >= 1.24.0)", func() {
-				returnedCm := v1.ConfigMap{
+				returnedCm := corev1.ConfigMap{
 					TypeMeta:   metav1.TypeMeta{},
 					ObjectMeta: metav1.ObjectMeta{ResourceVersion: "2"},
 					Data:       map[string]string{"policy": validAuditPolicyV1alpha1},
 				}
-				mockReader.EXPECT().Get(gomock.Any(), kutil.Key(shootNamespace, cmName), gomock.AssignableToTypeOf(&v1.ConfigMap{})).DoAndReturn(func(_ context.Context, key client.ObjectKey, cm *v1.ConfigMap, _ ...client.GetOption) error {
+				mockReader.EXPECT().Get(gomock.Any(), kutil.Key(shootNamespace, cmName), gomock.AssignableToTypeOf(&corev1.ConfigMap{})).DoAndReturn(func(_ context.Context, key client.ObjectKey, cm *corev1.ConfigMap, _ ...client.GetOption) error {
 					*cm = returnedCm
 					return nil
 				})
@@ -542,12 +542,12 @@ rules:
 			})
 
 			It("references a valid auditPolicy/v1alpha1 (UPDATE kubernetes version)", func() {
-				returnedCm := v1.ConfigMap{
+				returnedCm := corev1.ConfigMap{
 					TypeMeta:   metav1.TypeMeta{},
 					ObjectMeta: metav1.ObjectMeta{ResourceVersion: "2"},
 					Data:       map[string]string{"policy": validAuditPolicyV1alpha1},
 				}
-				mockReader.EXPECT().Get(gomock.Any(), kutil.Key(shootNamespace, cmName), gomock.AssignableToTypeOf(&v1.ConfigMap{})).DoAndReturn(func(_ context.Context, key client.ObjectKey, cm *v1.ConfigMap, _ ...client.GetOption) error {
+				mockReader.EXPECT().Get(gomock.Any(), kutil.Key(shootNamespace, cmName), gomock.AssignableToTypeOf(&corev1.ConfigMap{})).DoAndReturn(func(_ context.Context, key client.ObjectKey, cm *corev1.ConfigMap, _ ...client.GetOption) error {
 					*cm = returnedCm
 					return nil
 				})
@@ -558,12 +558,12 @@ rules:
 			})
 
 			It("references a valid auditPolicy/v1beta1 (CREATE k8s >= 1.24.0)", func() {
-				returnedCm := v1.ConfigMap{
+				returnedCm := corev1.ConfigMap{
 					TypeMeta:   metav1.TypeMeta{},
 					ObjectMeta: metav1.ObjectMeta{ResourceVersion: "2"},
 					Data:       map[string]string{"policy": validAuditPolicyV1beta1},
 				}
-				mockReader.EXPECT().Get(gomock.Any(), kutil.Key(shootNamespace, cmName), gomock.AssignableToTypeOf(&v1.ConfigMap{})).DoAndReturn(func(_ context.Context, key client.ObjectKey, cm *v1.ConfigMap, _ ...client.GetOption) error {
+				mockReader.EXPECT().Get(gomock.Any(), kutil.Key(shootNamespace, cmName), gomock.AssignableToTypeOf(&corev1.ConfigMap{})).DoAndReturn(func(_ context.Context, key client.ObjectKey, cm *corev1.ConfigMap, _ ...client.GetOption) error {
 					*cm = returnedCm
 					return nil
 				})
@@ -571,12 +571,12 @@ rules:
 			})
 
 			It("references a valid auditPolicy/v1beta1 (UPDATE kubernetes version)", func() {
-				returnedCm := v1.ConfigMap{
+				returnedCm := corev1.ConfigMap{
 					TypeMeta:   metav1.TypeMeta{},
 					ObjectMeta: metav1.ObjectMeta{ResourceVersion: "2"},
 					Data:       map[string]string{"policy": validAuditPolicyV1beta1},
 				}
-				mockReader.EXPECT().Get(gomock.Any(), kutil.Key(shootNamespace, cmName), gomock.AssignableToTypeOf(&v1.ConfigMap{})).DoAndReturn(func(_ context.Context, key client.ObjectKey, cm *v1.ConfigMap, _ ...client.GetOption) error {
+				mockReader.EXPECT().Get(gomock.Any(), kutil.Key(shootNamespace, cmName), gomock.AssignableToTypeOf(&corev1.ConfigMap{})).DoAndReturn(func(_ context.Context, key client.ObjectKey, cm *corev1.ConfigMap, _ ...client.GetOption) error {
 					*cm = returnedCm
 					return nil
 				})
@@ -593,7 +593,7 @@ rules:
 		BeforeEach(func() {
 			request.Kind = metav1.GroupVersionKind{Group: "", Version: "v1", Kind: "ConfigMap"}
 
-			cm = &v1.ConfigMap{
+			cm = &corev1.ConfigMap{
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "ConfigMap",
 					APIVersion: "v1",

--- a/pkg/admissioncontroller/webhook/admission/auditpolicy/handler_test.go
+++ b/pkg/admissioncontroller/webhook/admission/auditpolicy/handler_test.go
@@ -352,7 +352,7 @@ rules:
 				test(admissionv1.Create, nil, shootv1alpha1, true, statusCodeAllowed, "referenced audit policy is valid", "")
 			})
 
-			It("references a valid auditPolicy/v1alhpa1 (CREATE k8s < 1.24.0)", func() {
+			It("references a valid auditPolicy/v1alpha1 (CREATE k8s < 1.24.0)", func() {
 				returnedCm := v1.ConfigMap{
 					TypeMeta:   metav1.TypeMeta{},
 					ObjectMeta: metav1.ObjectMeta{ResourceVersion: "1"},
@@ -528,7 +528,7 @@ rules:
 				test(admissionv1.Create, nil, shootv1beta1, false, statusCodeInvalid, "did not find expected key", "")
 			})
 
-			It("references a valid auditPolicy/v1alhpa1 (CREATE k8s >= 1.24.0)", func() {
+			It("references a valid auditPolicy/v1alpha1 (CREATE k8s >= 1.24.0)", func() {
 				returnedCm := v1.ConfigMap{
 					TypeMeta:   metav1.TypeMeta{},
 					ObjectMeta: metav1.ObjectMeta{ResourceVersion: "2"},
@@ -541,7 +541,7 @@ rules:
 				test(admissionv1.Create, nil, shootv1beta1K8sV124, false, statusCodeInvalid, "audit policy with apiVersion 'v1alpha1' is not supported for kubernetes version >= 1.24.0", "")
 			})
 
-			It("references a valid auditPolicy/v1alhpa1 (UPDATE kubernetes version)", func() {
+			It("references a valid auditPolicy/v1alpha1 (UPDATE kubernetes version)", func() {
 				returnedCm := v1.ConfigMap{
 					TypeMeta:   metav1.TypeMeta{},
 					ObjectMeta: metav1.ObjectMeta{ResourceVersion: "2"},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement

**What this PR does / why we need it**:


**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener/issues/6882

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
`gardener-admission-controller` now validates `Shoot` Kubernetes version compatibility with Audit Policy API version on `Shoot` update request.
```
