### PR TITLE
Add means to by-pass readiness checks

### DIFF
--- a/docs/usage/shoot_high_availability.md
+++ b/docs/usage/shoot_high_availability.md
@@ -49,7 +49,7 @@ If you already have a shoot cluster with non-HA control plane then following upg
 
 **Disallowed Transitions**
 
-If you have already set-up a HA shoot control plane with `node` failure tolerance then an upgrade to `zone` failure tolerance is currently not supported, mainly because already existing volumes are bound to the zone they were created in.
+If you have already set-up an HA shoot control plane with `node` failure tolerance, then an upgrade to `zone` failure tolerance is currently not supported, mainly because already existing volumes are bound to the zone they were created in originally.
 
 ## Zone Outage Situation
 
@@ -58,7 +58,7 @@ For instance, if the shoot cluster has worker nodes across three zones where one
 Changing the worker pool (`shoot.spec.provider.workers[]`) and infrastructure (`shoot.spec.provider.infrastructureConfig`) configuration can eliminate this disbalance, having enough machines in healthy availability zones that can cope with the requests of your applications.
 
 Gardener relies on a sophisticated reconciliation flow with several dependencies for which various flow steps wait for the _readiness_ of prior ones.
-During a zone outage this can block the entire flow, e.g. because all three `etcd` replicas can never be ready when a zone is down, and required changes mentioned above can never be accomplished.
+During a zone outage, this can block the entire flow, e.g. because all three `etcd` replicas can never be ready when a zone is down, and required changes mentioned above can never be accomplished.
 For this, a special one-off annotation `shoot.gardener.cloud/skip-readiness` helps to skip any readiness checks in the flow.
 
-> The `shoot.gardener.cloud/skip-readiness` annotation serves as a last resort if reconciliation is stuck because of important changes during an AZ outage. Use it with caution, only in exceptional cases and after a case-by-case evaluation with your Gardener landscape administrator. If used with other operations like Kubernetes version upgrades or credential rotation, the annotation may lead to a severe outage of your shoot control plane. 
+> The `shoot.gardener.cloud/skip-readiness` annotation serves as a last resort if reconciliation is stuck because of important changes during an AZ outage. Use it with caution, only in exceptional cases and after a case-by-case evaluation with your Gardener landscape administrator. If used together with other operations like Kubernetes version upgrades or credential rotation, the annotation may lead to a severe outage of your shoot control plane.

--- a/docs/usage/shoot_high_availability.md
+++ b/docs/usage/shoot_high_availability.md
@@ -50,3 +50,15 @@ If you already have a shoot cluster with non-HA control plane then following upg
 **Disallowed Transitions**
 
 If you have already set-up a HA shoot control plane with `node` failure tolerance then an upgrade to `zone` failure tolerance is currently not supported, mainly because already existing volumes are bound to the zone they were created in.
+
+## Zone Outage Situation
+
+An availability zone outage might lead to the requirement to change your cluster setup temporarily and on short notice, in order to compensate failures and shortages resulting from the outage.
+For instance, if the shoot cluster has worker nodes across three zones where one zone goes down, the computing power from these nodes is also gone during that time.
+Changing the worker pool (`shoot.spec.provider.workers[]`) and infrastructure (`shoot.spec.provider.infrastructureConfig`) configuration can eliminate this disbalance, having enough machines in healthy availability zones that can cope with the requests of your applications.
+
+Gardener relies on a sophisticated reconciliation flow with several dependencies for which various flow steps wait for the _readiness_ of prior ones.
+During a zone outage this can block the entire flow, e.g. because all three `etcd` replicas can never be ready when a zone is down, and required changes mentioned above can never be accomplished.
+For this, a special one-off annotation `shoot.gardener.cloud/skip-readiness` helps to skip any readiness checks in the flow.
+
+> The `shoot.gardener.cloud/skip-readiness` annotation serves as a last resort if reconciliation is stuck because of important changes during an AZ outage. Use it with caution, only in exceptional cases and after a case-by-case evaluation with your Gardener landscape administrator. If used with other operations like Kubernetes version upgrades or credential rotation, the annotation may lead to a severe outage of your shoot control plane. 

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -528,6 +528,8 @@ const (
 	// AnnotationShootSkipCleanup is a key for an annotation on a Shoot resource that declares that the clean up steps should be skipped when the
 	// cluster is deleted. Concretely, this will skip everything except the deletion of (load balancer) services and persistent volume resources.
 	AnnotationShootSkipCleanup = "shoot.gardener.cloud/skip-cleanup"
+	// AnnotationShootSkipReadiness is a key for an annotation on a Shoot resource that instructs the shoot flow to skip readiness steps during reconciliation.
+	AnnotationShootSkipReadiness = "shoot.gardener.cloud/skip-readiness"
 	// AnnotationShootCleanupWebhooksFinalizeGracePeriodSeconds is a key for an annotation on a Shoot resource that
 	// declares the grace period in seconds for finalizing the resources handled in the 'cleanup webhooks' step.
 	// Concretely, after the specified seconds, all the finalizers of the affected resources are forcefully removed.

--- a/test/e2e/gardener/shoot/create_update_delete.go
+++ b/test/e2e/gardener/shoot/create_update_delete.go
@@ -115,12 +115,12 @@ var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
 		defer cancel()
 		Expect(f.ShootFramework.UpdateShoot(ctx, func(shoot *gardencorev1beta1.Shoot) error {
 			metav1.SetMetaDataAnnotation(&shoot.ObjectMeta, "shoot.gardener.cloud/skip-readiness", "")
-			// Use maintain operation to also execute skipped steps in the reconcile flow.
+			// Use maintain operation to also execute tasks in the reconcile flow which are only performed during maintenance.
 			metav1.SetMetaDataAnnotation(&shoot.ObjectMeta, "gardener.cloud/operation", "maintain")
 			return nil
 		})).To(Succeed())
 
-		By("Wait for operation annotation to be gone. Controller picked up reconciliation request.")
+		By("Wait for operation annotation to be gone (meaning controller picked up reconciliation request)")
 		Eventually(func(g Gomega) {
 			shoot := &gardencorev1beta1.Shoot{
 				ObjectMeta: metav1.ObjectMeta{

--- a/test/e2e/gardener/shoot/create_update_delete.go
+++ b/test/e2e/gardener/shoot/create_update_delete.go
@@ -19,6 +19,8 @@ import (
 	"strconv"
 	"time"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/utils"
@@ -107,6 +109,22 @@ var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
 			GardenerFramework: f.GardenerFramework,
 			Shoot:             f.Shoot,
 		}, nil, nil)
+
+		By("Add skip readiness annotation")
+		ctx, cancel = context.WithTimeout(parentCtx, 10*time.Minute)
+		defer cancel()
+		Expect(f.ShootFramework.UpdateShoot(ctx, func(shoot *gardencorev1beta1.Shoot) error {
+			metav1.SetMetaDataAnnotation(&shoot.ObjectMeta, "shoot.gardener.cloud/skip-readiness", "")
+			// Use maintain operation to also execute skipped steps in the reconcile flow.
+			metav1.SetMetaDataAnnotation(&shoot.ObjectMeta, "gardener.cloud/operation", "maintain")
+			return nil
+		})).To(Succeed())
+		Expect(f.ShootFramework.UpdateShoot(ctx, func(shoot *gardencorev1beta1.Shoot) error {
+			metav1.SetMetaDataAnnotation(&shoot.ObjectMeta, "gardener.cloud/operation", "reconcile")
+			return nil
+		})).To(Succeed())
+
+		Expect(f.Shoot.Annotations).ToNot(HaveKey("shoot.gardener.cloud/skip-readiness"))
 
 		By("Delete Shoot")
 		ctx, cancel = context.WithTimeout(parentCtx, 20*time.Minute)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/area high-availability
/kind enhancement

**What this PR does / why we need it**:
This PR adds the `shoot.gardener.cloud/skip-readiness` annotation which, if set, skips most of the readiness checks in the shoot reconcile flow. Please see #7224 for more information.

**Which issue(s) this PR fixes**:
Fixes #7224

**Special notes for your reviewer**:
Some steps are still not skipped:

- `waitUntilKubeAPIServerServiceIsReady` -> Won't help to skip this step since a working KAS service is the foundation for most actions
- `waitUntilControlPlaneExposureDeleted` -> Only relevant if changed from non-SNI to SNI and will (probably) be gone soon
- `waitUntilOperatingSystemConfigReady` -> Will lead to a nil pointer exception since this step extracts data from the `OSC`'s status that is consumed by `DeployManagedResourceForCloudConfigExecutor`.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
A new shoot annotation `shoot.gardener.cloud/skip-readiness` has been added. Gardener skips most readiness checks in the shoot reconciliation flow when shoots have this annotation. It is meant to push through shoot spec changes in case of critical situations, e.g. an availability zone outage, in which various steps can never reach readiness. Once successfully reconciled, the annotation is automatically removed again. Using this annotation however, must be evaluated on a case-by-case basis since it can severely affect the availability of shoot control planes.
```
