### PR TITLE
Website Cleanup - Part 3 (Development) - Rebased

### DIFF
--- a/docs/development/changing-the-api.md
+++ b/docs/development/changing-the-api.md
@@ -1,37 +1,37 @@
 ---
-title: Changing the APIs
+title: Changing the API
 ---
 
-# Extending the API
+# Changing the API
 
 This document describes the steps that need to be performed when changing the API.
 It provides guidance for API changes to both (Gardener system in general or component configurations).
 
-Generally, as Gardener is a Kubernetes-native extension, it follows the same API conventions and guidelines like Kubernetes itself.
-[This document](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md) as well as [this document](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api_changes.md) already provide a good overview and general explanation of the basic concepts behind it.
+Generally, as Gardener is a Kubernetes-native extension, it follows the same API conventions and guidelines like Kubernetes itself. The Kubernetes 
+[API Conventions](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md) as well as [Changing the API](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api_changes.md) topics already provide a good overview and general explanation of the basic concepts behind it.
 We are following the same approaches.
 
 ## Gardener API
 
-The Gardener API is defined in `pkg/apis/{core,extensions,settings}` directories and is the main point of interaction with the system.
+The Gardener API is defined in the `pkg/apis/{core,extensions,settings}` directories and is the main point of interaction with the system.
 It must be ensured that the API is always backwards-compatible.
 
-#### Changing the API
+### Changing the API
 
 **Checklist** when changing the API:
 
-1. Modify the field(s) in the respective Golang files of all external and the internal version.
+1. Modify the field(s) in the respective Golang files of all external versions and the internal version.
     1. Make sure new fields are being added as "optional" fields, i.e., they are of pointer types, they have the `// +optional` comment, and they have the `omitempty` JSON tag.
     1. Make sure that the existing field numbers in the protobuf tags are not changed.
-1. If necessary then implement/adapt the conversion logic defined in the versioned APIs (e.g., `pkg/apis/core/v1beta1/conversions*.go`).
-1. If necessary then implement/adapt defaulting logic defined in the versioned APIs (e.g., `pkg/apis/core/v1beta1/defaults*.go`).
-1. Run the code generation: `make generate`
-1. If necessary then implement/adapt validation logic defined in the internal API (e.g., `pkg/apis/core/validation/validation*.go`).
-1. If necessary then adapt the exemplary YAML manifests of the Gardener resources defined in `example/*.yaml`.
-1. In most cases it makes sense to add/adapt the documentation for administrators/operators and/or end-users in the `docs` folder to provide information on purpose and usage of the added/changed fields.
-1. When opening the pull request then always add a release note so that end-users are becoming aware of the changes.
+2. If necessary, implement/adapt the conversion logic defined in the versioned APIs (e.g., `pkg/apis/core/v1beta1/conversions*.go`).
+3. If necessary, implement/adapt defaulting logic defined in the versioned APIs (e.g., `pkg/apis/core/v1beta1/defaults*.go`).
+4. Run the code generation: `make generate`
+5. If necessary, implement/adapt validation logic defined in the internal API (e.g., `pkg/apis/core/validation/validation*.go`).
+6. If necessary, adapt the exemplary YAML manifests of the Gardener resources defined in `example/*.yaml`.
+7. In most cases, it makes sense to add/adapt the documentation for administrators/operators and/or end-users in the `docs` folder to provide information on purpose and usage of the added/changed fields.
+8. When opening the pull request, always add a release note so that end-users are becoming aware of the changes.
 
-#### Removing a field
+### Removing a Field
 
 If fields shall be removed permanently from the API, then a proper deprecation period must be adhered to so that end-users have enough time to adapt their clients.
 
@@ -47,21 +47,21 @@ The steps for removing a field from the code base is:
    +	// SeedTemplate *gardencorev1beta1.SeedTemplate `json:"seedTemplate,omitempty" protobuf:"bytes,2,opt,name=seedTemplate"`
    ```
 
-   The reasoning behind this is to prevent the same protobuf number to be used by a new field. Introducing a new field with the same protobuf number would be a breaking change for clients still using the old protobuf definitions that have the old field for the given protobuf number.
+   The reasoning behind this is to prevent the same protobuf number being used by a new field. Introducing a new field with the same protobuf number would be a breaking change for clients still using the old protobuf definitions that have the old field for the given protobuf number.
    The field in the internal version can be removed.
 
-2. Unit test has to be added to make sure that a new field does not reuse the already reserved protobuf tag.
+2. A unit test has to be added to make sure that a new field does not reuse the already reserved protobuf tag.
 
-Example of field removal can be found in https://github.com/gardener/gardener/pull/6972.
+Example of field removal can be found in the [Remove `seedTemplate` field from ManagedSeed API](https://github.com/gardener/gardener/pull/6972) PR.
 
-## Component configuration APIs
+## Component Configuration APIs
 
 Most Gardener components have a component configuration that follows similar principles to the Gardener API.
 Those component configurations are defined in `pkg/{controllermanager,gardenlet,scheduler},pkg/apis/config`.
 Hence, the above checklist also applies for changes to those APIs.
-However, since these APIs are only used internally and only during the deployment of Gardener the guidelines with respect to changes and backwards-compatibility are slightly relaxed.
-If necessary then it is allowed to remove fields without a proper deprecation period if the release note uses the `breaking operator` keywords.
+However, since these APIs are only used internally and only during the deployment of Gardener, the guidelines with respect to changes and backwards-compatibility are slightly relaxed.
+If necessary, it is allowed to remove fields without a proper deprecation period if the release note uses the `breaking operator` keywords.
 
 In addition to the above checklist:
 
-1. If necessary then adapt the Helm chart of Gardener defined in `charts/gardener`. Adapt the `values.yaml` file as well as the manifest templates.
+1. If necessary, then adapt the Helm chart of Gardener defined in `charts/gardener`. Adapt the `values.yaml` file as well as the manifest templates.

--- a/docs/development/component-checklist.md
+++ b/docs/development/component-checklist.md
@@ -1,15 +1,15 @@
 # Checklist For Adding New Components
 
-Adding new components which run in garden, seed or shoot cluster is theoretically quite simple - we just need a `Deployment` (or similar other workload resource), the respective container image and maybe a bit of configuration.
-In practice however, there are a couple of things to keep in mind in order to make the deployment production-ready.
-This document provides a checklist for them which you can walk through. 
+Adding new components that run in the garden, seed, or shoot cluster is theoretically quite simple - we just need a `Deployment` (or other similar workload resource), the respective container image, and maybe a bit of configuration.
+In practice, however, there are a couple of things to keep in mind in order to make the deployment production-ready.
+This document provides a checklist for them that you can walk through. 
 
 ## General
 
 1. **Avoid usage of Helm charts** ([example](https://github.com/gardener/gardener/tree/6a0fea86850ffec8937d1956bdf1a8ca6d074f3b/pkg/operation/botanist/component/metricsserver))
 
    Nowadays, we use [Golang components](https://github.com/gardener/gardener/blob/6a0fea86850ffec8937d1956bdf1a8ca6d074f3b/pkg/operation/botanist/component/interfaces.go) instead of Helm charts for deploying components to a cluster.
-   Please find a typical structure of such components [here](https://github.com/gardener/gardener/blob/6a0fea86850ffec8937d1956bdf1a8ca6d074f3b/pkg/operation/botanist/component/metricsserver/metrics_server.go#L80-L97) (configuration values are typically managed in a `Values` structure).
+   Please find a typical structure of such components in the provided [metrics_server.go](https://github.com/gardener/gardener/blob/6a0fea86850ffec8937d1956bdf1a8ca6d074f3b/pkg/operation/botanist/component/metricsserver/metrics_server.go#L80-L97) file (configuration values are typically managed in a `Values` structure).
    There are a few exceptions (e.g., [Istio](https://github.com/gardener/gardener/tree/6a0fea86850ffec8937d1956bdf1a8ca6d074f3b/pkg/operation/botanist/component/istio)) still using charts, however the default should be using a Golang-based implementation.
    For the exceptional cases, use Golang's [embed](https://pkg.go.dev/embed) package to embed the Helm chart directory ([example 1](https://github.com/gardener/gardener/blob/6a0fea86850ffec8937d1956bdf1a8ca6d074f3b/pkg/operation/botanist/component/istio/istiod.go#L51-L52), [example 2](https://github.com/gardener/gardener/blob/6a0fea86850ffec8937d1956bdf1a8ca6d074f3b/pkg/operation/botanist/component/istio/istiod.go#L257-L273)). 
 
@@ -17,7 +17,7 @@ This document provides a checklist for them which you can walk through.
 
    For historic reasons, resources related to shoot control plane components are applied directly with the client.
    All other resources (seed or shoot system components) are deployed via `gardener-resource-manager`'s [Resource controller](../concepts/resource-manager.md#managedresource-controller) (`ManagedResource`s) since it performs health checks out-of-the-box and has a lot of other features (see its documentation for more information).
-   Components which can run as both seed system component or shoot control plane component (e.g., VPA or `kube-state-metrics`) can make use of [these utility functions](https://github.com/gardener/gardener/blob/6a0fea86850ffec8937d1956bdf1a8ca6d074f3b/pkg/operation/botanist/component/resourceconfig.go).
+   Components that can run as both seed system component or shoot control plane component (e.g., VPA or `kube-state-metrics`) can make use of [these utility functions](https://github.com/gardener/gardener/blob/6a0fea86850ffec8937d1956bdf1a8ca6d074f3b/pkg/operation/botanist/component/resourceconfig.go).
 
 3. **Do not hard-code container image references** ([example 1](https://github.com/gardener/gardener/blob/6a0fea86850ffec8937d1956bdf1a8ca6d074f3b/charts/images.yaml#L130-L133), [example 2](https://github.com/gardener/gardener/blob/6a0fea86850ffec8937d1956bdf1a8ca6d074f3b/pkg/operation/botanist/metricsserver.go#L28-L31), [example 3](https://github.com/gardener/gardener/blob/6a0fea86850ffec8937d1956bdf1a8ca6d074f3b/pkg/operation/botanist/component/metricsserver/metrics_server.go#L82-L83))
 
@@ -40,7 +40,7 @@ This document provides a checklist for them which you can walk through.
 
    You should use the [secrets manager](secrets_management.md) for the management of any kind of credentials.
    This makes sure that credentials rotation works out-of-the-box without you requiring to think about it.
-   Generally, do not use client certificates (see [security section](#security)).
+   Generally, do not use client certificates (see the [Security section](#security)).
 
 6. **Consider hibernation when calculating replica count** ([example](https://github.com/gardener/gardener/blob/6a0fea86850ffec8937d1956bdf1a8ca6d074f3b/pkg/operation/botanist/kubescheduler.go#L36))
 
@@ -54,35 +54,35 @@ This document provides a checklist for them which you can walk through.
 
 8. **Handle shoot system components**
 
-   Shoot system components deployed by `gardener-resource-manager` are labelled with `resource.gardener.cloud/managed-by: gardener`. This makes Gardener adding required label selectors and tolerations so that non-`DaemonSet` managed `Pod`s will exclusively run on selected nodes, [more information](../concepts/resource-manager.md#system-components-webhook).
+   Shoot system components deployed by `gardener-resource-manager` are labelled with `resource.gardener.cloud/managed-by: gardener`. This makes Gardener adding required label selectors and tolerations so that non-`DaemonSet` managed `Pod`s will exclusively run on selected nodes (for more information, see [System Components Webhook](../concepts/resource-manager.md#system-components-webhook)).
    `DaemonSet`s on the other hand, should generally tolerate any `NoSchedule` or `NoExecute` taints so that they can run on any `Node`, regardless of user added taints.
 
 ## Security
 
 1. **Use a [dedicated `ServiceAccount`](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/) and disable auto-mount** ([example](https://github.com/gardener/gardener/blob/6a0fea86850ffec8937d1956bdf1a8ca6d074f3b/pkg/operation/botanist/component/metricsserver/metrics_server.go#L145-L151))
 
-   Components which need to talk to the API server of their runtime cluster must always use a dedicated `ServiceAccount` (do not use `default`) which `automountServiceAccountToken` set to `false`.
-   This makes `gardener-resource-manager`'s [TokenInvalidator](../concepts/resource-manager.md#tokeninvalidator) invalidating the static token secret and its [`ProjectedTokenMount` webhook](../concepts/resource-manager.md#auto-mounting-projected-serviceaccount-tokens) injecting a projected token automatically.
+   Components that need to talk to the API server of their runtime cluster must always use a dedicated `ServiceAccount` (do not use `default`), with `automountServiceAccountToken` set to `false`.
+   This makes `gardener-resource-manager`'s [TokenInvalidator](../concepts/resource-manager.md#tokeninvalidator) invalidate the static token secret and its [`ProjectedTokenMount` webhook](../concepts/resource-manager.md#auto-mounting-projected-serviceaccount-tokens) inject a projected token automatically.
 
 2. **Use shoot access tokens instead of a client certificates** ([example](https://github.com/gardener/gardener/blob/6a0fea86850ffec8937d1956bdf1a8ca6d074f3b/pkg/operation/botanist/component/kubescheduler/kube_scheduler.go#L227-L229))
 
-   Components which need to talk to a target cluster different from their runtime cluster (e.g., running in seed cluster but talking to shoot) then the `gardener-resource-manager`'s [TokenRequestor](../concepts/resource-manager.md#tokenrequestor) should be used to manage a so-called "shoot access token".
+   For components that need to talk to a target cluster different from their runtime cluster (e.g., running in seed cluster but talking to shoot) the `gardener-resource-manager`'s [TokenRequestor](../concepts/resource-manager.md#tokenrequestor) should be used to manage a so-called "shoot access token".
 
 3. **Define RBAC roles with minimal privileges** ([example](https://github.com/gardener/gardener/blob/6a0fea86850ffec8937d1956bdf1a8ca6d074f3b/pkg/operation/botanist/component/metricsserver/metrics_server.go#L153-L223))
 
-   The component's `ServiceAccount` (if exists) should have as little privileges as possible.
+   The component's `ServiceAccount` (if it exists) should have as little privileges as possible.
    Consequently, please define proper [RBAC roles](https://kubernetes.io/docs/reference/access-authn-authz/rbac/) for it.
    This might include a combination of `ClusterRole`s and `Role`s.
-   Please do not provide elevated privileges due to laziness (e.g., because there is already a `ClusterRole` that can be extended vs. creating a `Role` only when only access to a single namespace is needed).
+   Please do not provide elevated privileges due to laziness (e.g., because there is already a `ClusterRole` that can be extended vs. creating a `Role` only when access to a single namespace is needed).
 
 4. **Use [`NetworkPolicy`s](https://kubernetes.io/docs/concepts/services-networking/network-policies/) to restrict network traffic** ([example](https://github.com/gardener/gardener/blob/6a0fea86850ffec8937d1956bdf1a8ca6d074f3b/pkg/operation/botanist/component/etcd/etcd.go#L293-L339))
 
    You should restrict both ingress and egress traffic to/from your component as much as possible to ensure that it only gets access to/from other components if really needed.
-   Gardener provides a few default policies for typical usage scenarios, please see [this document for seed clusters](seed_network_policies.md) and [this document for shoot clusters](../usage/shoot_network_policies.md).
+   Gardener provides a few default policies for typical usage scenarios. For more information, see [Seed Network Policies](seed_network_policies.md) and [Shoot Network Policies](../usage/shoot_network_policies.md).
 
 5. **Do not run components in privileged mode** ([example 1](https://github.com/gardener/gardener/blob/6a0fea86850ffec8937d1956bdf1a8ca6d074f3b/pkg/operation/botanist/component/nodelocaldns/nodelocaldns.go#L329-L333), [example 2](https://github.com/gardener/gardener/blob/6a0fea86850ffec8937d1956bdf1a8ca6d074f3b/pkg/operation/botanist/component/nodelocaldns/nodelocaldns.go#L507))
 
-   Avoid running components with `privileged=true` and define the needed [Linux capabilities](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-capabilities-for-a-container) instead.
+   Avoid running components with `privileged=true`. Instead, define the needed [Linux capabilities](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-capabilities-for-a-container).
 
 6. **Choose the proper Seccomp profile** ([example 1](https://github.com/gardener/gardener/blob/6a0fea86850ffec8937d1956bdf1a8ca6d074f3b/pkg/operation/botanist/component/nodelocaldns/nodelocaldns.go#L285-L287), [example 2](https://github.com/gardener/gardener/blob/6a0fea86850ffec8937d1956bdf1a8ca6d074f3b/pkg/operation/botanist/component/nginxingress/nginxingress.go#L427))
 
@@ -93,14 +93,14 @@ This document provides a checklist for them which you can walk through.
 
    `PodSecurityPolicy`s are deprecated, however Gardener still supports shoot clusters with older Kubernetes versions ([ref](../usage/supported_k8s_versions.md)).
    To make sure that such clusters can run with `.spec.kubernetes.allowPrivilegedContainers=false`, you have to define proper `PodSecurityPolicy`s.
-   See also [this document](../usage/pod-security.md) for more information.
+   For more information, see [Pod Security](../usage/pod-security.md).
 
 ## High Availability / Stability
 
 1. **Specify the component type label for high availability** ([example](https://github.com/gardener/gardener/blob/6a0fea86850ffec8937d1956bdf1a8ca6d074f3b/pkg/operation/botanist/component/kubescheduler/kube_scheduler.go#L234))
 
    To support high-availability deployments, `gardener-resource-manager`s [HighAvailabilityConfig](../concepts/resource-manager.md#high-availability-config) webhook injects the proper specification like replica or topology spread constraints.
-   You only need to specify the type label, see also [this document](high-availability.md) for more information.
+   You only need to specify the type label. For more information, see [High Availability Of Deployed Components](high-availability.md).
 
 2. **Define a `PodDisruptionBudget`** ([example](https://github.com/gardener/gardener/blob/6a0fea86850ffec8937d1956bdf1a8ca6d074f3b/pkg/operation/botanist/component/metricsserver/metrics_server.go#L398-L422))
 
@@ -109,7 +109,7 @@ This document provides a checklist for them which you can walk through.
 3. **Choose the right `PriorityClass`** ([example](https://github.com/gardener/gardener/blob/6a0fea86850ffec8937d1956bdf1a8ca6d074f3b/pkg/operation/botanist/component/kubescheduler/kube_scheduler.go#L301))
 
    Each cluster runs many components with different priorities.
-   Gardener provides a set of default [`PriorityClass`es](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#priorityclass), see [this document](priority-classes.md) for more information.
+   Gardener provides a set of default [`PriorityClass`es](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#priorityclass). For more information, see [Priority Classes](priority-classes.md).
 
 4. **Consider defining liveness and readiness probes** ([example](https://github.com/gardener/gardener/blob/6a0fea86850ffec8937d1956bdf1a8ca6d074f3b/pkg/operation/botanist/component/metricsserver/metrics_server.go#L335-L358))
 
@@ -120,17 +120,17 @@ This document provides a checklist for them which you can walk through.
 1. **Provide resource requirements** ([example](https://github.com/gardener/gardener/blob/6a0fea86850ffec8937d1956bdf1a8ca6d074f3b/pkg/operation/botanist/component/metricsserver/metrics_server.go#L359-L367))
 
    All components should have [resource requirements](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limits).
-   Generally, they should always request CPU and memory while only memory shall be limited (no CPU limits!).
+   Generally, they should always request CPU and memory, while only memory shall be limited (no CPU limits!).
 
 2. **Define a `VerticalPodAutoscaler`** ([example](https://github.com/gardener/gardener/blob/6a0fea86850ffec8937d1956bdf1a8ca6d074f3b/pkg/operation/botanist/component/metricsserver/metrics_server.go#L424-L460))
 
    We typically perform vertical auto-scaling via the VPA managed by the [Kubernetes community](https://github.com/kubernetes/autoscaler/tree/master/vertical-pod-autoscaler).
-   Each component should have a respective `VerticalPodAutoscaler` which "min allowed" resources, "auto update mode", and "requests only"-mode.
-   VPA is always enabled in garden or seed clusters while it is optional for shoot clusters.
+   Each component should have a respective `VerticalPodAutoscaler` with "min allowed" resources, "auto update mode", and "requests only"-mode.
+   VPA is always enabled in garden or seed clusters, while it is optional for shoot clusters.
 
 3. **Define a `HorizontalPodAutoscaler` if needed** ([example](https://github.com/gardener/gardener/blob/6a0fea86850ffec8937d1956bdf1a8ca6d074f3b/pkg/operation/botanist/component/coredns/coredns.go#L689-L738))
 
-   If your component is capable of scaling horizontally, the definition of a [`HorizontalPodAutoscaler`](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/) should be considered.
+   If your component is capable of scaling horizontally, you should consider defining a [`HorizontalPodAutoscaler`](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/).
 
 ## Observability / Operations Productivity
 
@@ -138,13 +138,13 @@ This document provides a checklist for them which you can walk through.
 
    Components should provide scrape configuration and alerting rules for Prometheus/Alertmanager if appropriate.
    This should be done inside a dedicated `monitoring.go` file.
-   Extensions should follow [this document](../extensions/logging-and-monitoring.md#extensions-monitoring-integration).
+   Extensions should follow the guidelines described in [Extensions Monitoring Integration](../extensions/logging-and-monitoring.md#extensions-monitoring-integration).
 
 2. **Provide logging parsers and filters** ([example 1](https://github.com/gardener/gardener/blob/6a0fea86850ffec8937d1956bdf1a8ca6d074f3b/pkg/operation/botanist/component/coredns/logging.go), [example 2](https://github.com/gardener/gardener/blob/6a0fea86850ffec8937d1956bdf1a8ca6d074f3b/pkg/gardenlet/controller/seed/seed/reconciler_reconcile.go#L563))
 
-   Components should provide parsers and filters for fluent-bit if appropriate.
+   Components should provide parsers and filters for fluent-bit, if appropriate.
    This should be done inside a dedicated `logging.go` file.
-   Extensions should follow [this document](../extensions/logging-and-monitoring.md#fluent-bit-log-parsers-and-filters).
+   Extensions should follow the guidelines described in [Fluent-bit log parsers and filters](../extensions/logging-and-monitoring.md#fluent-bit-log-parsers-and-filters).
 
 3. **Set the `revisionHistoryLimit` to `2` for `Deployment`s** ([example](https://github.com/gardener/gardener/blob/6a0fea86850ffec8937d1956bdf1a8ca6d074f3b/pkg/operation/botanist/component/metricsserver/metrics_server.go#L273))
 
@@ -157,5 +157,5 @@ This document provides a checklist for them which you can walk through.
 
 5. **Configure automatic restarts in shoot maintenance time window** ([example 1](https://github.com/gardener/gardener/blob/6a0fea86850ffec8937d1956bdf1a8ca6d074f3b/pkg/operation/botanist/component/kubescheduler/kube_scheduler.go#L243), [example 2](https://github.com/gardener/gardener/blob/6a0fea86850ffec8937d1956bdf1a8ca6d074f3b/pkg/operation/botanist/coredns.go#L90-L107))
 
-   Gardener offers to restart components during the maintenance time window, see [this document](../usage/shoot_maintenance.md#restart-control-plane-controllers) and [this document](../usage/shoot_maintenance.md#restart-some-core-addons).
+   Gardener offers to restart components during the maintenance time window. For more information, see [Restart Control Plane Controllers](../usage/shoot_maintenance.md#restart-control-plane-controllers) and [Restart Some Core Addons](../usage/shoot_maintenance.md#restart-some-core-addons).
    You can consider adding the needed label to your control plane component to get this automatic restart (probably not needed for most components).

--- a/docs/development/dependencies.md
+++ b/docs/development/dependencies.md
@@ -5,15 +5,15 @@ In order to add a new package dependency to the project, you can perform `go get
 
 ## Updating Dependencies
 
-The `Makefile` contains a rule called `revendor` which performs `go mod tidy` and `go mod vendor`.
-`go mod tidy` makes sure go.mod matches the source code in the module. It adds any missing modules necessary to build the current module's packages and dependencies, and it removes unused modules that don't provide any relevant packages.
-`go mod vendor` resets the main module's vendor directory to include all packages needed to build and test all the main module's packages. It does not include test code for vendored packages.
+The `Makefile` contains a rule called `revendor` which performs `go mod tidy` and `go mod vendor`:
+- `go mod tidy` makes sure `go.mod` matches the source code in the module. It adds any missing modules necessary to build the current module's packages and dependencies, and it removes unused modules that don't provide any relevant packages.
+- `go mod vendor` resets the main module's vendor directory to include all packages needed to build and test all the main module's packages. It does not include test code for vendored packages.
 
 ```bash
 make revendor
 ```
 
-The dependencies are installed into the `vendor` folder which **should be added** to the VCS.
+The dependencies are installed into the `vendor` folder, which **should be added** to the VCS.
 
 :warning: Make sure that you test the code after you have updated the dependencies!
 
@@ -26,7 +26,7 @@ For example:
 - Library for building Gardener extensions: `extensions`
 - Gardener's Test Framework: `test/framework`
 
-There are a few more folders in this repository (non-Go sources) that are reused across projects in the gardener organization:
+There are a few more folders in this repository (non-Go sources) that are reused across projects in the Gardener organization:
 
 - GitHub templates: `.github`
 - Concourse / cc-utils related helpers: `hack/.ci`
@@ -44,7 +44,7 @@ Currently, we don't have a mechanism yet for selectively syncing out these expor
 
 ## Import Restrictions
 
-We want to make sure, that other projects can depend on this repository's "exported" packages without pulling in the entire repository (including "non-exported" packages) or a high number of other unwanted dependencies.
+We want to make sure that other projects can depend on this repository's "exported" packages without pulling in the entire repository (including "non-exported" packages) or a high number of other unwanted dependencies.
 Hence, we have to be careful when adding new imports or references between our packages.
 
 > ℹ️ General rule of thumb: the mentioned "exported" packages should be as self-contained as possible and depend on as few other packages in the repository and other projects as possible.
@@ -52,8 +52,9 @@ Hence, we have to be careful when adding new imports or references between our p
 In order to support that rule and automatically check compliance with that goal, we leverage [import-boss](https://github.com/kubernetes/code-generator/tree/master/cmd/import-boss).
 The tool checks all imports of the given packages (including transitive imports) against rules defined in `.import-restrictions` files in each directory.
 An import is allowed if it matches at least one allowed prefix and does not match any forbidden prefixes.
-Note: `''` (the empty string) is a prefix of everything.
-For more details, see: https://github.com/kubernetes/code-generator/tree/master/cmd/import-boss
+
+> Note: `''` (the empty string) is a prefix of everything.
+For more details, see the [import-boss](https://github.com/kubernetes/code-generator/tree/master/cmd/import-boss/README.md) topic.
 
 `import-boss` is executed on every pull request and blocks the PR if it doesn't comply with the defined import restrictions.
 You can also run it locally using `make check`.

--- a/docs/development/getting_started_locally.md
+++ b/docs/development/getting_started_locally.md
@@ -33,7 +33,7 @@ The Gardener components, however, will be run as regular processes on your machi
 
     and reload the terminal.
 
-## Setting up the KinD cluster (garden and seed)
+## Setting Up the KinD Cluster (Garden and Seed)
 
 ```bash
 make kind-up KIND_ENV=local
@@ -55,7 +55,9 @@ With this, mirrored images don't have to be pulled again after recreating the cl
 The command also deploys a default [calico](https://github.com/projectcalico/calico) installation as the cluster's CNI implementation with `NetworkPolicy` support (the default `kindnet` CNI doesn't provide `NetworkPolicy` support).
 Furthermore, it deploys the [metrics-server](https://github.com/kubernetes-sigs/metrics-server) in order to support HPA and VPA on the seed cluster.
 
-## Setting up Gardener
+## Setting Up Gardener
+
+In a terminal pane, run:
 
 ```bash
 make dev-setup                                                                # preparing the environment (without webhooks for now)
@@ -63,34 +65,34 @@ kubectl wait --for=condition=ready pod -l run=etcd -n garden --timeout 2m     # 
 make start-apiserver                                                          # starting gardener-apiserver
 ```
 
-In a new terminal pane, run
+In a new terminal pane, run:
 
 ```bash
 kubectl wait --for=condition=available apiservice v1beta1.core.gardener.cloud # wait for gardener-apiserver to be ready
 make start-admission-controller                                               # starting gardener-admission-controller
 ```
 
-In a new terminal pane, run
+In a new terminal pane, run:
 
 ```bash
 make dev-setup DEV_SETUP_WITH_WEBHOOKS=true                                   # preparing the environment with webhooks
 make start-controller-manager                                                 # starting gardener-controller-manager
 ```
 
-(Optional): In a new terminal pane, run
+(Optional): In a new terminal pane, run:
 
 ```bash
 make start-scheduler                                                          # starting gardener-scheduler
 ```
 
-In a new terminal pane, run
+In a new terminal pane, run:
 
 ```bash
 make register-local-env                                                       # registering the local environment (CloudProfile, Seed, etc.)
 make start-gardenlet SEED_NAME=local                                          # starting gardenlet
 ```
 
-In a new terminal pane, run
+In a new terminal pane, run:
 
 ```bash
 make start-extension-provider-local                                           # starting gardener-extension-provider-local
@@ -98,9 +100,9 @@ make start-extension-provider-local                                           # 
 
 ℹ️ The [`provider-local`](../extensions/provider-local.md) is started with elevated privileges since it needs to manipulate your `/etc/hosts` file to enable you accessing the created shoot clusters from your local machine, see [this](../extensions/provider-local.md#dnsrecord) for more details.
 
-## Creating a `Shoot` cluster
+## Creating a `Shoot` Cluster
 
-You can wait for the `Seed` to be ready by running
+You can wait for the `Seed` to become ready by running:
 
 ```bash
 kubectl wait --for=condition=gardenletready --for=condition=extensionsready --for=condition=bootstrapped seed local --timeout=5m
@@ -113,13 +115,13 @@ NAME    STATUS   PROVIDER   REGION   AGE     VERSION       K8S VERSION
 local   Ready    local      local    4m42s   vX.Y.Z-dev    v1.21.1
 ```
 
-In order to create a first shoot cluster, just run
+In order to create a first shoot cluster, just run:
 
 ```bash
 kubectl apply -f example/provider-local/shoot.yaml
 ```
 
-You can wait for the `Shoot` to be ready by running
+You can wait for the `Shoot` to be ready by running:
 
 ```bash
 kubectl wait --for=condition=apiserveravailable --for=condition=controlplanehealthy --for=condition=observabilitycomponentshealthy --for=condition=everynodeready --for=condition=systemcomponentshealthy shoot local -n garden-local --timeout=10m
@@ -132,7 +134,7 @@ NAME    CLOUDPROFILE   PROVIDER   REGION   K8S VERSION   HIBERNATION   LAST OPER
 local   local          local      local    1.21.0        Awake         Create Processing (43%)   healthy   94s
 ```
 
-(Optional): You could also execute a simple e2e test (creating and deleting a shoot) by running
+(Optional): You could also execute a simple e2e test (creating and deleting a shoot) by running:
 
 ```shell
 make test-e2e-local-simple KUBECONFIG="$PWD/example/gardener-local/kind/local/kubeconfig"
@@ -145,7 +147,7 @@ kubectl -n garden-local get secret local.kubeconfig -o jsonpath={.data.kubeconfi
 kubectl --kubeconfig=/tmp/kubeconfig-shoot-local.yaml get nodes
 ```
 
-## (Optional): Setting up a second seed cluster
+## (Optional): Setting Up a Second Seed Cluster
 
 There are cases where you would want to create a second seed cluster in your local setup. For example, if you want to test the [control plane migration](../usage/control_plane_migration.md) feature. The following steps describe how to do that.
 
@@ -168,7 +170,7 @@ make register-kind2-env                                           # registering 
 make start-gardenlet SEED_NAME=local2                             # starting gardenlet for the local2 seed
 ```
 
-In a new terminal pane, run
+In a new terminal pane, run:
 
 ```bash
 export KUBECONFIG=./example/gardener-local/kind/local2/kubeconfig       # setting KUBECONFIG to point to second kind cluster
@@ -180,29 +182,29 @@ make start-extension-provider-local \
   HEALTH_BIND_ADDRESS=:8083                                       # starting gardener-extension-provider-local
 ```
 
-If you want to perform a control plane migration you can follow the steps outlined [here](../usage/control_plane_migration.md) to migrate the shoot cluster to the second seed you just created.
+If you want to perform a control plane migration you can follow the steps outlined in the [Control Plane Migration](../usage/control_plane_migration.md) topic to migrate the shoot cluster to the second seed you just created.
 
-## Deleting the `Shoot` cluster
+## Deleting the `Shoot` Cluster
 
 ```shell
 ./hack/usage/delete shoot local garden-local
 ```
 
-## (Optional): Tear down the second seed cluster
+## (Optional): Tear Down the Second Seed Cluster
 
 ```bash
 make tear-down-kind2-env
 make kind2-down
 ```
 
-## Tear down the Gardener environment
+## Tear Down the Gardener Environment
 
 ```shell
 make tear-down-local-env
 make kind-down
 ```
 
-## Remote local setup
+## Remote Local Setup
 
 Just like Prow is executing the KinD based integration tests in a K8s pod, it is
 possible to interactively run this KinD based Gardener development environment
@@ -220,7 +222,7 @@ tmux -u a
 Please refer to the [TMUX documentation](https://github.com/tmux/tmux/wiki) for
 working effectively inside the remote-local-setup pod.
 
-To access Grafana, Prometheus or other components in a browser, two port forwards are needed:
+To access Grafana, Prometheus, or other components in a browser, two port forwards are needed:
 
 The port forward from the laptop to the pod:
 
@@ -234,6 +236,6 @@ The port forward in the remote-local-setup pod to the respective component:
 k port-forward -n shoot--local--local deployment/grafana-operators 3000
 ```
 
-## Further reading
+## Related Links
 
-This setup makes use of the local provider extension. You can read more about it in [this document](../extensions/provider-local.md).
+- [Local Provider Extension](../extensions/provider-local.md)

--- a/docs/development/kubernetes-clients.md
+++ b/docs/development/kubernetes-clients.md
@@ -1,10 +1,10 @@
 # Kubernetes Clients in Gardener
 
 This document aims at providing a general developer guideline on different aspects of using Kubernetes clients in a large-scale distributed system and project like Gardener.
-The points included here are not meant to be consulted as absolute rules, but rather as general rules of thumb, that allow developers to get a better feeling about certain gotchas and caveats.
+The points included here are not meant to be consulted as absolute rules, but rather as general rules of thumb that allow developers to get a better feeling about certain gotchas and caveats.
 It should be updated with lessons learned from maintaining the project and running Gardener in production.
 
-**Prerequisites**:
+## Prerequisites:
 
 Please familiarize yourself with the following basic Kubernetes API concepts first, if you're new to Kubernetes. A good understanding of these basics will help you better comprehend the following document.
 
@@ -21,7 +21,7 @@ For historical reasons, you will find different kinds of Kubernetes clients in G
 ### Client-Go Clients
 
 [client-go](https://github.com/kubernetes/client-go) is the default/official client for talking to the Kubernetes API in Golang.
-It features so called ["client sets"](https://github.com/kubernetes/client-go/blob/release-1.21/kubernetes/clientset.go#L72) for all built-in Kubernetes API groups and versions (e.g. `v1` (aka `core/v1`), `apps/v1`, etc.).
+It features the so called ["client sets"](https://github.com/kubernetes/client-go/blob/release-1.21/kubernetes/clientset.go#L72) for all built-in Kubernetes API groups and versions (e.g. `v1` (aka `core/v1`), `apps/v1`, etc.).
 client-go clients are generated from the built-in API types using [client-gen](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-api-machinery/generating-clientset.md) and are composed of interfaces for every known API GroupVersionKind.
 A typical client-go usage looks like this:  
 ```go
@@ -38,7 +38,7 @@ _Important characteristics of client-go clients:_
 
 - clients are specific to a given API GroupVersionKind, i.e., clients are hard-coded to corresponding API-paths (don't need to use the discovery API to map GVK to a REST endpoint path).
 - client's don't modify the passed in-memory object (e.g. `deployment` in the above example). Instead, they return a new in-memory object.  
-  This means, controllers have to continue working with the new in-memory object or overwrite the shared object to not lose any state updates.
+  This means that controllers have to continue working with the new in-memory object or overwrite the shared object to not lose any state updates.
 
 ### Generated Client Sets for Gardener APIs
 
@@ -60,7 +60,7 @@ updatedShoot, err := c.CoreV1beta1().Shoots("garden-my-project").Update(ctx, sho
 ### Controller-Runtime Clients
 
 [controller-runtime](https://github.com/kubernetes-sigs/controller-runtime) is a Kubernetes community project ([kubebuilder](https://github.com/kubernetes-sigs/kubebuilder) subproject) for building controllers and operators for custom resources.
-Therefore, it features a generic client, that follows a different approach and does not rely on generated client sets. Instead, the client can be used for managing any Kubernetes resources (built-in or custom) homogeneously.
+Therefore, it features a generic client that follows a different approach and does not rely on generated client sets. Instead, the client can be used for managing any Kubernetes resources (built-in or custom) homogeneously.
 For example:
 
 ```go
@@ -76,7 +76,7 @@ err := c.Update(ctx, deployment)
 err = c.Update(ctx, shoot)
 ```
 
-A brief introduction to controller-runtime and its basic constructs can be found [here](https://pkg.go.dev/sigs.k8s.io/controller-runtime).
+A brief introduction to controller-runtime and its basic constructs can be found at the [official Go documentation](https://pkg.go.dev/sigs.k8s.io/controller-runtime).
 
 _Important characteristics of controller-runtime clients:_
 
@@ -85,11 +85,11 @@ _Important characteristics of controller-runtime clients:_
   A `runtime.Scheme` is basically a registry for Golang API types, defaulting and conversion functions. Schemes are usually provided per `GroupVersion` (see [this example](https://github.com/kubernetes/api/blob/release-1.21/apps/v1/register.go) for `apps/v1`) and can be combined to one single scheme for further usage ([example](https://github.com/gardener/gardener/blob/v1.29.0/pkg/client/kubernetes/types.go#L96)). In controller-runtime clients, schemes are used only for mapping a typed API object to its `GroupVersionKind`.
 - It then consults a `meta.RESTMapper` (also configured during client creation) for mapping the `GroupVersionKind` to a `RESTMapping`, which contains the `GroupVersionResource` and `Scope` (namespaced or cluster-scoped). From these values, the client can unambiguously determine the REST endpoint path of the corresponding API resource. For instance: `appsv1.DeploymentList` is available at `/apis/apps/v1/deployments` or `/apis/apps/v1/namespaces/<namespace>/deployments` respectively.
   - There are different `RESTMapper` implementations, but generally they are talking to the API server's discovery API for retrieving `RESTMappings` for all API resources known to the API server (either built-in, registered via API extension or `CustomResourceDefinition`s).
-  - The default implementation of controller-runtime (which Gardener uses as well), is the [dynamic `RESTMapper`](https://github.com/kubernetes-sigs/controller-runtime/blob/v0.9.0/pkg/client/apiutil/dynamicrestmapper.go#L77). It caches discovery results (i.e. `RESTMappings`) in-memory and only re-discovers resources from the API server, when a client tries to use an unknown `GroupVersionKind`, i.e., when it encounters a `No{Kind,Resource}MatchError`.
+  - The default implementation of a controller-runtime (which Gardener uses as well) is the [dynamic `RESTMapper`](https://github.com/kubernetes-sigs/controller-runtime/blob/v0.9.0/pkg/client/apiutil/dynamicrestmapper.go#L77). It caches discovery results (i.e. `RESTMappings`) in-memory and only re-discovers resources from the API server when a client tries to use an unknown `GroupVersionKind`, i.e., when it encounters a `No{Kind,Resource}MatchError`.
 - The client writes back results from the API server into the passed in-memory object.
-  - This means, that controllers don't have to worry about copying back the results and should just continue to work on the given in-memory object.
-  - This is a nice and flexible pattern and helper functions should try to follow it wherever applicable. Meaning, if possible accept an object param, pass it down to clients and keep working on the same in-memory object instead of creating a new one in your helper function.
-  - The benefit is, that you don't lose updates to the API object and always have the last-known state in memory. Therefore, you don't have to read it again, e.g., for getting the current `resourceVersion` when working with [optimistic locking](#conflicts-concurrency-control-and-optimistic-locking), and thus minimize the chances for running into conflicts.
+  - This means that controllers don't have to worry about copying back the results and should just continue to work on the given in-memory object.
+  - This is a nice and flexible pattern, and helper functions should try to follow it wherever applicable. Meaning, if possible accept an object param, pass it down to clients and keep working on the same in-memory object instead of creating a new one in your helper function.
+  - The benefit is that you don't lose updates to the API object and always have the last-known state in memory. Therefore, you don't have to read it again, e.g., for getting the current `resourceVersion` when working with [optimistic locking](#conflicts-concurrency-control-and-optimistic-locking), and thus minimize the chances for running into conflicts.
   - However, controllers *must not* use the same in-memory object concurrently in multiple goroutines. For example, decoding results from the API server in multiple goroutines into the same maps (e.g., labels, annotations) will cause panics because of "concurrent map writes". Also, reading from an in-memory API object in one goroutine while decoding into it in another goroutine will yield non-atomic reads, meaning data might be corrupt and represent a non-valid/non-existing API object.
   - Therefore, if you need to use the same in-memory object in multiple goroutines concurrently (e.g., shared state), remember to leverage proper synchronization techniques like channels, mutexes, `atomic.Value` and/or copy the object prior to use. The average controller however, will not need to share in-memory API objects between goroutines, and it's typically an indicator that the controller's design should be improved.
 - The client decoder erases the object's `TypeMeta` (`apiVersion` and `kind` fields) after retrieval from the API server, see [kubernetes/kubernetes#80609](https://github.com/kubernetes/kubernetes/issues/80609), [kubernetes-sigs/controller-runtime#1517](https://github.com/kubernetes-sigs/controller-runtime/issues/1517).
@@ -106,9 +106,9 @@ _Important characteristics of controller-runtime clients:_
 Additionally, controller-runtime clients can be used to easily retrieve metadata-only objects or lists.
 This is useful for efficiently checking if at least one object of a given kind exists, or retrieving metadata of an object, if one is not interested in the rest (e.g., spec/status).  
 The `Accept` header sent to the API server then contains `application/json;as=PartialObjectMetadataList;g=meta.k8s.io;v=v1`, which makes the API server only return metadata of the retrieved object(s).
-This saves network traffic and cpu/memory load on the API server and client side.
+This saves network traffic and CPU/memory load on the API server and client side.
 If the client fully lists all objects of a given kind including their spec/status, the resulting list can be quite large and easily exceed the controllers available memory.
-That's why it's important to carefully check, if a full list is actually needed or if metadata-only list can be used instead.
+That's why it's important to carefully check if a full list is actually needed, or if metadata-only list can be used instead.
 
 For example:
 
@@ -172,7 +172,7 @@ Informers are used in and created via several higher-level constructs:
 ### SharedInformerFactories, Listers
 
 The generated clients (built-in as well as extended) feature a `SharedInformerFactory` for every API group, which can be used to create and retrieve `Informers` for all GroupVersionKinds.
-Similarly, it can be used to retrieve `Listers`, that allow getting and listing objects from the `Informer`'s cache.
+Similarly, it can be used to retrieve `Listers` that allow getting and listing objects from the `Informer`'s cache.
 However, both of these constructs are only used for historical reasons, and we are in the process of migrating away from them in favor of cached controller-runtime clients (see [gardener/gardener#2414](https://github.com/gardener/gardener/issues/2414), [gardener/gardener#2822](https://github.com/gardener/gardener/issues/2822)). Thus, they are described only briefly here.
 
 _Important characteristics of Listers:_
@@ -186,16 +186,16 @@ _Important characteristics of Listers:_
 controller-runtime features a cache implementation that can be used equivalently as their clients. In fact, it implements a subset of the `client.Client` interface containing the `Get` and `List` functions.
 Under the hood, a `cache.Cache` dynamically creates `Informers` (i.e., opens watches) for every object GroupVersionKind that is being retrieved from it.
 
-Note, that the underlying Informers of a controller-runtime cache (`cache.Cache`) and the ones of a `SharedInformerFactory` (client-go) are not related in any way.
+Note that the underlying Informers of a controller-runtime cache (`cache.Cache`) and the ones of a `SharedInformerFactory` (client-go) are not related in any way.
 Both create `Informers` and watch objects on the API server individually.
-This means, that if you read the same object from different cache implementations, you may receive different versions of the object because the watch connections of the individual Informers are not synced.
+This means that if you read the same object from different cache implementations, you may receive different versions of the object because the watch connections of the individual Informers are not synced.
 
 > ⚠️ Because of this, controllers/reconcilers should get the object from the same cache in the reconcile loop, where the `EventHandler` was also added to set up the controller. For example, if a `SharedInformerFactory` is used for setting up the controller then read the object in the reconciler from the `Lister` instead of from a cached controller-runtime client.
 
-By default, the `client.Client` created by a controller-runtime `Manager` is a `DelegatingClient`. It delegates `Get` and `List` calls to a `Cache` and all other calls to a client, that talks directly to the API server. Exceptions are requests with `*unstructured.Unstructured` objects and object kinds that were configured to be excluded from the cache in the `DelegatingClient`.
+By default, the `client.Client` created by a controller-runtime `Manager` is a `DelegatingClient`. It delegates `Get` and `List` calls to a `Cache`, and all other calls to a client that talks directly to the API server. Exceptions are requests with `*unstructured.Unstructured` objects and object kinds that were configured to be excluded from the cache in the `DelegatingClient`.
 
 > ℹ️
-> `kubernetes.Interface.Client()` returns a `DelegatingClient` that uses the cache returned from `kubernetes.Interface.Cache()` under the hood. This means, all `Client()` usages need to be ready for cached clients and should be able to cater with stale cache reads.
+> `kubernetes.Interface.Client()` returns a `DelegatingClient` that uses the cache returned from `kubernetes.Interface.Cache()` under the hood. This means that all `Client()` usages need to be ready for cached clients and should be able to cater with stale cache reads.
 
 _Important characteristics of cached controller-runtime clients:_
 
@@ -229,20 +229,20 @@ Here are some general guidelines on choosing whether to read from a cache or not
   - Track the actions you took, e.g., when creating objects with `generateName` (this is what the `ReplicaSet` controller does [3]). The actions can be tracked in memory and repeated if the expected watch events don't occur after a given amount of time.
   - Always try to write controllers with the assumption that data will only be eventually correct and can be slightly out of date (even if read directly from the API server!).
   - If there is already some other code that needs a cache (e.g., a controller watch), reuse it instead of doing extra direct reads.
-  - Don't read an object again if you just sent a write request. Write requests (`Create`, `Update`, `Patch` and `Delete`) don't interact with the cache. Hence, use the current state that the API server returned (filled into the passed in-memory object), which is basically a "free direct read", instead of reading the object again from a cache, because this will probably set back the object to an older `resourceVersion`.
+  - Don't read an object again if you just sent a write request. Write requests (`Create`, `Update`, `Patch` and `Delete`) don't interact with the cache. Hence, use the current state that the API server returned (filled into the passed in-memory object), which is basically a "free direct read" instead of reading the object again from a cache, because this will probably set back the object to an older `resourceVersion`.
 - If you are concerned about the impact of the resulting cache, try to minimize that by using filtered or metadata-only watches.
 - If watching and caching an object type is not feasible, for example because there will be a lot of updates, and you are only interested in the object every ~5m, or because it will blow up the controllers memory footprint, fallback to a direct read. This can either be done by disabling caching the object type generally or doing a single request via an `APIReader`. In any case, please bear in mind that every direct API call results in a [quorum read from etcd](https://kubernetes.io/docs/reference/using-api/api-concepts/#the-resourceversion-parameter), which can be costly in a heavily-utilized cluster and impose significant scalability limits. Thus, always try to minimize the impact of direct calls by filtering results by namespace or labels, limiting the number of results and/or using metadata-only calls.
 
 [2] The `Deployment` controller uses the pattern `<deployment-name>-<podtemplate-hash>` for naming `ReplicaSets`. This means, the name of a `ReplicaSet` it tries to create/update/delete at any given time is deterministically calculated based on the `Deployment` object. By this, it is insusceptible to stale reads from its `ReplicaSets` cache.
 
-[3] In simple terms, the `ReplicaSet` controller tracks its `CREATE pod` actions as follows: when creating new `Pods`, it increases a counter of expected `ADDED` watch events for the corresponding `ReplicaSet`. As soon as such events arrive, it decreases the counter accordingly. It only creates new `Pods` for a given `ReplicaSet`, once all expected events occurred (counter is back to zero) or a timeout occurred. This way, it prevents creating more `Pods` than desired because of stale cache reads and makes the controller eventually consistent.
+[3] In simple terms, the `ReplicaSet` controller tracks its `CREATE pod` actions as follows: when creating new `Pods`, it increases a counter of expected `ADDED` watch events for the corresponding `ReplicaSet`. As soon as such events arrive, it decreases the counter accordingly. It only creates new `Pods` for a given `ReplicaSet` once all expected events occurred (counter is back to zero) or a timeout has occurred. This way, it prevents creating more `Pods` than desired because of stale cache reads and makes the controller eventually consistent.
 
-## Conflicts, Concurrency Control and Optimistic Locking
+## Conflicts, Concurrency Control, and Optimistic Locking
 
 Every Kubernetes API object contains the `metadata.resourceVersion` field, which identifies an object's version in the backing data store, i.e., etcd. Every write to an object in etcd results in a newer `resourceVersion`.
 This field is mainly used for concurrency control on the API server in an optimistic locking fashion, but also for efficient resumption of interrupted watch connections.
 
-Optimistic locking in the Kubernetes API sense means that when a client wants to update an API object then it includes the object's `resourceVersion` in the request to indicate the object's version the modifications are based on.
+Optimistic locking in the Kubernetes API sense means that when a client wants to update an API object, then it includes the object's `resourceVersion` in the request to indicate the object's version the modifications are based on.
 If the `resourceVersion` in etcd has not changed in the meantime, the update request is accepted by the API server and the updated object is written to etcd.
 If the `resourceVersion` sent by the client does not match the one of the object stored in etcd, there were concurrent modifications to the object. Consequently, the request is rejected with a conflict error (status code `409`, API reason `Conflict`), for example:
 
@@ -262,41 +262,41 @@ If the `resourceVersion` sent by the client does not match the one of the object
 }
 ```
 
-This concurrency control is an important mechanism in Kubernetes as there are typically multiple clients acting on API objects at the same time (humans, different controllers, etc.). If a client receives a conflict error, it should read the object's latest version from the API server, make the modifications based on the newest changes and retry the update.
+This concurrency control is an important mechanism in Kubernetes as there are typically multiple clients acting on API objects at the same time (humans, different controllers, etc.). If a client receives a conflict error, it should read the object's latest version from the API server, make the modifications based on the newest changes, and retry the update.
 The reasoning behind this is that a client might choose to make different decisions based on the concurrent changes made by other actors compared to the outdated version that it operated on.
 
 _Important points about concurrency control and conflicts:_
 
 - The `resourceVersion` field carries a string value and clients must not assume numeric values (the type and structure of versions depend on the backing data store). This means clients may compare `resourceVersion` values to detect whether objects were changed. But they must not compare `resourceVersion`s to figure out which one is newer/older, i.e., no greater/less-than comparisons are allowed.
-- By default, update calls (e.g. via client-go and controller-runtime clients) use optimistic locking as the passed in-memory usually object contains the latest `resourceVersion` known to the controller which is then also sent to the API server.
-- API servers can also choose to accept update calls without optimistic locking (i.e., without a `resourceVersion` in the object's metadata) for any given resource. However, sending update requests without optimistic locking is strongly discouraged as doing so overwrites the entire object discarding any concurrent changes made to it.
+- By default, update calls (e.g. via client-go and controller-runtime clients) use optimistic locking as the passed in-memory usually object contains the latest `resourceVersion` known to the controller, which is then also sent to the API server.
+- API servers can also choose to accept update calls without optimistic locking (i.e., without a `resourceVersion` in the object's metadata) for any given resource. However, sending update requests without optimistic locking is strongly discouraged, as doing so overwrites the entire object, discarding any concurrent changes made to it.
 - On the other side, patch requests can always be executed either with or without optimistic locking, by (not) including the `resourceVersion` in the patched object's metadata. Sending patch requests without optimistic locking might be safe and even desirable as a patch typically updates only a specific section of the object. However, there are also situations where patching without optimistic locking is not safe (see below).
 
 ### Don’t Retry on Conflict
 
 Similar to how a human would typically handle a conflict error, there are helper functions implementing `RetryOnConflict`-semantics, i.e., try an update call, then re-read the object if a conflict occurs, apply the modification again and retry the update.
 However, controllers should generally *not* use `RetryOnConflict`-semantics. Instead, controllers should abort their current reconciliation run and let the queue handle the conflict error with exponential backoff.
-The reasoning behind this is, that a conflict error indicates that the controller has operated on stale data and might have made wrong decisions earlier on in the reconciliation.
+The reasoning behind this is that a conflict error indicates that the controller has operated on stale data and might have made wrong decisions earlier on in the reconciliation.
 When using a helper function that implements `RetryOnConflict`-semantics, the controller doesn't check which fields were changed and doesn't revise its previous decisions accordingly.
 Instead, retrying on conflict basically just ignores any conflict error and blindly applies the modification.
 
 To properly solve the conflict situation, controllers should immediately return with the error from the update call. This will cause retries with exponential backoff so that the cache has a chance to observe the latest changes to the object.
-In a later run, the controller will then make correct decisions based on the newest version of the object, not run into conflict errors and will then be able to successfully reconcile the object. This way, the controller becomes eventually consistent.
+In a later run, the controller will then make correct decisions based on the newest version of the object, not run into conflict errors, and will then be able to successfully reconcile the object. This way, the controller becomes eventually consistent.
 
 The other way to solve the situation is to modify objects without optimistic locking in order to avoid running into a conflict in the first place (only if this is safe).
 This can be a preferable solution for controllers with long-running reconciliations (which is actually an anti-pattern but quite unavoidable in some of Gardener's controllers).
-Aborting the entire reconciliation run is rather undesirable in such cases as it will add a lot of unnecessary waiting time for end users and overhead in terms of compute and network usage.
+Aborting the entire reconciliation run is rather undesirable in such cases, as it will add a lot of unnecessary waiting time for end users and overhead in terms of compute and network usage.
 
-However, in any case retrying on conflict is probably not the right option to solve the situation (there are some correct use cases for it, though, they are very rare). Hence, don't retry on conflict.
+However, in any case, retrying on conflict is probably not the right option to solve the situation (there are some correct use cases for it, though, they are very rare). Hence, don't retry on conflict.
 
 ### To Lock or Not to Lock
 
-As explained before, conflicts are actually important and prevent clients from doing wrongful concurrent updates. This means, conflicts are not something we generally want to avoid or ignore.
+As explained before, conflicts are actually important and prevent clients from doing wrongful concurrent updates. This means that conflicts are not something we generally want to avoid or ignore.
 However, in many cases controllers are exclusive owners of the fields they want to update and thus it might be safe to run without optimistic locking.
 
 For example, the gardenlet is the exclusive owner of the `spec` section of the Extension resources it creates on behalf of a Shoot (e.g., the `Infrastructure` resource for creating VPC, etc.). Meaning, it knows the exact desired state and no other actor is supposed to update the Infrastructure's `spec` fields.
 When the gardenlet now updates the Infrastructures `spec` section as part of the Shoot reconciliation, it can simply issue a `PATCH` request that only updates the `spec` and runs without optimistic locking.
-If another controller concurrently updated the object in the meantime (e.g., the `status` section), the `resourceVersion` got changed which would cause a conflict error if running with optimistic locking.
+If another controller concurrently updated the object in the meantime (e.g., the `status` section), the `resourceVersion` got changed, which would cause a conflict error if running with optimistic locking.
 However, concurrent `status` updates would not change the gardenlet's mind on the desired `spec` of the Infrastructure resource as it is determined only by looking at the Shoot's specification.
 If the `spec` section was changed concurrently, it's still fine to overwrite it because the gardenlet should reconcile the `spec` back to its desired state.
 
@@ -307,7 +307,7 @@ Obviously, this applies only to patch requests that modify only a specific set o
 In such cases, it's even desirable to run without optimistic locking as it will be more performant and save retries.
 If certain requests are made with high frequency and have a good chance of causing conflicts, retries because of optimistic locking can cause a lot of additional network traffic in a large-scale Gardener installation. 
 
-## Updates, Patches, Server-side Apply
+## Updates, Patches, Server-Side Apply
 
 There are different ways of modifying Kubernetes API objects.
 The following snippet demonstrates how to do a given modification with the most frequently used options using a controller-runtime client: 
@@ -347,16 +347,16 @@ _Important characteristics of the shown request types:_
     patch = client.StrategicMergeFrom(shoot.DeepCopy(), client.MergeFromWithOptimisticLock{})
     // ...
     ```
-- Patch requests only contain the changes made to the in-memory object between the copy passed to `client.*MergeFrom` and the object passed to `Client.Patch()`. The diff is calculated on the client-side based on the in-memory objects only. This means, if in the meantime some fields were changed on the API server to a different value than the one on the client-side, the fields will not be changed back as long as they are not changed on the client-side as well (there will be no diff in memory).
-- Thus, if you want to ensure a given state using patch requests, always read the object first before patching it, as there will be no diff otherwise, meaning the patch will be empty. Also see [gardener/gardener#4057](https://github.com/gardener/gardener/pull/4057) and comments in [gardener/gardener#4027](https://github.com/gardener/gardener/pull/4027).
+- Patch requests only contain the changes made to the in-memory object between the copy passed to `client.*MergeFrom` and the object passed to `Client.Patch()`. The diff is calculated on the client-side based on the in-memory objects only. This means that if in the meantime some fields were changed on the API server to a different value than the one on the client-side, the fields will not be changed back as long as they are not changed on the client-side as well (there will be no diff in memory).
+- Thus, if you want to ensure a given state using patch requests, always read the object first before patching it, as there will be no diff otherwise, meaning the patch will be empty. For more information, see [gardener/gardener#4057](https://github.com/gardener/gardener/pull/4057) and the comments in [gardener/gardener#4027](https://github.com/gardener/gardener/pull/4027).
 - Also, always send updates and patch requests even if your controller hasn't made any changes to the current state on the API server. I.e., don't make any optimization for preventing empty patches or no-op updates. There might be mutating webhooks in the system that will modify the object and that rely on update/patch requests being sent (even if they are no-op). Gardener's extension concept makes heavy use of mutating webhooks, so it's important to keep this in mind.
 - JSON merge patches always replace lists as a whole and don't merge them. Keep this in mind when operating on lists with merge patch requests. If the controller is the exclusive owner of the entire list, it's safe to run without optimistic locking. Though, if you want to prevent overwriting concurrent changes to the list or its items made by other actors (e.g., additions/removals to the `metadata.finalizers` list), enable optimistic locking.
-- Strategic merge patches are able to make more granular modifications to lists and their elements without replacing the entire list. It uses Golang struct tags of the API types to determine which and how lists should be merged. See [this document](https://kubernetes.io/docs/tasks/manage-kubernetes-objects/update-api-object-kubectl-patch/) or the [strategic merge patch documentation](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-api-machinery/strategic-merge-patch.md) for more in-depth explanations and comparison with JSON merge patches.
+- Strategic merge patches are able to make more granular modifications to lists and their elements without replacing the entire list. It uses Golang struct tags of the API types to determine which and how lists should be merged. See [Update API Objects in Place Using kubectl patch](https://kubernetes.io/docs/tasks/manage-kubernetes-objects/update-api-object-kubectl-patch/) or the [strategic merge patch documentation](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-api-machinery/strategic-merge-patch.md) for more in-depth explanations and comparison with JSON merge patches.
   With this, controllers *might* be able to issue patch requests for individual list items without optimistic locking, even if they are not exclusive owners of the entire list. Remember to check the `patchStrategy` and `patchMergeKey` struct tags of the fields you want to modify before blindly adding patch requests without optimistic locking.
 - Strategic merge patches are only supported by built-in Kubernetes resources and custom resources served by Extension API servers. Strategic merge patches are not supported by custom resources defined by `CustomResourceDefinition`s (see [this comparison](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/#advanced-features-and-flexibility)). In that case, fallback to JSON merge patches.
 - [Server-side Apply](https://kubernetes.io/docs/reference/using-api/server-side-apply/) is yet another mechanism to modify API objects, which is supported by all API resources (in newer Kubernetes versions). However, it has a few problems and more caveats preventing us from using it in Gardener at the time of writing. See [gardener/gardener#4122](https://github.com/gardener/gardener/issues/4122) for more details.
 
-> Generally speaking, patches are often the better option compared to update requests because they can save network traffic, encoding/decoding effort and avoid conflicts under the presented conditions.
+> Generally speaking, patches are often the better option compared to update requests because they can save network traffic, encoding/decoding effort, and avoid conflicts under the presented conditions.
 > If choosing a patch type, consider which type is supported by the resource you're modifying and what will happen in case of a conflict. Consider whether your modification is safe to run without optimistic locking.
 > However, there is no simple rule of thumb on which patch type to choose.
 
@@ -369,7 +369,7 @@ That's why usage of this function was completely replaced in [gardener/gardener#
 
 `controllerutil.CreateOrPatch` is similar to `CreateOrUpdate` but does a patch request instead of an update request. It has the same drawback as `CreateOrUpdate` regarding no-op updates.
 Also, controllers can't use optimistic locking or strategic merge patches when using `CreateOrPatch`.
-Another reason for avoiding use of this function is, that it also implicitly patches the status section if it was changed, which is confusing for others reading the code. To accomplish this, the func does some back and forth conversion, comparison and checks, which are unnecessary in most of our cases and simply wasted CPU cycles and complexity we want to avoid.
+Another reason for avoiding use of this function is that it also implicitly patches the status section if it was changed, which is confusing for others reading the code. To accomplish this, the func does some back and forth conversion, comparison and checks, which are unnecessary in most of our cases and simply wasted CPU cycles and complexity we want to avoid.
 
 There were some `Try{Update,UpdateStatus,Patch,PatchStatus}` helper functions in Gardener that were already removed by [gardener/gardener#4378](https://github.com/gardener/gardener/pull/4378) but are still used in some extension code at the time of writing.
 The reason for eliminating these functions is that they implement `RetryOnConflict`-semantics. Meaning, they first get the object, mutate it, then try to update and retry if a conflict error occurs.
@@ -380,7 +380,7 @@ For the reasons explained above, there are similar helper functions that accompl
 These can be safely used as replacements for the aforementioned helper funcs.
 If they are not fitting for your use case, for example because you need to use optimistic locking, just do the appropriate calls in the controller directly.
 
-## Further Resources
+## Related Links
 
 - [Kubernetes Client usage in Gardener](https://www.youtube.com/watch?v=RPsUo925PUA&t=40s) (Community Meeting talk, 2020-06-26)
 

--- a/docs/development/local_setup.md
+++ b/docs/development/local_setup.md
@@ -16,7 +16,7 @@ This guide is split into three main parts:
 * [Building and starting Gardener components locally](#start-gardener-locally)
 * [Using your local Gardener setup to create a Shoot](#create-a-shoot)
 
-## Limitations of the local development setup
+## Limitations of the Local Development Setup
 
 You can run Gardener (API server, controller manager, scheduler, gardenlet) against any local Kubernetes cluster, however, your seed and shoot clusters must be deployed to a cloud provider.
 Currently, it is not possible to run Gardener entirely isolated from any cloud provider. This means that to be able create Shoot clusters you need to register an external Seed cluster (e.g., one created in AWS).
@@ -102,7 +102,7 @@ brew install jq
 brew install parallel
 ```
 
-## [macOS only] Install GNU core utilities
+## [macOS only] Install GNU Core Utilities
 
 When running on macOS, install the GNU core utilities and friends:
 
@@ -119,11 +119,11 @@ export PATH=/usr/local/opt/gnu-tar/libexec/gnubin:$PATH
 export PATH=/usr/local/opt/grep/libexec/gnubin:$PATH
 ```
 
-## [Windows only] WSL2
+## [Windows Only] WSL2
 
 Apart from Linux distributions and macOS, the local gardener setup can also run on the Windows Subsystem for Linux 2.
 
-While WSL1, plain docker for windows and various Linux distributions and local Kubernetes environments may be supported, this setup was verified with:
+While WSL1, plain docker for Windows and various Linux distributions and local Kubernetes environments may be supported, this setup was verified with:
 * [WSL2](https://docs.microsoft.com/en-us/windows/wsl/wsl2-index)
 * [Docker Desktop WSL2 Engine](https://docs.docker.com/docker-for-windows/wsl/)
 * [Ubuntu 18.04 LTS on WSL2](https://ubuntu.com/blog/ubuntu-on-wsl-2-is-generally-available)
@@ -131,9 +131,9 @@ While WSL1, plain docker for windows and various Linux distributions and local K
 
 The Gardener repository and all the above-mentioned tools (git, golang, kubectl, ...) should be installed in your WSL2 distro, according to the distribution-specific Linux installation instructions.
 
-# Start Gardener locally
+# Start Gardener Locally
 
-## Get the sources
+## Get the Sources
 
 Clone the repository from GitHub into your `$GOPATH`.
 
@@ -150,9 +150,9 @@ cd gardener
 
 ℹ️ In the following guide, you have to define the configuration (`CloudProfile`s, `SecretBinding`s, `Seed`s, etc.) manually for the infrastructure environment you want to develop against.
 Additionally, you have to register the respective Gardener extensions manually.
-If you are rather looking for a quick start guide to develop entirely locally on your machine (no real cloud provider or infrastructure involved) then you should rather follow [this guide](getting_started_locally.md).
+If you are rather looking for a quick start guide to develop entirely locally on your machine (no real cloud provider or infrastructure involved), then you should rather follow [this guide](getting_started_locally.md).
 
-### Start a local kubernetes cluster
+### Start a Local Kubernetes Cluster
 
 For the development of Gardener you need a Kubernetes API server on which you can register Gardener's own Extension API Server as `APIService`. This cluster doesn't need any worker nodes to run pods, though, therefore, you can use the "nodeless Garden cluster setup" residing in `hack/local-garden`. This will start all minimally required components of a Kubernetes cluster (`etcd`, `kube-apiserver`, `kube-controller-manager`)
 and an `etcd` Instance for the `gardener-apiserver` as Docker containers. This is the easiest way to get your
@@ -182,9 +182,9 @@ make local-garden-down
 ```
 
 <details>
-  <summary><b>Alternative: Using a local kubernetes cluster</b></summary>
+  <summary><b>Alternative: Using a local Kubernetes cluster</b></summary>
 
-  Instead of starting a kubernetes API server and etcd as docker containers, you can also opt for running a local kubernetes cluster, provided by e.g. [minikube](https://minikube.sigs.k8s.io/docs/start/), [kind](https://kind.sigs.k8s.io/docs/user/quick-start/) or docker desktop.
+  Instead of starting a Kubernetes API server and etcd as docker containers, you can also opt for running a local Kubernetes cluster, provided by e.g. [minikube](https://minikube.sigs.k8s.io/docs/start/), [kind](https://kind.sigs.k8s.io/docs/user/quick-start/) or docker desktop.
 
   > Note: Gardener requires self-contained kubeconfig files because of a [security issue](https://banzaicloud.com/blog/kubeconfig-security/). You can configure your minikube to create self-contained kubeconfig files via:
   > ```bash
@@ -198,7 +198,7 @@ make local-garden-down
 </details>
 
 <details>
-  <summary><b>Alternative: Using a remote kubernetes cluster</b></summary>
+  <summary><b>Alternative: Using a remote Kubernetes cluster</b></summary>
 
 For some testing scenarios, you may want to use a remote cluster instead of a local one as your Garden cluster.
 To do this, you can use the "remote Garden cluster setup" residing in `hack/remote-garden`. This will start an `etcd` instance for the `gardener-apiserver` as a Docker container, and open tunnels for accessing local gardener components from the remote cluster.
@@ -225,7 +225,7 @@ To close the tunnels and remove the locally-running Docker containers, run:
 make remote-garden-down
 ```
 
-ℹ️ [Optional] If you want to use the remote Garden cluster setup with the `SeedAuthorization` feature you have to adapt the `kube-apiserver` process of your remote Garden cluster. To do this, perform the following steps after running `make remote-garden-up`:
+ℹ️ [Optional] If you want to use the remote Garden cluster setup with the `SeedAuthorization` feature, you have to adapt the `kube-apiserver` process of your remote Garden cluster. To do this, perform the following steps after running `make remote-garden-up`:
 
 * Create an [authorization webhook configuration file](https://kubernetes.io/docs/reference/access-authn-authz/webhook/#configuration-file-format) using the IP of the `garden/quic-server` pod running in your remote Garden cluster and port 10444 that tunnels to your locally running `gardener-admission-controller` process.
 
@@ -298,7 +298,7 @@ apiservice.apiregistration.k8s.io/v1alpha1.seedmanagement.gardener.cloud created
 apiservice.apiregistration.k8s.io/v1alpha1.settings.gardener.cloud created
 ```
 
-ℹ️ [Optional] If you want to enable logging, in the Gardenlet configuration add:
+ℹ️ [Optional] If you want to enable logging, in the gardenlet configuration add:
 ```yaml
 logging:
   enabled: true
@@ -307,7 +307,7 @@ logging:
 The Gardener exposes the API servers of Shoot clusters via Kubernetes services of type `LoadBalancer`.
 In order to establish stable endpoints (robust against changes of the load balancer address), it creates DNS records pointing to these load balancer addresses. They are used internally and by all cluster components to communicate.
 You need to have control over a domain (or subdomain) for which these records will be created.
-Please provide an *internal domain secret* (see [this](../../example/10-secret-internal-domain.yaml) for an example) which contains credentials with the proper privileges. Further information can be found [here](../usage/configuration.md).
+Please provide an *internal domain secret* (see [this](../../example/10-secret-internal-domain.yaml) for an example) which contains credentials with the proper privileges. Further information can be found in [Gardener Configuration and Usage](../usage/configuration.md).
 
 ```bash
 kubectl apply -f example/10-secret-internal-domain-unmanaged.yaml
@@ -316,7 +316,7 @@ secret/internal-domain-unmanaged created
 
 ### Run the Gardener
 
-Next, run the Gardener API Server, the Gardener Controller Manager (optionally), the Gardener Scheduler (optionally), and the Gardenlet in different terminal windows/panes using rules in the `Makefile`.
+Next, run the Gardener API Server, the Gardener Controller Manager (optionally), the Gardener Scheduler (optionally), and the gardenlet in different terminal windows/panes using rules in the `Makefile`.
 
 ```bash
 make start-apiserver
@@ -375,7 +375,7 @@ to operate against your local running Gardener API Server.
 
 The steps below describe the general process of creating a Shoot. Have in mind that the steps do not provide full example manifests. The reader needs to check the provider documentation and adapt the manifests accordingly.
 
-#### 1. Copy the example manifests
+#### 1. Copy the Example Manifests
 
 The next steps require modifications of the example manifests. These modifications are part of local setup and should not be `git push`-ed. To do not interfere with git, let's copy the example manifests to `dev/` which is ignored by git.
 
@@ -408,11 +408,11 @@ The `CloudProfile` resource is provider specific and describes the underlying cl
 kubectl apply -f dev/30-cloudprofile.yaml
 ```
 
-#### 4. Install necessary Gardener Extensions
+#### 4. Install Necessary Gardener Extensions
 
-The [Known Extension Implementations](../../extensions/README.md#known-extension-implementations) section contains a list of available extension implementations. You need to create a ControllerRegistration and ControllerDeployment for
+The [Known Extension Implementations](../../extensions/README.md#known-extension-implementations) section contains a list of available extension implementations. You need to create a ControllerRegistration and ControllerDeployment for:
 * at least one infrastructure provider
-* a dns provider (if the DNS for the Seed is not disabled)
+* a DNS provider (if the DNS for the Seed is not disabled)
 * at least one operating system extension
 * at least one network plugin extension
 
@@ -423,13 +423,13 @@ kubectl apply -f https://raw.githubusercontent.com/gardener/gardener-extension-p
 ```
 
 Instead of updating extensions manually you can use [Gardener Extensions Manager](https://github.com/gardener/gem) to install and update extension controllers. This is especially useful if you want to keep and maintain your development setup for a longer time.
-Also, please refer to [this document](../extensions/controllerregistration.md) for further information about how extensions are registered in case you want to use other versions than the latest releases.
+Also, please refer to [Registering Extension Controllers](../extensions/controllerregistration.md) for further information about how extensions are registered in case you want to use other versions than the latest releases.
 
 #### 5. Register a Seed
 
 Shoot controlplanes run in seed clusters, so we need to create our first Seed now.
 
-Check the corresponding example manifest `dev/40-secret-seed.yaml` and `dev/50-seed.yaml`. Update `dev/40-secret-seed.yaml` with base64 encoded kubeconfig of the cluster that will be used as Seed (the scope of the permissions should be identical to the kubeconfig that the Gardenlet creates during bootstrapping - for now, `cluster-admin` privileges are recommended).
+Check the corresponding example manifest `dev/40-secret-seed.yaml` and `dev/50-seed.yaml`. Update `dev/40-secret-seed.yaml` with base64 encoded kubeconfig of the cluster that will be used as Seed (the scope of the permissions should be identical to the kubeconfig that the gardenlet creates during bootstrapping - for now, `cluster-admin` privileges are recommended).
 
 ```bash
 kubectl apply -f dev/40-secret-seed.yaml
@@ -441,9 +441,9 @@ Adapt `dev/50-seed.yaml` - adjust `.spec.secretRef` to refer the newly created S
 kubectl apply -f dev/50-seed.yaml
 ```
 
-#### 6. Start Gardenlet
+#### 6. Start the gardenlet
 
-Once the Seed is created, start the Gardenlet to reconcile it. The `make start-gardenlet` command will automatically configure the local Gardenlet process to use the Seed and its kubeconfig. If you have multiple Seeds, you have to specify which to use by setting the `SEED_NAME` environment variable like in `make start-gardenlet SEED_NAME=my-first-seed`.
+Once the Seed is created, start the gardenlet to reconcile it. The `make start-gardenlet` command will automatically configure the local gardenlet process to use the Seed and its kubeconfig. If you have multiple Seeds, you have to specify which to use by setting the `SEED_NAME` environment variable like in `make start-gardenlet SEED_NAME=my-first-seed`.
 
 ```bash
 make start-gardenlet
@@ -458,7 +458,7 @@ time="2019-11-06T15:24:18+02:00" level=info msg="Seed controller initialized."
 [...]
 ```
 
-The Gardenlet will now reconcile the Seed. Check the progess from time to time until it's `Ready`:
+The gardenlet will now reconcile the Seed. Check the progess from time to time until it's `Ready`:
 
 ```bash
 kubectl get seed
@@ -468,14 +468,14 @@ seed-aws   Ready     aws         eu-west-1   4m     v1.61.0-dev   v1.24.8
 
 #### 7. Create a Shoot
 
-A Shoot requires a SecretBinding. The SecretBinding refers to a Secret that contains the cloud provider credentials. The Secret data keys are provider specific and you need to check the documentation of the provider to find out which data keys are expected (for example for AWS the related documentation can be found [here](https://github.com/gardener/gardener-extension-provider-aws/blob/master/docs/usage-as-end-user.md#provider-secret-data)). Adapt `dev/70-secret-provider.yaml` and `dev/80-secretbinding.yaml` and apply them.
+A Shoot requires a SecretBinding. The SecretBinding refers to a Secret that contains the cloud provider credentials. The Secret data keys are provider specific and you need to check the documentation of the provider to find out which data keys are expected (for example for AWS the related documentation can be found at [Provider Secret Data](https://github.com/gardener/gardener-extension-provider-aws/blob/master/docs/usage-as-end-user.md#provider-secret-data)). Adapt `dev/70-secret-provider.yaml` and `dev/80-secretbinding.yaml` and apply them.
 
 ```bash
 kubectl apply -f dev/70-secret-provider.yaml
 kubectl apply -f dev/80-secretbinding.yaml
 ```
 
-After the SecretBinding creation, you are ready to proceed with the Shoot creation. You need to check the documentation of the provider to find out the expected configuration (for example for AWS the related documentation and example Shoot manifest can be found [here](https://github.com/gardener/gardener-extension-provider-aws/blob/master/docs/usage-as-end-user.md)). Adapt `dev/90-shoot.yaml` and apply it.
+After the SecretBinding creation, you are ready to proceed with the Shoot creation. You need to check the documentation of the provider to find out the expected configuration (for example for AWS the related documentation and example Shoot manifest can be found at [Using the AWS provider extension with Gardener as end-user](https://github.com/gardener/gardener-extension-provider-aws/blob/master/docs/usage-as-end-user.md)). Adapt `dev/90-shoot.yaml` and apply it.
 
 To make sure that a specific Seed cluster will be chosen or to skip the scheduling (the sheduling requires Gardener Scheduler to be running), specify the `.spec.seedName` field (see [here](../../example/90-shoot.yaml#L317-L318)).
 

--- a/docs/development/log_parsers.md
+++ b/docs/development/log_parsers.md
@@ -1,4 +1,4 @@
-# How to create log parser for container into fluent-bit
+# How to Create Log Parser for Container into fluent-bit
 
 If our log message is parsed correctly, it has to be showed in Grafana like this:
 
@@ -17,27 +17,26 @@ Otherwise it will looks like this:
 }
 ```
 
-## Lets make a custom parser now
+## Create a Custom Parser
 
-- First of all we need to know how does the log for the specific container look like (for example lets take a log from the `alertmanager` :
+- First of all, we need to know how the log for the specific container looks like (for example, lets take a log from the `alertmanager` :
 `level=info ts=2019-01-28T12:33:49.362015626Z caller=main.go:175 build_context="(go=go1.11.2, user=root@4ecc17c53d26, date=20181109-15:40:48)`)
 
 - We can see that this log contains 4 subfields(severity=info, timestamp=2019-01-28T12:33:49.362015626Z, source=main.go:175 and the actual message).
-So we have to write a regex which matches this log in 4 groups(We can use https://regex101.com/ like helping tool). So for this purpose our regex
-looks like this:
+So we have to write a regex which matches this log in 4 groups(We can use https://regex101.com/ like helping tool). So, for this purpose our regex looks like this:
 
 ```text
 ^level=(?<severity>\w+)\s+ts=(?<time>\d{4}-\d{2}-\d{2}[Tt].*[zZ])\s+caller=(?<source>[^\s]*+)\s+(?<log>.*)
 ```
 
-- Now we have to create correct time format for the timestamp(We can use this site for this purpose: http://ruby-doc.org/stdlib-2.4.1/libdoc/time/rdoc/Time.html#method-c-strptime).
+- Now we have to create correct time format for the timestamp (We can use this site for this purpose: http://ruby-doc.org/stdlib-2.4.1/libdoc/time/rdoc/Time.html#method-c-strptime).
 So our timestamp matches correctly the following format:
 
 ```text
 %Y-%m-%dT%H:%M:%S.%L
 ```
 
-- It's a time to apply our new regex into fluent-bit configuration. Go to fluent-bit-configmap.yaml and create new filter using the following template:
+- It's time to apply our new regex into fluent-bit configuration. Go to `fluent-bit-configmap.yaml` and create new filter using the following template:
 
 ```text
 [FILTER]
@@ -58,7 +57,7 @@ EXAMPLE
         Reserve_Data        True
 ```
 
-- Now lets check if there is already exists parser with such a regex and time format that we need. if not, let`s create one:
+- Now lets check if there already exists parser with such a regex and time format that we need. If it doesn't, create one:
 
 ```text
 [PARSER]
@@ -80,5 +79,5 @@ EXAMPLE
 ```
 
 ```text
-Follow your development setup to validate that parsers are working correctly.
+Follow your development setup to validate that the parsers are working correctly.
 ```

--- a/docs/development/logging.md
+++ b/docs/development/logging.md
@@ -1,8 +1,8 @@
 # Logging in Gardener Components
 
 This document aims at providing a general developer guideline on different aspects of logging practices and conventions used in the Gardener codebase.
-It contains mostly Gardener-specific points and references other existing and commonly accepted logging guidelines for general advice.
-Developers and reviewers should consult this guide when writing, refactoring and reviewing Gardener code.
+It contains mostly Gardener-specific points, and references other existing and commonly accepted logging guidelines for general advice.
+Developers and reviewers should consult this guide when writing, refactoring, and reviewing Gardener code.
 If parts are unclear or new learnings arise, this guide should be adapted accordingly.
 
 ## Logging Libraries / Implementations
@@ -41,17 +41,18 @@ As motivated above, we will use the logr interface instead of klog though.
 You can read more about the motivation behind structured logging in [logr's background and FAQ](https://github.com/go-logr/logr#background) (also see [this blog post by Dave Cheney](http://dave.cheney.net/2015/11/05/lets-talk-about-logging)).
 Also, make sure to check out controller-runtime's [logging guideline](https://github.com/kubernetes-sigs/controller-runtime/blob/v0.11.0/TMP-LOGGING.md) with specifics for projects using the library.
 The following sections will focus on the most important takeaways from those guidelines and give general instructions on how to apply them to Gardener and its controller-runtime components.
-Note: some parts in this guideline differ slightly from controller-runtime's document.
+
+> Note: Some parts in this guideline differ slightly from controller-runtime's document.
 
 ### TL;DR of Structured Logging
 
-❌ stop using `printf`-style logging:
+❌ Stop using `printf`-style logging:
 ```go
 var logger *logrus.Logger
 logger.Infof("Scaling deployment %s/%s to %d replicas", deployment.Namespace, deployment.Name, replicaCount)
 ```
 
-✅ instead, write static log messages and enrich them with additional structured information in form of key-value pairs:
+✅ Instead, write static log messages and enrich them with additional structured information in form of key-value pairs:
 
 ```go
 var logger logr.Logger
@@ -145,7 +146,7 @@ See [Dave Cheney's post](https://dave.cheney.net/2015/11/05/lets-talk-about-logg
 ### Messages
 
 - Log messages should be static. Don't put variable content in there, i.e., no `fmt.Sprintf` or string concatenation (`+`). Use key-value pairs instead.
-- Log messages should be capitalized. Note: this contrasts with error messages, that should not be capitalized. However, both should not end with a punctuation mark.
+- Log messages should be capitalized. Note: This contrasts with error messages, that should not be capitalized. However, both should not end with a punctuation mark.
 
 ### Keys and Values
 
@@ -160,8 +161,8 @@ See [Dave Cheney's post](https://dave.cheney.net/2015/11/05/lets-talk-about-logg
   // ...
   ```
 
-  Note: `WithValues` bypasses controller-runtime's special zap encoder that nicely encodes `ObjectKey`/`NamespacedName` and `runtime.Object` values, see [kubernetes-sigs/controller-runtime#1290](https://github.com/kubernetes-sigs/controller-runtime/issues/1290).
-  Thus, the end result might look different depending on the value and its `Stringer` implementation.
+> Note: `WithValues` bypasses controller-runtime's special zap encoder that nicely encodes `ObjectKey`/`NamespacedName` and `runtime.Object` values, see [kubernetes-sigs/controller-runtime#1290](https://github.com/kubernetes-sigs/controller-runtime/issues/1290).
+> Thus, the end result might look different depending on the value and its `Stringer` implementation.
 
 - Use [lowerCamelCase](https://en.wiktionary.org/wiki/lowerCamelCase) for keys. Don't put spaces in keys, as it will make log processing with simple tools like `jq` harder.
 - Keys should be constant, human-readable, consistent across the codebase and naturally match parts of the log message, see [logr guideline](https://github.com/go-logr/logr#how-do-i-choose-my-keys).

--- a/docs/development/monitoring-stack.md
+++ b/docs/development/monitoring-stack.md
@@ -28,7 +28,7 @@ In each Seed cluster there is a Prometheus in the `garden` namespace responsible
 
 The alerts for all Shoot clusters hosted on a Seed are routed to a central Alertmanger running in the `garden` namespace of the Seed. The purpose of this central alertmanager is to forward all important alerts to the operators of the Gardener setup.
 
-The Alertmanager in the Shoot namespace on the Seed is only responsible for forwarding alerts from its Shoot cluster to a cluster owner/cluster alert receiver via email. The Alertmanager is optional and the conditions for a deployment are already described [here](../monitoring/alerting.md).
+The Alertmanager in the Shoot namespace on the Seed is only responsible for forwarding alerts from its Shoot cluster to a cluster owner/cluster alert receiver via email. The Alertmanager is optional and the conditions for a deployment are already described in [Alerting](../monitoring/alerting.md).
 
 ## Adding New Monitoring Targets
 
@@ -39,7 +39,7 @@ New scrape jobs can be added in the section `scrape_configs`. Detailed informati
 
 The `job_name` of a scrape job should be the name of the component e.g. `kube-apiserver` or `vpn`. The collection interval should be the default of `30s`. You do not need to specify this in the configuration.
 
-Please do not ingest all metrics which are provided by a component. Rather collect only those metrics which are needed to define the alerts and dashboards (i.e. whitelist). This can be achieved by adding the following `metric_relabel_configs` statement to your scrape jobs (replace `exampleComponent` with component name).
+Please do not ingest all metrics which are provided by a component. Rather, collect only those metrics which are needed to define the alerts and dashboards (i.e. whitelist). This can be achieved by adding the following `metric_relabel_configs` statement to your scrape jobs (replace `exampleComponent` with component name).
 
 ```yaml
     - job_name: example-component
@@ -65,7 +65,7 @@ The alert definitons are located in `charts/seed-monitoring/charts/prometheus/ru
 
 1. Adding additional alerts for a component which already has a set of alerts. In this case you have to extend the existing rule file for the component.
 1. Adding alerts for a new component. In this case a new rule file with name scheme `example-component.rules.yaml` needs to be added.
-1. Add the new alert to `alertInhibitionGraph.dot`, add any required inhibition flows and render the new graph. To render the graph run:
+1. Add the new alert to `alertInhibitionGraph.dot`, add any required inhibition flows and render the new graph. To render the graph, run:
 ```bash
 dot -Tpng ./content/alertInhibitionGraph.dot -o ./content/alertInhibitionGraph.png
 ```
@@ -94,9 +94,9 @@ If the deployment of component is optional then the alert definitions needs to b
 
 Basic instruction how to define alert rules can be found in the [Prometheus documentation](https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules).
 
-### Routing tree
+### Routing Tree
 
-The Alertmanager is grouping incoming alerts based on labels into buckets. Each bucket has its own configuration like alert receivers, initial delaying duration or resending frequency etc. You can find more information about Alertmanager routing in the [Prometheus/Alertmanager documentation](https://prometheus.io/docs/alerting/configuration/#route). The routing trees for the Alertmanagers deployed by Gardener are depicted below.
+The Alertmanager is grouping incoming alerts based on labels into buckets. Each bucket has its own configuration like alert receivers, initial delaying duration or resending frequency, etc. You can find more information about Alertmanager routing in the [Prometheus/Alertmanager documentation](https://prometheus.io/docs/alerting/configuration/#route). The routing trees for the Alertmanagers deployed by Gardener are depicted below.
 
 Central Seed Alertmanager
 
@@ -121,7 +121,7 @@ Shoot Alertmanager
 
 ### Alert Inhibition
 
-All alerts related to components running on the Shoot workers are inhibited in case of an issue with the vpn connection, because those components can't be scraped anymore and Prometheus will fire alerts in consequence. The components running on the workers are probably healthy and the alerts are presumably false positives. The inhibition flow is shown in the figure below. If you add a new alert make sure to add it to the diagram.
+All alerts related to components running on the Shoot workers are inhibited in case of an issue with the vpn connection, because those components can't be scraped anymore and Prometheus will fire alerts in consequence. The components running on the workers are probably healthy and the alerts are presumably false positives. The inhibition flow is shown in the figure below. If you add a new alert, make sure to add it to the diagram.
 
 ![alertDiagram](content/alertInhibitionGraph.png)
 
@@ -132,7 +132,7 @@ Each alert rule definition has to contain the following annotations:
 * **summary**: A short description of the issue.
 * **description**: A detailed explanation of the issue with hints to the possible root causes and the impact assessment of the issue.
 
-In addtion each alert must contain the following labels:
+In addtion, each alert must contain the following labels:
 
 * **type**
   * `shoot`: Components running on the Shoot worker nodes in the `kube-system` namespace.
@@ -140,8 +140,8 @@ In addtion each alert must contain the following labels:
 * **service**
   * Name of the component (in lowercase) e.g. `kube-apiserver`, `alertmanager` or `vpn`.
 * **severity**
-  * `blocker`: All issues which make the cluster entirely unusable e.g. `KubeAPIServerDown` or `KubeSchedulerDown`
-  * `critical`: All issues which affect single functionalities/components but not affect the cluster in its core functionality e.g. `VPNDown` or `KubeletDown`.
+  * `blocker`: All issues which make the cluster entirely unusable, e.g. `KubeAPIServerDown` or `KubeSchedulerDown`
+  * `critical`: All issues which affect single functionalities/components but do not affect the cluster in its core functionality e.g. `VPNDown` or `KubeletDown`.
   * `info`: All issues that do not affect the cluster or its core functionality, but if this component is down we cannot determine if a blocker alert is firing. (i.e. A component with an info level severity is a dependency for a component with a blocker severity)
   * `warning`: No current existing issue, rather a hint for situations which could lead to real issue in the close future e.g. `HighLatencyApiServerToWorkers` or `ApiServerResponseSlow`.
 
@@ -192,7 +192,7 @@ For each new component, its corresponding dashboard should contain the following
 1. Pod/containers memorty consumption
 1. Pod/containers network i/o
 
-These information is provided by the cAdvisor metrics. These metrics are already integrated. Please check the other dashboards for detailed information on how to query.
+That information is provided by the cAdvisor metrics. These metrics are already integrated. Please check the other dashboards for detailed information on how to query.
 
 ##### Chart Requirements
 
@@ -208,7 +208,7 @@ Each chart needs to contain:
 
 The following parameters should be added to all dashboards to ensure a homogeneous experience across all dashboards.
 
-Dashboards have to ...
+Dashboards have to:
 
 * contain a title which refers to the component name(s)
 * contain a timezone statement which should be the browser time
@@ -216,7 +216,7 @@ Dashboards have to ...
 * contain a version statement with a value of 1
 * be immutable
 
-Example dashboard configuration
+Example dashboard configuration:
 
 ```json
 {
@@ -231,7 +231,7 @@ Example dashboard configuration
 }
 ```
 
-Furthermore all dashboards should contain the following time options:
+Furthermore, all dashboards should contain the following time options:
 
 ```json
 {

--- a/docs/development/new-cloud-provider.md
+++ b/docs/development/new-cloud-provider.md
@@ -19,22 +19,22 @@ This distinction becomes important when preparing the integration to a new cloud
 
 Gardener and its related components integrate with cloud providers at the following key lifecycle elements:
 
-* Create/destroy/get/list machines for the Shoot
+* Create/destroy/get/list machines for the Shoot.
 * Create/destroy/get/list infrastructure components for the Shoot, e.g. VPCs, subnets, routes, etc.
-* Backup/restore etcd for the Seed via writing files to and reading them from object storage
+* Backup/restore etcd for the Seed via writing files to and reading them from object storage.
 
 Thus, the integrations you need for your cloud provider depend on whether you want to deploy Shoot clusters to the provider, Seed or both.
 
-* Shoot Only: machine lifecycle management, infrastructure.
+* Shoot Only: machine lifecycle management, infrastructure
 * Seed: etcd backup/restore
 
 ## Gardener API
 
-In addition to the requirements to integrate with the cloud provider, you also need to enable the core Gardener app to receive, validate and process requests to use that cloud provider.
+In addition to the requirements to integrate with the cloud provider, you also need to enable the core Gardener app to receive, validate, and process requests to use that cloud provider.
 
-* Expose the cloud provider to the consumers of the Gardener API, so it can be told to use that cloud provider as an option
-* Validate that API as requests come in
-* Write cloud provider specific implementation (called "provider extension")
+* Expose the cloud provider to the consumers of the Gardener API, so it can be told to use that cloud provider as an option.
+* Validate that API as requests come in.
+* Write cloud provider specific implementation (called "provider extension").
 
 ## Cloud Provider API Requirements
 

--- a/docs/development/new-kubernetes-version.md
+++ b/docs/development/new-kubernetes-version.md
@@ -1,15 +1,15 @@
-# Adding Support For A New Kubernetes Version
+# Adding Support For a New Kubernetes Version
 
 This document describes the steps needed to perform in order to confidently add support for a new Kubernetes **minor** version.
 
-> ⚠️ Typically, once a minor Kubernetes version `vX.Y` is supported by Gardener then all patch versions `vX.Y.Z` are also automatically supported without any required action.
+> ⚠️ Typically, once a minor Kubernetes version `vX.Y` is supported by Gardener, then all patch versions `vX.Y.Z` are also automatically supported without any required action.
 This is because patch versions do not introduce any new feature or API changes, so there is nothing that needs to be adapted in `gardener/gardener` code.
 
 The Kubernetes community release a new minor version roughly every 4 months.
 Please refer to the [official documentation](https://kubernetes.io/releases/release/) about their release cycles for any additional information.
 
 Shortly before a new release, an "umbrella" issue should be opened which is used to collect the required adaptations and to track the work items.
-For example, [#5102](https://github.com/gardener/gardener/issues/5102) can be used as a template for the issue description.\
+For example, [#5102](https://github.com/gardener/gardener/issues/5102) can be used as a template for the issue description.
 As you can see, the task of supporting a new Kubernetes version also includes the provider extensions maintained in the `gardener` GitHub organization and is not restricted to `gardener/gardener` only.
 
 Generally, the work items can be split into two groups:
@@ -19,9 +19,9 @@ The first group contains Kubernetes release-independent tasks, the second group 
 
 ## Deriving Release-Specific Tasks
 
-Most new minor Kubernetes releases incorporate API changes, deprecations or new features.
+Most new minor Kubernetes releases incorporate API changes, deprecations, or new features.
 The community announces them via their [change logs](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/).
-In order to derive the release-specific tasks, the respective change log for the new version `vX.Y` has to be read and understood (for example, [this document](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.24.md) for `v1.24`).
+In order to derive the release-specific tasks, the respective change log for the new version `vX.Y` has to be read and understood (for example, [the changelog](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.24.md) for `v1.24`).
 
 As already mentioned, typical changes to watch out for are:
 
@@ -43,7 +43,7 @@ While reading the change log, add the tasks (along with the respective PR in `ku
 
 The following paragraphs describe recurring tasks that need to be performed for each new release.
 
-### Make Sure A New `hyperkube` Image Is Released
+### Make Sure a New `hyperkube` Image Is Released
 
 The [`gardener/hyperkube`](https://github.com/gardener/hyperkube) repository is used to release container images consisting of the `kubectl` and `kubelet` binaries.
 
@@ -79,7 +79,7 @@ There is a CI/CD job that runs periodically and releases a new `hyperkube` image
 - Bump the used Kubernetes version for local `Shoot` and local e2e test.
   - See [this](https://github.com/gardener/gardener/pull/5255/commits/5707c4c7a4fd265b176387178b755cabeea89ffe) example commit.
 
-#### Filing The Pull Request
+#### Filing the Pull Request
 
 Work on all the tasks you have collected and validate them using the [local provider](https://github.com/gardener/gardener/blob/master/docs/development/getting_started_locally.md).
 Execute the e2e tests and if everything looks good, then go ahead and file the PR ([example PR](https://github.com/gardener/gardener/pull/5255)).
@@ -94,7 +94,7 @@ After the PR in `gardener/gardener` for the support of the new version has been 
 - Revendor the `github.com/gardener/gardener` dependency in the extension and update the `README.md`.
 - Work on release-specific tasks related to this provider.
 
-#### Maintaining The `cloud-controller-manager` Images
+#### Maintaining the `cloud-controller-manager` Images
 
 Some of the cloud providers are not yet using upstream `cloud-controller-manager` images.
 Instead, we build and maintain them ourselves:
@@ -117,7 +117,7 @@ In this case, you need to checkout the `release-vX.{Y-{1,2,3}}` branches and onl
 
 Now you need to update the new releases in the `charts/images.yaml` of the respective provider extension so that they are used (see this [example commit](https://github.com/gardener/gardener-extension-provider-aws/pull/480/commits/76256de933d5a508aba26a8f589dd1a39026142e) for reference).
 
-#### Filing The Pull Request
+#### Filing the Pull Request
 
 Again, work on all the tasks you have collected.
 This time, you cannot use the local provider for validation but should create real clusters on the various infrastructures.

--- a/docs/development/priority-classes.md
+++ b/docs/development/priority-classes.md
@@ -1,7 +1,7 @@
 # `PriorityClass`es in Gardener Clusters
 
-Gardener makes use of [`PriorityClass`es](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/) to improve overall robustness of the system.
-In order to benefit from the full potential of `PriorityClass`es, gardenlet manages a set of well-known `PriorityClass`es with fine-granular priority values.
+Gardener makes use of [`PriorityClass`es](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/) to improve the overall robustness of the system.
+In order to benefit from the full potential of `PriorityClass`es, the gardenlet manages a set of well-known `PriorityClass`es with fine-granular priority values.
 
 All components of the system should use these well-known `PriorityClass`es instead of creating and using separate ones with arbitrary values, which would compromise the overall goal of using `PriorityClass`es in the first place.
 Gardenlet manages the well-known `PriorityClass`es listed in this document, so that third parties (e.g., Gardener extensions) can rely on them to be present when deploying components to Seed and Shoot clusters.

--- a/docs/development/process.md
+++ b/docs/development/process.md
@@ -2,9 +2,14 @@
 
 This document describes how to contribute features or hotfixes, and how new Gardener releases are usually scheduled, validated, etc.
 
-- [Releases](#releases)
-- [Contributing new Features or Fixes](#contributing-new-features-or-fixes)
-- [Cherry Picks](#cherry-picks)
+- [Releases, Features, Hotfixes](#releases-features-hotfixes)
+  - [Releases](#releases)
+    - [Release Responsible Plan](#release-responsible-plan)
+    - [Release Validation](#release-validation)
+  - [Contributing New Features or Fixes](#contributing-new-features-or-fixes)
+  - [Cherry Picks](#cherry-picks)
+    - [Prerequisites](#prerequisites)
+    - [Initiate a Cherry Pick](#initiate-a-cherry-pick)
 
 ## Releases
 
@@ -96,7 +101,7 @@ Typically, the first week is used for the validation of the release.
 This phase includes the following steps:
 
 1. `master` (or latest `release-*` branch) is deployed to a development landscape that already hosts some existing seed and shoot clusters.
-1. An extended test suite is triggered by the "release responsible" which
+1. An extended test suite is triggered by the "release responsible" which:
    1. executes the Gardener integration tests for different Kubernetes versions, infrastructures, and `Shoot` settings.
    1. executes the Kubernetes conformance tests.
    1. executes further tests like Kubernetes/OS patch/minor version upgrades.
@@ -105,7 +110,7 @@ This phase includes the following steps:
 
 Usually, the new release is triggered in the beginning of the second week if all tests are green, all checks were successful, and if all of the planned verifications were performed by the release responsible.
 
-## Contributing new Features or Fixes
+## Contributing New Features or Fixes
 
 Please refer to the [Gardener contributor guide](https://gardener.cloud/docs/contribute/).
 Besides a lot of a general information, it also provides a checklist for newly created pull requests that may help you to prepare your changes for an efficient review process.
@@ -134,18 +139,18 @@ This section explains how to initiate cherry picks on release branches within th
 Before you initiate a cherry pick, make sure that the following prerequisites are accomplished.
 
 - A pull request merged against the `master` branch.
-- The release branch exists (check in the [branches section](https://github.com/gardener/gardener/branches))
+- The release branch exists (check in the [branches section](https://github.com/gardener/gardener/branches)).
 - Have the `gardener/gardener` repository cloned as follows:
-  - the `origin` remote should point to your fork (alternatively this can be overwritten by passing `FORK_REMOTE=<fork-remote>`)
-  - the `upstream` remote should point to the Gardener github org (alternatively this can be overwritten by passing `UPSTREAM_REMOTE=<upstream-remote>`)
+  - the `origin` remote should point to your fork (alternatively this can be overwritten by passing `FORK_REMOTE=<fork-remote>`).
+  - the `upstream` remote should point to the Gardener github org (alternatively this can be overwritten by passing `UPSTREAM_REMOTE=<upstream-remote>`).
 - Have `hub` installed, which is most easily installed via
   `go get github.com/github/hub` assuming you have a standard golang
   development environment.
-- A github token which has permissions to create a PR in an upstream branch.
+- A Github token which has permissions to create a PR in an upstream branch.
 
 ### Initiate a Cherry Pick
 
-- Run the [cherry pick script][cherry-pick-script]
+- Run the [cherry pick script][cherry-pick-script].
 
   This example applies a master branch PR #3632 to the remote branch
   `upstream/release-v3.14`:
@@ -155,14 +160,14 @@ Before you initiate a cherry pick, make sure that the following prerequisites ar
   ```
 
   - Be aware the cherry pick script assumes you have a git remote called
-    `upstream` that points at the Gardener github org.
+    `upstream` that points at the Gardener Github org.
 
   - You will need to run the cherry pick script separately for each patch
     release you want to cherry pick to. Cherry picks should be applied to all
     active release branches where the fix is applicable.
 
-  - When asked for your github password, provide the created github token
-    rather than your actual github password.
+  - When asked for your Github password, provide the created Github token
+    rather than your actual Github password.
     Refer [https://github.com/github/hub/issues/2655#issuecomment-735836048](https://github.com/github/hub/issues/2655#issuecomment-735836048)
 
-[cherry-pick-script]: https://github.com/gardener/gardener/blob/master/hack/cherry-pick-pull.sh
+- [cherry-pick-script](https://github.com/gardener/gardener/blob/master/hack/cherry-pick-pull.sh)

--- a/docs/development/process.md
+++ b/docs/development/process.md
@@ -142,11 +142,11 @@ Before you initiate a cherry pick, make sure that the following prerequisites ar
 - The release branch exists (check in the [branches section](https://github.com/gardener/gardener/branches)).
 - Have the `gardener/gardener` repository cloned as follows:
   - the `origin` remote should point to your fork (alternatively this can be overwritten by passing `FORK_REMOTE=<fork-remote>`).
-  - the `upstream` remote should point to the Gardener github org (alternatively this can be overwritten by passing `UPSTREAM_REMOTE=<upstream-remote>`).
+  - the `upstream` remote should point to the Gardener GitHub org (alternatively this can be overwritten by passing `UPSTREAM_REMOTE=<upstream-remote>`).
 - Have `hub` installed, which is most easily installed via
   `go get github.com/github/hub` assuming you have a standard golang
   development environment.
-- A Github token which has permissions to create a PR in an upstream branch.
+- A GitHub token which has permissions to create a PR in an upstream branch.
 
 ### Initiate a Cherry Pick
 
@@ -160,14 +160,14 @@ Before you initiate a cherry pick, make sure that the following prerequisites ar
   ```
 
   - Be aware the cherry pick script assumes you have a git remote called
-    `upstream` that points at the Gardener Github org.
+    `upstream` that points at the Gardener GitHub org.
 
   - You will need to run the cherry pick script separately for each patch
     release you want to cherry pick to. Cherry picks should be applied to all
     active release branches where the fix is applicable.
 
-  - When asked for your Github password, provide the created Github token
-    rather than your actual Github password.
+  - When asked for your GitHub password, provide the created GitHub token
+    rather than your actual GitHub password.
     Refer [https://github.com/github/hub/issues/2655#issuecomment-735836048](https://github.com/github/hub/issues/2655#issuecomment-735836048)
 
 - [cherry-pick-script](https://github.com/gardener/gardener/blob/master/hack/cherry-pick-pull.sh)

--- a/docs/development/secrets_management.md
+++ b/docs/development/secrets_management.md
@@ -11,7 +11,7 @@ It is built on top of the `ConfigInterface` and `DataInterface` interfaces part 
 - `Generate(context.Context, secrets.ConfigInterface, ...GenerateOption) (*corev1.Secret, error)`
 
   This method either retrieves the current secret for the given configuration or it (re)generates it in case the configuration changed, the signing CA changed (for certificate secrets), or when proactive rotation was triggered.
-  If the configuration describes a certificate authority secret then this method automatically generates a bundle secret containing the current and potentially the old certificate.\
+  If the configuration describes a certificate authority secret then this method automatically generates a bundle secret containing the current and potentially the old certificate.
   Available `GenerateOption`s:
   - `SignedByCA(string, ...SignedByCAOption)`: This is only valid for certificate secrets and automatically retrieves the correct certificate authority in order to sign the provided server or client certificate.
     - There are two `SignedByCAOption`s:
@@ -27,7 +27,7 @@ It is built on top of the `ConfigInterface` and `DataInterface` interfaces part 
 
   This method retrieves the current secret for the given name.
   In case the secret in question is a certificate authority secret then it retrieves the bundle secret by default.
-  It is important that this method only knows about secrets for which there were prior `Generate` calls.\
+  It is important that this method only knows about secrets for which there were prior `Generate` calls.
   Available `GetOption`s:
   - `Bundle` (default): This retrieves the bundle secret.
   - `Current`: This retrieves the current secret.
@@ -61,9 +61,9 @@ if err != nil {
 ```
 
 As explained above, the caller does not need to care about the renewal, rotation or the persistence of this secret - all of these concerns are handled by the secrets manager.
-Automatic renewal of secrets happens when their validity  approaches 80% or less than `10d` are left until expiration.
+Automatic renewal of secrets happens when their validity approaches 80% or less than `10d` are left until expiration.
 
-In case a CA certificate is needed by some component then it can be retrieved as follows:
+In case a CA certificate is needed by some component, then it can be retrieved as follows:
 
 ```go
 caSecret, found := k.secretsManager.Get("my-ca")
@@ -86,7 +86,7 @@ This is to ensure a smooth exchange of certificate during a CA rotation (typical
   - In phase 1, servers still use their old/existing certificates to allow clients to update their CA bundle used for verification of the servers' certificates.
   - In phase 2, the old CA is dropped, hence servers need to get a certificate signed by the new/current CA. At this point in time, clients have already adapted their CA bundles.
 
-#### Always Sign Server Certificates With Current CA
+#### Always Sign Server Certificates with Current CA
 
 In case you control all clients and update them at the same time as the server, it is possible to make the secrets manager generate even server certificates with the new/current CA.
 This can help to prevent certificate mismatches when the CA bundle is already exchanged while the server still serves with a certificate signed by a CA no longer part of the bundle.
@@ -96,7 +96,7 @@ Let's consider the two following examples:
 1. `gardenlet` deploys a webhook server (`gardener-resource-manager`) and a corresponding `MutatingWebhookConfiguration` at the same time. In this case, the server certificate should be generated with the new/current CA to avoid above mentioned certificate mismatches during a CA rotation.
 2. `gardenlet` deploys a server (`etcd`) in one step, and a client (`kube-apiserver`) in a subsequent step. In this case, the default behaviour should apply (server certificate should be signed by old/existing CA).
 
-#### Always Sign Client Certificate With Old CA
+#### Always Sign Client Certificate with Old CA
 
 In the unusual case where the client is deployed before the server, it might be useful to always use the old CA for signing the client's certificate.
 This can help to prevent certificate mismatches when the client already gets a new certificate while the server still only accepts certificates signed by the old CA.
@@ -111,18 +111,18 @@ While the `SecretsManager` is primarily used by gardenlet, it can be reused by o
 
 External components that want to reuse the `SecretsManager` should consider the following aspects:
 
-- On initialization of a `SecretsManager`, pass an `identity` specific to the component, controller and purpose. For example, gardenlet's shoot controller uses `gardenlet` as the `SecretsManager`'s identity, the `Worker` controller in `provider-foo` should use `provider-foo-worker` and the `ControlPlane` controller should use `provider-foo-controlplane-exposure` for `ControlPlane` objects of purpose `exposure`.
+- On initialization of a `SecretsManager`, pass an `identity` specific to the component, controller and purpose. For example, gardenlet's shoot controller uses `gardenlet` as the `SecretsManager`'s identity, the `Worker` controller in `provider-foo` should use `provider-foo-worker`, and the `ControlPlane` controller should use `provider-foo-controlplane-exposure` for `ControlPlane` objects of purpose `exposure`.
   The given identity is added as a value for the `manager-identity` label on managed `Secret`s.
   This label is used by the `Cleanup` function to select only those `Secret`s that are actually managed by the particular `SecretManager` instance. This is done to prevent removing still needed `Secret`s that are managed by other instances.
 - Generate dedicated CAs for signing certificates instead of depending on CAs managed by gardenlet.
 - Names of `Secret`s managed by external `SecretsManager` instances must not conflict with `Secret` names from other instances (e.g. gardenlet).
 - For CAs that should be rotated in lock-step with the Shoot CAs managed by gardenlet, components need to pass information about the last rotation initiation time and the current rotation phase to the `SecretsManager` upon initialization.
   The relevant information can be retrieved from the `Cluster` resource under `.spec.shoot.status.credentials.rotation.certificateAuthorities`.
-- Independent of the specific identity, secrets marked with the `Persist` option are automatically saved in the `ShootState` resource by gardenlet and are also restored by gardenlet on Control Plane Migration to the new Seed.
+- Independent of the specific identity, secrets marked with the `Persist` option are automatically saved in the `ShootState` resource by the gardenlet and are also restored by the gardenlet on Control Plane Migration to the new Seed.
 
 ## Migrating Existing Secrets To SecretsManager
 
-If you already have existing secrets which were not created with `SecretsManager` then you can (optionally) migrate them by labeling them with `secrets-manager-use-data-for=<config-name>`.
+If you already have existing secrets which were not created with `SecretsManager`, then you can (optionally) migrate them by labeling them with `secrets-manager-use-data-for=<config-name>`.
 For example, if your `SecretsManager` generates a `CertificateConfigSecret` with name `foo` like this
 
 ```go

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -461,9 +461,9 @@ Below is a sequence describing how the tests are performed.
 ### How to Run Upgrade Tests Between Two Gardener Releases
 
 Sometimes, we need to verify/qualify two Gardener releases when we upgrade from one version to another.  
-This can performed by fetching the two Gardener versions from the  **[Github Gardener release page](https://github.com/gardener/gardener/releases/latest)** and setting appropriate env variables `GARDENER_PREVIOUS_RELEASE`, `GARDENER_NEXT_RELEASE`.   
+This can performed by fetching the two Gardener versions from the  **[GitHub Gardener release page](https://github.com/gardener/gardener/releases/latest)** and setting appropriate env variables `GARDENER_PREVIOUS_RELEASE`, `GARDENER_NEXT_RELEASE`.   
 
->**`GARDENER_PREVIOUS_RELEASE`** -- This env variable refers to a source revision/branch (or a specific release) which has to be installed first and then upgraded to version **`GARDENER_NEXT_RELEASE`**. By default, it fetches the latest release version from **[Github Gardener release page](https://github.com/gardener/gardener/releases/latest)**.
+>**`GARDENER_PREVIOUS_RELEASE`** -- This env variable refers to a source revision/branch (or a specific release) which has to be installed first and then upgraded to version **`GARDENER_NEXT_RELEASE`**. By default, it fetches the latest release version from **[GitHub Gardener release page](https://github.com/gardener/gardener/releases/latest)**.
 
 >**`GARDENER_NEXT_RELEASE`** -- This env variable refers to the target revision/branch (or a specific release) to be upgraded to after successful installation of **`GARDENER_PREVIOUS_RELEASE`**. By default, it considers the local HEAD revision, builds code, and installs Gardener from the current revision where the Gardener upgrade tests triggered.
 

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -1,19 +1,19 @@
 # Testing Strategy and Developer Guideline
 
-This document walks you through
+This document walks you through:
 
-- what kind of tests we have in Gardener
-- how to run each of them
-- what purpose each kind of test serves
-- how to best write tests that are correct, stable, fast and maintainable
-- how to debug tests that are not working as expected
+- What kind of tests we have in Gardener
+- How to run each of them
+- What purpose each kind of test serves
+- How to best write tests that are correct, stable, fast and maintainable
+- How to debug tests that are not working as expected
 
 The document is aimed towards developers that want to contribute code and need to write tests, as well as maintainers and reviewers that review test code.
-It serves as a common guide that we commit to follow in our project to ensure consistency in our tests, good coverage for high confidence and good maintainability.
+It serves as a common guide that we commit to follow in our project to ensure consistency in our tests, good coverage for high confidence, and good maintainability.
 
 The guidelines are not meant to be absolute rules.
 Always apply common sense and adapt the guideline if it doesn't make much sense for some cases.
-If in doubt, don't hesitate to ask questions during PR review (as an author but also as a reviewer).
+If in doubt, don't hesitate to ask questions during a PR review (as an author, but also as a reviewer).
 Add new learnings as soon as we make them!
 
 Generally speaking, **tests are a strict requirement for contributing new code**.
@@ -22,23 +22,23 @@ Ideally though, you would add the missing test cases for the current code as wel
 
 ## Writing Tests (Relevant for All Kinds)
 
-- we follow BDD (behavior-driven development) testing principles and use [Ginkgo](https://onsi.github.io/ginkgo/) along with [Gomega](http://onsi.github.io/gomega/)
-  - make sure to check out their extensive guides for more information and how to best leverage all of their features
-- use `By` to structure test cases with multiple steps, so that steps are easy to follow in the logs: [example test](https://github.com/gardener/gardener/blob/2eb54485231408cbdbabaa49812572a07124364f/pkg/client/kubernetes/clientmap/internal/generic_clientmap_test.go#L122-L138)
-- call `defer GinkgoRecover()` if making assertions in goroutines: [doc](https://pkg.go.dev/github.com/onsi/ginkgo#GinkgoRecover), [example test](https://github.com/gardener/gardener/blob/2eb54485231408cbdbabaa49812572a07124364f/test/integration/scheduler/scheduler_test.go#L65-L68)
-- use `DeferCleanup` instead of cleaning up manually (or use custom coding from the test framework): [example test](https://github.com/gardener/gardener/blob/2eb54485231408cbdbabaa49812572a07124364f/test/integration/resourcemanager/health/health_suite_test.go#L102-L105), [example test](https://github.com/gardener/gardener/blob/2eb54485231408cbdbabaa49812572a07124364f/test/integration/resourcemanager/health/health_test.go#L385-L390)
-  - `DeferCleanup` makes sure to run the cleanup code in the right point in time, e.g., a `DeferCleanup` added in `BeforeEach` is executed with `AfterEach`
-- test failures should point to an exact location, so that failures in CI aren't too difficult to debug/fix
-  - use `ExpectWithOffset` for making assertions in helper funcs like `expectSomethingWasCreated`: [example test](https://github.com/gardener/gardener/blob/2eb54485231408cbdbabaa49812572a07124364f/extensions/pkg/controller/controlplane/genericactuator/actuator_test.go#L732-L736)
-  - make sure to add additional descriptions to Gomega matchers if necessary (e.g. in a loop): [example test](https://github.com/gardener/gardener/blob/2eb54485231408cbdbabaa49812572a07124364f/test/e2e/shoot/internal/rotation/certificate_authorities.go#L89-L93)
-- introduce helper functions for assertions to make test more readable where applicable: [example test](https://github.com/gardener/gardener/blob/2eb54485231408cbdbabaa49812572a07124364f/test/integration/gardenlet/shootsecret/controller_test.go#L323-L331)
-- introduce custom matchers to make tests more readable where applicable: [example matcher](https://github.com/gardener/gardener/blob/2eb54485231408cbdbabaa49812572a07124364f/pkg/utils/test/matchers/matchers.go#L51-L57)
-- don't rely on accurate timing of `time.Sleep` and friends
-  - if doing so, CPU throttling in CI will make tests flaky, [example flake](https://github.com/gardener/gardener/issues/5410)
-  - use fake clocks instead, [example PR](https://github.com/gardener/gardener/pull/4569) 
-- use the same client schemes that are also used by production code to avoid subtle bugs/regressions: [example PR](https://github.com/gardener/gardener/pull/5469), [production schemes](https://github.com/gardener/gardener/blob/2de823d0a457beb9d680260243032c95fa47dc72/pkg/resourcemanager/cmd/source.go#L34-L43), [usage in test](https://github.com/gardener/gardener/blob/2de823d0a457beb9d680260243032c95fa47dc72/test/integration/resourcemanager/health/health_suite_test.go#L108-L109)
-- make sure, your test is actually asserting the right thing and it doesn't pass if the exact bug is introduced that you want to prevent
-  - use specific error matchers instead of asserting any error has happened, make sure that the corresponding branch in the code is tested, e.g., prefer
+- We follow BDD (behavior-driven development) testing principles and use [Ginkgo](https://onsi.github.io/ginkgo/), along with [Gomega](http://onsi.github.io/gomega/).
+  - Make sure to check out their extensive guides for more information and how to best leverage all of their features
+- Use `By` to structure test cases with multiple steps, so that steps are easy to follow in the logs: [example test](https://github.com/gardener/gardener/blob/2eb54485231408cbdbabaa49812572a07124364f/pkg/client/kubernetes/clientmap/internal/generic_clientmap_test.go#L122-L138)
+- Call `defer GinkgoRecover()` if making assertions in goroutines: [doc](https://pkg.go.dev/github.com/onsi/ginkgo#GinkgoRecover), [example test](https://github.com/gardener/gardener/blob/2eb54485231408cbdbabaa49812572a07124364f/test/integration/scheduler/scheduler_test.go#L65-L68)
+- Use `DeferCleanup` instead of cleaning up manually (or use custom coding from the test framework): [example test](https://github.com/gardener/gardener/blob/2eb54485231408cbdbabaa49812572a07124364f/test/integration/resourcemanager/health/health_suite_test.go#L102-L105), [example test](https://github.com/gardener/gardener/blob/2eb54485231408cbdbabaa49812572a07124364f/test/integration/resourcemanager/health/health_test.go#L385-L390)
+  - `DeferCleanup` makes sure to run the cleanup code in the right point in time, e.g., a `DeferCleanup` added in `BeforeEach` is executed with `AfterEach`.
+- Test failures should point to an exact location, so that failures in CI aren't too difficult to debug/fix.
+  - Use `ExpectWithOffset` for making assertions in helper funcs like `expectSomethingWasCreated`: [example test](https://github.com/gardener/gardener/blob/2eb54485231408cbdbabaa49812572a07124364f/extensions/pkg/controller/controlplane/genericactuator/actuator_test.go#L732-L736)
+  - Make sure to add additional descriptions to Gomega matchers if necessary (e.g. in a loop): [example test](https://github.com/gardener/gardener/blob/2eb54485231408cbdbabaa49812572a07124364f/test/e2e/shoot/internal/rotation/certificate_authorities.go#L89-L93)
+- Introduce helper functions for assertions to make test more readable where applicable: [example test](https://github.com/gardener/gardener/blob/2eb54485231408cbdbabaa49812572a07124364f/test/integration/gardenlet/shootsecret/controller_test.go#L323-L331)
+- Introduce custom matchers to make tests more readable where applicable: [example matcher](https://github.com/gardener/gardener/blob/2eb54485231408cbdbabaa49812572a07124364f/pkg/utils/test/matchers/matchers.go#L51-L57)
+- Don't rely on accurate timing of `time.Sleep` and friends.
+  - If doing so, CPU throttling in CI will make tests flaky, [example flake](https://github.com/gardener/gardener/issues/5410)
+  - Use fake clocks instead, [example PR](https://github.com/gardener/gardener/pull/4569) 
+- Use the same client schemes that are also used by production code to avoid subtle bugs/regressions: [example PR](https://github.com/gardener/gardener/pull/5469), [production schemes](https://github.com/gardener/gardener/blob/2de823d0a457beb9d680260243032c95fa47dc72/pkg/resourcemanager/cmd/source.go#L34-L43), [usage in test](https://github.com/gardener/gardener/blob/2de823d0a457beb9d680260243032c95fa47dc72/test/integration/resourcemanager/health/health_suite_test.go#L108-L109)
+- Make sure that your test is actually asserting the right thing and it doesn't pass if the exact bug is introduced that you want to prevent.
+  - Use specific error matchers instead of asserting any error has happened, make sure that the corresponding branch in the code is tested, e.g., prefer
     ```go
     Expect(err).To(MatchError("foo"))
     ```
@@ -46,23 +46,23 @@ Ideally though, you would add the missing test cases for the current code as wel
     ```go
     Expect(err).To(HaveOccurred())
     ```
-  - if you're unsure about your test's behavior, attaching the debugger can sometimes be helpful to make sure your test is correct
-- about overwriting global variables
-  - this is a common pattern (or hack?) in go for faking calls to external functions
-  - however, this can lead to races, when the global variable is used from a goroutine (e.g., the function is called)
-  - alternatively, set fields on structs (passed via parameter or set directly): this is not racy, as struct values are typically (and should be) only used for a single test case
-  - alternative to dealing with function variables and fields:
-    - add an interface, which your code depends on
-    - write a fake and a real implementation (similar to `clock.Clock.Sleep`)
-    - the real implementation calls the actual function (`clock.RealClock.Sleep` calls `time.Sleep`)
-    - the fake implementation does whatever you want it to do for your test (`clock.FakeClock.Sleep` waits until the test code advanced the time)
-- use constants in test code with care
-  - typically, you should not use constants from the same package as the tested code, instead use literals
-  - if the constant value is changed, tests using the constant will still pass, although the "specification" is not fulfilled anymore
-  - there are cases where it's fine to use constants, but keep this caveat in mind when doing so
-- creating sample data for tests can be a high effort
-  - if valuable, add a package for generating common sample data, e.g. Shoot/Cluster objects
-- make use of the `testdata` directory for storing arbitrary sample data needed by tests (helm charts, YAML manifests, etc.), [example PR](https://github.com/gardener/gardener/pull/2140)
+  - If you're unsure about your test's behavior, attaching the debugger can sometimes be helpful to make sure your test is correct.
+- About overwriting global variables:
+  - This is a common pattern (or hack?) in go for faking calls to external functions.
+  - However, this can lead to races, when the global variable is used from a goroutine (e.g., the function is called).
+  - Alternatively, set fields on structs (passed via parameter or set directly): this is not racy, as struct values are typically (and should be) only used for a single test case.
+  - An alternative to dealing with function variables and fields:
+    - Add an interface which your code depends on
+    - Write a fake and a real implementation (similar to `clock.Clock.Sleep`)
+    - The real implementation calls the actual function (`clock.RealClock.Sleep` calls `time.Sleep`)
+    - The fake implementation does whatever you want it to do for your test (`clock.FakeClock.Sleep` waits until the test code advanced the time)
+- Use constants in test code with care.
+  - Typically, you should not use constants from the same package as the tested code, instead use literals.
+  - If the constant value is changed, tests using the constant will still pass, although the "specification" is not fulfilled anymore.
+  - There are cases where it's fine to use constants, but keep this caveat in mind when doing so.
+- Creating sample data for tests can be a high effort.
+  - If valuable, add a package for generating common sample data, e.g. Shoot/Cluster objects.
+- Make use of the `testdata` directory for storing arbitrary sample data needed by tests (helm charts, YAML manifests, etc.), [example PR](https://github.com/gardener/gardener/pull/2140)
   - From https://pkg.go.dev/cmd/go/internal/test:
     > The go tool will ignore a directory named "testdata", making it available to hold ancillary data needed by the tests.
 
@@ -143,59 +143,59 @@ $ stress -p 16 ./pkg/resourcemanager/controller/garbagecollector/garbagecollecto
 10s: 2160 runs so far, 0 failures
 ```
 
-`stress` will output a path to a file containing the full failure message, when a test run fails.
+`stress` will output a path to a file containing the full failure message when a test run fails.
 
 ### Purpose of Unit Tests
 
-- unit tests prove correctness of a single unit according to the specification of its interface
-  - think: is the unit that I introduced doing what it is supposed to do for all cases?
-- unit tests protect against regressions caused by adding new functionality to or refactoring of a single unit
-  - think: is the unit that was introduced earlier (by someone else) and that I changed still doing what it was supposed to do for all cases?
-- example units: functions (conversion, defaulting, validation, helpers), structs (helpers, basic building blocks like the Secrets Manager), predicates, event handlers
-- for these purposes, unit tests need to cover all important cases of input for a single unit and cover edge cases / negative paths as well (e.g., errors)
-  - because of the possible high dimensionality of test input, unit tests need to be fast to execute: individual test cases should not take more than a few seconds, test suites not more than 2 minutes
-  - fuzzing can be used as a technique in addition to usual test cases for covering edge cases
-- test coverage can be used as a tool during test development for covering all cases of a unit
-- however, test coverage data can be a false safety net
-  - full line coverage doesn't mean you have covered all cases of valid input
-  - we don't have strict requirements for test coverage, as it doesn't necessarily yield the desired outcome
-- unit tests should not test too large components, e.g. entire controller `Reconcile` functions
-  - if a function/component does many steps, it's probably better to split it up into multiple functions/components that can be unit tested individually
-  - there might be special cases for very small `Reconcile` functions
-  - if there are a lot of edge cases, extract dedicated functions that cover them and use unit tests to test them
-  - usual-sized controllers should rather be tested in integration tests
-  - individual parts (e.g. helper functions) should still be tested in unit test for covering all cases, though
-- unit tests are especially easy to run with a debugger and can help in understanding concrete behavior of components
+- Unit tests prove the correctness of a single unit according to the specification of its interface.
+  - Think: Is the unit that I introduced doing what it is supposed to do for all cases?
+- Unit tests protect against regressions caused by adding new functionality to or refactoring of a single unit.
+  - Think: Is the unit that was introduced earlier (by someone else) and that I changed still doing what it was supposed to do for all cases?
+- Example units: functions (conversion, defaulting, validation, helpers), structs (helpers, basic building blocks like the Secrets Manager), predicates, event handlers.
+- For these purposes, unit tests need to cover all important cases of input for a single unit and cover edge cases / negative paths as well (e.g., errors).
+  - Because of the possible high dimensionality of test input, unit tests need to be fast to execute: individual test cases should not take more than a few seconds, test suites not more than 2 minutes.
+  - Fuzzing can be used as a technique in addition to usual test cases for covering edge cases.
+- Test coverage can be used as a tool during test development for covering all cases of a unit.
+- However, test coverage data can be a false safety net.
+  - Full line coverage doesn't mean you have covered all cases of valid input.
+  - We don't have strict requirements for test coverage, as it doesn't necessarily yield the desired outcome.
+- Unit tests should not test too large components, e.g. entire controller `Reconcile` functions.
+  - If a function/component does many steps, it's probably better to split it up into multiple functions/components that can be unit tested individually
+  - There might be special cases for very small `Reconcile` functions.
+  - If there are a lot of edge cases, extract dedicated functions that cover them and use unit tests to test them.
+  - Usual-sized controllers should rather be tested in integration tests.
+  - Individual parts (e.g. helper functions) should still be tested in unit test for covering all cases, though.
+- Unit tests are especially easy to run with a debugger and can help in understanding concrete behavior of components.
 
 ### Writing Unit Tests
 
-- for the sake of execution speed, fake expensive calls/operations, e.g. secret generation: [example test](https://github.com/gardener/gardener/blob/efcc0a9146d3558253b95071f2c652663f916d92/pkg/operation/botanist/component/kubescheduler/kube_scheduler_suite_test.go#L32-L34)
-- generally, prefer fakes over mocks, e.g., use controller-runtime fake client over mock clients
-  - mocks decrease maintainability because they expect the tested component to follow a certain way to reach the desired goal (e.g., call specific functions with particular arguments), [example consequence](https://github.com/gardener/gardener/pull/4027/commits/111aba2c8e306421f2fa6b27e5d8ed8b2fc52be9#diff-8e61507edf985df2625840a690115c43bca6c032f2ff818389633bd4365c3efdR293-R298)
-  - generally, fakes should be used in "result-oriented" test code (e.g., that a certain object was labelled, but the test doesn't care if it was via patch or update as both a valid ways to reach the desired goal)
-  - although rare, there are valid use cases for mocks, e.g. if the following aspects are important for correctness:
-    - asserting that an exact function is called
-    - asserting that functions are called in a specific order
-    - asserting that exact parameters/values/... are passed
-    - asserting that a certain function was not called
-    - many of these can also be verified with fakes, although mocks might be simpler
-  - only use mocks if the tested code directly calls the mock; never if the tested code only calls the mock indirectly (e.g., through a helper package/function)
-  - keep in mind the maintenance implications of using mocks:
-    - can you make a valid non-behavioral change in the code without breaking the test or dependent tests?
-  - it's valid to mix fakes and mocks in the same test or between test cases
-- generally, use the go test package, i.e., declare `package <production_package>_test`
-  - helps in avoiding cyclic dependencies between production, test and helper packages
-  - also forces you to distinguish between the public (exported) API surface of your code and internal state that might not be of interest to tests
-  - it might be valid to use the same package as the tested code if you want to test unexported functions
-    - alternatively, an [`internal` package](https://go.dev/doc/go1.4#internalpackages) can be used to host "internal" helpers: [example package](https://github.com/gardener/gardener/tree/2eb54485231408cbdbabaa49812572a07124364f/pkg/client/kubernetes/clientmap)
-  - helpers can also be exported if no one is supposed to import the containing package (e.g. controller package)
+- For the sake of execution speed, fake expensive calls/operations, e.g. secret generation: [example test](https://github.com/gardener/gardener/blob/efcc0a9146d3558253b95071f2c652663f916d92/pkg/operation/botanist/component/kubescheduler/kube_scheduler_suite_test.go#L32-L34)
+- Generally, prefer fakes over mocks, e.g., use controller-runtime fake client over mock clients.
+  - Mocks decrease maintainability because they expect the tested component to follow a certain way to reach the desired goal (e.g., call specific functions with particular arguments), [example consequence](https://github.com/gardener/gardener/pull/4027/commits/111aba2c8e306421f2fa6b27e5d8ed8b2fc52be9#diff-8e61507edf985df2625840a690115c43bca6c032f2ff818389633bd4365c3efdR293-R298)
+  - Generally, fakes should be used in "result-oriented" test code (e.g., that a certain object was labelled, but the test doesn't care if it was via patch or update as both a valid ways to reach the desired goal).
+  - Although rare, there are valid use cases for mocks, e.g. if the following aspects are important for correctness:
+    - Asserting that an exact function is called
+    - Asserting that functions are called in a specific order
+    - Asserting that exact parameters/values/... are passed
+    - Asserting that a certain function was not called
+    - Many of these can also be verified with fakes, although mocks might be simpler
+  - Only use mocks if the tested code directly calls the mock; never if the tested code only calls the mock indirectly (e.g., through a helper package/function).
+  - Keep in mind the maintenance implications of using mocks:
+    - Can you make a valid non-behavioral change in the code without breaking the test or dependent tests?
+  - It's valid to mix fakes and mocks in the same test or between test cases.
+- Generally, use the go test package, i.e., declare `package <production_package>_test`:
+  - Helps in avoiding cyclic dependencies between production, test and helper packages
+  - Also forces you to distinguish between the public (exported) API surface of your code and internal state that might not be of interest to tests
+  - It might be valid to use the same package as the tested code if you want to test unexported functions.
+    - Alternatively, an [`internal` package](https://go.dev/doc/go1.4#internalpackages) can be used to host "internal" helpers: [example package](https://github.com/gardener/gardener/tree/2eb54485231408cbdbabaa49812572a07124364f/pkg/client/kubernetes/clientmap)
+  - Helpers can also be exported if no one is supposed to import the containing package (e.g. controller package).
 
 ## Integration Tests (envtests)
 
 Integration tests in Gardener use the `sigs.k8s.io/controller-runtime/pkg/envtest` package.
 It sets up a temporary control plane (etcd + kube-apiserver) and runs the test against it.
 
-Package `github.com/gardener/gardener/pkg/envtest` augments controller-runtime's `envtest` package by starting and registering `gardener-apiserver`.
+Package `github.com/gardener/gardener/pkg/envtest` augments the controller-runtime's `envtest` package by starting and registering `gardener-apiserver`.
 This is used to test controllers that act on resources in the Gardener APIs (aggregated APIs).
 
 Historically, [test machinery tests](#test-machinery-tests) have also been called "integration tests".
@@ -222,7 +222,7 @@ If you want to execute the test suites directly via `go test` or `ginkgo`, you h
 ### Debugging Integration Tests
 
 You can configure envtest to use an existing cluster instead of starting a temporary control plane for your test.
-This can be helpful for debugging integration tests, because you can easily inspect what is going on in your test cluster with `kubectl`.
+This can be helpful for debugging integration tests because you can easily inspect what is going on in your test cluster with `kubectl`.
 
 Run an `envtest` suite (not using `gardener-apiserver`) against an existing cluster:
 
@@ -305,61 +305,61 @@ $ stress -ignore "unable to grab random port" -p 16 ./test/integration/controlle
 
 ### Purpose of Integration Tests
 
-- integration tests prove that multiple units are correctly integrated into a fully-functional component of the system
-- example components with multiple units:
-  - a controller with its reconciler, watches, predicates, event handlers, queues, etc.
-  - a webhook with its server, handler, decoder and webhook configuration
-- integration tests set up a full component (including used libraries) and run it against a test environment close to the actual setup
-  - e.g., start controllers against a real Kubernetes control plane to catch bugs that can only happen when talking to a real API server
-  - integration tests are generally more expensive to run (e.g., in terms of execution time)
-- integration tests should not cover each and every detailed case
-  - rather cover a good portion of the "usual" cases that components will face during normal operation (positive and negative test cases)
-  - but don't cover all failure cases or all cases of predicates -> they should be covered in unit tests already
-  - generally, not supposed to "generate test coverage" but to provide confidence that components work well
-- as integration tests typically test only one component (or a cohesive set of components) isolated from others, they cannot catch bugs that occur when multiple controllers interact (could be discovered by e2e tests, though)
-- rule of thumb: a new integration tests should be added for each new controller (an integration test doesn't replace unit tests though)
+- Integration tests prove that multiple units are correctly integrated into a fully-functional component of the system.
+- Example components with multiple units:
+  - A controller with its reconciler, watches, predicates, event handlers, queues, etc.
+  - A webhook with its server, handler, decoder, and webhook configuration.
+- Integration tests set up a full component (including used libraries) and run it against a test environment close to the actual setup.
+  - e.g., start controllers against a real Kubernetes control plane to catch bugs that can only happen when talking to a real API server.
+  - Integration tests are generally more expensive to run (e.g., in terms of execution time).
+- Integration tests should not cover each and every detailed case.
+  - Rather than that, cover a good portion of the "usual" cases that components will face during normal operation (positive and negative test cases).
+  - Also, there is no need to cover all failure cases or all cases of predicates -> they should be covered in unit tests already.
+  - Generally, not supposed to "generate test coverage" but to provide confidence that components work well.
+- As integration tests typically test only one component (or a cohesive set of components) isolated from others, they cannot catch bugs that occur when multiple controllers interact (could be discovered by e2e tests, though).
+- Rule of thumb: a new integration tests should be added for each new controller (an integration test doesn't replace unit tests though).
 
 ### Writing Integration Tests
 
-- make sure to have a clean test environment on both test suite and test case level:
-  - set up dedicated test environments (envtest instances) per test suite
-  - use dedicated namespaces per test suite
-    - use `GenerateName` with a test-specific prefix: [example test](https://github.com/gardener/gardener/blob/ee3e50387fc7e6298908242f59894a7ea6f91fa7/test/integration/resourcemanager/secret/secret_suite_test.go#L94-L105)
-    - restrict the controller-runtime manager to the test namespace by setting `manager.Options.Namespace`: [example test](https://github.com/gardener/gardener/blob/d9b00b574182094c5d03ab16dfc2d20515e9b6ed/test/integration/controllermanager/cloudprofile/cloudprofile_suite_test.go#L104)
-    - alternatively, use a test-specific prefix with a random suffix determined upfront: [example test](https://github.com/gardener/gardener/blob/ce3973a605886ab6a496cf7f9fb6a5de54a5e7c2/test/integration/resourcemanager/tokeninvalidator/tokeninvalidator_suite_test.go#L68)
-      - this can be used to restrict webhooks to a dedicated test namespace: [example test](https://github.com/gardener/gardener/blob/ce3973a605886ab6a496cf7f9fb6a5de54a5e7c2/test/integration/resourcemanager/tokeninvalidator/tokeninvalidator_suite_test.go#L73)
-    - this allows running a test in parallel against the same existing cluster for deflaking and stress testing: [example PR](https://github.com/gardener/gardener/pull/5953)
-  - if the controller works on cluster-scoped resources
-    - label the resources with a label specific to the test run, e.g. the test namespace's name: [example test](https://github.com/gardener/gardener/blob/b01239edfd594b09ecd44dd77fba7a05a74820e8/test/integration/controllermanager/cloudprofile/cloudprofile_test.go#L38)
-    - restrict the manager's cache for these objects with a corresponding label selector: [example test](https://github.com/gardener/gardener/blob/b01239edfd594b09ecd44dd77fba7a05a74820e8/test/integration/controllermanager/cloudprofile/cloudprofile_suite_test.go#L110-L116)
-    - alternatively, use a default label selector for all objects in the manager's cache: [example test](https://github.com/gardener/gardener/blob/b01239edfd594b09ecd44dd77fba7a05a74820e8/test/integration/controllermanager/controllerdeployment/controllerdeployment_suite_test.go#L112-L116)
-    - this allows running a test in parallel against the same existing cluster for deflaking and stress testing, even if it works with cluster-scoped resources that are visible to all parallel test runs: [example PR](https://github.com/gardener/gardener/pull/6527)
-  - use dedicated test resources for each test case
-    - use `GenerateName`: [example test](https://github.com/gardener/gardener/blob/ee3e50387fc7e6298908242f59894a7ea6f91fa7/test/integration/resourcemanager/health/health_test.go#L38-L48)
-    - alternatively, use a checksum of a random UUID using `uuid.NewUUID()` function: [example test](https://github.com/gardener/gardener/blob/3840acaaf57955fd65330c83b2b2d5bdaad56179/test/integration/resourcemanager/tokeninvalidator/tokeninvalidator_suite_test.go#L71-L72)
-    - logging the created object names is generally a good idea to support debugging failing or flaky tests: [example test](https://github.com/gardener/gardener/blob/50f92c5dc35160fe05da9002a79e7ce4a9cf3509/test/integration/controllermanager/cloudprofile/cloudprofile_test.go#L94-L96)
-    - always delete all resources after the test case (e.g., via `DeferCleanup`) that were created for the test case 
-    - this avoids conflicts between test cases and cascading failures which distract from the actual root failures
-  - don't tolerate already existing resources (~dirty test environment), code smell: ignoring already exist errors
-- don't use a cached client in test code (e.g., the one from a controller-runtime manager), always construct a dedicated test client (uncached): [example test](https://github.com/gardener/gardener/blob/ee3e50387fc7e6298908242f59894a7ea6f91fa7/test/integration/resourcemanager/managedresource/resource_suite_test.go#L96-L97)
-- use [asynchronous assertions](https://onsi.github.io/gomega/#making-asynchronous-assertions): `Eventually` and `Consistently`
-  - never `Expect` anything to happen synchronously (immediately)
-  - don't use retry or wait until functions -> use `Eventually`, `Consistently` instead: [example test](https://github.com/gardener/gardener/blob/ee3e50387fc7e6298908242f59894a7ea6f91fa7/test/integration/controllermanager/shootmaintenance/utils_test.go#L36-L48)
-  - this allows to override the interval/timeout values from outside instead of hard-coding this in the test (see `hack/test-integration.sh`): [example PR](https://github.com/gardener/gardener/pull/5938#discussion_r869155906)
-  - beware of the default `Eventually` / `Consistently` timeouts / poll intervals: [docs](https://onsi.github.io/gomega/#eventually)
-  - don't set custom (high) timeouts and intervals in test code: [example PR](https://github.com/gardener/gardener/pull/4983)
-    - instead, shorten sync period of controllers, overwrite intervals of the tested code, or use fake clocks: [example test](https://github.com/gardener/gardener/blob/7c4031a57836de20758f32e1015c8a0f6c754d0f/test/integration/resourcemanager/managedresource/resource_suite_test.go#L137-L139)
-  - pass `g Gomega` to `Eventually`/`Consistently` and use `g.Expect` in it: [docs](https://onsi.github.io/gomega/#category-3-making-assertions-eminem-the-function-passed-into-codeeventuallycode), [example test](https://github.com/gardener/gardener/blob/708f65c279276abd3a770c2f84a89e02876b3c38/test/e2e/shoot/internal/rotation/certificate_authorities.go#L111-L122), [example PR](https://github.com/gardener/gardener/pull/4936)
-  - don't forget to call `{Eventually,Consistently}.Should()`, otherwise the assertions always silently succeeds without errors: [onsi/gomega#561](https://github.com/onsi/gomega/issues/561)
-- when using Gardener's envtest (`envtest.GardenerTestEnvironment`):
-  - disable gardener-apiserver's admission plugins that are not relevant to the integration test itself by passing `--disable-admission-plugins`: [example test](https://github.com/gardener/gardener/blob/50f92c5dc35160fe05da9002a79e7ce4a9cf3509/test/integration/controllermanager/shoot/maintenance/maintenance_suite_test.go#L61-L67)
-  - this makes setup / teardown code simpler and ensures to only test code relevant to the tested component itself (but not the entire set of admission plugins)
+- Make sure to have a clean test environment on both test suite and test case level:
+  - Set up dedicated test environments (envtest instances) per test suite.
+  - Use dedicated namespaces per test suite:
+    - Use `GenerateName` with a test-specific prefix: [example test](https://github.com/gardener/gardener/blob/ee3e50387fc7e6298908242f59894a7ea6f91fa7/test/integration/resourcemanager/secret/secret_suite_test.go#L94-L105)
+    - Restrict the controller-runtime manager to the test namespace by setting `manager.Options.Namespace`: [example test](https://github.com/gardener/gardener/blob/d9b00b574182094c5d03ab16dfc2d20515e9b6ed/test/integration/controllermanager/cloudprofile/cloudprofile_suite_test.go#L104)
+    - Alternatively, use a test-specific prefix with a random suffix determined upfront: [example test](https://github.com/gardener/gardener/blob/ce3973a605886ab6a496cf7f9fb6a5de54a5e7c2/test/integration/resourcemanager/tokeninvalidator/tokeninvalidator_suite_test.go#L68)
+      - This can be used to restrict webhooks to a dedicated test namespace: [example test](https://github.com/gardener/gardener/blob/ce3973a605886ab6a496cf7f9fb6a5de54a5e7c2/test/integration/resourcemanager/tokeninvalidator/tokeninvalidator_suite_test.go#L73)
+    - This allows running a test in parallel against the same existing cluster for deflaking and stress testing: [example PR](https://github.com/gardener/gardener/pull/5953)
+  - If the controller works on cluster-scoped resources:
+    - Label the resources with a label specific to the test run, e.g. the test namespace's name: [example test](https://github.com/gardener/gardener/blob/b01239edfd594b09ecd44dd77fba7a05a74820e8/test/integration/controllermanager/cloudprofile/cloudprofile_test.go#L38)
+    - Restrict the manager's cache for these objects with a corresponding label selector: [example test](https://github.com/gardener/gardener/blob/b01239edfd594b09ecd44dd77fba7a05a74820e8/test/integration/controllermanager/cloudprofile/cloudprofile_suite_test.go#L110-L116)
+    - Alternatively, use a checksum of a random UUID using `uuid.NewUUID()` function: [example test](https://github.com/gardener/gardener/blob/3840acaaf57955fd65330c83b2b2d5bdaad56179/test/integration/resourcemanager/tokeninvalidator/tokeninvalidator_suite_test.go#L71-L72)
+    - This allows running a test in parallel against the same existing cluster for deflaking and stress testing, even if it works with cluster-scoped resources that are visible to all parallel test runs: [example PR](https://github.com/gardener/gardener/pull/6527)
+  - Use dedicated test resources for each test case:
+    - Use `GenerateName`: [example test](https://github.com/gardener/gardener/blob/ee3e50387fc7e6298908242f59894a7ea6f91fa7/test/integration/resourcemanager/health/health_test.go#L38-L48)
+    - Alternatively, use a checksum of a random UUID using `uuid.NewUUID()` function: [example test](https://github.com/gardener/gardener/blob/3840acaaf57955fd65330c83b2b2d5bdaad56179/test/integration/resourcemanager/tokeninvalidator/tokeninvalidator_suite_test.go#L71-L72)
+    - Logging the created object names is generally a good idea to support debugging failing or flaky tests: [example test](https://github.com/gardener/gardener/blob/50f92c5dc35160fe05da9002a79e7ce4a9cf3509/test/integration/controllermanager/cloudprofile/cloudprofile_test.go#L94-L96)
+    - Always delete all resources after the test case (e.g., via `DeferCleanup`) that were created for the test case 
+    - This avoids conflicts between test cases and cascading failures which distract from the actual root failures
+  - Don't tolerate already existing resources (~dirty test environment), code smell: ignoring already exist errors
+- Don't use a cached client in test code (e.g., the one from a controller-runtime manager), always construct a dedicated test client (uncached): [example test](https://github.com/gardener/gardener/blob/ee3e50387fc7e6298908242f59894a7ea6f91fa7/test/integration/resourcemanager/managedresource/resource_suite_test.go#L96-L97)
+- Use [asynchronous assertions](https://onsi.github.io/gomega/#making-asynchronous-assertions): `Eventually` and `Consistently`.
+  - Never `Expect` anything to happen synchronously (immediately).
+  - Don't use retry or wait until functions -> use `Eventually`, `Consistently` instead: [example test](https://github.com/gardener/gardener/blob/ee3e50387fc7e6298908242f59894a7ea6f91fa7/test/integration/controllermanager/shootmaintenance/utils_test.go#L36-L48)
+  - This allows to override the interval/timeout values from outside instead of hard-coding this in the test (see `hack/test-integration.sh`): [example PR](https://github.com/gardener/gardener/pull/5938#discussion_r869155906)
+  - Beware of the default `Eventually` / `Consistently` timeouts / poll intervals: [docs](https://onsi.github.io/gomega/#eventually)
+  - Don't set custom (high) timeouts and intervals in test code: [example PR](https://github.com/gardener/gardener/pull/4983)
+    - iInstead, shorten sync period of controllers, overwrite intervals of the tested code, or use fake clocks: [example test](https://github.com/gardener/gardener/blob/7c4031a57836de20758f32e1015c8a0f6c754d0f/test/integration/resourcemanager/managedresource/resource_suite_test.go#L137-L139)
+  - Pass `g Gomega` to `Eventually`/`Consistently` and use `g.Expect` in it: [docs](https://onsi.github.io/gomega/#category-3-making-assertions-eminem-the-function-passed-into-codeeventuallycode), [example test](https://github.com/gardener/gardener/blob/708f65c279276abd3a770c2f84a89e02876b3c38/test/e2e/shoot/internal/rotation/certificate_authorities.go#L111-L122), [example PR](https://github.com/gardener/gardener/pull/4936)
+  - Don't forget to call `{Eventually,Consistently}.Should()`, otherwise the assertions always silently succeeds without errors: [onsi/gomega#561](https://github.com/onsi/gomega/issues/561)
+- When using Gardener's envtest (`envtest.GardenerTestEnvironment`):
+  - Disable gardener-apiserver's admission plugins that are not relevant to the integration test itself by passing `--disable-admission-plugins`: [example test](https://github.com/gardener/gardener/blob/50f92c5dc35160fe05da9002a79e7ce4a9cf3509/test/integration/controllermanager/shoot/maintenance/maintenance_suite_test.go#L61-L67)
+  - This makes setup / teardown code simpler and ensures to only test code relevant to the tested component itself (but not the entire set of admission plugins)
   - e.g., you can disable the `ShootValidator` plugin to create `Shoots` that reference non-existing `SecretBindings` or disable the `DeletionConfirmation` plugin to delete Gardener resources without adding a deletion confirmation first.
-- use a custom rate limiter for controllers in integration tests: [example test](https://github.com/gardener/gardener/blob/3dd6b111d677eb4bceadaa8fc469877097660577/test/integration/controllermanager/exposureclass/exposureclass_suite_test.go#L130-L131)
-  - this can be used for limiting exponential backoff to shorten wait times
-  - otherwise, if using the default rate limiter, exponential backoff might exceed the timeout of `Eventually` calls and cause flakes
+- Use a custom rate limiter for controllers in integration tests: [example test](https://github.com/gardener/gardener/blob/3dd6b111d677eb4bceadaa8fc469877097660577/test/integration/controllermanager/exposureclass/exposureclass_suite_test.go#L130-L131)
+  - This can be used for limiting exponential backoff to shorten wait times.
+  - Otherwise, if using the default rate limiter, exponential backoff might exceed the timeout of `Eventually` calls and cause flakes.
 
-## End-to-end (e2e) Tests (using provider-local)
+## End-to-End (e2e) Tests (Using provider-local)
 
 We run a suite of e2e tests on every pull request and periodically on the `master` branch.
 It uses a [KinD cluster](https://kind.sigs.k8s.io/) and [skaffold](https://skaffold.dev/) to boostrap a full installation of Gardener based on the current revision, including [provider-local](../extensions/provider-local.md).
@@ -386,13 +386,13 @@ If you want to run a specific set of e2e test cases, you can also execute them u
 ```
 
 If you want to use an existing shoot instead of creating a new one for the test case and deleting it afterwards, you can specify the existing shoot via the following flags.
-This can be useful to speed of the development of e2e tests.
+This can be useful to speed up the development of e2e tests.
 
 ```bash
 ./hack/test-e2e-local.sh --label-filter "Shoot && credentials-rotation" -- --project-namespace=garden-local --existing-shoot-name=local
 ```
 
-Also see: [developing Gardener locally](getting_started_locally.md) and [deploying Gardener locally](../deployment/getting_started_locally.md).
+For more information, see [Developing Gardener Locally](getting_started_locally.md) and [Deploying Gardener Locally](../deployment/getting_started_locally.md).
 
 ### Debugging e2e Tests
 
@@ -409,39 +409,39 @@ gsutil cp -r gs://gardener-prow/pr-logs/pull/gardener_gardener/6136/pull-gardene
 
 ### Purpose of e2e Tests
 
-- e2e tests provide a high level of confidence that our code runs as expected by users when deployed to production
-- they are supposed to catch bugs resulting from interaction between multiple components
-- test cases should be as close as possible to real usage by endusers
-  - should test "from the perspective of the user" (or operator)
-  - example: I create a Shoot and expect to be able to connect to it via the provided kubeconfig
-  - accordingly, don't assert details of the system
+- e2e tests provide a high level of confidence that our code runs as expected by users when deployed to production.
+- They are supposed to catch bugs resulting from interaction between multiple components.
+- Test cases should be as close as possible to real usage by end users:
+  - You should test "from the perspective of the user" (or operator).
+  - Example: I create a Shoot and expect to be able to connect to it via the provided kubeconfig.
+  - Accordingly, don't assert details of the system.
     - e.g., the user also wouldn't expect that there is a kube-apiserver deployment in the seed, they rather expect that they can talk to it no matter how it is deployed
-    - only assert details of the system if the tested feature is not fully visible to the end-user and there is no other way of ensuring that the feature works reliably
+    - Only assert details of the system if the tested feature is not fully visible to the end-user and there is no other way of ensuring that the feature works reliably
     - e.g., the Shoot CA rotation is not fully visible to the user but is assertable by looking at the secrets in the Seed.
-- pro: can be executed by developers and users without any real infrastructure (provider-local)
-- con: they currently cannot be executed with real infrastructure (e.g., provider-aws), we will work on this as part of [#6016](https://github.com/gardener/gardener/issues/6016)
-- keep in mind that the tested scenario is still artificial in a sense of using default configuration, only a few objects, only a few config/settings combinations are covered
-  - we will never be able to cover the full "test matrix" and this should not be our goal
-  - bugs will still be released and will still happen in production; we can't avoid it
-  - instead, we should add test cases for preventing bugs in features or settings that were frequently regressed: [example PR](https://github.com/gardener/gardener/pull/5725)
-- usually e2e tests cover the "straight-forward cases"
-  - however, negative test cases can also be included, especially if they are important from the user's perspective
+- Pro: can be executed by developers and users without any real infrastructure (provider-local).
+- Con: they currently cannot be executed with real infrastructure (e.g., provider-aws), we will work on this as part of [#6016](https://github.com/gardener/gardener/issues/6016).
+- Keep in mind that the tested scenario is still artificial in a sense of using default configuration, only a few objects, only a few config/settings combinations are covered.
+  - We will never be able to cover the full "test matrix" and this should not be our goal.
+  - Bugs will still be released and will still happen in production; we can't avoid it.
+  - Instead, we should add test cases for preventing bugs in features or settings that were frequently regressed: [example PR](https://github.com/gardener/gardener/pull/5725)
+- Usually e2e tests cover the "straight-forward cases".
+  - However, negative test cases can also be included, especially if they are important from the user's perspective.
 
 ### Writing e2e Tests
 
-- always wrap API calls and similar things in `Eventually` blocks: [example test](https://github.com/gardener/gardener/blob/a66b8ec47995561393bf1ad9a817463089a0255e/test/e2e/shoot/internal/rotation/observability.go#L46-L55)
-  - at this point, we are pretty much working with a distributed system and failures can happen anytime
-  - wrapping calls in `Eventually` makes tests more stable and more realistic (usually, you wouldn't call the system broken if a single API call fails because of a short connectivity issue)
-- most of the points from [writing integration tests](#writing-integration-tests) are relevant for e2e tests as well (especially the points about asynchronous assertions)
-- in contrast to integration tests, in e2e tests, it might make sense to specify higher timeouts for `Eventually` calls, e.g., when waiting for a `Shoot` to be reconciled
-  - generally, try to use the default settings for `Eventually` specified via the environment variables
-  - only set higher timeouts if waiting for long-running reconciliations to be finished
+- Always wrap API calls and similar things in `Eventually` blocks: [example test](https://github.com/gardener/gardener/blob/a66b8ec47995561393bf1ad9a817463089a0255e/test/e2e/shoot/internal/rotation/observability.go#L46-L55)
+  - At this point, we are pretty much working with a distributed system and failures can happen anytime.
+  - Wrapping calls in `Eventually` makes tests more stable and more realistic (usually, you wouldn't call the system broken if a single API call fails because of a short connectivity issue).
+- Most of the points from [writing integration tests](#writing-integration-tests) are relevant for e2e tests as well (especially the points about asynchronous assertions).
+- In contrast to integration tests, in e2e tests, it might make sense to specify higher timeouts for `Eventually` calls, e.g., when waiting for a `Shoot` to be reconciled.
+  - Generally, try to use the default settings for `Eventually` specified via the environment variables.
+  - Only set higher timeouts if waiting for long-running reconciliations to be finished.
 
-## Gardener Upgrade Tests (using provider-local)
+## Gardener Upgrade Tests (Using provider-local)
 
 Gardener upgrade tests setup a kind cluster and deploy Gardener version `vX.X.X` before upgrading it to a given version `vY.Y.Y`.
 
-This allows verifying whether the current (unreleased) revision/branch (or a specific release) is compatible with the latest (or a specific other release). The `GARDENER_PREVIOUS_RELEASE` and `GARDENER_NEXT_RELEASE` environment variables are used to specify the respective versions.
+This allows verifying whether the current (unreleased) revision/branch (or a specific release) is compatible with the latest (or a specific other) release. The `GARDENER_PREVIOUS_RELEASE` and `GARDENER_NEXT_RELEASE` environment variables are used to specify the respective versions.
 
 This helps understanding what happens or how the system reacts when Gardener upgrades from versions `vX.X.X` to `vY.Y.Y` for existing shoots in different states (`creation`/`hibernation`/`wakeup`/`deletion`). Gardener upgrade tests also help qualifying releases for all flavors (**non-HA** or **HA** with failure tolerance `node`/`zone`). 
 
@@ -458,14 +458,14 @@ Below is a sequence describing how the tests are performed.
 - Run gardener post-upgrade tests which are labeled with `post-upgrade`
 - Tear down seed and kind cluster.
 
-### How to run upgrade tests between two Gardener releases
+### How to Run Upgrade Tests Between Two Gardener Releases
 
 Sometimes, we need to verify/qualify two Gardener releases when we upgrade from one version to another.  
-This can performed by fetching the two Gardener versions from **[Github Gardener release page](https://github.com/gardener/gardener/releases/latest)** and set appropriate env variables `GARDENER_PREVIOUS_RELEASE`, `GARDENER_NEXT_RELEASE`.   
+This can performed by fetching the two Gardener versions from the  **[Github Gardener release page](https://github.com/gardener/gardener/releases/latest)** and setting appropriate env variables `GARDENER_PREVIOUS_RELEASE`, `GARDENER_NEXT_RELEASE`.   
 
->**`GARDENER_PREVIOUS_RELEASE`** -- This env variable refers to a source revision/branch (or a specific release) which has to be installed first and then upgraded to version **`GARDENER_NEXT_RELEASE`**. By default it fetches latest release version from  **[Github Gardener release page](https://github.com/gardener/gardener/releases/latest)**.
+>**`GARDENER_PREVIOUS_RELEASE`** -- This env variable refers to a source revision/branch (or a specific release) which has to be installed first and then upgraded to version **`GARDENER_NEXT_RELEASE`**. By default, it fetches the latest release version from **[Github Gardener release page](https://github.com/gardener/gardener/releases/latest)**.
 
->**`GARDENER_NEXT_RELEASE`** -- This env variable refers to the target revision/branch (or a specific release) to be upgraded to after successful installation of **`GARDENER_PREVIOUS_RELEASE`**. By default it considers local HEAD revision, builds code and installs gardener from current revision where gardener upgrade tests triggered.
+>**`GARDENER_NEXT_RELEASE`** -- This env variable refers to the target revision/branch (or a specific release) to be upgraded to after successful installation of **`GARDENER_PREVIOUS_RELEASE`**. By default, it considers the local HEAD revision, builds code, and installs Gardener from the current revision where the Gardener upgrade tests triggered.
 
 
 - `make ci-e2e-kind-upgrade GARDENER_PREVIOUS_RELEASE=v1.60.0 GARDENER_NEXT_RELEASE=v1.61.0`
@@ -473,16 +473,16 @@ This can performed by fetching the two Gardener versions from **[Github Gardener
 - `make ci-e2e-kind-ha-multi-zone-upgrade GARDENER_PREVIOUS_RELEASE=v1.60.0 GARDENER_NEXT_RELEASE=v1.61.0`
 
 
-### Purpose of upgrade Tests
+### Purpose of Upgrade Tests
 
-- tests will ensure that shoot clusters reconciled with the previous version of Gardener work as expected even with the next Gardener version.
-- this will reproduce or catch actual issues faced by end users.
-- one of the test case ensures no downtime faced by end-users for shoots while upgrading Gardener if shoot's control-plane is configured as HA.
+- Tests will ensure that shoot clusters reconciled with the previous version of Gardener work as expected even with the next Gardener version.
+- This will reproduce or catch actual issues faced by end users.
+- One of the test cases ensures no downtime is faced by the end-users for shoots while upgrading Gardener if the shoot's control-plane is configured as HA.
 
-### Writing upgrade Tests
+### Writing Upgrade Tests
 
-- tests are divided into two parts and labeled with `pre-upgrade` and `post-upgrade` labels.
-- Example test case which ensures shoot which was `hibernated` in previous gardener release should `wakeup` as expected in next release. 
+- Tests are divided into two parts and labeled with `pre-upgrade` and `post-upgrade` labels.
+- An example test case which ensures a shoot which was `hibernated` in a previous Gardener release should `wakeup` as expected in next release:
   - Creating a shoot and hibernating a shoot is pre-upgrade test case which should be labeled `pre-upgrade` label.
   - Then wakeup a shoot and delete a shoot is post-upgrade test case which should be labeled `post-upgrade` label.
 
@@ -492,37 +492,37 @@ Please see [Test Machinery Tests](testmachinery_tests.md).
 
 ### Purpose of Test Machinery Tests
 
-- test machinery tests have to be executed against full-blown Gardener installations
-- they can provide a very high level of confidence that an installation is functional in its current state, this includes: all Gardener components, Extensions, the used Cloud Infrastructure, all relevant settings/configuration
-- this brings the following benefits:
-  - they test more realistic scenarios than e2e tests (real configuration, real infrastructure, etc.)
-  - tests run "where the users are"
-- however, this also brings significant drawbacks:
-  - tests are difficult to develop and maintain
-  - tests require a full Gardener installation and cannot be executed in CI (on PR-level or against master)
-  - tests require real infrastructure (think cloud provider credentials, cost)
-  - using `TestDefinitions` under `.test-defs` requires a full test machinery installation
-  - accordingly, tests are heavyweight and expensive to run
-  - testing against real infrastructure can cause flakes sometimes (e.g., in outage situations)
-  - failures are hard to debug, because clusters are deleted after the test (for obvious cost reasons)
-  - bugs can only be caught, once it's "too late", i.e., when code is merged and deployed
-- today, test machinery tests cover a bigger "test matrix" (e.g., Shoot creation across infrastructures, kubernetes versions, machine image versions, etc.)
-- test machinery also runs Kubernetes conformance tests
-- however, because of the listed drawbacks, we should rather focus on augmenting our e2e tests, as we can run them locally and in CI in order to catch bugs before they get merged
-- it's still a good idea to add test machinery tests if a feature needs to be tested that is depending on some installation-specific configuration
+- Test machinery tests have to be executed against full-blown Gardener installations.
+- They can provide a very high level of confidence that an installation is functional in its current state, this includes: all Gardener components, Extensions, the used Cloud Infrastructure, all relevant settings/configuration.
+- This brings the following benefits:
+  - They test more realistic scenarios than e2e tests (real configuration, real infrastructure, etc.).
+  - Tests run "where the users are".
+- However, this also brings significant drawbacks:
+  - Tests are difficult to develop and maintain.
+  - Tests require a full Gardener installation and cannot be executed in CI (on PR-level or against master).
+  - Tests require real infrastructure (think cloud provider credentials, cost).
+  - Using `TestDefinitions` under `.test-defs` requires a full test machinery installation.
+  - Accordingly, tests are heavyweight and expensive to run.
+  - Testing against real infrastructure can cause flakes sometimes (e.g., in outage situations).
+  - Failures are hard to debug, because clusters are deleted after the test (for obvious cost reasons).
+  - Bugs can only be caught, once it's "too late", i.e., when code is merged and deployed.
+- Today, test machinery tests cover a bigger "test matrix" (e.g., Shoot creation across infrastructures, kubernetes versions, machine image versions, etc.).
+- Test machinery also runs Kubernetes conformance tests.
+- However, because of the listed drawbacks, we should rather focus on augmenting our e2e tests, as we can run them locally and in CI in order to catch bugs before they get merged.
+- It's still a good idea to add test machinery tests if a feature that is depending on some installation-specific configuration needs to be tested.
 
 ### Writing Test Machinery Tests
 
-- generally speaking, most points from [writing integration tests](#writing-integration-tests) and [writing e2e tests](#writing-e2e-tests) apply here as well
-- however, test machinery tests contain a lot of technical debt and existing code doesn't follow these best practices
-- as test machinery tests are out of our general focus, we don't intend on reworking the tests soon or providing more guidance on how to write new ones
+- Generally speaking, most points from [writing integration tests](#writing-integration-tests) and [writing e2e tests](#writing-e2e-tests) apply here as well.
+- However, test machinery tests contain a lot of technical debt and existing code doesn't follow these best practices.
+- As test machinery tests are out of our general focus, we don't intend on reworking the tests soon or providing more guidance on how to write new ones.
 
 ## Manual Tests
 
-- manual tests can be useful when the cost of trying to automatically test certain functionality are too high
-- useful for PR verification, if a reviewer wants to verify that all cases are properly tested by automated tests
-- currently, it's the simplest option for testing upgrade scenarios
+- Manual tests can be useful when the cost of trying to automatically test certain functionality are too high.
+- Useful for PR verification, if a reviewer wants to verify that all cases are properly tested by automated tests.
+- Currently, it's the simplest option for testing upgrade scenarios.
   - e.g. migration coding is probably best tested manually, as it's a high effort to write an automated test for little benefit
-- obviously, the need for manual tests should be kept at a bare minimum
-  - instead, we should add e2e tests wherever sensible/valuable
-  - we want to implement some form of general upgrade tests as part of [#6016](https://github.com/gardener/gardener/issues/6016)
+- Obviously, the need for manual tests should be kept at a bare minimum.
+  - Instead, we should add e2e tests wherever sensible/valuable.
+  - We want to implement some form of general upgrade tests as part of [#6016](https://github.com/gardener/gardener/issues/6016).

--- a/docs/development/testmachinery_tests.md
+++ b/docs/development/testmachinery_tests.md
@@ -1,7 +1,7 @@
 # Test Machinery Tests
 
 In order to automatically qualify Gardener releases, we execute a set of end-to-end tests using [Test Machinery](https://github.com/gardener/test-infra).
-This requires a full Gardener installation including infrastructure extensions as well as a setup of Test Machinery itself.
+This requires a full Gardener installation including infrastructure extensions, as well as a setup of Test Machinery itself.
 These tests operate on Shoot clusters across different Cloud Providers, using different supported Kubernetes versions and various configuration options (huge test matrix).
 
 This manual gives an overview about test machinery tests in Gardener.
@@ -18,8 +18,8 @@ Gardener test machinery tests are split into two test suites that can be found u
 * The **Gardener Test Suite** contains all tests that only require a running gardener instance.
 * The **Shoot Test Suite** contains all tests that require a predefined running shoot cluster.
 
-The corresponding tests of a test suite are defined in the import statement of the suite definition see [`shoot/run_suite_test.go`](../../test/testmachinery/suites/shoot/run_suite_test.go)
-and their source code can be found under [`test/testmachinery`](../../test/testmachinery)
+The corresponding tests of a test suite are defined in the import statement of the suite definition (see [`shoot/run_suite_test.go`](../../test/testmachinery/suites/shoot/run_suite_test.go))
+and their source code can be found under [`test/testmachinery`](../../test/testmachinery).
 
 The `test` directory is structured as follows:
 
@@ -61,7 +61,7 @@ test
 ```
 
 A suite can be executed by running the suite definition with ginkgo's `focus` and `skip` flags 
-to control the execution of specific labeled test. See example below:
+to control the execution of specific labeled test. See the example below:
 ```console
 go test -timeout=0 -mod=vendor ./test/testmachinery/suites/shoot \
       --v -ginkgo.v -ginkgo.progress -ginkgo.no-color \
@@ -74,7 +74,7 @@ go test -timeout=0 -mod=vendor ./test/testmachinery/suites/shoot \
       -ginkgo.skip="\[SERIAL\]|\[DISRUPTIVE\]"             # Exclude all tests that are tagged SERIAL or DISRUPTIVE
 ```
 
-## Add a new test
+## Add a New Test
 
 To add a new test the framework requires the following steps (step 1. and 2. can be skipped if the test is added to an existing package):
 
@@ -93,7 +93,7 @@ var _ = ginkgo.Describe("my suite", func(){
 ```
 
 The newly created test can be tested by focusing the test with the default ginkgo focus `f.Beta().FCIt("my first test", func(ctx context.Context)`
-and run the shoot test suite with:
+and running the shoot test suite with:
 ```
 go test -timeout=0 -mod=vendor ./test/testmachinery/suites/shoot \
       --v -ginkgo.v -ginkgo.progress -ginkgo.no-color \
@@ -150,25 +150,25 @@ They should be watched (and probably improved) until stable enough to be promote
 - _Default_: Tests that were _Beta_ before and proved to be stable are promoted to _Default_ eventually.
  _Default_ tests run more often, produce alerts and are _considered_ during the release decision although they don't necessarily block a release.
 - _Release_: Test are release relevant. A failing _Release_ test blocks the release pipeline.
-Therefore these tests need to be stable. Only tests proven to be stable will eventually be promoted to _Release_.
+Therefore, these tests need to be stable. Only tests proven to be stable will eventually be promoted to _Release_.
 
 Behavior Labels: 
-- _Serial_: The test should always be executed in serial with no other tests running as it may impact other tests.
-- _Destructive_: The test is destructive. Which means that is runs with no other tests and may break gardener or the shoot.
-Only create such tests if really necessary as the execution will be expensive (neither gardener nor the shoot can be reused in this case for other tests).
+- _Serial_: The test should always be executed in serial with no other tests running, as it may impact other tests.
+- _Destructive_: The test is destructive. Which means that is runs with no other tests and may break Gardener or the shoot.
+Only create such tests if really necessary, as the execution will be expensive (neither Gardener nor the shoot can be reused in this case for other tests).
 
 ## Framework
 
 The framework directory contains all the necessary functions / utilities for running test machinery tests. 
 For example, there are methods for creation/deletion of shoots, waiting for shoot deletion/creation, downloading/installing/deploying helm charts, logging, etc.
 
-The framework itself consists of 3 different framework that expect different prerequisites and offer context specific functionality.
+The framework itself consists of 3 different frameworks that expect different prerequisites and offer context specific functionality.
 - **CommonFramework**: The common framework is the base framework that handles logging and setup of commonly needed resources like helm.
-It also contains common functions for interacting with kubernetes clusters like `Waiting for resources to be ready` or `Exec into a running pod`.
-- **GardenerFramework** contains all functions of the common framework and expects a running gardener instance with the provided gardener kubeconfig and a project namespace.
+It also contains common functions for interacting with Kubernetes clusters like `Waiting for resources to be ready` or `Exec into a running pod`.
+- **GardenerFramework** contains all functions of the common framework and expects a running Gardener instance with the provided Gardener kubeconfig and a project namespace.
 It also contains functions to interact with gardener like `Waiting for a shoot to be reconciled` or `Patch a shoot` or `Get a seed`.
 - **ShootFramework**: contains all functions of the common and the gardener framework. 
-It expects a running shoot cluster defined by the shoot's name and namespace(project namespace).
+It expects a running shoot cluster defined by the shoot's name and namespace (project namespace).
 This framework contains functions to directly interact with the specific shoot.
 
 The whole framework also includes commonly used checks, ginkgo wrapper, etc. as well as commonly used tests.
@@ -177,7 +177,7 @@ Theses common application tests (like the guestbook test) can be used within mul
 
 **Config**
 
-Every framework commandline flag can also be defined by a configuration file (the value of the configuration file is only used if flag is not specified by commandline).
+Every framework commandline flag can also be defined by a configuration file (the value of the configuration file is only used if a flag is not specified by commandline).
 The test suite searches for a configuration file (yaml is preferred) if the command line flag `--config=/path/to/config/file` is provided.
 A framework can be defined in the configuration file by just using the flag name as root key e.g.
 ```yaml
@@ -188,8 +188,8 @@ project-namespace: garden-it
 
 **Report**
 
-The framework automatically writes the default ginkgo default report to stdout and a specifically structured elastichsearch bulk report file to a specified location.
-The elastichsearch bulk report will write one json document per testcase and injects metadata of the whole testsuite.
+The framework automatically writes the ginkgo default report to stdout and a specifically structured elastichsearch bulk report file to a specified location.
+The elastichsearch bulk report will write one json document per testcase and injects the metadata of the whole testsuite.
 An example document for one test case would look like the following document:
 ```
 {
@@ -229,20 +229,20 @@ resources
 
 There are two special directories that are dynamically filled with the correct test files:
 
-- **charts:** the charts will be downloaded and saved in this directory
-- **repository** contains the repository.yaml file that the target helm repos will be read from and the cache where the `stable-index.yaml` file will be created
+- **charts** - the charts will be downloaded and saved in this directory
+- **repository** - contains the `repository.yaml` file that the target helm repos will be read from and the cache where the `stable-index.yaml` file will be created
 
 ### System Tests
 
 This directory contains the system tests that have a special meaning for the testmachinery with their own Test Definition.
-Currently these system tests consists of:
+Currently, these system tests consist of:
 
 - Shoot creation
 - Shoot deletion
 - Shoot Kubernetes update
 - Gardener Full reconcile check
 
-#### Shoot Creation test
+#### Shoot Creation Test
 
 Create Shoot test is meant to test shoot creation.
 
@@ -271,7 +271,7 @@ go test -mod=vendor -timeout=0 ./test/testmachinery/system/shoot_creation \
   -start-hibernated=$START_HIBERNATED
 ```
 
-#### Shoot Deletion test
+#### Shoot Deletion Test
 
 Delete Shoot test is meant to test the deletion of a shoot.
 
@@ -285,11 +285,11 @@ go test -mod=vendor -timeout=0 -ginkgo.v -ginkgo.progress \
   -project-namespace=$PROJECT_NAMESPACE
 ```
 
-#### Shoot Update test
+#### Shoot Update Test
 
-The Update Shoot test is meant to test the kubernetes version update of a existing shoot.
-If no specific version is provided the next patch version is automatically selected.
-If there is no available newer version this test is a noop.
+The Update Shoot test is meant to test the Kubernetes version update of a existing shoot.
+If no specific version is provided, the next patch version is automatically selected.
+If there is no available newer version, this test is a noop.
 
 **Example Run**
 
@@ -302,9 +302,9 @@ go test -mod=vendor -timeout=0 ./test/testmachinery/system/shoot_update \
   -version=$K8S_VERSION
 ```
 
-#### Gardener Full Reconcile test
+#### Gardener Full Reconcile Test
 
-The Gardener Full Reconcile test is meant to test if all shoots of a gardener instance are successfully reconciled.
+The Gardener Full Reconcile test is meant to test if all shoots of a Gardener instance are successfully reconciled.
 
 **Example Run**
 

--- a/docs/extensions/conventions.md
+++ b/docs/extensions/conventions.md
@@ -14,7 +14,7 @@ Instead, they can and should rely on well-known [`PriorityClasses`](../developme
 ## High Availability Of Deployed Components
 
 Extensions might deploy components via `Deployment`s, `StatefulSet`s, etc. as part of the shoot control plane, or the seed or shoot system components.
-In case a seed or shoot cluster is highly available, there are various failure tolerance types, see also [this document](../usage/shoot_high_availability.md).
+In case a seed or shoot cluster is highly available, there are various failure tolerance types, see also [Highly Available Shoot Control Plane](../usage/shoot_high_availability.md).
 Accordingly, the `replicas`, `topologySpreadConstraints` or `affinity` settings of the deployed components might need to be adapted.
 
 Instead of doing this one-by-one for each and every component, extensions can rely on a mutating webhook provided by Gardener.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area documentation
/kind enhancement

**What this PR does / why we need it**:
This PR proofreads the topics in the Development section, fixing typos, grammar and formatting.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```doc developer
NONE
```
