### PR TITLE
Add `HPA`/`HVPA` handling to `HighAvailabilityConfig` webhook.

### DIFF
--- a/charts/gardener/resource-manager/charts/application/templates/mutatingwebhookconfiguration.yaml
+++ b/charts/gardener/resource-manager/charts/application/templates/mutatingwebhookconfiguration.yaml
@@ -54,7 +54,7 @@ webhooks:
       path: /webhooks/high-availability-config
       port: 443
   failurePolicy: Fail
-  matchPolicy: Exact
+  matchPolicy: Equivalent
   name: high-availability-config.resources.gardener.cloud
   namespaceSelector:
     matchLabels:

--- a/charts/gardener/resource-manager/charts/application/templates/mutatingwebhookconfiguration.yaml
+++ b/charts/gardener/resource-manager/charts/application/templates/mutatingwebhookconfiguration.yaml
@@ -75,6 +75,25 @@ webhooks:
     resources:
     - deployments
     - statefulsets
+  - apiGroups:
+    - autoscaling
+    apiVersions:
+    - v2beta1
+    - v2
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - horizontalpodautoscalers
+  - apiGroups:
+    - autoscaling.k8s.io
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - hvpas
     scope: '*'
   sideEffects: None
   timeoutSeconds: 10

--- a/docs/concepts/resource-manager.md
+++ b/docs/concepts/resource-manager.md
@@ -527,12 +527,12 @@ Otherwise, once approved, the `kube-controller-manager`'s `csrsigner` controller
 This webhook is used to conveniently apply the configuration to make components deployed to seed or shoot clusters highly available.
 The details and scenarios are described in [High Availability Of Deployed Components](../development/high-availability.md).
 
-The webhook reacts on creation/update of `Deployment`s and `StatefulSet`s in namespaces labeled with `high-availability-config.resources.gardener.cloud/consider=true`.
+The webhook reacts on creation/update of `Deployment`s, `StatefulSet`s, `HorizontalPodAutoscaler`s and `HVPA`s in namespaces labeled with `high-availability-config.resources.gardener.cloud/consider=true`.
 
 
 The webhook performs the following actions:
 
-1. The `.spec.replicas` field is mutated based on the `high-availability-config.resources.gardener.cloud/type` label of the resource and the `high-availability-config.resources.gardener.cloud/failure-tolerance-type` annotation of the namespace:
+1. The `.spec.replicas` (or `spec.minReplicas` respectively) field is mutated based on the `high-availability-config.resources.gardener.cloud/type` label of the resource and the `high-availability-config.resources.gardener.cloud/failure-tolerance-type` annotation of the namespace:
 
    | Failure Tolerance Type ➡️<br>/<br>⬇️ Component Type️ ️| unset | empty | non-empty |
    | --------------------------------------------------- | ----- | ----- | --------- |

--- a/docs/development/high-availability.md
+++ b/docs/development/high-availability.md
@@ -217,7 +217,7 @@ spec:
     matchLabels: ...
 ```
 
-3. Add label `high-availability-config.resources.gardener.cloud/type` to `deployment`s or `statefulset`s where the following two values are possible:
+3. Add label `high-availability-config.resources.gardener.cloud/type` to `deployment`s or `statefulset`s as well as optionally involved `horizontalpodautoscaler`s or `HVPA`s where the following two values are possible:
 
 - `controller`
 - `server`

--- a/example/resource-manager/10-mutatingwebhookconfiguration.yaml
+++ b/example/resource-manager/10-mutatingwebhookconfiguration.yaml
@@ -140,6 +140,25 @@ webhooks:
     operations:
     - CREATE
     - UPDATE
+  - apiGroups:
+    - autoscaling
+    apiVersions:
+    - v2beta1
+    - v2
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - horizontalpodautoscalers
+  - apiGroups:
+    - autoscaling.k8s.io
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - hvpas
   namespaceSelector:
     matchLabels:
       high-availability-config.resources.gardener.cloud/consider: "true"

--- a/example/resource-manager/10-mutatingwebhookconfiguration.yaml
+++ b/example/resource-manager/10-mutatingwebhookconfiguration.yaml
@@ -168,7 +168,7 @@ webhooks:
       operator: DoesNotExist
   sideEffects: None
   failurePolicy: Fail
-  matchPolicy: Exact
+  matchPolicy: Equivalent
   reinvocationPolicy: Never
   timeoutSeconds: 10
 - name: system-components-config.resources.gardener.cloud

--- a/pkg/operation/botanist/component/coredns/coredns.go
+++ b/pkg/operation/botanist/component/coredns/coredns.go
@@ -691,6 +691,9 @@ import custom/*.server
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "coredns",
 				Namespace: metav1.NamespaceSystem,
+				Labels: map[string]string{
+					resourcesv1alpha1.HighAvailabilityConfigType: resourcesv1alpha1.HighAvailabilityConfigTypeServer,
+				},
 			},
 			Spec: autoscalingv2.HorizontalPodAutoscalerSpec{
 				MinReplicas: pointer.Int32(2),
@@ -717,6 +720,9 @@ import custom/*.server
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "coredns",
 				Namespace: metav1.NamespaceSystem,
+				Labels: map[string]string{
+					resourcesv1alpha1.HighAvailabilityConfigType: resourcesv1alpha1.HighAvailabilityConfigTypeServer,
+				},
 			},
 			Spec: autoscalingv2beta1.HorizontalPodAutoscalerSpec{
 				MinReplicas: pointer.Int32(2),

--- a/pkg/operation/botanist/component/coredns/coredns_test.go
+++ b/pkg/operation/botanist/component/coredns/coredns_test.go
@@ -445,6 +445,8 @@ status:
 kind: HorizontalPodAutoscaler
 metadata:
   creationTimestamp: null
+  labels:
+    high-availability-config.resources.gardener.cloud/type: server
   name: coredns
   namespace: kube-system
 spec:

--- a/pkg/operation/botanist/component/etcd/etcd.go
+++ b/pkg/operation/botanist/component/etcd/etcd.go
@@ -561,8 +561,8 @@ func (e *etcd) Deploy(ctx context.Context) error {
 						Labels: hpaLabels,
 					},
 					Spec: hvpav1alpha1.HpaTemplateSpec{
-						MinReplicas: pointer.Int32(int32(replicas)),
-						MaxReplicas: int32(replicas),
+						MinReplicas: pointer.Int32(replicas),
+						MaxReplicas: replicas,
 						Metrics: []autoscalingv2beta1.MetricSpec{
 							{
 								Type: autoscalingv2beta1.ResourceMetricSourceType,

--- a/pkg/operation/botanist/component/kubeapiserver/hvpa.go
+++ b/pkg/operation/botanist/component/kubeapiserver/hvpa.go
@@ -113,7 +113,7 @@ func (k *kubeAPIServer) reconcileHVPA(ctx context.Context, hvpa *hvpav1alpha1.Hv
 	}
 
 	_, err := controllerutils.GetAndCreateOrMergePatch(ctx, k.client.Client(), hvpa, func() error {
-		hvpa.Spec.Replicas = pointer.Int32Ptr(1)
+		hvpa.Spec.Replicas = pointer.Int32(1)
 		hvpa.Spec.Hpa = hvpav1alpha1.HpaSpec{
 			Selector: &metav1.LabelSelector{MatchLabels: hpaLabels},
 			Deploy:   true,

--- a/pkg/operation/botanist/component/kubeapiserver/hvpa.go
+++ b/pkg/operation/botanist/component/kubeapiserver/hvpa.go
@@ -17,11 +17,7 @@ package kubeapiserver
 import (
 	"context"
 
-	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
-	"github.com/gardener/gardener/pkg/controllerutils"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
-
-	hvpav1alpha1 "github.com/gardener/hvpa-controller/api/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv2beta1 "k8s.io/api/autoscaling/v2beta1"
 	corev1 "k8s.io/api/core/v1"
@@ -29,6 +25,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	vpaautoscalingv1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
 	"k8s.io/utils/pointer"
+
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
+	"github.com/gardener/gardener/pkg/controllerutils"
+	hvpav1alpha1 "github.com/gardener/hvpa-controller/api/v1alpha1"
 )
 
 func (k *kubeAPIServer) emptyHVPA() *hvpav1alpha1.Hvpa {
@@ -113,6 +114,7 @@ func (k *kubeAPIServer) reconcileHVPA(ctx context.Context, hvpa *hvpav1alpha1.Hv
 	}
 
 	_, err := controllerutils.GetAndCreateOrMergePatch(ctx, k.client.Client(), hvpa, func() error {
+		metav1.SetMetaDataLabel(&hvpa.ObjectMeta, resourcesv1alpha1.HighAvailabilityConfigType, resourcesv1alpha1.HighAvailabilityConfigTypeServer)
 		hvpa.Spec.Replicas = pointer.Int32(1)
 		hvpa.Spec.Hpa = hvpav1alpha1.HpaSpec{
 			Selector: &metav1.LabelSelector{MatchLabels: hpaLabels},

--- a/pkg/operation/botanist/component/kubeapiserver/kube_apiserver_test.go
+++ b/pkg/operation/botanist/component/kubeapiserver/kube_apiserver_test.go
@@ -499,6 +499,9 @@ var _ = Describe("KubeAPIServer", func() {
 							Name:            hvpa.Name,
 							Namespace:       hvpa.Namespace,
 							ResourceVersion: "1",
+							Labels: map[string]string{
+								"high-availability-config.resources.gardener.cloud/type": "server",
+							},
 						},
 						Spec: hvpav1alpha1.HvpaSpec{
 							Replicas: pointer.Int32(1),

--- a/pkg/operation/botanist/component/kubecontrollermanager/kube_controller_manager.go
+++ b/pkg/operation/botanist/component/kubecontrollermanager/kube_controller_manager.go
@@ -412,7 +412,7 @@ func (k *kubeControllerManager) Deploy(ctx context.Context) error {
 
 		if _, err := controllerutils.GetAndCreateOrMergePatch(ctx, k.seedClient.Client(), hvpa, func() error {
 			hvpa.Labels = utils.MergeStringMaps(
-				hvpa.GetLabels(),
+				hvpa.Labels,
 				getLabels(),
 				map[string]string{
 					resourcesv1alpha1.HighAvailabilityConfigType: resourcesv1alpha1.HighAvailabilityConfigTypeController,

--- a/pkg/operation/botanist/component/kubecontrollermanager/kube_controller_manager.go
+++ b/pkg/operation/botanist/component/kubecontrollermanager/kube_controller_manager.go
@@ -411,7 +411,13 @@ func (k *kubeControllerManager) Deploy(ctx context.Context) error {
 		}
 
 		if _, err := controllerutils.GetAndCreateOrMergePatch(ctx, k.seedClient.Client(), hvpa, func() error {
-			hvpa.Labels = getLabels()
+			hvpa.Labels = utils.MergeStringMaps(
+				hvpa.GetLabels(),
+				getLabels(),
+				map[string]string{
+					resourcesv1alpha1.HighAvailabilityConfigType: resourcesv1alpha1.HighAvailabilityConfigTypeController,
+				},
+			)
 			hvpa.Spec.Replicas = pointer.Int32(1)
 			hvpa.Spec.Hpa = hvpav1alpha1.HpaSpec{
 				Deploy:   false,

--- a/pkg/operation/botanist/component/kubecontrollermanager/kube_controller_manager_test.go
+++ b/pkg/operation/botanist/component/kubecontrollermanager/kube_controller_manager_test.go
@@ -354,6 +354,7 @@ var _ = Describe("KubeControllerManager", func() {
 							Labels: map[string]string{
 								"app":  "kubernetes",
 								"role": "controller-manager",
+								"high-availability-config.resources.gardener.cloud/type": "controller",
 							},
 						},
 						Spec: hvpav1alpha1.HvpaSpec{

--- a/pkg/operation/botanist/component/resourcemanager/resource_manager.go
+++ b/pkg/operation/botanist/component/resourcemanager/resource_manager.go
@@ -1701,7 +1701,7 @@ func GetSystemComponentsConfigMutatingWebhook(namespaceSelector, objectSelector 
 func GetHighAvailabilityConfigMutatingWebhook(namespaceSelector, objectSelector *metav1.LabelSelector, secretServerCA *corev1.Secret, buildClientConfigFn func(*corev1.Secret, string) admissionregistrationv1.WebhookClientConfig) admissionregistrationv1.MutatingWebhook {
 	var (
 		failurePolicy = admissionregistrationv1.Fail
-		matchPolicy   = admissionregistrationv1.Exact
+		matchPolicy   = admissionregistrationv1.Equivalent
 		sideEffect    = admissionregistrationv1.SideEffectClassNone
 	)
 

--- a/pkg/operation/botanist/component/resourcemanager/resource_manager_test.go
+++ b/pkg/operation/botanist/component/resourcemanager/resource_manager_test.go
@@ -109,7 +109,8 @@ var _ = Describe("ResourceManager", func() {
 		targetDisableCache                   = true
 		maxUnavailable                       = intstr.FromInt(1)
 		failurePolicy                        = admissionregistrationv1.Fail
-		matchPolicy                          = admissionregistrationv1.Exact
+		matchPolicyExact                     = admissionregistrationv1.Exact
+		matchPolicyEquivalent                = admissionregistrationv1.Equivalent
 		sideEffect                           = admissionregistrationv1.SideEffectClassNone
 		networkPolicyProtocol                = corev1.ProtocolTCP
 		networkPolicyPort                    = intstr.FromInt(serverPort)
@@ -859,7 +860,7 @@ var _ = Describe("ResourceManager", func() {
 					},
 					AdmissionReviewVersions: []string{"v1beta1", "v1"},
 					FailurePolicy:           &failurePolicy,
-					MatchPolicy:             &matchPolicy,
+					MatchPolicy:             &matchPolicyExact,
 					SideEffects:             &sideEffect,
 					TimeoutSeconds:          pointer.Int32(10),
 				},
@@ -902,7 +903,7 @@ var _ = Describe("ResourceManager", func() {
 					},
 					AdmissionReviewVersions: []string{"v1beta1", "v1"},
 					FailurePolicy:           &failurePolicy,
-					MatchPolicy:             &matchPolicy,
+					MatchPolicy:             &matchPolicyExact,
 					SideEffects:             &sideEffect,
 					TimeoutSeconds:          pointer.Int32(10),
 				},
@@ -961,7 +962,7 @@ var _ = Describe("ResourceManager", func() {
 					},
 					AdmissionReviewVersions: []string{"v1beta1", "v1"},
 					FailurePolicy:           &failurePolicy,
-					MatchPolicy:             &matchPolicy,
+					MatchPolicy:             &matchPolicyEquivalent,
 					SideEffects:             &sideEffect,
 					TimeoutSeconds:          pointer.Int32(10),
 				},
@@ -1004,7 +1005,7 @@ var _ = Describe("ResourceManager", func() {
 					},
 					AdmissionReviewVersions: []string{"v1beta1", "v1"},
 					FailurePolicy:           &failurePolicy,
-					MatchPolicy:             &matchPolicy,
+					MatchPolicy:             &matchPolicyExact,
 					SideEffects:             &sideEffect,
 					TimeoutSeconds:          pointer.Int32(10),
 				},
@@ -1047,7 +1048,7 @@ var _ = Describe("ResourceManager", func() {
 					},
 					AdmissionReviewVersions: []string{"v1beta1", "v1"},
 					FailurePolicy:           &failurePolicy,
-					MatchPolicy:             &matchPolicy,
+					MatchPolicy:             &matchPolicyExact,
 					SideEffects:             &sideEffect,
 					TimeoutSeconds:          pointer.Int32(10),
 				},
@@ -1132,7 +1133,7 @@ webhooks:
   clientConfig:
     url: https://gardener-resource-manager.` + deployNamespace + `:443/webhooks/high-availability-config
   failurePolicy: Fail
-  matchPolicy: Exact
+  matchPolicy: Equivalent
   name: high-availability-config.resources.gardener.cloud
   namespaceSelector:
     matchExpressions:
@@ -1319,7 +1320,7 @@ subjects:
 						},
 					},
 					AdmissionReviewVersions: []string{"v1beta1", "v1"},
-					MatchPolicy:             &matchPolicy,
+					MatchPolicy:             &matchPolicyExact,
 					SideEffects:             &sideEffect,
 					TimeoutSeconds:          pointer.Int32(10),
 				},
@@ -1367,7 +1368,7 @@ subjects:
 						},
 					},
 					AdmissionReviewVersions: []string{"v1beta1", "v1"},
-					MatchPolicy:             &matchPolicy,
+					MatchPolicy:             &matchPolicyExact,
 					SideEffects:             &sideEffect,
 					TimeoutSeconds:          pointer.Int32(10),
 				},
@@ -1393,7 +1394,7 @@ subjects:
 						},
 					},
 					AdmissionReviewVersions: []string{"v1beta1", "v1"},
-					MatchPolicy:             &matchPolicy,
+					MatchPolicy:             &matchPolicyExact,
 					SideEffects:             &sideEffect,
 					TimeoutSeconds:          pointer.Int32(10),
 				},
@@ -1419,7 +1420,7 @@ subjects:
 						},
 					},
 					AdmissionReviewVersions: []string{"v1beta1", "v1"},
-					MatchPolicy:             &matchPolicy,
+					MatchPolicy:             &matchPolicyExact,
 					SideEffects:             &sideEffect,
 					TimeoutSeconds:          pointer.Int32(10),
 				},
@@ -1445,7 +1446,7 @@ subjects:
 						},
 					},
 					AdmissionReviewVersions: []string{"v1beta1", "v1"},
-					MatchPolicy:             &matchPolicy,
+					MatchPolicy:             &matchPolicyExact,
 					SideEffects:             &sideEffect,
 					TimeoutSeconds:          pointer.Int32(10),
 				},
@@ -1471,7 +1472,7 @@ subjects:
 						},
 					},
 					AdmissionReviewVersions: []string{"v1beta1", "v1"},
-					MatchPolicy:             &matchPolicy,
+					MatchPolicy:             &matchPolicyExact,
 					SideEffects:             &sideEffect,
 					TimeoutSeconds:          pointer.Int32(10),
 				},
@@ -1497,7 +1498,7 @@ subjects:
 						},
 					},
 					AdmissionReviewVersions: []string{"v1beta1", "v1"},
-					MatchPolicy:             &matchPolicy,
+					MatchPolicy:             &matchPolicyExact,
 					SideEffects:             &sideEffect,
 					TimeoutSeconds:          pointer.Int32(10),
 				},
@@ -1523,7 +1524,7 @@ subjects:
 						},
 					},
 					AdmissionReviewVersions: []string{"v1beta1", "v1"},
-					MatchPolicy:             &matchPolicy,
+					MatchPolicy:             &matchPolicyExact,
 					SideEffects:             &sideEffect,
 					TimeoutSeconds:          pointer.Int32(10),
 				},
@@ -1549,7 +1550,7 @@ subjects:
 						},
 					},
 					AdmissionReviewVersions: []string{"v1beta1", "v1"},
-					MatchPolicy:             &matchPolicy,
+					MatchPolicy:             &matchPolicyExact,
 					SideEffects:             &sideEffect,
 					TimeoutSeconds:          pointer.Int32(10),
 				},
@@ -1575,7 +1576,7 @@ subjects:
 						},
 					},
 					AdmissionReviewVersions: []string{"v1beta1", "v1"},
-					MatchPolicy:             &matchPolicy,
+					MatchPolicy:             &matchPolicyExact,
 					SideEffects:             &sideEffect,
 					TimeoutSeconds:          pointer.Int32(10),
 				},
@@ -1601,7 +1602,7 @@ subjects:
 						},
 					},
 					AdmissionReviewVersions: []string{"v1beta1", "v1"},
-					MatchPolicy:             &matchPolicy,
+					MatchPolicy:             &matchPolicyExact,
 					SideEffects:             &sideEffect,
 					TimeoutSeconds:          pointer.Int32(10),
 				},
@@ -1627,7 +1628,7 @@ subjects:
 						},
 					},
 					AdmissionReviewVersions: []string{"v1beta1", "v1"},
-					MatchPolicy:             &matchPolicy,
+					MatchPolicy:             &matchPolicyExact,
 					SideEffects:             &sideEffect,
 					TimeoutSeconds:          pointer.Int32(10),
 				},
@@ -1653,7 +1654,7 @@ subjects:
 						},
 					},
 					AdmissionReviewVersions: []string{"v1beta1", "v1"},
-					MatchPolicy:             &matchPolicy,
+					MatchPolicy:             &matchPolicyExact,
 					SideEffects:             &sideEffect,
 					TimeoutSeconds:          pointer.Int32(10),
 				},
@@ -1679,7 +1680,7 @@ subjects:
 						},
 					},
 					AdmissionReviewVersions: []string{"v1beta1", "v1"},
-					MatchPolicy:             &matchPolicy,
+					MatchPolicy:             &matchPolicyExact,
 					SideEffects:             &sideEffect,
 					TimeoutSeconds:          pointer.Int32(10),
 				},

--- a/pkg/operation/botanist/component/resourcemanager/resource_manager_test.go
+++ b/pkg/operation/botanist/component/resourcemanager/resource_manager_test.go
@@ -908,14 +908,32 @@ var _ = Describe("ResourceManager", func() {
 				},
 				{
 					Name: "high-availability-config.resources.gardener.cloud",
-					Rules: []admissionregistrationv1.RuleWithOperations{{
-						Rule: admissionregistrationv1.Rule{
-							APIGroups:   []string{"apps"},
-							APIVersions: []string{"v1"},
-							Resources:   []string{"deployments", "statefulsets"},
+					Rules: []admissionregistrationv1.RuleWithOperations{
+						{
+							Rule: admissionregistrationv1.Rule{
+								APIGroups:   []string{"apps"},
+								APIVersions: []string{"v1"},
+								Resources:   []string{"deployments", "statefulsets"},
+							},
+							Operations: []admissionregistrationv1.OperationType{"CREATE", "UPDATE"},
 						},
-						Operations: []admissionregistrationv1.OperationType{"CREATE", "UPDATE"},
-					}},
+						{
+							Rule: admissionregistrationv1.Rule{
+								APIGroups:   []string{"autoscaling"},
+								APIVersions: []string{"v2beta1", "v2"},
+								Resources:   []string{"horizontalpodautoscalers"},
+							},
+							Operations: []admissionregistrationv1.OperationType{"CREATE", "UPDATE"},
+						},
+						{
+							Rule: admissionregistrationv1.Rule{
+								APIGroups:   []string{"autoscaling.k8s.io"},
+								APIVersions: []string{"v1alpha1"},
+								Resources:   []string{"hvpas"},
+							},
+							Operations: []admissionregistrationv1.OperationType{"CREATE", "UPDATE"},
+						},
+					},
 					NamespaceSelector: &metav1.LabelSelector{
 						MatchExpressions: []metav1.LabelSelectorRequirement{{
 							Key:      "gardener.cloud/purpose",
@@ -1142,6 +1160,25 @@ webhooks:
     resources:
     - deployments
     - statefulsets
+  - apiGroups:
+    - autoscaling
+    apiVersions:
+    - v2beta1
+    - v2
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - horizontalpodautoscalers
+  - apiGroups:
+    - autoscaling.k8s.io
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - hvpas
   sideEffects: None
   timeoutSeconds: 10
 - admissionReviewVersions:

--- a/pkg/resourcemanager/webhook/highavailabilityconfig/handler.go
+++ b/pkg/resourcemanager/webhook/highavailabilityconfig/handler.go
@@ -108,6 +108,10 @@ func (h *Handler) Handle(ctx context.Context, req admission.Request) admission.R
 		obj, err = h.handleDeployment(req, failureToleranceType, zones, isHorizontallyScaled, maxReplicas, isZonePinningEnabled)
 	case appsv1.SchemeGroupVersion.WithKind("StatefulSet").GroupKind():
 		obj, err = h.handleStatefulSet(req, failureToleranceType, zones, isHorizontallyScaled, maxReplicas, isZonePinningEnabled)
+	case autoscalingv2.SchemeGroupVersion.WithKind("HorizontalPodAutoscaler").GroupKind():
+		obj, err = h.handleHorizontalPodAutoscaler(req, failureToleranceType)
+	case hvpav1alpha1.SchemeGroupVersionHvpa.WithKind("Hvpa").GroupKind():
+		obj, err = h.handleHvpa(req, failureToleranceType)
 	default:
 		return admission.Allowed(fmt.Sprintf("unexpected resource: %s", requestGK))
 	}
@@ -222,6 +226,78 @@ func (h *Handler) handleStatefulSet(
 	)
 
 	return statefulSet, nil
+}
+
+func (h *Handler) handleHvpa(req admission.Request, failureToleranceType *gardencorev1beta1.FailureToleranceType) (runtime.Object, error) {
+	hvpa := &hvpav1alpha1.Hvpa{}
+	if err := h.decoder.Decode(req, hvpa); err != nil {
+		return nil, err
+	}
+
+	log := h.Logger.WithValues("hvpa", kutil.ObjectKeyForCreateWebhooks(hvpa, req))
+
+	if err := mutateAutoscalingReplicas(
+		log,
+		failureToleranceType,
+		hvpa,
+		func() *int32 { return hvpa.Spec.Hpa.Template.Spec.MinReplicas },
+		func(n *int32) { hvpa.Spec.Hpa.Template.Spec.MinReplicas = n },
+		func() int32 { return hvpa.Spec.Hpa.Template.Spec.MaxReplicas },
+		func(n int32) { hvpa.Spec.Hpa.Template.Spec.MaxReplicas = n },
+	); err != nil {
+		return nil, err
+	}
+
+	return hvpa, nil
+}
+
+func (h *Handler) handleHorizontalPodAutoscaler(req admission.Request, failureToleranceType *gardencorev1beta1.FailureToleranceType) (runtime.Object, error) {
+	switch req.Kind.Version {
+	case autoscalingv2beta1.SchemeGroupVersion.Version:
+		hpa := &autoscalingv2beta1.HorizontalPodAutoscaler{}
+		if err := h.decoder.Decode(req, hpa); err != nil {
+			return nil, err
+		}
+
+		log := h.Logger.WithValues("hpa", kutil.ObjectKeyForCreateWebhooks(hpa, req))
+
+		if err := mutateAutoscalingReplicas(
+			log,
+			failureToleranceType,
+			hpa,
+			func() *int32 { return hpa.Spec.MinReplicas },
+			func(n *int32) { hpa.Spec.MinReplicas = n },
+			func() int32 { return hpa.Spec.MaxReplicas },
+			func(n int32) { hpa.Spec.MaxReplicas = n },
+		); err != nil {
+			return nil, err
+		}
+
+		return hpa, nil
+	case autoscalingv2.SchemeGroupVersion.Version:
+		hpa := &autoscalingv2.HorizontalPodAutoscaler{}
+		if err := h.decoder.Decode(req, hpa); err != nil {
+			return nil, err
+		}
+
+		log := h.Logger.WithValues("hpa", kutil.ObjectKeyForCreateWebhooks(hpa, req))
+
+		if err := mutateAutoscalingReplicas(
+			log,
+			failureToleranceType,
+			hpa,
+			func() *int32 { return hpa.Spec.MinReplicas },
+			func(n *int32) { hpa.Spec.MinReplicas = n },
+			func() int32 { return hpa.Spec.MaxReplicas },
+			func(n int32) { hpa.Spec.MaxReplicas = n },
+		); err != nil {
+			return nil, err
+		}
+
+		return hpa, nil
+	default:
+		return nil, fmt.Errorf("autoscaling version %q in request is not supported", req.Kind.Version)
+	}
 }
 
 func (h *Handler) mutateReplicas(
@@ -371,4 +447,47 @@ func (h *Handler) mutateTopologySpreadConstraints(
 
 		podTemplateSpec.Spec.TopologySpreadConstraints = append(filteredConstraints, constraints...)
 	}
+}
+
+func mutateAutoscalingReplicas(
+	log logr.Logger,
+	failureToleranceType *gardencorev1beta1.FailureToleranceType,
+	obj client.Object,
+	getMinReplicas func() *int32,
+	mutateMinReplicas func(*int32),
+	getMaxReplicas func() int32,
+	mutateMaxReplicas func(int32),
+) error {
+	// do not mutate replicas if they are set to 0 (HPA disabled case)
+	if pointer.Int32Deref(getMinReplicas(), 0) == 0 && getMaxReplicas() == 0 {
+		return nil
+	}
+
+	replicas := kutil.GetReplicaCount(failureToleranceType, obj.GetLabels()[resourcesv1alpha1.HighAvailabilityConfigType])
+	if replicas == nil {
+		return nil
+	}
+
+	// check if custom replica overwrite is desired
+	if replicasOverwrite := obj.GetAnnotations()[resourcesv1alpha1.HighAvailabilityConfigReplicas]; replicasOverwrite != "" {
+		v, err := strconv.Atoi(replicasOverwrite)
+		if err != nil {
+			return err
+		}
+		replicas = pointer.Int32(int32(v))
+	}
+
+	// For compatibility reasons, only overwrite minReplicas if the current count is lower than the calculated count.
+	// TODO(timuthy): Reconsider if this should be removed in a future version.
+	if pointer.Int32Deref(getMinReplicas(), 0) < *replicas {
+		log.Info("Mutating minReplicas", "minReplicas", replicas)
+		mutateMinReplicas(replicas)
+	}
+
+	if getMaxReplicas() < pointer.Int32Deref(getMinReplicas(), 0) {
+		log.Info("Mutating maxReplicas", "maxReplicas", replicas)
+		mutateMaxReplicas(*replicas)
+	}
+
+	return nil
 }

--- a/pkg/resourcemanager/webhook/highavailabilityconfig/handler.go
+++ b/pkg/resourcemanager/webhook/highavailabilityconfig/handler.go
@@ -150,7 +150,7 @@ func (h *Handler) handleDeployment(
 
 	log := h.Logger.WithValues("deployment", kutil.ObjectKeyForCreateWebhooks(deployment, req))
 
-	if err := h.mutateReplicas(
+	if err := mutateReplicas(
 		log,
 		failureToleranceType,
 		isHorizontallyScaled,
@@ -198,7 +198,7 @@ func (h *Handler) handleStatefulSet(
 
 	log := h.Logger.WithValues("statefulSet", kutil.ObjectKeyForCreateWebhooks(statefulSet, req))
 
-	if err := h.mutateReplicas(
+	if err := mutateReplicas(
 		log,
 		failureToleranceType,
 		isHorizontallyScaled,
@@ -300,13 +300,13 @@ func (h *Handler) handleHorizontalPodAutoscaler(req admission.Request, failureTo
 	}
 }
 
-func (h *Handler) mutateReplicas(
+func mutateReplicas(
 	log logr.Logger,
 	failureToleranceType *gardencorev1beta1.FailureToleranceType,
 	isHorizontallyScaled bool,
 	obj client.Object,
 	currentReplicas *int32,
-	mutateReplicas func(*int32),
+	setReplicas func(*int32),
 ) error {
 	// do not mutate replicas if they are set to 0 (hibernation case)
 	if pointer.Int32Deref(currentReplicas, 0) == 0 {
@@ -331,7 +331,7 @@ func (h *Handler) mutateReplicas(
 	// computed
 	if !isHorizontallyScaled || pointer.Int32Deref(currentReplicas, 0) < *replicas {
 		log.Info("Mutating replicas", "replicas", *replicas)
-		mutateReplicas(replicas)
+		setReplicas(replicas)
 	}
 
 	return nil

--- a/pkg/resourcemanager/webhook/highavailabilityconfig/handler.go
+++ b/pkg/resourcemanager/webhook/highavailabilityconfig/handler.go
@@ -352,7 +352,10 @@ func (h *Handler) mutateTopologySpreadConstraints(
 	podTemplateSpec *corev1.PodTemplateSpec,
 ) {
 	replicas := pointer.Int32Deref(currentReplicas, 0)
-	if !isHorizontallyScaled {
+
+	// Set maxReplicas to replicas if component is not scaled horizontally or of the replica count is higher than maxReplicas
+	// which can happen if the involved H(V)PA object is not mutated yet.
+	if !isHorizontallyScaled || replicas > maxReplicas {
 		maxReplicas = replicas
 	}
 

--- a/test/integration/resourcemanager/highavailabilityconfig/highavailabilityconfig_test.go
+++ b/test/integration/resourcemanager/highavailabilityconfig/highavailabilityconfig_test.go
@@ -15,6 +15,7 @@
 package highavailabilityconfig_test
 
 import (
+	"fmt"
 	"strings"
 
 	hvpav1alpha1 "github.com/gardener/hvpa-controller/api/v1alpha1"
@@ -36,14 +37,8 @@ import (
 
 var _ = Describe("HighAvailabilityConfig tests", func() {
 	var (
-		namespace   *corev1.Namespace
-		deployment  *appsv1.Deployment
-		statefulSet *appsv1.StatefulSet
-		hpa         *autoscalingv2.HorizontalPodAutoscaler
-		hvpa        *hvpav1alpha1.Hvpa
-
-		labels = map[string]string{"foo": "bar"}
-		zones  = []string{"a", "b", "c"}
+		namespace  *corev1.Namespace
+		objectMeta metav1.ObjectMeta
 	)
 
 	BeforeEach(func() {
@@ -53,80 +48,9 @@ var _ = Describe("HighAvailabilityConfig tests", func() {
 			},
 		}
 
-		deployment = &appsv1.Deployment{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      testIDPrefix + "-" + utils.ComputeSHA256Hex([]byte(uuid.NewUUID()))[:8],
-				Namespace: namespace.Name,
-			},
-			Spec: appsv1.DeploymentSpec{
-				Selector: &metav1.LabelSelector{MatchLabels: labels},
-				Replicas: pointer.Int32(1),
-				Template: corev1.PodTemplateSpec{
-					ObjectMeta: metav1.ObjectMeta{
-						Labels: labels,
-					},
-					Spec: corev1.PodSpec{
-						Containers: []corev1.Container{{
-							Name:  "foo-container",
-							Image: "foo",
-						}},
-					},
-				},
-			},
-		}
-
-		statefulSet = &appsv1.StatefulSet{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      testIDPrefix + "-" + utils.ComputeSHA256Hex([]byte(uuid.NewUUID()))[:8],
-				Namespace: namespace.Name,
-			},
-			Spec: appsv1.StatefulSetSpec{
-				Selector: &metav1.LabelSelector{MatchLabels: labels},
-				Replicas: pointer.Int32(1),
-				Template: corev1.PodTemplateSpec{
-					ObjectMeta: metav1.ObjectMeta{
-						Labels: labels,
-					},
-					Spec: corev1.PodSpec{
-						Containers: []corev1.Container{{
-							Name:  "foo-container",
-							Image: "foo",
-						}},
-					},
-				},
-			},
-		}
-
-		hpa = &autoscalingv2.HorizontalPodAutoscaler{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      testIDPrefix + "-" + utils.ComputeSHA256Hex([]byte(uuid.NewUUID()))[:8],
-				Namespace: namespace.Name,
-			},
-			Spec: autoscalingv2.HorizontalPodAutoscalerSpec{
-				MaxReplicas: 5,
-				ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{
-					APIVersion: "apps/v1",
-					Kind:       "something",
-					Name:       "something",
-				},
-			},
-		}
-
-		hvpa = &hvpav1alpha1.Hvpa{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      testIDPrefix + "-" + utils.ComputeSHA256Hex([]byte(uuid.NewUUID()))[:8],
-				Namespace: namespace.Name,
-			},
-			Spec: hvpav1alpha1.HvpaSpec{
-				Hpa: hvpav1alpha1.HpaSpec{
-					Deploy: true,
-				},
-				TargetRef: &autoscalingv2beta1.CrossVersionObjectReference{
-					APIVersion: "apps/v1",
-					Kind:       "something",
-					Name:       "something",
-				},
-			},
+		objectMeta = metav1.ObjectMeta{
+			Name:      testIDPrefix + "-" + utils.ComputeSHA256Hex([]byte(uuid.NewUUID()))[:8],
+			Namespace: namespace.Name,
 		}
 	})
 
@@ -135,459 +59,546 @@ var _ = Describe("HighAvailabilityConfig tests", func() {
 		Expect(testClient.Create(ctx, namespace)).To(Succeed())
 		log.Info("Created Namespace", "namespaceName", namespace.Name)
 
-		By("Create HorizontalPodAutoscaler")
-		Expect(testClient.Create(ctx, hpa)).To(Succeed())
-		log.Info("Created HorizontalPodAutoscaler", "horizontalPodAutoscaler", client.ObjectKeyFromObject(hpa))
-
-		By("Create HVPA")
-		Expect(testClient.Create(ctx, hvpa)).To(Succeed())
-		log.Info("Created HVPA", "hvpa", client.ObjectKeyFromObject(hvpa))
-
 		DeferCleanup(func() {
-			By("Delete HVPA")
-			Expect(testClient.Delete(ctx, hvpa)).To(Succeed())
-			log.Info("Deleted HorizontalPodAutoscaler", "hvpa", client.ObjectKeyFromObject(hvpa))
-
-			By("Delete HorizontalPodAutoscaler")
-			Expect(testClient.Delete(ctx, hpa)).To(Succeed())
-			log.Info("Deleted HorizontalPodAutoscaler", "horizontalPodAutoscaler", client.ObjectKeyFromObject(hpa))
-
 			By("Delete Namespace")
 			Expect(testClient.Delete(ctx, namespace)).To(Succeed())
 			log.Info("Deleted Namespace", "namespaceName", namespace.Name)
 		})
 	})
 
-	tests := func(
-		getObj func() client.Object,
-		getReplicas func() *int32,
-		setReplicas func(*int32),
-		getPodSpec func() corev1.PodSpec,
-		setPodSpec func(func(*corev1.PodSpec)),
-	) {
-		Context("when namespace is not labeled with consider=true", func() {
-			It("should not mutate anything", func() {
-				Expect(getReplicas()).To(PointTo(Equal(int32(1))))
-				Expect(getPodSpec().Affinity).To(BeNil())
-				Expect(getPodSpec().TopologySpreadConstraints).To(BeEmpty())
+	Describe("Mutation of pod template spec", func() {
+		var (
+			deployment  *appsv1.Deployment
+			statefulSet *appsv1.StatefulSet
+			hpa         *autoscalingv2.HorizontalPodAutoscaler
+			hvpa        *hvpav1alpha1.Hvpa
+
+			labels = map[string]string{"foo": "bar"}
+			zones  = []string{"a", "b", "c"}
+		)
+
+		BeforeEach(func() {
+			deployment = &appsv1.Deployment{
+				ObjectMeta: objectMeta,
+				Spec: appsv1.DeploymentSpec{
+					Selector: &metav1.LabelSelector{MatchLabels: labels},
+					Replicas: pointer.Int32(1),
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: labels,
+						},
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{{
+								Name:  "foo-container",
+								Image: "foo",
+							}},
+						},
+					},
+				},
+			}
+
+			statefulSet = &appsv1.StatefulSet{
+				ObjectMeta: objectMeta,
+				Spec: appsv1.StatefulSetSpec{
+					Selector: &metav1.LabelSelector{MatchLabels: labels},
+					Replicas: pointer.Int32(1),
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: labels,
+						},
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{{
+								Name:  "foo-container",
+								Image: "foo",
+							}},
+						},
+					},
+				},
+			}
+
+			hpa = &autoscalingv2.HorizontalPodAutoscaler{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testIDPrefix + "-" + utils.ComputeSHA256Hex([]byte(uuid.NewUUID()))[:8],
+					Namespace: namespace.Name,
+				},
+				Spec: autoscalingv2.HorizontalPodAutoscalerSpec{
+					MaxReplicas: 5,
+					ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{
+						APIVersion: "apps/v1",
+						Kind:       "something",
+						Name:       "something",
+					},
+				},
+			}
+
+			hvpa = &hvpav1alpha1.Hvpa{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testIDPrefix + "-" + utils.ComputeSHA256Hex([]byte(uuid.NewUUID()))[:8],
+					Namespace: namespace.Name,
+				},
+				Spec: hvpav1alpha1.HvpaSpec{
+					Hpa: hvpav1alpha1.HpaSpec{
+						Deploy: true,
+					},
+					TargetRef: &autoscalingv2beta1.CrossVersionObjectReference{
+						APIVersion: "apps/v1",
+						Kind:       "something",
+						Name:       "something",
+					},
+				},
+			}
+		})
+
+		JustBeforeEach(func() {
+			By("Create HorizontalPodAutoscaler")
+			Expect(testClient.Create(ctx, hpa)).To(Succeed())
+			log.Info("Created HorizontalPodAutoscaler", "horizontalPodAutoscaler", client.ObjectKeyFromObject(hpa))
+
+			By("Create HVPA")
+			Expect(testClient.Create(ctx, hvpa)).To(Succeed())
+			log.Info("Created HVPA", "hvpa", client.ObjectKeyFromObject(hvpa))
+
+			DeferCleanup(func() {
+				By("Delete HVPA")
+				Expect(testClient.Delete(ctx, hvpa)).To(Succeed())
+				log.Info("Deleted HorizontalPodAutoscaler", "hvpa", client.ObjectKeyFromObject(hvpa))
+
+				By("Delete HorizontalPodAutoscaler")
+				Expect(testClient.Delete(ctx, hpa)).To(Succeed())
+				log.Info("Deleted HorizontalPodAutoscaler", "horizontalPodAutoscaler", client.ObjectKeyFromObject(hpa))
 			})
 		})
 
-		Context("when namespace is labeled with consider=true", func() {
-			BeforeEach(func() {
-				metav1.SetMetaDataLabel(&namespace.ObjectMeta, resourcesv1alpha1.HighAvailabilityConfigConsider, "true")
+		tests := func(
+			getObj func() client.Object,
+			getReplicas func() *int32,
+			setReplicas func(*int32),
+			getPodSpec func() corev1.PodSpec,
+			setPodSpec func(func(*corev1.PodSpec)),
+		) {
+			Context("when namespace is not labeled with consider=true", func() {
+				It("should not mutate anything", func() {
+					Expect(getReplicas()).To(PointTo(Equal(int32(1))))
+					Expect(getPodSpec().Affinity).To(BeNil())
+					Expect(getPodSpec().TopologySpreadConstraints).To(BeEmpty())
+				})
 			})
 
-			Context("replicas", func() {
-				Context("when resource does not have type label", func() {
-					It("should not mutate the replicas", func() {
-						Expect(getReplicas()).To(PointTo(Equal(int32(1))))
-					})
+			Context("when namespace is labeled with consider=true", func() {
+				BeforeEach(func() {
+					metav1.SetMetaDataLabel(&namespace.ObjectMeta, resourcesv1alpha1.HighAvailabilityConfigConsider, "true")
 				})
 
-				horizontallyScaledTests := func(expectedReplicas int32) {
-					Context("via HPA", func() {
-						BeforeEach(func() {
-							hpa.Spec.ScaleTargetRef.Name = getObj().GetName()
-						})
-
-						Context("current replicas lower than the computed replicas", func() {
-							It("should mutate the replicas", func() {
-								Expect(getReplicas()).To(PointTo(Equal(expectedReplicas)))
-							})
-						})
-
-						Context("current replicas are higher than the computed replicas", func() {
-							BeforeEach(func() {
-								setReplicas(pointer.Int32(5))
-							})
-
-							It("should not mutate the replicas", func() {
-								Expect(getReplicas()).To(PointTo(Equal(int32(5))))
-							})
-						})
-					})
-
-					Context("via HVPA", func() {
-						BeforeEach(func() {
-							hvpa.Spec.TargetRef.Name = getObj().GetName()
-						})
-
-						Context("current replicas lower than the computed replicas", func() {
-							It("should mutate the replicas", func() {
-								Expect(getReplicas()).To(PointTo(Equal(expectedReplicas)))
-							})
-						})
-
-						Context("current replicas are higher than the computed replicas", func() {
-							BeforeEach(func() {
-								setReplicas(pointer.Int32(5))
-							})
-
-							It("should not mutate the replicas", func() {
-								Expect(getReplicas()).To(PointTo(Equal(int32(5))))
-							})
-						})
-					})
-				}
-
-				specialCasesTests := func(expectedReplicas int32) {
-					Context("when resource is horizontally scaled", func() {
-						horizontallyScaledTests(expectedReplicas)
-					})
-
-					Context("when replicas are 0", func() {
-						BeforeEach(func() {
-							setReplicas(pointer.Int32(0))
-						})
-
+				Context("replicas", func() {
+					Context("when resource does not have type label", func() {
 						It("should not mutate the replicas", func() {
-							Expect(getReplicas()).To(Equal(pointer.Int32(0)))
+							Expect(getReplicas()).To(PointTo(Equal(int32(1))))
 						})
 					})
 
-					Context("when replicas are overwritten", func() {
+					horizontallyScaledTests := func(expectedReplicas int32) {
+						Context("via HPA", func() {
+							BeforeEach(func() {
+								hpa.Spec.ScaleTargetRef.Name = getObj().GetName()
+							})
+
+							Context("current replicas lower than the computed replicas", func() {
+								It("should mutate the replicas", func() {
+									Expect(getReplicas()).To(PointTo(Equal(expectedReplicas)))
+								})
+							})
+
+							Context("current replicas are higher than the computed replicas", func() {
+								BeforeEach(func() {
+									setReplicas(pointer.Int32(5))
+								})
+
+								It("should not mutate the replicas", func() {
+									Expect(getReplicas()).To(PointTo(Equal(int32(5))))
+								})
+							})
+						})
+
+						Context("via HVPA", func() {
+							BeforeEach(func() {
+								hvpa.Spec.TargetRef.Name = getObj().GetName()
+							})
+
+							Context("current replicas lower than the computed replicas", func() {
+								It("should mutate the replicas", func() {
+									Expect(getReplicas()).To(PointTo(Equal(expectedReplicas)))
+								})
+							})
+
+							Context("current replicas are higher than the computed replicas", func() {
+								BeforeEach(func() {
+									setReplicas(pointer.Int32(5))
+								})
+
+								It("should not mutate the replicas", func() {
+									Expect(getReplicas()).To(PointTo(Equal(int32(5))))
+								})
+							})
+						})
+					}
+
+					specialCasesTests := func(expectedReplicas int32) {
+						Context("when resource is horizontally scaled", func() {
+							horizontallyScaledTests(expectedReplicas)
+						})
+
+						Context("when replicas are 0", func() {
+							BeforeEach(func() {
+								setReplicas(pointer.Int32(0))
+							})
+
+							It("should not mutate the replicas", func() {
+								Expect(getReplicas()).To(Equal(pointer.Int32(0)))
+							})
+						})
+
+						Context("when replicas are overwritten", func() {
+							BeforeEach(func() {
+								getObj().SetAnnotations(utils.MergeStringMaps(getObj().GetAnnotations(), map[string]string{
+									resourcesv1alpha1.HighAvailabilityConfigReplicas: "4",
+								}))
+							})
+
+							It("should use the overwritten value", func() {
+								Expect(getReplicas()).To(PointTo(Equal(int32(4))))
+							})
+						})
+					}
+
+					Context("when resource is of type 'controller'", func() {
 						BeforeEach(func() {
-							getObj().SetAnnotations(utils.MergeStringMaps(getObj().GetAnnotations(), map[string]string{
-								resourcesv1alpha1.HighAvailabilityConfigReplicas: "4",
+							getObj().SetLabels(utils.MergeStringMaps(getObj().GetLabels(), map[string]string{
+								resourcesv1alpha1.HighAvailabilityConfigType: resourcesv1alpha1.HighAvailabilityConfigTypeController,
 							}))
 						})
 
-						It("should use the overwritten value", func() {
-							Expect(getReplicas()).To(PointTo(Equal(int32(4))))
+						Context("when failure tolerance type is nil", func() {
+							It("should mutate the replicas", func() {
+								Expect(getReplicas()).To(Equal(pointer.Int32(2)))
+							})
+						})
+
+						Context("when failure tolerance type is empty", func() {
+							BeforeEach(func() {
+								metav1.SetMetaDataAnnotation(&namespace.ObjectMeta, resourcesv1alpha1.HighAvailabilityConfigFailureToleranceType, "")
+							})
+
+							It("should mutate the replicas", func() {
+								Expect(getReplicas()).To(Equal(pointer.Int32(1)))
+							})
+						})
+
+						Context("when failure tolerance type is non-empty", func() {
+							BeforeEach(func() {
+								metav1.SetMetaDataAnnotation(&namespace.ObjectMeta, resourcesv1alpha1.HighAvailabilityConfigFailureToleranceType, "foo")
+							})
+
+							It("should mutate the replicas", func() {
+								Expect(getReplicas()).To(Equal(pointer.Int32(2)))
+							})
+						})
+
+						Context("special cases", func() {
+							specialCasesTests(2)
 						})
 					})
-				}
 
-				Context("when resource is of type 'controller'", func() {
-					BeforeEach(func() {
-						getObj().SetLabels(utils.MergeStringMaps(getObj().GetLabels(), map[string]string{
-							resourcesv1alpha1.HighAvailabilityConfigType: resourcesv1alpha1.HighAvailabilityConfigTypeController,
-						}))
-					})
-
-					Context("when failure tolerance type is nil", func() {
-						It("should mutate the replicas", func() {
-							Expect(getReplicas()).To(Equal(pointer.Int32(2)))
-						})
-					})
-
-					Context("when failure tolerance type is empty", func() {
+					Context("when resource is of type 'server'", func() {
 						BeforeEach(func() {
-							metav1.SetMetaDataAnnotation(&namespace.ObjectMeta, resourcesv1alpha1.HighAvailabilityConfigFailureToleranceType, "")
+							getObj().SetLabels(utils.MergeStringMaps(getObj().GetLabels(), map[string]string{
+								resourcesv1alpha1.HighAvailabilityConfigType: resourcesv1alpha1.HighAvailabilityConfigTypeServer,
+							}))
 						})
 
-						It("should mutate the replicas", func() {
-							Expect(getReplicas()).To(Equal(pointer.Int32(1)))
+						Context("when failure tolerance type is nil", func() {
+							It("should mutate the replicas", func() {
+								Expect(getReplicas()).To(Equal(pointer.Int32(2)))
+							})
+						})
+
+						Context("when failure tolerance type is empty", func() {
+							BeforeEach(func() {
+								metav1.SetMetaDataAnnotation(&namespace.ObjectMeta, resourcesv1alpha1.HighAvailabilityConfigFailureToleranceType, "")
+							})
+
+							It("should mutate the replicas", func() {
+								Expect(getReplicas()).To(Equal(pointer.Int32(2)))
+							})
+						})
+
+						Context("when failure tolerance type is non-empty", func() {
+							BeforeEach(func() {
+								metav1.SetMetaDataAnnotation(&namespace.ObjectMeta, resourcesv1alpha1.HighAvailabilityConfigFailureToleranceType, "foo")
+							})
+
+							It("should mutate the replicas", func() {
+								Expect(getReplicas()).To(Equal(pointer.Int32(2)))
+							})
+						})
+
+						Context("special cases", func() {
+							specialCasesTests(2)
+						})
+					})
+				})
+
+				Context("affinity", func() {
+					Context("when namespace is not annotated with neither failure-tolerance-type nor zones", func() {
+						It("should not mutate the node affinity", func() {
+							Expect(getPodSpec().Affinity).To(BeNil())
 						})
 					})
 
-					Context("when failure tolerance type is non-empty", func() {
+					Context("when namespace is annotated with failure-tolerance-type but not with zones", func() {
 						BeforeEach(func() {
 							metav1.SetMetaDataAnnotation(&namespace.ObjectMeta, resourcesv1alpha1.HighAvailabilityConfigFailureToleranceType, "foo")
 						})
 
-						It("should mutate the replicas", func() {
-							Expect(getReplicas()).To(Equal(pointer.Int32(2)))
+						It("should not mutate the node affinity", func() {
+							Expect(getPodSpec().Affinity).To(BeNil())
 						})
 					})
 
-					Context("special cases", func() {
-						specialCasesTests(2)
-					})
-				})
-
-				Context("when resource is of type 'server'", func() {
-					BeforeEach(func() {
-						getObj().SetLabels(utils.MergeStringMaps(getObj().GetLabels(), map[string]string{
-							resourcesv1alpha1.HighAvailabilityConfigType: resourcesv1alpha1.HighAvailabilityConfigTypeServer,
-						}))
-					})
-
-					Context("when failure tolerance type is nil", func() {
-						It("should mutate the replicas", func() {
-							Expect(getReplicas()).To(Equal(pointer.Int32(2)))
-						})
-					})
-
-					Context("when failure tolerance type is empty", func() {
+					Context("when namespace is annotated with failure-tolerance-type but empty zones", func() {
 						BeforeEach(func() {
-							metav1.SetMetaDataAnnotation(&namespace.ObjectMeta, resourcesv1alpha1.HighAvailabilityConfigFailureToleranceType, "")
-						})
-
-						It("should mutate the replicas", func() {
-							Expect(getReplicas()).To(Equal(pointer.Int32(2)))
-						})
-					})
-
-					Context("when failure tolerance type is non-empty", func() {
-						BeforeEach(func() {
+							metav1.SetMetaDataAnnotation(&namespace.ObjectMeta, resourcesv1alpha1.HighAvailabilityConfigZones, "")
 							metav1.SetMetaDataAnnotation(&namespace.ObjectMeta, resourcesv1alpha1.HighAvailabilityConfigFailureToleranceType, "foo")
 						})
 
-						It("should mutate the replicas", func() {
-							Expect(getReplicas()).To(Equal(pointer.Int32(2)))
+						It("should not mutate the node affinity", func() {
+							Expect(getPodSpec().Affinity).To(BeNil())
 						})
 					})
 
-					Context("special cases", func() {
-						specialCasesTests(2)
-					})
-				})
-			})
-
-			Context("affinity", func() {
-				Context("when namespace is not annotated with neither failure-tolerance-type nor zones", func() {
-					It("should not mutate the node affinity", func() {
-						Expect(getPodSpec().Affinity).To(BeNil())
-					})
-				})
-
-				Context("when namespace is annotated with failure-tolerance-type but not with zones", func() {
-					BeforeEach(func() {
-						metav1.SetMetaDataAnnotation(&namespace.ObjectMeta, resourcesv1alpha1.HighAvailabilityConfigFailureToleranceType, "foo")
-					})
-
-					It("should not mutate the node affinity", func() {
-						Expect(getPodSpec().Affinity).To(BeNil())
-					})
-				})
-
-				Context("when namespace is annotated with failure-tolerance-type but empty zones", func() {
-					BeforeEach(func() {
-						metav1.SetMetaDataAnnotation(&namespace.ObjectMeta, resourcesv1alpha1.HighAvailabilityConfigZones, "")
-						metav1.SetMetaDataAnnotation(&namespace.ObjectMeta, resourcesv1alpha1.HighAvailabilityConfigFailureToleranceType, "foo")
-					})
-
-					It("should not mutate the node affinity", func() {
-						Expect(getPodSpec().Affinity).To(BeNil())
-					})
-				})
-
-				Context("when namespace is annotated with failure-tolerance-type and non-empty zones", func() {
-					BeforeEach(func() {
-						metav1.SetMetaDataAnnotation(&namespace.ObjectMeta, resourcesv1alpha1.HighAvailabilityConfigZones, strings.Join(zones, ","))
-						metav1.SetMetaDataAnnotation(&namespace.ObjectMeta, resourcesv1alpha1.HighAvailabilityConfigFailureToleranceType, "foo")
-					})
-
-					Context("when there are no existing node affinities in spec", func() {
-						It("should add a node affinity", func() {
-							Expect(getPodSpec().Affinity).To(Equal(&corev1.Affinity{
-								NodeAffinity: &corev1.NodeAffinity{
-									RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
-										NodeSelectorTerms: []corev1.NodeSelectorTerm{{
-											MatchExpressions: []corev1.NodeSelectorRequirement{{
-												Key:      corev1.LabelTopologyZone,
-												Operator: corev1.NodeSelectorOpIn,
-												Values:   zones,
-											}},
-										}},
-									},
-								},
-							}))
-						})
-					})
-
-					Context("when there are existing node affinities in spec", func() {
+					Context("when namespace is annotated with failure-tolerance-type and non-empty zones", func() {
 						BeforeEach(func() {
-							setPodSpec(func(spec *corev1.PodSpec) {
-								spec.Affinity = &corev1.Affinity{
+							metav1.SetMetaDataAnnotation(&namespace.ObjectMeta, resourcesv1alpha1.HighAvailabilityConfigZones, strings.Join(zones, ","))
+							metav1.SetMetaDataAnnotation(&namespace.ObjectMeta, resourcesv1alpha1.HighAvailabilityConfigFailureToleranceType, "foo")
+						})
+
+						Context("when there are no existing node affinities in spec", func() {
+							It("should add a node affinity", func() {
+								Expect(getPodSpec().Affinity).To(Equal(&corev1.Affinity{
 									NodeAffinity: &corev1.NodeAffinity{
 										RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
-											NodeSelectorTerms: []corev1.NodeSelectorTerm{
-												{
-													MatchExpressions: []corev1.NodeSelectorRequirement{{
-														Key:      corev1.LabelHostname,
-														Operator: corev1.NodeSelectorOpExists,
-													}},
-												},
-												{
-													MatchExpressions: []corev1.NodeSelectorRequirement{{
-														Key:      corev1.LabelTopologyZone,
-														Operator: corev1.NodeSelectorOpNotIn,
-														Values:   []string{"some", "other", "zones"},
-													}},
-												},
-												{
-													MatchExpressions: []corev1.NodeSelectorRequirement{{
-														Key:      "foo",
-														Operator: corev1.NodeSelectorOpNotIn,
-														Values:   []string{"bar"},
-													}},
-												},
-											},
-										},
-									},
-								}
-							})
-						})
-
-						It("should add a node affinity", func() {
-							Expect(getPodSpec().Affinity).To(Equal(&corev1.Affinity{
-								NodeAffinity: &corev1.NodeAffinity{
-									RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
-										NodeSelectorTerms: []corev1.NodeSelectorTerm{
-											{
-												MatchExpressions: []corev1.NodeSelectorRequirement{
-													{
-														Key:      corev1.LabelHostname,
-														Operator: corev1.NodeSelectorOpExists,
-													},
-													{
-														Key:      corev1.LabelTopologyZone,
-														Operator: corev1.NodeSelectorOpIn,
-														Values:   zones,
-													},
-												},
-											},
-											{
-												MatchExpressions: []corev1.NodeSelectorRequirement{
-													{
-														Key:      "foo",
-														Operator: corev1.NodeSelectorOpNotIn,
-														Values:   []string{"bar"},
-													},
-													{
-														Key:      corev1.LabelTopologyZone,
-														Operator: corev1.NodeSelectorOpIn,
-														Values:   zones,
-													},
-												},
-											},
-										},
-									},
-								},
-							}))
-						})
-					})
-				})
-
-				Context("when namespace is annotated with zone pinning and non-empty zones, but not failure-tolerance-type", func() {
-					BeforeEach(func() {
-						metav1.SetMetaDataAnnotation(&namespace.ObjectMeta, resourcesv1alpha1.HighAvailabilityConfigZones, strings.Join(zones, ","))
-						metav1.SetMetaDataAnnotation(&namespace.ObjectMeta, resourcesv1alpha1.HighAvailabilityConfigZonePinning, "true")
-					})
-
-					Context("when there are no existing node affinities in spec", func() {
-						It("should add a node affinity", func() {
-							Expect(getPodSpec().Affinity).To(Equal(&corev1.Affinity{
-								NodeAffinity: &corev1.NodeAffinity{
-									RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
-										NodeSelectorTerms: []corev1.NodeSelectorTerm{{
-											MatchExpressions: []corev1.NodeSelectorRequirement{{
-												Key:      corev1.LabelTopologyZone,
-												Operator: corev1.NodeSelectorOpIn,
-												Values:   zones,
+											NodeSelectorTerms: []corev1.NodeSelectorTerm{{
+												MatchExpressions: []corev1.NodeSelectorRequirement{{
+													Key:      corev1.LabelTopologyZone,
+													Operator: corev1.NodeSelectorOpIn,
+													Values:   zones,
+												}},
 											}},
-										}},
+										},
 									},
-								},
-							}))
-						})
-					})
-				})
-
-				Context("when namespace is annotated with zones, but neither with zone-pinning nor failure-tolerance-type", func() {
-					BeforeEach(func() {
-						metav1.SetMetaDataAnnotation(&namespace.ObjectMeta, resourcesv1alpha1.HighAvailabilityConfigZones, strings.Join(zones, ","))
-					})
-
-					It("should not mutate the node affinity", func() {
-						Expect(getPodSpec().Affinity).To(BeNil())
-					})
-				})
-			})
-
-			Context("topology spread constraints", func() {
-				Context("when replicas are < 2", func() {
-					It("should not add topology spread constraints", func() {
-						Expect(getPodSpec().TopologySpreadConstraints).To(BeEmpty())
-					})
-				})
-
-				Context("when replicas are >= 2", func() {
-					BeforeEach(func() {
-						setReplicas(pointer.Int32(2))
-					})
-
-					Context("when failure-tolerance-type is empty", func() {
-						Context("when there are less than 2 zones", func() {
-							It("should add topology spread constraints", func() {
-								Expect(getPodSpec().TopologySpreadConstraints).To(ConsistOf(corev1.TopologySpreadConstraint{
-									TopologyKey:       corev1.LabelHostname,
-									MaxSkew:           1,
-									WhenUnsatisfiable: corev1.ScheduleAnyway,
-									LabelSelector:     &metav1.LabelSelector{MatchLabels: labels},
 								}))
 							})
 						})
 
-						Context("when there are at least 2 zones", func() {
+						Context("when there are existing node affinities in spec", func() {
 							BeforeEach(func() {
-								metav1.SetMetaDataAnnotation(&namespace.ObjectMeta, resourcesv1alpha1.HighAvailabilityConfigZones, strings.Join(zones, ","))
-							})
-
-							Context("when there are no existing constraints in spec", func() {
-								It("should add topology spread constraints", func() {
-									Expect(getPodSpec().TopologySpreadConstraints).To(ConsistOf(
-										corev1.TopologySpreadConstraint{
-											TopologyKey:       corev1.LabelHostname,
-											MaxSkew:           1,
-											WhenUnsatisfiable: corev1.ScheduleAnyway,
-											LabelSelector:     &metav1.LabelSelector{MatchLabels: labels},
+								setPodSpec(func(spec *corev1.PodSpec) {
+									spec.Affinity = &corev1.Affinity{
+										NodeAffinity: &corev1.NodeAffinity{
+											RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+												NodeSelectorTerms: []corev1.NodeSelectorTerm{
+													{
+														MatchExpressions: []corev1.NodeSelectorRequirement{{
+															Key:      corev1.LabelHostname,
+															Operator: corev1.NodeSelectorOpExists,
+														}},
+													},
+													{
+														MatchExpressions: []corev1.NodeSelectorRequirement{{
+															Key:      corev1.LabelTopologyZone,
+															Operator: corev1.NodeSelectorOpNotIn,
+															Values:   []string{"some", "other", "zones"},
+														}},
+													},
+													{
+														MatchExpressions: []corev1.NodeSelectorRequirement{{
+															Key:      "foo",
+															Operator: corev1.NodeSelectorOpNotIn,
+															Values:   []string{"bar"},
+														}},
+													},
+												},
+											},
 										},
-										corev1.TopologySpreadConstraint{
-											TopologyKey:       corev1.LabelTopologyZone,
-											MaxSkew:           1,
-											WhenUnsatisfiable: corev1.DoNotSchedule,
-											LabelSelector:     &metav1.LabelSelector{MatchLabels: labels},
-										},
-									))
+									}
 								})
 							})
 
-							Context("when there are existing constraints in spec", func() {
+							It("should add a node affinity", func() {
+								Expect(getPodSpec().Affinity).To(Equal(&corev1.Affinity{
+									NodeAffinity: &corev1.NodeAffinity{
+										RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+											NodeSelectorTerms: []corev1.NodeSelectorTerm{
+												{
+													MatchExpressions: []corev1.NodeSelectorRequirement{
+														{
+															Key:      corev1.LabelHostname,
+															Operator: corev1.NodeSelectorOpExists,
+														},
+														{
+															Key:      corev1.LabelTopologyZone,
+															Operator: corev1.NodeSelectorOpIn,
+															Values:   zones,
+														},
+													},
+												},
+												{
+													MatchExpressions: []corev1.NodeSelectorRequirement{
+														{
+															Key:      "foo",
+															Operator: corev1.NodeSelectorOpNotIn,
+															Values:   []string{"bar"},
+														},
+														{
+															Key:      corev1.LabelTopologyZone,
+															Operator: corev1.NodeSelectorOpIn,
+															Values:   zones,
+														},
+													},
+												},
+											},
+										},
+									},
+								}))
+							})
+						})
+					})
+				})
+
+				Context("topology spread constraints", func() {
+					Context("when replicas are < 2", func() {
+						It("should not add topology spread constraints", func() {
+							Expect(getPodSpec().TopologySpreadConstraints).To(BeEmpty())
+						})
+					})
+
+					Context("when replicas are >= 2", func() {
+						BeforeEach(func() {
+							setReplicas(pointer.Int32(2))
+						})
+
+						Context("when failure-tolerance-type is empty", func() {
+							Context("when there are less than 2 zones", func() {
+								It("should add topology spread constraints", func() {
+									Expect(getPodSpec().TopologySpreadConstraints).To(ConsistOf(corev1.TopologySpreadConstraint{
+										TopologyKey:       corev1.LabelHostname,
+										MaxSkew:           1,
+										WhenUnsatisfiable: corev1.ScheduleAnyway,
+										LabelSelector:     &metav1.LabelSelector{MatchLabels: labels},
+									}))
+								})
+							})
+
+							Context("when there are at least 2 zones", func() {
 								BeforeEach(func() {
-									setPodSpec(func(spec *corev1.PodSpec) {
-										spec.TopologySpreadConstraints = []corev1.TopologySpreadConstraint{
-											{
+									metav1.SetMetaDataAnnotation(&namespace.ObjectMeta, resourcesv1alpha1.HighAvailabilityConfigZones, strings.Join(zones, ","))
+								})
+
+								Context("when there are no existing constraints in spec", func() {
+									It("should add topology spread constraints", func() {
+										Expect(getPodSpec().TopologySpreadConstraints).To(ConsistOf(
+											corev1.TopologySpreadConstraint{
+												TopologyKey:       corev1.LabelHostname,
+												MaxSkew:           1,
+												WhenUnsatisfiable: corev1.ScheduleAnyway,
+												LabelSelector:     &metav1.LabelSelector{MatchLabels: labels},
+											},
+											corev1.TopologySpreadConstraint{
+												TopologyKey:       corev1.LabelTopologyZone,
+												MaxSkew:           1,
+												WhenUnsatisfiable: corev1.DoNotSchedule,
+												LabelSelector:     &metav1.LabelSelector{MatchLabels: labels},
+											},
+										))
+									})
+								})
+
+								Context("when there are existing constraints in spec", func() {
+									BeforeEach(func() {
+										setPodSpec(func(spec *corev1.PodSpec) {
+											spec.TopologySpreadConstraints = []corev1.TopologySpreadConstraint{
+												{
+													TopologyKey:       "some-key",
+													MaxSkew:           12,
+													WhenUnsatisfiable: corev1.DoNotSchedule,
+													LabelSelector:     &metav1.LabelSelector{MatchLabels: labels},
+												},
+												{
+													TopologyKey:       corev1.LabelHostname,
+													MaxSkew:           34,
+													WhenUnsatisfiable: corev1.DoNotSchedule,
+													LabelSelector:     &metav1.LabelSelector{MatchLabels: labels},
+												},
+												{
+													TopologyKey:       corev1.LabelTopologyZone,
+													MaxSkew:           56,
+													WhenUnsatisfiable: corev1.ScheduleAnyway,
+													LabelSelector:     &metav1.LabelSelector{MatchLabels: labels},
+												},
+											}
+										})
+									})
+
+									It("should add topology spread constraints", func() {
+										Expect(getPodSpec().TopologySpreadConstraints).To(ConsistOf(
+											corev1.TopologySpreadConstraint{
 												TopologyKey:       "some-key",
 												MaxSkew:           12,
 												WhenUnsatisfiable: corev1.DoNotSchedule,
 												LabelSelector:     &metav1.LabelSelector{MatchLabels: labels},
 											},
-											{
+											corev1.TopologySpreadConstraint{
 												TopologyKey:       corev1.LabelHostname,
-												MaxSkew:           34,
-												WhenUnsatisfiable: corev1.DoNotSchedule,
-												LabelSelector:     &metav1.LabelSelector{MatchLabels: labels},
-											},
-											{
-												TopologyKey:       corev1.LabelTopologyZone,
-												MaxSkew:           56,
+												MaxSkew:           1,
 												WhenUnsatisfiable: corev1.ScheduleAnyway,
 												LabelSelector:     &metav1.LabelSelector{MatchLabels: labels},
 											},
-										}
+											corev1.TopologySpreadConstraint{
+												TopologyKey:       corev1.LabelTopologyZone,
+												MaxSkew:           1,
+												WhenUnsatisfiable: corev1.DoNotSchedule,
+												LabelSelector:     &metav1.LabelSelector{MatchLabels: labels},
+											},
+										))
 									})
+								})
+							})
+						})
+
+						Context("when failure-tolerance-type is non-empty", func() {
+							BeforeEach(func() {
+								metav1.SetMetaDataAnnotation(&namespace.ObjectMeta, resourcesv1alpha1.HighAvailabilityConfigFailureToleranceType, "foo")
+							})
+
+							Context("when there are less than 2 zones", func() {
+								It("should add topology spread constraints", func() {
+									Expect(getPodSpec().TopologySpreadConstraints).To(ConsistOf(corev1.TopologySpreadConstraint{
+										TopologyKey:       corev1.LabelHostname,
+										MaxSkew:           1,
+										WhenUnsatisfiable: corev1.DoNotSchedule,
+										LabelSelector:     &metav1.LabelSelector{MatchLabels: labels},
+									}))
+								})
+							})
+
+							Context("when there are at least 2 zones", func() {
+								BeforeEach(func() {
+									metav1.SetMetaDataAnnotation(&namespace.ObjectMeta, resourcesv1alpha1.HighAvailabilityConfigZones, strings.Join(zones, ","))
 								})
 
 								It("should add topology spread constraints", func() {
 									Expect(getPodSpec().TopologySpreadConstraints).To(ConsistOf(
 										corev1.TopologySpreadConstraint{
-											TopologyKey:       "some-key",
-											MaxSkew:           12,
-											WhenUnsatisfiable: corev1.DoNotSchedule,
-											LabelSelector:     &metav1.LabelSelector{MatchLabels: labels},
-										},
-										corev1.TopologySpreadConstraint{
 											TopologyKey:       corev1.LabelHostname,
-											MaxSkew:           1,
-											WhenUnsatisfiable: corev1.ScheduleAnyway,
-											LabelSelector:     &metav1.LabelSelector{MatchLabels: labels},
-										},
-										corev1.TopologySpreadConstraint{
-											TopologyKey:       corev1.LabelTopologyZone,
 											MaxSkew:           1,
 											WhenUnsatisfiable: corev1.DoNotSchedule,
 											LabelSelector:     &metav1.LabelSelector{MatchLabels: labels},
@@ -596,171 +607,249 @@ var _ = Describe("HighAvailabilityConfig tests", func() {
 								})
 							})
 						})
-					})
 
-					Context("when failure-tolerance-type is non-empty", func() {
-						BeforeEach(func() {
-							metav1.SetMetaDataAnnotation(&namespace.ObjectMeta, resourcesv1alpha1.HighAvailabilityConfigFailureToleranceType, "foo")
-						})
-
-						Context("when there are less than 2 zones", func() {
-							It("should add topology spread constraints", func() {
-								Expect(getPodSpec().TopologySpreadConstraints).To(ConsistOf(corev1.TopologySpreadConstraint{
-									TopologyKey:       corev1.LabelHostname,
-									MaxSkew:           1,
-									WhenUnsatisfiable: corev1.DoNotSchedule,
-									LabelSelector:     &metav1.LabelSelector{MatchLabels: labels},
-								}))
-							})
-						})
-
-						Context("when there are at least 2 zones", func() {
+						Context("when max replicas are at least twice the number of zones", func() {
 							BeforeEach(func() {
 								metav1.SetMetaDataAnnotation(&namespace.ObjectMeta, resourcesv1alpha1.HighAvailabilityConfigZones, strings.Join(zones, ","))
 							})
 
-							It("should add topology spread constraints", func() {
-								Expect(getPodSpec().TopologySpreadConstraints).To(ConsistOf(
-									corev1.TopologySpreadConstraint{
-										TopologyKey:       corev1.LabelHostname,
-										MaxSkew:           1,
-										WhenUnsatisfiable: corev1.DoNotSchedule,
-										LabelSelector:     &metav1.LabelSelector{MatchLabels: labels},
-									},
-								))
-							})
-						})
-					})
+							test := func() {
+								It("should add topology spread constraints", func() {
+									Expect(getPodSpec().TopologySpreadConstraints).To(ConsistOf(
+										corev1.TopologySpreadConstraint{
+											TopologyKey:       corev1.LabelHostname,
+											MaxSkew:           1,
+											WhenUnsatisfiable: corev1.ScheduleAnyway,
+											LabelSelector:     &metav1.LabelSelector{MatchLabels: labels},
+										},
+										corev1.TopologySpreadConstraint{
+											TopologyKey:       corev1.LabelTopologyZone,
+											MaxSkew:           2,
+											WhenUnsatisfiable: corev1.DoNotSchedule,
+											LabelSelector:     &metav1.LabelSelector{MatchLabels: labels},
+										},
+									))
+								})
+							}
 
-					Context("when max replicas is lower than desired replicas", func() {
-						BeforeEach(func() {
-							metav1.SetMetaDataAnnotation(&namespace.ObjectMeta, resourcesv1alpha1.HighAvailabilityConfigZones, strings.Join(zones, ","))
+							Context("scaled w/ HPA", func() {
+								BeforeEach(func() {
+									hpa.Spec.ScaleTargetRef.Name = getObj().GetName()
+									hpa.Spec.MaxReplicas = int32(2 * len(zones))
+								})
 
-							setReplicas(pointer.Int32(2 * int32(len(zones))))
-						})
-
-						test := func() {
-							It("should add topology spread constraints", func() {
-								Expect(getPodSpec().TopologySpreadConstraints).To(ConsistOf(
-									corev1.TopologySpreadConstraint{
-										TopologyKey:       corev1.LabelHostname,
-										MaxSkew:           1,
-										WhenUnsatisfiable: corev1.ScheduleAnyway,
-										LabelSelector:     &metav1.LabelSelector{MatchLabels: labels},
-									},
-									corev1.TopologySpreadConstraint{
-										TopologyKey:       corev1.LabelTopologyZone,
-										MaxSkew:           2,
-										WhenUnsatisfiable: corev1.DoNotSchedule,
-										LabelSelector:     &metav1.LabelSelector{MatchLabels: labels},
-									},
-								))
-							})
-						}
-
-						Context("scaled w/ HPA", func() {
-							BeforeEach(func() {
-								hpa.Spec.ScaleTargetRef.Name = getObj().GetName()
-								hpa.Spec.MaxReplicas = 1
+								test()
 							})
 
-							test()
-						})
+							Context("scaled w/ HVPA", func() {
+								BeforeEach(func() {
+									hvpa.Spec.TargetRef.Name = getObj().GetName()
+									hvpa.Spec.Hpa.Template.Spec.MaxReplicas = int32(2 * len(zones))
+								})
 
-						Context("scaled w/ HVPA", func() {
-							BeforeEach(func() {
-								hvpa.Spec.TargetRef.Name = getObj().GetName()
-								hvpa.Spec.Hpa.Template.Spec.MaxReplicas = 1
+								test()
 							})
-
-							test()
-						})
-					})
-
-					Context("when max replicas are at least twice the number of zones", func() {
-						BeforeEach(func() {
-							metav1.SetMetaDataAnnotation(&namespace.ObjectMeta, resourcesv1alpha1.HighAvailabilityConfigZones, strings.Join(zones, ","))
-						})
-
-						test := func() {
-							It("should add topology spread constraints", func() {
-								Expect(getPodSpec().TopologySpreadConstraints).To(ConsistOf(
-									corev1.TopologySpreadConstraint{
-										TopologyKey:       corev1.LabelHostname,
-										MaxSkew:           1,
-										WhenUnsatisfiable: corev1.ScheduleAnyway,
-										LabelSelector:     &metav1.LabelSelector{MatchLabels: labels},
-									},
-									corev1.TopologySpreadConstraint{
-										TopologyKey:       corev1.LabelTopologyZone,
-										MaxSkew:           2,
-										WhenUnsatisfiable: corev1.DoNotSchedule,
-										LabelSelector:     &metav1.LabelSelector{MatchLabels: labels},
-									},
-								))
-							})
-						}
-
-						Context("scaled w/ HPA", func() {
-							BeforeEach(func() {
-								hpa.Spec.ScaleTargetRef.Name = getObj().GetName()
-								hpa.Spec.MaxReplicas = int32(2 * len(zones))
-							})
-
-							test()
-						})
-
-						Context("scaled w/ HVPA", func() {
-							BeforeEach(func() {
-								hvpa.Spec.TargetRef.Name = getObj().GetName()
-								hvpa.Spec.Hpa.Template.Spec.MaxReplicas = int32(2 * len(zones))
-							})
-
-							test()
 						})
 					})
 				})
 			})
-		})
-	}
+		}
 
-	Context("for deployments", func() {
-		BeforeEach(func() {
-			hpa.Spec.ScaleTargetRef.Kind = "Deployment"
-			hvpa.Spec.TargetRef.Kind = "Deployment"
+		Context("for deployments", func() {
+			BeforeEach(func() {
+				hpa.Spec.ScaleTargetRef.Kind = "Deployment"
+				hvpa.Spec.TargetRef.Kind = "Deployment"
+			})
+
+			JustBeforeEach(func() {
+				By("Create Deployment")
+				Expect(testClient.Create(ctx, deployment)).To(Succeed())
+			})
+
+			tests(
+				func() client.Object { return deployment },
+				func() *int32 { return deployment.Spec.Replicas },
+				func(replicas *int32) { deployment.Spec.Replicas = replicas },
+				func() corev1.PodSpec { return deployment.Spec.Template.Spec },
+				func(mutate func(spec *corev1.PodSpec)) { mutate(&deployment.Spec.Template.Spec) },
+			)
 		})
 
-		JustBeforeEach(func() {
-			By("Create Deployment")
-			Expect(testClient.Create(ctx, deployment)).To(Succeed())
-		})
+		Context("for statefulsets", func() {
+			BeforeEach(func() {
+				hpa.Spec.ScaleTargetRef.Kind = "StatefulSet"
+				hvpa.Spec.TargetRef.Kind = "StatefulSet"
+			})
 
-		tests(
-			func() client.Object { return deployment },
-			func() *int32 { return deployment.Spec.Replicas },
-			func(replicas *int32) { deployment.Spec.Replicas = replicas },
-			func() corev1.PodSpec { return deployment.Spec.Template.Spec },
-			func(mutate func(spec *corev1.PodSpec)) { mutate(&deployment.Spec.Template.Spec) },
-		)
+			JustBeforeEach(func() {
+				By("Create StatefulSet")
+				Expect(testClient.Create(ctx, statefulSet)).To(Succeed())
+			})
+
+			tests(
+				func() client.Object { return statefulSet },
+				func() *int32 { return statefulSet.Spec.Replicas },
+				func(replicas *int32) { statefulSet.Spec.Replicas = replicas },
+				func() corev1.PodSpec { return statefulSet.Spec.Template.Spec },
+				func(mutate func(spec *corev1.PodSpec)) { mutate(&statefulSet.Spec.Template.Spec) },
+			)
+		})
 	})
 
-	Context("for statefulsets", func() {
-		BeforeEach(func() {
-			hpa.Spec.ScaleTargetRef.Kind = "StatefulSet"
-			hvpa.Spec.TargetRef.Kind = "StatefulSet"
-		})
+	Describe("Mutation of scaling objects", func() {
+		var scalingObject client.Object
 
 		JustBeforeEach(func() {
-			By("Create StatefulSet")
-			Expect(testClient.Create(ctx, statefulSet)).To(Succeed())
+			By("Creating scaling object")
+			Expect(testClient.Create(ctx, scalingObject)).To(Succeed())
 		})
 
-		tests(
-			func() client.Object { return statefulSet },
-			func() *int32 { return statefulSet.Spec.Replicas },
-			func(replicas *int32) { statefulSet.Spec.Replicas = replicas },
-			func() corev1.PodSpec { return statefulSet.Spec.Template.Spec },
-			func(mutate func(spec *corev1.PodSpec)) { mutate(&statefulSet.Spec.Template.Spec) },
-		)
+		tests := func(
+			getObjectMeta func() *metav1.ObjectMeta,
+			getMinReplicas func() *int32,
+			setMinReplicas func(*int32),
+			getMaxReplicas func() int32,
+			setMaxReplicas func(int32),
+		) {
+			var minReplicas, maxReplicas int32
+
+			BeforeEach(func() {
+				minReplicas = 1
+				maxReplicas = 2
+
+				setMinReplicas(&minReplicas)
+				setMaxReplicas(maxReplicas)
+			})
+
+			Context("when namespace is not labeled with consider=true", func() {
+				BeforeEach(func() {
+					metav1.SetMetaDataLabel(getObjectMeta(), resourcesv1alpha1.HighAvailabilityConfigType, resourcesv1alpha1.HighAvailabilityConfigTypeServer)
+				})
+
+				It("should not modify replica counts", func() {
+					Expect(getMinReplicas()).To(PointTo(Equal(minReplicas)))
+					Expect(getMaxReplicas()).To(Equal(maxReplicas))
+				})
+			})
+
+			Context("when namespace is labeled with consider=true", func() {
+				BeforeEach(func() {
+					metav1.SetMetaDataLabel(&namespace.ObjectMeta, resourcesv1alpha1.HighAvailabilityConfigConsider, "true")
+				})
+
+				Context("when failureToleranceType is not set", func() {
+					It("should not modify replica counts", func() {
+						Expect(getMinReplicas()).To(PointTo(Equal(minReplicas)))
+						Expect(getMaxReplicas()).To(Equal(maxReplicas))
+					})
+				})
+
+				Context("when failureToleranceType and component type are set", func() {
+					BeforeEach(func() {
+						metav1.SetMetaDataAnnotation(&namespace.ObjectMeta, resourcesv1alpha1.HighAvailabilityConfigFailureToleranceType, "zone")
+						metav1.SetMetaDataLabel(getObjectMeta(), resourcesv1alpha1.HighAvailabilityConfigType, resourcesv1alpha1.HighAvailabilityConfigTypeController)
+					})
+
+					It("should match expected replica count configuration", func() {
+						Expect(getMinReplicas()).To(PointTo(Equal(int32(2))))
+						Expect(getMaxReplicas()).To(Equal(maxReplicas))
+					})
+
+					Context("when minReplicas <= maxReplicas", func() {
+						BeforeEach(func() {
+							setMaxReplicas(minReplicas)
+						})
+
+						It("should set maxReplicas to minReplicas", func() {
+							Expect(getMinReplicas()).To(PointTo(Equal(int32(2))))
+							Expect(getMaxReplicas()).To(Equal(int32(2)))
+						})
+					})
+
+					Context("when replica count is overwritten by annotation", func() {
+						var newReplicaCount int32
+
+						BeforeEach(func() {
+							newReplicaCount = 12
+							metav1.SetMetaDataAnnotation(getObjectMeta(), resourcesv1alpha1.HighAvailabilityConfigReplicas, fmt.Sprintf("%d", newReplicaCount))
+						})
+
+						It("should set replica counts to value in annotation", func() {
+							Expect(getMinReplicas()).To(PointTo(Equal(newReplicaCount)))
+							Expect(getMaxReplicas()).To(Equal(newReplicaCount))
+						})
+					})
+
+					Context("when current replica counts are higher than calculated ones", func() {
+						var newMinReplicas, newMaxReplicas int32
+
+						BeforeEach(func() {
+							newMinReplicas = 12
+							newMaxReplicas = 16
+
+							setMinReplicas(&newMinReplicas)
+							setMaxReplicas(newMaxReplicas)
+						})
+
+						It("should not modify replica counts", func() {
+							Expect(getMinReplicas()).To(PointTo(Equal(newMinReplicas)))
+							Expect(getMaxReplicas()).To(Equal(newMaxReplicas))
+						})
+					})
+				})
+			})
+		}
+
+		Context("for HVPAs", func() {
+			var hvpa *hvpav1alpha1.Hvpa
+
+			BeforeEach(func() {
+				hvpa = &hvpav1alpha1.Hvpa{
+					ObjectMeta: objectMeta,
+					Spec: hvpav1alpha1.HvpaSpec{
+						TargetRef: &autoscalingv2beta1.CrossVersionObjectReference{
+							Kind: "someKind",
+							Name: "someName",
+						},
+					},
+				}
+
+				scalingObject = hvpa
+			})
+
+			tests(
+				func() *metav1.ObjectMeta { return &hvpa.ObjectMeta },
+				func() *int32 { return hvpa.Spec.Hpa.Template.Spec.MinReplicas },
+				func(n *int32) { hvpa.Spec.Hpa.Template.Spec.MinReplicas = n },
+				func() int32 { return hvpa.Spec.Hpa.Template.Spec.MaxReplicas },
+				func(n int32) { hvpa.Spec.Hpa.Template.Spec.MaxReplicas = n },
+			)
+		})
+
+		Context("for HPAs", func() {
+			var hpa *autoscalingv2.HorizontalPodAutoscaler
+
+			BeforeEach(func() {
+				hpa = &autoscalingv2.HorizontalPodAutoscaler{
+					ObjectMeta: objectMeta,
+					Spec: autoscalingv2.HorizontalPodAutoscalerSpec{
+						ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{
+							Kind: "someKind",
+							Name: "someName",
+						},
+					},
+				}
+
+				scalingObject = hpa
+			})
+
+			tests(
+				func() *metav1.ObjectMeta { return &hpa.ObjectMeta },
+				func() *int32 { return hpa.Spec.MinReplicas },
+				func(n *int32) { hpa.Spec.MinReplicas = n },
+				func() int32 { return hpa.Spec.MaxReplicas },
+				func(n int32) { hpa.Spec.MaxReplicas = n },
+			)
+		})
 	})
 })

--- a/test/integration/resourcemanager/highavailabilityconfig/highavailabilityconfig_test.go
+++ b/test/integration/resourcemanager/highavailabilityconfig/highavailabilityconfig_test.go
@@ -18,13 +18,15 @@ import (
 	"fmt"
 	"strings"
 
+	autoscalingv2beta1 "k8s.io/api/autoscaling/v2beta1"
+
 	hvpav1alpha1 "github.com/gardener/hvpa-controller/api/v1alpha1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
 	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
-	autoscalingv2beta1 "k8s.io/api/autoscaling/v2beta1"
+	autoscalingv2beta2 "k8s.io/api/autoscaling/v2beta2"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/uuid"
@@ -827,29 +829,57 @@ var _ = Describe("HighAvailabilityConfig tests", func() {
 		})
 
 		Context("for HPAs", func() {
-			var hpa *autoscalingv2.HorizontalPodAutoscaler
+			Context("with version v2beta2", func() {
+				var hpa *autoscalingv2beta2.HorizontalPodAutoscaler
 
-			BeforeEach(func() {
-				hpa = &autoscalingv2.HorizontalPodAutoscaler{
-					ObjectMeta: objectMeta,
-					Spec: autoscalingv2.HorizontalPodAutoscalerSpec{
-						ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{
-							Kind: "someKind",
-							Name: "someName",
+				BeforeEach(func() {
+					hpa = &autoscalingv2beta2.HorizontalPodAutoscaler{
+						ObjectMeta: objectMeta,
+						Spec: autoscalingv2beta2.HorizontalPodAutoscalerSpec{
+							ScaleTargetRef: autoscalingv2beta2.CrossVersionObjectReference{
+								Kind: "someKind",
+								Name: "someName",
+							},
 						},
-					},
-				}
+					}
 
-				scalingObject = hpa
+					scalingObject = hpa
+				})
+
+				tests(
+					func() *metav1.ObjectMeta { return &hpa.ObjectMeta },
+					func() *int32 { return hpa.Spec.MinReplicas },
+					func(n *int32) { hpa.Spec.MinReplicas = n },
+					func() int32 { return hpa.Spec.MaxReplicas },
+					func(n int32) { hpa.Spec.MaxReplicas = n },
+				)
 			})
 
-			tests(
-				func() *metav1.ObjectMeta { return &hpa.ObjectMeta },
-				func() *int32 { return hpa.Spec.MinReplicas },
-				func(n *int32) { hpa.Spec.MinReplicas = n },
-				func() int32 { return hpa.Spec.MaxReplicas },
-				func(n int32) { hpa.Spec.MaxReplicas = n },
-			)
+			Context("with version v2", func() {
+				var hpa *autoscalingv2.HorizontalPodAutoscaler
+
+				BeforeEach(func() {
+					hpa = &autoscalingv2.HorizontalPodAutoscaler{
+						ObjectMeta: objectMeta,
+						Spec: autoscalingv2.HorizontalPodAutoscalerSpec{
+							ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{
+								Kind: "someKind",
+								Name: "someName",
+							},
+						},
+					}
+
+					scalingObject = hpa
+				})
+
+				tests(
+					func() *metav1.ObjectMeta { return &hpa.ObjectMeta },
+					func() *int32 { return hpa.Spec.MinReplicas },
+					func(n *int32) { hpa.Spec.MinReplicas = n },
+					func() int32 { return hpa.Spec.MaxReplicas },
+					func(n int32) { hpa.Spec.MaxReplicas = n },
+				)
+			})
 		})
 	})
 })


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area high-availability
/kind enhancement

**What this PR does / why we need it**:
This PR adds `HPA` and `HVPA` handling to the `HighAvailabilityConfig` webhook.

**Which issue(s) this PR fixes**:
Fixes #7105

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature developer
The `HighAvailabilityConfig` webhook now also mutates replica settings of `HPA` and `HVPA` resources. To make use of this handling, please label respective resources with the well known `high-availability-config.resource.gardener.cloud/type` label, see `docs/development/high-availability.md` for more information.
```
