### PR TITLE
Improve reconciliation of extension `BackupBucket` and `BackupEntry`

### DIFF
--- a/pkg/gardenlet/controller/backupbucket/reconciler.go
+++ b/pkg/gardenlet/controller/backupbucket/reconciler.go
@@ -185,7 +185,7 @@ func (r *Reconciler) reconcileBackupBucket(
 		// if the spec of the extensionBackupBucket has changed or it has not been reconciled after the last updation of secret, reconcile it
 		mustReconcileExtensionBackupBucket = true
 	} else if extensionBackupBucket.Status.LastOperation == nil {
-		// if the extension did not record a lastOperation yet, don't update the status
+		// if the extension did not record a lastOperation yet, record it as error in the extension backupbucket status
 		reconciliationSuccessful = false
 		lastObservedError = fmt.Errorf("extension did not record a last operation yet")
 	} else {

--- a/pkg/gardenlet/controller/backupbucket/reconciler.go
+++ b/pkg/gardenlet/controller/backupbucket/reconciler.go
@@ -127,7 +127,9 @@ func (r *Reconciler) reconcileBackupBucket(
 
 	var (
 		mustReconcileExtensionBackupBucket = false
-		mustReconcileExtensionSecret       = false
+		// we should reconcile the secret only when the data has changed, since now we depend on
+		// the timestamp in the secret to reconcile the extension.
+		mustReconcileExtensionSecret = false
 
 		lastObservedError         error
 		extensionSecret           = r.emptyExtensionSecret(backupBucket.Name)

--- a/pkg/gardenlet/controller/backupbucket/reconciler.go
+++ b/pkg/gardenlet/controller/backupbucket/reconciler.go
@@ -157,6 +157,10 @@ func (r *Reconciler) reconcileBackupBucket(
 			mustReconcileExtensionBackupBucket = true
 			mustReconcileExtensionSecret = true
 		}
+		// if the timestamp is not present yet (needed for existing secrets), reconcile the secret
+		if _, timestampPresent := extensionSecret.Annotations[v1beta1constants.GardenerTimestamp]; !timestampPresent {
+			mustReconcileExtensionSecret = true
+		}
 	}
 
 	if mustReconcileExtensionSecret {

--- a/pkg/gardenlet/controller/backupbucket/reconciler_test.go
+++ b/pkg/gardenlet/controller/backupbucket/reconciler_test.go
@@ -202,6 +202,24 @@ var _ = Describe("Controller", func() {
 		Expect(extensionBackupBucket.Annotations).NotTo(HaveKey(v1beta1constants.GardenerOperation))
 	})
 
+	It("should reconcile the extension secret and extension backupentry if the secret currently doesn't have a timestamp", func() {
+		extensionSecret.Annotations = nil
+		Expect(seedClient.Create(ctx, extensionSecret)).To(Succeed())
+		Expect(seedClient.Create(ctx, extensionBackupBucket)).To(Succeed())
+
+		// step the clock so that the updated timestamp of the secret is greater than the extensionSecret lastUpdate time.
+		fakeClock.Step(time.Minute)
+
+		result, err := reconciler.Reconcile(ctx, request)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(Equal(reconcile.Result{}))
+
+		Expect(seedClient.Get(ctx, client.ObjectKeyFromObject(extensionSecret), extensionSecret)).To(Succeed())
+		Expect(extensionSecret.Annotations).To(HaveKeyWithValue(v1beta1constants.GardenerTimestamp, fakeClock.Now().UTC().Format(time.RFC3339)))
+		Expect(seedClient.Get(ctx, client.ObjectKeyFromObject(extensionBackupBucket), extensionBackupBucket)).To(Succeed())
+		Expect(extensionBackupBucket.Annotations).To(HaveKey(v1beta1constants.GardenerOperation))
+	})
+
 	It("should reconcile the extension BackupBucket if the secret data has changed", func() {
 		extensionSecret.Data = map[string][]byte{"dash": []byte("bash")}
 		Expect(seedClient.Create(ctx, extensionSecret)).To(Succeed())

--- a/pkg/gardenlet/controller/backupbucket/reconciler_test.go
+++ b/pkg/gardenlet/controller/backupbucket/reconciler_test.go
@@ -202,7 +202,7 @@ var _ = Describe("Controller", func() {
 		Expect(extensionBackupBucket.Annotations).NotTo(HaveKey(v1beta1constants.GardenerOperation))
 	})
 
-	It("should reconcile the extension secret and extension backupentry if the secret currently doesn't have a timestamp", func() {
+	It("should reconcile the extension secret and extension BackupBucket if the secret currently doesn't have a timestamp", func() {
 		extensionSecret.Annotations = nil
 		Expect(seedClient.Create(ctx, extensionSecret)).To(Succeed())
 		Expect(seedClient.Create(ctx, extensionBackupBucket)).To(Succeed())
@@ -233,7 +233,7 @@ var _ = Describe("Controller", func() {
 		Expect(extensionBackupBucket.Annotations).To(HaveKeyWithValue(v1beta1constants.GardenerOperation, v1beta1constants.GardenerOperationReconcile))
 	})
 
-	It("should reconcile the extension BackupBucket if the secret update timestamp is after the extension lastupdate time", func() {
+	It("should reconcile the extension BackupBucket if the secret update timestamp is after the extension last update time", func() {
 		time := fakeClock.Now().Add(time.Second).UTC().Format(time.RFC3339)
 		metav1.SetMetaDataAnnotation(&extensionSecret.ObjectMeta, v1beta1constants.GardenerTimestamp, time)
 		Expect(seedClient.Create(ctx, extensionSecret)).To(Succeed())

--- a/pkg/gardenlet/controller/backupbucket/reconciler_test.go
+++ b/pkg/gardenlet/controller/backupbucket/reconciler_test.go
@@ -1,0 +1,235 @@
+// Copyright (c) 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package backupbucket_test
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	testclock "k8s.io/utils/clock/testing"
+	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	"github.com/gardener/gardener/pkg/gardenlet/apis/config"
+	. "github.com/gardener/gardener/pkg/gardenlet/controller/backupbucket"
+)
+
+const (
+	seedName            = "seed"
+	gardenNamespaceName = "garden"
+)
+
+var _ = Describe("Controller", func() {
+	var (
+		ctx          = context.TODO()
+		gardenClient client.Client
+		seedClient   client.Client
+		reconciler   reconcile.Reconciler
+
+		fakeClock *testclock.FakeClock
+
+		gardenSecret          *corev1.Secret
+		backupBucket          *gardencorev1beta1.BackupBucket
+		extensionBackupBucket *extensionsv1alpha1.BackupBucket
+		extensionSecret       *corev1.Secret
+		providerConfig        = &runtime.RawExtension{Raw: []byte(`{"dash":"baz"}`)}
+		providerStatus        = &runtime.RawExtension{Raw: []byte(`{"foo":"bar"}`)}
+
+		request reconcile.Request
+	)
+
+	BeforeEach(func() {
+		gardenClient = fakeclient.NewClientBuilder().WithScheme(kubernetes.GardenScheme).Build()
+
+		testScheme := kubernetes.SeedScheme
+		Expect(extensionsv1alpha1.AddToScheme(testScheme)).To(Succeed())
+		seedClient = fakeclient.NewClientBuilder().WithScheme(testScheme).Build()
+
+		fakeClock = testclock.NewFakeClock(time.Now())
+
+		reconciler = &Reconciler{
+			GardenClient: gardenClient,
+			SeedClient:   seedClient,
+			Recorder:     &record.FakeRecorder{},
+			Config: config.BackupBucketControllerConfiguration{
+				ConcurrentSyncs: pointer.Int(5),
+			},
+			Clock:           fakeClock,
+			GardenNamespace: gardenNamespaceName,
+			SeedName:        seedName,
+		}
+
+		gardenSecret = &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-secret",
+				Namespace: gardenNamespaceName,
+			},
+			Data: map[string][]byte{
+				"foo": []byte("bar"),
+			},
+		}
+		Expect(gardenClient.Create(ctx, gardenSecret)).To(Succeed())
+
+		backupBucket = &gardencorev1beta1.BackupBucket{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       "foo",
+				Generation: 1,
+			},
+			Spec: gardencorev1beta1.BackupBucketSpec{
+				Provider: gardencorev1beta1.BackupBucketProvider{
+					Type:   "provider-type",
+					Region: "some-region",
+				},
+				ProviderConfig: providerConfig,
+				SecretRef: corev1.SecretReference{
+					Name:      gardenSecret.Name,
+					Namespace: gardenSecret.Namespace,
+				},
+				SeedName: pointer.String(seedName),
+			},
+			Status: gardencorev1beta1.BackupBucketStatus{
+				ObservedGeneration: 1,
+				LastOperation: &gardencorev1beta1.LastOperation{
+					State: gardencorev1beta1.LastOperationStateSucceeded,
+					Type:  gardencorev1beta1.LastOperationTypeReconcile,
+				},
+				ProviderStatus: providerStatus,
+			},
+		}
+		Expect(gardenClient.Create(ctx, backupBucket)).To(Succeed())
+
+		extensionSecret = &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      generateBackupBucketSecretName(backupBucket.Name),
+				Namespace: gardenNamespaceName,
+				Annotations: map[string]string{
+					v1beta1constants.GardenerTimestamp: fakeClock.Now().UTC().Format(time.RFC3339),
+				},
+			},
+			Data: gardenSecret.Data,
+		}
+
+		extensionBackupBucket = &extensionsv1alpha1.BackupBucket{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: backupBucket.Name,
+			},
+			Spec: extensionsv1alpha1.BackupBucketSpec{
+				DefaultSpec: extensionsv1alpha1.DefaultSpec{
+					Type:           backupBucket.Spec.Provider.Type,
+					ProviderConfig: backupBucket.Spec.ProviderConfig,
+				},
+				Region: backupBucket.Spec.Provider.Region,
+				SecretRef: corev1.SecretReference{
+					Name:      extensionSecret.Name,
+					Namespace: extensionSecret.Namespace,
+				},
+			},
+			Status: extensionsv1alpha1.BackupBucketStatus{
+				DefaultStatus: extensionsv1alpha1.DefaultStatus{
+					LastOperation: &gardencorev1beta1.LastOperation{
+						State:          gardencorev1beta1.LastOperationStateSucceeded,
+						LastUpdateTime: metav1.NewTime(fakeClock.Now().UTC()),
+					},
+				},
+			},
+		}
+
+		request = reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Name:      backupBucket.Name,
+				Namespace: backupBucket.Namespace,
+			},
+		}
+	})
+
+	It("should create the extension secret and extension BackupBucket if it doesn't exist yet", func() {
+		result, err := reconciler.Reconcile(ctx, request)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(Equal(reconcile.Result{}))
+
+		Expect(seedClient.Get(ctx, client.ObjectKeyFromObject(extensionSecret), extensionSecret)).To(Succeed())
+		Expect(extensionSecret.Data).To(Equal(gardenSecret.Data))
+
+		Expect(seedClient.Get(ctx, client.ObjectKeyFromObject(extensionBackupBucket), extensionBackupBucket)).To(Succeed())
+		Expect(extensionBackupBucket.Spec).To(Equal(extensionsv1alpha1.BackupBucketSpec{
+			DefaultSpec: extensionsv1alpha1.DefaultSpec{
+				Type:           backupBucket.Spec.Provider.Type,
+				ProviderConfig: backupBucket.Spec.ProviderConfig,
+			},
+			Region: backupBucket.Spec.Provider.Region,
+			SecretRef: corev1.SecretReference{
+				Name:      extensionSecret.Name,
+				Namespace: extensionSecret.Namespace,
+			},
+		}))
+	})
+
+	It("should not reconcile the extension BackupBucket if the secret data or extension spec hasn't changed", func() {
+		Expect(seedClient.Create(ctx, extensionSecret)).To(Succeed())
+		Expect(seedClient.Create(ctx, extensionBackupBucket)).To(Succeed())
+
+		result, err := reconciler.Reconcile(ctx, request)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(Equal(reconcile.Result{}))
+
+		Expect(seedClient.Get(ctx, client.ObjectKeyFromObject(extensionBackupBucket), extensionBackupBucket)).To(Succeed())
+		Expect(extensionBackupBucket.Annotations).NotTo(HaveKey(v1beta1constants.GardenerOperation))
+	})
+
+	It("should reconcile the extension BackupBucket if the secret data has changed", func() {
+		extensionSecret.Data = map[string][]byte{"dash": []byte("bash")}
+		Expect(seedClient.Create(ctx, extensionSecret)).To(Succeed())
+		Expect(seedClient.Create(ctx, extensionBackupBucket)).To(Succeed())
+
+		result, err := reconciler.Reconcile(ctx, request)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(Equal(reconcile.Result{}))
+
+		Expect(seedClient.Get(ctx, client.ObjectKeyFromObject(extensionBackupBucket), extensionBackupBucket)).To(Succeed())
+		Expect(extensionBackupBucket.Annotations).To(HaveKeyWithValue(v1beta1constants.GardenerOperation, v1beta1constants.GardenerOperationReconcile))
+	})
+
+	It("should reconcile the extension BackupBucket if the secret update timestamp is after the extension lastupdate time", func() {
+		time := fakeClock.Now().Add(time.Second).UTC().Format(time.RFC3339)
+		metav1.SetMetaDataAnnotation(&extensionSecret.ObjectMeta, v1beta1constants.GardenerTimestamp, time)
+		Expect(seedClient.Create(ctx, extensionSecret)).To(Succeed())
+		Expect(seedClient.Create(ctx, extensionBackupBucket)).To(Succeed())
+
+		result, err := reconciler.Reconcile(ctx, request)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(Equal(reconcile.Result{}))
+
+		Expect(seedClient.Get(ctx, client.ObjectKeyFromObject(extensionBackupBucket), extensionBackupBucket)).To(Succeed())
+		Expect(extensionBackupBucket.Annotations).To(HaveKeyWithValue(v1beta1constants.GardenerOperation, v1beta1constants.GardenerOperationReconcile))
+	})
+})
+
+func generateBackupBucketSecretName(backupBucketName string) string {
+	return fmt.Sprintf("bucket-%s", backupBucketName)
+}

--- a/pkg/gardenlet/controller/backupentry/backupentry/reconciler.go
+++ b/pkg/gardenlet/controller/backupentry/backupentry/reconciler.go
@@ -210,7 +210,7 @@ func (r *Reconciler) reconcileBackupEntry(
 		// if the spec of the extensionBackupEntry has changed or it has not been reconciled after the last updation of secret, reconcile it
 		mustReconcileExtensionBackupEntry = true
 	} else if extensionBackupEntry.Status.LastOperation == nil {
-		// if the extension did not record a lastOperation yet, don't update the status
+		// if the extension did not record a lastOperation yet, record it in the extension backupentry status
 		reconciliationSuccessful = false
 		lastObservedError = fmt.Errorf("extension did not record a last operation yet")
 	} else {

--- a/pkg/gardenlet/controller/backupentry/backupentry/reconciler.go
+++ b/pkg/gardenlet/controller/backupentry/backupentry/reconciler.go
@@ -128,7 +128,9 @@ func (r *Reconciler) reconcileBackupEntry(
 
 	var (
 		mustReconcileExtensionBackupEntry = false
-		mustReconcileExtensionSecret      = false
+		// we should reconcile the secret only when the data has changed, since now we depend on
+		// the timestamp in the secret to reconcile the extension.
+		mustReconcileExtensionSecret = false
 
 		lastObservedError error
 		extensionSecret   = r.emptyExtensionSecret(backupEntry)

--- a/pkg/gardenlet/controller/backupentry/backupentry/reconciler.go
+++ b/pkg/gardenlet/controller/backupentry/backupentry/reconciler.go
@@ -211,7 +211,7 @@ func (r *Reconciler) reconcileBackupEntry(
 		// if the spec of the extensionBackupEntry has changed or it has not been reconciled after the last updation of secret, reconcile it
 		mustReconcileExtensionBackupEntry = true
 	} else if extensionBackupEntry.Status.LastOperation == nil {
-		// if the extension did not record a lastOperation yet, record it as error in the extension backupentry status
+		// if the extension did not record a lastOperation yet, record it as error in the backupentry status
 		lastObservedError = fmt.Errorf("extension did not record a last operation yet")
 	} else {
 		// check for errors, and if none are present, reconciliation has succeeded
@@ -226,16 +226,6 @@ func (r *Reconciler) reconcileBackupEntry(
 			lastObservedError = fmt.Errorf("extension state is not Succeeded but %v", lastOperationState)
 			if extensionBackupEntry.Status.LastError != nil {
 				lastObservedError = v1beta1helper.NewErrorWithCodes(fmt.Errorf("error during reconciliation: %s", extensionBackupEntry.Status.LastError.Description), extensionBackupEntry.Status.LastError.Codes...)
-			}
-		} else if lastOperationState == gardencorev1beta1.LastOperationStateSucceeded {
-			if updateErr := r.updateBackupEntryStatusSucceeded(ctx, backupEntry, operationType); updateErr != nil {
-				return reconcile.Result{}, fmt.Errorf("could not update status after reconciliation success: %w", updateErr)
-			}
-
-			if kubernetesutils.HasMetaDataAnnotation(&backupEntry.ObjectMeta, v1beta1constants.GardenerOperation, v1beta1constants.GardenerOperationRestore) {
-				if updateErr := removeGardenerOperationAnnotation(ctx, r.GardenClient, backupEntry); updateErr != nil {
-					return reconcile.Result{}, fmt.Errorf("could not remove %q annotation: %w", v1beta1constants.GardenerOperation, updateErr)
-				}
 			}
 		}
 	}
@@ -262,6 +252,17 @@ func (r *Reconciler) reconcileBackupEntry(
 		return reconcile.Result{}, nil
 	}
 
+	if extensionBackupEntry.Status.LastOperation.State == gardencorev1beta1.LastOperationStateSucceeded {
+		if updateErr := r.updateBackupEntryStatusSucceeded(ctx, backupEntry, operationType); updateErr != nil {
+			return reconcile.Result{}, fmt.Errorf("could not update status after reconciliation success: %w", updateErr)
+		}
+
+		if kubernetesutils.HasMetaDataAnnotation(&backupEntry.ObjectMeta, v1beta1constants.GardenerOperation, v1beta1constants.GardenerOperationRestore) {
+			if updateErr := removeGardenerOperationAnnotation(ctx, r.GardenClient, backupEntry); updateErr != nil {
+				return reconcile.Result{}, fmt.Errorf("could not remove %q annotation: %w", v1beta1constants.GardenerOperation, updateErr)
+			}
+		}
+	}
 	return reconcile.Result{}, nil
 }
 

--- a/pkg/gardenlet/controller/backupentry/backupentry/reconciler.go
+++ b/pkg/gardenlet/controller/backupentry/backupentry/reconciler.go
@@ -168,6 +168,10 @@ func (r *Reconciler) reconcileBackupEntry(
 			mustReconcileExtensionBackupEntry = true
 			mustReconcileExtensionSecret = true
 		}
+		// if the timestamp is not present yet (needed for existing secrets), reconcile the secret
+		if _, timestampPresent := extensionSecret.Annotations[v1beta1constants.GardenerTimestamp]; !timestampPresent {
+			mustReconcileExtensionSecret = true
+		}
 	}
 
 	if mustReconcileExtensionSecret {

--- a/pkg/gardenlet/controller/backupentry/backupentry/reconciler_test.go
+++ b/pkg/gardenlet/controller/backupentry/backupentry/reconciler_test.go
@@ -224,7 +224,7 @@ var _ = Describe("Controller", func() {
 		Expect(extensionBackupEntry.Annotations).NotTo(HaveKey(v1beta1constants.GardenerOperation))
 	})
 
-	It("should reconcile the extension secret and extension backupentry if the secret currently doesn't have a timestamp", func() {
+	It("should reconcile the extension secret and extension BackupEntry if the secret currently doesn't have a timestamp", func() {
 		extensionSecret.Annotations = nil
 		Expect(seedClient.Create(ctx, extensionSecret)).To(Succeed())
 		Expect(seedClient.Create(ctx, extensionBackupEntry)).To(Succeed())
@@ -255,7 +255,7 @@ var _ = Describe("Controller", func() {
 		Expect(extensionBackupEntry.Annotations).To(HaveKeyWithValue(v1beta1constants.GardenerOperation, v1beta1constants.GardenerOperationReconcile))
 	})
 
-	It("should reconcile the extension BackupEntry if the secret update timestamp is after the extension lastupdate time", func() {
+	It("should reconcile the extension BackupEntry if the secret update timestamp is after the extension last update time", func() {
 		time := fakeClock.Now().Add(time.Second).UTC().Format(time.RFC3339)
 		metav1.SetMetaDataAnnotation(&extensionSecret.ObjectMeta, v1beta1constants.GardenerTimestamp, time)
 		Expect(seedClient.Create(ctx, extensionSecret)).To(Succeed())

--- a/pkg/gardenlet/controller/backupentry/backupentry/reconciler_test.go
+++ b/pkg/gardenlet/controller/backupentry/backupentry/reconciler_test.go
@@ -1,0 +1,253 @@
+// Copyright (c) 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package backupentry_test
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	testclock "k8s.io/utils/clock/testing"
+	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	gardencore "github.com/gardener/gardener/pkg/apis/core"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	"github.com/gardener/gardener/pkg/gardenlet/apis/config"
+	. "github.com/gardener/gardener/pkg/gardenlet/controller/backupentry/backupentry"
+)
+
+const (
+	seedName            = "seed"
+	gardenNamespaceName = "garden"
+	testNamespaceName   = "test"
+)
+
+var _ = Describe("Controller", func() {
+	var (
+		ctx          = context.TODO()
+		gardenClient client.Client
+		seedClient   client.Client
+		reconciler   reconcile.Reconciler
+
+		fakeClock                *testclock.FakeClock
+		deletionGracePeriodHours = 24
+
+		gardenSecret         *corev1.Secret
+		backupBucket         *gardencorev1beta1.BackupBucket
+		backupEntry          *gardencorev1beta1.BackupEntry
+		extensionBackupEntry *extensionsv1alpha1.BackupEntry
+		extensionSecret      *corev1.Secret
+		providerConfig       = &runtime.RawExtension{Raw: []byte(`{"dash":"baz"}`)}
+		providerStatus       = &runtime.RawExtension{Raw: []byte(`{"foo":"bar"}`)}
+
+		request reconcile.Request
+	)
+
+	BeforeEach(func() {
+		gardenClient = fakeclient.NewClientBuilder().WithScheme(kubernetes.GardenScheme).Build()
+
+		testScheme := kubernetes.SeedScheme
+		Expect(extensionsv1alpha1.AddToScheme(testScheme)).To(Succeed())
+		seedClient = fakeclient.NewClientBuilder().WithScheme(testScheme).Build()
+
+		fakeClock = testclock.NewFakeClock(time.Now())
+
+		reconciler = &Reconciler{
+			GardenClient: gardenClient,
+			SeedClient:   seedClient,
+			Recorder:     &record.FakeRecorder{},
+			Config: config.BackupEntryControllerConfiguration{
+				ConcurrentSyncs:                  pointer.Int(5),
+				DeletionGracePeriodHours:         pointer.Int(deletionGracePeriodHours),
+				DeletionGracePeriodShootPurposes: []gardencore.ShootPurpose{gardencore.ShootPurposeProduction},
+			},
+			Clock:           fakeClock,
+			GardenNamespace: gardenNamespaceName,
+			SeedName:        seedName,
+		}
+
+		gardenSecret = &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-secret",
+				Namespace: gardenNamespaceName,
+			},
+			Data: map[string][]byte{
+				"foo": []byte("bar"),
+			},
+		}
+		Expect(gardenClient.Create(ctx, gardenSecret)).To(Succeed())
+
+		backupBucket = &gardencorev1beta1.BackupBucket{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       "foo",
+				Generation: 1,
+			},
+			Spec: gardencorev1beta1.BackupBucketSpec{
+				Provider: gardencorev1beta1.BackupBucketProvider{
+					Type:   "provider-type",
+					Region: "some-region",
+				},
+				ProviderConfig: providerConfig,
+				SecretRef: corev1.SecretReference{
+					Name:      gardenSecret.Name,
+					Namespace: gardenSecret.Namespace,
+				},
+				SeedName: pointer.String(seedName),
+			},
+			Status: gardencorev1beta1.BackupBucketStatus{
+				ObservedGeneration: 1,
+				LastOperation: &gardencorev1beta1.LastOperation{
+					State: gardencorev1beta1.LastOperationStateSucceeded,
+					Type:  gardencorev1beta1.LastOperationTypeReconcile,
+				},
+				ProviderStatus: providerStatus,
+			},
+		}
+		Expect(gardenClient.Create(ctx, backupBucket)).To(Succeed())
+
+		backupEntry = &gardencorev1beta1.BackupEntry{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "bar",
+				Namespace: testNamespaceName,
+			},
+			Spec: gardencorev1beta1.BackupEntrySpec{
+				BucketName: backupBucket.Name,
+				SeedName:   pointer.String(seedName),
+			},
+		}
+
+		Expect(gardenClient.Create(ctx, backupEntry)).To(Succeed())
+
+		extensionSecret = &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "entry-" + backupEntry.Name,
+				Namespace: gardenNamespaceName,
+				Annotations: map[string]string{
+					v1beta1constants.GardenerTimestamp: fakeClock.Now().UTC().Format(time.RFC3339),
+				},
+			},
+			Data: gardenSecret.Data,
+		}
+
+		extensionBackupEntry = &extensionsv1alpha1.BackupEntry{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: backupEntry.Name,
+			},
+			Spec: extensionsv1alpha1.BackupEntrySpec{
+				DefaultSpec: extensionsv1alpha1.DefaultSpec{
+					Type:           backupBucket.Spec.Provider.Type,
+					ProviderConfig: backupBucket.Spec.ProviderConfig,
+				},
+				Region: backupBucket.Spec.Provider.Region,
+				SecretRef: corev1.SecretReference{
+					Name:      extensionSecret.Name,
+					Namespace: extensionSecret.Namespace,
+				},
+				BucketName:                 backupEntry.Spec.BucketName,
+				BackupBucketProviderStatus: backupBucket.Status.ProviderStatus,
+			},
+			Status: extensionsv1alpha1.BackupEntryStatus{
+				DefaultStatus: extensionsv1alpha1.DefaultStatus{
+					LastOperation: &gardencorev1beta1.LastOperation{
+						State:          gardencorev1beta1.LastOperationStateSucceeded,
+						LastUpdateTime: metav1.NewTime(fakeClock.Now().UTC()),
+					},
+				},
+			},
+		}
+
+		request = reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Name:      backupEntry.Name,
+				Namespace: backupEntry.Namespace,
+			},
+		}
+	})
+
+	It("should create the extension secret and extension BackupEntry if it doesn't exist yet", func() {
+		result, err := reconciler.Reconcile(ctx, request)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(Equal(reconcile.Result{}))
+
+		Expect(seedClient.Get(ctx, client.ObjectKeyFromObject(extensionSecret), extensionSecret)).To(Succeed())
+		Expect(extensionSecret.Data).To(Equal(gardenSecret.Data))
+
+		Expect(seedClient.Get(ctx, client.ObjectKeyFromObject(extensionBackupEntry), extensionBackupEntry)).To(Succeed())
+		Expect(extensionBackupEntry.Spec).To(MatchFields(IgnoreExtras, Fields{
+			"DefaultSpec": MatchFields(IgnoreExtras, Fields{
+				"Type":           Equal(backupBucket.Spec.Provider.Type),
+				"ProviderConfig": Equal(backupBucket.Spec.ProviderConfig),
+			}),
+			"Region":                     Equal(backupBucket.Spec.Provider.Region),
+			"BackupBucketProviderStatus": Equal(backupBucket.Status.ProviderStatus),
+			"SecretRef": MatchFields(IgnoreExtras, Fields{
+				"Name":      Equal(extensionSecret.Name),
+				"Namespace": Equal(extensionSecret.Namespace),
+			}),
+		}))
+	})
+
+	It("should not reconcile the extension BackupEntry if the secret data or extension spec hasn't changed", func() {
+		Expect(seedClient.Create(ctx, extensionSecret)).To(Succeed())
+		Expect(seedClient.Create(ctx, extensionBackupEntry)).To(Succeed())
+
+		result, err := reconciler.Reconcile(ctx, request)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(Equal(reconcile.Result{}))
+
+		Expect(seedClient.Get(ctx, client.ObjectKeyFromObject(extensionBackupEntry), extensionBackupEntry)).To(Succeed())
+		Expect(extensionBackupEntry.Annotations).NotTo(HaveKey(v1beta1constants.GardenerOperation))
+	})
+
+	It("should reconcile the extension BackupEntry if the secret data has changed", func() {
+		extensionSecret.Data = map[string][]byte{"dash": []byte("bash")}
+		Expect(seedClient.Create(ctx, extensionSecret)).To(Succeed())
+		Expect(seedClient.Create(ctx, extensionBackupEntry)).To(Succeed())
+
+		result, err := reconciler.Reconcile(ctx, request)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(Equal(reconcile.Result{}))
+
+		Expect(seedClient.Get(ctx, client.ObjectKeyFromObject(extensionBackupEntry), extensionBackupEntry)).To(Succeed())
+		Expect(extensionBackupEntry.Annotations).To(HaveKeyWithValue(v1beta1constants.GardenerOperation, v1beta1constants.GardenerOperationReconcile))
+	})
+
+	It("should reconcile the extension BackupEntry if the secret update timestamp is after the extension lastupdate time", func() {
+		time := fakeClock.Now().Add(time.Second).UTC().Format(time.RFC3339)
+		metav1.SetMetaDataAnnotation(&extensionSecret.ObjectMeta, v1beta1constants.GardenerTimestamp, time)
+		Expect(seedClient.Create(ctx, extensionSecret)).To(Succeed())
+		Expect(seedClient.Create(ctx, extensionBackupEntry)).To(Succeed())
+
+		result, err := reconciler.Reconcile(ctx, request)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(Equal(reconcile.Result{}))
+
+		Expect(seedClient.Get(ctx, client.ObjectKeyFromObject(extensionBackupEntry), extensionBackupEntry)).To(Succeed())
+		Expect(extensionBackupEntry.Annotations).To(HaveKeyWithValue(v1beta1constants.GardenerOperation, v1beta1constants.GardenerOperationReconcile))
+	})
+})

--- a/test/integration/gardenlet/backupentry/backupentry/backupentry_suite_test.go
+++ b/test/integration/gardenlet/backupentry/backupentry/backupentry_suite_test.go
@@ -140,7 +140,7 @@ var _ = BeforeSuite(func() {
 		},
 	}
 
-	Expect(testClient.Create(ctx, gardenNamespace)).To(Or(Succeed(), BeAlreadyExistsError()))
+	Expect(testClient.Create(ctx, gardenNamespace)).To(Or(Succeed()))
 	log.Info("Created namespace for test", "namespaceName", gardenNamespace)
 
 	DeferCleanup(func() {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug

**What this PR does / why we need it**:
#6926 added watch in the `BackupEntry` controller for extension `BackupEntry`, so we added optimizations to reconcile the extension only when the spec has changed or related secret data has been modified. 
But if the secret gets updated but the controller restarts before the extension `BackupEntry` is reconciled, in the next reconciliation, the extension won't be reconciled because now the secret data is same.
We now add a timestamp to the secret on reconciliation and if the extension `lastUpdateTime` is older than this, we reconcile the extension.

**Which issue(s) this PR fixes**:
Fixes #7276

**Special notes for your reviewer**:
/cc @timuthy 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
A bug causing the extension `BackupEntry` not to be correctly reconciled in case of secret rotation and a controller restart is now fixed.
```
