### PR TITLE
Fix the `should download shoot kubeconfig successfully` integration test

### DIFF
--- a/docs/api-reference/core.md
+++ b/docs/api-reference/core.md
@@ -2110,7 +2110,7 @@ string
 </em>
 </td>
 <td>
-<p>Name is an an availability zone name.</p>
+<p>Name is an availability zone name.</p>
 </td>
 </tr>
 <tr>

--- a/docs/concepts/gardenlet.md
+++ b/docs/concepts/gardenlet.md
@@ -401,7 +401,7 @@ This reconciler performs three "care" actions related to `Shoot`s.
 
 ##### Conditions
 
-It maintains four conditions and performs the following checks:
+It maintains five conditions and performs the following checks:
 
 - `APIServerAvailable`: The `/healthz` endpoint of the shoot's `kube-apiserver` is called and considered healthy when it responds with `200 OK`.
 - `ControlPlaneHealthy`: The control plane is considered healthy when the respective `Deployment`s (for example `kube-apiserver`,`kube-controller-manager`), and `Etcd`s (for example `etcd-main`) exist and are healthy.

--- a/docs/usage/shoot_status.md
+++ b/docs/usage/shoot_status.md
@@ -21,6 +21,7 @@ Currently the available Shoot condition types are:
 - `APIServerAvailable`
 - `ControlPlaneHealthy`
 - `EveryNodeReady`
+- `ObservabilityComponentsHealthy`
 - `SystemComponentsHealthy`
 
 The Shoot conditions are maintained by the [shoot care reconciler](../../pkg/gardenlet/controller/shoot/care/reconciler.go) of gardenlet.

--- a/pkg/apis/core/types_cloudprofile.go
+++ b/pkg/apis/core/types_cloudprofile.go
@@ -170,7 +170,7 @@ type Region struct {
 
 // AvailabilityZone is an availability zone.
 type AvailabilityZone struct {
-	// Name is an an availability zone name.
+	// Name is an availability zone name.
 	Name string
 	// UnavailableMachineTypes is a list of machine type names that are not availability in this zone.
 	UnavailableMachineTypes []string

--- a/pkg/apis/core/v1alpha1/generated.proto
+++ b/pkg/apis/core/v1alpha1/generated.proto
@@ -88,7 +88,7 @@ message AuditPolicy {
 
 // AvailabilityZone is an availability zone.
 message AvailabilityZone {
-  // Name is an an availability zone name.
+  // Name is an availability zone name.
   optional string name = 1;
 
   // UnavailableMachineTypes is a list of machine type names that are not availability in this zone.

--- a/pkg/apis/core/v1alpha1/types_cloudprofile.go
+++ b/pkg/apis/core/v1alpha1/types_cloudprofile.go
@@ -199,7 +199,7 @@ type Region struct {
 
 // AvailabilityZone is an availability zone.
 type AvailabilityZone struct {
-	// Name is an an availability zone name.
+	// Name is an availability zone name.
 	Name string `json:"name" protobuf:"bytes,1,opt,name=name"`
 	// UnavailableMachineTypes is a list of machine type names that are not availability in this zone.
 	// +optional

--- a/pkg/apis/core/v1beta1/generated.proto
+++ b/pkg/apis/core/v1beta1/generated.proto
@@ -87,7 +87,7 @@ message AuditPolicy {
 
 // AvailabilityZone is an availability zone.
 message AvailabilityZone {
-  // Name is an an availability zone name.
+  // Name is an availability zone name.
   optional string name = 1;
 
   // UnavailableMachineTypes is a list of machine type names that are not availability in this zone.

--- a/pkg/apis/core/v1beta1/types_cloudprofile.go
+++ b/pkg/apis/core/v1beta1/types_cloudprofile.go
@@ -199,7 +199,7 @@ type Region struct {
 
 // AvailabilityZone is an availability zone.
 type AvailabilityZone struct {
-	// Name is an an availability zone name.
+	// Name is an availability zone name.
 	Name string `json:"name" protobuf:"bytes,1,opt,name=name"`
 	// UnavailableMachineTypes is a list of machine type names that are not availability in this zone.
 	// +optional

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -990,7 +990,7 @@ func schema_pkg_apis_core_v1alpha1_AvailabilityZone(ref common.ReferenceCallback
 				Properties: map[string]spec.Schema{
 					"name": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Name is an an availability zone name.",
+							Description: "Name is an availability zone name.",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -8661,7 +8661,7 @@ func schema_pkg_apis_core_v1beta1_AvailabilityZone(ref common.ReferenceCallback)
 				Properties: map[string]spec.Schema{
 					"name": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Name is an an availability zone name.",
+							Description: "Name is an availability zone name.",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",

--- a/test/testmachinery/shoots/applications/shoot_app.go
+++ b/test/testmachinery/shoots/applications/shoot_app.go
@@ -57,7 +57,7 @@ var _ = ginkgo.Describe("Shoot application testing", func() {
 	f := framework.NewShootFramework(nil)
 
 	f.Default().Release().CIt("should download shoot kubeconfig successfully", func(ctx context.Context) {
-		err := framework.DownloadKubeconfig(ctx, f.SeedClient, f.ShootSeedNamespace(), v1beta1constants.SecretNameGardener, "")
+		err := framework.DownloadKubeconfig(ctx, f.SeedClient, f.ShootSeedNamespace(), v1beta1constants.SecretNameGardener, "test-kubecfg")
 		framework.ExpectNoError(err)
 
 		ginkgo.By("Shoot Kubeconfig downloaded successfully from seed")

--- a/test/testmachinery/shoots/applications/shoot_app.go
+++ b/test/testmachinery/shoots/applications/shoot_app.go
@@ -36,6 +36,7 @@ import (
 	"time"
 
 	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
@@ -56,10 +57,10 @@ var _ = ginkgo.Describe("Shoot application testing", func() {
 
 	f := framework.NewShootFramework(nil)
 
-	f.Default().Release().CIt("should download shoot kubeconfig successfully", func(ctx context.Context) {
-		err := framework.DownloadKubeconfig(ctx, f.SeedClient, f.ShootSeedNamespace(), v1beta1constants.SecretNameGardener, "test-kubecfg")
+	f.Default().Release().CIt("should fetch the shoot kubeconfig from the Seed cluster successfully", func(ctx context.Context) {
+		kubeconfig, err := framework.GetObjectFromSecret(ctx, f.SeedClient, f.ShootSeedNamespace(), v1beta1constants.SecretNameGardener, framework.KubeconfigSecretKeyName)
 		framework.ExpectNoError(err)
-
+		gomega.Expect(kubeconfig).ToNot(gomega.BeNil())
 		ginkgo.By("Shoot Kubeconfig downloaded successfully from seed")
 	}, downloadKubeconfigTimeout)
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind bug

**What this PR does / why we need it**:
https://github.com/gardener/gardener/pull/7495 changed the logic in `DownloadKubeconfig` and now it doesn't check if the file path is nil before writing in the file.  This PR adds a test-file to path, for downloading kubeconfig test.
Apart from the above, this PR also improves a few other things, done in separate commits.

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
