### PR TITLE
Deploy `cluster-identity` managed resource on the seed conditionally

### DIFF
--- a/cmd/gardener-apiserver/app/gardener_apiserver.go
+++ b/cmd/gardener-apiserver/app/gardener_apiserver.go
@@ -346,7 +346,7 @@ func (o *Options) Run(ctx context.Context) error {
 			Immutable: pointer.Bool(true),
 			Data: map[string]string{
 				v1beta1constants.ClusterIdentity:       o.ExtraOptions.ClusterIdentity,
-				v1beta1constants.ClusterIdentityOrigin: v1beta1constants.ClusterIdentityOriginGardenerApiServer,
+				v1beta1constants.ClusterIdentityOrigin: v1beta1constants.ClusterIdentityOriginGardenerAPIServer,
 			},
 		}, kubernetesclient.DefaultCreateOptions())
 		return err

--- a/cmd/gardener-apiserver/app/gardener_apiserver.go
+++ b/cmd/gardener-apiserver/app/gardener_apiserver.go
@@ -44,6 +44,7 @@ import (
 	"k8s.io/component-base/version"
 	"k8s.io/component-base/version/verflag"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -332,6 +333,7 @@ func (o *Options) Run(ctx context.Context) error {
 		if _, err := kubeClient.CoreV1().ConfigMaps(metav1.NamespaceSystem).Get(ctx, v1beta1constants.ClusterIdentity, metav1.GetOptions{}); client.IgnoreNotFound(err) != nil {
 			return err
 		} else if err == nil {
+			// TODO(oliver-goetz): set immutable flag to true and origin to gardener-apiserver if the origin is empty in a future release when shoot clusters have been reconciled at least once
 			// Cluster identity ConfigMap already exists
 			return nil
 		}
@@ -341,8 +343,10 @@ func (o *Options) Run(ctx context.Context) error {
 				Name:      v1beta1constants.ClusterIdentity,
 				Namespace: metav1.NamespaceSystem,
 			},
+			Immutable: pointer.Bool(true),
 			Data: map[string]string{
-				v1beta1constants.ClusterIdentity: o.ExtraOptions.ClusterIdentity,
+				v1beta1constants.ClusterIdentity:       o.ExtraOptions.ClusterIdentity,
+				v1beta1constants.ClusterIdentityOrigin: v1beta1constants.ClusterIdentityOriginGardenerApiServer,
 			},
 		}, kubernetesclient.DefaultCreateOptions())
 		return err

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -649,9 +649,9 @@ const (
 	// ClusterIdentity is a constant equal to the name and data key (that stores the identity) of the cluster-identity ConfigMap
 	ClusterIdentity = "cluster-identity"
 	// ClusterIdentityOrigin is a constant equal to the data key that stores the identity origin of the cluster-identity ConfigMap
-	ClusterIdentityOrigin = "cluster-identity-origin"
-	// ClusterIdentityOriginGardenerApiServer defines a cluster-identity ConfigMap originated from gardener-apiserver
-	ClusterIdentityOriginGardenerApiServer = "gardener-apiserver"
+	ClusterIdentityOrigin = "origin"
+	// ClusterIdentityOriginGardenerAPIServer defines a cluster-identity ConfigMap originated from gardener-apiserver
+	ClusterIdentityOriginGardenerAPIServer = "gardener-apiserver"
 	// ClusterIdentityOriginSeed defines a cluster-identity ConfigMap originated from seed
 	ClusterIdentityOriginSeed = "seed"
 	// ClusterIdentityOriginShoot defines a cluster-identity ConfigMap originated from shoot

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -648,6 +648,14 @@ const (
 
 	// ClusterIdentity is a constant equal to the name and data key (that stores the identity) of the cluster-identity ConfigMap
 	ClusterIdentity = "cluster-identity"
+	// ClusterIdentityOrigin is a constant equal to the data key that stores the identity origin of the cluster-identity ConfigMap
+	ClusterIdentityOrigin = "cluster-identity-origin"
+	// ClusterIdentityOriginGardenerApiServer defines a cluster-identity ConfigMap originated from gardener-apiserver
+	ClusterIdentityOriginGardenerApiServer = "gardener-apiserver"
+	// ClusterIdentityOriginSeed defines a cluster-identity ConfigMap originated from seed
+	ClusterIdentityOriginSeed = "seed"
+	// ClusterIdentityOriginShoot defines a cluster-identity ConfigMap originated from shoot
+	ClusterIdentityOriginShoot = "shoot"
 
 	// SeedNginxIngressClass defines the ingress class for the seed nginx ingress controller
 	SeedNginxIngressClass = "nginx-gardener"

--- a/pkg/gardenlet/controller/seed/seed/reconciler_delete.go
+++ b/pkg/gardenlet/controller/seed/seed/reconciler_delete.go
@@ -307,6 +307,21 @@ func (r *Reconciler) runDeleteSeedFlow(
 			})
 		)
 		syncPointCleanedUp.Insert(destroyClusterIdentity)
+	} else {
+		// This is the migration scenario for the "cluster-identity" managed resource.
+		// In the first step the "cluster-identity" config map is annotated with "resources.gardener.cloud/mode: Ignore"
+		// In the second step (next release) the migration managed resource will be destroyed.
+		// In the last step the migration scenario will be removed entirely.
+		// TODO(oliver-goetz): Remove this migration scenario in a future release at the second step of migration.
+		var (
+			clusterIdentity = clusteridentity.NewIgnoredManagedResourceForSeed(seedClient, r.GardenNamespace, "")
+
+			destroyClusterIdentity = g.Add(flow.Task{
+				Name: "Destroying cluster-identity migration",
+				Fn:   component.OpDestroyAndWait(clusterIdentity).Destroy,
+			})
+		)
+		syncPointCleanedUp.Insert(destroyClusterIdentity)
 	}
 
 	// When the seed is the garden cluster then these components are reconciled by the gardener-operator.

--- a/pkg/gardenlet/controller/seed/seed/reconciler_delete.go
+++ b/pkg/gardenlet/controller/seed/seed/reconciler_delete.go
@@ -160,6 +160,11 @@ func (r *Reconciler) runDeleteSeedFlow(
 		return err
 	}
 
+	seedIsOriginOfClusterIdentity, err := clusteridentity.IsClusterIdentityEmptyOrFromOrigin(ctx, seedClient, v1beta1constants.ClusterIdentityOriginSeed)
+	if err != nil {
+		return err
+	}
+
 	secretData, err := getDNSProviderSecretData(ctx, r.GardenClient, seed.GetInfo())
 	if err != nil {
 		return err
@@ -195,7 +200,6 @@ func (r *Reconciler) runDeleteSeedFlow(
 		kubeStateMetrics   = kubestatemetrics.New(seedClient, r.GardenNamespace, nil, kubestatemetrics.Values{ClusterType: component.ClusterTypeSeed})
 		nginxIngress       = nginxingress.New(seedClient, r.GardenNamespace, nginxingress.Values{})
 		networkPolicies    = networkpolicies.NewBootstrapper(seedClient, r.GardenNamespace, networkpolicies.GlobalValues{})
-		clusterIdentity    = clusteridentity.NewForSeed(seedClient, r.GardenNamespace, "")
 		dwdEndpoint        = dependencywatchdog.NewBootstrapper(seedClient, r.GardenNamespace, dependencywatchdog.BootstrapperValues{Role: dependencywatchdog.RoleEndpoint})
 		dwdProbe           = dependencywatchdog.NewBootstrapper(seedClient, r.GardenNamespace, dependencywatchdog.BootstrapperValues{Role: dependencywatchdog.RoleProbe})
 		systemResources    = seedsystem.New(seedClient, r.GardenNamespace, seedsystem.Values{})
@@ -225,10 +229,6 @@ func (r *Reconciler) runDeleteSeedFlow(
 			Name:         "Ensuring no ControllerInstallations are left",
 			Fn:           ensureNoControllerInstallations(r.GardenClient, seed.GetInfo().Name),
 			Dependencies: flow.NewTaskIDs(destroyDNSRecord),
-		})
-		destroyClusterIdentity = g.Add(flow.Task{
-			Name: "Destroying cluster-identity",
-			Fn:   component.OpDestroyAndWait(clusterIdentity).Destroy,
 		})
 		destroyClusterAutoscaler = g.Add(flow.Task{
 			Name: "Destroying cluster-autoscaler",
@@ -277,7 +277,6 @@ func (r *Reconciler) runDeleteSeedFlow(
 		})
 		syncPointCleanedUp = flow.NewTaskIDs(
 			destroyNginxIngress,
-			destroyClusterIdentity,
 			destroyClusterAutoscaler,
 			destroyNetworkPolicies,
 			destroyDWDEndpoint,
@@ -295,6 +294,20 @@ func (r *Reconciler) runDeleteSeedFlow(
 			Dependencies: flow.NewTaskIDs(syncPointCleanedUp),
 		})
 	)
+
+	// Use the managed resource for cluster-identity only if there is no cluster-identity config map in kube-system namespace from a different origin than seed.
+	// This prevents gardenlet from deleting the config map accidently on seed deletion when it was created by a different party (gardener-apiserver or shoot).
+	if seedIsOriginOfClusterIdentity {
+		var (
+			clusterIdentity = clusteridentity.NewForSeed(seedClient, r.GardenNamespace, "")
+
+			destroyClusterIdentity = g.Add(flow.Task{
+				Name: "Destroying cluster-identity",
+				Fn:   component.OpDestroyAndWait(clusterIdentity).Destroy,
+			})
+		)
+		syncPointCleanedUp.Insert(destroyClusterIdentity)
+	}
 
 	// When the seed is the garden cluster then these components are reconciled by the gardener-operator.
 	if !seedIsGarden {

--- a/pkg/gardenlet/controller/seed/seed/reconciler_delete.go
+++ b/pkg/gardenlet/controller/seed/seed/reconciler_delete.go
@@ -296,7 +296,7 @@ func (r *Reconciler) runDeleteSeedFlow(
 	)
 
 	// Use the managed resource for cluster-identity only if there is no cluster-identity config map in kube-system namespace from a different origin than seed.
-	// This prevents gardenlet from deleting the config map accidently on seed deletion when it was created by a different party (gardener-apiserver or shoot).
+	// This prevents gardenlet from deleting the config map accidentally on seed deletion when it was created by a different party (gardener-apiserver or shoot).
 	if seedIsOriginOfClusterIdentity {
 		var (
 			clusterIdentity = clusteridentity.NewForSeed(seedClient, r.GardenNamespace, "")

--- a/pkg/gardenlet/controller/seed/seed/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/seed/seed/reconciler_reconcile.go
@@ -951,7 +951,7 @@ func (r *Reconciler) runReconcileSeedFlow(
 	)
 
 	// Use the managed resource for cluster-identity only if there is no cluster-identity config map in kube-system namespace from a different origin than seed.
-	// This prevents gardenlet from deleting the config map accidently on seed deletion when it was created by a different party (gardener-apiserver or shoot).
+	// This prevents gardenlet from deleting the config map accidentally on seed deletion when it was created by a different party (gardener-apiserver or shoot).
 	if seedIsOriginOfClusterIdentity {
 		_ = g.Add(flow.Task{
 			Name: "Deploying cluster-identity",

--- a/pkg/gardenlet/controller/seed/seed/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/seed/seed/reconciler_reconcile.go
@@ -957,6 +957,16 @@ func (r *Reconciler) runReconcileSeedFlow(
 			Name: "Deploying cluster-identity",
 			Fn:   clusteridentity.NewForSeed(seedClient, r.GardenNamespace, *seed.GetInfo().Status.ClusterIdentity).Deploy,
 		})
+	} else {
+		// This is the migration scenario for the "cluster-identity" managed resource.
+		// In the first step the "cluster-identity" config map is annotated with "resources.gardener.cloud/mode: Ignore"
+		// In the second step (next release) the migration managed resource will be destroyed.
+		// In the last step the migration scenario will be removed entirely.
+		// TODO(oliver-goetz): Remove this migration scenario in a future release.
+		_ = g.Add(flow.Task{
+			Name: "Deploying cluster-identity migration",
+			Fn:   clusteridentity.NewIgnoredManagedResourceForSeed(seedClient, r.GardenNamespace, *seed.GetInfo().Status.ClusterIdentity).Deploy,
+		})
 	}
 
 	// When the seed is the garden cluster then the VPA is reconciled by the gardener-operator

--- a/pkg/operation/botanist/component/clusteridentity/clusteridentity.go
+++ b/pkg/operation/botanist/component/clusteridentity/clusteridentity.go
@@ -200,6 +200,5 @@ func IsClusterIdentityEmptyOrFromOrigin(ctx context.Context, c client.Client, or
 		return false, err
 	}
 	// TODO(oliver-goetz): do not treat an empty origin as foreign origin anymore in a future release when shoot clusters have been reconciled at least once
-	sameOrigin := clusterIdentity.Data[v1beta1constants.ClusterIdentityOrigin] == origin
-	return sameOrigin, nil
+	return clusterIdentity.Data[v1beta1constants.ClusterIdentityOrigin] == origin, nil
 }

--- a/pkg/operation/botanist/component/clusteridentity/clusteridentity.go
+++ b/pkg/operation/botanist/component/clusteridentity/clusteridentity.go
@@ -26,6 +26,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/operation/botanist/component"
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
@@ -46,10 +47,12 @@ type Interface interface {
 }
 
 type clusterIdentity struct {
-	client                  client.Client
-	namespace               string
-	identity                string
-	identityType            string
+	client       client.Client
+	namespace    string
+	identity     string
+	identityType string
+	//TODO(oliver-goetz): Remove this migration scenario in a future release
+	ignoreManagedResource   bool
 	managedResourceRegistry *managedresources.Registry
 	managedResourceName     string
 	managedResourceDeleteFn func(ctx context.Context, client client.Client, namespace string, name string) error
@@ -60,6 +63,7 @@ func new(
 	namespace string,
 	identity string,
 	identityType string,
+	ignoreManagedResource bool,
 	managedResourceRegistry *managedresources.Registry,
 	managedResourceName string,
 	managedResourceDeleteFn func(ctx context.Context, client client.Client, namespace string, name string) error,
@@ -69,6 +73,7 @@ func new(
 		namespace:               namespace,
 		identity:                identity,
 		identityType:            identityType,
+		ignoreManagedResource:   ignoreManagedResource,
 		managedResourceRegistry: managedResourceRegistry,
 		managedResourceName:     managedResourceName,
 		managedResourceDeleteFn: managedResourceDeleteFn,
@@ -82,6 +87,23 @@ func NewForSeed(c client.Client, namespace, identity string) Interface {
 		namespace,
 		identity,
 		v1beta1constants.ClusterIdentityOriginSeed,
+		false,
+		managedresources.NewRegistry(kubernetes.SeedScheme, kubernetes.SeedCodec, kubernetes.SeedSerializer),
+		ManagedResourceControlName,
+		managedresources.DeleteForSeed,
+	)
+}
+
+// NewIgnoredManagedResourceForSeed creates new instance of Deployer for the seed's cluster identity for migration purposes.
+// The cluster-identity config map is annotated with "resources.gardener.cloud/mode: Ignore".
+// TODO(oliver-goetz): Remove this migration scenario in a future release
+func NewIgnoredManagedResourceForSeed(c client.Client, namespace, identity string) Interface {
+	return new(
+		c,
+		namespace,
+		identity,
+		v1beta1constants.ClusterIdentityOriginSeed,
+		true,
 		managedresources.NewRegistry(kubernetes.SeedScheme, kubernetes.SeedCodec, kubernetes.SeedSerializer),
 		ManagedResourceControlName,
 		managedresources.DeleteForSeed,
@@ -95,6 +117,7 @@ func NewForShoot(c client.Client, namespace, identity string) Interface {
 		namespace,
 		identity,
 		v1beta1constants.ClusterIdentityOriginShoot,
+		false,
 		managedresources.NewRegistry(kubernetes.ShootScheme, kubernetes.ShootCodec, kubernetes.ShootSerializer),
 		ShootManagedResourceName,
 		managedresources.DeleteForShoot,
@@ -112,6 +135,17 @@ func (c *clusterIdentity) Deploy(ctx context.Context) error {
 			v1beta1constants.ClusterIdentity:       c.identity,
 			v1beta1constants.ClusterIdentityOrigin: c.identityType,
 		},
+	}
+
+	// TODO(oliver-goetz): Remove this migration scenario in a future release
+	if c.ignoreManagedResource {
+		configMap = &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        v1beta1constants.ClusterIdentity,
+				Namespace:   metav1.NamespaceSystem,
+				Annotations: map[string]string{resourcesv1alpha1.Mode: resourcesv1alpha1.ModeIgnore},
+			},
+		}
 	}
 
 	resources, err := c.managedResourceRegistry.AddAllAndSerialize(configMap)

--- a/pkg/operation/botanist/component/clusteridentity/clusteridentity_test.go
+++ b/pkg/operation/botanist/component/clusteridentity/clusteridentity_test.go
@@ -55,7 +55,7 @@ var _ = Describe("ClusterIdentity", func() {
 		configMapYAML = `apiVersion: v1
 data:
   cluster-identity: ` + identity + `
-  cluster-identity-origin: ` + origin + `
+  origin: ` + origin + `
 immutable: true
 kind: ConfigMap
 metadata:
@@ -290,7 +290,7 @@ metadata:
 		})
 	})
 
-	Describe("CheckNonSeedClusterIdentityExists", func() {
+	Describe("#IsClusterIdentityEmptyOrFromOrigin", func() {
 		var (
 			seedClient client.Client
 
@@ -308,8 +308,8 @@ metadata:
 				},
 				Immutable: pointer.Bool(true),
 				Data: map[string]string{
-					"cluster-identity":        "foo",
-					"cluster-identity-origin": "seed",
+					"cluster-identity": "foo",
+					"origin":           "seed",
 				},
 			}
 			configMapNonSeed = &corev1.ConfigMap{
@@ -319,8 +319,8 @@ metadata:
 				},
 				Immutable: pointer.Bool(true),
 				Data: map[string]string{
-					"cluster-identity":        "foo",
-					"cluster-identity-origin": "bar",
+					"cluster-identity": "foo",
+					"origin":           "bar",
 				},
 			}
 		})

--- a/pkg/operation/care/seed_health.go
+++ b/pkg/operation/care/seed_health.go
@@ -47,7 +47,6 @@ import (
 var requiredManagedResourcesSeed = sets.NewString(
 	etcd.Druid,
 	networkpolicies.ManagedResourceControlName,
-	clusteridentity.ManagedResourceControlName,
 	clusterautoscaler.ManagedResourceControlName,
 	kubestatemetrics.ManagedResourceName,
 	seedsystem.ManagedResourceName,
@@ -101,6 +100,14 @@ func (h *SeedHealth) checkSeedSystemComponents(
 	error,
 ) {
 	managedResources := requiredManagedResourcesSeed.List()
+
+	seedIsOriginOfClusterIdentity, err := clusteridentity.IsClusterIdentityEmptyOrFromOrigin(ctx, h.seedClient, v1beta1constants.ClusterIdentityOriginSeed)
+	if err != nil {
+		return nil, err
+	}
+	if seedIsOriginOfClusterIdentity {
+		managedResources = append(managedResources, clusteridentity.ManagedResourceControlName)
+	}
 
 	if gardenletfeatures.FeatureGate.Enabled(features.ManagedIstio) {
 		managedResources = append(managedResources, istio.ManagedResourceControlName)

--- a/test/integration/gardenlet/seed/seed/seed_test.go
+++ b/test/integration/gardenlet/seed/seed/seed_test.go
@@ -313,6 +313,8 @@ var _ = Describe("Seed controller tests", func() {
 					By("Verify that the seed system components have been deployed")
 					expectedManagedResources := []gomegatypes.GomegaMatcher{
 						MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("cluster-autoscaler")})}),
+						// TODO(oliver-goetz): "cluster-identity" managed resource won't be created by gardenlet anymore in the test scenario in the future.
+						MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("cluster-identity")})}),
 						MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("dependency-watchdog-endpoint")})}),
 						MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("dependency-watchdog-probe")})}),
 						MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("global-network-policies")})}),

--- a/test/integration/gardenlet/seed/seed/seed_test.go
+++ b/test/integration/gardenlet/seed/seed/seed_test.go
@@ -313,7 +313,6 @@ var _ = Describe("Seed controller tests", func() {
 					By("Verify that the seed system components have been deployed")
 					expectedManagedResources := []gomegatypes.GomegaMatcher{
 						MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("cluster-autoscaler")})}),
-						MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("cluster-identity")})}),
 						MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("dependency-watchdog-endpoint")})}),
 						MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("dependency-watchdog-probe")})}),
 						MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("global-network-policies")})}),


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind technical-debt

**What this PR does / why we need it**:
With this PR the `cluster-identity` config map in the `kube-system` namespace of the seed is deployed only if it is not existing yet.
This prevents that this config map is deleted on seed deletion even if it was created by a different origin. 
Additionally, `cluster-identity` config map now becomes immutable as it should not change in the clusters lifetime. 

There is a migration scenario which includes three steps.
1. Annotate the content of `cluster-identity`  managed resource of the seed with `resources.gardener.cloud/mode: Ignore` if `cluster-identity` config map is already existing.
  Switch `cluster-identity` config maps originated by the shoots to immutable.
2. Delete `cluster-identity` config map in the same case.
    Switch `cluster-identity` config maps originated by gardener-apiserver and the seeds to immutable. 
3. Remove the migration code.

This PR represents step 1.

**Which issue(s) this PR fixes**:
Part of #6896

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
5. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
When deleting a seed the `cluster-identity` config map in `kube-system` namespace is not deleted anymore if it was already existing on seed creation.
```
