### PR TITLE
Update gardener/autoscaler for K8S v1.25

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -67,8 +67,13 @@ images:
 - name: cluster-autoscaler
   sourceRepository: github.com/gardener/autoscaler
   repository: eu.gcr.io/gardener-project/gardener/autoscaler/cluster-autoscaler
+  tag: "v1.25.0"
+  targetVersion: ">= 1.25"
+- name: cluster-autoscaler
+  sourceRepository: github.com/gardener/autoscaler
+  repository: eu.gcr.io/gardener-project/gardener/autoscaler/cluster-autoscaler
   tag: "v1.24.0"
-  targetVersion: ">= 1.24"
+  targetVersion: "1.24.x"
 - name: cluster-autoscaler
   sourceRepository: github.com/gardener/autoscaler
   repository: eu.gcr.io/gardener-project/gardener/autoscaler/cluster-autoscaler
@@ -88,7 +93,7 @@ images:
   sourceRepository: github.com/gardener/autoscaler
   repository: eu.gcr.io/gardener-project/gardener/autoscaler/cluster-autoscaler
   tag: "v1.20.3"
-  targetVersion: "< 1.21"
+  targetVersion: "1.20.x" #gardener supports K8S version >=1.20 only. See https://github.com/gardener/gardener/blob/master/docs/usage/supported_k8s_versions.md#:~:text=Gardener%20itself%20is%20capable%20of%20spinning%20up%20clusters%20with%20Kubernetes%20versions%201.20%20up%20to%201.25 for reference.
 - name: vpn-seed
   sourceRepository: github.com/gardener/vpn
   repository: eu.gcr.io/gardener-project/gardener/vpn-seed

--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -93,7 +93,7 @@ images:
   sourceRepository: github.com/gardener/autoscaler
   repository: eu.gcr.io/gardener-project/gardener/autoscaler/cluster-autoscaler
   tag: "v1.20.3"
-  targetVersion: "1.20.x" #gardener supports K8S version >=1.20 only. See https://github.com/gardener/gardener/blob/master/docs/usage/supported_k8s_versions.md#:~:text=Gardener%20itself%20is%20capable%20of%20spinning%20up%20clusters%20with%20Kubernetes%20versions%201.20%20up%20to%201.25 for reference.
+  targetVersion: "< 1.21"
 - name: vpn-seed
   sourceRepository: github.com/gardener/vpn
   repository: eu.gcr.io/gardener-project/gardener/vpn-seed


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area auto-scaling
/kind enhancement

**What this PR does / why we need it**:
Updates the CA image in the charts for v1.25.0.

**Which issue(s) this PR fixes**:
Part of #6567

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The following image is updated:
- eu.gcr.io/gardener-project/gardener/autoscaler/cluster-autoscaler: v1.24.0 -> v1.25.0 (for Kubernetes >= 1.25)
```