### PR TITLE
[release-v1.62] Use istio tunnel port for prometheus endpoint check.

### DIFF
--- a/pkg/operation/botanist/component/istio/ingress_gateway.go
+++ b/pkg/operation/botanist/component/istio/ingress_gateway.go
@@ -25,10 +25,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-const (
-	istioIngressGatewayServicePortNameStatus = "status-port"
-)
-
 var (
 	//go:embed charts/istio/istio-ingress
 	chartIngress     embed.FS
@@ -70,9 +66,6 @@ func (i *istiod) generateIstioIngressGatewayChart() (*chartrenderer.RenderedChar
 			"istiodNamespace":   istioIngressGateway.Values.IstiodNamespace,
 			"loadBalancerIP":    istioIngressGateway.Values.LoadBalancerIP,
 			"serviceName":       v1beta1constants.DefaultSNIIngressServiceName,
-			"portsNames": map[string]interface{}{
-				"status": istioIngressGatewayServicePortNameStatus,
-			},
 		}
 
 		renderedIngressChart, err := i.chartRenderer.RenderEmbeddedFS(chartIngress, chartPathIngress, ManagedResourceControlName, istioIngressGateway.Namespace, values)

--- a/pkg/operation/botanist/component/istio/monitoring.go
+++ b/pkg/operation/botanist/component/istio/monitoring.go
@@ -178,7 +178,7 @@ relabel_configs:
   - __meta_kubernetes_endpoint_port_name
   - __meta_kubernetes_namespace
   action: keep
-  regex: ` + v1beta1constants.DefaultSNIIngressServiceName + `;` + istioIngressGatewayServicePortNameStatus + `;` + v1beta1constants.DefaultSNIIngressNamespace + `
+  regex: ` + v1beta1constants.DefaultSNIIngressServiceName + `;tls-tunnel;` + v1beta1constants.DefaultSNIIngressNamespace + `
 - source_labels: [__meta_kubernetes_pod_ip]
   action: replace
   target_label: __address__

--- a/pkg/operation/botanist/component/istio/monitoring_test.go
+++ b/pkg/operation/botanist/component/istio/monitoring_test.go
@@ -66,7 +66,7 @@ relabel_configs:
   - __meta_kubernetes_endpoint_port_name
   - __meta_kubernetes_namespace
   action: keep
-  regex: istio-ingressgateway;status-port;istio-ingress
+  regex: istio-ingressgateway;tls-tunnel;istio-ingress
 - source_labels: [__meta_kubernetes_pod_ip]
   action: replace
   target_label: __address__


### PR DESCRIPTION
This is a manual cherry-pick of #7375.
**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fix Prometheus scrape config for Istio ingress gateway.
```
