### PR TITLE
Revert "Disable the static token kubeconfig in the shoot template used for TM integration tests"

### DIFF
--- a/test/framework/resources/templates/default-shoot.yaml
+++ b/test/framework/resources/templates/default-shoot.yaml
@@ -5,6 +5,16 @@ metadata:
   namespace: abc
 spec:
   kubernetes:
+    # TODO(ialidzhikov): Remove the enableStaticTokenKubeconfig field and let the defaulting on gardener-apiserver to be used.
+    # The desired behaviour we want to achieve is to have the field:
+    # - defaulted to true for Shoots with K8s < 1.26
+    # - defaulted to false for Shoots with K8s >= 1.25
+    #
+    # Currently the Shoot creation tests is using UniversalDecoder().Decode to convert the Shoot yaml to a Shoot object.
+    # This Decode func also performs defaulting. As this Shoot manifest does not have a K8s version set, the defaulting logic for
+    # the enableStaticTokenKubeconfig field cannot parse the K8s version and sets the field always to false.
+    # We should consider switching to UniversalDeserializer or use other approach that will allow the desired behaviour to be achieved.
+    enableStaticTokenKubeconfig: true
     kubeAPIServer:
       enableBasicAuthentication: false
   dns: {}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind bug

**What this PR does / why we need it**:

This reverts commit 8615236902f6163b581d6c6f738bad29841c4766. 

8615236902f6163b581d6c6f738bad29841c4766 (https://github.com/gardener/gardener/pull/7503) was not enough to achieve the desired effect. Currently all Shoots created with the Shoot creation tests are created with `enableStaticTokenKubeconfig=false`. From the PR:
```
    # TODO(ialidzhikov): Remove the enableStaticTokenKubeconfig field and let the defaulting on gardener-apiserver to be used.
    # The desired behaviour we want to achieve is to have the field:
    # - defaulted to true for Shoots with K8s < 1.26
    # - defaulted to false for Shoots with K8s >= 1.25
    #
    # Currently the Shoot creation tests is using UniversalDecoder().Decode to convert the Shoot yaml to a Shoot object.
    # This Decode func also performs defaulting. As this Shoot manifest does not have a K8s version set, the defaulting logic for
    # the enableStaticTokenKubeconfig field cannot parse the K8s version and sets the field always to false.
    # We should consider switching to UniversalDeserializer or use other approach that will allow the desired behaviour to be achieved.
```

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
