### PR TITLE
Use metadata-only GET when reading secrets in `botanist.DeleteOldServiceAccountSecrets`.

### DIFF
--- a/pkg/operation/botanist/secrets.go
+++ b/pkg/operation/botanist/secrets.go
@@ -542,14 +542,15 @@ func (b *Botanist) DeleteOldServiceAccountSecrets(ctx context.Context) error {
 			// the list have been created before the credentials rotation completion has been triggered. We only delete
 			// those and keep the rest of the list untouched to not interfere with the user's operations.
 			for _, secretReference := range serviceAccount.Secrets {
-				secret := &corev1.Secret{}
-				if err := b.ShootClientSet.Client().Get(ctx, client.ObjectKey{Name: secretReference.Name, Namespace: serviceAccount.Namespace}, secret); err != nil {
+				secretMeta := &metav1.PartialObjectMetadata{}
+				secretMeta.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("Secret"))
+				if err := b.ShootClientSet.Client().Get(ctx, client.ObjectKey{Name: secretReference.Name, Namespace: serviceAccount.Namespace}, secretMeta); err != nil {
 					if !apierrors.IsNotFound(err) {
 						return err
 					}
 					// We don't care about secrets in the list which do not exist actually - it is the responsibility of the user to clean this up.
-				} else if secret.CreationTimestamp.UTC().Before(b.Shoot.GetInfo().Status.Credentials.Rotation.ServiceAccountKey.LastInitiationFinishedTime.Time.UTC()) {
-					secretsToDelete = append(secretsToDelete, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: secret.Name, Namespace: secret.Namespace}})
+				} else if secretMeta.CreationTimestamp.UTC().Before(b.Shoot.GetInfo().Status.Credentials.Rotation.ServiceAccountKey.LastInitiationFinishedTime.Time.UTC()) {
+					secretsToDelete = append(secretsToDelete, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: secretMeta.Name, Namespace: secretMeta.Namespace}})
 					continue
 				}
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area scalability
/kind enhancement

**What this PR does / why we need it**:
Use metadata-only GET when reading secrets in `botanist.DeleteOldServiceAccountSecrets`.

**Which issue(s) this PR fixes**:
https://github.com/gardener/gardener/pull/7313#discussion_r1070936229

**Special notes for your reviewer**:
Follow-up of https://github.com/gardener/gardener/pull/7313

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
