### PR TITLE
Use previous minor version of Gardener for upgrade tests

### DIFF
--- a/hack/ci-e2e-kind-upgrade.sh
+++ b/hack/ci-e2e-kind-upgrade.sh
@@ -125,7 +125,16 @@ function upgrade_to_next_release() {
 
 function set_gardener_upgrade_version_env_variables() {
   if [[ -z "$GARDENER_PREVIOUS_RELEASE" ]]; then
-    export GARDENER_PREVIOUS_RELEASE="$(curl -s https://api.github.com/repos/gardener/gardener/releases/latest | grep tag_name | cut -d '"' -f 4)"
+    previous_minor_version=$(echo "$VERSION" | awk -F. '{printf("%s.%d.*\n", $1, $2-1)}')
+    # List all the tags that match the previous minor version pattern
+    tag_list=$(git tag -l "$previous_minor_version")
+
+    if [ -z "$tag_list" ]; then
+      echo "No tags found for the previous minor version ($VERSION) to upgrade Gardener." >&2
+      exit 1
+    fi
+      # Find the most recent tag for the previous minor version
+      export GARDENER_PREVIOUS_RELEASE=$(echo "$tag_list" | sort -r | head -n 1)
   fi
 
   if [[ -z "$GARDENER_NEXT_RELEASE" ]]; then

--- a/hack/ci-e2e-kind-upgrade.sh
+++ b/hack/ci-e2e-kind-upgrade.sh
@@ -133,8 +133,8 @@ function set_gardener_upgrade_version_env_variables() {
       echo "No tags found for the previous minor version ($VERSION) to upgrade Gardener." >&2
       exit 1
     fi
-      # Find the most recent tag for the previous minor version
-      export GARDENER_PREVIOUS_RELEASE=$(echo "$tag_list" | tail -n 1)
+    # Find the most recent tag for the previous minor version
+    export GARDENER_PREVIOUS_RELEASE=$(echo "$tag_list" | tail -n 1)
   fi
 
   if [[ -z "$GARDENER_NEXT_RELEASE" ]]; then

--- a/hack/ci-e2e-kind-upgrade.sh
+++ b/hack/ci-e2e-kind-upgrade.sh
@@ -134,7 +134,7 @@ function set_gardener_upgrade_version_env_variables() {
       exit 1
     fi
       # Find the most recent tag for the previous minor version
-      export GARDENER_PREVIOUS_RELEASE=$(echo "$tag_list" | sort -r | head -n 1)
+      export GARDENER_PREVIOUS_RELEASE=$(echo "$tag_list" | tail -n 1)
   fi
 
   if [[ -z "$GARDENER_NEXT_RELEASE" ]]; then


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing robustness
/kind bug test

**What this PR does / why we need it**:
This change modifies the Gardener upgrade script to use the previous minor version instead of the latest release tag if `GARDENER_PREVIOUS_RELEASE ` is empty. 

Thanks @acumino for the suggestion!
**Special notes for your reviewer**:
cc: @rfranzke @acumino 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix developer
The Gardener upgrade tests have been updated to use the previous minor version of Gardener instead of the latest release tag when the environment variable `GARDENER_PREVIOUS_RELEASE` is not specified.
```
