### PR TITLE
Use a single dash for the ingress prefix of Grafana: "gu-" vs. "gu--"

### DIFF
--- a/hack/test-e2e-local.sh
+++ b/hack/test-e2e-local.sh
@@ -53,7 +53,7 @@ if [[ "$1" != "operator" ]]; then
       fi
       printf "\n127.0.0.1 api.%s.external.local.gardener.cloud\n127.0.0.1 api.%s.internal.local.gardener.cloud\n" $shoot $shoot >>/etc/hosts
     done
-    printf "\n127.0.0.1 gu--local--e2e-rotate.ingress.$seed_name.seed.local.gardener.cloud\n" >>/etc/hosts
+    printf "\n127.0.0.1 gu-local--e2e-rotate.ingress.$seed_name.seed.local.gardener.cloud\n" >>/etc/hosts
     printf "\n127.0.0.1 api.e2e-managedseed.garden.external.local.gardener.cloud\n127.0.0.1 api.e2e-managedseed.garden.internal.local.gardener.cloud\n" >>/etc/hosts
   else
     for shoot in "${shoot_names[@]}" ; do

--- a/pkg/operation/botanist/monitoring_test.go
+++ b/pkg/operation/botanist/monitoring_test.go
@@ -232,7 +232,7 @@ var _ = Describe("Monitoring", func() {
 
 			secret := &corev1.Secret{}
 			Expect(gardenClient.Get(ctx, kubernetesutils.Key(projectNamespace, shootName+".monitoring"), secret)).To(Succeed())
-			Expect(secret.Annotations).To(HaveKeyWithValue("url", "https://gu--foo--bar."))
+			Expect(secret.Annotations).To(HaveKeyWithValue("url", "https://gu-foo--bar."))
 			Expect(secret.Labels).To(HaveKeyWithValue("gardener.cloud/role", "monitoring"))
 			Expect(secret.Data).To(And(HaveKey("username"), HaveKey("password"), HaveKey("auth")))
 		})

--- a/pkg/operation/operation.go
+++ b/pkg/operation/operation.go
@@ -17,6 +17,7 @@ package operation
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/Masterminds/semver"
@@ -603,9 +604,12 @@ func (o *Operation) ComputeLokiHost() string {
 	return o.ComputeIngressHost(common.LokiPrefix)
 }
 
+// technicalIDPattern addresses the ambiguity that one or two dashes could follow the prefix "shoot" in the technical ID of the shoot.
+var technicalIDPattern = regexp.MustCompile(fmt.Sprintf("^%s-?", v1beta1constants.TechnicalIDPrefix))
+
 // ComputeIngressHost computes the host for a given prefix.
 func (o *Operation) ComputeIngressHost(prefix string) string {
-	shortID := strings.Replace(o.Shoot.GetInfo().Status.TechnicalID, v1beta1constants.TechnicalIDPrefix, "", 1)
+	shortID := technicalIDPattern.ReplaceAllString(o.Shoot.GetInfo().Status.TechnicalID, "")
 	return fmt.Sprintf("%s-%s.%s", prefix, shortID, o.Seed.IngressDomain())
 }
 

--- a/pkg/operation/operation_test.go
+++ b/pkg/operation/operation_test.go
@@ -48,7 +48,7 @@ import (
 var _ = Describe("operation", func() {
 	ctx := context.TODO()
 
-	DescribeTable("#ComputeIngressHost", func(prefix, shootName, projectName, domain string, matcher gomegatypes.GomegaMatcher) {
+	DescribeTable("#ComputeIngressHost", func(prefix, shootName, projectName, storedTechnicalID, domain string, matcher gomegatypes.GomegaMatcher) {
 		var (
 			seed = &gardencorev1beta1.Seed{
 				Spec: gardencorev1beta1.SeedSpec{
@@ -69,54 +69,37 @@ var _ = Describe("operation", func() {
 		)
 
 		shoot.Status = gardencorev1beta1.ShootStatus{
-			TechnicalID: shootpkg.ComputeTechnicalID(projectName, shoot),
+			TechnicalID: storedTechnicalID,
 		}
+		shoot.Status.TechnicalID = shootpkg.ComputeTechnicalID(projectName, shoot)
 
 		o.Seed.SetInfo(seed)
 		o.Shoot.SetInfo(shoot)
 
 		Expect(o.ComputeIngressHost(prefix)).To(matcher)
 	},
-		Entry("ingress calculation",
+		Entry("ingress calculation (no stored technical ID)",
 			"t",
 			"fooShoot",
 			"barProject",
+			"",
 			"ingress.seed.example.com",
 			Equal("t-barProject--fooShoot.ingress.seed.example.com"),
 		),
-	)
-
-	DescribeTable("#ComputeIngressHost", func(prefix, technicalID, domain string, matcher gomegatypes.GomegaMatcher) {
-		var (
-			seed = &gardencorev1beta1.Seed{
-				Spec: gardencorev1beta1.SeedSpec{
-					DNS: gardencorev1beta1.SeedDNS{
-						IngressDomain: &domain,
-					},
-				},
-			}
-			shoot = &gardencorev1beta1.Shoot{}
-			o     = &Operation{
-				Seed:  &seedpkg.Seed{},
-				Shoot: &shootpkg.Shoot{},
-			}
-		)
-
-		shoot.Status = gardencorev1beta1.ShootStatus{
-			TechnicalID: technicalID,
-		}
-
-		o.Seed.SetInfo(seed)
-		o.Shoot.SetInfo(shoot)
-
-		Expect(o.ComputeIngressHost(prefix)).To(matcher)
-	},
-		Entry("ingress calculation with historic technical ID prefix 'shoot-'",
+		Entry("ingress calculation (historic stored technical ID with a single dash)",
 			"t",
+			"fooShoot",
+			"barProject",
 			"shoot-barProject--fooShoot",
 			"ingress.seed.example.com",
-			Equal("t-barProject--fooShoot.ingress.seed.example.com"),
-		),
+			Equal("t-barProject--fooShoot.ingress.seed.example.com")),
+		Entry("ingress calculation (current stored technical ID with two dashes)",
+			"t",
+			"fooShoot",
+			"barProject",
+			"shoot--barProject--fooShoot",
+			"ingress.seed.example.com",
+			Equal("t-barProject--fooShoot.ingress.seed.example.com")),
 	)
 
 	Context("ShootState", func() {

--- a/pkg/operation/operation_test.go
+++ b/pkg/operation/operation_test.go
@@ -82,7 +82,40 @@ var _ = Describe("operation", func() {
 			"fooShoot",
 			"barProject",
 			"ingress.seed.example.com",
-			Equal("t--barProject--fooShoot.ingress.seed.example.com"),
+			Equal("t-barProject--fooShoot.ingress.seed.example.com"),
+		),
+	)
+
+	DescribeTable("#ComputeIngressHost", func(prefix, technicalID, domain string, matcher gomegatypes.GomegaMatcher) {
+		var (
+			seed = &gardencorev1beta1.Seed{
+				Spec: gardencorev1beta1.SeedSpec{
+					DNS: gardencorev1beta1.SeedDNS{
+						IngressDomain: &domain,
+					},
+				},
+			}
+			shoot = &gardencorev1beta1.Shoot{}
+			o     = &Operation{
+				Seed:  &seedpkg.Seed{},
+				Shoot: &shootpkg.Shoot{},
+			}
+		)
+
+		shoot.Status = gardencorev1beta1.ShootStatus{
+			TechnicalID: technicalID,
+		}
+
+		o.Seed.SetInfo(seed)
+		o.Shoot.SetInfo(shoot)
+
+		Expect(o.ComputeIngressHost(prefix)).To(matcher)
+	},
+		Entry("ingress calculation with historic technical ID prefix 'shoot-'",
+			"t",
+			"shoot-barProject--fooShoot",
+			"ingress.seed.example.com",
+			Equal("t-barProject--fooShoot.ingress.seed.example.com"),
 		),
 	)
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind bug

**What this PR does / why we need it**:

Use a single dash for the ingress prefix of Grafana: `gu-` vs. `gu--`

Before https://github.com/gardener/gardener/pull/7408#discussion_r1092008535 the ingress domain for the user's Grafana had a `gu-` prefix, e.g. `gu-local--local.ingress.local.seed.local.gardener.cloud`

As a side effect of the change in
https://github.com/gardener/gardener/pull/7408/files#diff-5f6f1c2ea9e5643e60056fa6812709bc31edf03af4752897a694d3fed1f208adR439 the ingress domain changed to:

`gu--local--local.ingress.local.seed.local.gardener.cloud`, i.e. had a prefix `gu--` instead of `gu-`.

The intention of that change was that the technical ID of new shoots should consistently use 2 dashes after the prefix "shoot".

This commit adjusts the ComputeIngressHost function to chop off the "shoot--?" prefix when computing the ingress host name to restore the previous behavior of the "gu-" prefix. It supports the historic case with the technical ID prefix "shoot-" of old shoots and the now common case with the technical ID prefix "shoot--".

Currently the "gu-" prefix (and the other prefixes for Prometheus and the alert manager) are hard coded in the Gardener Dashboard
https://github.com/gardener/dashboard/blob/1bff671380286345a6d2228a73306f3d524e4a3f/frontend/src/store/modules/shoots/index.js#L185-L190 so changing the prefix would require adjusting the Dashboard links and the links would be broken until the shoot cluster is reconciled. A better approach could be to add all the monitoring links (besides Grafana also the link to Prometheus and to the Alert manager) to the `<shoot>.monitoring` secret so that the Dashboard does not need to hard code the said prefixes.

With this PR, the original behavior (prefix with a single dash) is restored and the Dashboard does not need to be adopted.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

/cc @rfranzke @rickardsjp 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
