### PR TITLE
Remove user tenants logs, adjust testmachinery and rename docker_id

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -313,7 +313,7 @@ images:
 - name: fluent-bit-plugin-installer
   sourceRepository: github.com/gardener/logging
   repository: eu.gcr.io/gardener-project/gardener/fluent-bit-to-loki
-  tag: "v0.48.0"
+  tag: "v0.49.0"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:
@@ -340,7 +340,7 @@ images:
 - name: loki-curator
   sourceRepository: github.com/gardener/logging
   repository: eu.gcr.io/gardener-project/gardener/loki-curator
-  tag: "v0.48.0"
+  tag: "v0.49.0"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:
@@ -381,7 +381,7 @@ images:
 - name: telegraf
   sourceRepository: github.com/gardener/logging
   repository: eu.gcr.io/gardener-project/gardener/telegraf-iptables
-  tag: "v0.48.0"
+  tag: "v0.49.0"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:
@@ -397,7 +397,7 @@ images:
 - name: event-logger
   sourceRepository: github.com/gardener/logging
   repository: eu.gcr.io/gardener-project/gardener/event-logger
-  tag: "v0.48.0"
+  tag: "v0.49.0"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:

--- a/charts/seed-bootstrap/charts/fluent-bit/values.yaml
+++ b/charts/seed-bootstrap/charts/fluent-bit/values.yaml
@@ -28,7 +28,7 @@ lokiLabels:
     container_name: "container_name"
     namespace_name: "namespace_name"
     pod_name: "pod_name"
-    docker_id: "docker_id"
+    container_id: "container_id"
   systemdLabels:
     hostname: "host_name"
     unit: "systemd_component"

--- a/docs/extensions/logging-and-monitoring.md
+++ b/docs/extensions/logging-and-monitoring.md
@@ -134,31 +134,6 @@ data:
         Reserve_Data        True
 ```
 
-#### How to Expose Logs to the Users
-
-To expose logs from extension components to the users, the extension owners have to specify a `modify` filter which will add `__gardener_multitenant_id__=operator;user` entry to the log record. This entry contains all of the tenants, which have to receive this log. The tenants are semicolon separated. This specific dedicated entry will be extracted and removed from the log in the `gardener fluent-bit-to-loki` output plugin and added to the label set of that log. Then it will be parsed and removed from the label set. Any whitespace will be truncated during the parsing. The extension components logs can be found in `Controlplane Logs Dashboard` Grafana dashboard.
-
-**Example:** In this example we configure fluent-bit when it finds a log with field `tag`, which matches the `Condition`, to add `__gardener_multitenant_id__=operator;user` into the log record.
-
-```yaml
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: gardener-extension-provider-aws-logging-config
-  namespace: garden
-  labels:
-    extensions.gardener.cloud/configuration: logging
-data:
-  filter-kubernetes.conf: |
-    [FILTER]
-        Name          modify
-        Match         kubernetes.*
-        Condition     Key_value_matches tag ^kubernetes\.var\.log\.containers\.(cloud-controller-manager-.+?_.+?_aws-cloud-controller-manager|csi-driver-controller-.+?_.+?_aws-csi)_.+?
-        Add           __gardener_multitenant_id__ operator;user
-```
-In this case we have predefined filter which copies the log's tag into the log record under the `tag` field. The tag consists of the container logs directories path, plus `<pod_name>_<shoot_controlplane_namespace>_<container_name>_<container_id>`, so here we say:
-> When you see a record from pod `cloud-controller-manager` and some of the `aws-cloud-controller-manager`, `csi-driver-controller` or  `aws-csi` containers add `__gardener_multitenant_id__` key with `operator;user` value into the log record.
-
 Further details how to define parsers and use them with examples can be found in the following [guide](../development/log_parsers.md).
 
 ### Grafana

--- a/test/testmachinery/shoots/logging/utils.go
+++ b/test/testmachinery/shoots/logging/utils.go
@@ -128,7 +128,7 @@ func create(ctx context.Context, c client.Client, obj client.Object) error {
 func getShootNamesapce(number int) *corev1.Namespace {
 	return &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: fmt.Sprintf("%s%v", simulatesShootNamespacePrefix, number),
+			Name: fmt.Sprintf("%s%v", simulatedShootNamespacePrefix, number),
 		},
 	}
 }
@@ -149,7 +149,7 @@ func getCluster(number int) *extensionsv1alpha1.Cluster {
 			APIVersion: "extensions.gardener.cloud/v1alpha1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name: fmt.Sprintf("%s%v", simulatesShootNamespacePrefix, number),
+			Name: fmt.Sprintf("%s%v", simulatedShootNamespacePrefix, number),
 		},
 		Spec: extensionsv1alpha1.ClusterSpec{
 			Shoot: runtime.RawExtension{
@@ -169,7 +169,7 @@ func getLokiShootService(number int) *corev1.Service {
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      lokiName,
-			Namespace: fmt.Sprintf("%s%v", simulatesShootNamespacePrefix, number),
+			Namespace: fmt.Sprintf("%s%v", simulatedShootNamespacePrefix, number),
 		},
 		Spec: corev1.ServiceSpec{
 			Type:         corev1.ServiceType(corev1.ServiceTypeExternalName),


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area logging
/kind cleanup

**What this PR does / why we need it**:
With this PR the Loki user tenant is removed, although the Loki multi-tenancy is not switched off.
The testmachinery is tuned to no longer test for user logs.
The log label `docker_id` is renamed to `container_id`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Loki user tenant is removed.
```
```other operator github.com/gardener/logging #172 @vlvasilev
Loki label `docker_id` is replaced by `container_id`.
```
```other operator github.com/gardener/logging #172 @vlvasilev
Logging Gardener-specific multi-tenancy can be switched off by `EnableMultiTenancy`.
```