### PR TITLE
Allow `ControlPlane` spec modifications for unscheduled shoots

### DIFF
--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -2013,10 +2013,12 @@ func validateHAShootControlPlaneConfigurationValue(shoot *core.Shoot) field.Erro
 
 func validateShootHAControlPlaneSpecUpdate(newSpec, oldSpec *core.ShootSpec, fldPath *field.Path) field.ErrorList {
 	var (
+		allErrs          = field.ErrorList{}
+		shootIsScheduled = newSpec.SeedName != nil
+
 		oldVal, newVal core.FailureToleranceType
 		oldValExists   bool
 	)
-	allErrs := field.ErrorList{}
 
 	if oldSpec.ControlPlane != nil && oldSpec.ControlPlane.HighAvailability != nil {
 		oldVal = oldSpec.ControlPlane.HighAvailability.FailureTolerance.Type
@@ -2027,7 +2029,7 @@ func validateShootHAControlPlaneSpecUpdate(newSpec, oldSpec *core.ShootSpec, fld
 		newVal = newSpec.ControlPlane.HighAvailability.FailureTolerance.Type
 	}
 
-	if oldValExists {
+	if oldValExists && shootIsScheduled {
 		// If the HighAvailability field is already set for the shoot then enforce that it cannot be changed.
 		allErrs = append(allErrs, apivalidation.ValidateImmutableField(newVal, oldVal, fldPath.Child("highAvailability", "failureTolerance", "type"))...)
 	}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/area high-availability
/kind enhancement

**What this PR does / why we need it**:
This PR relaxes the `Shoot` API validation. Concretely, it allows modifying the `ControlPlane` configuration as long as the shoot is not scheduled.
It'll become handy if users define `failureTolerance.type: zone` but the shoot remains `Pending` when there is no seed candidate with multiple zones. Now, they can change the specification to `failureTolerance.type: node`.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other users
It is now possible to change `shoot.spec.controlPlane` for shoot clusters which haven't been scheduled yet.
```
