### PR TITLE
Fix nil pointer error in `seed-lifecycle` controller

### DIFF
--- a/pkg/controllermanager/controller/seed/lifecycle/reconciler.go
+++ b/pkg/controllermanager/controller/seed/lifecycle/reconciler.go
@@ -132,8 +132,13 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		return reconcile.Result{RequeueAfter: r.Config.SyncPeriod.Duration}, nil
 	}
 
+	var gardenletOfflineSince interface{} = "Unknown"
+	if conditionGardenletReady != nil {
+		gardenletOfflineSince = conditionGardenletReady.LastTransitionTime.UTC()
+	}
+
 	log.Info("Gardenlet has not sent heartbeats for at least the configured shoot monitor period, setting shoot conditions and constraints to 'Unknown' for all shoots on this seed",
-		"gardenletOfflineSince", conditionGardenletReady.LastTransitionTime.UTC(),
+		"gardenletOfflineSince", gardenletOfflineSince,
 		"now", r.Clock.Now().UTC(),
 		"shootMonitorPeriod", r.Config.ShootMonitorPeriod.Duration,
 	)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug

**What this PR does / why we need it**:
A nil pointer Panic can occur in `seed-lifecycle`  controller in case `GardenletReady` condition is not set on seed.
This PR fixes nil pointer issues in the `seed-lifecycle` controller.

**Which issue(s) this PR fixes**:
Fixes #7235

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
An issue causing a nil pointer error in the `seed-lifecycle` controller is fixed.
```
