### PR TITLE
Add Gardener CAs to CA bundle on Debian based OS

### DIFF
--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/rootcertificates/component.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/rootcertificates/component.go
@@ -20,6 +20,7 @@ import (
 	"text/template"
 
 	"github.com/Masterminds/sprig"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/utils/pointer"
 
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
@@ -47,9 +48,7 @@ func init() {
 		New(tplNameUpdateLocalCaCertificates).
 		Funcs(sprig.TxtFuncMap()).
 		Parse(tplContentUpdateLocalCaCertificates)
-	if err != nil {
-		panic(err)
-	}
+	utilruntime.Must(err)
 }
 
 type component struct{}
@@ -68,7 +67,7 @@ func (component) Config(ctx components.Context) ([]extensionsv1alpha1.Unit, []ex
 		return nil, nil, nil
 	}
 
-	updateLocalCaCertificatesScriptFile, err := getUpdateLocalCaCertificatesScriptFile()
+	updateLocalCaCertificatesScriptFile, err := updateLocalCACertificatesScriptFile()
 	if err != nil {
 		return nil, nil, err
 	}
@@ -126,7 +125,7 @@ WantedBy=multi-user.target`),
 		nil
 }
 
-func getUpdateLocalCaCertificatesScriptFile() (extensionsv1alpha1.File, error) {
+func updateLocalCACertificatesScriptFile() (extensionsv1alpha1.File, error) {
 	var script bytes.Buffer
 	if err := tplUpdateLocalCaCertificates.Execute(&script, map[string]interface{}{
 		"pathLocalSSLCerts": pathLocalSSLCerts,

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/rootcertificates/component.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/rootcertificates/component.go
@@ -15,14 +15,42 @@
 package rootcertificates
 
 import (
+	"bytes"
+	_ "embed"
+	"text/template"
+
+	"github.com/Masterminds/sprig"
+	"k8s.io/utils/pointer"
+
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/docker"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/kubelet"
 	"github.com/gardener/gardener/pkg/utils"
-
-	"k8s.io/utils/pointer"
 )
+
+const (
+	pathLocalSSLCerts             = "/var/lib/ca-certificates-local"
+	pathUpdateLocalCaCertificates = "/etc/ssl/update-local-ca-certificates.sh"
+)
+
+var (
+	tplNameUpdateLocalCaCertificates = "update-local-ca-certificates"
+	//go:embed templates/scripts/update-local-ca-certificates.tpl.sh
+	tplContentUpdateLocalCaCertificates string
+	tplUpdateLocalCaCertificates        *template.Template
+)
+
+func init() {
+	var err error
+	tplUpdateLocalCaCertificates, err = template.
+		New(tplNameUpdateLocalCaCertificates).
+		Funcs(sprig.TxtFuncMap()).
+		Parse(tplContentUpdateLocalCaCertificates)
+	if err != nil {
+		panic(err)
+	}
+}
 
 type component struct{}
 
@@ -40,7 +68,12 @@ func (component) Config(ctx components.Context) ([]extensionsv1alpha1.Unit, []ex
 		return nil, nil, nil
 	}
 
-	const pathEtcdSSLCerts = "/etc/ssl/certs"
+	updateLocalCaCertificatesScriptFile, err := getUpdateLocalCaCertificatesScriptFile()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	const pathEtcSSLCerts = "/etc/ssl/certs"
 	var caBundleBase64 = utils.EncodeBase64([]byte(*ctx.CABundle))
 
 	return []extensionsv1alpha1.Unit{
@@ -48,25 +81,28 @@ func (component) Config(ctx components.Context) ([]extensionsv1alpha1.Unit, []ex
 				Name:    "updatecacerts.service",
 				Command: pointer.String("start"),
 				Content: pointer.String(`[Unit]
-Description=Update CA bundle at ` + pathEtcdSSLCerts + `/ca-certificates.crt
+Description=Update local certificate authorities
 # Since other services depend on the certificate store run this early
 DefaultDependencies=no
 Wants=systemd-tmpfiles-setup.service clean-ca-certificates.service
 After=systemd-tmpfiles-setup.service clean-ca-certificates.service
 Before=sysinit.target ` + kubelet.UnitName + `
-ConditionPathIsReadWrite=` + pathEtcdSSLCerts + `
+ConditionPathIsReadWrite=` + pathEtcSSLCerts + `
+ConditionPathIsReadWrite=` + pathLocalSSLCerts + `
 ConditionPathExists=!` + kubelet.PathKubeconfigReal + `
 [Service]
 Type=oneshot
-ExecStart=/usr/sbin/update-ca-certificates --fresh
+ExecStart=` + pathUpdateLocalCaCertificates + `
 ExecStartPost=/bin/systemctl restart ` + docker.UnitName + `
 [Install]
 WantedBy=multi-user.target`),
 			},
 		},
 		[]extensionsv1alpha1.File{
+			updateLocalCaCertificatesScriptFile,
+			// This file contains Gardener CAs for Debian based OS
 			{
-				Path:        pathEtcdSSLCerts + "/ROOTcerts.pem",
+				Path:        pathLocalSSLCerts + "/ROOTcerts.crt",
 				Permissions: pointer.Int32(0644),
 				Content: extensionsv1alpha1.FileContent{
 					Inline: &extensionsv1alpha1.FileContentInline{
@@ -75,6 +111,7 @@ WantedBy=multi-user.target`),
 					},
 				},
 			},
+			// This file contains Gardener CAs for Redhat/SUSE OS
 			{
 				Path:        "/etc/pki/trust/anchors/ROOTcerts.pem",
 				Permissions: pointer.Int32(0644),
@@ -87,4 +124,24 @@ WantedBy=multi-user.target`),
 			},
 		},
 		nil
+}
+
+func getUpdateLocalCaCertificatesScriptFile() (extensionsv1alpha1.File, error) {
+	var script bytes.Buffer
+	if err := tplUpdateLocalCaCertificates.Execute(&script, map[string]interface{}{
+		"pathLocalSSLCerts": pathLocalSSLCerts,
+	}); err != nil {
+		return extensionsv1alpha1.File{}, err
+	}
+
+	return extensionsv1alpha1.File{
+		Path:        pathUpdateLocalCaCertificates,
+		Permissions: pointer.Int32(0744),
+		Content: extensionsv1alpha1.FileContent{
+			Inline: &extensionsv1alpha1.FileContentInline{
+				Encoding: "b64",
+				Data:     utils.EncodeBase64(script.Bytes()),
+			},
+		},
+	}, nil
 }

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/rootcertificates/templates/scripts/update-local-ca-certificates.tpl.sh
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/rootcertificates/templates/scripts/update-local-ca-certificates.tpl.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+if [[ -f "/etc/debian_version" ]]; then
+    # Copy certificates from default "localcertsdir" because /usr is mounted read-only in Garden Linux.
+    # See https://github.com/gardenlinux/gardenlinux/issues/1490
+    mkdir -p "{{ .pathLocalSSLCerts }}"
+    if [[ -d "/usr/local/share/ca-certificates" ]]; then
+        cp -af /usr/local/share/ca-certificates/* "{{ .pathLocalSSLCerts }}"
+    fi
+    # localcertsdir is supported on Debian based OS only
+    /usr/sbin/update-ca-certificates --fresh --localcertsdir "{{ .pathLocalSSLCerts }}"
+else
+    /usr/sbin/update-ca-certificates --fresh
+fi


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area os
/kind bug

**What this PR does / why we need it**:
On Debian based OS like gardenlinux Gardener CAs are not added to the CA bundle `/etc/ssl/certs/ca-certificates.crt`. 
The CAs are just copied to `/etc/ssl/certs` which prevents `update-ca-certificates` from adding them to the CA bundle.

The correct way on Debian based OS is to copy local CAs to `/usr/local/share/ca-certificates` and run `update-ca-certificates` afterwards.
However, in the Gardener context this does not work, because the widely used Garden Linux mounts the `/usr` directory read-only (see https://github.com/gardenlinux/gardenlinux-backlog/issues/44).
Thus, this PR puts Gardener CAs into `/var/lib/ca-certificates-local` and runs `update-ca-certificates` with the `--localcertsdir` argument. Beforehand, CAs from the default `/usr/local/share/ca-certificates` are copied into the new localcertsdir that we don't drop other local CAs.
 
On Redhat/SUSE OS it is sufficient to put the CAs into `/etc/pki/trust/anchors` as it is currently implemented. Here it is not needed to copy the CA into `/etc/ssl/certs`. Manually copied certificates are deleted by `update-ca-certificates` anyway. 

**Which issue(s) this PR fixes**:
Fixes #6847 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
On Debian-based operating systems, Gardener CAs are now added correctly to the CA bundle for shoot worker nodes.
```
