### PR TITLE
Fix bug where `kubelet-monitor` kills processes other than `kubelet`

### DIFF
--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/kubelet/component_test.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/kubelet/component_test.go
@@ -198,7 +198,7 @@ function kubelet_monitoring {
   }
 
   function restart_kubelet {
-    pkill -f "kubelet"
+    pkill -x "kubelet"
   }
 
   function patch_internal_ip {

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/kubelet/templates/scripts/health-monitor.tpl.sh
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/kubelet/templates/scripts/health-monitor.tpl.sh
@@ -13,7 +13,7 @@ function kubelet_monitoring {
   }
 
   function restart_kubelet {
-    pkill -f "kubelet"
+    pkill "kubelet"
   }
 
   function patch_internal_ip {

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/kubelet/templates/scripts/health-monitor.tpl.sh
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/kubelet/templates/scripts/health-monitor.tpl.sh
@@ -13,7 +13,7 @@ function kubelet_monitoring {
   }
 
   function restart_kubelet {
-    pkill "kubelet"
+    pkill -x "kubelet"
   }
 
   function patch_internal_ip {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind bug

**What this PR does / why we need it**:

Fixes a bug where `kubelet-monitor` incorrectly kills processes other than kubelet when trying to restart kubelet.
 
The existing `kubelet-monitor` executes `pkill -f "kubelet"` to restart kubelet.
The `-f` flag causes it to match any process which has "kubelet" anywhere in its arguments.
That causes it to incorrectly kill processes which pass "/var/lib/kubelet/..." as arguments  (eg. CSI drivers).
Fix this by removing the `-f` flag from `pkill` so that it only matches the process name.

**Which issue(s) this PR fixes**:
Fixes #7252

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
A bug in the `kubelet-monitor` script running on all shoot worker nodes has been fixed which was causing to also kill processes other than `kubelet` only.
```
