### PR TITLE
Support TLS SNI configurations for `kube-apiserver`

### DIFF
--- a/pkg/operation/botanist/component/kubeapiserver/deployment.go
+++ b/pkg/operation/botanist/component/kubeapiserver/deployment.go
@@ -74,7 +74,7 @@ const (
 	volumeNameServiceAccountKey          = "service-account-key"
 	volumeNameServiceAccountKeyBundle    = "service-account-key-bundle"
 	volumeNameStaticToken                = "static-token"
-	volumeNamePathPrefixTLSSNISecret     = "tls-sni-"
+	volumeNamePrefixTLSSNISecret         = "tls-sni-"
 	volumeNameVPNSeedClient              = "vpn-seed-client"
 	volumeNameAPIServerAccess            = "kube-api-access-gardener"
 	volumeNameVPNSeedTLSAuth             = "vpn-seed-tlsauth"
@@ -710,7 +710,7 @@ func (k *kubeAPIServer) handleTLSSNISettings(deployment *appsv1.Deployment, secr
 
 	for i, sni := range k.values.SNI.TLS {
 		var (
-			volumeName      = fmt.Sprintf("%s%d", volumeNamePathPrefixTLSSNISecret, i)
+			volumeName      = fmt.Sprintf("%s%d", volumeNamePrefixTLSSNISecret, i)
 			volumeMountPath = fmt.Sprintf("%s%d", volumeMountPathPrefixTLSSNISecret, i)
 			flag            = fmt.Sprintf("--tls-sni-cert-key=%s/tls.crt,%s/tls.key", volumeMountPath, volumeMountPath)
 		)

--- a/pkg/operation/botanist/component/kubeapiserver/deployment.go
+++ b/pkg/operation/botanist/component/kubeapiserver/deployment.go
@@ -139,7 +139,7 @@ func (k *kubeAPIServer) reconcileDeployment(
 	secretHTTPProxy *corev1.Secret,
 	secretHAVPNSeedClient *corev1.Secret,
 	secretHAVPNSeedClientSeedTLSAuth *corev1.Secret,
-	secretNamesTLSSNI []string,
+	tlsSNISecrets []tlsSNISecret,
 ) error {
 	var (
 		maxSurge       = intstr.FromString("25%")
@@ -456,6 +456,7 @@ func (k *kubeAPIServer) reconcileDeployment(
 		k.handleLifecycleSettings(deployment)
 		k.handleHostCertVolumes(deployment)
 		k.handleSNISettings(deployment)
+		k.handleTLSSNISettings(deployment, tlsSNISecrets)
 		k.handlePodMutatorSettings(deployment)
 		k.handleOIDCSettings(deployment, secretOIDCCABundle)
 		k.handleServiceAccountSigningKeySettings(deployment)
@@ -463,9 +464,6 @@ func (k *kubeAPIServer) reconcileDeployment(
 			return err
 		}
 		if err := k.handleKubeletSettings(deployment, secretKubeletClient); err != nil {
-			return err
-		}
-		if err := k.handleTLSSNISettings(deployment, secretNamesTLSSNI); err != nil {
 			return err
 		}
 
@@ -703,20 +701,16 @@ func (k *kubeAPIServer) handleSNISettings(deployment *appsv1.Deployment) {
 	deployment.Spec.Template.Spec.Containers[0].Command = append(deployment.Spec.Template.Spec.Containers[0].Command, fmt.Sprintf("--advertise-address=%s", k.values.SNI.AdvertiseAddress))
 }
 
-func (k *kubeAPIServer) handleTLSSNISettings(deployment *appsv1.Deployment, secretNames []string) error {
-	if len(k.values.SNI.TLS) != len(secretNames) {
-		return fmt.Errorf("number of TLS SNI configs and provided secret names is not equal (%d vs. %d)", len(k.values.SNI.TLS), len(secretNames))
-	}
-
-	for i, sni := range k.values.SNI.TLS {
+func (k *kubeAPIServer) handleTLSSNISettings(deployment *appsv1.Deployment, tlsSNISecrets []tlsSNISecret) {
+	for i, sni := range tlsSNISecrets {
 		var (
 			volumeName      = fmt.Sprintf("%s%d", volumeNamePrefixTLSSNISecret, i)
 			volumeMountPath = fmt.Sprintf("%s%d", volumeMountPathPrefixTLSSNISecret, i)
 			flag            = fmt.Sprintf("--tls-sni-cert-key=%s/tls.crt,%s/tls.key", volumeMountPath, volumeMountPath)
 		)
 
-		if len(sni.DomainPatters) > 0 {
-			flag += ":" + strings.Join(sni.DomainPatters, ",")
+		if len(sni.domainPatterns) > 0 {
+			flag += ":" + strings.Join(sni.domainPatterns, ",")
 		}
 
 		deployment.Spec.Template.Spec.Containers[0].Command = append(deployment.Spec.Template.Spec.Containers[0].Command, flag)
@@ -729,13 +723,11 @@ func (k *kubeAPIServer) handleTLSSNISettings(deployment *appsv1.Deployment, secr
 			Name: volumeName,
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
-					SecretName: secretNames[i],
+					SecretName: sni.secretName,
 				},
 			},
 		})
 	}
-
-	return nil
 }
 
 func (k *kubeAPIServer) handleLifecycleSettings(deployment *appsv1.Deployment) {

--- a/pkg/operation/botanist/component/kubeapiserver/kube_apiserver.go
+++ b/pkg/operation/botanist/component/kubeapiserver/kube_apiserver.go
@@ -289,6 +289,27 @@ type SNIConfig struct {
 	APIServerFQDN string
 	// AdvertiseAddress is the address which should be advertised by the kube-apiserver.
 	AdvertiseAddress string
+	// TLS contains information for the configuring the TLS SNI settings for the kube-apiserver.
+	TLS []TLSSNIConfig
+}
+
+// TLSSNIConfig contains information for the configuring the TLS SNI settings for the kube-apiserver.
+type TLSSNIConfig struct {
+	// SecretName is the name for an existing secret containing the TLS certificate and private key. Either this or both
+	// Certificate and PrivateKey must be specified. If both is provided, SecretName is taking precedence.
+	SecretName *string
+	// Certificate is the TLS certificate. Either both this and PrivateKey, or SecretName must be specified. If both is
+	// provided, SecretName is taking precedence.
+	Certificate []byte
+	// PrivateKey is the TLS certificate. Either both this and Certificate, or SecretName must be specified. If both is
+	// provided, SecretName is taking precedence.
+	PrivateKey []byte
+	// DomainPatters is an optional list of domain patterns which are fully qualified domain names, possibly with
+	// prefixed wildcard segments. The domain patterns also allow IP addresses, but IPs should only be used if the
+	// apiserver has visibility to the IP address requested by a client. If no domain patterns are provided, the names
+	// of the certificate are extracted. Non-wildcard matches trump over wildcard matches, explicit domain patterns
+	// trump over extracted names.
+	DomainPatters []string
 }
 
 // New creates a new instance of DeployWaiter for the kube-apiserver.

--- a/pkg/operation/botanist/component/kubeapiserver/kube_apiserver.go
+++ b/pkg/operation/botanist/component/kubeapiserver/kube_apiserver.go
@@ -492,6 +492,7 @@ func (k *kubeAPIServer) Deploy(ctx context.Context) error {
 		secretHTTPProxy,
 		secretHAVPNSeedClient,
 		secretHAVPNClientSeedTLSAuth,
+		secretNamesTLSSNI,
 	); err != nil {
 		return err
 	}

--- a/pkg/operation/botanist/component/kubeapiserver/kube_apiserver.go
+++ b/pkg/operation/botanist/component/kubeapiserver/kube_apiserver.go
@@ -442,6 +442,11 @@ func (k *kubeAPIServer) Deploy(ctx context.Context) error {
 		return err
 	}
 
+	secretNamesTLSSNI, err := k.reconcileTLSSNISecrets(ctx)
+	if err != nil {
+		return err
+	}
+
 	if k.values.VPN.Enabled && k.values.VPN.HighAvailabilityEnabled {
 		if err := k.reconcileServiceAccount(ctx); err != nil {
 			return err

--- a/pkg/operation/botanist/component/kubeapiserver/kube_apiserver.go
+++ b/pkg/operation/botanist/component/kubeapiserver/kube_apiserver.go
@@ -304,12 +304,12 @@ type TLSSNIConfig struct {
 	// PrivateKey is the TLS certificate. Either both this and Certificate, or SecretName must be specified. If both is
 	// provided, SecretName is taking precedence.
 	PrivateKey []byte
-	// DomainPatters is an optional list of domain patterns which are fully qualified domain names, possibly with
+	// DomainPatterns is an optional list of domain patterns which are fully qualified domain names, possibly with
 	// prefixed wildcard segments. The domain patterns also allow IP addresses, but IPs should only be used if the
 	// apiserver has visibility to the IP address requested by a client. If no domain patterns are provided, the names
 	// of the certificate are extracted. Non-wildcard matches trump over wildcard matches, explicit domain patterns
 	// trump over extracted names.
-	DomainPatters []string
+	DomainPatterns []string
 }
 
 // New creates a new instance of DeployWaiter for the kube-apiserver.
@@ -442,7 +442,7 @@ func (k *kubeAPIServer) Deploy(ctx context.Context) error {
 		return err
 	}
 
-	secretNamesTLSSNI, err := k.reconcileTLSSNISecrets(ctx)
+	tlsSNISecrets, err := k.reconcileTLSSNISecrets(ctx)
 	if err != nil {
 		return err
 	}
@@ -492,7 +492,7 @@ func (k *kubeAPIServer) Deploy(ctx context.Context) error {
 		secretHTTPProxy,
 		secretHAVPNSeedClient,
 		secretHAVPNClientSeedTLSAuth,
-		secretNamesTLSSNI,
+		tlsSNISecrets,
 	); err != nil {
 		return err
 	}

--- a/pkg/operation/botanist/component/kubeapiserver/kube_apiserver.go
+++ b/pkg/operation/botanist/component/kubeapiserver/kube_apiserver.go
@@ -289,11 +289,11 @@ type SNIConfig struct {
 	APIServerFQDN string
 	// AdvertiseAddress is the address which should be advertised by the kube-apiserver.
 	AdvertiseAddress string
-	// TLS contains information for the configuring the TLS SNI settings for the kube-apiserver.
+	// TLS contains information for configuring the TLS SNI settings for the kube-apiserver.
 	TLS []TLSSNIConfig
 }
 
-// TLSSNIConfig contains information for the configuring the TLS SNI settings for the kube-apiserver.
+// TLSSNIConfig contains information for configuring the TLS SNI settings for the kube-apiserver.
 type TLSSNIConfig struct {
 	// SecretName is the name for an existing secret containing the TLS certificate and private key. Either this or both
 	// Certificate and PrivateKey must be specified. If both is provided, SecretName is taking precedence.

--- a/pkg/operation/botanist/component/kubeapiserver/kube_apiserver_test.go
+++ b/pkg/operation/botanist/component/kubeapiserver/kube_apiserver_test.go
@@ -3381,7 +3381,7 @@ rules:
 				It("should properly set the TLS SNI flag if necessary", func() {
 					values.SNI.TLS = []TLSSNIConfig{
 						{SecretName: pointer.String("existing-secret")},
-						{Certificate: []byte("foo"), PrivateKey: []byte("bar"), DomainPatters: []string{"foo1.com", "*.foo2.com"}},
+						{Certificate: []byte("foo"), PrivateKey: []byte("bar"), DomainPatterns: []string{"foo1.com", "*.foo2.com"}},
 					}
 					kapi = New(kubernetesInterface, namespace, sm, values)
 					deployAndRead()

--- a/pkg/operation/botanist/component/kubeapiserver/secrets.go
+++ b/pkg/operation/botanist/component/kubeapiserver/secrets.go
@@ -336,3 +336,35 @@ func (k *kubeAPIServer) reconcileSecretHAVPNSeedClientTLSAuth(ctx context.Contex
 		Name: vpnseedserver.SecretNameTLSAuth,
 	}, secretsmanager.Rotate(secretsmanager.InPlace))
 }
+
+func (k *kubeAPIServer) reconcileTLSSNISecrets(ctx context.Context) ([]string, error) {
+	var out []string
+
+	for i, sni := range k.values.SNI.TLS {
+		switch {
+		case sni.SecretName != nil:
+			out = append(out, *sni.SecretName)
+
+		case len(sni.Certificate) > 0 && len(sni.PrivateKey) > 0:
+			secret := k.emptySecret(fmt.Sprintf("kube-apiserver-tls-sni-%d", i))
+
+			secret.Data = map[string][]byte{
+				corev1.TLSCertKey:       sni.Certificate,
+				corev1.TLSPrivateKeyKey: sni.PrivateKey,
+			}
+			utilruntime.Must(kubernetesutils.MakeUnique(secret))
+
+			if err := client.IgnoreAlreadyExists(k.client.Client().Create(ctx, secret)); err != nil {
+				return nil, err
+			}
+
+			out = append(out, secret.Name)
+
+		default:
+			return nil, fmt.Errorf("either the name of an existing secret or both certificate and private key must be provided for TLS SNI config")
+		}
+
+	}
+
+	return out, nil
+}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability networking
/kind enhancement

**What this PR does / why we need it**:
This PR allows to configure the `kubeapiserver` component with TLS SNI configuration for the `--tls-sni-cert-key` flag.

Generally, this is a prerequisite for `gardener-operator` managing the `kube-apiserver` deployment.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/7233

**Special notes for your reviewer**:
/cc @shafeeqes 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
