### PR TITLE
Add response rewrite to dns-search-path-optimization.

### DIFF
--- a/docs/usage/dns-search-path-optimization.md
+++ b/docs/usage/dns-search-path-optimization.md
@@ -86,7 +86,7 @@ featureGates:
 In case the feature is enabled in the Gardenlet it can be disabled per shoot cluster by setting the annotation
 `alpha.featuregates.shoot.gardener.cloud/core-dns-rewriting-disabled` to any value.
 
-This will automatically rewrite requests like `service.namespace.svc.cluster.local.other-namespace.svc.cluster.local` to
+This will automatically rewrite requests like `service.namespace.svc.cluster.local.svc.cluster.local` to
 `service.namespace.svc.cluster.local`.
 
 In case applications also target services for name resolution, which are outside of the cluster and have less than `ndots` dots,
@@ -117,5 +117,6 @@ requires that common suffixes contain at least one dot (.) and adds a second dot
 suffix of `example.com` in the configuration would match `*.example.com`.
 
 Since some clients verify the host in the response of a DNS query, the host must also be rewritten.
-For that reason we can't rewrite `www.example.com.default.svc.cluster.local`, as for a rewrite the namespace would not be known.
+For that reason we can't rewrite a query for `service.dst-namespace.svc.cluster.local.src-namespace.svc.cluster.local` or
+`www.example.com.src-namespace.svc.cluster.local` as for an answer rewrite `src-namespace` would not be known.
 

--- a/docs/usage/dns-search-path-optimization.md
+++ b/docs/usage/dns-search-path-optimization.md
@@ -87,8 +87,7 @@ In case the feature is enabled in the Gardenlet it can be disabled per shoot clu
 `alpha.featuregates.shoot.gardener.cloud/core-dns-rewriting-disabled` to any value.
 
 This will automatically rewrite requests like `service.namespace.svc.cluster.local.other-namespace.svc.cluster.local` to
-`service.namespace.svc.cluster.local`. The same holds true for `service.namespace.svc.other-namespace.svc.cluster.local`,
-which will also be rewritten to `service.namespace.svc.cluster.local`.
+`service.namespace.svc.cluster.local`.
 
 In case applications also target services for name resolution, which are outside of the cluster and have less than `ndots` dots,
 it might be helpful to prevent search path application for them as well. One way to achieve it is by adding them to the
@@ -103,14 +102,20 @@ spec:
       rewriting:
         commonSuffixes:
         - gardener.cloud
-        - github.com
+        - example.com
 ...
 ```
 
-DNS requests containing a common suffix and ending in `<namespace>.svc.cluster.local` are assumed to be incorrect application of the
-DNS search path. Therefore, they are rewritten to everything ending in the common suffix. For example, `www.gardener.cloud.namespace.svc.cluster.local` would be rewritten to `www.gardener.cloud`.
+DNS requests containing a common suffix and ending in `.svc.cluster.local` are assumed to be incorrect application of the DNS
+search path. Therefore, they are rewritten to everything ending in the common suffix. For example, `www.gardener.cloud.svc.cluster.local`
+would be rewritten to `www.gardener.cloud`.
 
 Please note that the common suffixes should be long enough and include enough dots (`.`) to prevent random overlap with
 other DNS queries. For example, it would be a bad idea to simply put `com` on the list of common suffixes as there may be
-services/namespaces, which have `com` as part of their name. The effect would be seemingly random DNS requests. Gardener
-enforces at least two dots (`.`) in the common suffixes.
+services/namespaces, which have `com` as part of their name. The effect would be seemingly random DNS requests. Gardener 
+requires that common suffixes contain at least one dot (.) and adds a second dot at the beginning. For instance, a common
+suffix of `example.com` in the configuration would match `*.example.com`.
+
+Since some clients verify the host in the response of a DNS query, the host must also be rewritten.
+For that reason we can't rewrite `www.example.com.default.svc.cluster.local`, as for a rewrite the namespace would not be known.
+

--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -1880,9 +1880,7 @@ func ValidateCoreDNSRewritingCommonSuffixes(commonSuffixes []string, fldPath *fi
 		if strings.Count(s, ".") < 1 {
 			allErrs = append(allErrs, field.Invalid(fldPath.Child("commonSuffixes").Index(i), s, "not enough dots ('.'), at least one dot required"))
 		}
-		if strings.HasPrefix(s, ".") {
-			s = s[1:]
-		}
+		s = strings.TrimPrefix(s, ".")
 		if _, found := suffixes[s]; found {
 			allErrs = append(allErrs, field.Duplicate(fldPath.Child("commonSuffixes").Index(i), s))
 		} else {

--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -1880,6 +1880,9 @@ func ValidateCoreDNSRewritingCommonSuffixes(commonSuffixes []string, fldPath *fi
 		if strings.Count(s, ".") < 1 {
 			allErrs = append(allErrs, field.Invalid(fldPath.Child("commonSuffixes").Index(i), s, "not enough dots ('.'), at least one dot required"))
 		}
+		if strings.HasPrefix(s, ".") {
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("commonSuffixes").Index(i), s, "should not start with a dot ('.'), as it is automatically appended"))
+		}
 		if _, found := suffixes[s]; found {
 			allErrs = append(allErrs, field.Duplicate(fldPath.Child("commonSuffixes").Index(i), s))
 		} else {

--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -1877,8 +1877,8 @@ func ValidateCoreDNSRewritingCommonSuffixes(commonSuffixes []string, fldPath *fi
 
 	suffixes := map[string]struct{}{}
 	for i, s := range commonSuffixes {
-		if strings.Count(s, ".") < 2 {
-			allErrs = append(allErrs, field.Invalid(fldPath.Child("commonSuffixes").Index(i), s, "not enough dots ('.'), at least two dots required"))
+		if strings.Count(s, ".") < 1 {
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("commonSuffixes").Index(i), s, "not enough dots ('.'), at least one dot required"))
 		}
 		if _, found := suffixes[s]; found {
 			allErrs = append(allErrs, field.Duplicate(fldPath.Child("commonSuffixes").Index(i), s))

--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -1881,7 +1881,7 @@ func ValidateCoreDNSRewritingCommonSuffixes(commonSuffixes []string, fldPath *fi
 			allErrs = append(allErrs, field.Invalid(fldPath.Child("commonSuffixes").Index(i), s, "not enough dots ('.'), at least one dot required"))
 		}
 		if strings.HasPrefix(s, ".") {
-			allErrs = append(allErrs, field.Invalid(fldPath.Child("commonSuffixes").Index(i), s, "should not start with a dot ('.'), as it is automatically appended"))
+			s = s[1:]
 		}
 		if _, found := suffixes[s]; found {
 			allErrs = append(allErrs, field.Duplicate(fldPath.Child("commonSuffixes").Index(i), s))

--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -1877,8 +1877,8 @@ func ValidateCoreDNSRewritingCommonSuffixes(commonSuffixes []string, fldPath *fi
 
 	suffixes := map[string]struct{}{}
 	for i, s := range commonSuffixes {
-		if strings.Count(s, ".") < 1 {
-			allErrs = append(allErrs, field.Invalid(fldPath.Child("commonSuffixes").Index(i), s, "not enough dots ('.'), at least one dot required"))
+		if strings.Count(s, ".") < 1 || (s[0] == '.' && strings.Count(s, ".") < 2) {
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("commonSuffixes").Index(i), s, "must contain at least one non-leading dot ('.')"))
 		}
 		s = strings.TrimPrefix(s, ".")
 		if _, found := suffixes[s]; found {

--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -3017,16 +3017,18 @@ var _ = Describe("Shoot Validation Tests", func() {
 				},
 				Entry("should allow no common suffixes", nil, BeEmpty()),
 				Entry("should allow empty common suffixes", []string{}, BeEmpty()),
-				Entry("should allow normal suffixes", []string{".gardener.cloud", ".github.com"}, BeEmpty()),
+				Entry("should allow normal common suffixes", []string{"gardener.cloud", "github.com"}, BeEmpty()),
+				Entry("should not start with a dot", []string{".gardener.cloud"}, ConsistOf(
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":     Equal(field.ErrorTypeInvalid),
+						"BadValue": Equal(".gardener.cloud"),
+						"Detail":   ContainSubstring("should not start with"),
+					})),
+				)),
 				Entry("should not allow too few dots", []string{"foo", "foo.bar"}, ConsistOf(
 					PointTo(MatchFields(IgnoreExtras, Fields{
 						"Type":     Equal(field.ErrorTypeInvalid),
 						"BadValue": Equal("foo"),
-						"Detail":   ContainSubstring("not enough dots"),
-					})),
-					PointTo(MatchFields(IgnoreExtras, Fields{
-						"Type":     Equal(field.ErrorTypeInvalid),
-						"BadValue": Equal("foo.bar"),
 						"Detail":   ContainSubstring("not enough dots"),
 					})),
 				)),

--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -3022,7 +3022,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 					PointTo(MatchFields(IgnoreExtras, Fields{
 						"Type":     Equal(field.ErrorTypeInvalid),
 						"BadValue": Equal("foo"),
-						"Detail":   ContainSubstring("not enough dots"),
+						"Detail":   ContainSubstring("must contain at least one non-leading dot"),
 					})),
 				)),
 				Entry("should not allow duplicate entries", []string{"foo.bar.", ".foo.bar."}, ConsistOf(

--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -3017,14 +3017,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 				},
 				Entry("should allow no common suffixes", nil, BeEmpty()),
 				Entry("should allow empty common suffixes", []string{}, BeEmpty()),
-				Entry("should allow normal common suffixes", []string{"gardener.cloud", "github.com"}, BeEmpty()),
-				Entry("should not start with a dot", []string{".gardener.cloud"}, ConsistOf(
-					PointTo(MatchFields(IgnoreExtras, Fields{
-						"Type":     Equal(field.ErrorTypeInvalid),
-						"BadValue": Equal(".gardener.cloud"),
-						"Detail":   ContainSubstring("should not start with"),
-					})),
-				)),
+				Entry("should allow normal common suffixes", []string{"gardener.cloud", "github.com", ".example.com"}, BeEmpty()),
 				Entry("should not allow too few dots", []string{"foo", "foo.bar"}, ConsistOf(
 					PointTo(MatchFields(IgnoreExtras, Fields{
 						"Type":     Equal(field.ErrorTypeInvalid),
@@ -3032,7 +3025,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 						"Detail":   ContainSubstring("not enough dots"),
 					})),
 				)),
-				Entry("should not allow duplicate entries", []string{"foo.bar.", "foo.bar."}, ConsistOf(
+				Entry("should not allow duplicate entries", []string{"foo.bar.", ".foo.bar."}, ConsistOf(
 					PointTo(MatchFields(IgnoreExtras, Fields{
 						"Type":     Equal(field.ErrorTypeDuplicate),
 						"BadValue": Equal("foo.bar."),

--- a/pkg/operation/botanist/component/coredns/coredns.go
+++ b/pkg/operation/botanist/component/coredns/coredns.go
@@ -800,9 +800,15 @@ func getSearchPathRewrites(enabled bool, clusterDomain string, commonSuffixes []
 	suffixRewrites := ""
 	for _, suffix := range commonSuffixes {
 		suffixRewrites = suffixRewrites + `
-  rewrite stop name regex (.*)` + regexp.QuoteMeta(suffix) + `\.(.+)\.svc\.` + quotedClusterDomain + ` {1}` + suffix
+  rewrite stop {
+    name regex (.*)\.` + regexp.QuoteMeta(suffix) + `\.svc\.` + quotedClusterDomain + ` {1}.` + suffix + `
+    answer name (.*)\.` + regexp.QuoteMeta(suffix) + ` {1}.` + suffix + `.svc.` +clusterDomain + `
+  }`
 	}
-	return `
-  rewrite stop name regex (.+)\.svc\.` + quotedClusterDomain + `\.(.+)\.svc\.` + quotedClusterDomain + ` {1}.svc.` + clusterDomain + `
-  rewrite stop name regex (.+)\.(.+)\.svc\.(.+)\.svc\.` + quotedClusterDomain + ` {1}.{2}.svc.` + clusterDomain + suffixRewrites
+	return suffixRewrites + `
+  rewrite stop {
+    name regex ([^\.]+)\.([^\.]+)\.svc\.` + quotedClusterDomain + `\.([^\.]+)\.svc\.` + quotedClusterDomain + ` {1}.{2}.svc.` + clusterDomain + `
+    answer name ([^\.]+)\.([^\.]+)\.svc\.` + quotedClusterDomain + ` {1}.{2}.svc.` + clusterDomain + `.{2}.svc.` + clusterDomain + `
+  }`
+
 }

--- a/pkg/operation/botanist/component/coredns/coredns.go
+++ b/pkg/operation/botanist/component/coredns/coredns.go
@@ -802,13 +802,12 @@ func getSearchPathRewrites(enabled bool, clusterDomain string, commonSuffixes []
 		suffixRewrites = suffixRewrites + `
   rewrite stop {
     name regex (.*)\.` + regexp.QuoteMeta(suffix) + `\.svc\.` + quotedClusterDomain + ` {1}.` + suffix + `
-    answer name (.*)\.` + regexp.QuoteMeta(suffix) + ` {1}.` + suffix + `.svc.` +clusterDomain + `
+    answer name (.*)\.` + regexp.QuoteMeta(suffix) + ` {1}.` + suffix + `.svc.` + clusterDomain + `
   }`
 	}
-	return suffixRewrites + `
+	return `
   rewrite stop {
-    name regex ([^\.]+)\.([^\.]+)\.svc\.` + quotedClusterDomain + `\.([^\.]+)\.svc\.` + quotedClusterDomain + ` {1}.{2}.svc.` + clusterDomain + `
-    answer name ([^\.]+)\.([^\.]+)\.svc\.` + quotedClusterDomain + ` {1}.{2}.svc.` + clusterDomain + `.{2}.svc.` + clusterDomain + `
-  }`
-
+    name regex ([^\.]+)\.([^\.]+)\.svc\.` + quotedClusterDomain + `\.svc\.` + quotedClusterDomain + ` {1}.{2}.svc.` + clusterDomain + `
+    answer name ([^\.]+)\.([^\.]+)\.svc\.` + quotedClusterDomain + ` {1}.{2}.svc.` + clusterDomain + `.svc.` + clusterDomain + `
+  }` + suffixRewrites
 }

--- a/pkg/operation/botanist/component/coredns/coredns_test.go
+++ b/pkg/operation/botanist/component/coredns/coredns_test.go
@@ -47,7 +47,6 @@ var _ = Describe("CoreDNS", func() {
 		managedResourceName = "shoot-core-coredns"
 		namespace           = "some-namespace"
 		clusterDomain       = "foo.bar"
-		quotedClusterDomain = regexp.QuoteMeta(clusterDomain)
 		clusterIP           = "1.2.3.4"
 		image               = "some-image:some-tag"
 		cpaImage            = "cpa-image:cpa-tag"
@@ -130,11 +129,16 @@ data:
       ready`
 			if rewritingEnabled {
 				out += `
-      rewrite stop name regex (.+)\.svc\.` + quotedClusterDomain + `\.(.+)\.svc\.` + quotedClusterDomain + ` {1}.svc.` + clusterDomain + `
-      rewrite stop name regex (.+)\.(.+)\.svc\.(.+)\.svc\.` + quotedClusterDomain + ` {1}.{2}.svc.` + clusterDomain
+      rewrite stop {
+        name regex ([^\.]+)\.([^\.]+)\.svc\.foo\.bar\.svc\.foo\.bar {1}.{2}.svc.foo.bar
+        answer name ([^\.]+)\.([^\.]+)\.svc\.foo\.bar {1}.{2}.svc.foo.bar.svc.foo.bar
+      }`
 				for _, suffix := range commonSuffixes {
 					out += `
-      rewrite stop name regex (.*)` + regexp.QuoteMeta(suffix) + `\.(.+)\.svc\.` + quotedClusterDomain + ` {1}` + suffix
+      rewrite stop {
+        name regex (.*)\.` + regexp.QuoteMeta(suffix) + `\.svc\.foo\.bar {1}.` + suffix + `
+        answer name (.*)\.` + regexp.QuoteMeta(suffix) + ` {1}.` + suffix + `.svc.foo.bar
+      }`
 				}
 			}
 			out += `

--- a/plugin/pkg/shoot/dnsrewriting/apis/shootdnsrewriting/validation/validation_test.go
+++ b/plugin/pkg/shoot/dnsrewriting/apis/shootdnsrewriting/validation/validation_test.go
@@ -39,7 +39,7 @@ var _ = Describe("Validation", func() {
 		})
 
 		It("should allow valid suffixes", func() {
-			config.CommonSuffixes = []string{".gardener.cloud", ".github.com"}
+			config.CommonSuffixes = []string{"gardener.cloud", "github.com"}
 
 			errorList := ValidateConfiguration(config)
 
@@ -47,7 +47,7 @@ var _ = Describe("Validation", func() {
 		})
 
 		It("should forbid invalid suffixes", func() {
-			config.CommonSuffixes = []string{"foo", "foo.bar", "foo", ".foo.bar"}
+			config.CommonSuffixes = []string{"foo", ".foo.bar", "foo.bar", "foo.bar"}
 
 			errorList := ValidateConfiguration(config)
 
@@ -55,25 +55,19 @@ var _ = Describe("Validation", func() {
 				PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":     Equal(field.ErrorTypeInvalid),
 					"Field":    Equal("commonSuffixes[0]"),
-					"Detail":   Equal("not enough dots ('.'), at least two dots required"),
+					"Detail":   Equal("not enough dots ('.'), at least one dot required"),
 					"BadValue": Equal("foo"),
 				})),
 				PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":     Equal(field.ErrorTypeInvalid),
 					"Field":    Equal("commonSuffixes[1]"),
-					"Detail":   Equal("not enough dots ('.'), at least two dots required"),
-					"BadValue": Equal("foo.bar"),
-				})),
-				PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":     Equal(field.ErrorTypeInvalid),
-					"Field":    Equal("commonSuffixes[2]"),
-					"Detail":   Equal("not enough dots ('.'), at least two dots required"),
-					"BadValue": Equal("foo"),
+					"Detail":   Equal("should not start with a dot ('.'), as it is automatically appended"),
+					"BadValue": Equal(".foo.bar"),
 				})),
 				PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":     Equal(field.ErrorTypeDuplicate),
-					"Field":    Equal("commonSuffixes[2]"),
-					"BadValue": Equal("foo"),
+					"Field":    Equal("commonSuffixes[3]"),
+					"BadValue": Equal("foo.bar"),
 				})),
 			))
 		})

--- a/plugin/pkg/shoot/dnsrewriting/apis/shootdnsrewriting/validation/validation_test.go
+++ b/plugin/pkg/shoot/dnsrewriting/apis/shootdnsrewriting/validation/validation_test.go
@@ -39,7 +39,7 @@ var _ = Describe("Validation", func() {
 		})
 
 		It("should allow valid suffixes", func() {
-			config.CommonSuffixes = []string{"gardener.cloud", "github.com"}
+			config.CommonSuffixes = []string{"gardener.cloud", ".github.com"}
 
 			errorList := ValidateConfiguration(config)
 
@@ -47,7 +47,7 @@ var _ = Describe("Validation", func() {
 		})
 
 		It("should forbid invalid suffixes", func() {
-			config.CommonSuffixes = []string{"foo", ".foo.bar", "foo.bar", "foo.bar"}
+			config.CommonSuffixes = []string{"foo", ".foo.bar", "foo.bar"}
 
 			errorList := ValidateConfiguration(config)
 
@@ -59,14 +59,8 @@ var _ = Describe("Validation", func() {
 					"BadValue": Equal("foo"),
 				})),
 				PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":     Equal(field.ErrorTypeInvalid),
-					"Field":    Equal("commonSuffixes[1]"),
-					"Detail":   Equal("should not start with a dot ('.'), as it is automatically appended"),
-					"BadValue": Equal(".foo.bar"),
-				})),
-				PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":     Equal(field.ErrorTypeDuplicate),
-					"Field":    Equal("commonSuffixes[3]"),
+					"Field":    Equal("commonSuffixes[2]"),
 					"BadValue": Equal("foo.bar"),
 				})),
 			))

--- a/plugin/pkg/shoot/dnsrewriting/apis/shootdnsrewriting/validation/validation_test.go
+++ b/plugin/pkg/shoot/dnsrewriting/apis/shootdnsrewriting/validation/validation_test.go
@@ -47,7 +47,7 @@ var _ = Describe("Validation", func() {
 		})
 
 		It("should forbid invalid suffixes", func() {
-			config.CommonSuffixes = []string{"foo", ".foo.bar", "foo.bar"}
+			config.CommonSuffixes = []string{"foo", ".foo", ".foo.bar", "foo.bar"}
 
 			errorList := ValidateConfiguration(config)
 
@@ -55,12 +55,23 @@ var _ = Describe("Validation", func() {
 				PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":     Equal(field.ErrorTypeInvalid),
 					"Field":    Equal("commonSuffixes[0]"),
-					"Detail":   Equal("not enough dots ('.'), at least one dot required"),
+					"Detail":   Equal("must contain at least one non-leading dot ('.')"),
+					"BadValue": Equal("foo"),
+				})),
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":     Equal(field.ErrorTypeInvalid),
+					"Field":    Equal("commonSuffixes[1]"),
+					"Detail":   Equal("must contain at least one non-leading dot ('.')"),
+					"BadValue": Equal(".foo"),
+				})),
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":     Equal(field.ErrorTypeDuplicate),
+					"Field":    Equal("commonSuffixes[1]"),
 					"BadValue": Equal("foo"),
 				})),
 				PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":     Equal(field.ErrorTypeDuplicate),
-					"Field":    Equal("commonSuffixes[2]"),
+					"Field":    Equal("commonSuffixes[3]"),
 					"BadValue": Equal("foo.bar"),
 				})),
 			))


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement

**What this PR does / why we need it**:
To ensure proper validation by clients / DNS resolvers that compare the hostname in a DNS response to the host in the query, it is necessary to rewrite the hostname in the answer.
https://coredns.io/plugins/rewrite/#response-rewrites

As the namespace is not known in all cases, we do not rewrite the following requests:

* `app.dst-namespace.svc.src-namespace.svc.cluster.local`. In this case, the 3rd entry in the search-path will match.
* `app.namespace.svc.cluster.local.namespace.svc.cluster.local` and `custom.example.com.namespace.svc.cluster.local`. These requests will not result in an answer. 
However, the next case in the search path (`.svc.cluster.local`) can be rewritten.


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Add response rewrite to dns-search-path-optimization, as some clients require matching hostnames in a DNS query and the answer. 
```
