### PR TITLE
Make `kind-up` volume paths absolute

### DIFF
--- a/example/gardener-local/kind/cluster/templates/_extra_mounts.tpl
+++ b/example/gardener-local/kind/cluster/templates/_extra_mounts.tpl
@@ -1,6 +1,6 @@
 {{- define "extraMounts.gardener.controlPlane" -}}
 {{- if .Values.gardener.controlPlane.deployed }}
-- hostPath: example/gardener-local/controlplane
+- hostPath: {{.Values.gardener.repositoryRoot}}/example/gardener-local/controlplane
   containerPath: /etc/gardener/controlplane
   readOnly: true
 {{- end }}
@@ -8,14 +8,14 @@
 
 {{- define "extraMounts.backupBucket" -}}
 {{- if .Values.backupBucket.deployed -}}
-- hostPath: dev/local-backupbuckets
+- hostPath: {{.Values.gardener.repositoryRoot}}/dev/local-backupbuckets
   containerPath: /etc/gardener/local-backupbuckets
 {{- end -}}
 {{- end -}}
 
 {{- define "extraMounts.registry" -}}
 {{- if .Values.registry.deployed }}
-- hostPath: dev/local-registry
+- hostPath: {{.Values.gardener.repositoryRoot}}/dev/local-registry
   containerPath: /etc/gardener/local-registry
 {{- end }}
 {{- end -}}

--- a/example/gardener-local/kind/cluster/values.yaml
+++ b/example/gardener-local/kind/cluster/values.yaml
@@ -13,6 +13,7 @@ gardener:
       listenAddressZone0: 127.0.0.10
       listenAddressZone1: 127.0.0.11
       listenAddressZone2: 127.0.0.12
+  repositoryRoot: "."
   garden:
     deployed: false
 

--- a/hack/kind-up.sh
+++ b/hack/kind-up.sh
@@ -66,7 +66,7 @@ setup_loopback_device
 
 kind create cluster \
   --name "$CLUSTER_NAME" \
-  --config <(helm template $CHART --values "$PATH_CLUSTER_VALUES" --set "environment=$ENVIRONMENT")
+  --config <(helm template $CHART --values "$PATH_CLUSTER_VALUES" --set "environment=$ENVIRONMENT" --set "gardener.repositoryRoot"=$(dirname "$0")/..)
 
 # workaround https://kind.sigs.k8s.io/docs/user/known-issues/#pod-errors-due-to-too-many-open-files
 kubectl get nodes -o name |\


### PR DESCRIPTION
Make `kind-up` volume paths absolute. Fixes issue when scripts are used from provider extension path.

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind cleanup

**What this PR does / why we need it**:
When `kind-up.sh` is running from a directory outside g/g, the kind configuration has incorrect paths for volume mounts. This fix passes the directory that the script is running in to Helm templating, converting the kind volume configurations to absolute filesystem locations.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
