### PR TITLE
Deflake garden controller integration test

### DIFF
--- a/pkg/operation/botanist/component/kubeapiserverexposure/kube_apiserver_service.go
+++ b/pkg/operation/botanist/component/kubeapiserverexposure/kube_apiserver_service.go
@@ -34,6 +34,14 @@ import (
 	"github.com/gardener/gardener/pkg/utils/retry"
 )
 
+var (
+	// DefaultInterval is the default interval for retry operations.
+	DefaultInterval = 5 * time.Second
+	// DefaultTimeout is the default timeout and defines how long Gardener should wait
+	// for a successful reconciliation of the service resource.
+	DefaultTimeout = 10 * time.Minute
+)
+
 // ServiceValues configure the kube-apiserver service.
 type ServiceValues struct {
 	AnnotationsFunc func() map[string]string
@@ -172,10 +180,10 @@ func (s *service) Destroy(ctx context.Context) error {
 }
 
 func (s *service) Wait(ctx context.Context) error {
-	ctx, cancel := context.WithTimeout(ctx, 10*time.Minute)
+	ctx, cancel := context.WithTimeout(ctx, DefaultTimeout)
 	defer cancel()
 
-	return s.waiter.Until(ctx, 5*time.Second, func(ctx context.Context) (done bool, err error) {
+	return s.waiter.Until(ctx, DefaultInterval, func(ctx context.Context) (done bool, err error) {
 		// this ingress can be either the kube-apiserver's service or istio's IGW loadbalancer.
 		svc := &corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/operation/botanist/component/resourcemanager/resource_manager.go
+++ b/pkg/operation/botanist/component/resourcemanager/resource_manager.go
@@ -88,6 +88,10 @@ var (
 	//go:embed assets/crd-resources.gardener.cloud_managedresources.yaml
 	// CRD is the custom resource definition for ManagedResources.
 	CRD string
+
+	// SkipWebhookDeployment is a variable which controls whether the webhook deployment should be skipped.
+	// Exposed for testing.
+	SkipWebhookDeployment bool
 )
 
 func init() {
@@ -1026,6 +1030,10 @@ func (r *resourceManager) emptyPodDisruptionBudget() client.Object {
 }
 
 func (r *resourceManager) ensureMutatingWebhookConfiguration(ctx context.Context) error {
+	if SkipWebhookDeployment {
+		return nil
+	}
+
 	mutatingWebhookConfiguration := r.emptyMutatingWebhookConfiguration()
 
 	secretServerCA, found := r.secretsManager.Get(r.values.SecretNameServerCA)
@@ -1052,6 +1060,10 @@ func (r *resourceManager) emptyMutatingWebhookConfiguration() *admissionregistra
 }
 
 func (r *resourceManager) ensureValidatingWebhookConfiguration(ctx context.Context) error {
+	if SkipWebhookDeployment {
+		return nil
+	}
+
 	validatingWebhookConfiguration := r.emptyValidatingWebhookConfiguration()
 
 	secretServerCA, found := r.secretsManager.Get(r.values.SecretNameServerCA)

--- a/test/integration/operator/garden/garden_suite_test.go
+++ b/test/integration/operator/garden/garden_suite_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 	"time"
 
+	druidv1alpha1 "github.com/gardener/etcd-druid/api/v1alpha1"
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -45,6 +46,7 @@ import (
 	"github.com/gardener/gardener/pkg/operator/features"
 	"github.com/gardener/gardener/pkg/utils/imagevector"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
+	"github.com/gardener/gardener/test/utils/operationannotation"
 )
 
 func TestGarden(t *testing.T) {
@@ -129,6 +131,10 @@ var _ = BeforeSuite(func() {
 	})
 	Expect(err).NotTo(HaveOccurred())
 	mgrClient = mgr.GetClient()
+
+	// The controller waits for the operation annotation to be removed from Etcd resources, so we need to add a
+	// reconciler for it since envtest does not run the responsible controller (etcd-druid).
+	Expect((&operationannotation.Reconciler{ForObject: func() client.Object { return &druidv1alpha1.Etcd{} }}).AddToManager(mgr)).To(Succeed())
 
 	By("Register controller")
 	chartsPath := filepath.Join("..", "..", "..", "..", charts.Path)

--- a/test/integration/operator/garden/garden_test.go
+++ b/test/integration/operator/garden/garden_test.go
@@ -21,7 +21,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
-	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -199,10 +198,6 @@ var _ = Describe("Garden controller tests", func() {
 				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(etcd), etcd)).To(Succeed(), "for "+etcd.Name)
 
 				patch := client.MergeFrom(etcd.DeepCopy())
-				delete(etcd.Annotations, "gardener.cloud/operation")
-				g.Expect(testClient.Patch(ctx, etcd, patch)).To(Succeed(), "for "+etcd.Name)
-
-				patch = client.MergeFrom(etcd.DeepCopy())
 				etcd.Status.ObservedGeneration = &etcd.Generation
 				etcd.Status.Ready = pointer.Bool(true)
 				g.Expect(testClient.Status().Patch(ctx, etcd, patch)).To(Succeed(), "for "+etcd.Name)

--- a/test/integration/operator/garden/garden_test.go
+++ b/test/integration/operator/garden/garden_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/features"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/etcd"
+	"github.com/gardener/gardener/pkg/operation/botanist/component/kubeapiserverexposure"
 	operatorfeatures "github.com/gardener/gardener/pkg/operator/features"
 	secretsutils "github.com/gardener/gardener/pkg/utils/secrets"
 	"github.com/gardener/gardener/pkg/utils/test"
@@ -53,6 +54,8 @@ var _ = Describe("Garden controller tests", func() {
 		DeferCleanup(test.WithVars(
 			&etcd.DefaultInterval, 100*time.Millisecond,
 			&etcd.DefaultTimeout, 500*time.Millisecond,
+			&kubeapiserverexposure.DefaultInterval, 100*time.Millisecond,
+			&kubeapiserverexposure.DefaultTimeout, 500*time.Millisecond,
 		))
 
 		garden = &operatorv1alpha1.Garden{

--- a/test/utils/operationannotation/operationannotation.go
+++ b/test/utils/operationannotation/operationannotation.go
@@ -1,0 +1,84 @@
+// Copyright (c) 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package operationannotation
+
+import (
+	"context"
+	"fmt"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+)
+
+// Reconciler is a reconciler that removes operation annotations from objects.
+// This is useful for integration testing against an envtest control plane, which doesn't run the responsible
+// controller. Hence, if the tested controller must wait for the annotation to be removed, it will be stuck forever.
+type Reconciler struct {
+	Client    client.Client
+	ForObject func() client.Object
+}
+
+// AddToManager adds Reconciler to the given manager.
+func (r *Reconciler) AddToManager(mgr manager.Manager) error {
+	if r.Client == nil {
+		r.Client = mgr.GetClient()
+	}
+
+	return builder.ControllerManagedBy(mgr).
+		Named("operationannotation").
+		For(r.ForObject(), builder.WithPredicates(r.hasOperationAnnotation())).
+		WithOptions(controller.Options{
+			MaxConcurrentReconciles: 5,
+			RecoverPanic:            true,
+		}).
+		Complete(r)
+}
+
+// Reconcile finalizes namespaces as soon as they are marked for deletion.
+func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
+	log := logf.FromContext(ctx)
+
+	obj := r.ForObject()
+	if err := r.Client.Get(ctx, req.NamespacedName, obj); err != nil {
+		if apierrors.IsNotFound(err) {
+			log.V(1).Info("Object is gone, stop reconciling")
+			return reconcile.Result{}, nil
+		}
+		return reconcile.Result{}, fmt.Errorf("error retrieving object from store: %w", err)
+	}
+
+	if obj.GetAnnotations()[v1beta1constants.GardenerOperation] == "" {
+		return reconcile.Result{}, nil
+	}
+
+	log.V(1).Info("Removing operation annotation")
+	patch := client.MergeFrom(obj.DeepCopyObject().(client.Object))
+	delete(obj.GetAnnotations(), v1beta1constants.GardenerOperation)
+	return reconcile.Result{}, r.Client.Patch(ctx, obj, patch)
+}
+
+func (r *Reconciler) hasOperationAnnotation() predicate.Predicate {
+	return predicate.NewPredicateFuncs(func(obj client.Object) bool {
+		return obj.GetAnnotations()[v1beta1constants.GardenerOperation] != ""
+	})
+}

--- a/test/utils/operationannotation/operationannotation.go
+++ b/test/utils/operationannotation/operationannotation.go
@@ -54,7 +54,7 @@ func (r *Reconciler) AddToManager(mgr manager.Manager) error {
 		Complete(r)
 }
 
-// Reconcile finalizes namespaces as soon as they are marked for deletion.
+// Reconcile removes the operation annotation from the object.
 func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
 	log := logf.FromContext(ctx)
 
@@ -65,10 +65,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 			return reconcile.Result{}, nil
 		}
 		return reconcile.Result{}, fmt.Errorf("error retrieving object from store: %w", err)
-	}
-
-	if obj.GetAnnotations()[v1beta1constants.GardenerOperation] == "" {
-		return reconcile.Result{}, nil
 	}
 
 	log.V(1).Info("Removing operation annotation")


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind flake

**What this PR does / why we need it**:

Deflakes one problem in the garden controller integration test: the controller doesn't retry fast enough for the test to succeed.

Co-Authored-By: @rfranzke 

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener/issues/7200

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
