### PR TITLE
Fix the bin-packing scheduling profile for K8s 1.25 Shoot clusters

### DIFF
--- a/pkg/operation/botanist/component/kubescheduler/kube_scheduler.go
+++ b/pkg/operation/botanist/component/kubescheduler/kube_scheduler.go
@@ -95,7 +95,7 @@ profiles:
       - name: NodeResourcesBalancedAllocation
       enabled:
       - name: NodeResourcesMostAllocated
-{{- else if or (eq .apiVersion "kubescheduler.config.k8s.io/v1beta2") (eq .apiVersion "kubescheduler.config.k8s.io/v1beta3") }}
+{{- else if or (eq .apiVersion "kubescheduler.config.k8s.io/v1beta2") (eq .apiVersion "kubescheduler.config.k8s.io/v1beta3") (eq .apiVersion "kubescheduler.config.k8s.io/v1") }}
 - schedulerName: ` + BinPackingSchedulerName + `
   pluginConfig:
   - name: NodeResourcesFit

--- a/pkg/operation/botanist/component/kubescheduler/testdata/component-config-1.20-bin-packing.yaml
+++ b/pkg/operation/botanist/component/kubescheduler/testdata/component-config-1.20-bin-packing.yaml
@@ -1,0 +1,16 @@
+apiVersion: kubescheduler.config.k8s.io/v1beta1
+kind: KubeSchedulerConfiguration
+clientConnection:
+  kubeconfig: /var/run/secrets/gardener.cloud/shoot/generic-kubeconfig/kubeconfig
+leaderElection:
+  leaderElect: true
+profiles:
+- schedulerName: default-scheduler
+- schedulerName: bin-packing-scheduler
+  plugins:
+    score:
+      disabled:
+      - name: NodeResourcesLeastAllocated
+      - name: NodeResourcesBalancedAllocation
+      enabled:
+      - name: NodeResourcesMostAllocated

--- a/pkg/operation/botanist/component/kubescheduler/testdata/component-config-1.20.yaml
+++ b/pkg/operation/botanist/component/kubescheduler/testdata/component-config-1.20.yaml
@@ -1,0 +1,6 @@
+apiVersion: kubescheduler.config.k8s.io/v1beta1
+kind: KubeSchedulerConfiguration
+clientConnection:
+  kubeconfig: /var/run/secrets/gardener.cloud/shoot/generic-kubeconfig/kubeconfig
+leaderElection:
+  leaderElect: true

--- a/pkg/operation/botanist/component/kubescheduler/testdata/component-config-1.22-bin-packing.yaml
+++ b/pkg/operation/botanist/component/kubescheduler/testdata/component-config-1.22-bin-packing.yaml
@@ -1,0 +1,18 @@
+apiVersion: kubescheduler.config.k8s.io/v1beta2
+kind: KubeSchedulerConfiguration
+clientConnection:
+  kubeconfig: /var/run/secrets/gardener.cloud/shoot/generic-kubeconfig/kubeconfig
+leaderElection:
+  leaderElect: true
+profiles:
+- schedulerName: default-scheduler
+- schedulerName: bin-packing-scheduler
+  pluginConfig:
+  - name: NodeResourcesFit
+    args:
+      scoringStrategy:
+        type: MostAllocated
+  plugins:
+    score:
+      disabled:
+      - name: NodeResourcesBalancedAllocation

--- a/pkg/operation/botanist/component/kubescheduler/testdata/component-config-1.22.yaml
+++ b/pkg/operation/botanist/component/kubescheduler/testdata/component-config-1.22.yaml
@@ -1,0 +1,6 @@
+apiVersion: kubescheduler.config.k8s.io/v1beta2
+kind: KubeSchedulerConfiguration
+clientConnection:
+  kubeconfig: /var/run/secrets/gardener.cloud/shoot/generic-kubeconfig/kubeconfig
+leaderElection:
+  leaderElect: true

--- a/pkg/operation/botanist/component/kubescheduler/testdata/component-config-1.23-bin-packing.yaml
+++ b/pkg/operation/botanist/component/kubescheduler/testdata/component-config-1.23-bin-packing.yaml
@@ -1,0 +1,18 @@
+apiVersion: kubescheduler.config.k8s.io/v1beta3
+kind: KubeSchedulerConfiguration
+clientConnection:
+  kubeconfig: /var/run/secrets/gardener.cloud/shoot/generic-kubeconfig/kubeconfig
+leaderElection:
+  leaderElect: true
+profiles:
+- schedulerName: default-scheduler
+- schedulerName: bin-packing-scheduler
+  pluginConfig:
+  - name: NodeResourcesFit
+    args:
+      scoringStrategy:
+        type: MostAllocated
+  plugins:
+    score:
+      disabled:
+      - name: NodeResourcesBalancedAllocation

--- a/pkg/operation/botanist/component/kubescheduler/testdata/component-config-1.23.yaml
+++ b/pkg/operation/botanist/component/kubescheduler/testdata/component-config-1.23.yaml
@@ -1,0 +1,6 @@
+apiVersion: kubescheduler.config.k8s.io/v1beta3
+kind: KubeSchedulerConfiguration
+clientConnection:
+  kubeconfig: /var/run/secrets/gardener.cloud/shoot/generic-kubeconfig/kubeconfig
+leaderElection:
+  leaderElect: true

--- a/pkg/operation/botanist/component/kubescheduler/testdata/component-config-1.25-bin-packing.yaml
+++ b/pkg/operation/botanist/component/kubescheduler/testdata/component-config-1.25-bin-packing.yaml
@@ -1,0 +1,18 @@
+apiVersion: kubescheduler.config.k8s.io/v1
+kind: KubeSchedulerConfiguration
+clientConnection:
+  kubeconfig: /var/run/secrets/gardener.cloud/shoot/generic-kubeconfig/kubeconfig
+leaderElection:
+  leaderElect: true
+profiles:
+- schedulerName: default-scheduler
+- schedulerName: bin-packing-scheduler
+  pluginConfig:
+  - name: NodeResourcesFit
+    args:
+      scoringStrategy:
+        type: MostAllocated
+  plugins:
+    score:
+      disabled:
+      - name: NodeResourcesBalancedAllocation

--- a/pkg/operation/botanist/component/kubescheduler/testdata/component-config-1.25.yaml
+++ b/pkg/operation/botanist/component/kubescheduler/testdata/component-config-1.25.yaml
@@ -1,0 +1,6 @@
+apiVersion: kubescheduler.config.k8s.io/v1
+kind: KubeSchedulerConfiguration
+clientConnection:
+  kubeconfig: /var/run/secrets/gardener.cloud/shoot/generic-kubeconfig/kubeconfig
+leaderElection:
+  leaderElect: true


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug

**What this PR does / why we need it**:
For K8s 1.25 Shoot the scheduling profile used when `spec.kubernetes.kubeScheduler.profile=bin-packing` is wrong:
```yaml
apiVersion: kubescheduler.config.k8s.io/v1
kind: KubeSchedulerConfiguration
clientConnection:
  kubeconfig: /var/run/secrets/gardener.cloud/shoot/generic-kubeconfig/kubeconfig
leaderElection:
  leaderElect: true
profiles:
- schedulerName: default-scheduler
```

It should be:
```yaml
apiVersion: kubescheduler.config.k8s.io/v1
kind: KubeSchedulerConfiguration
clientConnection:
  kubeconfig: /var/run/secrets/gardener.cloud/shoot/generic-kubeconfig/kubeconfig
leaderElection:
  leaderElect: true
profiles:
- schedulerName: default-scheduler
- schedulerName: bin-packing-scheduler
  pluginConfig:
  - name: NodeResourcesFit
    args:
      scoringStrategy:
        type: MostAllocated
  plugins:
    score:
      disabled:
      - name: NodeResourcesBalancedAllocation
```

The issue is introduced with https://github.com/gardener/gardener/pull/6638.

**Which issue(s) this PR fixes**:
See above

**Special notes for your reviewer**:
The PR also improves the kube-scheduler's unit test to do not duplicate the real logic but rather to have predefined expectations for kube-scheduler's component config. When in the test we duplicate the same logic from the component, we are not testing much.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
An issue causing for K8s 1.25 Shoots the `bin-packing-scheduler` not to be added to the kube-scheduler configuration when the bin-packing profile is configured in the Shoot spec is now fixed.
```
