### PR TITLE
Deflake `E2E Operator` test

### DIFF
--- a/hack/test-e2e-local.sh
+++ b/hack/test-e2e-local.sh
@@ -67,4 +67,4 @@ if [[ "$1" != "operator" ]]; then
   fi
 fi
 
-GO111MODULE=on ginkgo run --timeout=1h $ginkgo_flags --v --progress "$@"
+GO111MODULE=on ginkgo run --timeout=1h $ginkgo_flags --v --show-node-events "$@"

--- a/test/e2e/gardener/shoot/internal/rotation/certificate_authorities.go
+++ b/test/e2e/gardener/shoot/internal/rotation/certificate_authorities.go
@@ -197,7 +197,8 @@ func (v *CAVerifier) AfterPrepared(ctx context.Context) {
 func (v *CAVerifier) ExpectCompletingStatus(g Gomega) {
 	g.Expect(v1beta1helper.GetShootCARotationPhase(v.Shoot.Status.Credentials)).To(Equal(gardencorev1beta1.RotationCompleting))
 	Expect(v.Shoot.Status.Credentials.Rotation.CertificateAuthorities.LastCompletionTriggeredTime).NotTo(BeNil())
-	Expect(v.Shoot.Status.Credentials.Rotation.CertificateAuthorities.LastCompletionTriggeredTime.After(v.Shoot.Status.Credentials.Rotation.CertificateAuthorities.LastInitiationFinishedTime.Time)).To(BeTrue())
+	Expect(v.Shoot.Status.Credentials.Rotation.CertificateAuthorities.LastCompletionTriggeredTime.Time.Equal(v.Shoot.Status.Credentials.Rotation.CertificateAuthorities.LastInitiationFinishedTime.Time) ||
+		v.Shoot.Status.Credentials.Rotation.CertificateAuthorities.LastCompletionTriggeredTime.After(v.Shoot.Status.Credentials.Rotation.CertificateAuthorities.LastInitiationFinishedTime.Time)).To(BeTrue())
 }
 
 // AfterCompleted is called when the Shoot is in Completed status.

--- a/test/e2e/gardener/shoot/internal/rotation/etcd_encryption_key.go
+++ b/test/e2e/gardener/shoot/internal/rotation/etcd_encryption_key.go
@@ -165,7 +165,8 @@ func (v *ETCDEncryptionKeyVerifier) AfterPrepared(ctx context.Context) {
 func (v *ETCDEncryptionKeyVerifier) ExpectCompletingStatus(g Gomega) {
 	g.Expect(v1beta1helper.GetShootETCDEncryptionKeyRotationPhase(v.Shoot.Status.Credentials)).To(Equal(gardencorev1beta1.RotationCompleting))
 	Expect(v.Shoot.Status.Credentials.Rotation.ETCDEncryptionKey.LastCompletionTriggeredTime).NotTo(BeNil())
-	Expect(v.Shoot.Status.Credentials.Rotation.ETCDEncryptionKey.LastCompletionTriggeredTime.After(v.Shoot.Status.Credentials.Rotation.ETCDEncryptionKey.LastInitiationFinishedTime.Time)).To(BeTrue())
+	Expect(v.Shoot.Status.Credentials.Rotation.ETCDEncryptionKey.LastCompletionTriggeredTime.Time.Equal(v.Shoot.Status.Credentials.Rotation.ETCDEncryptionKey.LastInitiationFinishedTime.Time) ||
+		v.Shoot.Status.Credentials.Rotation.ETCDEncryptionKey.LastCompletionTriggeredTime.After(v.Shoot.Status.Credentials.Rotation.ETCDEncryptionKey.LastInitiationFinishedTime.Time)).To(BeTrue())
 }
 
 // AfterCompleted is called when the Shoot is in Completed status.

--- a/test/e2e/gardener/shoot/internal/rotation/service_account_key.go
+++ b/test/e2e/gardener/shoot/internal/rotation/service_account_key.go
@@ -93,7 +93,8 @@ func (v *ServiceAccountKeyVerifier) AfterPrepared(ctx context.Context) {
 func (v *ServiceAccountKeyVerifier) ExpectCompletingStatus(g Gomega) {
 	g.Expect(v1beta1helper.GetShootServiceAccountKeyRotationPhase(v.Shoot.Status.Credentials)).To(Equal(gardencorev1beta1.RotationCompleting))
 	Expect(v.Shoot.Status.Credentials.Rotation.ServiceAccountKey.LastCompletionTriggeredTime).NotTo(BeNil())
-	Expect(v.Shoot.Status.Credentials.Rotation.ServiceAccountKey.LastCompletionTriggeredTime.After(v.Shoot.Status.Credentials.Rotation.ServiceAccountKey.LastInitiationFinishedTime.Time)).To(BeTrue())
+	Expect(v.Shoot.Status.Credentials.Rotation.ServiceAccountKey.LastCompletionTriggeredTime.Time.Equal(v.Shoot.Status.Credentials.Rotation.ServiceAccountKey.LastInitiationFinishedTime.Time) ||
+		v.Shoot.Status.Credentials.Rotation.ServiceAccountKey.LastCompletionTriggeredTime.After(v.Shoot.Status.Credentials.Rotation.ServiceAccountKey.LastInitiationFinishedTime.Time)).To(BeTrue())
 }
 
 // AfterCompleted is called when the Shoot is in Completed status.

--- a/test/e2e/operator/garden/internal/rotation/certificate_authorities.go
+++ b/test/e2e/operator/garden/internal/rotation/certificate_authorities.go
@@ -106,7 +106,8 @@ func (v *CAVerifier) AfterPrepared(ctx context.Context) {
 func (v *CAVerifier) ExpectCompletingStatus(g Gomega) {
 	g.Expect(helper.GetCARotationPhase(v.Garden.Status.Credentials)).To(Equal(gardencorev1beta1.RotationCompleting))
 	Expect(v.Garden.Status.Credentials.Rotation.CertificateAuthorities.LastCompletionTriggeredTime).NotTo(BeNil())
-	Expect(v.Garden.Status.Credentials.Rotation.CertificateAuthorities.LastCompletionTriggeredTime.After(v.Garden.Status.Credentials.Rotation.CertificateAuthorities.LastInitiationFinishedTime.Time)).To(BeTrue())
+	Expect(v.Garden.Status.Credentials.Rotation.CertificateAuthorities.LastCompletionTriggeredTime.Time.Equal(v.Garden.Status.Credentials.Rotation.CertificateAuthorities.LastInitiationFinishedTime.Time) ||
+		v.Garden.Status.Credentials.Rotation.CertificateAuthorities.LastCompletionTriggeredTime.After(v.Garden.Status.Credentials.Rotation.CertificateAuthorities.LastInitiationFinishedTime.Time)).To(BeTrue())
 }
 
 // AfterCompleted is called when the Shoot is in Completed status.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind flake

**What this PR does / why we need it**:
The test was failing at [this](https://github.com/gardener/gardener/blob/ebca5ce49bd5ac6c3edd0bbbda76be44a963798a/test/e2e/operator/garden/internal/rotation/certificate_authorities.go#L109) step because there can be the case where both `lastCompletionTriggeredTime` and `lastInitiationFinishedTime` are exactly same up to the seconds precision, one such example while executing the test locally
```
status:
  conditions:
  - lastTransitionTime: "2023-02-13T08:22:57Z"
    lastUpdateTime: "2023-02-13T08:22:57Z"
    message: Garden operation is currently being processed.
    reason: ReconciliationProgressing
    status: Progressing
    type: Reconciled
  credentials:
    rotation:
      certificateAuthorities:
        lastCompletionTriggeredTime: "2023-02-13T08:22:57Z"
        lastInitiationFinishedTime: "2023-02-13T08:22:57Z"
        lastInitiationTime: "2023-02-13T08:20:46Z"
        phase: Completing
  gardener:
    id: 6GqyhkihlzCu4Bx7CnMMUHkM0C2zGZzvHZ1abfCLB15UvOcdIt49gQ7LK9ysJBJ2
    name: gardener-operator-b4888759d-fbcck
    version: v1.65.0-dev
  observedGeneration: 1
```

This PR now considers the scenario where both `lastCompletionTriggeredTime` and `lastInitiationFinishedTime` are same.
Also it adds the cleanup part of `Garden` in `DeferCleanup` so it gets executed even though test fails in between at some step.

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener/issues/7334

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
