### PR TITLE
Improve `addons-nginx-ingress-controller` component refactoring

### DIFF
--- a/pkg/gardenlet/controller/shoot/care/add_test.go
+++ b/pkg/gardenlet/controller/shoot/care/add_test.go
@@ -164,13 +164,13 @@ var _ = Describe("Add", func() {
 				Expect(p.Update(event.UpdateEvent{ObjectOld: oldShoot, ObjectNew: shoot})).To(BeTrue())
 			})
 
-			It("should return false when the seed name is unchanged in the shoot specs", func() {
+			It("should return false when the seed name is unchanged in the Shoot spec", func() {
 				shoot.Spec.SeedName = pointer.String("test-seed")
 				oldShoot := shoot.DeepCopy()
 				Expect(p.Update(event.UpdateEvent{ObjectOld: oldShoot, ObjectNew: shoot})).To(BeFalse())
 			})
 
-			It("should return false when the seed name is changed in the shoot specs", func() {
+			It("should return false when the seed name is changed in the Shoot spec", func() {
 				shoot.Spec.SeedName = pointer.String("test-seed")
 				oldShoot := shoot.DeepCopy()
 				shoot.Spec.SeedName = pointer.String("test-seed1")

--- a/pkg/operation/botanist/component/nginxingressshoot/nginxingress.go
+++ b/pkg/operation/botanist/component/nginxingressshoot/nginxingress.go
@@ -283,7 +283,7 @@ func (n *nginxIngress) computeResourcesData() (map[string][]byte, error) {
 						},
 					},
 					Spec: corev1.PodSpec{
-						PriorityClassName:             "system-cluster-critical",
+						PriorityClassName:             v1beta1constants.PriorityClassNameShootSystem600,
 						NodeSelector:                  map[string]string{v1beta1constants.LabelWorkerPoolSystemComponents: "true"},
 						TerminationGracePeriodSeconds: pointer.Int64(60),
 						SecurityContext: &corev1.PodSecurityContext{
@@ -366,7 +366,7 @@ func (n *nginxIngress) computeResourcesData() (map[string][]byte, error) {
 						},
 					},
 					Spec: corev1.PodSpec{
-						PriorityClassName:             "system-cluster-critical",
+						PriorityClassName:             v1beta1constants.PriorityClassNameShootSystem600,
 						DNSPolicy:                     corev1.DNSClusterFirst,
 						RestartPolicy:                 corev1.RestartPolicyAlways,
 						SchedulerName:                 corev1.DefaultSchedulerName,

--- a/pkg/operation/botanist/component/nginxingressshoot/nginxingress_test.go
+++ b/pkg/operation/botanist/component/nginxingressshoot/nginxingress_test.go
@@ -32,7 +32,7 @@ import (
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/operation/botanist/component"
-	"github.com/gardener/gardener/pkg/resourcemanager/controller/garbagecollector/references"
+	"github.com/gardener/gardener/pkg/utils"
 	"github.com/gardener/gardener/pkg/utils/retry"
 	retryfake "github.com/gardener/gardener/pkg/utils/retry/fake"
 	"github.com/gardener/gardener/pkg/utils/test"
@@ -81,7 +81,6 @@ metadata:
     app: nginx-ingress
     component: controller
     release: addons
-    resources.gardener.cloud/garbage-collectable-reference: "true"
   name: ` + configMapName + `
   namespace: kube-system
 `
@@ -346,7 +345,7 @@ spec:
   template:
     metadata:
       annotations:
-        ` + references.AnnotationKey(references.KindConfigMap, configMapName) + `: ` + configMapName + `
+        checksum/config: ` + utils.ComputeChecksum(configMapData) + `
       creationTimestamp: null
       labels:
         app: nginx-ingress
@@ -383,8 +382,6 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        - name: KUBERNETES_SERVICE_HOST
-          value: foo.bar
         image: ` + nginxControllerImage + `
         imagePullPolicy: IfNotPresent
         livenessProbe:

--- a/pkg/operation/botanist/component/nginxingressshoot/nginxingress_test.go
+++ b/pkg/operation/botanist/component/nginxingressshoot/nginxingress_test.go
@@ -309,7 +309,7 @@ spec:
             memory: 20Mi
       nodeSelector:
         worker.gardener.cloud/system-components: "true"
-      priorityClassName: system-cluster-critical
+      priorityClassName: gardener-shoot-system-600
       securityContext:
         fsGroup: 65534
         runAsUser: 65534
@@ -442,7 +442,7 @@ spec:
       dnsPolicy: ClusterFirst
       nodeSelector:
         worker.gardener.cloud/system-components: "true"
-      priorityClassName: system-cluster-critical
+      priorityClassName: gardener-shoot-system-600
       restartPolicy: Always
       schedulerName: default-scheduler
       serviceAccountName: addons-nginx-ingress

--- a/pkg/operation/botanist/component/nodeproblemdetector/node_problem_detector.go
+++ b/pkg/operation/botanist/component/nodeproblemdetector/node_problem_detector.go
@@ -212,7 +212,7 @@ func (c *nodeProblemDetector) computeResourcesData() (map[string][]byte, error) 
 						ServiceAccountName:            serviceAccount.Name,
 						HostNetwork:                   false,
 						TerminationGracePeriodSeconds: pointer.Int64(daemonSetTerminationGracePeriodSeconds),
-						PriorityClassName:             "system-cluster-critical",
+						PriorityClassName:             v1beta1constants.PriorityClassNameShootSystem900,
 						SecurityContext: &corev1.PodSecurityContext{
 							SeccompProfile: &corev1.SeccompProfile{
 								Type: corev1.SeccompProfileTypeRuntimeDefault,

--- a/pkg/operation/botanist/component/nodeproblemdetector/node_problem_detector_test.go
+++ b/pkg/operation/botanist/component/nodeproblemdetector/node_problem_detector_test.go
@@ -300,7 +300,7 @@ spec:
           name: kmsg
           readOnly: true
       dnsPolicy: Default
-      priorityClassName: system-cluster-critical
+      priorityClassName: gardener-shoot-system-900
       securityContext:
         seccompProfile:
           type: RuntimeDefault


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind bug

**What this PR does / why we need it**:
#7294 refactored the `addons-nginx-ingress-controller` component, but few settings were missed. Therefore, guestbook test was failing with:
```
    {"level":"info","ts":"2023-01-23T19:29:07.612+0530","logger":"test","msg":"Guestbook app is not available yet (unexpected response)","url":"http://guestbook-ats.ingress.example.com","statusCode":400}
```
This PR improves the refactoring to fix the issues.

1. election-id in the deployment should be `ingress-controller-leader` and not  `ingress-controller-seed-leader`
2. Provider-aws mutates the configmap `addons-nginx-ingress-controller`, it sets `"use-proxy-protocol": "true"`. [ref](https://github.com/gardener/gardener-extension-provider-aws/blob/master/pkg/webhook/shoot/nginx_ingress_controller.go). The configmap name is hardcoded here. When we make it unique, this can't happen and the tests were failing only for aws.
3. `addons-nginx-ingress-controller` and `node-problem-detector` were using the wrong priorityclass as per https://github.com/gardener/gardener/blob/master/docs/development/priority-classes.md.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @ary1992 @acumino 
/milestone v1.63
/hold few more tests to be run locally for confirmation

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
5. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
