### PR TITLE
Fix wrong count of pods per node in grafana dashboard

### DIFF
--- a/charts/seed-monitoring/charts/grafana/dashboards/owners/node-pool-dashboard.json
+++ b/charts/seed-monitoring/charts/grafana/dashboards/owners/node-pool-dashboard.json
@@ -578,7 +578,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg by (label_worker_gardener_cloud_pool) (\n    count by (node) (kube_pod_info{type=\"shoot\"})\n  + on (node) group_right ()\n    sum by (label_worker_gardener_cloud_pool, node) (\n      0 * kube_node_labels{label_worker_gardener_cloud_pool=~\"$worker_group\"}\n    )\n)",
+          "expr": "avg by (label_worker_gardener_cloud_pool) (\n    sum by (node) (\n      label_replace(\n        sum by (kubernetes_io_hostname) (kubelet_running_pods),\n        \"node\",\n        \"$1\",\n        \"kubernetes_io_hostname\",\n        \"(.+)\"\n      )\n    )\n  + on (node) group_right ()\n    sum by (label_worker_gardener_cloud_pool, node) (\n      0 * kube_node_labels{label_worker_gardener_cloud_pool=~\"$worker_group\"}\n    )\n)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{label_worker_gardener_cloud_pool}}",
@@ -884,7 +884,7 @@
           "refId": "G"
         },
         {
-          "expr": "  sum without (kubernetes_io_hostname) (label_replace(sum (kubelet_running_pods) by (kubernetes_io_hostname), \"node\",\"$1\",\"kubernetes_io_hostname\", \"(.+)\")\n  )",
+          "expr": "sum without (kubernetes_io_hostname) (\n  label_replace(\n    sum by (kubernetes_io_hostname) (kubelet_running_pods),\n    \"node\",\n    \"$1\",\n    \"kubernetes_io_hostname\",\n    \"(.+)\"\n  )\n)",
           "format": "table",
           "instant": true,
           "intervalFactor": 1,

--- a/charts/seed-monitoring/charts/grafana/dashboards/owners/node-pool-dashboard.json
+++ b/charts/seed-monitoring/charts/grafana/dashboards/owners/node-pool-dashboard.json
@@ -884,7 +884,7 @@
           "refId": "G"
         },
         {
-          "expr": "  count by (node) (kube_pod_info{type=\"shoot\"})\n+ on (node) group_right ()\n  sum by (label_worker_gardener_cloud_pool, node) (\n    0 * kube_node_labels{label_worker_gardener_cloud_pool=~\"$worker_group\"}\n  )",
+          "expr": "  sum without (kubernetes_io_hostname) (label_replace(sum (kubelet_running_pods) by (kubernetes_io_hostname), \"node\",\"$1\",\"kubernetes_io_hostname\", \"(.+)\")\n  )",
           "format": "table",
           "instant": true,
           "intervalFactor": 1,


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind bug

**What this PR does / why we need it**:
Previously `kube_pod_info` metric was used to calculate the count of pods per node, but we scrape only `kube-system` namespace for `shoot` because of this in the dashboard pods per node count was wrong as it used to show the count of pods which are in `kube-system` namespace only per node.
This PR uses `kubelet_running_pods` metrics which show nodes with pods count.  

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener/issues/6892

**Special notes for your reviewer**:
/cc @istvanballok 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
An issue causing grafana dashboard panel to show wrong count of pods per node is fixed. Previously the panel was only showing the count of pods in the `kube-system` namespace only. Now it shows the count of pods in all namespaces.
```
