### PR TITLE
Improve problematic webhook detector

### DIFF
--- a/pkg/operation/botanist/matchers/matcher.go
+++ b/pkg/operation/botanist/matchers/matcher.go
@@ -198,15 +198,10 @@ func (w *WebhookConstraintMatcher) Match(
 	var (
 		objLabels = w.ObjectLabels
 		nsLabels  = w.NamespaceLabels
+
+		matchAllObjects    = objLabels == nil
+		matchAllNamespaces = nsLabels == nil
 	)
-
-	if objLabels == nil {
-		objLabels = labels.Set{}
-	}
-
-	if nsLabels == nil {
-		nsLabels = labels.Set{}
-	}
 
 	nsSelector, err := defaultEmptySelector(namespaceLabelSelector)
 	if err != nil {
@@ -220,8 +215,8 @@ func (w *WebhookConstraintMatcher) Match(
 		return true
 	}
 
-	matchObj := objSelector.Empty() || objSelector.Matches(objLabels)
-	matchNS := nsSelector.Empty() || nsSelector.Matches(nsLabels)
+	matchObj := matchAllObjects || objSelector.Empty() || objSelector.Matches(objLabels)
+	matchNS := matchAllNamespaces || nsSelector.Empty() || nsSelector.Matches(nsLabels)
 
 	rm := ruleMatcher{rule: r, gvr: w.GVR, subresource: w.Subresource}
 	if !w.ClusterScoped {

--- a/pkg/operation/care/constraints_test.go
+++ b/pkg/operation/care/constraints_test.go
@@ -345,6 +345,9 @@ var _ = Describe("Constraints", func() {
 		kubeSystemNamespaceTables(extensionsv1beta1.SchemeGroupVersion.WithResource("networkpolicies"))
 		withoutSelectorsTables(extensionsv1beta1.SchemeGroupVersion.WithResource("podsecuritypolicies"))
 
+		// there are no non-problematic webhooks expected for leases because
+		// Gardener considers all leases in all namespaces
+		commonTests(coordinationv1.SchemeGroupVersion.WithResource("leases"), kubeSystemNamespaceProblematic, nil)
 		withoutSelectorsTables(coordinationv1.SchemeGroupVersion.WithResource("leases"))
 		withoutSelectorsTables(coordinationv1beta1.SchemeGroupVersion.WithResource("leases"))
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind enhancement

**What this PR does / why we need it**:
This PR improves matches of the problematic webhook detector when GVRs should be considered for all namespaces and all labels.

_Example:_ 

A webhook should be considered problematic if it acts on any `Lease` object. Earlier, the webhook was detected only if it didn't have any namespace or label selector in place. It was not reported problematic anymore, as soon as a dummy selector was added.

_This configuration was reported as problematic_

```
  namespaceSelector: {}
  objectSelector: {}
  rules:
  - apiGroups:
    - coordination.k8s.io
    apiVersions:
    - v1
    operations:
    - CREATE
    - UPDATE
    resources:
    - leases
```

_This configuration was not reported_

```
  namespaceSelector: {}
  objectSelector:
    matchExpressions:
    - key: foo
      operator: In
      values:
      - bar
  rules:
  - apiGroups:
    - coordination.k8s.io
    apiVersions:
    - v1
    operations:
    - CREATE
    - UPDATE
    resources:
    - leases
```

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The problematic webhook detector has been adapted to match webhooks acting on `endpoint` and `lease` objects in all namespaces. Under some circumstances, such webhooks were not reported as problematic before.
```
