### PR TITLE
Reintroduce seed zones admission checks

### DIFF
--- a/plugin/pkg/managedseed/validator/admission.go
+++ b/plugin/pkg/managedseed/validator/admission.go
@@ -25,6 +25,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/apiserver/pkg/admission"
 	kubeinformers "k8s.io/client-go/informers"
@@ -35,6 +36,7 @@ import (
 	gardencorehelper "github.com/gardener/gardener/pkg/apis/core/helper"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/apis/seedmanagement"
+	seedmanagementhelper "github.com/gardener/gardener/pkg/apis/seedmanagement/helper"
 	admissioninitializer "github.com/gardener/gardener/pkg/apiserver/admission/initializer"
 	gardencoreclientset "github.com/gardener/gardener/pkg/client/core/clientset/internalversion"
 	gardencoreinformers "github.com/gardener/gardener/pkg/client/core/informers/internalversion"
@@ -45,6 +47,7 @@ import (
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/plugin/pkg/utils"
+	admissionutils "github.com/gardener/gardener/plugin/pkg/utils"
 )
 
 const (
@@ -196,7 +199,6 @@ func (v *ManagedSeed) Admit(ctx context.Context, a admission.Attributes, o admis
 		return apierrors.NewInvalid(gk, managedSeed.Name, append(allErrs, field.Required(shootNamePath, "shoot name is required")))
 	}
 
-	// Get shoot
 	shoot, err := v.getShoot(ctx, managedSeed.Namespace, managedSeed.Spec.Shoot.Name)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
@@ -205,7 +207,7 @@ func (v *ManagedSeed) Admit(ctx context.Context, a admission.Attributes, o admis
 		return apierrors.NewInternalError(fmt.Errorf("could not get shoot %s/%s: %v", managedSeed.Namespace, managedSeed.Spec.Shoot.Name, err))
 	}
 
-	// Ensure shoot can be registered as seed (specifies a domain)
+	// Ensure shoot can be registered as seed
 	if shoot.Spec.DNS == nil || shoot.Spec.DNS.Domain == nil || *shoot.Spec.DNS.Domain == "" {
 		return apierrors.NewInvalid(gk, managedSeed.Name, append(allErrs, field.Invalid(shootNamePath, managedSeed.Spec.Shoot.Name, fmt.Sprintf("shoot %s does not specify a domain", kubernetesutils.ObjectName(shoot)))))
 	}
@@ -238,7 +240,28 @@ func (v *ManagedSeed) Admit(ctx context.Context, a admission.Attributes, o admis
 		return apierrors.NewInvalid(gk, managedSeed.Name, allErrs)
 	}
 
+	if a.GetOperation() == admission.Update {
+		oldManagedSeed, ok := a.GetOldObject().(*seedmanagement.ManagedSeed)
+		if !ok {
+			return apierrors.NewInternalError(errors.New("could not covert old resource into ManagedSeed object"))
+		}
+		return v.validateManagedSeedUpdate(oldManagedSeed, managedSeed)
+	}
+
 	return nil
+}
+
+func (v *ManagedSeed) validateManagedSeedUpdate(oldManagedSeed, newManagedSeed *seedmanagement.ManagedSeed) error {
+	oldSeedSpec, err := seedmanagementhelper.ExtractSeedSpec(oldManagedSeed)
+	if err != nil {
+		return err
+	}
+	newSeedSpec, err := seedmanagementhelper.ExtractSeedSpec(newManagedSeed)
+	if err != nil {
+		return err
+	}
+
+	return admissionutils.ValidateZoneRemovalFromSeeds(oldSeedSpec, newSeedSpec, newManagedSeed.Name, v.shootLister, "ManagedSeed")
 }
 
 func (v *ManagedSeed) admitGardenlet(gardenlet *seedmanagement.Gardenlet, shoot *gardencore.Shoot, fldPath *field.Path) (field.ErrorList, error) {
@@ -339,6 +362,8 @@ func (v *ManagedSeed) admitSeedSpec(spec *gardencore.SeedSpec, shoot *gardencore
 	}
 	if shootZones := helper.GetAllZonesFromShoot(shoot); len(spec.Provider.Zones) == 0 && shootZones.Len() > 0 {
 		spec.Provider.Zones = shootZones.List()
+	} else if len(spec.Provider.Zones) > 0 && !sets.NewString(spec.Provider.Zones...).Equal(shootZones) {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("provider", "zones"), spec.Provider.Zones, fmt.Sprintf("seed provider zones must be equal to shoot zones (%v)", shootZones.List())))
 	}
 
 	// At this point the Shoot VPA should be already enabled (validated earlier). If the Seed does not specify VPA settings,

--- a/plugin/pkg/managedseed/validator/admission_test.go
+++ b/plugin/pkg/managedseed/validator/admission_test.go
@@ -16,6 +16,7 @@ package validator_test
 
 import (
 	"context"
+	"net/http"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -471,6 +472,10 @@ var _ = Describe("ManagedSeed", func() {
 					})),
 					PointTo(MatchFields(IgnoreExtras, Fields{
 						"Type":  Equal(field.ErrorTypeInvalid),
+						"Field": Equal("spec.gardenlet.config.seedConfig.spec.provider.zones"),
+					})),
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":  Equal(field.ErrorTypeInvalid),
 						"Field": Equal("spec.gardenlet.config.seedConfig.spec.settings.verticalPodAutoscaler.enabled"),
 					})),
 				))
@@ -511,6 +516,62 @@ var _ = Describe("ManagedSeed", func() {
 						"Field": Equal("spec.gardenlet.config.seedConfig.spec.ingress.domain"),
 					})),
 				))
+			})
+		})
+
+		Context("ManagedSeed Update", func() {
+			var (
+				ctx                            = context.Background()
+				oldManagedSeed, newManagedSeed *seedmanagement.ManagedSeed
+			)
+
+			BeforeEach(func() {
+				oldManagedSeed = managedSeed.DeepCopy()
+				newManagedSeed = managedSeed.DeepCopy()
+
+				gardenletConfig := &gardenletv1alpha1.GardenletConfiguration{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: gardenletv1alpha1.SchemeGroupVersion.String(),
+						Kind:       "GardenletConfiguration",
+					},
+					SeedConfig: &gardenletv1alpha1.SeedConfig{
+						SeedTemplate: gardencorev1beta1.SeedTemplate{
+							Spec: gardencorev1beta1.SeedSpec{
+								Provider: gardencorev1beta1.SeedProvider{
+									Zones: []string{zone1, zone2},
+								},
+							},
+						},
+					},
+				}
+				oldManagedSeed.Spec.Gardenlet = &seedmanagement.Gardenlet{Config: gardenletConfig}
+
+				shoot.Spec.Provider.Workers[0].Zones = []string{zone2}
+				newGardenletConfig := gardenletConfig.DeepCopy()
+				newGardenletConfig.SeedConfig.Spec.Provider.Zones = shoot.Spec.Provider.Workers[0].Zones
+				newManagedSeed.Spec.Gardenlet = &seedmanagement.Gardenlet{Config: newGardenletConfig}
+			})
+
+			It("should allow zone removal there are no shoots", func() {
+				coreClient.AddReactor("get", "shoots", func(action testing.Action) (bool, runtime.Object, error) {
+					return true, shoot, nil
+				})
+				Expect(admissionHandler.Admit(ctx, getManagedSeedUpdateAttributes(oldManagedSeed, newManagedSeed), nil)).To(Succeed())
+			})
+
+			It("should forbid zone removal there are shoots", func() {
+				coreClient.AddReactor("get", "shoots", func(action testing.Action) (bool, runtime.Object, error) {
+					return true, shoot, nil
+				})
+
+				shoot := &core.Shoot{Spec: core.ShootSpec{SeedName: &newManagedSeed.Name}}
+				Expect(coreInformerFactory.Core().InternalVersion().Shoots().Informer().GetStore().Add(shoot)).To(Succeed())
+
+				err := admissionHandler.Admit(ctx, getManagedSeedUpdateAttributes(oldManagedSeed, newManagedSeed), nil)
+				statusError, ok := err.(*apierrors.StatusError)
+				Expect(ok).To(BeTrue())
+				Expect(statusError.Status().Code).To(Equal(int32(http.StatusForbidden)))
+				Expect(statusError.Status().Status).To(Equal(metav1.StatusFailure))
 			})
 		})
 	})

--- a/plugin/pkg/seed/validator/admission_test.go
+++ b/plugin/pkg/seed/validator/admission_test.go
@@ -78,6 +78,31 @@ var _ = Describe("validator", func() {
 			admissionHandler.SetInternalCoreInformerFactory(coreInformerFactory)
 		})
 
+		Context("Seed Update", func() {
+			var oldSeed, newSeed *core.Seed
+
+			BeforeEach(func() {
+				oldSeed = seedBase.DeepCopy()
+				newSeed = seedBase.DeepCopy()
+
+				oldSeed.Spec.Provider.Zones = []string{"1", "2"}
+				newSeed.Spec.Provider.Zones = []string{"2"}
+			})
+
+			It("should allow zone removal there are no shoots", func() {
+				attrs := admission.NewAttributesRecord(newSeed, oldSeed, core.Kind("Seed").WithVersion("version"), "", seed.Name, core.Resource("seeds").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, nil)
+
+				Expect(admissionHandler.Validate(context.TODO(), attrs, nil)).To(Succeed())
+			})
+
+			It("should forbid zone removal when there are shoots", func() {
+				Expect(coreInformerFactory.Core().InternalVersion().Shoots().Informer().GetStore().Add(&shoot)).To(Succeed())
+				attrs := admission.NewAttributesRecord(newSeed, oldSeed, core.Kind("Seed").WithVersion("version"), "", seed.Name, core.Resource("seeds").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, nil)
+
+				Expect(admissionHandler.Validate(context.TODO(), attrs, nil)).To(BeForbiddenError())
+			})
+		})
+
 		// The verification of protection is independent of the Cloud Provider (being checked before).
 		Context("Seed deletion", func() {
 			BeforeEach(func() {

--- a/plugin/pkg/utils/miscellaneous.go
+++ b/plugin/pkg/utils/miscellaneous.go
@@ -20,7 +20,9 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apiserver/pkg/admission"
+	"k8s.io/utils/pointer"
 
 	"github.com/gardener/gardener/pkg/apis/core"
 	gardencorelisters "github.com/gardener/gardener/pkg/client/core/listers/core/internalversion"
@@ -72,4 +74,23 @@ func NewAttributesWithName(a admission.Attributes, name string) admission.Attrib
 		a.GetOperationOptions(),
 		a.IsDryRun(),
 		a.GetUserInfo())
+}
+
+// ValidateZoneRemovalFromSeeds returns an error when zones are removed from the old seed while it is still in use by
+// shoots.
+func ValidateZoneRemovalFromSeeds(oldSeedSpec, newSeedSpec *core.SeedSpec, seedName string, shootLister gardencorelisters.ShootLister, kind string) error {
+	if removedZones := sets.NewString(oldSeedSpec.Provider.Zones...).Difference(sets.NewString(newSeedSpec.Provider.Zones...)); removedZones.Len() > 0 {
+		shootList, err := GetFilteredShootList(shootLister, func(shoot *core.Shoot) bool {
+			return pointer.StringDeref(shoot.Spec.SeedName, "") == seedName
+		})
+		if err != nil {
+			return err
+		}
+
+		if len(shootList) > 0 {
+			return apierrors.NewForbidden(core.Resource(kind), seedName, fmt.Errorf("cannot remove zones %v from %s %s as there are %d Shoots scheduled to this Seed", removedZones.List(), kind, seedName, len(shootList)))
+		}
+	}
+
+	return nil
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area high-availability
/kind api-change
/kind technical-debt

**What this PR does / why we need it**:
This PR reintroduces admission checks for seed zones, removed by https://github.com/gardener/gardener/commit/8d28452e7f718d0041fbe82eb83543e3a87ea8ad. In the meantime, the Azure provider extension can deal with a zone mismatch on its own, see https://github.com/gardener/gardener-extension-provider-azure/pull/602.
 
**Which issue(s) this PR fixes**:
Part of #6529

**Special notes for your reviewer**:
/cc @kon-angelo

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
`Seed` and `ManagedSeed` API validation has been enhanced by the following checks:
(a) `ManagedSeed`s can only use the very same zone(s) (`managedSeed.spec.gardenlet.config.seedConfig.spec.provider.zones`) that are available in the registered `Shoot` (`shoot.spec.provider.workers[].zones`).
(b) `seed.spec.provider.zones` can only be removed if no shoots are scheduled to affected seed.
These restrictions were removed in Gardener `v1.60` to compensate a zone mismatch issues in Azure that is in the meantime fixed by the Azure provider extension [v1.33](https://github.com/gardener/gardener-extension-provider-azure/releases/tag/v1.33.0).
⚠️ Before upgrading to this Gardener version, please make sure the zone configuration of your seeds matches the ones from registered shoots, i.e. `seed.spec.provider.zones == shoot.spec.provider.workers[].zones`.
```
