### PR TITLE
Improve `ManagedSeed` e2e tests to reduce flakiness

### DIFF
--- a/test/e2e/gardener/managedseed/create_rotate_delete.go
+++ b/test/e2e/gardener/managedseed/create_rotate_delete.go
@@ -286,8 +286,13 @@ func buildManagedSeed(shoot *gardencorev1beta1.Shoot) (*seedmanagementv1alpha1.M
 			Namespace: shoot.Namespace,
 		},
 		Spec: seedmanagementv1alpha1.ManagedSeedSpec{
-			Shoot:     &seedmanagementv1alpha1.Shoot{Name: shoot.Name},
-			Gardenlet: &seedmanagementv1alpha1.Gardenlet{Config: *gardenletConfig},
+			Shoot: &seedmanagementv1alpha1.Shoot{Name: shoot.Name},
+			Gardenlet: &seedmanagementv1alpha1.Gardenlet{
+				Config: *gardenletConfig,
+				Deployment: &seedmanagementv1alpha1.GardenletDeployment{
+					ReplicaCount: pointer.Int32(1), // the default replicaCount is 2, however in this e2e test we don't need 2 replicas
+				},
+			},
 		},
 	}, nil
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind test

**What this PR does / why we need it**:
See https://github.com/gardener/gardener/issues/7229#issuecomment-1361071276 ff.

**Which issue(s) this PR fixes**:
Fixes #7229

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
