### PR TITLE
Improve docs: Running integration tests

### DIFF
--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -210,10 +210,10 @@ The `test-integration` make rule prepares the environment automatically by downl
 make test-integration
 ```
 
-If you want to run a specific set of integration tests, you can also execute them using `./hack/test-integration.sh` directly instead of using the `test-integration` rule. Prior to execution the `PATH` environment variable needs to be set to also included the `/hack/tools/bin` directory. For example:
+If you want to run a specific set of integration tests, you can also execute them using `./hack/test-integration.sh` directly instead of using the `test-integration` rule. Prior to execution, the `PATH` environment variable needs to be set to also included the tools binary directory. For example:
 
 ```bash
-export PATH=$PATH:$(pwd)/hack/tools/bin
+export PATH="$PATH:$PWD/hack/tools/bin"
 
 ./hack/test-integration.sh ./test/integration/resourcemanager/tokenrequestor
 ```

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -210,14 +210,16 @@ The `test-integration` make rule prepares the environment automatically by downl
 make test-integration
 ```
 
-If you want to run a specific set of integration tests, you can also execute them using `./hack/test-integration.sh` directly instead of using the `test-integration` rule. For example:
+If you want to run a specific set of integration tests, you can also execute them using `./hack/test-integration.sh` directly instead of using the `test-integration` rule. Prior to execution the `PATH` environment variable needs to be set to also included the `/hack/tools/bin` directory. For example:
 
 ```bash
+export PATH=$PATH:$(pwd)/hack/tools/bin
+
 ./hack/test-integration.sh ./test/integration/resourcemanager/tokenrequestor
 ```
 
 The script takes care of preparing the environment for you.
-If you want to execute the test suites directly via `go test` or `ginkgo`, you have to point the `KUBEBUILDER_ASSETS` environment variable to the path that contains the etcd and kube-apiserver binaries. Alternatively, you can install the binaries to `/usr/local/kubebuilder/bin`.
+If you want to execute the test suites directly via `go test` or `ginkgo`, you have to point the `KUBEBUILDER_ASSETS` environment variable to the path that contains the etcd and kube-apiserver binaries. Alternatively, you can install the binaries to `/usr/local/kubebuilder/bin`. Additionally the environment variables from `hack/test-integration.env` should be sourced.
 
 ### Debugging Integration Tests
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area documentation
/area dev-productivity
/area testing
/kind enhancement

**What this PR does / why we need it**:
Improvment for "running integration tests" testing docs.
Instructions for "If you want to run a specific set of integration tests..." were not complete. This PR adds the missing instruction.


**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
