### PR TITLE
Cleanup of old/unusable istio configuration flags/options.

### DIFF
--- a/pkg/operation/botanist/component/istio/charts/istio/istio-ingress/templates/deployment.yaml
+++ b/pkg/operation/botanist/component/istio/charts/istio/istio-ingress/templates/deployment.yaml
@@ -64,15 +64,8 @@ spec:
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
         - --log_output_level=all:warn,ads:error
-        - --drainDuration=45s
-        - --parentShutdownDuration=1m0s
-        - --connectTimeout=10s
         - --serviceCluster=istio-ingressgateway
-        - --proxyAdminPort=15000
         - --concurrency=4
-        - --statusPort=15021
-        - --controlPlaneAuthPolicy=NONE
-        - --discoveryAddress=istiod.{{ .Values.istiodNamespace }}.svc:15012
         readinessProbe:
           failureThreshold: 30
           httpGet:

--- a/pkg/operation/botanist/component/istio/charts/istio/istio-istiod/templates/configmap.yaml
+++ b/pkg/operation/botanist/component/istio/charts/istio/istio-istiod/templates/configmap.yaml
@@ -12,6 +12,9 @@ data:
     networks: {}
 
   mesh: |-
+    # TCP connection timeout between Envoy & the application, and between Envoys.
+    connectTimeout: 10s
+
     # Set enableTracing to false to disable request tracing.
     enableTracing: false
 
@@ -23,15 +26,6 @@ data:
     accessLogEncoding: 'TEXT'
 
     enableEnvoyAccessLogService: false
-    # reportBatchMaxEntries is the number of requests that are batched before telemetry data is sent to the mixer server
-    reportBatchMaxEntries: 100
-    # reportBatchMaxTime is the max waiting time before the telemetry data of a request is sent to the mixer server
-    reportBatchMaxTime: 1s
-    disableMixerHttpReports: false
-
-    # Set the following variable to true to disable policy checks by the Mixer.
-    # Note that metrics will still be reported to the Mixer.
-    disablePolicyChecks: true
 
     # Automatic protocol detection uses a set of heuristics to
     # determine whether the connection is using TLS or not (on the
@@ -53,9 +47,6 @@ data:
     # Refer to https://github.com/spiffe/spiffe/blob/master/standards/SPIFFE-ID.md#21-trust-domain
     trustDomain: "{{ .Values.trustDomain }}"
 
-    # Used by pilot-agent
-    sdsUdsPath: "unix:/etc/istio/proxy/SDS"
-
     # If true, automatically configure client side mTLS settings to match the corresponding service's
     # server side mTLS authentication policy, when destination rule for that service does not specify
     # TLS settings.
@@ -69,6 +60,7 @@ data:
 
     # Configures DNS certificates provisioned through Chiron linked into Pilot.
     # The DNS certificate provisioning is enabled by default now so it get tested.
+    # deprecated
     certificates: []
 
     # Disable the advertisment of services and endpoints which are no explictly marked in
@@ -79,9 +71,6 @@ data:
     defaultDestinationRuleExportTo: ["-"]
 
     defaultConfig:
-      #
-      # TCP connection timeout between Envoy & the application, and between Envoys.
-      connectTimeout: 10s
       #
       ### ADVANCED SETTINGS #############
       # Where should envoy's configuration be stored in the istio-proxy container
@@ -110,5 +99,5 @@ data:
       controlPlaneAuthPolicy: NONE
       discoveryAddress: istiod.{{ .Release.Namespace }}.svc:15012
 
-    rootNamespace: istio-system
+    rootNamespace: {{ .Release.Namespace }}
     enablePrometheusMerge: true

--- a/pkg/operation/botanist/component/istio/charts/istio/istio-istiod/templates/deployment.yaml
+++ b/pkg/operation/botanist/component/istio/charts/istio/istio-istiod/templates/deployment.yaml
@@ -39,7 +39,6 @@ spec:
         - --log_output_level=all:warn,ads:error
         - --domain
         - {{ .Values.trustDomain }}
-        - --plugins=authn,authz,health # remove mixer plugin
         - --keepaliveMaxServerConnectionAge
         - "30m"
         ports:

--- a/pkg/operation/botanist/component/istio/istiod_test.go
+++ b/pkg/operation/botanist/component/istio/istiod_test.go
@@ -598,6 +598,9 @@ data:
     networks: {}
 
   mesh: |-
+    # TCP connection timeout between Envoy & the application, and between Envoys.
+    connectTimeout: 10s
+
     # Set enableTracing to false to disable request tracing.
     enableTracing: false
 
@@ -609,15 +612,6 @@ data:
     accessLogEncoding: 'TEXT'
 
     enableEnvoyAccessLogService: false
-    # reportBatchMaxEntries is the number of requests that are batched before telemetry data is sent to the mixer server
-    reportBatchMaxEntries: 100
-    # reportBatchMaxTime is the max waiting time before the telemetry data of a request is sent to the mixer server
-    reportBatchMaxTime: 1s
-    disableMixerHttpReports: false
-
-    # Set the following variable to true to disable policy checks by the Mixer.
-    # Note that metrics will still be reported to the Mixer.
-    disablePolicyChecks: true
 
     # Automatic protocol detection uses a set of heuristics to
     # determine whether the connection is using TLS or not (on the
@@ -639,9 +633,6 @@ data:
     # Refer to https://github.com/spiffe/spiffe/blob/master/standards/SPIFFE-ID.md#21-trust-domain
     trustDomain: "foo.local"
 
-    # Used by pilot-agent
-    sdsUdsPath: "unix:/etc/istio/proxy/SDS"
-
     # If true, automatically configure client side mTLS settings to match the corresponding service's
     # server side mTLS authentication policy, when destination rule for that service does not specify
     # TLS settings.
@@ -655,6 +646,7 @@ data:
 
     # Configures DNS certificates provisioned through Chiron linked into Pilot.
     # The DNS certificate provisioning is enabled by default now so it get tested.
+    # deprecated
     certificates: []
 
     # Disable the advertisment of services and endpoints which are no explictly marked in
@@ -665,9 +657,6 @@ data:
     defaultDestinationRuleExportTo: ["-"]
 
     defaultConfig:
-      #
-      # TCP connection timeout between Envoy & the application, and between Envoys.
-      connectTimeout: 10s
       #
       ### ADVANCED SETTINGS #############
       # Where should envoy's configuration be stored in the istio-proxy container
@@ -696,7 +685,7 @@ data:
       controlPlaneAuthPolicy: NONE
       discoveryAddress: istiod.` + deployNS + `.svc:15012
 
-    rootNamespace: istio-system
+    rootNamespace: ` + deployNS + `
     enablePrometheusMerge: true
 `
 
@@ -730,7 +719,7 @@ spec:
         
       annotations:
         sidecar.istio.io/inject: "false"
-        checksum/istio-config: 8af0ee1ba7d53be8bcb9cda04e3f601a771448f2a460e6455dc5710c1e753f43
+        checksum/istio-config: d34796e6fc25a26d4a8a4cb3276e34961b18f867d70f5a1984255d57bfefb4c6
     spec:
       serviceAccountName: istiod
       securityContext:
@@ -747,7 +736,6 @@ spec:
         - --log_output_level=all:warn,ads:error
         - --domain
         - foo.local
-        - --plugins=authn,authz,health # remove mixer plugin
         - --keepaliveMaxServerConnectionAge
         - "30m"
         ports:
@@ -1604,15 +1592,8 @@ spec:
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
         - --log_output_level=all:warn,ads:error
-        - --drainDuration=45s
-        - --parentShutdownDuration=1m0s
-        - --connectTimeout=10s
         - --serviceCluster=istio-ingressgateway
-        - --proxyAdminPort=15000
         - --concurrency=4
-        - --statusPort=15021
-        - --controlPlaneAuthPolicy=NONE
-        - --discoveryAddress=istiod.istio-test-system.svc:15012
         readinessProbe:
           failureThreshold: 30
           httpGet:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind cleanup

**What this PR does / why we need it**:
Cleanup of old/unusable istio configuration flags/options.

Some of the command line flags and configuration options were already deprecated when the SNI support was first introduced in gardener. They were in parts removed with the first istio update (1.6). Some other flags/options were only removed later.
Overall, there should be no change with regards to functionality as the command line flags were simply ignore. The same was true for the options. The only change was the move of the connectTimeout. However, this is still the default value. Hence, it should not affect clusters in any way. (Istio would have complained about some of the options when set to debug log level.)

**Which issue(s) this PR fixes**:
None.

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```

/cc @axel7born @DockToFuture @acumino 