### PR TITLE
local-provider: recociling permissions for local backup directory

### DIFF
--- a/pkg/provider-local/controller/backupbucket/actuator.go
+++ b/pkg/provider-local/controller/backupbucket/actuator.go
@@ -52,6 +52,12 @@ func (a *actuator) Reconcile(_ context.Context, log logr.Logger, bb *extensionsv
 	if err := os.Mkdir(filePath, fileMode); err != nil && !os.IsExist(err) {
 		return err
 	}
+
+	// ensure the backup-bucket directory has the correct set of permissions, even if they have been changed externally
+	if err := os.Chmod(filePath, fileMode); err != nil {
+		return err
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind bug

**What this PR does / why we need it**:
Ensures the correct set of permissions (0775) for the host-mounted bucket-directory during backup bucket reconciliation in the local-provider (local-setup).
This is important if the filesystem permissions are changed externally (this happened to multiple people, including me, and is not obvious to debug).

Please see the attached issue for a more detailed description.

**Which issue(s) this PR fixes**:
Fixes #7236

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix developer
Ensures the correct set of permissions (0775) for the host-mounted bucket-directory during backup bucket reconciliation in the local-provider 
```
