### PR TITLE
Cleanup deprecated Condition builder functions

### DIFF
--- a/pkg/apis/core/v1beta1/helper/helper.go
+++ b/pkg/apis/core/v1beta1/helper/helper.go
@@ -35,16 +35,6 @@ import (
 	versionutils "github.com/gardener/gardener/pkg/utils/version"
 )
 
-// Clock defines the clock for the helper functions
-// Deprecated: Use ...WithClock(...) functions instead.
-var Clock clock.Clock = clock.RealClock{}
-
-// InitCondition initializes a new Condition with an Unknown status.
-// Deprecated: Use InitConditionWithClock(...) instead.
-func InitCondition(conditionType gardencorev1beta1.ConditionType) gardencorev1beta1.Condition {
-	return InitConditionWithClock(Clock, conditionType)
-}
-
 // InitConditionWithClock initializes a new Condition with an Unknown status. It allows passing a custom clock for testing.
 func InitConditionWithClock(clock clock.Clock, conditionType gardencorev1beta1.ConditionType) gardencorev1beta1.Condition {
 	now := metav1.Time{Time: clock.Now()}
@@ -70,13 +60,6 @@ func GetCondition(conditions []gardencorev1beta1.Condition, conditionType garden
 	return nil
 }
 
-// GetOrInitCondition tries to retrieve the condition with the given condition type from the given conditions.
-// If the condition could not be found, it returns an initialized condition of the given type.
-// Deprecated: Use GetOrInitConditionWithClock(...) instead.
-func GetOrInitCondition(conditions []gardencorev1beta1.Condition, conditionType gardencorev1beta1.ConditionType) gardencorev1beta1.Condition {
-	return GetOrInitConditionWithClock(Clock, conditions, conditionType)
-}
-
 // GetOrInitConditionWithClock tries to retrieve the condition with the given condition type from the given conditions.
 // If the condition could not be found, it returns an initialized condition of the given type. It allows passing a custom clock for testing.
 func GetOrInitConditionWithClock(clock clock.Clock, conditions []gardencorev1beta1.Condition, conditionType gardencorev1beta1.ConditionType) gardencorev1beta1.Condition {
@@ -84,12 +67,6 @@ func GetOrInitConditionWithClock(clock clock.Clock, conditions []gardencorev1bet
 		return *condition
 	}
 	return InitConditionWithClock(clock, conditionType)
-}
-
-// UpdatedCondition updates the properties of one specific condition.
-// Deprecated: Use UpdatedConditionWithClock(...) instead.
-func UpdatedCondition(condition gardencorev1beta1.Condition, status gardencorev1beta1.ConditionStatus, reason, message string, codes ...gardencorev1beta1.ErrorCode) gardencorev1beta1.Condition {
-	return UpdatedConditionWithClock(Clock, condition, status, reason, message, codes...)
 }
 
 // UpdatedConditionWithClock updates the properties of one specific condition. It allows passing a custom clock for testing.
@@ -108,21 +85,9 @@ func UpdatedConditionWithClock(clock clock.Clock, condition gardencorev1beta1.Co
 	return newCondition
 }
 
-// UpdatedConditionUnknownError updates the condition to 'Unknown' status and the message of the given error.
-// Deprecated: Use UpdatedConditionUnknownErrorWithClock(...) instead.
-func UpdatedConditionUnknownError(condition gardencorev1beta1.Condition, err error, codes ...gardencorev1beta1.ErrorCode) gardencorev1beta1.Condition {
-	return UpdatedConditionUnknownErrorWithClock(Clock, condition, err, codes...)
-}
-
 // UpdatedConditionUnknownErrorWithClock updates the condition to 'Unknown' status and the message of the given error. It allows passing a custom clock for testing.
 func UpdatedConditionUnknownErrorWithClock(clock clock.Clock, condition gardencorev1beta1.Condition, err error, codes ...gardencorev1beta1.ErrorCode) gardencorev1beta1.Condition {
 	return UpdatedConditionUnknownErrorMessageWithClock(clock, condition, err.Error(), codes...)
-}
-
-// UpdatedConditionUnknownErrorMessage updates the condition with 'Unknown' status and the given message.
-// Deprecated: Use UpdatedConditionUnknownErrorMessageWithClock(...) instead.
-func UpdatedConditionUnknownErrorMessage(condition gardencorev1beta1.Condition, message string, codes ...gardencorev1beta1.ErrorCode) gardencorev1beta1.Condition {
-	return UpdatedConditionUnknownErrorMessageWithClock(Clock, condition, message, codes...)
 }
 
 // UpdatedConditionUnknownErrorMessageWithClock updates the condition with 'Unknown' status and the given message. It allows passing a custom clock for testing.

--- a/pkg/controllermanager/controller/seed/backupbucketscheck/reconciler_test.go
+++ b/pkg/controllermanager/controller/seed/backupbucketscheck/reconciler_test.go
@@ -24,6 +24,7 @@ import (
 	. "github.com/gardener/gardener/pkg/controllermanager/controller/seed/backupbucketscheck"
 	backupbucketstrategy "github.com/gardener/gardener/pkg/registry/core/backupbucket"
 	"github.com/gardener/gardener/pkg/utils/test"
+	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -124,12 +125,12 @@ var _ = Describe("Reconciler", func() {
 			})
 
 			It("should set condition to `True` when none was given", func() {
-				matchExpectedCondition = MatchFields(IgnoreExtras, Fields{
-					"Message": Equal("Backup Buckets are available."),
-					"Reason":  Equal("BackupBucketsAvailable"),
-					"Status":  Equal(gardencorev1beta1.ConditionTrue),
-					"Type":    Equal(gardencorev1beta1.SeedBackupBucketsReady),
-				})
+				matchExpectedCondition = And(
+					WithMessage("Backup Buckets are available."),
+					WithReason("BackupBucketsAvailable"),
+					WithStatus(gardencorev1beta1.ConditionTrue),
+					OfType(gardencorev1beta1.SeedBackupBucketsReady),
+				)
 			})
 
 			It("should set condition to `True` when it was false", func() {
@@ -143,12 +144,12 @@ var _ = Describe("Reconciler", func() {
 				}
 				Expect(c.Update(ctx, seed)).To(Succeed())
 
-				matchExpectedCondition = MatchFields(IgnoreExtras, Fields{
-					"Message": Equal("Backup Buckets are available."),
-					"Reason":  Equal("BackupBucketsAvailable"),
-					"Status":  Equal(gardencorev1beta1.ConditionTrue),
-					"Type":    Equal(gardencorev1beta1.SeedBackupBucketsReady),
-				})
+				matchExpectedCondition = And(
+					WithMessage("Backup Buckets are available."),
+					WithReason("BackupBucketsAvailable"),
+					WithStatus(gardencorev1beta1.ConditionTrue),
+					OfType(gardencorev1beta1.SeedBackupBucketsReady),
+				)
 			})
 		})
 

--- a/pkg/controllermanager/controller/seed/extensionscheck/reconciler_test.go
+++ b/pkg/controllermanager/controller/seed/extensionscheck/reconciler_test.go
@@ -22,10 +22,10 @@ import (
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/controllermanager/apis/config"
 	. "github.com/gardener/gardener/pkg/controllermanager/controller/seed/extensionscheck"
+	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	. "github.com/onsi/gomega/gstruct"
 	"github.com/onsi/gomega/types"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -282,10 +282,5 @@ var _ = Describe("Reconciler", func() {
 })
 
 func matchConditionWithStatusReasonAndMessage(status gardencorev1beta1.ConditionStatus, reason, message string) types.GomegaMatcher {
-	return MatchFields(IgnoreExtras, Fields{
-		"Type":    Equal(gardencorev1beta1.SeedExtensionsReady),
-		"Status":  Equal(status),
-		"Reason":  Equal(reason),
-		"Message": ContainSubstring(message),
-	})
+	return And(OfType(gardencorev1beta1.SeedExtensionsReady), WithStatus(status), WithReason(reason), WithMessage(message))
 }

--- a/pkg/gardenlet/controller/controllerinstallation/care/add.go
+++ b/pkg/gardenlet/controller/controllerinstallation/care/add.go
@@ -20,6 +20,7 @@ import (
 	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/workqueue"
+	"k8s.io/utils/clock"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/cluster"
@@ -48,6 +49,9 @@ func (r *Reconciler) AddToManager(mgr manager.Manager, gardenCluster, seedCluste
 	}
 	if r.SeedClient == nil {
 		r.SeedClient = seedCluster.GetClient()
+	}
+	if r.Clock == nil {
+		r.Clock = clock.RealClock{}
 	}
 	if r.GardenNamespace == "" {
 		r.GardenNamespace = v1beta1constants.GardenNamespace

--- a/pkg/gardenlet/controller/controllerinstallation/care/reconciler_test.go
+++ b/pkg/gardenlet/controller/controllerinstallation/care/reconciler_test.go
@@ -31,6 +31,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	testclock "k8s.io/utils/clock/testing"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -53,6 +54,7 @@ var _ = Describe("Reconciler", func() {
 		request                reconcile.Request
 
 		reconciler reconcile.Reconciler
+		fakeClock  *testclock.FakeClock
 	)
 
 	BeforeEach(func() {
@@ -78,12 +80,14 @@ var _ = Describe("Reconciler", func() {
 		gardenClient = fakeclient.NewClientBuilder().WithScheme(kubernetes.GardenScheme).Build()
 		seedClient = fakeclient.NewClientBuilder().WithScheme(kubernetes.SeedScheme).Build()
 
+		fakeClock = testclock.NewFakeClock(time.Now())
 		reconciler = &Reconciler{
 			GardenClient: gardenClient,
 			SeedClient:   seedClient,
 			Config: config.ControllerInstallationCareControllerConfiguration{
 				SyncPeriod: &metav1.Duration{Duration: syncPeriodDuration},
 			},
+			Clock:           fakeClock,
 			GardenNamespace: gardenNamespace,
 		}
 	})

--- a/pkg/gardenlet/controller/controllerinstallation/care/reconciler_test.go
+++ b/pkg/gardenlet/controller/controllerinstallation/care/reconciler_test.go
@@ -23,10 +23,10 @@ import (
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/gardenlet/apis/config"
 	. "github.com/gardener/gardener/pkg/gardenlet/controller/controllerinstallation/care"
+	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	. "github.com/onsi/gomega/gstruct"
 	gomegatypes "github.com/onsi/gomega/types"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -180,12 +180,7 @@ func conditionWithTypeStatusAndReason(condType gardencorev1beta1.ConditionType, 
 }
 
 func conditionWithTypeStatusReasonAndMesssage(condType gardencorev1beta1.ConditionType, status gardencorev1beta1.ConditionStatus, reason, message string) gomegatypes.GomegaMatcher {
-	return MatchFields(IgnoreExtras, Fields{
-		"Type":    Equal(condType),
-		"Status":  Equal(status),
-		"Reason":  Equal(reason),
-		"Message": ContainSubstring(message),
-	})
+	return And(OfType(condType), WithStatus(status), WithReason(reason), WithMessage(message))
 }
 
 func healthyManagedResource() *resourcesv1alpha1.ManagedResource {

--- a/pkg/gardenlet/controller/controllerinstallation/controllerinstallation/add.go
+++ b/pkg/gardenlet/controller/controllerinstallation/controllerinstallation/add.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"reflect"
 
+	"k8s.io/utils/clock"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/cluster"
@@ -40,6 +41,9 @@ const ControllerName = "controllerinstallation"
 func (r *Reconciler) AddToManager(mgr manager.Manager, gardenCluster cluster.Cluster) error {
 	if r.GardenClient == nil {
 		r.GardenClient = gardenCluster.GetClient()
+	}
+	if r.Clock == nil {
+		r.Clock = clock.RealClock{}
 	}
 
 	// It's not possible to overwrite the event handler when using the controller builder. Hence, we have to build up

--- a/pkg/gardenlet/controller/controllerinstallation/required/add.go
+++ b/pkg/gardenlet/controller/controllerinstallation/required/add.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/utils/clock"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/cluster"
@@ -51,6 +52,9 @@ func (r *Reconciler) AddToManager(mgr manager.Manager, gardenCluster, seedCluste
 	}
 	if r.SeedClient == nil {
 		r.SeedClient = seedCluster.GetClient()
+	}
+	if r.Clock == nil {
+		r.Clock = clock.RealClock{}
 	}
 	r.Lock = &sync.RWMutex{}
 	r.KindToRequiredTypes = make(map[string]sets.String)

--- a/pkg/gardenlet/controller/managedseed/actuator_test.go
+++ b/pkg/gardenlet/controller/managedseed/actuator_test.go
@@ -47,6 +47,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
 	"k8s.io/component-base/config/v1alpha1"
+	"k8s.io/utils/clock"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -116,7 +117,7 @@ var _ = Describe("Actuator", func() {
 		shootClientSet.EXPECT().ChartApplier().Return(shootChartApplier).AnyTimes()
 
 		log = logr.Discard()
-		actuator = newActuator(&rest.Config{}, gardenAPIReader, gardenClient, seedClient, shootClientMap, vh, recorder, charts.Path, namespace)
+		actuator = newActuator(&rest.Config{}, gardenAPIReader, gardenClient, seedClient, shootClientMap, clock.RealClock{}, vh, recorder, charts.Path, namespace)
 
 		ctx = context.TODO()
 

--- a/pkg/gardenlet/controller/managedseed/actuator_test.go
+++ b/pkg/gardenlet/controller/managedseed/actuator_test.go
@@ -34,12 +34,12 @@ import (
 	"github.com/gardener/gardener/pkg/utils"
 	gutil "github.com/gardener/gardener/pkg/utils/gardener"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
+	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 
 	"github.com/go-logr/logr"
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	. "github.com/onsi/gomega/gstruct"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -574,12 +574,10 @@ var _ = Describe("Actuator", func() {
 
 			status, wait, err := actuator.Reconcile(ctx, log, managedSeed)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(status.Conditions).To(ConsistOf(
-				MatchFields(IgnoreExtras, Fields{
-					"Type":   Equal(seedmanagementv1alpha1.ManagedSeedShootReconciled),
-					"Status": Equal(gardencorev1beta1.ConditionFalse),
-					"Reason": Equal(gardencorev1beta1.EventReconciling),
-				}),
+			Expect(status.Conditions).To(ContainCondition(
+				OfType(seedmanagementv1alpha1.ManagedSeedShootReconciled),
+				WithStatus(gardencorev1beta1.ConditionFalse),
+				WithReason(gardencorev1beta1.EventReconciling),
 			))
 			Expect(wait).To(Equal(true))
 		})
@@ -605,17 +603,17 @@ var _ = Describe("Actuator", func() {
 
 				status, wait, err := actuator.Reconcile(ctx, log, managedSeed)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(status.Conditions).To(ConsistOf(
-					MatchFields(IgnoreExtras, Fields{
-						"Type":   Equal(seedmanagementv1alpha1.ManagedSeedShootReconciled),
-						"Status": Equal(gardencorev1beta1.ConditionTrue),
-						"Reason": Equal(gardencorev1beta1.EventReconciled),
-					}),
-					MatchFields(IgnoreExtras, Fields{
-						"Type":   Equal(seedmanagementv1alpha1.ManagedSeedSeedRegistered),
-						"Status": Equal(gardencorev1beta1.ConditionTrue),
-						"Reason": Equal(gardencorev1beta1.EventReconciled),
-					}),
+				Expect(status.Conditions).To(And(
+					ContainCondition(
+						OfType(seedmanagementv1alpha1.ManagedSeedShootReconciled),
+						WithStatus(gardencorev1beta1.ConditionTrue),
+						WithReason(gardencorev1beta1.EventReconciled),
+					),
+					ContainCondition(
+						OfType(seedmanagementv1alpha1.ManagedSeedSeedRegistered),
+						WithStatus(gardencorev1beta1.ConditionTrue),
+						WithReason(gardencorev1beta1.EventReconciled),
+					),
 				))
 				Expect(wait).To(Equal(false))
 			})
@@ -638,17 +636,17 @@ var _ = Describe("Actuator", func() {
 
 				status, wait, err := actuator.Reconcile(ctx, log, managedSeed)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(status.Conditions).To(ConsistOf(
-					MatchFields(IgnoreExtras, Fields{
-						"Type":   Equal(seedmanagementv1alpha1.ManagedSeedShootReconciled),
-						"Status": Equal(gardencorev1beta1.ConditionTrue),
-						"Reason": Equal(gardencorev1beta1.EventReconciled),
-					}),
-					MatchFields(IgnoreExtras, Fields{
-						"Type":   Equal(seedmanagementv1alpha1.ManagedSeedSeedRegistered),
-						"Status": Equal(gardencorev1beta1.ConditionTrue),
-						"Reason": Equal(gardencorev1beta1.EventReconciled),
-					}),
+				Expect(status.Conditions).To(And(
+					ContainCondition(
+						OfType(seedmanagementv1alpha1.ManagedSeedShootReconciled),
+						WithStatus(gardencorev1beta1.ConditionTrue),
+						WithReason(gardencorev1beta1.EventReconciled),
+					),
+					ContainCondition(
+						OfType(seedmanagementv1alpha1.ManagedSeedSeedRegistered),
+						WithStatus(gardencorev1beta1.ConditionTrue),
+						WithReason(gardencorev1beta1.EventReconciled),
+					),
 				))
 				Expect(wait).To(Equal(false))
 			})
@@ -672,17 +670,17 @@ var _ = Describe("Actuator", func() {
 
 				status, wait, err := actuator.Reconcile(ctx, log, managedSeed)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(status.Conditions).To(ConsistOf(
-					MatchFields(IgnoreExtras, Fields{
-						"Type":   Equal(seedmanagementv1alpha1.ManagedSeedShootReconciled),
-						"Status": Equal(gardencorev1beta1.ConditionTrue),
-						"Reason": Equal(gardencorev1beta1.EventReconciled),
-					}),
-					MatchFields(IgnoreExtras, Fields{
-						"Type":   Equal(seedmanagementv1alpha1.ManagedSeedSeedRegistered),
-						"Status": Equal(gardencorev1beta1.ConditionTrue),
-						"Reason": Equal(gardencorev1beta1.EventReconciled),
-					}),
+				Expect(status.Conditions).To(And(
+					ContainCondition(
+						OfType(seedmanagementv1alpha1.ManagedSeedShootReconciled),
+						WithStatus(gardencorev1beta1.ConditionTrue),
+						WithReason(gardencorev1beta1.EventReconciled),
+					),
+					ContainCondition(
+						OfType(seedmanagementv1alpha1.ManagedSeedSeedRegistered),
+						WithStatus(gardencorev1beta1.ConditionTrue),
+						WithReason(gardencorev1beta1.EventReconciled),
+					),
 				))
 				Expect(wait).To(Equal(false))
 			})
@@ -714,17 +712,17 @@ var _ = Describe("Actuator", func() {
 
 				status, wait, err := actuator.Reconcile(ctx, log, managedSeed)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(status.Conditions).To(ConsistOf(
-					MatchFields(IgnoreExtras, Fields{
-						"Type":   Equal(seedmanagementv1alpha1.ManagedSeedShootReconciled),
-						"Status": Equal(gardencorev1beta1.ConditionTrue),
-						"Reason": Equal(gardencorev1beta1.EventReconciled),
-					}),
-					MatchFields(IgnoreExtras, Fields{
-						"Type":   Equal(seedmanagementv1alpha1.ManagedSeedSeedRegistered),
-						"Status": Equal(gardencorev1beta1.ConditionTrue),
-						"Reason": Equal(gardencorev1beta1.EventReconciled),
-					}),
+				Expect(status.Conditions).To(And(
+					ContainCondition(
+						OfType(seedmanagementv1alpha1.ManagedSeedShootReconciled),
+						WithStatus(gardencorev1beta1.ConditionTrue),
+						WithReason(gardencorev1beta1.EventReconciled),
+					),
+					ContainCondition(
+						OfType(seedmanagementv1alpha1.ManagedSeedSeedRegistered),
+						WithStatus(gardencorev1beta1.ConditionTrue),
+						WithReason(gardencorev1beta1.EventReconciled),
+					),
 				))
 				Expect(wait).To(Equal(false))
 			})
@@ -746,17 +744,17 @@ var _ = Describe("Actuator", func() {
 
 				status, wait, err := actuator.Reconcile(ctx, log, managedSeed)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(status.Conditions).To(ConsistOf(
-					MatchFields(IgnoreExtras, Fields{
-						"Type":   Equal(seedmanagementv1alpha1.ManagedSeedShootReconciled),
-						"Status": Equal(gardencorev1beta1.ConditionTrue),
-						"Reason": Equal(gardencorev1beta1.EventReconciled),
-					}),
-					MatchFields(IgnoreExtras, Fields{
-						"Type":   Equal(seedmanagementv1alpha1.ManagedSeedSeedRegistered),
-						"Status": Equal(gardencorev1beta1.ConditionTrue),
-						"Reason": Equal(gardencorev1beta1.EventReconciled),
-					}),
+				Expect(status.Conditions).To(And(
+					ContainCondition(
+						OfType(seedmanagementv1alpha1.ManagedSeedShootReconciled),
+						WithStatus(gardencorev1beta1.ConditionTrue),
+						WithReason(gardencorev1beta1.EventReconciled),
+					),
+					ContainCondition(
+						OfType(seedmanagementv1alpha1.ManagedSeedSeedRegistered),
+						WithStatus(gardencorev1beta1.ConditionTrue),
+						WithReason(gardencorev1beta1.EventReconciled),
+					),
 				))
 				Expect(wait).To(Equal(false))
 			})
@@ -781,12 +779,10 @@ var _ = Describe("Actuator", func() {
 
 				status, wait, removeFinalizer, err := actuator.Delete(ctx, log, managedSeed)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(status.Conditions).To(ConsistOf(
-					MatchFields(IgnoreExtras, Fields{
-						"Type":   Equal(seedmanagementv1alpha1.ManagedSeedSeedRegistered),
-						"Status": Equal(gardencorev1beta1.ConditionFalse),
-						"Reason": Equal(gardencorev1beta1.EventDeleting),
-					}),
+				Expect(status.Conditions).To(ContainCondition(
+					OfType(seedmanagementv1alpha1.ManagedSeedSeedRegistered),
+					WithStatus(gardencorev1beta1.ConditionFalse),
+					WithReason(gardencorev1beta1.EventDeleting),
 				))
 				Expect(wait).To(Equal(false))
 				Expect(removeFinalizer).To(Equal(false))
@@ -804,12 +800,10 @@ var _ = Describe("Actuator", func() {
 
 				status, wait, removeFinalizer, err := actuator.Delete(ctx, log, managedSeed)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(status.Conditions).To(ConsistOf(
-					MatchFields(IgnoreExtras, Fields{
-						"Type":   Equal(seedmanagementv1alpha1.ManagedSeedSeedRegistered),
-						"Status": Equal(gardencorev1beta1.ConditionFalse),
-						"Reason": Equal(gardencorev1beta1.EventDeleting),
-					}),
+				Expect(status.Conditions).To(ContainCondition(
+					OfType(seedmanagementv1alpha1.ManagedSeedSeedRegistered),
+					WithStatus(gardencorev1beta1.ConditionFalse),
+					WithReason(gardencorev1beta1.EventDeleting),
 				))
 				Expect(wait).To(Equal(true))
 				Expect(removeFinalizer).To(Equal(false))
@@ -825,13 +819,12 @@ var _ = Describe("Actuator", func() {
 
 				status, wait, removeFinalizer, err := actuator.Delete(ctx, log, managedSeed)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(status.Conditions).To(ConsistOf(
-					MatchFields(IgnoreExtras, Fields{
-						"Type":   Equal(seedmanagementv1alpha1.ManagedSeedSeedRegistered),
-						"Status": Equal(gardencorev1beta1.ConditionFalse),
-						"Reason": Equal(gardencorev1beta1.EventDeleting),
-					}),
-				))
+				Expect(status.Conditions).To(ContainCondition(
+					OfType(seedmanagementv1alpha1.ManagedSeedSeedRegistered),
+					WithStatus(gardencorev1beta1.ConditionFalse),
+					WithReason(gardencorev1beta1.EventDeleting),
+				),
+				)
 				Expect(wait).To(Equal(true))
 				Expect(removeFinalizer).To(Equal(false))
 			})
@@ -847,12 +840,10 @@ var _ = Describe("Actuator", func() {
 
 				status, wait, removeFinalizer, err := actuator.Delete(ctx, log, managedSeed)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(status.Conditions).To(ConsistOf(
-					MatchFields(IgnoreExtras, Fields{
-						"Type":   Equal(seedmanagementv1alpha1.ManagedSeedSeedRegistered),
-						"Status": Equal(gardencorev1beta1.ConditionFalse),
-						"Reason": Equal(gardencorev1beta1.EventDeleting),
-					}),
+				Expect(status.Conditions).To(ContainCondition(
+					OfType(seedmanagementv1alpha1.ManagedSeedSeedRegistered),
+					WithStatus(gardencorev1beta1.ConditionFalse),
+					WithReason(gardencorev1beta1.EventDeleting),
 				))
 				Expect(wait).To(Equal(true))
 				Expect(removeFinalizer).To(Equal(false))
@@ -867,12 +858,10 @@ var _ = Describe("Actuator", func() {
 
 				status, wait, removeFinalizer, err := actuator.Delete(ctx, log, managedSeed)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(status.Conditions).To(ConsistOf(
-					MatchFields(IgnoreExtras, Fields{
-						"Type":   Equal(seedmanagementv1alpha1.ManagedSeedSeedRegistered),
-						"Status": Equal(gardencorev1beta1.ConditionFalse),
-						"Reason": Equal(gardencorev1beta1.EventDeleted),
-					}),
+				Expect(status.Conditions).To(ContainCondition(
+					OfType(seedmanagementv1alpha1.ManagedSeedSeedRegistered),
+					WithStatus(gardencorev1beta1.ConditionFalse),
+					WithReason(gardencorev1beta1.EventDeleted),
 				))
 				Expect(wait).To(Equal(false))
 				Expect(removeFinalizer).To(Equal(true))

--- a/pkg/gardenlet/controller/managedseed/add.go
+++ b/pkg/gardenlet/controller/managedseed/add.go
@@ -20,6 +20,7 @@ import (
 	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/workqueue"
+	"k8s.io/utils/clock"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/cluster"
@@ -63,6 +64,9 @@ func (r *Reconciler) AddToManager(
 	if r.GardenClient == nil {
 		r.GardenClient = gardenCluster.GetClient()
 	}
+	if r.Clock == nil {
+		r.Clock = clock.RealClock{}
+	}
 	if r.GardenNamespaceGarden == "" {
 		r.GardenNamespaceGarden = v1beta1constants.GardenNamespace
 	}
@@ -80,6 +84,7 @@ func (r *Reconciler) AddToManager(
 			gardenCluster.GetClient(),
 			seedCluster.GetClient(),
 			r.ShootClientMap,
+			r.Clock,
 			NewValuesHelper(&r.Config, r.ImageVector),
 			gardenCluster.GetEventRecorderFor(ControllerName+"-controller"),
 			r.ChartsPath,

--- a/pkg/gardenlet/controller/managedseed/reconciler.go
+++ b/pkg/gardenlet/controller/managedseed/reconciler.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/go-logr/logr"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/utils/clock"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -39,6 +40,7 @@ type Reconciler struct {
 	GardenClient          client.Client
 	Actuator              Actuator
 	Config                config.GardenletConfiguration
+	Clock                 clock.Clock
 	ShootClientMap        clientmap.ClientMap
 	ImageVector           imagevector.ImageVector
 	ChartsPath            string

--- a/pkg/gardenlet/controller/seed/care/add.go
+++ b/pkg/gardenlet/controller/seed/care/add.go
@@ -20,6 +20,7 @@ import (
 	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/workqueue"
+	"k8s.io/utils/clock"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/cluster"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -48,6 +49,9 @@ func (r *Reconciler) AddToManager(mgr manager.Manager, gardenCluster, seedCluste
 	}
 	if r.SeedClient == nil {
 		r.SeedClient = seedCluster.GetClient()
+	}
+	if r.Clock == nil {
+		r.Clock = clock.RealClock{}
 	}
 
 	// It's not possible to overwrite the event handler when using the controller builder. Hence, we have to build up

--- a/pkg/gardenlet/controller/seed/care/reconciler.go
+++ b/pkg/gardenlet/controller/seed/care/reconciler.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/utils/clock"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -41,6 +42,7 @@ type Reconciler struct {
 	GardenClient client.Client
 	SeedClient   client.Client
 	Config       config.SeedCareControllerConfiguration
+	Clock        clock.Clock
 	Namespace    *string
 	SeedName     string
 }
@@ -67,7 +69,7 @@ func (r *Reconciler) Reconcile(reconcileCtx context.Context, req reconcile.Reque
 	conditionTypes := []gardencorev1beta1.ConditionType{gardencorev1beta1.SeedSystemComponentsHealthy}
 	var conditions []gardencorev1beta1.Condition
 	for _, cond := range conditionTypes {
-		conditions = append(conditions, gardencorev1beta1helper.GetOrInitCondition(seed.Status.Conditions, cond))
+		conditions = append(conditions, gardencorev1beta1helper.GetOrInitConditionWithClock(r.Clock, seed.Status.Conditions, cond))
 	}
 
 	// Trigger health check

--- a/pkg/gardenlet/controller/seed/care/reconciler.go
+++ b/pkg/gardenlet/controller/seed/care/reconciler.go
@@ -73,7 +73,7 @@ func (r *Reconciler) Reconcile(reconcileCtx context.Context, req reconcile.Reque
 	}
 
 	// Trigger health check
-	updatedConditions := NewHealthCheck(seed, r.SeedClient, r.Namespace).CheckSeed(ctx, conditions, r.conditionThresholdsToProgressingMapping())
+	updatedConditions := NewHealthCheck(seed, r.SeedClient, r.Clock, r.Namespace).CheckSeed(ctx, conditions, r.conditionThresholdsToProgressingMapping())
 
 	// Update Seed status conditions if necessary
 	if gardencorev1beta1helper.ConditionsNeedUpdate(conditions, updatedConditions) {

--- a/pkg/gardenlet/controller/seed/care/types.go
+++ b/pkg/gardenlet/controller/seed/care/types.go
@@ -21,6 +21,7 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	"github.com/gardener/gardener/pkg/operation/care"
 	seedpkg "github.com/gardener/gardener/pkg/operation/seed"
+	"k8s.io/utils/clock"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -30,11 +31,11 @@ var defaultNewSeedObjectFunc = func(ctx context.Context, seed *gardencorev1beta1
 }
 
 // NewHealthCheckFunc is a function used to create a new instance for performing health checks.
-type NewHealthCheckFunc func(*gardencorev1beta1.Seed, client.Client, *string) HealthCheck
+type NewHealthCheckFunc func(*gardencorev1beta1.Seed, client.Client, clock.Clock, *string) HealthCheck
 
 // defaultNewHealthCheck is the default function to create a new instance for performing health checks.
-var defaultNewHealthCheck NewHealthCheckFunc = func(seed *gardencorev1beta1.Seed, client client.Client, namespace *string) HealthCheck {
-	return care.NewHealthForSeed(seed, client, namespace)
+var defaultNewHealthCheck NewHealthCheckFunc = func(seed *gardencorev1beta1.Seed, client client.Client, clock clock.Clock, namespace *string) HealthCheck {
+	return care.NewHealthForSeed(seed, client, clock, namespace)
 }
 
 // HealthCheck is an interface used to perform health checks.

--- a/pkg/gardenlet/controller/seed/seed/add.go
+++ b/pkg/gardenlet/controller/seed/seed/add.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/clock"
 	"sigs.k8s.io/controller-runtime/pkg/cluster"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
@@ -39,6 +40,9 @@ const ControllerName = "seed"
 func (r *Reconciler) AddToManager(mgr manager.Manager, gardenCluster cluster.Cluster) error {
 	if r.GardenClient == nil {
 		r.GardenClient = gardenCluster.GetClient()
+	}
+	if r.Clock == nil {
+		r.Clock = clock.RealClock{}
 	}
 	if r.Recorder == nil {
 		r.Recorder = gardenCluster.GetEventRecorderFor(ControllerName + "-controller")

--- a/pkg/gardenlet/controller/seed/seed/reconciler_delete.go
+++ b/pkg/gardenlet/controller/seed/seed/reconciler_delete.go
@@ -114,8 +114,8 @@ func (r *Reconciler) delete(
 	log.Info("No Shoots or BackupBuckets are referencing the Seed, deletion accepted")
 
 	if err := r.runDeleteSeedFlow(ctx, log, seedObj, seedIsGarden); err != nil {
-		conditionSeedBootstrapped := gardencorev1beta1helper.GetOrInitCondition(seedObj.GetInfo().Status.Conditions, gardencorev1beta1.SeedBootstrapped)
-		conditionSeedBootstrapped = gardencorev1beta1helper.UpdatedCondition(conditionSeedBootstrapped, gardencorev1beta1.ConditionFalse, "DebootstrapFailed", fmt.Sprintf("Failed to delete Seed Cluster (%s).", err.Error()))
+		conditionSeedBootstrapped := gardencorev1beta1helper.GetOrInitConditionWithClock(r.Clock, seedObj.GetInfo().Status.Conditions, gardencorev1beta1.SeedBootstrapped)
+		conditionSeedBootstrapped = gardencorev1beta1helper.UpdatedConditionWithClock(r.Clock, conditionSeedBootstrapped, gardencorev1beta1.ConditionFalse, "DebootstrapFailed", fmt.Sprintf("Failed to delete Seed Cluster (%s).", err.Error()))
 		if err := r.patchSeedStatus(ctx, r.GardenClient, seed, "<unknown>", nil, nil, conditionSeedBootstrapped); err != nil {
 			return reconcile.Result{}, fmt.Errorf("could not patch seed status after deletion flow failed: %w", err)
 		}

--- a/pkg/gardenlet/controller/shoot/care/add.go
+++ b/pkg/gardenlet/controller/shoot/care/add.go
@@ -17,6 +17,7 @@ package care
 import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/workqueue"
+	"k8s.io/utils/clock"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/cluster"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -41,7 +42,9 @@ func (r *Reconciler) AddToManager(mgr manager.Manager, gardenCluster cluster.Clu
 	if r.GardenClient == nil {
 		r.GardenClient = gardenCluster.GetClient()
 	}
-
+	if r.Clock == nil {
+		r.Clock = clock.RealClock{}
+	}
 	// It's not possible to overwrite the event handler when using the controller builder. Hence, we have to build up
 	// the controller manually.
 	c, err := controller.New(

--- a/pkg/gardenlet/controller/shoot/care/reconciler.go
+++ b/pkg/gardenlet/controller/shoot/care/reconciler.go
@@ -158,7 +158,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	if err := flow.Parallel(
 		// Trigger health check
 		func(ctx context.Context) error {
-			shootHealth := NewHealthCheck(o, initializeShootClients)
+			shootHealth := NewHealthCheck(o, initializeShootClients, r.Clock)
 			updatedConditions = shootHealth.Check(
 				ctx,
 				r.conditionThresholdsToProgressingMapping(),

--- a/pkg/gardenlet/controller/shoot/care/reconciler_test.go
+++ b/pkg/gardenlet/controller/shoot/care/reconciler_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/gardener/gardener/pkg/utils/imagevector"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/test"
+	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
@@ -551,27 +552,27 @@ func nopGarbageCollectorFunc() NewGarbageCollectorFunc {
 }
 
 func consistOfConditionsInUnknownStatus(message string) types.GomegaMatcher {
-	return ConsistOf(
-		MatchFields(IgnoreExtras, Fields{
-			"Type":    Equal(gardencorev1beta1.ShootAPIServerAvailable),
-			"Status":  Equal(gardencorev1beta1.ConditionUnknown),
-			"Message": Equal(message),
-		}),
-		MatchFields(IgnoreExtras, Fields{
-			"Type":    Equal(gardencorev1beta1.ShootControlPlaneHealthy),
-			"Status":  Equal(gardencorev1beta1.ConditionUnknown),
-			"Message": Equal(message),
-		}),
-		MatchFields(IgnoreExtras, Fields{
-			"Type":    Equal(gardencorev1beta1.ShootEveryNodeReady),
-			"Status":  Equal(gardencorev1beta1.ConditionUnknown),
-			"Message": Equal(message),
-		}),
-		MatchFields(IgnoreExtras, Fields{
-			"Type":    Equal(gardencorev1beta1.ShootSystemComponentsHealthy),
-			"Status":  Equal(gardencorev1beta1.ConditionUnknown),
-			"Message": Equal(message),
-		}),
+	return And(
+		ContainCondition(
+			OfType(gardencorev1beta1.ShootAPIServerAvailable),
+			WithStatus(gardencorev1beta1.ConditionUnknown),
+			WithMessage(message),
+		),
+		ContainCondition(
+			OfType(gardencorev1beta1.ShootControlPlaneHealthy),
+			WithStatus(gardencorev1beta1.ConditionUnknown),
+			WithMessage(message),
+		),
+		ContainCondition(
+			OfType(gardencorev1beta1.ShootEveryNodeReady),
+			WithStatus(gardencorev1beta1.ConditionUnknown),
+			WithMessage(message),
+		),
+		ContainCondition(
+			OfType(gardencorev1beta1.ShootSystemComponentsHealthy),
+			WithStatus(gardencorev1beta1.ConditionUnknown),
+			WithMessage(message),
+		),
 	)
 }
 

--- a/pkg/gardenlet/controller/shoot/care/reconciler_test.go
+++ b/pkg/gardenlet/controller/shoot/care/reconciler_test.go
@@ -44,6 +44,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/clock"
+	testclock "k8s.io/utils/clock/testing"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -55,6 +56,7 @@ var _ = Describe("Shoot Care Control", func() {
 		gardenClient  client.Client
 		reconciler    reconcile.Reconciler
 		gardenletConf config.GardenletConfiguration
+		fakeClock     *testclock.FakeClock
 
 		shootName, shootNamespace, seedName string
 
@@ -79,6 +81,8 @@ var _ = Describe("Shoot Care Control", func() {
 				SeedName: &seedName,
 			},
 		}
+
+		fakeClock = testclock.NewFakeClock(time.Now())
 	})
 
 	AfterEach(func() {
@@ -149,6 +153,7 @@ var _ = Describe("Shoot Care Control", func() {
 						GardenClient:  gardenClient,
 						SeedClientSet: fakeclientset.NewClientSet(),
 						Config:        gardenletConf,
+						Clock:         fakeClock,
 						SeedName:      seedName,
 					}
 
@@ -175,6 +180,7 @@ var _ = Describe("Shoot Care Control", func() {
 						GardenClient:  gardenClient,
 						SeedClientSet: fakeclientset.NewClientSet(),
 						Config:        gardenletConf,
+						Clock:         fakeClock,
 						SeedName:      seedName,
 					}
 
@@ -213,6 +219,7 @@ var _ = Describe("Shoot Care Control", func() {
 					SeedClientSet:  fakeclientset.NewClientSet(),
 					ShootClientMap: shootClientMap,
 					Config:         gardenletConf,
+					Clock:          fakeClock,
 					SeedName:       seedName,
 				}
 			})
@@ -498,7 +505,7 @@ func (h resultingConditionFunc) Check(_ context.Context, _ map[gardencorev1beta1
 }
 
 func healthCheckFunc(fn resultingConditionFunc) NewHealthCheckFunc {
-	return func(op *operation.Operation, init care.ShootClientInit) HealthCheck {
+	return func(op *operation.Operation, init care.ShootClientInit, clock clock.Clock) HealthCheck {
 		return fn
 	}
 }

--- a/pkg/gardenlet/controller/shoot/care/types.go
+++ b/pkg/gardenlet/controller/shoot/care/types.go
@@ -39,11 +39,11 @@ type HealthCheck interface {
 }
 
 // NewHealthCheckFunc is a function used to create a new instance for performing health checks.
-type NewHealthCheckFunc func(op *operation.Operation, init care.ShootClientInit) HealthCheck
+type NewHealthCheckFunc func(op *operation.Operation, init care.ShootClientInit, clock clock.Clock) HealthCheck
 
 // defaultNewHealthCheck is the default function to create a new instance for performing health checks.
-var defaultNewHealthCheck NewHealthCheckFunc = func(op *operation.Operation, init care.ShootClientInit) HealthCheck {
-	return care.NewHealth(op, init)
+var defaultNewHealthCheck NewHealthCheckFunc = func(op *operation.Operation, init care.ShootClientInit, clock clock.Clock) HealthCheck {
+	return care.NewHealth(op, init, clock)
 }
 
 // ConstraintCheck is an interface used to perform constraint checks.

--- a/pkg/operation/care/constraints.go
+++ b/pkg/operation/care/constraints.go
@@ -95,7 +95,7 @@ func (c *Constraint) Check(
 	updatedConstraints := c.constraintsChecks(ctx, constraints)
 	lastOp := c.shoot.GetInfo().Status.LastOperation
 	lastErrors := c.shoot.GetInfo().Status.LastErrors
-	return PardonConditions(updatedConstraints, lastOp, lastErrors)
+	return PardonConditions(c.clock, updatedConstraints, lastOp, lastErrors)
 }
 
 func (c *Constraint) constraintsChecks(

--- a/pkg/operation/care/seed_health_test.go
+++ b/pkg/operation/care/seed_health_test.go
@@ -43,6 +43,7 @@ import (
 	. "github.com/onsi/gomega/gstruct"
 	"github.com/onsi/gomega/types"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	testclock "k8s.io/utils/clock/testing"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
@@ -69,8 +70,9 @@ var (
 
 var _ = Describe("Seed health", func() {
 	var (
-		ctx context.Context
-		c   client.Client
+		ctx       context.Context
+		c         client.Client
+		fakeClock *testclock.FakeClock
 
 		seed *gardencorev1beta1.Seed
 
@@ -109,8 +111,11 @@ var _ = Describe("Seed health", func() {
 			},
 		}
 
+		fakeClock = testclock.NewFakeClock(time.Now())
+
 		seedSystemComponentsHealthyCondition = gardencorev1beta1.Condition{
-			Type: gardencorev1beta1.SeedSystemComponentsHealthy,
+			Type:               gardencorev1beta1.SeedSystemComponentsHealthy,
+			LastTransitionTime: metav1.Time{Time: fakeClock.Now()},
 		}
 	})
 
@@ -123,7 +128,7 @@ var _ = Describe("Seed health", func() {
 			})
 
 			It("should set SeedSystemComponentsHealthy condition to true", func() {
-				healthCheck := care.NewHealthForSeed(seed, c, nil)
+				healthCheck := care.NewHealthForSeed(seed, c, fakeClock, nil)
 				updatedConditions := healthCheck.CheckSeed(ctx, []gardencorev1beta1.Condition{seedSystemComponentsHealthyCondition}, nil)
 				Expect(len(updatedConditions)).ToNot(BeZero())
 				Expect(updatedConditions[0]).To(beConditionWithStatusReasonAndMessage(gardencorev1beta1.ConditionTrue, "SystemComponentsRunning", "All system components are healthy."))
@@ -143,7 +148,7 @@ var _ = Describe("Seed health", func() {
 			})
 
 			It("should set SeedSystemComponentsHealthy condition to true", func() {
-				healthCheck := care.NewHealthForSeed(seed, c, nil)
+				healthCheck := care.NewHealthForSeed(seed, c, fakeClock, nil)
 				updatedConditions := healthCheck.CheckSeed(ctx, []gardencorev1beta1.Condition{seedSystemComponentsHealthyCondition}, nil)
 				Expect(len(updatedConditions)).ToNot(BeZero())
 				Expect(updatedConditions[0]).To(beConditionWithStatusReasonAndMessage(gardencorev1beta1.ConditionTrue, "SystemComponentsRunning", "All system components are healthy."))
@@ -152,11 +157,9 @@ var _ = Describe("Seed health", func() {
 
 		Context("When there are issues with seed managed resources", func() {
 			var (
-				now time.Time
-
 				tests = func(reason, message string) {
 					It("should set SeedSystemComponentsHealthy condition to False if there is no Progressing threshold duration mapping", func() {
-						healthCheck := care.NewHealthForSeed(seed, c, nil)
+						healthCheck := care.NewHealthForSeed(seed, c, fakeClock, nil)
 						updatedConditions := healthCheck.CheckSeed(ctx, []gardencorev1beta1.Condition{seedSystemComponentsHealthyCondition}, nil)
 
 						Expect(len(updatedConditions)).ToNot(BeZero())
@@ -164,12 +167,10 @@ var _ = Describe("Seed health", func() {
 					})
 
 					It("should set SeedSystemComponentsHealthy condition to Progressing if time is within threshold duration and condition is currently False", func() {
-						defer test.WithVars(
-							&care.Now, func() time.Time { return now.Add(30 * time.Second) },
-						)()
 						seedSystemComponentsHealthyCondition.Status = gardencorev1beta1.ConditionFalse
+						fakeClock.Step(30 * time.Second)
 
-						healthCheck := care.NewHealthForSeed(seed, c, nil)
+						healthCheck := care.NewHealthForSeed(seed, c, fakeClock, nil)
 						updatedConditions := healthCheck.CheckSeed(
 							ctx,
 							[]gardencorev1beta1.Condition{seedSystemComponentsHealthyCondition},
@@ -181,12 +182,25 @@ var _ = Describe("Seed health", func() {
 					})
 
 					It("should set SeedSystemComponentsHealthy condition to Progressing if time is within threshold duration and condition is currently True", func() {
-						defer test.WithVars(
-							&care.Now, func() time.Time { return now.Add(30 * time.Second) },
-						)()
 						seedSystemComponentsHealthyCondition.Status = gardencorev1beta1.ConditionTrue
+						fakeClock.Step(30 * time.Second)
 
-						healthCheck := care.NewHealthForSeed(seed, c, nil)
+						healthCheck := care.NewHealthForSeed(seed, c, fakeClock, nil)
+						updatedConditions := healthCheck.CheckSeed(
+							ctx,
+							[]gardencorev1beta1.Condition{seedSystemComponentsHealthyCondition},
+							map[gardencorev1beta1.ConditionType]time.Duration{gardencorev1beta1.SeedSystemComponentsHealthy: time.Minute},
+						)
+
+						Expect(len(updatedConditions)).ToNot(BeZero())
+						Expect(updatedConditions[0]).To(beConditionWithStatusReasonAndMessage(gardencorev1beta1.ConditionProgressing, reason, message))
+					})
+
+					It("should not set SeedSystemComponentsHealthy condition to false if Progressing threshold duration has not expired", func() {
+						seedSystemComponentsHealthyCondition.Status = gardencorev1beta1.ConditionProgressing
+						fakeClock.Step(30 * time.Second)
+
+						healthCheck := care.NewHealthForSeed(seed, c, fakeClock, nil)
 						updatedConditions := healthCheck.CheckSeed(
 							ctx,
 							[]gardencorev1beta1.Condition{seedSystemComponentsHealthyCondition},
@@ -198,13 +212,10 @@ var _ = Describe("Seed health", func() {
 					})
 
 					It("should set SeedSystemComponentsHealthy condition to false if Progressing threshold duration has expired", func() {
-						defer test.WithVars(
-							&care.Now, func() time.Time { return now.Add(90 * time.Second) },
-						)()
-
 						seedSystemComponentsHealthyCondition.Status = gardencorev1beta1.ConditionProgressing
+						fakeClock.Step(90 * time.Second)
 
-						healthCheck := care.NewHealthForSeed(seed, c, nil)
+						healthCheck := care.NewHealthForSeed(seed, c, fakeClock, nil)
 						updatedConditions := healthCheck.CheckSeed(
 							ctx,
 							[]gardencorev1beta1.Condition{seedSystemComponentsHealthyCondition},

--- a/pkg/operation/care/seed_health_test.go
+++ b/pkg/operation/care/seed_health_test.go
@@ -38,9 +38,9 @@ import (
 	"github.com/gardener/gardener/pkg/operation/care"
 	"github.com/gardener/gardener/pkg/utils/test"
 
+	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	. "github.com/onsi/gomega/gstruct"
 	"github.com/onsi/gomega/types"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	testclock "k8s.io/utils/clock/testing"
@@ -295,11 +295,8 @@ var _ = Describe("Seed health", func() {
 })
 
 func beConditionWithStatusReasonAndMessage(status gardencorev1beta1.ConditionStatus, reason, message string) types.GomegaMatcher {
-	return MatchFields(IgnoreExtras, Fields{
-		"Status":  Equal(status),
-		"Reason":  Equal(reason),
-		"Message": ContainSubstring(message),
-	})
+	return And(WithStatus(status), WithReason(reason), WithMessage(message))
+
 }
 
 func healthyManagedResource(name string) *resourcesv1alpha1.ManagedResource {

--- a/pkg/resourcemanager/controller/health/health/add.go
+++ b/pkg/resourcemanager/controller/health/health/add.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/workqueue"
+	"k8s.io/utils/clock"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/cluster"
@@ -52,6 +53,9 @@ func (r *Reconciler) AddToManager(mgr manager.Manager, sourceCluster, targetClus
 	}
 	if r.TargetScheme == nil {
 		r.TargetScheme = targetCluster.GetScheme()
+	}
+	if r.Clock == nil {
+		r.Clock = clock.RealClock{}
 	}
 
 	// It's not possible to overwrite the event handler when using the controller builder. Hence, we have to build up

--- a/pkg/resourcemanager/controller/health/progressing/add.go
+++ b/pkg/resourcemanager/controller/health/progressing/add.go
@@ -16,6 +16,7 @@ package progressing
 
 import (
 	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/utils/clock"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/cluster"
@@ -41,6 +42,9 @@ func (r *Reconciler) AddToManager(mgr manager.Manager, sourceCluster, targetClus
 	}
 	if r.TargetClient == nil {
 		r.TargetClient = targetCluster.GetClient()
+	}
+	if r.Clock == nil {
+		r.Clock = clock.RealClock{}
 	}
 
 	// It's not possible to overwrite the event handler when using the controller builder. Hence, we have to build up

--- a/pkg/resourcemanager/controller/managedresource/add.go
+++ b/pkg/resourcemanager/controller/managedresource/add.go
@@ -21,6 +21,7 @@ import (
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/clock"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -51,6 +52,9 @@ func (r *Reconciler) AddToManager(mgr manager.Manager, sourceCluster, targetClus
 	}
 	if r.TargetScheme == nil {
 		r.TargetScheme = targetCluster.GetScheme()
+	}
+	if r.Clock == nil {
+		r.Clock = clock.RealClock{}
 	}
 	if r.TargetRESTMapper == nil {
 		r.TargetRESTMapper = targetCluster.GetRESTMapper()

--- a/pkg/resourcemanager/controller/managedresource/reconciler.go
+++ b/pkg/resourcemanager/controller/managedresource/reconciler.go
@@ -44,6 +44,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/yaml"
+	"k8s.io/utils/clock"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -74,6 +75,7 @@ type Reconciler struct {
 	TargetScheme                  *runtime.Scheme
 	TargetRESTMapper              meta.RESTMapper
 	Config                        config.ManagedResourceControllerConfig
+	Clock                         clock.Clock
 	ClassFilter                   *resourcemanagerpredicate.ClassFilter
 	ClusterID                     string
 	GarbageCollectorActivated     bool
@@ -158,12 +160,12 @@ func (r *Reconciler) reconcile(ctx context.Context, log logr.Logger, mr *resourc
 	defer cancel()
 
 	// Initialize condition based on the current status.
-	conditionResourcesApplied := v1beta1helper.GetOrInitCondition(mr.Status.Conditions, resourcesv1alpha1.ResourcesApplied)
+	conditionResourcesApplied := v1beta1helper.GetOrInitConditionWithClock(r.Clock, mr.Status.Conditions, resourcesv1alpha1.ResourcesApplied)
 
 	for _, ref := range mr.Spec.SecretRefs {
 		secret := &corev1.Secret{}
 		if err := r.SourceClient.Get(reconcileCtx, client.ObjectKey{Namespace: mr.Namespace, Name: ref.Name}, secret); err != nil {
-			conditionResourcesApplied = v1beta1helper.UpdatedCondition(conditionResourcesApplied, gardencorev1beta1.ConditionFalse, "CannotReadSecret", err.Error())
+			conditionResourcesApplied = v1beta1helper.UpdatedConditionWithClock(r.Clock, conditionResourcesApplied, gardencorev1beta1.ConditionFalse, "CannotReadSecret", err.Error())
 			if err := updateConditions(ctx, r.SourceClient, mr, conditionResourcesApplied); err != nil {
 				return reconcile.Result{}, fmt.Errorf("could not update the ManagedResource status: %w", err)
 			}
@@ -288,11 +290,11 @@ func (r *Reconciler) reconcile(ctx context.Context, log logr.Logger, mr *resourc
 
 	// invalidate conditions, if resources have been added/removed from the managed resource
 	if !apiequality.Semantic.DeepEqual(mr.Status.Resources, newResourcesObjectReferences) || mr.Status.SecretsDataChecksum == nil || *mr.Status.SecretsDataChecksum != secretsDataChecksum {
-		conditionResourcesHealthy := v1beta1helper.GetOrInitCondition(mr.Status.Conditions, resourcesv1alpha1.ResourcesHealthy)
-		conditionResourcesHealthy = v1beta1helper.UpdatedCondition(conditionResourcesHealthy, gardencorev1beta1.ConditionUnknown,
+		conditionResourcesHealthy := v1beta1helper.GetOrInitConditionWithClock(r.Clock, mr.Status.Conditions, resourcesv1alpha1.ResourcesHealthy)
+		conditionResourcesHealthy = v1beta1helper.UpdatedConditionWithClock(r.Clock, conditionResourcesHealthy, gardencorev1beta1.ConditionUnknown,
 			resourcesv1alpha1.ConditionChecksPending, "The health checks have not yet been executed for the current set of resources.")
-		conditionResourcesProgressing := v1beta1helper.GetOrInitCondition(mr.Status.Conditions, resourcesv1alpha1.ResourcesProgressing)
-		conditionResourcesProgressing = v1beta1helper.UpdatedCondition(conditionResourcesProgressing, gardencorev1beta1.ConditionUnknown,
+		conditionResourcesProgressing := v1beta1helper.GetOrInitConditionWithClock(r.Clock, mr.Status.Conditions, resourcesv1alpha1.ResourcesProgressing)
+		conditionResourcesProgressing = v1beta1helper.UpdatedConditionWithClock(r.Clock, conditionResourcesProgressing, gardencorev1beta1.ConditionUnknown,
 			resourcesv1alpha1.ConditionChecksPending, "Checks have not yet been executed for the current set of resources.")
 
 		reason := resourcesv1alpha1.ConditionApplyProgressing
@@ -303,7 +305,7 @@ func (r *Reconciler) reconcile(ctx context.Context, log logr.Logger, mr *resourc
 			reason = conditionResourcesApplied.Reason
 			msg = conditionResourcesApplied.Message
 		}
-		conditionResourcesApplied = v1beta1helper.UpdatedCondition(conditionResourcesApplied, gardencorev1beta1.ConditionProgressing, reason, msg)
+		conditionResourcesApplied = v1beta1helper.UpdatedConditionWithClock(r.Clock, conditionResourcesApplied, gardencorev1beta1.ConditionProgressing, reason, msg)
 
 		if err := updateConditions(ctx, r.SourceClient, mr, conditionResourcesHealthy, conditionResourcesProgressing, conditionResourcesApplied); err != nil {
 			return reconcile.Result{}, fmt.Errorf("could not update the ManagedResource status: %w", err)
@@ -325,7 +327,7 @@ func (r *Reconciler) reconcile(ctx context.Context, log logr.Logger, mr *resourc
 			log.Error(err, "Deletion of old resources failed")
 		}
 
-		conditionResourcesApplied = v1beta1helper.UpdatedCondition(conditionResourcesApplied, status, reason, err.Error())
+		conditionResourcesApplied = v1beta1helper.UpdatedConditionWithClock(r.Clock, conditionResourcesApplied, status, reason, err.Error())
 		if err := updateConditions(ctx, r.SourceClient, mr, conditionResourcesApplied); err != nil {
 			return reconcile.Result{}, fmt.Errorf("could not update the ManagedResource status: %w", err)
 		}
@@ -338,7 +340,7 @@ func (r *Reconciler) reconcile(ctx context.Context, log logr.Logger, mr *resourc
 	}
 
 	if err := r.releaseOrphanedResources(ctx, log, orphanedObjectReferences, origin); err != nil {
-		conditionResourcesApplied = v1beta1helper.UpdatedCondition(conditionResourcesApplied, gardencorev1beta1.ConditionFalse, resourcesv1alpha1.ReleaseOfOrphanedResourcesFailed, err.Error())
+		conditionResourcesApplied = v1beta1helper.UpdatedConditionWithClock(r.Clock, conditionResourcesApplied, gardencorev1beta1.ConditionFalse, resourcesv1alpha1.ReleaseOfOrphanedResourcesFailed, err.Error())
 		if err := updateConditions(ctx, r.SourceClient, mr, conditionResourcesApplied); err != nil {
 			return reconcile.Result{}, fmt.Errorf("could not update the ManagedResource status: %w", err)
 		}
@@ -348,7 +350,7 @@ func (r *Reconciler) reconcile(ctx context.Context, log logr.Logger, mr *resourc
 
 	injectLabels := mergeMaps(mr.Spec.InjectLabels, map[string]string{resourcesv1alpha1.ManagedBy: *r.Config.ManagedByLabelValue})
 	if err := r.applyNewResources(reconcileCtx, log, origin, newResourcesObjects, injectLabels, equivalences); err != nil {
-		conditionResourcesApplied = v1beta1helper.UpdatedCondition(conditionResourcesApplied, gardencorev1beta1.ConditionFalse, resourcesv1alpha1.ConditionApplyFailed, err.Error())
+		conditionResourcesApplied = v1beta1helper.UpdatedConditionWithClock(r.Clock, conditionResourcesApplied, gardencorev1beta1.ConditionFalse, resourcesv1alpha1.ConditionApplyFailed, err.Error())
 		if err := updateConditions(ctx, r.SourceClient, mr, conditionResourcesApplied); err != nil {
 			return reconcile.Result{}, fmt.Errorf("could not update the ManagedResource status: %w", err)
 		}
@@ -357,9 +359,9 @@ func (r *Reconciler) reconcile(ctx context.Context, log logr.Logger, mr *resourc
 	}
 
 	if len(decodingErrors) != 0 {
-		conditionResourcesApplied = v1beta1helper.UpdatedCondition(conditionResourcesApplied, gardencorev1beta1.ConditionFalse, resourcesv1alpha1.ConditionDecodingFailed, fmt.Sprintf("Could not decode all new resources: %v", decodingErrors))
+		conditionResourcesApplied = v1beta1helper.UpdatedConditionWithClock(r.Clock, conditionResourcesApplied, gardencorev1beta1.ConditionFalse, resourcesv1alpha1.ConditionDecodingFailed, fmt.Sprintf("Could not decode all new resources: %v", decodingErrors))
 	} else {
-		conditionResourcesApplied = v1beta1helper.UpdatedCondition(conditionResourcesApplied, gardencorev1beta1.ConditionTrue, resourcesv1alpha1.ConditionApplySucceeded, "All resources are applied.")
+		conditionResourcesApplied = v1beta1helper.UpdatedConditionWithClock(r.Clock, conditionResourcesApplied, gardencorev1beta1.ConditionTrue, resourcesv1alpha1.ConditionApplySucceeded, "All resources are applied.")
 	}
 
 	if err := updateManagedResourceStatus(ctx, r.SourceClient, mr, &secretsDataChecksum, newResourcesObjectReferences, conditionResourcesApplied); err != nil {
@@ -380,7 +382,7 @@ func (r *Reconciler) delete(ctx context.Context, log logr.Logger, mr *resourcesv
 		return reconcile.Result{}, fmt.Errorf("could not update the ManagedResource status: %w", err)
 	}
 
-	conditionResourcesApplied := v1beta1helper.GetOrInitCondition(mr.Status.Conditions, resourcesv1alpha1.ResourcesApplied)
+	conditionResourcesApplied := v1beta1helper.GetOrInitConditionWithClock(r.Clock, mr.Status.Conditions, resourcesv1alpha1.ResourcesApplied)
 
 	if keepObjects := mr.Spec.KeepObjects; keepObjects == nil || !*keepObjects {
 		existingResourcesIndex := NewObjectIndex(mr.Status.Resources, nil)
@@ -391,7 +393,7 @@ func (r *Reconciler) delete(ctx context.Context, log logr.Logger, mr *resourcesv
 			// keep condition message if deletion is pending / failed
 			msg = conditionResourcesApplied.Message
 		}
-		conditionResourcesApplied = v1beta1helper.UpdatedCondition(conditionResourcesApplied, gardencorev1beta1.ConditionProgressing, resourcesv1alpha1.ConditionDeletionPending, msg)
+		conditionResourcesApplied = v1beta1helper.UpdatedConditionWithClock(r.Clock, conditionResourcesApplied, gardencorev1beta1.ConditionProgressing, resourcesv1alpha1.ConditionDeletionPending, msg)
 		if err := updateConditions(ctx, r.SourceClient, mr, conditionResourcesApplied); err != nil {
 			return reconcile.Result{}, fmt.Errorf("could not update the ManagedResource status: %w", err)
 		}
@@ -411,7 +413,7 @@ func (r *Reconciler) delete(ctx context.Context, log logr.Logger, mr *resourcesv
 				log.Error(err, "Deletion of all resources failed")
 			}
 
-			conditionResourcesApplied = v1beta1helper.UpdatedCondition(conditionResourcesApplied, status, reason, err.Error())
+			conditionResourcesApplied = v1beta1helper.UpdatedConditionWithClock(r.Clock, conditionResourcesApplied, status, reason, err.Error())
 			if err := updateConditions(ctx, r.SourceClient, mr, conditionResourcesApplied); err != nil {
 				return reconcile.Result{}, fmt.Errorf("could not update the ManagedResource status: %w", err)
 			}
@@ -441,12 +443,12 @@ func (r *Reconciler) delete(ctx context.Context, log logr.Logger, mr *resourcesv
 
 func (r *Reconciler) updateConditionsForIgnoredManagedResource(ctx context.Context, mr *resourcesv1alpha1.ManagedResource) error {
 	message := "ManagedResource is marked to be ignored."
-	conditionResourcesApplied := v1beta1helper.GetOrInitCondition(mr.Status.Conditions, resourcesv1alpha1.ResourcesApplied)
-	conditionResourcesApplied = v1beta1helper.UpdatedCondition(conditionResourcesApplied, gardencorev1beta1.ConditionTrue, resourcesv1alpha1.ConditionManagedResourceIgnored, message)
-	conditionResourcesHealthy := v1beta1helper.GetOrInitCondition(mr.Status.Conditions, resourcesv1alpha1.ResourcesHealthy)
-	conditionResourcesHealthy = v1beta1helper.UpdatedCondition(conditionResourcesHealthy, gardencorev1beta1.ConditionTrue, resourcesv1alpha1.ConditionManagedResourceIgnored, message)
-	conditionResourcesProgressing := v1beta1helper.GetOrInitCondition(mr.Status.Conditions, resourcesv1alpha1.ResourcesProgressing)
-	conditionResourcesProgressing = v1beta1helper.UpdatedCondition(conditionResourcesProgressing, gardencorev1beta1.ConditionFalse, resourcesv1alpha1.ConditionManagedResourceIgnored, message)
+	conditionResourcesApplied := v1beta1helper.GetOrInitConditionWithClock(r.Clock, mr.Status.Conditions, resourcesv1alpha1.ResourcesApplied)
+	conditionResourcesApplied = v1beta1helper.UpdatedConditionWithClock(r.Clock, conditionResourcesApplied, gardencorev1beta1.ConditionTrue, resourcesv1alpha1.ConditionManagedResourceIgnored, message)
+	conditionResourcesHealthy := v1beta1helper.GetOrInitConditionWithClock(r.Clock, mr.Status.Conditions, resourcesv1alpha1.ResourcesHealthy)
+	conditionResourcesHealthy = v1beta1helper.UpdatedConditionWithClock(r.Clock, conditionResourcesHealthy, gardencorev1beta1.ConditionTrue, resourcesv1alpha1.ConditionManagedResourceIgnored, message)
+	conditionResourcesProgressing := v1beta1helper.GetOrInitConditionWithClock(r.Clock, mr.Status.Conditions, resourcesv1alpha1.ResourcesProgressing)
+	conditionResourcesProgressing = v1beta1helper.UpdatedConditionWithClock(r.Clock, conditionResourcesProgressing, gardencorev1beta1.ConditionFalse, resourcesv1alpha1.ConditionManagedResourceIgnored, message)
 
 	oldMr := mr.DeepCopy()
 	mr.Status.Conditions = v1beta1helper.MergeConditions(mr.Status.Conditions, conditionResourcesApplied, conditionResourcesHealthy, conditionResourcesProgressing)
@@ -458,10 +460,10 @@ func (r *Reconciler) updateConditionsForIgnoredManagedResource(ctx context.Conte
 }
 
 func (r *Reconciler) updateConditionsForDeletion(ctx context.Context, mr *resourcesv1alpha1.ManagedResource) error {
-	conditionResourcesHealthy := v1beta1helper.GetOrInitCondition(mr.Status.Conditions, resourcesv1alpha1.ResourcesHealthy)
-	conditionResourcesHealthy = v1beta1helper.UpdatedCondition(conditionResourcesHealthy, gardencorev1beta1.ConditionFalse, resourcesv1alpha1.ConditionDeletionPending, "The resources are currently being deleted.")
-	conditionResourcesProgressing := v1beta1helper.GetOrInitCondition(mr.Status.Conditions, resourcesv1alpha1.ResourcesProgressing)
-	conditionResourcesProgressing = v1beta1helper.UpdatedCondition(conditionResourcesProgressing, gardencorev1beta1.ConditionTrue, resourcesv1alpha1.ConditionDeletionPending, "The resources are currently being deleted.")
+	conditionResourcesHealthy := v1beta1helper.GetOrInitConditionWithClock(r.Clock, mr.Status.Conditions, resourcesv1alpha1.ResourcesHealthy)
+	conditionResourcesHealthy = v1beta1helper.UpdatedConditionWithClock(r.Clock, conditionResourcesHealthy, gardencorev1beta1.ConditionFalse, resourcesv1alpha1.ConditionDeletionPending, "The resources are currently being deleted.")
+	conditionResourcesProgressing := v1beta1helper.GetOrInitConditionWithClock(r.Clock, mr.Status.Conditions, resourcesv1alpha1.ResourcesProgressing)
+	conditionResourcesProgressing = v1beta1helper.UpdatedConditionWithClock(r.Clock, conditionResourcesProgressing, gardencorev1beta1.ConditionTrue, resourcesv1alpha1.ConditionDeletionPending, "The resources are currently being deleted.")
 	return updateConditions(ctx, r.SourceClient, mr, conditionResourcesHealthy, conditionResourcesProgressing)
 }
 

--- a/pkg/utils/test/matchers/conditions.go
+++ b/pkg/utils/test/matchers/conditions.go
@@ -51,7 +51,14 @@ func WithReason(reason string) gomegatypes.GomegaMatcher {
 // WithMessage returns a matcher for checking whether a condition has a certain message.
 func WithMessage(message string) gomegatypes.GomegaMatcher {
 	return gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
-		"Message": Equal(message),
+		"Message": ContainSubstring(message),
+	})
+}
+
+// WithCodes returns a matcher for checking whether a condition contains certain error codes.
+func WithCodes(codes ...gardencorev1beta1.ErrorCode) gomegatypes.GomegaMatcher {
+	return gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+		"Codes": ContainElements(codes),
 	})
 }
 

--- a/test/integration/controllermanager/seed/backupbucketscheck/backupbucketscheck_suite_test.go
+++ b/test/integration/controllermanager/seed/backupbucketscheck/backupbucketscheck_suite_test.go
@@ -21,14 +21,12 @@ import (
 
 	"github.com/gardener/gardener/pkg/api/indexer"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
-	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/controllermanager/apis/config"
 	"github.com/gardener/gardener/pkg/controllermanager/controller/seed/backupbucketscheck"
 	gardenerenvtest "github.com/gardener/gardener/pkg/envtest"
 	"github.com/gardener/gardener/pkg/logger"
 	"github.com/gardener/gardener/pkg/utils"
-	"github.com/gardener/gardener/pkg/utils/test"
 
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
@@ -114,11 +112,6 @@ var _ = BeforeSuite(func() {
 	Expect(indexer.AddBackupBucketSeedName(ctx, mgr.GetFieldIndexer())).To(Succeed())
 
 	fakeClock = testclock.NewFakeClock(time.Now())
-	// This is required so that the BackupsBucketReady condition is created with appropriate lastUpdateTimestamp and
-	// lastTransitionTimestamp.
-	DeferCleanup(test.WithVars(
-		&gardencorev1beta1helper.Clock, fakeClock,
-	))
 
 	By("registering controller")
 	Expect((&backupbucketscheck.Reconciler{

--- a/test/integration/controllermanager/seed/extensionscheck/extensionscheck_suite_test.go
+++ b/test/integration/controllermanager/seed/extensionscheck/extensionscheck_suite_test.go
@@ -21,14 +21,12 @@ import (
 
 	"github.com/gardener/gardener/pkg/api/indexer"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
-	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/controllermanager/apis/config"
 	"github.com/gardener/gardener/pkg/controllermanager/controller/seed/extensionscheck"
 	gardenerenvtest "github.com/gardener/gardener/pkg/envtest"
 	"github.com/gardener/gardener/pkg/logger"
 	"github.com/gardener/gardener/pkg/utils"
-	"github.com/gardener/gardener/pkg/utils/test"
 
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
@@ -118,13 +116,7 @@ var _ = BeforeSuite(func() {
 	By("setting up field indexes")
 	Expect(indexer.AddControllerInstallationSeedRefName(ctx, mgr.GetFieldIndexer())).To(Succeed())
 
-	// This is required so that the ExtensionsReady condition is created with appropriate lastUpdateTimestamp and
-	// lastTransitionTimestamp.
 	fakeClock = testclock.NewFakeClock(time.Now())
-	DeferCleanup(test.WithVars(
-		&gardencorev1beta1helper.Clock, fakeClock,
-	))
-
 	By("registering controller")
 	Expect((&extensionscheck.Reconciler{
 		Config: config.SeedExtensionsCheckControllerConfiguration{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind cleanup

**What this PR does / why we need it**:
Cleanup after #6729
Also Reuse matchers for `gardencorev1beta.Condition` wherever possible.

**Which issue(s) this PR fixes**:
Fixes #7231

**Special notes for your reviewer**:
/cc @oliver-goetz 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
