### PR TITLE
Introduce `ObservabilityComponentsHealthy` Shoot condition for status of observability components

### DIFF
--- a/charts/gardener/gardenlet/values.yaml
+++ b/charts/gardener/gardenlet/values.yaml
@@ -105,6 +105,8 @@ config:
         duration: 1m
       - type: ControlPlaneHealthy
         duration: 1m
+      - type: ObservabilityComponentsHealthy
+        duration: 1m
       - type: SystemComponentsHealthy
         duration: 1m
       - type: EveryNodeReady

--- a/docs/concepts/gardenlet.md
+++ b/docs/concepts/gardenlet.md
@@ -404,7 +404,8 @@ This reconciler performs three "care" actions related to `Shoot`s.
 It maintains four conditions and performs the following checks:
 
 - `APIServerAvailable`: The `/healthz` endpoint of the shoot's `kube-apiserver` is called and considered healthy when it responds with `200 OK`.
-- `ControlPlaneHealthy`: The control plane is considered healthy when the respective `Deployment`s (for example `kube-apiserver`), `StatefulSet`s (for example `prometheus`), and `Etcd`s (for example `etcd-main`) exist and are healthy.
+- `ControlPlaneHealthy`: The control plane is considered healthy when the respective `Deployment`s (for example `kube-apiserver`,`kube-controller-manager`), and `Etcd`s (for example `etcd-main`) exist and are healthy.
+- `ObservabilityComponentsHealthy`: This condition is considered healthy when the respective `Deployment`s (for example `grafana`), `StatefulSet`s (for example `prometheus`,`loki`), exist and are healthy.
 - `EveryNodyReady`: The conditions of the worker nodes are checked (e.g., `Ready`, `MemoryPressure`, etc.). Also, it's checked whether the Kubernetes version of the installed `kubelet` matches the desired version specified in the `Shoot` resource.
 - `SystemComponentsHealthy`: The conditions of the `ManagedResource`s are checked (e.g. `ResourcesApplied`, etc.). Also, it is verified whether the VPN tunnel connection is established (which is required for the `kube-apiserver` to communicate with the worker nodes).
 

--- a/docs/deployment/getting_started_locally.md
+++ b/docs/deployment/getting_started_locally.md
@@ -79,7 +79,7 @@ kubectl apply -f example/provider-local/shoot.yaml
 You can wait for the `Shoot` to be ready by running:
 
 ```bash
-kubectl wait --for=condition=apiserveravailable --for=condition=controlplanehealthy --for=condition=everynodeready --for=condition=systemcomponentshealthy shoot local -n garden-local --timeout=10m
+kubectl wait --for=condition=apiserveravailable --for=condition=controlplanehealthy --for=condition=observabilitycomponentshealthy --for=condition=everynodeready --for=condition=systemcomponentshealthy shoot local -n garden-local --timeout=10m
 ```
 
 Alternatively, you can run `kubectl -n garden-local get shoot local` and wait for the `LAST OPERATION` to reach `100%`:

--- a/docs/development/getting_started_locally.md
+++ b/docs/development/getting_started_locally.md
@@ -122,7 +122,7 @@ kubectl apply -f example/provider-local/shoot.yaml
 You can wait for the `Shoot` to be ready by running
 
 ```bash
-kubectl wait --for=condition=apiserveravailable --for=condition=controlplanehealthy --for=condition=everynodeready --for=condition=systemcomponentshealthy shoot local -n garden-local --timeout=10m
+kubectl wait --for=condition=apiserveravailable --for=condition=controlplanehealthy --for=condition=observabilitycomponentshealthy --for=condition=everynodeready --for=condition=systemcomponentshealthy shoot local -n garden-local --timeout=10m
 ```
 
 Alternatively, you can run `kubectl -n garden-local get shoot local` and wait for the `LAST OPERATION` to reach `100%`:

--- a/example/20-componentconfig-gardenlet.yaml
+++ b/example/20-componentconfig-gardenlet.yaml
@@ -57,6 +57,8 @@ controllers:
       duration: 1m
     - type: ControlPlaneHealthy
       duration: 1m
+    - type: ObservabilityComponentsHealthy 
+      duration: 1m
     - type: SystemComponentsHealthy
       duration: 1m
     - type: EveryNodeReady

--- a/pkg/apis/core/types_shoot.go
+++ b/pkg/apis/core/types_shoot.go
@@ -1258,8 +1258,10 @@ const (
 const (
 	// ShootAPIServerAvailable is a constant for a condition type indicating that the Shoot cluster's API server is available.
 	ShootAPIServerAvailable ConditionType = "APIServerAvailable"
-	// ShootControlPlaneHealthy is a constant for a condition type indicating the control plane health.
+	// ShootControlPlaneHealthy is a constant for a condition type indicating the health of core control plane components.
 	ShootControlPlaneHealthy ConditionType = "ControlPlaneHealthy"
+	// ShootObservabilityComponentsHealthy is a constant for a condition type indicating the health of observability components.
+	ShootObservabilityComponentsHealthy ConditionType = "ObservabilityComponentsHealthy"
 	// ShootEveryNodeReady is a constant for a condition type indicating the node health.
 	ShootEveryNodeReady ConditionType = "EveryNodeReady"
 	// ShootSystemComponentsHealthy is a constant for a condition type indicating the system components health.

--- a/pkg/apis/core/v1alpha1/types_shoot.go
+++ b/pkg/apis/core/v1alpha1/types_shoot.go
@@ -1570,8 +1570,10 @@ const (
 const (
 	// ShootAPIServerAvailable is a constant for a condition type indicating that the Shoot cluster's API server is available.
 	ShootAPIServerAvailable ConditionType = "APIServerAvailable"
-	// ShootControlPlaneHealthy is a constant for a condition type indicating the control plane health.
+	// ShootControlPlaneHealthy is a constant for a condition type indicating the health of core control plane components.
 	ShootControlPlaneHealthy ConditionType = "ControlPlaneHealthy"
+	// ShootObservabilityComponentsHealthy is a constant for a condition type indicating the health of observability components.
+	ShootObservabilityComponentsHealthy ConditionType = "ObservabilityComponentsHealthy"
 	// ShootEveryNodeReady is a constant for a condition type indicating the node health.
 	ShootEveryNodeReady ConditionType = "EveryNodeReady"
 	// ShootSystemComponentsHealthy is a constant for a condition type indicating the system components health.

--- a/pkg/apis/core/v1beta1/types_shoot.go
+++ b/pkg/apis/core/v1beta1/types_shoot.go
@@ -1589,8 +1589,10 @@ const (
 const (
 	// ShootAPIServerAvailable is a constant for a condition type indicating that the Shoot cluster's API server is available.
 	ShootAPIServerAvailable ConditionType = "APIServerAvailable"
-	// ShootControlPlaneHealthy is a constant for a condition type indicating the control plane health.
+	// ShootControlPlaneHealthy is a constant for a condition type indicating the health of core control plane components.
 	ShootControlPlaneHealthy ConditionType = "ControlPlaneHealthy"
+	// ShootObservabilityComponentsHealthy is a constant for a condition type indicating the health of observability components.
+	ShootObservabilityComponentsHealthy ConditionType = "ObservabilityComponentsHealthy"
 	// ShootEveryNodeReady is a constant for a condition type indicating the node health.
 	ShootEveryNodeReady ConditionType = "EveryNodeReady"
 	// ShootSystemComponentsHealthy is a constant for a condition type indicating the system components health.

--- a/pkg/controllermanager/controller/seed/lifecycle/reconciler.go
+++ b/pkg/controllermanager/controller/seed/lifecycle/reconciler.go
@@ -164,10 +164,11 @@ func setShootStatusToUnknown(ctx context.Context, clock clock.Clock, c client.St
 		msg    = "Gardenlet stopped sending heartbeats."
 
 		conditions = map[gardencorev1beta1.ConditionType]gardencorev1beta1.Condition{
-			gardencorev1beta1.ShootAPIServerAvailable:      {},
-			gardencorev1beta1.ShootControlPlaneHealthy:     {},
-			gardencorev1beta1.ShootEveryNodeReady:          {},
-			gardencorev1beta1.ShootSystemComponentsHealthy: {},
+			gardencorev1beta1.ShootAPIServerAvailable:             {},
+			gardencorev1beta1.ShootControlPlaneHealthy:            {},
+			gardencorev1beta1.ShootObservabilityComponentsHealthy: {},
+			gardencorev1beta1.ShootEveryNodeReady:                 {},
+			gardencorev1beta1.ShootSystemComponentsHealthy:        {},
 		}
 
 		constraints = map[gardencorev1beta1.ConditionType]gardencorev1beta1.Condition{

--- a/pkg/gardenlet/controller/managedseed/charttest/charttest.go
+++ b/pkg/gardenlet/controller/managedseed/charttest/charttest.go
@@ -781,6 +781,12 @@ func ComputeExpectedGardenletConfiguration(
 						},
 					},
 					{
+						Type: string(gardencorev1beta1.ShootObservabilityComponentsHealthy),
+						Duration: metav1.Duration{
+							Duration: 1 * time.Minute,
+						},
+					},
+					{
 						Type: string(gardencorev1beta1.ShootSystemComponentsHealthy),
 						Duration: metav1.Duration{
 							Duration: 1 * time.Minute,

--- a/pkg/gardenlet/controller/managedseed/charttest/gardenlet_chart_test.go
+++ b/pkg/gardenlet/controller/managedseed/charttest/gardenlet_chart_test.go
@@ -349,13 +349,13 @@ var _ = Describe("#Gardenlet Chart Test", func() {
 				ValidateGardenletChartVPA(ctx, c)
 			}
 		},
-		Entry("verify the default values for the Gardenlet chart & the Gardenlet component config", nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, map[string]string{"gardenlet-configmap": "gardenlet-configmap-70905508"}),
+		Entry("verify the default values for the Gardenlet chart & the Gardenlet component config", nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, map[string]string{"gardenlet-configmap": "gardenlet-configmap-9e6148ef"}),
 		Entry("verify Gardenlet with component config having the Garden client connection kubeconfig set", pointer.String("dummy garden kubeconfig"), nil, nil, nil, nil, nil, nil, nil, nil, nil, map[string]string{
-			"gardenlet-configmap":         "gardenlet-configmap-17ad2cbe",
+			"gardenlet-configmap":         "gardenlet-configmap-fe6942d7",
 			"gardenlet-kubeconfig-garden": "gardenlet-kubeconfig-garden-8c9ae097",
 		}),
 		Entry("verify Gardenlet with component config having the Seed client connection kubeconfig set", nil, pointer.String("dummy seed kubeconfig"), nil, nil, nil, nil, nil, nil, nil, nil, map[string]string{
-			"gardenlet-configmap":       "gardenlet-configmap-ab8ae39e",
+			"gardenlet-configmap":       "gardenlet-configmap-1f1ad46c",
 			"gardenlet-kubeconfig-seed": "gardenlet-kubeconfig-seed-662d92ae",
 		}),
 		Entry("verify Gardenlet with component config having a Bootstrap kubeconfig set", nil, nil, &corev1.SecretReference{
@@ -365,7 +365,7 @@ var _ = Describe("#Gardenlet Chart Test", func() {
 			Name:      "gardenlet-kubeconfig",
 			Namespace: v1beta1constants.GardenNamespace,
 		}, pointer.String("dummy bootstrap kubeconfig"), nil, nil, nil, nil, nil, map[string]string{
-			"gardenlet-configmap": "gardenlet-configmap-72fee494",
+			"gardenlet-configmap": "gardenlet-configmap-1e1445a0",
 		}),
 		Entry("verify that the SeedConfig is set in the component config Config Map", nil, nil, nil, nil, nil,
 			&gardenletv1alpha1.SeedConfig{
@@ -377,7 +377,7 @@ var _ = Describe("#Gardenlet Chart Test", func() {
 						Provider: gardencorev1beta1.SeedProvider{},
 					},
 				},
-			}, nil, nil, nil, nil, map[string]string{"gardenlet-configmap": "gardenlet-configmap-df47eaf0"}),
+			}, nil, nil, nil, nil, map[string]string{"gardenlet-configmap": "gardenlet-configmap-50421b75"}),
 		Entry("verify deployment with two replica and three zones", nil, nil, nil, nil, nil,
 			&gardenletv1alpha1.SeedConfig{
 				SeedTemplate: gardencorev1beta1.SeedTemplate{
@@ -392,7 +392,7 @@ var _ = Describe("#Gardenlet Chart Test", func() {
 				},
 			}, &seedmanagement.GardenletDeployment{
 				ReplicaCount: pointer.Int32(2),
-			}, nil, nil, nil, map[string]string{"gardenlet-configmap": "gardenlet-configmap-5de2a0f2"}),
+			}, nil, nil, nil, map[string]string{"gardenlet-configmap": "gardenlet-configmap-b733b9d7"}),
 		Entry("verify deployment with only one replica", nil, nil, nil, nil, nil,
 			&gardenletv1alpha1.SeedConfig{
 				SeedTemplate: gardencorev1beta1.SeedTemplate{
@@ -407,7 +407,7 @@ var _ = Describe("#Gardenlet Chart Test", func() {
 				},
 			}, &seedmanagement.GardenletDeployment{
 				ReplicaCount: pointer.Int32(1),
-			}, nil, nil, nil, map[string]string{"gardenlet-configmap": "gardenlet-configmap-5de2a0f2"}),
+			}, nil, nil, nil, map[string]string{"gardenlet-configmap": "gardenlet-configmap-b733b9d7"}),
 		Entry("verify deployment with only one zone", nil, nil, nil, nil, nil,
 			&gardenletv1alpha1.SeedConfig{
 				SeedTemplate: gardencorev1beta1.SeedTemplate{
@@ -420,23 +420,23 @@ var _ = Describe("#Gardenlet Chart Test", func() {
 						},
 					},
 				},
-			}, nil, nil, nil, nil, map[string]string{"gardenlet-configmap": "gardenlet-configmap-9ae20db3"}),
+			}, nil, nil, nil, nil, map[string]string{"gardenlet-configmap": "gardenlet-configmap-87ebb263"}),
 		Entry("verify deployment with image vector override", nil, nil, nil, nil, nil, nil, nil, pointer.String("dummy-override-content"), nil, nil, map[string]string{
-			"gardenlet-configmap":             "gardenlet-configmap-70905508",
+			"gardenlet-configmap":             "gardenlet-configmap-9e6148ef",
 			"gardenlet-imagevector-overwrite": "gardenlet-imagevector-overwrite-32ecb769",
 		}),
 		Entry("verify deployment with component image vector override", nil, nil, nil, nil, nil, nil, nil, nil, pointer.String("dummy-override-content"), nil, map[string]string{
-			"gardenlet-configmap":                        "gardenlet-configmap-70905508",
+			"gardenlet-configmap":                        "gardenlet-configmap-9e6148ef",
 			"gardenlet-imagevector-overwrite-components": "gardenlet-imagevector-overwrite-components-53f94952",
 		}),
 
 		Entry("verify deployment with custom replica count", nil, nil, nil, nil, nil, nil, &seedmanagement.GardenletDeployment{
 			ReplicaCount: pointer.Int32(3),
-		}, nil, nil, nil, map[string]string{"gardenlet-configmap": "gardenlet-configmap-70905508"}),
+		}, nil, nil, nil, map[string]string{"gardenlet-configmap": "gardenlet-configmap-9e6148ef"}),
 
 		Entry("verify deployment with service account", nil, nil, nil, nil, nil, nil, &seedmanagement.GardenletDeployment{
 			ServiceAccountName: pointer.String("ax"),
-		}, nil, nil, nil, map[string]string{"gardenlet-configmap": "gardenlet-configmap-70905508"}),
+		}, nil, nil, nil, map[string]string{"gardenlet-configmap": "gardenlet-configmap-9e6148ef"}),
 
 		Entry("verify deployment with resources", nil, nil, nil, nil, nil, nil, &seedmanagement.GardenletDeployment{
 			Resources: &corev1.ResourceRequirements{
@@ -448,19 +448,19 @@ var _ = Describe("#Gardenlet Chart Test", func() {
 					corev1.ResourceMemory: resource.MustParse("25Mi"),
 				},
 			},
-		}, nil, nil, nil, map[string]string{"gardenlet-configmap": "gardenlet-configmap-70905508"}),
+		}, nil, nil, nil, map[string]string{"gardenlet-configmap": "gardenlet-configmap-9e6148ef"}),
 
 		Entry("verify deployment with pod labels", nil, nil, nil, nil, nil, nil, &seedmanagement.GardenletDeployment{
 			PodLabels: map[string]string{
 				"x": "y",
 			},
-		}, nil, nil, nil, map[string]string{"gardenlet-configmap": "gardenlet-configmap-70905508"}),
+		}, nil, nil, nil, map[string]string{"gardenlet-configmap": "gardenlet-configmap-9e6148ef"}),
 
 		Entry("verify deployment with pod annotations", nil, nil, nil, nil, nil, nil, &seedmanagement.GardenletDeployment{
 			PodAnnotations: map[string]string{
 				"x": "y",
 			},
-		}, nil, nil, nil, map[string]string{"gardenlet-configmap": "gardenlet-configmap-70905508"}),
+		}, nil, nil, nil, map[string]string{"gardenlet-configmap": "gardenlet-configmap-9e6148ef"}),
 
 		Entry("verify deployment with additional volumes", nil, nil, nil, nil, nil, nil, &seedmanagement.GardenletDeployment{
 			AdditionalVolumes: []corev1.Volume{
@@ -469,7 +469,7 @@ var _ = Describe("#Gardenlet Chart Test", func() {
 					VolumeSource: corev1.VolumeSource{},
 				},
 			},
-		}, nil, nil, nil, map[string]string{"gardenlet-configmap": "gardenlet-configmap-70905508"}),
+		}, nil, nil, nil, map[string]string{"gardenlet-configmap": "gardenlet-configmap-9e6148ef"}),
 
 		Entry("verify deployment with additional volume mounts", nil, nil, nil, nil, nil, nil, &seedmanagement.GardenletDeployment{
 			AdditionalVolumeMounts: []corev1.VolumeMount{
@@ -477,7 +477,7 @@ var _ = Describe("#Gardenlet Chart Test", func() {
 					Name: "a",
 				},
 			},
-		}, nil, nil, nil, map[string]string{"gardenlet-configmap": "gardenlet-configmap-70905508"}),
+		}, nil, nil, nil, map[string]string{"gardenlet-configmap": "gardenlet-configmap-9e6148ef"}),
 
 		Entry("verify deployment with env variables", nil, nil, nil, nil, nil, nil, &seedmanagement.GardenletDeployment{
 			Env: []corev1.EnvVar{
@@ -486,14 +486,14 @@ var _ = Describe("#Gardenlet Chart Test", func() {
 					Value: "XY",
 				},
 			},
-		}, nil, nil, nil, map[string]string{"gardenlet-configmap": "gardenlet-configmap-70905508"}),
+		}, nil, nil, nil, map[string]string{"gardenlet-configmap": "gardenlet-configmap-9e6148ef"}),
 
 		Entry("verify deployment with VPA enabled", nil, nil, nil, nil, nil, nil, &seedmanagement.GardenletDeployment{
 			VPA: pointer.Bool(true),
-		}, nil, nil, nil, map[string]string{"gardenlet-configmap": "gardenlet-configmap-70905508"}),
-		Entry("verify Gardenlet RBACs when ManagedIstio is enabled", nil, nil, nil, nil, nil, nil, nil, nil, nil, map[string]bool{string(features.ManagedIstio): true}, map[string]string{"gardenlet-configmap": "gardenlet-configmap-f5acb7a6"}),
-		Entry("verify Gardenlet RBACs when APIServerSNI is enabled", nil, nil, nil, nil, nil, nil, nil, nil, nil, map[string]bool{string(features.APIServerSNI): true}, map[string]string{"gardenlet-configmap": "gardenlet-configmap-b72aa081"}),
-		Entry("verify Gardenlet RBACs when APIServerSNI is disabled", nil, nil, nil, nil, nil, nil, nil, nil, nil, map[string]bool{string(features.APIServerSNI): false}, map[string]string{"gardenlet-configmap": "gardenlet-configmap-7ea177ea"}),
+		}, nil, nil, nil, map[string]string{"gardenlet-configmap": "gardenlet-configmap-9e6148ef"}),
+		Entry("verify Gardenlet RBACs when ManagedIstio is enabled", nil, nil, nil, nil, nil, nil, nil, nil, nil, map[string]bool{string(features.ManagedIstio): true}, map[string]string{"gardenlet-configmap": "gardenlet-configmap-565c8a53"}),
+		Entry("verify Gardenlet RBACs when APIServerSNI is enabled", nil, nil, nil, nil, nil, nil, nil, nil, nil, map[string]bool{string(features.APIServerSNI): true}, map[string]string{"gardenlet-configmap": "gardenlet-configmap-716469c2"}),
+		Entry("verify Gardenlet RBACs when APIServerSNI is disabled", nil, nil, nil, nil, nil, nil, nil, nil, nil, map[string]bool{string(features.APIServerSNI): false}, map[string]string{"gardenlet-configmap": "gardenlet-configmap-81b87b39"}),
 	)
 })
 

--- a/pkg/gardenlet/controller/shoot/care/reconciler.go
+++ b/pkg/gardenlet/controller/shoot/care/reconciler.go
@@ -101,6 +101,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	conditionTypes := []gardencorev1beta1.ConditionType{
 		gardencorev1beta1.ShootAPIServerAvailable,
 		gardencorev1beta1.ShootControlPlaneHealthy,
+		gardencorev1beta1.ShootObservabilityComponentsHealthy,
 		gardencorev1beta1.ShootEveryNodeReady,
 		gardencorev1beta1.ShootSystemComponentsHealthy,
 	}

--- a/pkg/gardenlet/controller/shoot/care/reconciler_test.go
+++ b/pkg/gardenlet/controller/shoot/care/reconciler_test.go
@@ -321,6 +321,11 @@ var _ = Describe("Shoot Care Control", func() {
 							Reason: "bar",
 						},
 						{
+							Type:   gardencorev1beta1.ShootObservabilityComponentsHealthy,
+							Status: gardencorev1beta1.ConditionFalse,
+							Reason: "dash",
+						},
+						{
 							Type:   gardencorev1beta1.ShootEveryNodeReady,
 							Status: gardencorev1beta1.ConditionProgressing,
 						},

--- a/pkg/gardenlet/controller/shoot/shoot/reconciler.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler.go
@@ -639,6 +639,7 @@ func (r *Reconciler) patchShootStatusOperationSuccess(
 			switch cond.Type {
 			case gardencorev1beta1.ShootAPIServerAvailable,
 				gardencorev1beta1.ShootControlPlaneHealthy,
+				gardencorev1beta1.ShootObservabilityComponentsHealthy,
 				gardencorev1beta1.ShootEveryNodeReady,
 				gardencorev1beta1.ShootSystemComponentsHealthy:
 				if cond.Status != gardencorev1beta1.ConditionFalse {

--- a/pkg/registry/core/shoot/storage/tableconvertor.go
+++ b/pkg/registry/core/shoot/storage/tableconvertor.go
@@ -53,6 +53,7 @@ func newTableConvertor() rest.TableConvertor {
 			{Name: "Gardener Version", Type: "string", Format: "name", Description: swaggerMetadataDescriptions["gardenerVersion"], Priority: 1},
 			{Name: "APIServer", Type: "string", Format: "name", Description: swaggerMetadataDescriptions["apiserver"], Priority: 1},
 			{Name: "Control", Type: "string", Format: "name", Description: swaggerMetadataDescriptions["control"], Priority: 1},
+			{Name: "Observability", Type: "string", Format: "name", Description: swaggerMetadataDescriptions["observability"], Priority: 1},
 			{Name: "Nodes", Type: "string", Format: "name", Description: swaggerMetadataDescriptions["nodes"], Priority: 1},
 			{Name: "System", Type: "string", Format: "name", Description: swaggerMetadataDescriptions["system"], Priority: 1},
 			{Name: "Age", Type: "date", Description: swaggerMetadataDescriptions["creationTimestamp"]},

--- a/pkg/registry/core/shoot/storage/tableconvertor.go
+++ b/pkg/registry/core/shoot/storage/tableconvertor.go
@@ -139,6 +139,11 @@ func (c *convertor) ConvertToTable(ctx context.Context, obj runtime.Object, tabl
 		} else {
 			cells = append(cells, "<unknown>")
 		}
+		if cond := helper.GetCondition(shoot.Status.Conditions, core.ShootObservabilityComponentsHealthy); cond != nil {
+			cells = append(cells, cond.Status)
+		} else {
+			cells = append(cells, "<unknown>")
+		}
 		if cond := helper.GetCondition(shoot.Status.Conditions, core.ShootEveryNodeReady); cond != nil {
 			cells = append(cells, cond.Status)
 		} else {

--- a/test/framework/k8s_utils.go
+++ b/test/framework/k8s_utils.go
@@ -321,10 +321,11 @@ func ShootReconciliationSuccessful(shoot *gardencorev1beta1.Shoot) (bool, string
 	}
 
 	shootConditions := map[gardencorev1beta1.ConditionType]struct{}{
-		gardencorev1beta1.ShootAPIServerAvailable:      {},
-		gardencorev1beta1.ShootControlPlaneHealthy:     {},
-		gardencorev1beta1.ShootEveryNodeReady:          {},
-		gardencorev1beta1.ShootSystemComponentsHealthy: {},
+		gardencorev1beta1.ShootAPIServerAvailable:             {},
+		gardencorev1beta1.ShootControlPlaneHealthy:            {},
+		gardencorev1beta1.ShootObservabilityComponentsHealthy: {},
+		gardencorev1beta1.ShootEveryNodeReady:                 {},
+		gardencorev1beta1.ShootSystemComponentsHealthy:        {},
 	}
 
 	for _, condition := range shoot.Status.Conditions {

--- a/test/framework/k8s_utils_test.go
+++ b/test/framework/k8s_utils_test.go
@@ -193,6 +193,10 @@ func appendShootConditionsToShoot(shoot *gardencorev1beta1.Shoot) {
 			Status: gardencorev1beta1.ConditionTrue,
 		},
 		{
+			Type:   gardencorev1beta1.ShootObservabilityComponentsHealthy,
+			Status: gardencorev1beta1.ConditionTrue,
+		},
+		{
 			Type:   gardencorev1beta1.ShootEveryNodeReady,
 			Status: gardencorev1beta1.ConditionTrue,
 		},

--- a/test/integration/controllermanager/seed/lifecycle/lifecycle_test.go
+++ b/test/integration/controllermanager/seed/lifecycle/lifecycle_test.go
@@ -259,6 +259,7 @@ var _ = Describe("Seed Lifecycle controller tests", func() {
 					Conditions: []gardencorev1beta1.Condition{
 						{Type: gardencorev1beta1.ShootAPIServerAvailable, Status: gardencorev1beta1.ConditionTrue},
 						{Type: gardencorev1beta1.ShootControlPlaneHealthy, Status: gardencorev1beta1.ConditionTrue},
+						{Type: gardencorev1beta1.ShootObservabilityComponentsHealthy, Status: gardencorev1beta1.ConditionTrue},
 						{Type: gardencorev1beta1.ShootEveryNodeReady, Status: gardencorev1beta1.ConditionTrue},
 						{Type: gardencorev1beta1.ShootSystemComponentsHealthy, Status: gardencorev1beta1.ConditionTrue},
 					},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity monitoring
/kind enhancement

**What this PR does / why we need it**:
Please see the https://github.com/gardener/gardener/issues/7143 issue description.
A new condition, `ObservabilityComponentsHealthy` has been introduced in the Shoot for tracking the status of observability components like Prometheus, Loki, Grafana, etc.
The `ControlPlaneHealthy` conditions now only tracks core control plane components like ETCD, KAPI, KCM etc. 

**Which issue(s) this PR fixes**:
Fixes #7143 

**Special notes for your reviewer**:
~Need to do some more testing, will mark it ready after that.~

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
A new condition, `ObservabilityComponentsHealthy` has been introduced in the Shoot for tracking the status of observability components like Prometheus, Loki, Grafana, etc. The `ControlPlaneHealthy` condition now only tracks core control plane components like ETCD, KAPI, KCM etc. 
```
