### PR TITLE
Fixed `wait-for.sh` not to exit script for `kubectl` errors until it reaches timeout

### DIFF
--- a/hack/usage/wait-for.sh
+++ b/hack/usage/wait-for.sh
@@ -47,10 +47,10 @@ retries=0
 while [ "${retries}" -lt "${TIMEOUT}" ]; do
   if [ -z "$NAMESPACE" ]; then
     # Get the condition types in jsonpath format and pipe to yq to extract the value of conditions
-    CONDITION_STATES=$(kubectl get "${RESOURCE_TYPE}" "${OBJECT_NAME}" --request-timeout='1s' -o json | yq '.status.conditions') || true
+    CONDITION_STATES=$(kubectl get "${RESOURCE_TYPE}" "${OBJECT_NAME}" -o json | yq '.status.conditions') || true
   else
     # Get the condition types in jsonpath format and pipe to yq to extract the value of conditions
-    CONDITION_STATES=$(kubectl get "${RESOURCE_TYPE}" "${OBJECT_NAME}" -n "$NAMESPACE" --request-timeout='1s' -o json | yq '.status.conditions') || true
+    CONDITION_STATES=$(kubectl get "${RESOURCE_TYPE}" "${OBJECT_NAME}" -n "$NAMESPACE" -o json | yq '.status.conditions') || true
   fi
 
   # A flag to indicate if all conditions have passed

--- a/hack/usage/wait-for.sh
+++ b/hack/usage/wait-for.sh
@@ -47,10 +47,10 @@ retries=0
 while [ "${retries}" -lt "${TIMEOUT}" ]; do
   if [ -z "$NAMESPACE" ]; then
     # Get the condition types in jsonpath format and pipe to yq to extract the value of conditions
-    CONDITION_STATES=$(kubectl get "${RESOURCE_TYPE}" "${OBJECT_NAME}" --request-timeout='1s' -o json | yq '.status.conditions')
+    CONDITION_STATES=$(kubectl get "${RESOURCE_TYPE}" "${OBJECT_NAME}" --request-timeout='1s' -o json | yq '.status.conditions') || true
   else
     # Get the condition types in jsonpath format and pipe to yq to extract the value of conditions
-    CONDITION_STATES=$(kubectl get "${RESOURCE_TYPE}" "${OBJECT_NAME}" -n "$NAMESPACE" --request-timeout='1s' -o json | yq '.status.conditions')
+    CONDITION_STATES=$(kubectl get "${RESOURCE_TYPE}" "${OBJECT_NAME}" -n "$NAMESPACE" --request-timeout='1s' -o json | yq '.status.conditions') || true
   fi
 
   # A flag to indicate if all conditions have passed


### PR DESCRIPTION

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing robustness
/kind test

**What this PR does / why we need it**:
This PR fixes the script `wait-for.sh` not to exit for `kubectl` errors until it reaches timeout.
 
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
NONE
```
