### PR TITLE
Label all ETCD encryption secrets with 'garbage-collectable' label

### DIFF
--- a/cmd/gardenlet/app/app.go
+++ b/cmd/gardenlet/app/app.go
@@ -66,6 +66,7 @@ import (
 	gardenletfeatures "github.com/gardener/gardener/pkg/gardenlet/features"
 	gardenerhealthz "github.com/gardener/gardener/pkg/healthz"
 	"github.com/gardener/gardener/pkg/logger"
+	"github.com/gardener/gardener/pkg/resourcemanager/controller/garbagecollector/references"
 	"github.com/gardener/gardener/pkg/utils"
 	"github.com/gardener/gardener/pkg/utils/flow"
 	gutil "github.com/gardener/gardener/pkg/utils/gardener"
@@ -216,6 +217,30 @@ func run(ctx context.Context, cancel context.CancelFunc, log logr.Logger, cfg *c
 				Config:     cfg,
 				Result:     kubeconfigBootstrapResult,
 			},
+
+			// TODO(rfranzke): Remove this in a future version.
+			// Ensure all existing ETCD encryption secrets get the 'garbage-collectable' label. There was a bug which
+			// prevented this from happening, see https://github.com/gardener/gardener/pull/7244.
+			manager.RunnableFunc(func(ctx context.Context) error {
+				secretList := &corev1.SecretList{}
+				if err := mgr.GetClient().List(ctx, secretList, client.MatchingLabels{v1beta1constants.LabelRole: v1beta1constants.SecretNamePrefixETCDEncryptionConfiguration}); err != nil {
+					return err
+				}
+
+				var tasks []flow.TaskFn
+
+				for _, obj := range secretList.Items {
+					secret := obj
+
+					tasks = append(tasks, func(ctx context.Context) error {
+						patch := client.MergeFrom(secret.DeepCopy())
+						metav1.SetMetaDataLabel(&secret.ObjectMeta, references.LabelKeyGarbageCollectable, references.LabelValueGarbageCollectable)
+						return mgr.GetClient().Patch(ctx, &secret, patch)
+					})
+				}
+
+				return flow.Parallel(tasks...)(ctx)
+			}),
 		},
 		ActualRunnables: []manager.Runnable{
 			&garden{

--- a/pkg/operation/botanist/component/kubeapiserver/secrets.go
+++ b/pkg/operation/botanist/component/kubeapiserver/secrets.go
@@ -214,9 +214,9 @@ func (k *kubeAPIServer) reconcileSecretETCDEncryptionConfiguration(ctx context.C
 	}
 
 	secret.Labels = map[string]string{v1beta1constants.LabelRole: v1beta1constants.SecretNamePrefixETCDEncryptionConfiguration}
-	desiredLabels := utils.MergeStringMaps(secret.Labels) // copy
 	secret.Data = map[string][]byte{secretETCDEncryptionConfigurationDataKey: data}
 	utilruntime.Must(kutil.MakeUnique(secret))
+	desiredLabels := utils.MergeStringMaps(secret.Labels) // copy
 
 	if err := k.client.Client().Create(ctx, secret); err == nil || !apierrors.IsAlreadyExists(err) {
 		return err


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind bug

**What this PR does / why we need it**:
Earlier, there was a bug which removed the 'garbage-collectable' label on ETCD encryption secrets with the second reconciliation. This caused ETCD encryption secrets which were no longer in-use to not get auto-deleted.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
A bug has been fixed which caused ETCD encryption secrets which were no longer in-use to not get auto-deleted.
```
