### PR TITLE
[GEP-21] `DNSRecord`: add support for `AAAA` record type

### DIFF
--- a/docs/extensions/dnsrecord.md
+++ b/docs/extensions/dnsrecord.md
@@ -45,7 +45,7 @@ This resource contains the following information:
 * The DNS provider type (e.g., `aws-route53`, `google-clouddns`, ...)
 * A reference to a `Secret` object that contains the provider-specific credentials used to communicate with the provider's API.
 * The fully qualified domain name (FQDN) of the DNS record, e.g. "api.\<shoot domain\>".
-* The DNS record type, one of `A`, `CNAME`, or `TXT`.
+* The DNS record type, one of `A`, `AAAA`, `CNAME`, or `TXT`.
 * The DNS record values, that is a list of IP addresses for A records, a single hostname for CNAME records, or a list of texts for TXT records.
 
 Optionally, the `DNSRecord` resource may contain also the following information:
@@ -146,6 +146,23 @@ The following table contains information about the provider extension version th
 | provider-equinix-metal                       |    N/A   |
 | provider-kubevirt                            |    N/A   |
 | provider-openshift                           |    N/A   |
+
+### Support for `DNSRecord` IPv6 `recordType: AAAA` in the provider extensions
+
+The following table contains information about the provider extension version that adds support for `DNSRecord` IPv6 `recordType: AAAA`:
+
+| Extension              | Version   |
+|------------------------|-----------|
+| provider-alicloud      | N/A       |
+| provider-aws           | N/A       |
+| provider-azure         | N/A       |
+| provider-gcp           | N/A       |
+| provider-openstack     | N/A       |
+| provider-vsphere       | N/A       |
+| provider-equinix-metal | N/A       |
+| provider-kubevirt      | N/A       |
+| provider-openshift     | N/A       |
+| provider-local         | `v1.63.0` |
 
 ## References and additional resources
 

--- a/pkg/apis/extensions/v1alpha1/helper/helper.go
+++ b/pkg/apis/extensions/v1alpha1/helper/helper.go
@@ -31,10 +31,13 @@ func ClusterAutoscalerRequired(pools []extensionsv1alpha1.WorkerPool) bool {
 	return false
 }
 
-// GetDNSRecordType returns the appropriate DNS record type (A or CNAME) for the given address.
+// GetDNSRecordType returns the appropriate DNS record type (A/AAAA or CNAME) for the given address.
 func GetDNSRecordType(address string) extensionsv1alpha1.DNSRecordType {
-	if ip := net.ParseIP(address); ip != nil && ip.To4() != nil {
-		return extensionsv1alpha1.DNSRecordTypeA
+	if ip := net.ParseIP(address); ip != nil {
+		if ip.To4() != nil {
+			return extensionsv1alpha1.DNSRecordTypeA
+		}
+		return extensionsv1alpha1.DNSRecordTypeAAAA
 	}
 	return extensionsv1alpha1.DNSRecordTypeCNAME
 }

--- a/pkg/apis/extensions/v1alpha1/helper/helper_test.go
+++ b/pkg/apis/extensions/v1alpha1/helper/helper_test.go
@@ -46,6 +46,7 @@ var _ = Describe("helper", func() {
 		},
 
 		Entry("valid IPv4 address", "1.2.3.4", extensionsv1alpha1.DNSRecordTypeA),
+		Entry("valid IPv6 address", "2001:db8:f00::1", extensionsv1alpha1.DNSRecordTypeAAAA),
 		Entry("anything else", "foo", extensionsv1alpha1.DNSRecordTypeCNAME),
 	)
 

--- a/pkg/apis/extensions/v1alpha1/types_dnsrecord.go
+++ b/pkg/apis/extensions/v1alpha1/types_dnsrecord.go
@@ -106,6 +106,8 @@ type DNSRecordType string
 const (
 	// DNSRecordTypeA specifies that the DNSRecord is of type A.
 	DNSRecordTypeA DNSRecordType = "A"
+	// DNSRecordTypeAAAA specifies that the DNSRecord is of type AAAA.
+	DNSRecordTypeAAAA DNSRecordType = "AAAA"
 	// DNSRecordTypeCNAME specifies that the DNSRecord is of type CNAME.
 	DNSRecordTypeCNAME DNSRecordType = "CNAME"
 	// DNSRecordTypeTXT specifies that the DNSRecord is of type TXT.

--- a/pkg/apis/extensions/validation/dnsrecord.go
+++ b/pkg/apis/extensions/validation/dnsrecord.go
@@ -69,7 +69,7 @@ func ValidateDNSRecordSpec(spec *extensionsv1alpha1.DNSRecordSpec, fldPath *fiel
 	// This will return FieldValueRequired for an empty spec.Name
 	allErrs = append(allErrs, validation.IsFullyQualifiedDomainName(fldPath.Child("name"), strings.TrimPrefix(spec.Name, "*."))...)
 
-	validRecordTypes := []string{string(extensionsv1alpha1.DNSRecordTypeA), string(extensionsv1alpha1.DNSRecordTypeCNAME), string(extensionsv1alpha1.DNSRecordTypeTXT)}
+	validRecordTypes := []string{string(extensionsv1alpha1.DNSRecordTypeA), string(extensionsv1alpha1.DNSRecordTypeAAAA), string(extensionsv1alpha1.DNSRecordTypeCNAME), string(extensionsv1alpha1.DNSRecordTypeTXT)}
 	if !utils.ValueExists(string(spec.RecordType), validRecordTypes) {
 		allErrs = append(allErrs, field.NotSupported(fldPath.Child("recordType"), spec.RecordType, validRecordTypes))
 	}
@@ -126,6 +126,8 @@ func validateValue(recordType extensionsv1alpha1.DNSRecordType, value string, fl
 	switch recordType {
 	case extensionsv1alpha1.DNSRecordTypeA:
 		allErrs = append(allErrs, validation.IsValidIPv4Address(fldPath, value)...)
+	case extensionsv1alpha1.DNSRecordTypeAAAA:
+		allErrs = append(allErrs, validation.IsValidIPv6Address(fldPath, value)...)
 	case extensionsv1alpha1.DNSRecordTypeCNAME:
 		allErrs = append(allErrs, validation.IsFullyQualifiedDomainName(fldPath, value)...)
 	}

--- a/pkg/provider-local/controller/ingress/reconciler.go
+++ b/pkg/provider-local/controller/ingress/reconciler.go
@@ -17,6 +17,7 @@ package ingress
 import (
 	"context"
 	"fmt"
+	"github.com/gardener/gardener/pkg/apis/extensions/v1alpha1/helper"
 
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/provider-local/local"
@@ -113,7 +114,7 @@ func dnsRecordsForIngress(ingress *networkingv1.Ingress, ip string, scheme *runt
 				DefaultSpec: extensionsv1alpha1.DefaultSpec{
 					Type: local.Type,
 				},
-				RecordType: extensionsv1alpha1.DNSRecordTypeA,
+				RecordType: helper.GetDNSRecordType(ip),
 				Name:       host,
 				Values:     []string{ip},
 				SecretRef: corev1.SecretReference{

--- a/pkg/provider-local/controller/ingress/reconciler.go
+++ b/pkg/provider-local/controller/ingress/reconciler.go
@@ -17,6 +17,7 @@ package ingress
 import (
 	"context"
 	"fmt"
+
 	"github.com/gardener/gardener/pkg/apis/extensions/v1alpha1/helper"
 
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"


### PR DESCRIPTION
Signed-off-by: Niclas Schad <niclas.schad@stackit.cloud>

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement

**What this PR does / why we need it**:

This is part of GEP-21. Implementation of `extend DNSRecord` #7051 

**Which issue(s) this PR fixes**:
Part of #7051

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature dependency
The `DNSRecord` API now supports records of type `AAAA`. If you implement a `DNSRecord` controller, you can start implementing support for this record type.
```
