### PR TITLE
[release-v1.64] Fix `etcd` peer-tls configuration

### DIFF
--- a/pkg/operation/botanist/component/etcd/etcd.go
+++ b/pkg/operation/botanist/component/etcd/etcd.go
@@ -172,6 +172,7 @@ type Values struct {
 	BackupConfig            *BackupConfig
 	HvpaConfig              *HVPAConfig
 	PriorityClassName       string
+	HighAvailabilityEnabled bool
 }
 
 func (e *etcd) Deploy(ctx context.Context) error {
@@ -276,8 +277,7 @@ func (e *etcd) Deploy(ctx context.Context) error {
 		peerServerSecretName string
 	)
 
-	peerTLSAlreadyEnabled := existingEtcd != nil && existingEtcd.Spec.Etcd.PeerUrlTLS != nil
-	if etcdPeerCASecretName, peerServerSecretName, err = e.handlePeerCertificates(ctx, peerTLSAlreadyEnabled); err != nil {
+	if etcdPeerCASecretName, peerServerSecretName, err = e.handlePeerCertificates(ctx); err != nil {
 		return err
 	}
 
@@ -334,8 +334,8 @@ func (e *etcd) Deploy(ctx context.Context) error {
 			return err
 		}
 
-		// create peer network policy only if there are 3 replicas
-		if pointer.Int32Deref(e.values.Replicas, 0) > 1 {
+		// create peer network policy only if high availability is enabled
+		if e.values.HighAvailabilityEnabled {
 			if _, err := controllerutils.GetAndCreateOrMergePatch(ctx, e.client, peerNetworkPolicy, func() error {
 				peerNetworkPolicy.Annotations = map[string]string{
 					v1beta1constants.GardenerDescription: "Allows Ingress to etcd pods from etcd pods for peer communication.",
@@ -462,7 +462,7 @@ func (e *etcd) Deploy(ctx context.Context) error {
 		}
 
 		// TODO(timuthy): Once https://github.com/gardener/etcd-backup-restore/issues/538 is resolved we can enable PeerUrlTLS for all remaining clusters as well.
-		if pointer.Int32Deref(e.values.Replicas, 0) > 1 || peerTLSAlreadyEnabled {
+		if e.values.HighAvailabilityEnabled {
 			e.etcd.Spec.Etcd.PeerUrlTLS = &druidv1alpha1.TLSConfig{
 				TLSCASecretRef: druidv1alpha1.SecretReference{
 					SecretReference: corev1.SecretReference{
@@ -662,8 +662,8 @@ func (e *etcd) Deploy(ctx context.Context) error {
 			hvpa.Spec.WeightBasedScalingIntervals = []hvpav1alpha1.WeightBasedScalingInterval{
 				{
 					VpaWeight:         hvpav1alpha1.VpaOnly,
-					StartReplicaCount: int32(replicas),
-					LastReplicaCount:  int32(replicas),
+					StartReplicaCount: replicas,
+					LastReplicaCount:  replicas,
 				},
 			}
 			hvpa.Spec.TargetRef = &autoscalingv2beta1.CrossVersionObjectReference{
@@ -695,7 +695,7 @@ func (e *etcd) Destroy(ctx context.Context) error {
 		e.emptyNetworkPolicy(NetworkPolicyNameClient),
 	}
 
-	if pointer.Int32Deref(e.values.Replicas, 0) > 1 {
+	if e.values.HighAvailabilityEnabled {
 		objects = append(objects, e.emptyNetworkPolicy(NetworkPolicyNamePeer))
 	}
 
@@ -812,7 +812,7 @@ func (e *etcd) Scale(ctx context.Context, replicas int32) error {
 }
 
 func (e *etcd) RolloutPeerCA(ctx context.Context) error {
-	if pointer.Int32Deref(e.values.Replicas, 0) != 3 {
+	if !e.values.HighAvailabilityEnabled {
 		return nil
 	}
 
@@ -922,9 +922,9 @@ func (e *etcd) computeFullSnapshotSchedule(existingEtcd *druidv1alpha1.Etcd) *st
 	return fullSnapshotSchedule
 }
 
-func (e *etcd) handlePeerCertificates(ctx context.Context, peerTLSAlreadyEnabled bool) (caSecretName, peerSecretName string, err error) {
+func (e *etcd) handlePeerCertificates(ctx context.Context) (caSecretName, peerSecretName string, err error) {
 	// TODO(timuthy): Remove this once https://github.com/gardener/etcd-backup-restore/issues/538 is resolved.
-	if pointer.Int32Deref(e.values.Replicas, 0) != 3 && !peerTLSAlreadyEnabled {
+	if !e.values.HighAvailabilityEnabled {
 		return
 	}
 

--- a/pkg/operation/botanist/component/etcd/etcd_test.go
+++ b/pkg/operation/botanist/component/etcd/etcd_test.go
@@ -1375,6 +1375,7 @@ var _ = Describe("Etcd", func() {
 					DefragmentationSchedule: &defragmentationSchedule,
 					CARotationPhase:         rotationPhase,
 					PriorityClassName:       priorityClassName,
+					HighAvailabilityEnabled: true,
 				})
 			})
 
@@ -1493,6 +1494,33 @@ var _ = Describe("Etcd", func() {
 		})
 
 		Context("when etcd cluster is hibernated", func() {
+			BeforeEach(func() {
+				secretNamesToTimes := map[string]time.Time{}
+
+				var err error
+				sm, err = secretsmanager.New(
+					ctx,
+					logr.New(logf.NullLogSink{}),
+					testclock.NewFakeClock(time.Now()),
+					fakeClient,
+					testNamespace,
+					"",
+					secretsmanager.Config{
+						SecretNamesToTimes: secretNamesToTimes,
+					})
+				Expect(err).ToNot(HaveOccurred())
+
+				// Create new etcd CA
+				_, err = sm.Generate(ctx,
+					&secretsutils.CertificateSecretConfig{Name: v1beta1constants.SecretNameCAETCD, CommonName: "etcd", CertType: secretsutils.CACert})
+				Expect(err).ToNot(HaveOccurred())
+
+				// Create new peer CA
+				_, err = sm.Generate(ctx,
+					&secretsutils.CertificateSecretConfig{Name: v1beta1constants.SecretNameCAETCDPeer, CommonName: "etcd-peer", CertType: secretsutils.CACert})
+				Expect(err).ToNot(HaveOccurred())
+			})
+
 			JustBeforeEach(func() {
 				etcd = New(log, c, testNamespace, sm, Values{
 					Role:                    testRole,
@@ -1503,35 +1531,11 @@ var _ = Describe("Etcd", func() {
 					DefragmentationSchedule: &defragmentationSchedule,
 					CARotationPhase:         gardencorev1beta1.RotationCompleted,
 					PriorityClassName:       priorityClassName,
+					HighAvailabilityEnabled: true,
 				})
 			})
+
 			Context("when peer url secrets are present in etcd CR", func() {
-				BeforeEach(func() {
-					secretNamesToTimes := map[string]time.Time{}
-
-					var err error
-					sm, err = secretsmanager.New(
-						ctx,
-						logr.New(logf.NullLogSink{}),
-						testclock.NewFakeClock(time.Now()),
-						fakeClient,
-						testNamespace,
-						"",
-						secretsmanager.Config{
-							SecretNamesToTimes: secretNamesToTimes,
-						})
-					Expect(err).ToNot(HaveOccurred())
-
-					// Create new etcd CA
-					_, err = sm.Generate(ctx,
-						&secretsutils.CertificateSecretConfig{Name: v1beta1constants.SecretNameCAETCD, CommonName: "etcd", CertType: secretsutils.CACert})
-					Expect(err).ToNot(HaveOccurred())
-
-					// Create new peer CA
-					_, err = sm.Generate(ctx,
-						&secretsutils.CertificateSecretConfig{Name: v1beta1constants.SecretNameCAETCDPeer, CommonName: "etcd-peer", CertType: secretsutils.CACert})
-					Expect(err).ToNot(HaveOccurred())
-				})
 				It("should not remove peer URL secrets", func() {
 					gomock.InOrder(
 						c.EXPECT().Get(ctx, kubernetesutils.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).DoAndReturn(func(ctx context.Context, _ client.ObjectKey, obj client.Object, _ ...client.GetOption) error {
@@ -1557,6 +1561,10 @@ var _ = Describe("Etcd", func() {
 						c.EXPECT().Get(ctx, kubernetesutils.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&appsv1.StatefulSet{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
 						c.EXPECT().Get(ctx, kubernetesutils.Key(testNamespace, networkPolicyClientName), gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{})),
 						c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{}), gomock.Any()),
+						c.EXPECT().Get(ctx, kubernetesutils.Key(testNamespace, networkPolicyPeerName), gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{})),
+						c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{}), gomock.Any()).Do(func(ctx context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
+							Expect(obj).To(DeepEqual(peerNetworkPolicy))
+						}),
 						c.EXPECT().Get(ctx, kubernetesutils.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).DoAndReturn(
 							func(_ context.Context, _ client.ObjectKey, etcd *druidv1alpha1.Etcd, _ ...client.GetOption) error {
 								etcd.Spec.Etcd.PeerUrlTLS = &druidv1alpha1.TLSConfig{
@@ -1569,7 +1577,7 @@ var _ = Describe("Etcd", func() {
 							}),
 						c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{}), gomock.Any()).Do(func(ctx context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 							Expect(obj.(*druidv1alpha1.Etcd).Spec.Replicas).To(Equal(int32(0)))
-							Expect(obj.(*druidv1alpha1.Etcd).Spec.Etcd.PeerUrlTLS).ToNot(BeNil())
+							Expect(obj.(*druidv1alpha1.Etcd).Spec.Etcd.PeerUrlTLS).NotTo(BeNil())
 						}),
 						c.EXPECT().Delete(ctx, &hvpav1alpha1.Hvpa{ObjectMeta: metav1.ObjectMeta{Name: "etcd-" + testRole, Namespace: testNamespace}}),
 					)
@@ -1577,8 +1585,9 @@ var _ = Describe("Etcd", func() {
 					Expect(etcd.Deploy(ctx)).To(Succeed())
 				})
 			})
+
 			Context("when peer url secrets are not present in etcd CR", func() {
-				It("should not add peer url secrets", func() {
+				It("should add peer url secrets", func() {
 					gomock.InOrder(
 						c.EXPECT().Get(ctx, kubernetesutils.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).DoAndReturn(func(ctx context.Context, _ client.ObjectKey, obj client.Object, _ ...client.GetOption) error {
 							(&druidv1alpha1.Etcd{
@@ -1598,13 +1607,17 @@ var _ = Describe("Etcd", func() {
 						c.EXPECT().Get(ctx, kubernetesutils.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&appsv1.StatefulSet{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
 						c.EXPECT().Get(ctx, kubernetesutils.Key(testNamespace, networkPolicyClientName), gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{})),
 						c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{}), gomock.Any()),
+						c.EXPECT().Get(ctx, kubernetesutils.Key(testNamespace, networkPolicyPeerName), gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{})),
+						c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{}), gomock.Any()).Do(func(ctx context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
+							Expect(obj).To(DeepEqual(peerNetworkPolicy))
+						}),
 						c.EXPECT().Get(ctx, kubernetesutils.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).DoAndReturn(
 							func(_ context.Context, _ client.ObjectKey, etcd *druidv1alpha1.Etcd, _ ...client.GetOption) error {
 								return nil
 							}),
 						c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{}), gomock.Any()).Do(func(ctx context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 							Expect(obj.(*druidv1alpha1.Etcd).Spec.Replicas).To(Equal(int32(0)))
-							Expect(obj.(*druidv1alpha1.Etcd).Spec.Etcd.PeerUrlTLS).To(BeNil())
+							Expect(obj.(*druidv1alpha1.Etcd).Spec.Etcd.PeerUrlTLS).NotTo(BeNil())
 						}),
 						c.EXPECT().Delete(ctx, &hvpav1alpha1.Hvpa{ObjectMeta: metav1.ObjectMeta{Name: "etcd-" + testRole, Namespace: testNamespace}}),
 					)
@@ -1924,6 +1937,8 @@ var _ = Describe("Etcd", func() {
 	})
 
 	Describe("#RolloutPeerCA", func() {
+		var highAvailability bool
+
 		JustBeforeEach(func() {
 			etcd = New(log, c, testNamespace, sm, Values{
 				Role:                    testRole,
@@ -1934,6 +1949,7 @@ var _ = Describe("Etcd", func() {
 				DefragmentationSchedule: &defragmentationSchedule,
 				CARotationPhase:         "",
 				PriorityClassName:       priorityClassName,
+				HighAvailabilityEnabled: highAvailability,
 			})
 		})
 
@@ -1948,6 +1964,10 @@ var _ = Describe("Etcd", func() {
 		})
 
 		Context("when HA control-plane is requested", func() {
+			BeforeEach(func() {
+				highAvailability = true
+			})
+
 			createEtcdObj := func(caName string) *druidv1alpha1.Etcd {
 				return &druidv1alpha1.Etcd{
 					ObjectMeta: metav1.ObjectMeta{

--- a/pkg/operation/botanist/etcd.go
+++ b/pkg/operation/botanist/etcd.go
@@ -66,6 +66,7 @@ func (b *Botanist) DefaultEtcd(role string, class etcd.Class) (etcd.Interface, e
 			CARotationPhase:         v1beta1helper.GetShootCARotationPhase(b.Shoot.GetInfo().Status.Credentials),
 			KubernetesVersion:       b.Shoot.KubernetesVersion,
 			PriorityClassName:       v1beta1constants.PriorityClassNameShootControlPlane500,
+			HighAvailabilityEnabled: v1beta1helper.IsHAControlPlaneConfigured(b.Shoot.GetInfo()),
 		},
 	)
 

--- a/pkg/operation/botanist/etcd_test.go
+++ b/pkg/operation/botanist/etcd_test.go
@@ -36,6 +36,7 @@ import (
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	kubernetesfake "github.com/gardener/gardener/pkg/client/kubernetes/fake"
@@ -154,6 +155,7 @@ var _ = Describe("Etcd", func() {
 								MaintenanceTimeWindow: maintenanceTimeWindow,
 								ScaleDownUpdateMode:   pointer.String(computeUpdateMode(class, purpose)),
 							}),
+							expectedHighAvailabilityEnabled: Equal(v1beta1helper.IsHAControlPlaneConfigured(botanist.Shoot.GetInfo())),
 						}
 
 						oldNewEtcd := NewEtcd
@@ -193,6 +195,7 @@ var _ = Describe("Etcd", func() {
 						MaintenanceTimeWindow: maintenanceTimeWindow,
 						ScaleDownUpdateMode:   pointer.String(hvpav1alpha1.UpdateModeMaintenanceWindow),
 					}),
+					expectedHighAvailabilityEnabled: Equal(v1beta1helper.IsHAControlPlaneConfigured(botanist.Shoot.GetInfo())),
 				}
 
 				oldNewEtcd := NewEtcd
@@ -224,6 +227,7 @@ var _ = Describe("Etcd", func() {
 						MaintenanceTimeWindow: maintenanceTimeWindow,
 						ScaleDownUpdateMode:   pointer.String(hvpav1alpha1.UpdateModeMaintenanceWindow),
 					}),
+					expectedHighAvailabilityEnabled: Equal(v1beta1helper.IsHAControlPlaneConfigured(botanist.Shoot.GetInfo())),
 				}
 
 				oldNewEtcd := NewEtcd
@@ -461,6 +465,7 @@ type newEtcdValidator struct {
 	expectedStorageCapacity         gomegatypes.GomegaMatcher
 	expectedDefragmentationSchedule gomegatypes.GomegaMatcher
 	expectedHVPAConfig              gomegatypes.GomegaMatcher
+	expectedHighAvailabilityEnabled gomegatypes.GomegaMatcher
 }
 
 func (v *newEtcdValidator) NewEtcd(
@@ -479,6 +484,7 @@ func (v *newEtcdValidator) NewEtcd(
 	Expect(values.Replicas).To(v.expectedReplicas)
 	Expect(values.StorageCapacity).To(v.expectedStorageCapacity)
 	Expect(values.DefragmentationSchedule).To(v.expectedDefragmentationSchedule)
+	Expect(values.HighAvailabilityEnabled).To(v.expectedHighAvailabilityEnabled)
 
 	return v
 }

--- a/pkg/operator/controller/garden/components.go
+++ b/pkg/operator/controller/garden/components.go
@@ -146,8 +146,10 @@ func (r *Reconciler) newEtcd(
 		return nil, err
 	}
 
+	highAvailabilityEnabled := garden.Spec.VirtualCluster.ControlPlane != nil && garden.Spec.VirtualCluster.ControlPlane.HighAvailability != nil
+
 	replicas := pointer.Int32(1)
-	if garden.Spec.VirtualCluster.ControlPlane != nil && garden.Spec.VirtualCluster.ControlPlane.HighAvailability != nil {
+	if highAvailabilityEnabled {
 		replicas = pointer.Int32(3)
 	}
 
@@ -170,7 +172,8 @@ func (r *Reconciler) newEtcd(
 				MaintenanceTimeWindow: garden.Spec.VirtualCluster.Maintenance.TimeWindow,
 				ScaleDownUpdateMode:   hvpaScaleDownUpdateMode,
 			},
-			PriorityClassName: v1beta1constants.PriorityClassNameGardenSystem500,
+			PriorityClassName:       v1beta1constants.PriorityClassNameGardenSystem500,
+			HighAvailabilityEnabled: highAvailabilityEnabled,
 		},
 	), nil
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area high-availability
/kind bug

**What this PR does / why we need it**:
Cherry-pick of https://github.com/gardener/gardener/pull/7554.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
An issue has been fixed that caused hibernated shoots with HA control-planes being stuck in deletion.
```
