### PR TITLE
"NET_RAW" capability for the vpn-seed-server

### DIFF
--- a/pkg/operation/botanist/component/vpnseedserver/vpn_seed_server.go
+++ b/pkg/operation/botanist/component/vpnseedserver/vpn_seed_server.go
@@ -322,6 +322,7 @@ func (v *vpnSeedServer) podTemplate(configMap *corev1.ConfigMap, dhSecret, secre
 						Capabilities: &corev1.Capabilities{
 							Add: []corev1.Capability{
 								"NET_ADMIN",
+								"NET_RAW",
 							},
 						},
 					},

--- a/pkg/operation/botanist/component/vpnseedserver/vpn_seed_server_test.go
+++ b/pkg/operation/botanist/component/vpnseedserver/vpn_seed_server_test.go
@@ -298,6 +298,7 @@ admin:
 								Capabilities: &corev1.Capabilities{
 									Add: []corev1.Capability{
 										"NET_ADMIN",
+										"NET_RAW",
 									},
 								},
 							},


### PR DESCRIPTION
**How to categorize this PR?**
/area networking
/kind bug

**What this PR does / why we need it**:
Installation of Gardener 1.62.2 in Debian 11 on k8s 1.25.6 fails to create shoots because `vpn-seed-server` is in state `CrashLoopBackOff`. After debugging I found that `CAP_NET_RAW` is not set automatically on cri-o. In fact the project decided to [remove it for improved security](https://github.com/cri-o/cri-o/pull/2378).

As this might happen with Docker as well in the future and it seems to be the only blocker at the moment to run Gardener on cri-o I would highly appreciate integration of the fix.

**Which issue(s) this PR fixes**:
Fixes #7468