### PR TITLE
Deflake Shootstate secret controller

### DIFF
--- a/test/integration/gardenlet/backupbucket/backupbucket_suite_test.go
+++ b/test/integration/gardenlet/backupbucket/backupbucket_suite_test.go
@@ -193,7 +193,6 @@ var _ = BeforeSuite(func() {
 	mgr, err := manager.New(restConfig, manager.Options{
 		Scheme:             testScheme,
 		MetricsBindAddress: "0",
-
 		NewCache: cache.BuilderWithOptions(cache.Options{
 			SelectorsByObject: map[client.Object]cache.ObjectSelector{
 				&gardencorev1beta1.BackupBucket{}: {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind flake

**What this PR does / why we need it**:
This PR deflakes Shootstate secret controller test suite.

1. The cluster is created per test case, but uses the seedNamespace.Name which is created per test, which is fixed. Something similar to #7158 
2. Use labelselector for the manager cache.
3. Wait until the manager cache has observed relevant changes.

**Which issue(s) this PR fixes**:
Fixes #7171 

**Special notes for your reviewer**:
/cc @acumino

Before:
```
❯ stress -ignore "unable to grab random port | resource quota evaluation timed out" -p 32 ./test/integration/gardenlet/shootstate/secret/secret.test -ginkgo.v -ginkgo.progress
...
2m35s: 99 runs so far, 3 failures (3.03%)
2m40s: 114 runs so far, 3 failures (2.63%)
2m45s: 128 runs so far, 3 failures (2.34%)
2m50s: 128 runs so far, 3 failures (2.34%)
```
After:
```
❯ stress -ignore "unable to grab random port | resource quota evaluation timed out" -p 32 ./test/integration/gardenlet/shootstate/secret/secret.test -ginkgo.v -ginkgo.progress
...
21m5s: 992 runs so far, 0 failures
21m10s: 1015 runs so far, 0 failures
21m15s: 1024 runs so far, 0 failures
21m20s: 1024 runs so far, 0 failures 
```

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
4. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
