### PR TITLE
Support audit, authentication, authorization webhook configurations for `kube-apiserver`

### DIFF
--- a/pkg/operation/botanist/component/kubeapiserver/deployment.go
+++ b/pkg/operation/botanist/component/kubeapiserver/deployment.go
@@ -59,69 +59,71 @@ const (
 	containerNameAPIServerProxyPodMutator = "apiserver-proxy-pod-mutator"
 	containerNameWatchdog                 = "watchdog"
 
-	volumeNameAdmissionConfiguration     = "admission-config"
-	volumeNameAdmissionKubeconfigSecrets = "admission-kubeconfigs"
-	volumeNameAuditPolicy                = "audit-policy-config"
-	volumeNameAuditWebhookKubeconfig     = "audit-webhook-kubeconfig"
-	volumeNameCA                         = "ca"
-	volumeNameCAClient                   = "ca-client"
-	volumeNameCAEtcd                     = "ca-etcd"
-	volumeNameCAFrontProxy               = "ca-front-proxy"
-	volumeNameCAKubelet                  = "ca-kubelet"
-	volumeNameCAVPN                      = "ca-vpn"
-	volumeNameEgressSelector             = "egress-selection-config"
-	volumeNameEtcdClient                 = "etcd-client"
-	volumeNameEtcdEncryptionConfig       = "etcd-encryption-secret"
-	volumeNameHTTPProxy                  = "http-proxy"
-	volumeNameKubeAPIServerToKubelet     = "kubelet-client"
-	volumeNameKubeAggregator             = "kube-aggregator"
-	volumeNameOIDCCABundle               = "oidc-cabundle"
-	volumeNameServer                     = "kube-apiserver-server"
-	volumeNameServiceAccountKey          = "service-account-key"
-	volumeNameServiceAccountKeyBundle    = "service-account-key-bundle"
-	volumeNameStaticToken                = "static-token"
-	volumeNamePrefixTLSSNISecret         = "tls-sni-"
-	volumeNameVPNSeedClient              = "vpn-seed-client"
-	volumeNameAPIServerAccess            = "kube-api-access-gardener"
-	volumeNameVPNSeedTLSAuth             = "vpn-seed-tlsauth"
-	volumeNameDevNetTun                  = "dev-net-tun"
-	volumeNameFedora                     = "fedora-rhel6-openelec-cabundle"
-	volumeNameCentOS                     = "centos-rhel7-cabundle"
-	volumeNameEtcSSL                     = "etc-ssl"
-	volumeNameUsrShareCaCerts            = "usr-share-cacerts"
-	volumeNameWatchdog                   = "watchdog"
+	volumeNameAdmissionConfiguration          = "admission-config"
+	volumeNameAdmissionKubeconfigSecrets      = "admission-kubeconfigs"
+	volumeNameAuditPolicy                     = "audit-policy-config"
+	volumeNameAuditWebhookKubeconfig          = "audit-webhook-kubeconfig"
+	volumeNameAuthenticationWebhookKubeconfig = "authentication-webhook-kubeconfig"
+	volumeNameCA                              = "ca"
+	volumeNameCAClient                        = "ca-client"
+	volumeNameCAEtcd                          = "ca-etcd"
+	volumeNameCAFrontProxy                    = "ca-front-proxy"
+	volumeNameCAKubelet                       = "ca-kubelet"
+	volumeNameCAVPN                           = "ca-vpn"
+	volumeNameEgressSelector                  = "egress-selection-config"
+	volumeNameEtcdClient                      = "etcd-client"
+	volumeNameEtcdEncryptionConfig            = "etcd-encryption-secret"
+	volumeNameHTTPProxy                       = "http-proxy"
+	volumeNameKubeAPIServerToKubelet          = "kubelet-client"
+	volumeNameKubeAggregator                  = "kube-aggregator"
+	volumeNameOIDCCABundle                    = "oidc-cabundle"
+	volumeNameServer                          = "kube-apiserver-server"
+	volumeNameServiceAccountKey               = "service-account-key"
+	volumeNameServiceAccountKeyBundle         = "service-account-key-bundle"
+	volumeNameStaticToken                     = "static-token"
+	volumeNamePrefixTLSSNISecret              = "tls-sni-"
+	volumeNameVPNSeedClient                   = "vpn-seed-client"
+	volumeNameAPIServerAccess                 = "kube-api-access-gardener"
+	volumeNameVPNSeedTLSAuth                  = "vpn-seed-tlsauth"
+	volumeNameDevNetTun                       = "dev-net-tun"
+	volumeNameFedora                          = "fedora-rhel6-openelec-cabundle"
+	volumeNameCentOS                          = "centos-rhel7-cabundle"
+	volumeNameEtcSSL                          = "etc-ssl"
+	volumeNameUsrShareCaCerts                 = "usr-share-cacerts"
+	volumeNameWatchdog                        = "watchdog"
 
-	volumeMountPathAdmissionConfiguration     = "/etc/kubernetes/admission"
-	volumeMountPathAdmissionKubeconfigSecrets = "/etc/kubernetes/admission-kubeconfigs"
-	volumeMountPathAuditPolicy                = "/etc/kubernetes/audit"
-	volumeMountPathAuditWebhookKubeconfig     = "/etc/kubernetes/webhook/audit"
-	volumeMountPathCA                         = "/srv/kubernetes/ca"
-	volumeMountPathCAClient                   = "/srv/kubernetes/ca-client"
-	volumeMountPathCAEtcd                     = "/srv/kubernetes/etcd/ca"
-	volumeMountPathCAFrontProxy               = "/srv/kubernetes/ca-front-proxy"
-	volumeMountPathCAKubelet                  = "/srv/kubernetes/ca-kubelet"
-	volumeMountPathCAVPN                      = "/srv/kubernetes/ca-vpn"
-	volumeMountPathEgressSelector             = "/etc/kubernetes/egress"
-	volumeMountPathEtcdEncryptionConfig       = "/etc/kubernetes/etcd-encryption-secret"
-	volumeMountPathEtcdClient                 = "/srv/kubernetes/etcd/client"
-	volumeMountPathHTTPProxy                  = "/etc/srv/kubernetes/envoy"
-	volumeMountPathKubeAPIServerToKubelet     = "/srv/kubernetes/apiserver-kubelet"
-	volumeMountPathKubeAggregator             = "/srv/kubernetes/aggregator"
-	volumeMountPathOIDCCABundle               = "/srv/kubernetes/oidc"
-	volumeMountPathServer                     = "/srv/kubernetes/apiserver"
-	volumeMountPathServiceAccountKey          = "/srv/kubernetes/service-account-key"
-	volumeMountPathServiceAccountKeyBundle    = "/srv/kubernetes/service-account-key-bundle"
-	volumeMountPathStaticToken                = "/srv/kubernetes/token"
-	volumeMountPathPrefixTLSSNISecret         = "/srv/kubernetes/tls-sni/"
-	volumeMountPathVPNSeedClient              = "/srv/secrets/vpn-client"
-	volumeMountPathAPIServerAccess            = "/var/run/secrets/kubernetes.io/serviceaccount"
-	volumeMountPathVPNSeedTLSAuth             = "/srv/secrets/tlsauth"
-	volumeMountPathDevNetTun                  = "/dev/net/tun"
-	volumeMountPathFedora                     = "/etc/pki/tls"
-	volumeMountPathCentOS                     = "/etc/pki/ca-trust/extracted/pem"
-	volumeMountPathEtcSSL                     = "/etc/ssl"
-	volumeMountPathUsrShareCaCerts            = "/usr/share/ca-certificates"
-	volumeMountPathWatchdog                   = "/var/watchdog/bin"
+	volumeMountPathAdmissionConfiguration          = "/etc/kubernetes/admission"
+	volumeMountPathAdmissionKubeconfigSecrets      = "/etc/kubernetes/admission-kubeconfigs"
+	volumeMountPathAuditPolicy                     = "/etc/kubernetes/audit"
+	volumeMountPathAuditWebhookKubeconfig          = "/etc/kubernetes/webhook/audit"
+	volumeMountPathAuthenticationWebhookKubeconfig = "/etc/kubernetes/webhook/authentication"
+	volumeMountPathCA                              = "/srv/kubernetes/ca"
+	volumeMountPathCAClient                        = "/srv/kubernetes/ca-client"
+	volumeMountPathCAEtcd                          = "/srv/kubernetes/etcd/ca"
+	volumeMountPathCAFrontProxy                    = "/srv/kubernetes/ca-front-proxy"
+	volumeMountPathCAKubelet                       = "/srv/kubernetes/ca-kubelet"
+	volumeMountPathCAVPN                           = "/srv/kubernetes/ca-vpn"
+	volumeMountPathEgressSelector                  = "/etc/kubernetes/egress"
+	volumeMountPathEtcdEncryptionConfig            = "/etc/kubernetes/etcd-encryption-secret"
+	volumeMountPathEtcdClient                      = "/srv/kubernetes/etcd/client"
+	volumeMountPathHTTPProxy                       = "/etc/srv/kubernetes/envoy"
+	volumeMountPathKubeAPIServerToKubelet          = "/srv/kubernetes/apiserver-kubelet"
+	volumeMountPathKubeAggregator                  = "/srv/kubernetes/aggregator"
+	volumeMountPathOIDCCABundle                    = "/srv/kubernetes/oidc"
+	volumeMountPathServer                          = "/srv/kubernetes/apiserver"
+	volumeMountPathServiceAccountKey               = "/srv/kubernetes/service-account-key"
+	volumeMountPathServiceAccountKeyBundle         = "/srv/kubernetes/service-account-key-bundle"
+	volumeMountPathStaticToken                     = "/srv/kubernetes/token"
+	volumeMountPathPrefixTLSSNISecret              = "/srv/kubernetes/tls-sni/"
+	volumeMountPathVPNSeedClient                   = "/srv/secrets/vpn-client"
+	volumeMountPathAPIServerAccess                 = "/var/run/secrets/kubernetes.io/serviceaccount"
+	volumeMountPathVPNSeedTLSAuth                  = "/srv/secrets/tlsauth"
+	volumeMountPathDevNetTun                       = "/dev/net/tun"
+	volumeMountPathFedora                          = "/etc/pki/tls"
+	volumeMountPathCentOS                          = "/etc/pki/ca-trust/extracted/pem"
+	volumeMountPathEtcSSL                          = "/etc/ssl"
+	volumeMountPathUsrShareCaCerts                 = "/usr/share/ca-certificates"
+	volumeMountPathWatchdog                        = "/var/watchdog/bin"
 )
 
 func (k *kubeAPIServer) emptyDeployment() *appsv1.Deployment {
@@ -147,6 +149,7 @@ func (k *kubeAPIServer) reconcileDeployment(
 	secretHAVPNSeedClient *corev1.Secret,
 	secretHAVPNSeedClientSeedTLSAuth *corev1.Secret,
 	secretAuditWebhookKubeconfig *corev1.Secret,
+	secretAuthenticationWebhookKubeconfig *corev1.Secret,
 	tlsSNISecrets []tlsSNISecret,
 ) error {
 	var (
@@ -459,6 +462,7 @@ func (k *kubeAPIServer) reconcileDeployment(
 		k.handleOIDCSettings(deployment, secretOIDCCABundle)
 		k.handleServiceAccountSigningKeySettings(deployment)
 		k.handleAuditSettings(deployment, configMapAuditPolicy, secretAuditWebhookKubeconfig)
+		k.handleAuthenticationSettings(deployment, secretAuthenticationWebhookKubeconfig)
 		if err := k.handleVPNSettings(deployment, configMapEgressSelector, secretHTTPProxy, secretHAVPNSeedClient, secretHAVPNSeedClientSeedTLSAuth); err != nil {
 			return err
 		}
@@ -1318,5 +1322,36 @@ func (k *kubeAPIServer) handleAuditSettings(deployment *appsv1.Deployment, confi
 
 	if v := k.values.Audit.Webhook.Version; v != nil {
 		deployment.Spec.Template.Spec.Containers[0].Command = append(deployment.Spec.Template.Spec.Containers[0].Command, fmt.Sprintf("--audit-webhook-version=%s", *v))
+	}
+}
+
+func (k *kubeAPIServer) handleAuthenticationSettings(deployment *appsv1.Deployment, secretWebhookKubeconfig *corev1.Secret) {
+	if k.values.AuthenticationWebhook == nil {
+		return
+	}
+
+	if len(k.values.AuthenticationWebhook.Kubeconfig) > 0 {
+		deployment.Spec.Template.Spec.Containers[0].Command = append(deployment.Spec.Template.Spec.Containers[0].Command, fmt.Sprintf("--authentication-token-webhook-config-file=%s/%s", volumeMountPathAuthenticationWebhookKubeconfig, secretWebhookKubeconfigDataKey))
+		deployment.Spec.Template.Spec.Containers[0].VolumeMounts = append(deployment.Spec.Template.Spec.Containers[0].VolumeMounts, corev1.VolumeMount{
+			Name:      volumeNameAuthenticationWebhookKubeconfig,
+			MountPath: volumeMountPathAuthenticationWebhookKubeconfig,
+			ReadOnly:  true,
+		})
+		deployment.Spec.Template.Spec.Volumes = append(deployment.Spec.Template.Spec.Volumes, corev1.Volume{
+			Name: volumeNameAuthenticationWebhookKubeconfig,
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName: secretWebhookKubeconfig.Name,
+				},
+			},
+		})
+	}
+
+	if v := k.values.AuthenticationWebhook.CacheTTL; v != nil {
+		deployment.Spec.Template.Spec.Containers[0].Command = append(deployment.Spec.Template.Spec.Containers[0].Command, fmt.Sprintf("--authentication-token-webhook-cache-ttl=%s", v.String()))
+	}
+
+	if v := k.values.AuthenticationWebhook.Version; v != nil {
+		deployment.Spec.Template.Spec.Containers[0].Command = append(deployment.Spec.Template.Spec.Containers[0].Command, fmt.Sprintf("--authentication-token-webhook-version=%s", *v))
 	}
 }

--- a/pkg/operation/botanist/component/kubeapiserver/secrets.go
+++ b/pkg/operation/botanist/component/kubeapiserver/secrets.go
@@ -49,6 +49,7 @@ const (
 
 	secretAuditWebhookKubeconfigNamePrefix          = "kube-apiserver-audit-webhook-kubeconfig"
 	secretAuthenticationWebhookKubeconfigNamePrefix = "kube-apiserver-authentication-webhook-kubeconfig"
+	secretAuthorizationWebhookKubeconfigNamePrefix  = "kube-apiserver-authorization-webhook-kubeconfig"
 	secretWebhookKubeconfigDataKey                  = "kubeconfig.yaml"
 
 	secretETCDEncryptionConfigurationDataKey = "encryption-configuration.yaml"
@@ -403,4 +404,14 @@ func (k *kubeAPIServer) reconcileSecretAuthenticationWebhookKubeconfig(ctx conte
 	}
 
 	return k.reconcileSecretWebhookKubeconfig(ctx, secret, k.values.AuthenticationWebhook.Kubeconfig)
+}
+
+func (k *kubeAPIServer) reconcileSecretAuthorizationWebhookKubeconfig(ctx context.Context, secret *corev1.Secret) error {
+	if k.values.AuthorizationWebhook == nil || len(k.values.AuthorizationWebhook.Kubeconfig) == 0 {
+		// We don't delete the secret here as we don't know its name (as it's unique). Instead, we rely on the usual
+		// garbage collection for unique secrets/configmaps.
+		return nil
+	}
+
+	return k.reconcileSecretWebhookKubeconfig(ctx, secret, k.values.AuthorizationWebhook.Kubeconfig)
 }

--- a/pkg/operation/botanist/component/kubeapiserver/secrets.go
+++ b/pkg/operation/botanist/component/kubeapiserver/secrets.go
@@ -47,8 +47,9 @@ const (
 	secretOIDCCABundleNamePrefix   = "kube-apiserver-oidc-cabundle"
 	secretOIDCCABundleDataKeyCaCrt = "ca.crt"
 
-	secretAuditWebhookKubeconfigNamePrefix = "kube-apiserver-audit-webhook-kubeconfig"
-	secretWebhookKubeconfigDataKey         = "kubeconfig.yaml"
+	secretAuditWebhookKubeconfigNamePrefix          = "kube-apiserver-audit-webhook-kubeconfig"
+	secretAuthenticationWebhookKubeconfigNamePrefix = "kube-apiserver-authentication-webhook-kubeconfig"
+	secretWebhookKubeconfigDataKey                  = "kubeconfig.yaml"
 
 	secretETCDEncryptionConfigurationDataKey = "encryption-configuration.yaml"
 	secretAdmissionKubeconfigsNamePrefix     = "kube-apiserver-admission-kubeconfigs"
@@ -392,4 +393,14 @@ func (k *kubeAPIServer) reconcileSecretAuditWebhookKubeconfig(ctx context.Contex
 	}
 
 	return k.reconcileSecretWebhookKubeconfig(ctx, secret, k.values.Audit.Webhook.Kubeconfig)
+}
+
+func (k *kubeAPIServer) reconcileSecretAuthenticationWebhookKubeconfig(ctx context.Context, secret *corev1.Secret) error {
+	if k.values.AuthenticationWebhook == nil || len(k.values.AuthenticationWebhook.Kubeconfig) == 0 {
+		// We don't delete the secret here as we don't know its name (as it's unique). Instead, we rely on the usual
+		// garbage collection for unique secrets/configmaps.
+		return nil
+	}
+
+	return k.reconcileSecretWebhookKubeconfig(ctx, secret, k.values.AuthenticationWebhook.Kubeconfig)
 }

--- a/pkg/operation/botanist/component/kubeapiserver/secrets.go
+++ b/pkg/operation/botanist/component/kubeapiserver/secrets.go
@@ -44,8 +44,12 @@ const (
 	// SecretStaticTokenName is a constant for the name of the static-token secret.
 	SecretStaticTokenName = "kube-apiserver-static-token"
 
-	secretOIDCCABundleNamePrefix             = "kube-apiserver-oidc-cabundle"
-	secretOIDCCABundleDataKeyCaCrt           = "ca.crt"
+	secretOIDCCABundleNamePrefix   = "kube-apiserver-oidc-cabundle"
+	secretOIDCCABundleDataKeyCaCrt = "ca.crt"
+
+	secretAuditWebhookKubeconfigNamePrefix = "kube-apiserver-audit-webhook-kubeconfig"
+	secretWebhookKubeconfigDataKey         = "kubeconfig.yaml"
+
 	secretETCDEncryptionConfigurationDataKey = "encryption-configuration.yaml"
 	secretAdmissionKubeconfigsNamePrefix     = "kube-apiserver-admission-kubeconfigs"
 
@@ -372,4 +376,20 @@ func (k *kubeAPIServer) reconcileTLSSNISecrets(ctx context.Context) ([]tlsSNISec
 	}
 
 	return out, nil
+}
+
+func (k *kubeAPIServer) reconcileSecretWebhookKubeconfig(ctx context.Context, secret *corev1.Secret, kubeconfig []byte) error {
+	secret.Data = map[string][]byte{secretWebhookKubeconfigDataKey: kubeconfig}
+	utilruntime.Must(kubernetesutils.MakeUnique(secret))
+	return client.IgnoreAlreadyExists(k.client.Client().Create(ctx, secret))
+}
+
+func (k *kubeAPIServer) reconcileSecretAuditWebhookKubeconfig(ctx context.Context, secret *corev1.Secret) error {
+	if k.values.Audit == nil || k.values.Audit.Webhook == nil || len(k.values.Audit.Webhook.Kubeconfig) == 0 {
+		// We don't delete the secret here as we don't know its name (as it's unique). Instead, we rely on the usual
+		// garbage collection for unique secrets/configmaps.
+		return nil
+	}
+
+	return k.reconcileSecretWebhookKubeconfig(ctx, secret, k.values.Audit.Webhook.Kubeconfig)
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind enhancement

**What this PR does / why we need it**:
This PR allows to configure the `kubeapiserver` component with kubeconfigs (and some additional configuration options) for the audit, authentication, and authorization webhook configs.

Note that this PR does not yet expose this via the `Shoot` resource in any way. This can be done separately, but it is not planned for `Shoot`s to support this yet.
Generally, this is a prerequisite for `gardener-operator` managing the `kube-apiserver` deployment.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
