### PR TITLE
Remove limit defaults from helm charts for controlplane components

### DIFF
--- a/charts/gardener/controlplane/values.yaml
+++ b/charts/gardener/controlplane/values.yaml
@@ -29,8 +29,6 @@ global:
       requests:
         cpu: 100m
         memory: 100Mi
-      limits:
-        memory: 256Mi
   # podAnnotations: # YAML formated annotations used for pod template
   # podLabels: # YAML formated labels used for pod template
     minReadySeconds: 30
@@ -285,8 +283,6 @@ global:
       requests:
         cpu: 100m
         memory: 200Mi
-      limits:
-        memory: 512Mi
   # service:
   #   clusterIP: 1.2.3.4
   # podAnnotations: # YAML formated annotations used for pod template
@@ -359,8 +355,6 @@ global:
       requests:
         cpu: 100m
         memory: 100Mi
-      limits:
-        memory: 512Mi
   # podAnnotations: # YAML formated annotations used for pod template
   # podLabels: # YAML formated labels used for pod template
     additionalVolumes: []
@@ -471,8 +465,6 @@ global:
       requests:
         cpu: 50m
         memory: 50Mi
-      limits:
-        memory: 256Mi
   # podAnnotations: # YAML formatted annotations used for pod template
   # podLabels: # YAML formatted labels used for pod template
     vpa: false


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/area auto-scaling
/kind enhancement

**What this PR does / why we need it**:
Removes the limit defaults for controlplane components, such that we can actually remove them during installation.

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Remove limit defaults from helm charts for controlplane components
```
