### PR TITLE
Build dedicated Schemes in tests

### DIFF
--- a/pkg/client/kubernetes/types.go
+++ b/pkg/client/kubernetes/types.go
@@ -91,8 +91,8 @@ func DefaultCreateOptions() metav1.CreateOptions { return metav1.CreateOptions{}
 // DefaultUpdateOptions are the default options for UPDATE requests.
 func DefaultUpdateOptions() metav1.UpdateOptions { return metav1.UpdateOptions{} }
 
-func init() {
-	gardenSchemeBuilder := runtime.NewSchemeBuilder(
+var (
+	gardenSchemeBuilder = runtime.NewSchemeBuilder(
 		kubernetesscheme.AddToScheme,
 		gardencoreinstall.AddToScheme,
 		seedmanagementinstall.AddToScheme,
@@ -100,9 +100,8 @@ func init() {
 		operationsinstall.AddToScheme,
 		apiregistrationscheme.AddToScheme,
 	)
-	utilruntime.Must(gardenSchemeBuilder.AddToScheme(GardenScheme))
 
-	seedSchemeBuilder := runtime.NewSchemeBuilder(
+	seedSchemeBuilder = runtime.NewSchemeBuilder(
 		kubernetesscheme.AddToScheme,
 		extensionsv1alpha1.AddToScheme,
 		resourcesv1alpha1.AddToScheme,
@@ -114,9 +113,8 @@ func init() {
 		istionetworkingv1beta1.AddToScheme,
 		istionetworkingv1alpha3.AddToScheme,
 	)
-	utilruntime.Must(seedSchemeBuilder.AddToScheme(SeedScheme))
 
-	shootSchemeBuilder := runtime.NewSchemeBuilder(
+	shootSchemeBuilder = runtime.NewSchemeBuilder(
 		kubernetesscheme.AddToScheme,
 		apiextensionsscheme.AddToScheme,
 		apiregistrationscheme.AddToScheme,
@@ -124,7 +122,21 @@ func init() {
 		metricsv1beta1.AddToScheme,
 		volumesnapshotv1beta1.AddToScheme,
 	)
-	utilruntime.Must(shootSchemeBuilder.AddToScheme(ShootScheme))
+)
+
+var (
+	// AddGardenSchemeToScheme adds all object kinds used in the Garden cluster into the given scheme.
+	AddGardenSchemeToScheme = gardenSchemeBuilder.AddToScheme
+	// AddSeedSchemeToScheme adds all object kinds used in the Seed cluster into the given scheme.
+	AddSeedSchemeToScheme = seedSchemeBuilder.AddToScheme
+	// AddShootSchemeToScheme adds all object kinds used in the Shoot cluster into the given scheme.
+	AddShootSchemeToScheme = shootSchemeBuilder.AddToScheme
+)
+
+func init() {
+	utilruntime.Must(AddGardenSchemeToScheme(GardenScheme))
+	utilruntime.Must(AddSeedSchemeToScheme(SeedScheme))
+	utilruntime.Must(AddShootSchemeToScheme(ShootScheme))
 }
 
 // MergeFunc determines how oldOj is merged into new oldObj.

--- a/test/integration/gardenlet/backupbucket/backupbucket_suite_test.go
+++ b/test/integration/gardenlet/backupbucket/backupbucket_suite_test.go
@@ -27,6 +27,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/util/workqueue"
@@ -103,9 +104,14 @@ var _ = BeforeSuite(func() {
 		Expect(testEnv.Stop()).To(Succeed())
 	})
 
+	testSchemeBuilder := runtime.NewSchemeBuilder(
+		kubernetes.AddGardenSchemeToScheme,
+		extensionsv1alpha1.AddToScheme,
+	)
+	testScheme := runtime.NewScheme()
+	Expect(testSchemeBuilder.AddToScheme(testScheme)).To(Succeed())
+
 	By("Create test client")
-	testScheme := kubernetes.GardenScheme
-	Expect(extensionsv1alpha1.AddToScheme(testScheme)).To(Succeed())
 	testClient, err = client.New(restConfig, client.Options{Scheme: testScheme})
 	Expect(err).NotTo(HaveOccurred())
 

--- a/test/integration/gardenlet/backupentry/backupentry/backupentry_suite_test.go
+++ b/test/integration/gardenlet/backupentry/backupentry/backupentry_suite_test.go
@@ -26,6 +26,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/util/workqueue"
@@ -107,9 +108,14 @@ var _ = BeforeSuite(func() {
 		Expect(testEnv.Stop()).To(Succeed())
 	})
 
+	testSchemeBuilder := runtime.NewSchemeBuilder(
+		kubernetes.AddGardenSchemeToScheme,
+		extensionsv1alpha1.AddToScheme,
+	)
+	testScheme := runtime.NewScheme()
+	Expect(testSchemeBuilder.AddToScheme(testScheme)).To(Succeed())
+
 	By("Create test client")
-	testScheme := kubernetes.GardenScheme
-	Expect(extensionsv1alpha1.AddToScheme(testScheme)).To(Succeed())
 	testClient, err = client.New(restConfig, client.Options{Scheme: testScheme})
 	Expect(err).NotTo(HaveOccurred())
 

--- a/test/integration/gardenlet/backupentry/migration/migration_suite_test.go
+++ b/test/integration/gardenlet/backupentry/migration/migration_suite_test.go
@@ -26,6 +26,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/client-go/rest"
 	testclock "k8s.io/utils/clock/testing"
@@ -102,9 +103,14 @@ var _ = BeforeSuite(func() {
 		Expect(testEnv.Stop()).To(Succeed())
 	})
 
+	testSchemeBuilder := runtime.NewSchemeBuilder(
+		kubernetes.AddGardenSchemeToScheme,
+		extensionsv1alpha1.AddToScheme,
+	)
+	testScheme := runtime.NewScheme()
+	Expect(testSchemeBuilder.AddToScheme(testScheme)).To(Succeed())
+
 	By("Create test client")
-	testScheme := kubernetes.GardenScheme
-	Expect(extensionsv1alpha1.AddToScheme(testScheme)).To(Succeed())
 	testClient, err = client.New(restConfig, client.Options{Scheme: testScheme})
 	Expect(err).NotTo(HaveOccurred())
 

--- a/test/integration/gardenlet/bastion/bastion_suite_test.go
+++ b/test/integration/gardenlet/bastion/bastion_suite_test.go
@@ -26,6 +26,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/util/workqueue"
 	testclock "k8s.io/utils/clock/testing"
@@ -107,9 +108,13 @@ var _ = BeforeSuite(func() {
 		Expect(testEnv.Stop()).To(Succeed())
 	})
 
-	testScheme := kubernetes.GardenScheme
-	Expect(resourcesv1alpha1.AddToScheme(testScheme)).To(Succeed())
-	Expect(extensionsv1alpha1.AddToScheme(testScheme)).To(Succeed())
+	testSchemeBuilder := runtime.NewSchemeBuilder(
+		kubernetes.AddGardenSchemeToScheme,
+		extensionsv1alpha1.AddToScheme,
+		resourcesv1alpha1.AddToScheme,
+	)
+	testScheme := runtime.NewScheme()
+	Expect(testSchemeBuilder.AddToScheme(testScheme)).To(Succeed())
 
 	By("Create test client")
 	testClient, err = client.New(restConfig, client.Options{Scheme: testScheme})

--- a/test/integration/gardenlet/controllerinstallation/care/care_suite_test.go
+++ b/test/integration/gardenlet/controllerinstallation/care/care_suite_test.go
@@ -26,6 +26,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
@@ -92,11 +93,15 @@ var _ = BeforeSuite(func() {
 		Expect(testEnv.Stop()).To(Succeed())
 	})
 
-	scheme := kubernetes.GardenScheme
-	Expect(resourcesv1alpha1.AddToScheme(scheme)).To(Succeed())
+	testSchemeBuilder := runtime.NewSchemeBuilder(
+		kubernetes.AddGardenSchemeToScheme,
+		resourcesv1alpha1.AddToScheme,
+	)
+	testScheme := runtime.NewScheme()
+	Expect(testSchemeBuilder.AddToScheme(testScheme)).To(Succeed())
 
 	By("Create test client")
-	testClient, err = client.New(restConfig, client.Options{Scheme: scheme})
+	testClient, err = client.New(restConfig, client.Options{Scheme: testScheme})
 	Expect(err).NotTo(HaveOccurred())
 
 	By("Create garden namespace for test")
@@ -117,7 +122,7 @@ var _ = BeforeSuite(func() {
 
 	By("Setup manager")
 	mgr, err := manager.New(restConfig, manager.Options{
-		Scheme:             scheme,
+		Scheme:             testScheme,
 		MetricsBindAddress: "0",
 		Namespace:          gardenNamespace.Name,
 		NewCache: cache.BuilderWithOptions(cache.Options{

--- a/test/integration/gardenlet/controllerinstallation/controllerinstallation/controllerinstallation_suite_test.go
+++ b/test/integration/gardenlet/controllerinstallation/controllerinstallation/controllerinstallation_suite_test.go
@@ -26,6 +26,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/client-go/rest"
 	"k8s.io/utils/pointer"
@@ -108,9 +109,14 @@ var _ = BeforeSuite(func() {
 		Expect(testEnv.Stop()).To(Succeed())
 	})
 
+	testSchemeBuilder := runtime.NewSchemeBuilder(
+		kubernetes.AddGardenSchemeToScheme,
+		resourcesv1alpha1.AddToScheme,
+	)
+	testScheme := runtime.NewScheme()
+	Expect(testSchemeBuilder.AddToScheme(testScheme)).To(Succeed())
+
 	By("Create test client")
-	testScheme := kubernetes.GardenScheme
-	Expect(resourcesv1alpha1.AddToScheme(testScheme)).To(Succeed())
 	testClient, err = client.New(restConfig, client.Options{Scheme: testScheme})
 	Expect(err).NotTo(HaveOccurred())
 

--- a/test/integration/gardenlet/managedseed/managedseed_suite_test.go
+++ b/test/integration/gardenlet/managedseed/managedseed_suite_test.go
@@ -26,6 +26,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/client-go/rest"
 	"k8s.io/utils/pointer"
@@ -107,11 +108,15 @@ var _ = BeforeSuite(func() {
 		Expect(testEnv.Stop()).To(Succeed())
 	})
 
-	scheme := kubernetes.GardenScheme
-	Expect(resourcesv1alpha1.AddToScheme(scheme)).To(Succeed())
+	testSchemeBuilder := runtime.NewSchemeBuilder(
+		kubernetes.AddGardenSchemeToScheme,
+		resourcesv1alpha1.AddToScheme,
+	)
+	testScheme := runtime.NewScheme()
+	Expect(testSchemeBuilder.AddToScheme(testScheme)).To(Succeed())
 
 	By("Create test client")
-	testClient, err = client.New(restConfig, client.Options{Scheme: scheme})
+	testClient, err = client.New(restConfig, client.Options{Scheme: testScheme})
 	Expect(err).NotTo(HaveOccurred())
 
 	testRunID = utils.ComputeSHA256Hex([]byte(uuid.NewUUID()))[:8]
@@ -162,7 +167,7 @@ var _ = BeforeSuite(func() {
 
 	By("Setup manager")
 	mgr, err := manager.New(restConfig, manager.Options{
-		Scheme:             scheme,
+		Scheme:             testScheme,
 		MetricsBindAddress: "0",
 		Namespace:          gardenNamespaceGarden.Name,
 		NewCache: cache.BuilderWithOptions(cache.Options{

--- a/test/integration/gardenlet/shootstate/secret/secret_suite_test.go
+++ b/test/integration/gardenlet/shootstate/secret/secret_suite_test.go
@@ -25,6 +25,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/client-go/rest"
 	"k8s.io/utils/pointer"
@@ -93,8 +94,12 @@ var _ = BeforeSuite(func() {
 		Expect(testEnv.Stop()).To(Succeed())
 	})
 
-	testScheme := kubernetes.GardenScheme
-	Expect(extensionsv1alpha1.AddToScheme(testScheme)).To(Succeed())
+	testSchemeBuilder := runtime.NewSchemeBuilder(
+		kubernetes.AddGardenSchemeToScheme,
+		extensionsv1alpha1.AddToScheme,
+	)
+	testScheme := runtime.NewScheme()
+	Expect(testSchemeBuilder.AddToScheme(testScheme)).To(Succeed())
 
 	By("Create test client")
 	testClient, err = client.New(restConfig, client.Options{Scheme: testScheme})


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind bug

**What this PR does / why we need it**:
Previously while Adding other clientsets to the scheme, we were mutating the global scheme variable, for eg: `GardenScheme`, `SeedScheme` etc.
This PR exposes the `AddToScheme` functions of `GardenScheme`,`SeedScheme` and `ShootScheme` and builds a dedicated test scheme in the tests.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
~Depends on https://github.com/gardener/gardener/pull/7248, hence in draft.~
/cc @timebertt 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
