### PR TITLE
Bump up kube-rbac-proxy to v0.14.0

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -231,7 +231,7 @@ images:
 - name: kube-rbac-proxy
   sourceRepository: github.com/brancz/kube-rbac-proxy
   repository: quay.io/brancz/kube-rbac-proxy
-  tag: v0.13.1
+  tag: v0.14.0
 - name: promtail
   sourceRepository: github.com/grafana/loki
   repository: "docker.io/grafana/promtail"


### PR DESCRIPTION
/area logging
/kind task

This PR bump ups kube-rbac-proxy version to v0.14.0.
It contains a [PR#214](https://github.com/brancz/kube-rbac-proxy/pull/214) by @vpnachev updating golang version to 1.19.4, fixing related CVEs

**Release note**:

```other operator
The following image is updated:
- quay.io/brancz/kube-rbac-proxy: v0.13.1 -> v0.14.0
```
