### PR TITLE
Consider all MR in `shoot` namespace in `seed` for health check except one having class seed

### DIFF
--- a/docs/extensions/healthcheck-library.md
+++ b/docs/extensions/healthcheck-library.md
@@ -95,6 +95,6 @@ The health check library will automatically transition the status to `False` if 
 
 It is up to the extension to decide how to conduct health checks, though it is recommended to make use of the build-in health check functionality of `managed-resources` for trivial checks.
 By [deploying the depending resources via managed resources](https://github.com/gardener/gardener/blob/master/extensions/pkg/controller/worker/genericactuator/machine_controller_manager.go), the [gardener resource manager](https://github.com/gardener/gardener-resource-manager) conducts basic checks for different API objects out-of-the-box (e.g `Deployments`, `DaemonSets`, ...) - and writes health conditions.
-In turn, the library contains a health check function to gather the health information from managed resources.
+By default, Gardener performs health check for all the managed resources created in the shoot control plane.
 
 More sophisticated health checks should be implemented by the extension controller itself (implementing the `HealthCheck` interface).

--- a/docs/extensions/healthcheck-library.md
+++ b/docs/extensions/healthcheck-library.md
@@ -95,6 +95,6 @@ The health check library will automatically transition the status to `False` if 
 
 It is up to the extension to decide how to conduct health checks, though it is recommended to make use of the build-in health check functionality of `managed-resources` for trivial checks.
 By [deploying the depending resources via managed resources](https://github.com/gardener/gardener/blob/master/extensions/pkg/controller/worker/genericactuator/machine_controller_manager.go), the [gardener resource manager](https://github.com/gardener/gardener-resource-manager) conducts basic checks for different API objects out-of-the-box (e.g `Deployments`, `DaemonSets`, ...) - and writes health conditions.
-By default, Gardener performs health check for all the managed resources created in the shoot control plane.
+By default, Gardener performs health check for all the `ManagedResource`s with `.spec.class=nil` created in the shoot namespaces.
 
 More sophisticated health checks should be implemented by the extension controller itself (implementing the `HealthCheck` interface).

--- a/docs/extensions/shoot-health-status-conditions.md
+++ b/docs/extensions/shoot-health-status-conditions.md
@@ -4,8 +4,9 @@ Gardener checks regularly (every minute by default) the health status of all sho
 It categorizes its checks into four different types:
 
 * `APIServerAvailable`: This type indicates whether the shoot's kube-apiserver is available or not.
-* `ControlPlaneHealthy`: This type indicates whether all the control plane components deployed to the shoot's namespace in the seed do exist and are running fine.
+* `ControlPlaneHealthy`: This type indicates whether the core components of the Shoot controlplane (ETCD, KAPI, KCM..) are healthy.
 * `EveryNodeReady`: This type indicates whether all `Node`s and all `Machine` objects report healthiness.
+* `ObservabilityComponentsHealthy`: This type indicates whether the  observability components of the Shoot control plane (Prometheus, Loki, Grafana..) are healthy.
 * `SystemComponentsHealthy`: This type indicates whether all system components deployed to the `kube-system` namespace in the shoot do exist and are running fine.
 
 Every `Shoot` resource has a `status.conditions[]` list that contains the mentioned types, together with a `status` (`True`/`False`) and a descriptive message/explanation of the `status`.
@@ -18,7 +19,7 @@ Now that the extensions deploy resources into the cluster, especially resources 
 
 Every extension resource in Gardener's `extensions.gardener.cloud/v1alpha1` API group also has a `status.conditions[]` list (like the `Shoot`).
 Extension controllers can write conditions to the resource they are acting on and use a type that also exists in the shoot's conditions.
-One exception is that `APIServerAvailable` can't be used, as Gardener clearly can identify the status of this condition and it doesn't make sense for extensions to try to contribute/modify it.
+One exception is that `APIServerAvailable` and `ObservabilityComponentsHealthy` can't be used, as Gardener clearly can identify the status of this condition and it doesn't make sense for extensions to try to contribute/modify it.
 
 As an example for the `ControlPlane` controller, let's take a look at the following resource:
 

--- a/pkg/operation/care/health.go
+++ b/pkg/operation/care/health.go
@@ -48,7 +48,6 @@ import (
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/kubernetes/health"
-	"github.com/gardener/gardener/pkg/utils/managedresources"
 )
 
 // Health contains information needed to execute shoot health checks.
@@ -399,7 +398,7 @@ func (h *Health) checkSystemComponents(
 	error,
 ) {
 	mrList := &resourcesv1alpha1.ManagedResourceList{}
-	if err := h.seedClient.Client().List(ctx, mrList, client.InNamespace(h.shoot.SeedNamespace), client.MatchingLabels{managedresources.LabelKeyOrigin: managedresources.LabelValueGardener}); err != nil {
+	if err := h.seedClient.Client().List(ctx, mrList, client.InNamespace(h.shoot.SeedNamespace)); err != nil {
 		return nil, err
 	}
 

--- a/pkg/operation/care/health.go
+++ b/pkg/operation/care/health.go
@@ -361,7 +361,7 @@ func (h *Health) checkControlPlane(
 	return &c, nil
 }
 
-// checkControlPlane checks whether the  observability components of the Shoot control plane (Prometheus, Loki, Grafana..) are healthy.
+// checkObservabilityComponents checks whether the  observability components of the Shoot control plane (Prometheus, Loki, Grafana..) are healthy.
 func (h *Health) checkObservabilityComponents(
 	ctx context.Context,
 	checker *HealthChecker,

--- a/test/integration/gardenlet/shoot/care/care_test.go
+++ b/test/integration/gardenlet/shoot/care/care_test.go
@@ -28,6 +28,7 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 )
@@ -325,55 +326,7 @@ var _ = Describe("Shoot Care controller tests", func() {
 
 		Context("when some control plane deployments for the Shoot are present", func() {
 			JustBeforeEach(func() {
-				for _, name := range []string{"gardener-resource-manager", "kube-controller-manager", "kube-scheduler", "grafana"} {
-					deployment := &appsv1.Deployment{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      name,
-							Namespace: testNamespace.Name,
-							Labels: map[string]string{
-								testID:                      testRunID,
-								v1beta1constants.GardenRole: getRole(name),
-							},
-						},
-						Spec: appsv1.DeploymentSpec{
-							Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"foo": "bar"}},
-							Replicas: pointer.Int32(1),
-							Template: corev1.PodTemplateSpec{
-								ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"foo": "bar"}},
-								Spec: corev1.PodSpec{
-									Containers: []corev1.Container{{
-										Name:  "foo-container",
-										Image: "foo",
-									}},
-								},
-							},
-						},
-					}
-
-					By("Create Deployment " + name)
-					Expect(testClient.Create(ctx, deployment)).To(Succeed(), "for deployment "+name)
-					log.Info("Created Deployment for test", "deployment", client.ObjectKeyFromObject(deployment))
-
-					By("Ensure manager has observed deployment " + name)
-					Eventually(func() error {
-						return mgrClient.Get(ctx, client.ObjectKeyFromObject(deployment), deployment)
-					}).Should(Succeed())
-
-					DeferCleanup(func() {
-						By("Delete Deployment " + name)
-						Expect(testClient.Delete(ctx, deployment)).To(Succeed(), "for deployment "+name)
-
-						By("Ensure Deployment " + name + " is gone")
-						Eventually(func() error {
-							return mgrClient.Get(ctx, client.ObjectKeyFromObject(deployment), deployment)
-						}).Should(BeNotFoundError(), "for deployment "+name)
-
-						By("Ensure manager has observed deployment deletion " + name)
-						Eventually(func() error {
-							return mgrClient.Get(ctx, client.ObjectKeyFromObject(deployment), deployment)
-						}).Should(BeNotFoundError())
-					})
-				}
+				createDeployment([]string{"gardener-resource-manager", "kube-controller-manager", "kube-scheduler", "grafana"})
 			})
 
 			It("should set conditions", func() {
@@ -390,8 +343,250 @@ var _ = Describe("Shoot Care controller tests", func() {
 				))
 			})
 		})
+
+		Context("when all Managed Resources of spec.class=nil in shoot namespace in seed are healthy except one with spec.class!=nil", func() {
+			JustBeforeEach(func() {
+				// kube-apiserver deployment is required because care controller doesn't check any other
+				// condition if APIServer is down.
+				createDeployment([]string{"kube-apiserver"})
+
+				managedResource1 := &resourcesv1alpha1.ManagedResource{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-1",
+						Namespace: testNamespace.Name,
+						Labels: map[string]string{
+							testID: testRunID,
+						},
+					},
+					Spec: resourcesv1alpha1.ManagedResourceSpec{
+						SecretRefs: []corev1.LocalObjectReference{
+							{Name: "test-1"},
+						},
+					},
+				}
+				Expect(testClient.Create(ctx, managedResource1)).To(Succeed())
+
+				Eventually(func() error {
+					return mgrClient.Get(ctx, client.ObjectKeyFromObject(managedResource1), managedResource1)
+				}).Should(Succeed())
+
+				By("Patch Managed Resource to report healthiness")
+				Eventually(func(g Gomega) {
+					g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(managedResource1), managedResource1)).To(Succeed())
+
+					patch := client.MergeFrom(managedResource1.DeepCopy())
+					managedResource1.Status.ObservedGeneration = managedResource1.Generation
+					managedResource1.Status.Conditions = []gardencorev1beta1.Condition{
+						{
+							Type:               resourcesv1alpha1.ResourcesApplied,
+							Status:             gardencorev1beta1.ConditionTrue,
+							LastTransitionTime: metav1.Time{Time: fakeClock.Now()},
+							LastUpdateTime:     metav1.Time{Time: fakeClock.Now()},
+						},
+						{
+							Type:               resourcesv1alpha1.ResourcesHealthy,
+							Status:             gardencorev1beta1.ConditionTrue,
+							LastTransitionTime: metav1.Time{Time: fakeClock.Now()},
+							LastUpdateTime:     metav1.Time{Time: fakeClock.Now()},
+						},
+						{
+							Type:               resourcesv1alpha1.ResourcesProgressing,
+							Status:             gardencorev1beta1.ConditionFalse,
+							LastTransitionTime: metav1.Time{Time: fakeClock.Now()},
+							LastUpdateTime:     metav1.Time{Time: fakeClock.Now()},
+						},
+					}
+					g.Expect(testClient.Status().Patch(ctx, managedResource1, patch)).To(Succeed())
+				}).Should(Succeed())
+
+				managedResource2 := &resourcesv1alpha1.ManagedResource{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-2",
+						Namespace: testNamespace.Name,
+						Labels: map[string]string{
+							testID: testRunID,
+						},
+					},
+					Spec: resourcesv1alpha1.ManagedResourceSpec{
+						Class: pointer.String("test"),
+						SecretRefs: []corev1.LocalObjectReference{
+							{Name: "test-2"},
+						},
+					},
+				}
+				Expect(testClient.Create(ctx, managedResource2)).To(Succeed())
+
+				Eventually(func() error {
+					return mgrClient.Get(ctx, client.ObjectKeyFromObject(managedResource2), managedResource2)
+				}).Should(Succeed())
+
+				DeferCleanup(func() {
+					By("Delete Managed Resource")
+					Expect(testClient.Delete(ctx, managedResource1)).To(Succeed())
+					Expect(testClient.Delete(ctx, managedResource2)).To(Succeed())
+
+					By("Ensure Managed Resource is gone")
+					Eventually(func() error {
+						return mgrClient.Get(ctx, client.ObjectKeyFromObject(managedResource1), managedResource1)
+					}).Should(BeNotFoundError())
+
+					Eventually(func() error {
+						return mgrClient.Get(ctx, client.ObjectKeyFromObject(managedResource2), managedResource2)
+					}).Should(BeNotFoundError())
+				})
+			})
+
+			It("SystemComponentsHealthy condition should not fail beacause of Managed Resource", func() {
+				By("Expect conditions to be set")
+				Eventually(func(g Gomega) []gardencorev1beta1.Condition {
+					g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(shoot), shoot)).To(Succeed())
+					return shoot.Status.Conditions
+				}).Should(And(
+					ContainCondition(OfType(gardencorev1beta1.ShootAPIServerAvailable), WithStatus(gardencorev1beta1.ConditionTrue), WithReason("HealthzRequestSucceeded"), WithMessageSubstrings("API server /healthz endpoint responded with success status code.")),
+					ContainCondition(OfType(gardencorev1beta1.ShootControlPlaneHealthy), WithStatus(gardencorev1beta1.ConditionProgressing), WithReason("DeploymentMissing"), WithMessageSubstrings("Missing required deployments: [gardener-resource-manager kube-apiserver kube-controller-manager kube-scheduler]")),
+					ContainCondition(OfType(gardencorev1beta1.ShootObservabilityComponentsHealthy), WithStatus(gardencorev1beta1.ConditionProgressing), WithReason("DeploymentMissing"), WithMessageSubstrings("Missing required deployments: [grafana kube-state-metrics]")),
+					ContainCondition(OfType(gardencorev1beta1.ShootEveryNodeReady), WithStatus(gardencorev1beta1.ConditionProgressing), WithReason("MissingNodes")),
+					ContainCondition(OfType(gardencorev1beta1.ShootSystemComponentsHealthy), WithStatus(gardencorev1beta1.ConditionProgressing), WithReason("NoTunnelDeployed"), WithMessageSubstrings("no tunnels are currently deployed to perform health-check on")),
+				))
+			})
+		})
+
+		Context("when Managed Resources of spec.class=nil in shoot namespace in seed are not healthy", func() {
+			JustBeforeEach(func() {
+				// kube-apiserver deployment is required because care controller doesn't check any other
+				// condition if APIServer is down.
+				createDeployment([]string{"kube-apiserver"})
+
+				managedResource1 := &resourcesv1alpha1.ManagedResource{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-1",
+						Namespace: testNamespace.Name,
+						Labels: map[string]string{
+							testID: testRunID,
+						},
+					},
+					Spec: resourcesv1alpha1.ManagedResourceSpec{
+						SecretRefs: []corev1.LocalObjectReference{
+							{Name: "test-1"},
+						},
+					},
+				}
+				Expect(testClient.Create(ctx, managedResource1)).To(Succeed())
+
+				Eventually(func() error {
+					return mgrClient.Get(ctx, client.ObjectKeyFromObject(managedResource1), managedResource1)
+				}).Should(Succeed())
+
+				By("Patch Managed Resource status")
+				Eventually(func(g Gomega) {
+					g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(managedResource1), managedResource1)).To(Succeed())
+
+					patch := client.MergeFrom(managedResource1.DeepCopy())
+					managedResource1.Status.ObservedGeneration = managedResource1.Generation
+					managedResource1.Status.Conditions = []gardencorev1beta1.Condition{
+						{
+							Type:               resourcesv1alpha1.ResourcesApplied,
+							Status:             gardencorev1beta1.ConditionFalse,
+							LastTransitionTime: metav1.Time{Time: fakeClock.Now()},
+							LastUpdateTime:     metav1.Time{Time: fakeClock.Now()},
+							Reason:             "ApplyFailed",
+							Message:            "Resources failed to get applied",
+						},
+						{
+							Type:               resourcesv1alpha1.ResourcesHealthy,
+							Status:             gardencorev1beta1.ConditionTrue,
+							LastTransitionTime: metav1.Time{Time: fakeClock.Now()},
+							LastUpdateTime:     metav1.Time{Time: fakeClock.Now()},
+						},
+						{
+							Type:               resourcesv1alpha1.ResourcesProgressing,
+							Status:             gardencorev1beta1.ConditionFalse,
+							LastTransitionTime: metav1.Time{Time: fakeClock.Now()},
+							LastUpdateTime:     metav1.Time{Time: fakeClock.Now()},
+						},
+					}
+					g.Expect(testClient.Status().Patch(ctx, managedResource1, patch)).To(Succeed())
+				}).Should(Succeed())
+
+				DeferCleanup(func() {
+					By("Delete Managed Resource")
+					Expect(testClient.Delete(ctx, managedResource1)).To(Succeed())
+
+					By("Ensure Managed Resource is gone")
+					Eventually(func() error {
+						return mgrClient.Get(ctx, client.ObjectKeyFromObject(managedResource1), managedResource1)
+					}).Should(BeNotFoundError())
+				})
+			})
+
+			It("SystemComponentsHealthy condition should fail because of Managed Resource healthiness", func() {
+				By("Expect conditions to be set")
+				Eventually(func(g Gomega) []gardencorev1beta1.Condition {
+					g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(shoot), shoot)).To(Succeed())
+					return shoot.Status.Conditions
+				}).Should(And(
+					ContainCondition(OfType(gardencorev1beta1.ShootAPIServerAvailable), WithStatus(gardencorev1beta1.ConditionTrue), WithReason("HealthzRequestSucceeded"), WithMessageSubstrings("API server /healthz endpoint responded with success status code.")),
+					ContainCondition(OfType(gardencorev1beta1.ShootControlPlaneHealthy), WithStatus(gardencorev1beta1.ConditionProgressing), WithReason("DeploymentMissing"), WithMessageSubstrings("Missing required deployments: [gardener-resource-manager kube-apiserver kube-controller-manager kube-scheduler]")),
+					ContainCondition(OfType(gardencorev1beta1.ShootObservabilityComponentsHealthy), WithStatus(gardencorev1beta1.ConditionProgressing), WithReason("DeploymentMissing"), WithMessageSubstrings("Missing required deployments: [grafana kube-state-metrics]")),
+					ContainCondition(OfType(gardencorev1beta1.ShootEveryNodeReady), WithStatus(gardencorev1beta1.ConditionProgressing), WithReason("MissingNodes")),
+					ContainCondition(OfType(gardencorev1beta1.ShootSystemComponentsHealthy), WithStatus(gardencorev1beta1.ConditionProgressing), WithReason("ApplyFailed"), WithMessageSubstrings("Resources failed to get applied")),
+				))
+			})
+		})
 	})
 })
+
+func createDeployment(names []string) {
+	for _, name := range names {
+		deployment := &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: testNamespace.Name,
+				Labels: map[string]string{
+					testID:                      testRunID,
+					v1beta1constants.GardenRole: getRole(name),
+				},
+			},
+			Spec: appsv1.DeploymentSpec{
+				Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"foo": "bar"}},
+				Replicas: pointer.Int32(1),
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"foo": "bar"}},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{{
+							Name:  "foo-container",
+							Image: "foo",
+						}},
+					},
+				},
+			},
+		}
+
+		By("Create Deployment " + name)
+		Expect(testClient.Create(ctx, deployment)).To(Succeed(), "for deployment "+name)
+		log.Info("Created Deployment for test", "deployment", client.ObjectKeyFromObject(deployment))
+
+		By("Ensure manager has observed deployment " + name)
+		Eventually(func() error {
+			return mgrClient.Get(ctx, client.ObjectKeyFromObject(deployment), deployment)
+		}).Should(Succeed())
+
+		DeferCleanup(func() {
+			By("Delete Deployment " + name)
+			Expect(testClient.Delete(ctx, deployment)).To(Succeed(), "for deployment "+name)
+
+			By("Ensure Deployment " + name + " is gone")
+			Eventually(func() error {
+				return mgrClient.Get(ctx, client.ObjectKeyFromObject(deployment), deployment)
+			}).Should(BeNotFoundError(), "for deployment "+name)
+
+			By("Ensure manager has observed deployment deletion " + name)
+			Eventually(func() error {
+				return mgrClient.Get(ctx, client.ObjectKeyFromObject(deployment), deployment)
+			}).Should(BeNotFoundError())
+		})
+	}
+}
 
 func getRole(name string) string {
 	switch name {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane quality
/kind enhancement

**What this PR does / why we need it**:
This PR considers all MRs present in `shoot` namespace in `seed` for health check except one having class `seed`. Now all MR which follow the above condition is considered for shoot `ShootSystemComponentsHealthy` condition.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/6775

**Special notes for your reviewer**:
If any MR gets stuck in `Progressing` for more than `managedResourceProgressingThreshold`, It will set `SystemComponentsHealthy` to false as follow.
```
 - lastTransitionTime: "2023-02-07T11:19:26Z"
      lastUpdateTime: "2023-02-07T11:19:26Z"
      message: ManagedResource extension-networking-calico-config is progressing for
        more than 5m0s
      reason: ProgressingRolloutStuck
      status: Progressing
      type: SystemComponentsHealthy
```
After this PR all extensions can drop MR health check.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature developer
Now by default, Gardener performs health check for all the `ManagedResource`s with `.spec.class=nil` created in the shoot namespaces. Extensions using Gardener `v1.65.0` onwards can drop the health check for the MangedResource.
```
