### PR TITLE
Minor Makefile enhancement

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -316,11 +316,7 @@ kind2-down: $(KIND)
 	./hack/kind-down.sh --cluster-name gardener-local2 --path-kubeconfig $(REPO_ROOT)/example/provider-local/seed-kind2/base/kubeconfig --keep-backupbuckets-dir
 
 kind-extensions-up: $(KIND) $(KUBECTL)
-ifneq ($(shell docker ps -aq -f name=gardener-extensions-control-plane), $(nullstring))
-	docker start gardener-extensions-control-plane
-else
-	./hack/kind-up.sh --cluster-name gardener-extensions --environment $(KIND_ENV) --path-kubeconfig $(REPO_ROOT)/example/provider-extensions/garden/kubeconfig --path-cluster-values $(REPO_ROOT)/example/gardener-local/kind/extensions/values.yaml
-endif
+	KIND_ENV=$(KIND_ENV) REPO_ROOT=$(REPO_ROOT) ./hack/kind-extensions-up.sh
 kind-extensions-down: $(KIND)
 	docker stop gardener-extensions-control-plane
 kind-extensions-clean:

--- a/hack/kind-extensions-up.sh
+++ b/hack/kind-extensions-up.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+if [[ -n "$(docker ps -aq -f name=gardener-extensions-control-plane)" ]]; then 
+    docker start gardener-extensions-control-plane
+else 
+    ./hack/kind-up.sh --cluster-name gardener-extensions --environment "$KIND_ENV" --path-kubeconfig "${REPO_ROOT}/example/provider-extensions/garden/kubeconfig" --path-cluster-values "${REPO_ROOT}/example/gardener-local/kind/extensions/values.yaml"
+fi

--- a/hack/tools.mk
+++ b/hack/tools.mk
@@ -19,7 +19,7 @@
 # as needed. If the required tool (version) is not built/installed yet, make will make sure to build/install it.
 # The *_VERSION variables in this file contain the "default" values, but can be overwritten in the top level make file.
 
-ifeq ($(strip $(shell go list -m)),github.com/gardener/gardener)
+ifeq ($(strip $(shell go list -m 2>/dev/null)),github.com/gardener/gardener)
 TOOLS_PKG_PATH             := ./hack/tools
 else
 # dependency on github.com/gardener/gardener/hack/tools is optional and only needed if other projects want to reuse
@@ -122,7 +122,7 @@ $(GOLANGCI_LINT): $(call tool_version_file,$(GOLANGCI_LINT),$(GOLANGCI_LINT_VERS
 	@# see https://github.com/golangci/golangci-lint/issues/1276
 	GOBIN=$(abspath $(TOOLS_BIN_DIR)) CGO_ENABLED=1 go install github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
 
-ifeq ($(strip $(shell go list -m)),github.com/gardener/gardener)
+ifeq ($(strip $(shell go list -m 2>/dev/null)),github.com/gardener/gardener)
 $(GOMEGACHECK): $(TOOLS_PKG_PATH)/gomegacheck/go.* $(shell find $(TOOLS_PKG_PATH)/gomegacheck -type f -name '*.go')
 	cd $(TOOLS_PKG_PATH)/gomegacheck; CGO_ENABLED=1 go build -o $(abspath $(GOMEGACHECK)) -buildmode=plugin ./plugin
 else
@@ -153,7 +153,7 @@ $(KUBECTL): $(call tool_version_file,$(KUBECTL),$(KUBECTL_VERSION))
 	curl -Lo $(KUBECTL) https://dl.k8s.io/release/$(KUBECTL_VERSION)/bin/$(shell uname -s | tr '[:upper:]' '[:lower:]')/$(shell uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')/kubectl
 	chmod +x $(KUBECTL)
 
-ifeq ($(strip $(shell go list -m)),github.com/gardener/gardener)
+ifeq ($(strip $(shell go list -m 2>/dev/null)),github.com/gardener/gardener)
 $(LOGCHECK): $(TOOLS_PKG_PATH)/logcheck/go.* $(shell find $(TOOLS_PKG_PATH)/logcheck -type f -name '*.go')
 	cd $(TOOLS_PKG_PATH)/logcheck; CGO_ENABLED=1 go build -o $(abspath $(LOGCHECK)) -buildmode=plugin ./plugin
 else
@@ -173,7 +173,7 @@ $(PROMTOOL): $(TOOLS_PKG_PATH)/install-promtool.sh
 $(PROTOC_GEN_GOGO): go.mod
 	go build -o $(PROTOC_GEN_GOGO) k8s.io/code-generator/cmd/go-to-protobuf/protoc-gen-gogo
 
-ifeq ($(strip $(shell go list -m)),github.com/gardener/gardener)
+ifeq ($(strip $(shell go list -m 2>/dev/null)),github.com/gardener/gardener)
 $(REPORT_COLLECTOR): $(TOOLS_PKG_PATH)/report-collector/*.go
 	go build -o $(REPORT_COLLECTOR) $(TOOLS_PKG_PATH)/report-collector
 else


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind enhancement

**What this PR does / why we need it**:
1. When running `make revendor` after a manual version bump in `go.mod` of an extension, 4 `go list -m` commands are executed before the `make revendor` target. This leads to `go: inconsistent vendoring in ...` error dump of `go list -m`that would be resolved after revendoring is finished
2. Currently the code under `kind-extensions-up `target is not bash but make's syntax that is executed on every `make <target>`(example `make revendor`). The fix changes it to bash code that prevents this behaviour. An shell script is used because a one-liner will be too long and unreadable

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
3. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
NONE
```
