### PR TITLE
Fix `make kind2-up` locally

### DIFF
--- a/example/gardener-local/kind/local2/values.yaml
+++ b/example/gardener-local/kind/local2/values.yaml
@@ -5,9 +5,6 @@ gardener:
     istio:
       listenAddresses:
       - 127.0.0.2
-      - 127.0.0.20
-      - 127.0.0.21
-      - 127.0.0.22
 
 registry:
   deployed: false

--- a/pkg/gardenlet/controller/managedseed/add.go
+++ b/pkg/gardenlet/controller/managedseed/add.go
@@ -122,17 +122,15 @@ func (r *Reconciler) AddToManager(
 // ManagedSeedPredicate returns the predicate for ManagedSeed events.
 func (r *Reconciler) ManagedSeedPredicate(seedName string) predicate.Predicate {
 	return &managedSeedPredicate{
-		reader:          r.GardenClient,
-		gardenNamespace: r.GardenNamespaceGarden,
-		seedName:        seedName,
+		reader:   r.GardenClient,
+		seedName: seedName,
 	}
 }
 
 type managedSeedPredicate struct {
-	ctx             context.Context
-	reader          client.Reader
-	gardenNamespace string
-	seedName        string
+	ctx      context.Context
+	reader   client.Reader
+	seedName string
 }
 
 func (p *managedSeedPredicate) InjectStopChannel(stopChan <-chan struct{}) error {
@@ -162,7 +160,7 @@ func (p *managedSeedPredicate) filterManagedSeed(obj client.Object) bool {
 		return false
 	}
 
-	return filterManagedSeed(p.ctx, p.reader, managedSeed, p.gardenNamespace, p.seedName)
+	return filterManagedSeed(p.ctx, p.reader, managedSeed, p.seedName)
 }
 
 // SeedOfManagedSeedPredicate returns the predicate for Seed events.
@@ -213,10 +211,10 @@ func (p *seedOfManagedSeedPredicate) filterSeedOfManagedSeed(obj client.Object) 
 		return false
 	}
 
-	return filterManagedSeed(p.ctx, p.reader, managedSeed, p.gardenNamespace, p.seedName)
+	return filterManagedSeed(p.ctx, p.reader, managedSeed, p.seedName)
 }
 
-func filterManagedSeed(ctx context.Context, reader client.Reader, managedSeed *seedmanagementv1alpha1.ManagedSeed, gardenNamespace, seedName string) bool {
+func filterManagedSeed(ctx context.Context, reader client.Reader, managedSeed *seedmanagementv1alpha1.ManagedSeed, seedName string) bool {
 	if managedSeed.Spec.Shoot == nil || managedSeed.Spec.Shoot.Name == "" {
 		return false
 	}

--- a/pkg/operation/care/checker.go
+++ b/pkg/operation/care/checker.go
@@ -272,11 +272,11 @@ func defaultSuccessfulCheck() func(condition gardencorev1beta1.Condition) bool {
 	}
 }
 
-func resourcesNotProgressingCheck(clock clock.Clock, theshold *metav1.Duration) func(condition gardencorev1beta1.Condition) bool {
+func resourcesNotProgressingCheck(clock clock.Clock, threshold *metav1.Duration) func(condition gardencorev1beta1.Condition) bool {
 	return func(condition gardencorev1beta1.Condition) bool {
 		notProgressing := condition.Status != gardencorev1beta1.ConditionTrue && condition.Status != gardencorev1beta1.ConditionUnknown
 
-		if theshold != nil && !notProgressing && clock.Since(condition.LastTransitionTime.Time) < theshold.Duration {
+		if threshold != nil && !notProgressing && clock.Since(condition.LastTransitionTime.Time) < threshold.Duration {
 			// ManagedResource is progressing but the given threshold didn't pass.
 			// Hence, return that the ManagedResource is not progressing.
 			return true


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind bug

**What this PR does / why we need it**:
This PR fixes an issue with bootstrapping a second seed locally:

```
make kind2-up KIND_ENV=local

docker: Error response from daemon: Ports are not available: listen tcp 127.0.0.21:443: bind: can't assign requested address.
make: *** [kind2-up] Error 1
```

**Special notes for your reviewer**:
The PR cleans up two minor aspects in the code along the way.

/invite @ScheererJ because the additional IPs were added through [#6997](https://github.com/gardener/gardener/pull/6997/files#diff-ed1d028871249fc3e87b0cf39740c1620bfb8dc2f70059bf090d6eab306aa9f3).

Thanks @Kostov6 and @ialidzhikov for reporting.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```developer bugfix
An issue has been fixed that caused `make kind2-up KIND_ENV=local` to fail.
```
