### PR TITLE
[release-v1.61] Improve reconciliation of extension `BackupBucket` and `BackupEntry`

### DIFF
--- a/pkg/gardenlet/controller/backupentry/backupentry/reconciler.go
+++ b/pkg/gardenlet/controller/backupentry/backupentry/reconciler.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+// Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -129,10 +129,13 @@ func (r *Reconciler) reconcileBackupEntry(
 
 	var (
 		mustReconcileExtensionBackupEntry = false
-		reconciliationSuccessful          = true
+		// we should reconcile the secret only when the data has changed, since now we depend on
+		// the timestamp in the secret to reconcile the extension.
+		mustReconcileExtensionSecret = false
 
-		extensionSecret = r.emptyExtensionSecret(backupEntry)
-		component       = r.newExtensionComponent(log, backupEntry)
+		lastObservedError error
+		extensionSecret   = r.emptyExtensionSecret(backupEntry)
+		component         = r.newExtensionComponent(log, backupEntry)
 
 		backupBucket = &gardencorev1beta1.BackupBucket{
 			ObjectMeta: metav1.ObjectMeta{
@@ -159,15 +162,24 @@ func (r *Reconciler) reconcileBackupEntry(
 		if !apierrors.IsNotFound(err) {
 			return reconcile.Result{}, err
 		}
+		// if the extension secret doesn't exist yet, create it
+		mustReconcileExtensionSecret = true
 	} else {
-		// if the backupBucket secret data has changed, reconcile extension backupEntry
+		// if the backupBucket secret data has changed, reconcile extension backupEntry and extension secret
 		if !reflect.DeepEqual(extensionSecret.Data, gardenSecret.Data) {
 			mustReconcileExtensionBackupEntry = true
+			mustReconcileExtensionSecret = true
+		}
+		// if the timestamp is not present yet (needed for existing secrets), reconcile the secret
+		if _, timestampPresent := extensionSecret.Annotations[v1beta1constants.GardenerTimestamp]; !timestampPresent {
+			mustReconcileExtensionSecret = true
 		}
 	}
 
-	if err := r.reconcileBackupEntryExtensionSecret(ctx, backupBucket, backupEntry, gardenSecret); err != nil {
-		return reconcile.Result{}, err
+	if mustReconcileExtensionSecret {
+		if err := r.reconcileBackupEntryExtensionSecret(ctx, extensionSecret, gardenSecret); err != nil {
+			return reconcile.Result{}, err
+		}
 	}
 
 	extensionBackupEntrySpec := extensionsv1alpha1.BackupEntrySpec{
@@ -184,18 +196,24 @@ func (r *Reconciler) reconcileBackupEntry(
 		BackupBucketProviderStatus: backupBucket.Status.ProviderStatus,
 	}
 
+	secretLastUpdateTime, err := time.Parse(time.RFC3339, extensionSecret.Annotations[v1beta1constants.GardenerTimestamp])
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
 	if err := r.SeedClient.Get(ctx, client.ObjectKeyFromObject(extensionBackupEntry), extensionBackupEntry); err != nil {
 		if !apierrors.IsNotFound(err) {
 			return reconcile.Result{}, err
 		}
 		// if the extension BackupEntry doesn't exist yet, create it
 		mustReconcileExtensionBackupEntry = true
-	} else if !reflect.DeepEqual(extensionBackupEntry.Spec, extensionBackupEntrySpec) {
-		// if the extensionBackupEntry spec has changed, reconcile it
+	} else if !reflect.DeepEqual(extensionBackupEntry.Spec, extensionBackupEntrySpec) ||
+		(extensionBackupEntry.Status.LastOperation != nil && extensionBackupEntry.Status.LastOperation.LastUpdateTime.Time.UTC().Before(secretLastUpdateTime)) {
+		// if the spec of the extensionBackupEntry has changed or it has not been reconciled after the last updation of secret, reconcile it
 		mustReconcileExtensionBackupEntry = true
 	} else if extensionBackupEntry.Status.LastOperation == nil {
-		// if the extension did not record a lastOperation yet, don't update the status
-		reconciliationSuccessful = false
+		// if the extension did not record a lastOperation yet, record it as error in the backupentry status
+		lastObservedError = fmt.Errorf("extension did not record a last operation yet")
 	} else {
 		// check for errors, and if none are present, reconciliation has succeeded
 		lastOperationState := extensionBackupEntry.Status.LastOperation.State
@@ -205,28 +223,25 @@ func (r *Reconciler) reconcileBackupEntry(
 			if lastOperationState == gardencorev1beta1.LastOperationStateFailed {
 				mustReconcileExtensionBackupEntry = true
 			}
-			reconciliationSuccessful = false
 
-			lastError := fmt.Errorf("extension state is not Succeeded but %v", lastOperationState)
+			lastObservedError = fmt.Errorf("extension state is not Succeeded but %v", lastOperationState)
 			if extensionBackupEntry.Status.LastError != nil {
-				lastError = v1beta1helper.NewErrorWithCodes(fmt.Errorf("error during reconciliation: %s", extensionBackupEntry.Status.LastError.Description), extensionBackupEntry.Status.LastError.Codes...)
+				lastObservedError = v1beta1helper.NewErrorWithCodes(fmt.Errorf("error during reconciliation: %s", extensionBackupEntry.Status.LastError.Description), extensionBackupEntry.Status.LastError.Codes...)
 			}
+		}
+	}
 
-			lastObservedError := v1beta1helper.NewErrorWithCodes(lastError, v1beta1helper.DeprecatedDetermineErrorCodes(lastError)...)
-			reconcileErr := &gardencorev1beta1.LastError{
-				Codes:       v1beta1helper.ExtractErrorCodes(lastObservedError),
-				Description: lastObservedError.Error(),
-			}
+	if lastObservedError != nil {
+		lastObservedError := v1beta1helper.NewErrorWithCodes(lastObservedError, v1beta1helper.DeprecatedDetermineErrorCodes(lastObservedError)...)
+		reconcileErr := &gardencorev1beta1.LastError{
+			Codes:       v1beta1helper.ExtractErrorCodes(lastObservedError),
+			Description: lastObservedError.Error(),
+		}
 
-			r.Recorder.Event(backupEntry, corev1.EventTypeWarning, gardencorev1beta1.EventReconcileError, reconcileErr.Description)
+		r.Recorder.Event(backupEntry, corev1.EventTypeWarning, gardencorev1beta1.EventReconcileError, reconcileErr.Description)
 
-			description := reconcileErr.Description
-			if lastOperationState == gardencorev1beta1.LastOperationStateFailed {
-				description += ". Operation will be retried."
-			}
-			if updateErr := r.updateBackupEntryStatusError(ctx, backupEntry, operationType, description, reconcileErr); updateErr != nil {
-				return reconcile.Result{}, fmt.Errorf("could not update status after reconciliation error: %w", updateErr)
-			}
+		if updateErr := r.updateBackupEntryStatusError(ctx, backupEntry, operationType, reconcileErr.Description, reconcileErr); updateErr != nil {
+			return reconcile.Result{}, fmt.Errorf("could not update status after reconciliation error: %w", updateErr)
 		}
 	}
 
@@ -238,7 +253,7 @@ func (r *Reconciler) reconcileBackupEntry(
 		return reconcile.Result{}, nil
 	}
 
-	if reconciliationSuccessful {
+	if extensionBackupEntry.Status.LastOperation.State == gardencorev1beta1.LastOperationStateSucceeded {
 		if updateErr := r.updateBackupEntryStatusSucceeded(ctx, backupEntry, operationType); updateErr != nil {
 			return reconcile.Result{}, fmt.Errorf("could not update status after reconciliation success: %w", updateErr)
 		}
@@ -249,7 +264,6 @@ func (r *Reconciler) reconcileBackupEntry(
 			}
 		}
 	}
-
 	return reconcile.Result{}, nil
 }
 
@@ -290,7 +304,7 @@ func (r *Reconciler) deleteBackupEntry(
 			return reconcile.Result{}, err
 		}
 
-		if err := r.reconcileBackupEntryExtensionSecret(ctx, backupBucket, backupEntry, gardenSecret); err != nil {
+		if err := r.reconcileBackupEntryExtensionSecret(ctx, extensionSecret, gardenSecret); err != nil {
 			return reconcile.Result{}, err
 		}
 
@@ -602,10 +616,9 @@ func (r *Reconciler) getGardenSecret(ctx context.Context, backupBucket *gardenco
 	return gardenSecret, nil
 }
 
-func (r *Reconciler) reconcileBackupEntryExtensionSecret(ctx context.Context, backupBucket *gardencorev1beta1.BackupBucket, backupEntry *gardencorev1beta1.BackupEntry, gardenSecret *corev1.Secret) error {
-	// create secret for extension BackupEntry in seed
-	extensionSecret := r.emptyExtensionSecret(backupEntry)
+func (r *Reconciler) reconcileBackupEntryExtensionSecret(ctx context.Context, extensionSecret, gardenSecret *corev1.Secret) error {
 	if _, err := controllerutils.GetAndCreateOrMergePatch(ctx, r.SeedClient, extensionSecret, func() error {
+		metav1.SetMetaDataAnnotation(&extensionSecret.ObjectMeta, v1beta1constants.GardenerTimestamp, r.Clock.Now().UTC().Format(time.RFC3339))
 		extensionSecret.Data = gardenSecret.DeepCopy().Data
 		return nil
 	}); err != nil {

--- a/pkg/gardenlet/controller/bastion/reconciler.go
+++ b/pkg/gardenlet/controller/bastion/reconciler.go
@@ -105,7 +105,6 @@ func (r *Reconciler) reconcileBastion(
 	bastion *operationsv1alpha1.Bastion,
 	shoot *gardencorev1beta1.Shoot,
 ) error {
-	// ensure finalizer is set
 	if !controllerutil.ContainsFinalizer(bastion, finalizerName) {
 		log.Info("Adding finalizer")
 		if err := controllerutils.AddFinalizers(ctx, r.GardenClient, bastion, finalizerName); err != nil {
@@ -113,59 +112,56 @@ func (r *Reconciler) reconcileBastion(
 		}
 	}
 
-	// prepare extension resource
-	extBastion := newBastionExtension(bastion, shoot)
-	extensionsIngress := make([]extensionsv1alpha1.BastionIngressPolicy, len(bastion.Spec.Ingress))
+	extensionBastion := newBastionExtension(bastion, shoot)
+	extensionIngress := make([]extensionsv1alpha1.BastionIngressPolicy, len(bastion.Spec.Ingress))
 	for i, ingress := range bastion.Spec.Ingress {
-		extensionsIngress[i] = extensionsv1alpha1.BastionIngressPolicy{
+		extensionIngress[i] = extensionsv1alpha1.BastionIngressPolicy{
 			IPBlock: ingress.IPBlock,
 		}
 	}
 
 	var (
 		mustReconcileExtensionBastion = false
-		reconciliationSuccessful      = true
 		lastObservedError             error
 		extensionBastionSpec          = extensionsv1alpha1.BastionSpec{
 			DefaultSpec: extensionsv1alpha1.DefaultSpec{
 				Type: *bastion.Spec.ProviderType,
 			},
 			UserData: createUserData(bastion),
-			Ingress:  extensionsIngress,
+			Ingress:  extensionIngress,
 		}
 	)
 
-	if err := r.SeedClient.Get(ctx, client.ObjectKeyFromObject(extBastion), extBastion); err != nil {
+	if err := r.SeedClient.Get(ctx, client.ObjectKeyFromObject(extensionBastion), extensionBastion); err != nil {
 		if !apierrors.IsNotFound(err) {
 			return err
 		}
 		// if the extension Bastion doesn't exist yet, create it
 		mustReconcileExtensionBastion = true
-	} else if !reflect.DeepEqual(extBastion.Spec, extensionBastionSpec) {
+	} else if !reflect.DeepEqual(extensionBastion.Spec, extensionBastionSpec) {
 		// if the extensionBastionSpec has changed, reconcile it
 		mustReconcileExtensionBastion = true
-	} else if extBastion.Status.LastOperation == nil {
-		reconciliationSuccessful = false
+	} else if extensionBastion.Status.LastOperation == nil {
+		// if the extension did not record a lastOperation yet, record it as error in the bastion status
 		lastObservedError = fmt.Errorf("extension did not record a last operation yet")
 	} else {
-		lastOperationState := extBastion.Status.LastOperation.State
-		if extBastion.Status.LastError != nil ||
+		lastOperationState := extensionBastion.Status.LastOperation.State
+		if extensionBastion.Status.LastError != nil ||
 			lastOperationState == gardencorev1beta1.LastOperationStateError ||
 			lastOperationState == gardencorev1beta1.LastOperationStateFailed {
 			if lastOperationState == gardencorev1beta1.LastOperationStateFailed {
 				mustReconcileExtensionBastion = true
 			}
-			reconciliationSuccessful = false
 
 			lastObservedError = fmt.Errorf("extension state is not Succeeded but %v", lastOperationState)
-			if extBastion.Status.LastError != nil {
-				lastObservedError = v1beta1helper.NewErrorWithCodes(fmt.Errorf("error during reconciliation: %s", extBastion.Status.LastError.Description), extBastion.Status.LastError.Codes...)
+			if extensionBastion.Status.LastError != nil {
+				lastObservedError = v1beta1helper.NewErrorWithCodes(fmt.Errorf("error during reconciliation: %s", extensionBastion.Status.LastError.Description), extensionBastion.Status.LastError.Codes...)
 			}
 		}
 	}
 
 	if lastObservedError != nil {
-		message := fmt.Sprintf("Error while waiting for %s %s/%s to become ready", extensionsv1alpha1.BastionResource, extBastion.Namespace, extBastion.Name)
+		message := fmt.Sprintf("Error while waiting for %s %s/%s to become ready", extensionsv1alpha1.BastionResource, extensionBastion.Namespace, extensionBastion.Name)
 		err := v1beta1helper.NewErrorWithCodes(fmt.Errorf("%s: %w", message, lastObservedError), v1beta1helper.DeprecatedDetermineErrorCodes(lastObservedError)...)
 
 		if patchErr := patchReadyCondition(ctx, r.GardenClient, bastion, gardencorev1alpha1.ConditionFalse, "FailedReconciling", err.Error()); patchErr != nil {
@@ -174,28 +170,27 @@ func (r *Reconciler) reconcileBastion(
 	}
 
 	if mustReconcileExtensionBastion {
-		if _, err := controllerutils.GetAndCreateOrMergePatch(ctx, r.SeedClient, extBastion, func() error {
-			metav1.SetMetaDataAnnotation(&extBastion.ObjectMeta, v1beta1constants.GardenerOperation, v1beta1constants.GardenerOperationReconcile)
-			metav1.SetMetaDataAnnotation(&extBastion.ObjectMeta, v1beta1constants.GardenerTimestamp, r.Clock.Now().UTC().String())
+		if _, err := controllerutils.GetAndCreateOrMergePatch(ctx, r.SeedClient, extensionBastion, func() error {
+			metav1.SetMetaDataAnnotation(&extensionBastion.ObjectMeta, v1beta1constants.GardenerOperation, v1beta1constants.GardenerOperationReconcile)
+			metav1.SetMetaDataAnnotation(&extensionBastion.ObjectMeta, v1beta1constants.GardenerTimestamp, r.Clock.Now().UTC().String())
 
-			extBastion.Spec = extensionBastionSpec
+			extensionBastion.Spec = extensionBastionSpec
 			return nil
 		}); err != nil {
 			if patchErr := patchReadyCondition(ctx, r.GardenClient, bastion, gardencorev1alpha1.ConditionFalse, "FailedReconciling", err.Error()); patchErr != nil {
 				log.Error(patchErr, "Failed patching ready condition")
 			}
-
 			return fmt.Errorf("failed to ensure bastion extension resource: %w", err)
 		}
 		// return early here, the Bastion status will be updated by the reconciliation caused by the extension Bastion status update.
 		return nil
 	}
 
-	if reconciliationSuccessful && extBastion.Status.LastOperation.State == gardencorev1beta1.LastOperationStateSucceeded {
+	if extensionBastion.Status.LastOperation.State == gardencorev1beta1.LastOperationStateSucceeded {
 		// copy over the extension's status to the operation bastion and set the condition
 		patch := client.MergeFrom(bastion.DeepCopy())
 		setReadyCondition(bastion, gardencorev1alpha1.ConditionTrue, "SuccessfullyReconciled", "The bastion has been reconciled successfully.")
-		bastion.Status.Ingress = extBastion.Status.Ingress.DeepCopy()
+		bastion.Status.Ingress = extensionBastion.Status.Ingress.DeepCopy()
 		bastion.Status.ObservedGeneration = &bastion.Generation
 		if err := r.GardenClient.Status().Patch(ctx, bastion, patch); err != nil {
 			return fmt.Errorf("failed patching ready condition of Bastion: %w", err)
@@ -220,9 +215,8 @@ func (r *Reconciler) cleanupBastion(
 	}
 
 	// delete bastion extension resource in seed cluster
-	extBastion := newBastionExtension(bastion, shoot)
-
-	if err := r.SeedClient.Delete(ctx, extBastion); err != nil {
+	extensionBastion := newBastionExtension(bastion, shoot)
+	if err := r.SeedClient.Delete(ctx, extensionBastion); err != nil {
 		if apierrors.IsNotFound(err) {
 			log.Info("Successfully deleted")
 

--- a/test/integration/gardenlet/backupentry/backupentry/backupentry_suite_test.go
+++ b/test/integration/gardenlet/backupentry/backupentry/backupentry_suite_test.go
@@ -140,7 +140,7 @@ var _ = BeforeSuite(func() {
 		},
 	}
 
-	Expect(testClient.Create(ctx, gardenNamespace)).To(Or(Succeed(), BeAlreadyExistsError()))
+	Expect(testClient.Create(ctx, gardenNamespace)).To(Or(Succeed()))
 	log.Info("Created namespace for test", "namespaceName", gardenNamespace)
 
 	DeferCleanup(func() {


### PR DESCRIPTION
Cherry-pick of #7281 on `release-v1.61`

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
A bug causing the extension `BackupEntry` not to be correctly reconciled in case of secret rotation and a controller restart is now fixed.
```
