### PR TITLE
Update HVPA to 0.9.0

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -323,7 +323,7 @@ images:
 - name: hvpa-controller
   sourceRepository: github.com/gardener/hvpa-controller
   repository: eu.gcr.io/gardener-project/gardener/hvpa-controller
-  tag: "v0.8.0"
+  tag: "v0.9.0"
   labels:
     - name: 'gardener.cloud/cve-categorisation'
       value:

--- a/pkg/operation/botanist/component/hvpa/hvpa.go
+++ b/pkg/operation/botanist/component/hvpa/hvpa.go
@@ -206,7 +206,7 @@ func (h *hvpa) Deploy(ctx context.Context) error {
 								"./manager",
 								"--logtostderr=true",
 								"--enable-detailed-metrics=true",
-								fmt.Sprintf("--metrics-addr=:%d", portMetrics),
+								fmt.Sprintf("--metrics-bind-address=:%d", portMetrics),
 								"--v=2",
 							},
 							Resources: corev1.ResourceRequirements{

--- a/pkg/operation/botanist/component/hvpa/hvpa_test.go
+++ b/pkg/operation/botanist/component/hvpa/hvpa_test.go
@@ -218,7 +218,7 @@ var _ = Describe("HVPA", func() {
 								"./manager",
 								"--logtostderr=true",
 								"--enable-detailed-metrics=true",
-								"--metrics-addr=:9569",
+								"--metrics-bind-address=:9569",
 								"--v=2",
 							},
 							Resources: corev1.ResourceRequirements{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area auto-scaling
/kind enhancement

**What this PR does / why we need it**:
Update HVPA to 0.9.0, which brings in security fixes with updated go 1.19.4


**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
``` breaking operator github.com/gardener/hvpa-controller #113 @voelzmo
The parameters `metrics-addr` and `enable-leader-election` have been changed to `metrics-bind-address` and `leader-elect` respectively to be in-line with kubebuilder v3 scaffolding.
```

``` other developer github.com/gardener/hvpa-controller #113 @voelzmo
`make test` is adapted to automatically configure envtest to use k8s 1.24.2 binaries
```

``` other developer github.com/gardener/hvpa-controller #113 @voelzmo
Necessary binaries, such as `controller-gen`, `kustomize` and `setup-envtest` are automatically downloaded and installed into `./bin`
```

``` other operator github.com/gardener/hvpa-controller #115 @voelzmo
Bumped go to 1.19.4
```

``` other developer github.com/gardener/hvpa-controller #111 @voelzmo
Bump api module golang dep to 1.18
```

``` other developer github.com/gardener/hvpa-controller #111 @voelzmo
Update k8s.io dependencies to include k8s 1.25
```

``` other developer github.com/gardener/hvpa-controller #111 @voelzmo
Switch to klog/v2
```