### PR TITLE
Updates etcd-druid CRDs to v0.16.0

### DIFF
--- a/pkg/operation/botanist/component/etcd/crds/templates/crd-druid.gardener.cloud_etcdcopybackupstasks.yaml
+++ b/pkg/operation/botanist/component/etcd/crds/templates/crd-druid.gardener.cloud_etcdcopybackupstasks.yaml
@@ -1,4 +1,4 @@
-# Source: https://github.com/gardener/etcd-druid/blob/v0.15.3/charts/druid/charts/crds/templates/10-crd-druid.gardener.cloud_etcdcopybackupstasks.yaml
+# Source: https://github.com/gardener/etcd-druid/blob/v0.16.0/charts/druid/charts/crds/templates/10-crd-druid.gardener.cloud_etcdcopybackupstasks.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/pkg/operation/botanist/component/etcd/crds/templates/crd-druid.gardener.cloud_etcds.yaml
+++ b/pkg/operation/botanist/component/etcd/crds/templates/crd-druid.gardener.cloud_etcds.yaml
@@ -1,4 +1,4 @@
-# Source: https://github.com/gardener/etcd-druid/blob/v0.15.3/charts/druid/charts/crds/templates/10-crd-druid.gardener.cloud_etcds.yaml
+# Source: https://github.com/gardener/etcd-druid/blob/v0.16.0/charts/druid/charts/crds/templates/10-crd-druid.gardener.cloud_etcds.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -20,9 +20,30 @@ spec:
     - jsonPath: .status.ready
       name: Ready
       type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Quorate
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="AllMembersReady")].status
+      name: All Members Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="BackupReady")].status
+      name: Backup Ready
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    - jsonPath: .spec.replicas
+      name: Cluster Size
+      priority: 1
+      type: integer
+    - jsonPath: .status.currentReplicas
+      name: Current Replicas
+      priority: 1
+      type: integer
+    - jsonPath: .status.readyReplicas
+      name: Ready Replicas
+      priority: 1
+      type: integer
     name: v1alpha1
     schema:
       openAPIV3Schema:
@@ -143,31 +164,6 @@ spec:
                         description: ReelectionPeriod defines the Period after which
                           leadership status of corresponding etcd is checked.
                         type: string
-                    type: object
-                  ownerCheck:
-                    description: OwnerCheck defines parameters related to checking
-                      if the cluster owner, as specified in the owner DNS record,
-                      is the expected one.
-                    properties:
-                      dnsCacheTTL:
-                        description: DNSCacheTTL is the DNS cache TTL for owner checks.
-                        type: string
-                      id:
-                        description: ID is the owner id value that is expected to
-                          be found in the owner DNS record.
-                        type: string
-                      interval:
-                        description: Interval is the time interval between owner checks.
-                        type: string
-                      name:
-                        description: Name is the domain name of the owner DNS record.
-                        type: string
-                      timeout:
-                        description: Timeout is the timeout for owner checks.
-                        type: string
-                    required:
-                    - id
-                    - name
                     type: object
                   port:
                     description: Port define the port on which etcd-backup-restore


### PR DESCRIPTION
**How to categorize this PR?**
/kind enhancement

**What this PR does / why we need it**:
This PR updates the etcd-druid CRDs to `v0.16.0` to match the version of the etcd-druid deployed by gardenlet.


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Should be merged after this PR: https://github.com/gardener/gardener/pull/7550

**Release note**:
```other operator
NONE
```
