### PR TITLE
Shoot validation: check worker's zones for duplicates

### DIFF
--- a/plugin/pkg/shoot/validator/admission.go
+++ b/plugin/pkg/shoot/validator/admission.go
@@ -1220,6 +1220,7 @@ func validateZones(constraints []core.Region, region, oldRegion string, worker, 
 		return allErrs
 	}
 
+	usedZones := sets.NewString()
 	for j, zone := range worker.Zones {
 		jdxPath := fldPath.Child("zones").Index(j)
 		if ok, validZones := validateZone(constraints, region, zone); !ok {
@@ -1229,6 +1230,10 @@ func validateZones(constraints []core.Region, region, oldRegion string, worker, 
 				allErrs = append(allErrs, field.NotSupported(jdxPath, zone, validZones))
 			}
 		}
+		if usedZones.Has(zone) {
+			allErrs = append(allErrs, field.Duplicate(jdxPath, zone))
+		}
+		usedZones.Insert(zone)
 	}
 
 	return allErrs


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement

**What this PR does / why we need it**:
A validation for duplicate zones in the zones list of a worker has been added.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
A validation for duplicate zones in the zones list of a worker has been added.
```
