### PR TITLE
Creating new K8SNodeNotReady alert

### DIFF
--- a/charts/seed-bootstrap/aggregate-prometheus-rules/nodes.rules.yaml
+++ b/charts/seed-bootstrap/aggregate-prometheus-rules/nodes.rules.yaml
@@ -1,0 +1,14 @@
+groups:
+- name: node.rules
+  rules:
+  - alert: K8SNodeNotReady
+    expr: ALERTS{alertname="K8SNodeNotReady", alertstate="firing"} > 0
+    labels:
+      severity: warning
+      service: logging
+      type: seed
+      visibility: operator
+    annotations:
+      summary: Node is in not in a ready state
+      description: One or many node have not been ready for more than 10 minutes 
+      

--- a/charts/seed-bootstrap/aggregate-prometheus-rules/nodes.rules.yaml
+++ b/charts/seed-bootstrap/aggregate-prometheus-rules/nodes.rules.yaml
@@ -9,6 +9,5 @@ groups:
       type: seed
       visibility: operator
     annotations:
-      summary: Node is in not in a ready state
-      description: One or many node have not been ready for more than 10 minutes 
-      
+      summary: Nodes that are in the NotReady state
+      description: One or many nodes have not been ready for more than 10 minutes 

--- a/charts/seed-monitoring/charts/core/charts/prometheus/rules/node-exporter.rules.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/rules/node-exporter.rules.yaml
@@ -61,8 +61,8 @@ groups:
       type: shoot
       visibility: owner
     annotations:
-      summary: Node is in not in a ready state
-      description: One or many node have not been ready for more than 10 minutes 
+      summary: Nodes that are in the NotReady state
+      description: One or many nodes have not been ready for more than 10 minutes 
 
   # alert if the root filesystem is full
   - alert: VMRootfsFull

--- a/charts/seed-monitoring/charts/core/charts/prometheus/rules/node-exporter.rules.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/rules/node-exporter.rules.yaml
@@ -52,6 +52,18 @@ groups:
   - record: instance:conntrack_entries_usage:percent
     expr: (node_nf_conntrack_entries / node_nf_conntrack_entries_limit) * 100
 
+  - alert: K8SNodeNotReady
+    expr: sum(kube_node_status_condition{condition="Ready",status!="true"}) > 0
+    for: 10m
+    labels:
+      service: node-exporter
+      severity: critical
+      type: shoot
+      visibility: owner
+    annotations:
+      summary: Node is in not in a ready state
+      description: One or many node have not been ready for more than 10 minutes 
+
   # alert if the root filesystem is full
   - alert: VMRootfsFull
     expr: node_filesystem_free{mountpoint="/"} < 1024

--- a/docs/monitoring/user_alerts.md
+++ b/docs/monitoring/user_alerts.md
@@ -11,6 +11,7 @@
 |K8SNodeOutOfDisk|critical|shoot|`Node {{ $labels.node }} has run out of disk space.`|
 |K8SNodeMemoryPressure|warning|shoot|`Node {{ $labels.node }} is under memory pressure.`|
 |K8SNodeDiskPressure|warning|shoot|`Node {{ $labels.node }} is under disk pressure`|
+|K8SNodeNotReady|critical|shoot|`One or many node have not been ready for more than 10 minutes`|
 |VMRootfsFull|critical|shoot|`Root filesystem device on instance {{ $labels.instance }} is almost full.`|
 |VMConntrackTableFull|critical|shoot|`The nf_conntrack table is {{ $value }}% full.`|
 |VPNProbeAPIServerProxyFailed|critical|shoot|`The API Server proxy functionality is not working. Probably the vpn connection from an API Server pod to the vpn-shoot endpoint on the Shoot workers does not work.`|


### PR DESCRIPTION
**How to categorize this PR?**
/area monitoring
/kind enhancement

**What this PR does / why we need it**:
Add new alert to monitor node that are not ready for a period that is over 10 minutes 


We are trying to count how often nodes emit `NotReady` events leading to getting replaced. This should give us a hint whether there is a problem with our nodes which we would normally not spot as node becoming `NotReady` are usually self-healed.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```other operator
Add new alert to monitor node that are not ready 
```
