### PR TITLE
Don't install yq every time

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,8 +112,8 @@ start-admission-controller:
 start-resource-manager:
 	@./hack/local-development/start-resource-manager
 
-.PHONY: start-operator $(YQ)
-start-operator:
+.PHONY: start-operator
+start-operator: $(YQ)
 	@./hack/local-development/start-operator
 
 .PHONY: start-gardenlet


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind bug

**What this PR does / why we need it**:

Without this PR, `yq` is installed every time that you invoke a make target that requires `yq`, even if it is already present:

```bash
$ make check
curl -L -o hack/tools/bin/yq https://github.com/mikefarah/yq/releases/download/v4.30.4/yq_darwin_arm64
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100 11.6M  100 11.6M    0     0  6649k      0  0:00:01  0:00:01 --:--:-- 8948k
chmod +x hack/tools/bin/yq
> Check
...

$ l hack/tools/bin/yq
.rwxr-xr-x 12M ebertti 20 Jan 15:06 hack/tools/bin/yq

$ make check
curl -L -o hack/tools/bin/yq https://github.com/mikefarah/yq/releases/download/v4.30.4/yq_darwin_arm64
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100 11.6M  100 11.6M    0     0  5786k      0  0:00:02  0:00:02 --:--:-- 10.1M
chmod +x hack/tools/bin/yq
> Check
...
```

With this PR, `yq` is only installed if it's not present or the version variable was bumped:

```bash
$ make check
> Check
...
```

**Which issue(s) this PR fixes**:
Caused by https://github.com/gardener/gardener/pull/7144

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
