### PR TITLE
Improve logging in `ManagedResource` controller

### DIFF
--- a/pkg/resourcemanager/controller/managedresource/reconciler.go
+++ b/pkg/resourcemanager/controller/managedresource/reconciler.go
@@ -532,7 +532,7 @@ func (r *Reconciler) applyNewResources(ctx context.Context, log logr.Logger, ori
 		case controllerutil.OperationResultUpdated:
 			resourceLogger.Info("Updated resource because its actual state differed from the desired state")
 		case controllerutil.OperationResultNone:
-			resourceLogger.V(1).Info("Resource was neither created or updated because its actual state matches with the desired state")
+			resourceLogger.V(1).Info("Resource was neither created nor updated because its actual state matches with the desired state")
 		}
 	}
 

--- a/pkg/resourcemanager/controller/managedresource/reconciler.go
+++ b/pkg/resourcemanager/controller/managedresource/reconciler.go
@@ -486,9 +486,11 @@ func (r *Reconciler) applyNewResources(ctx context.Context, log logr.Logger, ori
 			scaledVertically   = isScaled(obj.obj, verticallyScaledObjects, equivalences)
 		)
 
-		log.Info("Applying", "resource", resource)
+		resourceLogger := log.WithValues("resource", resource)
 
-		if operationResult, err := controllerutils.TypedCreateOrUpdate(ctx, r.TargetClient, r.TargetScheme, current, pointer.BoolDeref(r.Config.AlwaysUpdate, false), func() error {
+		resourceLogger.V(1).Info("Applying")
+
+		operationResult, err := controllerutils.TypedCreateOrUpdate(ctx, r.TargetClient, r.TargetScheme, current, pointer.BoolDeref(r.Config.AlwaysUpdate, false), func() error {
 			metadata, err := meta.Accessor(obj.obj)
 			if err != nil {
 				return fmt.Errorf("error getting metadata of object %q: %s", resource, err)
@@ -507,10 +509,9 @@ func (r *Reconciler) applyNewResources(ctx context.Context, log logr.Logger, ori
 			}
 
 			return merge(origin, obj.obj, current, obj.forceOverwriteLabels, obj.oldInformation.Labels, obj.forceOverwriteAnnotations, obj.oldInformation.Annotations, scaledHorizontally, scaledVertically)
-		}); err != nil {
+		})
+		if err != nil {
 			if apierrors.IsConflict(err) {
-				log.Info("Conflict while applying object", "object", resource, "err", err)
-				// return conflict error directly, so that the update will be retried
 				return err
 			}
 
@@ -523,6 +524,15 @@ func (r *Reconciler) applyNewResources(ctx context.Context, log logr.Logger, ori
 			}
 
 			return fmt.Errorf("error during apply of object %q: %s", resource, err)
+		}
+
+		switch operationResult {
+		case controllerutil.OperationResultCreated:
+			resourceLogger.Info("Created resource because it was not existing before")
+		case controllerutil.OperationResultUpdated:
+			resourceLogger.Info("Updated resource because its actual state differed from the desired state")
+		case controllerutil.OperationResultNone:
+			resourceLogger.V(1).Info("Resource was neither created or updated because its actual state matches with the desired state")
 		}
 	}
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area logging ops-productivity
/kind enhancement

**What this PR does / why we need it**:
Improve logging in `ManagedResource` controller by only logging something for a resource when the operation result is not `None` (otherwise, logging is behind `V(1)`).

**Special notes for your reviewer**:
/cc @ScheererJ 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
