### PR TITLE
[GEP-21] Use `int64` for `maxNodeCount` validation error

### DIFF
--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -459,9 +459,9 @@ func ValidateTotalNodeCountWithPodCIDR(shoot *core.Shoot) field.ErrorList {
 	}
 
 	// calculate maximum number of total nodes
-	totalNodes := big.NewInt(0)
+	totalNodes := int64(0)
 	for _, worker := range shoot.Spec.Provider.Workers {
-		totalNodes = totalNodes.Add(totalNodes, big.NewInt(int64(worker.Maximum)))
+		totalNodes += int64(worker.Maximum)
 	}
 
 	podNetworkCIDR := core.DefaultPodNetworkCIDR
@@ -487,7 +487,7 @@ func ValidateTotalNodeCountWithPodCIDR(shoot *core.Shoot) field.ErrorList {
 	bitLen.Sub(big.NewInt(nodeCIDRMaskSize), big.NewInt(int64(podCIDRMaskSize)))
 	maxNodeCount.Exp(big.NewInt(2), bitLen, nil)
 
-	if maxNodeCount.Cmp(totalNodes) < 0 {
+	if maxNodeCount.Cmp(big.NewInt(totalNodes)) < 0 {
 		allErrs = append(allErrs, field.Invalid(field.NewPath("spec").Child("provider").Child("workers"), totalNodes, fmt.Sprintf("worker configuration incorrect. The podCIDRs in `spec.networking.pod` can only support a maximum of %d nodes. The total number of worker pool nodes should be less than %d ", maxNodeCount, maxNodeCount)))
 	}
 

--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -979,9 +979,10 @@ var _ = Describe("Shoot Validation Tests", func() {
 						errorList := ValidateTotalNodeCountWithPodCIDR(shoot)
 
 						Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
-							"Type":   Equal(field.ErrorTypeInvalid),
-							"Field":  Equal("spec.provider.workers"),
-							"Detail": ContainSubstring("The podCIDRs in `spec.networking.pod` can only support a maximum of 8 nodes"),
+							"Type":     Equal(field.ErrorTypeInvalid),
+							"Field":    Equal("spec.provider.workers"),
+							"BadValue": BeEquivalentTo(32),
+							"Detail":   ContainSubstring("The podCIDRs in `spec.networking.pod` can only support a maximum of 8 nodes"),
 						}))))
 					})
 
@@ -999,9 +1000,10 @@ var _ = Describe("Shoot Validation Tests", func() {
 						errorList := ValidateTotalNodeCountWithPodCIDR(shoot)
 
 						Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
-							"Type":   Equal(field.ErrorTypeInvalid),
-							"Field":  Equal("spec.provider.workers"),
-							"Detail": ContainSubstring("The podCIDRs in `spec.networking.pod` can only support a maximum of 256 nodes"),
+							"Type":     Equal(field.ErrorTypeInvalid),
+							"Field":    Equal("spec.provider.workers"),
+							"BadValue": BeEquivalentTo(257),
+							"Detail":   ContainSubstring("The podCIDRs in `spec.networking.pod` can only support a maximum of 256 nodes"),
 						}))))
 					})
 				})
@@ -1057,9 +1059,10 @@ var _ = Describe("Shoot Validation Tests", func() {
 						errorList := ValidateTotalNodeCountWithPodCIDR(shoot)
 
 						Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
-							"Type":   Equal(field.ErrorTypeInvalid),
-							"Field":  Equal("spec.provider.workers"),
-							"Detail": ContainSubstring("The podCIDRs in `spec.networking.pod` can only support a maximum of 8 nodes"),
+							"Type":     Equal(field.ErrorTypeInvalid),
+							"Field":    Equal("spec.provider.workers"),
+							"BadValue": BeEquivalentTo(32),
+							"Detail":   ContainSubstring("The podCIDRs in `spec.networking.pod` can only support a maximum of 8 nodes"),
 						}))))
 					})
 
@@ -1077,9 +1080,10 @@ var _ = Describe("Shoot Validation Tests", func() {
 						errorList := ValidateTotalNodeCountWithPodCIDR(shoot)
 
 						Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
-							"Type":   Equal(field.ErrorTypeInvalid),
-							"Field":  Equal("spec.provider.workers"),
-							"Detail": ContainSubstring("The podCIDRs in `spec.networking.pod` can only support a maximum of 256 nodes"),
+							"Type":     Equal(field.ErrorTypeInvalid),
+							"Field":    Equal("spec.provider.workers"),
+							"BadValue": BeEquivalentTo(257),
+							"Detail":   ContainSubstring("The podCIDRs in `spec.networking.pod` can only support a maximum of 256 nodes"),
 						}))))
 					})
 				})


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind bug

**What this PR does / why we need it**:

This PR makes the validation error returned by `ValidateTotalNodeCountWithPodCIDR` readable by using `int64` instead of `*big.Int` for the `BadValue` field.

Without this PR, an invalid combination of `podCIDR`, `nodeCIDRMaskSize`, and `workers[].maximum` settings yields the following validation error:
```
$ kubectl apply -f shoot-ipv6.yaml
The Shoot "ipv6" is invalid: spec.provider.workers: Invalid value: big.Int{neg:false, abs:big.nat{0x11}}: worker configuration incorrect. The podCIDRs in `spec.networking.pod` can only support a maximum of 16 nodes. The total number of worker pool nodes should be less than 16
```

With this PR, the error looks like this:
```
$ kubectl apply -f shoot-ipv6.yaml
The Shoot "ipv6" is invalid: spec.provider.workers: Invalid value: 17: worker configuration incorrect. The podCIDRs in `spec.networking.pod` can only support a maximum of 16 nodes. The total number of worker pool nodes should be less than 16
```

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/7051
Follow-up on https://github.com/gardener/gardener/pull/7288

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
