### PR TITLE
[release-v1.62] Improve reconciliation of extension `BackupBucket` and `BackupEntry`

### DIFF
--- a/pkg/gardenlet/controller/backupbucket/reconciler_test.go
+++ b/pkg/gardenlet/controller/backupbucket/reconciler_test.go
@@ -1,0 +1,253 @@
+// Copyright (c) 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package backupbucket_test
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	testclock "k8s.io/utils/clock/testing"
+	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	"github.com/gardener/gardener/pkg/gardenlet/apis/config"
+	. "github.com/gardener/gardener/pkg/gardenlet/controller/backupbucket"
+)
+
+const (
+	seedName            = "seed"
+	gardenNamespaceName = "garden"
+)
+
+var _ = Describe("Reconciler", func() {
+	var (
+		ctx          = context.TODO()
+		gardenClient client.Client
+		seedClient   client.Client
+		reconciler   reconcile.Reconciler
+
+		fakeClock *testclock.FakeClock
+
+		gardenSecret          *corev1.Secret
+		backupBucket          *gardencorev1beta1.BackupBucket
+		extensionBackupBucket *extensionsv1alpha1.BackupBucket
+		extensionSecret       *corev1.Secret
+		providerConfig        = &runtime.RawExtension{Raw: []byte(`{"dash":"baz"}`)}
+		providerStatus        = &runtime.RawExtension{Raw: []byte(`{"foo":"bar"}`)}
+
+		request reconcile.Request
+	)
+
+	BeforeEach(func() {
+		gardenClient = fakeclient.NewClientBuilder().WithScheme(kubernetes.GardenScheme).Build()
+
+		testScheme := kubernetes.SeedScheme
+		Expect(extensionsv1alpha1.AddToScheme(testScheme)).To(Succeed())
+		seedClient = fakeclient.NewClientBuilder().WithScheme(testScheme).Build()
+
+		fakeClock = testclock.NewFakeClock(time.Now())
+
+		reconciler = &Reconciler{
+			GardenClient: gardenClient,
+			SeedClient:   seedClient,
+			Recorder:     &record.FakeRecorder{},
+			Config: config.BackupBucketControllerConfiguration{
+				ConcurrentSyncs: pointer.Int(5),
+			},
+			Clock:           fakeClock,
+			GardenNamespace: gardenNamespaceName,
+			SeedName:        seedName,
+		}
+
+		gardenSecret = &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-secret",
+				Namespace: gardenNamespaceName,
+			},
+			Data: map[string][]byte{
+				"foo": []byte("bar"),
+			},
+		}
+		Expect(gardenClient.Create(ctx, gardenSecret)).To(Succeed())
+
+		backupBucket = &gardencorev1beta1.BackupBucket{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       "foo",
+				Generation: 1,
+			},
+			Spec: gardencorev1beta1.BackupBucketSpec{
+				Provider: gardencorev1beta1.BackupBucketProvider{
+					Type:   "provider-type",
+					Region: "some-region",
+				},
+				ProviderConfig: providerConfig,
+				SecretRef: corev1.SecretReference{
+					Name:      gardenSecret.Name,
+					Namespace: gardenSecret.Namespace,
+				},
+				SeedName: pointer.String(seedName),
+			},
+			Status: gardencorev1beta1.BackupBucketStatus{
+				ObservedGeneration: 1,
+				LastOperation: &gardencorev1beta1.LastOperation{
+					State: gardencorev1beta1.LastOperationStateSucceeded,
+					Type:  gardencorev1beta1.LastOperationTypeReconcile,
+				},
+				ProviderStatus: providerStatus,
+			},
+		}
+		Expect(gardenClient.Create(ctx, backupBucket)).To(Succeed())
+
+		extensionSecret = &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      generateBackupBucketSecretName(backupBucket.Name),
+				Namespace: gardenNamespaceName,
+				Annotations: map[string]string{
+					v1beta1constants.GardenerTimestamp: fakeClock.Now().UTC().Format(time.RFC3339),
+				},
+			},
+			Data: gardenSecret.Data,
+		}
+
+		extensionBackupBucket = &extensionsv1alpha1.BackupBucket{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: backupBucket.Name,
+			},
+			Spec: extensionsv1alpha1.BackupBucketSpec{
+				DefaultSpec: extensionsv1alpha1.DefaultSpec{
+					Type:           backupBucket.Spec.Provider.Type,
+					ProviderConfig: backupBucket.Spec.ProviderConfig,
+				},
+				Region: backupBucket.Spec.Provider.Region,
+				SecretRef: corev1.SecretReference{
+					Name:      extensionSecret.Name,
+					Namespace: extensionSecret.Namespace,
+				},
+			},
+			Status: extensionsv1alpha1.BackupBucketStatus{
+				DefaultStatus: extensionsv1alpha1.DefaultStatus{
+					LastOperation: &gardencorev1beta1.LastOperation{
+						State:          gardencorev1beta1.LastOperationStateSucceeded,
+						LastUpdateTime: metav1.NewTime(fakeClock.Now().UTC()),
+					},
+				},
+			},
+		}
+
+		request = reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Name:      backupBucket.Name,
+				Namespace: backupBucket.Namespace,
+			},
+		}
+	})
+
+	It("should create the extension secret and extension BackupBucket if it doesn't exist yet", func() {
+		result, err := reconciler.Reconcile(ctx, request)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(Equal(reconcile.Result{}))
+
+		Expect(seedClient.Get(ctx, client.ObjectKeyFromObject(extensionSecret), extensionSecret)).To(Succeed())
+		Expect(extensionSecret.Data).To(Equal(gardenSecret.Data))
+
+		Expect(seedClient.Get(ctx, client.ObjectKeyFromObject(extensionBackupBucket), extensionBackupBucket)).To(Succeed())
+		Expect(extensionBackupBucket.Spec).To(Equal(extensionsv1alpha1.BackupBucketSpec{
+			DefaultSpec: extensionsv1alpha1.DefaultSpec{
+				Type:           backupBucket.Spec.Provider.Type,
+				ProviderConfig: backupBucket.Spec.ProviderConfig,
+			},
+			Region: backupBucket.Spec.Provider.Region,
+			SecretRef: corev1.SecretReference{
+				Name:      extensionSecret.Name,
+				Namespace: extensionSecret.Namespace,
+			},
+		}))
+	})
+
+	It("should not reconcile the extension BackupBucket if the secret data or extension spec hasn't changed", func() {
+		Expect(seedClient.Create(ctx, extensionSecret)).To(Succeed())
+		Expect(seedClient.Create(ctx, extensionBackupBucket)).To(Succeed())
+
+		result, err := reconciler.Reconcile(ctx, request)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(Equal(reconcile.Result{}))
+
+		Expect(seedClient.Get(ctx, client.ObjectKeyFromObject(extensionBackupBucket), extensionBackupBucket)).To(Succeed())
+		Expect(extensionBackupBucket.Annotations).NotTo(HaveKey(v1beta1constants.GardenerOperation))
+	})
+
+	It("should reconcile the extension secret and extension BackupBucket if the secret currently doesn't have a timestamp", func() {
+		extensionSecret.Annotations = nil
+		Expect(seedClient.Create(ctx, extensionSecret)).To(Succeed())
+		Expect(seedClient.Create(ctx, extensionBackupBucket)).To(Succeed())
+
+		// step the clock so that the updated timestamp of the secret is greater than the extensionSecret lastUpdate time.
+		fakeClock.Step(time.Minute)
+
+		result, err := reconciler.Reconcile(ctx, request)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(Equal(reconcile.Result{}))
+
+		Expect(seedClient.Get(ctx, client.ObjectKeyFromObject(extensionSecret), extensionSecret)).To(Succeed())
+		Expect(extensionSecret.Annotations).To(HaveKeyWithValue(v1beta1constants.GardenerTimestamp, fakeClock.Now().UTC().Format(time.RFC3339)))
+		Expect(seedClient.Get(ctx, client.ObjectKeyFromObject(extensionBackupBucket), extensionBackupBucket)).To(Succeed())
+		Expect(extensionBackupBucket.Annotations).To(HaveKey(v1beta1constants.GardenerOperation))
+	})
+
+	It("should reconcile the extension BackupBucket if the secret data has changed", func() {
+		extensionSecret.Data = map[string][]byte{"dash": []byte("bash")}
+		Expect(seedClient.Create(ctx, extensionSecret)).To(Succeed())
+		Expect(seedClient.Create(ctx, extensionBackupBucket)).To(Succeed())
+
+		result, err := reconciler.Reconcile(ctx, request)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(Equal(reconcile.Result{}))
+
+		Expect(seedClient.Get(ctx, client.ObjectKeyFromObject(extensionBackupBucket), extensionBackupBucket)).To(Succeed())
+		Expect(extensionBackupBucket.Annotations).To(HaveKeyWithValue(v1beta1constants.GardenerOperation, v1beta1constants.GardenerOperationReconcile))
+	})
+
+	It("should reconcile the extension BackupBucket if the secret update timestamp is after the extension last update time", func() {
+		time := fakeClock.Now().Add(time.Second).UTC().Format(time.RFC3339)
+		metav1.SetMetaDataAnnotation(&extensionSecret.ObjectMeta, v1beta1constants.GardenerTimestamp, time)
+		Expect(seedClient.Create(ctx, extensionSecret)).To(Succeed())
+		Expect(seedClient.Create(ctx, extensionBackupBucket)).To(Succeed())
+
+		result, err := reconciler.Reconcile(ctx, request)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(Equal(reconcile.Result{}))
+
+		Expect(seedClient.Get(ctx, client.ObjectKeyFromObject(extensionBackupBucket), extensionBackupBucket)).To(Succeed())
+		Expect(extensionBackupBucket.Annotations).To(HaveKeyWithValue(v1beta1constants.GardenerOperation, v1beta1constants.GardenerOperationReconcile))
+	})
+})
+
+func generateBackupBucketSecretName(backupBucketName string) string {
+	return fmt.Sprintf("bucket-%s", backupBucketName)
+}

--- a/pkg/gardenlet/controller/backupentry/backupentry/reconciler_test.go
+++ b/pkg/gardenlet/controller/backupentry/backupentry/reconciler_test.go
@@ -1,0 +1,271 @@
+// Copyright (c) 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package backupentry_test
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	testclock "k8s.io/utils/clock/testing"
+	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	gardencore "github.com/gardener/gardener/pkg/apis/core"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	"github.com/gardener/gardener/pkg/gardenlet/apis/config"
+	. "github.com/gardener/gardener/pkg/gardenlet/controller/backupentry/backupentry"
+)
+
+const (
+	seedName            = "seed"
+	gardenNamespaceName = "garden"
+	testNamespaceName   = "test"
+)
+
+var _ = Describe("Reconciler", func() {
+	var (
+		ctx          = context.TODO()
+		gardenClient client.Client
+		seedClient   client.Client
+		reconciler   reconcile.Reconciler
+
+		fakeClock                *testclock.FakeClock
+		deletionGracePeriodHours = 24
+
+		gardenSecret         *corev1.Secret
+		backupBucket         *gardencorev1beta1.BackupBucket
+		backupEntry          *gardencorev1beta1.BackupEntry
+		extensionBackupEntry *extensionsv1alpha1.BackupEntry
+		extensionSecret      *corev1.Secret
+		providerConfig       = &runtime.RawExtension{Raw: []byte(`{"dash":"baz"}`)}
+		providerStatus       = &runtime.RawExtension{Raw: []byte(`{"foo":"bar"}`)}
+
+		request reconcile.Request
+	)
+
+	BeforeEach(func() {
+		gardenClient = fakeclient.NewClientBuilder().WithScheme(kubernetes.GardenScheme).Build()
+
+		testScheme := kubernetes.SeedScheme
+		Expect(extensionsv1alpha1.AddToScheme(testScheme)).To(Succeed())
+		seedClient = fakeclient.NewClientBuilder().WithScheme(testScheme).Build()
+
+		fakeClock = testclock.NewFakeClock(time.Now())
+
+		reconciler = &Reconciler{
+			GardenClient: gardenClient,
+			SeedClient:   seedClient,
+			Recorder:     &record.FakeRecorder{},
+			Config: config.BackupEntryControllerConfiguration{
+				ConcurrentSyncs:                  pointer.Int(5),
+				DeletionGracePeriodHours:         pointer.Int(deletionGracePeriodHours),
+				DeletionGracePeriodShootPurposes: []gardencore.ShootPurpose{gardencore.ShootPurposeProduction},
+			},
+			Clock:           fakeClock,
+			GardenNamespace: gardenNamespaceName,
+			SeedName:        seedName,
+		}
+
+		gardenSecret = &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-secret",
+				Namespace: gardenNamespaceName,
+			},
+			Data: map[string][]byte{
+				"foo": []byte("bar"),
+			},
+		}
+		Expect(gardenClient.Create(ctx, gardenSecret)).To(Succeed())
+
+		backupBucket = &gardencorev1beta1.BackupBucket{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       "foo",
+				Generation: 1,
+			},
+			Spec: gardencorev1beta1.BackupBucketSpec{
+				Provider: gardencorev1beta1.BackupBucketProvider{
+					Type:   "provider-type",
+					Region: "some-region",
+				},
+				ProviderConfig: providerConfig,
+				SecretRef: corev1.SecretReference{
+					Name:      gardenSecret.Name,
+					Namespace: gardenSecret.Namespace,
+				},
+				SeedName: pointer.String(seedName),
+			},
+			Status: gardencorev1beta1.BackupBucketStatus{
+				ObservedGeneration: 1,
+				LastOperation: &gardencorev1beta1.LastOperation{
+					State: gardencorev1beta1.LastOperationStateSucceeded,
+					Type:  gardencorev1beta1.LastOperationTypeReconcile,
+				},
+				ProviderStatus: providerStatus,
+			},
+		}
+		Expect(gardenClient.Create(ctx, backupBucket)).To(Succeed())
+
+		backupEntry = &gardencorev1beta1.BackupEntry{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "bar",
+				Namespace: testNamespaceName,
+			},
+			Spec: gardencorev1beta1.BackupEntrySpec{
+				BucketName: backupBucket.Name,
+				SeedName:   pointer.String(seedName),
+			},
+		}
+
+		Expect(gardenClient.Create(ctx, backupEntry)).To(Succeed())
+
+		extensionSecret = &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "entry-" + backupEntry.Name,
+				Namespace: gardenNamespaceName,
+				Annotations: map[string]string{
+					v1beta1constants.GardenerTimestamp: fakeClock.Now().UTC().Format(time.RFC3339),
+				},
+			},
+			Data: gardenSecret.Data,
+		}
+
+		extensionBackupEntry = &extensionsv1alpha1.BackupEntry{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: backupEntry.Name,
+			},
+			Spec: extensionsv1alpha1.BackupEntrySpec{
+				DefaultSpec: extensionsv1alpha1.DefaultSpec{
+					Type:           backupBucket.Spec.Provider.Type,
+					ProviderConfig: backupBucket.Spec.ProviderConfig,
+				},
+				Region: backupBucket.Spec.Provider.Region,
+				SecretRef: corev1.SecretReference{
+					Name:      extensionSecret.Name,
+					Namespace: extensionSecret.Namespace,
+				},
+				BucketName:                 backupEntry.Spec.BucketName,
+				BackupBucketProviderStatus: backupBucket.Status.ProviderStatus,
+			},
+			Status: extensionsv1alpha1.BackupEntryStatus{
+				DefaultStatus: extensionsv1alpha1.DefaultStatus{
+					LastOperation: &gardencorev1beta1.LastOperation{
+						State:          gardencorev1beta1.LastOperationStateSucceeded,
+						LastUpdateTime: metav1.NewTime(fakeClock.Now().UTC()),
+					},
+				},
+			},
+		}
+
+		request = reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Name:      backupEntry.Name,
+				Namespace: backupEntry.Namespace,
+			},
+		}
+	})
+
+	It("should create the extension secret and extension BackupEntry if it doesn't exist yet", func() {
+		result, err := reconciler.Reconcile(ctx, request)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(Equal(reconcile.Result{}))
+
+		Expect(seedClient.Get(ctx, client.ObjectKeyFromObject(extensionSecret), extensionSecret)).To(Succeed())
+		Expect(extensionSecret.Data).To(Equal(gardenSecret.Data))
+
+		Expect(seedClient.Get(ctx, client.ObjectKeyFromObject(extensionBackupEntry), extensionBackupEntry)).To(Succeed())
+		Expect(extensionBackupEntry.Spec).To(MatchFields(IgnoreExtras, Fields{
+			"DefaultSpec": MatchFields(IgnoreExtras, Fields{
+				"Type":           Equal(backupBucket.Spec.Provider.Type),
+				"ProviderConfig": Equal(backupBucket.Spec.ProviderConfig),
+			}),
+			"Region":                     Equal(backupBucket.Spec.Provider.Region),
+			"BackupBucketProviderStatus": Equal(backupBucket.Status.ProviderStatus),
+			"SecretRef": MatchFields(IgnoreExtras, Fields{
+				"Name":      Equal(extensionSecret.Name),
+				"Namespace": Equal(extensionSecret.Namespace),
+			}),
+		}))
+	})
+
+	It("should not reconcile the extension BackupEntry if the secret data or extension spec hasn't changed", func() {
+		Expect(seedClient.Create(ctx, extensionSecret)).To(Succeed())
+		Expect(seedClient.Create(ctx, extensionBackupEntry)).To(Succeed())
+
+		result, err := reconciler.Reconcile(ctx, request)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(Equal(reconcile.Result{}))
+
+		Expect(seedClient.Get(ctx, client.ObjectKeyFromObject(extensionBackupEntry), extensionBackupEntry)).To(Succeed())
+		Expect(extensionBackupEntry.Annotations).NotTo(HaveKey(v1beta1constants.GardenerOperation))
+	})
+
+	It("should reconcile the extension secret and extension BackupEntry if the secret currently doesn't have a timestamp", func() {
+		extensionSecret.Annotations = nil
+		Expect(seedClient.Create(ctx, extensionSecret)).To(Succeed())
+		Expect(seedClient.Create(ctx, extensionBackupEntry)).To(Succeed())
+
+		// step the clock so that the updated timestamp of the secret is greater than the extensionSecret lastUpdate time.
+		fakeClock.Step(time.Minute)
+
+		result, err := reconciler.Reconcile(ctx, request)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(Equal(reconcile.Result{}))
+
+		Expect(seedClient.Get(ctx, client.ObjectKeyFromObject(extensionSecret), extensionSecret)).To(Succeed())
+		Expect(extensionSecret.Annotations).To(HaveKeyWithValue(v1beta1constants.GardenerTimestamp, fakeClock.Now().UTC().Format(time.RFC3339)))
+		Expect(seedClient.Get(ctx, client.ObjectKeyFromObject(extensionBackupEntry), extensionBackupEntry)).To(Succeed())
+		Expect(extensionBackupEntry.Annotations).To(HaveKey(v1beta1constants.GardenerOperation))
+	})
+
+	It("should reconcile the extension BackupEntry if the secret data has changed", func() {
+		extensionSecret.Data = map[string][]byte{"dash": []byte("bash")}
+		Expect(seedClient.Create(ctx, extensionSecret)).To(Succeed())
+		Expect(seedClient.Create(ctx, extensionBackupEntry)).To(Succeed())
+
+		result, err := reconciler.Reconcile(ctx, request)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(Equal(reconcile.Result{}))
+
+		Expect(seedClient.Get(ctx, client.ObjectKeyFromObject(extensionBackupEntry), extensionBackupEntry)).To(Succeed())
+		Expect(extensionBackupEntry.Annotations).To(HaveKeyWithValue(v1beta1constants.GardenerOperation, v1beta1constants.GardenerOperationReconcile))
+	})
+
+	It("should reconcile the extension BackupEntry if the secret update timestamp is after the extension last update time", func() {
+		time := fakeClock.Now().Add(time.Second).UTC().Format(time.RFC3339)
+		metav1.SetMetaDataAnnotation(&extensionSecret.ObjectMeta, v1beta1constants.GardenerTimestamp, time)
+		Expect(seedClient.Create(ctx, extensionSecret)).To(Succeed())
+		Expect(seedClient.Create(ctx, extensionBackupEntry)).To(Succeed())
+
+		result, err := reconciler.Reconcile(ctx, request)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(Equal(reconcile.Result{}))
+
+		Expect(seedClient.Get(ctx, client.ObjectKeyFromObject(extensionBackupEntry), extensionBackupEntry)).To(Succeed())
+		Expect(extensionBackupEntry.Annotations).To(HaveKeyWithValue(v1beta1constants.GardenerOperation, v1beta1constants.GardenerOperationReconcile))
+	})
+})

--- a/pkg/gardenlet/controller/bastion/reconciler.go
+++ b/pkg/gardenlet/controller/bastion/reconciler.go
@@ -105,7 +105,6 @@ func (r *Reconciler) reconcileBastion(
 	bastion *operationsv1alpha1.Bastion,
 	shoot *gardencorev1beta1.Shoot,
 ) error {
-	// ensure finalizer is set
 	if !controllerutil.ContainsFinalizer(bastion, finalizerName) {
 		log.Info("Adding finalizer")
 		if err := controllerutils.AddFinalizers(ctx, r.GardenClient, bastion, finalizerName); err != nil {
@@ -113,59 +112,56 @@ func (r *Reconciler) reconcileBastion(
 		}
 	}
 
-	// prepare extension resource
-	extBastion := newBastionExtension(bastion, shoot)
-	extensionsIngress := make([]extensionsv1alpha1.BastionIngressPolicy, len(bastion.Spec.Ingress))
+	extensionBastion := newBastionExtension(bastion, shoot)
+	extensionIngress := make([]extensionsv1alpha1.BastionIngressPolicy, len(bastion.Spec.Ingress))
 	for i, ingress := range bastion.Spec.Ingress {
-		extensionsIngress[i] = extensionsv1alpha1.BastionIngressPolicy{
+		extensionIngress[i] = extensionsv1alpha1.BastionIngressPolicy{
 			IPBlock: ingress.IPBlock,
 		}
 	}
 
 	var (
 		mustReconcileExtensionBastion = false
-		reconciliationSuccessful      = true
 		lastObservedError             error
 		extensionBastionSpec          = extensionsv1alpha1.BastionSpec{
 			DefaultSpec: extensionsv1alpha1.DefaultSpec{
 				Type: *bastion.Spec.ProviderType,
 			},
 			UserData: createUserData(bastion),
-			Ingress:  extensionsIngress,
+			Ingress:  extensionIngress,
 		}
 	)
 
-	if err := r.SeedClient.Get(ctx, client.ObjectKeyFromObject(extBastion), extBastion); err != nil {
+	if err := r.SeedClient.Get(ctx, client.ObjectKeyFromObject(extensionBastion), extensionBastion); err != nil {
 		if !apierrors.IsNotFound(err) {
 			return err
 		}
 		// if the extension Bastion doesn't exist yet, create it
 		mustReconcileExtensionBastion = true
-	} else if !reflect.DeepEqual(extBastion.Spec, extensionBastionSpec) {
+	} else if !reflect.DeepEqual(extensionBastion.Spec, extensionBastionSpec) {
 		// if the extensionBastionSpec has changed, reconcile it
 		mustReconcileExtensionBastion = true
-	} else if extBastion.Status.LastOperation == nil {
-		reconciliationSuccessful = false
+	} else if extensionBastion.Status.LastOperation == nil {
+		// if the extension did not record a lastOperation yet, record it as error in the bastion status
 		lastObservedError = fmt.Errorf("extension did not record a last operation yet")
 	} else {
-		lastOperationState := extBastion.Status.LastOperation.State
-		if extBastion.Status.LastError != nil ||
+		lastOperationState := extensionBastion.Status.LastOperation.State
+		if extensionBastion.Status.LastError != nil ||
 			lastOperationState == gardencorev1beta1.LastOperationStateError ||
 			lastOperationState == gardencorev1beta1.LastOperationStateFailed {
 			if lastOperationState == gardencorev1beta1.LastOperationStateFailed {
 				mustReconcileExtensionBastion = true
 			}
-			reconciliationSuccessful = false
 
 			lastObservedError = fmt.Errorf("extension state is not Succeeded but %v", lastOperationState)
-			if extBastion.Status.LastError != nil {
-				lastObservedError = v1beta1helper.NewErrorWithCodes(fmt.Errorf("error during reconciliation: %s", extBastion.Status.LastError.Description), extBastion.Status.LastError.Codes...)
+			if extensionBastion.Status.LastError != nil {
+				lastObservedError = v1beta1helper.NewErrorWithCodes(fmt.Errorf("error during reconciliation: %s", extensionBastion.Status.LastError.Description), extensionBastion.Status.LastError.Codes...)
 			}
 		}
 	}
 
 	if lastObservedError != nil {
-		message := fmt.Sprintf("Error while waiting for %s %s/%s to become ready", extensionsv1alpha1.BastionResource, extBastion.Namespace, extBastion.Name)
+		message := fmt.Sprintf("Error while waiting for %s %s/%s to become ready", extensionsv1alpha1.BastionResource, extensionBastion.Namespace, extensionBastion.Name)
 		err := v1beta1helper.NewErrorWithCodes(fmt.Errorf("%s: %w", message, lastObservedError), v1beta1helper.DeprecatedDetermineErrorCodes(lastObservedError)...)
 
 		if patchErr := patchReadyCondition(ctx, r.GardenClient, bastion, gardencorev1alpha1.ConditionFalse, "FailedReconciling", err.Error()); patchErr != nil {
@@ -174,28 +170,27 @@ func (r *Reconciler) reconcileBastion(
 	}
 
 	if mustReconcileExtensionBastion {
-		if _, err := controllerutils.GetAndCreateOrMergePatch(ctx, r.SeedClient, extBastion, func() error {
-			metav1.SetMetaDataAnnotation(&extBastion.ObjectMeta, v1beta1constants.GardenerOperation, v1beta1constants.GardenerOperationReconcile)
-			metav1.SetMetaDataAnnotation(&extBastion.ObjectMeta, v1beta1constants.GardenerTimestamp, r.Clock.Now().UTC().String())
+		if _, err := controllerutils.GetAndCreateOrMergePatch(ctx, r.SeedClient, extensionBastion, func() error {
+			metav1.SetMetaDataAnnotation(&extensionBastion.ObjectMeta, v1beta1constants.GardenerOperation, v1beta1constants.GardenerOperationReconcile)
+			metav1.SetMetaDataAnnotation(&extensionBastion.ObjectMeta, v1beta1constants.GardenerTimestamp, r.Clock.Now().UTC().String())
 
-			extBastion.Spec = extensionBastionSpec
+			extensionBastion.Spec = extensionBastionSpec
 			return nil
 		}); err != nil {
 			if patchErr := patchReadyCondition(ctx, r.GardenClient, bastion, gardencorev1alpha1.ConditionFalse, "FailedReconciling", err.Error()); patchErr != nil {
 				log.Error(patchErr, "Failed patching ready condition")
 			}
-
 			return fmt.Errorf("failed to ensure bastion extension resource: %w", err)
 		}
 		// return early here, the Bastion status will be updated by the reconciliation caused by the extension Bastion status update.
 		return nil
 	}
 
-	if reconciliationSuccessful && extBastion.Status.LastOperation.State == gardencorev1beta1.LastOperationStateSucceeded {
+	if extensionBastion.Status.LastOperation.State == gardencorev1beta1.LastOperationStateSucceeded {
 		// copy over the extension's status to the operation bastion and set the condition
 		patch := client.MergeFrom(bastion.DeepCopy())
 		setReadyCondition(bastion, gardencorev1alpha1.ConditionTrue, "SuccessfullyReconciled", "The bastion has been reconciled successfully.")
-		bastion.Status.Ingress = extBastion.Status.Ingress.DeepCopy()
+		bastion.Status.Ingress = extensionBastion.Status.Ingress.DeepCopy()
 		bastion.Status.ObservedGeneration = &bastion.Generation
 		if err := r.GardenClient.Status().Patch(ctx, bastion, patch); err != nil {
 			return fmt.Errorf("failed patching ready condition of Bastion: %w", err)
@@ -220,9 +215,8 @@ func (r *Reconciler) cleanupBastion(
 	}
 
 	// delete bastion extension resource in seed cluster
-	extBastion := newBastionExtension(bastion, shoot)
-
-	if err := r.SeedClient.Delete(ctx, extBastion); err != nil {
+	extensionBastion := newBastionExtension(bastion, shoot)
+	if err := r.SeedClient.Delete(ctx, extensionBastion); err != nil {
 		if apierrors.IsNotFound(err) {
 			log.Info("Successfully deleted")
 

--- a/test/integration/gardenlet/backupentry/backupentry/backupentry_suite_test.go
+++ b/test/integration/gardenlet/backupentry/backupentry/backupentry_suite_test.go
@@ -140,7 +140,7 @@ var _ = BeforeSuite(func() {
 		},
 	}
 
-	Expect(testClient.Create(ctx, gardenNamespace)).To(Or(Succeed(), BeAlreadyExistsError()))
+	Expect(testClient.Create(ctx, gardenNamespace)).To(Or(Succeed()))
 	log.Info("Created namespace for test", "namespaceName", gardenNamespace)
 
 	DeferCleanup(func() {


### PR DESCRIPTION
Cherry-pick of #7281 on `release-v1.62`

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
A bug causing the extension `BackupEntry` not to be correctly reconciled in case of secret rotation and a controller restart is now fixed.
```
