### PR TITLE
`ManagedResource` controller should recreate `ConfigMap`s/`Secret`s on invalid update

### DIFF
--- a/pkg/resourcemanager/controller/managedresource/reconciler.go
+++ b/pkg/resourcemanager/controller/managedresource/reconciler.go
@@ -517,27 +517,12 @@ func (r *Reconciler) applyNewResources(ctx context.Context, log logr.Logger, ori
 				return err
 			}
 
-			if apierrors.IsInvalid(err) && operationResult == controllerutil.OperationResultUpdated {
-				if current.GetAPIVersion() == "v1" && sets.New[string]("ConfigMap", "Secret").Has(current.GetKind()) {
-					cause, ok := apierrors.StatusCause(err, metav1.CauseType(field.ErrorTypeForbidden))
-					if !ok || !strings.Contains(cause.Message, "field is immutable when `immutable` is set") {
-						continue
-					}
-
-					if deleteErr := r.TargetClient.Delete(ctx, current); client.IgnoreNotFound(deleteErr) != nil {
-						return fmt.Errorf("error deleting immutable object %q after 'invalid' update error: %s", resource, deleteErr)
-					}
-					// return error directly, so that the create after delete will be retried
-					return fmt.Errorf("deleted immutable object %q because of 'invalid' update error: %s", resource, err)
+			if apierrors.IsInvalid(err) && operationResult == controllerutil.OperationResultUpdated && deleteOnInvalidUpdate(current, err) {
+				if deleteErr := r.TargetClient.Delete(ctx, current); client.IgnoreNotFound(deleteErr) != nil {
+					return fmt.Errorf("error deleting object %q after 'invalid' update error: %s", resource, deleteErr)
 				}
-
-				if deleteOnInvalidUpdate(current) {
-					if deleteErr := r.TargetClient.Delete(ctx, current); client.IgnoreNotFound(deleteErr) != nil {
-						return fmt.Errorf("error deleting object %q after 'invalid' update error: %s", resource, deleteErr)
-					}
-					// return error directly, so that the create after delete will be retried
-					return fmt.Errorf("deleted object %q because of 'invalid' update error and 'delete-on-invalid-update' annotation on object (%s)", resource, err)
-				}
+				// return error directly, so that the create after delete will be retried
+				return fmt.Errorf("deleted object %q because of 'invalid' update error, and 'delete-on-invalid-update' annotation on object or the resource is an immutable ConfigMap/Secret: %s", resource, err)
 			}
 
 			return fmt.Errorf("error during apply of object %q: %s", resource, err)
@@ -653,8 +638,16 @@ func ignore(meta metav1.Object) bool {
 	return keyExistsAndValueTrue(meta.GetAnnotations(), resourcesv1alpha1.Ignore)
 }
 
-func deleteOnInvalidUpdate(meta metav1.Object) bool {
-	return keyExistsAndValueTrue(meta.GetAnnotations(), resourcesv1alpha1.DeleteOnInvalidUpdate)
+func deleteOnInvalidUpdate(obj *unstructured.Unstructured, err error) bool {
+	isImmutableConfigMapOrSecret := false
+	if obj.GetAPIVersion() == "v1" && sets.New[string]("ConfigMap", "Secret").Has(obj.GetKind()) {
+		cause, ok := apierrors.StatusCause(err, metav1.CauseType(field.ErrorTypeForbidden))
+		if ok && strings.Contains(cause.Message, "field is immutable when `immutable` is set") {
+			isImmutableConfigMapOrSecret = true
+		}
+	}
+
+	return keyExistsAndValueTrue(obj.GetAnnotations(), resourcesv1alpha1.DeleteOnInvalidUpdate) || isImmutableConfigMapOrSecret
 }
 
 func keepObject(meta metav1.Object) bool {

--- a/test/integration/resourcemanager/managedresource/resource_suite_test.go
+++ b/test/integration/resourcemanager/managedresource/resource_suite_test.go
@@ -124,7 +124,8 @@ var _ = BeforeSuite(func() {
 	Expect((&managedresource.Reconciler{
 		Config: config.ManagedResourceControllerConfig{
 			ConcurrentSyncs: pointer.Int(5),
-			// Higher sync period is used since we don't want the changes in the test to be reconciled back quickly.
+			// Higher sync period is used because in some tests, we want to assert an intermediate state of the
+			// resource, which won't be possible if the controller reconciles it back too quickly.
 			SyncPeriod:          &metav1.Duration{Duration: time.Minute},
 			ManagedByLabelValue: pointer.String("gardener"),
 		},

--- a/test/integration/resourcemanager/managedresource/resource_suite_test.go
+++ b/test/integration/resourcemanager/managedresource/resource_suite_test.go
@@ -123,8 +123,9 @@ var _ = BeforeSuite(func() {
 
 	Expect((&managedresource.Reconciler{
 		Config: config.ManagedResourceControllerConfig{
-			ConcurrentSyncs:     pointer.Int(5),
-			SyncPeriod:          &metav1.Duration{Duration: 500 * time.Millisecond},
+			ConcurrentSyncs: pointer.Int(5),
+			// Higher sync period is used since we don't want the changes in the test to be reconciled back quickly.
+			SyncPeriod:          &metav1.Duration{Duration: time.Minute},
 			ManagedByLabelValue: pointer.String("gardener"),
 		},
 		Clock:                         fakeClock,

--- a/test/integration/resourcemanager/managedresource/resource_test.go
+++ b/test/integration/resourcemanager/managedresource/resource_test.go
@@ -880,6 +880,10 @@ var _ = Describe("ManagedResource controller tests", func() {
 						deployment.Spec.Replicas = pointer.Int32(5)
 						Expect(testClient.Patch(ctx, deployment, patch)).To(Succeed())
 
+						patch = client.MergeFrom(managedResource.DeepCopy())
+						metav1.SetMetaDataAnnotation(&managedResource.ObjectMeta, "gardener.cloud/operation", "reconcile")
+						Expect(testClient.Patch(ctx, managedResource, patch)).To(Succeed())
+
 						Eventually(func(g Gomega) int32 {
 							g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(deployment), deployment)).To(Succeed())
 							return *deployment.Spec.Replicas
@@ -942,6 +946,10 @@ var _ = Describe("ManagedResource controller tests", func() {
 						patch := client.MergeFrom(deployment.DeepCopy())
 						deployment.Spec.Template = *newPodTemplateSpec
 						Expect(testClient.Patch(ctx, deployment, patch)).To(Succeed())
+
+						patch = client.MergeFrom(managedResource.DeepCopy())
+						metav1.SetMetaDataAnnotation(&managedResource.ObjectMeta, "gardener.cloud/operation", "reconcile")
+						Expect(testClient.Patch(ctx, managedResource, patch)).To(Succeed())
 
 						Eventually(func(g Gomega) corev1.ResourceRequirements {
 							g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(deployment), deployment)).To(Succeed())

--- a/test/integration/resourcemanager/managedresource/resource_test.go
+++ b/test/integration/resourcemanager/managedresource/resource_test.go
@@ -987,7 +987,7 @@ var _ = Describe("ManagedResource controller tests", func() {
 	})
 
 	Describe("Immutable resources", func() {
-		It("should fail to apply the resource if the update is invalid", func() {
+		It("should recreate the resource if the update is invalid", func() {
 			newData := map[string]string{
 				"foo": "bar",
 			}
@@ -1001,6 +1001,7 @@ var _ = Describe("ManagedResource controller tests", func() {
 
 			Expect(testClient.Delete(ctx, configMap)).To(Succeed())
 
+			oldData := configMap.Data
 			configMap.Data = newData
 			configMap.Immutable = pointer.Bool(true)
 			Expect(testClient.Create(ctx, configMap)).To(Succeed())
@@ -1018,14 +1019,10 @@ var _ = Describe("ManagedResource controller tests", func() {
 			metav1.SetMetaDataAnnotation(&managedResource.ObjectMeta, "gardener.cloud/operation", "reconcile")
 			Expect(testClient.Patch(ctx, managedResource, patch)).To(Succeed())
 
-			Eventually(func(g Gomega) []gardencorev1beta1.Condition {
-				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)).To(Succeed())
-				return managedResource.Status.Conditions
-			}).Should(ContainCondition(
-				OfType(resourcesv1alpha1.ResourcesApplied),
-				WithStatus(gardencorev1beta1.ConditionFalse),
-				WithMessage("Forbidden: field is immutable when `immutable` is set"),
-			))
+			Eventually(func(g Gomega) map[string]string {
+				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(configMap), configMap)).To(Succeed())
+				return configMap.Data
+			}).Should(Equal(oldData))
 		})
 	})
 })


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity
/kind enhancement

**What this PR does / why we need it**:
ManagedResource controller now recreates immutable resources on invalid update error.
Read the issue description for more details.

**Which issue(s) this PR fixes**:
Fixes #7452

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The resource-manager now recreates immutable Secrets/ConfigMaps on invalid update error.
```
