### PR TITLE
Cleanup deprecated variables

### DIFF
--- a/extensions/pkg/controller/cmd/options.go
+++ b/extensions/pkg/controller/cmd/options.go
@@ -230,11 +230,11 @@ func (m *ManagerOptions) AddFlags(fs *pflag.FlagSet) {
 
 // Complete implements Completer.Complete.
 func (m *ManagerOptions) Complete() error {
-	if !sets.NewString(logger.AllLogLevels...).Has(m.LogLevel) {
+	if !sets.New[string](logger.AllLogLevels...).Has(m.LogLevel) {
 		return fmt.Errorf("invalid --%s: %s", LogLevelFlag, m.LogLevel)
 	}
 
-	if !sets.NewString(logger.AllLogFormats...).Has(m.LogFormat) {
+	if !sets.New[string](logger.AllLogFormats...).Has(m.LogFormat) {
 		return fmt.Errorf("invalid --%s: %s", LogFormatFlag, m.LogFormat)
 	}
 
@@ -463,7 +463,7 @@ func (d *SwitchOptions) AddFlags(fs *pflag.FlagSet) {
 
 // Complete implements Option.
 func (d *SwitchOptions) Complete() error {
-	disabled := sets.NewString()
+	disabled := sets.New[string]()
 	for _, disabledName := range d.Disabled {
 		if _, ok := d.nameToAddToManager[disabledName]; !ok {
 			return fmt.Errorf("cannot disable unknown controller %q", disabledName)

--- a/extensions/pkg/controller/healthcheck/controller.go
+++ b/extensions/pkg/controller/healthcheck/controller.go
@@ -191,7 +191,7 @@ func add(mgr manager.Manager, args AddArgs) error {
 }
 
 func getHealthCheckTypes(healthChecks []ConditionTypeToHealthCheck) []string {
-	types := sets.NewString()
+	types := sets.New[string]()
 	for _, healthCheck := range healthChecks {
 		types.Insert(healthCheck.ConditionType)
 	}

--- a/extensions/pkg/controller/worker/genericactuator/actuator.go
+++ b/extensions/pkg/controller/worker/genericactuator/actuator.go
@@ -135,12 +135,12 @@ func (a *genericActuator) cleanupMachineDeployments(ctx context.Context, logger 
 	return nil
 }
 
-func (a *genericActuator) listMachineClassNames(ctx context.Context, namespace string, machineClassList client.ObjectList) (sets.String, error) {
+func (a *genericActuator) listMachineClassNames(ctx context.Context, namespace string, machineClassList client.ObjectList) (sets.Set[string], error) {
 	if err := a.client.List(ctx, machineClassList, client.InNamespace(namespace)); err != nil {
 		return nil, err
 	}
 
-	classNames := sets.NewString()
+	classNames := sets.New[string]()
 
 	if err := meta.EachListItem(machineClassList, func(machineClass runtime.Object) error {
 		accessor, err := meta.Accessor(machineClass)

--- a/extensions/pkg/controller/worker/genericactuator/actuator_reconcile.go
+++ b/extensions/pkg/controller/worker/genericactuator/actuator_reconcile.go
@@ -139,7 +139,7 @@ func (a *genericActuator) Reconcile(ctx context.Context, log logr.Logger, worker
 		return fmt.Errorf("failed to update the machine image status: %w", err)
 	}
 
-	existingMachineDeploymentNames := sets.String{}
+	existingMachineDeploymentNames := sets.Set[string]{}
 	for _, deployment := range existingMachineDeployments.Items {
 		existingMachineDeploymentNames.Insert(deployment.Name)
 	}
@@ -347,7 +347,7 @@ func (a *genericActuator) deployMachineDeployments(ctx context.Context, log logr
 
 // waitUntilWantedMachineDeploymentsAvailable waits until all the desired <machineDeployments> were marked as healthy /
 // available by the machine-controller-manager. It polls the status every 5 seconds.
-func (a *genericActuator) waitUntilWantedMachineDeploymentsAvailable(ctx context.Context, log logr.Logger, cluster *extensionscontroller.Cluster, worker *extensionsv1alpha1.Worker, alreadyExistingMachineDeploymentNames sets.String, alreadyExistingMachineClassNames sets.String, wantedMachineDeployments extensionsworkercontroller.MachineDeployments) error {
+func (a *genericActuator) waitUntilWantedMachineDeploymentsAvailable(ctx context.Context, log logr.Logger, cluster *extensionscontroller.Cluster, worker *extensionsv1alpha1.Worker, alreadyExistingMachineDeploymentNames sets.Set[string], alreadyExistingMachineClassNames sets.Set[string], wantedMachineDeployments extensionsworkercontroller.MachineDeployments) error {
 	log.Info("Waiting until wanted machine deployments are available")
 
 	return retryutils.UntilTimeout(ctx, 5*time.Second, 5*time.Minute, func(ctx context.Context) (bool, error) {

--- a/extensions/pkg/terraformer/state.go
+++ b/extensions/pkg/terraformer/state.go
@@ -66,8 +66,8 @@ func (t *terraformer) GetStateOutputVariables(ctx context.Context, variables ...
 	var (
 		output = make(map[string]string)
 
-		wantedVariables = sets.NewString(variables...)
-		foundVariables  = sets.NewString()
+		wantedVariables = sets.New[string](variables...)
+		foundVariables  = sets.New[string]()
 	)
 
 	stateConfigMap, err := t.GetState(ctx)
@@ -76,7 +76,7 @@ func (t *terraformer) GetStateOutputVariables(ctx context.Context, variables ...
 	}
 
 	if len(stateConfigMap) == 0 {
-		return nil, &variablesNotFoundError{wantedVariables.List()}
+		return nil, &variablesNotFoundError{sets.List(wantedVariables)}
 	}
 
 	outputVariables, err := getOutputVariables(stateConfigMap)
@@ -92,7 +92,7 @@ func (t *terraformer) GetStateOutputVariables(ctx context.Context, variables ...
 	}
 
 	if wantedVariables.Len() != foundVariables.Len() {
-		return nil, &variablesNotFoundError{wantedVariables.Difference(foundVariables).List()}
+		return nil, &variablesNotFoundError{sets.List(wantedVariables.Difference(foundVariables))}
 	}
 
 	return output, nil

--- a/extensions/pkg/util/errors.go
+++ b/extensions/pkg/util/errors.go
@@ -48,7 +48,7 @@ func DetermineErrorCodes(err error, knownCodes map[gardencorev1beta1.ErrorCode]f
 	var (
 		coder   v1beta1helper.Coder
 		message = err.Error()
-		codes   = sets.NewString()
+		codes   = sets.New[string]()
 	)
 
 	if err == nil {
@@ -71,7 +71,7 @@ func DetermineErrorCodes(err error, knownCodes map[gardencorev1beta1.ErrorCode]f
 
 	// compute error code list based on code string set
 	var out []gardencorev1beta1.ErrorCode
-	for _, c := range codes.List() {
+	for _, c := range sets.List(codes) {
 		out = append(out, gardencorev1beta1.ErrorCode(c))
 	}
 	return out

--- a/extensions/pkg/webhook/cmd/options.go
+++ b/extensions/pkg/webhook/cmd/options.go
@@ -130,7 +130,7 @@ func (w *SwitchOptions) AddFlags(fs *pflag.FlagSet) {
 
 // Complete implements Option.
 func (w *SwitchOptions) Complete() error {
-	disabled := sets.NewString()
+	disabled := sets.New[string]()
 	for _, disabledName := range w.Disabled {
 		if _, ok := w.nameToWebhookFactory[disabledName]; !ok {
 			return fmt.Errorf("cannot disable unknown webhook %q", disabledName)

--- a/pkg/admissioncontroller/apis/config/validation/admissioncontrollerconfiguration.go
+++ b/pkg/admissioncontroller/apis/config/validation/admissioncontrollerconfiguration.go
@@ -28,10 +28,10 @@ import (
 func ValidateAdmissionControllerConfiguration(config *admissioncontrollerconfig.AdmissionControllerConfiguration) field.ErrorList {
 	allErrs := field.ErrorList{}
 
-	if !sets.NewString(logger.AllLogLevels...).Has(config.LogLevel) {
+	if !sets.New[string](logger.AllLogLevels...).Has(config.LogLevel) {
 		allErrs = append(allErrs, field.NotSupported(field.NewPath("logLevel"), config.LogLevel, logger.AllLogLevels))
 	}
-	if !sets.NewString(logger.AllLogFormats...).Has(config.LogFormat) {
+	if !sets.New[string](logger.AllLogFormats...).Has(config.LogFormat) {
 		allErrs = append(allErrs, field.NotSupported(field.NewPath("logFormat"), config.LogFormat, logger.AllLogFormats))
 	}
 
@@ -45,13 +45,13 @@ func ValidateAdmissionControllerConfiguration(config *admissioncontrollerconfig.
 // ValidateResourceAdmissionConfiguration validates the given `ResourceAdmissionConfiguration`.
 func validateResourceAdmissionConfiguration(config *admissioncontrollerconfig.ResourceAdmissionConfiguration, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
-	validValues := sets.NewString(string(admissioncontrollerconfig.AdmissionModeBlock), string(admissioncontrollerconfig.AdmissionModeLog))
+	validValues := sets.New[string](string(admissioncontrollerconfig.AdmissionModeBlock), string(admissioncontrollerconfig.AdmissionModeLog))
 
 	if config.OperationMode != nil && !validValues.Has(string(*config.OperationMode)) {
 		allErrs = append(allErrs, field.NotSupported(fldPath.Child("mode"), string(*config.OperationMode), validValues.UnsortedList()))
 	}
 
-	allowedSubjectKinds := sets.NewString(rbacv1.UserKind, rbacv1.GroupKind, rbacv1.ServiceAccountKind)
+	allowedSubjectKinds := sets.New[string](rbacv1.UserKind, rbacv1.GroupKind, rbacv1.ServiceAccountKind)
 
 	for i, subject := range config.UnrestrictedSubjects {
 		fld := fldPath.Child("unrestrictedSubjects").Index(i)

--- a/pkg/apis/core/helper/helpers.go
+++ b/pkg/apis/core/helper/helpers.go
@@ -271,7 +271,7 @@ func GetAddedVersions(old, new []core.ExpirableVersion) map[string]int {
 // getVersionDiff gets versions that are in v1 but not in v2.
 // Returns versions mapped to their index in v1.
 func getVersionDiff(v1, v2 []core.ExpirableVersion) map[string]int {
-	v2Versions := sets.String{}
+	v2Versions := sets.Set[string]{}
 	for _, x := range v2 {
 		v2Versions.Insert(x.Version)
 	}
@@ -463,12 +463,12 @@ func SecretBindingHasType(secretBinding *core.SecretBinding, providerType string
 		return false
 	}
 
-	return sets.NewString(types...).Has(providerType)
+	return sets.New[string](types...).Has(providerType)
 }
 
 // GetAllZonesFromShoot returns the set of all availability zones defined in the worker pools of the Shoot specification.
-func GetAllZonesFromShoot(shoot *core.Shoot) sets.String {
-	out := sets.NewString()
+func GetAllZonesFromShoot(shoot *core.Shoot) sets.Set[string] {
+	out := sets.New[string]()
 	for _, worker := range shoot.Spec.Provider.Workers {
 		out.Insert(worker.Zones...)
 	}

--- a/pkg/apis/core/helper/helpers_test.go
+++ b/pkg/apis/core/helper/helpers_test.go
@@ -24,6 +24,7 @@ import (
 	gomegatypes "github.com/onsi/gomega/types"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/utils/pointer"
 
 	"github.com/gardener/gardener/pkg/apis/core"
@@ -736,11 +737,11 @@ var _ = Describe("helper", func() {
 
 	Describe("#GetAllZonesFromShoot", func() {
 		It("should return an empty list because there are no zones", func() {
-			Expect(GetAllZonesFromShoot(&core.Shoot{}).List()).To(BeEmpty())
+			Expect(sets.List(GetAllZonesFromShoot(&core.Shoot{}))).To(BeEmpty())
 		})
 
 		It("should return the expected list when there is only one pool", func() {
-			Expect(GetAllZonesFromShoot(&core.Shoot{
+			Expect(sets.List(GetAllZonesFromShoot(&core.Shoot{
 				Spec: core.ShootSpec{
 					Provider: core.Provider{
 						Workers: []core.Worker{
@@ -748,11 +749,11 @@ var _ = Describe("helper", func() {
 						},
 					},
 				},
-			}).List()).To(ConsistOf("a", "b"))
+			}))).To(ConsistOf("a", "b"))
 		})
 
 		It("should return the expected list when there are more than one pools", func() {
-			Expect(GetAllZonesFromShoot(&core.Shoot{
+			Expect(sets.List(GetAllZonesFromShoot(&core.Shoot{
 				Spec: core.ShootSpec{
 					Provider: core.Provider{
 						Workers: []core.Worker{
@@ -761,7 +762,7 @@ var _ = Describe("helper", func() {
 						},
 					},
 				},
-			}).List()).To(ConsistOf("a", "b", "c", "d"))
+			}))).To(ConsistOf("a", "b", "c", "d"))
 		})
 	})
 

--- a/pkg/apis/core/v1beta1/helper/condition_builder_test.go
+++ b/pkg/apis/core/v1beta1/helper/condition_builder_test.go
@@ -150,7 +150,7 @@ var _ = Describe("Builder", func() {
 			},
 				Entry("reason is not set", nil, initializedReason),
 				Entry("empty reason is set", pointer.String(""), unspecifiedReason),
-				Entry("reason is set", pointer.StringPtr(bazReason), bazReason),
+				Entry("reason is set", pointer.String(bazReason), bazReason),
 			)
 
 			DescribeTable("With old condition", func(reason *string, previousReason, expectedReason string) {
@@ -192,8 +192,8 @@ var _ = Describe("Builder", func() {
 				Entry("reason is not set", nil, bazReason, bazReason),
 				Entry("reason was previously empty", nil, "", initializedReason),
 				Entry("empty reason is set", pointer.String(""), bazReason, unspecifiedReason),
-				Entry("message is the same", pointer.StringPtr("ReasonA"), "ReasonA", "ReasonA"),
-				Entry("message changed", pointer.StringPtr("ReasonA"), bazReason, "ReasonA"),
+				Entry("message is the same", pointer.String("ReasonA"), "ReasonA", "ReasonA"),
+				Entry("message changed", pointer.String("ReasonA"), bazReason, "ReasonA"),
 			)
 		})
 
@@ -220,7 +220,7 @@ var _ = Describe("Builder", func() {
 			},
 				Entry("message is not set", nil, unitializedMessage),
 				Entry("empty message is set", pointer.String(""), unspecifiedMessage),
-				Entry("message is set", pointer.StringPtr(fubarMessage), fubarMessage),
+				Entry("message is set", pointer.String(fubarMessage), fubarMessage),
 			)
 
 			DescribeTable("With old condition", func(message *string, previousMessage, expectedMessage string) {
@@ -262,8 +262,8 @@ var _ = Describe("Builder", func() {
 				Entry("message is not set", nil, fubarMessage, fubarMessage),
 				Entry("message was previously empty", nil, "", unitializedMessage),
 				Entry("empty message is set", pointer.String(""), fubarMessage, unspecifiedMessage),
-				Entry("message is the same", pointer.StringPtr("another message"), "another message", "another message"),
-				Entry("message changed", pointer.StringPtr("another message"), fubarMessage, "another message"),
+				Entry("message is the same", pointer.String("another message"), "another message", "another message"),
+				Entry("message changed", pointer.String("another message"), fubarMessage, "another message"),
 			)
 		})
 

--- a/pkg/apis/core/v1beta1/helper/errors.go
+++ b/pkg/apis/core/v1beta1/helper/errors.go
@@ -95,7 +95,7 @@ func DeprecatedDetermineErrorCodes(err error) []gardencorev1beta1.ErrorCode {
 	var (
 		coder   Coder
 		message = err.Error()
-		codes   = sets.NewString()
+		codes   = sets.New[string]()
 
 		knownCodes = map[gardencorev1beta1.ErrorCode]func(string) bool{
 			gardencorev1beta1.ErrorInfraUnauthenticated:          unauthenticatedRegexp.MatchString,
@@ -128,7 +128,7 @@ func DeprecatedDetermineErrorCodes(err error) []gardencorev1beta1.ErrorCode {
 
 	// compute error code list based on code string set
 	var out []gardencorev1beta1.ErrorCode
-	for _, c := range codes.List() {
+	for _, c := range sets.List(codes) {
 		out = append(out, gardencorev1beta1.ErrorCode(c))
 	}
 	return out
@@ -159,7 +159,7 @@ type MultiErrorWithCodes struct {
 	errors      []error
 	errorFormat func(errs []error) string
 
-	errorCodeStr sets.String
+	errorCodeStr sets.Set[string]
 	codes        []gardencorev1beta1.ErrorCode
 }
 
@@ -167,7 +167,7 @@ type MultiErrorWithCodes struct {
 func NewMultiErrorWithCodes(errorFormat func(errs []error) string) *MultiErrorWithCodes {
 	return &MultiErrorWithCodes{
 		errorFormat:  errorFormat,
-		errorCodeStr: sets.NewString(),
+		errorCodeStr: sets.New[string](),
 	}
 }
 

--- a/pkg/apis/core/v1beta1/helper/helper.go
+++ b/pkg/apis/core/v1beta1/helper/helper.go
@@ -976,8 +976,8 @@ func SeedBackupSecretRefEqual(oldBackup, newBackup *gardencorev1beta1.SeedBackup
 // same.
 func ShootDNSProviderSecretNamesEqual(oldDNS, newDNS *gardencorev1beta1.DNS) bool {
 	var (
-		oldNames = sets.NewString()
-		newNames = sets.NewString()
+		oldNames = sets.New[string]()
+		newNames = sets.New[string]()
 	)
 
 	if oldDNS != nil {
@@ -1003,8 +1003,8 @@ func ShootDNSProviderSecretNamesEqual(oldDNS, newDNS *gardencorev1beta1.DNS) boo
 // has been changed.
 func ShootSecretResourceReferencesEqual(oldResources, newResources []gardencorev1beta1.NamedResourceReference) bool {
 	var (
-		oldNames = sets.NewString()
-		newNames = sets.NewString()
+		oldNames = sets.New[string]()
+		newNames = sets.New[string]()
 	)
 
 	for _, resource := range oldResources {
@@ -1098,7 +1098,7 @@ func SecretBindingHasType(secretBinding *gardencorev1beta1.SecretBinding, provid
 		return false
 	}
 
-	return sets.NewString(types...).Has(providerType)
+	return sets.New[string](types...).Has(providerType)
 }
 
 // AddTypeToSecretBinding adds the given provider type to the SecretBinding.
@@ -1111,7 +1111,7 @@ func AddTypeToSecretBinding(secretBinding *gardencorev1beta1.SecretBinding, prov
 	}
 
 	types := GetSecretBindingTypes(secretBinding)
-	if !sets.NewString(types...).Has(providerType) {
+	if !sets.New[string](types...).Has(providerType) {
 		types = append(types, providerType)
 	}
 	secretBinding.Provider.Type = strings.Join(types, ",")

--- a/pkg/apis/core/validation/controllerregistration.go
+++ b/pkg/apis/core/validation/controllerregistration.go
@@ -28,13 +28,13 @@ import (
 	"github.com/gardener/gardener/pkg/extensions"
 )
 
-var availablePolicies = sets.NewString(
+var availablePolicies = sets.New[string](
 	string(core.ControllerDeploymentPolicyOnDemand),
 	string(core.ControllerDeploymentPolicyAlways),
 	string(core.ControllerDeploymentPolicyAlwaysExceptNoShoots),
 )
 
-var availableExtensionStrategies = sets.NewString(
+var availableExtensionStrategies = sets.New[string](
 	string(core.BeforeKubeAPIServer),
 	string(core.AfterKubeAPIServer),
 )
@@ -50,7 +50,7 @@ func ValidateControllerRegistration(controllerRegistration *core.ControllerRegis
 }
 
 // SupportedExtensionKinds contains all supported extension kinds.
-var SupportedExtensionKinds = sets.NewString(
+var SupportedExtensionKinds = sets.New[string](
 	extensionsv1alpha1.BackupBucketResource,
 	extensionsv1alpha1.BackupEntryResource,
 	extensionsv1alpha1.BastionResource,
@@ -108,13 +108,13 @@ func ValidateControllerRegistrationSpec(spec *core.ControllerRegistrationSpec, f
 		if resource.Kind == extensionsv1alpha1.ExtensionResource && resource.Lifecycle != nil {
 			lifecyclePath := idxPath.Child("lifecycle")
 			if resource.Lifecycle.Reconcile != nil && !availableExtensionStrategies.Has(string(*resource.Lifecycle.Reconcile)) {
-				allErrs = append(allErrs, field.NotSupported(lifecyclePath.Child("reconcile"), *resource.Lifecycle.Reconcile, availableExtensionStrategies.List()))
+				allErrs = append(allErrs, field.NotSupported(lifecyclePath.Child("reconcile"), *resource.Lifecycle.Reconcile, sets.List(availableExtensionStrategies)))
 			}
 			if resource.Lifecycle.Delete != nil && !availableExtensionStrategies.Has(string(*resource.Lifecycle.Delete)) {
-				allErrs = append(allErrs, field.NotSupported(lifecyclePath.Child("delete"), *resource.Lifecycle.Delete, availableExtensionStrategies.List()))
+				allErrs = append(allErrs, field.NotSupported(lifecyclePath.Child("delete"), *resource.Lifecycle.Delete, sets.List(availableExtensionStrategies)))
 			}
 			if resource.Lifecycle.Migrate != nil && !availableExtensionStrategies.Has(string(*resource.Lifecycle.Migrate)) {
-				allErrs = append(allErrs, field.NotSupported(lifecyclePath.Child("migrate"), *resource.Lifecycle.Migrate, availableExtensionStrategies.List()))
+				allErrs = append(allErrs, field.NotSupported(lifecyclePath.Child("migrate"), *resource.Lifecycle.Migrate, sets.List(availableExtensionStrategies)))
 			}
 		}
 
@@ -126,7 +126,7 @@ func ValidateControllerRegistrationSpec(spec *core.ControllerRegistrationSpec, f
 
 	if deployment := spec.Deployment; deployment != nil {
 		if policy := deployment.Policy; policy != nil && !availablePolicies.Has(string(*policy)) {
-			allErrs = append(allErrs, field.NotSupported(deploymentPath.Child("policy"), *policy, availablePolicies.List()))
+			allErrs = append(allErrs, field.NotSupported(deploymentPath.Child("policy"), *policy, sets.List(availablePolicies)))
 		}
 
 		if deployment.SeedSelector != nil {

--- a/pkg/apis/core/validation/project.go
+++ b/pkg/apis/core/validation/project.go
@@ -159,7 +159,7 @@ func ValidateSubject(subject rbacv1.Subject, fldPath *field.Path) field.ErrorLis
 	return allErrs
 }
 
-var supportedRoles = sets.NewString(
+var supportedRoles = sets.New[string](
 	core.ProjectMemberOwner,
 	core.ProjectMemberAdmin,
 	core.ProjectMemberViewer,
@@ -185,7 +185,7 @@ func ValidateProjectMember(member core.ProjectMember, fldPath *field.Path) field
 		foundRoles[role] = struct{}{}
 
 		if !supportedRoles.Has(role) && !strings.HasPrefix(role, core.ProjectMemberExtensionPrefix) {
-			allErrs = append(allErrs, field.NotSupported(rolesPath, role, append(supportedRoles.List(), core.ProjectMemberExtensionPrefix+"*")))
+			allErrs = append(allErrs, field.NotSupported(rolesPath, role, append(sets.List(supportedRoles), core.ProjectMemberExtensionPrefix+"*")))
 		}
 
 		if strings.HasPrefix(role, core.ProjectMemberExtensionPrefix) {
@@ -209,7 +209,7 @@ func ValidateProjectMember(member core.ProjectMember, fldPath *field.Path) field
 func ValidateTolerations(tolerations []core.Toleration, fldPath *field.Path) field.ErrorList {
 	var (
 		allErrs   field.ErrorList
-		keyValues = sets.NewString()
+		keyValues = sets.New[string]()
 	)
 
 	for i, toleration := range tolerations {
@@ -233,7 +233,7 @@ func ValidateTolerations(tolerations []core.Toleration, fldPath *field.Path) fie
 func ValidateTolerationsAgainstAllowlist(tolerations, allowlist []core.Toleration, fldPath *field.Path) field.ErrorList {
 	var (
 		allErrs            field.ErrorList
-		allowedTolerations = sets.NewString()
+		allowedTolerations = sets.New[string]()
 	)
 
 	for _, toleration := range allowlist {

--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -5529,20 +5529,20 @@ var _ = Describe("Shoot Validation Tests", func() {
 
 	Describe("#ValidateHibernationCronSpec", func() {
 		DescribeTable("validate cron spec",
-			func(seenSpecs sets.String, spec string, matcher gomegatypes.GomegaMatcher) {
+			func(seenSpecs sets.Set[string], spec string, matcher gomegatypes.GomegaMatcher) {
 				Expect(ValidateHibernationCronSpec(seenSpecs, spec, nil)).To(matcher)
 			},
-			Entry("invalid spec", sets.NewString(), "foo", ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+			Entry("invalid spec", sets.New[string](), "foo", ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 				"Type": Equal(field.ErrorTypeInvalid),
 			})))),
-			Entry("duplicate spec", sets.NewString("* * * * *"), "* * * * *", ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+			Entry("duplicate spec", sets.New[string]("* * * * *"), "* * * * *", ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 				"Type": Equal(field.ErrorTypeDuplicate),
 			})))),
 		)
 
 		It("should add the inspected cron spec to the set if there were no issues", func() {
 			var (
-				s    = sets.NewString()
+				s    = sets.New[string]()
 				spec = "* * * * *"
 			)
 			Expect(ValidateHibernationCronSpec(s, spec, nil)).To(BeEmpty())
@@ -5551,7 +5551,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 
 		It("should not add the inspected cron spec to the set if there were issues", func() {
 			var (
-				s    = sets.NewString()
+				s    = sets.New[string]()
 				spec = "foo"
 			)
 			Expect(ValidateHibernationCronSpec(s, spec, nil)).NotTo(BeEmpty())
@@ -5574,35 +5574,35 @@ var _ = Describe("Shoot Validation Tests", func() {
 
 	Describe("#ValidateHibernationSchedule", func() {
 		DescribeTable("validate schedule",
-			func(seenSpecs sets.String, schedule *core.HibernationSchedule, matcher gomegatypes.GomegaMatcher) {
+			func(seenSpecs sets.Set[string], schedule *core.HibernationSchedule, matcher gomegatypes.GomegaMatcher) {
 				errList := ValidateHibernationSchedule(seenSpecs, schedule, nil)
 				Expect(errList).To(matcher)
 			},
 
-			Entry("valid schedule", sets.NewString(), &core.HibernationSchedule{Start: pointer.String("1 * * * *"), End: pointer.String("2 * * * *")}, BeEmpty()),
-			Entry("invalid start value", sets.NewString(), &core.HibernationSchedule{Start: pointer.String(""), End: pointer.String("* * * * *")}, ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+			Entry("valid schedule", sets.New[string](), &core.HibernationSchedule{Start: pointer.String("1 * * * *"), End: pointer.String("2 * * * *")}, BeEmpty()),
+			Entry("invalid start value", sets.New[string](), &core.HibernationSchedule{Start: pointer.String(""), End: pointer.String("* * * * *")}, ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 				"Type":  Equal(field.ErrorTypeInvalid),
 				"Field": Equal(field.NewPath("start").String()),
 			})))),
-			Entry("invalid end value", sets.NewString(), &core.HibernationSchedule{Start: pointer.String("* * * * *"), End: pointer.String("")}, ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+			Entry("invalid end value", sets.New[string](), &core.HibernationSchedule{Start: pointer.String("* * * * *"), End: pointer.String("")}, ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 				"Type":  Equal(field.ErrorTypeInvalid),
 				"Field": Equal(field.NewPath("end").String()),
 			})))),
-			Entry("invalid location", sets.NewString(), &core.HibernationSchedule{Start: pointer.String("1 * * * *"), End: pointer.String("2 * * * *"), Location: pointer.String("foo")}, ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+			Entry("invalid location", sets.New[string](), &core.HibernationSchedule{Start: pointer.String("1 * * * *"), End: pointer.String("2 * * * *"), Location: pointer.String("foo")}, ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 				"Type":  Equal(field.ErrorTypeInvalid),
 				"Field": Equal(field.NewPath("location").String()),
 			})))),
-			Entry("equal start and end value", sets.NewString(), &core.HibernationSchedule{Start: pointer.String("* * * * *"), End: pointer.String("* * * * *")}, ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+			Entry("equal start and end value", sets.New[string](), &core.HibernationSchedule{Start: pointer.String("* * * * *"), End: pointer.String("* * * * *")}, ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 				"Type":  Equal(field.ErrorTypeDuplicate),
 				"Field": Equal(field.NewPath("end").String()),
 			})))),
-			Entry("nil start", sets.NewString(), &core.HibernationSchedule{End: pointer.String("* * * * *")}, BeEmpty()),
-			Entry("nil end", sets.NewString(), &core.HibernationSchedule{Start: pointer.String("* * * * *")}, BeEmpty()),
-			Entry("start and end nil", sets.NewString(), &core.HibernationSchedule{},
+			Entry("nil start", sets.New[string](), &core.HibernationSchedule{End: pointer.String("* * * * *")}, BeEmpty()),
+			Entry("nil end", sets.New[string](), &core.HibernationSchedule{Start: pointer.String("* * * * *")}, BeEmpty()),
+			Entry("start and end nil", sets.New[string](), &core.HibernationSchedule{},
 				ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type": Equal(field.ErrorTypeRequired),
 				})))),
-			Entry("invalid start and end value", sets.NewString(), &core.HibernationSchedule{Start: pointer.String(""), End: pointer.String("")},
+			Entry("invalid start and end value", sets.New[string](), &core.HibernationSchedule{Start: pointer.String(""), End: pointer.String("")},
 				ConsistOf(
 					PointTo(MatchFields(IgnoreExtras, Fields{
 						"Type":  Equal(field.ErrorTypeInvalid),

--- a/pkg/apis/core/validation/utils.go
+++ b/pkg/apis/core/validation/utils.go
@@ -117,7 +117,7 @@ func getPercentValue(intOrStringValue intstr.IntOrString) (int, bool) {
 	return value, true
 }
 
-var availableFailureTolerance = sets.NewString(
+var availableFailureTolerance = sets.New[string](
 	string(core.FailureToleranceTypeNode),
 	string(core.FailureToleranceTypeZone),
 )
@@ -128,7 +128,7 @@ func ValidateFailureToleranceTypeValue(value core.FailureToleranceType, fldPath 
 
 	failureToleranceType := string(value)
 	if !availableFailureTolerance.Has(failureToleranceType) {
-		allErrs = append(allErrs, field.NotSupported(fldPath, failureToleranceType, availableFailureTolerance.List()))
+		allErrs = append(allErrs, field.NotSupported(fldPath, failureToleranceType, sets.List(availableFailureTolerance)))
 	}
 
 	return allErrs
@@ -156,7 +156,7 @@ func shootReconciliationSuccessful(shoot *core.Shoot) (bool, string) {
 	return false, fmt.Sprintf("last operation was %s, not Reconcile", shoot.Status.LastOperation.Type)
 }
 
-var availableIPFamilies = sets.NewString(
+var availableIPFamilies = sets.New[string](
 	string(core.IPFamilyIPv4),
 	string(core.IPFamilyIPv6),
 )
@@ -165,11 +165,11 @@ var availableIPFamilies = sets.NewString(
 func ValidateIPFamilies(ipFamilies []core.IPFamily, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
-	ipFamiliesSeen := sets.NewString()
+	ipFamiliesSeen := sets.New[string]()
 	for i, ipFamily := range ipFamilies {
 		// validate: only supported IP families
 		if !availableIPFamilies.Has(string(ipFamily)) {
-			allErrs = append(allErrs, field.NotSupported(fldPath.Index(i), ipFamily, availableIPFamilies.List()))
+			allErrs = append(allErrs, field.NotSupported(fldPath.Index(i), ipFamily, sets.List(availableIPFamilies)))
 		}
 
 		// validate: no duplicate IP families

--- a/pkg/apis/extensions/validation/network.go
+++ b/pkg/apis/extensions/validation/network.go
@@ -113,7 +113,7 @@ func ValidateNetworkStatusUpdate(newStatus, oldStatus *extensionsv1alpha1.Networ
 	return allErrs
 }
 
-var availableIPFamilies = sets.NewString(
+var availableIPFamilies = sets.New[string](
 	string(extensionsv1alpha1.IPFamilyIPv4),
 	string(extensionsv1alpha1.IPFamilyIPv6),
 )
@@ -122,11 +122,11 @@ var availableIPFamilies = sets.NewString(
 func ValidateIPFamilies(ipFamilies []extensionsv1alpha1.IPFamily, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
-	ipFamiliesSeen := sets.NewString()
+	ipFamiliesSeen := sets.New[string]()
 	for i, ipFamily := range ipFamilies {
 		// validate: only supported IP families
 		if !availableIPFamilies.Has(string(ipFamily)) {
-			allErrs = append(allErrs, field.NotSupported(fldPath.Index(i), ipFamily, availableIPFamilies.List()))
+			allErrs = append(allErrs, field.NotSupported(fldPath.Index(i), ipFamily, sets.List(availableIPFamilies)))
 		}
 
 		// validate: no duplicate IP families

--- a/pkg/apis/extensions/validation/operatingsystemconfig.go
+++ b/pkg/apis/extensions/validation/operatingsystemconfig.go
@@ -96,7 +96,7 @@ func ValidateUnits(units []extensionsv1alpha1.Unit, fldPath *field.Path) field.E
 func ValidateFiles(files []extensionsv1alpha1.File, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
-	paths := sets.NewString()
+	paths := sets.New[string]()
 
 	for i, file := range files {
 		idxPath := fldPath.Index(i)

--- a/pkg/apis/operator/v1alpha1/types.go
+++ b/pkg/apis/operator/v1alpha1/types.go
@@ -222,7 +222,7 @@ const (
 )
 
 // AvailableOperationAnnotations is the set of available operation annotations for Garden resources.
-var AvailableOperationAnnotations = sets.NewString(
+var AvailableOperationAnnotations = sets.New[string](
 	v1beta1constants.GardenerOperationReconcile,
 	v1beta1constants.OperationRotateCAStart,
 	v1beta1constants.OperationRotateCAComplete,

--- a/pkg/apis/operator/v1alpha1/validation/validation.go
+++ b/pkg/apis/operator/v1alpha1/validation/validation.go
@@ -16,6 +16,7 @@ package validation
 
 import (
 	apivalidation "k8s.io/apimachinery/pkg/api/validation"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
@@ -58,7 +59,7 @@ func validateOperation(operation string, garden *operatorv1alpha1.Garden, fldPat
 	fldPathOp := fldPath.Key(v1beta1constants.GardenerOperation)
 
 	if operation != "" && !operatorv1alpha1.AvailableOperationAnnotations.Has(operation) {
-		allErrs = append(allErrs, field.NotSupported(fldPathOp, operation, operatorv1alpha1.AvailableOperationAnnotations.List()))
+		allErrs = append(allErrs, field.NotSupported(fldPathOp, operation, sets.List(operatorv1alpha1.AvailableOperationAnnotations)))
 	}
 	allErrs = append(allErrs, validateOperationContext(operation, garden, fldPathOp)...)
 

--- a/pkg/apis/settings/validation/validation.go
+++ b/pkg/apis/settings/validation/validation.go
@@ -28,9 +28,9 @@ import (
 
 var (
 	// See https://tools.ietf.org/html/rfc7518#section-3.1 (without "none")
-	validSigningAlgs = sets.NewString("RS256", "RS384", "RS512", "ES256", "ES384", "ES512", "PS256", "PS384", "PS512")
+	validSigningAlgs = sets.New[string]("RS256", "RS384", "RS512", "ES256", "ES384", "ES512", "PS256", "PS384", "PS512")
 	// used by oidc-provider
-	forbiddenKeys = sets.NewString("idp-issuer-url", "client-id", "client-secret", "idp-certificate-authority", "idp-certificate-authority-data", "id-token", "refresh-token")
+	forbiddenKeys = sets.New[string]("idp-issuer-url", "client-id", "client-secret", "idp-certificate-authority", "idp-certificate-authority-data", "id-token", "refresh-token")
 )
 
 func validateOpenIDConnectPresetSpec(spec *settings.OpenIDConnectPresetSpec, fldPath *field.Path) field.ErrorList {
@@ -82,11 +82,11 @@ func validateServer(server *settings.KubeAPIServerOpenIDConnect, fldPath *field.
 			allErrs = append(allErrs, field.Invalid(path, server.SigningAlgs, "must not be empty"))
 		}
 
-		existingAlgs := sets.String{}
+		existingAlgs := sets.Set[string]{}
 
 		for i, alg := range server.SigningAlgs {
 			if !validSigningAlgs.Has(alg) {
-				allErrs = append(allErrs, field.Invalid(path.Index(i), alg, fmt.Sprintf("must be one of: %v", validSigningAlgs.List())))
+				allErrs = append(allErrs, field.Invalid(path.Index(i), alg, fmt.Sprintf("must be one of: %v", sets.List(validSigningAlgs))))
 			}
 			if existingAlgs.Has(alg) {
 				allErrs = append(allErrs, field.Duplicate(path.Index(i), alg))
@@ -116,7 +116,7 @@ func validateClient(client *settings.OpenIDConnectClientAuthentication, fldPath 
 			allErrs = append(allErrs, field.Invalid(scopeFldPath.Key(key), val, "must not be empty"))
 		}
 		if forbiddenKeys.Has(key) {
-			allErrs = append(allErrs, field.Forbidden(scopeFldPath.Key(key), fmt.Sprintf("cannot be any of %v", forbiddenKeys.List())))
+			allErrs = append(allErrs, field.Forbidden(scopeFldPath.Key(key), fmt.Sprintf("cannot be any of %v", sets.List(forbiddenKeys))))
 		}
 	}
 

--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -118,11 +118,11 @@ func (o *ExtraOptions) Validate() []error {
 		allErrors = append(allErrors, fmt.Errorf("--shoot-credentials-rotation-interval must be between 24 hours and 2^32 seconds"))
 	}
 
-	if !sets.NewString(logger.AllLogLevels...).Has(o.LogLevel) {
+	if !sets.New[string](logger.AllLogLevels...).Has(o.LogLevel) {
 		allErrors = append(allErrors, fmt.Errorf("invalid --log-level: %s", o.LogLevel))
 	}
 
-	if !sets.NewString(logger.AllLogFormats...).Has(o.LogFormat) {
+	if !sets.New[string](logger.AllLogFormats...).Has(o.LogFormat) {
 		allErrors = append(allErrors, fmt.Errorf("invalid --log-format: %s", o.LogFormat))
 	}
 

--- a/pkg/client/kubernetes/scaling_test.go
+++ b/pkg/client/kubernetes/scaling_test.go
@@ -53,7 +53,7 @@ var _ = Describe("scale", func() {
 				Generation: 2,
 			},
 			Spec: appsv1.StatefulSetSpec{
-				Replicas: pointer.Int32Ptr(2),
+				Replicas: pointer.Int32(2),
 			},
 			Status: appsv1.StatefulSetStatus{
 				ObservedGeneration: 2,
@@ -95,7 +95,7 @@ var _ = Describe("scale", func() {
 							Generation: 2,
 						},
 						Spec: appsv1.DeploymentSpec{
-							Replicas: pointer.Int32Ptr(2),
+							Replicas: pointer.Int32(2),
 						},
 						Status: appsv1.DeploymentStatus{
 							ObservedGeneration: 2,

--- a/pkg/controllermanager/apis/config/validation/validation.go
+++ b/pkg/controllermanager/apis/config/validation/validation.go
@@ -28,13 +28,13 @@ func ValidateControllerManagerConfiguration(conf *config.ControllerManagerConfig
 	allErrs := field.ErrorList{}
 
 	if conf.LogLevel != "" {
-		if !sets.NewString(logger.AllLogLevels...).Has(conf.LogLevel) {
+		if !sets.New[string](logger.AllLogLevels...).Has(conf.LogLevel) {
 			allErrs = append(allErrs, field.NotSupported(field.NewPath("logLevel"), conf.LogLevel, logger.AllLogLevels))
 		}
 	}
 
 	if conf.LogFormat != "" {
-		if !sets.NewString(logger.AllLogFormats...).Has(conf.LogFormat) {
+		if !sets.New[string](logger.AllLogFormats...).Has(conf.LogFormat) {
 			allErrs = append(allErrs, field.NotSupported(field.NewPath("logFormat"), conf.LogFormat, logger.AllLogFormats))
 		}
 	}

--- a/pkg/controllermanager/controller/cloudprofile/reconciler.go
+++ b/pkg/controllermanager/controller/cloudprofile/reconciler.go
@@ -57,7 +57,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	// no Shoots and Seed are assigned to the CloudProfile anymore. If this is the case then the controller will remove
 	// the finalizers from the CloudProfile so that it can be garbage collected.
 	if cloudProfile.DeletionTimestamp != nil {
-		if !sets.NewString(cloudProfile.Finalizers...).Has(gardencorev1beta1.GardenerName) {
+		if !sets.New[string](cloudProfile.Finalizers...).Has(gardencorev1beta1.GardenerName) {
 			return reconcile.Result{}, nil
 		}
 

--- a/pkg/controllermanager/controller/controllerregistration/seed/reconciler_test.go
+++ b/pkg/controllermanager/controller/controllerregistration/seed/reconciler_test.go
@@ -457,7 +457,7 @@ var _ = Describe("Reconciler", func() {
 		It("should correctly compute the result", func() {
 			kindTypes, bs := computeKindTypesForBackupBuckets(backupBucketList)
 
-			Expect(kindTypes).To(Equal(sets.NewString(
+			Expect(kindTypes).To(Equal(sets.New[string](
 				extensionsv1alpha1.BackupBucketResource+"/"+backupBucket1.Spec.Provider.Type,
 				extensionsv1alpha1.BackupBucketResource+"/"+backupBucket2.Spec.Provider.Type,
 			)))
@@ -475,7 +475,7 @@ var _ = Describe("Reconciler", func() {
 		It("should correctly compute the result", func() {
 			kindTypes := computeKindTypesForBackupEntries(nopLogger, backupEntryList, buckets)
 
-			Expect(kindTypes).To(Equal(sets.NewString(
+			Expect(kindTypes).To(Equal(sets.New[string](
 				extensionsv1alpha1.BackupEntryResource + "/" + backupBucket1.Spec.Provider.Type,
 			)))
 		})
@@ -496,7 +496,7 @@ var _ = Describe("Reconciler", func() {
 
 			kindTypes := computeKindTypesForShoots(ctx, nopLogger, nil, shootList, seed, controllerRegistrationList, internalDomain, nil)
 
-			Expect(kindTypes).To(Equal(sets.NewString(
+			Expect(kindTypes).To(Equal(sets.New[string](
 				// seed types
 				extensionsv1alpha1.BackupBucketResource+"/"+type8,
 				extensionsv1alpha1.BackupEntryResource+"/"+type8,
@@ -557,7 +557,7 @@ var _ = Describe("Reconciler", func() {
 
 			kindTypes := computeKindTypesForShoots(ctx, nopLogger, nil, shootList, seed, controllerRegistrationList, internalDomain, nil)
 
-			Expect(kindTypes).To(Equal(sets.NewString(
+			Expect(kindTypes).To(Equal(sets.New[string](
 				// seed types
 				extensionsv1alpha1.BackupBucketResource+"/"+type8,
 				extensionsv1alpha1.BackupEntryResource+"/"+type8,
@@ -592,7 +592,7 @@ var _ = Describe("Reconciler", func() {
 				},
 			}
 
-			expected := sets.NewString(extensions.Id(extensionsv1alpha1.DNSRecordResource, providerType))
+			expected := sets.New[string](extensions.Id(extensionsv1alpha1.DNSRecordResource, providerType))
 			actual := computeKindTypesForSeed(seed)
 			Expect(actual).To(Equal(expected))
 		})
@@ -612,7 +612,7 @@ var _ = Describe("Reconciler", func() {
 				},
 			}
 
-			expected := sets.NewString()
+			expected := sets.New[string]()
 			actual := computeKindTypesForSeed(seed)
 			Expect(actual).To(Equal(expected))
 		})
@@ -622,7 +622,7 @@ var _ = Describe("Reconciler", func() {
 				Spec: gardencorev1beta1.SeedSpec{},
 			}
 
-			expected := sets.NewString()
+			expected := sets.New[string]()
 			actual := computeKindTypesForSeed(seed)
 			Expect(actual).To(Equal(expected))
 		})
@@ -638,32 +638,32 @@ var _ = Describe("Reconciler", func() {
 
 	Describe("#computeWantedControllerRegistrationNames", func() {
 		It("should correctly compute the result w/o error", func() {
-			wantedKindTypeCombinations := sets.NewString(
+			wantedKindTypeCombinations := sets.New[string](
 				extensionsv1alpha1.NetworkResource+"/"+type2,
 				extensionsv1alpha1.ControlPlaneResource+"/"+type3,
 			)
 
 			names, err := computeWantedControllerRegistrationNames(wantedKindTypeCombinations, controllerInstallationList, controllerRegistrations, len(shootList), seedObjectMeta)
 
-			Expect(names).To(Equal(sets.NewString(controllerRegistration1.Name, controllerRegistration2.Name, controllerRegistration3.Name, controllerRegistration4.Name, controllerRegistration7.Name, controllerRegistration8.Name)))
+			Expect(names).To(Equal(sets.New[string](controllerRegistration1.Name, controllerRegistration2.Name, controllerRegistration3.Name, controllerRegistration4.Name, controllerRegistration7.Name, controllerRegistration8.Name)))
 			Expect(err).NotTo(HaveOccurred())
 		})
 
 		It("should not consider 'always-deploy-if-shoots' registrations when seed has no shoots", func() {
-			wantedKindTypeCombinations := sets.NewString()
+			wantedKindTypeCombinations := sets.New[string]()
 
 			names, err := computeWantedControllerRegistrationNames(wantedKindTypeCombinations, controllerInstallationList, controllerRegistrations, 0, seedObjectMeta)
 
-			Expect(names).To(Equal(sets.NewString(controllerRegistration4.Name, controllerRegistration7.Name)))
+			Expect(names).To(Equal(sets.New[string](controllerRegistration4.Name, controllerRegistration7.Name)))
 			Expect(err).NotTo(HaveOccurred())
 		})
 
 		It("should consider 'always-deploy' registrations when seed has no shoots but no deletion timestamp", func() {
-			wantedKindTypeCombinations := sets.NewString()
+			wantedKindTypeCombinations := sets.New[string]()
 
 			names, err := computeWantedControllerRegistrationNames(wantedKindTypeCombinations, controllerInstallationList, controllerRegistrations, 0, seedObjectMeta)
 
-			Expect(names).To(Equal(sets.NewString(controllerRegistration4.Name, controllerRegistration7.Name)))
+			Expect(names).To(Equal(sets.New[string](controllerRegistration4.Name, controllerRegistration7.Name)))
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -671,11 +671,11 @@ var _ = Describe("Reconciler", func() {
 			seedObjectMetaCopy := seedObjectMeta.DeepCopy()
 			time := metav1.Time{}
 			seedObjectMetaCopy.DeletionTimestamp = &time
-			wantedKindTypeCombinations := sets.NewString()
+			wantedKindTypeCombinations := sets.New[string]()
 
 			names, err := computeWantedControllerRegistrationNames(wantedKindTypeCombinations, controllerInstallationList, controllerRegistrations, 0, *seedObjectMetaCopy)
 
-			Expect(names).To(Equal(sets.NewString(controllerRegistration7.Name)))
+			Expect(names).To(Equal(sets.New[string](controllerRegistration7.Name)))
 			Expect(err).NotTo(HaveOccurred())
 		})
 	})
@@ -727,7 +727,7 @@ var _ = Describe("Reconciler", func() {
 		Describe("#deployNeededInstallations", func() {
 			It("should return an error when cannot get controller installation", func() {
 				var (
-					wantedControllerRegistrations  = sets.NewString(controllerRegistration2.Name)
+					wantedControllerRegistrations  = sets.New[string](controllerRegistration2.Name)
 					registrationNameToInstallation = map[string]*gardencorev1beta1.ControllerInstallation{
 						controllerRegistration1.Name: controllerInstallation1,
 						controllerRegistration2.Name: controllerInstallation2,
@@ -747,7 +747,7 @@ var _ = Describe("Reconciler", func() {
 				installation2 := controllerInstallation2.DeepCopy()
 				installation2.DeletionTimestamp = &now
 				var (
-					wantedControllerRegistrations  = sets.NewString(controllerRegistration2.Name)
+					wantedControllerRegistrations  = sets.New[string](controllerRegistration2.Name)
 					registrationNameToInstallation = map[string]*gardencorev1beta1.ControllerInstallation{
 						controllerRegistration1.Name: controllerInstallation1,
 						controllerRegistration2.Name: installation2,
@@ -761,7 +761,7 @@ var _ = Describe("Reconciler", func() {
 
 			It("should correctly deploy needed controller installations", func() {
 				var (
-					wantedControllerRegistrations  = sets.NewString(controllerRegistration2.Name, controllerRegistration3.Name, controllerRegistration4.Name)
+					wantedControllerRegistrations  = sets.New[string](controllerRegistration2.Name, controllerRegistration3.Name, controllerRegistration4.Name)
 					registrationNameToInstallation = map[string]*gardencorev1beta1.ControllerInstallation{
 						controllerRegistration1.Name: controllerInstallation1,
 						controllerRegistration2.Name: controllerInstallation2,
@@ -800,7 +800,7 @@ var _ = Describe("Reconciler", func() {
 				registration1 := controllerRegistration1.DeepCopy()
 				registration1.DeletionTimestamp = &now
 				var (
-					wantedControllerRegistrations  = sets.NewString(registration1.Name, controllerRegistration2.Name)
+					wantedControllerRegistrations  = sets.New[string](registration1.Name, controllerRegistration2.Name)
 					registrationNameToInstallation = map[string]*gardencorev1beta1.ControllerInstallation{
 						registration1.Name:           controllerInstallation1,
 						controllerRegistration2.Name: controllerInstallation2,
@@ -832,7 +832,7 @@ var _ = Describe("Reconciler", func() {
 				registration2 := controllerRegistration2.DeepCopy()
 				registration2.DeletionTimestamp = &now
 				var (
-					wantedControllerRegistrations  = sets.NewString(registration1.Name, registration2.Name)
+					wantedControllerRegistrations  = sets.New[string](registration1.Name, registration2.Name)
 					registrationNameToInstallation = map[string]*gardencorev1beta1.ControllerInstallation{
 						registration1.Name: controllerInstallation1,
 						registration2.Name: nil,
@@ -852,7 +852,7 @@ var _ = Describe("Reconciler", func() {
 		Describe("#deleteUnneededInstallations", func() {
 			It("should return an error", func() {
 				var (
-					wantedControllerRegistrationNames = sets.NewString()
+					wantedControllerRegistrationNames = sets.New[string]()
 					registrationNameToInstallation    = map[string]*gardencorev1beta1.ControllerInstallation{
 						controllerRegistration1.Name: controllerInstallation1,
 					}
@@ -868,7 +868,7 @@ var _ = Describe("Reconciler", func() {
 
 			It("should correctly delete unneeded controller installations", func() {
 				var (
-					wantedControllerRegistrationNames = sets.NewString(controllerRegistration2.Name)
+					wantedControllerRegistrationNames = sets.New[string](controllerRegistration2.Name)
 					registrationNameToInstallation    = map[string]*gardencorev1beta1.ControllerInstallation{
 						controllerRegistration1.Name: controllerInstallation1,
 						controllerRegistration2.Name: controllerInstallation2,

--- a/pkg/controllermanager/controller/exposureclass/reconciler.go
+++ b/pkg/controllermanager/controller/exposureclass/reconciler.go
@@ -60,7 +60,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 
 	if exposureClass.DeletionTimestamp != nil {
 		// Ignore the exposure class if it has no gardener finalizer.
-		if !sets.NewString(exposureClass.Finalizers...).Has(gardencorev1alpha1.GardenerName) {
+		if !sets.New[string](exposureClass.Finalizers...).Has(gardencorev1alpha1.GardenerName) {
 			return reconcile.Result{}, nil
 		}
 

--- a/pkg/controllermanager/controller/project/stale/reconciler.go
+++ b/pkg/controllermanager/controller/project/stale/reconciler.go
@@ -204,14 +204,14 @@ func (r *Reconciler) relevantSecretBindingsInUse(ctx context.Context, isSecretBi
 		return false, err
 	}
 
-	namespaceToSecretBindingNames := make(map[string]sets.String)
+	namespaceToSecretBindingNames := make(map[string]sets.Set[string])
 	for _, secretBinding := range secretBindingList.Items {
 		if !isSecretBindingRelevantFunc(secretBinding) {
 			continue
 		}
 
 		if _, ok := namespaceToSecretBindingNames[secretBinding.Namespace]; !ok {
-			namespaceToSecretBindingNames[secretBinding.Namespace] = sets.NewString(secretBinding.Name)
+			namespaceToSecretBindingNames[secretBinding.Namespace] = sets.New[string](secretBinding.Name)
 		} else {
 			namespaceToSecretBindingNames[secretBinding.Namespace].Insert(secretBinding.Name)
 		}
@@ -255,7 +255,7 @@ func (r *Reconciler) markProjectAsStale(ctx context.Context, project *gardencore
 	return r.Client.Status().Patch(ctx, project, patch)
 }
 
-func (r *Reconciler) secretBindingInUse(ctx context.Context, namespaceToSecretBindingNames map[string]sets.String) (bool, error) {
+func (r *Reconciler) secretBindingInUse(ctx context.Context, namespaceToSecretBindingNames map[string]sets.Set[string]) (bool, error) {
 	if len(namespaceToSecretBindingNames) == 0 {
 		return false, nil
 	}
@@ -278,8 +278,8 @@ func (r *Reconciler) secretBindingInUse(ctx context.Context, namespaceToSecretBi
 
 // computeSecretNames determines the names of Secrets that are of type Opaque and don't have owner references to a
 // Shoot.
-func computeSecretNames(secretList []corev1.Secret) sets.String {
-	names := sets.NewString()
+func computeSecretNames(secretList []corev1.Secret) sets.Set[string] {
+	names := sets.New[string]()
 
 	for _, secret := range secretList {
 		if secret.Type != corev1.SecretTypeOpaque {
@@ -304,8 +304,8 @@ func computeSecretNames(secretList []corev1.Secret) sets.String {
 }
 
 // computeQuotaNames determines the names of Quotas from the given slice.
-func computeQuotaNames(quotaList []metav1.PartialObjectMetadata) sets.String {
-	names := sets.NewString()
+func computeQuotaNames(quotaList []metav1.PartialObjectMetadata) sets.Set[string] {
+	names := sets.New[string]()
 
 	for _, quota := range quotaList {
 		names.Insert(quota.Name)

--- a/pkg/controllermanager/controller/quota/reconciler.go
+++ b/pkg/controllermanager/controller/quota/reconciler.go
@@ -57,7 +57,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	// it has to be ensured that no SecretBindings are depending on the Quota anymore.
 	// When this happens the controller will remove the finalizers from the Quota so that it can be garbage collected.
 	if quota.DeletionTimestamp != nil {
-		if !sets.NewString(quota.Finalizers...).Has(gardencorev1beta1.GardenerName) {
+		if !sets.New[string](quota.Finalizers...).Has(gardencorev1beta1.GardenerName) {
 			return reconcile.Result{}, nil
 		}
 

--- a/pkg/controllermanager/controller/seed/secrets/reconciler.go
+++ b/pkg/controllermanager/controller/seed/secrets/reconciler.go
@@ -92,7 +92,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 
 func (r *Reconciler) cleanupStaleSecrets(ctx context.Context, existingSecrets []string, namespace string) error {
 	var fns []flow.TaskFn
-	exclude := sets.NewString(existingSecrets...)
+	exclude := sets.New[string](existingSecrets...)
 
 	secretList := &corev1.SecretList{}
 	if err := r.Client.List(ctx, secretList, client.InNamespace(namespace), client.MatchingLabelsSelector{Selector: gardenRoleSelector}); err != nil {

--- a/pkg/controllermanager/controller/shoot/reference/reconciler.go
+++ b/pkg/controllermanager/controller/shoot/reference/reconciler.go
@@ -243,7 +243,7 @@ func (r *Reconciler) getUnreferencedSecrets(ctx context.Context, shoot *gardenco
 		return nil, err
 	}
 
-	referencedSecrets := sets.NewString()
+	referencedSecrets := sets.New[string]()
 	for _, s := range shoots.Items {
 		// Ignore own references if shoot is in deletion and references are not needed any more by Gardener.
 		if s.Name == shoot.Name && shoot.DeletionTimestamp != nil && !controllerutil.ContainsFinalizer(&s, gardencorev1beta1.GardenerName) {
@@ -284,7 +284,7 @@ func (r *Reconciler) getUnreferencedConfigMaps(ctx context.Context, shoot *garde
 		return nil, err
 	}
 
-	referencedConfigMaps := sets.NewString()
+	referencedConfigMaps := sets.New[string]()
 	for _, s := range shoots.Items {
 		// Ignore own references if shoot is in deletion and references are not needed any more by Gardener.
 		if s.Name == shoot.Name && shoot.DeletionTimestamp != nil && !controllerutil.ContainsFinalizer(&s, gardencorev1beta1.GardenerName) {

--- a/pkg/controllerutils/update_test.go
+++ b/pkg/controllerutils/update_test.go
@@ -88,7 +88,7 @@ var _ = Describe("utils", func() {
 						Namespace: namespace,
 					},
 					Spec: appsv1.DeploymentSpec{
-						Replicas: pointer.Int32Ptr(1),
+						Replicas: pointer.Int32(1),
 					},
 				}
 

--- a/pkg/envtest/apiserver.go
+++ b/pkg/envtest/apiserver.go
@@ -363,7 +363,7 @@ func (g *GardenerAPIServer) registerGardenerAPIs(ctx context.Context) error {
 		return err
 	}
 
-	undiscoverableGardenerAPIGroups := make(sets.String, len(apiserver.AllGardenerAPIGroupVersions))
+	undiscoverableGardenerAPIGroups := make(sets.Set[string], len(apiserver.AllGardenerAPIGroupVersions))
 	for _, gv := range apiserver.AllGardenerAPIGroupVersions {
 		undiscoverableGardenerAPIGroups.Insert(gv.String())
 	}
@@ -383,7 +383,7 @@ func (g *GardenerAPIServer) registerGardenerAPIs(ctx context.Context) error {
 			}
 		}
 		if undiscoverableGardenerAPIGroups.Len() > 0 {
-			return retry.MinorError(fmt.Errorf("the following Gardener API GroupVersions are not discoverable: %v", undiscoverableGardenerAPIGroups.List()))
+			return retry.MinorError(fmt.Errorf("the following Gardener API GroupVersions are not discoverable: %v", sets.List(undiscoverableGardenerAPIGroups)))
 		}
 		log.V(1).Info("All Gardener APIs discoverable")
 		return retry.Ok()

--- a/pkg/gardenlet/apis/config/validation/validation.go
+++ b/pkg/gardenlet/apis/config/validation/validation.go
@@ -74,13 +74,13 @@ func ValidateGardenletConfiguration(cfg *config.GardenletConfiguration, fldPath 
 	}
 
 	if cfg.LogLevel != "" {
-		if !sets.NewString(logger.AllLogLevels...).Has(cfg.LogLevel) {
+		if !sets.New[string](logger.AllLogLevels...).Has(cfg.LogLevel) {
 			allErrs = append(allErrs, field.NotSupported(field.NewPath("logLevel"), cfg.LogLevel, logger.AllLogLevels))
 		}
 	}
 
 	if cfg.LogFormat != "" {
-		if !sets.NewString(logger.AllLogFormats...).Has(cfg.LogFormat) {
+		if !sets.New[string](logger.AllLogFormats...).Has(cfg.LogFormat) {
 			allErrs = append(allErrs, field.NotSupported(field.NewPath("logFormat"), cfg.LogFormat, logger.AllLogFormats))
 		}
 	}
@@ -228,7 +228,7 @@ func ValidateManagedSeedControllerConfiguration(cfg *config.ManagedSeedControlle
 	return allErrs
 }
 
-var availableShootPurposes = sets.NewString(
+var availableShootPurposes = sets.New[string](
 	string(gardencore.ShootPurposeEvaluation),
 	string(gardencore.ShootPurposeTesting),
 	string(gardencore.ShootPurposeDevelopment),
@@ -246,7 +246,7 @@ func ValidateBackupEntryControllerConfiguration(cfg *config.BackupEntryControlle
 
 	for i, purpose := range cfg.DeletionGracePeriodShootPurposes {
 		if !availableShootPurposes.Has(string(purpose)) {
-			allErrs = append(allErrs, field.NotSupported(fldPath.Child("deletionGracePeriodShootPurposes").Index(i), purpose, availableShootPurposes.List()))
+			allErrs = append(allErrs, field.NotSupported(fldPath.Child("deletionGracePeriodShootPurposes").Index(i), purpose, sets.List(availableShootPurposes)))
 		}
 	}
 

--- a/pkg/gardenlet/apis/config/validation/validation_test.go
+++ b/pkg/gardenlet/apis/config/validation/validation_test.go
@@ -448,14 +448,14 @@ var _ = Describe("GardenletConfiguration", func() {
 			})
 
 			It("should pass as sni config contains a valid external service ip", func() {
-				cfg.SNI.Ingress.ServiceExternalIP = pointer.StringPtr("1.1.1.1")
+				cfg.SNI.Ingress.ServiceExternalIP = pointer.String("1.1.1.1")
 
 				errorList := ValidateGardenletConfiguration(cfg, nil, false)
 				Expect(errorList).To(BeEmpty())
 			})
 
 			It("should forbid as sni config contains an empty external service ip", func() {
-				cfg.SNI.Ingress.ServiceExternalIP = pointer.StringPtr("")
+				cfg.SNI.Ingress.ServiceExternalIP = pointer.String("")
 
 				errorList := ValidateGardenletConfiguration(cfg, nil, false)
 				Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
@@ -465,7 +465,7 @@ var _ = Describe("GardenletConfiguration", func() {
 			})
 
 			It("should forbid as sni config contains an invalid external service ip", func() {
-				cfg.SNI.Ingress.ServiceExternalIP = pointer.StringPtr("a.b.c.d")
+				cfg.SNI.Ingress.ServiceExternalIP = pointer.String("a.b.c.d")
 
 				errorList := ValidateGardenletConfiguration(cfg, nil, false)
 				Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
@@ -517,7 +517,7 @@ var _ = Describe("GardenletConfiguration", func() {
 
 			Context("serviceExternalIP", func() {
 				It("should allow to use an external service ip as loadbalancer ip is valid", func() {
-					cfg.ExposureClassHandlers[0].SNI.Ingress.ServiceExternalIP = pointer.StringPtr("1.1.1.1")
+					cfg.ExposureClassHandlers[0].SNI.Ingress.ServiceExternalIP = pointer.String("1.1.1.1")
 
 					errorList := ValidateGardenletConfiguration(cfg, nil, false)
 
@@ -525,7 +525,7 @@ var _ = Describe("GardenletConfiguration", func() {
 				})
 
 				It("should allow to use an external service ip as APIServerSNI feature gate is explicitly activated", func() {
-					cfg.ExposureClassHandlers[0].SNI.Ingress.ServiceExternalIP = pointer.StringPtr("1.1.1.1")
+					cfg.ExposureClassHandlers[0].SNI.Ingress.ServiceExternalIP = pointer.String("1.1.1.1")
 					cfg.FeatureGates["APIServerSNI"] = true
 
 					errorList := ValidateGardenletConfiguration(cfg, nil, false)
@@ -534,7 +534,7 @@ var _ = Describe("GardenletConfiguration", func() {
 				})
 
 				It("should forbid to use an external service ip when APIServerSNI feature gate is disabled", func() {
-					cfg.ExposureClassHandlers[0].SNI.Ingress.ServiceExternalIP = pointer.StringPtr("1.1.1.1")
+					cfg.ExposureClassHandlers[0].SNI.Ingress.ServiceExternalIP = pointer.String("1.1.1.1")
 					cfg.FeatureGates["APIServerSNI"] = false
 
 					errorList := ValidateGardenletConfiguration(cfg, nil, false)
@@ -545,7 +545,7 @@ var _ = Describe("GardenletConfiguration", func() {
 				})
 
 				It("should forbid to use an empty external service ip", func() {
-					cfg.ExposureClassHandlers[0].SNI.Ingress.ServiceExternalIP = pointer.StringPtr("")
+					cfg.ExposureClassHandlers[0].SNI.Ingress.ServiceExternalIP = pointer.String("")
 
 					errorList := ValidateGardenletConfiguration(cfg, nil, false)
 					Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
@@ -555,7 +555,7 @@ var _ = Describe("GardenletConfiguration", func() {
 				})
 
 				It("should forbid to use an invalid external service ip", func() {
-					cfg.ExposureClassHandlers[0].SNI.Ingress.ServiceExternalIP = pointer.StringPtr("a.b.c.d")
+					cfg.ExposureClassHandlers[0].SNI.Ingress.ServiceExternalIP = pointer.String("a.b.c.d")
 
 					errorList := ValidateGardenletConfiguration(cfg, nil, false)
 					Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{

--- a/pkg/gardenlet/controller/backupbucket/reconciler.go
+++ b/pkg/gardenlet/controller/backupbucket/reconciler.go
@@ -255,7 +255,7 @@ func (r *Reconciler) deleteBackupBucket(
 	reconcile.Result,
 	error,
 ) {
-	if !sets.NewString(backupBucket.Finalizers...).Has(gardencorev1beta1.GardenerName) {
+	if !sets.New[string](backupBucket.Finalizers...).Has(gardencorev1beta1.GardenerName) {
 		return reconcile.Result{}, nil
 	}
 

--- a/pkg/gardenlet/controller/backupbucket/reconciler_test.go
+++ b/pkg/gardenlet/controller/backupbucket/reconciler_test.go
@@ -67,8 +67,13 @@ var _ = Describe("Controller", func() {
 	BeforeEach(func() {
 		gardenClient = fakeclient.NewClientBuilder().WithScheme(kubernetes.GardenScheme).Build()
 
-		testScheme := kubernetes.SeedScheme
-		Expect(extensionsv1alpha1.AddToScheme(testScheme)).To(Succeed())
+		testSchemeBuilder := runtime.NewSchemeBuilder(
+			kubernetes.AddSeedSchemeToScheme,
+			extensionsv1alpha1.AddToScheme,
+		)
+		testScheme := runtime.NewScheme()
+		Expect(testSchemeBuilder.AddToScheme(testScheme)).To(Succeed())
+
 		seedClient = fakeclient.NewClientBuilder().WithScheme(testScheme).Build()
 
 		fakeClock = testclock.NewFakeClock(time.Now())

--- a/pkg/gardenlet/controller/backupentry/backupentry/reconciler.go
+++ b/pkg/gardenlet/controller/backupentry/backupentry/reconciler.go
@@ -274,7 +274,7 @@ func (r *Reconciler) deleteBackupEntry(
 	reconcile.Result,
 	error,
 ) {
-	if !sets.NewString(backupEntry.Finalizers...).Has(gardencorev1beta1.GardenerName) {
+	if !sets.New[string](backupEntry.Finalizers...).Has(gardencorev1beta1.GardenerName) {
 		log.V(1).Info("Do not need to do anything as the BackupEntry does not have my finalizer")
 		return reconcile.Result{}, nil
 	}
@@ -374,7 +374,7 @@ func (r *Reconciler) migrateBackupEntry(
 	reconcile.Result,
 	error,
 ) {
-	if !sets.NewString(backupEntry.Finalizers...).Has(gardencorev1beta1.GardenerName) {
+	if !sets.New[string](backupEntry.Finalizers...).Has(gardencorev1beta1.GardenerName) {
 		log.V(1).Info("Do not need to do anything as the BackupEntry does not have my finalizer")
 		return reconcile.Result{}, nil
 	}

--- a/pkg/gardenlet/controller/backupentry/backupentry/reconciler_test.go
+++ b/pkg/gardenlet/controller/backupentry/backupentry/reconciler_test.go
@@ -71,8 +71,13 @@ var _ = Describe("Controller", func() {
 	BeforeEach(func() {
 		gardenClient = fakeclient.NewClientBuilder().WithScheme(kubernetes.GardenScheme).Build()
 
-		testScheme := kubernetes.SeedScheme
-		Expect(extensionsv1alpha1.AddToScheme(testScheme)).To(Succeed())
+		testSchemeBuilder := runtime.NewSchemeBuilder(
+			kubernetes.AddSeedSchemeToScheme,
+			extensionsv1alpha1.AddToScheme,
+		)
+		testScheme := runtime.NewScheme()
+		Expect(testSchemeBuilder.AddToScheme(testScheme)).To(Succeed())
+
 		seedClient = fakeclient.NewClientBuilder().WithScheme(testScheme).Build()
 
 		fakeClock = testclock.NewFakeClock(time.Now())

--- a/pkg/gardenlet/controller/bastion/reconciler.go
+++ b/pkg/gardenlet/controller/bastion/reconciler.go
@@ -206,7 +206,7 @@ func (r *Reconciler) cleanupBastion(
 	bastion *operationsv1alpha1.Bastion,
 	shoot *gardencorev1beta1.Shoot,
 ) error {
-	if !sets.NewString(bastion.Finalizers...).Has(finalizerName) {
+	if !sets.New[string](bastion.Finalizers...).Has(finalizerName) {
 		return nil
 	}
 

--- a/pkg/gardenlet/controller/controllerinstallation/required/add.go
+++ b/pkg/gardenlet/controller/controllerinstallation/required/add.go
@@ -57,7 +57,7 @@ func (r *Reconciler) AddToManager(mgr manager.Manager, gardenCluster, seedCluste
 		r.Clock = clock.RealClock{}
 	}
 	r.Lock = &sync.RWMutex{}
-	r.KindToRequiredTypes = make(map[string]sets.String)
+	r.KindToRequiredTypes = make(map[string]sets.Set[string])
 
 	// It's not possible to call builder.Build() without adding atleast one watch, and without this, we can't get the controller logger.
 	// Hence, we have to build up the controller manually.
@@ -167,7 +167,7 @@ func (r *Reconciler) MapObjectKindToControllerInstallations(objectKind string, n
 		r.Lock.RLock()
 		oldRequiredTypes, kindCalculated := r.KindToRequiredTypes[objectKind]
 		r.Lock.RUnlock()
-		newRequiredTypes := sets.NewString()
+		newRequiredTypes := sets.New[string]()
 
 		if err := meta.EachListItem(listObj, func(o runtime.Object) error {
 			obj, err := extensions.Accessor(o)
@@ -200,7 +200,7 @@ func (r *Reconciler) MapObjectKindToControllerInstallations(objectKind string, n
 			return nil
 		}
 
-		controllerRegistrationNamesForKind := sets.NewString()
+		controllerRegistrationNamesForKind := sets.New[string]()
 		for _, controllerRegistration := range controllerRegistrationList.Items {
 			for _, resource := range controllerRegistration.Spec.Resources {
 				if resource.Kind == objectKind {

--- a/pkg/gardenlet/controller/controllerinstallation/required/add_test.go
+++ b/pkg/gardenlet/controller/controllerinstallation/required/add_test.go
@@ -137,7 +137,7 @@ var _ = Describe("Add", func() {
 			reconciler.SeedClient = fakeSeedClient
 			reconciler.SeedName = seedName
 			reconciler.Lock = &sync.RWMutex{}
-			reconciler.KindToRequiredTypes = make(map[string]sets.String)
+			reconciler.KindToRequiredTypes = make(map[string]sets.Set[string])
 
 			controllerRegistration1 = &gardencorev1beta1.ControllerRegistration{
 				ObjectMeta: metav1.ObjectMeta{Name: "reg1"},
@@ -195,7 +195,7 @@ var _ = Describe("Add", func() {
 
 		It("should do nothing when there are no infrastructure resources", func() {
 			Expect(mapFn(ctx, log, nil, nil)).To(BeEmpty())
-			Expect(reconciler.KindToRequiredTypes).To(HaveKeyWithValue(extensionsv1alpha1.InfrastructureResource, sets.NewString()))
+			Expect(reconciler.KindToRequiredTypes).To(HaveKeyWithValue(extensionsv1alpha1.InfrastructureResource, sets.New[string]()))
 		})
 
 		It("should do nothing when there are no controllerregistration resources", func() {
@@ -206,7 +206,7 @@ var _ = Describe("Add", func() {
 			Expect(fakeSeedClient.Create(ctx, infrastructure2)).To(Succeed())
 
 			Expect(mapFn(ctx, log, nil, nil)).To(BeEmpty())
-			Expect(reconciler.KindToRequiredTypes).To(HaveKeyWithValue(extensionsv1alpha1.InfrastructureResource, sets.NewString(type1, type2)))
+			Expect(reconciler.KindToRequiredTypes).To(HaveKeyWithValue(extensionsv1alpha1.InfrastructureResource, sets.New[string](type1, type2)))
 		})
 
 		It("should do nothing when there are no controllerinstallation resources", func() {
@@ -217,7 +217,7 @@ var _ = Describe("Add", func() {
 			Expect(fakeSeedClient.Create(ctx, infrastructure2)).To(Succeed())
 
 			Expect(mapFn(ctx, log, nil, nil)).To(BeEmpty())
-			Expect(reconciler.KindToRequiredTypes).To(HaveKeyWithValue(extensionsv1alpha1.InfrastructureResource, sets.NewString(type1, type2)))
+			Expect(reconciler.KindToRequiredTypes).To(HaveKeyWithValue(extensionsv1alpha1.InfrastructureResource, sets.New[string](type1, type2)))
 		})
 
 		It("should return the expected names of controllerinstallations", func() {
@@ -236,7 +236,7 @@ var _ = Describe("Add", func() {
 				reconcile.Request{NamespacedName: types.NamespacedName{Name: controllerInstallation1.Name}},
 				reconcile.Request{NamespacedName: types.NamespacedName{Name: controllerInstallation2.Name}},
 			))
-			Expect(reconciler.KindToRequiredTypes).To(HaveKeyWithValue(extensionsv1alpha1.InfrastructureResource, sets.NewString(type1, type2)))
+			Expect(reconciler.KindToRequiredTypes).To(HaveKeyWithValue(extensionsv1alpha1.InfrastructureResource, sets.New[string](type1, type2)))
 		})
 	})
 })

--- a/pkg/gardenlet/controller/controllerinstallation/required/reconciler.go
+++ b/pkg/gardenlet/controller/controllerinstallation/required/reconciler.go
@@ -43,7 +43,7 @@ type Reconciler struct {
 	SeedName     string
 
 	Lock                *sync.RWMutex
-	KindToRequiredTypes map[string]sets.String
+	KindToRequiredTypes map[string]sets.Set[string]
 }
 
 // Reconcile performs the main reconciliation logic.
@@ -67,7 +67,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	var (
 		allKindsCalculated = true
 		required           *bool
-		requiredKindTypes  = sets.NewString()
+		requiredKindTypes  = sets.New[string]()
 		message            string
 	)
 

--- a/pkg/gardenlet/controller/managedseed/charttest/charttest.go
+++ b/pkg/gardenlet/controller/managedseed/charttest/charttest.go
@@ -859,9 +859,9 @@ func ComputeExpectedGardenletConfiguration(
 		LogLevel:  logLevelInfo,
 		LogFormat: logFormatJson,
 		Logging: &gardenletv1alpha1.Logging{
-			Enabled: pointer.BoolPtr(false),
+			Enabled: pointer.Bool(false),
 			Loki: &gardenletv1alpha1.Loki{
-				Enabled: pointer.BoolPtr(false),
+				Enabled: pointer.Bool(false),
 				Garden: &gardenletv1alpha1.GardenLoki{
 					Storage: &defaultCentralLokiStorage,
 				},

--- a/pkg/gardenlet/controller/networkpolicy/add.go
+++ b/pkg/gardenlet/controller/networkpolicy/add.go
@@ -177,7 +177,7 @@ func (r *Reconciler) MapToNamespaces(ctx context.Context, log logr.Logger, _ cli
 		return nil
 	}
 
-	namespaceNames := sets.NewString()
+	namespaceNames := sets.New[string]()
 	for _, namespace := range namespaceList.Items {
 		if labelsMatchAnySelector(namespace.Labels, selectors) {
 			namespaceNames.Insert(namespace.Name)

--- a/pkg/gardenlet/controller/networkpolicy/helper/helper.go
+++ b/pkg/gardenlet/controller/networkpolicy/helper/helper.go
@@ -29,7 +29,7 @@ func GetEgressRules(subsets ...corev1.EndpointSubset) []networkingv1.NetworkPoli
 
 	for _, subset := range subsets {
 		egressRule := networkingv1.NetworkPolicyEgressRule{}
-		existingIPs := sets.NewString()
+		existingIPs := sets.New[string]()
 
 		for _, address := range subset.Addresses {
 			if existingIPs.Has(address.IP) {

--- a/pkg/gardenlet/controller/seed/seed/reconciler_delete.go
+++ b/pkg/gardenlet/controller/seed/seed/reconciler_delete.go
@@ -71,7 +71,7 @@ func (r *Reconciler) delete(
 ) {
 	seed := seedObj.GetInfo()
 
-	if !sets.NewString(seed.Finalizers...).Has(gardencorev1beta1.GardenerName) {
+	if !sets.New[string](seed.Finalizers...).Has(gardencorev1beta1.GardenerName) {
 		return reconcile.Result{}, nil
 	}
 

--- a/pkg/gardenlet/controller/seed/seed/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/seed/seed/reconciler_reconcile.go
@@ -1147,7 +1147,7 @@ func cleanupOrphanExposureClassHandlerResources(
 		return err
 	}
 
-	zoneSet := sets.NewString(zones...)
+	zoneSet := sets.New[string](zones...)
 	for _, namespace := range zonalExposureClassHandlerNamespaces.Items {
 		if ok, zone := operation.IsZonalIstioExtension(namespace.Labels); ok {
 			if err := cleanupOrphanIstioNamespace(ctx, log, c, namespace, true, func() bool {

--- a/pkg/gardenlet/controller/seed/seed/reconciler_reconcile_test.go
+++ b/pkg/gardenlet/controller/seed/seed/reconciler_reconcile_test.go
@@ -119,7 +119,7 @@ var _ = Describe("Reconcile", func() {
 					Generation: 2,
 				},
 				Spec: appsv1.StatefulSetSpec{
-					Replicas: pointer.Int32Ptr(0),
+					Replicas: pointer.Int32(0),
 				},
 				Status: appsv1.StatefulSetStatus{
 					ObservedGeneration: 2,

--- a/pkg/gardenlet/controller/shoot/shoot/reconciler.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler.go
@@ -451,7 +451,7 @@ func (r *Reconciler) removeFinalizerFromShoot(ctx context.Context, log logr.Logg
 			return retryutils.SevereError(err)
 		}
 		lastOperation := shoot.Status.LastOperation
-		if !sets.NewString(shoot.Finalizers...).Has(gardencorev1beta1.GardenerName) && lastOperation != nil && lastOperation.Type == gardencorev1beta1.LastOperationTypeDelete && lastOperation.State == gardencorev1beta1.LastOperationStateSucceeded {
+		if !sets.New[string](shoot.Finalizers...).Has(gardencorev1beta1.GardenerName) && lastOperation != nil && lastOperation.Type == gardencorev1beta1.LastOperationTypeDelete && lastOperation.State == gardencorev1beta1.LastOperationStateSucceeded {
 			return retryutils.Ok()
 		}
 		return retryutils.MinorError(fmt.Errorf("shoot still has finalizer %s", gardencorev1beta1.GardenerName))

--- a/pkg/gardenlet/controller/shootstate/extensions/add.go
+++ b/pkg/gardenlet/controller/shootstate/extensions/add.go
@@ -95,7 +95,7 @@ func (r *Reconciler) ObjectPredicate() predicate.Predicate {
 	}
 }
 
-var invalidOperationAnnotations = sets.NewString(
+var invalidOperationAnnotations = sets.New[string](
 	v1beta1constants.GardenerOperationWaitForState,
 	v1beta1constants.GardenerOperationRestore,
 	v1beta1constants.GardenerOperationMigrate,

--- a/pkg/operation/botanist/component/coredns/coredns_test.go
+++ b/pkg/operation/botanist/component/coredns/coredns_test.go
@@ -666,7 +666,7 @@ status: {}
 					SecretRefs: []corev1.LocalObjectReference{{
 						Name: managedResourceSecret.Name,
 					}},
-					KeepObjects: pointer.BoolPtr(false),
+					KeepObjects: pointer.Bool(false),
 				},
 			}))
 

--- a/pkg/operation/botanist/component/dependencywatchdog/bootstrap_test.go
+++ b/pkg/operation/botanist/component/dependencywatchdog/bootstrap_test.go
@@ -448,7 +448,7 @@ status:
 						SecretRefs: []corev1.LocalObjectReference{{
 							Name: managedResourceSecret.Name,
 						}},
-						KeepObjects: pointer.BoolPtr(false),
+						KeepObjects: pointer.Bool(false),
 					},
 				}))
 

--- a/pkg/operation/botanist/component/dependencywatchdog/bootstrap_test.go
+++ b/pkg/operation/botanist/component/dependencywatchdog/bootstrap_test.go
@@ -444,7 +444,7 @@ status:
 						ResourceVersion: "1",
 					},
 					Spec: resourcesv1alpha1.ManagedResourceSpec{
-						Class: pointer.StringPtr("seed"),
+						Class: pointer.String("seed"),
 						SecretRefs: []corev1.LocalObjectReference{{
 							Name: managedResourceSecret.Name,
 						}},

--- a/pkg/operation/botanist/component/etcd/bootstrap_test.go
+++ b/pkg/operation/botanist/component/etcd/bootstrap_test.go
@@ -78,13 +78,13 @@ var _ = Describe("Etcd", func() {
 		c = mockclient.NewMockClient(ctrl)
 		etcdConfig = &config.ETCDConfig{
 			ETCDController: &config.ETCDController{
-				Workers: pointer.Int64Ptr(50),
+				Workers: pointer.Int64(50),
 			},
 			CustodianController: &config.CustodianController{
-				Workers: pointer.Int64Ptr(3),
+				Workers: pointer.Int64(3),
 			},
 			BackupCompactionController: &config.BackupCompactionController{
-				Workers:                pointer.Int64Ptr(3),
+				Workers:                pointer.Int64(3),
 				EnableBackupCompaction: pointer.Bool(true),
 				EventsThreshold:        pointer.Int64(1000000),
 				ActiveDeadlineDuration: &metav1.Duration{Duration: time.Hour * 3},

--- a/pkg/operation/botanist/component/extensions/containerruntime/containerruntime.go
+++ b/pkg/operation/botanist/component/extensions/containerruntime/containerruntime.go
@@ -123,7 +123,7 @@ func (c *containerRuntime) deploy(ctx context.Context, cr *extensionsv1alpha1.Co
 
 // Destroy deletes the ContainerRuntime resources.
 func (c *containerRuntime) Destroy(ctx context.Context) error {
-	return c.deleteContainerRuntimeResources(ctx, sets.NewString())
+	return c.deleteContainerRuntimeResources(ctx, sets.New[string]())
 }
 
 // Wait waits until the ContainerRuntime resources are ready.
@@ -147,7 +147,7 @@ func (c *containerRuntime) Wait(ctx context.Context) error {
 
 // WaitCleanup waits until all ContainerRuntime resources are cleaned up.
 func (c *containerRuntime) WaitCleanup(ctx context.Context) error {
-	return c.waitCleanup(ctx, sets.NewString())
+	return c.waitCleanup(ctx, sets.New[string]())
 }
 
 // Restore uses the seed client and the ShootState to create the ContainerRuntime resources and restore their state.
@@ -191,7 +191,7 @@ func (c *containerRuntime) DeleteStaleResources(ctx context.Context) error {
 	return c.deleteContainerRuntimeResources(ctx, c.getWantedContainerRuntimeNames())
 }
 
-func (c *containerRuntime) deleteContainerRuntimeResources(ctx context.Context, wantedContainerRuntimeNames sets.String) error {
+func (c *containerRuntime) deleteContainerRuntimeResources(ctx context.Context, wantedContainerRuntimeNames sets.Set[string]) error {
 	return extensions.DeleteExtensionObjects(
 		ctx,
 		c.client,
@@ -208,7 +208,7 @@ func (c *containerRuntime) WaitCleanupStaleResources(ctx context.Context) error 
 	return c.waitCleanup(ctx, c.getWantedContainerRuntimeNames())
 }
 
-func (c *containerRuntime) waitCleanup(ctx context.Context, wantedContainerRuntimeNames sets.String) error {
+func (c *containerRuntime) waitCleanup(ctx context.Context, wantedContainerRuntimeNames sets.Set[string]) error {
 	return extensions.WaitUntilExtensionObjectsDeleted(
 		ctx,
 		c.client,
@@ -226,8 +226,8 @@ func (c *containerRuntime) waitCleanup(ctx context.Context, wantedContainerRunti
 
 // getWantedContainerRuntimeNames returns the names of all container runtime resources, that are currently needed based
 // on the configured worker pools.
-func (c *containerRuntime) getWantedContainerRuntimeNames() sets.String {
-	wantedContainerRuntimeNames := sets.NewString()
+func (c *containerRuntime) getWantedContainerRuntimeNames() sets.Set[string] {
+	wantedContainerRuntimeNames := sets.New[string]()
 	for _, worker := range c.values.Workers {
 		if worker.CRI != nil {
 			for _, cr := range worker.CRI.ContainerRuntimes {

--- a/pkg/operation/botanist/component/extensions/extension/extension.go
+++ b/pkg/operation/botanist/component/extensions/extension/extension.go
@@ -386,8 +386,8 @@ func (e *extension) waitCleanup(ctx context.Context, predicate func(obj extensio
 
 // getWantedExtensionTypes returns the types of all extension resources, that are currently needed based
 // on the configured shoot settings and globally enabled extensions.
-func (e *extension) getWantedExtensionTypes() sets.String {
-	wantedExtensionTypes := sets.NewString()
+func (e *extension) getWantedExtensionTypes() sets.Set[string] {
+	wantedExtensionTypes := sets.New[string]()
 	for _, ext := range e.values.Extensions {
 		wantedExtensionTypes.Insert(ext.Spec.Type)
 	}

--- a/pkg/operation/botanist/component/extensions/extension/filters.go
+++ b/pkg/operation/botanist/component/extensions/extension/filters.go
@@ -64,8 +64,8 @@ func migrateAfterKubeAPIServer(e Extension) bool {
 	return *e.Lifecycle.Migrate == gardencorev1beta1.AfterKubeAPIServer
 }
 
-func (e *extension) filterExtensions(f filter) sets.String {
-	extensions := sets.NewString()
+func (e *extension) filterExtensions(f filter) sets.Set[string] {
+	extensions := sets.New[string]()
 	for _, ext := range e.values.Extensions {
 		if f(ext) {
 			extensions.Insert(ext.Spec.Type)

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/operatingsystemconfig.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/operatingsystemconfig.go
@@ -310,10 +310,10 @@ func (o *operatingSystemConfig) WaitMigrate(ctx context.Context) error {
 
 // Destroy deletes all the OperatingSystemConfig resources.
 func (o *operatingSystemConfig) Destroy(ctx context.Context) error {
-	return o.deleteOperatingSystemConfigResources(ctx, sets.NewString())
+	return o.deleteOperatingSystemConfigResources(ctx, sets.New[string]())
 }
 
-func (o *operatingSystemConfig) deleteOperatingSystemConfigResources(ctx context.Context, wantedOSCNames sets.String) error {
+func (o *operatingSystemConfig) deleteOperatingSystemConfigResources(ctx context.Context, wantedOSCNames sets.Set[string]) error {
 	return extensions.DeleteExtensionObjects(
 		ctx,
 		o.client,
@@ -327,7 +327,7 @@ func (o *operatingSystemConfig) deleteOperatingSystemConfigResources(ctx context
 
 // WaitCleanup waits until all OperatingSystemConfig resources are cleaned up.
 func (o *operatingSystemConfig) WaitCleanup(ctx context.Context) error {
-	return o.waitCleanup(ctx, sets.NewString())
+	return o.waitCleanup(ctx, sets.New[string]())
 }
 
 // DeleteStaleResources deletes unused OperatingSystemConfig resources from the shoot namespace in the seed.
@@ -348,7 +348,7 @@ func (o *operatingSystemConfig) WaitCleanupStaleResources(ctx context.Context) e
 	return o.waitCleanup(ctx, wantedOSCs)
 }
 
-func (o *operatingSystemConfig) waitCleanup(ctx context.Context, wantedOSCNames sets.String) error {
+func (o *operatingSystemConfig) waitCleanup(ctx context.Context, wantedOSCNames sets.Set[string]) error {
 	return extensions.WaitUntilExtensionObjectsDeleted(
 		ctx,
 		o.client,
@@ -366,8 +366,8 @@ func (o *operatingSystemConfig) waitCleanup(ctx context.Context, wantedOSCNames 
 
 // getWantedOSCNames returns the names of all OSC resources, that are currently needed based
 // on the configured worker pools.
-func (o *operatingSystemConfig) getWantedOSCNames() (sets.String, error) {
-	wantedOSCNames := sets.NewString()
+func (o *operatingSystemConfig) getWantedOSCNames() (sets.Set[string], error) {
+	wantedOSCNames := sets.New[string]()
 
 	for _, worker := range o.values.Workers {
 		if worker.Machine.Image == nil {

--- a/pkg/operation/botanist/component/kubeapiserver/hvpa.go
+++ b/pkg/operation/botanist/component/kubeapiserver/hvpa.go
@@ -151,11 +151,11 @@ func (k *kubeAPIServer) reconcileHVPA(ctx context.Context, hvpa *hvpav1alpha1.Hv
 				MinChange: hvpav1alpha1.ScaleParams{
 					CPU: hvpav1alpha1.ChangeParams{
 						Value:      pointer.String("300m"),
-						Percentage: pointer.Int32Ptr(80),
+						Percentage: pointer.Int32(80),
 					},
 					Memory: hvpav1alpha1.ChangeParams{
 						Value:      pointer.String("200M"),
-						Percentage: pointer.Int32Ptr(80),
+						Percentage: pointer.Int32(80),
 					},
 				},
 			},
@@ -167,22 +167,22 @@ func (k *kubeAPIServer) reconcileHVPA(ctx context.Context, hvpa *hvpav1alpha1.Hv
 				MinChange: hvpav1alpha1.ScaleParams{
 					CPU: hvpav1alpha1.ChangeParams{
 						Value:      pointer.String("300m"),
-						Percentage: pointer.Int32Ptr(80),
+						Percentage: pointer.Int32(80),
 					},
 					Memory: hvpav1alpha1.ChangeParams{
 						Value:      pointer.String("200M"),
-						Percentage: pointer.Int32Ptr(80),
+						Percentage: pointer.Int32(80),
 					},
 				},
 			},
 			LimitsRequestsGapScaleParams: hvpav1alpha1.ScaleParams{
 				CPU: hvpav1alpha1.ChangeParams{
 					Value:      pointer.String("1"),
-					Percentage: pointer.Int32Ptr(70),
+					Percentage: pointer.Int32(70),
 				},
 				Memory: hvpav1alpha1.ChangeParams{
 					Value:      pointer.String("1G"),
-					Percentage: pointer.Int32Ptr(70),
+					Percentage: pointer.Int32(70),
 				},
 			},
 			Template: hvpav1alpha1.VpaTemplate{

--- a/pkg/operation/botanist/component/kubeapiserver/hvpa.go
+++ b/pkg/operation/botanist/component/kubeapiserver/hvpa.go
@@ -147,14 +147,14 @@ func (k *kubeAPIServer) reconcileHVPA(ctx context.Context, hvpa *hvpav1alpha1.Hv
 				UpdatePolicy: hvpav1alpha1.UpdatePolicy{
 					UpdateMode: &updateModeAuto,
 				},
-				StabilizationDuration: pointer.StringPtr("3m"),
+				StabilizationDuration: pointer.String("3m"),
 				MinChange: hvpav1alpha1.ScaleParams{
 					CPU: hvpav1alpha1.ChangeParams{
-						Value:      pointer.StringPtr("300m"),
+						Value:      pointer.String("300m"),
 						Percentage: pointer.Int32Ptr(80),
 					},
 					Memory: hvpav1alpha1.ChangeParams{
-						Value:      pointer.StringPtr("200M"),
+						Value:      pointer.String("200M"),
 						Percentage: pointer.Int32Ptr(80),
 					},
 				},
@@ -163,25 +163,25 @@ func (k *kubeAPIServer) reconcileHVPA(ctx context.Context, hvpa *hvpav1alpha1.Hv
 				UpdatePolicy: hvpav1alpha1.UpdatePolicy{
 					UpdateMode: &scaleDownUpdateMode,
 				},
-				StabilizationDuration: pointer.StringPtr("15m"),
+				StabilizationDuration: pointer.String("15m"),
 				MinChange: hvpav1alpha1.ScaleParams{
 					CPU: hvpav1alpha1.ChangeParams{
-						Value:      pointer.StringPtr("300m"),
+						Value:      pointer.String("300m"),
 						Percentage: pointer.Int32Ptr(80),
 					},
 					Memory: hvpav1alpha1.ChangeParams{
-						Value:      pointer.StringPtr("200M"),
+						Value:      pointer.String("200M"),
 						Percentage: pointer.Int32Ptr(80),
 					},
 				},
 			},
 			LimitsRequestsGapScaleParams: hvpav1alpha1.ScaleParams{
 				CPU: hvpav1alpha1.ChangeParams{
-					Value:      pointer.StringPtr("1"),
+					Value:      pointer.String("1"),
 					Percentage: pointer.Int32Ptr(70),
 				},
 				Memory: hvpav1alpha1.ChangeParams{
-					Value:      pointer.StringPtr("1G"),
+					Value:      pointer.String("1G"),
 					Percentage: pointer.Int32Ptr(70),
 				},
 			},

--- a/pkg/operation/botanist/component/kubernetesdashboard/kubernetes_dashboard_test.go
+++ b/pkg/operation/botanist/component/kubernetesdashboard/kubernetes_dashboard_test.go
@@ -510,7 +510,7 @@ status: {}
 					SecretRefs: []corev1.LocalObjectReference{{
 						Name: managedResourceSecret.Name,
 					}},
-					KeepObjects: pointer.BoolPtr(false),
+					KeepObjects: pointer.Bool(false),
 				},
 			}))
 

--- a/pkg/operation/botanist/component/logging/eventlogger/event_logger_test.go
+++ b/pkg/operation/botanist/component/logging/eventlogger/event_logger_test.go
@@ -453,7 +453,7 @@ var _ = Describe("EventLogger", func() {
 														LocalObjectReference: corev1.LocalObjectReference{
 															Name: "generic-token-kubeconfig",
 														},
-														Optional: pointer.BoolPtr(false),
+														Optional: pointer.Bool(false),
 													},
 												},
 												{
@@ -467,7 +467,7 @@ var _ = Describe("EventLogger", func() {
 														LocalObjectReference: corev1.LocalObjectReference{
 															Name: "shoot-access-" + name,
 														},
-														Optional: pointer.BoolPtr(false),
+														Optional: pointer.Bool(false),
 													},
 												},
 											},

--- a/pkg/operation/botanist/component/namespaces/namespaces.go
+++ b/pkg/operation/botanist/component/namespaces/namespaces.go
@@ -86,7 +86,7 @@ func (n *namespaces) WaitCleanup(ctx context.Context) error {
 }
 
 func (n *namespaces) computeResourcesData() (map[string][]byte, error) {
-	zones := sets.NewString()
+	zones := sets.New[string]()
 
 	for _, pool := range n.workerPools {
 		if v1beta1helper.SystemComponentsAllowed(&pool) {
@@ -105,7 +105,7 @@ func (n *namespaces) computeResourcesData() (map[string][]byte, error) {
 					resourcesv1alpha1.HighAvailabilityConfigConsider: "true",
 				},
 				Annotations: map[string]string{
-					resourcesv1alpha1.HighAvailabilityConfigZones: strings.Join(zones.List(), ","),
+					resourcesv1alpha1.HighAvailabilityConfigZones: strings.Join(sets.List(zones), ","),
 				},
 			},
 		}

--- a/pkg/operation/botanist/component/nginxingress/nginxingress_test.go
+++ b/pkg/operation/botanist/component/nginxingress/nginxingress_test.go
@@ -573,7 +573,7 @@ status: {}
 					SecretRefs: []corev1.LocalObjectReference{{
 						Name: managedResourceSecret.Name,
 					}},
-					KeepObjects: pointer.BoolPtr(false),
+					KeepObjects: pointer.Bool(false),
 				},
 			}))
 

--- a/pkg/operation/botanist/component/nginxingress/nginxingress_test.go
+++ b/pkg/operation/botanist/component/nginxingress/nginxingress_test.go
@@ -569,7 +569,7 @@ status: {}
 					ResourceVersion: "1",
 				},
 				Spec: resourcesv1alpha1.ManagedResourceSpec{
-					Class: pointer.StringPtr("seed"),
+					Class: pointer.String("seed"),
 					SecretRefs: []corev1.LocalObjectReference{{
 						Name: managedResourceSecret.Name,
 					}},

--- a/pkg/operation/botanist/component/nginxingressshoot/nginxingress_test.go
+++ b/pkg/operation/botanist/component/nginxingressshoot/nginxingress_test.go
@@ -626,7 +626,7 @@ status: {}
 					SecretRefs: []corev1.LocalObjectReference{{
 						Name: managedResourceSecret.Name,
 					}},
-					KeepObjects: pointer.BoolPtr(false),
+					KeepObjects: pointer.Bool(false),
 				},
 			}))
 

--- a/pkg/operation/botanist/component/nodelocaldns/nodelocaldns_test.go
+++ b/pkg/operation/botanist/component/nodelocaldns/nodelocaldns_test.go
@@ -505,7 +505,7 @@ status: {}
 					SecretRefs: []corev1.LocalObjectReference{{
 						Name: managedResourceSecret.Name,
 					}},
-					KeepObjects: pointer.BoolPtr(false),
+					KeepObjects: pointer.Bool(false),
 				},
 			}))
 

--- a/pkg/operation/botanist/component/nodeproblemdetector/node_problem_detector_test.go
+++ b/pkg/operation/botanist/component/nodeproblemdetector/node_problem_detector_test.go
@@ -377,7 +377,7 @@ status: {}
 					SecretRefs: []corev1.LocalObjectReference{{
 						Name: managedResourceSecret.Name,
 					}},
-					KeepObjects: pointer.BoolPtr(false),
+					KeepObjects: pointer.Bool(false),
 				},
 			}))
 

--- a/pkg/operation/botanist/component/shootsystem/shootsystem_test.go
+++ b/pkg/operation/botanist/component/shootsystem/shootsystem_test.go
@@ -173,7 +173,7 @@ var _ = Describe("ShootSystem", func() {
 					SecretRefs: []corev1.LocalObjectReference{{
 						Name: managedResourceSecret.Name,
 					}},
-					KeepObjects: pointer.BoolPtr(false),
+					KeepObjects: pointer.Bool(false),
 				},
 			}))
 

--- a/pkg/operation/botanist/component/vpnshoot/vpnshoot_test.go
+++ b/pkg/operation/botanist/component/vpnshoot/vpnshoot_test.go
@@ -679,7 +679,7 @@ status: {}
 				Spec: resourcesv1alpha1.ManagedResourceSpec{
 					InjectLabels: map[string]string{"shoot.gardener.cloud/no-cleanup": "true"},
 					SecretRefs:   []corev1.LocalObjectReference{{Name: managedResourceSecret.Name}},
-					KeepObjects:  pointer.BoolPtr(false),
+					KeepObjects:  pointer.Bool(false),
 				},
 			}))
 

--- a/pkg/operation/botanist/kubeapiserver.go
+++ b/pkg/operation/botanist/kubeapiserver.go
@@ -360,7 +360,7 @@ func (b *Botanist) computeKubeAPIServerAutoscalingConfig() kubeapiserver.Autosca
 
 func resourcesRequirementsForKubeAPIServer(nodeCount int32, scalingClass string) corev1.ResourceRequirements {
 	var (
-		validScalingClasses = sets.NewString("small", "medium", "large", "xlarge", "2xlarge")
+		validScalingClasses = sets.New[string]("small", "medium", "large", "xlarge", "2xlarge")
 		cpuRequest          string
 		memoryRequest       string
 	)

--- a/pkg/operation/botanist/kubeapiserver_test.go
+++ b/pkg/operation/botanist/kubeapiserver_test.go
@@ -1730,9 +1730,9 @@ usernames: ["admin"]
 					func() {
 						botanist.Garden.InternalDomain = &gardenpkg.Domain{}
 						botanist.Shoot.ExternalDomain = &gardenpkg.Domain{}
-						botanist.Shoot.ExternalClusterDomain = pointer.StringPtr("some-domain")
+						botanist.Shoot.ExternalClusterDomain = pointer.String("some-domain")
 						botanist.Shoot.GetInfo().Spec.DNS = &gardencorev1beta1.DNS{
-							Domain:    pointer.StringPtr("some-domain"),
+							Domain:    pointer.String("some-domain"),
 							Providers: []gardencorev1beta1.DNSProvider{{}},
 						}
 					},

--- a/pkg/operation/botanist/logging_test.go
+++ b/pkg/operation/botanist/logging_test.go
@@ -93,9 +93,9 @@ var _ = Describe("Logging", func() {
 				SeedClientSet:  k8sSeedClient,
 				Config: &config.GardenletConfiguration{
 					Logging: &config.Logging{
-						Enabled: pointer.BoolPtr(true),
+						Enabled: pointer.Bool(true),
 						Loki: &config.Loki{
-							Enabled: pointer.BoolPtr(true),
+							Enabled: pointer.Bool(true),
 						},
 						ShootNodeLogging: &config.ShootNodeLogging{
 							ShootPurposes: []gardencore.ShootPurpose{
@@ -103,7 +103,7 @@ var _ = Describe("Logging", func() {
 							},
 						},
 						ShootEventLogging: &config.ShootEventLogging{
-							Enabled: pointer.BoolPtr(true),
+							Enabled: pointer.Bool(true),
 						},
 					},
 				},

--- a/pkg/operation/botanist/operatingsystemconfig.go
+++ b/pkg/operation/botanist/operatingsystemconfig.go
@@ -159,7 +159,7 @@ func (b *Botanist) DeployManagedResourceForCloudConfigExecutor(ctx context.Conte
 		managedResource                  = managedresources.NewForShoot(b.SeedClientSet.Client(), b.Shoot.SeedNamespace, CloudConfigExecutionManagedResourceName, managedresources.LabelValueGardener, false)
 		managedResourceSecretsCount      = len(b.Shoot.GetInfo().Spec.Provider.Workers) + 1
 		managedResourceSecretLabels      = map[string]string{SecretLabelKeyManagedResource: CloudConfigExecutionManagedResourceName}
-		managedResourceSecretNamesWanted = sets.NewString()
+		managedResourceSecretNamesWanted = sets.New[string]()
 		managedResourceSecretNameToData  = make(map[string]map[string][]byte, managedResourceSecretsCount)
 
 		cloudConfigExecutorSecretNames        []string

--- a/pkg/operation/botanist/waiter.go
+++ b/pkg/operation/botanist/waiter.go
@@ -122,7 +122,7 @@ func (b *Botanist) WaitUntilEndpointsDoNotContainPodIPs(ctx context.Context) err
 			return retry.SevereError(err)
 		}
 
-		epsNotReconciledByKCM := sets.NewString()
+		epsNotReconciledByKCM := sets.New[string]()
 		for _, service := range serviceList.Items {
 			// if service.Spec.Selector is empty or nil, kube-controller-manager will not reconcile Endpoints for this Service
 			if len(service.Spec.Selector) == 0 {

--- a/pkg/operation/care/seed_health.go
+++ b/pkg/operation/care/seed_health.go
@@ -44,7 +44,7 @@ import (
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 )
 
-var requiredManagedResourcesSeed = sets.NewString(
+var requiredManagedResourcesSeed = sets.New[string](
 	etcd.Druid,
 	networkpolicies.ManagedResourceControlName,
 	clusterautoscaler.ManagedResourceControlName,
@@ -99,7 +99,7 @@ func (h *SeedHealth) checkSeedSystemComponents(
 	*gardencorev1beta1.Condition,
 	error,
 ) {
-	managedResources := requiredManagedResourcesSeed.List()
+	managedResources := sets.List(requiredManagedResourcesSeed)
 
 	seedIsOriginOfClusterIdentity, err := clusteridentity.IsClusterIdentityEmptyOrFromOrigin(ctx, h.seedClient, v1beta1constants.ClusterIdentityOriginSeed)
 	if err != nil {

--- a/pkg/operation/care/webhook_remediation.go
+++ b/pkg/operation/care/webhook_remediation.go
@@ -297,7 +297,7 @@ func newNotInLabelSelectorRequirement(key, value string) metav1.LabelSelectorReq
 
 func removeDuplicateRequirements(requirements []metav1.LabelSelectorRequirement) []metav1.LabelSelectorRequirement {
 	var (
-		keyValues   = sets.NewString()
+		keyValues   = sets.New[string]()
 		keyValuesID = func(requirement metav1.LabelSelectorRequirement) string {
 			return requirement.Key + strings.Join(requirement.Values, "")
 		}

--- a/pkg/operation/istio_config.go
+++ b/pkg/operation/istio_config.go
@@ -104,7 +104,7 @@ func (o *Operation) singleZoneIfPinned() *string {
 		return nil
 	}
 	if v, ok := o.SeedNamespaceObject.Annotations[resourcesv1alpha1.HighAvailabilityConfigZones]; ok {
-		zones := sets.NewString(strings.Split(v, ",")...).Delete("").List()
+		zones := sets.List(sets.New[string](strings.Split(v, ",")...).Delete(""))
 		if len(zones) == 1 {
 			return &zones[0]
 		}

--- a/pkg/operation/shoot/shoot.go
+++ b/pkg/operation/shoot/shoot.go
@@ -561,8 +561,8 @@ func ToNetworks(s *gardencorev1beta1.Shoot) (*Networks, error) {
 
 // ComputeRequiredExtensions compute the extension kind/type combinations that are required for the
 // reconciliation flow.
-func ComputeRequiredExtensions(shoot *gardencorev1beta1.Shoot, seed *gardencorev1beta1.Seed, controllerRegistrationList *gardencorev1beta1.ControllerRegistrationList, internalDomain, externalDomain *garden.Domain) sets.String {
-	requiredExtensions := sets.NewString()
+func ComputeRequiredExtensions(shoot *gardencorev1beta1.Shoot, seed *gardencorev1beta1.Seed, controllerRegistrationList *gardencorev1beta1.ControllerRegistrationList, internalDomain, externalDomain *garden.Domain) sets.Set[string] {
+	requiredExtensions := sets.New[string]()
 
 	if seed.Spec.Backup != nil {
 		requiredExtensions.Insert(gardenerextensions.Id(extensionsv1alpha1.BackupBucketResource, seed.Spec.Backup.Provider))
@@ -578,7 +578,7 @@ func ComputeRequiredExtensions(shoot *gardencorev1beta1.Shoot, seed *gardencorev
 	requiredExtensions.Insert(gardenerextensions.Id(extensionsv1alpha1.NetworkResource, shoot.Spec.Networking.Type))
 	requiredExtensions.Insert(gardenerextensions.Id(extensionsv1alpha1.WorkerResource, shoot.Spec.Provider.Type))
 
-	disabledExtensions := sets.NewString()
+	disabledExtensions := sets.New[string]()
 	for _, extension := range shoot.Spec.Extensions {
 		id := gardenerextensions.Id(extensionsv1alpha1.ExtensionResource, extension.Type)
 

--- a/pkg/operation/shoot/shoot_test.go
+++ b/pkg/operation/shoot/shoot_test.go
@@ -467,7 +467,7 @@ var _ = Describe("shoot", func() {
 		It("should compute the correct list of required extensions", func() {
 			result := ComputeRequiredExtensions(shoot, seed, controllerRegistrationList, internalDomain, externalDomain)
 
-			Expect(result).To(Equal(sets.NewString(
+			Expect(result).To(Equal(sets.New[string](
 				extensions.Id(extensionsv1alpha1.BackupBucketResource, backupProvider),
 				extensions.Id(extensionsv1alpha1.BackupEntryResource, backupProvider),
 				extensions.Id(extensionsv1alpha1.ControlPlaneResource, seedProvider),
@@ -489,7 +489,7 @@ var _ = Describe("shoot", func() {
 
 			result := ComputeRequiredExtensions(shoot, seed, controllerRegistrationList, internalDomain, externalDomain)
 
-			Expect(result).To(Equal(sets.NewString(
+			Expect(result).To(Equal(sets.New[string](
 				extensions.Id(extensionsv1alpha1.ControlPlaneResource, seedProvider),
 				extensions.Id(extensionsv1alpha1.ControlPlaneResource, shootProvider),
 				extensions.Id(extensionsv1alpha1.InfrastructureResource, shootProvider),
@@ -512,7 +512,7 @@ var _ = Describe("shoot", func() {
 
 			result := ComputeRequiredExtensions(shoot, seed, controllerRegistrationList, internalDomain, externalDomain)
 
-			Expect(result).To(Equal(sets.NewString(
+			Expect(result).To(Equal(sets.New[string](
 				extensions.Id(extensionsv1alpha1.BackupBucketResource, backupProvider),
 				extensions.Id(extensionsv1alpha1.BackupEntryResource, backupProvider),
 				extensions.Id(extensionsv1alpha1.ControlPlaneResource, seedProvider),

--- a/pkg/operator/apis/config/validation/validation.go
+++ b/pkg/operator/apis/config/validation/validation.go
@@ -30,11 +30,11 @@ import (
 func ValidateOperatorConfiguration(conf *config.OperatorConfiguration) field.ErrorList {
 	allErrs := field.ErrorList{}
 
-	if conf.LogLevel != "" && !sets.NewString(logger.AllLogLevels...).Has(conf.LogLevel) {
+	if conf.LogLevel != "" && !sets.New[string](logger.AllLogLevels...).Has(conf.LogLevel) {
 		allErrs = append(allErrs, field.NotSupported(field.NewPath("logLevel"), conf.LogLevel, logger.AllLogLevels))
 	}
 
-	if conf.LogFormat != "" && !sets.NewString(logger.AllLogFormats...).Has(conf.LogFormat) {
+	if conf.LogFormat != "" && !sets.New[string](logger.AllLogFormats...).Has(conf.LogFormat) {
 		allErrs = append(allErrs, field.NotSupported(field.NewPath("logFormat"), conf.LogFormat, logger.AllLogFormats))
 	}
 

--- a/pkg/resourcemanager/apis/config/validation/validation.go
+++ b/pkg/resourcemanager/apis/config/validation/validation.go
@@ -39,10 +39,10 @@ func ValidateResourceManagerConfiguration(conf *config.ResourceManagerConfigurat
 	allErrs = append(allErrs, validateServerConfiguration(conf.Server, field.NewPath("server"))...)
 	allErrs = append(allErrs, componentbaseconfigvalidation.ValidateLeaderElectionConfiguration(&conf.LeaderElection, field.NewPath("leaderElection"))...)
 
-	if !sets.NewString(logger.AllLogLevels...).Has(conf.LogLevel) {
+	if !sets.New[string](logger.AllLogLevels...).Has(conf.LogLevel) {
 		allErrs = append(allErrs, field.NotSupported(field.NewPath("logLevel"), conf.LogLevel, logger.AllLogLevels))
 	}
-	if !sets.NewString(logger.AllLogFormats...).Has(conf.LogFormat) {
+	if !sets.New[string](logger.AllLogFormats...).Has(conf.LogFormat) {
 		allErrs = append(allErrs, field.NotSupported(field.NewPath("logFormat"), conf.LogFormat, logger.AllLogFormats))
 	}
 

--- a/pkg/resourcemanager/controller/csrapprover/reconciler.go
+++ b/pkg/resourcemanager/controller/csrapprover/reconciler.go
@@ -157,7 +157,7 @@ func (r *Reconciler) mustApprove(ctx context.Context, csr *certificatesv1.Certif
 		}
 	}
 
-	if !sets.NewString(hostNames...).Equal(sets.NewString(x509cr.DNSNames...)) {
+	if !sets.New[string](hostNames...).Equal(sets.New[string](x509cr.DNSNames...)) {
 		return "DNS names in CSR do not match addresses of type 'Hostname' or 'InternalDNS' or 'ExternalDNS' in node object", false, nil
 	}
 
@@ -166,7 +166,7 @@ func (r *Reconciler) mustApprove(ctx context.Context, csr *certificatesv1.Certif
 		ipAddressesInCSR = append(ipAddressesInCSR, ip.String())
 	}
 
-	if !sets.NewString(ipAddresses...).Equal(sets.NewString(ipAddressesInCSR...)) {
+	if !sets.New[string](ipAddresses...).Equal(sets.New[string](ipAddressesInCSR...)) {
 		return "IP addresses in CSR do not match addresses of type 'InternalIP' or 'ExternalIP' in node object", false, nil
 	}
 

--- a/pkg/resourcemanager/controller/managedresource/add_test.go
+++ b/pkg/resourcemanager/controller/managedresource/add_test.go
@@ -94,7 +94,7 @@ var _ = Describe("#MapSecretToManagedResources", func() {
 
 	It("should do nothing, if there are no ManagedResources we are responsible for", func() {
 		mr := resourcesv1alpha1.ManagedResource{
-			Spec: resourcesv1alpha1.ManagedResourceSpec{Class: pointer.StringPtr("other")},
+			Spec: resourcesv1alpha1.ManagedResourceSpec{Class: pointer.String("other")},
 		}
 
 		c.EXPECT().List(ctx, gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResourceList{}), client.InNamespace(secret.Namespace)).
@@ -114,7 +114,7 @@ var _ = Describe("#MapSecretToManagedResources", func() {
 				Namespace: secret.Namespace,
 			},
 			Spec: resourcesv1alpha1.ManagedResourceSpec{
-				Class:      pointer.StringPtr(filter.ResourceClass()),
+				Class:      pointer.String(filter.ResourceClass()),
 				SecretRefs: []corev1.LocalObjectReference{{Name: secret.Name}},
 			},
 		}

--- a/pkg/resourcemanager/controller/managedresource/cleaner_test.go
+++ b/pkg/resourcemanager/controller/managedresource/cleaner_test.go
@@ -59,7 +59,7 @@ var _ = Describe("cleaner", func() {
 					Selector: &metav1.LabelSelector{
 						MatchLabels: map[string]string{"foo": "bar"},
 					},
-					Replicas: pointer.Int32Ptr(1),
+					Replicas: pointer.Int32(1),
 					VolumeClaimTemplates: []corev1.PersistentVolumeClaim{
 						{
 							Spec: corev1.PersistentVolumeClaimSpec{

--- a/pkg/resourcemanager/controller/managedresource/cleaner_test.go
+++ b/pkg/resourcemanager/controller/managedresource/cleaner_test.go
@@ -65,7 +65,7 @@ var _ = Describe("cleaner", func() {
 							Spec: corev1.PersistentVolumeClaimSpec{
 								AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
 								VolumeName:       "foo-pvc",
-								StorageClassName: pointer.StringPtr("ultra-fast"),
+								StorageClassName: pointer.String("ultra-fast"),
 							},
 						},
 					},
@@ -129,7 +129,7 @@ var _ = Describe("cleaner", func() {
 								Spec: corev1.PersistentVolumeClaimSpec{
 									AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
 									VolumeName:       "foo-pvc-foo-0",
-									StorageClassName: pointer.StringPtr("ultra-fast"),
+									StorageClassName: pointer.String("ultra-fast"),
 								},
 							},
 						}
@@ -154,7 +154,7 @@ var _ = Describe("cleaner", func() {
 								Spec: corev1.PersistentVolumeClaimSpec{
 									AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
 									VolumeName:       "foo-pvc-foo-0",
-									StorageClassName: pointer.StringPtr("ultra-fast"),
+									StorageClassName: pointer.String("ultra-fast"),
 								},
 							},
 						}

--- a/pkg/resourcemanager/controller/managedresource/merger_test.go
+++ b/pkg/resourcemanager/controller/managedresource/merger_test.go
@@ -61,8 +61,8 @@ var _ = Describe("merger", func() {
 						Kind:               "Namespace",
 						Name:               "default",
 						UID:                "18590d53-3e4d-4616-b411-88212dc69ac6",
-						Controller:         pointer.BoolPtr(true),
-						BlockOwnerDeletion: pointer.BoolPtr(true),
+						Controller:         pointer.Bool(true),
+						BlockOwnerDeletion: pointer.Bool(true),
 					}},
 				},
 			}

--- a/pkg/resourcemanager/controller/managedresource/merger_test.go
+++ b/pkg/resourcemanager/controller/managedresource/merger_test.go
@@ -533,7 +533,7 @@ var _ = Describe("merger", func() {
 					Spec: corev1.PersistentVolumeClaimSpec{
 						AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
 						VolumeName:       "pvc-foo",
-						StorageClassName: pointer.StringPtr("ultra-fast"),
+						StorageClassName: pointer.String("ultra-fast"),
 					},
 				},
 			}
@@ -551,7 +551,7 @@ var _ = Describe("merger", func() {
 					Spec: corev1.PersistentVolumeClaimSpec{
 						AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
 						VolumeName:       "pvc-foo",
-						StorageClassName: pointer.StringPtr("ultra-fast"),
+						StorageClassName: pointer.String("ultra-fast"),
 					},
 				},
 			}

--- a/pkg/resourcemanager/controller/managedresource/merger_test.go
+++ b/pkg/resourcemanager/controller/managedresource/merger_test.go
@@ -302,7 +302,7 @@ var _ = Describe("merger", func() {
 					Selector: &metav1.LabelSelector{
 						MatchLabels: map[string]string{"controller-uid": "1a2b3c"},
 					},
-					Replicas: pointer.Int32Ptr(1),
+					Replicas: pointer.Int32(1),
 					Template: defaultPodTemplateSpec,
 				},
 			}
@@ -320,7 +320,7 @@ var _ = Describe("merger", func() {
 		})
 
 		It("should not overwrite old .spec.replicas if preserveReplicas is true", func() {
-			new.Spec.Replicas = pointer.Int32Ptr(2)
+			new.Spec.Replicas = pointer.Int32(2)
 
 			expected := old.DeepCopy()
 
@@ -329,7 +329,7 @@ var _ = Describe("merger", func() {
 		})
 
 		It("should use new .spec.replicas if preserveReplicas is false", func() {
-			new.Spec.Replicas = pointer.Int32Ptr(2)
+			new.Spec.Replicas = pointer.Int32(2)
 
 			expected := new.DeepCopy()
 
@@ -377,7 +377,7 @@ var _ = Describe("merger", func() {
 					Selector: &metav1.LabelSelector{
 						MatchLabels: map[string]string{"controller-uid": "1a2b3c"},
 					},
-					Replicas: pointer.Int32Ptr(1),
+					Replicas: pointer.Int32(1),
 					Template: defaultPodTemplateSpec,
 				},
 			}
@@ -387,7 +387,7 @@ var _ = Describe("merger", func() {
 		})
 
 		It("should use new .spec.replicas if preserve-replicas is unset", func() {
-			new.Spec.Replicas = pointer.Int32Ptr(2)
+			new.Spec.Replicas = pointer.Int32(2)
 
 			Expect(s.Convert(old, current, nil)).Should(Succeed())
 			Expect(s.Convert(new, desired, nil)).Should(Succeed())
@@ -399,7 +399,7 @@ var _ = Describe("merger", func() {
 		})
 
 		It("should not overwrite old .spec.replicas if preserve-replicas is true", func() {
-			new.Spec.Replicas = pointer.Int32Ptr(2)
+			new.Spec.Replicas = pointer.Int32(2)
 			new.ObjectMeta.Annotations["resources.gardener.cloud/preserve-replicas"] = "true"
 
 			Expect(s.Convert(old, current, nil)).Should(Succeed())
@@ -473,7 +473,7 @@ var _ = Describe("merger", func() {
 					Selector: &metav1.LabelSelector{
 						MatchLabels: map[string]string{"controller-uid": "1a2b3c"},
 					},
-					Replicas: pointer.Int32Ptr(1),
+					Replicas: pointer.Int32(1),
 					Template: defaultPodTemplateSpec,
 				},
 			}
@@ -491,7 +491,7 @@ var _ = Describe("merger", func() {
 		})
 
 		It("should not overwrite old .spec.replicas if preserveReplicas is true", func() {
-			new.Spec.Replicas = pointer.Int32Ptr(2)
+			new.Spec.Replicas = pointer.Int32(2)
 
 			expected := old.DeepCopy()
 
@@ -500,7 +500,7 @@ var _ = Describe("merger", func() {
 		})
 
 		It("should use new .spec.replicas if preserveReplicas is false", func() {
-			new.Spec.Replicas = pointer.Int32Ptr(2)
+			new.Spec.Replicas = pointer.Int32(2)
 
 			expected := new.DeepCopy()
 

--- a/pkg/resourcemanager/controller/managedresource/merger_test.go
+++ b/pkg/resourcemanager/controller/managedresource/merger_test.go
@@ -55,7 +55,7 @@ var _ = Describe("merger", func() {
 					DeletionTimestamp:          &metav1.Time{Time: time.Now().Add(1 * time.Hour)},
 					UID:                        "8c3d49f6-e177-4938-8547-c61283a84876",
 					GenerateName:               "foo",
-					DeletionGracePeriodSeconds: pointer.Int64Ptr(30),
+					DeletionGracePeriodSeconds: pointer.Int64(30),
 					OwnerReferences: []metav1.OwnerReference{{
 						APIVersion:         "v1",
 						Kind:               "Namespace",

--- a/pkg/resourcemanager/controller/managedresource/objectindex.go
+++ b/pkg/resourcemanager/controller/managedresource/objectindex.go
@@ -25,7 +25,7 @@ import (
 
 type objectIndex struct {
 	index        map[string]resourcesv1alpha1.ObjectReference
-	found        sets.String
+	found        sets.Set[string]
 	equivalences Equivalences
 }
 
@@ -36,7 +36,7 @@ type objectIndex struct {
 func NewObjectIndex(references []resourcesv1alpha1.ObjectReference, withEquivalences Equivalences) *objectIndex {
 	index := &objectIndex{
 		make(map[string]resourcesv1alpha1.ObjectReference, len(references)),
-		sets.String{},
+		sets.Set[string]{},
 		withEquivalences,
 	}
 

--- a/pkg/resourcemanager/controller/networkpolicy/reconciler.go
+++ b/pkg/resourcemanager/controller/networkpolicy/reconciler.go
@@ -135,7 +135,7 @@ func (r *Reconciler) namespaceIsHandled(ctx context.Context, namespaceName strin
 	return false, nil
 }
 
-func (r *Reconciler) fetchRelevantNamespaceNames(ctx context.Context, service *corev1.Service) (sets.String, error) {
+func (r *Reconciler) fetchRelevantNamespaceNames(ctx context.Context, service *corev1.Service) (sets.Set[string], error) {
 	var namespaceSelectors []metav1.LabelSelector
 	if v, ok := service.Annotations[resourcesv1alpha1.NetworkingNamespaceSelectors]; ok {
 		if err := json.Unmarshal([]byte(v), &namespaceSelectors); err != nil {
@@ -143,7 +143,7 @@ func (r *Reconciler) fetchRelevantNamespaceNames(ctx context.Context, service *c
 		}
 	}
 
-	namespaceNames := sets.NewString(service.Namespace)
+	namespaceNames := sets.New[string](service.Namespace)
 
 	for _, n := range namespaceSelectors {
 		namespaceSelector := n
@@ -169,7 +169,7 @@ func (r *Reconciler) fetchRelevantNamespaceNames(ctx context.Context, service *c
 	return namespaceNames, nil
 }
 
-func (r *Reconciler) reconcileDesiredPolicies(service *corev1.Service, namespaceNames sets.String) ([]flow.TaskFn, []string, error) {
+func (r *Reconciler) reconcileDesiredPolicies(service *corev1.Service, namespaceNames sets.Set[string]) ([]flow.TaskFn, []string, error) {
 	var (
 		taskFns               []flow.TaskFn
 		desiredObjectMetaKeys []string

--- a/pkg/resourcemanager/controller/secret/reconciler_test.go
+++ b/pkg/resourcemanager/controller/secret/reconciler_test.go
@@ -134,7 +134,7 @@ var _ = Describe("SecretReconciler", func() {
 		It("should do nothing if there is no MR which we are responsible for", func() {
 			mrs := []resourcesv1alpha1.ManagedResource{{
 				Spec: resourcesv1alpha1.ManagedResourceSpec{
-					Class: pointer.StringPtr("other"),
+					Class: pointer.String("other"),
 					SecretRefs: []corev1.LocalObjectReference{{
 						Name: "foo",
 					}},
@@ -164,7 +164,7 @@ var _ = Describe("SecretReconciler", func() {
 		It("should do nothing if there is no MR referencing this secret", func() {
 			mrs := []resourcesv1alpha1.ManagedResource{{
 				Spec: resourcesv1alpha1.ManagedResourceSpec{
-					Class: pointer.StringPtr(classFilter.ResourceClass()),
+					Class: pointer.String(classFilter.ResourceClass()),
 					SecretRefs: []corev1.LocalObjectReference{{
 						Name: "foo",
 					}},
@@ -196,7 +196,7 @@ var _ = Describe("SecretReconciler", func() {
 
 			mrs := []resourcesv1alpha1.ManagedResource{{
 				Spec: resourcesv1alpha1.ManagedResourceSpec{
-					Class: pointer.StringPtr(classFilter.ResourceClass()),
+					Class: pointer.String(classFilter.ResourceClass()),
 					SecretRefs: []corev1.LocalObjectReference{{
 						Name: secret.Name,
 					}},
@@ -224,7 +224,7 @@ var _ = Describe("SecretReconciler", func() {
 		It("should add finalizer to secret if referenced by MR", func() {
 			mrs := []resourcesv1alpha1.ManagedResource{{
 				Spec: resourcesv1alpha1.ManagedResourceSpec{
-					Class: pointer.StringPtr(classFilter.ResourceClass()),
+					Class: pointer.String(classFilter.ResourceClass()),
 					SecretRefs: []corev1.LocalObjectReference{{
 						Name: secret.Name,
 					}},
@@ -256,7 +256,7 @@ var _ = Describe("SecretReconciler", func() {
 		It("should do nothing if finalizer was already removed", func() {
 			mrs := []resourcesv1alpha1.ManagedResource{{
 				Spec: resourcesv1alpha1.ManagedResourceSpec{
-					Class:      pointer.StringPtr(classFilter.ResourceClass()),
+					Class:      pointer.String(classFilter.ResourceClass()),
 					SecretRefs: []corev1.LocalObjectReference{},
 				},
 			}}
@@ -284,7 +284,7 @@ var _ = Describe("SecretReconciler", func() {
 
 			mrs := []resourcesv1alpha1.ManagedResource{{
 				Spec: resourcesv1alpha1.ManagedResourceSpec{
-					Class:      pointer.StringPtr(classFilter.ResourceClass()),
+					Class:      pointer.String(classFilter.ResourceClass()),
 					SecretRefs: []corev1.LocalObjectReference{},
 				},
 			}}
@@ -316,7 +316,7 @@ var _ = Describe("SecretReconciler", func() {
 
 			mrs := []resourcesv1alpha1.ManagedResource{{
 				Spec: resourcesv1alpha1.ManagedResourceSpec{
-					Class: pointer.StringPtr("other"),
+					Class: pointer.String("other"),
 					SecretRefs: []corev1.LocalObjectReference{{
 						Name: secret.Name,
 					}},
@@ -350,7 +350,7 @@ var _ = Describe("SecretReconciler", func() {
 
 			mrs := []resourcesv1alpha1.ManagedResource{{
 				Spec: resourcesv1alpha1.ManagedResourceSpec{
-					Class: pointer.StringPtr("other"),
+					Class: pointer.String("other"),
 					SecretRefs: []corev1.LocalObjectReference{{
 						Name: secret.Name,
 					}},

--- a/pkg/resourcemanager/predicate/class_changed_test.go
+++ b/pkg/resourcemanager/predicate/class_changed_test.go
@@ -37,7 +37,7 @@ var _ = Describe("Predicate", func() {
 	BeforeEach(func() {
 		managedResource = &resourcesv1alpha1.ManagedResource{
 			Spec: resourcesv1alpha1.ManagedResourceSpec{
-				Class: pointer.StringPtr("shoot"),
+				Class: pointer.String("shoot"),
 			},
 		}
 		createEvent = event.CreateEvent{
@@ -111,7 +111,7 @@ var _ = Describe("Predicate", func() {
 
 		It("should match on update (class changed)", func() {
 			managedResourceNew := managedResource.DeepCopy()
-			managedResourceNew.Spec.Class = pointer.StringPtr("other")
+			managedResourceNew.Spec.Class = pointer.String("other")
 			updateEvent.ObjectNew = managedResourceNew
 
 			predicate := resourcemanagerpredicate.ClassChangedPredicate()

--- a/pkg/resourcemanager/predicate/condition_status_test.go
+++ b/pkg/resourcemanager/predicate/condition_status_test.go
@@ -40,7 +40,7 @@ var _ = Describe("#ConditionStatusChanged", func() {
 	BeforeEach(func() {
 		managedResource = &resourcesv1alpha1.ManagedResource{
 			Spec: resourcesv1alpha1.ManagedResourceSpec{
-				Class: pointer.StringPtr("shoot"),
+				Class: pointer.String("shoot"),
 			},
 		}
 		createEvent = event.CreateEvent{

--- a/pkg/resourcemanager/webhook/highavailabilityconfig/handler.go
+++ b/pkg/resourcemanager/webhook/highavailabilityconfig/handler.go
@@ -91,7 +91,7 @@ func (h *Handler) Handle(ctx context.Context, req admission.Request) admission.R
 	}
 
 	if v, ok := namespace.Annotations[resourcesv1alpha1.HighAvailabilityConfigZones]; ok {
-		zones = sets.NewString(strings.Split(v, ",")...).Delete("").List()
+		zones = sets.List(sets.New[string](strings.Split(v, ",")...).Delete(""))
 	}
 
 	if v, err := strconv.ParseBool(namespace.Annotations[resourcesv1alpha1.HighAvailabilityConfigZonePinning]); err == nil {

--- a/pkg/scheduler/apis/config/validation/validation.go
+++ b/pkg/scheduler/apis/config/validation/validation.go
@@ -29,13 +29,13 @@ func ValidateConfiguration(config *schedulerconfig.SchedulerConfiguration) field
 	allErrs = append(allErrs, validateStrategy(config.Schedulers.Shoot.Strategy, field.NewPath("schedulers", "shoot", "strategy"))...)
 
 	if config.LogLevel != "" {
-		if !sets.NewString(logger.AllLogLevels...).Has(config.LogLevel) {
+		if !sets.New[string](logger.AllLogLevels...).Has(config.LogLevel) {
 			allErrs = append(allErrs, field.NotSupported(field.NewPath("logLevel"), config.LogLevel, logger.AllLogLevels))
 		}
 	}
 
 	if config.LogFormat != "" {
-		if !sets.NewString(logger.AllLogFormats...).Has(config.LogFormat) {
+		if !sets.New[string](logger.AllLogFormats...).Has(config.LogFormat) {
 			allErrs = append(allErrs, field.NotSupported(field.NewPath("logFormat"), config.LogFormat, logger.AllLogFormats))
 		}
 	}

--- a/pkg/utils/kubernetes/client/client.go
+++ b/pkg/utils/kubernetes/client/client.go
@@ -237,7 +237,7 @@ func gracePeriodIsPassed(obj client.Object, ops *CleanOptions, t timeutils.Ops) 
 		op.ApplyToDelete(deleteOp)
 	}
 
-	gracePeriod := time.Second * time.Duration(pointer.Int64PtrDerefOr(deleteOp.GracePeriodSeconds, 0))
+	gracePeriod := time.Second * time.Duration(pointer.Int64Deref(deleteOp.GracePeriodSeconds, 0))
 	return obj.GetDeletionTimestamp().Time.Add(gracePeriod).Before(t.Now())
 }
 

--- a/pkg/utils/test/test_resources.go
+++ b/pkg/utils/test/test_resources.go
@@ -72,7 +72,7 @@ func ReadTestResources(scheme *runtime.Scheme, namespaceName, path string) ([]cl
 	}
 
 	// file extensions that may contain Webhooks
-	resourceExtensions := sets.NewString(".json", ".yaml", ".yml")
+	resourceExtensions := sets.New[string](".json", ".yaml", ".yml")
 
 	var objects []client.Object
 	for _, file := range files {

--- a/plugin/pkg/global/customverbauthorizer/admission.go
+++ b/plugin/pkg/global/customverbauthorizer/admission.go
@@ -183,8 +183,8 @@ func mustCheckProjectMembers(oldMembers, members []core.ProjectMember, owner *rb
 	return !oldHumanUsers.Equal(newHumanUsers)
 }
 
-func findHumanUsers(members []core.ProjectMember) sets.String {
-	result := sets.NewString()
+func findHumanUsers(members []core.ProjectMember) sets.Set[string] {
+	result := sets.New[string]()
 
 	for _, member := range members {
 		if isHumanUser(member.Subject) {
@@ -220,7 +220,7 @@ func userIsOwner(userInfo user.Info, owner *rbacv1.Subject) bool {
 		return owner.Name == userInfo.GetName()
 
 	case rbacv1.GroupKind:
-		return sets.NewString(userInfo.GetGroups()...).Has(owner.Name)
+		return sets.New[string](userInfo.GetGroups()...).Has(owner.Name)
 	}
 
 	return false

--- a/plugin/pkg/global/extensionlabels/admission.go
+++ b/plugin/pkg/global/extensionlabels/admission.go
@@ -244,8 +244,8 @@ func addMetaDataLabelsShoot(shoot *core.Shoot, controllerRegistrations []*core.C
 	metav1.SetMetaDataLabel(&shoot.ObjectMeta, v1beta1constants.LabelExtensionNetworkingTypePrefix+shoot.Spec.Networking.Type, "true")
 }
 
-func getEnabledExtensionsForShoot(shoot *core.Shoot, controllerRegistrations []*core.ControllerRegistration) sets.String {
-	enabledExtensions := sets.NewString()
+func getEnabledExtensionsForShoot(shoot *core.Shoot, controllerRegistrations []*core.ControllerRegistration) sets.Set[string] {
+	enabledExtensions := sets.New[string]()
 
 	// add globally enabled extensions
 	for _, reg := range controllerRegistrations {

--- a/plugin/pkg/global/resourcereferencemanager/admission.go
+++ b/plugin/pkg/global/resourcereferencemanager/admission.go
@@ -444,13 +444,13 @@ func (r *ReferenceManager) Admit(ctx context.Context, a admission.Attributes, o 
 			removedKubernetesVersions := sets.StringKeySet(helper.GetRemovedVersions(oldCloudProfile.Spec.Kubernetes.Versions, cloudProfile.Spec.Kubernetes.Versions))
 
 			// getting Machine image versions that have been removed from the CloudProfile
-			removedMachineImageVersions := map[string]sets.String{}
+			removedMachineImageVersions := map[string]sets.Set[string]{}
 			for _, oldImage := range oldCloudProfile.Spec.MachineImages {
 				imageFound := false
 				for _, newImage := range cloudProfile.Spec.MachineImages {
 					if oldImage.Name == newImage.Name {
 						imageFound = true
-						removedMachineImageVersions[oldImage.Name] = sets.StringKeySet(
+						removedMachineImageVersions[oldImage.Name] = sets.KeySet(
 							helper.GetRemovedVersions(
 								helper.ToExpirableVersions(oldImage.Versions),
 								helper.ToExpirableVersions(newImage.Versions),
@@ -461,7 +461,7 @@ func (r *ReferenceManager) Admit(ctx context.Context, a admission.Attributes, o 
 				if !imageFound {
 					for _, version := range oldImage.Versions {
 						if removedMachineImageVersions[oldImage.Name] == nil {
-							removedMachineImageVersions[oldImage.Name] = sets.NewString()
+							removedMachineImageVersions[oldImage.Name] = sets.New[string]()
 						}
 						removedMachineImageVersions[oldImage.Name] = removedMachineImageVersions[oldImage.Name].Insert(version.Version)
 					}

--- a/plugin/pkg/managedseed/validator/admission.go
+++ b/plugin/pkg/managedseed/validator/admission.go
@@ -361,9 +361,9 @@ func (v *ManagedSeed) admitSeedSpec(spec *gardencore.SeedSpec, shoot *gardencore
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("provider", "region"), spec.Provider.Region, fmt.Sprintf("seed provider region must be equal to shoot region %s", shoot.Spec.Region)))
 	}
 	if shootZones := helper.GetAllZonesFromShoot(shoot); len(spec.Provider.Zones) == 0 && shootZones.Len() > 0 {
-		spec.Provider.Zones = shootZones.List()
-	} else if len(spec.Provider.Zones) > 0 && !sets.NewString(spec.Provider.Zones...).Equal(shootZones) {
-		allErrs = append(allErrs, field.Invalid(fldPath.Child("provider", "zones"), spec.Provider.Zones, fmt.Sprintf("seed provider zones must be equal to shoot zones (%v)", shootZones.List())))
+		spec.Provider.Zones = sets.List(shootZones)
+	} else if len(spec.Provider.Zones) > 0 && !sets.New[string](spec.Provider.Zones...).Equal(shootZones) {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("provider", "zones"), spec.Provider.Zones, fmt.Sprintf("seed provider zones must be equal to shoot zones (%v)", sets.List(shootZones))))
 	}
 
 	// At this point the Shoot VPA should be already enabled (validated earlier). If the Seed does not specify VPA settings,

--- a/plugin/pkg/shoot/exposureclass/admission.go
+++ b/plugin/pkg/shoot/exposureclass/admission.go
@@ -183,15 +183,15 @@ func uniteSeedSelectors(shootSeedSelector *core.SeedSelector, exposureClassSeedS
 	shootSeedSelector.MatchExpressions = append(shootSeedSelector.MatchExpressions, exposureClassSeedSelector.MatchExpressions...)
 
 	// Unite provider types.
-	shootProviderTypes := sets.NewString().Insert(shootSeedSelector.ProviderTypes...)
-	exposureclasssProviderTypes := sets.NewString().Insert(exposureClassSeedSelector.ProviderTypes...)
-	shootSeedSelector.ProviderTypes = shootProviderTypes.Union(exposureclasssProviderTypes).List()
+	shootProviderTypes := sets.New[string]().Insert(shootSeedSelector.ProviderTypes...)
+	exposureclasssProviderTypes := sets.New[string]().Insert(exposureClassSeedSelector.ProviderTypes...)
+	shootSeedSelector.ProviderTypes = sets.List(shootProviderTypes.Union(exposureclasssProviderTypes))
 
 	return shootSeedSelector, nil
 }
 
 func uniteTolerations(shootTolerations []core.Toleration, exposureClassTolerations []v1alpha1.Toleration) ([]core.Toleration, error) {
-	shootTolerationsKeys := sets.NewString()
+	shootTolerationsKeys := sets.New[string]()
 	for _, toleration := range shootTolerations {
 		shootTolerationsKeys.Insert(toleration.Key)
 	}

--- a/plugin/pkg/shoot/exposureclass/admission_test.go
+++ b/plugin/pkg/shoot/exposureclass/admission_test.go
@@ -192,7 +192,7 @@ var _ = Describe("exposureclass", func() {
 			BeforeEach(func() {
 				exposureClass.Scheduling.Tolerations = []gardencorev1alpha1.Toleration{{
 					Key:   "abc",
-					Value: pointer.StringPtr("def"),
+					Value: pointer.String("def"),
 				}}
 
 				shoot.Spec.Tolerations = []core.Toleration{{
@@ -226,7 +226,7 @@ var _ = Describe("exposureclass", func() {
 					},
 					{
 						Key:   "abc",
-						Value: pointer.StringPtr("def"),
+						Value: pointer.String("def"),
 					},
 				}))
 			})

--- a/plugin/pkg/shoot/tolerationrestriction/admission.go
+++ b/plugin/pkg/shoot/tolerationrestriction/admission.go
@@ -164,7 +164,7 @@ func (t *TolerationRestriction) admitShoot(shoot *core.Shoot) error {
 		defaults = append(defaults, project.Spec.Tolerations.Defaults...)
 	}
 
-	existingKeys := sets.NewString()
+	existingKeys := sets.New[string]()
 	for _, toleration := range shoot.Spec.Tolerations {
 		existingKeys.Insert(toleration.Key)
 	}
@@ -233,7 +233,7 @@ func (t *TolerationRestriction) validateShoot(shoot, oldShoot *core.Shoot) error
 
 func getNewOrChangedTolerations(shoot, oldShoot *core.Shoot) []core.Toleration {
 	var (
-		oldTolerations          = sets.NewString()
+		oldTolerations          = sets.New[string]()
 		newOrChangedTolerations []core.Toleration
 	)
 

--- a/plugin/pkg/shoot/validator/admission.go
+++ b/plugin/pkg/shoot/validator/admission.go
@@ -440,7 +440,7 @@ func (c *validationContext) validateScheduling(ctx context.Context, a admission.
 			}
 
 			if seedSelector.ProviderTypes != nil {
-				if !sets.NewString(seedSelector.ProviderTypes...).HasAny(c.seed.Spec.Provider.Type, "*") {
+				if !sets.New[string](seedSelector.ProviderTypes...).HasAny(c.seed.Spec.Provider.Type, "*") {
 					return admission.NewForbidden(a, fmt.Errorf("cannot schedule shoot '%s' on seed '%s' because none of the provider types in the seed selector of cloud profile '%s' is matching the provider type of the seed", c.shoot.Name, c.seed.Name, c.cloudProfile.Name))
 				}
 			}
@@ -579,8 +579,8 @@ func (c *validationContext) validateDeletion(a admission.Attributes) error {
 
 	// Allow removal of `gardener` finalizer only if the Shoot deletion has completed successfully
 	if len(c.shoot.Status.TechnicalID) > 0 && c.shoot.Status.LastOperation != nil {
-		oldFinalizers := sets.NewString(c.oldShoot.Finalizers...)
-		newFinalizers := sets.NewString(c.shoot.Finalizers...)
+		oldFinalizers := sets.New[string](c.oldShoot.Finalizers...)
+		newFinalizers := sets.New[string](c.shoot.Finalizers...)
 
 		if oldFinalizers.Has(core.GardenerName) && !newFinalizers.Has(core.GardenerName) {
 			lastOperation := c.shoot.Status.LastOperation
@@ -1242,7 +1242,7 @@ func validateZones(constraints []core.Region, region, oldRegion string, worker, 
 		return allErrs
 	}
 
-	usedZones := sets.NewString()
+	usedZones := sets.New[string]()
 	for j, zone := range worker.Zones {
 		jdxPath := fldPath.Child("zones").Index(j)
 		if ok, validZones := validateZone(constraints, region, zone); !ok {

--- a/plugin/pkg/shoot/validator/admission_test.go
+++ b/plugin/pkg/shoot/validator/admission_test.go
@@ -477,7 +477,7 @@ var _ = Describe("validator", func() {
 
 				// set old shoot for update and add gardener finalizer to it
 				oldShoot = shoot.DeepCopy()
-				finalizers := sets.NewString(oldShoot.GetFinalizers()...)
+				finalizers := sets.New[string](oldShoot.GetFinalizers()...)
 				finalizers.Insert(core.GardenerName)
 				oldShoot.SetFinalizers(finalizers.UnsortedList())
 			})

--- a/plugin/pkg/utils/miscellaneous.go
+++ b/plugin/pkg/utils/miscellaneous.go
@@ -79,7 +79,7 @@ func NewAttributesWithName(a admission.Attributes, name string) admission.Attrib
 // ValidateZoneRemovalFromSeeds returns an error when zones are removed from the old seed while it is still in use by
 // shoots.
 func ValidateZoneRemovalFromSeeds(oldSeedSpec, newSeedSpec *core.SeedSpec, seedName string, shootLister gardencorelisters.ShootLister, kind string) error {
-	if removedZones := sets.NewString(oldSeedSpec.Provider.Zones...).Difference(sets.NewString(newSeedSpec.Provider.Zones...)); removedZones.Len() > 0 {
+	if removedZones := sets.New[string](oldSeedSpec.Provider.Zones...).Difference(sets.New[string](newSeedSpec.Provider.Zones...)); removedZones.Len() > 0 {
 		shootList, err := GetFilteredShootList(shootLister, func(shoot *core.Shoot) bool {
 			return pointer.StringDeref(shoot.Spec.SeedName, "") == seedName
 		})
@@ -88,7 +88,7 @@ func ValidateZoneRemovalFromSeeds(oldSeedSpec, newSeedSpec *core.SeedSpec, seedN
 		}
 
 		if len(shootList) > 0 {
-			return apierrors.NewForbidden(core.Resource(kind), seedName, fmt.Errorf("cannot remove zones %v from %s %s as there are %d Shoots scheduled to this Seed", removedZones.List(), kind, seedName, len(shootList)))
+			return apierrors.NewForbidden(core.Resource(kind), seedName, fmt.Errorf("cannot remove zones %v from %s %s as there are %d Shoots scheduled to this Seed", sets.List(removedZones), kind, seedName, len(shootList)))
 		}
 	}
 

--- a/test/e2e/gardener/shoot/internal/rotation/ssh_keypair.go
+++ b/test/e2e/gardener/shoot/internal/rotation/ssh_keypair.go
@@ -17,7 +17,7 @@ package rotation
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -151,7 +151,7 @@ func (v *SSHKeypairVerifier) readAuthorizedKeysFile(ctx context.Context) (string
 		return "", err
 	}
 
-	result, err := ioutil.ReadAll(reader)
+	result, err := io.ReadAll(reader)
 	if err != nil {
 		return "", err
 	}

--- a/test/framework/config/config.go
+++ b/test/framework/config/config.go
@@ -49,7 +49,7 @@ func ParseConfigForFlags(configFilePath string, fs *flag.FlagSet) error {
 // Only flags are updated that are not defined by command line.
 func applyConfig(fs *flag.FlagSet) error {
 	var allErrs *multierror.Error
-	definedFlags := sets.String{}
+	definedFlags := sets.Set[string]{}
 
 	// get all flags that are defined by command line
 	fs.Visit(func(f *flag.Flag) {

--- a/test/framework/pod_executor.go
+++ b/test/framework/pod_executor.go
@@ -64,7 +64,7 @@ func (p *podExecutor) Execute(ctx context.Context, namespace, name, containerNam
 		return nil, fmt.Errorf("failed to initialized the command exector: %v", err)
 	}
 
-	err = executor.Stream(remotecommand.StreamOptions{
+	err = executor.StreamWithContext(ctx, remotecommand.StreamOptions{
 		Stdin:  strings.NewReader(command),
 		Stdout: &stdout,
 		Stderr: &stderr,

--- a/test/framework/test_description.go
+++ b/test/framework/test_description.go
@@ -25,13 +25,13 @@ import (
 
 // TestDescription labels tests according to the provided labels in the expected order.
 type TestDescription struct {
-	labels sets.String
+	labels sets.Set[string]
 }
 
 // NewTestDescription creates a new test description
 func NewTestDescription(baseLabel string) TestDescription {
 	return TestDescription{
-		labels: sets.NewString(baseLabel),
+		labels: sets.New[string](baseLabel),
 	}
 }
 
@@ -111,7 +111,7 @@ func (t TestDescription) FCIt(text string, body func(context.Context), timeout t
 
 // String returns the test description labels
 func (t TestDescription) String() string {
-	labelsList := t.labels.List()
+	labelsList := sets.List(t.labels)
 	testText := fmt.Sprintf("[%s]", labelsList[0])
 	for i := 1; i < len(labelsList); i++ {
 		testText = fmt.Sprintf("%s [%s]", testText, labelsList[i])

--- a/test/integration/gardenlet/networkpolicy/networkpolicy_suite_test.go
+++ b/test/integration/gardenlet/networkpolicy/networkpolicy_suite_test.go
@@ -24,6 +24,7 @@ import (
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/client-go/rest"
 	"k8s.io/utils/pointer"
@@ -95,10 +96,14 @@ var _ = BeforeSuite(func() {
 	})
 
 	By("Create testClient")
-	scheme := kubernetes.GardenScheme
-	Expect(extensionsv1alpha1.AddToScheme(scheme)).To(Succeed())
+	testSchemeBuilder := runtime.NewSchemeBuilder(
+		kubernetes.AddGardenSchemeToScheme,
+		extensionsv1alpha1.AddToScheme,
+	)
+	testScheme := runtime.NewScheme()
+	Expect(testSchemeBuilder.AddToScheme(testScheme)).To(Succeed())
 
-	testClient, err = client.New(restConfig, client.Options{Scheme: scheme})
+	testClient, err = client.New(restConfig, client.Options{Scheme: testScheme})
 	Expect(err).NotTo(HaveOccurred())
 
 	testRunID = utils.ComputeSHA256Hex([]byte(uuid.NewUUID()))[:8]
@@ -106,7 +111,7 @@ var _ = BeforeSuite(func() {
 
 	By("Setup manager")
 	mgr, err := manager.New(restConfig, manager.Options{
-		Scheme:             scheme,
+		Scheme:             testScheme,
 		MetricsBindAddress: "0",
 		NewCache: cache.BuilderWithOptions(cache.Options{
 			SelectorsByObject: map[client.Object]cache.ObjectSelector{

--- a/test/integration/resourcemanager/managedresource/resource_test.go
+++ b/test/integration/resourcemanager/managedresource/resource_test.go
@@ -708,7 +708,7 @@ var _ = Describe("ManagedResource controller tests", func() {
 						Selector: &metav1.LabelSelector{
 							MatchLabels: map[string]string{"foo": "bar"},
 						},
-						Replicas: pointer.Int32Ptr(1),
+						Replicas: pointer.Int32(1),
 						Template: *defaultPodTemplateSpec,
 					},
 				}
@@ -838,7 +838,7 @@ var _ = Describe("ManagedResource controller tests", func() {
 						Selector: &metav1.LabelSelector{
 							MatchLabels: map[string]string{"foo": "bar"},
 						},
-						Replicas: pointer.Int32Ptr(1),
+						Replicas: pointer.Int32(1),
 						Template: *defaultPodTemplateSpec,
 					},
 				}
@@ -877,7 +877,7 @@ var _ = Describe("ManagedResource controller tests", func() {
 						)
 
 						patch := client.MergeFrom(deployment.DeepCopy())
-						deployment.Spec.Replicas = pointer.Int32Ptr(5)
+						deployment.Spec.Replicas = pointer.Int32(5)
 						Expect(testClient.Patch(ctx, deployment, patch)).To(Succeed())
 
 						Eventually(func(g Gomega) int32 {
@@ -902,7 +902,7 @@ var _ = Describe("ManagedResource controller tests", func() {
 						)
 
 						patch := client.MergeFrom(deployment.DeepCopy())
-						deployment.Spec.Replicas = pointer.Int32Ptr(5)
+						deployment.Spec.Replicas = pointer.Int32(5)
 						Expect(testClient.Patch(ctx, deployment, patch)).To(Succeed())
 
 						Consistently(func(g Gomega) int32 {

--- a/test/start-envtest/main.go
+++ b/test/start-envtest/main.go
@@ -81,7 +81,7 @@ const (
 	typeGardener   = "gardener"
 )
 
-var supportedTypes = sets.NewString(typeKubernetes, typeGardener)
+var supportedTypes = sets.New[string](typeKubernetes, typeGardener)
 
 type options struct {
 	environmentType string
@@ -89,13 +89,13 @@ type options struct {
 }
 
 func (o *options) addFlags(fs *pflag.FlagSet) {
-	fs.StringVar(&o.environmentType, "environment-type", typeKubernetes, fmt.Sprintf("Type of environment to start. Supported values: %s", strings.Join(supportedTypes.List(), ", ")))
+	fs.StringVar(&o.environmentType, "environment-type", typeKubernetes, fmt.Sprintf("Type of environment to start. Supported values: %s", strings.Join(sets.List(supportedTypes), ", ")))
 	fs.StringVar(&o.kubeconfig, "kubeconfig", path.Join("..", "..", "dev", "envtest-kubeconfig.yaml"), "File to place the environment's admin kubeconfig in.")
 }
 
 func (o *options) validate() error {
 	if !supportedTypes.Has(o.environmentType) {
-		return fmt.Errorf("unsupported environment type %q, supported types are: %s", o.environmentType, strings.Join(supportedTypes.List(), ", "))
+		return fmt.Errorf("unsupported environment type %q, supported types are: %s", o.environmentType, strings.Join(sets.List(supportedTypes), ", "))
 	}
 	return nil
 }

--- a/test/testmachinery/shoots/logging/seed_logging_stack.go
+++ b/test/testmachinery/shoots/logging/seed_logging_stack.go
@@ -424,6 +424,6 @@ func prepareClusterCRD(crd *apiextensionsv1.CustomResourceDefinition) *apiextens
 }
 
 func prepareFluentBitServiceAccount(serviceAccount *corev1.ServiceAccount) *corev1.ServiceAccount {
-	serviceAccount.AutomountServiceAccountToken = pointer.BoolPtr(true)
+	serviceAccount.AutomountServiceAccountToken = pointer.Bool(true)
 	return serviceAccount
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability robustness quality
/kind cleanup

**What this PR does / why we need it**:
This PR cleans up some deprecated variables in the code base and replaces them appropriately.
Also use dedicated schemes for unit tests which was not covered in #7409

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
