### PR TITLE
Enhance etcd deploy flow to consider existing peer secrets when setting peer secrets

### DIFF
--- a/pkg/operation/botanist/component/etcd/etcd.go
+++ b/pkg/operation/botanist/component/etcd/etcd.go
@@ -258,7 +258,7 @@ func (e *etcd) Deploy(ctx context.Context) error {
 		peerServerSecretName string
 	)
 
-	if etcdPeerCASecretName, peerServerSecretName, err = e.handlePeerCertificates(ctx); err != nil {
+	if etcdPeerCASecretName, peerServerSecretName, err = e.handlePeerCertificates(ctx, existingEtcd); err != nil {
 		return err
 	}
 
@@ -410,7 +410,7 @@ func (e *etcd) Deploy(ctx context.Context) error {
 		}
 
 		// TODO(timuthy): Once https://github.com/gardener/etcd-backup-restore/issues/538 is resolved we can enable PeerUrlTLS for all remaining clusters as well.
-		if pointer.Int32Deref(e.values.Replicas, 0) > 1 {
+		if pointer.Int32Deref(e.values.Replicas, 0) > 1 || (existingEtcd != nil && existingEtcd.Spec.Etcd.PeerUrlTLS != nil) {
 			e.etcd.Spec.Etcd.PeerUrlTLS = &druidv1alpha1.TLSConfig{
 				TLSCASecretRef: druidv1alpha1.SecretReference{
 					SecretReference: corev1.SecretReference{
@@ -870,9 +870,9 @@ func (e *etcd) computeFullSnapshotSchedule(existingEtcd *druidv1alpha1.Etcd) *st
 	return fullSnapshotSchedule
 }
 
-func (e *etcd) handlePeerCertificates(ctx context.Context) (caSecretName, peerSecretName string, err error) {
+func (e *etcd) handlePeerCertificates(ctx context.Context, existingEtcd *druidv1alpha1.Etcd) (caSecretName, peerSecretName string, err error) {
 	// TODO(timuthy): Remove this once https://github.com/gardener/etcd-backup-restore/issues/538 is resolved.
-	if pointer.Int32Deref(e.values.Replicas, 0) != 3 {
+	if pointer.Int32Deref(e.values.Replicas, 0) != 3 && (existingEtcd == nil || existingEtcd.Spec.Etcd.PeerUrlTLS == nil) {
 		return
 	}
 

--- a/pkg/operation/botanist/component/etcd/etcd_test.go
+++ b/pkg/operation/botanist/component/etcd/etcd_test.go
@@ -1456,11 +1456,7 @@ var _ = Describe("Etcd", func() {
 							return nil
 						}),
 						c.EXPECT().Get(ctx, kubernetesutils.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&appsv1.StatefulSet{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
-
-						c.EXPECT().Get(ctx, kubernetesutils.Key(testNamespace, networkPolicyClientName), gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{})),
-						c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{}), gomock.Any()).Do(func(ctx context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
-							Expect(obj).To(DeepEqual(clientNetworkPolicy))
-						}),
+						c.EXPECT().Delete(ctx, &networkingv1.NetworkPolicy{ObjectMeta: metav1.ObjectMeta{Name: networkPolicyClientName, Namespace: testNamespace}}),
 						c.EXPECT().Get(ctx, kubernetesutils.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).DoAndReturn(
 							func(_ context.Context, _ client.ObjectKey, etcd *druidv1alpha1.Etcd, _ ...client.GetOption) error {
 								etcd.Spec.Etcd.PeerUrlTLS = &druidv1alpha1.TLSConfig{
@@ -1500,11 +1496,7 @@ var _ = Describe("Etcd", func() {
 							return nil
 						}),
 						c.EXPECT().Get(ctx, kubernetesutils.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&appsv1.StatefulSet{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
-
-						c.EXPECT().Get(ctx, kubernetesutils.Key(testNamespace, networkPolicyClientName), gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{})),
-						c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{}), gomock.Any()).Do(func(ctx context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
-							Expect(obj).To(DeepEqual(clientNetworkPolicy))
-						}),
+						c.EXPECT().Delete(ctx, &networkingv1.NetworkPolicy{ObjectMeta: metav1.ObjectMeta{Name: networkPolicyClientName, Namespace: testNamespace}}),
 						c.EXPECT().Get(ctx, kubernetesutils.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).DoAndReturn(
 							func(_ context.Context, _ client.ObjectKey, etcd *druidv1alpha1.Etcd, _ ...client.GetOption) error {
 								return nil

--- a/pkg/operation/botanist/component/etcd/etcd_test.go
+++ b/pkg/operation/botanist/component/etcd/etcd_test.go
@@ -1393,33 +1393,7 @@ var _ = Describe("Etcd", func() {
 			})
 		})
 
-		Context("When etcd cluster is hibernated", func() {
-			BeforeEach(func() {
-				secretNamesToTimes := map[string]time.Time{}
-
-				var err error
-				sm, err = secretsmanager.New(
-					ctx,
-					logr.New(logf.NullLogSink{}),
-					testclock.NewFakeClock(time.Now()),
-					fakeClient,
-					testNamespace,
-					"",
-					secretsmanager.Config{
-						SecretNamesToTimes: secretNamesToTimes,
-					})
-				Expect(err).ToNot(HaveOccurred())
-
-				// Create new etcd CA
-				_, err = sm.Generate(ctx,
-					&secretsutils.CertificateSecretConfig{Name: v1beta1constants.SecretNameCAETCD, CommonName: "etcd", CertType: secretsutils.CACert})
-				Expect(err).ToNot(HaveOccurred())
-
-				// Create new peer CA
-				_, err = sm.Generate(ctx,
-					&secretsutils.CertificateSecretConfig{Name: v1beta1constants.SecretNameCAETCDPeer, CommonName: "etcd-peer", CertType: secretsutils.CACert})
-				Expect(err).ToNot(HaveOccurred())
-			})
+		Context("when etcd cluster is hibernated", func() {
 			JustBeforeEach(func() {
 				etcd = New(log, c, testNamespace, sm, Values{
 					Role:                    testRole,
@@ -1432,52 +1406,118 @@ var _ = Describe("Etcd", func() {
 					PriorityClassName:       priorityClassName,
 				})
 			})
-			It("Should not remove peer URL secrets", func() {
-				gomock.InOrder(
-					c.EXPECT().Get(ctx, kubernetesutils.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).DoAndReturn(func(ctx context.Context, _ client.ObjectKey, obj client.Object, _ ...client.GetOption) error {
-						(&druidv1alpha1.Etcd{
-							ObjectMeta: metav1.ObjectMeta{
-								Name:      etcdName,
-								Namespace: testNamespace,
-							},
-							Spec: druidv1alpha1.EtcdSpec{
-								Replicas: 3,
-								Etcd: druidv1alpha1.EtcdConfig{
-									PeerUrlTLS: &druidv1alpha1.TLSConfig{
-										ServerTLSSecretRef: corev1.SecretReference{
-											Name:      "peerServerSecretName",
-											Namespace: testNamespace,
+			Context("when peer url secrets are present in etcd CR", func() {
+				BeforeEach(func() {
+					secretNamesToTimes := map[string]time.Time{}
+
+					var err error
+					sm, err = secretsmanager.New(
+						ctx,
+						logr.New(logf.NullLogSink{}),
+						testclock.NewFakeClock(time.Now()),
+						fakeClient,
+						testNamespace,
+						"",
+						secretsmanager.Config{
+							SecretNamesToTimes: secretNamesToTimes,
+						})
+					Expect(err).ToNot(HaveOccurred())
+
+					// Create new etcd CA
+					_, err = sm.Generate(ctx,
+						&secretsutils.CertificateSecretConfig{Name: v1beta1constants.SecretNameCAETCD, CommonName: "etcd", CertType: secretsutils.CACert})
+					Expect(err).ToNot(HaveOccurred())
+
+					// Create new peer CA
+					_, err = sm.Generate(ctx,
+						&secretsutils.CertificateSecretConfig{Name: v1beta1constants.SecretNameCAETCDPeer, CommonName: "etcd-peer", CertType: secretsutils.CACert})
+					Expect(err).ToNot(HaveOccurred())
+				})
+				It("should not remove peer URL secrets", func() {
+					gomock.InOrder(
+						c.EXPECT().Get(ctx, kubernetesutils.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).DoAndReturn(func(ctx context.Context, _ client.ObjectKey, obj client.Object, _ ...client.GetOption) error {
+							(&druidv1alpha1.Etcd{
+								ObjectMeta: metav1.ObjectMeta{
+									Name:      etcdName,
+									Namespace: testNamespace,
+								},
+								Spec: druidv1alpha1.EtcdSpec{
+									Replicas: 3,
+									Etcd: druidv1alpha1.EtcdConfig{
+										PeerUrlTLS: &druidv1alpha1.TLSConfig{
+											ServerTLSSecretRef: corev1.SecretReference{
+												Name:      "peerServerSecretName",
+												Namespace: testNamespace,
+											},
 										},
 									},
 								},
-							},
-						}).DeepCopyInto(obj.(*druidv1alpha1.Etcd))
-						return nil
-					}),
-					c.EXPECT().Get(ctx, kubernetesutils.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&appsv1.StatefulSet{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
-
-					c.EXPECT().Get(ctx, kubernetesutils.Key(testNamespace, networkPolicyClientName), gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{})),
-					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{}), gomock.Any()).Do(func(ctx context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
-						Expect(obj).To(DeepEqual(clientNetworkPolicy))
-					}),
-					c.EXPECT().Get(ctx, kubernetesutils.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).DoAndReturn(
-						func(_ context.Context, _ client.ObjectKey, etcd *druidv1alpha1.Etcd, _ ...client.GetOption) error {
-							etcd.Spec.Etcd.PeerUrlTLS = &druidv1alpha1.TLSConfig{
-								ServerTLSSecretRef: corev1.SecretReference{
-									Name:      "peerServerSecretName",
-									Namespace: testNamespace,
-								},
-							}
+							}).DeepCopyInto(obj.(*druidv1alpha1.Etcd))
 							return nil
 						}),
-					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{}), gomock.Any()).Do(func(ctx context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
-						Expect(obj.(*druidv1alpha1.Etcd).Spec.Replicas).To(Equal(int32(0)))
-						Expect(obj.(*druidv1alpha1.Etcd).Spec.Etcd.PeerUrlTLS).ToNot(BeNil())
-					}),
-					c.EXPECT().Delete(ctx, &hvpav1alpha1.Hvpa{ObjectMeta: metav1.ObjectMeta{Name: "etcd-" + testRole, Namespace: testNamespace}}),
-				)
+						c.EXPECT().Get(ctx, kubernetesutils.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&appsv1.StatefulSet{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
 
-				Expect(etcd.Deploy(ctx)).To(Succeed())
+						c.EXPECT().Get(ctx, kubernetesutils.Key(testNamespace, networkPolicyClientName), gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{})),
+						c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{}), gomock.Any()).Do(func(ctx context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
+							Expect(obj).To(DeepEqual(clientNetworkPolicy))
+						}),
+						c.EXPECT().Get(ctx, kubernetesutils.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).DoAndReturn(
+							func(_ context.Context, _ client.ObjectKey, etcd *druidv1alpha1.Etcd, _ ...client.GetOption) error {
+								etcd.Spec.Etcd.PeerUrlTLS = &druidv1alpha1.TLSConfig{
+									ServerTLSSecretRef: corev1.SecretReference{
+										Name:      "peerServerSecretName",
+										Namespace: testNamespace,
+									},
+								}
+								return nil
+							}),
+						c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{}), gomock.Any()).Do(func(ctx context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
+							Expect(obj.(*druidv1alpha1.Etcd).Spec.Replicas).To(Equal(int32(0)))
+							Expect(obj.(*druidv1alpha1.Etcd).Spec.Etcd.PeerUrlTLS).ToNot(BeNil())
+						}),
+						c.EXPECT().Delete(ctx, &hvpav1alpha1.Hvpa{ObjectMeta: metav1.ObjectMeta{Name: "etcd-" + testRole, Namespace: testNamespace}}),
+					)
+
+					Expect(etcd.Deploy(ctx)).To(Succeed())
+				})
+			})
+			Context("when peer url secrets are not present in etcd CR", func() {
+				It("should not add peer url secrets", func() {
+					gomock.InOrder(
+						c.EXPECT().Get(ctx, kubernetesutils.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).DoAndReturn(func(ctx context.Context, _ client.ObjectKey, obj client.Object, _ ...client.GetOption) error {
+							(&druidv1alpha1.Etcd{
+								ObjectMeta: metav1.ObjectMeta{
+									Name:      etcdName,
+									Namespace: testNamespace,
+								},
+								Spec: druidv1alpha1.EtcdSpec{
+									Replicas: 3,
+									Etcd: druidv1alpha1.EtcdConfig{
+										PeerUrlTLS: nil,
+									},
+								},
+							}).DeepCopyInto(obj.(*druidv1alpha1.Etcd))
+							return nil
+						}),
+						c.EXPECT().Get(ctx, kubernetesutils.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&appsv1.StatefulSet{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
+
+						c.EXPECT().Get(ctx, kubernetesutils.Key(testNamespace, networkPolicyClientName), gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{})),
+						c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{}), gomock.Any()).Do(func(ctx context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
+							Expect(obj).To(DeepEqual(clientNetworkPolicy))
+						}),
+						c.EXPECT().Get(ctx, kubernetesutils.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).DoAndReturn(
+							func(_ context.Context, _ client.ObjectKey, etcd *druidv1alpha1.Etcd, _ ...client.GetOption) error {
+								return nil
+							}),
+						c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{}), gomock.Any()).Do(func(ctx context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
+							Expect(obj.(*druidv1alpha1.Etcd).Spec.Replicas).To(Equal(int32(0)))
+							Expect(obj.(*druidv1alpha1.Etcd).Spec.Etcd.PeerUrlTLS).To(BeNil())
+						}),
+						c.EXPECT().Delete(ctx, &hvpav1alpha1.Hvpa{ObjectMeta: metav1.ObjectMeta{Name: "etcd-" + testRole, Namespace: testNamespace}}),
+					)
+
+					Expect(etcd.Deploy(ctx)).To(Succeed())
+				})
 			})
 		})
 	})

--- a/pkg/operation/botanist/component/etcd/etcd_test.go
+++ b/pkg/operation/botanist/component/etcd/etcd_test.go
@@ -1392,6 +1392,94 @@ var _ = Describe("Etcd", func() {
 				})
 			})
 		})
+
+		Context("When etcd cluster is hibernated", func() {
+			BeforeEach(func() {
+				secretNamesToTimes := map[string]time.Time{}
+
+				var err error
+				sm, err = secretsmanager.New(
+					ctx,
+					logr.New(logf.NullLogSink{}),
+					testclock.NewFakeClock(time.Now()),
+					fakeClient,
+					testNamespace,
+					"",
+					secretsmanager.Config{
+						SecretNamesToTimes: secretNamesToTimes,
+					})
+				Expect(err).ToNot(HaveOccurred())
+
+				// Create new etcd CA
+				_, err = sm.Generate(ctx,
+					&secretsutils.CertificateSecretConfig{Name: v1beta1constants.SecretNameCAETCD, CommonName: "etcd", CertType: secretsutils.CACert})
+				Expect(err).ToNot(HaveOccurred())
+
+				// Create new peer CA
+				_, err = sm.Generate(ctx,
+					&secretsutils.CertificateSecretConfig{Name: v1beta1constants.SecretNameCAETCDPeer, CommonName: "etcd-peer", CertType: secretsutils.CACert})
+				Expect(err).ToNot(HaveOccurred())
+			})
+			JustBeforeEach(func() {
+				etcd = New(log, c, testNamespace, sm, Values{
+					Role:                    testRole,
+					Class:                   class,
+					Replicas:                pointer.Int32(0),
+					StorageCapacity:         storageCapacity,
+					StorageClassName:        &storageClassName,
+					DefragmentationSchedule: &defragmentationSchedule,
+					CARotationPhase:         gardencorev1beta1.RotationCompleted,
+					PriorityClassName:       priorityClassName,
+				})
+			})
+			It("Should not remove peer URL secrets", func() {
+				gomock.InOrder(
+					c.EXPECT().Get(ctx, kubernetesutils.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).DoAndReturn(func(ctx context.Context, _ client.ObjectKey, obj client.Object, _ ...client.GetOption) error {
+						(&druidv1alpha1.Etcd{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      etcdName,
+								Namespace: testNamespace,
+							},
+							Spec: druidv1alpha1.EtcdSpec{
+								Replicas: 3,
+								Etcd: druidv1alpha1.EtcdConfig{
+									PeerUrlTLS: &druidv1alpha1.TLSConfig{
+										ServerTLSSecretRef: corev1.SecretReference{
+											Name:      "peerServerSecretName",
+											Namespace: testNamespace,
+										},
+									},
+								},
+							},
+						}).DeepCopyInto(obj.(*druidv1alpha1.Etcd))
+						return nil
+					}),
+					c.EXPECT().Get(ctx, kubernetesutils.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&appsv1.StatefulSet{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
+
+					c.EXPECT().Get(ctx, kubernetesutils.Key(testNamespace, networkPolicyClientName), gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{})),
+					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{}), gomock.Any()).Do(func(ctx context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
+						Expect(obj).To(DeepEqual(clientNetworkPolicy))
+					}),
+					c.EXPECT().Get(ctx, kubernetesutils.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).DoAndReturn(
+						func(_ context.Context, _ client.ObjectKey, etcd *druidv1alpha1.Etcd, _ ...client.GetOption) error {
+							etcd.Spec.Etcd.PeerUrlTLS = &druidv1alpha1.TLSConfig{
+								ServerTLSSecretRef: corev1.SecretReference{
+									Name:      "peerServerSecretName",
+									Namespace: testNamespace,
+								},
+							}
+							return nil
+						}),
+					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{}), gomock.Any()).Do(func(ctx context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
+						Expect(obj.(*druidv1alpha1.Etcd).Spec.Replicas).To(Equal(int32(0)))
+						Expect(obj.(*druidv1alpha1.Etcd).Spec.Etcd.PeerUrlTLS).ToNot(BeNil())
+					}),
+					c.EXPECT().Delete(ctx, &hvpav1alpha1.Hvpa{ObjectMeta: metav1.ObjectMeta{Name: "etcd-" + testRole, Namespace: testNamespace}}),
+				)
+
+				Expect(etcd.Deploy(ctx)).To(Succeed())
+			})
+		})
 	})
 
 	Describe("#Destroy", func() {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane high-availability
/kind bug

**What this PR does / why we need it**:
This PR updates the etcd deploy flow to considers existing peer secrets while computing the peer secrets to be used in the etcd spec
Essentially it now checks for `etcd.Spec.Etcd.PeerUrlTls` in the etcd spec and does not unset this field if already set

**Which issue(s) this PR fixes**:
Fixes #7497 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fix a bug in the etcd deploy flow that erroneously unsets `etcd.Spec.Etcd.PeerUrlTls` in the ETCD CRs of high available shoots when marked for hibernation.
Before this change, high availability clusters failed to be deleted while being hibernated.
```
