### PR TITLE
Docs: use `brew --prefix` instead of hardcoded path

### DIFF
--- a/docs/development/local_setup.md
+++ b/docs/development/local_setup.md
@@ -96,13 +96,14 @@ When running on macOS, install the GNU core utilities and friends:
 brew install coreutils gnu-sed gnu-tar grep
 ```
 
-This will create symbolic links for the GNU utilities with `g` prefix in `/usr/local/bin`, e.g., `gsed` or `gbase64`. To allow using them without the `g` prefix please put `/usr/local/opt/coreutils/libexec/gnubin` etc., at the beginning of your `PATH` environment variable, e.g., `export PATH=/usr/local/opt/coreutils/libexec/gnubin:$PATH` (`brew` will print out instructions for each installed formula).
+This will create symbolic links for the GNU utilities with `g` prefix on your `PATH`, e.g., `gsed` or `gbase64`.
+To allow using them without the `g` prefix, add the `gnubin` directories to the beginning of your `PATH` environment variable (`brew install` and `brew info` will print out instructions for each formula):
 
 ```bash
-export PATH=/usr/local/opt/coreutils/libexec/gnubin:$PATH
-export PATH=/usr/local/opt/gnu-sed/libexec/gnubin:$PATH
-export PATH=/usr/local/opt/gnu-tar/libexec/gnubin:$PATH
-export PATH=/usr/local/opt/grep/libexec/gnubin:$PATH
+export PATH=$(brew --prefix)/opt/coreutils/libexec/gnubin:$PATH
+export PATH=$(brew --prefix)/opt/gnu-sed/libexec/gnubin:$PATH
+export PATH=$(brew --prefix)/opt/gnu-tar/libexec/gnubin:$PATH
+export PATH=$(brew --prefix)/opt/grep/libexec/gnubin:$PATH
 ```
 
 ## [Windows Only] WSL2


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:

On new installations, homebrew uses `/opt/homebrew` as a prefix instead of the legacy `/usr/local`.
Adapt the docs, to determine the prefix using `brew --prefix` instead of hardcoding the legacy one.
