### PR TITLE
Prepare for the removal of the `enableBasicAuthentication` field

### DIFF
--- a/docs/api-reference/core.md
+++ b/docs/api-reference/core.md
@@ -4750,9 +4750,8 @@ bool
 </td>
 <td>
 <em>(Optional)</em>
-<p>EnableBasicAuthentication defines whether basic authentication should be enabled for this cluster or not.
-Defaults to false.
-Deprecated: basic authentication has been removed in Kubernetes v1.19+. This field will be removed in a future version.</p>
+<p>EnableBasicAuthentication defines whether basic authentication should be enabled for this cluster or not.</p>
+<p>Deprecated: basic authentication has been removed in Kubernetes v1.19+. The field is no-op and will be removed in a future version.</p>
 </td>
 </tr>
 <tr>

--- a/example/90-shoot.yaml
+++ b/example/90-shoot.yaml
@@ -354,7 +354,7 @@ spec:
     #   enable-access-log-for-default-backend: "false"
     kubernetesDashboard:
       enabled: true
-    # authenticationMode: basic # allowed values: basic,token
+    # authenticationMode: token # allowed values: token
 # tolerations:
 # - key: <some-key>
 # Explicitly specify the seed that will run the shoot control plane. Only possible for users having RBAC for 

--- a/pkg/apis/core/helper/helpers.go
+++ b/pkg/apis/core/helper/helpers.go
@@ -152,18 +152,6 @@ func ToExpirableVersions(versions []core.MachineImageVersion) []core.ExpirableVe
 	return expirableVersions
 }
 
-// ShootWantsBasicAuthentication returns true if basic authentication is not configured or
-// if it is set explicitly to 'true'.
-func ShootWantsBasicAuthentication(kubeAPIServerConfig *core.KubeAPIServerConfig) bool {
-	if kubeAPIServerConfig == nil {
-		return true
-	}
-	if kubeAPIServerConfig.EnableBasicAuthentication == nil {
-		return true
-	}
-	return *kubeAPIServerConfig.EnableBasicAuthentication
-}
-
 // TaintsHave returns true if the given key is part of the taints list.
 func TaintsHave(taints []core.SeedTaint, key string) bool {
 	for _, taint := range taints {

--- a/pkg/apis/core/helper/helpers_test.go
+++ b/pkg/apis/core/helper/helpers_test.go
@@ -76,18 +76,6 @@ var _ = Describe("helper", func() {
 		falseVar = false
 	)
 
-	DescribeTable("#ShootWantsBasicAuthentication",
-		func(kubeAPIServerConfig *core.KubeAPIServerConfig, wantsBasicAuth bool) {
-			actualWantsBasicAuth := ShootWantsBasicAuthentication(kubeAPIServerConfig)
-			Expect(actualWantsBasicAuth).To(Equal(wantsBasicAuth))
-		},
-
-		Entry("no kubeapiserver configuration", nil, true),
-		Entry("field not set", &core.KubeAPIServerConfig{}, true),
-		Entry("explicitly enabled", &core.KubeAPIServerConfig{EnableBasicAuthentication: &trueVar}, true),
-		Entry("explicitly disabled", &core.KubeAPIServerConfig{EnableBasicAuthentication: &falseVar}, false),
-	)
-
 	DescribeTable("#GetShootCARotationPhase",
 		func(credentials *core.ShootCredentials, expectedPhase core.CredentialsRotationPhase) {
 			Expect(GetShootCARotationPhase(credentials)).To(Equal(expectedPhase))

--- a/pkg/apis/core/types_shoot.go
+++ b/pkg/apis/core/types_shoot.go
@@ -533,8 +533,8 @@ type KubeAPIServerConfig struct {
 	// AuditConfig contains configuration settings for the audit of the kube-apiserver.
 	AuditConfig *AuditConfig
 	// EnableBasicAuthentication defines whether basic authentication should be enabled for this cluster or not.
-	// Defaults to false.
-	// Deprecated: basic authentication has been removed in Kubernetes v1.19+. This field will be removed in a future version.
+	//
+	// Deprecated: basic authentication has been removed in Kubernetes v1.19+. The field is no-op and will be removed in a future version.
 	EnableBasicAuthentication *bool
 	// OIDCConfig contains configuration settings for the OIDC provider.
 	OIDCConfig *OIDCConfig

--- a/pkg/apis/core/types_shoot.go
+++ b/pkg/apis/core/types_shoot.go
@@ -312,9 +312,6 @@ type KubernetesDashboard struct {
 }
 
 const (
-	// KubernetesDashboardAuthModeBasic uses basic authentication mode for auth.
-	// Deprecated: basic authentication has been removed in Kubernetes v1.19+.
-	KubernetesDashboardAuthModeBasic = "basic"
 	// KubernetesDashboardAuthModeToken uses token-based mode for auth.
 	KubernetesDashboardAuthModeToken = "token"
 )

--- a/pkg/apis/core/v1alpha1/defaults.go
+++ b/pkg/apis/core/v1alpha1/defaults.go
@@ -100,9 +100,6 @@ func SetDefaults_Shoot(obj *Shoot) {
 	if obj.Spec.Kubernetes.KubeAPIServer == nil {
 		obj.Spec.Kubernetes.KubeAPIServer = &KubeAPIServerConfig{}
 	}
-	if obj.Spec.Kubernetes.KubeAPIServer.EnableBasicAuthentication == nil {
-		obj.Spec.Kubernetes.KubeAPIServer.EnableBasicAuthentication = pointer.Bool(false)
-	}
 	if obj.Spec.Kubernetes.KubeAPIServer.Requests == nil {
 		obj.Spec.Kubernetes.KubeAPIServer.Requests = &KubeAPIServerRequests{}
 	}
@@ -176,12 +173,7 @@ func SetDefaults_Shoot(obj *Shoot) {
 		obj.Spec.Addons.KubernetesDashboard = &KubernetesDashboard{}
 	}
 	if obj.Spec.Addons.KubernetesDashboard.AuthenticationMode == nil {
-		var defaultAuthMode string
-		if *obj.Spec.Kubernetes.KubeAPIServer.EnableBasicAuthentication {
-			defaultAuthMode = KubernetesDashboardAuthModeBasic
-		} else {
-			defaultAuthMode = KubernetesDashboardAuthModeToken
-		}
+		defaultAuthMode := KubernetesDashboardAuthModeToken
 		obj.Spec.Addons.KubernetesDashboard.AuthenticationMode = &defaultAuthMode
 	}
 

--- a/pkg/apis/core/v1alpha1/defaults_test.go
+++ b/pkg/apis/core/v1alpha1/defaults_test.go
@@ -365,12 +365,6 @@ var _ = Describe("Defaults", func() {
 			Expect(obj.Spec.Maintenance).NotTo(BeNil())
 		})
 
-		It("should disable basic auth", func() {
-			obj.Spec.Kubernetes.Version = "1.20.1"
-			SetObjectDefaults_Shoot(obj)
-			Expect(obj.Spec.Kubernetes.KubeAPIServer.EnableBasicAuthentication).To(PointTo(BeFalse()))
-		})
-
 		It("should default the max inflight requests fields", func() {
 			SetObjectDefaults_Shoot(obj)
 			Expect(obj.Spec.Kubernetes.KubeAPIServer.Requests.MaxNonMutatingInflight).To(Equal(pointer.Int32(400)))

--- a/pkg/apis/core/v1alpha1/generated.proto
+++ b/pkg/apis/core/v1alpha1/generated.proto
@@ -919,9 +919,9 @@ message KubeAPIServerConfig {
   optional AuditConfig auditConfig = 4;
 
   // EnableBasicAuthentication defines whether basic authentication should be enabled for this cluster or not.
+  //
+  // Deprecated: basic authentication has been removed in Kubernetes v1.19+. The field is no-op and will be removed in a future version.
   // +optional
-  // Defaults to false.
-  // Deprecated: basic authentication has been removed in Kubernetes v1.19+. This field will be removed in a future version.
   optional bool enableBasicAuthentication = 5;
 
   // OIDCConfig contains configuration settings for the OIDC provider.

--- a/pkg/apis/core/v1alpha1/types_shoot.go
+++ b/pkg/apis/core/v1alpha1/types_shoot.go
@@ -370,9 +370,6 @@ type KubernetesDashboard struct {
 }
 
 const (
-	// KubernetesDashboardAuthModeBasic uses basic authentication mode for auth.
-	// Deprecated: basic authentication has been removed in Kubernetes v1.19+.
-	KubernetesDashboardAuthModeBasic = "basic"
 	// KubernetesDashboardAuthModeToken uses token-based mode for auth.
 	KubernetesDashboardAuthModeToken = "token"
 )

--- a/pkg/apis/core/v1alpha1/types_shoot.go
+++ b/pkg/apis/core/v1alpha1/types_shoot.go
@@ -664,9 +664,9 @@ type KubeAPIServerConfig struct {
 	// +optional
 	AuditConfig *AuditConfig `json:"auditConfig,omitempty" protobuf:"bytes,4,opt,name=auditConfig"`
 	// EnableBasicAuthentication defines whether basic authentication should be enabled for this cluster or not.
+	//
+	// Deprecated: basic authentication has been removed in Kubernetes v1.19+. The field is no-op and will be removed in a future version.
 	// +optional
-	// Defaults to false.
-	// Deprecated: basic authentication has been removed in Kubernetes v1.19+. This field will be removed in a future version.
 	EnableBasicAuthentication *bool `json:"enableBasicAuthentication,omitempty" protobuf:"varint,5,opt,name=enableBasicAuthentication"`
 	// OIDCConfig contains configuration settings for the OIDC provider.
 	// +optional

--- a/pkg/apis/core/v1beta1/defaults.go
+++ b/pkg/apis/core/v1beta1/defaults.go
@@ -100,9 +100,6 @@ func SetDefaults_Shoot(obj *Shoot) {
 	if obj.Spec.Kubernetes.KubeAPIServer == nil {
 		obj.Spec.Kubernetes.KubeAPIServer = &KubeAPIServerConfig{}
 	}
-	if obj.Spec.Kubernetes.KubeAPIServer.EnableBasicAuthentication == nil {
-		obj.Spec.Kubernetes.KubeAPIServer.EnableBasicAuthentication = pointer.Bool(false)
-	}
 	if obj.Spec.Kubernetes.KubeAPIServer.Requests == nil {
 		obj.Spec.Kubernetes.KubeAPIServer.Requests = &KubeAPIServerRequests{}
 	}
@@ -176,12 +173,7 @@ func SetDefaults_Shoot(obj *Shoot) {
 		obj.Spec.Addons.KubernetesDashboard = &KubernetesDashboard{}
 	}
 	if obj.Spec.Addons.KubernetesDashboard.AuthenticationMode == nil {
-		var defaultAuthMode string
-		if *obj.Spec.Kubernetes.KubeAPIServer.EnableBasicAuthentication {
-			defaultAuthMode = KubernetesDashboardAuthModeBasic
-		} else {
-			defaultAuthMode = KubernetesDashboardAuthModeToken
-		}
+		defaultAuthMode := KubernetesDashboardAuthModeToken
 		obj.Spec.Addons.KubernetesDashboard.AuthenticationMode = &defaultAuthMode
 	}
 

--- a/pkg/apis/core/v1beta1/defaults_test.go
+++ b/pkg/apis/core/v1beta1/defaults_test.go
@@ -365,12 +365,6 @@ var _ = Describe("Defaults", func() {
 			Expect(obj.Spec.Maintenance).NotTo(BeNil())
 		})
 
-		It("should disable basic auth", func() {
-			obj.Spec.Kubernetes.Version = "1.20.1"
-			SetObjectDefaults_Shoot(obj)
-			Expect(obj.Spec.Kubernetes.KubeAPIServer.EnableBasicAuthentication).To(PointTo(BeFalse()))
-		})
-
 		It("should default the max inflight requests fields", func() {
 			SetObjectDefaults_Shoot(obj)
 			Expect(obj.Spec.Kubernetes.KubeAPIServer.Requests.MaxNonMutatingInflight).To(Equal(pointer.Int32(400)))

--- a/pkg/apis/core/v1beta1/generated.proto
+++ b/pkg/apis/core/v1beta1/generated.proto
@@ -918,9 +918,9 @@ message KubeAPIServerConfig {
   optional AuditConfig auditConfig = 4;
 
   // EnableBasicAuthentication defines whether basic authentication should be enabled for this cluster or not.
+  //
+  // Deprecated: basic authentication has been removed in Kubernetes v1.19+. The field is no-op and will be removed in a future version.
   // +optional
-  // Defaults to false.
-  // Deprecated: basic authentication has been removed in Kubernetes v1.19+. This field will be removed in a future version.
   optional bool enableBasicAuthentication = 5;
 
   // OIDCConfig contains configuration settings for the OIDC provider.

--- a/pkg/apis/core/v1beta1/helper/helper.go
+++ b/pkg/apis/core/v1beta1/helper/helper.go
@@ -470,19 +470,6 @@ func ShootWantsAlertManager(shoot *gardencorev1beta1.Shoot) bool {
 	return !ShootIgnoresAlerts(shoot) && shoot.Spec.Monitoring != nil && shoot.Spec.Monitoring.Alerting != nil && len(shoot.Spec.Monitoring.Alerting.EmailReceivers) > 0
 }
 
-// ShootWantsBasicAuthentication returns true if basic authentication is not configured or
-// if it is set explicitly to 'true'.
-func ShootWantsBasicAuthentication(shoot *gardencorev1beta1.Shoot) bool {
-	kubeAPIServerConfig := shoot.Spec.Kubernetes.KubeAPIServer
-	if kubeAPIServerConfig == nil {
-		return true
-	}
-	if kubeAPIServerConfig.EnableBasicAuthentication == nil {
-		return true
-	}
-	return *kubeAPIServerConfig.EnableBasicAuthentication
-}
-
 // ShootUsesUnmanagedDNS returns true if the shoot's DNS section is marked as 'unmanaged'.
 func ShootUsesUnmanagedDNS(shoot *gardencorev1beta1.Shoot) bool {
 	return shoot.Spec.DNS != nil && len(shoot.Spec.DNS.Providers) > 0 && shoot.Spec.DNS.Providers[0].Type != nil && *shoot.Spec.DNS.Providers[0].Type == "unmanaged"

--- a/pkg/apis/core/v1beta1/types_shoot.go
+++ b/pkg/apis/core/v1beta1/types_shoot.go
@@ -382,9 +382,6 @@ type KubernetesDashboard struct {
 }
 
 const (
-	// KubernetesDashboardAuthModeBasic uses basic authentication mode for auth.
-	// Deprecated: basic authentication has been removed in Kubernetes v1.19+.
-	KubernetesDashboardAuthModeBasic = "basic"
 	// KubernetesDashboardAuthModeToken uses token-based mode for auth.
 	KubernetesDashboardAuthModeToken = "token"
 )

--- a/pkg/apis/core/v1beta1/types_shoot.go
+++ b/pkg/apis/core/v1beta1/types_shoot.go
@@ -676,9 +676,9 @@ type KubeAPIServerConfig struct {
 	// +optional
 	AuditConfig *AuditConfig `json:"auditConfig,omitempty" protobuf:"bytes,4,opt,name=auditConfig"`
 	// EnableBasicAuthentication defines whether basic authentication should be enabled for this cluster or not.
+	//
+	// Deprecated: basic authentication has been removed in Kubernetes v1.19+. The field is no-op and will be removed in a future version.
 	// +optional
-	// Defaults to false.
-	// Deprecated: basic authentication has been removed in Kubernetes v1.19+. This field will be removed in a future version.
 	EnableBasicAuthentication *bool `json:"enableBasicAuthentication,omitempty" protobuf:"varint,5,opt,name=enableBasicAuthentication"`
 	// OIDCConfig contains configuration settings for the OIDC provider.
 	// +optional

--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -405,10 +405,6 @@ func validateAddons(addons *core.Addons, kubernetes core.Kubernetes, purpose *co
 			if !availableKubernetesDashboardAuthenticationModes.Has(*authMode) {
 				allErrs = append(allErrs, field.NotSupported(fldPath.Child("kubernetesDashboard", "authenticationMode"), *authMode, sets.List(availableKubernetesDashboardAuthenticationModes)))
 			}
-
-			if *authMode == core.KubernetesDashboardAuthModeBasic && !helper.ShootWantsBasicAuthentication(kubernetes.KubeAPIServer) {
-				allErrs = append(allErrs, field.Invalid(fldPath.Child("kubernetesDashboard", "authenticationMode"), *authMode, "cannot use basic auth mode when basic auth is not enabled in kube-apiserver configuration"))
-			}
 		}
 	}
 
@@ -737,10 +733,6 @@ func validateKubernetes(kubernetes core.Kubernetes, networking core.Networking, 
 	}
 
 	if kubeAPIServer := kubernetes.KubeAPIServer; kubeAPIServer != nil {
-		if helper.ShootWantsBasicAuthentication(kubeAPIServer) {
-			allErrs = append(allErrs, field.Forbidden(fldPath.Child("kubeAPIServer", "enableBasicAuthentication"), "basic authentication has been removed in Kubernetes v1.19+"))
-		}
-
 		if oidc := kubeAPIServer.OIDCConfig; oidc != nil {
 			oidcPath := fldPath.Child("kubeAPIServer", "oidcConfig")
 

--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -59,7 +59,6 @@ var (
 		string(core.ProxyModeIPVS),
 	)
 	availableKubernetesDashboardAuthenticationModes = sets.New[string](
-		core.KubernetesDashboardAuthModeBasic,
 		core.KubernetesDashboardAuthModeToken,
 	)
 	availableNginxIngressExternalTrafficPolicies = sets.New[string](

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -3433,7 +3433,7 @@ func schema_pkg_apis_core_v1alpha1_KubeAPIServerConfig(ref common.ReferenceCallb
 					},
 					"enableBasicAuthentication": {
 						SchemaProps: spec.SchemaProps{
-							Description: "EnableBasicAuthentication defines whether basic authentication should be enabled for this cluster or not. Defaults to false. Deprecated: basic authentication has been removed in Kubernetes v1.19+. This field will be removed in a future version.",
+							Description: "EnableBasicAuthentication defines whether basic authentication should be enabled for this cluster or not.\n\nDeprecated: basic authentication has been removed in Kubernetes v1.19+. The field is no-op and will be removed in a future version.",
 							Type:        []string{"boolean"},
 							Format:      "",
 						},
@@ -11104,7 +11104,7 @@ func schema_pkg_apis_core_v1beta1_KubeAPIServerConfig(ref common.ReferenceCallba
 					},
 					"enableBasicAuthentication": {
 						SchemaProps: spec.SchemaProps{
-							Description: "EnableBasicAuthentication defines whether basic authentication should be enabled for this cluster or not. Defaults to false. Deprecated: basic authentication has been removed in Kubernetes v1.19+. This field will be removed in a future version.",
+							Description: "EnableBasicAuthentication defines whether basic authentication should be enabled for this cluster or not.\n\nDeprecated: basic authentication has been removed in Kubernetes v1.19+. The field is no-op and will be removed in a future version.",
 							Type:        []string{"boolean"},
 							Format:      "",
 						},

--- a/pkg/operation/botanist/component/kubernetesdashboard/kubernetes_dashboard_test.go
+++ b/pkg/operation/botanist/component/kubernetesdashboard/kubernetes_dashboard_test.go
@@ -548,7 +548,7 @@ status: {}
 			Context("w/ apiserver host, w/ authentication mode, w/ vpa", func() {
 				var (
 					apiserverHost      = "apiserver.host"
-					authenticationMode = "basic"
+					authenticationMode = "token"
 				)
 
 				BeforeEach(func() {
@@ -577,7 +577,7 @@ status: {}
 			Context("w/ apiserver host w/ authentication mode, w/ vpa", func() {
 				var (
 					apiserverHost      = "apiserver.host"
-					authenticationMode = "basic"
+					authenticationMode = "token"
 				)
 
 				BeforeEach(func() {

--- a/pkg/registry/core/shoot/strategy.go
+++ b/pkg/registry/core/shoot/strategy.go
@@ -67,6 +67,7 @@ func (shootStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object) {
 	shoot.Status = core.ShootStatus{}
 
 	dropDisabledFields(shoot, nil)
+	dropEnableBasicAuthenticationField(shoot)
 }
 
 func (shootStrategy) PrepareForUpdate(ctx context.Context, obj, old runtime.Object) {
@@ -81,6 +82,7 @@ func (shootStrategy) PrepareForUpdate(ctx context.Context, obj, old runtime.Obje
 	}
 
 	dropDisabledFields(newShoot, oldShoot)
+	dropEnableBasicAuthenticationField(newShoot)
 }
 
 // dropDisabledFields removes disabled fields from shoot.
@@ -89,6 +91,13 @@ func dropDisabledFields(newShoot, oldShoot *core.Shoot) {
 	oldShootIsHA := oldShoot != nil && helper.IsHAControlPlaneConfigured(oldShoot)
 	if !utilfeature.DefaultFeatureGate.Enabled(features.HAControlPlanes) && !oldShootIsHA && newShoot.Spec.ControlPlane != nil {
 		newShoot.Spec.ControlPlane.HighAvailability = nil
+	}
+}
+
+// dropEnableBasicAuthenticationField sets the enableBasicAuthentication to nil.
+func dropEnableBasicAuthenticationField(shoot *core.Shoot) {
+	if shoot.Spec.Kubernetes.KubeAPIServer != nil {
+		shoot.Spec.Kubernetes.KubeAPIServer.EnableBasicAuthentication = nil
 	}
 }
 

--- a/pkg/registry/core/shoot/strategy.go
+++ b/pkg/registry/core/shoot/strategy.go
@@ -68,6 +68,7 @@ func (shootStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object) {
 
 	dropDisabledFields(shoot, nil)
 	dropEnableBasicAuthenticationField(shoot)
+	setKubernetesDashboardAuthMode(shoot)
 }
 
 func (shootStrategy) PrepareForUpdate(ctx context.Context, obj, old runtime.Object) {
@@ -83,6 +84,7 @@ func (shootStrategy) PrepareForUpdate(ctx context.Context, obj, old runtime.Obje
 
 	dropDisabledFields(newShoot, oldShoot)
 	dropEnableBasicAuthenticationField(newShoot)
+	setKubernetesDashboardAuthMode(newShoot)
 }
 
 // dropDisabledFields removes disabled fields from shoot.
@@ -98,6 +100,16 @@ func dropDisabledFields(newShoot, oldShoot *core.Shoot) {
 func dropEnableBasicAuthenticationField(shoot *core.Shoot) {
 	if shoot.Spec.Kubernetes.KubeAPIServer != nil {
 		shoot.Spec.Kubernetes.KubeAPIServer.EnableBasicAuthentication = nil
+	}
+}
+
+// setKubernetesDashboardAuthMode sets the kubernetes-dashboard authentication mode to "token", if its current value is "basic".
+func setKubernetesDashboardAuthMode(shoot *core.Shoot) {
+	if shoot.Spec.Addons != nil && shoot.Spec.Addons.KubernetesDashboard != nil {
+		if authMode := shoot.Spec.Addons.KubernetesDashboard.AuthenticationMode; authMode != nil && *authMode == core.KubernetesDashboardAuthModeBasic {
+			defaultAuthMode := core.KubernetesDashboardAuthModeToken
+			shoot.Spec.Addons.KubernetesDashboard.AuthenticationMode = &defaultAuthMode
+		}
 	}
 }
 

--- a/pkg/registry/core/shoot/strategy.go
+++ b/pkg/registry/core/shoot/strategy.go
@@ -103,10 +103,10 @@ func dropEnableBasicAuthenticationField(shoot *core.Shoot) {
 	}
 }
 
-// setKubernetesDashboardAuthMode sets the kubernetes-dashboard authentication mode to "token", if its current value is "basic".
+// setKubernetesDashboardAuthMode sets the kubernetes-dashboard authentication mode to "token", if its current value is not "token" (for example "basic").
 func setKubernetesDashboardAuthMode(shoot *core.Shoot) {
 	if shoot.Spec.Addons != nil && shoot.Spec.Addons.KubernetesDashboard != nil {
-		if authMode := shoot.Spec.Addons.KubernetesDashboard.AuthenticationMode; authMode != nil && *authMode == core.KubernetesDashboardAuthModeBasic {
+		if authMode := shoot.Spec.Addons.KubernetesDashboard.AuthenticationMode; authMode != nil && *authMode != core.KubernetesDashboardAuthModeToken {
 			defaultAuthMode := core.KubernetesDashboardAuthModeToken
 			shoot.Spec.Addons.KubernetesDashboard.AuthenticationMode = &defaultAuthMode
 		}

--- a/pkg/registry/core/shoot/strategy_test.go
+++ b/pkg/registry/core/shoot/strategy_test.go
@@ -108,6 +108,41 @@ var _ = Describe("Strategy", func() {
 				Expect(shoot.Spec.Kubernetes.KubeAPIServer).To(BeNil())
 			})
 		})
+
+		DescribeTable("kubernetesDashboard.authenticationMode field",
+			func(addons *core.Addons, expected *core.Addons) {
+				shoot := &core.Shoot{
+					Spec: core.ShootSpec{
+						Addons: addons,
+					},
+				}
+
+				shootregistry.NewStrategy(0).PrepareForCreate(context.TODO(), shoot)
+
+				Expect(shoot.Spec.Addons).To(Equal(expected))
+			},
+
+			Entry("addons field is nil",
+				nil,
+				nil,
+			),
+			Entry("kubernetesDashboard field is nil",
+				&core.Addons{KubernetesDashboard: nil},
+				&core.Addons{KubernetesDashboard: nil},
+			),
+			Entry("authMode is nil",
+				&core.Addons{KubernetesDashboard: &core.KubernetesDashboard{AuthenticationMode: nil}},
+				&core.Addons{KubernetesDashboard: &core.KubernetesDashboard{AuthenticationMode: nil}},
+			),
+			Entry("authMode is basic",
+				&core.Addons{KubernetesDashboard: &core.KubernetesDashboard{AuthenticationMode: pointer.String("basic")}},
+				&core.Addons{KubernetesDashboard: &core.KubernetesDashboard{AuthenticationMode: pointer.String("token")}},
+			),
+			Entry("authMode is token",
+				&core.Addons{KubernetesDashboard: &core.KubernetesDashboard{AuthenticationMode: pointer.String("token")}},
+				&core.Addons{KubernetesDashboard: &core.KubernetesDashboard{AuthenticationMode: pointer.String("token")}},
+			),
+		)
 	})
 
 	Describe("#PrepareForUpdate", func() {
@@ -547,6 +582,42 @@ var _ = Describe("Strategy", func() {
 				Expect(newShoot.Spec.Kubernetes.KubeAPIServer).To(BeNil())
 			})
 		})
+
+		DescribeTable("kubernetesDashboard.authenticationMode field",
+			func(addons *core.Addons, expected *core.Addons) {
+				newShoot := &core.Shoot{
+					Spec: core.ShootSpec{
+						Addons: addons,
+					},
+				}
+				oldShoot := &core.Shoot{}
+
+				shootregistry.NewStrategy(0).PrepareForUpdate(context.TODO(), newShoot, oldShoot)
+
+				Expect(newShoot.Spec.Addons).To(Equal(expected))
+			},
+
+			Entry("addons field is nil",
+				nil,
+				nil,
+			),
+			Entry("kubernetesDashboard field is nil",
+				&core.Addons{KubernetesDashboard: nil},
+				&core.Addons{KubernetesDashboard: nil},
+			),
+			Entry("authMode is nil",
+				&core.Addons{KubernetesDashboard: &core.KubernetesDashboard{AuthenticationMode: nil}},
+				&core.Addons{KubernetesDashboard: &core.KubernetesDashboard{AuthenticationMode: nil}},
+			),
+			Entry("authMode is basic",
+				&core.Addons{KubernetesDashboard: &core.KubernetesDashboard{AuthenticationMode: pointer.String("basic")}},
+				&core.Addons{KubernetesDashboard: &core.KubernetesDashboard{AuthenticationMode: pointer.String("token")}},
+			),
+			Entry("authMode is token",
+				&core.Addons{KubernetesDashboard: &core.KubernetesDashboard{AuthenticationMode: pointer.String("token")}},
+				&core.Addons{KubernetesDashboard: &core.KubernetesDashboard{AuthenticationMode: pointer.String("token")}},
+			),
+		)
 	})
 
 	Describe("#Canonicalize", func() {

--- a/pkg/registry/core/shoot/strategy_test.go
+++ b/pkg/registry/core/shoot/strategy_test.go
@@ -36,7 +36,6 @@ import (
 )
 
 var _ = Describe("Strategy", func() {
-
 	Describe("#PrepareForCreate", func() {
 		var (
 			shoot *core.Shoot

--- a/pkg/registry/core/shoot/strategy_test.go
+++ b/pkg/registry/core/shoot/strategy_test.go
@@ -36,6 +36,80 @@ import (
 )
 
 var _ = Describe("Strategy", func() {
+
+	Describe("#PrepareForCreate", func() {
+		var (
+			shoot *core.Shoot
+		)
+
+		BeforeEach(func() {
+			shoot = &core.Shoot{}
+		})
+
+		DescribeTable("HAControlPlanes feature gate on shoot creation",
+			func(featureGateEnabled bool, shootCP, resultingShootCP *core.ControlPlane) {
+
+				testFeatureGate := featuregate.NewFeatureGate()
+				Expect(testFeatureGate.Add(features.GetFeatures(
+					features.HAControlPlanes,
+				))).To(Succeed())
+				Expect(testFeatureGate.Set(fmt.Sprintf("%s=%v", features.HAControlPlanes, featureGateEnabled))).To(Succeed())
+
+				DeferCleanup(test.WithVars(
+					&utilfeature.DefaultFeatureGate,
+					testFeatureGate,
+				))
+
+				shoot.Spec.ControlPlane = shootCP
+
+				shootregistry.NewStrategy(0).PrepareForCreate(context.TODO(), shoot)
+
+				Expect(shoot.Spec.ControlPlane).To(Equal(resultingShootCP))
+			},
+
+			Entry("HAControlPlanes false, new shoot HA",
+				false,
+				newControlPlaneWithFailureTypeNode(),
+				newControlPlaneWithHighAvailabilityNil(),
+			),
+			Entry("HAControlPlanes true, new shoot HA",
+				true,
+				newControlPlaneWithFailureTypeNode(),
+				newControlPlaneWithFailureTypeNode(),
+			),
+			Entry("HAControlPlanes false, new shoot no HA",
+				false,
+				nil,
+				nil,
+			),
+			Entry("HAControlPlanes true, new shoot no HA",
+				true,
+				nil,
+				nil,
+			),
+		)
+
+		Context("enableBasicAuthentication field", func() {
+			It("should drop the enableBasicAuthentication field when the kubeAPIServer is not nil", func() {
+				shoot.Spec.Kubernetes.KubeAPIServer = &core.KubeAPIServerConfig{
+					EnableBasicAuthentication: pointer.Bool(false),
+				}
+
+				shootregistry.NewStrategy(0).PrepareForCreate(context.TODO(), shoot)
+
+				Expect(shoot.Spec.Kubernetes.KubeAPIServer.EnableBasicAuthentication).To(BeNil())
+			})
+
+			It("should do nothing when kubeAPIServer is nil", func() {
+				shoot.Spec.Kubernetes.KubeAPIServer = nil
+
+				shootregistry.NewStrategy(0).PrepareForCreate(context.TODO(), shoot)
+
+				Expect(shoot.Spec.Kubernetes.KubeAPIServer).To(BeNil())
+			})
+		})
+	})
+
 	Describe("#PrepareForUpdate", func() {
 		Context("seedName change", func() {
 			var (
@@ -244,49 +318,6 @@ var _ = Describe("Strategy", func() {
 				)
 			})
 
-			DescribeTable("HAControlPlanes feature gate on shoot creation",
-				func(featureGateEnabled bool, newShootCP, resultingShootCP *core.ControlPlane) {
-
-					testFeatureGate := featuregate.NewFeatureGate()
-					Expect(testFeatureGate.Add(features.GetFeatures(
-						features.HAControlPlanes,
-					))).To(Succeed())
-					Expect(testFeatureGate.Set(fmt.Sprintf("%s=%v", features.HAControlPlanes, featureGateEnabled))).To(Succeed())
-
-					DeferCleanup(test.WithVars(
-						&utilfeature.DefaultFeatureGate,
-						testFeatureGate,
-					))
-
-					newShoot.Spec.ControlPlane = newShootCP
-
-					shootregistry.NewStrategy(0).PrepareForCreate(context.TODO(), newShoot)
-
-					Expect(newShoot.Spec.ControlPlane).To(Equal(resultingShootCP))
-				},
-
-				Entry("HAControlPlanes false, new shoot HA",
-					false,
-					newControlPlaneWithFailureTypeNode(),
-					newControlPlaneWithHighAvailabilityNil(),
-				),
-				Entry("HAControlPlanes true, new shoot HA",
-					true,
-					newControlPlaneWithFailureTypeNode(),
-					newControlPlaneWithFailureTypeNode(),
-				),
-				Entry("HAControlPlanes false, new shoot no HA",
-					false,
-					nil,
-					nil,
-				),
-				Entry("HAControlPlanes true, new shoot no HA",
-					true,
-					nil,
-					nil,
-				),
-			)
-
 			DescribeTable("HAControlPlanes feature gate on shoot update",
 				func(featureGateEnabled bool, oldShootCP, newShootCP, resultingShootCP *core.ControlPlane) {
 
@@ -485,6 +516,36 @@ var _ = Describe("Strategy", func() {
 					true,
 				),
 			)
+		})
+
+		Context("enableBasicAuthentication field", func() {
+			var (
+				oldShoot *core.Shoot
+				newShoot *core.Shoot
+			)
+
+			BeforeEach(func() {
+				oldShoot = &core.Shoot{}
+				newShoot = oldShoot.DeepCopy()
+			})
+
+			It("should drop the enableBasicAuthentication field when the kubeAPIServer is not nil", func() {
+				newShoot.Spec.Kubernetes.KubeAPIServer = &core.KubeAPIServerConfig{
+					EnableBasicAuthentication: pointer.Bool(false),
+				}
+
+				shootregistry.NewStrategy(0).PrepareForUpdate(context.TODO(), newShoot, oldShoot)
+
+				Expect(newShoot.Spec.Kubernetes.KubeAPIServer.EnableBasicAuthentication).To(BeNil())
+			})
+
+			It("should do nothing when kubeAPIServer is nil", func() {
+				newShoot.Spec.Kubernetes.KubeAPIServer = nil
+
+				shootregistry.NewStrategy(0).PrepareForUpdate(context.TODO(), newShoot, oldShoot)
+
+				Expect(newShoot.Spec.Kubernetes.KubeAPIServer).To(BeNil())
+			})
 		})
 	})
 

--- a/test/framework/resources/templates/default-shoot.yaml
+++ b/test/framework/resources/templates/default-shoot.yaml
@@ -15,8 +15,6 @@ spec:
     # the enableStaticTokenKubeconfig field cannot parse the K8s version and sets the field always to false.
     # We should consider switching to UniversalDeserializer or use other approach that will allow the desired behaviour to be achieved.
     enableStaticTokenKubeconfig: true
-    kubeAPIServer:
-      enableBasicAuthentication: false
   dns: {}
   networking:
     type: calico


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind cleanup

**What this PR does / why we need it**:
The  `enableBasicAuthentication` field does no longer make sense after https://github.com/gardener/gardener/pull/6987. In https://github.com/gardener/gardener/pull/6987 we removed support for Shoots with K8s < 1.20. The basic authentication was removed in K8s 1.19.x. Hence, it is not possible to enable basic auth anymore for a Shoot that is within the support K8s versions of Gardener currently.

This PR is a preparation for the removal of the `enableBasicAuthentication` field:
- It makes the `enableBasicAuthentication` field no-op (removes validation, removes defaulting) - the field is not used anymore.
- It sets the `enableBasicAuthentication` field always to nil. So far the field was always defaulted to false, if it was not specified in the field.
- It overwrites the `.spec.kubernetes.addons.kubernetesDashboard.authenticationMode` to `token`, if it is set to `basic`.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/6911

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other user
The `.spec.kubernetes.kubeAPIServer.enableBasicAuthentication` field is now no-op - the `gardener-apiserver` no longer defaults this field and no longer validates it. The field will be set always to `nil` on CREATE/UPDATE request.
End users specifying this field should no longer specify it. The field will be removed in a future version of Gardener.
```
