### PR TITLE
Drop `nodeSelector` and `tolerations` from Shoot System Components

### DIFF
--- a/charts/shoot-addons/charts/nginx-ingress/values.yaml
+++ b/charts/shoot-addons/charts/nginx-ingress/values.yaml
@@ -131,13 +131,6 @@ defaultBackend:
 
   extraArgs: {}
 
-  ## Node labels for default backend pod assignment
-  ## Ref: https://kubernetes.io/docs/user-guide/node-selection/
-  ##
-  nodeSelector:
-    worker.gardener.cloud/system-components: "true"
-
-
   ## Annotations to be added to default backend pods
   ##
   podAnnotations: {}

--- a/charts/shoot-core/components/charts/apiserver-proxy/templates/apiserver-proxy-daemonset.yaml
+++ b/charts/shoot-core/components/charts/apiserver-proxy/templates/apiserver-proxy-daemonset.yaml
@@ -38,8 +38,6 @@ spec:
       tolerations:
       - effect: NoSchedule
         operator: Exists
-      - key: CriticalAddonsOnly
-        operator: Exists
       - effect: NoExecute
         operator: Exists
       hostNetwork: true

--- a/charts/shoot-core/components/charts/monitoring/charts/blackbox-exporter/templates/deployment.yaml
+++ b/charts/shoot-core/components/charts/monitoring/charts/blackbox-exporter/templates/deployment.yaml
@@ -37,8 +37,6 @@ spec:
       tolerations:
       - effect: NoSchedule
         operator: Exists
-      - key: CriticalAddonsOnly
-        operator: Exists
       - effect: NoExecute
         operator: Exists
       priorityClassName: system-cluster-critical

--- a/charts/shoot-core/components/charts/monitoring/charts/blackbox-exporter/templates/deployment.yaml
+++ b/charts/shoot-core/components/charts/monitoring/charts/blackbox-exporter/templates/deployment.yaml
@@ -42,8 +42,6 @@ spec:
       - effect: NoExecute
         operator: Exists
       priorityClassName: system-cluster-critical
-      nodeSelector:
-        worker.gardener.cloud/system-components: "true"
       securityContext:
         runAsUser: 65534
         fsGroup: 65534

--- a/charts/shoot-core/components/charts/monitoring/charts/blackbox-exporter/templates/deployment.yaml
+++ b/charts/shoot-core/components/charts/monitoring/charts/blackbox-exporter/templates/deployment.yaml
@@ -34,11 +34,6 @@ spec:
         networking.gardener.cloud/to-apiserver: allowed
     spec:
       serviceAccountName: blackbox-exporter
-      tolerations:
-      - effect: NoSchedule
-        operator: Exists
-      - effect: NoExecute
-        operator: Exists
       priorityClassName: system-cluster-critical
       securityContext:
         runAsUser: 65534

--- a/charts/shoot-core/components/charts/monitoring/charts/node-exporter/templates/node-exporter.yaml
+++ b/charts/shoot-core/components/charts/monitoring/charts/node-exporter/templates/node-exporter.yaml
@@ -51,8 +51,6 @@ spec:
       tolerations:
       - effect: NoSchedule
         operator: Exists
-      - key: CriticalAddonsOnly
-        operator: Exists
       - effect: NoExecute
         operator: Exists
       hostNetwork: true

--- a/pkg/operation/botanist/component/coredns/coredns.go
+++ b/pkg/operation/botanist/component/coredns/coredns.go
@@ -382,7 +382,6 @@ import custom/*.server
 					Spec: corev1.PodSpec{
 						PriorityClassName:  "system-cluster-critical",
 						ServiceAccountName: serviceAccount.Name,
-						NodeSelector:       map[string]string{v1beta1constants.LabelWorkerPoolSystemComponents: "true"},
 						DNSPolicy:          corev1.DNSDefault,
 						SecurityContext: &corev1.PodSecurityContext{
 							RunAsNonRoot:       pointer.Bool(true),

--- a/pkg/operation/botanist/component/coredns/coredns.go
+++ b/pkg/operation/botanist/component/coredns/coredns.go
@@ -392,10 +392,6 @@ import custom/*.server
 								Type: corev1.SeccompProfileTypeRuntimeDefault,
 							},
 						},
-						Tolerations: []corev1.Toleration{{
-							Key:      "CriticalAddonsOnly",
-							Operator: corev1.TolerationOpExists,
-						}},
 						Containers: []corev1.Container{{
 							Name:            containerName,
 							Image:           c.values.Image,
@@ -590,10 +586,6 @@ import custom/*.server
 								Type: corev1.SeccompProfileTypeRuntimeDefault,
 							},
 						},
-						Tolerations: []corev1.Toleration{{
-							Key:      "CriticalAddonsOnly",
-							Operator: corev1.TolerationOpExists,
-						}},
 						Containers: []corev1.Container{{
 							Name:            "autoscaler",
 							Image:           c.values.ClusterProportionalAutoscalerImage,

--- a/pkg/operation/botanist/component/coredns/coredns_test.go
+++ b/pkg/operation/botanist/component/coredns/coredns_test.go
@@ -373,9 +373,6 @@ spec:
         supplementalGroups:
         - 1
       serviceAccountName: coredns
-      tolerations:
-      - key: CriticalAddonsOnly
-        operator: Exists
       volumes:
       - configMap:
           items:
@@ -576,9 +573,6 @@ spec:
         supplementalGroups:
         - 65534
       serviceAccountName: coredns-autoscaler
-      tolerations:
-      - key: CriticalAddonsOnly
-        operator: Exists
 status: {}
 `
 

--- a/pkg/operation/botanist/component/coredns/coredns_test.go
+++ b/pkg/operation/botanist/component/coredns/coredns_test.go
@@ -363,8 +363,6 @@ spec:
           name: custom-config-volume
           readOnly: true
       dnsPolicy: Default
-      nodeSelector:
-        worker.gardener.cloud/system-components: "true"
       priorityClassName: system-cluster-critical
       securityContext:
         fsGroup: 1

--- a/pkg/operation/botanist/component/kubeproxy/kube_proxy_test.go
+++ b/pkg/operation/botanist/component/kubeproxy/kube_proxy_test.go
@@ -591,8 +591,6 @@ spec:
       tolerations:
       - effect: NoSchedule
         operator: Exists
-      - key: CriticalAddonsOnly
-        operator: Exists
       - effect: NoExecute
         operator: Exists
       volumes:

--- a/pkg/operation/botanist/component/kubeproxy/resources.go
+++ b/pkg/operation/botanist/component/kubeproxy/resources.go
@@ -387,10 +387,6 @@ func (k *kubeProxy) computePoolResourcesData(pool WorkerPool) (map[string][]byte
 								Operator: corev1.TolerationOpExists,
 							},
 							{
-								Key:      "CriticalAddonsOnly",
-								Operator: corev1.TolerationOpExists,
-							},
-							{
 								Effect:   corev1.TaintEffectNoExecute,
 								Operator: corev1.TolerationOpExists,
 							},

--- a/pkg/operation/botanist/component/kubernetesdashboard/kubernetes_dashboard.go
+++ b/pkg/operation/botanist/component/kubernetesdashboard/kubernetes_dashboard.go
@@ -299,9 +299,6 @@ func (k *kubernetesDashboard) computeResourcesData() (map[string][]byte, error) 
 						Labels: getLabels(name),
 					},
 					Spec: corev1.PodSpec{
-						NodeSelector: map[string]string{
-							v1beta1constants.LabelWorkerPoolSystemComponents: "true",
-						},
 						SecurityContext: &corev1.PodSecurityContext{
 							RunAsUser:          pointer.Int64(1001),
 							RunAsGroup:         pointer.Int64(2001),
@@ -402,9 +399,6 @@ func (k *kubernetesDashboard) computeResourcesData() (map[string][]byte, error) 
 						Labels: getLabels(scraperName),
 					},
 					Spec: corev1.PodSpec{
-						NodeSelector: map[string]string{
-							v1beta1constants.LabelWorkerPoolSystemComponents: "true",
-						},
 						SecurityContext: &corev1.PodSecurityContext{
 							FSGroup:            pointer.Int64(1),
 							SupplementalGroups: []int64{1},

--- a/pkg/operation/botanist/component/kubernetesdashboard/kubernetes_dashboard_test.go
+++ b/pkg/operation/botanist/component/kubernetesdashboard/kubernetes_dashboard_test.go
@@ -303,8 +303,6 @@ spec:
           name: kubernetes-dashboard-certs
         - mountPath: /tmp
           name: tmp-volume
-      nodeSelector:
-        worker.gardener.cloud/system-components: "true"
       securityContext:
         fsGroup: 1
         runAsGroup: 2001
@@ -387,8 +385,6 @@ spec:
 			out += `        volumeMounts:
         - mountPath: /tmp
           name: tmp-volume
-      nodeSelector:
-        worker.gardener.cloud/system-components: "true"
       securityContext:
         fsGroup: 1
         supplementalGroups:

--- a/pkg/operation/botanist/component/metricsserver/metrics_server.go
+++ b/pkg/operation/botanist/component/metricsserver/metrics_server.go
@@ -289,13 +289,6 @@ func (m *metricsServer) computeResourcesData(serverSecret, caSecret *corev1.Secr
 						}),
 					},
 					Spec: corev1.PodSpec{
-						Tolerations: []corev1.Toleration{{
-							Effect:   corev1.TaintEffectNoSchedule,
-							Operator: corev1.TolerationOpExists,
-						}, {
-							Effect:   corev1.TaintEffectNoExecute,
-							Operator: corev1.TolerationOpExists,
-						}},
 						PriorityClassName: "system-cluster-critical",
 						SecurityContext: &corev1.PodSecurityContext{
 							RunAsUser:          pointer.Int64(65534),

--- a/pkg/operation/botanist/component/metricsserver/metrics_server.go
+++ b/pkg/operation/botanist/component/metricsserver/metrics_server.go
@@ -290,9 +290,6 @@ func (m *metricsServer) computeResourcesData(serverSecret, caSecret *corev1.Secr
 					},
 					Spec: corev1.PodSpec{
 						Tolerations: []corev1.Toleration{{
-							Key:      "CriticalAddonsOnly",
-							Operator: corev1.TolerationOpExists,
-						}, {
 							Effect:   corev1.TaintEffectNoSchedule,
 							Operator: corev1.TolerationOpExists,
 						}, {

--- a/pkg/operation/botanist/component/metricsserver/metrics_server.go
+++ b/pkg/operation/botanist/component/metricsserver/metrics_server.go
@@ -300,9 +300,6 @@ func (m *metricsServer) computeResourcesData(serverSecret, caSecret *corev1.Secr
 							Operator: corev1.TolerationOpExists,
 						}},
 						PriorityClassName: "system-cluster-critical",
-						NodeSelector: map[string]string{
-							v1beta1constants.LabelWorkerPoolSystemComponents: "true",
-						},
 						SecurityContext: &corev1.PodSecurityContext{
 							RunAsUser:          pointer.Int64(65534),
 							FSGroup:            pointer.Int64(65534),

--- a/pkg/operation/botanist/component/metricsserver/metrics_server_test.go
+++ b/pkg/operation/botanist/component/metricsserver/metrics_server_test.go
@@ -288,8 +288,6 @@ spec:
         - 1
       serviceAccountName: metrics-server
       tolerations:
-      - key: CriticalAddonsOnly
-        operator: Exists
       - effect: NoSchedule
         operator: Exists
       - effect: NoExecute

--- a/pkg/operation/botanist/component/metricsserver/metrics_server_test.go
+++ b/pkg/operation/botanist/component/metricsserver/metrics_server_test.go
@@ -287,11 +287,6 @@ spec:
         supplementalGroups:
         - 1
       serviceAccountName: metrics-server
-      tolerations:
-      - effect: NoSchedule
-        operator: Exists
-      - effect: NoExecute
-        operator: Exists
       volumes:
       - name: metrics-server
         secret:

--- a/pkg/operation/botanist/component/metricsserver/metrics_server_test.go
+++ b/pkg/operation/botanist/component/metricsserver/metrics_server_test.go
@@ -278,8 +278,6 @@ spec:
         - mountPath: /srv/metrics-server/tls
           name: metrics-server
       dnsPolicy: Default
-      nodeSelector:
-        worker.gardener.cloud/system-components: "true"
       priorityClassName: system-cluster-critical
       securityContext:
         fsGroup: 65534

--- a/pkg/operation/botanist/component/nodelocaldns/nodelocaldns.go
+++ b/pkg/operation/botanist/component/nodelocaldns/nodelocaldns.go
@@ -288,10 +288,6 @@ ip6.arpa:53 {
 						},
 						Tolerations: []corev1.Toleration{
 							{
-								Key:      "CriticalAddonsOnly",
-								Operator: corev1.TolerationOpExists,
-							},
-							{
 								Operator: corev1.TolerationOpExists,
 								Effect:   corev1.TaintEffectNoExecute,
 							},

--- a/pkg/operation/botanist/component/nodelocaldns/nodelocaldns_test.go
+++ b/pkg/operation/botanist/component/nodelocaldns/nodelocaldns_test.go
@@ -316,10 +316,6 @@ status:
 								DNSPolicy:          corev1.DNSDefault,
 								Tolerations: []corev1.Toleration{
 									{
-										Key:      "CriticalAddonsOnly",
-										Operator: corev1.TolerationOpExists,
-									},
-									{
 										Operator: corev1.TolerationOpExists,
 										Effect:   corev1.TaintEffectNoExecute,
 									},

--- a/pkg/operation/botanist/component/nodeproblemdetector/node_problem_detector.go
+++ b/pkg/operation/botanist/component/nodeproblemdetector/node_problem_detector.go
@@ -278,10 +278,6 @@ func (c *nodeProblemDetector) computeResourcesData() (map[string][]byte, error) 
 								Operator: corev1.TolerationOpExists,
 							},
 							{
-								Key:      "CriticalAddonsOnly",
-								Operator: corev1.TolerationOpExists,
-							},
-							{
 								Effect:   corev1.TaintEffectNoExecute,
 								Operator: corev1.TolerationOpExists,
 							},

--- a/pkg/operation/botanist/component/nodeproblemdetector/node_problem_detector_test.go
+++ b/pkg/operation/botanist/component/nodeproblemdetector/node_problem_detector_test.go
@@ -309,8 +309,6 @@ spec:
       tolerations:
       - effect: NoSchedule
         operator: Exists
-      - key: CriticalAddonsOnly
-        operator: Exists
       - effect: NoExecute
         operator: Exists
       volumes:

--- a/pkg/operation/botanist/component/vpnshoot/vpnshoot.go
+++ b/pkg/operation/botanist/component/vpnshoot/vpnshoot.go
@@ -508,7 +508,6 @@ func (v *vpnShoot) podTemplate(serviceAccount *corev1.ServiceAccount, secrets []
 			ServiceAccountName:           serviceAccount.Name,
 			PriorityClassName:            "system-cluster-critical",
 			DNSPolicy:                    corev1.DNSDefault,
-			NodeSelector:                 map[string]string{v1beta1constants.LabelWorkerPoolSystemComponents: "true"},
 			SecurityContext: &corev1.PodSecurityContext{
 				SeccompProfile: &corev1.SeccompProfile{
 					Type: corev1.SeccompProfileTypeRuntimeDefault,

--- a/pkg/operation/botanist/component/vpnshoot/vpnshoot.go
+++ b/pkg/operation/botanist/component/vpnshoot/vpnshoot.go
@@ -513,10 +513,6 @@ func (v *vpnShoot) podTemplate(serviceAccount *corev1.ServiceAccount, secrets []
 					Type: corev1.SeccompProfileTypeRuntimeDefault,
 				},
 			},
-			Tolerations: []corev1.Toleration{{
-				Key:      "CriticalAddonsOnly",
-				Operator: corev1.TolerationOpExists,
-			}},
 			InitContainers: v.getInitContainers(),
 			Volumes:        v.getVolumes(secrets, secretCA, secretTLSAuth, secretDH),
 		},

--- a/pkg/operation/botanist/component/vpnshoot/vpnshoot_test.go
+++ b/pkg/operation/botanist/component/vpnshoot/vpnshoot_test.go
@@ -508,7 +508,6 @@ status: {}
 						ServiceAccountName:           "vpn-shoot",
 						PriorityClassName:            "system-cluster-critical",
 						DNSPolicy:                    corev1.DNSDefault,
-						NodeSelector:                 map[string]string{"worker.gardener.cloud/system-components": "true"},
 						Tolerations: []corev1.Toleration{{
 							Key:      "CriticalAddonsOnly",
 							Operator: corev1.TolerationOpExists,

--- a/pkg/operation/botanist/component/vpnshoot/vpnshoot_test.go
+++ b/pkg/operation/botanist/component/vpnshoot/vpnshoot_test.go
@@ -508,10 +508,6 @@ status: {}
 						ServiceAccountName:           "vpn-shoot",
 						PriorityClassName:            "system-cluster-critical",
 						DNSPolicy:                    corev1.DNSDefault,
-						Tolerations: []corev1.Toleration{{
-							Key:      "CriticalAddonsOnly",
-							Operator: corev1.TolerationOpExists,
-						}},
 						SecurityContext: &corev1.PodSecurityContext{
 							SeccompProfile: &corev1.SeccompProfile{
 								Type: corev1.SeccompProfileTypeRuntimeDefault,


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area scalability
/kind cleanup

**What this PR does / why we need it**:
After the integration of #7204, this PR cleans up relevant deployments of Shoot System Components:
- removes `nodeSelector`
- removes general `tolerations`
- removes all `CriticalAddonsOnly` tolerations (not related to #7204 but removed along the way)

Please see the individual commit messages for more information.

**Which issue(s) this PR fixes**:
Part of #7103

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
None
```
