### PR TITLE
Add the alerts for pods requesting resource reaching node capacity

### DIFF
--- a/charts/seed-monitoring/charts/core/charts/prometheus/rules-tests/node-exporter.rules.test.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/rules-tests/node-exporter.rules.test.yaml
@@ -26,6 +26,16 @@ tests:
     values: '95+0x120'
   - series: 'node_nf_conntrack_entries_limit'
     values: '100+0x120'
+  # PodsRequestCPUApproachNodeCapacity
+  - series: 'kube_pod_container_resource_requests_cpu_cores{node="node1"}'
+    values: '1+0x100'
+  - series: 'kube_node_status_allocatable{resource="cpu",node="node1"}'
+    values: '1+0x120'
+  # PodsRequestMemoryApproachNodeCapacity
+  - series: 'kube_pod_container_resource_requests_memory_bytes{node="node1"}'
+    values: '1+0x100'
+  - series: 'kube_node_status_allocatable{resource="memory",node="node1"}'
+    values: '1+0x120'
   alert_rule_test:
   - eval_time: 1h
     alertname: K8SNodeOutOfDisk
@@ -104,3 +114,25 @@ tests:
       exp_annotations:
         description: The nf_conntrack table is 95% full.
         summary: Number of tracked connections is near the limit
+  - eval_time: 1h
+    alertname: PodsRequestCPUApproachNodeCapacity
+    exp_alerts:
+    - exp_labels:
+        service: node-exporter
+        severity: critical
+        type: shoot
+        visibility: operator
+      exp_annotations:
+        summary: Pods request CPU approach Node capacity.
+        description: Pods request CPU is approaching Node node1 capacity.
+  - eval_time: 1h
+    alertname: PodsRequestMemoryApproachNodeCapacity
+    exp_alerts:
+    - exp_labels:
+        service: node-exporter
+        severity: critical
+        type: shoot
+        visibility: operator
+      exp_annotations:
+        summary: Pods request memory approach Node capacity.
+        description: Pods request memory is approaching Node node1 capacity.

--- a/charts/seed-monitoring/charts/core/charts/prometheus/rules/node-exporter.rules.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/rules/node-exporter.rules.yaml
@@ -49,6 +49,30 @@ groups:
       summary: Node is under disk pressure.
       description: Node {{ $labels.node }} is under disk pressure
 
+  - alert: PodsRequestCPUApproachNodeCapacity
+    expr: sum by (node)(kube_pod_container_resource_requests_cpu_cores) / sum by (node)(kube_node_status_allocatable{resource="cpu"}) > 80
+    for: 1h
+    labels:
+      service: node-exporter
+      severity: critical
+      type: shoot
+      visibility: operator
+    annotations:
+      summary: Pods request CPU approach Node capacity.
+      description: Pods request CPU is approaching Node {{ $labels.node }} capacity.
+
+  - alert: PodsRequestMemoryApproachNodeCapacity
+    expr: sum by (node)(kube_pod_container_resource_requests_memory_bytes) / sum by (node)(kube_node_status_allocatable{resource="memory"}) > 80
+    for: 1h
+    labels:
+      service: node-exporter
+      severity: critical
+      type: shoot
+      visibility: operator
+    annotations:
+      summary: Pods request memory approach Node capacity.
+      description: Pods request memory is approaching Node {{ $labels.node }} capacity.
+
   - record: instance:conntrack_entries_usage:percent
     expr: (node_nf_conntrack_entries / node_nf_conntrack_entries_limit) * 100
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind enhancement

**What this PR does / why we need it**:
Many pods are scaled by VPA. While VPA resources often specify some maximum values (e.g. max 8 CPUs or 25 GB memory) these maximum values are static and not aware of node sizes.
So when the pods requesting memory/CPU reaching the node capacity, trigger critical alerts to report this risk. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Add the alerts for pods requesting resource reaching node capacity
```
