### PR TITLE
Update to Go 1.19.6

### DIFF
--- a/.test-defs/CreateShoot.yaml
+++ b/.test-defs/CreateShoot.yaml
@@ -41,4 +41,4 @@ spec:
 #    -machine-type=$MACHINE_TYPE
 #    -external-domain=
 
-  image: eu.gcr.io/gardener-project/3rd/golang:1.19.5
+  image: eu.gcr.io/gardener-project/3rd/golang:1.19.6

--- a/.test-defs/DeleteShoot.yaml
+++ b/.test-defs/DeleteShoot.yaml
@@ -15,4 +15,4 @@ spec:
     --shoot-name=$SHOOT_NAME
     --project-namespace=$PROJECT_NAMESPACE
     --kubecfg="$TM_KUBECONFIG_PATH/gardener.config"
-  image: eu.gcr.io/gardener-project/3rd/golang:1.19.5
+  image: eu.gcr.io/gardener-project/3rd/golang:1.19.6

--- a/.test-defs/HibernateShoot.yaml
+++ b/.test-defs/HibernateShoot.yaml
@@ -16,4 +16,4 @@ spec:
     --project-namespace=$PROJECT_NAMESPACE
     --kubecfg="$TM_KUBECONFIG_PATH/gardener.config"
 
-  image: eu.gcr.io/gardener-project/3rd/golang:1.19.5
+  image: eu.gcr.io/gardener-project/3rd/golang:1.19.6

--- a/.test-defs/MigrateShoot.yaml
+++ b/.test-defs/MigrateShoot.yaml
@@ -19,4 +19,4 @@ spec:
     -mr-exclude-list="$MR_EXCLUDE_LIST"
     -resources-with-generated-name="$RESOURCES_WITH_GENERATED_NAME"
     -add-test-run-taint="$ADD_TEST_RUN_TAINT"
-  image: eu.gcr.io/gardener-project/3rd/golang:1.19.5
+  image: eu.gcr.io/gardener-project/3rd/golang:1.19.6

--- a/.test-defs/ReconcileShoots.yaml
+++ b/.test-defs/ReconcileShoots.yaml
@@ -15,4 +15,4 @@ spec:
     -kubecfg=$TM_KUBECONFIG_PATH/gardener.config
     -version=$GARDENER_VERSION
 
-  image: eu.gcr.io/gardener-project/3rd/golang:1.19.5
+  image: eu.gcr.io/gardener-project/3rd/golang:1.19.6

--- a/.test-defs/ShootKubernetesUpdateTest.yaml
+++ b/.test-defs/ShootKubernetesUpdateTest.yaml
@@ -19,4 +19,4 @@ spec:
     -project-namespace=$PROJECT_NAMESPACE
     -version=$K8S_VERSION
     -version-worker-pools=$K8S_VERSION_WORKER_POOLS
-  image: eu.gcr.io/gardener-project/3rd/golang:1.19.5
+  image: eu.gcr.io/gardener-project/3rd/golang:1.19.6

--- a/.test-defs/TestSuiteGardenerBeta.yaml
+++ b/.test-defs/TestSuiteGardenerBeta.yaml
@@ -19,4 +19,4 @@ spec:
       -ginkgo.focus="\[BETA\]"
       -ginkgo.skip="\[SERIAL\]|\[DISRUPTIVE\]"
 
-  image: eu.gcr.io/gardener-project/3rd/golang:1.19.5
+  image: eu.gcr.io/gardener-project/3rd/golang:1.19.6

--- a/.test-defs/TestSuiteGardenerBetaSerial.yaml
+++ b/.test-defs/TestSuiteGardenerBetaSerial.yaml
@@ -21,4 +21,4 @@ spec:
       -ginkgo.focus="\[BETA\].*\[SERIAL\]"
       -ginkgo.skip="\[DISRUPTIVE\]"
 
-  image: eu.gcr.io/gardener-project/3rd/golang:1.19.5
+  image: eu.gcr.io/gardener-project/3rd/golang:1.19.6

--- a/.test-defs/TestSuiteGardenerDefault.yaml
+++ b/.test-defs/TestSuiteGardenerDefault.yaml
@@ -19,4 +19,4 @@ spec:
       -ginkgo.focus="\[DEFAULT\]"
       -ginkgo.skip="\[SERIAL\]|\[DISRUPTIVE\]"
 
-  image: eu.gcr.io/gardener-project/3rd/golang:1.19.5
+  image: eu.gcr.io/gardener-project/3rd/golang:1.19.6

--- a/.test-defs/TestSuiteGardenerDefaultSerial.yaml
+++ b/.test-defs/TestSuiteGardenerDefaultSerial.yaml
@@ -21,4 +21,4 @@ spec:
       -ginkgo.focus="\[DEFAULT\].*\[SERIAL\]"
       -ginkgo.skip="\[DISRUPTIVE\]"
 
-  image: eu.gcr.io/gardener-project/3rd/golang:1.19.5
+  image: eu.gcr.io/gardener-project/3rd/golang:1.19.6

--- a/.test-defs/TestSuiteGardenerRelease.yaml
+++ b/.test-defs/TestSuiteGardenerRelease.yaml
@@ -19,4 +19,4 @@ spec:
       -ginkgo.focus="\[RELEASE\]"
       -ginkgo.skip="\[SERIAL\]|\[DISRUPTIVE\]"
 
-  image: eu.gcr.io/gardener-project/3rd/golang:1.19.5
+  image: eu.gcr.io/gardener-project/3rd/golang:1.19.6

--- a/.test-defs/TestSuiteGardenerReleaseSerial.yaml
+++ b/.test-defs/TestSuiteGardenerReleaseSerial.yaml
@@ -21,4 +21,4 @@ spec:
       -ginkgo.focus="\[RELEASE\].*\[SERIAL\]"
       -ginkgo.skip="\[DISRUPTIVE\]"
 
-  image: eu.gcr.io/gardener-project/3rd/golang:1.19.5
+  image: eu.gcr.io/gardener-project/3rd/golang:1.19.6

--- a/.test-defs/TestSuiteShootBeta.yaml
+++ b/.test-defs/TestSuiteShootBeta.yaml
@@ -21,4 +21,4 @@ spec:
       -ginkgo.focus="\[BETA\]"
       -ginkgo.skip="\[SERIAL\]|\[DISRUPTIVE\]"
 
-  image: eu.gcr.io/gardener-project/3rd/golang:1.19.5
+  image: eu.gcr.io/gardener-project/3rd/golang:1.19.6

--- a/.test-defs/TestSuiteShootBetaDisruptive.yaml
+++ b/.test-defs/TestSuiteShootBetaDisruptive.yaml
@@ -23,4 +23,4 @@ spec:
       -ginkgo.focus="\[BETA\].*\[DISRUPTIVE\]"
       -ginkgo.skip="\[SERIAL\]"
 
-  image: eu.gcr.io/gardener-project/3rd/golang:1.19.5
+  image: eu.gcr.io/gardener-project/3rd/golang:1.19.6

--- a/.test-defs/TestSuiteShootBetaSerial.yaml
+++ b/.test-defs/TestSuiteShootBetaSerial.yaml
@@ -23,4 +23,4 @@ spec:
       -ginkgo.focus="\[BETA\].*\[SERIAL\]"
       -ginkgo.skip="\[DISRUPTIVE\]"
 
-  image: eu.gcr.io/gardener-project/3rd/golang:1.19.5
+  image: eu.gcr.io/gardener-project/3rd/golang:1.19.6

--- a/.test-defs/TestSuiteShootDefault.yaml
+++ b/.test-defs/TestSuiteShootDefault.yaml
@@ -22,4 +22,4 @@ spec:
       -ginkgo.skip="\[SERIAL\]|\[DISRUPTIVE\]"
       -ginkgo.timeout=2h
 
-  image: eu.gcr.io/gardener-project/3rd/golang:1.19.5
+  image: eu.gcr.io/gardener-project/3rd/golang:1.19.6

--- a/.test-defs/TestSuiteShootDefaultDisruptive.yaml
+++ b/.test-defs/TestSuiteShootDefaultDisruptive.yaml
@@ -23,4 +23,4 @@ spec:
       -ginkgo.focus="\[DEFAULT\].*\[DISRUPTIVE\]"
       -ginkgo.skip="\[SERIAL\]"
 
-  image: eu.gcr.io/gardener-project/3rd/golang:1.19.5
+  image: eu.gcr.io/gardener-project/3rd/golang:1.19.6

--- a/.test-defs/TestSuiteShootDefaultSerial.yaml
+++ b/.test-defs/TestSuiteShootDefaultSerial.yaml
@@ -24,4 +24,4 @@ spec:
       -ginkgo.skip="\[DISRUPTIVE\]"
       -ginkgo.timeout=2h
 
-  image: eu.gcr.io/gardener-project/3rd/golang:1.19.5
+  image: eu.gcr.io/gardener-project/3rd/golang:1.19.6

--- a/.test-defs/TestSuiteShootRelease.yaml
+++ b/.test-defs/TestSuiteShootRelease.yaml
@@ -21,4 +21,4 @@ spec:
       -ginkgo.focus="\[RELEASE\]"
       -ginkgo.skip="\[SERIAL\]|\[DISRUPTIVE\]"
 
-  image: eu.gcr.io/gardener-project/3rd/golang:1.19.5
+  image: eu.gcr.io/gardener-project/3rd/golang:1.19.6

--- a/.test-defs/TestSuiteShootReleaseDisruptive.yaml
+++ b/.test-defs/TestSuiteShootReleaseDisruptive.yaml
@@ -23,4 +23,4 @@ spec:
       -ginkgo.focus="\[RELEASE\].*\[DISRUPTIVE\]"
       -ginkgo.skip="\[SERIAL\]"
 
-  image: eu.gcr.io/gardener-project/3rd/golang:1.19.5
+  image: eu.gcr.io/gardener-project/3rd/golang:1.19.6

--- a/.test-defs/TestSuiteShootReleaseSerial.yaml
+++ b/.test-defs/TestSuiteShootReleaseSerial.yaml
@@ -23,4 +23,4 @@ spec:
       -ginkgo.focus="\[RELEASE\].*\[SERIAL\]"
       -ginkgo.skip="\[DISRUPTIVE\]"
 
-  image: eu.gcr.io/gardener-project/3rd/golang:1.19.5
+  image: eu.gcr.io/gardener-project/3rd/golang:1.19.6

--- a/.test-defs/WakeUpShoot.yaml
+++ b/.test-defs/WakeUpShoot.yaml
@@ -16,4 +16,4 @@ spec:
     --project-namespace=$PROJECT_NAMESPACE
     --kubecfg="$TM_KUBECONFIG_PATH/gardener.config"
 
-  image: eu.gcr.io/gardener-project/3rd/golang:1.19.5
+  image: eu.gcr.io/gardener-project/3rd/golang:1.19.6

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 #############      builder       #############
-FROM golang:1.19.5 AS builder
+FROM golang:1.19.6 AS builder
 
 WORKDIR /go/src/github.com/gardener/gardener
 COPY . .


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind enhancement

**What this PR does / why we need it**:
Go 1.19.6 is released: [ref](https://go.dev/doc/devel/release#go1.19.6)

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
Update to Go `1.19.6`.
```
