### PR TITLE
Simplify debugging integration tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,6 +85,12 @@ local-garden-up: $(HELM)
 local-garden-down:
 	@./hack/local-development/local-garden/stop.sh $(LOCAL_GARDEN_LABEL)
 
+ENVTEST_TYPE ?= kubernetes
+
+.PHONY: start-envtest
+start-envtest: $(SETUP_ENVTEST)
+	@./hack/start-envtest.sh --environment-type=$(ENVTEST_TYPE)
+
 .PHONY: remote-garden-up
 remote-garden-up: $(HELM)
 	@./hack/local-development/remote-garden/start.sh $(REMOTE_GARDEN_LABEL)

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -233,8 +233,8 @@ While you can use an existing cluster (e.g., `kind`), some test suites expect th
 Hence, using a full-blown cluster with controllers and nodes might sometimes be impractical, as you would need to stop cluster components for the tests to work.
 
 You can use `make start-envtest` to start an `envtest` test environment that is managed separately from individual test suites.
-This allows you to keep the test environment running for as long as you want and debug integration tests by executing multiple test runs in parallel or inspecting test runs using `kubectl`.
-When you are finished, just hit `^C` for tearing down the test environment.
+This allows you to keep the test environment running for as long as you want, and to debug integration tests by executing multiple test runs in parallel or inspecting test runs using `kubectl`.
+When you are finished, just hit `CTRL-C` for tearing down the test environment.
 The kubeconfig for the test environment is placed in `dev/envtest-kubeconfig.yaml`.
 
 `make start-envtest` brings up an `envtest` environment using the default configuration.

--- a/hack/prepare-envtest.sh
+++ b/hack/prepare-envtest.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+ENVTEST_K8S_VERSION=${ENVTEST_K8S_VERSION:-"1.26"}
+
+echo "> Installing envtest tools@${ENVTEST_K8S_VERSION} with setup-envtest if necessary"
+if ! command -v setup-envtest &> /dev/null ; then
+  >&2 echo "setup-envtest not available"
+  exit 1
+fi
+
+export KUBEBUILDER_ASSETS="$(setup-envtest use -p path ${ENVTEST_K8S_VERSION})"
+echo "using envtest tools installed at '$KUBEBUILDER_ASSETS'"
+
+source "$(dirname "$0")/test-integration.env"

--- a/hack/start-envtest.sh
+++ b/hack/start-envtest.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+source "$(dirname "$0")/prepare-envtest.sh"
+
+echo "> Starting envtest"
+
+# change to start-envtest directory to avoid confusing behavior of relative paths
+cd "$(dirname "$0")/../test/start-envtest"
+
+go run . "$@"

--- a/hack/test-integration.sh
+++ b/hack/test-integration.sh
@@ -18,20 +18,9 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-ENVTEST_K8S_VERSION=${ENVTEST_K8S_VERSION:-"1.26"}
-
-echo "> Installing envtest tools@${ENVTEST_K8S_VERSION} with setup-envtest if necessary"
-if ! command -v setup-envtest &> /dev/null ; then
-  >&2 echo "setup-envtest not available"
-  exit 1
-fi
-
-export KUBEBUILDER_ASSETS="$(setup-envtest use -p path ${ENVTEST_K8S_VERSION})"
-echo "using envtest tools installed at '$KUBEBUILDER_ASSETS'"
+source "$(dirname "$0")/prepare-envtest.sh"
 
 echo "> Integration Tests"
-
-source "$(dirname "$0")/test-integration.env"
 
 test_flags=
 # If running in Prow, we want to generate a machine-readable output file under the location specified via $ARTIFACTS.

--- a/test/start-envtest/main.go
+++ b/test/start-envtest/main.go
@@ -1,0 +1,164 @@
+// Copyright (c) 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path"
+	"strings"
+
+	"github.com/go-logr/logr"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/rest"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
+
+	gardenerenvtest "github.com/gardener/gardener/pkg/envtest"
+	"github.com/gardener/gardener/pkg/logger"
+)
+
+const name = "start-envtest"
+
+func main() {
+	opts := &options{}
+
+	cmd := &cobra.Command{
+		Use:   name,
+		Short: "Launch an envtest environment",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := opts.validate(); err != nil {
+				return err
+			}
+
+			log, err := logger.NewZapLogger(logger.DebugLevel, logger.FormatText)
+			if err != nil {
+				return fmt.Errorf("error instantiating zap logger: %w", err)
+			}
+
+			logf.SetLogger(log)
+			klog.SetLogger(log)
+
+			log = logf.Log.WithName(name)
+
+			// don't output usage on further errors raised during execution
+			cmd.SilenceUsage = true
+			// further errors will be logged properly, don't duplicate
+			cmd.SilenceErrors = true
+
+			return run(cmd.Context(), log, opts)
+		},
+	}
+
+	opts.addFlags(cmd.Flags())
+
+	if err := cmd.ExecuteContext(signals.SetupSignalHandler()); err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+}
+
+const (
+	typeKubernetes = "kubernetes"
+	typeGardener   = "gardener"
+)
+
+var supportedTypes = sets.NewString(typeKubernetes, typeGardener)
+
+type options struct {
+	environmentType string
+	kubeconfig      string
+}
+
+func (o *options) addFlags(fs *pflag.FlagSet) {
+	fs.StringVar(&o.environmentType, "environment-type", typeKubernetes, fmt.Sprintf("Type of environment to start. Supported values: %s", strings.Join(supportedTypes.List(), ", ")))
+	fs.StringVar(&o.kubeconfig, "kubeconfig", path.Join("..", "..", "dev", "envtest-kubeconfig.yaml"), "File to place the environment's admin kubeconfig in.")
+}
+
+func (o *options) validate() error {
+	if !supportedTypes.Has(o.environmentType) {
+		return fmt.Errorf("unsupported environment type %q, supported types are: %s", o.environmentType, strings.Join(supportedTypes.List(), ", "))
+	}
+	return nil
+}
+
+type testEnvironment interface {
+	Start() (*rest.Config, error)
+	Stop() error
+}
+
+func run(ctx context.Context, log logr.Logger, opts *options) error {
+	log.Info("Starting test environment", "type", opts.environmentType)
+
+	kubeEnvironment := &envtest.Environment{}
+	var testEnv testEnvironment = kubeEnvironment
+
+	if opts.environmentType == typeGardener {
+		testEnv = &gardenerenvtest.GardenerTestEnvironment{
+			Environment: kubeEnvironment,
+		}
+	}
+
+	_, err := testEnv.Start()
+	if err != nil {
+		return fmt.Errorf("error starting test environment: %w", err)
+	}
+
+	defer func() {
+		log.Info("Stopping test environment")
+		if err := testEnv.Stop(); err != nil {
+			log.Error(err, "Error stopping test environment")
+		}
+	}()
+
+	adminUser, err := kubeEnvironment.ControlPlane.AddUser(envtest.User{
+		Name:   "envtest-admin",
+		Groups: []string{"system:masters"},
+	}, nil)
+	if err != nil {
+		return fmt.Errorf("error adding admin user: %w", err)
+	}
+
+	kubeConfigBytes, err := adminUser.KubeConfig()
+	if err != nil {
+		return fmt.Errorf("error getting admin user kubeconfig: %w", err)
+	}
+
+	if err := os.WriteFile(opts.kubeconfig, kubeConfigBytes, 0600); err != nil {
+		return fmt.Errorf("error writing kubeconfig file: %w", err)
+	}
+	log.Info("Successfully written kubeconfig", "file", opts.kubeconfig)
+
+	defer func() {
+		log.Info("Cleaning up kubeconfig file", "file", opts.kubeconfig)
+		if err := os.Remove(opts.kubeconfig); err != nil {
+			log.Error(err, "Error cleaning up kubeconfig file", "file", opts.kubeconfig)
+		}
+	}()
+
+	log.Info("Test environment ready!")
+
+	// block until cancelled
+	<-ctx.Done()
+	log.Info("Stop procedure initiated")
+
+	return nil
+}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind enhancement

**What this PR does / why we need it**:

Adds `make start-envtest` to run a test environment (only kube or including gardener) separately from a test suite.
This allows developers to keep it running for as long as they want and inspect integration tests using kubectl.
This is closer to what is happening in CI and simpler to use for deflaking than a full-blown kind cluster or gardener setup.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/6016

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature developer
`make start-envtest` brings up a test environment that can simplify debugging of integration tests. See the [docs](https://github.com/gardener/gardener/blob/master/docs/development/testing.md#integration-tests-envtests) for more information.
```
