### PR TITLE
Adds a watchdog to forcefully shutdown v1.24 `kube-apiserver` that are stuck in shutdown

### DIFF
--- a/pkg/operation/botanist/component/kubeapiserver/deployment.go
+++ b/pkg/operation/botanist/component/kubeapiserver/deployment.go
@@ -52,6 +52,7 @@ const (
 	ContainerNameKubeAPIServer            = "kube-apiserver"
 	containerNameVPNSeedClient            = "vpn-client"
 	containerNameAPIServerProxyPodMutator = "apiserver-proxy-pod-mutator"
+	containerNameWatchdog                 = "watchdog"
 
 	volumeNameAdmissionConfiguration  = "admission-config"
 	volumeNameAuditPolicy             = "audit-policy-config"
@@ -80,6 +81,7 @@ const (
 	volumeNameCentOS                  = "centos-rhel7-cabundle"
 	volumeNameEtcSSL                  = "etc-ssl"
 	volumeNameUsrShareCaCerts         = "usr-share-cacerts"
+	volumeNameWatchdog                = "watchdog"
 
 	volumeMountPathAdmissionConfiguration  = "/etc/kubernetes/admission"
 	volumeMountPathAuditPolicy             = "/etc/kubernetes/audit"
@@ -108,6 +110,7 @@ const (
 	volumeMountPathCentOS                  = "/etc/pki/ca-trust/extracted/pem"
 	volumeMountPathEtcSSL                  = "/etc/ssl"
 	volumeMountPathUsrShareCaCerts         = "/usr/share/ca-certificates"
+	volumeMountPathWatchdog                = "/var/watchdog/bin"
 )
 
 func (k *kubeAPIServer) emptyDeployment() *appsv1.Deployment {
@@ -443,6 +446,14 @@ func (k *kubeAPIServer) reconcileDeployment(
 		}
 		if err := k.handleKubeletSettings(deployment, secretKubeletClient); err != nil {
 			return err
+		}
+
+		if version.ConstraintK8sEqual124.Check(k.values.Version) {
+			// For kube-apiserver version 1.24 there is a deadlock that can occur during shutdown that prevents the
+			// graceful termination of the kube-apiserver container to complete when the --audit-log-mode setting
+			// is set to batch. For more information check
+			// https://github.com/gardener/gardener/blob/a63e23a27dabc6a25fb470128a52f8585cd136ff/pkg/operation/botanist/component/kubeapiserver/deployment.go#L677-L683
+			k.handleWatchdogSidecar(deployment, healthCheckToken)
 		}
 
 		utilruntime.Must(references.InjectAnnotations(deployment))
@@ -1168,4 +1179,40 @@ func (k *kubeAPIServer) handleKubeletSettings(deployment *appsv1.Deployment, sec
 	}...)
 
 	return nil
+}
+
+func (k *kubeAPIServer) handleWatchdogSidecar(deployment *appsv1.Deployment, healthCheckToken string) {
+	deployment.Spec.Template.Spec.Containers = append(deployment.Spec.Template.Spec.Containers, corev1.Container{
+		Name:  containerNameWatchdog,
+		Image: k.values.Images.Watchdog,
+		Command: []string{
+			"/bin/sh",
+			fmt.Sprintf("%s/%s", volumeMountPathWatchdog, dataKeyWatchdogScript),
+			healthCheckToken,
+		},
+		SecurityContext: &corev1.SecurityContext{
+			Capabilities: &corev1.Capabilities{
+				Add: []corev1.Capability{"SYS_PTRACE"},
+			},
+		},
+		VolumeMounts: []corev1.VolumeMount{
+			{
+				Name:      volumeNameWatchdog,
+				MountPath: volumeMountPathWatchdog,
+			},
+		},
+	})
+
+	deployment.Spec.Template.Spec.ShareProcessNamespace = pointer.Bool(true)
+	deployment.Spec.Template.Spec.Volumes = append(deployment.Spec.Template.Spec.Volumes, corev1.Volume{
+		Name: volumeNameWatchdog,
+		VolumeSource: corev1.VolumeSource{
+			ConfigMap: &corev1.ConfigMapVolumeSource{
+				LocalObjectReference: corev1.LocalObjectReference{
+					Name: watchdogConfigMapName,
+				},
+				DefaultMode: pointer.Int32(500),
+			},
+		},
+	})
 }

--- a/pkg/operation/botanist/component/kubeapiserver/kube_apiserver.go
+++ b/pkg/operation/botanist/component/kubeapiserver/kube_apiserver.go
@@ -309,6 +309,7 @@ func (k *kubeAPIServer) Deploy(ctx context.Context) error {
 		configMapAdmission                   = k.emptyConfigMap(configMapAdmissionNamePrefix)
 		configMapAuditPolicy                 = k.emptyConfigMap(configMapAuditPolicyNamePrefix)
 		configMapEgressSelector              = k.emptyConfigMap(configMapEgressSelectorNamePrefix)
+		configMapTerminationHandler          = k.emptyConfigMap(watchdogConfigMapNamePrefix)
 	)
 
 	podDisruptionBudget = k.emptyPodDisruptionBudget()
@@ -424,7 +425,7 @@ func (k *kubeAPIServer) Deploy(ctx context.Context) error {
 	}
 
 	if version.ConstraintK8sEqual124.Check(k.values.Version) {
-		if err := k.reconcileTerminationHandlerConfigMap(ctx); err != nil {
+		if err := k.reconcileTerminationHandlerConfigMap(ctx, configMapTerminationHandler); err != nil {
 			return err
 		}
 	}
@@ -435,6 +436,7 @@ func (k *kubeAPIServer) Deploy(ctx context.Context) error {
 		configMapAuditPolicy,
 		configMapAdmission,
 		configMapEgressSelector,
+		configMapTerminationHandler,
 		secretETCDEncryptionConfiguration,
 		secretOIDCCABundle,
 		secretServiceAccountKey,

--- a/pkg/operation/botanist/component/kubeapiserver/kube_apiserver.go
+++ b/pkg/operation/botanist/component/kubeapiserver/kube_apiserver.go
@@ -46,6 +46,7 @@ import (
 	"github.com/gardener/gardener/pkg/utils/managedresources"
 	"github.com/gardener/gardener/pkg/utils/retry"
 	secretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager"
+	"github.com/gardener/gardener/pkg/utils/version"
 )
 
 var (
@@ -222,6 +223,8 @@ type Images struct {
 	KubeAPIServer string
 	// VPNClient is the container image for the vpn-seed-client.
 	VPNClient string
+	// Watchdog is the container image for the termination-handler.
+	Watchdog string
 }
 
 // VPNConfig contains information for configuring the VPN settings for the kube-apiserver.
@@ -416,6 +419,12 @@ func (k *kubeAPIServer) Deploy(ctx context.Context) error {
 			k.emptyRoleBindingHAVPN(),
 		)
 		if err != nil {
+			return err
+		}
+	}
+
+	if version.ConstraintK8sEqual124.Check(k.values.Version) {
+		if err := k.reconcileTerminationHandlerConfigMap(ctx); err != nil {
 			return err
 		}
 	}

--- a/pkg/operation/botanist/component/kubeapiserver/kube_apiserver_test.go
+++ b/pkg/operation/botanist/component/kubeapiserver/kube_apiserver_test.go
@@ -106,10 +106,11 @@ var _ = Describe("KubeAPIServer", func() {
 		secretNameVPNSeedClient           = "vpn-seed-client"
 		secretNameVPNSeedServerTLSAuth    = "vpn-seed-server-tlsauth-a1d0aa00"
 
-		secretNameAdmissionConfig      = "kube-apiserver-admission-config-e38ff146"
-		secretNameETCDEncryptionConfig = "kube-apiserver-etcd-encryption-configuration-235f7353"
-		configMapNameAuditPolicy       = "audit-policy-config-f5b578b4"
-		configMapNameEgressPolicy      = "kube-apiserver-egress-selector-config-53d92abc"
+		secretNameAdmissionConfig       = "kube-apiserver-admission-config-e38ff146"
+		secretNameETCDEncryptionConfig  = "kube-apiserver-etcd-encryption-configuration-235f7353"
+		configMapNameAuditPolicy        = "audit-policy-config-f5b578b4"
+		configMapNameEgressPolicy       = "kube-apiserver-egress-selector-config-53d92abc"
+		configMapNameTerminationHandler = "kube-apiserver-watchdog-f4f4b3d5"
 
 		deployment                           *appsv1.Deployment
 		horizontalPodAutoscalerV2beta1       *autoscalingv2beta1.HorizontalPodAutoscaler
@@ -2151,7 +2152,7 @@ rules:
 					VolumeSource: corev1.VolumeSource{
 						ConfigMap: &corev1.ConfigMapVolumeSource{
 							LocalObjectReference: corev1.LocalObjectReference{
-								Name: "kube-apiserver-watchdog",
+								Name: configMapNameTerminationHandler,
 							},
 							DefaultMode: pointer.Int32(500),
 						},
@@ -2167,7 +2168,7 @@ rules:
 
 						expectedConfigMap = &corev1.ConfigMap{
 							ObjectMeta: metav1.ObjectMeta{
-								Name:      "kube-apiserver-watchdog",
+								Name:      configMapNameTerminationHandler,
 								Namespace: namespace,
 							},
 						}

--- a/pkg/operation/botanist/component/kubeapiserver/resources/watchdog.sh
+++ b/pkg/operation/botanist/component/kubeapiserver/resources/watchdog.sh
@@ -1,0 +1,73 @@
+#!/bin/sh
+
+token=$1
+
+# Make sure that kube-apiserver process is running and then wait 15 seconds for it to start up.
+pid=$(pgrep kube-apiserver)
+retries=0
+while [ -z "$pid" ] && [ $retries -lt 12 ]; do
+    pid=$(pgrep kube-apiserver)
+    retries=$((retries+1))
+    sleep 5
+done
+if [ -z "$pid" ]; then
+    echo "$(date) Could not find kube-apiserver process, exiting."
+    exit 1
+fi
+
+sleep 15
+
+counter=0
+while true; do
+    resp=$(wget --no-check-certificate -qO- --header "Authorization: Bearer ${token}" https://127.0.0.1/version?timeout=10s 2>&1)
+
+    # When shutdown-send-retry-after=true is set on the kube-apiserver,
+    # requests will return a 429 status code response when the kube-apiserver is shutting down.
+    if echo "${resp}" | grep 429; then
+        echo "$(date): kube-apiserver is probably not running properly, trying /readyz endpoint to confirm if it is stuck in shutdown"
+        # When the kube-apiserver is shutting down it's readiness endpoint returns status code 500.
+        # This check is added to make sure that the 429 code above is not returned due to request rate limiting.
+        resp=$(wget --no-check-certificate -qO- --header "Authorization: Bearer ${token}" https://127.0.0.1/readyz?timeout=10s 2>&1)
+        if echo ${resp} | grep 500; then
+            echo "$(date): /readyz returned status code 500"
+            counter=$((counter+1))
+        else
+            echo "$(date): Could not confirm that kube-apiserver is stuck during shutdown"
+            counter=0
+        fi
+    else
+        counter=0
+    fi
+
+    # If 5 consecutive probes confirm that the kube-apiserver is shutting down, it is very likely that the kube-apiserver is stuck
+    # ref: https://github.com/kubernetes/kubernetes/pull/113741
+    if [ $counter -ge 5 ]; then
+        echo "$(date): Detected that kube-apiserver is stuck during shutdown"
+        pid=$(pgrep kube-apiserver)
+
+        if [ -z "$pid" ]; then
+            echo "could not find kube-apiserver pid"
+            sleep 10
+            continue
+        fi
+
+        kill -s TERM "${pid}"
+        echo "$(date): Sent TERM signal to kube-apiserver process"
+
+        new_pid=$(pgrep kube-apiserver)
+        retries=0
+        while { [ -z "$new_pid" ] || [ "$new_pid" = "$pid" ]; } && [ $retries -lt 12 ]; do
+            new_pid=$(pgrep kube-apiserver)
+            retries=$((retries+1))
+            sleep 5
+        done
+        if [ -z "$new_pid" ] || [ "$new_pid" = "$pid" ] ; then
+            echo "$(date): Could not find new kube-apiserver process, exiting."
+            exit 1
+        fi
+        echo "$(date): New kube-apiserver process has started."
+        sleep 5
+    fi
+
+    sleep 10
+done

--- a/pkg/operation/botanist/component/kubeapiserver/resources/watchdog.sh
+++ b/pkg/operation/botanist/component/kubeapiserver/resources/watchdog.sh
@@ -2,7 +2,12 @@
 
 token=$1
 
-# Make sure that kube-apiserver process is running and then wait 15 seconds for it to start up.
+get_http_status() {
+    wget -S --spider --no-check-certificate -qO- --header "Authorization: Bearer ${token}" "https://127.0.0.1/$1?timeout=10s" 2>&1 | grep "HTTP/" | awk '{print $2}'
+}
+
+# Make sure that kube-apiserver process is running and then wait 60 seconds for it to start up.
+echo "$(date): Getting pid of kube-apiserver"
 pid=$(pgrep kube-apiserver)
 retries=0
 while [ -z "$pid" ] && [ $retries -lt 12 ]; do
@@ -11,24 +16,23 @@ while [ -z "$pid" ] && [ $retries -lt 12 ]; do
     sleep 5
 done
 if [ -z "$pid" ]; then
-    echo "$(date) Could not find kube-apiserver process, exiting."
+    echo "$(date): Could not find kube-apiserver process, exiting."
     exit 1
 fi
+echo "$(date): Found pid ${pid}"
 
 sleep 15
 
+echo "$(date): Starting kube-apiserver health checks"
 counter=0
 while true; do
-    resp=$(wget --no-check-certificate -qO- --header "Authorization: Bearer ${token}" https://127.0.0.1/version?timeout=10s 2>&1)
-
     # When shutdown-send-retry-after=true is set on the kube-apiserver,
     # requests will return a 429 status code response when the kube-apiserver is shutting down.
-    if echo "${resp}" | grep 429; then
+    if get_http_status "version" | grep -q 429; then
         echo "$(date): kube-apiserver is probably not running properly, trying /readyz endpoint to confirm if it is stuck in shutdown"
         # When the kube-apiserver is shutting down it's readiness endpoint returns status code 500.
         # This check is added to make sure that the 429 code above is not returned due to request rate limiting.
-        resp=$(wget --no-check-certificate -qO- --header "Authorization: Bearer ${token}" https://127.0.0.1/readyz?timeout=10s 2>&1)
-        if echo ${resp} | grep 500; then
+        if get_http_status "readyz" | grep -q 500; then
             echo "$(date): /readyz returned status code 500"
             counter=$((counter+1))
         else
@@ -46,7 +50,7 @@ while true; do
         pid=$(pgrep kube-apiserver)
 
         if [ -z "$pid" ]; then
-            echo "could not find kube-apiserver pid"
+            echo "$(date): could not find kube-apiserver pid"
             sleep 10
             continue
         fi
@@ -65,7 +69,7 @@ while true; do
             echo "$(date): Could not find new kube-apiserver process, exiting."
             exit 1
         fi
-        echo "$(date): New kube-apiserver process has started."
+        echo "$(date): New kube-apiserver process has started with pid ${pid}."
         sleep 5
     fi
 

--- a/pkg/operation/botanist/component/kubeapiserver/watchdog.go
+++ b/pkg/operation/botanist/component/kubeapiserver/watchdog.go
@@ -1,0 +1,52 @@
+// Copyright (c) 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubeapiserver
+
+import (
+	"context"
+	_ "embed"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/gardener/gardener/pkg/controllerutils"
+)
+
+const (
+	watchdogConfigMapName = "kube-apiserver-watchdog"
+	dataKeyWatchdogScript = "watchdog.sh"
+)
+
+//go:embed resources/watchdog.sh
+var watchdogScript string
+
+func (k *kubeAPIServer) reconcileTerminationHandlerConfigMap(ctx context.Context) error {
+	configMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      watchdogConfigMapName,
+			Namespace: k.namespace,
+			Labels:    getLabels(),
+		},
+	}
+	_, err := controllerutils.GetAndCreateOrMergePatch(ctx, k.client.Client(), configMap, func() error {
+		configMap.Data = map[string]string{
+			dataKeyWatchdogScript: watchdogScript,
+		}
+
+		return nil
+	})
+
+	return err
+}

--- a/pkg/operation/botanist/kubeapiserver.go
+++ b/pkg/operation/botanist/kubeapiserver.go
@@ -430,10 +430,16 @@ func (b *Botanist) computeKubeAPIServerImages() (kubeapiserver.Images, error) {
 		vpnClient = imageVPNClient.String()
 	}
 
+	imageWatchdog, err := b.ImageVector.FindImage(images.ImageNameAlpine, imagevector.RuntimeVersion(b.SeedVersion()), imagevector.TargetVersion(b.ShootVersion()))
+	if err != nil {
+		return kubeapiserver.Images{}, err
+	}
+
 	return kubeapiserver.Images{
 		APIServerProxyPodWebhook: imageApiserverProxyPodWebhook.String(),
 		KubeAPIServer:            imageKubeAPIServer.String(),
 		VPNClient:                vpnClient,
+		Watchdog:                 imageWatchdog.String(),
 	}, nil
 }
 

--- a/pkg/operation/botanist/kubeapiserver_test.go
+++ b/pkg/operation/botanist/kubeapiserver_test.go
@@ -137,6 +137,7 @@ var _ = Describe("KubeAPIServer", func() {
 					{Name: "apiserver-proxy-pod-webhook"},
 					{Name: "kube-apiserver"},
 					{Name: "vpn-shoot-client"},
+					{Name: "alpine"},
 				},
 				APIServerAddress:   apiServerAddress,
 				APIServerClusterIP: apiServerClusterIP,


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/area ops-productivity
/kind bug

**What this PR does / why we need it**:
This PR improves #7250 by also adding a watchdog sidecar to the kube-apiserver when the k8s version is 1.24. The initial idea was that #7250 will prevent negative effects from happening if the `kube-apiserver` gets stuck during shutdown and then operators will have to manually clean up the broken `kube-apiserver` containers. However, we have seen that this issue occurs quite often and operators cannot always react quick enough to clean the broken `kube-apiservers`.

The sidecar that this PR adds tries to check the availability of the `kube-apiserver` every 10 seconds. When it receives an error code 429, which is the error code that is returned when the `kube-apiserver` is being shut down and the `shutdown--send-retry-after=true` flag is set. It then checks to see if the `/readyz` is successful or not. When the `kube-apiserver` is getting shutdown, the `/readyz` endpoint is not successfull. After 5 subsequent checks that return the same codes, the watchdog assumes that the `kube-apiserver` is stuck in shutdown and sends a SIGTERM which should stop the `kube-apiserver` process.

As an additional explanation to #7250, this issue can occur if the `kubelet`'s liveness probe for the `kube-apiserver` container fails. Then the `kubelet` will  send SIGTERM which will trigger the shutdown of the `kube-apiserver`. However the liveness probe can then become successful as it is not tied to whether the `kube-apiserver` is shutting down or not. Since `kubelet` now detects that the `kube-apiserver` is "live" it never sends a second SIGTERM signal to force the shutdown. Therefore due to the auditlog configuration the `kube-apiserver` process becomes stuck. 
Another way that the issue can happen, is if `kubelet` gets restarted after having sent the first SIGTERM.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
To reproduce the issue locally and test this PR you have to do the following changes:
1. Apply an empty auditlog policy configmap that just logs everything in your project in your local cluster. Here's an example of the policy:
```
apiVersion: v1
kind: ConfigMap
metadata:
  name: audit-everything
data:
  policy: |
    apiVersion: audit.k8s.io/v1
    kind: Policy
    rules:
      - level: Metadata
```
2. Configure the local shoot with the auditlog policy:
```diff
index 00f29e7a1..f0e60978f 100644
--- a/example/provider-local/shoot.yaml
+++ b/example/provider-local/shoot.yaml
@@ -32,10 +32,13 @@ spec:
       maxSurge: 1
       maxUnavailable: 0
   kubernetes:
-    # TODO(ialidzhikov): Update to 1.26.0 after the merge of https://github.com/gardener/gardener/pull/7275.
-    version: 1.25.4
+    version: 1.24.8
+    kubeAPIServer:
+      auditConfig:
+        auditPolicy:
+          configMapRef:
+            name: audit-everything
     kubelet:
-      seccompDefault: true
       serializeImagePulls: false
       registryPullQPS: 10
       registryBurst: 20
```
3. Change `pkg/operation/botanist/component/kubeapiserver/deployment.go` with 
```diff
--- a/pkg/operation/botanist/component/kubeapiserver/deployment.go
+++ b/pkg/operation/botanist/component/kubeapiserver/deployment.go
@@ -474,6 +474,8 @@ func (k *kubeAPIServer) computeKubeAPIServerCommand() []string {
        out = append(out, fmt.Sprintf("--audit-policy-file=%s/%s", volumeMountPathAuditPolicy, configMapAuditPolicyDataKey))
        out = append(out, "--audit-log-maxsize=100")
        out = append(out, "--audit-log-maxbackup=5")
+       out = append(out, "--audit-log-batch-max-size=2")
+       out = append(out, "--audit-log-mode=batch")
        out = append(out, "--authorization-mode=Node,RBAC")
 
        if len(k.values.APIAudiences) > 0 {
```

To send a single SIGTERM to a `kube-apiserver` container of your shoot, you first have to get its container ID (e.g. by using this `k  get po <kube-apiserver-pod-name> -ojson | jq -r '.items[] | .status.containerStatuses[] | select(.name == "kube-apiserver") | select(.ready) | .containerID' | sed  s^containerd://^^g` After that exec into the kind cluster that runs your shoot's control plane and run the following command:
```
ctr -n k8s.io task kill -s SIGTERM <container-id>
```
This will cause the `kube-apiserver` process to get stuck during shutdown.
Thanks @vpnachev for providing these steps.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Added a `watchdog` container to `kube-apiserver` pods for kubernetes `v1.24` which will monitor if the `kube-apiserver` process is working properly and use some heuristics to detect if it is stuck during shutdown. If that happens it will forcefully cause it to finish shutting down by sending a `SIGTERM` signal to it. 
```
