### PR TITLE
Raise error when `ip` command not found instead of skipping if `OS` is Mac.

### DIFF
--- a/hack/kind-up.sh
+++ b/hack/kind-up.sh
@@ -41,7 +41,7 @@ parse_flags() {
 setup_loopback_device() {
   if ! command -v ip &>/dev/null; then
     if [[ "$OSTYPE" == "darwin"* ]]; then
-      echo "'ip' command not found. Please install 'ip' command using 'brew install iproute2mac'" 1>&2
+      echo "'ip' command not found. Please install 'ip' command, refer https://github.com/gardener/gardener/blob/master/docs/development/local_setup.md#installing-iproute2'" 1>&2
       exit 1
     fi
     echo "Skipping loopback device setup because 'ip' command is not available..."

--- a/hack/kind-up.sh
+++ b/hack/kind-up.sh
@@ -41,7 +41,7 @@ parse_flags() {
 setup_loopback_device() {
   if ! command -v ip &>/dev/null; then
     if [[ "$OSTYPE" == "darwin"* ]]; then
-      echo "'ip' command not found. Please install 'ip' command, refer https://github.com/gardener/gardener/blob/master/docs/development/local_setup.md#installing-iproute2'" 1>&2
+      echo "'ip' command not found. Please install 'ip' command, refer https://github.com/gardener/gardener/blob/master/docs/development/local_setup.md#installing-iproute2" 1>&2
       exit 1
     fi
     echo "Skipping loopback device setup because 'ip' command is not available..."

--- a/hack/kind-up.sh
+++ b/hack/kind-up.sh
@@ -39,7 +39,11 @@ parse_flags() {
 }
 
 setup_loopback_device() {
-  if ! command -v ip &> /dev/null; then
+  if ! command -v ip &>/dev/null; then
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+      echo "'ip' command not found. Please install 'ip' command using 'brew install iproute2mac'" 1>&2
+      exit 1
+    fi
     echo "Skipping loopback device setup because 'ip' command is not available..."
     return
   fi


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity testing
/kind bug test

**What this PR does / why we need it**:
This PR raises error when `ip` not found instead of skipping if `OS` is `Mac`. By default, in Mac `ip` command is not installed and it's better to fail fast than waiting until e2e test to fail.

Recent PR https://github.com/gardener/gardener/pull/7245 introduced `ip` command to adapt multi availability zone handling of istio to local mac requirements.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
