### PR TITLE
Fix the typo in the hostnames that prevents running `make test-e2e-local-simple`

### DIFF
--- a/docs/deployment/getting_started_locally.md
+++ b/docs/deployment/getting_started_locally.md
@@ -121,10 +121,10 @@ cat <<EOF | sudo tee -a /etc/hosts
 127.0.0.1 api.e2e-rotate.local.internal.local.gardener.cloud
 127.0.0.1 api.e2e-default.local.external.local.gardener.cloud
 127.0.0.1 api.e2e-default.local.internal.local.gardener.cloud
-127.0.0.1 api.e2e-udpate-node.local.external.local.gardener.cloud
-127.0.0.1 api.e2e-udpate-node.local.internal.local.gardener.cloud
-127.0.0.1 api.e2e-udpate-zone.local.external.local.gardener.cloud
-127.0.0.1 api.e2e-udpate-zone.local.internal.local.gardener.cloud
+127.0.0.1 api.e2e-update-node.local.external.local.gardener.cloud
+127.0.0.1 api.e2e-update-node.local.internal.local.gardener.cloud
+127.0.0.1 api.e2e-update-zone.local.external.local.gardener.cloud
+127.0.0.1 api.e2e-update-zone.local.internal.local.gardener.cloud
 127.0.0.1 api.e2e-upgrade.local.external.local.gardener.cloud
 127.0.0.1 api.e2e-upgrade.local.internal.local.gardener.cloud
 EOF


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind bug
/kind regression

**What this PR does / why we need it**:
See https://github.com/gardener/gardener/issues/7270

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener/issues/7270

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix developer
A typo in the command to update the `/etc/hosts` file that also prevented `make test-e2e-local-simple` to be executed successfully is now fixed.
```
