### PR TITLE
Local Provider: Fix containerd configuration for registry mirrors

### DIFF
--- a/docs/usage/custom-containerd-config.md
+++ b/docs/usage/custom-containerd-config.md
@@ -12,6 +12,7 @@ imports = ["/etc/containerd/conf.d/*.toml"]
 ```
 
 This means that all `*.toml` files in the `/etc/containerd/conf.d` directory will be imported and merged with the default configuration.
+To prevent unintended configuration overwrites, please be aware that containerd merges config sections, not individual keys (see [here](https://github.com/containerd/containerd/issues/5837#issuecomment-894840240) and [here](https://github.com/gardener/gardener/pull/7316)).
 Please consult the [upstream `containerd` documentation](https://github.com/containerd/containerd/blob/main/docs/man/containerd-config.toml.5.md#format) for more information.
 
 > ⚠️ Note that this only applies to nodes which were newly created after `gardener/gardener@v1.51` was deployed. Existing nodes are not affected. 

--- a/pkg/provider-local/webhook/controlplane/ensurer.go
+++ b/pkg/provider-local/webhook/controlplane/ensurer.go
@@ -15,18 +15,44 @@
 package controlplane
 
 import (
+	"bytes"
 	"context"
+	_ "embed"
+	"text/template"
 
 	"github.com/Masterminds/semver"
+	"github.com/Masterminds/sprig"
 	"github.com/go-logr/logr"
 	kubeletconfigv1beta1 "k8s.io/kubelet/config/v1beta1"
 	"k8s.io/utils/pointer"
 
 	extensionscontextwebhook "github.com/gardener/gardener/extensions/pkg/webhook/context"
 	"github.com/gardener/gardener/extensions/pkg/webhook/controlplane/genericmutator"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	"github.com/gardener/gardener/pkg/utils"
 )
+
+const pathContainerdConfigScript = v1beta1constants.OperatingSystemConfigFilePathBinaries + "/init-containerd-with-registry-mirrors"
+
+var (
+	tplNameInitializer = "init"
+	//go:embed templates/scripts/configure-containerd.tpl.sh
+	tplContentInitializer string
+	tplInitializer        *template.Template
+)
+
+func init() {
+	var err error
+	tplInitializer, err = template.
+		New(tplNameInitializer).
+		Funcs(sprig.TxtFuncMap()).
+		Parse(tplContentInitializer)
+	if err != nil {
+		panic(err)
+	}
+}
 
 // NewEnsurer creates a new controlplane ensurer.
 func NewEnsurer(logger logr.Logger) genericmutator.Ensurer {
@@ -57,32 +83,49 @@ func (e *ensurer) EnsureAdditionalFiles(ctx context.Context, gc extensionscontex
 		kindClusterName = "gardener-local-ha-control-plane"
 	}
 
+	var script bytes.Buffer
+	if err := tplInitializer.Execute(&script, map[string]interface{}{
+		"kindClusterName": kindClusterName,
+	}); err != nil {
+		return err
+	}
+
 	appendUniqueFile(new, extensionsv1alpha1.File{
-		Path:        "/etc/containerd/conf.d/50-provider-local-registry.toml",
-		Permissions: pointer.Int32(0644),
+		Path:        pathContainerdConfigScript,
+		Permissions: pointer.Int32(0744),
 		Content: extensionsv1alpha1.FileContent{
 			Inline: &extensionsv1alpha1.FileContentInline{
-				Encoding: "",
-				Data: `[plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:5001"]
-  endpoint = ["http://` + kindClusterName + `:5001"]
-[plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]
-  endpoint = ["http://` + kindClusterName + `:5002"]
-[plugins."io.containerd.grpc.v1.cri".registry.mirrors."registry.ipv6.docker.com"]
-  endpoint = ["http://` + kindClusterName + `:5008"]
-[plugins."io.containerd.grpc.v1.cri".registry.mirrors."gcr.io"]
-  endpoint = ["http://` + kindClusterName + `:5003"]
-[plugins."io.containerd.grpc.v1.cri".registry.mirrors."eu.gcr.io"]
-  endpoint = ["http://` + kindClusterName + `:5004"]
-[plugins."io.containerd.grpc.v1.cri".registry.mirrors."ghcr.io"]
-  endpoint = ["http://` + kindClusterName + `:5005"]
-[plugins."io.containerd.grpc.v1.cri".registry.mirrors."registry.k8s.io"]
-  endpoint = ["http://` + kindClusterName + `:5006"]
-[plugins."io.containerd.grpc.v1.cri".registry.mirrors."quay.io"]
-  endpoint = ["http://` + kindClusterName + `:5007"]
-`,
+				Encoding: "b64",
+				Data:     utils.EncodeBase64(script.Bytes()),
 			},
 		},
 	})
+	return nil
+}
+
+func (e *ensurer) EnsureAdditionalUnits(_ context.Context, _ extensionscontextwebhook.GardenContext, new, _ *[]extensionsv1alpha1.Unit) error {
+	const unitNameInitializer = "containerd-configuration-local-setup.service"
+	unit := extensionsv1alpha1.Unit{
+		Name:    unitNameInitializer,
+		Command: pointer.String("start"),
+		Enable:  pointer.Bool(true),
+		Content: pointer.String(`[Unit]
+Description=Containerd config configuration for local-setup
+
+[Install]
+WantedBy=multi-user.target
+
+[Unit]
+After=containerd-initializer.service
+Requires=containerd-initializer.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=` + pathContainerdConfigScript)}
+
+	appendUniqueUnit(new, unit)
+
 	return nil
 }
 
@@ -97,4 +140,17 @@ func appendUniqueFile(files *[]extensionsv1alpha1.File, file extensionsv1alpha1.
 	}
 
 	*files = append(resFiles, file)
+}
+
+// appendUniqueUnit appends a unit only if it does not exist, otherwise overwrite content of previous unit
+func appendUniqueUnit(units *[]extensionsv1alpha1.Unit, unit extensionsv1alpha1.Unit) {
+	resFiles := make([]extensionsv1alpha1.Unit, 0, len(*units))
+
+	for _, f := range *units {
+		if f.Name != unit.Name {
+			resFiles = append(resFiles, f)
+		}
+	}
+
+	*units = append(resFiles, unit)
 }

--- a/pkg/provider-local/webhook/controlplane/templates/scripts/configure-containerd.tpl.sh
+++ b/pkg/provider-local/webhook/controlplane/templates/scripts/configure-containerd.tpl.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+cluster_name={{ .kindClusterName }}
+
+FILENAME=/etc/containerd/config.toml
+if ! grep -q plugins.\"io.containerd.grpc.v1.cri\".registry.mirrors.\"localhost:5001\" "$FILENAME"; then
+  cat <<EOF >> $FILENAME
+[plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:5001"]
+  endpoint = ["http://$cluster_name:5001"]
+[plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]
+  endpoint = ["http://$cluster_name:5002"]
+[plugins."io.containerd.grpc.v1.cri".registry.mirrors."gcr.io"]
+  endpoint = ["http://$cluster_name:5003"]
+[plugins."io.containerd.grpc.v1.cri".registry.mirrors."eu.gcr.io"]
+  endpoint = ["http://$cluster_name:5004"]
+[plugins."io.containerd.grpc.v1.cri".registry.mirrors."registry.ipv6.docker.com"]
+  endpoint = ["http://$cluster_name:5004"]
+[plugins."io.containerd.grpc.v1.cri".registry.mirrors."ghcr.io"]
+  endpoint = ["http://$cluster_name:5005"]
+[plugins."io.containerd.grpc.v1.cri".registry.mirrors."registry.k8s.io"]
+  endpoint = ["http://$cluster_name:5006"]
+[plugins."io.containerd.grpc.v1.cri".registry.mirrors."quay.io"]
+  endpoint = ["http://$cluster_name:5007"]
+EOF
+  echo "Configured containerd with registry mirrors for local-setup."
+else
+  echo "Containerd already configured with registry mirrors."
+fi


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind bug

**What this PR does / why we need it**:

The local provider configures the containerd config with registry mirrors by using containerd imports.
The imported file in `/etc/containerd/conf.d/50-provider-local-registry.toml` contains 

```
[plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:5001"]
....
```
Containerd merges config sections, not individual keys (see [here](https://github.com/containerd/containerd/issues/5837#issuecomment-894840240)). hence, the above imported configuration overwrites all configurations in the `plugins.cri` config section. That includes the container runtimes section under 

```
    [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runsc]
      runtime_type = "io.containerd.runsc.v1"

```

As a result, pods using gvisor with containerd are unable to start. The error is 
```
Failed to create pod sandbox: rpc error: code = Unknown desc = failed to get sandbox runtime: no runtime for "runsc" is configured
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

- To see the merged containerd config use `/opt/bin/containerd config dump`.
- this behavior is also important to remember for any other Gardener components (or stakeholders) wanting to customize the containerd configuration. It might accidentally overwrite the  `gvisor`-Extension or other Gardener non-default containerd configuration.



<details>
<summary>Make sure that when using the local-setup with gvisor, the merged containerd config file contains the following:</summary>

```

[plugins."io.containerd.grpc.v1.cri".containerd.runtimes]

        [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
          base_runtime_spec = "/etc/containerd/cri-base.json"
          cni_conf_dir = ""
          cni_max_conf_num = 0
          container_annotations = []
          pod_annotations = []
          privileged_without_host_devices = false
          runtime_engine = ""
          runtime_path = ""
          runtime_root = ""
          runtime_type = "io.containerd.runc.v2"

          [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
            SystemdCgroup = false

        [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runsc]
          base_runtime_spec = ""
          cni_conf_dir = ""
          cni_max_conf_num = 0
          container_annotations = []
          pod_annotations = []
          privileged_without_host_devices = false
          runtime_engine = ""
          runtime_path = ""
          runtime_root = ""
          runtime_type = "io.containerd.runsc.v1"

          [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runsc.options]

        [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.test-handler]
          base_runtime_spec = "/etc/containerd/cri-base.json"
          cni_conf_dir = ""
          cni_max_conf_num = 0
          container_annotations = []
          pod_annotations = []
          privileged_without_host_devices = false
          runtime_engine = ""
          runtime_path = ""
          runtime_root = ""
          runtime_type = "io.containerd.runc.v2"

          [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.test-handler.options]
            SystemdCgroup = false

      [plugins."io.containerd.grpc.v1.cri".containerd.untrusted_workload_runtime]
        base_runtime_spec = ""
        cni_conf_dir = ""
        cni_max_conf_num = 0
        container_annotations = []
        pod_annotations = []
        privileged_without_host_devices = false
        runtime_engine = ""
        runtime_path = ""
        runtime_root = ""
        runtime_type = ""

        [plugins."io.containerd.grpc.v1.cri".containerd.untrusted_workload_runtime.options]

    [plugins."io.containerd.grpc.v1.cri".image_decryption]
      key_model = "node"

    [plugins."io.containerd.grpc.v1.cri".registry]
      config_path = ""

      [plugins."io.containerd.grpc.v1.cri".registry.auths]

      [plugins."io.containerd.grpc.v1.cri".registry.configs]

      [plugins."io.containerd.grpc.v1.cri".registry.headers]

      [plugins."io.containerd.grpc.v1.cri".registry.mirrors]

        [plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]
          endpoint = ["http://gardener-local-control-plane:5002"]

        [plugins."io.containerd.grpc.v1.cri".registry.mirrors."eu.gcr.io"]
          endpoint = ["http://gardener-local-control-plane:5004"]

        [plugins."io.containerd.grpc.v1.cri".registry.mirrors."gcr.io"]
          endpoint = ["http://gardener-local-control-plane:5003"]

        [plugins."io.containerd.grpc.v1.cri".registry.mirrors."ghcr.io"]
          endpoint = ["http://gardener-local-control-plane:5005"]

        [plugins."io.containerd.grpc.v1.cri".registry.mirrors."k8s.gcr.io"]
          endpoint = ["https://registry.k8s.io", "https://k8s.gcr.io"]

        [plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:5001"]
          endpoint = ["http://gardener-local-control-plane:5001"]

        [plugins."io.containerd.grpc.v1.cri".registry.mirrors."quay.io"]
          endpoint = ["http://gardener-local-control-plane:5007"]

        [plugins."io.containerd.grpc.v1.cri".registry.mirrors."registry.k8s.io"]
          endpoint = ["http://gardener-local-control-plane:5006"]

``` 

</details>




**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix developer
A bug has been fixed in the `provider-local` extension that causes the local-setup to not work with the `runtime-gvisor` extension.
```
