### PR TITLE
[GEP-21] Prepare dev box on Google Cloud

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -113,6 +113,7 @@
 
 * [Getting started locally (using the local provider)](development/getting_started_locally.md)
 * [Setting up a development environment (using a cloud provider)](development/local_setup.md)
+* [Setting up a development box on Google Cloud](development/dev-box-on-google-cloud.md)
 * [Testing (Unit, Integration, E2E Tests)](development/testing.md)
 * [Test Machinery Tests](development/testmachinery_tests.md)
 * [Dependency Management](development/dependencies.md)

--- a/docs/development/dev-box-on-google-cloud.md
+++ b/docs/development/dev-box-on-google-cloud.md
@@ -1,0 +1,161 @@
+# Development Box on Google Cloud
+
+This guide walks you through setting up a development box on Google Cloud using [terraform](https://www.terraform.io/) configurations provided in this repository.
+It provides a good basis for trying or developing gardener.
+
+## Motivation
+
+Generally, you can try and develop gardener on your local development machine without any paid cloud infrastructure, see [this document](./getting_started_locally.md).
+However, there are certain scenarios in which it is desirable to use a cloud dev box instead.
+For example:
+
+- Developing and testing gardener's [IPv6 features](../usage/ipv6.md) might be not be possible locally, if you are not using Linux or don't have IPv6 connectivity.
+  - While the Docker daemon natively supports [IPv6 networking](https://docs.docker.com/config/daemon/ipv6/) on Linux machines, there is no support for IPv6 networking on macOS and Windows machines.
+    There is no easy way to work around this due to the networking architecture of the Docker VM based on [vpnkit](https://github.com/moby/vpnkit) (no "real" network connectivity, vpnkit intercepts socket calls, etc.).
+  - [Rancher Desktop](https://rancherdesktop.io/) provides an open source alternative to Docker Desktop, which uses a different networking architecture for connecting the virtual machine (qemu-integrated networking connection).
+    Nevertheless, Rancher Desktop doesn't support IPv6 either, and it is not easy to work around (see https://github.com/rancher-sandbox/rancher-desktop/issues).
+  - Using IPv6 single-stack networking in the local gardener setup requires that your machine has an IPv6 connection to the internet.
+    This is very rare in office environments and also not offered by all ISPs by default.
+- Running an entire gardener installation including multiple seed or shoot clusters on your local machine might require more compute resources than your development machine has (at least `10` CPUs and `16Gi` memory).
+
+If you face one of these problems, you can follow this guide to use a Google Cloud machine for development instead of your local machine.
+Google Cloud offers simple IPv6 support and machine types that are large enough to host gardener installations.
+If you don't have access to a paid Google Cloud project, you can use [free credits](https://cloud.google.com/free) for a new personal account.
+Alternatively, you can use another cloud provider that you have access to.
+The setup process should be similar on other cloud providers.
+However, this repository only contains configuration files for Google Cloud.
+Hence, you need to manually create matching configuration files for the cloud provider of your choice.
+
+## Prerequisites
+
+Install the `gcloud` CLI using [this guide](https://cloud.google.com/sdk/docs/install), if you haven't done so yet.
+Ensure access to a Google Cloud project and configure `gcloud` accordingly:
+
+```bash
+gcloud auth login
+gcloud config set project PROJECT_ID
+```
+
+## Prepare ServiceAccount Credentials
+
+You need a ServiceAccount with `Compute Admin` and `Compute Network Admin` roles in your Google Cloud project for use with the provided terraform configuration.
+If you already have a matching ServiceAccount, place its JSON key in `kube-secrets/gcp/gardener-dev.json` inside this repository's root directory.
+
+Alternatively, you can create a new ServiceAccount and key using the following `gcloud` commands:
+
+```bash
+PROJECT_ID="$(gcloud config get project)"
+SA_NAME="$USER-gardener-dev"
+
+gcloud iam service-accounts create "$SA_NAME" \
+  --description="ServiceAccount for Gardener development setup on GCP for $USER"
+
+gcloud projects add-iam-policy-binding $PROJECT_ID \
+    --member="serviceAccount:$SA_NAME@$PROJECT_ID.iam.gserviceaccount.com" \
+    --role="roles/compute.admin"
+gcloud projects add-iam-policy-binding $PROJECT_ID \
+    --member="serviceAccount:$SA_NAME@$PROJECT_ID.iam.gserviceaccount.com" \
+    --role="roles/compute.networkAdmin"
+
+mkdir -p .kube-secrets/gcp
+gcloud iam service-accounts keys create .kube-secrets/gcp/gardener-dev.json \
+    --iam-account="$SA_NAME@$PROJECT_ID.iam.gserviceaccount.com"
+```
+
+## Create Cloud Resources
+
+Create your dev box using `make gcp-box-up`:
+
+```bash
+export TF_VAR_project="$(gcloud config get project)"
+
+# Optionally, overwrite any other terraform variable default values (see variables.tf):
+# export TF_VAR_*=YOUR_VALUE
+# Keep in mind, that the env var name must match the case of the terraform variable name.
+# For example, overwrite the SSH key you want to use for logging into your dev box:
+# export TF_VAR_ssh_key=~/.ssh/id_ed255.pub
+
+make gcp-box-up
+...
+You can now connect to your dev box using:
+  ssh -l you 1.2.3.4
+```
+
+Once terraform has finished creating your cloud resources, you might need to wait a minute until the startup script has installed all necessary tools and configured your user.
+Connect to the dev box using the provided `ssh` command.
+You should be able to use the `docker` CLI to work with the machine's Docker daemon.
+
+```bash
+ssh -l you 1.2.3.4
+...
+Required development tools are being installed and configured. Waiting 5 more seconds...
+...
+All required development tools are installed and configured. Bringing you to the gardener/gardener directory.
+you@you-gardener-dev:~$ docker ps
+CONTAINER ID   IMAGE     COMMAND   CREATED   STATUS    PORTS     NAMES
+```
+
+## Stop Development Box
+
+You can stop your cloud dev box at the end of the day for saving cost:
+
+```bash
+make gcp-box-down
+```
+
+Afterwards, you can start your cloud dev box again:
+
+```bash
+make gcp-box-up
+```
+
+## Clean up Cloud Resources
+
+Clean up all cloud resources created for your dev box:
+
+```bash
+make gcp-box-clean
+```
+
+Note: this doesn't clean up the ServiceAccount you created earlier.
+Use `gcloud` to delete it manually and its related resources.
+
+## Where to Go from Here?
+
+When logging in to your dev box, the `ssh` session should take you straight to the `~/go/src/github.com/gardener/gardener` directory.
+Now, it's time to get productive.
+
+### Get the Gardener Sources
+
+Cloning the gardener repository is the easiest way to get started with gardener on your dev box:
+
+```bash
+git clone https://github.com/gardener/gardener.git .
+```
+
+### Work on/with GCP Box
+
+Besides working directly on the remote box, you could use VSCode or GoLand to run on or sync with it. 
+
+#### VS Code
+
+VS Code has a plugin that allows you to work on a remote machine as you would on your local box.
+Remote Development using SSH: https://code.visualstudio.com/docs/remote/ssh
+
+#### GoLand
+
+With GoLand there are two options:
+
+- File Synchronization: https://www.jetbrains.com/help/go/configuring-synchronization-with-a-remote-host.html
+  - be sure to use rsync instead of plain SFTP as it is a lot faster
+- Remote Development: https://www.jetbrains.com/help/go/remote-development-starting-page.html
+
+First one synchronizes your local working directory to the remote host and second starts a GoLand server on remote host.
+Both have their advantages and disadvantages, choose what suits you best.
+
+### Start Deploying or Developing Gardener
+
+Congratulations, you are now ready to try or develop gardener on your cloud dev box! 🎉
+
+- If you want to try or test gardener, you can follow [this guide](../deployment/getting_started_locally.md) for getting started.
+- If you want to develop a new feature or fix for gardener, you can get started following [this guide](./getting_started_locally.md).

--- a/docs/development/local_setup.md
+++ b/docs/development/local_setup.md
@@ -16,11 +16,6 @@ This guide is split into three main parts:
 * [Building and starting Gardener components locally](#start-gardener-locally)
 * [Using your local Gardener setup to create a Shoot](#create-a-shoot)
 
-## Limitations of the Local Development Setup
-
-You can run Gardener (API server, controller manager, scheduler, gardenlet) against any local Kubernetes cluster, however, your seed and shoot clusters must be deployed to a cloud provider.
-Currently, it is not possible to run Gardener entirely isolated from any cloud provider. This means that to be able create Shoot clusters you need to register an external Seed cluster (e.g., one created in AWS).
-
 # Preparing the Setup
 
 ## [macOS only] Installing homebrew
@@ -61,15 +56,6 @@ brew install kubernetes-cli
 ```
 
 For other OS, please check the [kubectl installation documentation](https://kubernetes.io/docs/tasks/tools/install-kubectl/).
-
-## Installing helm
-You also need the [Helm](https://github.com/kubernetes/helm) CLI. On macOS run
-
-```bash
-brew install helm
-```
-
-For other OS please check the [Helm installation documentation](https://helm.sh/docs/intro/install/).
 
 ## Installing Docker
 

--- a/docs/development/local_setup.md
+++ b/docs/development/local_setup.md
@@ -124,9 +124,9 @@ The Gardener repository and all the above-mentioned tools (git, golang, kubectl,
 Clone the repository from GitHub into your `$GOPATH`.
 
 ```bash
-mkdir -p $GOPATH/src/github.com/gardener
-cd $GOPATH/src/github.com/gardener
-git clone git@github.com:gardener/gardener.git
+mkdir -p $(go env GOPATH)/src/github.com/gardener
+cd $(go env GOPATH)/src/github.com/gardener
+git clone https://github.com/gardener/gardener.git
 cd gardener
 ```
 

--- a/hack/kind-up.sh
+++ b/hack/kind-up.sh
@@ -58,7 +58,7 @@ setup_loopback_device() {
       echo "IP address $address already assigned to ${LOOPBACK_DEVICE}."
     else
       echo "Adding IP address $address to ${LOOPBACK_DEVICE}..."
-      ip address add $address dev ${LOOPBACK_DEVICE}
+      sudo ip address add $address dev ${LOOPBACK_DEVICE}
     fi
   done
   echo "Setting up loopback device ${LOOPBACK_DEVICE} completed."

--- a/hack/local-development/gcp/.gitignore
+++ b/hack/local-development/gcp/.gitignore
@@ -1,0 +1,5 @@
+/.terraform
+/.terraform.lock.hcl
+/terraform.tfstate
+/terraform.tfstate.backup
+/.terraform.tfstate.lock.info

--- a/hack/local-development/gcp/instance.tf
+++ b/hack/local-development/gcp/instance.tf
@@ -1,0 +1,72 @@
+data "local_file" "ssh_key" {
+  filename = pathexpand(var.ssh_key)
+}
+
+resource "google_compute_instance" "dev-box" {
+  name           = var.name
+  machine_type   = var.machine_type
+  zone           = var.zone
+  can_ip_forward = true
+  desired_status = var.desired_status
+
+  boot_disk {
+    initialize_params {
+      image = "projects/ubuntu-os-cloud/global/images/ubuntu-2204-jammy-v20220924"
+
+      type  = "pd-ssd"
+      size  = 100
+    }
+  }
+
+  tags = ["allow-ssh"]
+
+  network_interface {
+    subnetwork = google_compute_subnetwork.dev-subnetwork.name
+    stack_type = "IPV4_IPV6"
+    access_config {}
+  }
+
+  metadata = {
+    ssh-keys = "${var.user}:${data.local_file.ssh_key.content}"
+  }
+
+  metadata_startup_script = <<EOS
+cd /home/${var.user}
+startup_script_done_file=.startup_script_done
+
+cat >>.bashrc <<EOF
+
+export PATH="/home/${var.user}/go/src/github.com/gardener/gardener/hack/tools/bin:\$PATH"
+alias k=kubectl
+EOF
+
+cat >>start-gardener-dev.sh <<EOF
+#!/usr/bin/env bash
+# guide the user when logging in
+if ! [ -e $startup_script_done_file ] ; then
+  until [ -e $startup_script_done_file ] ; do
+    echo "Required development tools are being installed and configured. Waiting 5 more seconds..."
+    sleep 5
+  done
+  echo "Please reconnect your SSH session to reload group membership (required for docker commands)"
+  exit
+fi
+echo "All required development tools are installed and configured. Bringing you to the gardener/gardener directory."
+cd ~/go/src/github.com/gardener/gardener
+exec \$SHELL
+EOF
+chmod +x start-gardener-dev.sh
+
+sudo -u ${var.user} mkdir -p go/src/github.com/gardener/gardener
+apt update
+apt install -y make docker.io golang jq
+gpasswd -a ${var.user} docker
+
+touch $startup_script_done_file
+EOS
+
+  # required for some projects by organization policy
+  shielded_instance_config {
+    enable_secure_boot = true
+  }
+}

--- a/hack/local-development/gcp/main.tf
+++ b/hack/local-development/gcp/main.tf
@@ -1,0 +1,20 @@
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+      version = "~> 4.38.0"
+    }
+    local = {
+      source = "hashicorp/local"
+      version = "~> 2.2.3"
+    }
+  }
+}
+
+provider "google" {
+  credentials = var.serviceaccount_file
+
+  project = var.project
+  region  = var.region
+  zone    = var.zone
+}

--- a/hack/local-development/gcp/network.tf
+++ b/hack/local-development/gcp/network.tf
@@ -1,0 +1,31 @@
+resource "google_compute_network" "dev-network" {
+  name                     = var.name
+  auto_create_subnetworks  = false
+  enable_ula_internal_ipv6 = false
+}
+
+resource "google_compute_subnetwork" "dev-subnetwork" {
+  name   = var.name
+  region = var.region
+
+  network          = google_compute_network.dev-network.id
+  stack_type       = "IPV4_IPV6"
+  ip_cidr_range    = "10.0.0.0/22"
+  ipv6_access_type = "EXTERNAL"
+}
+
+resource "google_compute_firewall" "dev-firewall" {
+  name    = var.name
+  network = google_compute_network.dev-network.name
+
+  source_ranges = ["0.0.0.0/0"]
+  allow {
+    protocol = "icmp"
+  }
+  allow {
+    protocol = "tcp"
+    ports    = ["22"]
+  }
+
+  target_tags = ["allow-ssh"]
+}

--- a/hack/local-development/gcp/output.tf
+++ b/hack/local-development/gcp/output.tf
@@ -1,0 +1,5 @@
+output "instance_ip_addr" {
+  value = google_compute_instance.dev-box.network_interface.0.access_config.0.nat_ip
+
+  depends_on = [ google_compute_instance.dev-box ]
+}

--- a/hack/local-development/gcp/variables.tf
+++ b/hack/local-development/gcp/variables.tf
@@ -1,0 +1,40 @@
+variable "serviceaccount_file" {
+  type = string
+}
+
+variable "project" {
+  type = string
+}
+
+variable "region" {
+  type    = string
+  default = "europe-west3"
+}
+
+variable "zone" {
+  type    = string
+  default = "europe-west3-c"
+}
+
+variable "user" {
+  type = string
+}
+
+variable "name" {
+  type = string
+}
+
+variable "machine_type" {
+  type    = string
+  default = "n2d-standard-8"
+}
+
+variable "ssh_key" {
+  type    = string
+  default = "~/.ssh/id_rsa.pub"
+}
+
+variable "desired_status" {
+  type    = string
+  default = "RUNNING"
+}

--- a/hack/tools.mk
+++ b/hack/tools.mk
@@ -52,6 +52,7 @@ PROTOC_GEN_GOGO            := $(TOOLS_BIN_DIR)/protoc-gen-gogo
 REPORT_COLLECTOR           := $(TOOLS_BIN_DIR)/report-collector
 SETUP_ENVTEST              := $(TOOLS_BIN_DIR)/setup-envtest
 SKAFFOLD                   := $(TOOLS_BIN_DIR)/skaffold
+TERRAFORM                  := $(TOOLS_BIN_DIR)/terraform
 YAML2JSON                  := $(TOOLS_BIN_DIR)/yaml2json
 YQ                         := $(TOOLS_BIN_DIR)/yq
 
@@ -65,6 +66,7 @@ HELM_VERSION ?= v3.6.3
 KIND_VERSION ?= v0.14.0
 KUBECTL_VERSION ?= v1.24.3
 SKAFFOLD_VERSION ?= v1.39.1
+TERRAFORM_VERSION ?= 1.3.7
 YQ_VERSION ?= v4.30.4
 
 export TOOLS_BIN_DIR := $(TOOLS_BIN_DIR)
@@ -187,6 +189,12 @@ $(SETUP_ENVTEST): go.mod
 $(SKAFFOLD): $(call tool_version_file,$(SKAFFOLD),$(SKAFFOLD_VERSION))
 	curl -Lo $(SKAFFOLD) https://storage.googleapis.com/skaffold/releases/$(SKAFFOLD_VERSION)/skaffold-$(shell uname -s | tr '[:upper:]' '[:lower:]')-$(shell uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
 	chmod +x $(SKAFFOLD)
+
+$(TERRAFORM): $(call tool_version_file,$(TERRAFORM),$(TERRAFORM_VERSION))
+	TMP_DIR=$$(mktemp -d); \
+		curl -Lo $$TMP_DIR/terraform.zip https://releases.hashicorp.com/terraform/$(TERRAFORM_VERSION)/terraform_$(TERRAFORM_VERSION)_$(shell uname -s | tr '[:upper:]' '[:lower:]')_$(shell uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').zip; \
+		unzip -o $$TMP_DIR/terraform.zip terraform -d $(TOOLS_BIN_DIR)
+	chmod +x $(TERRAFORM)
 
 $(YAML2JSON): go.mod
 	go build -o $(YAML2JSON) github.com/bronze1man/yaml2json

--- a/hack/tools.mk
+++ b/hack/tools.mk
@@ -193,7 +193,7 @@ $(SKAFFOLD): $(call tool_version_file,$(SKAFFOLD),$(SKAFFOLD_VERSION))
 $(TERRAFORM): $(call tool_version_file,$(TERRAFORM),$(TERRAFORM_VERSION))
 	TMP_DIR=$$(mktemp -d); \
 		curl -Lo $$TMP_DIR/terraform.zip https://releases.hashicorp.com/terraform/$(TERRAFORM_VERSION)/terraform_$(TERRAFORM_VERSION)_$(shell uname -s | tr '[:upper:]' '[:lower:]')_$(shell uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').zip; \
-		unzip -o $$TMP_DIR/terraform.zip terraform -d $(TOOLS_BIN_DIR)
+		unzip -DDo $$TMP_DIR/terraform.zip terraform -d $(TOOLS_BIN_DIR)
 	chmod +x $(TERRAFORM)
 
 $(YAML2JSON): go.mod


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking dev-productivity
/kind enhancement

**What this PR does / why we need it**:

This PR adds an easy way to create a development machine on Google Cloud.

This is needed to enable all developers to develop and test IPv6-related changes (GEP-21).
See the motivation section in the documentation for more background information.

Co-Authored-By: @einfachnuralex 

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/7051

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature developer
Developers can use `make gcp-box-up` to prepare a development machine on Google Cloud. Please see the [documentation](https://github.com/gardener/gardener/blob/master/docs/development/dev-box-on-google-cloud.md) for more information.
```
