### PR TITLE
Enhance `gardener-resource-manager`'s `NetworkPolicy` controller to allow custom pod label selector

### DIFF
--- a/docs/concepts/resource-manager.md
+++ b/docs/concepts/resource-manager.md
@@ -683,6 +683,22 @@ Now the component in namespace `bar` only needs this single label and is able to
 > Real-world examples for this scenario are the `kube-apiserver` `Service` (which exists in all shoot namespaces), or the `istio-ingressgateway` `Service` (which exists in all `istio-ingress*` namespaces).
 > In both cases, the names of the namespaces are not statically known and depend on user input.
 
+#### Overwriting The Pod Selector Label
+
+For a component which initiates the connection to many other components, it's sometimes impractical to specify all the respective labels in its pod template.
+For example, let's say a component `foo` talks to `bar{0..9}` on ports `tcp/808{0..9}`.
+`foo` would need to have the ten `networking.resources.gardener.cloud/to-bar{0..9}-tcp-808{0..9}=allowed` labels.
+
+As an alternative and to simplify this, it is also possible to annotate the targeted `Service`s with `networking.resources.gardener.cloud/from-policy-pod-selector-label=<some-alias>`.
+For our example, `<some-alias>` could be `all-bars`.
+
+As a result, component `foo` just needs to have the label `networking.resources.gardener.cloud/to-all-bars=allowed` instead of all the other ten explicit labels.
+
+⚠️ Note that this also requires to specify the list of allowed container ports since the pod selector label will no longer be specific for a dedicated service/port.
+For our example, the `Service` for `barX` with `X` in `{0..9}` needs to be annotated with `networking.resources.gardener.cloud/from-policy-allowed-ports=[{"port":808X,"protocol":"TCP"}]` in addition.
+
+> Real-world examples for this scenario are the `Prometheis` in seed clusters which initiate the communication to a lot of components in order to scrape their metrics.
+
 #### Ingress From Everywhere
 
 All above scenarios are about components initiating connections to some targets.

--- a/pkg/apis/resources/v1alpha1/types.go
+++ b/pkg/apis/resources/v1alpha1/types.go
@@ -158,6 +158,13 @@ const (
 	// NetworkingFromWorldToPorts is a constant for an annotation on a Service which contains a list of ports to which
 	// ingress traffic from everywhere shall be allowed.
 	NetworkingFromWorldToPorts = "networking.resources.gardener.cloud/from-world-to-ports"
+	// NetworkingFromPolicyPodLabelSelector is a constant for an annotation on a Service which contains the label
+	// selector which should be used for pods initiating the communication with this Service. Note that the ports must
+	// be container ports, not service ports.
+	NetworkingFromPolicyPodLabelSelector = "networking.resources.gardener.cloud/from-policy-pod-label-selector"
+	// NetworkingFromPolicyAllowedPorts is a constant for an annotation on a Service which contains a list of ports to
+	// which ingress traffic shall be allowed. Note that the ports must be container ports, not service ports.
+	NetworkingFromPolicyAllowedPorts = "networking.resources.gardener.cloud/from-policy-allowed-ports"
 	// NetworkingServiceName is a constant for a label on a NetworkPolicy which contains the name of the Service is has
 	// been created for.
 	NetworkingServiceName = "networking.resources.gardener.cloud/service-name"

--- a/pkg/resourcemanager/controller/networkpolicy/add.go
+++ b/pkg/resourcemanager/controller/networkpolicy/add.go
@@ -103,7 +103,9 @@ func (r *Reconciler) ServicePredicate() predicate.Predicate {
 				!apiequality.Semantic.DeepEqual(service.Spec.Ports, oldService.Spec.Ports) ||
 				oldService.Annotations[resourcesv1alpha1.NetworkingPodLabelSelectorNamespaceAlias] != service.Annotations[resourcesv1alpha1.NetworkingPodLabelSelectorNamespaceAlias] ||
 				oldService.Annotations[resourcesv1alpha1.NetworkingNamespaceSelectors] != service.Annotations[resourcesv1alpha1.NetworkingNamespaceSelectors] ||
-				oldService.Annotations[resourcesv1alpha1.NetworkingFromWorldToPorts] != service.Annotations[resourcesv1alpha1.NetworkingFromWorldToPorts]
+				oldService.Annotations[resourcesv1alpha1.NetworkingFromWorldToPorts] != service.Annotations[resourcesv1alpha1.NetworkingFromWorldToPorts] ||
+				oldService.Annotations[resourcesv1alpha1.NetworkingFromPolicyPodLabelSelector] != service.Annotations[resourcesv1alpha1.NetworkingFromPolicyPodLabelSelector] ||
+				oldService.Annotations[resourcesv1alpha1.NetworkingFromPolicyAllowedPorts] != service.Annotations[resourcesv1alpha1.NetworkingFromPolicyAllowedPorts]
 		},
 	}
 }

--- a/pkg/resourcemanager/controller/networkpolicy/add_test.go
+++ b/pkg/resourcemanager/controller/networkpolicy/add_test.go
@@ -119,6 +119,20 @@ var _ = Describe("Add", func() {
 
 				Expect(p.Update(event.UpdateEvent{ObjectOld: oldService, ObjectNew: service})).To(BeTrue())
 			})
+
+			It("should return true because the from-policy-pod-label-selector annotation was changed", func() {
+				oldService := service.DeepCopy()
+				service.Annotations = map[string]string{"networking.resources.gardener.cloud/from-policy-pod-label-selector": "foo"}
+
+				Expect(p.Update(event.UpdateEvent{ObjectOld: oldService, ObjectNew: service})).To(BeTrue())
+			})
+
+			It("should return true because the from-policy-allowed-ports annotation was changed", func() {
+				oldService := service.DeepCopy()
+				service.Annotations = map[string]string{"networking.resources.gardener.cloud/from-policy-allowed-ports": "foo"}
+
+				Expect(p.Update(event.UpdateEvent{ObjectOld: oldService, ObjectNew: service})).To(BeTrue())
+			})
 		})
 
 		Describe("#Delete", func() {

--- a/pkg/resourcemanager/controller/networkpolicy/reconciler.go
+++ b/pkg/resourcemanager/controller/networkpolicy/reconciler.go
@@ -119,6 +119,10 @@ func (r *Reconciler) namespaceIsHandled(ctx context.Context, namespaceName strin
 		return false, fmt.Errorf("failed to get namespace %q: %w", namespaceName, err)
 	}
 
+	if len(r.selectors) == 0 {
+		return true, nil
+	}
+
 	for _, selector := range r.selectors {
 		if selector.Matches(labels.Set(namespace.GetLabels())) {
 			return true, nil


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking dev-productivity
/kind enhancement

**What this PR does / why we need it**:
By default, for a `Service` called `foo` with a `tcp/80` port, the controller creates `NetworkPolicy`s allowing pods labeled with `networking.resources.gardener.cloud/to-foo-tcp-80=allowed` to initiate connections to `foo`.
However, for some cases, this is impractical (e.g., when a component initiates the connection to many other components). 

With this PR, it is possible to specify a custom pod label selector via the `networking.resources.gardener.cloud/from-policy-pod-label-selector` annotation on the `Service`. In addition, the respective container ports which are allowed to be contacted must be provided via the `networking.resources.gardener.cloud/from-policy-allowed-ports` annotation.

For example, when a `Service` `called `foo` is annotated with
- `networking.resources.gardener.cloud/from-policy-pod-label-selector=custom-selector`
- `networking.resources.gardener.cloud/from-policy-allowed-ports=[{"port":80,"protocol":"TCP"}]`
then pods labeled with `networking.resources.gardener.cloud/to-custom-selector=allowed` are allowed to communicate with it.

A real-world example of this are the Prometheis in the seed cluster. They scrape almost each and every other component in the cluster. Besides that, they scrape components deployed by extensions. Without this PR, extensions would need to mutate the labels of the Prometheis to allow the traffic (which is impractical).

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/7352

**Special notes for your reviewer**:
✅ ~~Depends on #7412 which must be merged first, hence PR is in draft state (though, all relevant commits for this change can be found after the [`------------ empty separator commit ------------`](https://github.com/gardener/gardener/commit/c07fce60792b59110488ff455a335d7166b52249) commit and are ready for review)~~.

/cc @ScheererJ @istvanballok 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
