### PR TITLE
Add additional information about custom server config to custom-dns-config docs.

### DIFF
--- a/docs/usage/custom-dns-config.md
+++ b/docs/usage/custom-dns-config.md
@@ -38,7 +38,7 @@ data:
          whoami
 ```
 
-The port number 8053 in `global:8053` is the specific port that CoreDN is bound to and cannot be changed to any other port. 
+The port number 8053 in `global:8053` is the specific port that CoreDNS is bound to and cannot be changed to any other port if it should act on ordinary name resolution requests from pods. Otherwise, CoreDNS will open a second port, but you are responsible to direct the traffic to this port. `kube-dns` service in `kube-system` namespace will direct name resolution requests within the cluster to port 8053 on the CoreDNS pods.
 In order for the destination DNS server to be reachable, it must listen on port 53 as it is required by network policies.
 
 It is important to have the `ConfigMap` keys ending with `*.server` (if you would like to add a new server) or `*.override`

--- a/docs/usage/custom-dns-config.md
+++ b/docs/usage/custom-dns-config.md
@@ -39,7 +39,7 @@ data:
 ```
 
 The port number 8053 in `global:8053` is the specific port that CoreDNS is bound to and cannot be changed to any other port if it should act on ordinary name resolution requests from pods. Otherwise, CoreDNS will open a second port, but you are responsible to direct the traffic to this port. `kube-dns` service in `kube-system` namespace will direct name resolution requests within the cluster to port 8053 on the CoreDNS pods.
-In order for the destination DNS server to be reachable, it must listen on port 53 as it is required by network policies.
+In order for the destination DNS server to be reachable, it must listen on port 53 as it is required by network policies. Other ports are only possible if additional network policies allow corresponding egress traffic from CoreDNS pods.
 
 It is important to have the `ConfigMap` keys ending with `*.server` (if you would like to add a new server) or `*.override`
 if you want to customize the current server configuration (it is optional setting both).

--- a/docs/usage/custom-dns-config.md
+++ b/docs/usage/custom-dns-config.md
@@ -39,7 +39,7 @@ data:
 ```
 
 The port number 8053 in `global:8053` is the specific port that CoreDNS is bound to and cannot be changed to any other port if it should act on ordinary name resolution requests from pods. Otherwise, CoreDNS will open a second port, but you are responsible to direct the traffic to this port. `kube-dns` service in `kube-system` namespace will direct name resolution requests within the cluster to port 8053 on the CoreDNS pods.
-Moreover, additional network policies are needed to allow corresponding ingress traffic to CoreDNS pods
+Moreover, additional network policies are needed to allow corresponding ingress traffic to CoreDNS pods.
 In order for the destination DNS server to be reachable, it must listen on port 53 as it is required by network policies. Other ports are only possible if additional network policies allow corresponding egress traffic from CoreDNS pods.
 
 It is important to have the `ConfigMap` keys ending with `*.server` (if you would like to add a new server) or `*.override`

--- a/docs/usage/custom-dns-config.md
+++ b/docs/usage/custom-dns-config.md
@@ -39,6 +39,7 @@ data:
 ```
 
 The port number 8053 in `global:8053` is the specific port that CoreDNS is bound to and cannot be changed to any other port if it should act on ordinary name resolution requests from pods. Otherwise, CoreDNS will open a second port, but you are responsible to direct the traffic to this port. `kube-dns` service in `kube-system` namespace will direct name resolution requests within the cluster to port 8053 on the CoreDNS pods.
+Moreover, additional network policies are needed to allow corresponding ingress traffic to CoreDNS pods
 In order for the destination DNS server to be reachable, it must listen on port 53 as it is required by network policies. Other ports are only possible if additional network policies allow corresponding egress traffic from CoreDNS pods.
 
 It is important to have the `ConfigMap` keys ending with `*.server` (if you would like to add a new server) or `*.override`

--- a/docs/usage/custom-dns-config.md
+++ b/docs/usage/custom-dns-config.md
@@ -38,6 +38,9 @@ data:
          whoami
 ```
 
+The port number 8053 in `global:8053` is the specific port that CoreDN is bound to and cannot be changed to any other port. 
+In order for the destination DNS server to be reachable, it must listen on port 53 as it is required by network policies.
+
 It is important to have the `ConfigMap` keys ending with `*.server` (if you would like to add a new server) or `*.override`
 if you want to customize the current server configuration (it is optional setting both).
 


### PR DESCRIPTION

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind docs

**What this PR does / why we need it**:
The restrictions to port 8053 and 53 should be known to users.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```doc user
Add additional information about custom server config to custom-dns-config docs.
```
