### PR TITLE
Streamline integration tests

### DIFF
--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -336,7 +336,7 @@ $ stress -ignore "unable to grab random port" -p 16 ./test/integration/controlle
     - this allows running a test in parallel against the same existing cluster for deflaking and stress testing, even if it works with cluster-scoped resources that are visible to all parallel test runs: [example PR](https://github.com/gardener/gardener/pull/6527)
   - use dedicated test resources for each test case
     - use `GenerateName`: [example test](https://github.com/gardener/gardener/blob/ee3e50387fc7e6298908242f59894a7ea6f91fa7/test/integration/resourcemanager/health/health_test.go#L38-L48)
-    - alternatively, use a checksum of `CurrentSpecReport().LeafNodeLocation.String()`: [example test](https://github.com/gardener/gardener/blob/ee3e50387fc7e6298908242f59894a7ea6f91fa7/test/integration/resourcemanager/managedresource/resource_test.go#L61-L67)
+    - alternatively, use a checksum of a random UUID using `uuid.NewUUID()` function: [example test](https://github.com/gardener/gardener/blob/3840acaaf57955fd65330c83b2b2d5bdaad56179/test/integration/resourcemanager/tokeninvalidator/tokeninvalidator_suite_test.go#L71-L72)
     - logging the created object names is generally a good idea to support debugging failing or flaky tests: [example test](https://github.com/gardener/gardener/blob/50f92c5dc35160fe05da9002a79e7ce4a9cf3509/test/integration/controllermanager/cloudprofile/cloudprofile_test.go#L94-L96)
     - always delete all resources after the test case (e.g., via `DeferCleanup`) that were created for the test case 
     - this avoids conflicts between test cases and cascading failures which distract from the actual root failures

--- a/test/integration/controllermanager/bastion/bastion_test.go
+++ b/test/integration/controllermanager/bastion/bastion_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/gardener/gardener/pkg/utils"
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
+	"k8s.io/apimachinery/pkg/util/uuid"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -48,7 +49,7 @@ var _ = Describe("Bastion controller tests", func() {
 	BeforeEach(func() {
 		fakeClock.SetTime(time.Now())
 
-		resourceName = "test-" + utils.ComputeSHA256Hex([]byte(CurrentSpecReport().LeafNodeLocation.String()))[:8]
+		resourceName = "test-" + utils.ComputeSHA256Hex([]byte(uuid.NewUUID()))[:8]
 		objectKey = client.ObjectKey{Namespace: testNamespace.Name, Name: resourceName}
 
 		providerType := "foo-provider"

--- a/test/integration/controllermanager/managedseedset/managedseedset_suite_test.go
+++ b/test/integration/controllermanager/managedseedset/managedseedset_suite_test.go
@@ -25,7 +25,6 @@ import (
 	gardenerenvtest "github.com/gardener/gardener/pkg/envtest"
 	"github.com/gardener/gardener/pkg/logger"
 	"github.com/gardener/gardener/pkg/utils"
-	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
@@ -96,7 +95,7 @@ var _ = BeforeSuite(func() {
 			Name: "garden",
 		},
 	}
-	Expect(testClient.Create(ctx, gardenNamespace)).To(Or(Succeed(), BeAlreadyExistsError()))
+	Expect(testClient.Create(ctx, gardenNamespace)).To(Succeed())
 	log.Info("Created Namespace for test", "gardenNamespace", client.ObjectKeyFromObject(gardenNamespace))
 
 	testRunID = utils.ComputeSHA256Hex([]byte(uuid.NewUUID()))[:8]

--- a/test/integration/controllermanager/project/activity/activity_suite_test.go
+++ b/test/integration/controllermanager/project/activity/activity_suite_test.go
@@ -108,6 +108,7 @@ var _ = BeforeSuite(func() {
 
 	By("Register controller")
 	fakeClock = testclock.NewFakeClock(time.Now())
+
 	Expect((&activity.Reconciler{
 		Config: config.ProjectControllerConfiguration{
 			ConcurrentSyncs: pointer.Int(5),

--- a/test/integration/controllermanager/project/project/project_test.go
+++ b/test/integration/controllermanager/project/project/project_test.go
@@ -98,7 +98,7 @@ var _ = Describe("Project controller tests", func() {
 
 	JustBeforeEach(func() {
 		if projectNamespace != nil {
-			By("Create project namespace")
+			By("Create project Namespace")
 			Expect(testClient.Create(ctx, projectNamespace)).To(Succeed())
 			log.Info("Created project namespace", "projectNamespace", projectNamespace)
 

--- a/test/integration/controllermanager/project/stale/stale_suite_test.go
+++ b/test/integration/controllermanager/project/stale/stale_suite_test.go
@@ -128,6 +128,7 @@ var _ = BeforeSuite(func() {
 
 	By("Register controller")
 	fakeClock = testclock.NewFakeClock(time.Now())
+
 	Expect((&stale.Reconciler{
 		Config: config.ProjectControllerConfiguration{
 			ConcurrentSyncs:         pointer.Int(5),

--- a/test/integration/controllermanager/quota/quota_test.go
+++ b/test/integration/controllermanager/quota/quota_test.go
@@ -19,6 +19,7 @@ import (
 	gardenerutils "github.com/gardener/gardener/pkg/utils"
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
+	"k8s.io/apimachinery/pkg/util/uuid"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -39,7 +40,7 @@ var _ = Describe("Quota controller tests", func() {
 
 	BeforeEach(func() {
 		providerType = "provider-type"
-		resourceName = "test-" + gardenerutils.ComputeSHA256Hex([]byte(CurrentSpecReport().LeafNodeLocation.String()))[:8]
+		resourceName = "test-" + gardenerutils.ComputeSHA256Hex([]byte(uuid.NewUUID()))[:8]
 		objectKey = client.ObjectKey{Namespace: testNamespace.Name, Name: resourceName}
 
 		secret = &corev1.Secret{

--- a/test/integration/controllermanager/seed/backupbucketscheck/backupbucketscheck_suite_test.go
+++ b/test/integration/controllermanager/seed/backupbucketscheck/backupbucketscheck_suite_test.go
@@ -111,9 +111,9 @@ var _ = BeforeSuite(func() {
 	By("Setup field indexes")
 	Expect(indexer.AddBackupBucketSeedName(ctx, mgr.GetFieldIndexer())).To(Succeed())
 
+	By("Register controller")
 	fakeClock = testclock.NewFakeClock(time.Now())
 
-	By("Register controller")
 	Expect((&backupbucketscheck.Reconciler{
 		Config: config.SeedBackupBucketsCheckControllerConfiguration{
 			ConcurrentSyncs: pointer.Int(5),

--- a/test/integration/controllermanager/seed/backupbucketscheck/backupbucketscheck_test.go
+++ b/test/integration/controllermanager/seed/backupbucketscheck/backupbucketscheck_test.go
@@ -41,6 +41,8 @@ var _ = Describe("Seed BackupBucketsCheck controller tests", func() {
 	)
 
 	BeforeEach(func() {
+		fakeClock.SetTime(time.Now())
+
 		By("Create Seed")
 		seed = &gardencorev1beta1.Seed{
 			ObjectMeta: metav1.ObjectMeta{

--- a/test/integration/controllermanager/seed/extensionscheck/extensionscheck_suite_test.go
+++ b/test/integration/controllermanager/seed/extensionscheck/extensionscheck_suite_test.go
@@ -116,8 +116,9 @@ var _ = BeforeSuite(func() {
 	By("Setup field indexes")
 	Expect(indexer.AddControllerInstallationSeedRefName(ctx, mgr.GetFieldIndexer())).To(Succeed())
 
-	fakeClock = testclock.NewFakeClock(time.Now())
 	By("Register controller")
+	fakeClock = testclock.NewFakeClock(time.Now())
+
 	Expect((&extensionscheck.Reconciler{
 		Config: config.SeedExtensionsCheckControllerConfiguration{
 			ConcurrentSyncs: pointer.Int(5),

--- a/test/integration/controllermanager/seed/extensionscheck/extensionscheck_test.go
+++ b/test/integration/controllermanager/seed/extensionscheck/extensionscheck_test.go
@@ -15,6 +15,8 @@
 package extensionscheck_test
 
 import (
+	"time"
+
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 
@@ -34,6 +36,8 @@ var _ = Describe("Seed ExtensionsCheck controller tests", func() {
 	)
 
 	BeforeEach(func() {
+		fakeClock.SetTime(time.Now())
+
 		By("Create Seed")
 		seed = &gardencorev1beta1.Seed{
 			ObjectMeta: metav1.ObjectMeta{

--- a/test/integration/controllermanager/seed/lifecycle/lifecycle_suite_test.go
+++ b/test/integration/controllermanager/seed/lifecycle/lifecycle_suite_test.go
@@ -120,9 +120,9 @@ var _ = BeforeSuite(func() {
 	By("Setup field indexes")
 	Expect(indexer.AddShootSeedName(ctx, mgr.GetFieldIndexer())).To(Succeed())
 
+	By("Register controller")
 	fakeClock = testclock.NewFakeClock(time.Now())
 
-	By("Register controller")
 	Expect((&lifecycle.Reconciler{
 		Config: config.SeedControllerConfiguration{
 			MonitorPeriod:      &metav1.Duration{Duration: seedMonitorPeriod},

--- a/test/integration/controllermanager/seed/lifecycle/lifecycle_suite_test.go
+++ b/test/integration/controllermanager/seed/lifecycle/lifecycle_suite_test.go
@@ -26,7 +26,6 @@ import (
 	gardenerenvtest "github.com/gardener/gardener/pkg/envtest"
 	"github.com/gardener/gardener/pkg/logger"
 	"github.com/gardener/gardener/pkg/utils"
-	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
@@ -102,7 +101,7 @@ var _ = BeforeSuite(func() {
 			GenerateName: testID + "-",
 		},
 	}
-	Expect(testClient.Create(ctx, testNamespace)).To(Or(Succeed(), BeAlreadyExistsError()))
+	Expect(testClient.Create(ctx, testNamespace)).To(Succeed())
 	log.Info("Created Namespace for test", "namespaceName", testNamespace.Name)
 	testRunID = testNamespace.Name + "-" + utils.ComputeSHA256Hex([]byte(uuid.NewUUID()))[:8]
 

--- a/test/integration/controllermanager/seed/lifecycle/lifecycle_test.go
+++ b/test/integration/controllermanager/seed/lifecycle/lifecycle_test.go
@@ -221,7 +221,7 @@ var _ = Describe("Seed Lifecycle controller tests", func() {
 		Context("rebootstrapping of ManagedSeed", func() {
 			JustBeforeEach(func() {
 				By("Create garden Namespace")
-				Expect(testClient.Create(ctx, gardenNamespace)).To(Or(Succeed(), BeAlreadyExistsError()))
+				Expect(testClient.Create(ctx, gardenNamespace)).To(Succeed())
 				log.Info("Created garden Namespace", "namespace", client.ObjectKeyFromObject(gardenNamespace))
 
 				By("Create ManagedSeed")

--- a/test/integration/controllermanager/seed/lifecycle/lifecycle_test.go
+++ b/test/integration/controllermanager/seed/lifecycle/lifecycle_test.go
@@ -40,6 +40,8 @@ var _ = Describe("Seed Lifecycle controller tests", func() {
 	)
 
 	BeforeEach(func() {
+		fakeClock.SetTime(time.Now())
+
 		lease = &coordinationv1.Lease{
 			ObjectMeta: metav1.ObjectMeta{
 				GenerateName: "test-",

--- a/test/integration/controllermanager/seed/secrets/secrets_suite_test.go
+++ b/test/integration/controllermanager/seed/secrets/secrets_suite_test.go
@@ -90,7 +90,7 @@ var _ = BeforeSuite(func() {
 			GenerateName: testID + "-",
 		},
 	}
-	Expect(testClient.Create(ctx, testNamespace)).To(Or(Succeed(), BeAlreadyExistsError()))
+	Expect(testClient.Create(ctx, testNamespace)).To(Succeed())
 	log.Info("Created Namespace for test", "namespaceName", testNamespace.Name)
 	testRunID = testNamespace.Name
 

--- a/test/integration/controllermanager/shoot/conditions/conditions_suite_test.go
+++ b/test/integration/controllermanager/shoot/conditions/conditions_suite_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/gardener/gardener/pkg/controllermanager/controller/shoot/conditions"
 	gardenerenvtest "github.com/gardener/gardener/pkg/envtest"
 	"github.com/gardener/gardener/pkg/logger"
-	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
@@ -92,7 +91,7 @@ var _ = BeforeSuite(func() {
 			Name: "garden",
 		},
 	}
-	Expect(testClient.Create(ctx, testNamespace)).To(Or(Succeed(), BeAlreadyExistsError()))
+	Expect(testClient.Create(ctx, testNamespace)).To(Succeed())
 	log.Info("Created Namespace for test", "namespaceName", testNamespace.Name)
 	testRunID = testNamespace.Name
 

--- a/test/integration/controllermanager/shoot/maintenance/maintenance_suite_test.go
+++ b/test/integration/controllermanager/shoot/maintenance/maintenance_suite_test.go
@@ -116,6 +116,7 @@ var _ = BeforeSuite(func() {
 
 	By("Register controller")
 	fakeClock = testclock.NewFakeClock(time.Now().Round(time.Second))
+
 	Expect((&maintenance.Reconciler{
 		Config: config.ShootMaintenanceControllerConfiguration{
 			ConcurrentSyncs: pointer.Int(5),

--- a/test/integration/controllermanager/shoot/maintenance/maintenance_test.go
+++ b/test/integration/controllermanager/shoot/maintenance/maintenance_test.go
@@ -67,6 +67,8 @@ var _ = Describe("Shoot Maintenance controller tests", func() {
 	)
 
 	BeforeEach(func() {
+		fakeClock.SetTime(time.Now().Round(time.Second))
+
 		cloudProfile = &gardencorev1beta1.CloudProfile{
 			ObjectMeta: metav1.ObjectMeta{
 				GenerateName: testID + "-",

--- a/test/integration/envtest/envtest_suite_test.go
+++ b/test/integration/envtest/envtest_suite_test.go
@@ -112,5 +112,5 @@ var _ = BeforeSuite(func() {
 
 	By("Ensure that garden namespace exists")
 	Expect(testClient.Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "garden"}})).
-		To(Or(Succeed(), BeAlreadyExistsError()))
+		To(Succeed())
 })

--- a/test/integration/extensions/controller/heartbeat/heartbeat_suite_test.go
+++ b/test/integration/extensions/controller/heartbeat/heartbeat_suite_test.go
@@ -105,6 +105,7 @@ var _ = BeforeSuite(func() {
 
 	By("Register controller")
 	fakeClock = testclock.NewFakeClock(time.Now())
+
 	Expect(heartbeat.Add(mgr, heartbeat.AddArgs{
 		ControllerOptions:    controller.Options{},
 		ExtensionName:        testID,

--- a/test/integration/extensions/controller/heartbeat/heartbeat_test.go
+++ b/test/integration/extensions/controller/heartbeat/heartbeat_test.go
@@ -29,6 +29,8 @@ var _ = Describe("Extensions Heartbeat Controller tests", func() {
 	var lease *coordinationv1.Lease
 
 	BeforeEach(func() {
+		fakeClock.SetTime(time.Now())
+
 		lease = &coordinationv1.Lease{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "gardener-extension-heartbeat",

--- a/test/integration/gardenlet/backupbucket/backupbucket_suite_test.go
+++ b/test/integration/gardenlet/backupbucket/backupbucket_suite_test.go
@@ -215,8 +215,9 @@ var _ = BeforeSuite(func() {
 	By("Setup field indexes")
 	Expect(indexer.AddBackupEntryBucketName(ctx, mgr.GetFieldIndexer())).To(Succeed())
 
-	fakeClock = testclock.NewFakeClock(time.Now())
 	By("Register controller")
+	fakeClock = testclock.NewFakeClock(time.Now())
+
 	Expect((&backupbucketcontroller.Reconciler{
 		Clock: fakeClock,
 		Config: config.BackupBucketControllerConfiguration{

--- a/test/integration/gardenlet/backupbucket/backupbucket_suite_test.go
+++ b/test/integration/gardenlet/backupbucket/backupbucket_suite_test.go
@@ -112,7 +112,7 @@ var _ = BeforeSuite(func() {
 	testRunID = testID + "-" + utils.ComputeSHA256Hex([]byte(uuid.NewUUID()))[:8]
 	log.Info("Using test run ID for test", "testRunID", testRunID)
 
-	By("Create project namespace")
+	By("Create test Namespace")
 	testNamespace = &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			// create dedicated namespace for each test run, so that we can run multiple tests concurrently for stress tests
@@ -120,7 +120,7 @@ var _ = BeforeSuite(func() {
 		},
 	}
 	Expect(testClient.Create(ctx, testNamespace)).To(Succeed())
-	log.Info("Created project Namespace for test", "namespaceName", testNamespace.Name)
+	log.Info("Created Namespace for test", "namespaceName", testNamespace.Name)
 
 	DeferCleanup(func() {
 		By("Delete project namespace")

--- a/test/integration/gardenlet/backupentry/backupentry/backupentry_suite_test.go
+++ b/test/integration/gardenlet/backupentry/backupentry/backupentry_suite_test.go
@@ -125,7 +125,7 @@ var _ = BeforeSuite(func() {
 		},
 	}
 	Expect(testClient.Create(ctx, testNamespace)).To(Succeed())
-	log.Info("Created test Namespace for test", "namespaceName", testNamespace.Name)
+	log.Info("Created Namespace for test", "namespaceName", testNamespace.Name)
 
 	DeferCleanup(func() {
 		By("Delete test Namespace")

--- a/test/integration/gardenlet/backupentry/backupentry/backupentry_suite_test.go
+++ b/test/integration/gardenlet/backupentry/backupentry/backupentry_suite_test.go
@@ -140,7 +140,7 @@ var _ = BeforeSuite(func() {
 		},
 	}
 
-	Expect(testClient.Create(ctx, gardenNamespace)).To(Or(Succeed()))
+	Expect(testClient.Create(ctx, gardenNamespace)).To(Succeed())
 	log.Info("Created namespace for test", "namespaceName", gardenNamespace)
 
 	DeferCleanup(func() {

--- a/test/integration/gardenlet/backupentry/backupentry/backupentry_suite_test.go
+++ b/test/integration/gardenlet/backupentry/backupentry/backupentry_suite_test.go
@@ -215,8 +215,9 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 	mgrClient = mgr.GetClient()
 
-	fakeClock = testclock.NewFakeClock(time.Now().Round(time.Second))
 	By("Register controller")
+	fakeClock = testclock.NewFakeClock(time.Now().Round(time.Second))
+
 	Expect((&backupentry.Reconciler{
 		Clock: fakeClock,
 		Config: config.BackupEntryControllerConfiguration{

--- a/test/integration/gardenlet/backupentry/migration/migration_suite_test.go
+++ b/test/integration/gardenlet/backupentry/migration/migration_suite_test.go
@@ -134,7 +134,7 @@ var _ = BeforeSuite(func() {
 		},
 	}
 
-	Expect(testClient.Create(ctx, gardenNamespace)).To(Or(Succeed(), BeAlreadyExistsError()))
+	Expect(testClient.Create(ctx, gardenNamespace)).To(Succeed())
 	log.Info("Created namespace for test", "namespaceName", gardenNamespace)
 
 	DeferCleanup(func() {

--- a/test/integration/gardenlet/backupentry/migration/migration_suite_test.go
+++ b/test/integration/gardenlet/backupentry/migration/migration_suite_test.go
@@ -111,7 +111,7 @@ var _ = BeforeSuite(func() {
 	testRunID = testID + "-" + utils.ComputeSHA256Hex([]byte(uuid.NewUUID()))[:8]
 	log.Info("Using test run ID for test", "testRunID", testRunID)
 
-	By("Create project namespace")
+	By("Create test Namespace")
 	testNamespace = &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			// create dedicated namespace for each test run, so that we can run multiple tests concurrently for stress tests
@@ -119,7 +119,7 @@ var _ = BeforeSuite(func() {
 		},
 	}
 	Expect(testClient.Create(ctx, testNamespace)).To(Succeed())
-	log.Info("Created test Namespace for test", "namespaceName", testNamespace.Name)
+	log.Info("Created Namespace for test", "namespaceName", testNamespace.Name)
 
 	DeferCleanup(func() {
 		By("Delete test Namespace")

--- a/test/integration/gardenlet/backupentry/migration/migration_suite_test.go
+++ b/test/integration/gardenlet/backupentry/migration/migration_suite_test.go
@@ -184,8 +184,9 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 	mgrClient = mgr.GetClient()
 
-	fakeClock = testclock.NewFakeClock(time.Now().Round(time.Second))
 	By("Register controller")
+	fakeClock = testclock.NewFakeClock(time.Now().Round(time.Second))
+
 	Expect((&migration.Reconciler{
 		Clock: fakeClock,
 		Config: config.BackupEntryMigrationControllerConfiguration{

--- a/test/integration/gardenlet/bastion/bastion_test.go
+++ b/test/integration/gardenlet/bastion/bastion_test.go
@@ -16,6 +16,7 @@ package bastion_test
 
 import (
 	"fmt"
+	"time"
 
 	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
@@ -75,6 +76,8 @@ var _ = Describe("Bastion controller tests", func() {
 	)
 
 	BeforeEach(func() {
+		fakeClock.SetTime(time.Now())
+
 		providerType := "foo-provider"
 
 		seed = &gardencorev1beta1.Seed{

--- a/test/integration/gardenlet/controllerinstallation/required/required_suite_test.go
+++ b/test/integration/gardenlet/controllerinstallation/required/required_suite_test.go
@@ -119,7 +119,7 @@ var _ = BeforeSuite(func() {
 			GenerateName: "garden-",
 		},
 	}
-	Expect(testClient.Create(ctx, testNamespace)).To(Or(Succeed(), BeAlreadyExistsError()))
+	Expect(testClient.Create(ctx, testNamespace)).To(Succeed())
 	log.Info("Created Namespace for test", "namespaceName", testNamespace.Name)
 	testRunID = testNamespace.Name
 

--- a/test/integration/gardenlet/seed/lease/lease_test.go
+++ b/test/integration/gardenlet/seed/lease/lease_test.go
@@ -37,6 +37,8 @@ var _ = Describe("Seed lease controller tests", func() {
 	var lease *coordinationv1.Lease
 
 	BeforeEach(func() {
+		fakeClock.SetTime(time.Now())
+
 		lease = &coordinationv1.Lease{ObjectMeta: metav1.ObjectMeta{Name: seed.Name, Namespace: testNamespace.Name}}
 	})
 

--- a/test/integration/gardenlet/shoot/migration/migration_suite_test.go
+++ b/test/integration/gardenlet/shoot/migration/migration_suite_test.go
@@ -109,7 +109,7 @@ var _ = BeforeSuite(func() {
 	testRunID = testID + "-" + utils.ComputeSHA256Hex([]byte(uuid.NewUUID()))[:8]
 	log.Info("Using test run ID for test", "testRunID", testRunID)
 
-	By("Create project namespace")
+	By("Create test Namespace")
 	testNamespace = &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			// create dedicated namespace for each test run, so that we can run multiple tests concurrently for stress tests
@@ -117,7 +117,7 @@ var _ = BeforeSuite(func() {
 		},
 	}
 	Expect(testClient.Create(ctx, testNamespace)).To(Succeed())
-	log.Info("Created test Namespace for test", "namespaceName", testNamespace.Name)
+	log.Info("Created Namespace for test", "namespaceName", testNamespace.Name)
 
 	DeferCleanup(func() {
 		By("Delete test Namespace")

--- a/test/integration/gardenlet/shoot/migration/migration_suite_test.go
+++ b/test/integration/gardenlet/shoot/migration/migration_suite_test.go
@@ -165,8 +165,9 @@ var _ = BeforeSuite(func() {
 	})
 	Expect(err).NotTo(HaveOccurred())
 
-	fakeClock = testclock.NewFakeClock(time.Now().Round(time.Second))
 	By("Register controller")
+	fakeClock = testclock.NewFakeClock(time.Now().Round(time.Second))
+
 	Expect((&migration.Reconciler{
 		Clock: fakeClock,
 		Config: config.ShootMigrationControllerConfiguration{

--- a/test/integration/gardenlet/shootstate/extensions/extensions_test.go
+++ b/test/integration/gardenlet/shootstate/extensions/extensions_test.go
@@ -46,7 +46,7 @@ var _ = Describe("ShootState Extensions controller tests", func() {
 				GenerateName: "garden-",
 			},
 		}
-		Expect(testClient.Create(ctx, testNamespace)).To(Or(Succeed(), BeAlreadyExistsError()))
+		Expect(testClient.Create(ctx, testNamespace)).To(Succeed())
 		log.Info("Created Namespace for test", "namespaceName", testNamespace.Name)
 
 		DeferCleanup(func() {

--- a/test/integration/gardenlet/shootstate/secret/secret_suite_test.go
+++ b/test/integration/gardenlet/shootstate/secret/secret_suite_test.go
@@ -104,7 +104,7 @@ var _ = BeforeSuite(func() {
 	testRunID = testID + "-" + utils.ComputeSHA256Hex([]byte(uuid.NewUUID()))[:8]
 	log.Info("Using test run ID for test", "testRunID", testRunID)
 
-	By("Create project namespace")
+	By("Create test Namespace")
 	testNamespace = &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			// create dedicated namespace for each test run, so that we can run multiple tests concurrently for stress tests
@@ -116,7 +116,7 @@ var _ = BeforeSuite(func() {
 		},
 	}
 	Expect(testClient.Create(ctx, testNamespace)).To(Succeed())
-	log.Info("Created project Namespace for test", "namespaceName", testNamespace.Name)
+	log.Info("Created Namespace for test", "namespaceName", testNamespace.Name)
 
 	DeferCleanup(func() {
 		By("Delete project namespace")

--- a/test/integration/resourcemanager/garbagecollector/garbagecollector_test.go
+++ b/test/integration/resourcemanager/garbagecollector/garbagecollector_test.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 
 	"github.com/gardener/gardener/pkg/utils"
+	"k8s.io/apimachinery/pkg/util/uuid"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -39,7 +40,7 @@ var _ = Describe("Garbage collector tests", func() {
 	)
 
 	BeforeEach(func() {
-		resourceName = "test-" + utils.ComputeSHA256Hex([]byte(CurrentSpecReport().LeafNodeLocation.String()))[:8]
+		resourceName = "test-" + utils.ComputeSHA256Hex([]byte(uuid.NewUUID()))[:8]
 		garbageCollectableObjects = make([]client.Object, 0, 14)
 
 		for i := 0; i < cap(garbageCollectableObjects)/2; i++ {

--- a/test/integration/resourcemanager/managedresource/resource_suite_test.go
+++ b/test/integration/resourcemanager/managedresource/resource_suite_test.go
@@ -117,9 +117,10 @@ var _ = BeforeSuite(func() {
 	})
 	Expect(err).NotTo(HaveOccurred())
 
-	fakeClock = testclock.NewFakeClock(time.Now())
 	By("Register controller")
+	fakeClock = testclock.NewFakeClock(time.Now())
 	filter = predicate.NewClassFilter(resourcemanagerv1alpha1.DefaultResourceClass)
+
 	Expect((&managedresource.Reconciler{
 		Config: config.ManagedResourceControllerConfig{
 			ConcurrentSyncs:     pointer.Int(5),

--- a/test/integration/resourcemanager/managedresource/resource_test.go
+++ b/test/integration/resourcemanager/managedresource/resource_test.go
@@ -27,6 +27,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/uuid"
 	testclock "k8s.io/utils/clock/testing"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -67,7 +68,7 @@ var _ = Describe("ManagedResource controller tests", func() {
 		// test all cases in a clean environment to make sure we don't have any unintended dependencies between test code.
 		// We could also use GenerateName for this purpose, but then we would need an extra call to update the name of the
 		// marshalled ConfigMap in the already created Secret.
-		resourceName = "test-" + utils.ComputeSHA256Hex([]byte(CurrentSpecReport().LeafNodeLocation.String()))[:8]
+		resourceName = "test-" + utils.ComputeSHA256Hex([]byte(uuid.NewUUID()))[:8]
 		objectKey = client.ObjectKey{Namespace: testNamespace.Name, Name: resourceName}
 
 		configMap = &corev1.ConfigMap{

--- a/test/integration/resourcemanager/managedresource/resource_test.go
+++ b/test/integration/resourcemanager/managedresource/resource_test.go
@@ -28,7 +28,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/uuid"
-	testclock "k8s.io/utils/clock/testing"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -49,8 +48,6 @@ var _ = Describe("ManagedResource controller tests", func() {
 	)
 
 	var (
-		fakeClock *testclock.FakeClock
-
 		// resourceName is used as a base name for all resources in the current test case
 		resourceName string
 		objectKey    client.ObjectKey
@@ -102,7 +99,7 @@ var _ = Describe("ManagedResource controller tests", func() {
 			},
 		}
 
-		fakeClock = testclock.NewFakeClock(time.Now())
+		fakeClock.SetTime(time.Now())
 	})
 
 	JustBeforeEach(func() {

--- a/test/integration/resourcemanager/tokeninvalidator/tokeninvalidator_test.go
+++ b/test/integration/resourcemanager/tokeninvalidator/tokeninvalidator_test.go
@@ -26,6 +26,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -53,7 +54,7 @@ var _ = Describe("TokenInvalidator tests", func() {
 	)
 
 	BeforeEach(func() {
-		resourceName = "test-" + utils.ComputeSHA256Hex([]byte(CurrentSpecReport().LeafNodeLocation.String()))[:8]
+		resourceName = "test-" + utils.ComputeSHA256Hex([]byte(uuid.NewUUID()))[:8]
 
 		serviceAccount = &corev1.ServiceAccount{
 			ObjectMeta: metav1.ObjectMeta{

--- a/test/integration/resourcemanager/tokenrequestor/tokenrequestor_test.go
+++ b/test/integration/resourcemanager/tokenrequestor/tokenrequestor_test.go
@@ -20,6 +20,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/client-go/rest"
 	clientcmdlatest "k8s.io/client-go/tools/clientcmd/api/latest"
 	clientcmdv1 "k8s.io/client-go/tools/clientcmd/api/v1"
@@ -39,7 +40,7 @@ var _ = Describe("TokenRequestor tests", func() {
 	)
 
 	BeforeEach(func() {
-		resourceName = "test-" + utils.ComputeSHA256Hex([]byte(CurrentSpecReport().LeafNodeLocation.String()))[:8]
+		resourceName = "test-" + utils.ComputeSHA256Hex([]byte(uuid.NewUUID()))[:8]
 
 		secret = &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind cleanup

**What this PR does / why we need it**:
Few streamlining in integration tests:
1. Don't tolerate already existing resources. 
From https://github.com/gardener/gardener/blob/master/docs/development/testing.md#writing-integration-tests,
> don't tolerate already existing resources (~dirty test environment), code smell: ignoring already exist errors

2. Streamline logs for test Namespace in tests, sometimes we use project namespace, sometimes we use test namespace etc.

3. Use a checksum of a random UUID for unique resource names

4. Reset fakeClock time in BeforeEach()

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
5. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
