### PR TITLE
Improve match for `service`s of problematic webhook detector

### DIFF
--- a/pkg/operation/botanist/matchers/matcher.go
+++ b/pkg/operation/botanist/matchers/matcher.go
@@ -46,10 +46,16 @@ import (
 )
 
 var (
-	kubeSystemLabels = labels.Set{
+	defaultNamespaceLabels = labels.Set{
+		corev1.LabelMetadataName: metav1.NamespaceDefault,
+	}
+
+	kubeSystemNamespaceLabels = labels.Set{
 		v1beta1constants.ShootNoCleanup:  "true",
 		v1beta1constants.GardenerPurpose: metav1.NamespaceSystem,
+		corev1.LabelMetadataName:         metav1.NamespaceSystem,
 	}
+
 	podsLabels = labels.Set{
 		v1beta1constants.ShootNoCleanup: "true",
 		managedresources.LabelKeyOrigin: managedresources.LabelValueGardener,
@@ -57,113 +63,118 @@ var (
 	// WebhookConstraintMatchers contains a list of all api resources which can break
 	// the waking up of a cluster.
 	WebhookConstraintMatchers = []WebhookConstraintMatcher{
-		{GVR: corev1.SchemeGroupVersion.WithResource("pods"), NamespaceLabels: kubeSystemLabels, ObjectLabels: podsLabels},
-		{GVR: corev1.SchemeGroupVersion.WithResource("pods"), NamespaceLabels: kubeSystemLabels, ObjectLabels: podsLabels, Subresource: "status"},
+		{GVR: corev1.SchemeGroupVersion.WithResource("pods"), NamespaceLabels: kubeSystemNamespaceLabels, ObjectLabels: podsLabels},
+		{GVR: corev1.SchemeGroupVersion.WithResource("pods"), NamespaceLabels: kubeSystemNamespaceLabels, ObjectLabels: podsLabels, Subresource: "status"},
 
-		// leader election of kube-controller-manager, kube-scheduler, cloud-controller-manager, cluster-autoscaler, ...
-		{GVR: corev1.SchemeGroupVersion.WithResource("configmaps"), NamespaceLabels: kubeSystemLabels},
+		// Leader election of kube-controller-manager, kube-scheduler, cloud-controller-manager, cluster-autoscaler, ...
+		{GVR: corev1.SchemeGroupVersion.WithResource("configmaps"), NamespaceLabels: kubeSystemNamespaceLabels},
 		// kube-system and default namespaces for leader election and apiserver in-cluster discovery.
 		{GVR: corev1.SchemeGroupVersion.WithResource("endpoints")},
 
-		{GVR: corev1.SchemeGroupVersion.WithResource("secrets"), NamespaceLabels: kubeSystemLabels},
-		{GVR: corev1.SchemeGroupVersion.WithResource("serviceaccounts"), NamespaceLabels: kubeSystemLabels},
+		{GVR: corev1.SchemeGroupVersion.WithResource("secrets"), NamespaceLabels: kubeSystemNamespaceLabels},
+		{GVR: corev1.SchemeGroupVersion.WithResource("serviceaccounts"), NamespaceLabels: kubeSystemNamespaceLabels},
 
-		// part of /readyz/poststarthook/bootstrap-controller which fixes all services in the cluster.
-		{GVR: corev1.SchemeGroupVersion.WithResource("services")},
-		{GVR: corev1.SchemeGroupVersion.WithResource("services"), Subresource: "status"},
+		{GVR: corev1.SchemeGroupVersion.WithResource("services"), NamespaceLabels: kubeSystemNamespaceLabels},
+		{GVR: corev1.SchemeGroupVersion.WithResource("services"), NamespaceLabels: kubeSystemNamespaceLabels, Subresource: "status"},
 
-		// kubelet must be allowed to register itself.
+		// Match services in the `default` namespace because the `kubernetes` service is essential for in-cluster communication.
+		// Unfortunately, it's not possible to restrict the match to this specific service since a remediated webhook on services
+		// would widen the scope, i.e. the webhook will have a combination of namespace and object selectors.
+		{GVR: corev1.SchemeGroupVersion.WithResource("services"), NamespaceLabels: defaultNamespaceLabels},
+		{GVR: corev1.SchemeGroupVersion.WithResource("services"), NamespaceLabels: defaultNamespaceLabels, Subresource: "status"},
+
+		// Kubelet must be allowed to register itself.
 		{GVR: corev1.SchemeGroupVersion.WithResource("nodes"), ClusterScoped: true},
 		{GVR: corev1.SchemeGroupVersion.WithResource("nodes"), ClusterScoped: true, Subresource: "status"},
 
-		// needed for gardener-resource-manager to update "kube-system" namespace labels
-		{GVR: corev1.SchemeGroupVersion.WithResource("namespaces"), ClusterScoped: true, ObjectLabels: kubeSystemLabels, NamespaceLabels: kubeSystemLabels},
-		{GVR: corev1.SchemeGroupVersion.WithResource("namespaces"), ClusterScoped: true, ObjectLabels: kubeSystemLabels, NamespaceLabels: kubeSystemLabels, Subresource: "status"},
+		// Needed for gardener-resource-manager to update "kube-system" namespace labels.
+		{GVR: corev1.SchemeGroupVersion.WithResource("namespaces"), ClusterScoped: true, ObjectLabels: kubeSystemNamespaceLabels, NamespaceLabels: kubeSystemNamespaceLabels},
+		{GVR: corev1.SchemeGroupVersion.WithResource("namespaces"), ClusterScoped: true, ObjectLabels: kubeSystemNamespaceLabels, NamespaceLabels: kubeSystemNamespaceLabels, Subresource: "status"},
 
-		{GVR: appsv1.SchemeGroupVersion.WithResource("controllerrevisions"), NamespaceLabels: kubeSystemLabels},
-		{GVR: appsv1.SchemeGroupVersion.WithResource("daemonsets"), NamespaceLabels: kubeSystemLabels},
-		{GVR: appsv1.SchemeGroupVersion.WithResource("daemonsets"), NamespaceLabels: kubeSystemLabels, Subresource: "status"},
-		{GVR: appsv1.SchemeGroupVersion.WithResource("deployments"), NamespaceLabels: kubeSystemLabels},
-		{GVR: appsv1.SchemeGroupVersion.WithResource("deployments"), NamespaceLabels: kubeSystemLabels, Subresource: "scale"},
-		{GVR: appsv1.SchemeGroupVersion.WithResource("replicasets"), NamespaceLabels: kubeSystemLabels},
-		{GVR: appsv1.SchemeGroupVersion.WithResource("replicasets"), NamespaceLabels: kubeSystemLabels, Subresource: "status"},
-		{GVR: appsv1.SchemeGroupVersion.WithResource("replicasets"), NamespaceLabels: kubeSystemLabels, Subresource: "scale"},
+		{GVR: appsv1.SchemeGroupVersion.WithResource("controllerrevisions"), NamespaceLabels: kubeSystemNamespaceLabels},
+		{GVR: appsv1.SchemeGroupVersion.WithResource("daemonsets"), NamespaceLabels: kubeSystemNamespaceLabels},
+		{GVR: appsv1.SchemeGroupVersion.WithResource("daemonsets"), NamespaceLabels: kubeSystemNamespaceLabels, Subresource: "status"},
+		{GVR: appsv1.SchemeGroupVersion.WithResource("deployments"), NamespaceLabels: kubeSystemNamespaceLabels},
+		{GVR: appsv1.SchemeGroupVersion.WithResource("deployments"), NamespaceLabels: kubeSystemNamespaceLabels, Subresource: "scale"},
+		{GVR: appsv1.SchemeGroupVersion.WithResource("replicasets"), NamespaceLabels: kubeSystemNamespaceLabels},
+		{GVR: appsv1.SchemeGroupVersion.WithResource("replicasets"), NamespaceLabels: kubeSystemNamespaceLabels, Subresource: "status"},
+		{GVR: appsv1.SchemeGroupVersion.WithResource("replicasets"), NamespaceLabels: kubeSystemNamespaceLabels, Subresource: "scale"},
 
-		{GVR: appsv1beta1.SchemeGroupVersion.WithResource("controllerrevisions"), NamespaceLabels: kubeSystemLabels},
-		{GVR: appsv1beta1.SchemeGroupVersion.WithResource("daemonsets"), NamespaceLabels: kubeSystemLabels},
-		{GVR: appsv1beta1.SchemeGroupVersion.WithResource("daemonsets"), NamespaceLabels: kubeSystemLabels, Subresource: "status"},
-		{GVR: appsv1beta1.SchemeGroupVersion.WithResource("deployments"), NamespaceLabels: kubeSystemLabels},
-		{GVR: appsv1beta1.SchemeGroupVersion.WithResource("deployments"), NamespaceLabels: kubeSystemLabels, Subresource: "scale"},
-		{GVR: appsv1beta1.SchemeGroupVersion.WithResource("replicasets"), NamespaceLabels: kubeSystemLabels},
-		{GVR: appsv1beta1.SchemeGroupVersion.WithResource("replicasets"), NamespaceLabels: kubeSystemLabels, Subresource: "status"},
-		{GVR: appsv1beta1.SchemeGroupVersion.WithResource("replicasets"), NamespaceLabels: kubeSystemLabels, Subresource: "scale"},
+		{GVR: appsv1beta1.SchemeGroupVersion.WithResource("controllerrevisions"), NamespaceLabels: kubeSystemNamespaceLabels},
+		{GVR: appsv1beta1.SchemeGroupVersion.WithResource("daemonsets"), NamespaceLabels: kubeSystemNamespaceLabels},
+		{GVR: appsv1beta1.SchemeGroupVersion.WithResource("daemonsets"), NamespaceLabels: kubeSystemNamespaceLabels, Subresource: "status"},
+		{GVR: appsv1beta1.SchemeGroupVersion.WithResource("deployments"), NamespaceLabels: kubeSystemNamespaceLabels},
+		{GVR: appsv1beta1.SchemeGroupVersion.WithResource("deployments"), NamespaceLabels: kubeSystemNamespaceLabels, Subresource: "scale"},
+		{GVR: appsv1beta1.SchemeGroupVersion.WithResource("replicasets"), NamespaceLabels: kubeSystemNamespaceLabels},
+		{GVR: appsv1beta1.SchemeGroupVersion.WithResource("replicasets"), NamespaceLabels: kubeSystemNamespaceLabels, Subresource: "status"},
+		{GVR: appsv1beta1.SchemeGroupVersion.WithResource("replicasets"), NamespaceLabels: kubeSystemNamespaceLabels, Subresource: "scale"},
 
-		{GVR: appsv1beta2.SchemeGroupVersion.WithResource("controllerrevisions"), NamespaceLabels: kubeSystemLabels},
-		{GVR: appsv1beta2.SchemeGroupVersion.WithResource("daemonsets"), NamespaceLabels: kubeSystemLabels},
-		{GVR: appsv1beta2.SchemeGroupVersion.WithResource("daemonsets"), NamespaceLabels: kubeSystemLabels, Subresource: "status"},
-		{GVR: appsv1beta2.SchemeGroupVersion.WithResource("deployments"), NamespaceLabels: kubeSystemLabels},
-		{GVR: appsv1beta2.SchemeGroupVersion.WithResource("deployments"), NamespaceLabels: kubeSystemLabels, Subresource: "scale"},
-		{GVR: appsv1beta2.SchemeGroupVersion.WithResource("replicasets"), NamespaceLabels: kubeSystemLabels},
-		{GVR: appsv1beta2.SchemeGroupVersion.WithResource("replicasets"), NamespaceLabels: kubeSystemLabels, Subresource: "status"},
-		{GVR: appsv1beta2.SchemeGroupVersion.WithResource("replicasets"), NamespaceLabels: kubeSystemLabels, Subresource: "scale"},
+		{GVR: appsv1beta2.SchemeGroupVersion.WithResource("controllerrevisions"), NamespaceLabels: kubeSystemNamespaceLabels},
+		{GVR: appsv1beta2.SchemeGroupVersion.WithResource("daemonsets"), NamespaceLabels: kubeSystemNamespaceLabels},
+		{GVR: appsv1beta2.SchemeGroupVersion.WithResource("daemonsets"), NamespaceLabels: kubeSystemNamespaceLabels, Subresource: "status"},
+		{GVR: appsv1beta2.SchemeGroupVersion.WithResource("deployments"), NamespaceLabels: kubeSystemNamespaceLabels},
+		{GVR: appsv1beta2.SchemeGroupVersion.WithResource("deployments"), NamespaceLabels: kubeSystemNamespaceLabels, Subresource: "scale"},
+		{GVR: appsv1beta2.SchemeGroupVersion.WithResource("replicasets"), NamespaceLabels: kubeSystemNamespaceLabels},
+		{GVR: appsv1beta2.SchemeGroupVersion.WithResource("replicasets"), NamespaceLabels: kubeSystemNamespaceLabels, Subresource: "status"},
+		{GVR: appsv1beta2.SchemeGroupVersion.WithResource("replicasets"), NamespaceLabels: kubeSystemNamespaceLabels, Subresource: "scale"},
 
-		{GVR: extensionsv1beta1.SchemeGroupVersion.WithResource("controllerrevisions"), NamespaceLabels: kubeSystemLabels},
-		{GVR: extensionsv1beta1.SchemeGroupVersion.WithResource("daemonsets"), NamespaceLabels: kubeSystemLabels},
-		{GVR: extensionsv1beta1.SchemeGroupVersion.WithResource("daemonsets"), NamespaceLabels: kubeSystemLabels, Subresource: "status"},
-		{GVR: extensionsv1beta1.SchemeGroupVersion.WithResource("deployments"), NamespaceLabels: kubeSystemLabels},
-		{GVR: extensionsv1beta1.SchemeGroupVersion.WithResource("deployments"), NamespaceLabels: kubeSystemLabels, Subresource: "scale"},
-		{GVR: extensionsv1beta1.SchemeGroupVersion.WithResource("replicasets"), NamespaceLabels: kubeSystemLabels},
-		{GVR: extensionsv1beta1.SchemeGroupVersion.WithResource("replicasets"), NamespaceLabels: kubeSystemLabels, Subresource: "status"},
-		{GVR: extensionsv1beta1.SchemeGroupVersion.WithResource("replicasets"), NamespaceLabels: kubeSystemLabels, Subresource: "scale"},
-		{GVR: extensionsv1beta1.SchemeGroupVersion.WithResource("networkpolicies"), NamespaceLabels: kubeSystemLabels},
+		{GVR: extensionsv1beta1.SchemeGroupVersion.WithResource("controllerrevisions"), NamespaceLabels: kubeSystemNamespaceLabels},
+		{GVR: extensionsv1beta1.SchemeGroupVersion.WithResource("daemonsets"), NamespaceLabels: kubeSystemNamespaceLabels},
+		{GVR: extensionsv1beta1.SchemeGroupVersion.WithResource("daemonsets"), NamespaceLabels: kubeSystemNamespaceLabels, Subresource: "status"},
+		{GVR: extensionsv1beta1.SchemeGroupVersion.WithResource("deployments"), NamespaceLabels: kubeSystemNamespaceLabels},
+		{GVR: extensionsv1beta1.SchemeGroupVersion.WithResource("deployments"), NamespaceLabels: kubeSystemNamespaceLabels, Subresource: "scale"},
+		{GVR: extensionsv1beta1.SchemeGroupVersion.WithResource("replicasets"), NamespaceLabels: kubeSystemNamespaceLabels},
+		{GVR: extensionsv1beta1.SchemeGroupVersion.WithResource("replicasets"), NamespaceLabels: kubeSystemNamespaceLabels, Subresource: "status"},
+		{GVR: extensionsv1beta1.SchemeGroupVersion.WithResource("replicasets"), NamespaceLabels: kubeSystemNamespaceLabels, Subresource: "scale"},
+		{GVR: extensionsv1beta1.SchemeGroupVersion.WithResource("networkpolicies"), NamespaceLabels: kubeSystemNamespaceLabels},
 		{GVR: extensionsv1beta1.SchemeGroupVersion.WithResource("podsecuritypolicies"), ClusterScoped: true},
 
-		// needed for kubelet and kube-system controllers leader election.
+		// Needed for kubelet and kube-system controllers leader election.
 		{GVR: coordinationv1.SchemeGroupVersion.WithResource("leases")},
 		{GVR: coordinationv1beta1.SchemeGroupVersion.WithResource("leases")},
 
-		// modifications might be needed for old clusters with new policies.
-		{GVR: networkingv1.SchemeGroupVersion.WithResource("networkpolicies"), NamespaceLabels: kubeSystemLabels},
-		{GVR: networkingv1beta1.SchemeGroupVersion.WithResource("networkpolicies"), NamespaceLabels: kubeSystemLabels},
+		// Modifications might be needed for old clusters with new policies.
+		{GVR: networkingv1.SchemeGroupVersion.WithResource("networkpolicies"), NamespaceLabels: kubeSystemNamespaceLabels},
+		{GVR: networkingv1beta1.SchemeGroupVersion.WithResource("networkpolicies"), NamespaceLabels: kubeSystemNamespaceLabels},
 
 		{GVR: policyv1beta1.SchemeGroupVersion.WithResource("podsecuritypolicies"), ClusterScoped: true},
 
-		// needed as part of /readyz/poststarthook/rbac/bootstrap-roles in kube-apiserver.
+		// Needed as part of /readyz/poststarthook/rbac/bootstrap-roles in kube-apiserver.
 		{GVR: rbacv1.SchemeGroupVersion.WithResource("clusterroles"), ClusterScoped: true},
 		{GVR: rbacv1.SchemeGroupVersion.WithResource("clusterrolebindings"), ClusterScoped: true},
-		{GVR: rbacv1.SchemeGroupVersion.WithResource("roles"), NamespaceLabels: kubeSystemLabels},
-		{GVR: rbacv1.SchemeGroupVersion.WithResource("rolebindings"), NamespaceLabels: kubeSystemLabels},
+		{GVR: rbacv1.SchemeGroupVersion.WithResource("roles"), NamespaceLabels: kubeSystemNamespaceLabels},
+		{GVR: rbacv1.SchemeGroupVersion.WithResource("rolebindings"), NamespaceLabels: kubeSystemNamespaceLabels},
 
 		{GVR: rbacv1alpha1.SchemeGroupVersion.WithResource("clusterroles"), ClusterScoped: true},
 		{GVR: rbacv1alpha1.SchemeGroupVersion.WithResource("clusterrolebindings"), ClusterScoped: true},
-		{GVR: rbacv1alpha1.SchemeGroupVersion.WithResource("roles"), NamespaceLabels: kubeSystemLabels},
-		{GVR: rbacv1alpha1.SchemeGroupVersion.WithResource("rolebindings"), NamespaceLabels: kubeSystemLabels},
+		{GVR: rbacv1alpha1.SchemeGroupVersion.WithResource("roles"), NamespaceLabels: kubeSystemNamespaceLabels},
+		{GVR: rbacv1alpha1.SchemeGroupVersion.WithResource("rolebindings"), NamespaceLabels: kubeSystemNamespaceLabels},
 
 		{GVR: rbacv1beta1.SchemeGroupVersion.WithResource("clusterroles"), ClusterScoped: true},
 		{GVR: rbacv1beta1.SchemeGroupVersion.WithResource("clusterrolebindings"), ClusterScoped: true},
-		{GVR: rbacv1beta1.SchemeGroupVersion.WithResource("roles"), NamespaceLabels: kubeSystemLabels},
-		{GVR: rbacv1beta1.SchemeGroupVersion.WithResource("rolebindings"), NamespaceLabels: kubeSystemLabels},
+		{GVR: rbacv1beta1.SchemeGroupVersion.WithResource("roles"), NamespaceLabels: kubeSystemNamespaceLabels},
+		{GVR: rbacv1beta1.SchemeGroupVersion.WithResource("rolebindings"), NamespaceLabels: kubeSystemNamespaceLabels},
 
-		// needed for networking extensions.
+		// Needed for networking extensions.
 		{GVR: apiextensionsv1.SchemeGroupVersion.WithResource("customresourcedefinitions"), ClusterScoped: true},
 		{GVR: apiextensionsv1.SchemeGroupVersion.WithResource("customresourcedefinitions"), ClusterScoped: true, Subresource: "status"},
 
 		{GVR: apiextensionsv1beta1.SchemeGroupVersion.WithResource("customresourcedefinitions"), ClusterScoped: true},
 		{GVR: apiextensionsv1beta1.SchemeGroupVersion.WithResource("customresourcedefinitions"), ClusterScoped: true, Subresource: "status"},
 
-		// needed as part of /healthz/poststarthook/apiservice-openapi-controller in kube-apiserver.
+		// Needed as part of /healthz/poststarthook/apiservice-openapi-controller in kube-apiserver.
 		{GVR: apiregistrationv1.SchemeGroupVersion.WithResource("apiservices"), ClusterScoped: true},
 		{GVR: apiregistrationv1.SchemeGroupVersion.WithResource("apiservices"), ClusterScoped: true, Subresource: "status"},
 
 		{GVR: apiregistrationv1beta1.SchemeGroupVersion.WithResource("apiservices"), ClusterScoped: true},
 		{GVR: apiregistrationv1beta1.SchemeGroupVersion.WithResource("apiservices"), ClusterScoped: true, Subresource: "status"},
 
-		// kubelet uses it to request a certificate for itself.
+		// Kubelet uses it to request a certificate for itself.
 		{GVR: certificatesv1.SchemeGroupVersion.WithResource("certificatesigningrequests"), ClusterScoped: true},
 		{GVR: certificatesv1.SchemeGroupVersion.WithResource("certificatesigningrequests"), ClusterScoped: true, Subresource: "status"},
 		{GVR: certificatesv1.SchemeGroupVersion.WithResource("certificatesigningrequests"), ClusterScoped: true, Subresource: "approval"},
 
-		// needed as part of /healthz/poststarthook/scheduling/bootstrap-system-priority-classes in kube-apiserver.
+		// Needed as part of /healthz/poststarthook/scheduling/bootstrap-system-priority-classes in kube-apiserver.
 		{GVR: schedulingv1.SchemeGroupVersion.WithResource("priorityclasses"), ClusterScoped: true},
 		{GVR: schedulingv1alpha1.SchemeGroupVersion.WithResource("priorityclasses"), ClusterScoped: true},
 		{GVR: schedulingv1beta1.SchemeGroupVersion.WithResource("priorityclasses"), ClusterScoped: true},

--- a/pkg/operation/care/constraints_test.go
+++ b/pkg/operation/care/constraints_test.go
@@ -120,11 +120,16 @@ var _ = Describe("Constraints", func() {
 					namespaceSelector: &metav1.LabelSelector{
 						MatchLabels: map[string]string{"gardener.cloud/purpose": "kube-system"}},
 				}),
+				Entry("namespaceSelector matching name label", webhookTestCase{
+					namespaceSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{"kubernetes.io/metadata.name": "kube-system"}},
+				}),
 				Entry("namespaceSelector matching all gardener labels", webhookTestCase{
 					namespaceSelector: &metav1.LabelSelector{
 						MatchLabels: map[string]string{
 							"shoot.gardener.cloud/no-cleanup": "true",
 							"gardener.cloud/purpose":          "kube-system",
+							"kubernetes.io/metadata.name":     "kube-system",
 						}},
 				}),
 			}

--- a/pkg/operation/care/constraints_test.go
+++ b/pkg/operation/care/constraints_test.go
@@ -139,6 +139,17 @@ var _ = Describe("Constraints", func() {
 					namespaceSelector: &metav1.LabelSelector{
 						MatchLabels: map[string]string{"foo": "bar"}},
 				}),
+				Entry("namespaceSelector excluding name label", webhookTestCase{
+					namespaceSelector: &metav1.LabelSelector{
+						MatchExpressions: []metav1.LabelSelectorRequirement{
+							{
+								Key:      "kubernetes.io/metadata.name",
+								Operator: metav1.LabelSelectorOpNotIn,
+								Values:   []string{"kube-system"},
+							},
+						},
+					},
+				}),
 			}
 
 			commonTests = func(gvr schema.GroupVersionResource, problematic, notProblematic []TableEntry) {

--- a/pkg/operation/care/webhook_remediation_test.go
+++ b/pkg/operation/care/webhook_remediation_test.go
@@ -226,6 +226,7 @@ var _ = Describe("WebhookRemediation", func() {
 					Expect(validatingWebhookConfiguration.Webhooks[0].NamespaceSelector.MatchExpressions).To(ConsistOf(
 						metav1.LabelSelectorRequirement{Key: "shoot.gardener.cloud/no-cleanup", Operator: metav1.LabelSelectorOpNotIn, Values: []string{"true"}},
 						metav1.LabelSelectorRequirement{Key: "gardener.cloud/purpose", Operator: metav1.LabelSelectorOpNotIn, Values: []string{"kube-system"}},
+						metav1.LabelSelectorRequirement{Key: "kubernetes.io/metadata.name", Operator: metav1.LabelSelectorOpNotIn, Values: []string{"kube-system"}},
 					))
 				})
 
@@ -393,6 +394,7 @@ var _ = Describe("WebhookRemediation", func() {
 					Expect(mutatingWebhookConfiguration.Webhooks[0].NamespaceSelector.MatchExpressions).To(ConsistOf(
 						metav1.LabelSelectorRequirement{Key: "shoot.gardener.cloud/no-cleanup", Operator: metav1.LabelSelectorOpNotIn, Values: []string{"true"}},
 						metav1.LabelSelectorRequirement{Key: "gardener.cloud/purpose", Operator: metav1.LabelSelectorOpNotIn, Values: []string{"kube-system"}},
+						metav1.LabelSelectorRequirement{Key: "kubernetes.io/metadata.name", Operator: metav1.LabelSelectorOpNotIn, Values: []string{"kube-system"}},
 					))
 				})
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind enhancement

**What this PR does / why we need it**:
This PR limits the scope of `service`s matched by the problematic webhook detector to those in the `kube-system` (usually managed by Gardener) and `default` (mainly because of `kubernetes` service) namespaces. Without this change it was not possible to define and `failurePolicy: Fail` webhooks on `service`s.

Earlier the code said that `service`s in all namespace should be considered for the KAS bootstrap-controller. This controller however mutates objects directly in the object store (etcd), see [both repair controllers](https://github.com/kubernetes/kubernetes/blob/76522eb1a339a95544523c1ed85da09f287f1ade/pkg/controlplane/controller.go#L162-L163).

To make it more convenient to create rules excluding multiple namespaces, i.e. here `kube-system` and `default`, the namespace labels were enhanced by the well known `kubernetes.io/metadata.name` label. It fixes #6747 at the same time.

**Which issue(s) this PR fixes**:
Fixes #6747

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other user
Gardener refined the scope of the problematic webhook matcher for `service` objects. Earlier, shoot clusters were assigned a constraint reporting a problem with a `failurePolocy: Fail` webhook acting on these objects. Now, only `service`s in the `kube-system` and `defaults` namespaces are considered for this check.
```
```other user
Webhook configurations can now exclude namespaces (mostly `kube-system`) by using the well known and Kubernetes standard label key `kubernetes.io/metadata.name`. Earlier, Gardener reported such webhooks as problematic.
```
