### PR TITLE
Deflake `Seed` controller integration test

### DIFF
--- a/test/integration/gardenlet/seed/seed/seed_suite_test.go
+++ b/test/integration/gardenlet/seed/seed/seed_suite_test.go
@@ -19,6 +19,7 @@ import (
 	_ "embed"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
@@ -62,6 +63,10 @@ var (
 )
 
 var _ = BeforeSuite(func() {
+	// a lot of CPU-intensive stuff is happening in this test, so to
+	// prevent flakes we have to increase the timeout here manually
+	SetDefaultEventuallyTimeout(10 * time.Second)
+
 	logf.SetLogger(logger.MustNewZapLogger(logger.DebugLevel, logger.FormatJSON, zap.WriteTo(GinkgoWriter)))
 	log = logf.Log.WithName(testID)
 

--- a/test/integration/gardenlet/seed/seed/seed_suite_test.go
+++ b/test/integration/gardenlet/seed/seed/seed_suite_test.go
@@ -19,39 +19,22 @@ import (
 	_ "embed"
 	"path/filepath"
 	"testing"
-	"time"
 
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
-	"k8s.io/utils/pointer"
-	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
-	"sigs.k8s.io/controller-runtime/pkg/manager"
 
-	"github.com/gardener/gardener/charts"
-	"github.com/gardener/gardener/pkg/api/indexer"
-	gardencore "github.com/gardener/gardener/pkg/apis/core"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
-	operatorv1alpha1 "github.com/gardener/gardener/pkg/apis/operator/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	gardenerenvtest "github.com/gardener/gardener/pkg/envtest"
-	"github.com/gardener/gardener/pkg/gardenlet/apis/config"
-	"github.com/gardener/gardener/pkg/gardenlet/controller/seed/seed"
 	"github.com/gardener/gardener/pkg/gardenlet/features"
 	"github.com/gardener/gardener/pkg/logger"
-	"github.com/gardener/gardener/pkg/utils/imagevector"
-	. "github.com/gardener/gardener/pkg/utils/test/matchers"
-	"github.com/gardener/gardener/test/utils/namespacefinalizer"
 )
 
 func TestSeed(t *testing.T) {
@@ -70,11 +53,7 @@ var (
 	testClient    client.Client
 	testClientSet kubernetes.Interface
 	mgrClient     client.Client
-
-	testRunID     string
-	testNamespace *corev1.Namespace
-	seedName      string
-	identity      = &gardencorev1beta1.Gardener{Version: "1.2.3"}
+	testScheme    *runtime.Scheme
 
 	//go:embed testdata/crd-managedresources.yaml
 	managedResourcesCRD string
@@ -115,124 +94,10 @@ var _ = BeforeSuite(func() {
 		kubernetes.AddSeedSchemeToScheme,
 		gardencorev1beta1.AddToScheme,
 	)
-	testScheme := runtime.NewScheme()
+	testScheme = runtime.NewScheme()
 	Expect(testSchemeBuilder.AddToScheme(testScheme)).To(Succeed())
 
 	By("Create test client")
 	testClient, err = client.New(restConfig, client.Options{Scheme: testScheme})
 	Expect(err).NotTo(HaveOccurred())
-
-	By("Create test Namespace")
-	testNamespace = &corev1.Namespace{
-		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: "garden-",
-		},
-	}
-	Expect(testClient.Create(ctx, testNamespace)).To(Succeed())
-	log.Info("Created Namespace for test", "namespaceName", testNamespace.Name)
-	testRunID = testNamespace.Name
-	seedName = "seed-" + testRunID
-
-	DeferCleanup(func() {
-		By("Delete test Namespace")
-		Expect(testClient.Delete(ctx, testNamespace)).To(Or(Succeed(), BeNotFoundError()))
-	})
-
-	By("Setup manager")
-	mapper, err := apiutil.NewDynamicRESTMapper(restConfig)
-	Expect(err).NotTo(HaveOccurred())
-
-	mgr, err := manager.New(restConfig, manager.Options{
-		Scheme:             testScheme,
-		MetricsBindAddress: "0",
-		NewCache: cache.BuilderWithOptions(cache.Options{
-			Mapper: mapper,
-			SelectorsByObject: map[client.Object]cache.ObjectSelector{
-				&gardencorev1beta1.Seed{}: {
-					Label: labels.SelectorFromSet(labels.Set{testID: testRunID}),
-				},
-				&operatorv1alpha1.Garden{}: {
-					Label: labels.SelectorFromSet(labels.Set{testID: testRunID}),
-				},
-			},
-		}),
-	})
-	Expect(err).NotTo(HaveOccurred())
-	mgrClient = mgr.GetClient()
-
-	// We create the seed namespace in the garden and delete it after every test, so let's ensure it gets finalized.
-	Expect((&namespacefinalizer.Reconciler{}).AddToManager(mgr)).To(Succeed())
-
-	By("Setup field indexes")
-	Expect(indexer.AddBackupBucketSeedName(ctx, mgr.GetFieldIndexer())).To(Succeed())
-	Expect(indexer.AddControllerInstallationSeedRefName(ctx, mgr.GetFieldIndexer())).To(Succeed())
-	Expect(indexer.AddShootSeedName(ctx, mgr.GetFieldIndexer())).To(Succeed())
-
-	By("Create test clientset")
-	testClientSet, err = kubernetes.NewWithConfig(
-		kubernetes.WithRESTConfig(mgr.GetConfig()),
-		kubernetes.WithRuntimeAPIReader(mgr.GetAPIReader()),
-		kubernetes.WithRuntimeClient(mgr.GetClient()),
-		kubernetes.WithRuntimeCache(mgr.GetCache()),
-	)
-	Expect(err).NotTo(HaveOccurred())
-
-	By("Register controller")
-	chartsPath := filepath.Join("..", "..", "..", "..", "..", charts.Path)
-	imageVector, err := imagevector.ReadGlobalImageVectorWithEnvOverride(filepath.Join(chartsPath, "images.yaml"))
-	Expect(err).NotTo(HaveOccurred())
-
-	Expect((&seed.Reconciler{
-		SeedClientSet: testClientSet,
-		Config: config.GardenletConfiguration{
-			Controllers: &config.GardenletControllerConfiguration{
-				Seed: &config.SeedControllerConfiguration{
-					// This controller is pretty heavy-weight, so use a higher duration.
-					SyncPeriod: &metav1.Duration{Duration: time.Minute},
-				},
-			},
-			SNI: &config.SNI{
-				Ingress: &config.SNIIngress{
-					Namespace: pointer.String(testNamespace.Name + "-istio"),
-				},
-			},
-			ETCDConfig: &config.ETCDConfig{
-				BackupCompactionController: &config.BackupCompactionController{
-					EnableBackupCompaction: pointer.Bool(false),
-					EventsThreshold:        pointer.Int64(1),
-					Workers:                pointer.Int64(1),
-				},
-				CustodianController: &config.CustodianController{
-					Workers: pointer.Int64(1),
-				},
-				ETCDController: &config.ETCDController{
-					Workers: pointer.Int64(1),
-				},
-			},
-			SeedConfig: &config.SeedConfig{
-				SeedTemplate: gardencore.SeedTemplate{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: seedName,
-					},
-				},
-			},
-		},
-		Identity:        identity,
-		ImageVector:     imageVector,
-		GardenNamespace: testNamespace.Name,
-		ChartsPath:      chartsPath,
-	}).AddToManager(mgr, mgr)).To(Succeed())
-
-	By("Start manager")
-	mgrContext, mgrCancel := context.WithCancel(ctx)
-
-	go func() {
-		defer GinkgoRecover()
-		Expect(mgr.Start(mgrContext)).To(Succeed())
-	}()
-
-	DeferCleanup(func() {
-		By("Stop manager")
-		mgrCancel()
-	})
 })

--- a/test/integration/gardenlet/seed/seed/seed_test.go
+++ b/test/integration/gardenlet/seed/seed/seed_test.go
@@ -510,13 +510,13 @@ var _ = Describe("Seed controller tests", func() {
 							managedResourceList := &resourcesv1alpha1.ManagedResourceList{}
 							g.Expect(testClient.List(ctx, managedResourceList, client.InNamespace(testNamespace.Name))).To(Succeed())
 							return managedResourceList.Items
-						}).Should(BeEmpty())
+						}).WithTimeout(10 * time.Second).Should(BeEmpty())
 					} else {
 						By("Verify that gardener-resource-manager has been deleted")
 						Eventually(func(g Gomega) error {
 							deployment := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "gardener-resource-manager", Namespace: testNamespace.Name}}
 							return testClient.Get(ctx, client.ObjectKeyFromObject(deployment), deployment)
-						}).Should(BeNotFoundError())
+						}).WithTimeout(10 * time.Second).Should(BeNotFoundError())
 
 						// We should wait for the CRD to be deleted since it is a cluster-scoped resource so that we do not interfere
 						// with other test cases.

--- a/test/integration/gardenlet/seed/seed/seed_test.go
+++ b/test/integration/gardenlet/seed/seed/seed_test.go
@@ -16,6 +16,7 @@ package seed_test
 
 import (
 	"context"
+	"path/filepath"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -26,28 +27,159 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
 
+	"github.com/gardener/gardener/charts"
+	"github.com/gardener/gardener/pkg/api/indexer"
+	gardencore "github.com/gardener/gardener/pkg/apis/core"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	operatorv1alpha1 "github.com/gardener/gardener/pkg/apis/operator/v1alpha1"
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/features"
+	"github.com/gardener/gardener/pkg/gardenlet/apis/config"
+	seedcontroller "github.com/gardener/gardener/pkg/gardenlet/controller/seed/seed"
 	gardenletfeatures "github.com/gardener/gardener/pkg/gardenlet/features"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/resourcemanager"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
+	"github.com/gardener/gardener/pkg/utils/imagevector"
 	"github.com/gardener/gardener/pkg/utils/retry"
 	secretsutils "github.com/gardener/gardener/pkg/utils/secrets"
 	"github.com/gardener/gardener/pkg/utils/test"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
+	"github.com/gardener/gardener/test/utils/namespacefinalizer"
 )
 
 var _ = Describe("Seed controller tests", func() {
 	var (
-		seed *gardencorev1beta1.Seed
+		testRunID     string
+		testNamespace *corev1.Namespace
+		seedName      string
+		seed          *gardencorev1beta1.Seed
+		identity      = &gardencorev1beta1.Gardener{Version: "1.2.3"}
 	)
+
+	BeforeEach(func() {
+		By("Create test Namespace")
+		testNamespace = &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "garden-",
+			},
+		}
+		Expect(testClient.Create(ctx, testNamespace)).To(Succeed())
+		log.Info("Created Namespace for test", "namespaceName", testNamespace.Name)
+		testRunID = testNamespace.Name
+		seedName = "seed-" + testRunID
+
+		DeferCleanup(func() {
+			By("Delete test Namespace")
+			Expect(testClient.Delete(ctx, testNamespace)).To(Or(Succeed(), BeNotFoundError()))
+		})
+
+		By("Setup manager")
+		mapper, err := apiutil.NewDynamicRESTMapper(restConfig)
+		Expect(err).NotTo(HaveOccurred())
+
+		mgr, err := manager.New(restConfig, manager.Options{
+			Scheme:             testScheme,
+			MetricsBindAddress: "0",
+			NewCache: cache.BuilderWithOptions(cache.Options{
+				Mapper: mapper,
+				SelectorsByObject: map[client.Object]cache.ObjectSelector{
+					&gardencorev1beta1.Seed{}: {
+						Label: labels.SelectorFromSet(labels.Set{testID: testRunID}),
+					},
+					&operatorv1alpha1.Garden{}: {
+						Label: labels.SelectorFromSet(labels.Set{testID: testRunID}),
+					},
+				},
+			}),
+		})
+		Expect(err).NotTo(HaveOccurred())
+		mgrClient = mgr.GetClient()
+
+		// We create the seed namespace in the garden and delete it after every test, so let's ensure it gets finalized.
+		Expect((&namespacefinalizer.Reconciler{}).AddToManager(mgr)).To(Succeed())
+
+		By("Setup field indexes")
+		Expect(indexer.AddBackupBucketSeedName(ctx, mgr.GetFieldIndexer())).To(Succeed())
+		Expect(indexer.AddControllerInstallationSeedRefName(ctx, mgr.GetFieldIndexer())).To(Succeed())
+		Expect(indexer.AddShootSeedName(ctx, mgr.GetFieldIndexer())).To(Succeed())
+
+		By("Create test clientset")
+		testClientSet, err = kubernetes.NewWithConfig(
+			kubernetes.WithRESTConfig(mgr.GetConfig()),
+			kubernetes.WithRuntimeAPIReader(mgr.GetAPIReader()),
+			kubernetes.WithRuntimeClient(mgr.GetClient()),
+			kubernetes.WithRuntimeCache(mgr.GetCache()),
+		)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Register controller")
+		chartsPath := filepath.Join("..", "..", "..", "..", "..", charts.Path)
+		imageVector, err := imagevector.ReadGlobalImageVectorWithEnvOverride(filepath.Join(chartsPath, "images.yaml"))
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect((&seedcontroller.Reconciler{
+			SeedClientSet: testClientSet,
+			Config: config.GardenletConfiguration{
+				Controllers: &config.GardenletControllerConfiguration{
+					Seed: &config.SeedControllerConfiguration{
+						// This controller is pretty heavy-weight, so use a higher duration.
+						SyncPeriod: &metav1.Duration{Duration: time.Minute},
+					},
+				},
+				SNI: &config.SNI{
+					Ingress: &config.SNIIngress{
+						Namespace: pointer.String(testNamespace.Name + "-istio"),
+					},
+				},
+				ETCDConfig: &config.ETCDConfig{
+					BackupCompactionController: &config.BackupCompactionController{
+						EnableBackupCompaction: pointer.Bool(false),
+						EventsThreshold:        pointer.Int64(1),
+						Workers:                pointer.Int64(1),
+					},
+					CustodianController: &config.CustodianController{
+						Workers: pointer.Int64(1),
+					},
+					ETCDController: &config.ETCDController{
+						Workers: pointer.Int64(1),
+					},
+				},
+				SeedConfig: &config.SeedConfig{
+					SeedTemplate: gardencore.SeedTemplate{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: seedName,
+						},
+					},
+				},
+			},
+			Identity:        identity,
+			ImageVector:     imageVector,
+			GardenNamespace: testNamespace.Name,
+			ChartsPath:      chartsPath,
+		}).AddToManager(mgr, mgr)).To(Succeed())
+
+		By("Start manager")
+		mgrContext, mgrCancel := context.WithCancel(ctx)
+
+		go func() {
+			defer GinkgoRecover()
+			Expect(mgr.Start(mgrContext)).To(Succeed())
+		}()
+
+		DeferCleanup(func() {
+			By("Stop manager")
+			mgrCancel()
+		})
+	})
 
 	JustBeforeEach(func() {
 		DeferCleanup(test.WithVars(

--- a/test/integration/gardenlet/seed/seed/seed_test.go
+++ b/test/integration/gardenlet/seed/seed/seed_test.go
@@ -66,10 +66,6 @@ var _ = Describe("Seed controller tests", func() {
 	)
 
 	BeforeEach(func() {
-		// a lot of CPU-intensive stuff is happening in this test, so to
-		// prevent flakes we have to increase the timeout here manually
-		SetDefaultEventuallyTimeout(10 * time.Second)
-
 		By("Create test Namespace")
 		testNamespace = &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind flake

**What this PR does / why we need it**:
This PR fixes the Seed controller integration test flake.
There are two improvements done in this PR : 
    - Use a unique garden namespace for each test, this is required cause sometimes if the first test fails and MR takes some delay to get cleaned up, another test fails because it finds extra MR already present in the garden namespace.
     *`Defer cleanup can affect other IT nodes` https://github.com/onsi/ginkgo/issues/969#issuecomment-1110921854*
    - Increase the timeout for steps that depend on the full reconciliation flow of the seed reconciler.

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener/issues/6933

**Special notes for your reviewer**:
Before -
```
stress -ignore "unable to grab random port" -p 16 ./test/integration/gardenlet/seed/seed/seed.test -ginkgo.v -ginkgo.progress.
.
10m10s: 238 runs so far, 3 failures (1.26%)
10m15s: 238 runs so far, 3 failures (1.26%)
10m20s: 238 runs so far, 3 failures (1.26%)
```
After -
```
stress -ignore "unable to grab random port" -p 16 ./test/integration/gardenlet/seed/seed/seed.test -ginkgo.v -ginkgo.progress
.
6m35s: 144 runs so far, 0 failures
6m40s: 144 runs so far, 0 failures
.
.
29m0s: 666 runs so far, 0 failures
29m5s: 669 runs so far, 0 failures
```
**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
