### PR TITLE
Export resource YAMLs of `seeds`, `shoots`, `etcds` for prow jobs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -295,7 +295,7 @@ verify-extended: check-generate check format test-cov test-cov-clean test-integr
 #####################################################################
 
 kind-% kind2-% gardener-%: export IPFAMILY := $(IPFAMILY)
-kind-up kind-down gardener-up gardener-down register-local-env tear-down-local-env register-kind2-env tear-down-kind2-env test-e2e-local-simple test-e2e-local-migration test-e2e-local ci-e2e-kind-upgrade: export KUBECONFIG = $(GARDENER_LOCAL_KUBECONFIG)
+kind-up kind-down gardener-up gardener-down register-local-env tear-down-local-env register-kind2-env tear-down-kind2-env test-e2e-local-simple test-e2e-local-migration test-e2e-local ci-e2e-kind ci-e2e-kind-upgrade: export KUBECONFIG = $(GARDENER_LOCAL_KUBECONFIG)
 kind2-up kind2-down gardenlet-kind2-up gardenlet-kind2-down: export KUBECONFIG = $(GARDENER_LOCAL2_KUBECONFIG)
 kind-extensions-up kind-extensions-down gardener-extensions-up gardener-extensions-down: export KUBECONFIG = $(GARDENER_EXTENSIONS_KUBECONFIG)
 kind-ha-single-zone-up kind-ha-single-zone-down gardener-ha-single-zone-up register-kind-ha-single-zone-env tear-down-kind-ha-single-zone-env ci-e2e-kind-ha-single-zone ci-e2e-kind-ha-single-zone-upgrade: export KUBECONFIG = $(GARDENER_LOCAL_HA_SINGLE_ZONE_KUBECONFIG)

--- a/Makefile
+++ b/Makefile
@@ -431,7 +431,7 @@ test-post-upgrade: $(GINKGO)
 ci-e2e-kind: $(KIND) $(YQ)
 	./hack/ci-e2e-kind.sh
 ci-e2e-kind-migration: $(KIND) $(YQ)
-	./hack/ci-e2e-kind-migration.sh
+	GARDENER_LOCAL_KUBECONFIG=$(GARDENER_LOCAL_KUBECONFIG) GARDENER_LOCAL2_KUBECONFIG=$(GARDENER_LOCAL2_KUBECONFIG) ./hack/ci-e2e-kind-migration.sh
 ci-e2e-kind-ha-single-zone: $(KIND) $(YQ)
 	./hack/ci-e2e-kind-ha-single-zone.sh
 ci-e2e-kind-ha-multi-zone: $(KIND) $(YQ)

--- a/hack/ci-common.sh
+++ b/hack/ci-common.sh
@@ -19,9 +19,13 @@ set -o errexit
 export_logs() {
   cluster_name="${1}"
   echo "> Exporting logs of kind cluster '$cluster_name'"
-  kind export logs "${ARTIFACTS:-}" --name "$cluster_name" || true
+  kind export logs "${ARTIFACTS:-}/$cluster_name" --name "$cluster_name" || true
+
+  echo "> Exporting events of kind cluster '$cluster_name' > '$ARTIFACTS/$cluster_name'"
+  export_events_for_cluster "$ARTIFACTS/$cluster_name"
 
   export_resource_yamls_for seeds shoots etcds leases
+  export_events_for_shoots
 
   # dump logs from shoot machine pods (similar to `kind export logs`)
   while IFS= read -r namespace; do

--- a/hack/ci-common.sh
+++ b/hack/ci-common.sh
@@ -21,6 +21,8 @@ export_logs() {
   echo "> Exporting logs of kind cluster '$cluster_name'"
   kind export logs "${ARTIFACTS:-}" --name "$cluster_name" || true
 
+  export_resource_yamls_for seeds shoots etcds leases
+
   # dump logs from shoot machine pods (similar to `kind export logs`)
   while IFS= read -r namespace; do
     while IFS= read -r node; do
@@ -46,7 +48,16 @@ export_logs() {
 
 export_events_for_kind() {
   echo "> Exporting events of kind cluster '$1'"
-  export_events_for_cluster "${1}-control-plane"
+  export_events_for_cluster "$ARTIFACTS"
+}
+
+export_resource_yamls_for() {
+  mkdir -p $ARTIFACTS
+  # Loop over the resource types
+  for resource_type in "$@"; do
+    echo "> Exporting Resource '$resource_type' yaml > $ARTIFACTS/$resource_type.yaml"
+    kubectl get "$resource_type" -A -o yaml >"$ARTIFACTS/$resource_type.yaml" || true
+  done
 }
 
 export_events_for_shoots() {
@@ -65,13 +76,13 @@ export_events_for_shoots() {
       base64 -d \
         >"$shoot_kubeconfig"
 
-    KUBECONFIG="$shoot_kubeconfig" export_events_for_cluster "$shoot_id"
+    KUBECONFIG="$shoot_kubeconfig" export_events_for_cluster "$ARTIFACTS/$shoot_id"
     rm -f "$shoot_kubeconfig"
   done < <(kubectl get shoot -A -o=custom-columns=namespace:metadata.namespace,name:metadata.name,id:status.technicalID --no-headers)
 }
 
 export_events_for_cluster() {
-  local dir="$ARTIFACTS/$1/events"
+  local dir="$1/events"
   mkdir -p "$dir"
 
   while IFS= read -r namespace; do

--- a/hack/ci-common.sh
+++ b/hack/ci-common.sh
@@ -16,7 +16,7 @@
 
 set -o errexit
 
-export_logs() {
+export_artifacts() {
   cluster_name="${1}"
   echo "> Exporting logs of kind cluster '$cluster_name'"
   kind export logs "${ARTIFACTS:-}/$cluster_name" --name "$cluster_name" || true

--- a/hack/ci-e2e-kind-ha-multi-zone.sh
+++ b/hack/ci-e2e-kind-ha-multi-zone.sh
@@ -27,11 +27,10 @@ clamp_mss_to_pmtu
 make kind-ha-multi-zone-up
 
 # export all container logs and events after test execution
-trap "
-  ( export_logs 'gardener-local-ha-multi-zone';
-    export_events_for_kind 'gardener-local-ha-multi-zone'; export_events_for_shoots )
-  ( make kind-ha-multi-zone-down )
-" EXIT
+trap '{
+  export_logs "gardener-local-ha-multi-zone"
+  make kind-ha-multi-zone-down
+}' EXIT
 
 make gardener-ha-multi-zone-up
 make test-e2e-local-ha-multi-zone PARALLEL_E2E_TESTS=10

--- a/hack/ci-e2e-kind-ha-multi-zone.sh
+++ b/hack/ci-e2e-kind-ha-multi-zone.sh
@@ -28,7 +28,7 @@ make kind-ha-multi-zone-up
 
 # export all container logs and events after test execution
 trap '{
-  export_logs "gardener-local-ha-multi-zone"
+  export_artifacts "gardener-local-ha-multi-zone"
   make kind-ha-multi-zone-down
 }' EXIT
 

--- a/hack/ci-e2e-kind-ha-single-zone.sh
+++ b/hack/ci-e2e-kind-ha-single-zone.sh
@@ -27,12 +27,11 @@ clamp_mss_to_pmtu
 make kind-ha-single-zone-up
 
 # export all container logs and events after test execution
-trap "
-  ( export_logs 'gardener-local-ha-single-zone';
-    export_events_for_kind 'gardener-local-ha-single-zone'; export_events_for_shoots )
-  ( make kind-ha-single-zone-down )
-" EXIT
+trap '{
+  export_logs "gardener-local-ha-single-zone"
+  make kind-ha-single-zone-down
+}' EXIT
 
 make gardener-ha-single-zone-up
-make test-e2e-local-ha-single-zone PARALLEL_E2E_TESTS=10 
+make test-e2e-local-ha-single-zone PARALLEL_E2E_TESTS=10
 make gardener-ha-single-zone-down

--- a/hack/ci-e2e-kind-ha-single-zone.sh
+++ b/hack/ci-e2e-kind-ha-single-zone.sh
@@ -28,7 +28,7 @@ make kind-ha-single-zone-up
 
 # export all container logs and events after test execution
 trap '{
-  export_logs "gardener-local-ha-single-zone"
+  export_artifacts "gardener-local-ha-single-zone"
   make kind-ha-single-zone-down
 }' EXIT
 

--- a/hack/ci-e2e-kind-migration.sh
+++ b/hack/ci-e2e-kind-migration.sh
@@ -27,13 +27,12 @@ make kind-up
 make kind2-up
 
 # export all container logs and events after test execution
-trap "
-  ( export KUBECONFIG=$PWD/example/gardener-local/kind/local/kubeconfig; export_logs 'gardener-local';
-    export_events_for_kind 'gardener-local'; export_events_for_shoots )
-  ( export KUBECONFIG=$PWD/example/gardener-local/kind/local2/kubeconfig; export_logs 'gardener-local2';
-    export_events_for_kind 'gardener-local2' )
-  ( make kind-down; make kind2-down )
-" EXIT
+trap '{
+  KUBECONFIG=$GARDENER_LOCAL_KUBECONFIG export_logs "gardener-local"
+  KUBECONFIG=$GARDENER_LOCAL2_KUBECONFIG; export_logs "gardener-local2"
+  make kind-down
+  make kind2-down
+}' EXIT
 
 make gardener-up
 make gardenlet-kind2-up

--- a/hack/ci-e2e-kind-migration.sh
+++ b/hack/ci-e2e-kind-migration.sh
@@ -28,8 +28,8 @@ make kind2-up
 
 # export all container logs and events after test execution
 trap '{
-  KUBECONFIG=$GARDENER_LOCAL_KUBECONFIG export_logs "gardener-local"
-  KUBECONFIG=$GARDENER_LOCAL2_KUBECONFIG; export_logs "gardener-local2"
+  KUBECONFIG=$GARDENER_LOCAL_KUBECONFIG export_artifacts "gardener-local"
+  KUBECONFIG=$GARDENER_LOCAL2_KUBECONFIG; export_artifacts "gardener-local2"
   make kind-down
   make kind2-down
 }' EXIT

--- a/hack/ci-e2e-kind-operator.sh
+++ b/hack/ci-e2e-kind-operator.sh
@@ -27,7 +27,7 @@ make kind-operator-up
 
 # export all container logs and events after test execution
 trap "
-  ( export KUBECONFIG=$PWD/example/gardener-local/kind/operator/kubeconfig; export_logs 'gardener-operator-local' )
+  ( export KUBECONFIG=$PWD/example/gardener-local/kind/operator/kubeconfig; export_artifacts 'gardener-operator-local' )
   ( make kind-down )
 " EXIT
 

--- a/hack/ci-e2e-kind-upgrade.sh
+++ b/hack/ci-e2e-kind-upgrade.sh
@@ -191,7 +191,7 @@ kind_up
 # export all container logs and events after test execution
 trap '{
   rm -rf "$GARDENER_RELEASE_DOWNLOAD_PATH/gardener-releases"
-  export_logs "$CLUSTER_NAME"
+  export_artifacts "$CLUSTER_NAME"
   kind_down
 }' EXIT
 

--- a/hack/ci-e2e-kind-upgrade.sh
+++ b/hack/ci-e2e-kind-upgrade.sh
@@ -189,11 +189,11 @@ export GARDENER_PREVIOUS_VERSION="$(cat $GARDENER_RELEASE_DOWNLOAD_PATH/gardener
 kind_up
 
 # export all container logs and events after test execution
-trap "
-( rm -rf $GARDENER_RELEASE_DOWNLOAD_PATH/gardener-releases);
-( export_logs '$CLUSTER_NAME'; export_events_for_kind '$CLUSTER_NAME'; export_events_for_shoots )
-( kind_down;)
-" EXIT
+trap '{
+  rm -rf "$GARDENER_RELEASE_DOWNLOAD_PATH/gardener-releases"
+  export_logs "$CLUSTER_NAME"
+  kind_down
+}' EXIT
 
 echo "Installing gardener version '$GARDENER_PREVIOUS_RELEASE'"
 install_previous_release

--- a/hack/ci-e2e-kind.sh
+++ b/hack/ci-e2e-kind.sh
@@ -26,11 +26,10 @@ clamp_mss_to_pmtu
 make kind-up
 
 # export all container logs and events after test execution
-trap "
-  ( export KUBECONFIG=$PWD/example/gardener-local/kind/local/kubeconfig; export_logs 'gardener-local';
-    export_events_for_kind 'gardener-local'; export_events_for_shoots )
-  ( make kind-down )
-" EXIT
+trap '{
+  export_logs "gardener-local"
+  make kind-down
+}' EXIT
 
 make gardener-up
 make test-e2e-local PARALLEL_E2E_TESTS=10

--- a/hack/ci-e2e-kind.sh
+++ b/hack/ci-e2e-kind.sh
@@ -27,7 +27,7 @@ make kind-up
 
 # export all container logs and events after test execution
 trap '{
-  export_logs "gardener-local"
+  export_artifacts "gardener-local"
   make kind-down
 }' EXIT
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing robustness 
/kind test

**What this PR does / why we need it**:
This PR export k8s resource YAMLs of `seeds`, `shoots`, `etcds`, `leases` to the Prow job's artifacts directory for easier debugging of Prow job and improved script [ci-common.sh](hack/ci-common.sh) to store events of cluster to artifact directory instead of storing inside node `gardener-local-control-plane` folder.



**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
NONE
```
