### PR TITLE
Fix shoot care reconciler predicate

### DIFF
--- a/pkg/gardenlet/controller/shoot/care/add.go
+++ b/pkg/gardenlet/controller/shoot/care/add.go
@@ -125,7 +125,7 @@ func (r *Reconciler) ShootPredicate() predicate.Predicate {
 			}
 
 			// re-evaluate shoot health status right after a reconciliation operation has succeeded
-			return shootReconciliationFinishedSuccessful(oldShoot, shoot)
+			return shootReconciliationFinishedSuccessful(oldShoot, shoot) || seedGotAssigned(oldShoot, shoot)
 		},
 		DeleteFunc:  func(event.DeleteEvent) bool { return false },
 		GenericFunc: func(event.GenericEvent) bool { return false },
@@ -139,4 +139,8 @@ func shootReconciliationFinishedSuccessful(oldShoot, newShoot *gardencorev1beta1
 		newShoot.Status.LastOperation != nil &&
 		newShoot.Status.LastOperation.Type != gardencorev1beta1.LastOperationTypeDelete &&
 		newShoot.Status.LastOperation.State == gardencorev1beta1.LastOperationStateSucceeded
+}
+
+func seedGotAssigned(oldShoot, newShoot *gardencorev1beta1.Shoot) bool {
+	return oldShoot.Spec.SeedName == nil && newShoot.Spec.SeedName != nil
 }

--- a/pkg/gardenlet/controller/shoot/care/add_test.go
+++ b/pkg/gardenlet/controller/shoot/care/add_test.go
@@ -164,6 +164,19 @@ var _ = Describe("Add", func() {
 				Expect(p.Update(event.UpdateEvent{ObjectOld: oldShoot, ObjectNew: shoot})).To(BeTrue())
 			})
 
+			It("should return false when the seed name is unchanged in the shoot specs", func() {
+				shoot.Spec.SeedName = pointer.String("test-seed")
+				oldShoot := shoot.DeepCopy()
+				Expect(p.Update(event.UpdateEvent{ObjectOld: oldShoot, ObjectNew: shoot})).To(BeFalse())
+			})
+
+			It("should return false when the seed name is changed in the shoot specs", func() {
+				shoot.Spec.SeedName = pointer.String("test-seed")
+				oldShoot := shoot.DeepCopy()
+				shoot.Spec.SeedName = pointer.String("test-seed1")
+				Expect(p.Update(event.UpdateEvent{ObjectOld: oldShoot, ObjectNew: shoot})).To(BeFalse())
+			})
+
 			It("should return true when seed gets assigned to shoot", func() {
 				oldShoot := shoot.DeepCopy()
 				shoot.Spec.SeedName = pointer.String("test-seed")

--- a/pkg/gardenlet/controller/shoot/care/add_test.go
+++ b/pkg/gardenlet/controller/shoot/care/add_test.go
@@ -22,6 +22,7 @@ import (
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
@@ -160,6 +161,12 @@ var _ = Describe("Add", func() {
 				shoot.Status.LastOperation.State = gardencorev1beta1.LastOperationStateSucceeded
 				oldShoot := shoot.DeepCopy()
 				oldShoot.Status.LastOperation.State = gardencorev1beta1.LastOperationStateProcessing
+				Expect(p.Update(event.UpdateEvent{ObjectOld: oldShoot, ObjectNew: shoot})).To(BeTrue())
+			})
+
+			It("should return true when seed gets assigned to shoot", func() {
+				oldShoot := shoot.DeepCopy()
+				shoot.Spec.SeedName = pointer.String("test-seed")
 				Expect(p.Update(event.UpdateEvent{ObjectOld: oldShoot, ObjectNew: shoot})).To(BeTrue())
 			})
 		})


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug

**What this PR does / why we need it**:
Check the motivation for this PR https://github.com/gardener/gardener/issues/7378. 


**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener/issues/7378

**Special notes for your reviewer**:
Thanks to @shafeeqes for notifying about this issue.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
