### PR TITLE
Drop HVPA job from shoot Prometheus

### DIFF
--- a/charts/seed-monitoring/charts/core/charts/prometheus/templates/allow-prometheus-network-policy.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/templates/allow-prometheus-network-policy.yaml
@@ -42,13 +42,6 @@ spec:
       namespaceSelector:
         matchLabels:
           role: garden
-    - podSelector:
-        matchLabels:
-          app: hvpa-controller
-          gardener.cloud/role: hvpa
-      namespaceSelector:
-        matchLabels:
-          role: garden
     {{- if .Values.shoot.sniEnabled }}
     - namespaceSelector: {}
       podSelector:

--- a/pkg/operation/botanist/botanist.go
+++ b/pkg/operation/botanist/botanist.go
@@ -31,7 +31,6 @@ import (
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/operation"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/etcd"
-	"github.com/gardener/gardener/pkg/operation/botanist/component/hvpa"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/logging/kuberbacproxy"
 	shootpkg "github.com/gardener/gardener/pkg/operation/shoot"
 	secretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager"
@@ -198,7 +197,6 @@ func New(ctx context.Context, o *operation.Operation) (*Botanist, error) {
 	o.Shoot.Components.DependencyWatchdogAccess = b.DefaultDependencyWatchdogAccess()
 	o.Shoot.Components.GardenerAccess = b.DefaultGardenerAccess()
 	o.Shoot.Components.NetworkPolicies = b.DefaultNetworkPolicies()
-	o.Shoot.Components.HVPA = hvpa.New(nil, b.Shoot.SeedNamespace, hvpa.Values{})
 
 	// Logging
 	o.Shoot.Components.Logging.ShootRBACProxy, err = kuberbacproxy.New(b.SeedClientSet.Client(), b.Shoot.SeedNamespace)

--- a/pkg/operation/botanist/component/hvpa/hvpa.go
+++ b/pkg/operation/botanist/component/hvpa/hvpa.go
@@ -57,7 +57,6 @@ const (
 // Interface contains functions for an HVPA deployer.
 type Interface interface {
 	component.DeployWaiter
-	component.MonitoringComponent
 }
 
 // New creates a new instance of DeployWaiter for the HVPA controller.

--- a/pkg/operation/botanist/component/hvpa/mock/mocks.go
+++ b/pkg/operation/botanist/component/hvpa/mock/mocks.go
@@ -34,21 +34,6 @@ func (m *MockInterface) EXPECT() *MockInterfaceMockRecorder {
 	return m.recorder
 }
 
-// AlertingRules mocks base method.
-func (m *MockInterface) AlertingRules() (map[string]string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AlertingRules")
-	ret0, _ := ret[0].(map[string]string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// AlertingRules indicates an expected call of AlertingRules.
-func (mr *MockInterfaceMockRecorder) AlertingRules() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AlertingRules", reflect.TypeOf((*MockInterface)(nil).AlertingRules))
-}
-
 // Deploy mocks base method.
 func (m *MockInterface) Deploy(arg0 context.Context) error {
 	m.ctrl.T.Helper()
@@ -75,21 +60,6 @@ func (m *MockInterface) Destroy(arg0 context.Context) error {
 func (mr *MockInterfaceMockRecorder) Destroy(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Destroy", reflect.TypeOf((*MockInterface)(nil).Destroy), arg0)
-}
-
-// ScrapeConfigs mocks base method.
-func (m *MockInterface) ScrapeConfigs() ([]string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ScrapeConfigs")
-	ret0, _ := ret[0].([]string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ScrapeConfigs indicates an expected call of ScrapeConfigs.
-func (mr *MockInterfaceMockRecorder) ScrapeConfigs() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ScrapeConfigs", reflect.TypeOf((*MockInterface)(nil).ScrapeConfigs))
 }
 
 // Wait mocks base method.

--- a/pkg/operation/botanist/component/hvpa/monitoring.go
+++ b/pkg/operation/botanist/component/hvpa/monitoring.go
@@ -101,22 +101,3 @@ func CentralMonitoringConfiguration() (component.CentralMonitoringConfig, error)
 
 	return component.CentralMonitoringConfig{ScrapeConfigs: []string{scrapeConfig.String()}}, nil
 }
-
-// ScrapeConfigs returns the scrape configurations for Prometheus.
-func (h *hvpa) ScrapeConfigs() ([]string, error) {
-	var scrapeConfig bytes.Buffer
-
-	if err := monitoringScrapeConfigTemplate.Execute(&scrapeConfig, map[string]interface{}{
-		"relabeledNamespace": h.namespace,
-		"allowedMetrics":     monitoringAllowedMetrics,
-	}); err != nil {
-		return nil, err
-	}
-
-	return []string{scrapeConfig.String()}, nil
-}
-
-// AlertingRules returns the alerting rules for AlertManager.
-func (h *hvpa) AlertingRules() (map[string]string, error) {
-	return nil, nil
-}

--- a/pkg/operation/botanist/component/hvpa/monitoring_test.go
+++ b/pkg/operation/botanist/component/hvpa/monitoring_test.go
@@ -18,9 +18,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/gardener/gardener/pkg/operation/botanist/component"
 	. "github.com/gardener/gardener/pkg/operation/botanist/component/hvpa"
-	"github.com/gardener/gardener/pkg/operation/botanist/component/test"
 )
 
 var _ = Describe("Monitoring", func() {
@@ -31,18 +29,6 @@ var _ = Describe("Monitoring", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(monitoringConfig.ScrapeConfigs).To(ConsistOf(expectedCentralScrapeConfig))
 			Expect(monitoringConfig.CAdvisorScrapeConfigMetricRelabelConfigs).To(BeEmpty())
-		})
-	})
-
-	Context("Shoot Monitoring Configuration", func() {
-		var hvpa component.MonitoringComponent
-
-		BeforeEach(func() {
-			hvpa = New(nil, "shoot--foo--bar", Values{})
-		})
-
-		It("should successfully test the scrape configs", func() {
-			test.ScrapeConfigs(hvpa, expectedScrapeConfig)
 		})
 	})
 })
@@ -64,26 +50,5 @@ metric_relabel_configs:
 - source_labels: [ __name__ ]
   action: keep
   regex: ^(hvpa_aggregate_applied_scaling_total|hvpa_aggregate_blocked_scalings_total|hvpa_spec_replicas|hvpa_status_replicas|hvpa_status_applied_hpa_current_replicas|hvpa_status_applied_hpa_desired_replicas|hvpa_status_applied_vpa_recommendation|hvpa_status_blocked_hpa_current_replicas|hvpa_status_blocked_hpa_desired_replicas|hvpa_status_blocked_vpa_recommendation)$
-`
-
-	expectedScrapeConfig = `job_name: hvpa-controller
-kubernetes_sd_configs:
-- role: endpoints
-  namespaces:
-    names: [ garden ]
-relabel_configs:
-- source_labels:
-  - __meta_kubernetes_service_name
-  - __meta_kubernetes_endpoint_port_name
-  - __meta_kubernetes_namespace
-  action: keep
-  regex: hvpa-controller;metrics;garden
-metric_relabel_configs:
-- source_labels: [ __name__ ]
-  action: keep
-  regex: ^(hvpa_aggregate_applied_scaling_total|hvpa_aggregate_blocked_scalings_total|hvpa_spec_replicas|hvpa_status_replicas|hvpa_status_applied_hpa_current_replicas|hvpa_status_applied_hpa_desired_replicas|hvpa_status_applied_vpa_recommendation|hvpa_status_blocked_hpa_current_replicas|hvpa_status_blocked_hpa_desired_replicas|hvpa_status_blocked_vpa_recommendation)$
-- source_labels: [namespace]
-  regex: shoot--foo--bar
-  action: keep
 `
 )

--- a/pkg/operation/botanist/monitoring.go
+++ b/pkg/operation/botanist/monitoring.go
@@ -32,9 +32,7 @@ import (
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/controllerutils"
-	"github.com/gardener/gardener/pkg/features"
 	gardenlethelper "github.com/gardener/gardener/pkg/gardenlet/apis/config/helper"
-	gardenletfeatures "github.com/gardener/gardener/pkg/gardenlet/features"
 	"github.com/gardener/gardener/pkg/operation/botanist/component"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/etcd"
 	"github.com/gardener/gardener/pkg/operation/common"
@@ -106,10 +104,6 @@ func (b *Botanist) DeploySeedMonitoring(ctx context.Context) error {
 
 	if b.Shoot.WantsClusterAutoscaler {
 		monitoringComponents = append(monitoringComponents, b.Shoot.Components.ControlPlane.ClusterAutoscaler)
-	}
-
-	if gardenletfeatures.FeatureGate.Enabled(features.HVPA) {
-		monitoringComponents = append(monitoringComponents, b.Shoot.Components.HVPA)
 	}
 
 	for _, component := range monitoringComponents {

--- a/pkg/operation/botanist/monitoring_test.go
+++ b/pkg/operation/botanist/monitoring_test.go
@@ -42,7 +42,6 @@ import (
 	. "github.com/gardener/gardener/pkg/operation/botanist"
 	mockcoredns "github.com/gardener/gardener/pkg/operation/botanist/component/coredns/mock"
 	mocketcd "github.com/gardener/gardener/pkg/operation/botanist/component/etcd/mock"
-	mockhvpa "github.com/gardener/gardener/pkg/operation/botanist/component/hvpa/mock"
 	mockkubeapiserver "github.com/gardener/gardener/pkg/operation/botanist/component/kubeapiserver/mock"
 	mockkubecontrollermanager "github.com/gardener/gardener/pkg/operation/botanist/component/kubecontrollermanager/mock"
 	mockkubeproxy "github.com/gardener/gardener/pkg/operation/botanist/component/kubeproxy/mock"
@@ -74,7 +73,6 @@ var _ = Describe("Monitoring", func() {
 		chartApplier kubernetes.ChartApplier
 		sm           secretsmanager.Interface
 
-		mockHVPA                  *mockhvpa.MockInterface
 		mockEtcdMain              *mocketcd.MockInterface
 		mockEtcdEvents            *mocketcd.MockInterface
 		mockKubeAPIServer         *mockkubeapiserver.MockInterface
@@ -116,7 +114,6 @@ var _ = Describe("Monitoring", func() {
 			Build()
 		sm = fakesecretsmanager.New(seedClient, seedNamespace)
 
-		mockHVPA = mockhvpa.NewMockInterface(ctrl)
 		mockEtcdMain = mocketcd.NewMockInterface(ctrl)
 		mockEtcdEvents = mocketcd.NewMockInterface(ctrl)
 		mockKubeAPIServer = mockkubeapiserver.NewMockInterface(ctrl)
@@ -164,7 +161,6 @@ var _ = Describe("Monitoring", func() {
 							KubeProxy: mockKubeProxy,
 							VPNShoot:  mockVPNShoot,
 						},
-						HVPA: mockHVPA,
 					},
 				},
 				ImageVector: imagevector.ImageVector{

--- a/pkg/operation/shoot/types.go
+++ b/pkg/operation/shoot/types.go
@@ -107,7 +107,6 @@ type Components struct {
 	Logging                  *Logging
 	GardenerAccess           component.Deployer
 	DependencyWatchdogAccess component.Deployer
-	HVPA                     component.MonitoringComponent
 	Addons                   *Addons
 }
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind cleanup

**What this PR does / why we need it**:
It does not use these metrics in any way. If they are needed in the future, they should be federated from the cache prometheus by applying the following diff:

```diff
diff --git a/charts/seed-monitoring/charts/core/charts/prometheus/templates/config.yaml b/charts/seed-monitoring/charts/core/charts/prometheus/templates/config.yaml
index 8770f7c34..948f91db9 100644
--- a/charts/seed-monitoring/charts/core/charts/prometheus/templates/config.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/templates/config.yaml
@@ -188,7 +188,6 @@ data:
         'match[]':
         - '{job="cadvisor",namespace="{{ .Release.Namespace }}"}'
         - '{job="kube-state-metrics",namespace="{{ .Release.Namespace }}"}'
+        - '{job="hvpa-controller",namespace="{{ .Release.Namespace }}"}'
         - '{__name__=~"metering:.+",namespace="{{ .Release.Namespace }}"}'
       static_configs:
       - targets:
```

/cc @istvanballok

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
