### PR TITLE
Remove EvictionRequirements from VPA CRD

### DIFF
--- a/pkg/operation/botanist/component/vpa/templates/crd-verticalpodautoscalers.tpl.yaml
+++ b/pkg/operation/botanist/component/vpa/templates/crd-verticalpodautoscalers.tpl.yaml
@@ -177,40 +177,6 @@ spec:
                   pods. If not specified, all fields in the `PodUpdatePolicy` are
                   set to their default values.
                 properties:
-                  evictionRequirements:
-                    description: EvictionRequirements is a list of EvictionRequirements
-                      that need to evaluate to true in order for a Pod to be evicted.
-                      If more than one EvictionRequirement is specified, they are
-                      combined with AND.
-                    items:
-                      description: EvictionRequirement defines a single condition
-                        which needs to be true in order to evict a Pod
-                      properties:
-                        changeRequirement:
-                          description: EvictionChangeRequirement refers to the relationship
-                            between the new target recommendation for a Pod and its
-                            current requests, what kind of change is necessary for
-                            the Pod to be evicted
-                          enum:
-                          - TargetHigherThanRequests
-                          - TargetHigherThanOrEqualToRequests
-                          - TargetLowerThanRequests
-                          - TargetLowerThanOrEqualToRequests
-                          type: string
-                        resource:
-                          description: Resources is a list of one or more resources
-                            that the condition applies to. If more than one resource
-                            is given, they are combined with OR, not with AND.
-                          items:
-                            description: ResourceName is the name identifying various
-                              resources in a ResourceList.
-                            type: string
-                          type: array
-                      required:
-                      - changeRequirement
-                      - resource
-                      type: object
-                    type: array
                   minReplicas:
                     description: Minimal number of replicas which need to be alive
                       for Updater to attempt pod eviction (pending other checks like

--- a/pkg/operation/botanist/component/vpa/vpa_test.go
+++ b/pkg/operation/botanist/component/vpa/vpa_test.go
@@ -2222,40 +2222,6 @@ spec:
                   pods. If not specified, all fields in the ` + "`" + `PodUpdatePolicy` + "`" + ` are
                   set to their default values.
                 properties:
-                  evictionRequirements:
-                    description: EvictionRequirements is a list of EvictionRequirements
-                      that need to evaluate to true in order for a Pod to be evicted.
-                      If more than one EvictionRequirement is specified, they are
-                      combined with AND.
-                    items:
-                      description: EvictionRequirement defines a single condition
-                        which needs to be true in order to evict a Pod
-                      properties:
-                        changeRequirement:
-                          description: EvictionChangeRequirement refers to the relationship
-                            between the new target recommendation for a Pod and its
-                            current requests, what kind of change is necessary for
-                            the Pod to be evicted
-                          enum:
-                          - TargetHigherThanRequests
-                          - TargetHigherThanOrEqualToRequests
-                          - TargetLowerThanRequests
-                          - TargetLowerThanOrEqualToRequests
-                          type: string
-                        resource:
-                          description: Resources is a list of one or more resources
-                            that the condition applies to. If more than one resource
-                            is given, they are combined with OR, not with AND.
-                          items:
-                            description: ResourceName is the name identifying various
-                              resources in a ResourceList.
-                            type: string
-                          type: array
-                      required:
-                      - changeRequirement
-                      - resource
-                      type: object
-                    type: array
                   minReplicas:
                     description: Minimal number of replicas which need to be alive
                       for Updater to attempt pod eviction (pending other checks like


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area auto-scaling
/kind bug

**What this PR does / why we need it**:
Removes `EvictionRequirement` from VPA CRD – the API PR isn't merged yet and made it into https://github.com/gardener/gardener/pull/7441 by accident.

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
