### PR TITLE
Document that 127.0.0.2 has to be added to the loopback interface

### DIFF
--- a/docs/deployment/getting_started_locally.md
+++ b/docs/deployment/getting_started_locally.md
@@ -173,8 +173,15 @@ To access the `Shoot`, you can acquire a `kubeconfig` by using the [`shoots/admi
 
 ## (Optional): Setting Up a Second Seed Cluster
 
-There are cases where you would want to create a second cluster seed in your local setup. For example, if you want to test the [control plane migration](../usage/control_plane_migration.md) feature. The following steps describe how to do that.
+There are cases where you would want to create a second seed cluster in your local setup. For example, if you want to test the [control plane migration](../usage/control_plane_migration.md) feature. The following steps describe how to do that.
 
+If you are on macOS, add a new IP address on your loopback device which will be necessary for the new KinD cluster that you will create. On macOS, the default loopback device is `lo0`.
+
+```bash
+sudo ip addr add 127.0.0.2 dev lo0                                     # adding 127.0.0.2 ip to the loopback interface
+```
+
+Next, setup the second KinD cluster:
 
 ```bash
 make kind2-up

--- a/docs/development/getting_started_locally.md
+++ b/docs/development/getting_started_locally.md
@@ -183,7 +183,8 @@ When the `Shoot` got created successfully, you can acquire a `kubeconfig` by usi
 
 There are cases where you would want to create a second seed cluster in your local setup. For example, if you want to test the [control plane migration](../usage/control_plane_migration.md) feature. The following steps describe how to do that.
 
-Add a new IP address on your loopback device which will be necessary for the new KinD cluster that you will create. On Mac, the default loopback device is `lo0`.
+If you are on macOS, add a new IP address on your loopback device which will be necessary for the new KinD cluster that you will create. On macOS, the default loopback device is `lo0`.
+
 
 ```bash
 sudo ip addr add 127.0.0.2 dev lo0                                     # adding 127.0.0.2 ip to the loopback interface


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind enhancement

**What this PR does / why we need it**:
While debugging with @Kostov6 on his local setup, we were not able to verify that https://github.com/gardener/gardener/pull/7526 fixes the 2nd Seed cluster creation. It was failing with:

```
% make kind2-up KIND_ENV=local

docker: Error response from daemon: Ports are not available: exposing port TCP 127.0.0.2:9443 -> 0.0.0.0: listen tcp 127.0.0.2:9443: bind can't assign requested address.
make: *** [kind2-up] Error 1
```

While on my side the 2nd Seed cluster creation was working with the fix from https://github.com/gardener/gardener/pull/7526.
We noticed that the instruction `sudo ip addr add 127.0.0.2 dev lo0` is not present in `deployment/getting_started_locally.md` while it is present in `development/getting_started_locally.md`.
We had to execute the above command to add 127.0.0.2 to `lo0`. After that he was able to successfully created the 2nd Seed cluster.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
