### PR TITLE
Clean up the deletion of the stale `kube-addon-manager-vpa` VPA 

### DIFF
--- a/pkg/operation/botanist/component/vpnshoot/vpnshoot_test.go
+++ b/pkg/operation/botanist/component/vpnshoot/vpnshoot_test.go
@@ -927,7 +927,6 @@ status:
 						secretNameTLSAuth = expectTLSAuthSecret(managedResourceSecret.Data)
 					)
 
-					_ = secretNameClient1 // TODO
 					statefulSet := &appsv1.StatefulSet{}
 					Expect(runtime.DecodeInto(newCodec(), managedResourceSecret.Data["statefulset__kube-system__vpn-shoot.yaml"], statefulSet)).To(Succeed())
 					expected := statefulSetFor(3, 2, []string{secretNameClient0, secretNameClient1}, secretNameCA, secretNameTLSAuth, values.ReversedVPN.Enabled, values.VPAEnabled)

--- a/pkg/operation/botanist/resource_manager.go
+++ b/pkg/operation/botanist/resource_manager.go
@@ -43,7 +43,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apiserver/pkg/authentication/user"
-	vpaautoscalingv1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
 	"k8s.io/component-base/version"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -155,12 +154,7 @@ func (b *Botanist) DeployGardenerResourceManager(ctx context.Context) error {
 	secrets.BootstrapKubeconfig = nil
 	b.Shoot.Components.ControlPlane.ResourceManager.SetSecrets(secrets)
 
-	if err := b.Shoot.Components.ControlPlane.ResourceManager.Deploy(ctx); err != nil {
-		return err
-	}
-
-	// TODO(ialidzhikov): Remove in 1.63.
-	return kutil.DeleteObject(ctx, b.SeedClientSet.Client(), &vpaautoscalingv1.VerticalPodAutoscaler{ObjectMeta: metav1.ObjectMeta{Namespace: b.Shoot.SeedNamespace, Name: "kube-addon-manager-vpa"}})
+	return b.Shoot.Components.ControlPlane.ResourceManager.Deploy(ctx)
 }
 
 // ScaleGardenerResourceManagerToOne scales the gardener-resource-manager deployment

--- a/pkg/operation/botanist/resource_manager_test.go
+++ b/pkg/operation/botanist/resource_manager_test.go
@@ -43,7 +43,6 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	vpaautoscalingv1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -146,12 +145,6 @@ var _ = Describe("ResourceManager", func() {
 
 						// set secrets
 						resourceManager.EXPECT().SetSecrets(secrets),
-
-						c.EXPECT().Delete(ctx, gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{})).DoAndReturn(func(_ context.Context, obj *vpaautoscalingv1.VerticalPodAutoscaler, opts ...client.DeleteOption) error {
-							Expect(obj.Name).To(Equal("kube-addon-manager-vpa"))
-							Expect(obj.Namespace).To(Equal(seedNamespace))
-							return nil
-						}),
 					)
 
 					resourceManager.EXPECT().Deploy(ctx)
@@ -265,12 +258,6 @@ var _ = Describe("ResourceManager", func() {
 				})
 
 				It("should set the secrets and deploy", func() {
-					c.EXPECT().Delete(ctx, gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{})).DoAndReturn(func(_ context.Context, obj *vpaautoscalingv1.VerticalPodAutoscaler, opts ...client.DeleteOption) error {
-						Expect(obj.Name).To(Equal("kube-addon-manager-vpa"))
-						Expect(obj.Namespace).To(Equal(seedNamespace))
-						return nil
-					})
-
 					resourceManager.EXPECT().Deploy(ctx)
 					Expect(botanist.DeployGardenerResourceManager(ctx)).To(Succeed())
 				})
@@ -324,12 +311,6 @@ var _ = Describe("ResourceManager", func() {
 						// set secrets and deploy with shoot access token
 						resourceManager.EXPECT().SetSecrets(secrets),
 						resourceManager.EXPECT().Deploy(ctx),
-
-						c.EXPECT().Delete(ctx, gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{})).DoAndReturn(func(_ context.Context, obj *vpaautoscalingv1.VerticalPodAutoscaler, opts ...client.DeleteOption) error {
-							Expect(obj.Name).To(Equal("kube-addon-manager-vpa"))
-							Expect(obj.Namespace).To(Equal(seedNamespace))
-							return nil
-						}),
 					)
 
 					Expect(botanist.DeployGardenerResourceManager(ctx)).To(Succeed())


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity
/kind cleanup

**What this PR does / why we need it**:
The cleanup was introduced in v1.61.0 with https://github.com/gardener/gardener/pull/7017.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
