### PR TITLE
Fix bug in `seed-lifecycle` controller changing conditions of `Shoot` to `Unknown` too fast

### DIFF
--- a/pkg/controllermanager/controller/seed/lifecycle/reconciler.go
+++ b/pkg/controllermanager/controller/seed/lifecycle/reconciler.go
@@ -102,6 +102,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		if err := r.Client.Status().Update(ctx, seed); err != nil {
 			return reconcile.Result{}, err
 		}
+		conditionGardenletReady = &newCondition
 	}
 
 	// If the gardenlet's client certificate is expired and the seed belongs to a `ManagedSeed` then we reconcile it in

--- a/test/integration/controllermanager/seed/lifecycle/lifecycle_test.go
+++ b/test/integration/controllermanager/seed/lifecycle/lifecycle_test.go
@@ -161,7 +161,7 @@ var _ = Describe("Seed Lifecycle controller tests", func() {
 			seed.Status.Conditions = []gardencorev1beta1.Condition{{
 				Type:               gardencorev1beta1.SeedGardenletReady,
 				Status:             gardencorev1beta1.ConditionTrue,
-				LastTransitionTime: metav1.Time{Time: fakeClock.Now()},
+				LastTransitionTime: metav1.Time{Time: fakeClock.Now().Add(-24 * time.Hour)},
 			}}
 			Expect(testClient.Status().Patch(ctx, seed, patch)).To(Succeed())
 		})


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity
/kind bug

**What this PR does / why we need it**:
This PR fixes a bug in the `seed-lifecycle` controller of `gardener-controller-manager`. When the `gardenlet` is no longer posting its heartbeat, the controller sets the status of the `GardenletReady` condition to `Unknown` after the configured `monitorPeriod` has passed: https://github.com/gardener/gardener/blob/f8e72722e0cbda37fb65eb70cfd21950211b1ea9/pkg/controllermanager/controller/seed/lifecycle/reconciler.go#L73-L105

Later, after the `shootMonitorPeriod` has passed as well and the `gardenlet` is still not available, the controller should also set the status of all conditions of `Shoot`s to `Unknown`: https://github.com/gardener/gardener/blob/f8e72722e0cbda37fb65eb70cfd21950211b1ea9/pkg/controllermanager/controller/seed/lifecycle/reconciler.go#L126-L132

However, this code is buggy since the `conditionGardenletReady.LastTransitionTime` might not be up-to-date after https://github.com/gardener/gardener/blob/f8e72722e0cbda37fb65eb70cfd21950211b1ea9/pkg/controllermanager/controller/seed/lifecycle/reconciler.go#L100-L105

This PR fixes this. There are two commits - the first commit makes the existing integration test fail to discover the bug, the second commit fixes it by updating `conditionGardenletReady`.

**Special notes for your reviewer**:
FYI @vlerenc 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
A bug has been fixed which caused the conditions of `Shoot`s to be set to `Unknown` too fast in case the responsible `gardenlet` is no longer posting its heartbeat.
```
