### PR TITLE
Configure shoot worker pool labels via `--node-labels`

### DIFF
--- a/docs/extensions/worker.md
+++ b/docs/extensions/worker.md
@@ -107,7 +107,7 @@ In the above example, one pool with machine type `m4.large` and `min=3`, `max=5`
 This information together with the infrastructure status must be used to determine the proper configuration for the machine classes.
 
 The `spec.pools[].labels` map contains all labels that should be added to all nodes of the corresponding worker pool.
-Gardener configures kubelet's `--node-labels` flag to contain all labels mentioned here.
+Gardener configures kubelet's `--node-labels` flag to contain all labels that are mentioned here and allowed by the [`NodeRestriction` admission plugin](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#noderestriction).
 This makes sure that kubelet adds all user-specified and gardener-managed labels to the new `Node` object when registering a new machine with the API server.
 Nevertheless, this is only effective when bootstrapping new nodes.
 The provider extension (respectively, machine-controller-manager) is still responsible for updating the labels of existing `Nodes` when the worker specification changes.

--- a/docs/extensions/worker.md
+++ b/docs/extensions/worker.md
@@ -76,6 +76,11 @@ spec:
         cpu: 2
         gpu: 0
         memory: 8Gi
+    labels:
+      node.kubernetes.io/role: node
+      worker.gardener.cloud/cri-name: containerd
+      worker.gardener.cloud/pool: cpu-worker
+      worker.gardener.cloud/system-components: "true"
     userData: c29tZSBkYXRhIHRvIGJvb3RzdHJhcCB0aGUgVk0K
     volume:
       size: 20Gi
@@ -100,6 +105,12 @@ Also, as you can see, Gardener copies the output of the infrastructure creation 
 In the `.spec.pools[]` field, the desired worker pools are listed.
 In the above example, one pool with machine type `m4.large` and `min=3`, `max=5` machines shall be spread over two availability zones (`eu-west-1b`, `eu-west-1c`).
 This information together with the infrastructure status must be used to determine the proper configuration for the machine classes.
+
+The `spec.pools[].labels` map contains all labels that should be added to all nodes of the corresponding worker pool.
+Gardener configures kubelet's `--node-labels` flag to contain all labels mentioned here.
+This makes sure that kubelet adds all user-specified and gardener-managed labels to the new `Node` object when registering a new machine with the API server.
+Nevertheless, this is only effective when bootstrapping new nodes.
+The provider extension (respectively, machine-controller-manager) is still responsible for updating the labels of existing `Nodes` when the worker specification changes.
 
 The `spec.pools[].nodeTemplate.capacity` field contains the resource information of the machine like `cpu`, `gpu`, and `memory`. This info is used by Cluster Autoscaler to generate `nodeTemplate` during scaling the `nodeGroup` from zero.
 

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/operatingsystemconfig.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/operatingsystemconfig.go
@@ -126,8 +126,8 @@ type OriginalValues struct {
 	PromtailEnabled bool
 	// LokiIngressHostName is the ingress host name of the shoot's Loki.
 	LokiIngressHostName string
-	// NodeLocalDNSENabled indicates whether node local dns is enabled or not.
-	NodeLocalDNSENabled bool
+	// NodeLocalDNSEnabled indicates whether node local dns is enabled or not.
+	NodeLocalDNSEnabled bool
 }
 
 // New creates a new instance of Interface.
@@ -520,7 +520,7 @@ func (o *operatingSystemConfig) newDeployer(osc *extensionsv1alpha1.OperatingSys
 		sshAccessEnabled:        o.values.SSHAccessEnabled,
 		lokiIngressHostName:     o.values.LokiIngressHostName,
 		promtailEnabled:         o.values.PromtailEnabled,
-		nodeLocalDNSENabled:     o.values.NodeLocalDNSENabled,
+		nodeLocalDNSEnabled:     o.values.NodeLocalDNSEnabled,
 	}, nil
 }
 
@@ -581,7 +581,7 @@ type deployer struct {
 	sshAccessEnabled        bool
 	lokiIngressHostName     string
 	promtailEnabled         bool
-	nodeLocalDNSENabled     bool
+	nodeLocalDNSEnabled     bool
 }
 
 // exposed for testing
@@ -621,7 +621,7 @@ func (d *deployer) deploy(ctx context.Context, operation string) (extensionsv1al
 			ClusterDomain:           d.clusterDomain,
 			CRIName:                 d.criName,
 			Images:                  d.images,
-			NodeLabels:              gutil.NodeLabelsForWorkerPool(d.worker, d.nodeLocalDNSENabled),
+			NodeLabels:              gardenerutils.NodeLabelsForWorkerPool(d.worker, d.nodeLocalDNSEnabled),
 			KubeletCABundle:         d.kubeletCABundle,
 			KubeletConfigParameters: d.kubeletConfigParameters,
 			KubeletCLIFlags:         d.kubeletCLIFlags,

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/operatingsystemconfig.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/operatingsystemconfig.go
@@ -126,6 +126,8 @@ type OriginalValues struct {
 	PromtailEnabled bool
 	// LokiIngressHostName is the ingress host name of the shoot's Loki.
 	LokiIngressHostName string
+	// NodeLocalDNSENabled indicates whether node local dns is enabled or not.
+	NodeLocalDNSENabled bool
 }
 
 // New creates a new instance of Interface.
@@ -518,6 +520,7 @@ func (o *operatingSystemConfig) newDeployer(osc *extensionsv1alpha1.OperatingSys
 		sshAccessEnabled:        o.values.SSHAccessEnabled,
 		lokiIngressHostName:     o.values.LokiIngressHostName,
 		promtailEnabled:         o.values.PromtailEnabled,
+		nodeLocalDNSENabled:     o.values.NodeLocalDNSENabled,
 	}, nil
 }
 
@@ -578,6 +581,7 @@ type deployer struct {
 	sshAccessEnabled        bool
 	lokiIngressHostName     string
 	promtailEnabled         bool
+	nodeLocalDNSENabled     bool
 }
 
 // exposed for testing
@@ -617,6 +621,7 @@ func (d *deployer) deploy(ctx context.Context, operation string) (extensionsv1al
 			ClusterDomain:           d.clusterDomain,
 			CRIName:                 d.criName,
 			Images:                  d.images,
+			NodeLabels:              gutil.NodeLabelsForWorkerPool(d.worker, d.nodeLocalDNSENabled),
 			KubeletCABundle:         d.kubeletCABundle,
 			KubeletConfigParameters: d.kubeletConfigParameters,
 			KubeletCLIFlags:         d.kubeletCLIFlags,

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/operatingsystemconfig_test.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/operatingsystemconfig_test.go
@@ -138,6 +138,7 @@ var _ = Describe("OperatingSystemConfig", func() {
 				{
 					Name: worker1Name,
 					Machine: gardencorev1beta1.Machine{
+						Architecture: pointer.String(v1beta1constants.ArchitectureAMD64),
 						Image: &gardencorev1beta1.ShootMachineImage{
 							Name:           "type1",
 							ProviderConfig: &runtime.RawExtension{Raw: []byte(`{"foo":"bar"}`)},
@@ -148,6 +149,7 @@ var _ = Describe("OperatingSystemConfig", func() {
 				{
 					Name: worker2Name,
 					Machine: gardencorev1beta1.Machine{
+						Architecture: pointer.String(v1beta1constants.ArchitectureAMD64),
 						Image: &gardencorev1beta1.ShootMachineImage{
 							Name: "type2",
 						},

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/components.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/components.go
@@ -36,6 +36,7 @@ type Context struct {
 	ClusterDomain           string
 	CRIName                 extensionsv1alpha1.CRIName
 	Images                  map[string]*imagevector.Image
+	NodeLabels              map[string]string
 	KubeletCABundle         []byte
 	KubeletCLIFlags         ConfigurableKubeletCLIFlags
 	KubeletConfigParameters ConfigurableKubeletConfigParameters

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/kubelet/cliflags.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/kubelet/cliflags.go
@@ -27,6 +27,7 @@ import (
 	"github.com/gardener/gardener/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/containerd"
 	"github.com/gardener/gardener/pkg/utils/imagevector"
+	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 )
 
 // CLIFlags returns a list of kubelet CLI flags based on the provided parameters and for the provided Kubernetes version.
@@ -41,18 +42,7 @@ func CLIFlags(kubernetesVersion *semver.Version, nodeLabels map[string]string, c
 		"--kubeconfig="+PathKubeconfigReal,
 		fmt.Sprintf("--node-labels=%s=%s", v1beta1constants.LabelWorkerKubernetesVersion, kubernetesVersion.String()),
 	)
-
-	// maps are unsorted in go, make sure to output node labels in the exact same order every time
-	// this ensures deterministic behavior so that tests are stable and the OSC doesn't change on every reconciliation
-	labelKeys := make([]string, 0, len(nodeLabels))
-	for key := range nodeLabels {
-		labelKeys = append(labelKeys, key)
-	}
-	sort.Strings(labelKeys)
-
-	for _, key := range labelKeys {
-		flags = append(flags, fmt.Sprintf("--node-labels=%s=%s", key, nodeLabels[key]))
-	}
+	flags = append(flags, nodeLabelFlags(nodeLabels)...)
 
 	if criName == extensionsv1alpha1.CRINameContainerD {
 		flags = append(flags,
@@ -80,4 +70,33 @@ func setCLIFlagsDefaults(f *components.ConfigurableKubeletCLIFlags) {
 	if f.ImagePullProgressDeadline == nil {
 		f.ImagePullProgressDeadline = &metav1.Duration{Duration: time.Minute}
 	}
+}
+
+func nodeLabelFlags(nodeLabels map[string]string) []string {
+	var flags []string
+
+	for key := range nodeLabels {
+		// Skip any node labels that kubelet is not allowed to add to its own Node object
+		// (ref https://github.com/gardener/gardener/pull/7424).
+		// The Worker extension (machine-controller-manager) is still responsible for adding/managing all worker pool labels
+		// (even the ones we exclude here). I.e., they will get added to the Node object asynchronously.
+		// We add all allowed worker pool labels (gardener-managed labels and allowed user-managed labels) via --node-labels
+		// to prevent a race between our node controller and machine-controller-manager
+		// (see https://github.com/gardener/gardener/issues/7117).
+		// If users specify prohibited worker pool labels (e.g., node-role.kubernetes.io/default) that are relevant for
+		// scheduling node-critical components (e.g., used in nodeSelectors of DaemonSets), they need to use different label
+		// keys. However, excluding those prohibited labels here doesn't make things worse than they are today for them.
+		// It only prevents them for making use of gardener's node readiness feature (see docs/usage/node-readiness.md).
+		if !kubernetesutils.IsNodeLabelAllowedForKubelet(key) {
+			continue
+		}
+
+		flags = append(flags, fmt.Sprintf("--node-labels=%s=%s", key, nodeLabels[key]))
+	}
+
+	// maps are unsorted in go, make sure to output node labels in the exact same order every time
+	// this ensures deterministic behavior so that tests are stable and the OSC doesn't change on every reconciliation
+	sort.Strings(flags)
+
+	return flags
 }

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/kubelet/cliflags.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/kubelet/cliflags.go
@@ -43,6 +43,7 @@ func CLIFlags(kubernetesVersion *semver.Version, nodeLabels map[string]string, c
 	)
 
 	// maps are unsorted in go, make sure to output node labels in the exact same order every time
+	// this ensures deterministic behavior so that tests are stable and the OSC doesn't change on every reconciliation
 	labelKeys := make([]string, 0, len(nodeLabels))
 	for key := range nodeLabels {
 		labelKeys = append(labelKeys, key)

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/kubelet/cliflags.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/kubelet/cliflags.go
@@ -16,6 +16,7 @@ package kubelet
 
 import (
 	"fmt"
+	"sort"
 	"time"
 
 	"github.com/Masterminds/semver"
@@ -29,7 +30,7 @@ import (
 )
 
 // CLIFlags returns a list of kubelet CLI flags based on the provided parameters and for the provided Kubernetes version.
-func CLIFlags(kubernetesVersion *semver.Version, criName extensionsv1alpha1.CRIName, image *imagevector.Image, cliFlags components.ConfigurableKubeletCLIFlags) []string {
+func CLIFlags(kubernetesVersion *semver.Version, nodeLabels map[string]string, criName extensionsv1alpha1.CRIName, image *imagevector.Image, cliFlags components.ConfigurableKubeletCLIFlags) []string {
 	setCLIFlagsDefaults(&cliFlags)
 
 	var flags []string
@@ -40,6 +41,17 @@ func CLIFlags(kubernetesVersion *semver.Version, criName extensionsv1alpha1.CRIN
 		"--kubeconfig="+PathKubeconfigReal,
 		fmt.Sprintf("--node-labels=%s=%s", v1beta1constants.LabelWorkerKubernetesVersion, kubernetesVersion.String()),
 	)
+
+	// maps are unsorted in go, make sure to output node labels in the exact same order every time
+	labelKeys := make([]string, 0, len(nodeLabels))
+	for key := range nodeLabels {
+		labelKeys = append(labelKeys, key)
+	}
+	sort.Strings(labelKeys)
+
+	for _, key := range labelKeys {
+		flags = append(flags, fmt.Sprintf("--node-labels=%s=%s", key, nodeLabels[key]))
+	}
 
 	if criName == extensionsv1alpha1.CRINameContainerD {
 		flags = append(flags,

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/kubelet/cliflags_test.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/kubelet/cliflags_test.go
@@ -41,7 +41,8 @@ var _ = Describe("CLIFlags", func() {
 		func(kubernetesVersion string, criName extensionsv1alpha1.CRIName, image *imagevector.Image, cliFlags components.ConfigurableKubeletCLIFlags, matcher gomegatypes.GomegaMatcher) {
 			v := semver.MustParse(kubernetesVersion)
 			nodeLabels := map[string]string{
-				"test": "foo",
+				"test":  "foo",
+				"test2": "bar",
 			}
 			Expect(kubelet.CLIFlags(v, nodeLabels, criName, image, cliFlags)).To(matcher)
 		},
@@ -61,6 +62,7 @@ var _ = Describe("CLIFlags", func() {
 				"--kubeconfig=/var/lib/kubelet/kubeconfig-real",
 				"--node-labels=worker.gardener.cloud/kubernetes-version=1.20.1",
 				"--node-labels=test=foo",
+				"--node-labels=test2=bar",
 				"--network-plugin=cni",
 				"--pod-infra-container-image=foo.io/hyperkube:version",
 				"--v=2",
@@ -78,6 +80,7 @@ var _ = Describe("CLIFlags", func() {
 				"--kubeconfig=/var/lib/kubelet/kubeconfig-real",
 				"--node-labels=worker.gardener.cloud/kubernetes-version=1.20.1",
 				"--node-labels=test=foo",
+				"--node-labels=test2=bar",
 				"--container-runtime=remote",
 				"--container-runtime-endpoint=unix:///run/containerd/containerd.sock",
 				"--runtime-cgroups=/system.slice/containerd.service",
@@ -100,6 +103,7 @@ var _ = Describe("CLIFlags", func() {
 				"--kubeconfig=/var/lib/kubelet/kubeconfig-real",
 				"--node-labels=worker.gardener.cloud/kubernetes-version=1.21.1",
 				"--node-labels=test=foo",
+				"--node-labels=test2=bar",
 				"--network-plugin=cni",
 				"--pod-infra-container-image=foo.io/hyperkube:version",
 				"--v=2",
@@ -117,6 +121,7 @@ var _ = Describe("CLIFlags", func() {
 				"--kubeconfig=/var/lib/kubelet/kubeconfig-real",
 				"--node-labels=worker.gardener.cloud/kubernetes-version=1.21.1",
 				"--node-labels=test=foo",
+				"--node-labels=test2=bar",
 				"--container-runtime=remote",
 				"--container-runtime-endpoint=unix:///run/containerd/containerd.sock",
 				"--runtime-cgroups=/system.slice/containerd.service",
@@ -139,6 +144,7 @@ var _ = Describe("CLIFlags", func() {
 				"--kubeconfig=/var/lib/kubelet/kubeconfig-real",
 				"--node-labels=worker.gardener.cloud/kubernetes-version=1.22.1",
 				"--node-labels=test=foo",
+				"--node-labels=test2=bar",
 				"--network-plugin=cni",
 				"--pod-infra-container-image=foo.io/hyperkube:version",
 				"--v=2",
@@ -156,6 +162,7 @@ var _ = Describe("CLIFlags", func() {
 				"--kubeconfig=/var/lib/kubelet/kubeconfig-real",
 				"--node-labels=worker.gardener.cloud/kubernetes-version=1.22.1",
 				"--node-labels=test=foo",
+				"--node-labels=test2=bar",
 				"--container-runtime=remote",
 				"--container-runtime-endpoint=unix:///run/containerd/containerd.sock",
 				"--runtime-cgroups=/system.slice/containerd.service",

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/kubelet/cliflags_test.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/kubelet/cliflags_test.go
@@ -40,7 +40,10 @@ var _ = Describe("CLIFlags", func() {
 	DescribeTable("#CLIFlags",
 		func(kubernetesVersion string, criName extensionsv1alpha1.CRIName, image *imagevector.Image, cliFlags components.ConfigurableKubeletCLIFlags, matcher gomegatypes.GomegaMatcher) {
 			v := semver.MustParse(kubernetesVersion)
-			Expect(kubelet.CLIFlags(v, criName, image, cliFlags)).To(matcher)
+			nodeLabels := map[string]string{
+				"test": "foo",
+			}
+			Expect(kubelet.CLIFlags(v, nodeLabels, criName, image, cliFlags)).To(matcher)
 		},
 
 		Entry(
@@ -57,6 +60,7 @@ var _ = Describe("CLIFlags", func() {
 				"--image-pull-progress-deadline=2m0s",
 				"--kubeconfig=/var/lib/kubelet/kubeconfig-real",
 				"--node-labels=worker.gardener.cloud/kubernetes-version=1.20.1",
+				"--node-labels=test=foo",
 				"--network-plugin=cni",
 				"--pod-infra-container-image=foo.io/hyperkube:version",
 				"--v=2",
@@ -73,6 +77,7 @@ var _ = Describe("CLIFlags", func() {
 				"--config=/var/lib/kubelet/config/kubelet",
 				"--kubeconfig=/var/lib/kubelet/kubeconfig-real",
 				"--node-labels=worker.gardener.cloud/kubernetes-version=1.20.1",
+				"--node-labels=test=foo",
 				"--container-runtime=remote",
 				"--container-runtime-endpoint=unix:///run/containerd/containerd.sock",
 				"--runtime-cgroups=/system.slice/containerd.service",
@@ -94,6 +99,7 @@ var _ = Describe("CLIFlags", func() {
 				"--image-pull-progress-deadline=2m0s",
 				"--kubeconfig=/var/lib/kubelet/kubeconfig-real",
 				"--node-labels=worker.gardener.cloud/kubernetes-version=1.21.1",
+				"--node-labels=test=foo",
 				"--network-plugin=cni",
 				"--pod-infra-container-image=foo.io/hyperkube:version",
 				"--v=2",
@@ -110,6 +116,7 @@ var _ = Describe("CLIFlags", func() {
 				"--config=/var/lib/kubelet/config/kubelet",
 				"--kubeconfig=/var/lib/kubelet/kubeconfig-real",
 				"--node-labels=worker.gardener.cloud/kubernetes-version=1.21.1",
+				"--node-labels=test=foo",
 				"--container-runtime=remote",
 				"--container-runtime-endpoint=unix:///run/containerd/containerd.sock",
 				"--runtime-cgroups=/system.slice/containerd.service",
@@ -131,6 +138,7 @@ var _ = Describe("CLIFlags", func() {
 				"--image-pull-progress-deadline=2m0s",
 				"--kubeconfig=/var/lib/kubelet/kubeconfig-real",
 				"--node-labels=worker.gardener.cloud/kubernetes-version=1.22.1",
+				"--node-labels=test=foo",
 				"--network-plugin=cni",
 				"--pod-infra-container-image=foo.io/hyperkube:version",
 				"--v=2",
@@ -147,6 +155,7 @@ var _ = Describe("CLIFlags", func() {
 				"--config=/var/lib/kubelet/config/kubelet",
 				"--kubeconfig=/var/lib/kubelet/kubeconfig-real",
 				"--node-labels=worker.gardener.cloud/kubernetes-version=1.22.1",
+				"--node-labels=test=foo",
 				"--container-runtime=remote",
 				"--container-runtime-endpoint=unix:///run/containerd/containerd.sock",
 				"--runtime-cgroups=/system.slice/containerd.service",

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/kubelet/cliflags_test.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/kubelet/cliflags_test.go
@@ -43,6 +43,13 @@ var _ = Describe("CLIFlags", func() {
 			nodeLabels := map[string]string{
 				"test":  "foo",
 				"test2": "bar",
+				// assert that we only pass allowed node labels to --node-labels
+				"kubernetes.io/arch":                            "amd64",  // allowed
+				"k8s.io/foo":                                    "bar",    // not allowed
+				"bar.k8s.io/foo":                                "bar",    // not allowed
+				"node-role.kubernetes.io/default":               "worker", // not allowed
+				"worker.gardener.cloud/pool":                    "worker", // allowed
+				"containerruntime.worker.gardener.cloud/gvisor": "true",   // allowed
 			}
 			Expect(kubelet.CLIFlags(v, nodeLabels, criName, image, cliFlags)).To(matcher)
 		},
@@ -61,8 +68,11 @@ var _ = Describe("CLIFlags", func() {
 				"--image-pull-progress-deadline=2m0s",
 				"--kubeconfig=/var/lib/kubelet/kubeconfig-real",
 				"--node-labels=worker.gardener.cloud/kubernetes-version=1.20.1",
+				"--node-labels=containerruntime.worker.gardener.cloud/gvisor=true",
+				"--node-labels=kubernetes.io/arch=amd64",
 				"--node-labels=test=foo",
 				"--node-labels=test2=bar",
+				"--node-labels=worker.gardener.cloud/pool=worker",
 				"--network-plugin=cni",
 				"--pod-infra-container-image=foo.io/hyperkube:version",
 				"--v=2",
@@ -79,8 +89,11 @@ var _ = Describe("CLIFlags", func() {
 				"--config=/var/lib/kubelet/config/kubelet",
 				"--kubeconfig=/var/lib/kubelet/kubeconfig-real",
 				"--node-labels=worker.gardener.cloud/kubernetes-version=1.20.1",
+				"--node-labels=containerruntime.worker.gardener.cloud/gvisor=true",
+				"--node-labels=kubernetes.io/arch=amd64",
 				"--node-labels=test=foo",
 				"--node-labels=test2=bar",
+				"--node-labels=worker.gardener.cloud/pool=worker",
 				"--container-runtime=remote",
 				"--container-runtime-endpoint=unix:///run/containerd/containerd.sock",
 				"--runtime-cgroups=/system.slice/containerd.service",
@@ -102,8 +115,11 @@ var _ = Describe("CLIFlags", func() {
 				"--image-pull-progress-deadline=2m0s",
 				"--kubeconfig=/var/lib/kubelet/kubeconfig-real",
 				"--node-labels=worker.gardener.cloud/kubernetes-version=1.21.1",
+				"--node-labels=containerruntime.worker.gardener.cloud/gvisor=true",
+				"--node-labels=kubernetes.io/arch=amd64",
 				"--node-labels=test=foo",
 				"--node-labels=test2=bar",
+				"--node-labels=worker.gardener.cloud/pool=worker",
 				"--network-plugin=cni",
 				"--pod-infra-container-image=foo.io/hyperkube:version",
 				"--v=2",
@@ -120,8 +136,11 @@ var _ = Describe("CLIFlags", func() {
 				"--config=/var/lib/kubelet/config/kubelet",
 				"--kubeconfig=/var/lib/kubelet/kubeconfig-real",
 				"--node-labels=worker.gardener.cloud/kubernetes-version=1.21.1",
+				"--node-labels=containerruntime.worker.gardener.cloud/gvisor=true",
+				"--node-labels=kubernetes.io/arch=amd64",
 				"--node-labels=test=foo",
 				"--node-labels=test2=bar",
+				"--node-labels=worker.gardener.cloud/pool=worker",
 				"--container-runtime=remote",
 				"--container-runtime-endpoint=unix:///run/containerd/containerd.sock",
 				"--runtime-cgroups=/system.slice/containerd.service",
@@ -143,8 +162,11 @@ var _ = Describe("CLIFlags", func() {
 				"--image-pull-progress-deadline=2m0s",
 				"--kubeconfig=/var/lib/kubelet/kubeconfig-real",
 				"--node-labels=worker.gardener.cloud/kubernetes-version=1.22.1",
+				"--node-labels=containerruntime.worker.gardener.cloud/gvisor=true",
+				"--node-labels=kubernetes.io/arch=amd64",
 				"--node-labels=test=foo",
 				"--node-labels=test2=bar",
+				"--node-labels=worker.gardener.cloud/pool=worker",
 				"--network-plugin=cni",
 				"--pod-infra-container-image=foo.io/hyperkube:version",
 				"--v=2",
@@ -161,8 +183,11 @@ var _ = Describe("CLIFlags", func() {
 				"--config=/var/lib/kubelet/config/kubelet",
 				"--kubeconfig=/var/lib/kubelet/kubeconfig-real",
 				"--node-labels=worker.gardener.cloud/kubernetes-version=1.22.1",
+				"--node-labels=containerruntime.worker.gardener.cloud/gvisor=true",
+				"--node-labels=kubernetes.io/arch=amd64",
 				"--node-labels=test=foo",
 				"--node-labels=test2=bar",
+				"--node-labels=worker.gardener.cloud/pool=worker",
 				"--container-runtime=remote",
 				"--container-runtime-endpoint=unix:///run/containerd/containerd.sock",
 				"--runtime-cgroups=/system.slice/containerd.service",

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/kubelet/component.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/kubelet/component.go
@@ -104,7 +104,7 @@ func (component) Config(ctx components.Context) ([]extensionsv1alpha1.Unit, []ex
 		return nil, nil, err
 	}
 
-	cliFlags := CLIFlags(ctx.KubernetesVersion, ctx.CRIName, ctx.Images[images.ImageNamePauseContainer], ctx.KubeletCLIFlags)
+	cliFlags := CLIFlags(ctx.KubernetesVersion, ctx.NodeLabels, ctx.CRIName, ctx.Images[images.ImageNamePauseContainer], ctx.KubeletCLIFlags)
 
 	return []extensionsv1alpha1.Unit{
 			{

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/kubelet/component_test.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/kubelet/component_test.go
@@ -62,7 +62,12 @@ var _ = Describe("Component", func() {
 					Tag:        pointer.String(pauseContainerImageTag),
 				},
 			}
-			cliFlags := CLIFlags(ctx.KubernetesVersion, ctx.CRIName, ctx.Images[images.ImageNamePauseContainer], ctx.KubeletCLIFlags)
+			ctx.NodeLabels = map[string]string{
+				"test": "foo",
+				"blub": "bar",
+			}
+
+			cliFlags := CLIFlags(ctx.KubernetesVersion, ctx.NodeLabels, ctx.CRIName, ctx.Images[images.ImageNamePauseContainer], ctx.KubeletCLIFlags)
 			units, files, err := component.Config(ctx)
 
 			Expect(err).NotTo(HaveOccurred())

--- a/pkg/operation/botanist/component/extensions/worker/worker.go
+++ b/pkg/operation/botanist/component/extensions/worker/worker.go
@@ -84,8 +84,8 @@ type Values struct {
 	InfrastructureProviderStatus *runtime.RawExtension
 	// WorkerNameToOperatingSystemConfigsMap contains the operating system configurations for the worker pools.
 	WorkerNameToOperatingSystemConfigsMap map[string]*operatingsystemconfig.OperatingSystemConfigs
-	// NodeLocalDNSENabled indicates whether node local dns is enabled or not.
-	NodeLocalDNSENabled bool
+	// NodeLocalDNSEnabled indicates whether node local dns is enabled or not.
+	NodeLocalDNSEnabled bool
 }
 
 // New creates a new instance of Interface.
@@ -206,7 +206,7 @@ func (w *worker) deploy(ctx context.Context, operation string) (extensionsv1alph
 			MaxSurge:       *workerPool.MaxSurge,
 			MaxUnavailable: *workerPool.MaxUnavailable,
 			Annotations:    workerPool.Annotations,
-			Labels:         gardenerutils.NodeLabelsForWorkerPool(workerPool, w.values.NodeLocalDNSENabled),
+			Labels:         gardenerutils.NodeLabelsForWorkerPool(workerPool, w.values.NodeLocalDNSEnabled),
 			Taints:         workerPool.Taints,
 			MachineType:    workerPool.Machine.Type,
 			MachineImage: extensionsv1alpha1.MachineImage{

--- a/pkg/operation/botanist/operatingsystemconfig.go
+++ b/pkg/operation/botanist/operatingsystemconfig.go
@@ -79,6 +79,7 @@ func (b *Botanist) DefaultOperatingSystemConfig() (operatingsystemconfig.Interfa
 				SSHAccessEnabled:    v1beta1helper.ShootEnablesSSHAccess(b.Shoot.GetInfo()),
 				PromtailEnabled:     promtailEnabled,
 				LokiIngressHostName: lokiIngressHost,
+				NodeLocalDNSENabled: v1beta1helper.IsNodeLocalDNSEnabled(b.Shoot.GetInfo().Spec.SystemComponents, b.Shoot.GetInfo().Annotations),
 			},
 		},
 		operatingsystemconfig.DefaultInterval,

--- a/pkg/operation/botanist/operatingsystemconfig.go
+++ b/pkg/operation/botanist/operatingsystemconfig.go
@@ -79,7 +79,7 @@ func (b *Botanist) DefaultOperatingSystemConfig() (operatingsystemconfig.Interfa
 				SSHAccessEnabled:    v1beta1helper.ShootEnablesSSHAccess(b.Shoot.GetInfo()),
 				PromtailEnabled:     promtailEnabled,
 				LokiIngressHostName: lokiIngressHost,
-				NodeLocalDNSENabled: v1beta1helper.IsNodeLocalDNSEnabled(b.Shoot.GetInfo().Spec.SystemComponents, b.Shoot.GetInfo().Annotations),
+				NodeLocalDNSEnabled: v1beta1helper.IsNodeLocalDNSEnabled(b.Shoot.GetInfo().Spec.SystemComponents, b.Shoot.GetInfo().Annotations),
 			},
 		},
 		operatingsystemconfig.DefaultInterval,

--- a/pkg/operation/botanist/worker.go
+++ b/pkg/operation/botanist/worker.go
@@ -52,7 +52,7 @@ func (b *Botanist) DefaultWorker() worker.Interface {
 			Workers:             b.Shoot.GetInfo().Spec.Provider.Workers,
 			KubernetesVersion:   b.Shoot.KubernetesVersion,
 			MachineTypes:        b.Shoot.CloudProfile.Spec.MachineTypes,
-			NodeLocalDNSENabled: v1beta1helper.IsNodeLocalDNSEnabled(b.Shoot.GetInfo().Spec.SystemComponents, b.Shoot.GetInfo().Annotations),
+			NodeLocalDNSEnabled: v1beta1helper.IsNodeLocalDNSEnabled(b.Shoot.GetInfo().Spec.SystemComponents, b.Shoot.GetInfo().Annotations),
 		},
 		worker.DefaultInterval,
 		worker.DefaultSevereThreshold,

--- a/pkg/utils/gardener/shoot.go
+++ b/pkg/utils/gardener/shoot.go
@@ -170,7 +170,7 @@ func GetShootNameFromOwnerReferences(objectMeta metav1.Object) string {
 }
 
 // NodeLabelsForWorkerPool returns a combined map of all user-specified and gardener-managed node labels.
-func NodeLabelsForWorkerPool(workerPool gardencorev1beta1.Worker, nodeLocalDNSENabled bool) map[string]string {
+func NodeLabelsForWorkerPool(workerPool gardencorev1beta1.Worker, nodeLocalDNSEnabled bool) map[string]string {
 	// copy worker pool labels map
 	labels := utils.MergeStringMaps(workerPool.Labels)
 	if labels == nil {
@@ -179,7 +179,7 @@ func NodeLabelsForWorkerPool(workerPool gardencorev1beta1.Worker, nodeLocalDNSEN
 	labels["node.kubernetes.io/role"] = "node"
 	labels["kubernetes.io/arch"] = *workerPool.Machine.Architecture
 
-	labels[v1beta1constants.LabelNodeLocalDNS] = strconv.FormatBool(nodeLocalDNSENabled)
+	labels[v1beta1constants.LabelNodeLocalDNS] = strconv.FormatBool(nodeLocalDNSEnabled)
 
 	if v1beta1helper.SystemComponentsAllowed(&workerPool) {
 		labels[v1beta1constants.LabelWorkerPoolSystemComponents] = "true"

--- a/pkg/utils/gardener/shoot.go
+++ b/pkg/utils/gardener/shoot.go
@@ -40,6 +40,7 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/utils"
@@ -166,6 +167,40 @@ func GetShootNameFromOwnerReferences(objectMeta metav1.Object) string {
 		}
 	}
 	return ""
+}
+
+// NodeLabelsForWorkerPool returns a combined map of all user-specified and gardener-managed node labels.
+func NodeLabelsForWorkerPool(workerPool gardencorev1beta1.Worker, nodeLocalDNSENabled bool) map[string]string {
+	// copy worker pool labels map
+	labels := utils.MergeStringMaps(workerPool.Labels)
+	if labels == nil {
+		labels = map[string]string{}
+	}
+	labels["node.kubernetes.io/role"] = "node"
+	labels["kubernetes.io/arch"] = *workerPool.Machine.Architecture
+
+	labels[v1beta1constants.LabelNodeLocalDNS] = strconv.FormatBool(nodeLocalDNSENabled)
+
+	if v1beta1helper.SystemComponentsAllowed(&workerPool) {
+		labels[v1beta1constants.LabelWorkerPoolSystemComponents] = "true"
+	}
+
+	// worker pool name labels
+	labels[v1beta1constants.LabelWorkerPool] = workerPool.Name
+	labels[v1beta1constants.LabelWorkerPoolDeprecated] = workerPool.Name
+
+	// add CRI labels selected by the RuntimeClass
+	if workerPool.CRI != nil {
+		labels[extensionsv1alpha1.CRINameWorkerLabel] = string(workerPool.CRI.Name)
+		if len(workerPool.CRI.ContainerRuntimes) > 0 {
+			for _, cr := range workerPool.CRI.ContainerRuntimes {
+				key := fmt.Sprintf(extensionsv1alpha1.ContainerRuntimeNameWorkerLabel, cr.Type)
+				labels[key] = "true"
+			}
+		}
+	}
+
+	return labels
 }
 
 const (

--- a/pkg/utils/kubernetes/node.go
+++ b/pkg/utils/kubernetes/node.go
@@ -1,0 +1,59 @@
+// Copyright (c) 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubernetes
+
+import (
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	kubeletapis "k8s.io/kubelet/pkg/apis"
+)
+
+// IsNodeLabelAllowedForKubelet determines whether kubelet is allowed by the NodeRestriction admission plugin to set a
+// label on its own Node object with the given key.
+// See https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#noderestriction.
+func IsNodeLabelAllowedForKubelet(key string) bool {
+	namespace := getLabelNamespace(key)
+
+	// kubelets are forbidden to set node-restriction labels
+	if namespace == corev1.LabelNamespaceNodeRestriction || strings.HasSuffix(namespace, "."+corev1.LabelNamespaceNodeRestriction) {
+		return false
+	}
+
+	// kubelets are forbidden to set unknown kubernetes.io and k8s.io labels
+	if isKubernetesLabelNamespace(namespace) && !kubeletapis.IsKubeletLabel(key) {
+		return false
+	}
+
+	return true
+}
+
+// same logic as in kube-apiserver and kubelet code
+func getLabelNamespace(key string) string {
+	if parts := strings.SplitN(key, "/", 2); len(parts) == 2 {
+		return parts[0]
+	}
+	return ""
+}
+
+func isKubernetesLabelNamespace(namespace string) bool {
+	if namespace == "kubernetes.io" || strings.HasSuffix(namespace, ".kubernetes.io") {
+		return true
+	}
+	if namespace == "k8s.io" || strings.HasSuffix(namespace, ".k8s.io") {
+		return true
+	}
+	return false
+}

--- a/pkg/utils/kubernetes/node_test.go
+++ b/pkg/utils/kubernetes/node_test.go
@@ -1,0 +1,76 @@
+// Copyright (c) 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubernetes_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	. "github.com/gardener/gardener/pkg/utils/kubernetes"
+)
+
+var _ = Describe("Node", func() {
+	Describe("IsNodeLabelAllowedForKubelet", func() {
+		It("should return false for labels with node-restriction.kubernetes.io/ prefix", func() {
+			Expect(IsNodeLabelAllowedForKubelet("node-restriction.kubernetes.io/foo")).To(BeFalse())
+			Expect(IsNodeLabelAllowedForKubelet("bar.node-restriction.kubernetes.io/foo")).To(BeFalse())
+		})
+
+		It("should return true for kubelet labels", func() {
+			var kubeletLabels = []string{
+				// see https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#noderestriction
+				"kubernetes.io/hostname",
+				"kubernetes.io/arch",
+				"kubernetes.io/os",
+				"beta.kubernetes.io/instance-type",
+				"node.kubernetes.io/instance-type",
+				"failure-domain.beta.kubernetes.io/region",
+				"failure-domain.beta.kubernetes.io/zone",
+				"topology.kubernetes.io/region",
+				"topology.kubernetes.io/zone",
+				// see https://github.com/kubernetes/kubernetes/blob/release-1.26/staging/src/k8s.io/kubelet/pkg/apis/well_known_labels.go#L46-L47
+				"beta.kubernetes.io/os",
+				"beta.kubernetes.io/arch",
+			}
+
+			for _, label := range kubeletLabels {
+				Expect(IsNodeLabelAllowedForKubelet(label)).To(BeTrue(), "should return true for %s", label)
+			}
+		})
+
+		It("should return true for labels with kubelet prefix", func() {
+			Expect(IsNodeLabelAllowedForKubelet("kubelet.kubernetes.io/foo")).To(BeTrue())
+			Expect(IsNodeLabelAllowedForKubelet("bar.kubelet.kubernetes.io/foo")).To(BeTrue())
+			Expect(IsNodeLabelAllowedForKubelet("node.kubernetes.io/foo")).To(BeTrue())
+			Expect(IsNodeLabelAllowedForKubelet("bar.node.kubernetes.io/foo")).To(BeTrue())
+		})
+
+		It("should return false for other labels in kubernetes.io and k8s.io namespaces", func() {
+			Expect(IsNodeLabelAllowedForKubelet("kubernetes.io/foo")).To(BeFalse())
+			Expect(IsNodeLabelAllowedForKubelet("bar.kubernetes.io/foo")).To(BeFalse())
+			Expect(IsNodeLabelAllowedForKubelet("k8s.io/foo")).To(BeFalse())
+			Expect(IsNodeLabelAllowedForKubelet("bar.k8s.io/foo")).To(BeFalse())
+		})
+
+		It("should return true for other allowed labels", func() {
+			Expect(IsNodeLabelAllowedForKubelet("gardener.cloud/foo")).To(BeTrue())
+			Expect(IsNodeLabelAllowedForKubelet("bar.gardener.cloud/foo")).To(BeTrue())
+			Expect(IsNodeLabelAllowedForKubelet("example.com/foo")).To(BeTrue())
+			Expect(IsNodeLabelAllowedForKubelet("bar.example.com/foo")).To(BeTrue())
+			Expect(IsNodeLabelAllowedForKubelet("foo")).To(BeTrue())
+			Expect(IsNodeLabelAllowedForKubelet("foo/bar")).To(BeTrue())
+		})
+	})
+})

--- a/test/e2e/gardener/common.go
+++ b/test/e2e/gardener/common.go
@@ -97,6 +97,9 @@ func DefaultShoot(name string) *gardencorev1beta1.Shoot {
 					CRI: &gardencorev1beta1.CRI{
 						Name: gardencorev1beta1.CRINameContainerD,
 					},
+					Labels: map[string]string{
+						"foo": "bar",
+					},
 					Minimum: 1,
 					Maximum: 1,
 				}},

--- a/test/e2e/gardener/shoot/create_update_delete.go
+++ b/test/e2e/gardener/shoot/create_update_delete.go
@@ -16,6 +16,7 @@ package shoot
 
 import (
 	"context"
+	"strconv"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -23,9 +24,11 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
+	"github.com/gardener/gardener/pkg/utils"
 	e2e "github.com/gardener/gardener/test/e2e/gardener"
 	"github.com/gardener/gardener/test/framework"
 	"github.com/gardener/gardener/test/utils/shoots/access"
@@ -66,6 +69,36 @@ var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
 			g.Expect(err).NotTo(HaveOccurred())
 
 			g.Expect(shootClient.Client().List(ctx, &corev1.NamespaceList{})).To(Succeed())
+		}).Should(Succeed())
+
+		By("Verify worker node labels")
+		commonNodeLabels := utils.MergeStringMaps(f.Shoot.Spec.Provider.Workers[0].Labels)
+		commonNodeLabels["networking.gardener.cloud/node-local-dns-enabled"] = "false"
+		commonNodeLabels["node.kubernetes.io/role"] = "node"
+
+		Eventually(func(g Gomega) {
+			for _, workerPool := range f.Shoot.Spec.Provider.Workers {
+				expectedNodeLabels := utils.MergeStringMaps(commonNodeLabels)
+				expectedNodeLabels["worker.gardener.cloud/pool"] = workerPool.Name
+				expectedNodeLabels["worker.gardener.cloud/cri-name"] = string(workerPool.CRI.Name)
+				expectedNodeLabels["worker.gardener.cloud/system-components"] = strconv.FormatBool(workerPool.SystemComponents.Allow)
+
+				kubernetesVersion := f.Shoot.Spec.Kubernetes.Version
+				if workerPool.Kubernetes != nil && workerPool.Kubernetes.Version != nil {
+					kubernetesVersion = *workerPool.Kubernetes.Version
+				}
+				expectedNodeLabels["worker.gardener.cloud/kubernetes-version"] = kubernetesVersion
+
+				nodeList := &corev1.NodeList{}
+				g.Expect(shootClient.Client().List(ctx, nodeList, runtimeclient.MatchingLabels{
+					"worker.gardener.cloud/pool": workerPool.Name,
+				})).To(Succeed())
+				g.Expect(nodeList.Items).To(HaveLen(1), "worker pool %s should have exactly three Nodes", workerPool.Name)
+
+				for key, value := range expectedNodeLabels {
+					g.Expect(nodeList.Items[0].Labels).To(HaveKeyWithValue(key, value), "worker pool %s should have expected labels", workerPool.Name)
+				}
+			}
 		}).Should(Succeed())
 
 		By("Update Shoot")

--- a/test/e2e/gardener/shoot/create_update_delete.go
+++ b/test/e2e/gardener/shoot/create_update_delete.go
@@ -24,7 +24,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
-	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
@@ -90,10 +90,10 @@ var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
 				expectedNodeLabels["worker.gardener.cloud/kubernetes-version"] = kubernetesVersion
 
 				nodeList := &corev1.NodeList{}
-				g.Expect(shootClient.Client().List(ctx, nodeList, runtimeclient.MatchingLabels{
+				g.Expect(shootClient.Client().List(ctx, nodeList, client.MatchingLabels{
 					"worker.gardener.cloud/pool": workerPool.Name,
 				})).To(Succeed())
-				g.Expect(nodeList.Items).To(HaveLen(1), "worker pool %s should have exactly three Nodes", workerPool.Name)
+				g.Expect(nodeList.Items).To(HaveLen(1), "worker pool %s should have exactly one Node", workerPool.Name)
 
 				for key, value := range expectedNodeLabels {
 					g.Expect(nodeList.Items[0].Labels).To(HaveKeyWithValue(key, value), "worker pool %s should have expected labels", workerPool.Name)

--- a/vendor/k8s.io/kubelet/pkg/apis/well_known_labels.go
+++ b/vendor/k8s.io/kubelet/pkg/apis/well_known_labels.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apis
+
+import (
+	"strings"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+const (
+	// LabelOS is a label to indicate the operating system of the node.
+	// The OS labels are promoted to GA in 1.14. kubelet applies GA labels and stop applying the beta OS labels in Kubernetes 1.19.
+	LabelOS = "beta.kubernetes.io/os"
+	// LabelArch is a label to indicate the architecture of the node.
+	// The Arch labels are promoted to GA in 1.14. kubelet applies GA labels and stop applying the beta Arch labels in Kubernetes 1.19.
+	LabelArch = "beta.kubernetes.io/arch"
+)
+
+var kubeletLabels = sets.NewString(
+	v1.LabelHostname,
+	v1.LabelTopologyZone,
+	v1.LabelTopologyRegion,
+	v1.LabelFailureDomainBetaZone,
+	v1.LabelFailureDomainBetaRegion,
+	v1.LabelInstanceType,
+	v1.LabelInstanceTypeStable,
+	v1.LabelOSStable,
+	v1.LabelArchStable,
+
+	LabelOS,
+	LabelArch,
+)
+
+var kubeletLabelNamespaces = sets.NewString(
+	v1.LabelNamespaceSuffixKubelet,
+	v1.LabelNamespaceSuffixNode,
+)
+
+// KubeletLabels returns the list of label keys kubelets are allowed to set on their own Node objects
+func KubeletLabels() []string {
+	return kubeletLabels.List()
+}
+
+// KubeletLabelNamespaces returns the list of label key namespaces kubelets are allowed to set on their own Node objects
+func KubeletLabelNamespaces() []string {
+	return kubeletLabelNamespaces.List()
+}
+
+// IsKubeletLabel returns true if the label key is one that kubelets are allowed to set on their own Node object.
+// This checks if the key is in the KubeletLabels() list, or has a namespace in the KubeletLabelNamespaces() list.
+func IsKubeletLabel(key string) bool {
+	if kubeletLabels.Has(key) {
+		return true
+	}
+
+	namespace := getLabelNamespace(key)
+	for allowedNamespace := range kubeletLabelNamespaces {
+		if namespace == allowedNamespace || strings.HasSuffix(namespace, "."+allowedNamespace) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func getLabelNamespace(key string) string {
+	if parts := strings.SplitN(key, "/", 2); len(parts) == 2 {
+		return parts[0]
+	}
+	return ""
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1588,6 +1588,7 @@ k8s.io/kube-proxy/config/v1alpha1
 # k8s.io/kubelet v0.26.1
 ## explicit; go 1.19
 k8s.io/kubelet/config/v1beta1
+k8s.io/kubelet/pkg/apis
 # k8s.io/metrics v0.26.1
 ## explicit; go 1.19
 k8s.io/metrics/pkg/apis/metrics


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind enhancement

**What this PR does / why we need it**:

This PR is a cherry-pick of https://github.com/gardener/gardener/pull/7202 (see first five commits) plus a fix for https://github.com/gardener/gardener/pull/7424 (see last commit).

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/7117

**Special notes for your reviewer**:

I verified the fix with the following shoot:

<details>

```yaml
apiVersion: core.gardener.cloud/v1beta1
kind: Shoot
metadata:
  name: local
  namespace: garden-local
  annotations:
    shoot.gardener.cloud/infrastructure-cleanup-wait-period-seconds: "0"
    shoot.gardener.cloud/cloud-config-execution-max-delay-seconds: "0"
spec:
  seedName: local
  cloudProfileName: local
  secretBindingName: local # dummy, doesn't contain any credentials
  region: local
  networking:
    type: calico
    providerConfig:
      apiVersion: calico.networking.extensions.gardener.cloud/v1alpha1
      kind: NetworkConfig
      backend: none
      typha:
        enabled: false
  provider:
    type: local
    workers:
    - name: local
      machine:
        type: local
      cri:
        name: containerd
      labels:
        # allowed label
        foo: bar
        # forbidden labels
        node-role.kubernetes.io/default: "worker"
        alpha.service-controller.kubernetes.io/exclude-balancer: "true"
      minimum: 1
      maximum: 1 # currently, only single-node clusters are supported
      maxSurge: 1
      maxUnavailable: 0
  kubernetes:
    version: 1.26.0
    kubelet:
      seccompDefault: true
      serializeImagePulls: false
      registryPullQPS: 10
      registryBurst: 20
      protectKernelDefaults: true
      streamingConnectionIdleTimeout: 5m
```

<summary>
Expand me
</summary>
</details>

... which resulted in the expected behavior: kubelet succeeds to register the node object without the prohibited labels which are added asynchronously by mcm:

<details>

```
$ k get no -L worker.gardener.cloud/pool,foo,node-role.kubernetes.io/default,alpha.service-controller.kubernetes.io/exclude-balancer -w --output-watch-events
EVENT      NAME                                            STATUS     ROLES    AGE   VERSION   POOL    FOO   DEFAULT   EXCLUDE-BALANCER
ADDED      machine-shoot--local--local-local-85db5-bgvbx   NotReady   <none>   0s    v1.26.0   local   bar
MODIFIED   machine-shoot--local--local-local-85db5-bgvbx   NotReady   <none>   0s    v1.26.0   local   bar
MODIFIED   machine-shoot--local--local-local-85db5-bgvbx   NotReady   <none>   0s    v1.26.0   local   bar
MODIFIED   machine-shoot--local--local-local-85db5-bgvbx   NotReady   <none>   0s    v1.26.0   local   bar
MODIFIED   machine-shoot--local--local-local-85db5-bgvbx   NotReady   <none>   0s    v1.26.0   local   bar
MODIFIED   machine-shoot--local--local-local-85db5-bgvbx   NotReady   <none>   0s    v1.26.0   local   bar
MODIFIED   machine-shoot--local--local-local-85db5-bgvbx   NotReady   <none>   10s   v1.26.0   local   bar
MODIFIED   machine-shoot--local--local-local-85db5-bgvbx   NotReady   default   15s   v1.26.0   local   bar   worker    true
MODIFIED   machine-shoot--local--local-local-85db5-bgvbx   NotReady   default   15s   v1.26.0   local   bar   worker    true
MODIFIED   machine-shoot--local--local-local-85db5-bgvbx   NotReady   default   19s   v1.26.0   local   bar   worker    true
MODIFIED   machine-shoot--local--local-local-85db5-bgvbx   NotReady   default   20s   v1.26.0   local   bar   worker    true
MODIFIED   machine-shoot--local--local-local-85db5-bgvbx   NotReady   default   21s   v1.26.0   local   bar   worker    true
MODIFIED   machine-shoot--local--local-local-85db5-bgvbx   Ready      default   25s   v1.26.0   local   bar   worker    true
MODIFIED   machine-shoot--local--local-local-85db5-bgvbx   Ready      default   25s   v1.26.0   local   bar   worker    true
MODIFIED   machine-shoot--local--local-local-85db5-bgvbx   Ready      default   25s   v1.26.0   local   bar   worker    true
MODIFIED   machine-shoot--local--local-local-85db5-bgvbx   Ready      default   25s   v1.26.0   local   bar   worker    true
```

<summary>
Expand me
</summar>
</details>


**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other user
User-specified and gardener-managed `Node` labels are added immediately on registration of new `Nodes`. Excluded from this are labels that kubelets are forbidden to add by the [`NodeRestriction` admission plugin](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#noderestriction) (they are still added asynchronously by machine-controller-manager).
```

