### PR TITLE
Fix `SecretRef` comment in `InfrastructureSpec`

### DIFF
--- a/docs/api-reference/extensions.md
+++ b/docs/api-reference/extensions.md
@@ -1157,7 +1157,7 @@ Kubernetes core/v1.SecretReference
 </em>
 </td>
 <td>
-<p>SecretRef is a reference to a secret that contains the actual result of the generated cloud config.</p>
+<p>SecretRef is a reference to a secret that contains the cloud provider credentials.</p>
 </td>
 </tr>
 <tr>
@@ -3212,7 +3212,7 @@ Kubernetes core/v1.SecretReference
 </em>
 </td>
 <td>
-<p>SecretRef is a reference to a secret that contains the actual result of the generated cloud config.</p>
+<p>SecretRef is a reference to a secret that contains the cloud provider credentials.</p>
 </td>
 </tr>
 <tr>

--- a/example/seed-crds/10-crd-extensions.gardener.cloud_infrastructures.yaml
+++ b/example/seed-crds/10-crd-extensions.gardener.cloud_infrastructures.yaml
@@ -65,7 +65,7 @@ spec:
                 type: string
               secretRef:
                 description: SecretRef is a reference to a secret that contains the
-                  actual result of the generated cloud config.
+                  cloud provider credentials.
                 properties:
                   name:
                     description: name is unique within a namespace to reference a

--- a/pkg/apis/extensions/v1alpha1/types_infrastructure.go
+++ b/pkg/apis/extensions/v1alpha1/types_infrastructure.go
@@ -73,7 +73,7 @@ type InfrastructureSpec struct {
 	DefaultSpec `json:",inline"`
 	// Region is the region of this infrastructure. This field is immutable.
 	Region string `json:"region"`
-	// SecretRef is a reference to a secret that contains the actual result of the generated cloud config.
+	// SecretRef is a reference to a secret that contains the cloud provider credentials.
 	SecretRef corev1.SecretReference `json:"secretRef"`
 	// SSHPublicKey is the public SSH key that should be used with this infrastructure.
 	// +optional

--- a/pkg/operation/botanist/component/extensions/crds/assets/crd-extensions.gardener.cloud_infrastructures.yaml
+++ b/pkg/operation/botanist/component/extensions/crds/assets/crd-extensions.gardener.cloud_infrastructures.yaml
@@ -67,7 +67,7 @@ spec:
                 type: string
               secretRef:
                 description: SecretRef is a reference to a secret that contains the
-                  actual result of the generated cloud config.
+                  cloud provider credentials.
                 properties:
                   name:
                     description: name is unique within a namespace to reference a


### PR DESCRIPTION
**How to categorize this PR?**

/area quality
/kind enhancement

**What this PR does / why we need it**:

This PR fixes a wrong comment in the `InfrastructureSpec` in the extension API. It wrongly stated, that the `secretRef` was an effective cloud-config were it actually represents the `Secret` containing the cloud provider credentials.

**Release note**:
```category doc
NONE
```
