### PR TITLE
managedseed controller: Do not sync the Seed kubeconfig secret when Shoot's static token kubeconfig is not enabled

### DIFF
--- a/pkg/gardenlet/controller/managedseed/actuator.go
+++ b/pkg/gardenlet/controller/managedseed/actuator.go
@@ -513,8 +513,9 @@ func (a *actuator) createOrUpdateSeedSecrets(ctx context.Context, spec *gardenco
 		}
 	}
 
-	// If secret reference is specified, create or update the corresponding secret
-	if spec.SecretRef != nil {
+	// If secret reference is specified and the static token kubeconfig is enabled,
+	// create or update the corresponding secret with the kubeconfig from the static token kubeconfig secret.
+	if spec.SecretRef != nil && pointer.BoolDeref(shoot.Spec.Kubernetes.EnableStaticTokenKubeconfig, false) {
 		// Get shoot kubeconfig secret
 		shootKubeconfigSecret, err := a.getShootKubeconfigSecret(ctx, shoot)
 		if err != nil {

--- a/plugin/pkg/managedseed/validator/admission.go
+++ b/plugin/pkg/managedseed/validator/admission.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/apiserver/pkg/admission"
 	kubeinformers "k8s.io/client-go/informers"
 	kubecorev1listers "k8s.io/client-go/listers/core/v1"
+	"k8s.io/utils/pointer"
 
 	"github.com/gardener/gardener/pkg/apis/core"
 	gardencore "github.com/gardener/gardener/pkg/apis/core"
@@ -350,6 +351,10 @@ func (v *ManagedSeed) admitSeedSpec(spec *gardencore.SeedSpec, shoot *gardencore
 		}
 	} else if spec.Settings.VerticalPodAutoscaler.Enabled {
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("settings", "verticalPodAutoscaler", "enabled"), spec.Settings.VerticalPodAutoscaler.Enabled, "seed VPA is not supported for managed seeds - use the shoot VPA"))
+	}
+
+	if spec.SecretRef != nil && !pointer.BoolDeref(shoot.Spec.Kubernetes.EnableStaticTokenKubeconfig, false) {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("secretRef"), spec.SecretRef, "seed secretRef cannot be specified when the shoot static token kubeconfig is disabled"))
 	}
 
 	return allErrs, nil

--- a/plugin/pkg/managedseed/validator/admission_test.go
+++ b/plugin/pkg/managedseed/validator/admission_test.go
@@ -93,6 +93,7 @@ var _ = Describe("ManagedSeed", func() {
 						Domain: pointer.String(domain),
 					},
 					Kubernetes: core.Kubernetes{
+						EnableStaticTokenKubeconfig: pointer.Bool(false),
 						VerticalPodAutoscaler: &core.VerticalPodAutoscaler{
 							Enabled: true,
 						},
@@ -380,6 +381,10 @@ var _ = Describe("ManagedSeed", func() {
 						Region: "bar-region",
 						Zones:  []string{"foo", "bar"},
 					},
+					SecretRef: &corev1.SecretReference{
+						Name:      name,
+						Namespace: namespace,
+					},
 					Settings: &gardencorev1beta1.SeedSettings{
 						VerticalPodAutoscaler: &gardencorev1beta1.SeedSettingVerticalPodAutoscaler{
 							Enabled: true,
@@ -438,6 +443,11 @@ var _ = Describe("ManagedSeed", func() {
 						"Type":   Equal(field.ErrorTypeInvalid),
 						"Field":  Equal("spec.gardenlet.config.seedConfig.spec.settings.verticalPodAutoscaler.enabled"),
 						"Detail": ContainSubstring("seed VPA is not supported for managed seeds - use the shoot VPA"),
+					})),
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":   Equal(field.ErrorTypeInvalid),
+						"Field":  Equal("spec.gardenlet.config.seedConfig.spec.secretRef"),
+						"Detail": ContainSubstring("seed secretRef cannot be specified when the shoot static token kubeconfig is disabled"),
 					})),
 				))
 			})

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -58,6 +58,7 @@ build:
         - pkg/apis/seedmanagement/helper
         - pkg/apis/seedmanagement/install
         - pkg/apis/seedmanagement/v1alpha1
+        - pkg/apis/seedmanagement/v1alpha1/helper
         - pkg/apis/seedmanagement/validation
         - pkg/apis/settings
         - pkg/apis/settings/install


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind bug

**What this PR does / why we need it**:
Currently the managedseed actuator would fail to reconcile a ManagedSeed when `.spec.gardenlet.config.seedConfig.spec.secretRef` is set and the Shoot is with `.spec.kubernetes.enableStaticTokenKubeconfig=false`:
```
2023-02-22T16:38:50.272+0200	ERROR	Reconciler error	{"controller": "managedseed", "namespace": "garden", "name": "managedseed", "reconcileID": "43754148-3d3e-4743-8271-391179272f77", "error": "could not reconcile ManagedSeed garden/managedseed creation or update: could not create or update seed managedseed secrets: secrets \"managedseed.kubeconfig\" not found"}
```

https://github.com/gardener/gardener/blob/e3dde16edf89fadf79c0e65a23273b6a9f759213/pkg/gardenlet/controller/managedseed/actuator.go#L511-L535

The handling shared above will try to sync the Seed kubeconfig Secret with the Shoot's static token kubeconfig. As the Shoot's static token kubeconfig is no longer present, it will fail to fetch it.

The Gardener API server now has the following validation enforced for ManagedSeeds:
- It is now forbidden to set the Seed `secretRef` when the Shoot static token kubeconfig is disabled. (`ManagedSeed` admission plugin)
- It is now forbidden to disable the Shoot static token kubeconfig when the Seed `secretRef` is set. (`ShootManagedSeed` admission plugin)

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/6773

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The ManagedSeed controller does no longer tries to sync the Seed kubeconfig Secret when Shoot's static token kubeconfig is not enabled.
```

```breaking operator
The Gardener API server now has the following validation enforced for ManagedSeeds:
- It is now forbidden to set the Seed `secretRef` when the Shoot static token kubeconfig is disabled. (`ManagedSeed` admission plugin)
- It is now forbidden to disable the Shoot static token kubeconfig when the Seed `secretRef` is set. (`ShootManagedSeed` admission plugin)
```
