### PR TITLE
Fix nil pointer exception in case extension `lastOperation` is nil

### DIFF
--- a/pkg/gardenlet/controller/backupbucket/reconciler.go
+++ b/pkg/gardenlet/controller/backupbucket/reconciler.go
@@ -237,7 +237,7 @@ func (r *Reconciler) reconcileBackupBucket(
 		return reconcile.Result{}, nil
 	}
 
-	if extensionBackupBucket.Status.LastOperation.State == gardencorev1beta1.LastOperationStateSucceeded {
+	if extensionBackupBucket.Status.LastOperation != nil && extensionBackupBucket.Status.LastOperation.State == gardencorev1beta1.LastOperationStateSucceeded {
 		if updateErr := r.updateBackupBucketStatusSucceeded(ctx, backupBucket, "Backup Bucket has been successfully reconciled."); updateErr != nil {
 			return reconcile.Result{}, fmt.Errorf("could not update status after reconciliation success: %w", updateErr)
 		}

--- a/pkg/gardenlet/controller/backupentry/backupentry/reconciler.go
+++ b/pkg/gardenlet/controller/backupentry/backupentry/reconciler.go
@@ -252,7 +252,7 @@ func (r *Reconciler) reconcileBackupEntry(
 		return reconcile.Result{}, nil
 	}
 
-	if extensionBackupEntry.Status.LastOperation.State == gardencorev1beta1.LastOperationStateSucceeded {
+	if extensionBackupEntry.Status.LastOperation != nil && extensionBackupEntry.Status.LastOperation.State == gardencorev1beta1.LastOperationStateSucceeded {
 		if updateErr := r.updateBackupEntryStatusSucceeded(ctx, backupEntry, operationType); updateErr != nil {
 			return reconcile.Result{}, fmt.Errorf("could not update status after reconciliation success: %w", updateErr)
 		}

--- a/pkg/gardenlet/controller/bastion/reconciler.go
+++ b/pkg/gardenlet/controller/bastion/reconciler.go
@@ -186,7 +186,7 @@ func (r *Reconciler) reconcileBastion(
 		return nil
 	}
 
-	if extensionBastion.Status.LastOperation.State == gardencorev1beta1.LastOperationStateSucceeded {
+	if extensionBastion.Status.LastOperation != nil && extensionBastion.Status.LastOperation.State == gardencorev1beta1.LastOperationStateSucceeded {
 		// copy over the extension's status to the operation bastion and set the condition
 		patch := client.MergeFrom(bastion.DeepCopy())
 		setReadyCondition(bastion, gardencorev1alpha1.ConditionTrue, "SuccessfullyReconciled", "The bastion has been reconciled successfully.")


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug

**What this PR does / why we need it**:
#7281 changed the condition to update status as the `lastOperationState=Succeeded`, but it could so happen that the extension has not been reconciled at least once (for eg, if the extension controller is down), but the BackupEntry or BackupBucket gets reconciled again before this time, it could panic since the `lastOperation` is nil.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @timuthy 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
