### PR TITLE
Fix bug preventing shoot deletion when never reconciled at least once

### DIFF
--- a/pkg/gardenlet/controller/shoot/shoot/reconciler.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler.go
@@ -422,6 +422,9 @@ func (r *Reconciler) finalizeShootDeletion(ctx context.Context, log logr.Logger,
 
 // deleteClusterResourceFromSeed deletes the `Cluster` extension resource for the shoot in the seed cluster.
 func (r *Reconciler) deleteClusterResourceFromSeed(ctx context.Context, shoot *gardencorev1beta1.Shoot) error {
+	if shoot.Status.TechnicalID == "" {
+		return nil
+	}
 	cluster := &extensionsv1alpha1.Cluster{ObjectMeta: metav1.ObjectMeta{Name: shoot.Status.TechnicalID}}
 	return client.IgnoreNotFound(r.SeedClientSet.Client().Delete(ctx, cluster))
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind bug

**What this PR does / why we need it**:
Deleting a `Shoot` that was never reconciled at least once with `gardenlet` (because it was down, for example) fails because the `.status.technicalID` is empty:

```
{"log":{"controller":"shoot","error":"Could not delete Cluster resource in seed: resource name may not be empty","level":"error","msg":"Reconciler error","name":"foo","namespace":"garden-bar","object":{"name":"foo","namespace":"garden-bar"},"reconcileID":"98bbe683-487a-41c7-bfd1-75414f5d511f","stacktrace":"sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\t/go/src/github.com/gardener/gardener/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:326\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/go/src/github.com/gardener/gardener/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:273\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2\n\t/go/src/github.com/gardener/gardener/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:234","ts":"2023-01-13T21:06:26.702Z"}}
{"log":{"controller":"shoot","level":"info","msg":"The `.status.uid` is empty, assuming Shoot cluster did never exist, deletion accepted","name":"foo","namespace":"garden-bar","object":{"name":"foo","namespace":"garden-bar"},"operation":"delete","reconcileID":"98bbe683-487a-41c7-bfd1-75414f5d511f","ts":"2023-01-13T21:06:24.908Z"}}
```

**Which issue(s) this PR fixes**:
Introduced with https://github.com/gardener/gardener/pull/7082 or https://github.com/gardener/gardener/pull/7189 when refactoring the shoot controller to a native controller-runtime controller.

**Special notes for your reviewer**:
/cc @timebertt 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
A bug has been fixed which prevented `Shoot`s from being deleted if they have never been reconciled at least once.
```
