### PR TITLE
[garden-local] Only add loopback addresses for multi-zonal setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -325,7 +325,7 @@ kind-ha-single-zone-down: $(KIND)
 	./hack/kind-down.sh --cluster-name gardener-local-ha-single-zone --path-kubeconfig $(REPO_ROOT)/example/provider-local/seed-kind-ha-single-zone/base/kubeconfig
 
 kind-ha-multi-zone-up: $(KIND) $(KUBECTL) $(HELM)
-	./hack/kind-up.sh --cluster-name gardener-local-ha-multi-zone --environment $(KIND_ENV) --path-kubeconfig $(REPO_ROOT)/example/provider-local/seed-kind-ha-multi-zone/base/kubeconfig --path-cluster-values $(REPO_ROOT)/example/gardener-local/kind/ha-multi-zone/values.yaml
+	./hack/kind-up.sh --cluster-name gardener-local-ha-multi-zone --environment $(KIND_ENV) --path-kubeconfig $(REPO_ROOT)/example/provider-local/seed-kind-ha-multi-zone/base/kubeconfig --path-cluster-values $(REPO_ROOT)/example/gardener-local/kind/ha-multi-zone/values.yaml --multi-zonal
 kind-ha-multi-zone-down: $(KIND)
 	./hack/kind-down.sh --cluster-name gardener-local-ha-multi-zone --path-kubeconfig $(REPO_ROOT)/example/provider-local/seed-kind-ha-multi-zone/base/kubeconfig
 

--- a/example/gardener-local/kind/cluster/templates/_extra_port_mappings.tpl
+++ b/example/gardener-local/kind/cluster/templates/_extra_port_mappings.tpl
@@ -17,9 +17,10 @@
   hostPort: 9443
 {{- end }}
   listenAddress: {{ .Values.gardener.seed.istio.listenAddressDefault }}
-{{- if .Values.gardener.seed.istio.listenAddressZone0 }}
-- containerPort: 30444
-{{- if or (eq .Values.environment "local") .Values.gardener.controlPlane.deployed }}
+{{- if .Values.gardener.seed.istio.additionalListenAddresses }}
+{{- range $i, $listenAddress := .Values.gardener.seed.istio.additionalListenAddresses }}
+- containerPort: {{ add 30444 $i }}
+{{- if or (eq $.Values.environment "local") $.Values.gardener.controlPlane.deployed }}
   hostPort: 443
 {{- else }}
   # TODO (plkokanov): when using skaffold to deploy, 127.0.0.2 is not used as listenAddress (unlike the local
@@ -27,34 +28,11 @@
   #  way currently to swap the dns record of the shoot's `kube-apiserver` once it is migrated to this seed.
   hostPort: 9443
 {{- end }}
-  listenAddress: {{ .Values.gardener.seed.istio.listenAddressZone0 }}
+  listenAddress: {{ $listenAddress }}
 {{- end }}
-{{- if .Values.gardener.seed.istio.listenAddressZone1 }}
-- containerPort: 30445
-{{- if or (eq .Values.environment "local") .Values.gardener.controlPlane.deployed }}
-  hostPort: 443
-{{- else }}
-  # TODO (plkokanov): when using skaffold to deploy, 127.0.0.2 is not used as listenAddress (unlike the local
-  #  deployment) because secondary IPs cannot be easily added to inside the `prow` containers. Additionally, there is no
-  #  way currently to swap the dns record of the shoot's `kube-apiserver` once it is migrated to this seed.
-  hostPort: 9443
 {{- end }}
-  listenAddress: {{ .Values.gardener.seed.istio.listenAddressZone1 }}
 {{- end }}
-{{- if .Values.gardener.seed.istio.listenAddressZone2 }}
-- containerPort: 30446
-{{- if or (eq .Values.environment "local") .Values.gardener.controlPlane.deployed }}
-  hostPort: 443
-{{- else }}
-  # TODO (plkokanov): when using skaffold to deploy, 127.0.0.2 is not used as listenAddress (unlike the local
-  #  deployment) because secondary IPs cannot be easily added to inside the `prow` containers. Additionally, there is no
-  #  way currently to swap the dns record of the shoot's `kube-apiserver` once it is migrated to this seed.
-  hostPort: 9443
 {{- end }}
-  listenAddress: {{ .Values.gardener.seed.istio.listenAddressZone2 }}
-{{- end -}}
-{{- end -}}
-{{- end -}}
 
 {{- define "extraPortMappings.gardener.operator.virtualGarden" -}}
 {{- if .Values.gardener.garden.deployed -}}

--- a/example/gardener-local/kind/cluster/templates/_extra_port_mappings.tpl
+++ b/example/gardener-local/kind/cluster/templates/_extra_port_mappings.tpl
@@ -7,19 +7,8 @@
 
 {{- define "extraPortMappings.gardener.seed.istio" -}}
 {{- if .Values.gardener.seed.deployed -}}
-- containerPort: 30443
-{{- if or (eq .Values.environment "local") .Values.gardener.controlPlane.deployed }}
-  hostPort: 443
-{{- else }}
-  # TODO (plkokanov): when using skaffold to deploy, 127.0.0.2 is not used as listenAddress (unlike the local
-  #  deployment) because secondary IPs cannot be easily added to inside the `prow` containers. Additionally, there is no
-  #  way currently to swap the dns record of the shoot's `kube-apiserver` once it is migrated to this seed.
-  hostPort: 9443
-{{- end }}
-  listenAddress: {{ .Values.gardener.seed.istio.listenAddressDefault }}
-{{- if .Values.gardener.seed.istio.additionalListenAddresses }}
-{{- range $i, $listenAddress := .Values.gardener.seed.istio.additionalListenAddresses }}
-- containerPort: {{ add 30444 $i }}
+{{- range $i, $listenAddress := (required ".Values.gardener.seed.istio.listenAddresses is required" .Values.gardener.seed.istio.listenAddresses) }}
+- containerPort: {{ add 30443 $i }}
 {{- if or (eq $.Values.environment "local") $.Values.gardener.controlPlane.deployed }}
   hostPort: 443
 {{- else }}
@@ -29,7 +18,6 @@
   hostPort: 9443
 {{- end }}
   listenAddress: {{ $listenAddress }}
-{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/example/gardener-local/kind/cluster/templates/_extra_port_mappings.tpl
+++ b/example/gardener-local/kind/cluster/templates/_extra_port_mappings.tpl
@@ -17,6 +17,7 @@
   hostPort: 9443
 {{- end }}
   listenAddress: {{ .Values.gardener.seed.istio.listenAddressDefault }}
+{{- if .Values.gardener.seed.istio.listenAddressZone0 }}
 - containerPort: 30444
 {{- if or (eq .Values.environment "local") .Values.gardener.controlPlane.deployed }}
   hostPort: 443
@@ -27,6 +28,8 @@
   hostPort: 9443
 {{- end }}
   listenAddress: {{ .Values.gardener.seed.istio.listenAddressZone0 }}
+{{- end }}
+{{- if .Values.gardener.seed.istio.listenAddressZone1 }}
 - containerPort: 30445
 {{- if or (eq .Values.environment "local") .Values.gardener.controlPlane.deployed }}
   hostPort: 443
@@ -37,6 +40,8 @@
   hostPort: 9443
 {{- end }}
   listenAddress: {{ .Values.gardener.seed.istio.listenAddressZone1 }}
+{{- end }}
+{{- if .Values.gardener.seed.istio.listenAddressZone2 }}
 - containerPort: 30446
 {{- if or (eq .Values.environment "local") .Values.gardener.controlPlane.deployed }}
   hostPort: 443
@@ -47,6 +52,7 @@
   hostPort: 9443
 {{- end }}
   listenAddress: {{ .Values.gardener.seed.istio.listenAddressZone2 }}
+{{- end -}}
 {{- end -}}
 {{- end -}}
 

--- a/example/gardener-local/kind/cluster/values.yaml
+++ b/example/gardener-local/kind/cluster/values.yaml
@@ -9,7 +9,8 @@ gardener:
   seed:
     deployed: true
     istio:
-      listenAddressDefault: 127.0.0.1
+      listenAddresses:
+      - 127.0.0.1
   repositoryRoot: "."
   garden:
     deployed: false

--- a/example/gardener-local/kind/cluster/values.yaml
+++ b/example/gardener-local/kind/cluster/values.yaml
@@ -10,9 +10,6 @@ gardener:
     deployed: true
     istio:
       listenAddressDefault: 127.0.0.1
-      listenAddressZone0: 127.0.0.10
-      listenAddressZone1: 127.0.0.11
-      listenAddressZone2: 127.0.0.12
   repositoryRoot: "."
   garden:
     deployed: false

--- a/example/gardener-local/kind/ha-multi-zone/values.yaml
+++ b/example/gardener-local/kind/ha-multi-zone/values.yaml
@@ -1,3 +1,10 @@
+gardener:
+  seed:
+    istio:
+      listenAddressZone0: 127.0.0.10
+      listenAddressZone1: 127.0.0.11
+      listenAddressZone2: 127.0.0.12
+
 registry:
   hostname: gardener-local-ha-multi-zone-control-plane
 

--- a/example/gardener-local/kind/ha-multi-zone/values.yaml
+++ b/example/gardener-local/kind/ha-multi-zone/values.yaml
@@ -1,9 +1,11 @@
 gardener:
   seed:
     istio:
-      listenAddressZone0: 127.0.0.10
-      listenAddressZone1: 127.0.0.11
-      listenAddressZone2: 127.0.0.12
+      # Add one address per zone
+      additionalListenAddresses:
+      - 127.0.0.10
+      - 127.0.0.11
+      - 127.0.0.12
 
 registry:
   hostname: gardener-local-ha-multi-zone-control-plane

--- a/example/gardener-local/kind/ha-multi-zone/values.yaml
+++ b/example/gardener-local/kind/ha-multi-zone/values.yaml
@@ -1,8 +1,9 @@
 gardener:
   seed:
     istio:
-      # Add one address per zone
-      additionalListenAddresses:
+      # Add one 'global' address and one per zone, see https://github.com/gardener/gardener/pull/6997
+      listenAddresses:
+      - 127.0.0.1
       - 127.0.0.10
       - 127.0.0.11
       - 127.0.0.12

--- a/hack/kind-up.sh
+++ b/hack/kind-up.sh
@@ -9,6 +9,7 @@ PATH_CLUSTER_VALUES=""
 PATH_KUBECONFIG=""
 ENVIRONMENT="skaffold"
 DEPLOY_REGISTRY=true
+MULTI_ZONAL=false
 CHART=$(dirname "$0")/../example/gardener-local/kind/cluster
 
 parse_flags() {
@@ -31,6 +32,9 @@ parse_flags() {
       ;;
     --skip-registry)
       DEPLOY_REGISTRY=false
+      ;;
+    --multi-zonal)
+      MULTI_ZONAL=true
       ;;
     esac
 
@@ -66,7 +70,9 @@ mkdir -m 0755 -p \
   "$(dirname "$0")/../dev/local-backupbuckets" \
   "$(dirname "$0")/../dev/local-registry"
 
-setup_loopback_device
+if [[ "$MULTI_ZONAL" == "true" ]]; then
+  setup_loopback_device
+fi
 
 kind create cluster \
   --name "$CLUSTER_NAME" \


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/area high-availability
/kind enhancement

**What this PR does / why we need it**:
Assuming that most developers will use the standard `local-setup` for testing and evaluation, it's not necessary to add additional addresses to the `loopback` device. This PR lets the setup only add those addresses if a multi-zonal environment is required.

**Special notes for your reviewer**:
/cc @ScheererJ

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
Gardener only adds additional addresses to the machine's loopback device if a local multi-zonal environment is used. Earlier this step was performed with all `make kind-*up` commands.
```
