### PR TITLE
Remove the CSV format from Basic Authentication secrets

### DIFF
--- a/docs/development/secrets_management.md
+++ b/docs/development/secrets_management.md
@@ -141,7 +141,7 @@ and you already have an existing secret in your system whose data should be kept
 
 | Secret Type          | Data Keys                                               |
 | -------------------- |---------------------------------------------------------|
-| Basic Auth           | `basic_auth.csv`, `username`, `password`, `auth`        |
+| Basic Auth           | `username`, `password`, `auth`                          |
 | CA Certificate       | `ca.crt`, `ca.key`                                      |
 | Non-CA Certificate   | `tls.crt`, `tls.key`                                    |
 | Control Plane Secret | `ca.crt`, `username`, `password`, `token`, `kubeconfig` |

--- a/docs/usage/shoot_credentials_rotation.md
+++ b/docs/usage/shoot_credentials_rotation.md
@@ -148,7 +148,6 @@ Those credentials are stored in a `Secret` with name `<shoot-name>.monitoring` i
 
 - `username`: the user name
 - `password`: the password
-- `basic_auth.csv`: the user name and password in CSV format
 - `auth`: the user name with SHA-1 representation of the password
 
 **It is the responsibility of the end-user to regularly rotate those credentials.**

--- a/extensions/pkg/util/secret/manager/manager_test.go
+++ b/extensions/pkg/util/secret/manager/manager_test.go
@@ -104,7 +104,7 @@ var _ = Describe("SecretsManager Extension Utils", func() {
 		otherConfig = SecretConfigWithOptions{
 			Config: &secretsutils.BasicAuthSecretConfig{
 				Name:           "some-secret",
-				Format:         secretsutils.BasicAuthFormatCSV,
+				Format:         secretsutils.BasicAuthFormatNormal,
 				Username:       "admin",
 				PasswordLength: 32,
 			},
@@ -253,7 +253,7 @@ var _ = Describe("SecretsManager Extension Utils", func() {
 				expectSecrets(fakeClient,
 					"my-extension-ca-013c464d", "my-extension-ca-bundle-d563c0b7",
 					"my-extension-ca-2-673cf9ab", "my-extension-ca-2-bundle-086fe2a7",
-					"some-server-7388feb3", "some-secret-2583adfe")
+					"some-server-7388feb3", "some-secret-4b8f9d51")
 			})
 		})
 
@@ -277,7 +277,7 @@ var _ = Describe("SecretsManager Extension Utils", func() {
 					expectSecrets(fakeClient,
 						"my-extension-ca-013c464d", "my-extension-ca-bundle-7c9e4d64",
 						"my-extension-ca-2-673cf9ab", "my-extension-ca-2-bundle-97af5249",
-						"some-server-70ec0461", "some-secret-2583adfe")
+						"some-server-70ec0461", "some-secret-4b8f9d51")
 				})
 			})
 
@@ -302,7 +302,7 @@ var _ = Describe("SecretsManager Extension Utils", func() {
 					expectSecrets(fakeClient,
 						"my-extension-ca-013c464d", "my-extension-ca-013c464d-431ab", "my-extension-ca-bundle-e595315e",
 						"my-extension-ca-2-673cf9ab", "my-extension-ca-2-673cf9ab-431ab", "my-extension-ca-2-bundle-fb324296",
-						"some-server-70ec0461", "some-secret-2583adfe")
+						"some-server-70ec0461", "some-secret-4b8f9d51")
 				})
 			})
 
@@ -327,7 +327,7 @@ var _ = Describe("SecretsManager Extension Utils", func() {
 					expectSecrets(fakeClient,
 						"my-extension-ca-013c464d-431ab", "my-extension-ca-bundle-0efe4bf3",
 						"my-extension-ca-2-673cf9ab-431ab", "my-extension-ca-2-bundle-11a56f33",
-						"some-server-bbe4c0f9", "some-secret-2583adfe")
+						"some-server-bbe4c0f9", "some-secret-4b8f9d51")
 				})
 			})
 		})

--- a/pkg/operation/botanist/monitoring_test.go
+++ b/pkg/operation/botanist/monitoring_test.go
@@ -234,7 +234,7 @@ var _ = Describe("Monitoring", func() {
 			Expect(gardenClient.Get(ctx, kubernetesutils.Key(projectNamespace, shootName+".monitoring"), secret)).To(Succeed())
 			Expect(secret.Annotations).To(HaveKeyWithValue("url", "https://gu-foo--bar."))
 			Expect(secret.Labels).To(HaveKeyWithValue("gardener.cloud/role", "monitoring"))
-			Expect(secret.Data).To(And(HaveKey("username"), HaveKey("password"), HaveKey("auth"), HaveKey("basic_auth.csv")))
+			Expect(secret.Data).To(And(HaveKey("username"), HaveKey("password"), HaveKey("auth")))
 		})
 
 		It("should cleanup the secrets when shoot purpose is changed", func() {

--- a/pkg/provider-local/controller/controlplane/valuesprovider.go
+++ b/pkg/provider-local/controller/controlplane/valuesprovider.go
@@ -71,7 +71,7 @@ func getSecretConfigs(namespace string) []extensionssecretsmanager.SecretConfigW
 		{
 			Config: &secretsutils.BasicAuthSecretConfig{
 				Name:           local.Name + "-dummy-auth",
-				Format:         secretsutils.BasicAuthFormatCSV,
+				Format:         secretsutils.BasicAuthFormatNormal,
 				PasswordLength: 32,
 			},
 			Options: []secretsmanager.GenerateOption{secretsmanager.Validity(time.Hour)},

--- a/pkg/utils/secrets/basic_auth_test.go
+++ b/pkg/utils/secrets/basic_auth_test.go
@@ -28,7 +28,6 @@ var _ = Describe("Basic Auth Secrets", func() {
 			Expect(ok).To(BeTrue())
 
 			Expect(basicAuth.Name).To(Equal(expected.Name))
-			Expect(basicAuth.Format).To(Equal(expected.Format))
 			Expect(basicAuth.Username).To(Equal(expected.Username))
 
 			if comparePasswords {
@@ -46,14 +45,13 @@ var _ = Describe("Basic Auth Secrets", func() {
 		BeforeEach(func() {
 			basicAuthConfiguration = &BasicAuthSecretConfig{
 				Name:           "basic-auth",
-				Format:         BasicAuthFormatCSV,
+				Format:         BasicAuthFormatNormal,
 				Username:       "admin",
 				PasswordLength: 32,
 			}
 
 			expectedBasicAuthObject = &BasicAuth{
 				Name:     "basic-auth",
-				Format:   BasicAuthFormatCSV,
 				Username: "admin",
 				Password: "foo",
 			}
@@ -72,37 +70,25 @@ var _ = Describe("Basic Auth Secrets", func() {
 		var (
 			basicAuth                *BasicAuth
 			expectedNormalFormatData map[string][]byte
-			expectedCSVFormatData    map[string][]byte
 		)
 		BeforeEach(func() {
 			basicAuth = &BasicAuth{
 				Name:     "basicauth",
 				Username: "admin",
 				Password: "foo",
-				Format:   BasicAuthFormatCSV,
 			}
 
 			expectedNormalFormatData = map[string][]byte{
 				DataKeyUserName: []byte("admin"),
 				DataKeyPassword: []byte("foo"),
-				DataKeyCSV:      []byte("foo,admin,admin,system:masters"),
 				DataKeySHA1Auth: []byte("admin:{SHA}C+7Hteo/D9vJXQ3UfzxbwnXaijM="),
-			}
-
-			expectedCSVFormatData = map[string][]byte{
-				DataKeyCSV: []byte("foo,admin,admin,system:masters"),
 			}
 		})
 
 		Describe("#SecretData", func() {
 			It("should properly return secret data if format is BasicAuthFormatNormal", func() {
-				basicAuth.Format = BasicAuthFormatNormal
 				data := basicAuth.SecretData()
 				Expect(data).To(Equal(expectedNormalFormatData))
-			})
-			It("should properly return secret data if format is CSV", func() {
-				data := basicAuth.SecretData()
-				Expect(data).To(Equal(expectedCSVFormatData))
 			})
 		})
 	})


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area open-source
/kind cleanup

**What this PR does / why we need it**:

Removes the CSV format from Basic Authentication secrets

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/6911

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
The newly created or recreated basic authentication Secrets will no longer contain the `basic_auth.csv` field under the Secret's `data`. The `basic_auth.csv` field was only required for the kube-apiserver basic auth which can no longer be enabled for K8s >= 1.19 Shoot clusters.
```
