### PR TITLE
Revert "Reintroduce seed zones admission checks #7403"

### DIFF
--- a/plugin/pkg/managedseed/validator/admission_test.go
+++ b/plugin/pkg/managedseed/validator/admission_test.go
@@ -16,7 +16,6 @@ package validator_test
 
 import (
 	"context"
-	"net/http"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -472,10 +471,6 @@ var _ = Describe("ManagedSeed", func() {
 					})),
 					PointTo(MatchFields(IgnoreExtras, Fields{
 						"Type":  Equal(field.ErrorTypeInvalid),
-						"Field": Equal("spec.gardenlet.config.seedConfig.spec.provider.zones"),
-					})),
-					PointTo(MatchFields(IgnoreExtras, Fields{
-						"Type":  Equal(field.ErrorTypeInvalid),
 						"Field": Equal("spec.gardenlet.config.seedConfig.spec.settings.verticalPodAutoscaler.enabled"),
 					})),
 				))
@@ -516,62 +511,6 @@ var _ = Describe("ManagedSeed", func() {
 						"Field": Equal("spec.gardenlet.config.seedConfig.spec.ingress.domain"),
 					})),
 				))
-			})
-		})
-
-		Context("ManagedSeed Update", func() {
-			var (
-				ctx                            = context.Background()
-				oldManagedSeed, newManagedSeed *seedmanagement.ManagedSeed
-			)
-
-			BeforeEach(func() {
-				oldManagedSeed = managedSeed.DeepCopy()
-				newManagedSeed = managedSeed.DeepCopy()
-
-				gardenletConfig := &gardenletv1alpha1.GardenletConfiguration{
-					TypeMeta: metav1.TypeMeta{
-						APIVersion: gardenletv1alpha1.SchemeGroupVersion.String(),
-						Kind:       "GardenletConfiguration",
-					},
-					SeedConfig: &gardenletv1alpha1.SeedConfig{
-						SeedTemplate: gardencorev1beta1.SeedTemplate{
-							Spec: gardencorev1beta1.SeedSpec{
-								Provider: gardencorev1beta1.SeedProvider{
-									Zones: []string{zone1, zone2},
-								},
-							},
-						},
-					},
-				}
-				oldManagedSeed.Spec.Gardenlet = &seedmanagement.Gardenlet{Config: gardenletConfig}
-
-				shoot.Spec.Provider.Workers[0].Zones = []string{zone2}
-				newGardenletConfig := gardenletConfig.DeepCopy()
-				newGardenletConfig.SeedConfig.Spec.Provider.Zones = shoot.Spec.Provider.Workers[0].Zones
-				newManagedSeed.Spec.Gardenlet = &seedmanagement.Gardenlet{Config: newGardenletConfig}
-			})
-
-			It("should allow zone removal there are no shoots", func() {
-				coreClient.AddReactor("get", "shoots", func(action testing.Action) (bool, runtime.Object, error) {
-					return true, shoot, nil
-				})
-				Expect(admissionHandler.Admit(ctx, getManagedSeedUpdateAttributes(oldManagedSeed, newManagedSeed), nil)).To(Succeed())
-			})
-
-			It("should forbid zone removal there are shoots", func() {
-				coreClient.AddReactor("get", "shoots", func(action testing.Action) (bool, runtime.Object, error) {
-					return true, shoot, nil
-				})
-
-				shoot := &core.Shoot{Spec: core.ShootSpec{SeedName: &newManagedSeed.Name}}
-				Expect(coreInformerFactory.Core().InternalVersion().Shoots().Informer().GetStore().Add(shoot)).To(Succeed())
-
-				err := admissionHandler.Admit(ctx, getManagedSeedUpdateAttributes(oldManagedSeed, newManagedSeed), nil)
-				statusError, ok := err.(*apierrors.StatusError)
-				Expect(ok).To(BeTrue())
-				Expect(statusError.Status().Code).To(Equal(int32(http.StatusForbidden)))
-				Expect(statusError.Status().Status).To(Equal(metav1.StatusFailure))
 			})
 		})
 	})

--- a/plugin/pkg/seed/validator/admission.go
+++ b/plugin/pkg/seed/validator/admission.go
@@ -124,23 +124,11 @@ func (v *ValidateSeed) Validate(_ context.Context, a admission.Attributes, _ adm
 		return nil
 	}
 
-	switch a.GetOperation() {
-	case admission.Update:
-		return v.validateSeedUpdate(a)
-	case admission.Delete:
+	if a.GetOperation() == admission.Delete {
 		return v.validateSeedDeletion(a)
 	}
 
 	return nil
-}
-
-func (v *ValidateSeed) validateSeedUpdate(a admission.Attributes) error {
-	oldSeed, newSeed, err := getOldAndNewSeeds(a)
-	if err != nil {
-		return err
-	}
-
-	return admissionutils.ValidateZoneRemovalFromSeeds(&oldSeed.Spec, &newSeed.Spec, newSeed.Name, v.shootLister, "Seed")
 }
 
 func (v *ValidateSeed) validateSeedDeletion(a admission.Attributes) error {
@@ -155,21 +143,4 @@ func (v *ValidateSeed) validateSeedDeletion(a admission.Attributes) error {
 		return admission.NewForbidden(a, fmt.Errorf("cannot delete seed %s since it is still used by shoot(s)", seedName))
 	}
 	return nil
-}
-
-func getOldAndNewSeeds(attrs admission.Attributes) (*core.Seed, *core.Seed, error) {
-	var (
-		oldSeed, newSeed *core.Seed
-		ok               bool
-	)
-
-	if oldSeed, ok = attrs.GetOldObject().(*core.Seed); !ok {
-		return nil, nil, apierrors.NewInternalError(errors.New("failed to convert old resource into Seed object"))
-	}
-
-	if newSeed, ok = attrs.GetObject().(*core.Seed); !ok {
-		return nil, nil, apierrors.NewInternalError(errors.New("failed to convert new resource into Seed object"))
-	}
-
-	return oldSeed, newSeed, nil
 }

--- a/plugin/pkg/seed/validator/admission_test.go
+++ b/plugin/pkg/seed/validator/admission_test.go
@@ -78,31 +78,6 @@ var _ = Describe("validator", func() {
 			admissionHandler.SetInternalCoreInformerFactory(coreInformerFactory)
 		})
 
-		Context("Seed Update", func() {
-			var oldSeed, newSeed *core.Seed
-
-			BeforeEach(func() {
-				oldSeed = seedBase.DeepCopy()
-				newSeed = seedBase.DeepCopy()
-
-				oldSeed.Spec.Provider.Zones = []string{"1", "2"}
-				newSeed.Spec.Provider.Zones = []string{"2"}
-			})
-
-			It("should allow zone removal there are no shoots", func() {
-				attrs := admission.NewAttributesRecord(newSeed, oldSeed, core.Kind("Seed").WithVersion("version"), "", seed.Name, core.Resource("seeds").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, nil)
-
-				Expect(admissionHandler.Validate(context.TODO(), attrs, nil)).To(Succeed())
-			})
-
-			It("should forbid zone removal when there are shoots", func() {
-				Expect(coreInformerFactory.Core().InternalVersion().Shoots().Informer().GetStore().Add(&shoot)).To(Succeed())
-				attrs := admission.NewAttributesRecord(newSeed, oldSeed, core.Kind("Seed").WithVersion("version"), "", seed.Name, core.Resource("seeds").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, nil)
-
-				Expect(admissionHandler.Validate(context.TODO(), attrs, nil)).To(BeForbiddenError())
-			})
-		})
-
 		// The verification of protection is independent of the Cloud Provider (being checked before).
 		Context("Seed deletion", func() {
 			BeforeEach(func() {

--- a/plugin/pkg/utils/miscellaneous.go
+++ b/plugin/pkg/utils/miscellaneous.go
@@ -20,9 +20,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apiserver/pkg/admission"
-	"k8s.io/utils/pointer"
 
 	"github.com/gardener/gardener/pkg/apis/core"
 	gardencorelisters "github.com/gardener/gardener/pkg/client/core/listers/core/internalversion"
@@ -74,23 +72,4 @@ func NewAttributesWithName(a admission.Attributes, name string) admission.Attrib
 		a.GetOperationOptions(),
 		a.IsDryRun(),
 		a.GetUserInfo())
-}
-
-// ValidateZoneRemovalFromSeeds returns an error when zones are removed from the old seed while it is still in use by
-// shoots.
-func ValidateZoneRemovalFromSeeds(oldSeedSpec, newSeedSpec *core.SeedSpec, seedName string, shootLister gardencorelisters.ShootLister, kind string) error {
-	if removedZones := sets.New[string](oldSeedSpec.Provider.Zones...).Difference(sets.New[string](newSeedSpec.Provider.Zones...)); removedZones.Len() > 0 {
-		shootList, err := GetFilteredShootList(shootLister, func(shoot *core.Shoot) bool {
-			return pointer.StringDeref(shoot.Spec.SeedName, "") == seedName
-		})
-		if err != nil {
-			return err
-		}
-
-		if len(shootList) > 0 {
-			return apierrors.NewForbidden(core.Resource(kind), seedName, fmt.Errorf("cannot remove zones %v from %s %s as there are %d Shoots scheduled to this Seed", sets.List(removedZones), kind, seedName, len(shootList)))
-		}
-	}
-
-	return nil
 }

--- a/plugin/pkg/utils/miscellaneous_test.go
+++ b/plugin/pkg/utils/miscellaneous_test.go
@@ -22,8 +22,6 @@ import (
 	"k8s.io/utils/pointer"
 
 	"github.com/gardener/gardener/pkg/apis/core"
-	gardencoreinformers "github.com/gardener/gardener/pkg/client/core/informers/internalversion"
-	gardencorelisters "github.com/gardener/gardener/pkg/client/core/listers/core/internalversion"
 	. "github.com/gardener/gardener/plugin/pkg/utils"
 )
 
@@ -99,66 +97,6 @@ var _ = Describe("Miscellaneous", func() {
 			newAttrs := NewAttributesWithName(attrs, name)
 
 			Expect(newAttrs.GetName()).To(Equal(name))
-		})
-	})
-
-	Describe("#ValidateZoneRemovalFromSeeds", func() {
-		var (
-			seedName = "foo"
-			kind     = "foo"
-
-			coreInformerFactory gardencoreinformers.SharedInformerFactory
-			shootLister         gardencorelisters.ShootLister
-
-			oldSeedSpec, newSeedSpec *core.SeedSpec
-			shoot                    *core.Shoot
-		)
-
-		BeforeEach(func() {
-			coreInformerFactory = gardencoreinformers.NewSharedInformerFactory(nil, 0)
-			shootLister = coreInformerFactory.Core().InternalVersion().Shoots().Lister()
-
-			oldSeedSpec = &core.SeedSpec{
-				Provider: core.SeedProvider{
-					Zones: []string{"1", "2"},
-				},
-			}
-			newSeedSpec = oldSeedSpec.DeepCopy()
-
-			shoot = &core.Shoot{
-				Spec: core.ShootSpec{
-					SeedName: &seedName,
-				},
-			}
-		})
-
-		It("should do nothing because a new zone was added", func() {
-			newSeedSpec.Provider.Zones = append(newSeedSpec.Provider.Zones, "3")
-
-			Expect(ValidateZoneRemovalFromSeeds(oldSeedSpec, newSeedSpec, seedName, shootLister, kind)).To(Succeed())
-		})
-
-		It("should do nothing because no zone was removed and no shoots exist", func() {
-			Expect(ValidateZoneRemovalFromSeeds(oldSeedSpec, newSeedSpec, seedName, shootLister, kind)).To(Succeed())
-		})
-
-		It("should do nothing because no zone was removed even though shoots exist", func() {
-			Expect(coreInformerFactory.Core().InternalVersion().Shoots().Informer().GetStore().Add(shoot)).To(Succeed())
-
-			Expect(ValidateZoneRemovalFromSeeds(oldSeedSpec, newSeedSpec, seedName, shootLister, kind)).To(Succeed())
-		})
-
-		It("should do nothing because zone was removed and no shoots exist", func() {
-			newSeedSpec.Provider.Zones = []string{"2"}
-
-			Expect(ValidateZoneRemovalFromSeeds(oldSeedSpec, newSeedSpec, seedName, shootLister, kind)).To(Succeed())
-		})
-
-		It("should return an error because zone was removed even though shoots exist", func() {
-			newSeedSpec.Provider.Zones = []string{"2"}
-			Expect(coreInformerFactory.Core().InternalVersion().Shoots().Informer().GetStore().Add(shoot)).To(Succeed())
-
-			Expect(ValidateZoneRemovalFromSeeds(oldSeedSpec, newSeedSpec, seedName, shootLister, kind)).To(MatchError(ContainSubstring("cannot remove zones")))
 		})
 	})
 })


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area high-availability
/kind api-change

**What this PR does / why we need it**:
This PR reverts the changes done in #7403 .
The `topology` webhook on the Azure provider extension does not act on `istio` namespace. Because of this pods in `istio` namespace was not able get scheduled on nodes, as the nodes are having `topology.kubernetes.io/zone=westeurope-1` and the pods are having the following pod affinity rules
```
spec:
  affinity:
    nodeAffinity:
      requiredDuringSchedulingIgnoredDuringExecution:
        nodeSelectorTerms:
        - matchExpressions:
          - key: topology.kubernetes.io/zone
            operator: In
            values:
            - 1
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
