### PR TITLE
Allow vpn-client in kube-apiserver to talk to seed apiserver in case of HA VPN.

### DIFF
--- a/pkg/operation/botanist/component/kubeapiserver/deployment.go
+++ b/pkg/operation/botanist/component/kubeapiserver/deployment.go
@@ -782,6 +782,7 @@ func (k *kubeAPIServer) handleVPNSettingsHA(
 ) {
 	deployment.Spec.Template.Spec.ServiceAccountName = serviceAccountName
 	deployment.Spec.Template.Labels[v1beta1constants.LabelNetworkPolicyToShootNetworks] = v1beta1constants.LabelNetworkPolicyAllowed
+	deployment.Spec.Template.Labels[v1beta1constants.LabelNetworkPolicyToRuntimeAPIServer] = v1beta1constants.LabelNetworkPolicyAllowed
 	for i := 0; i < k.values.VPN.HighAvailabilityNumberOfSeedServers; i++ {
 		deployment.Spec.Template.Spec.Containers = append(deployment.Spec.Template.Spec.Containers, *k.vpnSeedClientContainer(i))
 	}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind bug

**What this PR does / why we need it**:
Allow vpn-client in kube-apiserver to talk to seed apiserver in case of HA VPN.

In the HA VPN, the ip address management of the vpn clients on the seed is done via annotations. Therefore, vpn-client container of the kube-apiserver needs to be able to communicate with the seed's apiserver. In case the seed is a gardener shoot this most likely causes vpn-client to use the external address of the seed's apiserver. This is due to the apiserver-proxy pod mutator injecting the KUBERNETES_SERVICE_HOST environment variable with the external name. However, in other seed scenarios vpn-client might also connect to the seed's apiserver via other means, e.g. through in-cluster communication. For this general case, the existing network policies were not sufficient. This change adds allowance to the seed's apiserver via the corresponding network policy.

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fixed bug that cause HA VPN to fail in case the seed's apiserver was not targeted by kube-apiserver's vpn-client via a public address
```
