### PR TITLE
[GEP-22] Add HPlusVAutoscaling for kube-apiserver

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -334,7 +334,13 @@ images:
         integrity_requirement: 'high'
         availability_requirement: 'high'
 
-# Horizontal cluster-proportional-autoscaler
+# HPlusVAutoscaler
+- name: prometheus-metrics-adapter
+  sourceRepository: https://github.com/kubernetes-sigs/prometheus-adapter
+  repository: k8s.gcr.io/prometheus-adapter/prometheus-adapter
+  tag: "v0.9.1"
+
+  # Horizontal cluster-proportional-autoscaler
 - name: cluster-proportional-autoscaler
   sourceRepository: https://github.com/kubernetes-sigs/cluster-proportional-autoscaler
   repository: registry.k8s.io/cpa/cluster-proportional-autoscaler

--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -339,6 +339,15 @@ images:
   sourceRepository: https://github.com/kubernetes-sigs/prometheus-adapter
   repository: k8s.gcr.io/prometheus-adapter/prometheus-adapter
   tag: "v0.9.1"
+  labels:
+    - name: 'gardener.cloud/cve-categorisation'
+      value:
+        network_exposure: 'private'
+        authentication_enforced: false
+        user_interaction: 'gardener-operator'
+        confidentiality_requirement: 'low'
+        integrity_requirement: 'high'
+        availability_requirement: 'high'
 
   # Horizontal cluster-proportional-autoscaler
 - name: cluster-proportional-autoscaler

--- a/hack/local-development/start-gardenlet
+++ b/hack/local-development/start-gardenlet
@@ -181,16 +181,12 @@ else
 
   echo "Starting gardenlet for seed $SEED_NAME..."
 
-  echo "KUBECONFIG=${SEED_KUBECONFIG_GARDENLET_TOKEN}"
-  echo "GARDEN_KUBECONFIG=$GARDEN_KUBECONFIG"
-  echo "IMAGEVECTOR_OVERWRITE=${IMAGEVECTOR_OVERWRITE:-${file_imagevector_overwrite}}"
-
   KUBECONFIG="${SEED_KUBECONFIG_GARDENLET_TOKEN}" \
   GARDEN_KUBECONFIG="$GARDEN_KUBECONFIG" \
   IMAGEVECTOR_OVERWRITE="${IMAGEVECTOR_OVERWRITE:-${file_imagevector_overwrite}}" \
   GO111MODULE=on \
       go run \
-      -mod=vendor \
+        -mod=vendor \
         -ldflags "$("$(dirname $0)"/../get-build-ld-flags.sh)" \
         "$REPO_ROOT/cmd/gardenlet/main.go" \
         --config="$configFile"

--- a/hack/local-development/start-gardenlet
+++ b/hack/local-development/start-gardenlet
@@ -181,12 +181,16 @@ else
 
   echo "Starting gardenlet for seed $SEED_NAME..."
 
+  echo "KUBECONFIG=${SEED_KUBECONFIG_GARDENLET_TOKEN}"
+  echo "GARDEN_KUBECONFIG=$GARDEN_KUBECONFIG"
+  echo "IMAGEVECTOR_OVERWRITE=${IMAGEVECTOR_OVERWRITE:-${file_imagevector_overwrite}}"
+
   KUBECONFIG="${SEED_KUBECONFIG_GARDENLET_TOKEN}" \
   GARDEN_KUBECONFIG="$GARDEN_KUBECONFIG" \
   IMAGEVECTOR_OVERWRITE="${IMAGEVECTOR_OVERWRITE:-${file_imagevector_overwrite}}" \
   GO111MODULE=on \
       go run \
-        -mod=vendor \
+      -mod=vendor \
         -ldflags "$("$(dirname $0)"/../get-build-ld-flags.sh)" \
         "$REPO_ROOT/cmd/gardenlet/main.go" \
         --config="$configFile"

--- a/pkg/client/kubernetes/types.go
+++ b/pkg/client/kubernetes/types.go
@@ -111,6 +111,7 @@ func init() {
 		hvpav1alpha1.AddToScheme,
 		druidv1alpha1.AddToScheme,
 		apiextensionsscheme.AddToScheme,
+		apiregistrationscheme.AddToScheme,
 		istionetworkingv1beta1.AddToScheme,
 		istionetworkingv1alpha3.AddToScheme,
 	)

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -99,6 +99,12 @@ const (
 	// owner: @ScheererJ @DockToFuture
 	// alpha: v1.55.0
 	CoreDNSQueryRewriting featuregate.Feature = "CoreDNSQueryRewriting"
+
+	// HPlusVAutoscaling is applied to a seed cluster and enables simultaneous independent horizontal and vertical scaling.
+	// This feature is incompatible with the HVPA and HVPAForShootedSeed features.
+	// owner @andrerun
+	// alpha: v1.57.0
+	HPlusVAutoscaling featuregate.Feature = "HPlusVAutoscaling"
 )
 
 var allFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
@@ -113,6 +119,7 @@ var allFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	HAControlPlanes:       {Default: false, PreRelease: featuregate.Alpha},
 	DefaultSeccompProfile: {Default: false, PreRelease: featuregate.Alpha},
 	CoreDNSQueryRewriting: {Default: false, PreRelease: featuregate.Alpha},
+	HPlusVAutoscaling:     {Default: false, PreRelease: featuregate.Alpha},
 }
 
 // GetFeatures returns a feature gate map with the respective specifications. Non-existing feature gates are ignored.

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -100,10 +100,12 @@ const (
 	// alpha: v1.55.0
 	CoreDNSQueryRewriting featuregate.Feature = "CoreDNSQueryRewriting"
 
-	// HPlusVAutoscaling is applied to a seed cluster and enables simultaneous independent horizontal and vertical scaling.
-	// This feature is incompatible with the HVPA and HVPAForShootedSeed features.
+	// HPlusVAutoscaling is applied to a seed cluster. When enabled, kube-apiserver instances in the control planes
+	// of all shoots hosted on that seed are scaled as follows: Simultaneous horizontal and vertical autoscaling are
+	// applied, driven by signals which are sufficiently independent, as to avoid negative mutual interference.
+	// This feature is incompatible with the HVPA and HVPAForShootedSeed features, and takes precedence over them.
 	// owner @andrerun
-	// alpha: v1.57.0
+	// alpha: v1.63.0
 	HPlusVAutoscaling featuregate.Feature = "HPlusVAutoscaling"
 )
 

--- a/pkg/gardenlet/controller/seed/seed/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/seed/seed/reconciler_reconcile.go
@@ -877,6 +877,11 @@ func (r *Reconciler) runReconcileSeedFlow(
 	if err != nil {
 		return err
 	}
+	prometheusMetricsAdapter, err :=
+		defaultPrometheusMetricsAdapter(seedClient, kubernetesVersion, r.ImageVector, secretsManager, r.GardenNamespace)
+	if err != nil {
+		return err
+	}
 	vpnAuthzServer, err := defaultVPNAuthzServer(ctx, seedClient, kubernetesVersion, r.ImageVector, r.GardenNamespace)
 	if err != nil {
 		return err
@@ -946,6 +951,10 @@ func (r *Reconciler) runReconcileSeedFlow(
 		_ = g.Add(flow.Task{
 			Name: "Deploying system resources",
 			Fn:   systemResources.Deploy,
+		})
+		_ = g.Add(flow.Task{
+			Name: "Deploying Prometheus metrics adapter",
+			Fn:   prometheusMetricsAdapter.Deploy,
 		})
 	)
 

--- a/pkg/gardenlet/features/features.go
+++ b/pkg/gardenlet/features/features.go
@@ -36,5 +36,6 @@ func RegisterFeatureGates() {
 		features.ForceRestore,
 		features.DefaultSeccompProfile,
 		features.CoreDNSQueryRewriting,
+		features.HPlusVAutoscaling,
 	)))
 }

--- a/pkg/operation/botanist/component/kubeapiserver/horizontalpodautoscaler.go
+++ b/pkg/operation/botanist/component/kubeapiserver/horizontalpodautoscaler.go
@@ -53,7 +53,7 @@ func (k *kubeAPIServer) emptyHorizontalPodAutoscaler() client.Object {
 }
 
 func (k *kubeAPIServer) reconcileHorizontalPodAutoscaler(ctx context.Context, obj client.Object, deployment *appsv1.Deployment) error {
-	if k.values.Autoscaling.HVPAEnabled ||
+	if k.values.Autoscaling.AutoscalingMode != AutoscalingModeHPlusVClashing ||
 		k.values.Autoscaling.Replicas == nil ||
 		*k.values.Autoscaling.Replicas == 0 {
 

--- a/pkg/operation/botanist/component/kubeapiserver/hpva/h_plus_v_autoscaler.go
+++ b/pkg/operation/botanist/component/kubeapiserver/hpva/h_plus_v_autoscaler.go
@@ -1,0 +1,292 @@
+/*
+Package hpva implements the "HPlusVAutoscaler" - an autoscaling setup for kube-apiserver comprising an independently
+driven horizontal and vertical pod autoscalers.
+
+The HPA is driven by an application-specific load metric, based on the rate of requests made to the server. The goal of
+HPA is to determine a rough value for the minimal number of replicas guaranteed to suffice for processing the load. That
+rough estimate comes with a substantial safety margin which is offset by VPA shrinking the replicas as necessary (see below).
+
+The VPA element is a typical VPA setup acting on both CPU and memory. The goal of VPA is to vertically adjust the
+replicas provided based on HPA's rough estimate, to a scale that best matches the actual need for compute power.
+*/
+package hpva
+
+import (
+	"context"
+	"fmt"
+
+	appsv1 "k8s.io/api/apps/v1"
+	autoscalingv1 "k8s.io/api/autoscaling/v1"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	vpaautoscalingv1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
+	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	"github.com/gardener/gardener/pkg/controllerutils"
+	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
+)
+
+// DesiredStateParameters contains all configurable options of the HPlusVAutoscaler's desired state
+type DesiredStateParameters struct {
+	ContainerNameProxyPodMutator string // Empty string indicates that pod mutator is disabled
+	ContainerNameApiserver       string
+	ContainerNameVPNSeed         string
+	IsEnabled                    bool
+	MaxReplicaCount              int32
+	MinReplicaCount              int32
+}
+
+// HPlusVAutoscaler implements an autoscaling setup for kube-apiserver comprising an independently driven horizontal and
+// vertical pod autoscalers. For further overview of the autoscaling behavior, see package hpva.
+//
+// The underlying implementation is an arrangement of k8s resources deployed as part of the target shoot's control plane.
+// An HPlusVAutoscaler object itself is stateless. As far as state is concerned, it is nothing more than a handle,
+// pointing to the server-side setup.
+type HPlusVAutoscaler struct {
+	deploymentNameApiserver string // Also used as name for the underlying HPA and VPA resources
+	namespaceName           string
+}
+
+// NewHPlusVAutoscaler creates a local handle object, pointed at a server-side HPlusVAutoscaler instance of interest (either
+// already existing, or desired). The resulting object can be used to manipulate the server-side setup.
+func NewHPlusVAutoscaler(namespaceName string, deploymentNameApiserver string) *HPlusVAutoscaler {
+	return &HPlusVAutoscaler{
+		namespaceName:           namespaceName,
+		deploymentNameApiserver: deploymentNameApiserver,
+	}
+}
+
+// DeleteFromServer removes all HPlusVAutoscaler artefacts from the shoot's control plane.
+// The kubeClient parameter specifies a connection to the server hosting said control plane.
+func (hpva *HPlusVAutoscaler) DeleteFromServer(ctx context.Context, kubeClient client.Client) error {
+	baseErrorMessage :=
+		fmt.Sprintf("An error occurred while deleting HPlusVAutoscaler '%s' in namespace '%s'",
+			hpva.deploymentNameApiserver,
+			hpva.namespaceName)
+
+	if err := client.IgnoreNotFound(kutil.DeleteObject(ctx, kubeClient, hpva.makeHPA())); err != nil {
+		return fmt.Errorf(baseErrorMessage+
+			" - failed to delete the HPA which is part of the HPlusVAutoscaler from the server. "+
+			"The error message reported by the underlying operation follows: %w",
+			err)
+	}
+
+	if err := client.IgnoreNotFound(kutil.DeleteObject(ctx, kubeClient, hpva.makeVPA())); err != nil {
+		return fmt.Errorf(baseErrorMessage+
+			" - failed to delete the VPA which is part of the HPlusVAutoscaler from the server. "+
+			"The error message reported by the underlying operation follows: %w",
+			err)
+	}
+
+	return nil
+}
+
+// Reconcile brings the server-side HPlusVAutoscaler setup in compliance with the desired state specified by the
+// operation's parameters.
+// The kubeClient parameter specifies a connection to the server hosting said control plane.
+// The 'parameters' parameter specifies the desired state that is to be applied upon the server-side autoscaler setup.
+func (hpva *HPlusVAutoscaler) Reconcile(
+	ctx context.Context, kubeClient client.Client, parameters *DesiredStateParameters) error {
+
+	baseErrorMessage :=
+		fmt.Sprintf("An error occurred while reconciling HPlusVAutoscaler '%s' in namespace '%s'",
+			hpva.deploymentNameApiserver,
+			hpva.namespaceName)
+
+	if !parameters.IsEnabled {
+		if err := hpva.DeleteFromServer(ctx, kubeClient); err != nil {
+			return fmt.Errorf(baseErrorMessage+
+				" - failed to bring the HPlusVAutoscaler on the server to a disabled state. "+
+				"The error message reported by the underlying operation follows: %w",
+				err)
+		}
+		return nil
+	}
+
+	err := hpva.reconcileHPA(ctx, kubeClient, parameters.MinReplicaCount, parameters.MaxReplicaCount)
+	if err != nil {
+		return fmt.Errorf(baseErrorMessage+
+			" - failed to reconcile the HPA which is part of the HPlusVAutoscaler on the server. "+
+			"The error message reported by the underlying operation follows: %w",
+			err)
+	}
+
+	if err := hpva.reconcileVPA(
+		ctx,
+		kubeClient,
+		parameters.ContainerNameProxyPodMutator,
+		parameters.ContainerNameApiserver,
+		parameters.ContainerNameVPNSeed); err != nil {
+
+		return fmt.Errorf(baseErrorMessage+
+			" - failed to reconcile the VPA which is part of the HPlusVAutoscaler from the server. "+
+			"The error message reported by the underlying operation follows: %w",
+			err)
+	}
+
+	return nil
+}
+
+//#region Private implementation
+
+// Returns the name of HPlusVAutoscaler's server-side HPA
+func (hpva *HPlusVAutoscaler) GetHPAName() string {
+	return hpva.deploymentNameApiserver + "-hpva"
+}
+
+// Returns the name of HPlusVAutoscaler's server-side VPA
+func (hpva *HPlusVAutoscaler) GetVPAName() string {
+	return hpva.GetHPAName()
+}
+
+// Returns an empty HPA object pointing to the server-side HPA, which is part of this HPlusVAutoscaler
+func (hpva *HPlusVAutoscaler) makeHPA() *autoscalingv2.HorizontalPodAutoscaler {
+	return &autoscalingv2.HorizontalPodAutoscaler{
+		ObjectMeta: metav1.ObjectMeta{Name: hpva.GetHPAName(), Namespace: hpva.namespaceName},
+	}
+}
+
+// Returns an empty VPA object pointing to the server-side VPA, which is part of this HPlusVAutoscaler
+func (hpva *HPlusVAutoscaler) makeVPA() *vpaautoscalingv1.VerticalPodAutoscaler {
+	return &vpaautoscalingv1.VerticalPodAutoscaler{
+		ObjectMeta: metav1.ObjectMeta{Name: hpva.GetVPAName(), Namespace: hpva.namespaceName},
+	}
+}
+
+// Reconciles the HPA resource which is part of the HPlusVAutoscaler
+func (hpva *HPlusVAutoscaler) reconcileHPA(
+	ctx context.Context, kubeClient client.Client, minReplicaCount int32, maxReplicaCount int32) error {
+
+	hpa := hpva.makeHPA()
+	_, err := controllerutils.GetAndCreateOrMergePatch(ctx, kubeClient, hpa, func() error {
+		hpa.Spec.ScaleTargetRef = autoscalingv2.CrossVersionObjectReference{
+			APIVersion: appsv1.SchemeGroupVersion.String(),
+			Kind:       "Deployment",
+			Name:       hpva.deploymentNameApiserver,
+		}
+		hpa.Spec.Behavior = &autoscalingv2.HorizontalPodAutoscalerBehavior{
+			ScaleDown: &autoscalingv2.HPAScalingRules{
+				StabilizationWindowSeconds: pointer.Int32(900),
+			},
+		}
+
+		lvalue300 := resource.MustParse("300")
+		hpaMetrics := []autoscalingv2.MetricSpec{
+			{
+				Type: autoscalingv2.PodsMetricSourceType,
+				Pods: &autoscalingv2.PodsMetricSource{
+					Metric: autoscalingv2.MetricIdentifier{Name: "shoot:apiserver_request_total:sum"},
+					Target: autoscalingv2.MetricTarget{AverageValue: &lvalue300, Type: autoscalingv2.AverageValueMetricType},
+				},
+			},
+		}
+		hpa.Spec.Metrics = hpaMetrics
+		hpa.Spec.MinReplicas = &minReplicaCount
+		hpa.Spec.MaxReplicas = maxReplicaCount
+		hpa.ObjectMeta.Labels = map[string]string{v1beta1constants.LabelRole: v1beta1constants.LabelAPIServer + "-hpa"}
+
+		return nil
+	})
+
+	if err != nil {
+		return fmt.Errorf("An error occurred while reconciling the '%s' HPA which is part of the HPlusVAutoscaler "+
+			"in namespace '%s' - failed to apply the desired configuration values to the server-side object. "+
+			"The error message reported by the underlying operation follows: %w",
+			hpva.deploymentNameApiserver,
+			hpva.namespaceName,
+			err)
+	}
+
+	return nil
+}
+
+// Reconciles the VPA resource which part of the HPlusVAutoscaler
+// The containerNameAPIServerProxyPodMutator parameter is empty when the mutator is disabled
+func (hpva *HPlusVAutoscaler) reconcileVPA(
+	ctx context.Context,
+	kubeClient client.Client,
+	containerNameProxyPodMutator string,
+	containerNameApiserver string,
+	containerNameVPNSeed string) error {
+
+	vpa := hpva.makeVPA()
+	_, err := controllerutils.GetAndCreateOrMergePatch(ctx, kubeClient, vpa, func() error {
+		vpa.Spec.Recommenders = nil
+		vpa.Spec.TargetRef = &autoscalingv1.CrossVersionObjectReference{
+			APIVersion: appsv1.SchemeGroupVersion.String(),
+			Kind:       "Deployment",
+			Name:       hpva.deploymentNameApiserver,
+		}
+		updateModeAutoAsLvalue := vpaautoscalingv1.UpdateModeAuto
+		vpa.Spec.UpdatePolicy = &vpaautoscalingv1.PodUpdatePolicy{
+			MinReplicas: pointer.Int32(2),
+			UpdateMode:  &updateModeAutoAsLvalue,
+		}
+		vpa.Spec.ResourcePolicy = &vpaautoscalingv1.PodResourcePolicy{
+			ContainerPolicies: getVPAContainerResourcePolicies(
+				containerNameApiserver, containerNameProxyPodMutator, containerNameVPNSeed),
+		}
+		vpa.ObjectMeta.Labels = map[string]string{v1beta1constants.LabelRole: v1beta1constants.LabelAPIServer + "-vpa"}
+
+		return nil
+	})
+
+	if err != nil {
+		return fmt.Errorf("An error occurred while reconciling the '%s' VPA which is part of the HPlusVAutoscaler "+
+			"in namespace '%s' - failed to apply the desired configuration values to the server-side object. "+
+			"The error message reported by the underlying operation follows: %w",
+			hpva.deploymentNameApiserver,
+			hpva.namespaceName,
+			err)
+	}
+
+	return nil
+}
+
+// The containerNameAPIServerProxyPodMutator parameter must be empty when the mutator is disabled
+func getVPAContainerResourcePolicies(
+	containerNameApiserver string,
+	containerNameProxyPodMutator string,
+	containerNameVPNSeed string) []vpaautoscalingv1.ContainerResourcePolicy {
+
+	containerPolicyAutoAsLvalue := vpaautoscalingv1.ContainerScalingModeAuto
+	containerPolicyOffAsLvalue := vpaautoscalingv1.ContainerScalingModeOff
+	controlledValuesRequestsOnlyAsLvalue := vpaautoscalingv1.ContainerControlledValuesRequestsOnly
+
+	result := []vpaautoscalingv1.ContainerResourcePolicy{
+		{
+			ContainerName: containerNameApiserver,
+			Mode:          &containerPolicyAutoAsLvalue,
+			MinAllowed: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("300m"),
+				corev1.ResourceMemory: resource.MustParse("400M"),
+			},
+			MaxAllowed: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("8"),
+				corev1.ResourceMemory: resource.MustParse("25G"),
+			},
+			ControlledValues: &controlledValuesRequestsOnlyAsLvalue,
+		},
+		{
+			ContainerName:    containerNameVPNSeed,
+			Mode:             &containerPolicyOffAsLvalue,
+			ControlledValues: &controlledValuesRequestsOnlyAsLvalue,
+		},
+	}
+
+	if containerNameProxyPodMutator != "" {
+		result = append(result, vpaautoscalingv1.ContainerResourcePolicy{
+			ContainerName:    containerNameProxyPodMutator,
+			Mode:             &containerPolicyOffAsLvalue,
+			ControlledValues: &controlledValuesRequestsOnlyAsLvalue,
+		})
+	}
+
+	return result
+}
+
+//#endregion Private implementation

--- a/pkg/operation/botanist/component/kubeapiserver/hpva/h_plus_v_autoscaler_test.go
+++ b/pkg/operation/botanist/component/kubeapiserver/hpva/h_plus_v_autoscaler_test.go
@@ -1,0 +1,251 @@
+package hpva
+
+import (
+	autoscalingv1 "k8s.io/api/autoscaling/v1"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	vpaautoscalingv1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
+	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	"github.com/gardener/gardener/pkg/utils/test/matchers"
+)
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("HPlusVAutoscaler", func() {
+	const (
+		containerNameApiserver  = "kube-apiserver"
+		containerNamePodMutator = "apiserver-proxy-pod-mutator"
+		containerNameVPNSeed    = "vpn-seed"
+	)
+	var (
+		deploymentName = "test-deployment"
+		namespaceName  = "test-namespace"
+		hpaName        = deploymentName + "-hpva"
+		vpaName        = hpaName
+
+		kubeClient client.Client
+		ctx        = context.TODO()
+
+		//#region Helpers
+		assertObjectNotOnServer = func(obj client.Object, name string) {
+			err := kubeClient.Get(ctx, client.ObjectKey{Namespace: namespaceName, Name: name}, obj)
+			ExpectWithOffset(1, err).To(HaveOccurred())
+			ExpectWithOffset(1, err).To(matchers.BeNotFoundError())
+		}
+
+		newHpva = func(isEnabled bool) (*HPlusVAutoscaler, *DesiredStateParameters) {
+			return NewHPlusVAutoscaler(namespaceName, deploymentName),
+				&DesiredStateParameters{
+					IsEnabled:                    isEnabled,
+					MinReplicaCount:              1,
+					MaxReplicaCount:              4,
+					ContainerNameVPNSeed:         containerNameVPNSeed,
+					ContainerNameApiserver:       containerNameApiserver,
+					ContainerNameProxyPodMutator: containerNamePodMutator,
+				}
+		}
+
+		newHpa = func(minReplicaCount int32, maxReplicaCount int32) *autoscalingv2.HorizontalPodAutoscaler {
+			lvalue300 := resource.MustParse("300")
+			return &autoscalingv2.HorizontalPodAutoscaler{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: autoscalingv2.SchemeGroupVersion.String(),
+					Kind:       "HorizontalPodAutoscaler",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            hpaName,
+					Namespace:       namespaceName,
+					Labels:          map[string]string{v1beta1constants.LabelRole: v1beta1constants.LabelAPIServer + "-hpa"},
+					ResourceVersion: "1",
+				},
+				Spec: autoscalingv2.HorizontalPodAutoscalerSpec{
+					MinReplicas: &minReplicaCount,
+					MaxReplicas: maxReplicaCount,
+					ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{
+						APIVersion: "apps/v1",
+						Kind:       "Deployment",
+						Name:       deploymentName,
+					},
+					Behavior: &autoscalingv2.HorizontalPodAutoscalerBehavior{
+						ScaleDown: &autoscalingv2.HPAScalingRules{
+							StabilizationWindowSeconds: pointer.Int32(900),
+						},
+					},
+					Metrics: []autoscalingv2.MetricSpec{
+						{
+							Type: autoscalingv2.PodsMetricSourceType,
+							Pods: &autoscalingv2.PodsMetricSource{
+								Metric: autoscalingv2.MetricIdentifier{Name: "shoot:apiserver_request_total:sum"},
+								Target: autoscalingv2.MetricTarget{AverageValue: &lvalue300, Type: autoscalingv2.AverageValueMetricType},
+							},
+						},
+					},
+				},
+			}
+		}
+
+		newVpa = func() *vpaautoscalingv1.VerticalPodAutoscaler {
+			updateModeAutoAsLvalue := vpaautoscalingv1.UpdateModeAuto
+			return &vpaautoscalingv1.VerticalPodAutoscaler{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: vpaautoscalingv1.SchemeGroupVersion.String(),
+					Kind:       "VerticalPodAutoscaler",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            vpaName,
+					Namespace:       namespaceName,
+					Labels:          map[string]string{v1beta1constants.LabelRole: v1beta1constants.LabelAPIServer + "-vpa"},
+					ResourceVersion: "1",
+				},
+				Spec: vpaautoscalingv1.VerticalPodAutoscalerSpec{
+					TargetRef: &autoscalingv1.CrossVersionObjectReference{
+						APIVersion: "apps/v1",
+						Kind:       "Deployment",
+						Name:       deploymentName,
+					},
+					UpdatePolicy: &vpaautoscalingv1.PodUpdatePolicy{
+						MinReplicas: pointer.Int32(2),
+						UpdateMode:  &updateModeAutoAsLvalue,
+					},
+					ResourcePolicy: &vpaautoscalingv1.PodResourcePolicy{
+						ContainerPolicies: getVPAContainerResourcePolicies(
+							containerNameApiserver, containerNamePodMutator, containerNameVPNSeed),
+					},
+				},
+			}
+		}
+		//#endregion Helpers
+	)
+
+	BeforeEach(func() {
+		kubeClient = fakeclient.NewClientBuilder().WithScheme(kubernetes.SeedScheme).Build()
+	})
+
+	Describe(".Reconcile()", func() {
+		Context("in enabled state", func() {
+			It("should deploy the correct resources to the shoot control plane", func() {
+				// Arrange
+				hpva, desiredState := newHpva(true)
+
+				// Act
+				Expect(hpva.Reconcile(ctx, kubeClient, desiredState)).To(Succeed())
+
+				// Assert
+				actualHpa := autoscalingv2.HorizontalPodAutoscaler{}
+				Expect(kubeClient.Get(
+					ctx,
+					client.ObjectKey{Namespace: namespaceName, Name: hpaName},
+					&actualHpa),
+				).To(Succeed())
+				Expect(&actualHpa).To(matchers.DeepEqual(newHpa(desiredState.MinReplicaCount, desiredState.MaxReplicaCount)))
+
+				actualVpa := vpaautoscalingv1.VerticalPodAutoscaler{}
+				Expect(kubeClient.Get(
+					ctx,
+					client.ObjectKey{Namespace: namespaceName, Name: vpaName},
+					&actualVpa),
+				).To(Succeed())
+				Expect(&actualVpa).To(matchers.DeepEqual(newVpa()))
+			})
+			It("should not attempt to deploy proxy pod mutator, when the respective image argument is empty", func() {
+				// Arrange
+				hpva, desiredState := newHpva(true)
+				desiredState.ContainerNameProxyPodMutator = ""
+
+				// Act
+				Expect(hpva.Reconcile(ctx, kubeClient, desiredState)).To(Succeed())
+
+				// Assert
+				actualVpa := vpaautoscalingv1.VerticalPodAutoscaler{}
+				Expect(kubeClient.Get(
+					ctx,
+					client.ObjectKey{Namespace: namespaceName, Name: vpaName},
+					&actualVpa),
+				).To(Succeed())
+				Expect(len(actualVpa.Spec.ResourcePolicy.ContainerPolicies)).To(Equal(2))
+				Expect(actualVpa.Spec.ResourcePolicy.ContainerPolicies[0].ContainerName).To(Equal(containerNameApiserver))
+				Expect(actualVpa.Spec.ResourcePolicy.ContainerPolicies[1].ContainerName).To(Equal(containerNameVPNSeed))
+			})
+		})
+		Context("in disabled state", func() {
+			It("should not deploy any resources to the shoot control plane", func() {
+				// Arrange
+				hpva, desiredState := newHpva(false)
+
+				// Act
+				Expect(hpva.Reconcile(ctx, kubeClient, desiredState)).To(Succeed())
+
+				// Assert
+				assertObjectNotOnServer(&autoscalingv2.HorizontalPodAutoscaler{}, hpaName)
+				assertObjectNotOnServer(&vpaautoscalingv1.VerticalPodAutoscaler{}, vpaName)
+			})
+			It("should remove respective resources already in the shoot control plane", func() {
+				// Arrange
+				hpva, desiredState := newHpva(true)
+				Expect(hpva.reconcileHPA(ctx, kubeClient, desiredState.MinReplicaCount, desiredState.MaxReplicaCount)).To(Succeed())
+				desiredState.IsEnabled = false
+
+				// Act
+				Expect(hpva.Reconcile(ctx, kubeClient, desiredState)).To(Succeed())
+
+				// Assert
+				assertObjectNotOnServer(&autoscalingv2.HorizontalPodAutoscaler{}, hpaName)
+				assertObjectNotOnServer(&vpaautoscalingv1.VerticalPodAutoscaler{}, vpaName)
+			})
+		})
+	})
+	Describe(".DeleteFromServer()", func() {
+		Context("in enabled state", func() {
+			It("should destroy respective resources in the shoot control plane", func() {
+				// Arrange
+				hpva, desiredState := newHpva(true)
+				Expect(hpva.reconcileHPA(ctx, kubeClient, desiredState.MinReplicaCount, desiredState.MaxReplicaCount)).To(Succeed())
+
+				// Act
+				Expect(hpva.DeleteFromServer(ctx, kubeClient)).To(Succeed())
+
+				// Assert
+				assertObjectNotOnServer(&autoscalingv2.HorizontalPodAutoscaler{}, hpaName)
+				assertObjectNotOnServer(&vpaautoscalingv1.VerticalPodAutoscaler{}, vpaName)
+			})
+			It("should not fail if resources are missing on the seed", func() {
+				// Arrange
+				hpva, _ := newHpva(true)
+
+				// Act
+				err := hpva.DeleteFromServer(ctx, kubeClient)
+
+				// Assert
+				Expect(err).To(Succeed())
+				assertObjectNotOnServer(&autoscalingv2.HorizontalPodAutoscaler{}, hpaName)
+				assertObjectNotOnServer(&vpaautoscalingv1.VerticalPodAutoscaler{}, vpaName)
+			})
+		})
+		Context("in disabled state", func() {
+			It("should destroy respective resources in the shoot control plane", func() {
+				// Arrange
+				hpva, desiredState := newHpva(true)
+				Expect(hpva.reconcileHPA(ctx, kubeClient, desiredState.MinReplicaCount, desiredState.MaxReplicaCount)).To(Succeed())
+				desiredState.IsEnabled = false
+
+				// Act
+				Expect(hpva.DeleteFromServer(ctx, kubeClient)).To(Succeed())
+
+				// Assert
+				assertObjectNotOnServer(&autoscalingv2.HorizontalPodAutoscaler{}, hpaName)
+				assertObjectNotOnServer(&vpaautoscalingv1.VerticalPodAutoscaler{}, vpaName)
+			})
+		})
+	})
+})

--- a/pkg/operation/botanist/component/kubeapiserver/hpva/h_plus_v_autoscaler_test.go
+++ b/pkg/operation/botanist/component/kubeapiserver/hpva/h_plus_v_autoscaler_test.go
@@ -26,7 +26,6 @@ var _ = Describe("HPlusVAutoscaler", func() {
 	const (
 		containerNameApiserver  = "kube-apiserver"
 		containerNamePodMutator = "apiserver-proxy-pod-mutator"
-		containerNameVPNSeed    = "vpn-seed"
 	)
 	var (
 		deploymentName = "test-deployment"
@@ -50,7 +49,6 @@ var _ = Describe("HPlusVAutoscaler", func() {
 					IsEnabled:                    isEnabled,
 					MinReplicaCount:              1,
 					MaxReplicaCount:              4,
-					ContainerNameVPNSeed:         containerNameVPNSeed,
 					ContainerNameApiserver:       containerNameApiserver,
 					ContainerNameProxyPodMutator: containerNamePodMutator,
 				}
@@ -115,12 +113,10 @@ var _ = Describe("HPlusVAutoscaler", func() {
 						Name:       deploymentName,
 					},
 					UpdatePolicy: &vpaautoscalingv1.PodUpdatePolicy{
-						MinReplicas: pointer.Int32(2),
-						UpdateMode:  &updateModeAutoAsLvalue,
+						UpdateMode: &updateModeAutoAsLvalue,
 					},
 					ResourcePolicy: &vpaautoscalingv1.PodResourcePolicy{
-						ContainerPolicies: getVPAContainerResourcePolicies(
-							containerNameApiserver, containerNamePodMutator, containerNameVPNSeed),
+						ContainerPolicies: getVPAContainerResourcePolicies(containerNameApiserver, containerNamePodMutator),
 					},
 				},
 			}
@@ -173,9 +169,8 @@ var _ = Describe("HPlusVAutoscaler", func() {
 					client.ObjectKey{Namespace: namespaceName, Name: vpaName},
 					&actualVpa),
 				).To(Succeed())
-				Expect(len(actualVpa.Spec.ResourcePolicy.ContainerPolicies)).To(Equal(2))
+				Expect(len(actualVpa.Spec.ResourcePolicy.ContainerPolicies)).To(Equal(1))
 				Expect(actualVpa.Spec.ResourcePolicy.ContainerPolicies[0].ContainerName).To(Equal(containerNameApiserver))
-				Expect(actualVpa.Spec.ResourcePolicy.ContainerPolicies[1].ContainerName).To(Equal(containerNameVPNSeed))
 			})
 		})
 		Context("in disabled state", func() {

--- a/pkg/operation/botanist/component/kubeapiserver/hpva/suite_test.go
+++ b/pkg/operation/botanist/component/kubeapiserver/hpva/suite_test.go
@@ -1,0 +1,13 @@
+package hpva
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestPrometheusMetricsAdapter(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "HPlusVAutoscaler component unit test suite")
+}

--- a/pkg/operation/botanist/component/kubeapiserver/hvpa.go
+++ b/pkg/operation/botanist/component/kubeapiserver/hvpa.go
@@ -36,7 +36,7 @@ func (k *kubeAPIServer) emptyHVPA() *hvpav1alpha1.Hvpa {
 }
 
 func (k *kubeAPIServer) reconcileHVPA(ctx context.Context, hvpa *hvpav1alpha1.Hvpa, deployment *appsv1.Deployment) error {
-	if !k.values.Autoscaling.HVPAEnabled ||
+	if k.values.Autoscaling.AutoscalingMode != AutoscalingModeHVPA ||
 		k.values.Autoscaling.Replicas == nil ||
 		*k.values.Autoscaling.Replicas == 0 {
 

--- a/pkg/operation/botanist/component/kubeapiserver/kube_apiserver.go
+++ b/pkg/operation/botanist/component/kubeapiserver/kube_apiserver.go
@@ -617,6 +617,5 @@ func (k *kubeAPIServer) reconcileHPlusVAutoscaler(ctx context.Context, deploymen
 			MaxReplicaCount:              k.values.Autoscaling.MaxReplicas,
 			ContainerNameProxyPodMutator: desiredValueContainerNameAPIServerProxyPodMutator,
 			ContainerNameApiserver:       ContainerNameKubeAPIServer,
-			ContainerNameVPNSeed:         containerNameVPNSeed,
 		})
 }

--- a/pkg/operation/botanist/component/kubeapiserver/monitoring.go
+++ b/pkg/operation/botanist/component/kubeapiserver/monitoring.go
@@ -184,6 +184,8 @@ const (
 
   - record: shoot:kube_apiserver:sum_by_pod
     expr: sum(up{job="` + monitoringPrometheusJobName + `"}) by (pod)
+  - record: shoot:` + monitoringMetricApiserverRequestTotal + `:sum
+    expr: sum(rate(` + monitoringMetricApiserverRequestTotal + `[2m])) by (pod)
   ### API failure rate ###
   - alert: ApiserverRequestsFailureRate
     expr: max(sum by(instance,resource,verb) (rate(` + monitoringMetricApiserverRequestTotal + `{code=~"5.."}[10m])) / sum by(instance,resource,verb) (rate(` + monitoringMetricApiserverRequestTotal + `[10m]))) * 100 > 10

--- a/pkg/operation/botanist/component/kubeapiserver/monitoring_test.go
+++ b/pkg/operation/botanist/component/kubeapiserver/monitoring_test.go
@@ -191,6 +191,8 @@ metric_relabel_configs:
 
   - record: shoot:kube_apiserver:sum_by_pod
     expr: sum(up{job="kube-apiserver"}) by (pod)
+  - record: shoot:apiserver_request_total:sum
+    expr: sum(rate(apiserver_request_total[2m])) by (pod)
   ### API failure rate ###
   - alert: ApiserverRequestsFailureRate
     expr: max(sum by(instance,resource,verb) (rate(apiserver_request_total{code=~"5.."}[10m])) / sum by(instance,resource,verb) (rate(apiserver_request_total[10m]))) * 100 > 10

--- a/pkg/operation/botanist/component/kubeapiserver/verticalpodautoscaler.go
+++ b/pkg/operation/botanist/component/kubeapiserver/verticalpodautoscaler.go
@@ -20,6 +20,7 @@ import (
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/controllerutils"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
+
 	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -31,7 +32,7 @@ func (k *kubeAPIServer) emptyVerticalPodAutoscaler() *vpaautoscalingv1.VerticalP
 }
 
 func (k *kubeAPIServer) reconcileVerticalPodAutoscaler(ctx context.Context, verticalPodAutoscaler *vpaautoscalingv1.VerticalPodAutoscaler, deployment *appsv1.Deployment) error {
-	if k.values.Autoscaling.HVPAEnabled {
+	if k.values.Autoscaling.AutoscalingMode != AutoscalingModeHPlusVClashing {
 		return kutil.DeleteObject(ctx, k.client.Client(), verticalPodAutoscaler)
 	}
 

--- a/pkg/operation/botanist/component/prommetric/component.go
+++ b/pkg/operation/botanist/component/prommetric/component.go
@@ -1,0 +1,369 @@
+// Package prommetric implements the Prometheus Metrics Adapter seed component. It consumes data from the aggregate seed
+// Prometheus and exposes it in metrics server format. The adapter is registered as an extension service to the seed's
+// kube-apiserver, serving custom metrics.
+package prommetric
+
+import (
+	"bytes"
+	"context"
+	"embed"
+	_ "embed"
+	"fmt"
+	"io"
+	"io/fs"
+	"text/template"
+	"time"
+
+	"github.com/Masterminds/sprig"
+	"github.com/hashicorp/go-multierror"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	"github.com/gardener/gardener/pkg/operation/botanist/component"
+	utilerrors "github.com/gardener/gardener/pkg/utils/errors"
+	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
+	"github.com/gardener/gardener/pkg/utils/managedresources"
+	secretutils "github.com/gardener/gardener/pkg/utils/secrets"
+	secretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager"
+)
+
+// HPlusVAutoscaler implements an extension apiservice to the seed kube-apiserver. It serves custom metrics based on
+// data from the aggregate seed prometheus.
+type PrometheusMetricsAdapter struct {
+	namespaceName      string
+	containerImageName string
+	isEnabled          bool
+
+	kubeClient              client.Client
+	secretsManager          secretsmanager.Interface
+	managedResourceRegistry *managedresources.Registry
+
+	testIsolation prometheusMetricsAdapterTestIsolation // Provides indirections necessary to isolate the unit during tests
+}
+
+// Creates a new PrometheusMetricsAdapter instance tied to a specific server connection
+func NewPrometheusMetricsAdapter(
+	namespace string,
+	containerImageName string,
+	enabled bool,
+	kubeClient client.Client,
+	secretsManager secretsmanager.Interface) *PrometheusMetricsAdapter {
+
+	return &PrometheusMetricsAdapter{
+		namespaceName:           namespace,
+		containerImageName:      containerImageName,
+		isEnabled:               enabled,
+		kubeClient:              kubeClient,
+		secretsManager:          secretsManager,
+		managedResourceRegistry: managedresources.NewRegistry(kubernetes.SeedScheme, kubernetes.SeedCodec, kubernetes.SeedSerializer),
+
+		testIsolation: prometheusMetricsAdapterTestIsolation{
+			DeployResourceConfigs: component.DeployResourceConfigs,
+			DestroyResourceConfigs: func(
+				ctx context.Context, clt client.Client, ns string, clusterType component.ClusterType, mrName string) error {
+
+				return component.DestroyResourceConfigs(ctx, clt, ns, clusterType, mrName)
+			},
+		},
+	}
+}
+
+// Implements component.Deployer.Deploy()
+func (pma *PrometheusMetricsAdapter) Deploy(ctx context.Context) error {
+	baseErrorMessage :=
+		fmt.Sprintf("An error occurred while reconciling PrometheusMetricsAdapter component in namespace '%s' of the seed server",
+			pma.namespaceName)
+
+	if !pma.isEnabled {
+		if err := pma.Destroy(ctx); err != nil {
+			return fmt.Errorf(baseErrorMessage+
+				" - failed to bring the PrometheusMetricsAdapter on the server to a disabled state. "+
+				"The error message reported by the underlying operation follows: %w",
+				err)
+		}
+		return nil
+	}
+
+	serverCertificateSecret, err := pma.deployServerCertificate(ctx)
+	if err != nil {
+		return fmt.Errorf(baseErrorMessage+
+			" - failed to deploy the prommetric server TLS certificate to the seed server. "+
+			"The error message reported by the underlying operation follows: %w",
+			err)
+	}
+
+	resourceConfigs, err := getResourceConfigs(pma.namespaceName, pma.containerImageName, serverCertificateSecret)
+	if err != nil {
+		return fmt.Errorf(baseErrorMessage+
+			" - failed to acquire the necessary resource config objects. "+
+			"The error message reported by the underlying operation follows: %w",
+			err)
+	}
+
+	err = pma.testIsolation.DeployResourceConfigs(
+		ctx, pma.kubeClient, pma.namespaceName, component.ClusterTypeSeed, managedResourceName, pma.managedResourceRegistry, resourceConfigs)
+	if err != nil {
+		return fmt.Errorf(baseErrorMessage+
+			" - failed to deploy the necessary resource config objects as a ManagedResource named '%s' to the server. "+
+			"The error message reported by the underlying operation follows: %w",
+			managedResourceName,
+			err)
+	}
+
+	return nil
+}
+
+// Implements component.Deployer.Destroy()
+func (pma *PrometheusMetricsAdapter) Destroy(ctx context.Context) error {
+	if err := pma.testIsolation.DestroyResourceConfigs(
+		ctx, pma.kubeClient, pma.namespaceName, component.ClusterTypeSeed, managedResourceName); err != nil {
+
+		return fmt.Errorf(
+			"An error occurred while removing the PrometheusMetricsAdapter component in namespace '%s' from the seed server"+
+				" - failed to remove ManagedResource '%s'. "+
+				"The error message reported by the underlying operation follows: %w",
+			pma.namespaceName,
+			managedResourceName,
+			err)
+	}
+
+	return nil
+}
+
+// Implements component.Waiter.Wait()
+func (pma *PrometheusMetricsAdapter) Wait(ctx context.Context) error {
+	timeoutCtx, cancel := context.WithTimeout(ctx, managedResourceTimeout)
+	defer cancel()
+
+	if err := managedresources.WaitUntilHealthy(timeoutCtx, pma.kubeClient, pma.namespaceName, managedResourceName); err != nil {
+		return fmt.Errorf(
+			"An error occurred while waiting for the deployment process of PrometheusMetricsAdapter component to "+
+				"'%s' namespace in the seed server to finish and for the component to report ready status"+
+				" - the wait for ManagedResource '%s' to become healty failed. "+
+				"The error message reported by the underlying operation follows: %w",
+			pma.namespaceName,
+			managedResourceName,
+			err)
+	}
+
+	return nil
+}
+
+// Implements component.Waiter.WaitCleanup()
+func (pma *PrometheusMetricsAdapter) WaitCleanup(ctx context.Context) error {
+	timeoutCtx, cancel := context.WithTimeout(ctx, managedResourceTimeout)
+	defer cancel()
+
+	if err := managedresources.WaitUntilDeleted(timeoutCtx, pma.kubeClient, pma.namespaceName, managedResourceName); err != nil {
+		return fmt.Errorf(
+			"An error occurred while waiting for the PrometheusMetricsAdapter component to be fully removed from the "+
+				"'%s' namespace in the seed server"+
+				" - the wait for ManagedResource '%s' to be removed failed. "+
+				"The error message reported by the underlying operation follows: %w",
+			pma.namespaceName,
+			managedResourceName,
+			err)
+	}
+
+	return nil
+}
+
+const (
+	componentBaseName           = "prometheus-metrics-adapter"
+	deploymentName              = componentBaseName
+	managedResourceName         = componentBaseName // The implementing artifacts are deployed to the seed via this MR
+	serviceName                 = componentBaseName
+	serverCertificateSecretName = componentBaseName + "-server" // PMA's HTTPS certificate
+	managedResourceTimeout      = 2 * time.Minute               // Timeout for ManagedResources to become healthy or deleted
+)
+
+//go:embed templates/*.yaml
+var resourceTemplateFiles embed.FS         // Templates for the k8s resources realising PMA
+var resourceTemplates []*template.Template // resourceTemplateFiles loaded into Template objects
+
+func init() {
+	baseErrorMessage := "An error occurred while loading resource templates for the PrometheusMetricsAdapter component"
+
+	// Load the k8s resource templates
+	fs.WalkDir(resourceTemplateFiles, ".", func(path string, dirEntry fs.DirEntry, err error) error {
+		if err != nil {
+			return fmt.Errorf(baseErrorMessage+". The error message reported by the underlying operation follows: %w", err)
+		}
+		if dirEntry.IsDir() {
+			return nil
+		}
+
+		bytes, err := resourceTemplateFiles.ReadFile(path)
+		if err != nil {
+			return fmt.Errorf(
+				baseErrorMessage+" - reading file '%s' failed. "+
+					"The error message reported by the underlying operation follows: %w",
+				path,
+				err)
+		}
+
+		template, err := template.
+			New(dirEntry.Name()).
+			Funcs(sprig.TxtFuncMap()).
+			Parse(string(bytes))
+		if err != nil {
+			return fmt.Errorf(
+				baseErrorMessage+" - parsing template file '%s' failed. "+
+					"The error message reported by the underlying operation follows: %w",
+				path,
+				err)
+		}
+
+		resourceTemplates = append(resourceTemplates, template)
+		return nil
+	})
+}
+
+// prometheusMetricsAdapterTestIsolation contains all points of indirection necessary to isolate static function calls
+// in the PrometheusMetricsAdapter unit during tests
+type prometheusMetricsAdapterTestIsolation struct {
+	// Points to component.DeployResourceConfigs()
+	DeployResourceConfigs func(
+		context.Context, client.Client, string, component.ClusterType, string, *managedresources.Registry, component.ResourceConfigs) error
+
+	// Points to component.DestroyResourceConfigs()
+	DestroyResourceConfigs func(context.Context, client.Client, string, component.ClusterType, string) error
+}
+
+// Deploys the PMA server TLS certificate to a secret and returns the name of the created secret
+func (pma *PrometheusMetricsAdapter) deployServerCertificate(ctx context.Context) (*corev1.Secret, error) {
+	const baseErrorMessage = "An error occurred while deploying server TLS certificate for the prometheus metrics adapter"
+
+	_, found := pma.secretsManager.Get(v1beta1constants.SecretNameCASeed)
+	if !found {
+		return nil, fmt.Errorf(
+			baseErrorMessage+
+				" - the CA certificate, which is required to sign said server certificate, is missing. "+
+				"The CA certificate was expected in the '%s' secret, but that secret was not found",
+			v1beta1constants.SecretNameCASeed)
+	}
+
+	serverCertificateSecret, err := pma.secretsManager.Generate(
+		ctx,
+		&secretutils.CertificateSecretConfig{
+			Name:                        serverCertificateSecretName,
+			CommonName:                  fmt.Sprintf("%s.%s.svc", serviceName, pma.namespaceName),
+			DNSNames:                    kutil.DNSNamesForService(serviceName, pma.namespaceName),
+			CertType:                    secretutils.ServerCert,
+			SkipPublishingCACertificate: true,
+		},
+		secretsmanager.SignedByCA(v1beta1constants.SecretNameCASeed, secretsmanager.UseCurrentCA),
+		secretsmanager.Rotate(secretsmanager.InPlace))
+	if err != nil {
+		return nil, fmt.Errorf(
+			baseErrorMessage+
+				" - the attept to generate the certificate and store it in a secret named '%s' failed. "+
+				"The error message reported by the underlying operation follows: %w",
+			serverCertificateSecretName,
+			err)
+	}
+
+	return serverCertificateSecret, nil
+}
+
+//#region Manifest data retrieval
+
+// Reads and returns all objects from the specified manifestReader
+func readManifest(manifestReader kubernetes.UnstructuredReader) ([]client.Object, error) {
+	var objectsRead []client.Object
+	allErrors := &multierror.Error{
+		ErrorFormat: utilerrors.NewErrorFormatFuncWithPrefix("failed to read manifests for the prommetric component"),
+	}
+
+	for {
+		obj, err := manifestReader.Read()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			allErrors = multierror.Append(allErrors, fmt.Errorf("could not read object: %+v", err))
+			continue
+		}
+		if obj == nil {
+			continue
+		}
+
+		objectsRead = append(objectsRead, obj)
+	}
+
+	return objectsRead, allErrors.ErrorOrNil()
+}
+
+// Formats all prommetric manifests based on the specified parameters and returns them in the form of reader objects
+func getManifests(
+	namespaceName string, containerImageName string, serverCertificateSecret *corev1.Secret) ([]kubernetes.UnstructuredReader, error) {
+
+	templateParams := struct {
+		ContainerImageName string
+		DeploymentName     string
+		Namespace          string
+		ServerSecretName   string
+	}{
+		ContainerImageName: containerImageName,
+		DeploymentName:     deploymentName,
+		Namespace:          namespaceName,
+		ServerSecretName:   serverCertificateSecret.Name,
+	}
+
+	// Execute each manifest template and get object reader for the resulting raw output
+	var formattedManifests []kubernetes.UnstructuredReader
+	for i, template := range resourceTemplates {
+		var formattedManifest bytes.Buffer
+		if err := template.Execute(&formattedManifest, templateParams); err != nil {
+			return nil, fmt.Errorf(
+				"An error occurred while retrieving resource manifests for the prometheus metrics adapter component - "+
+					"executing the template at index %d failed. "+
+					"The error message reported by the underlying operation follows: %w",
+				i,
+				err)
+		}
+		formattedManifests = append(formattedManifests, kubernetes.NewManifestReader(formattedManifest.Bytes()))
+	}
+
+	return formattedManifests, nil
+}
+
+// Returns the resource configs which represent the seed resources required to support prommetric's operation
+func getResourceConfigs(
+	namespaceName string, containerImageName string, serverCertificateSecret *corev1.Secret) (component.ResourceConfigs, error) {
+
+	const baseErrorMessage = "An error occurred while retrieving the list of resource config objects describing the " +
+		"elements of the prometheus metrics adapter component"
+
+	manifestReaders, err := getManifests(namespaceName, containerImageName, serverCertificateSecret)
+	if err != nil {
+		return nil, fmt.Errorf(baseErrorMessage+" - failed to retrieve manifest data. "+
+			"The error message reported by the underlying operation follows: %w",
+			err)
+	}
+
+	var allResources component.ResourceConfigs
+	for i, manifest := range manifestReaders {
+		manifestObjects, err := readManifest(manifest)
+		if err != nil {
+			return nil, fmt.Errorf(baseErrorMessage+" - failed to parse the manifest at index %d. "+
+				"The error message reported by the underlying operation follows: %w",
+				i,
+				err)
+		}
+
+		for _, manifestObject := range manifestObjects {
+			resourceConfig := component.ResourceConfig{
+				Obj:   manifestObject,
+				Class: component.Runtime,
+			}
+			allResources = append(allResources, resourceConfig)
+		}
+	}
+
+	return allResources, nil
+}
+
+//#endregion Manifest data retrieval

--- a/pkg/operation/botanist/component/prommetric/component.go
+++ b/pkg/operation/botanist/component/prommetric/component.go
@@ -43,7 +43,8 @@ type PrometheusMetricsAdapter struct {
 	testIsolation prometheusMetricsAdapterTestIsolation // Provides indirections necessary to isolate the unit during tests
 }
 
-// Creates a new PrometheusMetricsAdapter instance tied to a specific server connection
+// Creates a new PrometheusMetricsAdapter instance tied to a specific server connection.
+// An empty string is acceptable for the containerImageName parameter, if the instance will only be used to effect removal.
 func NewPrometheusMetricsAdapter(
 	namespace string,
 	containerImageName string,

--- a/pkg/operation/botanist/component/prommetric/component_test.go
+++ b/pkg/operation/botanist/component/prommetric/component_test.go
@@ -1,0 +1,655 @@
+package prommetric
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	"github.com/gardener/gardener/pkg/operation/botanist/component"
+	"github.com/gardener/gardener/pkg/utils/managedresources"
+	"github.com/gardener/gardener/pkg/utils/retry"
+	retryfake "github.com/gardener/gardener/pkg/utils/retry/fake"
+	secretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager"
+	fakesecretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager/fake"
+	"github.com/gardener/gardener/pkg/utils/test"
+)
+
+//#region Fakes
+
+type testIsolation struct {
+	DeployedResourceConfigs component.ResourceConfigs
+}
+
+func (ti *testIsolation) DeployResourceConfigs(
+	ctx context.Context,
+	client client.Client,
+	namespace string,
+	clusterType component.ClusterType,
+	managedResourceName string,
+	registry *managedresources.Registry,
+	allResources component.ResourceConfigs,
+) error {
+	ti.DeployedResourceConfigs = allResources
+
+	return nil
+}
+
+func newTestIsolation() *testIsolation {
+	return &testIsolation{}
+}
+
+//#endregion Fakes
+
+func convertResourceConfigToJson(config *component.ResourceConfig) (string, error) {
+	json, err := json.MarshalIndent(config.Obj.(*unstructured.Unstructured), "", "\t")
+	if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("\n%s", strings.TrimSuffix(string(json), "\n")), nil
+}
+
+var _ = Describe("PrometheusMetricsAdapter", func() {
+	var (
+		caSecretName  = "ca-seed"
+		imageName     = "test-image"
+		namespaceName = "test-namespace"
+
+		ctx                = context.TODO()
+		seedClient         client.Client
+		fakeSecretsManager secretsmanager.Interface
+
+		//#region Helpers
+		newPma = func(isEnabled bool) (*PrometheusMetricsAdapter, *testIsolation) {
+			pma := NewPrometheusMetricsAdapter(namespaceName, imageName, isEnabled, seedClient, fakeSecretsManager)
+			ti := newTestIsolation()
+			// We isolate the deployment workflow at the DeployResourceConfigs() level, because that point offers a
+			// convenient, declarative representation
+			pma.testIsolation.DeployResourceConfigs = ti.DeployResourceConfigs
+
+			return pma, ti
+		}
+
+		assertNoServerCertificateOnServer = func() {
+			actualServerCertificateSecret := corev1.Secret{}
+			err := seedClient.Get(
+				ctx,
+				client.ObjectKey{Namespace: namespaceName, Name: serverCertificateSecretName},
+				&actualServerCertificateSecret)
+
+			ExpectWithOffset(1, err).To(HaveOccurred())
+			ExpectWithOffset(1, err.Error()).To(MatchRegexp(".*not.*found.*"))
+		}
+
+		assertNoManagedResourceOnServer = func() {
+			mr := resourcesv1alpha1.ManagedResource{}
+			err := seedClient.Get(ctx, client.ObjectKey{Namespace: namespaceName, Name: managedResourceName}, &mr)
+			ExpectWithOffset(1, err).To(HaveOccurred())
+			ExpectWithOffset(1, err.Error()).To(MatchRegexp(".*not.*found.*"))
+		}
+
+		createObjectOnSeed = func(obj client.Object, name string) {
+			obj.SetNamespace(namespaceName)
+			obj.SetName(name)
+			ExpectWithOffset(1, seedClient.Create(ctx, obj)).To(Succeed())
+		}
+		//#endregion Helpers
+	)
+
+	BeforeEach(func() {
+		seedClient = fakeclient.NewClientBuilder().WithScheme(kubernetes.SeedScheme).Build()
+		fakeSecretsManager = fakesecretsmanager.New(seedClient, namespaceName)
+	})
+
+	Describe(".Deploy()", func() {
+		Context("in enabled state", func() {
+			It("should deploy the correct resources to the seed", func() {
+				//#region Expected resource config values as bulk JSON
+				expectedResourceConfigsAsJson := []string{
+					`
+{
+	"apiVersion": "v1",
+	"data": {
+		"config.yaml": "rules:\n- seriesQuery: '{__name__=~\"shoot:apiserver_request_total:sum\",cluster!=\"\",pod!=\"\"}'\n  seriesFilters: []\n  resources:\n    overrides:\n      cluster:\n        resource: namespace\n      pod:\n        resource: pod\n  name:\n    matches: \"\"\n    as: \"\"\n  metricsQuery: sum(\u003c\u003c.Series\u003e\u003e{\u003c\u003c.LabelMatchers\u003e\u003e}) by (\u003c\u003c.GroupBy\u003e\u003e)    \n- seriesQuery: '{__name__=~\"^container_.*\",container!=\"POD\",namespace!=\"\",pod!=\"\"}'\n  seriesFilters: []\n  resources:\n    overrides:\n      namespace:\n        resource: namespace\n      pod:\n        resource: pod\n  name:\n    matches: ^container_(.*)_seconds_total$\n    as: \"\"\n  metricsQuery: sum(rate(\u003c\u003c.Series\u003e\u003e{\u003c\u003c.LabelMatchers\u003e\u003e,container!=\"POD\"}[1m])) by (\u003c\u003c.GroupBy\u003e\u003e)\n- seriesQuery: '{__name__=~\"^container_.*\",container!=\"POD\",namespace!=\"\",pod!=\"\"}'\n  seriesFilters:\n  - isNot: ^container_.*_seconds_total$\n  resources:\n    overrides:\n      namespace:\n        resource: namespace\n      pod:\n        resource: pod\n  name:\n    matches: ^container_(.*)_total$\n    as: \"\"\n  metricsQuery: sum(rate(\u003c\u003c.Series\u003e\u003e{\u003c\u003c.LabelMatchers\u003e\u003e,container!=\"POD\"}[1m])) by (\u003c\u003c.GroupBy\u003e\u003e)\n- seriesQuery: '{__name__=~\"^container_.*\",container!=\"POD\",namespace!=\"\",pod!=\"\"}'\n  seriesFilters:\n  - isNot: ^container_.*_total$\n  resources:\n    overrides:\n      namespace:\n        resource: namespace\n      pod:\n        resource: pod\n  name:\n    matches: ^container_(.*)$\n    as: \"\"\n  metricsQuery: sum(\u003c\u003c.Series\u003e\u003e{\u003c\u003c.LabelMatchers\u003e\u003e,container!=\"POD\"}) by (\u003c\u003c.GroupBy\u003e\u003e)\n- seriesQuery: '{namespace!=\"\",__name__!~\"^container_.*\"}'\n  seriesFilters:\n  - isNot: .*_total$\n  resources:\n    template: \u003c\u003c.Resource\u003e\u003e\n  name:\n    matches: \"\"\n    as: \"\"\n  metricsQuery: sum(\u003c\u003c.Series\u003e\u003e{\u003c\u003c.LabelMatchers\u003e\u003e}) by (\u003c\u003c.GroupBy\u003e\u003e)\n- seriesQuery: '{namespace!=\"\",__name__!~\"^container_.*\"}'\n  seriesFilters:\n  - isNot: .*_seconds_total\n  resources:\n    template: \u003c\u003c.Resource\u003e\u003e\n  name:\n    matches: ^(.*)_total$\n    as: \"\"\n  metricsQuery: sum(rate(\u003c\u003c.Series\u003e\u003e{\u003c\u003c.LabelMatchers\u003e\u003e}[1m])) by (\u003c\u003c.GroupBy\u003e\u003e)\n- seriesQuery: '{namespace!=\"\",__name__!~\"^container_.*\"}'\n  seriesFilters: []\n  resources:\n    template: \u003c\u003c.Resource\u003e\u003e\n  name:\n    matches: ^(.*)_seconds_total$\n    as: \"\"\n  metricsQuery: sum(rate(\u003c\u003c.Series\u003e\u003e{\u003c\u003c.LabelMatchers\u003e\u003e}[1m])) by (\u003c\u003c.GroupBy\u003e\u003e)\nresourceRules:\n  cpu:\n    containerQuery: sum(rate(container_cpu_usage_seconds_total{\u003c\u003c.LabelMatchers\u003e\u003e}[1m])) by (\u003c\u003c.GroupBy\u003e\u003e)\n    nodeQuery: sum(rate(container_cpu_usage_seconds_total{\u003c\u003c.LabelMatchers\u003e\u003e, id='/'}[1m])) by (\u003c\u003c.GroupBy\u003e\u003e)\n    resources:\n      overrides:\n        instance:\n          resource: node\n        namespace:\n          resource: namespace\n        pod:\n          resource: pod\n    containerLabel: container\n  memory:\n    containerQuery: sum(container_memory_working_set_bytes{\u003c\u003c.LabelMatchers\u003e\u003e}) by (\u003c\u003c.GroupBy\u003e\u003e)\n    nodeQuery: sum(container_memory_working_set_bytes{\u003c\u003c.LabelMatchers\u003e\u003e,id='/'}) by (\u003c\u003c.GroupBy\u003e\u003e)\n    resources:\n      overrides:\n        instance:\n          resource: node\n        namespace:\n          resource: namespace\n        pod:\n          resource: pod\n    containerLabel: container\n  window: 1m\nexternalRules:\n- seriesQuery: '{__name__=~\"^.*_queue_(length|size)$\",namespace!=\"\"}'\n  resources:\n    overrides:\n      namespace:\n        resource: namespace\n  name:\n    matches: ^.*_queue_(length|size)$\n    as: \"$0\"\n  metricsQuery: max(\u003c\u003c.Series\u003e\u003e{\u003c\u003c.LabelMatchers\u003e\u003e})\n- seriesQuery: '{__name__=~\"^.*_queue$\",namespace!=\"\"}'\n  resources:\n    overrides:\n      namespace:\n        resource: namespace\n  name:\n    matches: ^.*_queue$\n    as: \"$0\"\n  metricsQuery: max(\u003c\u003c.Series\u003e\u003e{\u003c\u003c.LabelMatchers\u003e\u003e})\n"
+	},
+	"kind": "ConfigMap",
+	"metadata": {
+		"name": "prometheus-metrics-adapter",
+		"namespace": "test-namespace"
+	}
+}`,
+					`
+{
+	"apiVersion": "v1",
+	"kind": "ServiceAccount",
+	"metadata": {
+		"name": "prometheus-metrics-adapter",
+		"namespace": "test-namespace"
+	}
+}`,
+					`
+{
+	"apiVersion": "rbac.authorization.k8s.io/v1",
+	"kind": "ClusterRole",
+	"metadata": {
+		"name": "prometheus-metrics-adapter-resources"
+	},
+	"rules": [
+		{
+			"apiGroups": [
+				"custom.metrics.k8s.io",
+				"external.metrics.k8s.io"
+			],
+			"resources": [
+				"*"
+			],
+			"verbs": [
+				"*"
+			]
+		}
+	]
+}`,
+					`
+{
+	"apiVersion": "rbac.authorization.k8s.io/v1",
+	"kind": "ClusterRole",
+	"metadata": {
+		"name": "prometheus-metrics-adapter-resource-reader"
+	},
+	"rules": [
+		{
+			"apiGroups": [
+				""
+			],
+			"resources": [
+				"pods",
+				"nodes",
+				"nodes/stats"
+			],
+			"verbs": [
+				"get",
+				"list",
+				"watch"
+			]
+		}
+	]
+}`,
+					`
+{
+	"apiVersion": "rbac.authorization.k8s.io/v1",
+	"kind": "ClusterRoleBinding",
+	"metadata": {
+		"name": "prometheus-metrics-adapter:system:auth-delegator"
+	},
+	"roleRef": {
+		"apiGroup": "rbac.authorization.k8s.io",
+		"kind": "ClusterRole",
+		"name": "system:auth-delegator"
+	},
+	"subjects": [
+		{
+			"kind": "ServiceAccount",
+			"name": "prometheus-metrics-adapter",
+			"namespace": "test-namespace"
+		}
+	]
+}`,
+					`
+{
+	"apiVersion": "rbac.authorization.k8s.io/v1",
+	"kind": "ClusterRoleBinding",
+	"metadata": {
+		"name": "prometheus-metrics-adapter-resource-reader"
+	},
+	"roleRef": {
+		"apiGroup": "rbac.authorization.k8s.io",
+		"kind": "ClusterRole",
+		"name": "prometheus-metrics-adapter-resource-reader"
+	},
+	"subjects": [
+		{
+			"kind": "ServiceAccount",
+			"name": "prometheus-metrics-adapter",
+			"namespace": "test-namespace"
+		}
+	]
+}`,
+					`
+{
+	"apiVersion": "rbac.authorization.k8s.io/v1",
+	"kind": "ClusterRoleBinding",
+	"metadata": {
+		"name": "hpa-prometheus-metrics-adapter-resources"
+	},
+	"roleRef": {
+		"apiGroup": "rbac.authorization.k8s.io",
+		"kind": "ClusterRole",
+		"name": "prometheus-metrics-adapter-resources"
+	},
+	"subjects": [
+		{
+			"kind": "ServiceAccount",
+			"name": "horizontal-pod-autoscaler",
+			"namespace": "kube-system"
+		}
+	]
+}`,
+					`
+{
+	"apiVersion": "rbac.authorization.k8s.io/v1",
+	"kind": "RoleBinding",
+	"metadata": {
+		"name": "prometheus-metrics-adapter-auth-reader",
+		"namespace": "kube-system"
+	},
+	"roleRef": {
+		"apiGroup": "rbac.authorization.k8s.io",
+		"kind": "Role",
+		"name": "extension-apiserver-authentication-reader"
+	},
+	"subjects": [
+		{
+			"kind": "ServiceAccount",
+			"name": "prometheus-metrics-adapter",
+			"namespace": "test-namespace"
+		}
+	]
+}`,
+					`
+{
+	"apiVersion": "apps/v1",
+	"kind": "Deployment",
+	"metadata": {
+		"labels": {
+			"app": "custom-metrics-apiserver"
+		},
+		"name": "prometheus-metrics-adapter",
+		"namespace": "test-namespace"
+	},
+	"spec": {
+		"replicas": 1,
+		"selector": {
+			"matchLabels": {
+				"app": "custom-metrics-apiserver"
+			}
+		},
+		"template": {
+			"metadata": {
+				"labels": {
+					"app": "custom-metrics-apiserver"
+				},
+				"name": "custom-metrics-apiserver"
+			},
+			"spec": {
+				"containers": [
+					{
+						"args": [
+							"--secure-port=6443",
+							"--tls-cert-file=/var/run/serving-cert/tls.crt",
+							"--tls-private-key-file=/var/run/serving-cert/tls.key",
+							"--logtostderr=true",
+							"--prometheus-url=http://aggregate-prometheus-web.garden.svc:80/",
+							"--metrics-relist-interval=2m",
+							"--v=2",
+							"--config=/etc/adapter/config.yaml"
+						],
+						"image": "k8s.gcr.io/prometheus-adapter/prometheus-adapter:v0.9.1",
+						"name": "custom-metrics-apiserver",
+						"ports": [
+							{
+								"containerPort": 6443
+							}
+						],
+						"volumeMounts": [
+							{
+								"mountPath": "/var/run/serving-cert",
+								"name": "volume-serving-cert",
+								"readOnly": true
+							},
+							{
+								"mountPath": "/etc/adapter/",
+								"name": "config",
+								"readOnly": true
+							},
+							{
+								"mountPath": "/tmp",
+								"name": "tmp-vol"
+							}
+						]
+					}
+				],
+				"serviceAccountName": "prometheus-metrics-adapter",
+				"volumes": [
+					{
+						"name": "volume-serving-cert",
+						"secret": {
+							"secretName": "prometheus-metrics-adapter-server"
+						}
+					},
+					{
+						"configMap": {
+							"name": "prometheus-metrics-adapter"
+						},
+						"name": "config"
+					},
+					{
+						"emptyDir": {},
+						"name": "tmp-vol"
+					}
+				]
+			}
+		}
+	}
+}`,
+					`
+{
+	"apiVersion": "v1",
+	"kind": "Service",
+	"metadata": {
+		"name": "prometheus-metrics-adapter",
+		"namespace": "test-namespace"
+	},
+	"spec": {
+		"ports": [
+			{
+				"port": 443,
+				"targetPort": 6443
+			}
+		],
+		"selector": {
+			"app": "custom-metrics-apiserver"
+		}
+	}
+}`,
+					`
+{
+	"apiVersion": "apiregistration.k8s.io/v1",
+	"kind": "APIService",
+	"metadata": {
+		"name": "v1beta1.custom.metrics.k8s.io"
+	},
+	"spec": {
+		"group": "custom.metrics.k8s.io",
+		"groupPriorityMinimum": 100,
+		"insecureSkipTLSVerify": true,
+		"service": {
+			"name": "prometheus-metrics-adapter",
+			"namespace": "test-namespace"
+		},
+		"version": "v1beta1",
+		"versionPriority": 100
+	}
+}`,
+					`
+{
+	"apiVersion": "apiregistration.k8s.io/v1",
+	"kind": "APIService",
+	"metadata": {
+		"name": "v1beta2.custom.metrics.k8s.io"
+	},
+	"spec": {
+		"group": "custom.metrics.k8s.io",
+		"groupPriorityMinimum": 100,
+		"insecureSkipTLSVerify": true,
+		"service": {
+			"name": "prometheus-metrics-adapter",
+			"namespace": "test-namespace"
+		},
+		"version": "v1beta2",
+		"versionPriority": 200
+	}
+}`,
+					`
+{
+	"apiVersion": "apiregistration.k8s.io/v1",
+	"kind": "APIService",
+	"metadata": {
+		"name": "v1beta1.external.metrics.k8s.io"
+	},
+	"spec": {
+		"group": "external.metrics.k8s.io",
+		"groupPriorityMinimum": 100,
+		"insecureSkipTLSVerify": true,
+		"service": {
+			"name": "prometheus-metrics-adapter",
+			"namespace": "test-namespace"
+		},
+		"version": "v1beta1",
+		"versionPriority": 100
+	}
+}`,
+				}
+				//#endregion Expected resource config values as bulk JSON
+
+				// Arrange
+				createObjectOnSeed(&corev1.Secret{}, caSecretName)
+				pma, ti := newPma(true)
+
+				// Act
+				Expect(pma.Deploy(ctx)).To(Succeed())
+
+				// Assert
+				actualServerCertificateSecret := corev1.Secret{}
+				Expect(seedClient.Get(
+					ctx,
+					client.ObjectKey{Namespace: namespaceName, Name: serverCertificateSecretName},
+					&actualServerCertificateSecret),
+				).To(Succeed())
+
+				Expect(ti.DeployedResourceConfigs).To(HaveLen(len(expectedResourceConfigsAsJson)))
+
+				for i := range expectedResourceConfigsAsJson {
+					actualJson, err := convertResourceConfigToJson(&ti.DeployedResourceConfigs[i])
+					Expect(err).To(Succeed())
+					message := fmt.Sprintf(
+						"The actual resource config JSON at position %d had unexpected value. Actual:\n%s\n"+
+							"Expected:\n%s\n",
+						i,
+						actualJson,
+						expectedResourceConfigsAsJson[i])
+					Expect(actualJson).To(Equal(expectedResourceConfigsAsJson[i]), message)
+				}
+			})
+			It("should fail if CA certificate is missing on the seed", func() {
+				// Arrange
+				pma, ti := newPma(true)
+
+				// Act
+				err := pma.Deploy(ctx)
+
+				// Assert
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(MatchRegexp(".*CA.*certificate.*secret.*"))
+				Expect(ti.DeployedResourceConfigs).To(BeNil())
+			})
+		})
+		Context("in disabled state", func() {
+			It("should not fail if CA certificate is missing on the seed", func() {
+				// Arrange
+				actualServerCertificateSecret := corev1.Secret{}
+				err := seedClient.Get(
+					ctx,
+					client.ObjectKey{Namespace: namespaceName, Name: caSecretName},
+					&actualServerCertificateSecret)
+				Expect(err.Error()).To(MatchRegexp(".*not.*found.*"))
+
+				pma, _ := newPma(false)
+
+				// Act
+				Expect(pma.Deploy(ctx)).To(Succeed())
+
+				// Assert
+			})
+			It("should not deploy any resources to the seed", func() {
+				// Arrange
+				pma, ti := newPma(false)
+
+				// Act
+				Expect(pma.Deploy(ctx)).To(Succeed())
+
+				// Assert
+				assertNoServerCertificateOnServer()
+				Expect(ti.DeployedResourceConfigs).To(BeNil())
+			})
+		})
+	})
+	Describe(".Destroy()", func() {
+		Context("in enabled state", func() {
+			It("should destroy the resources on the seed", func() {
+				// Arrange
+				createObjectOnSeed(&corev1.Secret{}, serverCertificateSecretName)
+				createObjectOnSeed(&resourcesv1alpha1.ManagedResource{}, managedResourceName)
+				pma, _ := newPma(true)
+
+				// Act
+				Expect(pma.Destroy(ctx)).To(Succeed())
+
+				// Assert
+				assertNoManagedResourceOnServer()
+			})
+			It("should not fail if resources are missing on the seed", func() {
+				// Arrange
+				pma, _ := newPma(true)
+
+				// Act
+				Expect(pma.Destroy(ctx)).To(Succeed())
+
+				// Assert
+			})
+		})
+		Context("in disabled state", func() {
+			It("should destroy the resources on the seed", func() {
+				// Arrange
+				createObjectOnSeed(&corev1.Secret{}, serverCertificateSecretName)
+				createObjectOnSeed(&resourcesv1alpha1.ManagedResource{}, managedResourceName)
+				pma, _ := newPma(false)
+
+				// Act
+				Expect(pma.Destroy(ctx)).To(Succeed())
+
+				// Assert
+				assertNoManagedResourceOnServer()
+			})
+		})
+	})
+
+	Context("waiting functions", func() {
+		var (
+			fakeOps   *retryfake.Ops
+			resetVars func()
+		)
+
+		BeforeEach(func() {
+			fakeOps = &retryfake.Ops{MaxAttempts: 1}
+			resetVars = test.WithVars(
+				&retry.Until, fakeOps.Until,
+				&retry.UntilTimeout, fakeOps.UntilTimeout,
+			)
+		})
+
+		AfterEach(func() {
+			resetVars()
+		})
+
+		Describe(".Wait()", func() {
+			It("should fail because reading the ManagedResource fails", func() {
+				// Arrange
+				pma, _ := newPma(true)
+
+				// Act
+				Expect(pma.Wait(ctx)).To(MatchError(ContainSubstring("not found")))
+			})
+
+			It("should fail because the ManagedResource doesn't become healthy", func() {
+				// Arrange
+				pma, _ := newPma(true)
+				fakeOps.MaxAttempts = 2
+
+				Expect(seedClient.Create(ctx, &resourcesv1alpha1.ManagedResource{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       managedResourceName,
+						Namespace:  namespaceName,
+						Generation: 1,
+					},
+					Status: resourcesv1alpha1.ManagedResourceStatus{
+						ObservedGeneration: 1,
+						Conditions: []gardencorev1beta1.Condition{
+							{
+								Type:   resourcesv1alpha1.ResourcesApplied,
+								Status: gardencorev1beta1.ConditionFalse,
+							},
+							{
+								Type:   resourcesv1alpha1.ResourcesHealthy,
+								Status: gardencorev1beta1.ConditionFalse,
+							},
+						},
+					},
+				})).To(Succeed())
+
+				// Act
+				Expect(pma.Wait(ctx)).To(MatchError(ContainSubstring("is not healthy")))
+			})
+
+			It("should successfully wait for the managed resource to become healthy", func() {
+				// Arrange
+				pma, _ := newPma(true)
+				fakeOps.MaxAttempts = 2
+
+				Expect(seedClient.Create(ctx, &resourcesv1alpha1.ManagedResource{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       managedResourceName,
+						Namespace:  namespaceName,
+						Generation: 1,
+					},
+					Status: resourcesv1alpha1.ManagedResourceStatus{
+						ObservedGeneration: 1,
+						Conditions: []gardencorev1beta1.Condition{
+							{
+								Type:   resourcesv1alpha1.ResourcesApplied,
+								Status: gardencorev1beta1.ConditionTrue,
+							},
+							{
+								Type:   resourcesv1alpha1.ResourcesHealthy,
+								Status: gardencorev1beta1.ConditionTrue,
+							},
+						},
+					},
+				})).To(Succeed())
+
+				// Act
+				Expect(pma.Wait(ctx)).To(Succeed())
+			})
+		})
+
+		Describe(".WaitCleanup()", func() {
+			It("should fail when the wait for the managed resource deletion times out", func() {
+				// Arrange
+				createObjectOnSeed(&corev1.Secret{}, serverCertificateSecretName)
+				createObjectOnSeed(&resourcesv1alpha1.ManagedResource{}, managedResourceName)
+				pma, _ := newPma(true)
+				fakeOps.MaxAttempts = 2
+
+				// Act
+				Expect(pma.WaitCleanup(ctx)).To(MatchError(ContainSubstring("still exists")))
+			})
+
+			It("should not return an error when it's already removed", func() {
+				// Arrange
+				pma, _ := newPma(true)
+				Expect(pma.WaitCleanup(ctx)).To(Succeed())
+			})
+		})
+	})
+})

--- a/pkg/operation/botanist/component/prommetric/component_test.go
+++ b/pkg/operation/botanist/component/prommetric/component_test.go
@@ -305,7 +305,7 @@ var _ = Describe("PrometheusMetricsAdapter", func() {
 							"--v=2",
 							"--config=/etc/adapter/config.yaml"
 						],
-						"image": "k8s.gcr.io/prometheus-adapter/prometheus-adapter:v0.9.1",
+						"image": "test-image",
 						"name": "custom-metrics-apiserver",
 						"ports": [
 							{

--- a/pkg/operation/botanist/component/prommetric/suite_test.go
+++ b/pkg/operation/botanist/component/prommetric/suite_test.go
@@ -1,0 +1,13 @@
+package prommetric
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestPrometheusMetricsAdapter(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "PrometheusMetricsAdapter component unit test suite")
+}

--- a/pkg/operation/botanist/component/prommetric/templates/10-custom-metrics-config-map.yaml
+++ b/pkg/operation/botanist/component/prommetric/templates/10-custom-metrics-config-map.yaml
@@ -1,0 +1,129 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prometheus-metrics-adapter
+  namespace: {{ .Namespace }}
+data:
+  config.yaml: |
+    rules:
+    - seriesQuery: '{__name__=~"shoot:apiserver_request_total:sum",cluster!="",pod!=""}'
+      seriesFilters: []
+      resources:
+        overrides:
+          cluster:
+            resource: namespace
+          pod:
+            resource: pod
+      name:
+        matches: ""
+        as: ""
+      metricsQuery: sum(<<.Series>>{<<.LabelMatchers>>}) by (<<.GroupBy>>)    
+    - seriesQuery: '{__name__=~"^container_.*",container!="POD",namespace!="",pod!=""}'
+      seriesFilters: []
+      resources:
+        overrides:
+          namespace:
+            resource: namespace
+          pod:
+            resource: pod
+      name:
+        matches: ^container_(.*)_seconds_total$
+        as: ""
+      metricsQuery: sum(rate(<<.Series>>{<<.LabelMatchers>>,container!="POD"}[1m])) by (<<.GroupBy>>)
+    - seriesQuery: '{__name__=~"^container_.*",container!="POD",namespace!="",pod!=""}'
+      seriesFilters:
+      - isNot: ^container_.*_seconds_total$
+      resources:
+        overrides:
+          namespace:
+            resource: namespace
+          pod:
+            resource: pod
+      name:
+        matches: ^container_(.*)_total$
+        as: ""
+      metricsQuery: sum(rate(<<.Series>>{<<.LabelMatchers>>,container!="POD"}[1m])) by (<<.GroupBy>>)
+    - seriesQuery: '{__name__=~"^container_.*",container!="POD",namespace!="",pod!=""}'
+      seriesFilters:
+      - isNot: ^container_.*_total$
+      resources:
+        overrides:
+          namespace:
+            resource: namespace
+          pod:
+            resource: pod
+      name:
+        matches: ^container_(.*)$
+        as: ""
+      metricsQuery: sum(<<.Series>>{<<.LabelMatchers>>,container!="POD"}) by (<<.GroupBy>>)
+    - seriesQuery: '{namespace!="",__name__!~"^container_.*"}'
+      seriesFilters:
+      - isNot: .*_total$
+      resources:
+        template: <<.Resource>>
+      name:
+        matches: ""
+        as: ""
+      metricsQuery: sum(<<.Series>>{<<.LabelMatchers>>}) by (<<.GroupBy>>)
+    - seriesQuery: '{namespace!="",__name__!~"^container_.*"}'
+      seriesFilters:
+      - isNot: .*_seconds_total
+      resources:
+        template: <<.Resource>>
+      name:
+        matches: ^(.*)_total$
+        as: ""
+      metricsQuery: sum(rate(<<.Series>>{<<.LabelMatchers>>}[1m])) by (<<.GroupBy>>)
+    - seriesQuery: '{namespace!="",__name__!~"^container_.*"}'
+      seriesFilters: []
+      resources:
+        template: <<.Resource>>
+      name:
+        matches: ^(.*)_seconds_total$
+        as: ""
+      metricsQuery: sum(rate(<<.Series>>{<<.LabelMatchers>>}[1m])) by (<<.GroupBy>>)
+    resourceRules:
+      cpu:
+        containerQuery: sum(rate(container_cpu_usage_seconds_total{<<.LabelMatchers>>}[1m])) by (<<.GroupBy>>)
+        nodeQuery: sum(rate(container_cpu_usage_seconds_total{<<.LabelMatchers>>, id='/'}[1m])) by (<<.GroupBy>>)
+        resources:
+          overrides:
+            instance:
+              resource: node
+            namespace:
+              resource: namespace
+            pod:
+              resource: pod
+        containerLabel: container
+      memory:
+        containerQuery: sum(container_memory_working_set_bytes{<<.LabelMatchers>>}) by (<<.GroupBy>>)
+        nodeQuery: sum(container_memory_working_set_bytes{<<.LabelMatchers>>,id='/'}) by (<<.GroupBy>>)
+        resources:
+          overrides:
+            instance:
+              resource: node
+            namespace:
+              resource: namespace
+            pod:
+              resource: pod
+        containerLabel: container
+      window: 1m
+    externalRules:
+    - seriesQuery: '{__name__=~"^.*_queue_(length|size)$",namespace!=""}'
+      resources:
+        overrides:
+          namespace:
+            resource: namespace
+      name:
+        matches: ^.*_queue_(length|size)$
+        as: "$0"
+      metricsQuery: max(<<.Series>>{<<.LabelMatchers>>})
+    - seriesQuery: '{__name__=~"^.*_queue$",namespace!=""}'
+      resources:
+        overrides:
+          namespace:
+            resource: namespace
+      name:
+        matches: ^.*_queue$
+        as: "$0"
+      metricsQuery: max(<<.Series>>{<<.LabelMatchers>>})

--- a/pkg/operation/botanist/component/prommetric/templates/20-custom-metrics-apiserver-service-account.yaml
+++ b/pkg/operation/botanist/component/prommetric/templates/20-custom-metrics-apiserver-service-account.yaml
@@ -1,0 +1,5 @@
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: prometheus-metrics-adapter
+  namespace: {{ .Namespace }}

--- a/pkg/operation/botanist/component/prommetric/templates/31-custom-metrics-cluster-role.yaml
+++ b/pkg/operation/botanist/component/prommetric/templates/31-custom-metrics-cluster-role.yaml
@@ -1,0 +1,10 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: prometheus-metrics-adapter-resources
+rules:
+- apiGroups:
+  - custom.metrics.k8s.io
+  - external.metrics.k8s.io
+  resources: ["*"]
+  verbs: ["*"]

--- a/pkg/operation/botanist/component/prommetric/templates/32-custom-metrics-resource-reader-cluster-role.yaml
+++ b/pkg/operation/botanist/component/prommetric/templates/32-custom-metrics-resource-reader-cluster-role.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: prometheus-metrics-adapter-resource-reader
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - nodes
+  - nodes/stats
+  verbs:
+  - get
+  - list
+  - watch

--- a/pkg/operation/botanist/component/prommetric/templates/41-custom-metrics-apiserver-auth-delegator-cluster-role-binding.yaml
+++ b/pkg/operation/botanist/component/prommetric/templates/41-custom-metrics-apiserver-auth-delegator-cluster-role-binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: prometheus-metrics-adapter:system:auth-delegator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:auth-delegator
+subjects:
+- kind: ServiceAccount
+  name: prometheus-metrics-adapter
+  namespace: {{ .Namespace }}

--- a/pkg/operation/botanist/component/prommetric/templates/42-custom-metrics-apiserver-resource-reader-cluster-role-binding.yaml
+++ b/pkg/operation/botanist/component/prommetric/templates/42-custom-metrics-apiserver-resource-reader-cluster-role-binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: prometheus-metrics-adapter-resource-reader
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: prometheus-metrics-adapter-resource-reader
+subjects:
+- kind: ServiceAccount
+  name: prometheus-metrics-adapter
+  namespace: {{ .Namespace }}

--- a/pkg/operation/botanist/component/prommetric/templates/43-hpa-custom-metrics-cluster-role-binding.yaml
+++ b/pkg/operation/botanist/component/prommetric/templates/43-hpa-custom-metrics-cluster-role-binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: hpa-prometheus-metrics-adapter-resources
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: prometheus-metrics-adapter-resources
+subjects:
+- kind: ServiceAccount
+  name: horizontal-pod-autoscaler
+  namespace: kube-system

--- a/pkg/operation/botanist/component/prommetric/templates/44-custom-metrics-apiserver-auth-reader-role-binding.yaml
+++ b/pkg/operation/botanist/component/prommetric/templates/44-custom-metrics-apiserver-auth-reader-role-binding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: prometheus-metrics-adapter-auth-reader
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: extension-apiserver-authentication-reader
+subjects:
+- kind: ServiceAccount
+  name: prometheus-metrics-adapter
+  namespace: {{ .Namespace }}

--- a/pkg/operation/botanist/component/prommetric/templates/50-custom-metrics-apiserver-deployment.yaml
+++ b/pkg/operation/botanist/component/prommetric/templates/50-custom-metrics-apiserver-deployment.yaml
@@ -1,0 +1,51 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: custom-metrics-apiserver
+  name: {{ .DeploymentName }}
+  namespace: {{ .Namespace }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: custom-metrics-apiserver
+  template:
+    metadata:
+      labels:
+        app: custom-metrics-apiserver
+      name: custom-metrics-apiserver
+    spec:
+      serviceAccountName: prometheus-metrics-adapter
+      containers:
+      - name: custom-metrics-apiserver
+        image: {{ .ContainerImageName }}
+        args:
+        - --secure-port=6443
+        - --tls-cert-file=/var/run/serving-cert/tls.crt
+        - --tls-private-key-file=/var/run/serving-cert/tls.key
+        - --logtostderr=true
+        - --prometheus-url=http://aggregate-prometheus-web.garden.svc:80/
+        - --metrics-relist-interval=2m
+        - --v=2
+        - --config=/etc/adapter/config.yaml
+        ports:
+        - containerPort: 6443
+        volumeMounts:
+        - mountPath: /var/run/serving-cert
+          name: volume-serving-cert
+          readOnly: true
+        - mountPath: /etc/adapter/
+          name: config
+          readOnly: true
+        - mountPath: /tmp
+          name: tmp-vol
+      volumes:
+      - name: volume-serving-cert
+        secret:
+          secretName: {{ .ServerSecretName }}
+      - name: config
+        configMap:
+          name: prometheus-metrics-adapter
+      - name: tmp-vol
+        emptyDir: {}

--- a/pkg/operation/botanist/component/prommetric/templates/60-custom-metrics-apiserver-service.yaml
+++ b/pkg/operation/botanist/component/prommetric/templates/60-custom-metrics-apiserver-service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: prometheus-metrics-adapter
+  namespace: {{ .Namespace }}
+spec:
+  ports:
+  - port: 443
+    targetPort: 6443
+  selector:
+    app: custom-metrics-apiserver

--- a/pkg/operation/botanist/component/prommetric/templates/70-custom-metrics-apiservice.yaml
+++ b/pkg/operation/botanist/component/prommetric/templates/70-custom-metrics-apiservice.yaml
@@ -1,0 +1,42 @@
+apiVersion: apiregistration.k8s.io/v1
+kind: APIService
+metadata:
+  name: v1beta1.custom.metrics.k8s.io
+spec:
+  service:
+    name: prometheus-metrics-adapter
+    namespace: {{ .Namespace }}
+  group: custom.metrics.k8s.io
+  version: v1beta1
+  insecureSkipTLSVerify: true
+  groupPriorityMinimum: 100
+  versionPriority: 100
+---
+apiVersion: apiregistration.k8s.io/v1
+kind: APIService
+metadata:
+  name: v1beta2.custom.metrics.k8s.io
+spec:
+  service:
+    name: prometheus-metrics-adapter
+    namespace: {{ .Namespace }}
+  group: custom.metrics.k8s.io
+  version: v1beta2
+  insecureSkipTLSVerify: true
+  groupPriorityMinimum: 100
+  versionPriority: 200
+---
+apiVersion: apiregistration.k8s.io/v1
+kind: APIService
+metadata:
+  name: v1beta1.external.metrics.k8s.io
+spec:
+  service:
+    name: prometheus-metrics-adapter
+    namespace: {{ .Namespace }}
+  group: external.metrics.k8s.io
+  version: v1beta1
+  insecureSkipTLSVerify: true
+  groupPriorityMinimum: 100
+  versionPriority: 100
+---

--- a/pkg/operation/botanist/kubeapiserver_test.go
+++ b/pkg/operation/botanist/kubeapiserver_test.go
@@ -806,7 +806,7 @@ usernames: ["admin"]
 					featureGatePtr(features.HVPA), pointer.Bool(false),
 					kubeapiserver.AutoscalingConfig{
 						APIServerResources:        resourcesRequirementsForKubeAPIServer(0, ""),
-						HVPAEnabled:               false,
+						AutoscalingMode:           kubeapiserver.AutoscalingModeHPlusVClashing,
 						MinReplicas:               1,
 						MaxReplicas:               4,
 						UseMemoryMetricForHvpaHPA: false,
@@ -818,7 +818,7 @@ usernames: ["admin"]
 					featureGatePtr(features.HVPA), pointer.Bool(true),
 					kubeapiserver.AutoscalingConfig{
 						APIServerResources:        resourcesRequirementsForKubeAPIServer(0, ""),
-						HVPAEnabled:               true,
+						AutoscalingMode:           kubeapiserver.AutoscalingModeHVPA,
 						MinReplicas:               1,
 						MaxReplicas:               4,
 						UseMemoryMetricForHvpaHPA: false,
@@ -832,7 +832,7 @@ usernames: ["admin"]
 					nil, nil,
 					kubeapiserver.AutoscalingConfig{
 						APIServerResources:        resourcesRequirementsForKubeAPIServer(0, ""),
-						HVPAEnabled:               false,
+						AutoscalingMode:           kubeapiserver.AutoscalingModeHPlusVClashing,
 						MinReplicas:               2,
 						MaxReplicas:               4,
 						UseMemoryMetricForHvpaHPA: false,
@@ -846,7 +846,7 @@ usernames: ["admin"]
 					nil, nil,
 					kubeapiserver.AutoscalingConfig{
 						APIServerResources:        resourcesRequirementsForKubeAPIServer(0, ""),
-						HVPAEnabled:               false,
+						AutoscalingMode:           kubeapiserver.AutoscalingModeHPlusVClashing,
 						MinReplicas:               4,
 						MaxReplicas:               4,
 						UseMemoryMetricForHvpaHPA: false,
@@ -860,7 +860,7 @@ usernames: ["admin"]
 					featureGatePtr(features.HVPAForShootedSeed), pointer.Bool(false),
 					kubeapiserver.AutoscalingConfig{
 						APIServerResources:        resourcesRequirementsForKubeAPIServer(0, ""),
-						HVPAEnabled:               false,
+						AutoscalingMode:           kubeapiserver.AutoscalingModeHPlusVClashing,
 						MinReplicas:               1,
 						MaxReplicas:               4,
 						UseMemoryMetricForHvpaHPA: true,
@@ -874,7 +874,7 @@ usernames: ["admin"]
 					featureGatePtr(features.HVPAForShootedSeed), pointer.Bool(true),
 					kubeapiserver.AutoscalingConfig{
 						APIServerResources:        resourcesRequirementsForKubeAPIServer(0, ""),
-						HVPAEnabled:               true,
+						AutoscalingMode:           kubeapiserver.AutoscalingModeHVPA,
 						MinReplicas:               1,
 						MaxReplicas:               4,
 						UseMemoryMetricForHvpaHPA: true,
@@ -895,7 +895,7 @@ usernames: ["admin"]
 					featureGatePtr(features.HVPAForShootedSeed), pointer.Bool(true),
 					kubeapiserver.AutoscalingConfig{
 						APIServerResources:        resourcesRequirementsForKubeAPIServer(0, ""),
-						HVPAEnabled:               true,
+						AutoscalingMode:           kubeapiserver.AutoscalingModeHVPA,
 						MinReplicas:               16,
 						MaxReplicas:               32,
 						UseMemoryMetricForHvpaHPA: true,
@@ -921,7 +921,7 @@ usernames: ["admin"]
 								corev1.ResourceMemory: resource.MustParse("2Gi"),
 							},
 						},
-						HVPAEnabled:               false,
+						AutoscalingMode:           kubeapiserver.AutoscalingModeHPlusVClashing,
 						MinReplicas:               16,
 						MaxReplicas:               32,
 						Replicas:                  pointer.Int32(24),
@@ -940,7 +940,7 @@ usernames: ["admin"]
 					nil, nil,
 					kubeapiserver.AutoscalingConfig{
 						APIServerResources:        resourcesRequirementsForKubeAPIServer(0, ""),
-						HVPAEnabled:               false,
+						AutoscalingMode:           kubeapiserver.AutoscalingModeHPlusVClashing,
 						MinReplicas:               3,
 						MaxReplicas:               4,
 						UseMemoryMetricForHvpaHPA: false,
@@ -1297,7 +1297,7 @@ usernames: ["admin"]
 						},
 					})).To(Succeed())
 				},
-				kubeapiserver.AutoscalingConfig{HVPAEnabled: false},
+				kubeapiserver.AutoscalingConfig{AutoscalingMode: kubeapiserver.AutoscalingModeHPlusVClashing},
 				nil,
 			),
 			Entry("set the existing requirements because deployment found and HVPA enabled",
@@ -1319,7 +1319,7 @@ usernames: ["admin"]
 						},
 					})).To(Succeed())
 				},
-				kubeapiserver.AutoscalingConfig{HVPAEnabled: true},
+				kubeapiserver.AutoscalingConfig{AutoscalingMode: kubeapiserver.AutoscalingModeHVPA},
 				&apiServerResources,
 			),
 		)

--- a/pkg/utils/images/images.go
+++ b/pkg/utils/images/images.go
@@ -103,6 +103,8 @@ const (
 	ImageNamePauseContainer = "pause-container"
 	// ImageNamePrometheus is a constant for an image in the image vector with name 'prometheus'.
 	ImageNamePrometheus = "prometheus"
+	// ImageNamePrometheusMeetricsAdapter is a constant for an image in the image vector with name 'prometheus-metrics-adapter'.
+	ImageNamePrometheusMeetricsAdapter = "prometheus-metrics-adapter"
 	// ImageNamePromtail is a constant for an image in the image vector with name 'promtail'.
 	ImageNamePromtail = "promtail"
 	// ImageNameTelegraf is a constant for an image in the image vector with name 'telegraf'.


### PR DESCRIPTION
**How to categorize this PR?**
/area auto-scaling
/kind enhancement

**What this PR does / why we need it**:
Adds feature-gated ability to scale shoot control plane kube-apiserver instances via simultaneous HPA and VPA. Undesirable interference between HPA and VPA is avoided through the use of sufficiently independent driving signals. HPA is driven by the rate of HTTP requests to kube-apiserver. VPA is driven by CPU and memory usage metrics.

The rationale behind this approach is:
  - A rough, heuristic horizontal sizing sets the stage for optimal VPA operation (horizontal size is within stable and reasonably efficient range)
  - Vertical scaling fine-tunes requests, ensuring high efficiency (requests not too high) and stability (requests not too low)

The request rate signal driving HPA originates in the aggregate seed prometheus. It is mediated by a prometheus-metrics-adapter service (one per seed), which pulls prometheus data on demand and converts it to the k8s metrics format. Said prometheus-metrics-adapter is registered as extension api service to the seed's kube-apiserver, and takes responsibility of providing all custom metrics for that kube-apiserver.

**Special notes for your reviewer**:

**Release note**:
```feature operator
A HPlusVAutoscaling feature was introduced, enabling improved simultaneous horizontal and vertical autoscaling of shoot control plane kube-apiservers.
```
