### PR TITLE
Disable the static token kubeconfig in the shoot template used for TM integration tests

### DIFF
--- a/test/framework/resources/templates/default-shoot.yaml
+++ b/test/framework/resources/templates/default-shoot.yaml
@@ -5,12 +5,6 @@ metadata:
   namespace: abc
 spec:
   kubernetes:
-    # Enable the static token kubeconfig for the test-machinery integration tests until we figure out
-    # which test/components need the Shoot kubeconfig that is downloaded to $TM_KUBECONFIG_PATH/shoot.config in the Shoot creation integration test.
-    # See https://github.com/gardener/gardener/blob/7c63e2a6c5d46f9f1cb676602f864275ab8cab40/test/framework/shootcreationframework.go#L423-L425
-    # TODO(ialidzhikov): Remove the enableStaticTokenKubeconfig field after we figure out which tests/components need it
-    # and let the default gardener-apiserver value to be used.
-    enableStaticTokenKubeconfig: true
     kubeAPIServer:
       enableBasicAuthentication: false
   dns: {}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind cleanup

**What this PR does / why we need it**:
In this way we let the gardener-apiserver default the `.spec.kubernetes.enableStaticTokenKubeconfig` field. For Shoots with K8s < 1.26, it will be defaulted to true, for Shoots with K8s >= 1.26 - to false. The plan is to lock this field to false for Shoots with K8s >= 1.27.
Integration tests in gardener/gardener should be already adapted to do not rely on the static token kubeconfig. Integration tests outside of gardener/gardener should use the kubeconfig provided under `$TM_KUBECONFIG_PATH/shoot.config` or should obtain kubeconfig from the `shoot/adminkubeconfig` subresource.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/6773

**Special notes for your reviewer**:
- ~✅ This PR depends on https://github.com/gardener/gardener/pull/7495, hence it is in draft state.~

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
NONE
```
