### PR TITLE
Fix bug where `sshd-ensurer` kills processes other than `sshd` when `SSHAccess` for worker nodes is disabled

### DIFF
--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/sshdensurer/component_test.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/sshdensurer/component_test.go
@@ -149,6 +149,6 @@ fi
 
 # Disabling the sshd service does not terminate already established connections
 # Kill all currently established ssh connections
-pkill sshd || true
+pkill -x sshd || true
 `
 )

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/sshdensurer/templates/scripts/disable-sshd.tpl.sh
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/sshdensurer/templates/scripts/disable-sshd.tpl.sh
@@ -13,4 +13,4 @@ fi
 
 # Disabling the sshd service does not terminate already established connections
 # Kill all currently established ssh connections
-pkill sshd || true
+pkill -x sshd || true


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/area compliance
/kind bug

**What this PR does / why we need it**:
Fixes a bug where `sshd-ensurer` incorrectly kills processes other than `sshd` when `SSHAccess` for worker nodes is disabled. The `pkill` command currently matches processes that have substring `sshd`. Using the `-x` flag it will match only `sshd` processes.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
cc @rfranzke 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
A bug in the `sshd-ensurer` script running on all shoot worker nodes has been fixed which was causing it to also kill processes other than `sshd` when `SSHAccess` for worker nodes is disabled.
```
