### PR TITLE
Use existing port of service `istio-ingressgateway` for prometheus endpoint check.

### DIFF
--- a/pkg/operation/botanist/component/istio/ingress_gateway.go
+++ b/pkg/operation/botanist/component/istio/ingress_gateway.go
@@ -25,10 +25,6 @@ import (
 	"github.com/gardener/gardener/pkg/chartrenderer"
 )
 
-const (
-	istioIngressGatewayServicePortNameStatus = "status-port"
-)
-
 var (
 	//go:embed charts/istio/istio-ingress
 	chartIngress     embed.FS
@@ -75,9 +71,6 @@ func (i *istiod) generateIstioIngressGatewayChart() (*chartrenderer.RenderedChar
 			"istiodNamespace":       istioIngressGateway.Values.IstiodNamespace,
 			"loadBalancerIP":        istioIngressGateway.Values.LoadBalancerIP,
 			"serviceName":           v1beta1constants.DefaultSNIIngressServiceName,
-			"portsNames": map[string]interface{}{
-				"status": istioIngressGatewayServicePortNameStatus,
-			},
 		}
 
 		if istioIngressGateway.Values.MinReplicas != nil {

--- a/pkg/operation/botanist/component/istio/monitoring.go
+++ b/pkg/operation/botanist/component/istio/monitoring.go
@@ -178,7 +178,7 @@ relabel_configs:
   - __meta_kubernetes_endpoint_port_name
   - __meta_kubernetes_namespace
   action: keep
-  regex: ` + v1beta1constants.DefaultSNIIngressServiceName + `;` + istioIngressGatewayServicePortNameStatus + `;` + v1beta1constants.DefaultSNIIngressNamespace + `
+  regex: ` + v1beta1constants.DefaultSNIIngressServiceName + `;tls-tunnel;` + v1beta1constants.DefaultSNIIngressNamespace + `
 - source_labels: [__meta_kubernetes_pod_ip]
   action: replace
   target_label: __address__

--- a/pkg/operation/botanist/component/istio/monitoring_test.go
+++ b/pkg/operation/botanist/component/istio/monitoring_test.go
@@ -66,7 +66,7 @@ relabel_configs:
   - __meta_kubernetes_endpoint_port_name
   - __meta_kubernetes_namespace
   action: keep
-  regex: istio-ingressgateway;status-port;istio-ingress
+  regex: istio-ingressgateway;tls-tunnel;istio-ingress
 - source_labels: [__meta_kubernetes_pod_ip]
   action: replace
   target_label: __address__


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind bug

**What this PR does / why we need it**:
With https://github.com/gardener/gardener/pull/7027  we removed the status port from service `istio-ingressgateway`.
However, the port is used in a prometheus scrape config.
With this PR the port 8132 with the name `tls-tunnel` of the service will be used instead.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fix Prometheus scrape config for Istio ingress gateway.
```
