### PR TITLE
refactor: use single `sigs.k8s.io/yaml` library

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,6 @@ require (
 	github.com/gardener/etcd-druid v0.15.3
 	github.com/gardener/hvpa-controller/api v0.5.0
 	github.com/gardener/machine-controller-manager v0.45.0
-	github.com/ghodss/yaml v1.0.0
 	github.com/go-logr/logr v1.2.3
 	github.com/gogo/protobuf v1.3.2
 	github.com/golang/mock v1.6.0
@@ -39,7 +38,6 @@ require (
 	gomodules.xyz/jsonpatch/v2 v2.2.0
 	gonum.org/v1/gonum v0.11.0
 	google.golang.org/protobuf v1.28.1
-	gopkg.in/yaml.v2 v2.4.0
 	istio.io/api v0.0.0-20221013011440-bc935762d2b9
 	istio.io/client-go v1.15.3
 	k8s.io/api v0.26.1
@@ -88,6 +86,7 @@ require (
 	github.com/felixge/httpsnoop v1.0.3 // indirect
 	github.com/fluent/fluent-operator v1.7.0
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
+	github.com/ghodss/yaml v1.0.0 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-logr/zapr v1.2.3 // indirect
 	github.com/go-openapi/errors v0.20.3 // indirect
@@ -169,6 +168,7 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/ini.v1 v1.66.4 // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/gengo v0.0.0-20220902162205-c0856e24416d // indirect
 	k8s.io/kms v0.26.1 // indirect

--- a/pkg/client/kubernetes/applier_test.go
+++ b/pkg/client/kubernetes/applier_test.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"context"
 
-	"github.com/ghodss/yaml"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
@@ -31,6 +30,7 @@ import (
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/yaml"
 
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"

--- a/pkg/provider-local/imagevector/imagevector.go
+++ b/pkg/provider-local/imagevector/imagevector.go
@@ -17,7 +17,6 @@ package imagevector
 
 import (
 	_ "embed"
-	"strings"
 
 	"k8s.io/apimachinery/pkg/util/runtime"
 
@@ -33,7 +32,7 @@ var (
 func init() {
 	var err error
 
-	imageVector, err = imagevector.Read(strings.NewReader(imagesYAML))
+	imageVector, err = imagevector.Read([]byte(imagesYAML))
 	runtime.Must(err)
 
 	imageVector, err = imagevector.WithEnvOverride(imageVector)

--- a/pkg/utils/imagevector/imagevector.go
+++ b/pkg/utils/imagevector/imagevector.go
@@ -17,14 +17,13 @@ package imagevector
 import (
 	"crypto/sha256"
 	"fmt"
-	"io"
 	"os"
 	"regexp"
 	"strings"
 
-	"gopkg.in/yaml.v2"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/utils/strings/slices"
+	"sigs.k8s.io/yaml"
 
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	versionutils "github.com/gardener/gardener/pkg/utils/version"
@@ -38,12 +37,12 @@ const (
 )
 
 // Read reads an ImageVector from the given io.Reader.
-func Read(r io.Reader) (ImageVector, error) {
+func Read(buf []byte) (ImageVector, error) {
 	vector := struct {
 		Images ImageVector `json:"images" yaml:"images"`
 	}{}
 
-	if err := yaml.NewDecoder(r).Decode(&vector); err != nil {
+	if err := yaml.Unmarshal(buf, &vector); err != nil {
 		return nil, err
 	}
 
@@ -56,13 +55,12 @@ func Read(r io.Reader) (ImageVector, error) {
 
 // ReadFile reads an ImageVector from the file with the given name.
 func ReadFile(name string) (ImageVector, error) {
-	file, err := os.Open(name)
+	buf, err := os.ReadFile(name)
 	if err != nil {
 		return nil, err
 	}
-	defer file.Close()
 
-	return Read(file)
+	return Read(buf)
 }
 
 // ReadGlobalImageVectorWithEnvOverride reads the global image vector and applies the env override. Exposed for testing.

--- a/pkg/utils/imagevector/imagevector_components.go
+++ b/pkg/utils/imagevector/imagevector_components.go
@@ -15,11 +15,10 @@
 package imagevector
 
 import (
-	"io"
 	"os"
 
-	"gopkg.in/yaml.v2"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"sigs.k8s.io/yaml"
 )
 
 const (
@@ -29,12 +28,12 @@ const (
 )
 
 // ReadComponentOverwrite reads an ComponentImageVector from the given io.Reader.
-func ReadComponentOverwrite(r io.Reader) (ComponentImageVectors, error) {
+func ReadComponentOverwrite(buf []byte) (ComponentImageVectors, error) {
 	data := struct {
 		Components []ComponentImageVector `json:"components" yaml:"components"`
 	}{}
 
-	if err := yaml.NewDecoder(r).Decode(&data); err != nil {
+	if err := yaml.Unmarshal(buf, &data); err != nil {
 		return nil, err
 	}
 
@@ -52,11 +51,10 @@ func ReadComponentOverwrite(r io.Reader) (ComponentImageVectors, error) {
 
 // ReadComponentOverwriteFile reads an ComponentImageVector from the file with the given name.
 func ReadComponentOverwriteFile(name string) (ComponentImageVectors, error) {
-	file, err := os.Open(name)
+	buf, err := os.ReadFile(name)
 	if err != nil {
 		return nil, err
 	}
-	defer file.Close()
 
-	return ReadComponentOverwrite(file)
+	return ReadComponentOverwrite(buf)
 }

--- a/pkg/utils/imagevector/imagevector_components_test.go
+++ b/pkg/utils/imagevector/imagevector_components_test.go
@@ -16,7 +16,6 @@ package imagevector_test
 
 import (
 	"fmt"
-	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -63,13 +62,13 @@ components:
 
 		Describe("#ReadComponentOverwrite", func() {
 			It("should successfully read a JSON image vector", func() {
-				vector, err := ReadComponentOverwrite(strings.NewReader(componentImagesJSON))
+				vector, err := ReadComponentOverwrite([]byte(componentImagesJSON))
 				Expect(err).NotTo(HaveOccurred())
 				Expect(vector).To(Equal(componentImageVectors))
 			})
 
 			It("should successfully read a YAML image vector", func() {
-				vector, err := ReadComponentOverwrite(strings.NewReader(componentImagesYAML))
+				vector, err := ReadComponentOverwrite([]byte(componentImagesYAML))
 				Expect(err).NotTo(HaveOccurred())
 				Expect(vector).To(Equal(componentImageVectors))
 			})

--- a/pkg/utils/imagevector/imagevector_test.go
+++ b/pkg/utils/imagevector/imagevector_test.go
@@ -17,7 +17,6 @@ package imagevector_test
 import (
 	"fmt"
 	"os"
-	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -274,13 +273,13 @@ images:
 
 		Describe("#Read", func() {
 			It("should successfully read a JSON image vector", func() {
-				vector, err := Read(strings.NewReader(image1Src1VectorJSON))
+				vector, err := Read([]byte(image1Src1VectorJSON))
 				Expect(err).NotTo(HaveOccurred())
 				Expect(vector).To(Equal(image1Src1Vector))
 			})
 
 			It("should successfully read a YAML image vector", func() {
-				vector, err := Read(strings.NewReader(image1Src1VectorYAML))
+				vector, err := Read([]byte(image1Src1VectorYAML))
 				Expect(err).NotTo(HaveOccurred())
 				Expect(vector).To(Equal(image1Src1Vector))
 			})

--- a/pkg/utils/imagevector/imagevector_validation.go
+++ b/pkg/utils/imagevector/imagevector_validation.go
@@ -15,8 +15,6 @@
 package imagevector
 
 import (
-	"strings"
-
 	"github.com/Masterminds/semver"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 )
@@ -87,7 +85,7 @@ func validateComponentImageVector(componentImageVector *ComponentImageVector, fl
 	}
 
 	// Read (and validate) imageVectorOverwrite as image vector
-	imageVector, err := Read(strings.NewReader(componentImageVector.ImageVectorOverwrite))
+	imageVector, err := Read([]byte(componentImageVector.ImageVectorOverwrite))
 	if err != nil {
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("imageVectorOverwrite"), imageVector, err.Error()))
 	}

--- a/pkg/utils/imagevector/imagevector_validation_test.go
+++ b/pkg/utils/imagevector/imagevector_validation_test.go
@@ -15,15 +15,12 @@
 package imagevector_test
 
 import (
-	"bytes"
-	"io"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
-	"gopkg.in/yaml.v2"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/utils/pointer"
+	"sigs.k8s.io/yaml"
 
 	. "github.com/gardener/gardener/pkg/utils/imagevector"
 )
@@ -48,12 +45,17 @@ var _ = Describe("validation", func() {
 		}
 
 		componentImageVectors = func(name string, imageVector ImageVector) ComponentImageVectors {
-			var buf bytes.Buffer
-			err := write(&buf, imageVector)
+			vector := struct {
+				Images ImageVector `json:"images" yaml:"images"`
+			}{
+				Images: imageVector,
+			}
+
+			buf, err := yaml.Marshal(vector)
 			Expect(err).NotTo(HaveOccurred())
 
 			return ComponentImageVectors{
-				name: buf.String(),
+				name: string(buf),
 			}
 		}
 	})
@@ -116,13 +118,3 @@ var _ = Describe("validation", func() {
 		})
 	})
 })
-
-func write(w io.Writer, imageVector ImageVector) error {
-	vector := struct {
-		Images ImageVector `json:"images" yaml:"images"`
-	}{
-		Images: imageVector,
-	}
-
-	return yaml.NewEncoder(w).Encode(&vector)
-}

--- a/pkg/utils/secrets/control_plane_test.go
+++ b/pkg/utils/secrets/control_plane_test.go
@@ -15,10 +15,10 @@
 package secrets
 
 import (
-	"github.com/ghodss/yaml"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	clientcmdv1 "k8s.io/client-go/tools/clientcmd/api/v1"
+	"sigs.k8s.io/yaml"
 )
 
 var _ = Describe("utils", func() {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area open-source
/kind enhancement

**What this PR does / why we need it**:

Currently three YAML libraries are used:
1. `github.com/ghodss/yaml v1.0.0`
2. `gopkg.in/yaml.v2 v2.4.0`
3. `sigs.k8s.io/yaml v1.3.0`

The package `github.com/ghodss/yaml` is no longer actively maintained. See discussion in https://github.com/ghodss/yaml/issues/80 and https://github.com/ghodss/yaml/issues/75. `sigs.k8s.io/yaml` is a permanent fork of `ghodss/yaml` and is actively maintained by Kubernetes SIG, also widely used in K8s projects.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

No breaking changes expected.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
4. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking dependency
The function signature of `imagevector.Read` has changed. Please adapt your usages accordingly.
```
