### PR TITLE
Validate `PodSecurity` kube-apiserver admission plugin config

### DIFF
--- a/pkg/operation/botanist/kubeapiserver_test.go
+++ b/pkg/operation/botanist/kubeapiserver_test.go
@@ -604,7 +604,7 @@ exemptions:
 					})
 				})
 
-				Context("PodSecurity admission config is neither v1alpha1 nor v1beta1", func() {
+				Context("PodSecurity admission config is neither v1alpha1 nor v1beta1 nor v1", func() {
 					BeforeEach(func() {
 						shootCopy.Spec.Kubernetes.KubeAPIServer.AdmissionPlugins = []gardencorev1beta1.AdmissionPlugin{
 							{
@@ -612,10 +612,10 @@ exemptions:
 								Config: &runtime.RawExtension{Raw: []byte(`apiVersion: pod-security.admission.config.k8s.io/foo
 kind: PodSecurityConfiguration-bar
 defaults:
-enforce: "privileged"
-enforce-version: "latest"
+  enforce: "privileged"
+  enforce-version: "latest"
 exemptions:
-usernames: ["admin"]
+  usernames: ["admin"]
 `),
 								},
 							},

--- a/pkg/utils/validation/admissionplugins/admissionplugins.go
+++ b/pkg/utils/validation/admissionplugins/admissionplugins.go
@@ -17,62 +17,97 @@ package admissionplugins
 import (
 	"fmt"
 
+	"github.com/Masterminds/semver"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/apimachinery/pkg/runtime/serializer/json"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	admissionapiv1 "k8s.io/pod-security-admission/admission/api/v1"
+	admissionapiv1alpha1 "k8s.io/pod-security-admission/admission/api/v1alpha1"
+	admissionapiv1beta1 "k8s.io/pod-security-admission/admission/api/v1beta1"
 	"k8s.io/utils/pointer"
 
 	"github.com/gardener/gardener/pkg/apis/core"
 	versionutils "github.com/gardener/gardener/pkg/utils/version"
 )
 
-// admissionPluginsVersionRanges contains the version ranges for all Kubernetes admission plugins.
-// Extracted from https://raw.githubusercontent.com/kubernetes/kubernetes/release-${version}/pkg/kubeapiserver/options/plugins.go
-// and https://raw.githubusercontent.com/kubernetes/kubernetes/release-${version}/staging/src/k8s.io/apiserver/pkg/server/plugins.go.
-// To maintain this list for each new Kubernetes version:
-//   - Run hack/compare-k8s-admission-plugins.sh <old-version> <new-version> (e.g. 'hack/compare-k8s-admission-plugins.sh 1.22 1.23').
-//     It will present 2 lists of admission plugins: those added and those removed in <new-version> compared to <old-version> and
-//   - Add all added admission plugins to the map with <new-version> as AddedInVersion and no RemovedInVersion.
-//   - For any removed admission plugin, add <new-version> as RemovedInVersion to the already existing admission plugin in the map.
+var (
+	// admissionPluginsVersionRanges contains the version ranges for all Kubernetes admission plugins.
+	// Extracted from https://raw.githubusercontent.com/kubernetes/kubernetes/release-${version}/pkg/kubeapiserver/options/plugins.go
+	// and https://raw.githubusercontent.com/kubernetes/kubernetes/release-${version}/staging/src/k8s.io/apiserver/pkg/server/plugins.go.
+	// To maintain this list for each new Kubernetes version:
+	//   - Run hack/compare-k8s-admission-plugins.sh <old-version> <new-version> (e.g. 'hack/compare-k8s-admission-plugins.sh 1.22 1.23').
+	//     It will present 2 lists of admission plugins: those added and those removed in <new-version> compared to <old-version> and
+	//   - Add all added admission plugins to the map with <new-version> as AddedInVersion and no RemovedInVersion.
+	//   - For any removed admission plugin, add <new-version> as RemovedInVersion to the already existing admission plugin in the map.
+	admissionPluginsVersionRanges = map[string]*AdmissionPluginVersionRange{
+		"AlwaysAdmit":                          {},
+		"AlwaysDeny":                           {},
+		"AlwaysPullImages":                     {},
+		"CertificateApproval":                  {AddedInVersion: "1.18"},
+		"CertificateSigning":                   {AddedInVersion: "1.18"},
+		"CertificateSubjectRestriction":        {AddedInVersion: "1.18"},
+		"DefaultIngressClass":                  {AddedInVersion: "1.18"},
+		"DefaultStorageClass":                  {},
+		"DefaultTolerationSeconds":             {},
+		"DenyEscalatingExec":                   {RemovedInVersion: "1.21"},
+		"DenyExecOnPrivileged":                 {RemovedInVersion: "1.21"},
+		"DenyServiceExternalIPs":               {AddedInVersion: "1.21"},
+		"EventRateLimit":                       {},
+		"ExtendedResourceToleration":           {},
+		"ImagePolicyWebhook":                   {},
+		"LimitPodHardAntiAffinityTopology":     {},
+		"LimitRanger":                          {},
+		"MutatingAdmissionWebhook":             {Required: true},
+		"NamespaceAutoProvision":               {},
+		"NamespaceExists":                      {},
+		"NamespaceLifecycle":                   {Required: true},
+		"NodeRestriction":                      {Required: true},
+		"OwnerReferencesPermissionEnforcement": {},
+		"PersistentVolumeClaimResize":          {},
+		"PersistentVolumeLabel":                {},
+		"PodNodeSelector":                      {},
+		"PodPreset":                            {RemovedInVersion: "1.20"},
+		"PodSecurity":                          {AddedInVersion: "1.22", Required: true},
+		"PodSecurityPolicy":                    {RemovedInVersion: "1.25"},
+		"PodTolerationRestriction":             {},
+		"Priority":                             {Required: true},
+		"ResourceQuota":                        {},
+		"RuntimeClass":                         {},
+		"SecurityContextDeny":                  {Forbidden: true},
+		"ServiceAccount":                       {},
+		"StorageObjectInUseProtection":         {Required: true},
+		"TaintNodesByCondition":                {},
+		"ValidatingAdmissionPolicy":            {AddedInVersion: "1.26"},
+		"ValidatingAdmissionWebhook":           {Required: true},
+	}
 
-var admissionPluginsVersionRanges = map[string]*AdmissionPluginVersionRange{
-	"AlwaysAdmit":                          {},
-	"AlwaysDeny":                           {},
-	"AlwaysPullImages":                     {},
-	"CertificateApproval":                  {AddedInVersion: "1.18"},
-	"CertificateSigning":                   {AddedInVersion: "1.18"},
-	"CertificateSubjectRestriction":        {AddedInVersion: "1.18"},
-	"DefaultIngressClass":                  {AddedInVersion: "1.18"},
-	"DefaultStorageClass":                  {},
-	"DefaultTolerationSeconds":             {},
-	"DenyEscalatingExec":                   {RemovedInVersion: "1.21"},
-	"DenyExecOnPrivileged":                 {RemovedInVersion: "1.21"},
-	"DenyServiceExternalIPs":               {AddedInVersion: "1.21"},
-	"EventRateLimit":                       {},
-	"ExtendedResourceToleration":           {},
-	"ImagePolicyWebhook":                   {},
-	"LimitPodHardAntiAffinityTopology":     {},
-	"LimitRanger":                          {},
-	"MutatingAdmissionWebhook":             {Required: true},
-	"NamespaceAutoProvision":               {},
-	"NamespaceExists":                      {},
-	"NamespaceLifecycle":                   {Required: true},
-	"NodeRestriction":                      {Required: true},
-	"OwnerReferencesPermissionEnforcement": {},
-	"PersistentVolumeClaimResize":          {},
-	"PersistentVolumeLabel":                {},
-	"PodNodeSelector":                      {},
-	"PodPreset":                            {RemovedInVersion: "1.20"},
-	"PodSecurity":                          {AddedInVersion: "1.22", Required: true},
-	"PodSecurityPolicy":                    {RemovedInVersion: "1.25"},
-	"PodTolerationRestriction":             {},
-	"Priority":                             {Required: true},
-	"ResourceQuota":                        {},
-	"RuntimeClass":                         {},
-	"SecurityContextDeny":                  {Forbidden: true},
-	"ServiceAccount":                       {},
-	"StorageObjectInUseProtection":         {Required: true},
-	"TaintNodesByCondition":                {},
-	"ValidatingAdmissionPolicy":            {AddedInVersion: "1.26"},
-	"ValidatingAdmissionWebhook":           {Required: true},
+	runtimeScheme *runtime.Scheme
+	codec         runtime.Codec
+)
+
+func init() {
+	runtimeScheme = runtime.NewScheme()
+	utilruntime.Must(admissionapiv1alpha1.AddToScheme(runtimeScheme))
+	utilruntime.Must(admissionapiv1beta1.AddToScheme(runtimeScheme))
+	utilruntime.Must(admissionapiv1.AddToScheme(runtimeScheme))
+
+	var (
+		ser = json.NewSerializerWithOptions(json.DefaultMetaFactory, runtimeScheme, runtimeScheme, json.SerializerOptions{
+			Yaml:   true,
+			Pretty: false,
+			Strict: false,
+		})
+		versions = schema.GroupVersions([]schema.GroupVersion{
+			admissionapiv1alpha1.SchemeGroupVersion,
+			admissionapiv1beta1.SchemeGroupVersion,
+			admissionapiv1.SchemeGroupVersion,
+		})
+	)
+
+	codec = serializer.NewCodecFactory(runtimeScheme).CodecForVersions(ser, ser, versions, versions)
 }
 
 // IsAdmissionPluginSupported returns true if the given admission plugin is supported for the given Kubernetes version.
@@ -145,8 +180,63 @@ func ValidateAdmissionPlugins(admissionPlugins []core.AdmissionPlugin, version s
 			if pointer.BoolDeref(plugin.Disabled, false) && admissionPluginsVersionRanges[plugin.Name].Required {
 				allErrs = append(allErrs, field.Forbidden(idxPath, fmt.Sprintf("admission plugin %q cannot be disabled", plugin.Name)))
 			}
+			if err := validateAdmissionPluginConfig(plugin, version, idxPath); err != nil {
+				allErrs = append(allErrs, err)
+			}
 		}
+
 	}
 
 	return allErrs
+}
+
+func validateAdmissionPluginConfig(plugin core.AdmissionPlugin, version string, fldPath *field.Path) *field.Error {
+	kubernetesVersion, err := semver.NewVersion(version)
+	if err != nil {
+		return field.Invalid(field.NewPath("spec", "kubernetes", "version"), version, err.Error())
+	}
+
+	switch plugin.Name {
+	case "PodSecurity":
+		if plugin.Config != nil {
+			config, err := runtime.Decode(codec, plugin.Config.Raw)
+			if err != nil {
+				if runtime.IsNotRegisteredError(err) {
+					return field.Invalid(fldPath.Child("config"), string(plugin.Config.Raw), "expected pod-security.admission.config.k8s.io/v1alpha1.PodSecurityConfiguration, pod-security.admission.config.k8s.io/v1beta1.PodSecurityConfiguration or pod-security.admission.config.k8s.io/v1.PodSecurityConfiguration")
+				}
+				return field.Invalid(fldPath.Child("config"), string(plugin.Config.Raw), fmt.Sprintf("cannot decode the given config: %s", err.Error()))
+			}
+
+			var errorString = "PodSecurityConfiguration apiVersion for Kubernetes version %q should be %q but got %q"
+
+			switch admissionConfigType := config.(type) {
+			case *admissionapiv1alpha1.PodSecurityConfiguration:
+				if !versionutils.ConstraintK8sEqual122.Check(kubernetesVersion) {
+					return field.Invalid(fldPath.Child("config"), string(plugin.Config.Raw), fmt.Sprintf(errorString, version, getPodSecurityConfigAPIVersionForKubernetesVersion(kubernetesVersion), admissionConfigType.APIVersion))
+				}
+			case *admissionapiv1beta1.PodSecurityConfiguration:
+				if !versionutils.ConstraintK8sEqual123.Check(kubernetesVersion) && !versionutils.ConstraintK8sEqual124.Check(kubernetesVersion) {
+					return field.Invalid(fldPath.Child("config"), string(plugin.Config.Raw), fmt.Sprintf(errorString, version, getPodSecurityConfigAPIVersionForKubernetesVersion(kubernetesVersion), admissionConfigType.APIVersion))
+				}
+			case *admissionapiv1.PodSecurityConfiguration:
+				if !versionutils.ConstraintK8sGreaterEqual125.Check(kubernetesVersion) {
+					return field.Invalid(fldPath.Child("config"), string(plugin.Config.Raw), fmt.Sprintf(errorString, version, getPodSecurityConfigAPIVersionForKubernetesVersion(kubernetesVersion), admissionConfigType.APIVersion))
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+func getPodSecurityConfigAPIVersionForKubernetesVersion(version *semver.Version) string {
+	switch {
+	case versionutils.ConstraintK8sEqual122.Check(version):
+		return "pod-security.admission.config.k8s.io/v1alpha1"
+	case versionutils.ConstraintK8sEqual123.Check(version), versionutils.ConstraintK8sEqual124.Check(version):
+		return "pod-security.admission.config.k8s.io/v1beta1"
+	case versionutils.ConstraintK8sGreaterEqual125.Check(version):
+		return "pod-security.admission.config.k8s.io/v1"
+	}
+	return ""
 }

--- a/pkg/utils/validation/admissionplugins/admissionplugins.go
+++ b/pkg/utils/validation/admissionplugins/admissionplugins.go
@@ -184,7 +184,6 @@ func ValidateAdmissionPlugins(admissionPlugins []core.AdmissionPlugin, version s
 				allErrs = append(allErrs, err)
 			}
 		}
-
 	}
 
 	return allErrs

--- a/pkg/utils/validation/admissionplugins/admissionplugins_test.go
+++ b/pkg/utils/validation/admissionplugins/admissionplugins_test.go
@@ -187,7 +187,6 @@ var _ = Describe("admissionplugins", func() {
 							"Detail": ContainSubstring("PodSecurityConfiguration apiVersion for Kubernetes version %q should be %q but got %q", kubernetesVersion, "pod-security.admission.config.k8s.io/v1alpha1", "pod-security.admission.config.k8s.io/v1"),
 						}))))
 					})
-
 				}
 			}
 

--- a/pkg/utils/version/version.go
+++ b/pkg/utils/version/version.go
@@ -43,6 +43,8 @@ var (
 	ConstraintK8sEqual123 *semver.Constraints
 	// ConstraintK8sGreaterEqual123 is a version constraint for versions >= 1.23.
 	ConstraintK8sGreaterEqual123 *semver.Constraints
+	// ConstraintK8sLess123 is a version constraint for versions < 1.23.
+	ConstraintK8sLess123 *semver.Constraints
 	// ConstraintK8sEqual124 is a version constraint for versions == 1.24.
 	ConstraintK8sEqual124 *semver.Constraints
 	// ConstraintK8sLess124 is a version constraint for versions < 1.24.
@@ -78,6 +80,8 @@ func init() {
 	ConstraintK8sEqual123, err = semver.NewConstraint("~ 1.23.x-0")
 	utilruntime.Must(err)
 	ConstraintK8sGreaterEqual123, err = semver.NewConstraint(">= 1.23-0")
+	utilruntime.Must(err)
+	ConstraintK8sLess123, err = semver.NewConstraint("< 1.23-0")
 	utilruntime.Must(err)
 	ConstraintK8sEqual124, err = semver.NewConstraint("~ 1.24.x-0")
 	utilruntime.Must(err)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality usability
/kind enhancement

**What this PR does / why we need it**:
In https://github.com/gardener/gardener/blob/master/docs/usage/pod-security.md#admission-configuration-for-the-podsecurity-admission-plugin, It is clearly stated that:
> ⚠️ Note that pod-security.admission.config.k8s.io/v1 configuration requires v1.25+. For v1.23 and v1.24, use pod-security.admission.config.k8s.io/v1beta1. For v1.22, use pod-security.admission.config.k8s.io/v1alpha1.

Still, if a user provides wrong config for the plugin in the Shoot spec, `kube-apiserver` will fail with:
```
E0208 09:22:16.294759       1 run.go:74] "command failed" err="failed to initialize admission: couldn't init admission plugin \"PodSecurity\": no kind \"PodSecurityConfiguration\" is registered for version \"pod-security.admission.config.k8s.io/v1\" in scheme \"vendor/k8s.io/pod-security-admission/admission/api/scheme/scheme.go:30\""
```

This PR adds validation to prevent such cases.

**Which issue(s) this PR fixes**:
Part of #5250

**Special notes for your reviewer**:
/cc @rfranzke @ary1992 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other user
The `PodSecurity` kube-apiserver admission plugin config in the Shoot, if provided, is now validated.
```
