### PR TITLE
Add `VERSION` file in skaffold dependencies of gardener component

### DIFF
--- a/hack/check-skaffold-deps.sh
+++ b/hack/check-skaffold-deps.sh
@@ -47,8 +47,9 @@ function check() {
     sort |\
     uniq > "$path_actual_dependencies"
 
-  # always add vendor directory
+  # always add vendor directory and VERSION file
   echo "vendor" >> "$path_actual_dependencies"
+  echo -e "VERSION\n$(cat $path_actual_dependencies)" > $path_actual_dependencies
 
   echo -n ">> Checking defined dependencies in Skaffold config '$skaffold_config_name' for '$binary_name' in '$skaffold_file'..."
   if ! diff="$(diff "$path_current_skaffold_dependencies" "$path_actual_dependencies")"; then

--- a/hack/check-skaffold-deps.sh
+++ b/hack/check-skaffold-deps.sh
@@ -49,7 +49,11 @@ function check() {
 
   # always add vendor directory and VERSION file
   echo "vendor" >> "$path_actual_dependencies"
-  echo -e "VERSION\n$(cat $path_actual_dependencies)" > $path_actual_dependencies
+  echo "VERSION" >> "$path_actual_dependencies"
+
+  # sort dependencies
+  sort -o $path_current_skaffold_dependencies{,}
+  sort -o $path_actual_dependencies{,}
 
   echo -n ">> Checking defined dependencies in Skaffold config '$skaffold_config_name' for '$binary_name' in '$skaffold_file'..."
   if ! diff="$(diff "$path_current_skaffold_dependencies" "$path_actual_dependencies")"; then

--- a/skaffold-operator.yaml
+++ b/skaffold-operator.yaml
@@ -123,6 +123,7 @@ build:
         - pkg/utils/validation/features
         - pkg/utils/version
         - vendor
+        - VERSION
   - image: eu.gcr.io/gardener-project/gardener/resource-manager
     ko:
       main: ./cmd/gardener-resource-manager
@@ -221,6 +222,7 @@ build:
         - pkg/utils/validation/features
         - pkg/utils/version
         - vendor
+        - VERSION
 deploy:
   helm:
     releases:

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -207,6 +207,7 @@ build:
         - plugin/pkg/shoot/vpa
         - plugin/pkg/utils
         - vendor
+        - VERSION
   - image: eu.gcr.io/gardener-project/gardener/controller-manager
     ko:
       main: ./cmd/gardener-controller-manager
@@ -381,6 +382,7 @@ build:
         - pkg/utils/validation/features
         - pkg/utils/version
         - vendor
+        - VERSION
   - image: eu.gcr.io/gardener-project/gardener/scheduler
     ko:
       main: ./cmd/gardener-scheduler
@@ -449,6 +451,7 @@ build:
         - pkg/utils/validation/cidr
         - pkg/utils/version
         - vendor
+        - VERSION
   - image: eu.gcr.io/gardener-project/gardener/admission-controller
     ko:
       main: ./cmd/gardener-admission-controller
@@ -524,6 +527,7 @@ build:
         - third_party/apiserver/pkg/apis/audit/v1alpha1
         - third_party/apiserver/pkg/apis/audit/v1beta1
         - vendor
+        - VERSION
 deploy:
   helm:
     releases:
@@ -728,6 +732,7 @@ build:
         - pkg/utils/timewindow
         - pkg/utils/version
         - vendor
+        - VERSION
 deploy:
   helm:
     flags:
@@ -1016,6 +1021,7 @@ build:
         - pkg/utils/validation/features
         - pkg/utils/version
         - vendor
+        - VERSION
   - image: eu.gcr.io/gardener-project/gardener/resource-manager
     ko:
       main: ./cmd/gardener-resource-manager
@@ -1114,6 +1120,7 @@ build:
         - pkg/utils/validation/features
         - pkg/utils/version
         - vendor
+        - VERSION
 deploy:
   helm:
     hooks:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind bug

**What this PR does / why we need it**:
This PR adds `VERSION` file in skaffold dependencies of gardener component. This is required so in provider-local image tags are populated properly

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener/issues/7116

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
