### PR TITLE
Adds `--shutdown-send-retry-after=true` for `kube-apiserver` `v1.24`

### DIFF
--- a/pkg/operation/botanist/component/kubeapiserver/kube_apiserver_test.go
+++ b/pkg/operation/botanist/component/kubeapiserver/kube_apiserver_test.go
@@ -3014,6 +3014,16 @@ rules:
 
 					Expect(deployment.Spec.Template.Spec.Containers[0].Lifecycle).To(BeNil())
 				})
+
+				It("should set the --shutdown-send-retry-after=true flag if the kubernetes version is 1.24", func() {
+					version = semver.MustParse("1.24.7")
+					kapi = New(kubernetesInterface, namespace, sm, Values{Images: images, RuntimeVersion: runtimeVersion, Version: version})
+					deployAndRead()
+
+					Expect(deployment.Spec.Template.Spec.Containers[0].Command).To(ContainElements(
+						"--shutdown-send-retry-after=true",
+					))
+				})
 			})
 		})
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/area disaster-recovery
/kind bug

**What this PR does / why we need it**:
When `gardenlet` deploys `kube-apiserver` version `v1.24`, the `--shutdown-send-retry-after=true` option is set so that the `kube-apiserver`  replies to new requests with the `Connection: close` and `Retry-After: N` during the graceful termination of the `kube-apiserver`. This is necessary so that active TCP connections are closed and clients get a chance to open new connections to healthy `kube-apiservers`. Otherwise even if the `kube-apiserver` container is not `Ready` and the corresponding `endpoint` is removed, persistent TCP connections to that `kube-apiserver` are kept. If this persists for too long, it can lead to various problems, e.g. the `Nodes` can become `NotReady`, if their `kubelet` is connected to a `kube-apiserver` that is shutting down, whereas KCM is connected to a healthy one.
On `v1.24` there is a deadlock that can occur when `--audit-log-mode=batch` is set and the `kube-apiserver` container is signaled with `SIGTERM` (it is shutting down gracefully), leading to the problem mentioned above, if for whatever reason there is no second `SIGTERM` to force the termination of the `kube-apiserver` container.

Generally this is a workaround while we wait for https://github.com/kubernetes/kubernetes/pull/113741.

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:
I've only specified the option for version 1.24 to not bring any unexpected side effects to other versions. The `--shutdown-send-retry-after` generally modifies the order in which the `kube-apiserver` is being shut down. You can find more detailed information about it here:
https://github.com/kubernetes/kubernetes/blob/55181b72a2c0aacb344998460b08c708cd069bf1/staging/src/k8s.io/apiserver/pkg/server/lifecycle_signals.go#L23-L88
And
https://github.com/kubernetes/kubernetes/blob/55181b72a2c0aacb344998460b08c708cd069bf1/staging/src/k8s.io/apiserver/pkg/server/filters/with_retry_after.go#L55-L64

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
When deploying `kube-apiserver` version v1.24, gardener will add the `--shutdown-send-retry-after=true` command line flag to the kube-apiserver command. This is necessary so that during the graceful termination of the `kube-apiserver` process, it responds to new requests with the `Connection: close` and `Retry-After: N` headers so that any active TCP connections are closed and they have a chance to be reopened to running `kube-apiserver`s. This is a workaround for an issue in which if the `--audit-log-mode=batch` is set on the `kube-apiserver`, it can enter a deadlock during graceful termination. This deadlock can lead to `kubelet`s not being able to update their corresponding `Node`'s status as the TCP connection to the broken `kube-apiserver` will never be closed.
```
