### PR TITLE
Update `kubectl wait` command to handle multiple conditions correctly

### DIFF
--- a/docs/deployment/getting_started_locally.md
+++ b/docs/deployment/getting_started_locally.md
@@ -94,6 +94,12 @@ Afterwards, the Gardener resources will be deployed into the cluster.
 
 ## Creating a `Shoot` Cluster
 
+You can wait for the `Seed` to be ready by running:
+
+```bash
+./hack/usage/wait-for.sh seed local GardenletReady Bootstrapped SeedSystemComponentsHealthy ExtensionsReady
+```
+
 Alternatively, you can run `kubectl get seed local` and wait for the `STATUS` to indicate readiness:
 
 ```bash
@@ -110,7 +116,7 @@ kubectl apply -f example/provider-local/shoot.yaml
 You can wait for the `Shoot` to be ready by running:
 
 ```bash
-NAMESPACE=garden-local ./hack/usage/wait.sh shoot APIServerAvailable ControlPlaneHealthy ObservabilityComponentsHealthy EveryNodeReady SystemComponentsHealthy
+NAMESPACE=garden-local ./hack/usage/wait-for.sh shoot APIServerAvailable ControlPlaneHealthy ObservabilityComponentsHealthy EveryNodeReady SystemComponentsHealthy
 ```
 
 Alternatively, you can run `kubectl -n garden-local get shoot local` and wait for the `LAST OPERATION` to reach `100%`:
@@ -183,6 +189,12 @@ make gardenlet-kind2-up
 ```
 
 The following steps assume that you are using the kubeconfig that points to the `gardener-local` cluster (first KinD cluster): `export KUBECONFIG=example/gardener-local/kind/local/kubeconfig`.
+
+You can wait for the `local2` `Seed` to be ready by running:
+
+```bash
+./hack/usage/wait-for.sh seed local2 GardenletReady Bootstrapped ExtensionsReady
+```
 
 Alternatively, you can run `kubectl get seed local2` and wait for the `STATUS` to indicate readiness:
 

--- a/docs/deployment/getting_started_locally.md
+++ b/docs/deployment/getting_started_locally.md
@@ -110,11 +110,7 @@ kubectl apply -f example/provider-local/shoot.yaml
 You can wait for the `Shoot` to be ready by running:
 
 ```bash
-kubectl wait --for=condition=apiserveravailable shoot local -n garden-local --timeout=10m
-kubectl wait --for=condition=controlplanehealthy shoot local -n garden-local --timeout=10m
-kubectl wait --for=condition=observabilitycomponentshealthy shoot local -n garden-local --timeout=10m
-kubectl wait --for=condition=everynodeready shoot local -n garden-local --timeout=10m
-kubectl wait --for=condition=systemcomponentshealthy shoot local -n garden-local --timeout=10m
+NAMESPACE=garden-local ./hack/usage/wait.sh shoot APIServerAvailable ControlPlaneHealthy ObservabilityComponentsHealthy EveryNodeReady SystemComponentsHealthy
 ```
 
 Alternatively, you can run `kubectl -n garden-local get shoot local` and wait for the `LAST OPERATION` to reach `100%`:

--- a/docs/deployment/getting_started_locally.md
+++ b/docs/deployment/getting_started_locally.md
@@ -94,12 +94,6 @@ Afterwards, the Gardener resources will be deployed into the cluster.
 
 ## Creating a `Shoot` Cluster
 
-You can wait for the `Seed` to be ready by running:
-
-```bash
-kubectl wait --for=condition=gardenletready --for=condition=extensionsready --for=condition=bootstrapped seed local --timeout=5m
-```
-
 Alternatively, you can run `kubectl get seed local` and wait for the `STATUS` to indicate readiness:
 
 ```bash
@@ -116,7 +110,11 @@ kubectl apply -f example/provider-local/shoot.yaml
 You can wait for the `Shoot` to be ready by running:
 
 ```bash
-kubectl wait --for=condition=apiserveravailable --for=condition=controlplanehealthy --for=condition=observabilitycomponentshealthy --for=condition=everynodeready --for=condition=systemcomponentshealthy shoot local -n garden-local --timeout=10m
+kubectl wait --for=condition=apiserveravailable shoot local -n garden-local --timeout=10m
+kubectl wait --for=condition=controlplanehealthy shoot local -n garden-local --timeout=10m
+kubectl wait --for=condition=observabilitycomponentshealthy shoot local -n garden-local --timeout=10m
+kubectl wait --for=condition=everynodeready shoot local -n garden-local --timeout=10m
+kubectl wait --for=condition=systemcomponentshealthy shoot local -n garden-local --timeout=10m
 ```
 
 Alternatively, you can run `kubectl -n garden-local get shoot local` and wait for the `LAST OPERATION` to reach `100%`:
@@ -189,12 +187,6 @@ make gardenlet-kind2-up
 ```
 
 The following steps assume that you are using the kubeconfig that points to the `gardener-local` cluster (first KinD cluster): `export KUBECONFIG=example/gardener-local/kind/local/kubeconfig`.
-
-You can wait for the `local2` `Seed` to be ready by running:
-
-```bash
-kubectl wait --for=condition=gardenletready --for=condition=extensionsready --for=condition=bootstrapped seed local2 --timeout=5m
-```
 
 Alternatively, you can run `kubectl get seed local2` and wait for the `STATUS` to indicate readiness:
 

--- a/docs/development/getting_started_locally.md
+++ b/docs/development/getting_started_locally.md
@@ -142,7 +142,7 @@ make start-extension-provider-local                                           # 
 You can wait for the `Seed` to become ready by running:
 
 ```bash
-kubectl wait --for=condition=gardenletready --for=condition=extensionsready --for=condition=bootstrapped seed local --timeout=5m
+./hack/usage/wait.sh seed local GardenletReady Bootstrapped SeedSystemComponentsHealthy ExtensionsReady
 ```
 
 Alternatively, you can run `kubectl get seed local` and wait for the `STATUS` to indicate readiness:
@@ -161,7 +161,7 @@ kubectl apply -f example/provider-local/shoot.yaml
 You can wait for the `Shoot` to be ready by running:
 
 ```bash
-kubectl wait --for=condition=apiserveravailable --for=condition=controlplanehealthy --for=condition=observabilitycomponentshealthy --for=condition=everynodeready --for=condition=systemcomponentshealthy shoot local -n garden-local --timeout=10m
+NAMESPACE=garden-local ./hack/usage/wait.sh shoot local APIServerAvailable ControlPlaneHealthy ObservabilityComponentsHealthy EveryNodeReady SystemComponentsHealthy
 ```
 
 Alternatively, you can run `kubectl -n garden-local get shoot local` and wait for the `LAST OPERATION` to reach `100%`:

--- a/docs/development/getting_started_locally.md
+++ b/docs/development/getting_started_locally.md
@@ -142,7 +142,7 @@ make start-extension-provider-local                                           # 
 You can wait for the `Seed` to become ready by running:
 
 ```bash
-./hack/usage/wait.sh seed local GardenletReady Bootstrapped SeedSystemComponentsHealthy ExtensionsReady
+./hack/usage/wait-for.sh seed local GardenletReady Bootstrapped SeedSystemComponentsHealthy ExtensionsReady
 ```
 
 Alternatively, you can run `kubectl get seed local` and wait for the `STATUS` to indicate readiness:
@@ -161,7 +161,7 @@ kubectl apply -f example/provider-local/shoot.yaml
 You can wait for the `Shoot` to be ready by running:
 
 ```bash
-NAMESPACE=garden-local ./hack/usage/wait.sh shoot local APIServerAvailable ControlPlaneHealthy ObservabilityComponentsHealthy EveryNodeReady SystemComponentsHealthy
+NAMESPACE=garden-local ./hack/usage/wait-for.sh shoot local APIServerAvailable ControlPlaneHealthy ObservabilityComponentsHealthy EveryNodeReady SystemComponentsHealthy
 ```
 
 Alternatively, you can run `kubectl -n garden-local get shoot local` and wait for the `LAST OPERATION` to reach `100%`:

--- a/example/gardener-local/kind/cluster/templates/cluster.yaml
+++ b/example/gardener-local/kind/cluster/templates/cluster.yaml
@@ -1,6 +1,9 @@
 apiVersion: kind.x-k8s.io/v1alpha4
 kind: Cluster
 featureGates:
+# Introudced due to https://github.com/gardener/gardener/issues/7297#issuecomment-1377515385.
+# Feature gate 'ExpandedDNSConfig' will be true by default from k8s version 1.26.
+# Remove this once kind cluster upgraded to k8s version 1.26
   ExpandedDNSConfig: true
 nodes:
 - role: control-plane

--- a/example/gardener-local/kind/cluster/templates/cluster.yaml
+++ b/example/gardener-local/kind/cluster/templates/cluster.yaml
@@ -3,7 +3,7 @@ kind: Cluster
 featureGates:
 # Introudced due to https://github.com/gardener/gardener/issues/7297#issuecomment-1377515385.
 # Feature gate 'ExpandedDNSConfig' will be true by default from k8s version 1.26.
-# Remove this once kind cluster upgraded to k8s version 1.26
+# Remove this once kind cluster version is upgraded to 1.26
   ExpandedDNSConfig: true
 nodes:
 - role: control-plane

--- a/example/gardener-local/kind/cluster/templates/cluster.yaml
+++ b/example/gardener-local/kind/cluster/templates/cluster.yaml
@@ -1,5 +1,7 @@
 apiVersion: kind.x-k8s.io/v1alpha4
 kind: Cluster
+featureGates:
+  ExpandedDNSConfig: true
 nodes:
 - role: control-plane
   image: {{ .Values.image }}

--- a/example/gardener-local/kind/cluster/templates/cluster.yaml
+++ b/example/gardener-local/kind/cluster/templates/cluster.yaml
@@ -1,7 +1,7 @@
 apiVersion: kind.x-k8s.io/v1alpha4
 kind: Cluster
 featureGates:
-# Introudced due to https://github.com/gardener/gardener/issues/7297#issuecomment-1377515385.
+# Introduced due to the issue outlined in the following link: https://github.com/gardener/gardener/issues/7297#issuecomment-1377515385."
 # Feature gate 'ExpandedDNSConfig' will be true by default from k8s version 1.26.
 # Remove this once kind cluster version is upgraded to 1.26
   ExpandedDNSConfig: true

--- a/hack/ci-e2e-kind-upgrade.sh
+++ b/hack/ci-e2e-kind-upgrade.sh
@@ -192,7 +192,7 @@ upgrade_to_next_release
 echo "Wait until seed '$SEED_NAME' gets upgraded from version '$GARDENER_PREVIOUS_RELEASE' to '$GARDENER_NEXT_RELEASE'"
 kubectl wait seed $SEED_NAME --timeout=5m --for=jsonpath="{.status.gardener.version}=$GARDENER_NEXT_RELEASE"
 # TIMEOUT has been increased to 1200 (20 minutes) due to the upgrading of Gardener for seed.
-# In a single-zone setup, 3 istio-ingressgateway pods will be running, and it will take 9 minutes to complete the rollout.
+# In a single-zone setup, 2 istio-ingressgateway pods will be running, and it will take 9 minutes to complete the rollout.
 # In a multi-zone setup, 6 istio-ingressgateway pods will be running, and it will take 18 minutes to complete the rollout.
 TIMEOUT=1200 ./hack/usage/wait-for.sh seed "$SEED_NAME" GardenletReady Bootstrapped SeedSystemComponentsHealthy ExtensionsReady BackupBucketsReady
 

--- a/hack/ci-e2e-kind-upgrade.sh
+++ b/hack/ci-e2e-kind-upgrade.sh
@@ -191,10 +191,10 @@ upgrade_to_next_release
 
 echo "Wait until seed '$SEED_NAME' gets upgraded from version '$GARDENER_PREVIOUS_RELEASE' to '$GARDENER_NEXT_RELEASE'"
 kubectl wait seed $SEED_NAME --timeout=5m --for=jsonpath="{.status.gardener.version}=$GARDENER_NEXT_RELEASE"
-# RETRY_LIMIT has been increased to 240 (20 minutes) due to the upgrading of Gardener for seed.
+# TIMEOUT has been increased to 1200 (20 minutes) due to the upgrading of Gardener for seed.
 # In a single-zone setup, 3 istio-ingressgateway pods will be running, and it will take 9 minutes to complete the rollout.
 # In a multi-zone setup, 6 istio-ingressgateway pods will be running, and it will take 18 minutes to complete the rollout.
-RETRY_LIMIT=240 ./hack/usage/wait-for.sh seed "$SEED_NAME" GardenletReady Bootstrapped SeedSystemComponentsHealthy ExtensionsReady BackupBucketsReady
+TIMEOUT=1200 ./hack/usage/wait-for.sh seed "$SEED_NAME" GardenletReady Bootstrapped SeedSystemComponentsHealthy ExtensionsReady BackupBucketsReady
 
 echo "Running gardener post-upgrade tests"
 make test-post-upgrade GARDENER_PREVIOUS_RELEASE=$GARDENER_PREVIOUS_RELEASE GARDENER_NEXT_RELEASE=$GARDENER_NEXT_RELEASE

--- a/hack/ci-e2e-kind-upgrade.sh
+++ b/hack/ci-e2e-kind-upgrade.sh
@@ -190,7 +190,8 @@ echo "Upgrading gardener version '$GARDENER_PREVIOUS_RELEASE' to '$GARDENER_NEXT
 upgrade_to_next_release
 
 echo "Wait until seed '$SEED_NAME' gets upgraded from version '$GARDENER_PREVIOUS_RELEASE' to '$GARDENER_NEXT_RELEASE'"
-./hack/usage/wait.sh seed "$SEED_NAME" GardenletReady Bootstrapped SeedSystemComponentsHealthy ExtensionsReady BackupBucketsReady
+kubectl wait seed $SEED_NAME --timeout=5m --for=jsonpath="{.status.gardener.version}=$GARDENER_NEXT_RELEASE"
+./hack/usage/wait-for.sh seed "$SEED_NAME" GardenletReady Bootstrapped SeedSystemComponentsHealthy ExtensionsReady BackupBucketsReady
 
 echo "Running gardener post-upgrade tests"
 make test-post-upgrade GARDENER_PREVIOUS_RELEASE=$GARDENER_PREVIOUS_RELEASE GARDENER_NEXT_RELEASE=$GARDENER_NEXT_RELEASE

--- a/hack/ci-e2e-kind-upgrade.sh
+++ b/hack/ci-e2e-kind-upgrade.sh
@@ -191,7 +191,10 @@ upgrade_to_next_release
 
 echo "Wait until seed '$SEED_NAME' gets upgraded from version '$GARDENER_PREVIOUS_RELEASE' to '$GARDENER_NEXT_RELEASE'"
 kubectl wait seed $SEED_NAME --timeout=5m --for=jsonpath="{.status.gardener.version}=$GARDENER_NEXT_RELEASE"
-./hack/usage/wait-for.sh seed "$SEED_NAME" GardenletReady Bootstrapped SeedSystemComponentsHealthy ExtensionsReady BackupBucketsReady
+# RETRY_LIMIT has been increased to 240 (20 minutes) due to the upgrading of Gardener for seed.
+# In a single-zone setup, 3 istio-ingressgateway pods will be running, and it will take 9 minutes to complete the rollout.
+# In a multi-zone setup, 6 istio-ingressgateway pods will be running, and it will take 18 minutes to complete the rollout.
+RETRY_LIMIT=240 ./hack/usage/wait-for.sh seed "$SEED_NAME" GardenletReady Bootstrapped SeedSystemComponentsHealthy ExtensionsReady BackupBucketsReady
 
 echo "Running gardener post-upgrade tests"
 make test-post-upgrade GARDENER_PREVIOUS_RELEASE=$GARDENER_PREVIOUS_RELEASE GARDENER_NEXT_RELEASE=$GARDENER_NEXT_RELEASE

--- a/hack/ci-e2e-kind-upgrade.sh
+++ b/hack/ci-e2e-kind-upgrade.sh
@@ -162,9 +162,20 @@ function set_seed_name() {
 }
 
 function wait_until_seed_gets_upgraded() {
-  echo "Wait until seed gets upgraded from version '$GARDENER_PREVIOUS_RELEASE' to '$GARDENER_NEXT_RELEASE'"
-  kubectl wait seed $1 --timeout=5m \
-    --for=jsonpath='{.status.gardener.version}'=$GARDENER_NEXT_RELEASE && condition=gardenletready && condition=extensionsready && condition=bootstrapped
+  echo "Wait until seed '$1' gets upgraded from version '$GARDENER_PREVIOUS_RELEASE' to '$GARDENER_NEXT_RELEASE'"
+  for _ in $(seq 1 60); do
+    if [ "$(kubectl get seed "$1" -o jsonpath='{.status.conditions[?(@.type=="GardenletReady")].status}')" == "True" ] &&
+      [ "$(kubectl get seed "$1" -o jsonpath='{.status.conditions[?(@.type=="Bootstrapped")].status}')" == "True" ] &&
+      [ "$(kubectl get seed "$1" -o jsonpath='{.status.conditions[?(@.type=="SeedSystemComponentsHealthy")].status}')" == "True" ] &&
+      [ "$(kubectl get seed "$1" -o jsonpath='{.status.conditions[?(@.type=="ExtensionsReady")].status}')" == "True" ] &&
+      [ "$(kubectl get seed "$1" -o jsonpath='{.status.conditions[?(@.type=="BackupBucketsReady")].status}')" == "True" ]; then
+      echo "Seed has become ready!"
+      break
+    fi
+
+    echo "Wait until seed gets ready"
+    sleep 5
+  done
 }
 
 clamp_mss_to_pmtu

--- a/hack/ci-e2e-kind-upgrade.sh
+++ b/hack/ci-e2e-kind-upgrade.sh
@@ -161,23 +161,6 @@ function set_seed_name() {
   esac
 }
 
-function wait_until_seed_gets_upgraded() {
-  echo "Wait until seed '$1' gets upgraded from version '$GARDENER_PREVIOUS_RELEASE' to '$GARDENER_NEXT_RELEASE'"
-  for _ in $(seq 1 60); do
-    if [ "$(kubectl get seed "$1" -o jsonpath='{.status.conditions[?(@.type=="GardenletReady")].status}')" == "True" ] &&
-      [ "$(kubectl get seed "$1" -o jsonpath='{.status.conditions[?(@.type=="Bootstrapped")].status}')" == "True" ] &&
-      [ "$(kubectl get seed "$1" -o jsonpath='{.status.conditions[?(@.type=="SeedSystemComponentsHealthy")].status}')" == "True" ] &&
-      [ "$(kubectl get seed "$1" -o jsonpath='{.status.conditions[?(@.type=="ExtensionsReady")].status}')" == "True" ] &&
-      [ "$(kubectl get seed "$1" -o jsonpath='{.status.conditions[?(@.type=="BackupBucketsReady")].status}')" == "True" ]; then
-      echo "Seed has become ready!"
-      break
-    fi
-
-    echo "Wait until seed gets ready"
-    sleep 5
-  done
-}
-
 clamp_mss_to_pmtu
 set_gardener_upgrade_version_env_variables
 set_cluster_name
@@ -190,7 +173,7 @@ export GARDENER_PREVIOUS_VERSION="$(cat $GARDENER_RELEASE_DOWNLOAD_PATH/gardener
 # test setup
 kind_up
 
-# export all container logs and events after test execution
+export all container logs and events after test execution
 trap "
 ( rm -rf $GARDENER_RELEASE_DOWNLOAD_PATH/gardener-releases);
 ( export_logs '$CLUSTER_NAME'; export_events_for_kind '$CLUSTER_NAME'; export_events_for_shoots )
@@ -205,7 +188,9 @@ make test-pre-upgrade GARDENER_PREVIOUS_RELEASE=$GARDENER_PREVIOUS_RELEASE GARDE
 
 echo "Upgrading gardener version '$GARDENER_PREVIOUS_RELEASE' to '$GARDENER_NEXT_RELEASE'"
 upgrade_to_next_release
-wait_until_seed_gets_upgraded "$SEED_NAME"
+
+echo "Wait until seed '$SEED_NAME' gets upgraded from version '$GARDENER_PREVIOUS_RELEASE' to '$GARDENER_NEXT_RELEASE'"
+./hack/usage/wait.sh seed "$SEED_NAME" GardenletReady Bootstrapped SeedSystemComponentsHealthy ExtensionsReady BackupBucketsReady
 
 echo "Running gardener post-upgrade tests"
 make test-post-upgrade GARDENER_PREVIOUS_RELEASE=$GARDENER_PREVIOUS_RELEASE GARDENER_NEXT_RELEASE=$GARDENER_NEXT_RELEASE

--- a/hack/ci-e2e-kind-upgrade.sh
+++ b/hack/ci-e2e-kind-upgrade.sh
@@ -173,7 +173,7 @@ export GARDENER_PREVIOUS_VERSION="$(cat $GARDENER_RELEASE_DOWNLOAD_PATH/gardener
 # test setup
 kind_up
 
-export all container logs and events after test execution
+# export all container logs and events after test execution
 trap "
 ( rm -rf $GARDENER_RELEASE_DOWNLOAD_PATH/gardener-releases);
 ( export_logs '$CLUSTER_NAME'; export_events_for_kind '$CLUSTER_NAME'; export_events_for_shoots )

--- a/hack/usage/wait-for.sh
+++ b/hack/usage/wait-for.sh
@@ -20,7 +20,7 @@ set -euo pipefail
 
 if [ "$#" -lt 3 ]; then
   echo "Usage: $0 <resource_type> <object_name> <condition_1> <condition_2> ... <condition_n>
-Note: Namespace/RETRY_LIMIT will be used from the 'NAMESPACE'/'RETRY_LIMIT' environment variables if set, otherwise it is optional.
+Note: Namespace/RETRY_LIMIT will be used from the 'NAMESPACE'/'RETRY_LIMIT' environment variable if set, otherwise it is optional.
       RETRY_LIMIT: The operation will be retried a maximum of 120 times (default), with a 5 second sleep interval between each retry.
 "
   exit 1

--- a/hack/usage/wait.sh
+++ b/hack/usage/wait.sh
@@ -20,7 +20,7 @@ set -euo pipefail
 
 if [ "$#" -lt 3 ]; then
   echo "Usage: $0 <resource_type> <object_name> <condition_1> <condition_2> ... <condition_n>
-Note: Namespace/RETRY_LIMIT will be used from the 'NAMESPACE'/'RETRY_LIMIT' environment variable if set, otherwise it is optional.
+Note: Namespace/RETRY_LIMIT will be used from the 'NAMESPACE'/'RETRY_LIMIT' environment variables if set, otherwise it is optional.
       RETRY_LIMIT: The operation will be retried a maximum of 120 times (default), with a 5 second sleep interval between each retry.
 "
   exit 1

--- a/hack/usage/wait.sh
+++ b/hack/usage/wait.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script waits until all conditions are passed for a given resource in a kubernetes cluster.
+# It takes the resource type, object name, and a list of conditions as arguments
+set -euo pipefail
+
+if [ "$#" -lt 3 ]; then
+  echo "Usage: $0 <resource_type> <object_name> <condition_1> <condition_2> ... <condition_n>
+Note: Namespace will be used from the 'NAMESPACE' environment variable if set, otherwise it is optional.
+  "
+  exit 1
+fi
+
+RESOURCE_TYPE=$1
+OBJECT_NAME=$2
+shift 2
+CONDITIONS=("$@")
+NAMESPACE=${NAMESPACE:-}
+
+# The number of retries before failing
+RETRY_LIMIT=60
+
+# The interval between each retry in seconds
+SLEEP_INTERVAL=5
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NO_COLOR='\033[0m'
+
+echo "Checking conditions for ${RESOURCE_TYPE}/${OBJECT_NAME}..."
+retries=0
+while [ "${retries}" -lt "${RETRY_LIMIT}" ]; do
+  if [ -z "$NAMESPACE" ]; then
+    CONDITION_STATES=$(kubectl get "${RESOURCE_TYPE}" "${OBJECT_NAME}" -o jsonpath='{.status.conditions}')
+  else
+    CONDITION_STATES=$(kubectl get "${RESOURCE_TYPE}" "${OBJECT_NAME}" -n "$NAMESPACE" -o jsonpath='{.status.conditions}')
+  fi
+  ALL_PASSED=true
+
+  for condition in "${CONDITIONS[@]}"; do
+    if ! echo "${CONDITION_STATES}" | jq -e '.[] | select(.type == "'"${condition}"'").status == "True"' > /dev/null; then
+      echo -e "${RED}Condition: ${condition} not met for ${RESOURCE_TYPE}/${OBJECT_NAME}${NO_COLOR}"
+      ALL_PASSED=false
+      break
+    fi
+  done
+
+  if [ "${ALL_PASSED}" = true ]; then
+    echo -e "${GREEN}✅All conditions passed for ${RESOURCE_TYPE}/${OBJECT_NAME}.${NO_COLOR}"
+    break
+  fi
+
+  echo "⏳ Waiting for all conditions to pass. Retry $retries/$RETRY_LIMIT"
+  ((retries++))
+  sleep "${SLEEP_INTERVAL}"
+done
+
+if [ "${retries}" -eq "${RETRY_LIMIT}" ]; then
+  echo -e "${RED}❌ ERROR: Not all conditions were met for ${RESOURCE_TYPE}/${OBJECT_NAME} after ${RETRY_LIMIT} retries"
+  exit 1
+fi

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -1120,16 +1120,21 @@ deploy:
           - -ec
           - |
             echo "Wait until seed is ready"
-            for i in `seq 1 30`;
-            do
-              if kubectl get seed local 2> /dev/null; then
+            for _ in $(seq 1 60); do
+              seed_name="local"
+
+              if [ "$(kubectl get seed "$seed_name" -o jsonpath='{.status.conditions[?(@.type=="GardenletReady")].status}')" == "True" ] &&
+                [ "$(kubectl get seed "$seed_name" -o jsonpath='{.status.conditions[?(@.type=="Bootstrapped")].status}')" == "True" ] &&
+                [ "$(kubectl get seed "$seed_name" -o jsonpath='{.status.conditions[?(@.type=="SeedSystemComponentsHealthy")].status}')" == "True" ] &&
+                [ "$(kubectl get seed "$seed_name" -o jsonpath='{.status.conditions[?(@.type=="ExtensionsReady")].status}')" == "True" ] &&
+                [ "$(kubectl get seed "$seed_name" -o jsonpath='{.status.conditions[?(@.type=="BackupBucketsReady")].status}')" == "True" ]; then
+                echo "Seed has become ready!"
                 break
               fi
-              echo "Wait until seed gets created by gardenlet"
-              sleep 2
+
+              echo "Wait until seed gets ready"
+              sleep 5
             done
-            kubectl wait --for=condition=gardenletready --for=condition=extensionsready --for=condition=bootstrapped \
-              --for=condition=seedsystemcomponentshealthy --for=condition=backupbucketsready seed local --timeout=5m
     releases:
     - name: gardener-gardenlet
       chartPath: charts/gardener/gardenlet
@@ -1167,15 +1172,21 @@ profiles:
     - -ec
     - |
       echo "Wait until seed is ready"
-      for i in `seq 1 30`;
-      do
-        if kubectl --kubeconfig=$GARDENER_LOCAL_KUBECONFIG get seed local2 2> /dev/null; then
+      for _ in $(seq 1 60); do
+        seed_name="local2"
+
+        if [ "$(kubectl get seed "$seed_name" -o jsonpath='{.status.conditions[?(@.type=="GardenletReady")].status}')" == "True" ] &&
+          [ "$(kubectl get seed "$seed_name" -o jsonpath='{.status.conditions[?(@.type=="Bootstrapped")].status}')" == "True" ] &&
+          [ "$(kubectl get seed "$seed_name" -o jsonpath='{.status.conditions[?(@.type=="SeedSystemComponentsHealthy")].status}')" == "True" ] &&
+          [ "$(kubectl get seed "$seed_name" -o jsonpath='{.status.conditions[?(@.type=="ExtensionsReady")].status}')" == "True" ] &&
+          [ "$(kubectl get seed "$seed_name" -o jsonpath='{.status.conditions[?(@.type=="BackupBucketsReady")].status}')" == "True" ]; then
+          echo "Seed has become ready!"
           break
         fi
-        echo "Wait until seed gets created by gardenlet"
-        sleep 2
+
+        echo "Wait until seed gets ready"
+        sleep 5
       done
-      kubectl --kubeconfig=$GARDENER_LOCAL_KUBECONFIG wait --for=condition=gardenletready --for=condition=extensionsready --for=condition=bootstrapped seed local2 --timeout=5m
   - op: add
     path: /deploy/helm/releases/0/valuesFiles/-
     value: example/gardener-local/gardenlet/values-kind2.yaml
@@ -1198,15 +1209,19 @@ profiles:
     - -ec
     - |
       echo "Wait until seed is ready"
-      for i in `seq 1 60`;
-      do
-        if kubectl --kubeconfig=$GARDENER_LOCAL_KUBECONFIG get seed $SEED_NAME 2> /dev/null; then
+      for _ in $(seq 1 60); do
+        if [ "$(kubectl get seed "$seed_name" -o jsonpath='{.status.conditions[?(@.type=="GardenletReady")].status}')" == "True" ] &&
+          [ "$(kubectl get seed "$SEED_NAME" -o jsonpath='{.status.conditions[?(@.type=="Bootstrapped")].status}')" == "True" ] &&
+          [ "$(kubectl get seed "$SEED_NAME" -o jsonpath='{.status.conditions[?(@.type=="SeedSystemComponentsHealthy")].status}')" == "True" ] &&
+          [ "$(kubectl get seed "$SEED_NAME" -o jsonpath='{.status.conditions[?(@.type=="ExtensionsReady")].status}')" == "True" ] &&
+          [ "$(kubectl get seed "$SEED_NAME" -o jsonpath='{.status.conditions[?(@.type=="BackupBucketsReady")].status}')" == "True" ]; then
+          echo "Seed has become ready!"
           break
         fi
-        echo "Wait until seed gets created by gardenlet"
-        sleep 2
+
+        echo "Wait until seed gets ready"
+        sleep 5
       done
-      kubectl --kubeconfig=$GARDENER_LOCAL_KUBECONFIG wait --for=condition=gardenletready --for=condition=bootstrapped seed $SEED_NAME --timeout=5m
   - op: add
     path: /deploy/helm/releases/0/valuesFiles/-
     value: example/gardener-local/gardenlet/values-provider-extensions.yaml
@@ -1239,15 +1254,21 @@ profiles:
     - -ec
     - |
       echo "Wait until seed is ready"
-      for i in `seq 1 30`;
-      do
-        if kubectl --kubeconfig=$GARDENER_LOCAL_HA_SINGLE_ZONE_KUBECONFIG get seed local-ha-single-zone 2> /dev/null; then
+      for _ in $(seq 1 60); do
+        seed_name="local-ha-single-zone"
+
+        if [ "$(kubectl get seed "$seed_name" -o jsonpath='{.status.conditions[?(@.type=="GardenletReady")].status}')" == "True" ] &&
+          [ "$(kubectl get seed "$seed_name" -o jsonpath='{.status.conditions[?(@.type=="Bootstrapped")].status}')" == "True" ] &&
+          [ "$(kubectl get seed "$seed_name" -o jsonpath='{.status.conditions[?(@.type=="SeedSystemComponentsHealthy")].status}')" == "True" ] &&
+          [ "$(kubectl get seed "$seed_name" -o jsonpath='{.status.conditions[?(@.type=="ExtensionsReady")].status}')" == "True" ] &&
+          [ "$(kubectl get seed "$seed_name" -o jsonpath='{.status.conditions[?(@.type=="BackupBucketsReady")].status}')" == "True" ]; then
+          echo "Seed has become ready!"
           break
         fi
-        echo "Wait until seed gets created by gardenlet"
-        sleep 2
+
+        echo "Wait until seed gets ready"
+        sleep 5
       done
-      kubectl --kubeconfig=$GARDENER_LOCAL_HA_SINGLE_ZONE_KUBECONFIG wait --for=condition=gardenletready --for=condition=extensionsready --for=condition=bootstrapped seed local-ha-single-zone --timeout=5m
 
 - name: ha-multi-zone
   patches:
@@ -1261,12 +1282,18 @@ profiles:
     - -ec
     - |
       echo "Wait until seed is ready"
-      for i in `seq 1 30`;
-      do
-        if kubectl --kubeconfig=$GARDENER_LOCAL_HA_MULTI_ZONE_KUBECONFIG get seed local-ha-multi-zone 2> /dev/null; then
+      for _ in $(seq 1 60); do
+        seed_name="local-ha-multi-zone"
+
+        if [ "$(kubectl get seed "$seed_name" -o jsonpath='{.status.conditions[?(@.type=="GardenletReady")].status}')" == "True" ] &&
+          [ "$(kubectl get seed "$seed_name" -o jsonpath='{.status.conditions[?(@.type=="Bootstrapped")].status}')" == "True" ] &&
+          [ "$(kubectl get seed "$seed_name" -o jsonpath='{.status.conditions[?(@.type=="SeedSystemComponentsHealthy")].status}')" == "True" ] &&
+          [ "$(kubectl get seed "$seed_name" -o jsonpath='{.status.conditions[?(@.type=="ExtensionsReady")].status}')" == "True" ] &&
+          [ "$(kubectl get seed "$seed_name" -o jsonpath='{.status.conditions[?(@.type=="BackupBucketsReady")].status}')" == "True" ]; then
+          echo "Seed has become ready!"
           break
         fi
-        echo "Wait until seed gets created by gardenlet"
-        sleep 2
+
+        echo "Wait until seed gets ready"
+        sleep 5
       done
-      kubectl --kubeconfig=$GARDENER_LOCAL_HA_MULTI_ZONE_KUBECONFIG wait --for=condition=gardenletready --for=condition=extensionsready --for=condition=bootstrapped seed local-ha-multi-zone --timeout=5m

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -1218,4 +1218,4 @@ profiles:
     value:
     - bash
     - -ec
-    - RETRY_LIMIT=240 hack/usage/wait-for.sh seed local-ha-multi-zone GardenletReady Bootstrapped SeedSystemComponentsHealthy ExtensionsReady BackupBucketsReady
+    - TIMEOUT=1200 hack/usage/wait-for.sh seed local-ha-multi-zone GardenletReady Bootstrapped SeedSystemComponentsHealthy ExtensionsReady BackupBucketsReady

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -1118,7 +1118,7 @@ deploy:
           command:
           - bash
           - -ec
-          - hack/usage/wait.sh seed local GardenletReady Bootstrapped SeedSystemComponentsHealthy ExtensionsReady BackupBucketsReady
+          - hack/usage/wait-for.sh seed local GardenletReady Bootstrapped SeedSystemComponentsHealthy ExtensionsReady BackupBucketsReady
     releases:
     - name: gardener-gardenlet
       chartPath: charts/gardener/gardenlet
@@ -1154,7 +1154,7 @@ profiles:
     value:
     - bash
     - -ec
-    - KUBECONFIG=$GARDENER_LOCAL_KUBECONFIG hack/usage/wait.sh seed local2 GardenletReady Bootstrapped SeedSystemComponentsHealthy ExtensionsReady BackupBucketsReady
+    - KUBECONFIG=$GARDENER_LOCAL_KUBECONFIG hack/usage/wait-for.sh seed local2 GardenletReady Bootstrapped SeedSystemComponentsHealthy ExtensionsReady BackupBucketsReady
   - op: add
     path: /deploy/helm/releases/0/valuesFiles/-
     value: example/gardener-local/gardenlet/values-kind2.yaml
@@ -1175,7 +1175,7 @@ profiles:
     value:
     - bash
     - -ec
-    - KUBECONFIG=$GARDENER_LOCAL_KUBECONFIG hack/usage/wait.sh seed "$SEED_NAME" GardenletReady Bootstrapped SeedSystemComponentsHealthy ExtensionsReady
+    - KUBECONFIG=$GARDENER_LOCAL_KUBECONFIG hack/usage/wait-for.sh seed "$SEED_NAME" GardenletReady Bootstrapped SeedSystemComponentsHealthy ExtensionsReady
   - op: add
     path: /deploy/helm/releases/0/valuesFiles/-
     value: example/gardener-local/gardenlet/values-provider-extensions.yaml
@@ -1206,7 +1206,7 @@ profiles:
     value:
     - bash
     - -ec
-    - hack/usage/wait.sh seed local-ha-single-zone GardenletReady Bootstrapped SeedSystemComponentsHealthy ExtensionsReady BackupBucketsReady
+    - hack/usage/wait-for.sh seed local-ha-single-zone GardenletReady Bootstrapped SeedSystemComponentsHealthy ExtensionsReady BackupBucketsReady
 
 - name: ha-multi-zone
   patches:
@@ -1218,4 +1218,4 @@ profiles:
     value:
     - bash
     - -ec
-    - RETRY_LIMIT=180 hack/usage/wait.sh seed local-ha-multi-zone GardenletReady Bootstrapped SeedSystemComponentsHealthy ExtensionsReady BackupBucketsReady
+    - RETRY_LIMIT=180 hack/usage/wait-for.sh seed local-ha-multi-zone GardenletReady Bootstrapped SeedSystemComponentsHealthy ExtensionsReady BackupBucketsReady

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -1118,23 +1118,7 @@ deploy:
           command:
           - bash
           - -ec
-          - |
-            echo "Wait until seed is ready"
-            for _ in $(seq 1 60); do
-              seed_name="local"
-
-              if [ "$(kubectl get seed "$seed_name" -o jsonpath='{.status.conditions[?(@.type=="GardenletReady")].status}')" == "True" ] &&
-                [ "$(kubectl get seed "$seed_name" -o jsonpath='{.status.conditions[?(@.type=="Bootstrapped")].status}')" == "True" ] &&
-                [ "$(kubectl get seed "$seed_name" -o jsonpath='{.status.conditions[?(@.type=="SeedSystemComponentsHealthy")].status}')" == "True" ] &&
-                [ "$(kubectl get seed "$seed_name" -o jsonpath='{.status.conditions[?(@.type=="ExtensionsReady")].status}')" == "True" ] &&
-                [ "$(kubectl get seed "$seed_name" -o jsonpath='{.status.conditions[?(@.type=="BackupBucketsReady")].status}')" == "True" ]; then
-                echo "Seed has become ready!"
-                break
-              fi
-
-              echo "Wait until seed gets ready"
-              sleep 5
-            done
+          - hack/usage/wait.sh seed local GardenletReady Bootstrapped SeedSystemComponentsHealthy ExtensionsReady BackupBucketsReady
     releases:
     - name: gardener-gardenlet
       chartPath: charts/gardener/gardenlet
@@ -1170,23 +1154,7 @@ profiles:
     value:
     - bash
     - -ec
-    - |
-      echo "Wait until seed is ready"
-      for _ in $(seq 1 60); do
-        seed_name="local2"
-
-        if [ "$(kubectl get seed "$seed_name" -o jsonpath='{.status.conditions[?(@.type=="GardenletReady")].status}')" == "True" ] &&
-          [ "$(kubectl get seed "$seed_name" -o jsonpath='{.status.conditions[?(@.type=="Bootstrapped")].status}')" == "True" ] &&
-          [ "$(kubectl get seed "$seed_name" -o jsonpath='{.status.conditions[?(@.type=="SeedSystemComponentsHealthy")].status}')" == "True" ] &&
-          [ "$(kubectl get seed "$seed_name" -o jsonpath='{.status.conditions[?(@.type=="ExtensionsReady")].status}')" == "True" ] &&
-          [ "$(kubectl get seed "$seed_name" -o jsonpath='{.status.conditions[?(@.type=="BackupBucketsReady")].status}')" == "True" ]; then
-          echo "Seed has become ready!"
-          break
-        fi
-
-        echo "Wait until seed gets ready"
-        sleep 5
-      done
+    - hack/usage/wait.sh seed local2 GardenletReady Bootstrapped SeedSystemComponentsHealthy ExtensionsReady BackupBucketsReady
   - op: add
     path: /deploy/helm/releases/0/valuesFiles/-
     value: example/gardener-local/gardenlet/values-kind2.yaml
@@ -1207,21 +1175,7 @@ profiles:
     value:
     - bash
     - -ec
-    - |
-      echo "Wait until seed is ready"
-      for _ in $(seq 1 60); do
-        if [ "$(kubectl get seed "$seed_name" -o jsonpath='{.status.conditions[?(@.type=="GardenletReady")].status}')" == "True" ] &&
-          [ "$(kubectl get seed "$SEED_NAME" -o jsonpath='{.status.conditions[?(@.type=="Bootstrapped")].status}')" == "True" ] &&
-          [ "$(kubectl get seed "$SEED_NAME" -o jsonpath='{.status.conditions[?(@.type=="SeedSystemComponentsHealthy")].status}')" == "True" ] &&
-          [ "$(kubectl get seed "$SEED_NAME" -o jsonpath='{.status.conditions[?(@.type=="ExtensionsReady")].status}')" == "True" ] &&
-          [ "$(kubectl get seed "$SEED_NAME" -o jsonpath='{.status.conditions[?(@.type=="BackupBucketsReady")].status}')" == "True" ]; then
-          echo "Seed has become ready!"
-          break
-        fi
-
-        echo "Wait until seed gets ready"
-        sleep 5
-      done
+    - hack/usage/wait.sh seed "$SEED_NAME" GardenletReady Bootstrapped SeedSystemComponentsHealthy ExtensionsReady BackupBucketsReady
   - op: add
     path: /deploy/helm/releases/0/valuesFiles/-
     value: example/gardener-local/gardenlet/values-provider-extensions.yaml
@@ -1252,23 +1206,7 @@ profiles:
     value:
     - bash
     - -ec
-    - |
-      echo "Wait until seed is ready"
-      for _ in $(seq 1 60); do
-        seed_name="local-ha-single-zone"
-
-        if [ "$(kubectl get seed "$seed_name" -o jsonpath='{.status.conditions[?(@.type=="GardenletReady")].status}')" == "True" ] &&
-          [ "$(kubectl get seed "$seed_name" -o jsonpath='{.status.conditions[?(@.type=="Bootstrapped")].status}')" == "True" ] &&
-          [ "$(kubectl get seed "$seed_name" -o jsonpath='{.status.conditions[?(@.type=="SeedSystemComponentsHealthy")].status}')" == "True" ] &&
-          [ "$(kubectl get seed "$seed_name" -o jsonpath='{.status.conditions[?(@.type=="ExtensionsReady")].status}')" == "True" ] &&
-          [ "$(kubectl get seed "$seed_name" -o jsonpath='{.status.conditions[?(@.type=="BackupBucketsReady")].status}')" == "True" ]; then
-          echo "Seed has become ready!"
-          break
-        fi
-
-        echo "Wait until seed gets ready"
-        sleep 5
-      done
+    - hack/usage/wait.sh seed local-ha-single-zone GardenletReady Bootstrapped SeedSystemComponentsHealthy ExtensionsReady BackupBucketsReady
 
 - name: ha-multi-zone
   patches:
@@ -1279,21 +1217,4 @@ profiles:
     path: /deploy/helm/hooks/after/0/host/command
     value:
     - bash
-    - -ec
-    - |
-      echo "Wait until seed is ready"
-      for _ in $(seq 1 60); do
-        seed_name="local-ha-multi-zone"
-
-        if [ "$(kubectl get seed "$seed_name" -o jsonpath='{.status.conditions[?(@.type=="GardenletReady")].status}')" == "True" ] &&
-          [ "$(kubectl get seed "$seed_name" -o jsonpath='{.status.conditions[?(@.type=="Bootstrapped")].status}')" == "True" ] &&
-          [ "$(kubectl get seed "$seed_name" -o jsonpath='{.status.conditions[?(@.type=="SeedSystemComponentsHealthy")].status}')" == "True" ] &&
-          [ "$(kubectl get seed "$seed_name" -o jsonpath='{.status.conditions[?(@.type=="ExtensionsReady")].status}')" == "True" ] &&
-          [ "$(kubectl get seed "$seed_name" -o jsonpath='{.status.conditions[?(@.type=="BackupBucketsReady")].status}')" == "True" ]; then
-          echo "Seed has become ready!"
-          break
-        fi
-
-        echo "Wait until seed gets ready"
-        sleep 5
-      done
+    - hack/usage/wait.sh seed local-ha-multi-zone GardenletReady Bootstrapped SeedSystemComponentsHealthy ExtensionsReady BackupBucketsReady

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -1154,7 +1154,7 @@ profiles:
     value:
     - bash
     - -ec
-    - hack/usage/wait.sh seed local2 GardenletReady Bootstrapped SeedSystemComponentsHealthy ExtensionsReady BackupBucketsReady
+    - KUBECONFIG=$GARDENER_LOCAL_KUBECONFIG hack/usage/wait.sh seed local2 GardenletReady Bootstrapped SeedSystemComponentsHealthy ExtensionsReady BackupBucketsReady
   - op: add
     path: /deploy/helm/releases/0/valuesFiles/-
     value: example/gardener-local/gardenlet/values-kind2.yaml
@@ -1175,7 +1175,7 @@ profiles:
     value:
     - bash
     - -ec
-    - hack/usage/wait.sh seed "$SEED_NAME" GardenletReady Bootstrapped SeedSystemComponentsHealthy ExtensionsReady BackupBucketsReady
+    - KUBECONFIG=$GARDENER_LOCAL_KUBECONFIG hack/usage/wait.sh seed "$SEED_NAME" GardenletReady Bootstrapped SeedSystemComponentsHealthy ExtensionsReady
   - op: add
     path: /deploy/helm/releases/0/valuesFiles/-
     value: example/gardener-local/gardenlet/values-provider-extensions.yaml
@@ -1217,4 +1217,5 @@ profiles:
     path: /deploy/helm/hooks/after/0/host/command
     value:
     - bash
-    - hack/usage/wait.sh seed local-ha-multi-zone GardenletReady Bootstrapped SeedSystemComponentsHealthy ExtensionsReady BackupBucketsReady
+    - -ec
+    - RETRY_LIMIT=180 hack/usage/wait.sh seed local-ha-multi-zone GardenletReady Bootstrapped SeedSystemComponentsHealthy ExtensionsReady BackupBucketsReady

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -1218,4 +1218,4 @@ profiles:
     value:
     - bash
     - -ec
-    - RETRY_LIMIT=180 hack/usage/wait-for.sh seed local-ha-multi-zone GardenletReady Bootstrapped SeedSystemComponentsHealthy ExtensionsReady BackupBucketsReady
+    - RETRY_LIMIT=240 hack/usage/wait-for.sh seed local-ha-multi-zone GardenletReady Bootstrapped SeedSystemComponentsHealthy ExtensionsReady BackupBucketsReady


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind bug test

**What this PR does / why we need it**:

- This PR updates the `kubectl wait` command used to check conditions for a seed to handle multiple conditions correctly. 
- **In the previous version, each `--for` option would override the previous one.**  So always checks last conditions only.
```
kubectl wait --for=condition=gardenletready --for=condition=extensionsready --for=condition=bootstrapped seed local2 --timeout=5m
```
- This PR resolves this issue by using separate `kubectl wait` commands for each condition, rather than relying on multiple `--for` options.
- This ensures that all conditions are properly checked and eliminates any risk of the conditions being overwritten or ignored.


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
cc: @rfranzke 
**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
