### PR TITLE
Enhance `gardener-resource-manager`'s `NetworkPolicy` controller to allow simple "ingress-from-world" policy management

### DIFF
--- a/pkg/apis/resources/v1alpha1/types.go
+++ b/pkg/apis/resources/v1alpha1/types.go
@@ -155,6 +155,9 @@ const (
 	// scenarios where the target service can exist n-times in multiple namespaces and a component needs to talk to all
 	// of them but doesn't know the namespace names upfront.
 	NetworkingPodLabelSelectorNamespaceAlias = "networking.resources.gardener.cloud/pod-label-selector-namespace-alias"
+	// NetworkingFromWorldToPorts is a constant for an annotation on a Service which contains a list of ports to which
+	// ingress traffic from everywhere shall be allowed.
+	NetworkingFromWorldToPorts = "networking.resources.gardener.cloud/from-world-to-ports"
 	// NetworkingServiceName is a constant for a label on a NetworkPolicy which contains the name of the Service is has
 	// been created for.
 	NetworkingServiceName = "networking.resources.gardener.cloud/service-name"

--- a/pkg/resourcemanager/controller/networkpolicy/add.go
+++ b/pkg/resourcemanager/controller/networkpolicy/add.go
@@ -34,6 +34,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
+	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	"github.com/gardener/gardener/pkg/controllerutils/mapper"
 )
 
@@ -88,7 +89,7 @@ func (r *Reconciler) AddToManager(mgr manager.Manager, targetCluster cluster.Clu
 }
 
 // ServicePredicate returns a predicate which filters UPDATE events on services such that only updates to the deletion
-// timestamp, the port list or the pod label selector are relevant.
+// timestamp, the port list, the pod label selector, or well-known annotations are relevant.
 func (r *Reconciler) ServicePredicate() predicate.Predicate {
 	return predicate.Funcs{
 		UpdateFunc: func(e event.UpdateEvent) bool {
@@ -104,7 +105,10 @@ func (r *Reconciler) ServicePredicate() predicate.Predicate {
 
 			return (oldService.DeletionTimestamp == nil && service.DeletionTimestamp != nil) ||
 				!apiequality.Semantic.DeepEqual(service.Spec.Selector, oldService.Spec.Selector) ||
-				!apiequality.Semantic.DeepEqual(service.Spec.Ports, oldService.Spec.Ports)
+				!apiequality.Semantic.DeepEqual(service.Spec.Ports, oldService.Spec.Ports) ||
+				oldService.Annotations[resourcesv1alpha1.NetworkingPodLabelSelectorNamespaceAlias] != service.Annotations[resourcesv1alpha1.NetworkingPodLabelSelectorNamespaceAlias] ||
+				oldService.Annotations[resourcesv1alpha1.NetworkingNamespaceSelectors] != service.Annotations[resourcesv1alpha1.NetworkingNamespaceSelectors] ||
+				oldService.Annotations[resourcesv1alpha1.NetworkingFromWorldToPorts] != service.Annotations[resourcesv1alpha1.NetworkingFromWorldToPorts]
 		},
 	}
 }

--- a/pkg/resourcemanager/controller/networkpolicy/add_test.go
+++ b/pkg/resourcemanager/controller/networkpolicy/add_test.go
@@ -98,6 +98,27 @@ var _ = Describe("Add", func() {
 
 				Expect(p.Update(event.UpdateEvent{ObjectOld: oldService, ObjectNew: service})).To(BeTrue())
 			})
+
+			It("should return true because the namespace-selectors annotation was changed", func() {
+				oldService := service.DeepCopy()
+				service.Annotations = map[string]string{"networking.resources.gardener.cloud/namespace-selectors": "foo"}
+
+				Expect(p.Update(event.UpdateEvent{ObjectOld: oldService, ObjectNew: service})).To(BeTrue())
+			})
+
+			It("should return true because the pod-label-selector-namespace-alias annotation was changed", func() {
+				oldService := service.DeepCopy()
+				service.Annotations = map[string]string{"networking.resources.gardener.cloud/pod-label-selector-namespace-alias": "foo"}
+
+				Expect(p.Update(event.UpdateEvent{ObjectOld: oldService, ObjectNew: service})).To(BeTrue())
+			})
+
+			It("should return true because the from-world-to-ports annotation was changed", func() {
+				oldService := service.DeepCopy()
+				service.Annotations = map[string]string{"networking.resources.gardener.cloud/from-world-to-ports": "foo"}
+
+				Expect(p.Update(event.UpdateEvent{ObjectOld: oldService, ObjectNew: service})).To(BeTrue())
+			})
 		})
 
 		Describe("#Delete", func() {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking dev-productivity
/kind enhancement

**What this PR does / why we need it**:
This PR extends the `NetworkPolicy` controller in `gardener-resource-manager` (introduced with #7392) such that it can reconcile `NetworkPolicy`s allowing ingress traffic from everywhere in case a `Service` was annotated with `networking.resources.gardener.cloud/from-world-to-ports`. Please find more information in the documentation.

This can be used to easily allow ingress traffic from everywhere for the `kube-apiserver` of shoots, `istio-ingressgateway`s, or `nginx-ingress`.

**Which issue(s) this PR fixes**:
Part of #7352

**Special notes for your reviewer**:
/cc @ScheererJ 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
