### PR TITLE
Fix `etcd` peer-tls configuration

### DIFF
--- a/pkg/operation/botanist/etcd.go
+++ b/pkg/operation/botanist/etcd.go
@@ -66,6 +66,7 @@ func (b *Botanist) DefaultEtcd(role string, class etcd.Class) (etcd.Interface, e
 			CARotationPhase:         v1beta1helper.GetShootCARotationPhase(b.Shoot.GetInfo().Status.Credentials),
 			KubernetesVersion:       b.Shoot.KubernetesVersion,
 			PriorityClassName:       v1beta1constants.PriorityClassNameShootControlPlane500,
+			HighAvailabilityEnabled: v1beta1helper.IsHAControlPlaneConfigured(b.Shoot.GetInfo()),
 		},
 	)
 

--- a/pkg/operation/botanist/etcd_test.go
+++ b/pkg/operation/botanist/etcd_test.go
@@ -36,6 +36,7 @@ import (
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	kubernetesfake "github.com/gardener/gardener/pkg/client/kubernetes/fake"
@@ -154,6 +155,7 @@ var _ = Describe("Etcd", func() {
 								MaintenanceTimeWindow: maintenanceTimeWindow,
 								ScaleDownUpdateMode:   pointer.String(computeUpdateMode(class, purpose)),
 							}),
+							expectedHighAvailabilityEnabled: Equal(v1beta1helper.IsHAControlPlaneConfigured(botanist.Shoot.GetInfo())),
 						}
 
 						oldNewEtcd := NewEtcd
@@ -193,6 +195,7 @@ var _ = Describe("Etcd", func() {
 						MaintenanceTimeWindow: maintenanceTimeWindow,
 						ScaleDownUpdateMode:   pointer.String(hvpav1alpha1.UpdateModeMaintenanceWindow),
 					}),
+					expectedHighAvailabilityEnabled: Equal(v1beta1helper.IsHAControlPlaneConfigured(botanist.Shoot.GetInfo())),
 				}
 
 				oldNewEtcd := NewEtcd
@@ -224,6 +227,7 @@ var _ = Describe("Etcd", func() {
 						MaintenanceTimeWindow: maintenanceTimeWindow,
 						ScaleDownUpdateMode:   pointer.String(hvpav1alpha1.UpdateModeMaintenanceWindow),
 					}),
+					expectedHighAvailabilityEnabled: Equal(v1beta1helper.IsHAControlPlaneConfigured(botanist.Shoot.GetInfo())),
 				}
 
 				oldNewEtcd := NewEtcd
@@ -461,6 +465,7 @@ type newEtcdValidator struct {
 	expectedStorageCapacity         gomegatypes.GomegaMatcher
 	expectedDefragmentationSchedule gomegatypes.GomegaMatcher
 	expectedHVPAConfig              gomegatypes.GomegaMatcher
+	expectedHighAvailabilityEnabled gomegatypes.GomegaMatcher
 }
 
 func (v *newEtcdValidator) NewEtcd(
@@ -479,6 +484,7 @@ func (v *newEtcdValidator) NewEtcd(
 	Expect(values.Replicas).To(v.expectedReplicas)
 	Expect(values.StorageCapacity).To(v.expectedStorageCapacity)
 	Expect(values.DefragmentationSchedule).To(v.expectedDefragmentationSchedule)
+	Expect(values.HighAvailabilityEnabled).To(v.expectedHighAvailabilityEnabled)
 
 	return v
 }

--- a/pkg/operator/controller/garden/components.go
+++ b/pkg/operator/controller/garden/components.go
@@ -146,8 +146,10 @@ func (r *Reconciler) newEtcd(
 		return nil, err
 	}
 
+	highAvailabilityEnabled := garden.Spec.VirtualCluster.ControlPlane != nil && garden.Spec.VirtualCluster.ControlPlane.HighAvailability != nil
+
 	replicas := pointer.Int32(1)
-	if garden.Spec.VirtualCluster.ControlPlane != nil && garden.Spec.VirtualCluster.ControlPlane.HighAvailability != nil {
+	if highAvailabilityEnabled {
 		replicas = pointer.Int32(3)
 	}
 
@@ -170,7 +172,8 @@ func (r *Reconciler) newEtcd(
 				MaintenanceTimeWindow: garden.Spec.VirtualCluster.Maintenance.TimeWindow,
 				ScaleDownUpdateMode:   hvpaScaleDownUpdateMode,
 			},
-			PriorityClassName: v1beta1constants.PriorityClassNameGardenSystem500,
+			PriorityClassName:       v1beta1constants.PriorityClassNameGardenSystem500,
+			HighAvailabilityEnabled: highAvailabilityEnabled,
 		},
 	), nil
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area high-availability
/kind bug

**What this PR does / why we need it**:
This PR enables `peer-tls` whenever a high availability control plane is requested, independent from the calculated replica count. This is mainly necessary to support shoot deletions while they being hibernated. Since this bug was introduced with Gardener v1.63 (a89ca663f0ba4c6f576db6f06258e627bd5c56f4, disabled `peer-tls` for hibernated clusters), it is not sufficient to just check if peer-tls was once enabled.

In contrast to https://github.com/gardener/gardener/pull/7514, this PR also fixes already failing clusters.

**Special notes for your reviewer**:
/cc @aaronfern @rfranzke

Release notes will be added to cherry-pick PRs only since we already have a note for the fix for the upcoming release (see #7514).

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
