### PR TITLE
[release-v1.60] Improve reconciliation of extension `BackupBucket`

### DIFF
--- a/pkg/gardenlet/controller/backupbucket/reconciler.go
+++ b/pkg/gardenlet/controller/backupbucket/reconciler.go
@@ -29,7 +29,7 @@ import (
 	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/extensions"
 	"github.com/gardener/gardener/pkg/gardenlet/apis/config"
-	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
+	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
@@ -112,7 +112,7 @@ func (r *Reconciler) reconcileBackupBucket(
 		return reconcile.Result{}, fmt.Errorf("could not update status after reconciliation start: %w", updateErr)
 	}
 
-	gardenSecret, err := kutil.GetSecretByReference(ctx, r.GardenClient, &backupBucket.Spec.SecretRef)
+	gardenSecret, err := kubernetesutils.GetSecretByReference(ctx, r.GardenClient, &backupBucket.Spec.SecretRef)
 	if err != nil {
 		log.Error(err, "Failed to get backup secret", "secret", client.ObjectKey{Namespace: backupBucket.Spec.SecretRef.Namespace, Name: backupBucket.Spec.SecretRef.Name})
 		r.Recorder.Eventf(backupBucket, corev1.EventTypeWarning, gardencorev1beta1.EventReconcileError, "Failed to get backup secret %s/%s: %w", backupBucket.Spec.SecretRef.Namespace, backupBucket.Spec.SecretRef.Name, err)
@@ -128,8 +128,11 @@ func (r *Reconciler) reconcileBackupBucket(
 
 	var (
 		mustReconcileExtensionBackupBucket = false
-		reconciliationSuccessful           = true
+		// we should reconcile the secret only when the data has changed, since now we depend on
+		// the timestamp in the secret to reconcile the extension.
+		mustReconcileExtensionSecret = false
 
+		lastObservedError         error
 		extensionSecret           = r.emptyExtensionSecret(backupBucket.Name)
 		extensionBackupBucketSpec = extensionsv1alpha1.BackupBucketSpec{
 			DefaultSpec: extensionsv1alpha1.DefaultSpec{
@@ -148,14 +151,28 @@ func (r *Reconciler) reconcileBackupBucket(
 		if !apierrors.IsNotFound(err) {
 			return reconcile.Result{}, err
 		}
+		// if the extension secret doesn't exist yet, create it
+		mustReconcileExtensionSecret = true
 	} else {
-		// if the backupBucket secret data has changed, reconcile extension backupBucket
+		// if the backupBucket secret data has changed, reconcile extension backupBucket and extension secret
 		if !reflect.DeepEqual(extensionSecret.Data, gardenSecret.Data) {
 			mustReconcileExtensionBackupBucket = true
+			mustReconcileExtensionSecret = true
+		}
+		// if the timestamp is not present yet (needed for existing secrets), reconcile the secret
+		if _, timestampPresent := extensionSecret.Annotations[v1beta1constants.GardenerTimestamp]; !timestampPresent {
+			mustReconcileExtensionSecret = true
 		}
 	}
 
-	if err := r.reconcileExtensionBackupBucketSecret(ctx, backupBucket); err != nil {
+	if mustReconcileExtensionSecret {
+		if err := r.reconcileBackupBucketExtensionSecret(ctx, extensionSecret, gardenSecret, backupBucket); err != nil {
+			return reconcile.Result{}, err
+		}
+	}
+
+	secretLastUpdateTime, err := time.Parse(time.RFC3339, extensionSecret.Annotations[v1beta1constants.GardenerTimestamp])
+	if err != nil {
 		return reconcile.Result{}, err
 	}
 
@@ -165,12 +182,13 @@ func (r *Reconciler) reconcileBackupBucket(
 		}
 		// if the extension BackupBucket doesn't exist yet, create it
 		mustReconcileExtensionBackupBucket = true
-	} else if !reflect.DeepEqual(extensionBackupBucket.Spec, extensionBackupBucketSpec) {
-		// if the extensionBackupBucketSpec has changed, reconcile it
+	} else if !reflect.DeepEqual(extensionBackupBucket.Spec, extensionBackupBucketSpec) ||
+		(extensionBackupBucket.Status.LastOperation != nil && extensionBackupBucket.Status.LastOperation.LastUpdateTime.Time.UTC().Before(secretLastUpdateTime)) {
+		// if the spec of the extensionBackupBucket has changed or it has not been reconciled after the last updation of secret, reconcile it
 		mustReconcileExtensionBackupBucket = true
 	} else if extensionBackupBucket.Status.LastOperation == nil {
-		// if the extension did not record a lastOperation yet, don't update the status
-		reconciliationSuccessful = false
+		// if the extension did not record a lastOperation yet, record it as error in the backupbucket status
+		lastObservedError = fmt.Errorf("extension did not record a last operation yet")
 	} else {
 		// check for errors, and if none are present, sync generated Secret to garden
 		lastOperationState := extensionBackupBucket.Status.LastOperation.State
@@ -180,32 +198,29 @@ func (r *Reconciler) reconcileBackupBucket(
 			if lastOperationState == gardencorev1beta1.LastOperationStateFailed {
 				mustReconcileExtensionBackupBucket = true
 			}
-			reconciliationSuccessful = false
 
-			lastError := fmt.Errorf("extension state is not Succeeded but %v", lastOperationState)
+			lastObservedError = fmt.Errorf("extension state is not Succeeded but %v", lastOperationState)
 			if extensionBackupBucket.Status.LastError != nil {
-				lastError = v1beta1helper.NewErrorWithCodes(fmt.Errorf("error during reconciliation: %s", extensionBackupBucket.Status.LastError.Description), extensionBackupBucket.Status.LastError.Codes...)
-			}
-
-			lastObservedError := v1beta1helper.NewErrorWithCodes(lastError, v1beta1helper.DeprecatedDetermineErrorCodes(lastError)...)
-			reconcileErr := &gardencorev1beta1.LastError{
-				Codes:       v1beta1helper.ExtractErrorCodes(lastObservedError),
-				Description: lastObservedError.Error(),
-			}
-
-			r.Recorder.Event(backupBucket, corev1.EventTypeWarning, gardencorev1beta1.EventReconcileError, reconcileErr.Description)
-
-			description := reconcileErr.Description
-			if lastOperationState == gardencorev1beta1.LastOperationStateFailed {
-				description += ". Operation will be retried."
-			}
-			if updateErr := r.updateBackupBucketStatusError(ctx, backupBucket, description, reconcileErr); updateErr != nil {
-				return reconcile.Result{}, fmt.Errorf("could not update status after reconciliation error: %w", updateErr)
+				lastObservedError = v1beta1helper.NewErrorWithCodes(fmt.Errorf("error during reconciliation: %s", extensionBackupBucket.Status.LastError.Description), extensionBackupBucket.Status.LastError.Codes...)
 			}
 		} else if lastOperationState == gardencorev1beta1.LastOperationStateSucceeded {
 			if err := r.syncGeneratedSecretToGarden(ctx, backupBucket, extensionBackupBucket); err != nil {
 				return reconcile.Result{}, err
 			}
+		}
+	}
+
+	if lastObservedError != nil {
+		lastObservedError := v1beta1helper.NewErrorWithCodes(lastObservedError, v1beta1helper.DeprecatedDetermineErrorCodes(lastObservedError)...)
+		reconcileErr := &gardencorev1beta1.LastError{
+			Codes:       v1beta1helper.ExtractErrorCodes(lastObservedError),
+			Description: lastObservedError.Error(),
+		}
+
+		r.Recorder.Event(backupBucket, corev1.EventTypeWarning, gardencorev1beta1.EventReconcileError, reconcileErr.Description)
+
+		if updateErr := r.updateBackupBucketStatusError(ctx, backupBucket, reconcileErr.Description, reconcileErr); updateErr != nil {
+			return reconcile.Result{}, fmt.Errorf("could not update status after reconciliation error: %w", updateErr)
 		}
 	}
 
@@ -223,7 +238,7 @@ func (r *Reconciler) reconcileBackupBucket(
 		return reconcile.Result{}, nil
 	}
 
-	if reconciliationSuccessful {
+	if extensionBackupBucket.Status.LastOperation.State == gardencorev1beta1.LastOperationStateSucceeded {
 		if updateErr := r.updateBackupBucketStatusSucceeded(ctx, backupBucket, "Backup Bucket has been successfully reconciled."); updateErr != nil {
 			return reconcile.Result{}, fmt.Errorf("could not update status after reconciliation success: %w", updateErr)
 		}
@@ -272,7 +287,13 @@ func (r *Reconciler) deleteBackupBucket(
 		return reconcile.Result{}, err
 	}
 
-	if err := r.reconcileExtensionBackupBucketSecret(ctx, backupBucket); err != nil {
+	gardenSecret, err := kubernetesutils.GetSecretByReference(ctx, r.GardenClient, &backupBucket.Spec.SecretRef)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
+	extensionSecret := r.emptyExtensionSecret(backupBucket.Name)
+	if err := r.reconcileBackupBucketExtensionSecret(ctx, extensionSecret, gardenSecret, backupBucket); err != nil {
 		return reconcile.Result{}, err
 	}
 
@@ -307,7 +328,7 @@ func (r *Reconciler) deleteBackupBucket(
 
 	log.Info("Successfully deleted")
 
-	secret, err := kutil.GetSecretByReference(ctx, r.GardenClient, &backupBucket.Spec.SecretRef)
+	secret, err := kubernetesutils.GetSecretByReference(ctx, r.GardenClient, &backupBucket.Spec.SecretRef)
 	if err != nil {
 		log.Error(err, "Failed to get backup secret", "secret", client.ObjectKey{Namespace: backupBucket.Spec.SecretRef.Namespace, Name: backupBucket.Spec.SecretRef.Name})
 		return reconcile.Result{}, err
@@ -339,14 +360,9 @@ func (r *Reconciler) emptyExtensionSecret(backupBucketName string) *corev1.Secre
 	}
 }
 
-func (r *Reconciler) reconcileExtensionBackupBucketSecret(ctx context.Context, backupBucket *gardencorev1beta1.BackupBucket) error {
-	gardenSecret, err := kutil.GetSecretByReference(ctx, r.GardenClient, &backupBucket.Spec.SecretRef)
-	if err != nil {
-		return err
-	}
-
-	extensionSecret := r.emptyExtensionSecret(backupBucket.Name)
-	_, err = controllerutils.GetAndCreateOrMergePatch(ctx, r.SeedClient, extensionSecret, func() error {
+func (r *Reconciler) reconcileBackupBucketExtensionSecret(ctx context.Context, extensionSecret, gardenSecret *corev1.Secret, backupBucket *gardencorev1beta1.BackupBucket) error {
+	_, err := controllerutils.GetAndCreateOrMergePatch(ctx, r.SeedClient, extensionSecret, func() error {
+		metav1.SetMetaDataAnnotation(&extensionSecret.ObjectMeta, v1beta1constants.GardenerTimestamp, r.Clock.Now().UTC().Format(time.RFC3339))
 		extensionSecret.Data = gardenSecret.Data
 		return nil
 	})
@@ -357,7 +373,7 @@ func (r *Reconciler) syncGeneratedSecretToGarden(ctx context.Context, backupBuck
 	var gardenGeneratedSecretRef *corev1.SecretReference
 
 	if extensionBackupBucket.Status.GeneratedSecretRef != nil {
-		seedGeneratedSecret, err := kutil.GetSecretByReference(ctx, r.SeedClient, extensionBackupBucket.Status.GeneratedSecretRef)
+		seedGeneratedSecret, err := kubernetesutils.GetSecretByReference(ctx, r.SeedClient, extensionBackupBucket.Status.GeneratedSecretRef)
 		if err != nil {
 			return err
 		}

--- a/pkg/gardenlet/controller/backupbucket/reconciler_test.go
+++ b/pkg/gardenlet/controller/backupbucket/reconciler_test.go
@@ -1,0 +1,253 @@
+// Copyright (c) 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package backupbucket_test
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	testclock "k8s.io/utils/clock/testing"
+	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	"github.com/gardener/gardener/pkg/gardenlet/apis/config"
+	. "github.com/gardener/gardener/pkg/gardenlet/controller/backupbucket"
+)
+
+const (
+	seedName            = "seed"
+	gardenNamespaceName = "garden"
+)
+
+var _ = Describe("Controller", func() {
+	var (
+		ctx          = context.TODO()
+		gardenClient client.Client
+		seedClient   client.Client
+		reconciler   reconcile.Reconciler
+
+		fakeClock *testclock.FakeClock
+
+		gardenSecret          *corev1.Secret
+		backupBucket          *gardencorev1beta1.BackupBucket
+		extensionBackupBucket *extensionsv1alpha1.BackupBucket
+		extensionSecret       *corev1.Secret
+		providerConfig        = &runtime.RawExtension{Raw: []byte(`{"dash":"baz"}`)}
+		providerStatus        = &runtime.RawExtension{Raw: []byte(`{"foo":"bar"}`)}
+
+		request reconcile.Request
+	)
+
+	BeforeEach(func() {
+		gardenClient = fakeclient.NewClientBuilder().WithScheme(kubernetes.GardenScheme).Build()
+
+		testScheme := kubernetes.SeedScheme
+		Expect(extensionsv1alpha1.AddToScheme(testScheme)).To(Succeed())
+		seedClient = fakeclient.NewClientBuilder().WithScheme(testScheme).Build()
+
+		fakeClock = testclock.NewFakeClock(time.Now())
+
+		reconciler = &Reconciler{
+			GardenClient: gardenClient,
+			SeedClient:   seedClient,
+			Recorder:     &record.FakeRecorder{},
+			Config: config.BackupBucketControllerConfiguration{
+				ConcurrentSyncs: pointer.Int(5),
+			},
+			Clock:           fakeClock,
+			GardenNamespace: gardenNamespaceName,
+			SeedName:        seedName,
+		}
+
+		gardenSecret = &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-secret",
+				Namespace: gardenNamespaceName,
+			},
+			Data: map[string][]byte{
+				"foo": []byte("bar"),
+			},
+		}
+		Expect(gardenClient.Create(ctx, gardenSecret)).To(Succeed())
+
+		backupBucket = &gardencorev1beta1.BackupBucket{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       "foo",
+				Generation: 1,
+			},
+			Spec: gardencorev1beta1.BackupBucketSpec{
+				Provider: gardencorev1beta1.BackupBucketProvider{
+					Type:   "provider-type",
+					Region: "some-region",
+				},
+				ProviderConfig: providerConfig,
+				SecretRef: corev1.SecretReference{
+					Name:      gardenSecret.Name,
+					Namespace: gardenSecret.Namespace,
+				},
+				SeedName: pointer.String(seedName),
+			},
+			Status: gardencorev1beta1.BackupBucketStatus{
+				ObservedGeneration: 1,
+				LastOperation: &gardencorev1beta1.LastOperation{
+					State: gardencorev1beta1.LastOperationStateSucceeded,
+					Type:  gardencorev1beta1.LastOperationTypeReconcile,
+				},
+				ProviderStatus: providerStatus,
+			},
+		}
+		Expect(gardenClient.Create(ctx, backupBucket)).To(Succeed())
+
+		extensionSecret = &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      generateBackupBucketSecretName(backupBucket.Name),
+				Namespace: gardenNamespaceName,
+				Annotations: map[string]string{
+					v1beta1constants.GardenerTimestamp: fakeClock.Now().UTC().Format(time.RFC3339),
+				},
+			},
+			Data: gardenSecret.Data,
+		}
+
+		extensionBackupBucket = &extensionsv1alpha1.BackupBucket{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: backupBucket.Name,
+			},
+			Spec: extensionsv1alpha1.BackupBucketSpec{
+				DefaultSpec: extensionsv1alpha1.DefaultSpec{
+					Type:           backupBucket.Spec.Provider.Type,
+					ProviderConfig: backupBucket.Spec.ProviderConfig,
+				},
+				Region: backupBucket.Spec.Provider.Region,
+				SecretRef: corev1.SecretReference{
+					Name:      extensionSecret.Name,
+					Namespace: extensionSecret.Namespace,
+				},
+			},
+			Status: extensionsv1alpha1.BackupBucketStatus{
+				DefaultStatus: extensionsv1alpha1.DefaultStatus{
+					LastOperation: &gardencorev1beta1.LastOperation{
+						State:          gardencorev1beta1.LastOperationStateSucceeded,
+						LastUpdateTime: metav1.NewTime(fakeClock.Now().UTC()),
+					},
+				},
+			},
+		}
+
+		request = reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Name:      backupBucket.Name,
+				Namespace: backupBucket.Namespace,
+			},
+		}
+	})
+
+	It("should create the extension secret and extension BackupBucket if it doesn't exist yet", func() {
+		result, err := reconciler.Reconcile(ctx, request)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(Equal(reconcile.Result{}))
+
+		Expect(seedClient.Get(ctx, client.ObjectKeyFromObject(extensionSecret), extensionSecret)).To(Succeed())
+		Expect(extensionSecret.Data).To(Equal(gardenSecret.Data))
+
+		Expect(seedClient.Get(ctx, client.ObjectKeyFromObject(extensionBackupBucket), extensionBackupBucket)).To(Succeed())
+		Expect(extensionBackupBucket.Spec).To(Equal(extensionsv1alpha1.BackupBucketSpec{
+			DefaultSpec: extensionsv1alpha1.DefaultSpec{
+				Type:           backupBucket.Spec.Provider.Type,
+				ProviderConfig: backupBucket.Spec.ProviderConfig,
+			},
+			Region: backupBucket.Spec.Provider.Region,
+			SecretRef: corev1.SecretReference{
+				Name:      extensionSecret.Name,
+				Namespace: extensionSecret.Namespace,
+			},
+		}))
+	})
+
+	It("should not reconcile the extension BackupBucket if the secret data or extension spec hasn't changed", func() {
+		Expect(seedClient.Create(ctx, extensionSecret)).To(Succeed())
+		Expect(seedClient.Create(ctx, extensionBackupBucket)).To(Succeed())
+
+		result, err := reconciler.Reconcile(ctx, request)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(Equal(reconcile.Result{}))
+
+		Expect(seedClient.Get(ctx, client.ObjectKeyFromObject(extensionBackupBucket), extensionBackupBucket)).To(Succeed())
+		Expect(extensionBackupBucket.Annotations).NotTo(HaveKey(v1beta1constants.GardenerOperation))
+	})
+
+	It("should reconcile the extension secret and extension BackupBucket if the secret currently doesn't have a timestamp", func() {
+		extensionSecret.Annotations = nil
+		Expect(seedClient.Create(ctx, extensionSecret)).To(Succeed())
+		Expect(seedClient.Create(ctx, extensionBackupBucket)).To(Succeed())
+
+		// step the clock so that the updated timestamp of the secret is greater than the extensionSecret lastUpdate time.
+		fakeClock.Step(time.Minute)
+
+		result, err := reconciler.Reconcile(ctx, request)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(Equal(reconcile.Result{}))
+
+		Expect(seedClient.Get(ctx, client.ObjectKeyFromObject(extensionSecret), extensionSecret)).To(Succeed())
+		Expect(extensionSecret.Annotations).To(HaveKeyWithValue(v1beta1constants.GardenerTimestamp, fakeClock.Now().UTC().Format(time.RFC3339)))
+		Expect(seedClient.Get(ctx, client.ObjectKeyFromObject(extensionBackupBucket), extensionBackupBucket)).To(Succeed())
+		Expect(extensionBackupBucket.Annotations).To(HaveKey(v1beta1constants.GardenerOperation))
+	})
+
+	It("should reconcile the extension BackupBucket if the secret data has changed", func() {
+		extensionSecret.Data = map[string][]byte{"dash": []byte("bash")}
+		Expect(seedClient.Create(ctx, extensionSecret)).To(Succeed())
+		Expect(seedClient.Create(ctx, extensionBackupBucket)).To(Succeed())
+
+		result, err := reconciler.Reconcile(ctx, request)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(Equal(reconcile.Result{}))
+
+		Expect(seedClient.Get(ctx, client.ObjectKeyFromObject(extensionBackupBucket), extensionBackupBucket)).To(Succeed())
+		Expect(extensionBackupBucket.Annotations).To(HaveKeyWithValue(v1beta1constants.GardenerOperation, v1beta1constants.GardenerOperationReconcile))
+	})
+
+	It("should reconcile the extension BackupBucket if the secret update timestamp is after the extension last update time", func() {
+		time := fakeClock.Now().Add(time.Second).UTC().Format(time.RFC3339)
+		metav1.SetMetaDataAnnotation(&extensionSecret.ObjectMeta, v1beta1constants.GardenerTimestamp, time)
+		Expect(seedClient.Create(ctx, extensionSecret)).To(Succeed())
+		Expect(seedClient.Create(ctx, extensionBackupBucket)).To(Succeed())
+
+		result, err := reconciler.Reconcile(ctx, request)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(Equal(reconcile.Result{}))
+
+		Expect(seedClient.Get(ctx, client.ObjectKeyFromObject(extensionBackupBucket), extensionBackupBucket)).To(Succeed())
+		Expect(extensionBackupBucket.Annotations).To(HaveKeyWithValue(v1beta1constants.GardenerOperation, v1beta1constants.GardenerOperationReconcile))
+	})
+})
+
+func generateBackupBucketSecretName(backupBucketName string) string {
+	return fmt.Sprintf("bucket-%s", backupBucketName)
+}


### PR DESCRIPTION
/kind bug

Cherry-pick of BackupBucket related commits of #7281 on `release-v1.60` because `BackupEntry` was not refactored yet.
