### PR TITLE
Allow vpn-client in kube-apiserver to talk to seed apiserver in case of HA VPN

### DIFF
--- a/pkg/operation/botanist/component/kubeapiserver/deployment.go
+++ b/pkg/operation/botanist/component/kubeapiserver/deployment.go
@@ -968,6 +968,7 @@ func (k *kubeAPIServer) handleVPNSettingsHAReversedVPN(
 ) {
 	deployment.Spec.Template.Spec.ServiceAccountName = serviceAccountName
 	deployment.Spec.Template.Labels[v1beta1constants.LabelNetworkPolicyToShootNetworks] = v1beta1constants.LabelNetworkPolicyAllowed
+	deployment.Spec.Template.Labels[v1beta1constants.LabelNetworkPolicyToSeedAPIServer] = v1beta1constants.LabelNetworkPolicyAllowed
 	for i := 0; i < k.values.VPN.HighAvailabilityNumberOfSeedServers; i++ {
 		deployment.Spec.Template.Spec.Containers = append(deployment.Spec.Template.Spec.Containers, *k.vpnSeedClientContainer(i))
 	}


### PR DESCRIPTION
Cherry-pick of #7440

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fixed bug that cause HA VPN to fail in case the seed's apiserver was not targeted by kube-apiserver's vpn-client via a public address
```
