### PR TITLE
Fix `make start-gardenlet` for a new Seed

### DIFF
--- a/hack/local-development/start-gardenlet
+++ b/hack/local-development/start-gardenlet
@@ -152,14 +152,14 @@ kubectl   --kubeconfig="$SEED_KUBECONFIG" get    namespace garden &>/dev/null ||
   kubectl --kubeconfig="$SEED_KUBECONFIG" create namespace garden
 
 # apply RBAC resources in seed cluster
-helm template gardenlet "$GARDENLET_CHARTS_DIR" -f "$gardenletChartValues" |
+helm template gardenlet "$GARDENLET_CHARTS_DIR" -f "$gardenletChartValues" -n garden |
   yq eval 'select(.apiVersion=="rbac.authorization.k8s.io/v1")' - |
   kubectl --kubeconfig="$SEED_KUBECONFIG" auth reconcile --remove-extra-permissions --remove-extra-subjects -f -
-helm template gardenlet "$GARDENLET_CHARTS_DIR" -s templates/serviceaccount.yaml -f "$gardenletChartValues" |
+helm template gardenlet "$GARDENLET_CHARTS_DIR" -s templates/serviceaccount.yaml -f "$gardenletChartValues" -n garden |
   kubectl --kubeconfig="$SEED_KUBECONFIG" apply -f -
 
 # apply gardener-system-critical priority class in seed cluster
-helm template gardenlet "$GARDENLET_CHARTS_DIR" -s templates/priorityclass.yaml -f "$gardenletChartValues" |
+helm template gardenlet "$GARDENLET_CHARTS_DIR" -s templates/priorityclass.yaml -f "$gardenletChartValues" -n garden |
   kubectl --kubeconfig="$SEED_KUBECONFIG" apply -f -
 
 rm -f "$gardenletChartValues"


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind bug
/kind regression

**What this PR does / why we need it**:
See https://github.com/gardener/gardener/issues/7272

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener/issues/7272

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
