### PR TITLE
Fix `ssh-keypair` secrets deletion when `SSHAccess` is disabled

### DIFF
--- a/pkg/operation/botanist/secrets.go
+++ b/pkg/operation/botanist/secrets.go
@@ -326,7 +326,7 @@ func (b *Botanist) deleteShootCredentialFromGarden(ctx context.Context, nameSuff
 		})
 	}
 
-	return kubernetesutils.DeleteObjects(ctx, b.ShootClientSet.Client(), secretsToDelete...)
+	return kubernetesutils.DeleteObjects(ctx, b.GardenClient, secretsToDelete...)
 }
 
 func (b *Botanist) reconcileWildcardIngressCertificate(ctx context.Context) error {

--- a/pkg/operation/botanist/secrets_test.go
+++ b/pkg/operation/botanist/secrets_test.go
@@ -167,8 +167,8 @@ var _ = Describe("Secrets", func() {
 			})
 
 			It("should delete ssh-keypair secrets when ssh access is set to false in workers settings", func() {
-				Expect(seedClient.Create(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: shootName + ".ssh-keypair", Namespace: seedNamespace}})).To(Succeed())
-				Expect(seedClient.Create(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: shootName + ".ssh-keypair.old", Namespace: seedNamespace}})).To(Succeed())
+				Expect(gardenClient.Create(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: shootName + ".ssh-keypair", Namespace: gardenNamespace}})).To(Succeed())
+				Expect(gardenClient.Create(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: shootName + ".ssh-keypair.old", Namespace: gardenNamespace}})).To(Succeed())
 
 				shoot := botanist.Shoot.GetInfo()
 				shoot.Spec = gardencorev1beta1.ShootSpec{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind bug

**What this PR does / why we need it**:
This PR fixes the unit test for `ssh-keypair` secrets deletion when `SSHAccess` is disabled for worker nodes. After fixing the test, it started failing since the secrets where not being deleted from the garden namespace. This PR fixes that bug as well.
There are two commits - the first commit makes the existing unit test fail to discover the bug, the second commit fixes it by updating `deleteShootCredentialFromGarden`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Please cherry-pick this PR on v1.63

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
A bug has been fixed which prevented the `ssh-keypair` secrets from being deleted when `SSHAccess` for worker nodes is disabled.
```
