### PR TITLE
Fix failing logging integration tests against arm flavors

### DIFF
--- a/test/framework/resources/templates/logger-app.yaml.tpl
+++ b/test/framework/resources/templates/logger-app.yaml.tpl
@@ -18,39 +18,20 @@ spec:
     spec:
       containers:
       - name: logger
-        image: registry.k8s.io/logs-generator:v0.1.1
+        image: registry.k8s.io/e2e-test-images/agnhost:2.40
+        command: ["/bin/sh"]
         args:
-          - /bin/sh
           - -c
           - |-
 {{ if .DeltaLogsCount }}
-            /logs-generator --logtostderr --log-lines-total=${DELTA_LOGS_GENERATOR_LINES_TOTAL} --run-duration=${DELTA_LOGS_GENERATOR_DURATION}
+            /agnhost logs-generator --log-lines-total={{ .DeltaLogsCount }} --run-duration={{ .DeltaLogsDuration }}
 {{- end }}
-            /logs-generator --logtostderr --log-lines-total=${LOGS_GENERATOR_LINES_TOTAL} --run-duration=${LOGS_GENERATOR_DURATION}
+            /agnhost logs-generator --log-lines-total={{ .LogsCount }} --run-duration={{ .LogsDuration }}
 
             # Sleep forever to prevent restarts
             while true; do
               sleep 3600;
             done
-        env:
-{{ if .DeltaLogsCount }}
-        - name: DELTA_LOGS_GENERATOR_LINES_TOTAL
-          value: "{{ .DeltaLogsCount }}"
-        - name: DELTA_LOGS_GENERATOR_DURATION
-{{ if .DeltaLogsDuration }}
-          value: "{{ .DeltaLogsDuration }}"
-{{ else }}
-          value: 0s
-{{- end }}
-{{- end }}
-        - name: LOGS_GENERATOR_LINES_TOTAL
-          value: "{{ .LogsCount }}"
-        - name: LOGS_GENERATOR_DURATION
-{{ if .LogsDuration }}
-          value: "{{ .LogsDuration }}"
-{{ else }}
-          value: 0s
-{{- end }}
         resources:
           limits:
             cpu: 8m

--- a/test/framework/resources/templates/vpntunnel.yaml.tpl
+++ b/test/framework/resources/templates/vpntunnel.yaml.tpl
@@ -29,9 +29,9 @@ spec:
       - name: logger
         image: registry.k8s.io/e2e-test-images/agnhost:2.40
         args:
-          - logs-generator 
-          - --logtostderr 
-          - --log-lines-total={{ .LogsCount }} 
+          - logs-generator
+          - --logtostderr
+          - --log-lines-total={{ .LogsCount }}
           - --run-duration={{ .LogsDuration }}
       securityContext:
         fsGroup: 65532


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind bug

**What this PR does / why we need it**:
The shoot-beta-serial-test-suite is  always failing for arm:
![Screenshot 2023-02-06 at 18 24 30](https://user-images.githubusercontent.com/9372594/217027463-daa32d27-3196-4079-828c-fac5a0e89f29.png)
 
 Checking the `should get container logs from loki for all namespaces` test, the deployed logger Pods are with images that are not multi-arch:
 ```
 % k -n shoot--logging--test-33 logs kube-apiserver-57b67859b9-mjv4w
exec /bin/sh: exec format error
```

In https://github.com/gardener/gardener/pull/6632, one occurrence of the `registry.k8s.io/logs-generator:v0.1.1` image (which is not multi-arch) was adapted. This PR adapts the other occurrence by switching to the multi-arch `registry.k8s.io/e2e-test-images/agnhost:2.40` image.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/backlog/issues/19

**Special notes for your reviewer**:
The `--logtostderr` flag is dropped because the container logs the following warning:
```
Flag --logtostderr has been deprecated, will be removed in a future release, see https://github.com/kubernetes/enhancements/tree/master/keps/sig-instrumentation/2845-deprecate-klog-specific-flags-in-k8s-components
```

This can cause the integration tests to fail, it is a log that is logged to stdout that is not expected by the test.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
The logging integration tests which were failing for arm Shoots are now fixed. The Pods deployed by the test do now use multi-arch image.
```
