### PR TITLE
Increase verbosity for check whether pods are still running

### DIFF
--- a/test/e2e/gardener/shoot/create_and_delete_hibernated.go
+++ b/test/e2e/gardener/shoot/create_and_delete_hibernated.go
@@ -57,5 +57,5 @@ func verifyNoPodsRunning(ctx context.Context, f *framework.ShootCreationFramewor
 	podList := &metav1.PartialObjectMetadataList{}
 	podList.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("PodList"))
 	ExpectWithOffset(1, f.ShootFramework.SeedClient.Client().List(ctx, podList, client.InNamespace(f.Shoot.Status.TechnicalID))).To(Succeed())
-	ExpectWithOffset(1, podList.Items).To(HaveLen(0))
+	ExpectWithOffset(1, podList.Items).To(BeEmpty())
 }

--- a/test/e2e/gardener/shoot/create_and_delete_hibernated.go
+++ b/test/e2e/gardener/shoot/create_and_delete_hibernated.go
@@ -18,16 +18,16 @@ import (
 	"context"
 	"time"
 
-	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
-	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
-	e2e "github.com/gardener/gardener/test/e2e/gardener"
-	"github.com/gardener/gardener/test/framework"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	e2e "github.com/gardener/gardener/test/e2e/gardener"
+	"github.com/gardener/gardener/test/framework"
 )
 
 var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
@@ -54,7 +54,8 @@ var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
 })
 
 func verifyNoPodsRunning(ctx context.Context, f *framework.ShootCreationFramework) {
-	podsAreExisting, err := kubernetesutils.ResourcesExist(ctx, f.ShootFramework.SeedClient.Client(), corev1.SchemeGroupVersion.WithKind("PodList"), client.InNamespace(f.Shoot.Status.TechnicalID))
-	Expect(err).To(Succeed())
-	Expect(podsAreExisting).To(BeFalse())
+	podList := &metav1.PartialObjectMetadataList{}
+	podList.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("PodList"))
+	ExpectWithOffset(1, f.ShootFramework.SeedClient.Client().List(ctx, podList, client.InNamespace(f.Shoot.Status.TechnicalID))).To(Succeed())
+	ExpectWithOffset(1, podList.Items).To(HaveLen(0))
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind flake

**What this PR does / why we need it**:
This PR increases the verbosity when checking whether pods are still running in our e2e test.

**Which issue(s) this PR fixes**:
Part of #7266

**Special notes for your reviewer**:
This is just the first step to get more information which pods are still running - next step is to discuss the correct remediation/expectation.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
