### PR TITLE
Website Cleanup Part 5 - Monitoring

### DIFF
--- a/docs/development/monitoring-stack.md
+++ b/docs/development/monitoring-stack.md
@@ -26,7 +26,7 @@ Each Shoot cluster comes with its own monitoring stack. The following components
 
 In each Seed cluster there is a Prometheus in the `garden` namespace responsible for collecting metrics from the Seed kubelets and cAdvisors. These metrics are provided to each Shoot Prometheus via federation.
 
-The alerts for all Shoot clusters hosted on a Seed are routed to a central Alertmanger running in the `garden` namespace of the Seed. The purpose of this central alertmanager is to forward all important alerts to the operators of the Gardener setup.
+The alerts for all Shoot clusters hosted on a Seed are routed to a central Alertmanger running in the `garden` namespace of the Seed. The purpose of this central Alertmanager is to forward all important alerts to the operators of the Gardener setup.
 
 The Alertmanager in the Shoot namespace on the Seed is only responsible for forwarding alerts from its Shoot cluster to a cluster owner/cluster alert receiver via email. The Alertmanager is optional and the conditions for a deployment are already described in [Alerting](../monitoring/alerting.md).
 

--- a/docs/monitoring/alerting.md
+++ b/docs/monitoring/alerting.md
@@ -1,13 +1,13 @@
 # Alerting
 
-Gardener uses [Prometheus](https://prometheus.io/) to gather metrics from each component. A Prometheus is deployed in each shoot control plane (on the seed) which is responsible for gathering control plane and cluster metrics. Prometheus can be configured to fire alerts based on these metrics and send them to an [alertmanager](https://prometheus.io/docs/alerting/alertmanager/). The alertmanager is responsible for sending the alerts to users and operators. This document describes how to setup alerting for:
+Gardener uses [Prometheus](https://prometheus.io/) to gather metrics from each component. A Prometheus is deployed in each shoot control plane (on the seed) which is responsible for gathering control plane and cluster metrics. Prometheus can be configured to fire alerts based on these metrics and send them to an [Alertmanager](https://prometheus.io/docs/alerting/alertmanager/). The Alertmanager is responsible for sending the alerts to users and operators. This document describes how to setup alerting for:
 
 - [end-users/stakeholders/customers](#Alerting-for-Users)
 - [operators/administrators](#Alerting-for-Operators)
 
 # Alerting for Users
 
-To receive email alerts as a user set the following values in the shoot spec:
+To receive email alerts as a user, set the following values in the shoot spec:
 
 ```yaml
 spec:
@@ -16,24 +16,24 @@ spec:
       emailReceivers:
       - john.doe@example.com
 ```
-`emailReceivers` is a list of emails that will receive alerts if something is wrong with the shoot cluster. A list of alerts for users can be found [here](user_alerts.md).
+`emailReceivers` is a list of emails that will receive alerts if something is wrong with the shoot cluster. A list of alerts for users can be found in the [User Alerts](user_alerts.md) topic.
 
 # Alerting for Operators
 
 Currently, Gardener supports two options for alerting:
 
 - [Email Alerting](#Email-Alerting)
-- [Sending Alerts to an external alertmanager](#External-Alertmanager)
+- [Sending Alerts to an External Alertmanager](#External-Alertmanager)
 
-A list of operator alerts can be found [here](operator_alerts.md).
+A list of operator alerts can be found in the [Operator Alerts](operator_alerts.md) topic.
 
 ## Email Alerting
 
-Gardener provides the option to deploy an alertmanager into each seed. This alertmanager is responsible for sending out alerts to operators for each shoot cluster in the seed. Only email alerts are supported by the alertmanager managed by Gardener. This is configurable by setting the Gardener controller manager configuration values `alerting`. See [this](../usage/configuration.md) on how to configure the Gardener's SMTP secret. If the values are set, a secret with the label `gardener.cloud/role: alerting` will be created in the garden namespace of the garden cluster. This secret will be used by each alertmanager in each seed.
+Gardener provides the option to deploy an Alertmanager into each seed. This Alertmanager is responsible for sending out alerts to operators for each shoot cluster in the seed. Only email alerts are supported by the Alertmanager managed by Gardener. This is configurable by setting the Gardener controller manager configuration values `alerting`. See [Gardener Configuration and Usage](../usage/configuration.md) on how to configure the Gardener's SMTP secret. If the values are set, a secret with the label `gardener.cloud/role: alerting` will be created in the garden namespace of the garden cluster. This secret will be used by each Alertmanager in each seed.
 
 ## External Alertmanager
 
-The alertmanager supports different kinds of [alerting configurations](https://prometheus.io/docs/alerting/configuration/). The alertmanager provided by Gardener only supports email alerts. If email is not sufficient, then alerts can be sent to an external alertmanager. Prometheus will send alerts to a URL and then alerts will be handled by the external alertmanager. This external alertmanager is operated and configured by the operator (i.e. Gardener does not configure or deploy this alertmanager). To configure sending alerts to an external alertmanager, create a secret in the virtual garden cluster in the garden namespace with the label: `gardener.cloud/role: alerting`. This secret needs to contain a URL to the external alertmanager and information regarding authentication. Supported authentication types are:
+The Alertmanager supports different kinds of [alerting configurations](https://prometheus.io/docs/alerting/configuration/). The Alertmanager provided by Gardener only supports email alerts. If email is not sufficient, then alerts can be sent to an external Alertmanager. Prometheus will send alerts to a URL and then alerts will be handled by the external Alertmanager. This external Alertmanager is operated and configured by the operator (i.e. Gardener does not configure or deploy this Alertmanager). To configure sending alerts to an external Alertmanager, create a secret in the virtual garden cluster in the garden namespace with the label: `gardener.cloud/role: alerting`. This secret needs to contain a URL to the external Alertmanager and information regarding authentication. Supported authentication types are:
 
 - No Authentication (none)
 - Basic Authentication (basic)
@@ -41,7 +41,7 @@ The alertmanager supports different kinds of [alerting configurations](https://p
 
 ### Remote Alertmanager Examples
 
-Note: the `url` value cannot be prepended with `http` or `https`.
+> **Note:** The `url` value cannot be prepended with `http` or `https`.
 
 ```yaml
 # No Authentication
@@ -82,11 +82,11 @@ data:
 type: Opaque
 ```
 
-### Configuring your External Alertmanager
+### Configuring Your External Alertmanager
 
-Please refer to the [alertmanager](https://prometheus.io/docs/alerting/alertmanager/) documentation on how to configure an alertmanager.
+Please refer to the [Alertmanager](https://prometheus.io/docs/alerting/alertmanager/) documentation on how to configure an Alertmanager.
 
-We recommend you use at least the following inhibition rules in your alertmanager configuration to prevent excessive alerts:
+We recommend you use at least the following inhibition rules in your Alertmanager configuration to prevent excessive alerts:
 ```yaml
 inhibit_rules:
 # Apply inhibition if the alert name is the same.

--- a/docs/monitoring/connectivity.md
+++ b/docs/monitoring/connectivity.md
@@ -2,7 +2,7 @@
 
 ## Shoot Connectivity
 
-We measure the connectivity from the shoot to the API Server. This is done via the `blackbox exporter` which is deployed in the shoot's `kube-system` namespace. Prometheus will scrape the `blackbox exporter` and then the exporter will try to access the API Server. Metrics are exposed if the connection was successful or not. This can be seen in the dashboard `Kubernetes Control Plane Status` dashboard under the `API Server Connectivity` panel. The `shoot` line represents the connectivity from the shoot.
+We measure the connectivity from the shoot to the API Server. This is done via the `blackbox exporter` which is deployed in the shoot's `kube-system` namespace. Prometheus will scrape the `blackbox exporter` and then the exporter will try to access the API Server. Metrics are exposed if the connection was successful or not. This can be seen in the `Kubernetes Control Plane Status` dashboard under the `API Server Connectivity` panel. The `shoot` line represents the connectivity from the shoot.
 
 ![image](images/panel.png)
 

--- a/docs/monitoring/profiling.md
+++ b/docs/monitoring/profiling.md
@@ -29,7 +29,7 @@ Entering interactive mode (type "help" for commands, "o" for options)
 
 ## gardener-apiserver
 
-gardener-apiserver provides the same flags as kube-apiserver for enabling profiling handlers (enabled by default):
+`gardener-apiserver` provides the same flags as `kube-apiserver` for enabling profiling handlers (enabled by default):
 
 ```
 --contention-profiling    Enable lock contention profiling, if profiling is enabled
@@ -37,7 +37,7 @@ gardener-apiserver provides the same flags as kube-apiserver for enabling profil
 ```
 
 The handlers are served on the same port as the API endpoints (configured via `--secure-port`).
-This means, you will also have to authenticate against the API server according to the configured authentication and authorization policy.
+This means that you will also have to authenticate against the API server according to the configured authentication and authorization policy.
 
 For example, in the [local-setup](../development/local_setup.md) you can use:
 
@@ -48,7 +48,7 @@ $ go tool pprof /tmp/heap
 
 ## gardener-{admission-controller,controller-manager,scheduler,resource-manager}, gardenlet
 
-gardener-controller-manager, gardener-admission-controller, gardener-scheduler, gardener-resource-manager and gardenlet also allow enabling profiling handlers via their respective component configs (currently disabled by default).
+`gardener-controller-manager`, `gardener-admission-controller`, `gardener-scheduler`, `gardener-resource-manager` and `gardenlet` also allow enabling profiling handlers via their respective component configs (currently disabled by default).
 Here is an example for the `gardener-admission-controller`'s configuration and how to enable it (it looks similar for the other components):
 
 ```yaml


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area documentation
/kind enhancement

**What this PR does / why we need it**:
This PR proofreads the Monitoring documentation
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```doc developer
NONE
```
