### PR TITLE
Enable secrets manager to adopt existing secrets

### DIFF
--- a/pkg/utils/secrets/manager/generate.go
+++ b/pkg/utils/secrets/manager/generate.go
@@ -196,6 +196,19 @@ func (m *manager) keepExistingSecretsIfNeeded(ctx context.Context, configName st
 		return existingSecret.Data, nil
 	}
 
+	existingSecrets := &corev1.SecretList{}
+	if err := m.client.List(ctx, existingSecrets, client.InNamespace(m.namespace), client.MatchingLabels{LabelKeyUseDataForName: configName}); err != nil {
+		return nil, err
+	}
+
+	if len(existingSecrets.Items) > 1 {
+		return nil, fmt.Errorf("found more than one existing secret with %q label for config %q", LabelKeyUseDataForName, configName)
+	}
+
+	if len(existingSecrets.Items) == 1 {
+		return existingSecrets.Items[0].Data, nil
+	}
+
 	return newData, nil
 }
 

--- a/pkg/utils/secrets/manager/generate.go
+++ b/pkg/utils/secrets/manager/generate.go
@@ -115,9 +115,6 @@ func (m *manager) generateAndCreate(ctx context.Context, config secretutils.Conf
 		return nil, err
 	}
 
-	// For backwards-compatibility, we need to keep some of the existing secrets (cluster-admin token, basic auth
-	// password, etc.).
-	// TODO(rfranzke): Remove this code in the future
 	dataMap, err := m.keepExistingSecretsIfNeeded(ctx, config.GetName(), data.SecretData())
 	if err != nil {
 		return nil, err
@@ -141,6 +138,9 @@ func (m *manager) generateAndCreate(ctx context.Context, config secretutils.Conf
 func (m *manager) keepExistingSecretsIfNeeded(ctx context.Context, configName string, newData map[string][]byte) (map[string][]byte, error) {
 	existingSecret := &corev1.Secret{}
 
+	// For backwards-compatibility, we need to keep some of the existing secrets (cluster-admin token, basic auth
+	// password, etc.).
+	// TODO(rfranzke): Remove this switch statement in the future.
 	switch configName {
 	case "kube-apiserver-etcd-encryption-key":
 		if err := m.client.Get(ctx, kutil.Key(m.namespace, "etcd-encryption-secret"), existingSecret); err != nil {

--- a/pkg/utils/secrets/manager/manager.go
+++ b/pkg/utils/secrets/manager/manager.go
@@ -61,6 +61,9 @@ const (
 	// data is valid. In case the data contains a certificate it is the time part of the certificate's 'not after'
 	// field.
 	LabelKeyValidUntilTime = "valid-until-time"
+	// LabelKeyUseDataForName is a constant for a key of a label on a Secret describing that its data should be used
+	// instead of generating a fresh secret with the same name.
+	LabelKeyUseDataForName = "secrets-manager-use-data-for-name"
 
 	// LabelValueTrue is a constant for a value of a label on a Secret describing the value 'true'.
 	LabelValueTrue = "true"


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind enhancement

**What this PR does / why we need it**:
The data of existing secrets labeled with `secrets-manager-use-data-for=<config-name>` is now used instead of generating new data when a secret is generated by secrets manager.

**Special notes for your reviewer**:
Needed when `gardener-operator` deploys `kube-apiserver` and existing secrets should be reused instead of regenerated.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature developer
It is now possible to make secrets manager adopt existing secrets. Find out more in [this document](https://github.com/gardener/gardener/blob/master/docs/development/secrets_management.md#migrating-existing-secrets-to-secretsmanager).
```
