### PR TITLE
Use dynamic base id for apiserver-proxy to allow running multiple envoy proxy processes.

### DIFF
--- a/charts/shoot-core/components/charts/apiserver-proxy/templates/apiserver-proxy-daemonset.yaml
+++ b/charts/shoot-core/components/charts/apiserver-proxy/templates/apiserver-proxy-daemonset.yaml
@@ -89,6 +89,7 @@ spec:
         - envoy
         - --concurrency
         - "2"
+        - --use-dynamic-base-id
         - -c
         - /etc/apiserver-proxy/envoy.yaml
         securityContext:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement

**What this PR does / why we need it**:
Use dynamic base id for apiserver-proxy to allow running multiple envoy proxy processes.

Envoy uses shared memory to be able to reattach to the same session during hot restarts. This requires statically setup identifiers so that the same shared memory segments are used. It is possible that this clashes if more than one envoy-proxy runs on the same node. According to https://github.com/envoyproxy/envoy/issues/88, running more than one envoy-proxy per node is not recommended.
Now, we try to use a dynamic base id for apiserver-proxy as we do not use hot restarts anyway.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
We have seen clashes between `apiserver-proxy` and the `envoy-proxy` of `cilium` as cilium hardcodes `base-id` to `0`, which is the default that `apiserver-proxy` used previously.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
`apiserver-proxy` now uses a dynamic `base-id` for shared memory segments and hence allows multiple `envoy-proxy` servers to run on the same node.
```
