### PR TITLE
Adapt `kubeapiserver` component for "nodeless" scenario

### DIFF
--- a/pkg/operation/botanist/component/kubeapiserver/configmaps.go
+++ b/pkg/operation/botanist/component/kubeapiserver/configmaps.go
@@ -19,9 +19,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/gardener/gardener/pkg/operation/botanist/component/vpnseedserver"
-	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
-	secretutils "github.com/gardener/gardener/pkg/utils/secrets"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -29,6 +26,10 @@ import (
 	apiserverv1alpha1 "k8s.io/apiserver/pkg/apis/apiserver/v1alpha1"
 	auditv1 "k8s.io/apiserver/pkg/apis/audit/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/gardener/gardener/pkg/operation/botanist/component/vpnseedserver"
+	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
+	secretutils "github.com/gardener/gardener/pkg/utils/secrets"
 )
 
 const (
@@ -67,8 +68,8 @@ func (k *kubeAPIServer) reconcileConfigMapAdmission(ctx context.Context, configM
 	if err != nil {
 		return err
 	}
-	configMap.Data[configMapAdmissionDataKey] = string(data)
 
+	configMap.Data[configMapAdmissionDataKey] = string(data)
 	utilruntime.Must(kutil.MakeUnique(configMap))
 
 	return client.IgnoreAlreadyExists(k.client.Client().Create(ctx, configMap))
@@ -107,8 +108,6 @@ func (k *kubeAPIServer) reconcileConfigMapEgressSelector(ctx context.Context, co
 		return nil
 	}
 
-	egressSelectionControlPlaneName := "controlplane"
-
 	egressSelectorConfig := &apiserverv1alpha1.EgressSelectorConfiguration{
 		EgressSelections: []apiserverv1alpha1.EgressSelection{
 			{
@@ -128,7 +127,7 @@ func (k *kubeAPIServer) reconcileConfigMapEgressSelector(ctx context.Context, co
 				},
 			},
 			{
-				Name:       egressSelectionControlPlaneName,
+				Name:       "controlplane",
 				Connection: apiserverv1alpha1.Connection{ProxyProtocol: apiserverv1alpha1.ProtocolDirect},
 			},
 			{

--- a/pkg/operation/botanist/component/kubeapiserver/configmaps.go
+++ b/pkg/operation/botanist/component/kubeapiserver/configmaps.go
@@ -102,8 +102,8 @@ func (k *kubeAPIServer) reconcileConfigMapAuditPolicy(ctx context.Context, confi
 }
 
 func (k *kubeAPIServer) reconcileConfigMapEgressSelector(ctx context.Context, configMap *corev1.ConfigMap) error {
-	if k.values.VPN.HighAvailabilityEnabled {
-		// We don't delete the confimap here as we don't know its name (as it's unique). Instead, we rely on the usual
+	if !k.values.VPN.Enabled || k.values.VPN.HighAvailabilityEnabled {
+		// We don't delete the configmap here as we don't know its name (as it's unique). Instead, we rely on the usual
 		// garbage collection for unique secrets/configmaps.
 		return nil
 	}

--- a/pkg/operation/botanist/component/kubeapiserver/deployment.go
+++ b/pkg/operation/botanist/component/kubeapiserver/deployment.go
@@ -42,12 +42,11 @@ import (
 )
 
 const (
-	secretNameHAVPNSeedClient = "vpn-seed-client"
-
 	secretNameServer                 = "kube-apiserver"
 	secretNameKubeAPIServerToKubelet = "kube-apiserver-kubelet"
 	secretNameKubeAggregator         = "kube-aggregator"
 	secretNameHTTPProxy              = "kube-apiserver-http-proxy"
+	secretNameHAVPNSeedClient        = "vpn-seed-client"
 
 	// ContainerNameKubeAPIServer is the name of the kube-apiserver container.
 	ContainerNameKubeAPIServer            = "kube-apiserver"

--- a/pkg/operation/botanist/component/kubeapiserver/deployment.go
+++ b/pkg/operation/botanist/component/kubeapiserver/deployment.go
@@ -561,7 +561,7 @@ func (k *kubeAPIServer) computeKubeAPIServerCommand() []string {
 		out = append(out, fmt.Sprintf("--service-account-max-token-expiration=%s", k.values.ServiceAccount.MaxTokenExpiration.Duration))
 	}
 
-	out = append(out, fmt.Sprintf("--service-cluster-ip-range=%s", k.values.VPN.ServiceNetworkCIDR))
+	out = append(out, fmt.Sprintf("--service-cluster-ip-range=%s", k.values.ServiceNetworkCIDR))
 	out = append(out, fmt.Sprintf("--secure-port=%d", Port))
 	out = append(out, fmt.Sprintf("--token-auth-file=%s/%s", volumeMountPathStaticToken, secrets.DataKeyStaticTokenCSV))
 	out = append(out, fmt.Sprintf("--tls-cert-file=%s/%s", volumeMountPathServer, secrets.DataKeyCertificate))
@@ -938,7 +938,7 @@ func (k *kubeAPIServer) vpnSeedClientContainer(index int) *corev1.Container {
 			},
 			{
 				Name:  "SERVICE_NETWORK",
-				Value: k.values.VPN.ServiceNetworkCIDR,
+				Value: k.values.ServiceNetworkCIDR,
 			},
 			{
 				Name:  "POD_NETWORK",
@@ -1012,7 +1012,7 @@ func (k *kubeAPIServer) vpnSeedPathControllerContainer() *corev1.Container {
 		Env: []corev1.EnvVar{
 			{
 				Name:  "SERVICE_NETWORK",
-				Value: k.values.VPN.ServiceNetworkCIDR,
+				Value: k.values.ServiceNetworkCIDR,
 			},
 			{
 				Name:  "POD_NETWORK",

--- a/pkg/operation/botanist/component/kubeapiserver/kube_apiserver.go
+++ b/pkg/operation/botanist/component/kubeapiserver/kube_apiserver.go
@@ -218,6 +218,8 @@ type Images struct {
 
 // VPNConfig contains information for configuring the VPN settings for the kube-apiserver.
 type VPNConfig struct {
+	// Enabled states whether VPN is enabled.
+	Enabled bool
 	// PodNetworkCIDR is the CIDR of the pod network.
 	PodNetworkCIDR string
 	// NodeNetworkCIDR is the CIDR of the node network.
@@ -389,7 +391,7 @@ func (k *kubeAPIServer) Deploy(ctx context.Context) error {
 		return err
 	}
 
-	if k.values.VPN.HighAvailabilityEnabled {
+	if k.values.VPN.Enabled && k.values.VPN.HighAvailabilityEnabled {
 		if err := k.reconcileServiceAccount(ctx); err != nil {
 			return err
 		}

--- a/pkg/operation/botanist/component/kubeapiserver/kube_apiserver.go
+++ b/pkg/operation/botanist/component/kubeapiserver/kube_apiserver.go
@@ -142,6 +142,8 @@ type Values struct {
 	FeatureGates map[string]bool
 	// Images is a set of container images used for the containers of the kube-apiserver pods.
 	Images Images
+	// IsNodeless specifies whether the cluster managed by this API server has worker nodes.
+	IsNodeless bool
 	// Logging contains configuration settings for the log and access logging verbosity
 	Logging *gardencorev1beta1.KubeAPIServerLogging
 	// OIDC contains information for configuring OIDC settings for the kube-apiserver.

--- a/pkg/operation/botanist/component/kubeapiserver/kube_apiserver.go
+++ b/pkg/operation/botanist/component/kubeapiserver/kube_apiserver.go
@@ -156,6 +156,8 @@ type Values struct {
 	ServerCertificate ServerCertificateConfig
 	// ServiceAccount contains information for configuring ServiceAccount settings for the kube-apiserver.
 	ServiceAccount ServiceAccountConfig
+	// ServiceNetworkCIDR is the CIDR of the service network.
+	ServiceNetworkCIDR string
 	// SNI contains information for configuring SNI settings for the kube-apiserver.
 	SNI SNIConfig
 	// StaticTokenKubeconfigEnabled indicates whether static token kubeconfig secret will be created for shoot.
@@ -218,8 +220,6 @@ type Images struct {
 type VPNConfig struct {
 	// PodNetworkCIDR is the CIDR of the pod network.
 	PodNetworkCIDR string
-	// ServiceNetworkCIDR is the CIDR of the service network.
-	ServiceNetworkCIDR string
 	// NodeNetworkCIDR is the CIDR of the node network.
 	NodeNetworkCIDR *string
 	// HighAvailabilityEnabled states if VPN uses HA configuration.

--- a/pkg/operation/botanist/component/kubeapiserver/kube_apiserver_test.go
+++ b/pkg/operation/botanist/component/kubeapiserver/kube_apiserver_test.go
@@ -1565,13 +1565,13 @@ rules:
 
 			It("should have one init container and three vpn-seed-client sidecar containers when vpn high availability are enabled", func() {
 				values := Values{
-					Images: Images{VPNClient: "vpn-client-image:really-latest"},
+					Images:             Images{VPNClient: "vpn-client-image:really-latest"},
+					ServiceNetworkCIDR: "4.5.6.0/24",
 					VPN: VPNConfig{
 						HighAvailabilityEnabled:              true,
 						HighAvailabilityNumberOfSeedServers:  2,
 						HighAvailabilityNumberOfShootClients: 3,
 						PodNetworkCIDR:                       "1.2.3.0/24",
-						ServiceNetworkCIDR:                   "4.5.6.0/24",
 						NodeNetworkCIDR:                      pointer.String("7.8.9.0/24"),
 					},
 					RuntimeVersion: runtimeVersion,
@@ -1592,7 +1592,7 @@ rules:
 							},
 							{
 								Name:  "SERVICE_NETWORK",
-								Value: values.VPN.ServiceNetworkCIDR,
+								Value: values.ServiceNetworkCIDR,
 							},
 							{
 								Name:  "POD_NETWORK",
@@ -1703,7 +1703,7 @@ rules:
 					Env: []corev1.EnvVar{
 						{
 							Name:  "SERVICE_NETWORK",
-							Value: values.VPN.ServiceNetworkCIDR,
+							Value: values.ServiceNetworkCIDR,
 						},
 						{
 							Name:  "POD_NETWORK",
@@ -1885,9 +1885,10 @@ rules:
 							MaxTokenExpiration:    &metav1.Duration{Duration: serviceAccountMaxTokenExpiration},
 							ExtendTokenExpiration: &serviceAccountExtendTokenExpiration,
 						},
-						RuntimeVersion: runtimeVersion,
-						Version:        version,
-						VPN:            VPNConfig{ServiceNetworkCIDR: serviceNetworkCIDR},
+						RuntimeVersion:     runtimeVersion,
+						ServiceNetworkCIDR: serviceNetworkCIDR,
+						Version:            version,
+						VPN:                VPNConfig{},
 					})
 					deployAndRead()
 
@@ -2691,13 +2692,13 @@ rules:
 			Context("HA VPN role", func() {
 				It("should not deploy role, rolebinding and service account w/o HA VPN", func() {
 					values := Values{
-						Images: Images{VPNClient: "vpn-client-image:really-latest"},
+						Images:             Images{VPNClient: "vpn-client-image:really-latest"},
+						ServiceNetworkCIDR: "4.5.6.0/24",
 						VPN: VPNConfig{
 							HighAvailabilityEnabled:              false,
 							HighAvailabilityNumberOfSeedServers:  2,
 							HighAvailabilityNumberOfShootClients: 3,
 							PodNetworkCIDR:                       "1.2.3.0/24",
-							ServiceNetworkCIDR:                   "4.5.6.0/24",
 							NodeNetworkCIDR:                      pointer.String("7.8.9.0/24"),
 						},
 						RuntimeVersion: runtimeVersion,
@@ -2714,13 +2715,13 @@ rules:
 
 				It("should successfully deploy and destroy the role, rolebinding and service account w/ HA VPN", func() {
 					values := Values{
-						Images: Images{VPNClient: "vpn-client-image:really-latest"},
+						Images:             Images{VPNClient: "vpn-client-image:really-latest"},
+						ServiceNetworkCIDR: "4.5.6.0/24",
 						VPN: VPNConfig{
 							HighAvailabilityEnabled:              true,
 							HighAvailabilityNumberOfSeedServers:  2,
 							HighAvailabilityNumberOfShootClients: 3,
 							PodNetworkCIDR:                       "1.2.3.0/24",
-							ServiceNetworkCIDR:                   "4.5.6.0/24",
 							NodeNetworkCIDR:                      pointer.String("7.8.9.0/24"),
 						},
 						RuntimeVersion: runtimeVersion,

--- a/pkg/operation/botanist/component/kubeapiserver/kube_apiserver_test.go
+++ b/pkg/operation/botanist/component/kubeapiserver/kube_apiserver_test.go
@@ -55,6 +55,7 @@ import (
 	fakekubernetes "github.com/gardener/gardener/pkg/client/kubernetes/fake"
 	. "github.com/gardener/gardener/pkg/operation/botanist/component/kubeapiserver"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/vpnseedserver"
+	"github.com/gardener/gardener/pkg/utils"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 	secretutils "github.com/gardener/gardener/pkg/utils/secrets"
 	secretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager"
@@ -103,6 +104,7 @@ var _ = Describe("KubeAPIServer", func() {
 		secretNameServiceAccountKey       = "service-account-key-c37a87f6"
 		secretNameServiceAccountKeyBundle = "service-account-key-bundle"
 		secretNameVPNSeedClient           = "vpn-seed-client"
+		secretNameVPNSeedServerTLSAuth    = "vpn-seed-server-tlsauth-a1d0aa00"
 
 		secretNameAdmissionConfig      = "kube-apiserver-admission-config-e38ff146"
 		secretNameETCDEncryptionConfig = "kube-apiserver-etcd-encryption-configuration-235f7353"
@@ -138,9 +140,10 @@ var _ = Describe("KubeAPIServer", func() {
 
 	JustBeforeEach(func() {
 		values = Values{
+			Autoscaling:    autoscalingConfig,
 			RuntimeVersion: runtimeVersion,
 			Version:        version,
-			Autoscaling:    autoscalingConfig,
+			VPN:            VPNConfig{Enabled: true},
 		}
 		kubernetesInterface = fakekubernetes.NewClientSetBuilder().WithAPIReader(c).WithClient(c).Build()
 		kapi = New(kubernetesInterface, namespace, sm, values)
@@ -870,17 +873,21 @@ var _ = Describe("KubeAPIServer", func() {
 				}))
 			})
 
-			Context("should successfully deploy the allow-kube-apiserver NetworkPolicy resource", func() {
-				var (
-					protocol             = corev1.ProtocolTCP
-					portAPIServer        = intstr.FromInt(443)
-					portBlackboxExporter = intstr.FromInt(9115)
-					portEtcd             = intstr.FromInt(2379)
-					portVPNSeedServer    = intstr.FromInt(9443)
-				)
+			var (
+				protocol             = corev1.ProtocolTCP
+				portAPIServer        = intstr.FromInt(443)
+				portBlackboxExporter = intstr.FromInt(9115)
+				portEtcd             = intstr.FromInt(2379)
+				portVPNSeedServer    = intstr.FromInt(9443)
+			)
 
-				It("w/ ReversedVPN", func() {
-					kapi = New(kubernetesInterface, namespace, sm, Values{RuntimeVersion: runtimeVersion, Version: version})
+			Context("allow-kube-apiserver NetworkPolicy resource", func() {
+				It("should successfully deploy when VPN is enabled", func() {
+					kapi = New(kubernetesInterface, namespace, sm, Values{
+						RuntimeVersion: runtimeVersion,
+						Version:        version,
+						VPN:            VPNConfig{Enabled: true},
+					})
 
 					Expect(c.Get(ctx, client.ObjectKeyFromObject(networkPolicyAllowKubeAPIServer), networkPolicyAllowKubeAPIServer)).To(MatchError(apierrors.NewNotFound(schema.GroupResource{Group: networkingv1.SchemeGroupVersion.Group, Resource: "networkpolicies"}, networkPolicyAllowKubeAPIServer.Name)))
 					Expect(kapi.Deploy(ctx)).To(Succeed())
@@ -935,6 +942,93 @@ var _ = Describe("KubeAPIServer", func() {
 									Ports: []networkingv1.NetworkPolicyPort{{
 										Protocol: &protocol,
 										Port:     &portVPNSeedServer,
+									}},
+								},
+							},
+							Ingress: []networkingv1.NetworkPolicyIngressRule{
+								{
+									From: []networkingv1.NetworkPolicyPeer{
+										{PodSelector: &metav1.LabelSelector{}, NamespaceSelector: &metav1.LabelSelector{}},
+										{IPBlock: &networkingv1.IPBlock{CIDR: "0.0.0.0/0"}},
+									},
+									Ports: []networkingv1.NetworkPolicyPort{{
+										Protocol: &protocol,
+										Port:     &portAPIServer,
+									}},
+								},
+								{
+									From: []networkingv1.NetworkPolicyPeer{{
+										PodSelector: &metav1.LabelSelector{
+											MatchLabels: map[string]string{
+												"gardener.cloud/role": "monitoring",
+												"app":                 "prometheus",
+												"role":                "monitoring",
+											},
+										},
+									}},
+									Ports: []networkingv1.NetworkPolicyPort{
+										{
+											Protocol: &protocol,
+											Port:     &portBlackboxExporter,
+										},
+										{
+											Protocol: &protocol,
+											Port:     &portAPIServer,
+										},
+									},
+								},
+							},
+							PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress, networkingv1.PolicyTypeEgress},
+						},
+					}))
+				})
+
+				It("should successfully deploy when VPN is disabled", func() {
+					kapi = New(kubernetesInterface, namespace, sm, Values{
+						RuntimeVersion: runtimeVersion,
+						Version:        version,
+						VPN:            VPNConfig{Enabled: false},
+					})
+
+					Expect(c.Get(ctx, client.ObjectKeyFromObject(networkPolicyAllowKubeAPIServer), networkPolicyAllowKubeAPIServer)).To(MatchError(apierrors.NewNotFound(schema.GroupResource{Group: networkingv1.SchemeGroupVersion.Group, Resource: "networkpolicies"}, networkPolicyAllowKubeAPIServer.Name)))
+					Expect(kapi.Deploy(ctx)).To(Succeed())
+					Expect(c.Get(ctx, client.ObjectKeyFromObject(networkPolicyAllowKubeAPIServer), networkPolicyAllowKubeAPIServer)).To(Succeed())
+					Expect(networkPolicyAllowKubeAPIServer).To(DeepEqual(&networkingv1.NetworkPolicy{
+						TypeMeta: metav1.TypeMeta{
+							APIVersion: networkingv1.SchemeGroupVersion.String(),
+							Kind:       "NetworkPolicy",
+						},
+						ObjectMeta: metav1.ObjectMeta{
+							Name:            networkPolicyAllowKubeAPIServer.Name,
+							Namespace:       networkPolicyAllowKubeAPIServer.Namespace,
+							ResourceVersion: "1",
+							Annotations: map[string]string{
+								"gardener.cloud/description": "Allows Ingress to the Shoot's Kubernetes API Server from " +
+									"pods labeled with 'networking.gardener.cloud/to-shoot-apiserver=allowed' and " +
+									"Prometheus, and Egress to etcd pods.",
+							},
+						},
+						Spec: networkingv1.NetworkPolicySpec{
+							PodSelector: metav1.LabelSelector{
+								MatchLabels: map[string]string{
+									"app":                 "kubernetes",
+									"gardener.cloud/role": "controlplane",
+									"role":                "apiserver",
+								},
+							},
+							Egress: []networkingv1.NetworkPolicyEgressRule{
+								{
+									To: []networkingv1.NetworkPolicyPeer{{
+										PodSelector: &metav1.LabelSelector{
+											MatchLabels: map[string]string{
+												"app":                 "etcd-statefulset",
+												"gardener.cloud/role": "controlplane",
+											},
+										},
+									}},
+									Ports: []networkingv1.NetworkPolicyPort{{
+										Protocol: &protocol,
+										Port:     &portEtcd,
 									}},
 								},
 							},
@@ -1396,9 +1490,12 @@ rules:
 			})
 
 			Context("egress selector", func() {
-
 				It("should successfully deploy the configmap resource for K8s >= 1.20", func() {
-					kapi = New(kubernetesInterface, namespace, sm, Values{RuntimeVersion: runtimeVersion, Version: version})
+					kapi = New(kubernetesInterface, namespace, sm, Values{
+						RuntimeVersion: runtimeVersion,
+						Version:        version,
+						VPN:            VPNConfig{Enabled: true},
+					})
 
 					configMapEgressSelector = &corev1.ConfigMap{
 						ObjectMeta: metav1.ObjectMeta{Name: "kube-apiserver-egress-selector-config", Namespace: namespace},
@@ -1424,6 +1521,31 @@ rules:
 						Data:      configMapEgressSelector.Data,
 					}))
 				})
+
+				DescribeTable("do nothing",
+					func(vpnConfig VPNConfig) {
+						kapi = New(kubernetesInterface, namespace, sm, Values{
+							Version: version,
+							VPN:     vpnConfig,
+						})
+
+						var found bool
+
+						configMapList := &corev1.ConfigMapList{}
+						Expect(c.List(ctx, configMapList, client.InNamespace(namespace))).To(Succeed())
+						for _, configMap := range configMapList.Items {
+							if strings.HasPrefix(configMap.Name, "kube-apiserver-egress-selector-config") {
+								found = true
+								break
+							}
+						}
+
+						Expect(found).To(BeFalse())
+					},
+
+					Entry("VPN is disabled", VPNConfig{Enabled: false}),
+					Entry("VPN is enabled but HA is disabled", VPNConfig{Enabled: true, HighAvailabilityEnabled: false}),
+				)
 			})
 		})
 
@@ -1446,7 +1568,11 @@ rules:
 			})
 
 			It("should have the expected labels w/ SNI", func() {
-				kapi = New(kubernetesInterface, namespace, sm, Values{SNI: SNIConfig{Enabled: true}, RuntimeVersion: runtimeVersion, Version: version})
+				kapi = New(kubernetesInterface, namespace, sm, Values{
+					SNI:            SNIConfig{Enabled: true},
+					RuntimeVersion: runtimeVersion,
+					Version:        version,
+				})
 				deployAndRead()
 
 				Expect(deployment.Labels).To(Equal(map[string]string{
@@ -1458,29 +1584,70 @@ rules:
 				}))
 			})
 
-			It("should have the expected annotations", func() {
-				deployAndRead()
+			Context("expected annotations", func() {
+				var defaultAnnotations map[string]string
 
-				Expect(deployment.Annotations).To(Equal(map[string]string{
-					"reference.resources.gardener.cloud/secret-0acc967c":    secretNameHTTPProxy,
-					"reference.resources.gardener.cloud/secret-8ddd8e24":    secretNameCAVPN,
-					"reference.resources.gardener.cloud/secret-a92da147":    secretNameCAFrontProxy,
-					"reference.resources.gardener.cloud/secret-a709ce3a":    secretNameServiceAccountKey,
-					"reference.resources.gardener.cloud/secret-ad29e1cc":    secretNameServiceAccountKeyBundle,
-					"reference.resources.gardener.cloud/configmap-f79954be": configMapNameEgressPolicy,
-					"reference.resources.gardener.cloud/secret-69590970":    secretNameCA,
-					"reference.resources.gardener.cloud/secret-17c26aa4":    secretNameCAClient,
-					"reference.resources.gardener.cloud/secret-e01f5645":    secretNameCAEtcd,
-					"reference.resources.gardener.cloud/secret-77bc5458":    secretNameCAKubelet,
-					"reference.resources.gardener.cloud/secret-389fbba5":    secretNameEtcd,
-					"reference.resources.gardener.cloud/secret-c1267cc2":    secretNameKubeAPIServerToKubelet,
-					"reference.resources.gardener.cloud/secret-998b2966":    secretNameKubeAggregator,
-					"reference.resources.gardener.cloud/secret-3ddd1800":    secretNameServer,
-					"reference.resources.gardener.cloud/secret-430944e0":    secretNameStaticToken,
-					"reference.resources.gardener.cloud/secret-b1b53288":    secretNameETCDEncryptionConfig,
-					"reference.resources.gardener.cloud/configmap-130aa219": secretNameAdmissionConfig,
-					"reference.resources.gardener.cloud/configmap-d4419cd4": configMapNameAuditPolicy,
-				}))
+				BeforeEach(func() {
+					defaultAnnotations = map[string]string{
+						"reference.resources.gardener.cloud/secret-a92da147":    secretNameCAFrontProxy,
+						"reference.resources.gardener.cloud/secret-a709ce3a":    secretNameServiceAccountKey,
+						"reference.resources.gardener.cloud/secret-ad29e1cc":    secretNameServiceAccountKeyBundle,
+						"reference.resources.gardener.cloud/secret-69590970":    secretNameCA,
+						"reference.resources.gardener.cloud/secret-17c26aa4":    secretNameCAClient,
+						"reference.resources.gardener.cloud/secret-e01f5645":    secretNameCAEtcd,
+						"reference.resources.gardener.cloud/secret-77bc5458":    secretNameCAKubelet,
+						"reference.resources.gardener.cloud/secret-389fbba5":    secretNameEtcd,
+						"reference.resources.gardener.cloud/secret-c1267cc2":    secretNameKubeAPIServerToKubelet,
+						"reference.resources.gardener.cloud/secret-998b2966":    secretNameKubeAggregator,
+						"reference.resources.gardener.cloud/secret-3ddd1800":    secretNameServer,
+						"reference.resources.gardener.cloud/secret-430944e0":    secretNameStaticToken,
+						"reference.resources.gardener.cloud/secret-b1b53288":    secretNameETCDEncryptionConfig,
+						"reference.resources.gardener.cloud/configmap-130aa219": secretNameAdmissionConfig,
+						"reference.resources.gardener.cloud/configmap-d4419cd4": configMapNameAuditPolicy,
+					}
+				})
+
+				It("should have the expected annotations when VPN is disabled", func() {
+					kapi = New(kubernetesInterface, namespace, sm, Values{
+						RuntimeVersion: runtimeVersion,
+						Version:        version,
+						VPN:            VPNConfig{Enabled: false},
+					})
+					deployAndRead()
+
+					Expect(deployment.Annotations).To(Equal(defaultAnnotations))
+				})
+
+				It("should have the expected annotations when VPN is enabled but HA is disabled", func() {
+					kapi = New(kubernetesInterface, namespace, sm, Values{
+						RuntimeVersion: runtimeVersion,
+						Version:        version,
+						VPN:            VPNConfig{Enabled: true, HighAvailabilityEnabled: false},
+					})
+					deployAndRead()
+
+					Expect(deployment.Annotations).To(Equal(utils.MergeStringMaps(defaultAnnotations, map[string]string{
+						"reference.resources.gardener.cloud/secret-0acc967c":    secretNameHTTPProxy,
+						"reference.resources.gardener.cloud/secret-8ddd8e24":    secretNameCAVPN,
+						"reference.resources.gardener.cloud/configmap-f79954be": configMapNameEgressPolicy,
+					})))
+				})
+
+				It("should have the expected annotations when VPN and HA is enabled", func() {
+					kapi = New(kubernetesInterface, namespace, sm, Values{
+						RuntimeVersion: runtimeVersion,
+						Version:        version,
+						VPN:            VPNConfig{Enabled: true, HighAvailabilityEnabled: true},
+					})
+					deployAndRead()
+
+					Expect(deployment.Annotations).To(Equal(utils.MergeStringMaps(defaultAnnotations, map[string]string{
+						"reference.resources.gardener.cloud/secret-8ddd8e24":    secretNameCAVPN,
+						"reference.resources.gardener.cloud/secret-a41fe9a3":    secretNameVPNSeedClient,
+						"reference.resources.gardener.cloud/secret-facfe649":    secretNameVPNSeedServerTLSAuth,
+						"reference.resources.gardener.cloud/configmap-a9a818ab": "kube-root-ca.crt",
+					})))
+				})
 			})
 
 			It("should have the expected deployment settings", func() {
@@ -1490,7 +1657,11 @@ rules:
 					intStrZero            = intstr.FromInt(0)
 				)
 
-				kapi = New(kubernetesInterface, namespace, sm, Values{Autoscaling: AutoscalingConfig{Replicas: &replicas}, RuntimeVersion: runtimeVersion, Version: version})
+				kapi = New(kubernetesInterface, namespace, sm, Values{
+					Autoscaling:    AutoscalingConfig{Replicas: &replicas},
+					RuntimeVersion: runtimeVersion,
+					Version:        version,
+				})
 				deployAndRead()
 
 				Expect(deployment.Spec.MinReadySeconds).To(Equal(int32(30)))
@@ -1509,30 +1680,9 @@ rules:
 				}))
 			})
 
-			It("should have the expected pod template metadata", func() {
-				kapi = New(kubernetesInterface, namespace, sm, Values{RuntimeVersion: runtimeVersion, Version: version})
+			It("should have the expected pod template labels", func() {
 				deployAndRead()
 
-				Expect(deployment.Spec.Template.Annotations).To(Equal(map[string]string{
-					"reference.resources.gardener.cloud/secret-a709ce3a":    secretNameServiceAccountKey,
-					"reference.resources.gardener.cloud/secret-ad29e1cc":    secretNameServiceAccountKeyBundle,
-					"reference.resources.gardener.cloud/secret-69590970":    secretNameCA,
-					"reference.resources.gardener.cloud/secret-17c26aa4":    secretNameCAClient,
-					"reference.resources.gardener.cloud/secret-e01f5645":    secretNameCAEtcd,
-					"reference.resources.gardener.cloud/secret-a92da147":    secretNameCAFrontProxy,
-					"reference.resources.gardener.cloud/secret-77bc5458":    secretNameCAKubelet,
-					"reference.resources.gardener.cloud/secret-389fbba5":    secretNameEtcd,
-					"reference.resources.gardener.cloud/secret-c1267cc2":    secretNameKubeAPIServerToKubelet,
-					"reference.resources.gardener.cloud/secret-998b2966":    secretNameKubeAggregator,
-					"reference.resources.gardener.cloud/secret-3ddd1800":    secretNameServer,
-					"reference.resources.gardener.cloud/secret-430944e0":    secretNameStaticToken,
-					"reference.resources.gardener.cloud/secret-b1b53288":    secretNameETCDEncryptionConfig,
-					"reference.resources.gardener.cloud/secret-0acc967c":    secretNameHTTPProxy,
-					"reference.resources.gardener.cloud/secret-8ddd8e24":    secretNameCAVPN,
-					"reference.resources.gardener.cloud/configmap-f79954be": configMapNameEgressPolicy,
-					"reference.resources.gardener.cloud/configmap-130aa219": secretNameAdmissionConfig,
-					"reference.resources.gardener.cloud/configmap-d4419cd4": configMapNameAuditPolicy,
-				}))
 				Expect(deployment.Spec.Template.Labels).To(Equal(map[string]string{
 					"gardener.cloud/role":              "controlplane",
 					"app":                              "kubernetes",
@@ -1542,6 +1692,72 @@ rules:
 					"networking.gardener.cloud/to-public-networks":  "allowed",
 					"networking.gardener.cloud/from-prometheus":     "allowed",
 				}))
+			})
+
+			Context("expected pod template annotations", func() {
+				var defaultAnnotations map[string]string
+
+				BeforeEach(func() {
+					defaultAnnotations = map[string]string{
+						"reference.resources.gardener.cloud/secret-a709ce3a":    secretNameServiceAccountKey,
+						"reference.resources.gardener.cloud/secret-ad29e1cc":    secretNameServiceAccountKeyBundle,
+						"reference.resources.gardener.cloud/secret-69590970":    secretNameCA,
+						"reference.resources.gardener.cloud/secret-17c26aa4":    secretNameCAClient,
+						"reference.resources.gardener.cloud/secret-e01f5645":    secretNameCAEtcd,
+						"reference.resources.gardener.cloud/secret-a92da147":    secretNameCAFrontProxy,
+						"reference.resources.gardener.cloud/secret-77bc5458":    secretNameCAKubelet,
+						"reference.resources.gardener.cloud/secret-389fbba5":    secretNameEtcd,
+						"reference.resources.gardener.cloud/secret-c1267cc2":    secretNameKubeAPIServerToKubelet,
+						"reference.resources.gardener.cloud/secret-998b2966":    secretNameKubeAggregator,
+						"reference.resources.gardener.cloud/secret-3ddd1800":    secretNameServer,
+						"reference.resources.gardener.cloud/secret-430944e0":    secretNameStaticToken,
+						"reference.resources.gardener.cloud/secret-b1b53288":    secretNameETCDEncryptionConfig,
+						"reference.resources.gardener.cloud/configmap-130aa219": secretNameAdmissionConfig,
+						"reference.resources.gardener.cloud/configmap-d4419cd4": configMapNameAuditPolicy,
+					}
+				})
+
+				It("should have the expected annotations when VPN is disabled", func() {
+					kapi = New(kubernetesInterface, namespace, sm, Values{
+						RuntimeVersion: runtimeVersion,
+						Version:        version,
+						VPN:            VPNConfig{Enabled: false},
+					})
+					deployAndRead()
+
+					Expect(deployment.Spec.Template.Annotations).To(Equal(defaultAnnotations))
+				})
+
+				It("should have the expected annotations when VPN is enabled but HA is disabled", func() {
+					kapi = New(kubernetesInterface, namespace, sm, Values{
+						RuntimeVersion: runtimeVersion,
+						Version:        version,
+						VPN:            VPNConfig{Enabled: true, HighAvailabilityEnabled: false},
+					})
+					deployAndRead()
+
+					Expect(deployment.Spec.Template.Annotations).To(Equal(utils.MergeStringMaps(defaultAnnotations, map[string]string{
+						"reference.resources.gardener.cloud/secret-0acc967c":    secretNameHTTPProxy,
+						"reference.resources.gardener.cloud/secret-8ddd8e24":    secretNameCAVPN,
+						"reference.resources.gardener.cloud/configmap-f79954be": configMapNameEgressPolicy,
+					})))
+				})
+
+				It("should have the expected annotations when VPN and HA is enabled", func() {
+					kapi = New(kubernetesInterface, namespace, sm, Values{
+						RuntimeVersion: runtimeVersion,
+						Version:        version,
+						VPN:            VPNConfig{Enabled: true, HighAvailabilityEnabled: true},
+					})
+					deployAndRead()
+
+					Expect(deployment.Spec.Template.Annotations).To(Equal(utils.MergeStringMaps(defaultAnnotations, map[string]string{
+						"reference.resources.gardener.cloud/secret-8ddd8e24":    secretNameCAVPN,
+						"reference.resources.gardener.cloud/secret-a41fe9a3":    secretNameVPNSeedClient,
+						"reference.resources.gardener.cloud/secret-facfe649":    secretNameVPNSeedServerTLSAuth,
+						"reference.resources.gardener.cloud/configmap-a9a818ab": "kube-root-ca.crt",
+					})))
+				})
 			})
 
 			It("should have the expected pod settings", func() {
@@ -1563,11 +1779,12 @@ rules:
 				Expect(deployment.Spec.Template.Spec.InitContainers).To(BeEmpty())
 			})
 
-			It("should have one init container and three vpn-seed-client sidecar containers when vpn high availability are enabled", func() {
+			It("should have one init container and three vpn-seed-client sidecar containers when VPN high availability are enabled", func() {
 				values := Values{
 					Images:             Images{VPNClient: "vpn-client-image:really-latest"},
 					ServiceNetworkCIDR: "4.5.6.0/24",
 					VPN: VPNConfig{
+						Enabled:                              true,
 						HighAvailabilityEnabled:              true,
 						HighAvailabilityNumberOfSeedServers:  2,
 						HighAvailabilityNumberOfShootClients: 3,
@@ -1783,7 +2000,7 @@ rules:
 					corev1.Volume{
 						Name: "vpn-seed-tlsauth",
 						VolumeSource: corev1.VolumeSource{
-							Secret: &corev1.SecretVolumeSource{SecretName: "vpn-seed-server-tlsauth-a1d0aa00"},
+							Secret: &corev1.SecretVolumeSource{SecretName: secretNameVPNSeedServerTLSAuth},
 						},
 					},
 					corev1.Volume{
@@ -1844,32 +2061,31 @@ rules:
 			})
 
 			Context("kube-apiserver container", func() {
-				images := Images{KubeAPIServer: "some-kapi-image:latest"}
+				var (
+					acceptedIssuers    = []string{"issuer1", "issuer2"}
+					admissionPlugin1   = "foo"
+					admissionPlugin2   = "foo"
+					admissionPlugins   = []gardencorev1beta1.AdmissionPlugin{{Name: admissionPlugin1}, {Name: admissionPlugin2}}
+					apiServerResources = corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("1"),
+							corev1.ResourceMemory: resource.MustParse("2Gi"),
+						},
+						Limits: corev1.ResourceList{
+							corev1.ResourceMemory: resource.MustParse("4Gi"),
+						},
+					}
+					eventTTL                            = 2 * time.Hour
+					externalHostname                    = "api.foo.bar.com"
+					images                              = Images{KubeAPIServer: "some-kapi-image:latest"}
+					serviceAccountIssuer                = "issuer"
+					serviceAccountMaxTokenExpiration    = time.Hour
+					serviceAccountExtendTokenExpiration = false
+					serviceNetworkCIDR                  = "1.2.3.4/5"
+				)
 
-				It("should have the kube-apiserver container with the expected spec", func() {
-					var (
-						apiServerResources = corev1.ResourceRequirements{
-							Requests: corev1.ResourceList{
-								corev1.ResourceCPU:    resource.MustParse("1"),
-								corev1.ResourceMemory: resource.MustParse("2Gi"),
-							},
-							Limits: corev1.ResourceList{
-								corev1.ResourceMemory: resource.MustParse("4Gi"),
-							},
-						}
-						admissionPlugin1                    = "foo"
-						admissionPlugin2                    = "foo"
-						admissionPlugins                    = []gardencorev1beta1.AdmissionPlugin{{Name: admissionPlugin1}, {Name: admissionPlugin2}}
-						eventTTL                            = 2 * time.Hour
-						externalHostname                    = "api.foo.bar.com"
-						serviceAccountIssuer                = "issuer"
-						acceptedIssuers                     = []string{"issuer1", "issuer2"}
-						serviceAccountMaxTokenExpiration    = time.Hour
-						serviceAccountExtendTokenExpiration = false
-						serviceNetworkCIDR                  = "1.2.3.4/5"
-					)
-
-					kapi = New(kubernetesInterface, namespace, sm, Values{
+				JustBeforeEach(func() {
+					values = Values{
 						EnabledAdmissionPlugins: admissionPlugins,
 						Autoscaling:             AutoscalingConfig{APIServerResources: apiServerResources},
 						EventTTL:                &metav1.Duration{Duration: eventTTL},
@@ -1889,7 +2105,11 @@ rules:
 						ServiceNetworkCIDR: serviceNetworkCIDR,
 						Version:            version,
 						VPN:                VPNConfig{},
-					})
+					}
+					kapi = New(kubernetesInterface, namespace, sm, values)
+				})
+
+				It("should have the kube-apiserver container with the expected spec", func() {
 					deployAndRead()
 
 					issuerIdx := indexOfElement(deployment.Spec.Template.Spec.Containers[0].Command, "--service-account-issuer="+serviceAccountIssuer)
@@ -1953,7 +2173,6 @@ rules:
 						"--tls-cipher-suites="+strings.Join(tlscipherSuites, ","),
 						"--vmodule=httplog=3",
 						"--v=3",
-						"--egress-selector-config-file=/etc/kubernetes/egress/egress-selector-configuration.yaml",
 					))
 					Expect(issuerIdx).To(BeNumerically(">=", 0))
 					Expect(issuerIdx).To(BeNumerically("<", issuerIdx1))
@@ -2047,21 +2266,6 @@ rules:
 							Name:      "usr-share-cacerts",
 							MountPath: "/usr/share/ca-certificates",
 							ReadOnly:  true,
-						},
-						corev1.VolumeMount{
-							Name:      "ca-vpn",
-							MountPath: "/srv/kubernetes/ca-vpn",
-							ReadOnly:  false,
-						},
-						corev1.VolumeMount{
-							Name:      "http-proxy",
-							MountPath: "/etc/srv/kubernetes/envoy",
-							ReadOnly:  false,
-						},
-						corev1.VolumeMount{
-							Name:      "egress-selection-config",
-							MountPath: "/etc/kubernetes/egress",
-							ReadOnly:  false,
 						},
 					))
 					Expect(deployment.Spec.Template.Spec.Volumes).To(ConsistOf(
@@ -2225,16 +2429,58 @@ rules:
 								},
 							},
 						},
-
-						// VPN-related secrets (will be asserted in detail later)
-						MatchFields(IgnoreExtras, Fields{"Name": Equal("ca-vpn")}),
-						MatchFields(IgnoreExtras, Fields{"Name": Equal("http-proxy")}),
-						MatchFields(IgnoreExtras, Fields{"Name": Equal("egress-selection-config")}),
 					))
 
 					secret := &corev1.Secret{}
 					Expect(c.Get(ctx, kutil.Key(namespace, secretNameStaticToken), secret)).To(Succeed())
 					Expect(secret.Data).To(HaveKey("static_tokens.csv"))
+				})
+
+				It("should have the kube-apiserver container with the expected spec when VPN is enabled but HA is disabled", func() {
+					values.VPN = VPNConfig{Enabled: true, HighAvailabilityEnabled: false}
+					kapi = New(kubernetesInterface, namespace, sm, values)
+					deployAndRead()
+
+					Expect(deployment.Spec.Template.Spec.Containers[0].Command).To(ContainElement(
+						"--egress-selector-config-file=/etc/kubernetes/egress/egress-selector-configuration.yaml",
+					))
+					Expect(deployment.Spec.Template.Spec.Containers[0].VolumeMounts).To(ContainElements(
+						corev1.VolumeMount{
+							Name:      "ca-vpn",
+							MountPath: "/srv/kubernetes/ca-vpn",
+							ReadOnly:  false,
+						},
+						corev1.VolumeMount{
+							Name:      "http-proxy",
+							MountPath: "/etc/srv/kubernetes/envoy",
+							ReadOnly:  false,
+						},
+						corev1.VolumeMount{
+							Name:      "egress-selection-config",
+							MountPath: "/etc/kubernetes/egress",
+							ReadOnly:  false,
+						},
+					))
+					Expect(deployment.Spec.Template.Spec.Volumes).To(ContainElements(
+						// VPN-related secrets (will be asserted in detail later)
+						MatchFields(IgnoreExtras, Fields{"Name": Equal("ca-vpn")}),
+						MatchFields(IgnoreExtras, Fields{"Name": Equal("http-proxy")}),
+						MatchFields(IgnoreExtras, Fields{"Name": Equal("egress-selection-config")}),
+					))
+				})
+
+				It("should have the kube-apiserver container with the expected spec when VPN and HA is enabled", func() {
+					values.VPN = VPNConfig{Enabled: true, HighAvailabilityEnabled: true}
+					kapi = New(kubernetesInterface, namespace, sm, values)
+					deployAndRead()
+
+					Expect(deployment.Spec.Template.Spec.Volumes).To(ContainElements(
+						// VPN-related secrets (will be asserted in detail later)
+						MatchFields(IgnoreExtras, Fields{"Name": Equal("vpn-seed-client")}),
+						MatchFields(IgnoreExtras, Fields{"Name": Equal("vpn-seed-tlsauth")}),
+						MatchFields(IgnoreExtras, Fields{"Name": Equal("dev-net-tun")}),
+						MatchFields(IgnoreExtras, Fields{"Name": Equal("kube-api-access-gardener")}),
+					))
 				})
 
 				It("should generate a kubeconfig secret for the user when StaticTokenKubeconfigEnabled is set to true", func() {
@@ -2461,7 +2707,7 @@ rules:
 						HTTPAccessVerbosity: pointer.Int32(3),
 					}
 
-					kapi = New(kubernetesInterface, namespace, sm, Values{Logging: logging, Images: images, RuntimeVersion: runtimeVersion, Version: version})
+					kapi = New(kubernetesInterface, namespace, sm, Values{Logging: logging, RuntimeVersion: runtimeVersion, Version: version})
 					deployAndRead()
 
 					Expect(deployment.Spec.Template.Spec.Containers[0].Command).To(ContainElements(
@@ -2471,6 +2717,7 @@ rules:
 				})
 
 				It("should not configure the KubeAPISeverLogging settings if not provided", func() {
+					kapi = New(kubernetesInterface, namespace, sm, Values{RuntimeVersion: runtimeVersion, Version: version})
 					deployAndRead()
 
 					Expect(deployment.Spec.Template.Spec.Containers[0].Command).NotTo(ContainElements(
@@ -2549,7 +2796,12 @@ rules:
 				})
 
 				It("should properly configure the settings related to reversed vpn if enabled", func() {
-					kapi = New(kubernetesInterface, namespace, sm, Values{Images: images, RuntimeVersion: runtimeVersion, Version: version})
+					kapi = New(kubernetesInterface, namespace, sm, Values{
+						Images:         images,
+						RuntimeVersion: runtimeVersion,
+						Version:        version,
+						VPN:            VPNConfig{Enabled: true},
+					})
 					deployAndRead()
 
 					Expect(deployment.Spec.Template.Spec.Containers[0].Command).To(ContainElement(
@@ -2695,6 +2947,7 @@ rules:
 						Images:             Images{VPNClient: "vpn-client-image:really-latest"},
 						ServiceNetworkCIDR: "4.5.6.0/24",
 						VPN: VPNConfig{
+							Enabled:                              true,
 							HighAvailabilityEnabled:              false,
 							HighAvailabilityNumberOfSeedServers:  2,
 							HighAvailabilityNumberOfShootClients: 3,
@@ -2718,6 +2971,7 @@ rules:
 						Images:             Images{VPNClient: "vpn-client-image:really-latest"},
 						ServiceNetworkCIDR: "4.5.6.0/24",
 						VPN: VPNConfig{
+							Enabled:                              true,
 							HighAvailabilityEnabled:              true,
 							HighAvailabilityNumberOfSeedServers:  2,
 							HighAvailabilityNumberOfShootClients: 3,

--- a/pkg/operation/botanist/component/kubeapiserver/networkpolicies.go
+++ b/pkg/operation/botanist/component/kubeapiserver/networkpolicies.go
@@ -120,11 +120,6 @@ func (k *kubeAPIServer) reconcileNetworkPolicyAllowKubeAPIServer(ctx context.Con
 				v1beta1constants.LabelNetworkPolicyToShootAPIServer, v1beta1constants.LabelNetworkPolicyAllowed),
 		}
 
-		port := &portVPNSeedServerNonHA
-		if k.values.VPN.HighAvailabilityEnabled {
-			port = &portVPNSeedServerHA
-		}
-
 		networkPolicy.Spec = networkingv1.NetworkPolicySpec{
 			PodSelector: metav1.LabelSelector{
 				MatchLabels: GetLabels(),
@@ -142,17 +137,7 @@ func (k *kubeAPIServer) reconcileNetworkPolicyAllowKubeAPIServer(ctx context.Con
 						Port:     &portEtcd,
 					}},
 				},
-				{
-					To: []networkingv1.NetworkPolicyPeer{{
-						PodSelector: &metav1.LabelSelector{
-							MatchLabels: vpnseedserver.GetLabels(),
-						},
-					}},
-					Ports: []networkingv1.NetworkPolicyPort{{
-						Protocol: &protocol,
-						Port:     port,
-					}},
-				}},
+			},
 			// Allow connections from everything which needs to talk to the API server.
 			Ingress: []networkingv1.NetworkPolicyIngressRule{
 				{
@@ -187,6 +172,26 @@ func (k *kubeAPIServer) reconcileNetworkPolicyAllowKubeAPIServer(ctx context.Con
 			},
 			PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress, networkingv1.PolicyTypeEgress},
 		}
+
+		if k.values.VPN.Enabled {
+			portVPNSeedServer := &portVPNSeedServerNonHA
+			if k.values.VPN.HighAvailabilityEnabled {
+				portVPNSeedServer = &portVPNSeedServerHA
+			}
+
+			networkPolicy.Spec.Egress = append(networkPolicy.Spec.Egress, networkingv1.NetworkPolicyEgressRule{
+				To: []networkingv1.NetworkPolicyPeer{{
+					PodSelector: &metav1.LabelSelector{
+						MatchLabels: vpnseedserver.GetLabels(),
+					},
+				}},
+				Ports: []networkingv1.NetworkPolicyPort{{
+					Protocol: &protocol,
+					Port:     portVPNSeedServer,
+				}},
+			})
+		}
+
 		return nil
 	})
 	return err

--- a/pkg/operation/botanist/component/kubeapiserver/secrets.go
+++ b/pkg/operation/botanist/component/kubeapiserver/secrets.go
@@ -109,12 +109,7 @@ func (k *kubeAPIServer) reconcileSecretStaticToken(ctx context.Context) (*corev1
 		}
 	}
 
-	secret, err := k.secretsManager.Generate(ctx, staticTokenSecretConfig, secretsmanager.Persist(), secretsmanager.Rotate(secretsmanager.InPlace))
-	if err != nil {
-		return nil, err
-	}
-
-	return secret, nil
+	return k.secretsManager.Generate(ctx, staticTokenSecretConfig, secretsmanager.Persist(), secretsmanager.Rotate(secretsmanager.InPlace))
 }
 
 func (k *kubeAPIServer) reconcileSecretUserKubeconfig(ctx context.Context, secretStaticToken *corev1.Secret) error {
@@ -250,7 +245,7 @@ func (k *kubeAPIServer) reconcileSecretServer(ctx context.Context) (*corev1.Secr
 		}, kutil.DNSNamesForService("kubernetes", metav1.NamespaceDefault)...)
 	)
 
-	secret, err := k.secretsManager.Generate(ctx, &secretutils.CertificateSecretConfig{
+	return k.secretsManager.Generate(ctx, &secretutils.CertificateSecretConfig{
 		Name:                        secretNameServer,
 		CommonName:                  v1beta1constants.DeploymentNameKubeAPIServer,
 		IPAddresses:                 append(ipAddresses, k.values.ServerCertificate.ExtraIPAddresses...),
@@ -258,39 +253,24 @@ func (k *kubeAPIServer) reconcileSecretServer(ctx context.Context) (*corev1.Secr
 		CertType:                    secretutils.ServerCert,
 		SkipPublishingCACertificate: true,
 	}, secretsmanager.SignedByCA(v1beta1constants.SecretNameCACluster), secretsmanager.Rotate(secretsmanager.InPlace))
-	if err != nil {
-		return nil, err
-	}
-
-	return secret, nil
 }
 
 func (k *kubeAPIServer) reconcileSecretKubeletClient(ctx context.Context) (*corev1.Secret, error) {
-	secret, err := k.secretsManager.Generate(ctx, &secretutils.CertificateSecretConfig{
+	return k.secretsManager.Generate(ctx, &secretutils.CertificateSecretConfig{
 		Name:                        secretNameKubeAPIServerToKubelet,
 		CommonName:                  userName,
 		CertType:                    secretutils.ClientCert,
 		SkipPublishingCACertificate: true,
 	}, secretsmanager.SignedByCA(v1beta1constants.SecretNameCAKubelet, secretsmanager.UseOldCA), secretsmanager.Rotate(secretsmanager.InPlace))
-	if err != nil {
-		return nil, err
-	}
-
-	return secret, nil
 }
 
 func (k *kubeAPIServer) reconcileSecretKubeAggregator(ctx context.Context) (*corev1.Secret, error) {
-	secret, err := k.secretsManager.Generate(ctx, &secretutils.CertificateSecretConfig{
+	return k.secretsManager.Generate(ctx, &secretutils.CertificateSecretConfig{
 		Name:                        secretNameKubeAggregator,
 		CommonName:                  "system:kube-aggregator",
 		CertType:                    secretutils.ClientCert,
 		SkipPublishingCACertificate: true,
 	}, secretsmanager.SignedByCA(v1beta1constants.SecretNameCAFrontProxy), secretsmanager.Rotate(secretsmanager.InPlace))
-	if err != nil {
-		return nil, err
-	}
-
-	return secret, nil
 }
 
 func (k *kubeAPIServer) reconcileSecretHTTPProxy(ctx context.Context) (*corev1.Secret, error) {
@@ -298,17 +278,12 @@ func (k *kubeAPIServer) reconcileSecretHTTPProxy(ctx context.Context) (*corev1.S
 		return nil, nil
 	}
 
-	secret, err := k.secretsManager.Generate(ctx, &secretutils.CertificateSecretConfig{
+	return k.secretsManager.Generate(ctx, &secretutils.CertificateSecretConfig{
 		Name:                        secretNameHTTPProxy,
 		CommonName:                  "kube-apiserver-http-proxy",
 		CertType:                    secretutils.ClientCert,
 		SkipPublishingCACertificate: true,
 	}, secretsmanager.SignedByCA(v1beta1constants.SecretNameCAVPN), secretsmanager.Rotate(secretsmanager.InPlace))
-	if err != nil {
-		return nil, err
-	}
-
-	return secret, nil
 }
 
 func (k *kubeAPIServer) reconcileSecretHAVPNSeedClient(ctx context.Context) (*corev1.Secret, error) {
@@ -316,17 +291,12 @@ func (k *kubeAPIServer) reconcileSecretHAVPNSeedClient(ctx context.Context) (*co
 		return nil, nil
 	}
 
-	secret, err := k.secretsManager.Generate(ctx, &secretutils.CertificateSecretConfig{
+	return k.secretsManager.Generate(ctx, &secretutils.CertificateSecretConfig{
 		Name:                        secretNameHAVPNSeedClient,
 		CommonName:                  UserNameVPNSeedClient,
 		CertType:                    secretutils.ClientCert,
 		SkipPublishingCACertificate: true,
 	}, secretsmanager.SignedByCA(v1beta1constants.SecretNameCAVPN), secretsmanager.Rotate(secretsmanager.InPlace))
-	if err != nil {
-		return nil, err
-	}
-
-	return secret, nil
 }
 
 func (k *kubeAPIServer) reconcileSecretHAVPNSeedClientTLSAuth(ctx context.Context) (*corev1.Secret, error) {
@@ -334,12 +304,7 @@ func (k *kubeAPIServer) reconcileSecretHAVPNSeedClientTLSAuth(ctx context.Contex
 		return nil, nil
 	}
 
-	secretTLSAuth, err := k.secretsManager.Generate(ctx, &secretutils.VPNTLSAuthConfig{
+	return k.secretsManager.Generate(ctx, &secretutils.VPNTLSAuthConfig{
 		Name: vpnseedserver.SecretNameTLSAuth,
 	}, secretsmanager.Rotate(secretsmanager.InPlace))
-	if err != nil {
-		return nil, err
-	}
-
-	return secretTLSAuth, nil
 }

--- a/pkg/operation/botanist/component/kubeapiserver/secrets.go
+++ b/pkg/operation/botanist/component/kubeapiserver/secrets.go
@@ -242,11 +242,11 @@ func (k *kubeAPIServer) reconcileSecretServer(ctx context.Context) (*corev1.Secr
 		}
 	)
 
-	if k.values.SNI.PodMutatorEnabled || k.values.VPN.HighAvailabilityEnabled {
+	if k.values.SNI.PodMutatorEnabled || (k.values.VPN.Enabled && k.values.VPN.HighAvailabilityEnabled) {
 		ipAddresses = append(ipAddresses, net.ParseIP("127.0.0.1"))
 	}
 
-	if k.values.IsNodeless {
+	if !k.values.IsNodeless {
 		dnsNames = append(dnsNames, kutil.DNSNamesForService("kubernetes", metav1.NamespaceDefault)...)
 	}
 

--- a/pkg/operation/botanist/kubeapiserver.go
+++ b/pkg/operation/botanist/kubeapiserver.go
@@ -154,11 +154,11 @@ func (b *Botanist) DefaultKubeAPIServer(ctx context.Context) (kubeapiserver.Inte
 			Requests:                       requests,
 			RuntimeConfig:                  runtimeConfig,
 			RuntimeVersion:                 b.Seed.KubernetesVersion,
+			ServiceNetworkCIDR:             b.Shoot.Networks.Services.String(),
 			StaticTokenKubeconfigEnabled:   b.Shoot.GetInfo().Spec.Kubernetes.EnableStaticTokenKubeconfig,
 			Version:                        b.Shoot.KubernetesVersion,
 			VPN: kubeapiserver.VPNConfig{
 				PodNetworkCIDR:                       b.Shoot.Networks.Pods.String(),
-				ServiceNetworkCIDR:                   b.Shoot.Networks.Services.String(),
 				NodeNetworkCIDR:                      b.Shoot.GetInfo().Spec.Networking.Nodes,
 				HighAvailabilityEnabled:              b.Shoot.VPNHighAvailabilityEnabled,
 				HighAvailabilityNumberOfSeedServers:  b.Shoot.VPNHighAvailabilityNumberOfSeedServers,

--- a/pkg/operation/botanist/kubeapiserver.go
+++ b/pkg/operation/botanist/kubeapiserver.go
@@ -158,6 +158,7 @@ func (b *Botanist) DefaultKubeAPIServer(ctx context.Context) (kubeapiserver.Inte
 			StaticTokenKubeconfigEnabled:   b.Shoot.GetInfo().Spec.Kubernetes.EnableStaticTokenKubeconfig,
 			Version:                        b.Shoot.KubernetesVersion,
 			VPN: kubeapiserver.VPNConfig{
+				Enabled:                              true,
 				PodNetworkCIDR:                       b.Shoot.Networks.Pods.String(),
 				NodeNetworkCIDR:                      b.Shoot.GetInfo().Spec.Networking.Nodes,
 				HighAvailabilityEnabled:              b.Shoot.VPNHighAvailabilityEnabled,

--- a/pkg/operation/botanist/kubeapiserver.go
+++ b/pkg/operation/botanist/kubeapiserver.go
@@ -150,6 +150,7 @@ func (b *Botanist) DefaultKubeAPIServer(ctx context.Context) (kubeapiserver.Inte
 			EventTTL:                       eventTTL,
 			FeatureGates:                   featureGates,
 			Images:                         images,
+			IsNodeless:                     false,
 			OIDC:                           oidcConfig,
 			Requests:                       requests,
 			RuntimeConfig:                  runtimeConfig,

--- a/pkg/operation/botanist/kubeapiserver_test.go
+++ b/pkg/operation/botanist/kubeapiserver_test.go
@@ -1095,9 +1095,8 @@ usernames: ["admin"]
 				Entry("ReversedVPN enabled",
 					nil,
 					kubeapiserver.VPNConfig{
-						PodNetworkCIDR:     podNetworkCIDR,
-						ServiceNetworkCIDR: serviceNetworkCIDR,
-						NodeNetworkCIDR:    &nodeNetworkCIDR,
+						PodNetworkCIDR:  podNetworkCIDR,
+						NodeNetworkCIDR: &nodeNetworkCIDR,
 					},
 				),
 				Entry("no node network",
@@ -1107,8 +1106,7 @@ usernames: ["admin"]
 						botanist.Shoot.SetInfo(shootCopy)
 					},
 					kubeapiserver.VPNConfig{
-						PodNetworkCIDR:     podNetworkCIDR,
-						ServiceNetworkCIDR: serviceNetworkCIDR,
+						PodNetworkCIDR: podNetworkCIDR,
 					},
 				),
 			)

--- a/pkg/operation/botanist/kubeapiserver_test.go
+++ b/pkg/operation/botanist/kubeapiserver_test.go
@@ -1095,6 +1095,7 @@ usernames: ["admin"]
 				Entry("ReversedVPN enabled",
 					nil,
 					kubeapiserver.VPNConfig{
+						Enabled:         true,
 						PodNetworkCIDR:  podNetworkCIDR,
 						NodeNetworkCIDR: &nodeNetworkCIDR,
 					},
@@ -1106,6 +1107,7 @@ usernames: ["admin"]
 						botanist.Shoot.SetInfo(shootCopy)
 					},
 					kubeapiserver.VPNConfig{
+						Enabled:        true,
 						PodNetworkCIDR: podNetworkCIDR,
 					},
 				),


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind enhancement

**What this PR does / why we need it**:
This PR adapts the `kubeapiserver` component such that it can be used for the "nodeless" scenario, i.e. when the Kubernetes cluster will never have any worker nodes.
Concretely, this means that VPN and all kubelet-related settings can be disabled.

**Special notes for your reviewer**:
This is a prerequisite for `gardener-operator` to deploy `kube-apiserver` as part of the virtual garden cluster.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
