### PR TITLE
Improve docs for accessing shoot in `provider-local` setup

### DIFF
--- a/docs/deployment/getting_started_locally.md
+++ b/docs/deployment/getting_started_locally.md
@@ -169,7 +169,7 @@ cat <<EOF | sudo tee -a /etc/hosts
 EOF
 ```
 
-To access the `Shoot` you can get the shoot `kubeconfig` by following [Accessing Shoot Clusters](../usage/shoot_access.md).
+To access the `Shoot`, you can acquire a `kubeconfig` by using the [`shoots/adminkubeconfig` subresource](../usage/shoot_access.md#shootsadminkubeconfig-subresource).
 
 ## (Optional): Setting Up a Second Seed Cluster
 

--- a/docs/deployment/getting_started_locally.md
+++ b/docs/deployment/getting_started_locally.md
@@ -169,12 +169,7 @@ cat <<EOF | sudo tee -a /etc/hosts
 EOF
 ```
 
-Now you can access it by running:
-
-```bash
-kubectl -n garden-local get secret local.kubeconfig -o jsonpath={.data.kubeconfig} | base64 -d > /tmp/kubeconfig-shoot-local.yaml
-kubectl --kubeconfig=/tmp/kubeconfig-shoot-local.yaml get nodes
-```
+To access the `Shoot` you can get the shoot `kubeconfig` by following [Accessing Shoot Clusters](../usage/shoot_access.md).
 
 ## (Optional): Setting Up a Second Seed Cluster
 

--- a/docs/development/getting_started_locally.md
+++ b/docs/development/getting_started_locally.md
@@ -177,7 +177,7 @@ local   local          local      local    1.21.0        Awake         Create Pr
 make test-e2e-local-simple KUBECONFIG="$PWD/example/gardener-local/kind/local/kubeconfig"
 ```
 
-When the shoot got successfully created to access the `Shoot` you can get the shoot `kubeconfig` by following [Accessing Shoot Clusters](../usage/shoot_access.md).
+When the `Shoot` got created successfully, you can acquire a `kubeconfig` by using the [`shoots/adminkubeconfig` subresource](../usage/shoot_access.md#shootsadminkubeconfig-subresource) to access the cluster.
 
 ## (Optional): Setting Up a Second Seed Cluster
 

--- a/docs/development/getting_started_locally.md
+++ b/docs/development/getting_started_locally.md
@@ -177,12 +177,7 @@ local   local          local      local    1.21.0        Awake         Create Pr
 make test-e2e-local-simple KUBECONFIG="$PWD/example/gardener-local/kind/local/kubeconfig"
 ```
 
-When the shoot got successfully created you can access it as follows:
-
-```bash
-kubectl -n garden-local get secret local.kubeconfig -o jsonpath={.data.kubeconfig} | base64 -d > /tmp/kubeconfig-shoot-local.yaml
-kubectl --kubeconfig=/tmp/kubeconfig-shoot-local.yaml get nodes
-```
+When the shoot got successfully created to access the `Shoot` you can get the shoot `kubeconfig` by following [Accessing Shoot Clusters](../usage/shoot_access.md).
 
 ## (Optional): Setting Up a Second Seed Cluster
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area documentation
/kind enhancement

**What this PR does / why we need it**:
In the `provider-local` setup by default we create Shoot without `Static Token`. So there is no `kubeconfig` present in the project namespace in the garden cluster. To access shoot one need to follow [this](https://github.com/gardener/gardener/blob/master/docs/usage/shoot_access.md) guide.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
