### PR TITLE
Allow vpn-client in kube-apiserver to talk to seed apiserver in case of HA VPN

### DIFF
--- a/pkg/operation/botanist/component/kubeapiserver/deployment.go
+++ b/pkg/operation/botanist/component/kubeapiserver/deployment.go
@@ -782,6 +782,7 @@ func (k *kubeAPIServer) handleVPNSettingsHA(
 ) {
 	deployment.Spec.Template.Spec.ServiceAccountName = serviceAccountName
 	deployment.Spec.Template.Labels[v1beta1constants.LabelNetworkPolicyToShootNetworks] = v1beta1constants.LabelNetworkPolicyAllowed
+	deployment.Spec.Template.Labels[v1beta1constants.LabelNetworkPolicyToSeedAPIServer] = v1beta1constants.LabelNetworkPolicyAllowed
 	for i := 0; i < k.values.VPN.HighAvailabilityNumberOfSeedServers; i++ {
 		deployment.Spec.Template.Spec.Containers = append(deployment.Spec.Template.Spec.Containers, *k.vpnSeedClientContainer(i))
 	}

--- a/pkg/operation/botanist/component/kubeapiserver/kube_apiserver_test.go
+++ b/pkg/operation/botanist/component/kubeapiserver/kube_apiserver_test.go
@@ -1710,18 +1710,53 @@ rules:
 				}))
 			})
 
-			It("should have the expected pod template labels", func() {
-				deployAndRead()
+			Context("expected pod template labels", func() {
+				var defaultLabels map[string]string
 
-				Expect(deployment.Spec.Template.Labels).To(Equal(map[string]string{
-					"gardener.cloud/role":              "controlplane",
-					"app":                              "kubernetes",
-					"role":                             "apiserver",
-					"networking.gardener.cloud/to-dns": "allowed",
-					"networking.gardener.cloud/to-private-networks": "allowed",
-					"networking.gardener.cloud/to-public-networks":  "allowed",
-					"networking.gardener.cloud/from-prometheus":     "allowed",
-				}))
+				BeforeEach(func() {
+					defaultLabels = map[string]string{
+						"gardener.cloud/role":              "controlplane",
+						"app":                              "kubernetes",
+						"role":                             "apiserver",
+						"networking.gardener.cloud/to-dns": "allowed",
+						"networking.gardener.cloud/to-private-networks": "allowed",
+						"networking.gardener.cloud/to-public-networks":  "allowed",
+						"networking.gardener.cloud/from-prometheus":     "allowed",
+					}
+				})
+
+				It("should have the expected pod template labels", func() {
+					deployAndRead()
+
+					Expect(deployment.Spec.Template.Labels).To(Equal(defaultLabels))
+				})
+
+				It("should have the expected pod template labels with vpn enabled", func() {
+					kapi = New(kubernetesInterface, namespace, sm, Values{
+						IsNodeless:     true,
+						RuntimeVersion: runtimeVersion,
+						Version:        version,
+						VPN:            VPNConfig{Enabled: true},
+					})
+					deployAndRead()
+
+					Expect(deployment.Spec.Template.Labels).To(Equal(defaultLabels))
+				})
+
+				It("should have the expected pod template labels with ha vpn enabled", func() {
+					kapi = New(kubernetesInterface, namespace, sm, Values{
+						IsNodeless:     true,
+						RuntimeVersion: runtimeVersion,
+						Version:        version,
+						VPN:            VPNConfig{Enabled: true, HighAvailabilityEnabled: true},
+					})
+					deployAndRead()
+
+					Expect(deployment.Spec.Template.Labels).To(Equal(utils.MergeStringMaps(defaultLabels, map[string]string{
+						"networking.gardener.cloud/to-shoot-networks": "allowed",
+						"networking.gardener.cloud/to-seed-apiserver": "allowed",
+					})))
+				})
 			})
 
 			Context("expected pod template annotations", func() {


### PR DESCRIPTION
Cherry-pick of #7440

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fixed bug that cause HA VPN to fail in case the seed's apiserver was not targeted by kube-apiserver's vpn-client via a public address
```
