### PR TITLE
Check existing machine deployment for mcm replica count

### DIFF
--- a/extensions/pkg/controller/worker/genericactuator/actuator_reconcile.go
+++ b/extensions/pkg/controller/worker/genericactuator/actuator_reconcile.go
@@ -64,14 +64,14 @@ func (a *genericActuator) Reconcile(ctx context.Context, log logr.Logger, worker
 	// mcmReplicaFunc returns the desired replicas for machine controller manager
 	var mcmReplicaFunc = func() int32 {
 		switch {
+		// if there are any existing machine deployments present with a positive replica count then MCM is needed.
+		case isExistingMachineDeploymentWithPositiveReplicaCountPresent(existingMachineDeployments):
+			return 1
 		// If the cluster is hibernated then there is no further need of MCM and therefore its desired replicas is 0
 		case extensionscontroller.IsHibernated(cluster):
 			return 0
-		// If the cluster is created with hibernation enabled, then desired replicas for MCM is 0 if there are no existing machine deployments with positive replica count
+		// If the cluster is created with hibernation enabled, then desired replicas for MCM is 0
 		case extensionscontroller.IsHibernationEnabled(cluster) && extensionscontroller.IsCreationInProcess(cluster):
-			if isExistingMachineDeploymentWithPositiveReplicaCountPresent(existingMachineDeployments) {
-				return 1
-			}
 			return 0
 		// If shoot is either waking up or in the process of hibernation then, MCM is required and therefore its desired replicas is 1
 		case extensionscontroller.IsHibernatingOrWakingUp(cluster):


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/area robustness
/kind enhancement


**What this PR does / why we need it**:
When a shoot cluster is hibernated, it has `hibernated: true` in its status and the spec has `hibernation.enabled: true`. When the cluster wakes up, the spec changes to `hibernation.enabled: false`, but the status remains in `hibernated: true` until the reconciliation succeeds. If, for some reason, the reconciliation fails, then `hibernated: true` status will remain as it is. Consider a scenario where we have a cluster which is woken up from hibernation but encounters some error in bringing up machines. After some time, we again hibernate the cluster. In this case, we will have `hibernated: true` in the status and `hibernation.enabled:  true` in the spec. According to https://github.com/gardener/gardener/blob/1c2fe03d3a645ad73b819352894e62e8797f35d7/extensions/pkg/controller/worker/genericactuator/actuator_reconcile.go#L65-L84 MCM will not scale up for such a cluster. We have machines in the cluster in a `Pending` state, but MCM will not be present. To fix this and any such corner cases, we have decided to check existing machine deployments first when deciding the replica count for MCM deployment. This PR adds this fix.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Testing was done on a local kind-based gardener setup.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
