### PR TITLE
Don't pass the loop init variable as pointer to go routines

### DIFF
--- a/cmd/gardenlet/app/app.go
+++ b/cmd/gardenlet/app/app.go
@@ -474,7 +474,9 @@ func (g *garden) updateProcessingShootStatusToAborted(ctx context.Context, garde
 
 	var taskFns []flow.TaskFn
 
-	for _, shoot := range shoots.Items {
+	for _, s := range shoots.Items {
+		shoot := s
+
 		if specSeedName, statusSeedName := gardenerutils.GetShootSeedNames(&shoot); gardenerutils.GetResponsibleSeedName(specSeedName, statusSeedName) != g.config.SeedConfig.Name {
 			continue
 		}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality control-plane
/kind bug

**What this PR does / why we need it**:
In the gardenlet, while adding the Shoots to the `TaskFn`, we were using the loop init variable.

From [Go spec](https://golang.org/ref/spec#For_statements):
> Variables declared by the init statement are re-used in each iteration.

Read more [here](https://eli.thegreenplace.net/2019/go-internals-capturing-loop-variables-in-closures/).

This caused the pointer to always point to the last Shoot in the list, and this Shoot may not belong to this Seed or gardenlet, which caused the `SeedAuthorizer` webhook to reject the request and the gardenlet panics with:
```
panic: 1 error occurred:
 * failed to set status to 'Aborted' for shoot "garden-test/shoot-test": shoots.core.gardener.cloud "shoot-test" is forbidden: User "gardener.cloud:system:seed:gcp-ha" cannot patch resource "shoots/status" in API group "core.gardener.cloud" in the namespace "garden-test": no relationship found between seed 'gcp-ha' and this object
```
This PR fixes this by assigning the Shoot to a new variable.

/milestone v1.63

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Introduced with #7206 

/cc @rfranzke @timuthy 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
