### PR TITLE
Fix NetworkPolicy labels for HA VPN

### DIFF
--- a/pkg/gardenlet/controller/seed/seed/components.go
+++ b/pkg/gardenlet/controller/seed/seed/components.go
@@ -125,6 +125,7 @@ func defaultIstio(
 		Namespace:             *conf.SNI.Ingress.Namespace,
 		ProxyProtocolEnabled:  gardenletfeatures.FeatureGate.Enabled(features.APIServerSNI),
 		VPNEnabled:            true,
+		VPNHAEnabled:          len(seed.GetInfo().Spec.Provider.Zones) > 1,
 	}
 
 	// even if SNI is being disabled, the existing ports must stay the same

--- a/pkg/gardenlet/controller/seed/seed/components.go
+++ b/pkg/gardenlet/controller/seed/seed/components.go
@@ -125,7 +125,6 @@ func defaultIstio(
 		Namespace:             *conf.SNI.Ingress.Namespace,
 		ProxyProtocolEnabled:  gardenletfeatures.FeatureGate.Enabled(features.APIServerSNI),
 		VPNEnabled:            true,
-		VPNHAEnabled:          len(seed.GetInfo().Spec.Provider.Zones) > 1,
 	}
 
 	// even if SNI is being disabled, the existing ports must stay the same

--- a/pkg/operation/botanist/component/istio/charts/istio/istio-ingress/templates/deployment.yaml
+++ b/pkg/operation/botanist/component/istio/charts/istio/istio-ingress/templates/deployment.yaml
@@ -23,6 +23,11 @@ spec:
         service.istio.io/canonical-revision: "1.7"
         networking.gardener.cloud/to-dns: allowed
         networking.resources.gardener.cloud/to-all-shoots-vpn-seed-server-tcp-1194: allowed
+{{- if .Values.vpn.highAvailabilityEnabled }}
+{{- range $i := until (int .Values.vpn.highAvailabilityReplicas) }}
+        networking.resources.gardener.cloud/to-all-shoots-vpn-seed-server-{{$i}}-tcp-1194: allowed
+{{- end }}
+{{- end }}
       annotations:
         sidecar.istio.io/inject: "false"
         checksum/configmap-bootstrap-config-override: {{ include (print $.Template.BasePath "/bootstrap-config-override.yaml") . | sha256sum }}

--- a/pkg/operation/botanist/component/istio/charts/istio/istio-ingress/templates/deployment.yaml
+++ b/pkg/operation/botanist/component/istio/charts/istio/istio-ingress/templates/deployment.yaml
@@ -22,9 +22,11 @@ spec:
         service.istio.io/canonical-name: "istio-ingressgateway"
         service.istio.io/canonical-revision: "1.7"
         networking.gardener.cloud/to-dns: allowed
+{{- if .Values.vpn.enabled }}
         networking.resources.gardener.cloud/to-all-shoots-vpn-seed-server-tcp-1194: allowed
 {{- range $i := until (int .Values.vpn.highAvailabilityReplicas) }}
         networking.resources.gardener.cloud/to-all-shoots-vpn-seed-server-{{$i}}-tcp-1194: allowed
+{{- end }}
 {{- end }}
       annotations:
         sidecar.istio.io/inject: "false"

--- a/pkg/operation/botanist/component/istio/charts/istio/istio-ingress/templates/deployment.yaml
+++ b/pkg/operation/botanist/component/istio/charts/istio/istio-ingress/templates/deployment.yaml
@@ -23,10 +23,8 @@ spec:
         service.istio.io/canonical-revision: "1.7"
         networking.gardener.cloud/to-dns: allowed
         networking.resources.gardener.cloud/to-all-shoots-vpn-seed-server-tcp-1194: allowed
-{{- if .Values.vpn.highAvailabilityEnabled }}
 {{- range $i := until (int .Values.vpn.highAvailabilityReplicas) }}
         networking.resources.gardener.cloud/to-all-shoots-vpn-seed-server-{{$i}}-tcp-1194: allowed
-{{- end }}
 {{- end }}
       annotations:
         sidecar.istio.io/inject: "false"

--- a/pkg/operation/botanist/component/istio/charts/istio/istio-ingress/templates/vpn-envoy-filter.yaml
+++ b/pkg/operation/botanist/component/istio/charts/istio/istio-ingress/templates/vpn-envoy-filter.yaml
@@ -1,4 +1,4 @@
-{{- if eq .Values.vpnEnabled true -}}
+{{- if eq .Values.vpn.enabled true -}}
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:

--- a/pkg/operation/botanist/component/istio/charts/istio/istio-ingress/templates/vpn-gateway.yaml
+++ b/pkg/operation/botanist/component/istio/charts/istio/istio-ingress/templates/vpn-gateway.yaml
@@ -1,4 +1,4 @@
-{{- if eq .Values.vpnEnabled true -}}
+{{- if eq .Values.vpn.enabled true -}}
 apiVersion: networking.istio.io/v1beta1
 kind: Gateway
 metadata:

--- a/pkg/operation/botanist/component/istio/charts/istio/istio-ingress/values.yaml
+++ b/pkg/operation/botanist/component/istio/charts/istio/istio-ingress/values.yaml
@@ -26,6 +26,5 @@ maxReplicas: 5
 proxyProtocolEnabled: false
 vpn:
   enabled: false
-  highAvailabilityEnabled: false
   highAvailabilityReplicas: 2
 

--- a/pkg/operation/botanist/component/istio/charts/istio/istio-ingress/values.yaml
+++ b/pkg/operation/botanist/component/istio/charts/istio/istio-ingress/values.yaml
@@ -24,4 +24,8 @@ maxReplicas: 5
 
 # Istio Ingress Configuration Resources
 proxyProtocolEnabled: false
-vpnEnabled: false
+vpn:
+  enabled: false
+  highAvailabilityEnabled: false
+  highAvailabilityReplicas: 2
+

--- a/pkg/operation/botanist/component/istio/ingress_gateway.go
+++ b/pkg/operation/botanist/component/istio/ingress_gateway.go
@@ -47,7 +47,6 @@ type IngressGatewayValues struct {
 	TrustDomain           string
 	ProxyProtocolEnabled  bool
 	VPNEnabled            bool
-	VPNHAEnabled          bool
 	Zones                 []string
 
 	// Ports is a list of all Ports the istio-ingress gateways is listening on.
@@ -73,8 +72,9 @@ func (i *istiod) generateIstioIngressGatewayChart() (*chartrenderer.RenderedChar
 			"serviceName":           v1beta1constants.DefaultSNIIngressServiceName,
 			"proxyProtocolEnabled":  istioIngressGateway.ProxyProtocolEnabled,
 			"vpn": map[string]interface{}{
-				"enabled":                  istioIngressGateway.VPNEnabled,
-				"highAvailabilityEnabled":  istioIngressGateway.VPNHAEnabled,
+				"enabled": istioIngressGateway.VPNEnabled,
+				// Always pass replicas here since every seed can potentially host shoot clusters with
+				// highly available control-planes.
 				"highAvailabilityReplicas": vpnseedserver.HighAvailabilityReplicaCount,
 			},
 		}

--- a/pkg/operation/botanist/component/istio/ingress_gateway.go
+++ b/pkg/operation/botanist/component/istio/ingress_gateway.go
@@ -23,6 +23,7 @@ import (
 
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/chartrenderer"
+	"github.com/gardener/gardener/pkg/operation/botanist/component/vpnseedserver"
 )
 
 var (
@@ -46,6 +47,7 @@ type IngressGatewayValues struct {
 	TrustDomain           string
 	ProxyProtocolEnabled  bool
 	VPNEnabled            bool
+	VPNHAEnabled          bool
 	Zones                 []string
 
 	// Ports is a list of all Ports the istio-ingress gateways is listening on.
@@ -70,7 +72,11 @@ func (i *istiod) generateIstioIngressGatewayChart() (*chartrenderer.RenderedChar
 			"loadBalancerIP":        istioIngressGateway.LoadBalancerIP,
 			"serviceName":           v1beta1constants.DefaultSNIIngressServiceName,
 			"proxyProtocolEnabled":  istioIngressGateway.ProxyProtocolEnabled,
-			"vpnEnabled":            istioIngressGateway.VPNEnabled,
+			"vpn": map[string]interface{}{
+				"enabled":                  istioIngressGateway.VPNEnabled,
+				"highAvailabilityEnabled":  istioIngressGateway.VPNHAEnabled,
+				"highAvailabilityReplicas": vpnseedserver.HighAvailabilityReplicaCount,
+			},
 		}
 
 		if istioIngressGateway.MinReplicas != nil {

--- a/pkg/operation/botanist/component/istio/istiod_test.go
+++ b/pkg/operation/botanist/component/istio/istiod_test.go
@@ -1631,15 +1631,7 @@ metadata:
 automountServiceAccountToken: false
 `
 
-		istioIngressDeployment = func(haVPNEnabled bool) string {
-			var additionalLabels string
-			if haVPNEnabled {
-				additionalLabels = `
-        networking.resources.gardener.cloud/to-all-shoots-vpn-seed-server-0-tcp-1194: allowed
-        networking.resources.gardener.cloud/to-all-shoots-vpn-seed-server-1-tcp-1194: allowed`
-			}
-
-			return `apiVersion: apps/v1
+		istioIngressDeployment = `apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: istio-ingressgateway
@@ -1669,7 +1661,9 @@ spec:
         service.istio.io/canonical-name: "istio-ingressgateway"
         service.istio.io/canonical-revision: "1.7"
         networking.gardener.cloud/to-dns: allowed
-        networking.resources.gardener.cloud/to-all-shoots-vpn-seed-server-tcp-1194: allowed` + additionalLabels + `
+        networking.resources.gardener.cloud/to-all-shoots-vpn-seed-server-tcp-1194: allowed
+        networking.resources.gardener.cloud/to-all-shoots-vpn-seed-server-0-tcp-1194: allowed
+        networking.resources.gardener.cloud/to-all-shoots-vpn-seed-server-1-tcp-1194: allowed
       annotations:
         sidecar.istio.io/inject: "false"
         checksum/configmap-bootstrap-config-override: a357fe81829c12ad57e92721b93fd6efa1670d19e4cab94dfb7c792f9665c51a
@@ -1856,8 +1850,6 @@ spec:
                   - bar
               topologyKey: "kubernetes.io/hostname"
 `
-		}
-
 		istioSystemNetworkPolicyAllowFromAggregatePrometheus = `apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -2343,7 +2335,7 @@ spec:
 			Expect(string(managedResourceIstioSecret.Data["istio-ingress_templates_rolebindings_test-ingress.yaml"])).To(Equal(istioIngressRoleBinding))
 			Expect(string(managedResourceIstioSecret.Data["istio-ingress_templates_service_test-ingress.yaml"])).To(Equal(istioIngressService(nil)))
 			Expect(string(managedResourceIstioSecret.Data["istio-ingress_templates_serviceaccount_test-ingress.yaml"])).To(Equal(istioIngressServiceAccount))
-			Expect(string(managedResourceIstioSecret.Data["istio-ingress_templates_deployment_test-ingress.yaml"])).To(Equal(istioIngressDeployment(false)))
+			Expect(string(managedResourceIstioSecret.Data["istio-ingress_templates_deployment_test-ingress.yaml"])).To(Equal(istioIngressDeployment))
 
 			By("Verify istio-ingress network policies")
 			Expect(string(managedResourceIstioSecret.Data["networkpolicy__test-ingress__deny-all-egress.yaml"])).To(Equal(istioIngressNetworkPolicyDenyAllEgress))
@@ -2530,38 +2522,6 @@ spec:
 			It("should successfully deploy correct external traffic policy", func() {
 				Expect(c.Get(ctx, client.ObjectKeyFromObject(managedResourceIstioSecret), managedResourceIstioSecret)).To(Succeed())
 				Expect(string(managedResourceIstioSecret.Data["istio-ingress_templates_service_test-ingress.yaml"])).To(Equal(istioIngressService(&externalTrafficPolicy)))
-			})
-		})
-
-		Context("VPN HA enabled", func() {
-			BeforeEach(func() {
-				for i := range igw {
-					igw[i].VPNHAEnabled = true
-					igw[i].VPNHAEnabled = true
-				}
-
-				istiod = NewIstio(
-					c,
-					renderer,
-					Values{
-						Istiod: IstiodValues{
-							Enabled:     true,
-							Image:       "foo/bar",
-							Namespace:   deployNS,
-							TrustDomain: "foo.local",
-							Zones:       []string{"a", "b", "c"},
-						},
-						IngressGateway: igw,
-					},
-				)
-			})
-
-			It("should successfully deploy all resources", func() {
-				Expect(c.Get(ctx, client.ObjectKeyFromObject(managedResourceIstioSecret), managedResourceIstioSecret)).To(Succeed())
-				Expect(managedResourceIstioSecret.Type).To(Equal(corev1.SecretTypeOpaque))
-				Expect(managedResourceIstioSecret.Data).To(HaveLen(41))
-
-				Expect(string(managedResourceIstioSecret.Data["istio-ingress_templates_deployment_test-ingress.yaml"])).To(Equal(istioIngressDeployment(true)))
 			})
 		})
 

--- a/pkg/operation/botanist/component/istio/istiod_test.go
+++ b/pkg/operation/botanist/component/istio/istiod_test.go
@@ -1631,7 +1631,16 @@ metadata:
 automountServiceAccountToken: false
 `
 
-		istioIngressDeployment = `apiVersion: apps/v1
+		istioIngressDeployment = func(vpnEnabled bool) string {
+			var additionalAnnotations string
+			if vpnEnabled {
+				additionalAnnotations = `
+        networking.resources.gardener.cloud/to-all-shoots-vpn-seed-server-tcp-1194: allowed
+        networking.resources.gardener.cloud/to-all-shoots-vpn-seed-server-0-tcp-1194: allowed
+        networking.resources.gardener.cloud/to-all-shoots-vpn-seed-server-1-tcp-1194: allowed`
+			}
+
+			return `apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: istio-ingressgateway
@@ -1660,10 +1669,7 @@ spec:
         
         service.istio.io/canonical-name: "istio-ingressgateway"
         service.istio.io/canonical-revision: "1.7"
-        networking.gardener.cloud/to-dns: allowed
-        networking.resources.gardener.cloud/to-all-shoots-vpn-seed-server-tcp-1194: allowed
-        networking.resources.gardener.cloud/to-all-shoots-vpn-seed-server-0-tcp-1194: allowed
-        networking.resources.gardener.cloud/to-all-shoots-vpn-seed-server-1-tcp-1194: allowed
+        networking.gardener.cloud/to-dns: allowed` + additionalAnnotations + `
       annotations:
         sidecar.istio.io/inject: "false"
         checksum/configmap-bootstrap-config-override: a357fe81829c12ad57e92721b93fd6efa1670d19e4cab94dfb7c792f9665c51a
@@ -1850,6 +1856,8 @@ spec:
                   - bar
               topologyKey: "kubernetes.io/hostname"
 `
+		}
+
 		istioSystemNetworkPolicyAllowFromAggregatePrometheus = `apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -2335,7 +2343,7 @@ spec:
 			Expect(string(managedResourceIstioSecret.Data["istio-ingress_templates_rolebindings_test-ingress.yaml"])).To(Equal(istioIngressRoleBinding))
 			Expect(string(managedResourceIstioSecret.Data["istio-ingress_templates_service_test-ingress.yaml"])).To(Equal(istioIngressService(nil)))
 			Expect(string(managedResourceIstioSecret.Data["istio-ingress_templates_serviceaccount_test-ingress.yaml"])).To(Equal(istioIngressServiceAccount))
-			Expect(string(managedResourceIstioSecret.Data["istio-ingress_templates_deployment_test-ingress.yaml"])).To(Equal(istioIngressDeployment))
+			Expect(string(managedResourceIstioSecret.Data["istio-ingress_templates_deployment_test-ingress.yaml"])).To(Equal(istioIngressDeployment(true)))
 
 			By("Verify istio-ingress network policies")
 			Expect(string(managedResourceIstioSecret.Data["networkpolicy__test-ingress__deny-all-egress.yaml"])).To(Equal(istioIngressNetworkPolicyDenyAllEgress))
@@ -2554,6 +2562,7 @@ spec:
 
 				Expect(string(managedResourceIstioSecret.Data["istio-ingress_templates_vpn-gateway_test-ingress.yaml"])).To(BeEmpty())
 				Expect(string(managedResourceIstioSecret.Data["istio-ingress_templates_vpn-envoy-filter_test-ingress.yaml"])).To(BeEmpty())
+				Expect(string(managedResourceIstioSecret.Data["istio-ingress_templates_deployment_test-ingress.yaml"])).To(Equal(istioIngressDeployment(false)))
 			})
 		})
 

--- a/pkg/operation/botanist/component/istio/istiod_test.go
+++ b/pkg/operation/botanist/component/istio/istiod_test.go
@@ -1632,9 +1632,9 @@ automountServiceAccountToken: false
 `
 
 		istioIngressDeployment = func(vpnEnabled bool) string {
-			var additionalAnnotations string
+			var additionalLabels string
 			if vpnEnabled {
-				additionalAnnotations = `
+				additionalLabels = `
         networking.resources.gardener.cloud/to-all-shoots-vpn-seed-server-tcp-1194: allowed
         networking.resources.gardener.cloud/to-all-shoots-vpn-seed-server-0-tcp-1194: allowed
         networking.resources.gardener.cloud/to-all-shoots-vpn-seed-server-1-tcp-1194: allowed`
@@ -1669,7 +1669,7 @@ spec:
         
         service.istio.io/canonical-name: "istio-ingressgateway"
         service.istio.io/canonical-revision: "1.7"
-        networking.gardener.cloud/to-dns: allowed` + additionalAnnotations + `
+        networking.gardener.cloud/to-dns: allowed` + additionalLabels + `
       annotations:
         sidecar.istio.io/inject: "false"
         checksum/configmap-bootstrap-config-override: a357fe81829c12ad57e92721b93fd6efa1670d19e4cab94dfb7c792f9665c51a

--- a/pkg/operation/botanist/component/vpnseedserver/vpn_seed_server.go
+++ b/pkg/operation/botanist/component/vpnseedserver/vpn_seed_server.go
@@ -66,9 +66,11 @@ const (
 	// EnvoyPort is the port exposed by the envoy proxy on which it receives http proxy/connect requests.
 	EnvoyPort = 9443
 	// OpenVPNPort is the port exposed by the vpn seed server for tcp tunneling.
-	OpenVPNPort     = 1194
-	metricsPort     = 15000
-	metricsPortName = "metrics"
+	OpenVPNPort = 1194
+	// HighAvailabilityReplicaCount is the replica count used when highly available VPN is configured.
+	HighAvailabilityReplicaCount = 2
+	metricsPort                  = 15000
+	metricsPortName              = "metrics"
 
 	secretNameDH            = "vpn-seed-server-dh"
 	envoyProxyContainerName = "envoy-proxy"

--- a/pkg/operation/shoot/shoot.go
+++ b/pkg/operation/shoot/shoot.go
@@ -37,6 +37,7 @@ import (
 	"github.com/gardener/gardener/pkg/gardenlet/apis/config"
 	gardenlethelper "github.com/gardener/gardener/pkg/gardenlet/apis/config/helper"
 	"github.com/gardener/gardener/pkg/operation/botanist/component"
+	"github.com/gardener/gardener/pkg/operation/botanist/component/vpnseedserver"
 	"github.com/gardener/gardener/pkg/operation/common"
 	"github.com/gardener/gardener/pkg/operation/garden"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
@@ -203,12 +204,12 @@ func (b *Builder) Build(ctx context.Context, c client.Reader) (*Shoot, error) {
 	}
 	shoot.GardenerVersion = gardenerVersion
 
-	shoot.VPNHighAvailabilityEnabled = shoot.GetInfo().Spec.ControlPlane != nil && shoot.GetInfo().Spec.ControlPlane.HighAvailability != nil
+	shoot.VPNHighAvailabilityEnabled = v1beta1helper.IsHAControlPlaneConfigured(shoot.GetInfo())
 	if haVPNEnabled, err := strconv.ParseBool(shoot.GetInfo().GetAnnotations()[v1beta1constants.ShootAlphaControlPlaneHAVPN]); err == nil {
 		shoot.VPNHighAvailabilityEnabled = haVPNEnabled
 	}
-	shoot.VPNHighAvailabilityNumberOfSeedServers = 2
-	shoot.VPNHighAvailabilityNumberOfShootClients = 2
+	shoot.VPNHighAvailabilityNumberOfSeedServers = vpnseedserver.HighAvailabilityReplicaCount
+	shoot.VPNHighAvailabilityNumberOfShootClients = vpnseedserver.HighAvailabilityReplicaCount
 
 	needsClusterAutoscaler, err := v1beta1helper.ShootWantsClusterAutoscaler(shootObject)
 	if err != nil {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area high-availability
/area security
/kind bug

**What this PR does / why we need it**:
This PR fixes network policy settings when VPN is set up for highly available shoot control planes. One important aspect was missed by the adaptations in #7515: HA control-planes have multiple VPN-Server `service`s which all must be considered when adding Labels for `Istio-Ingress` and `Kube-Apiserver`.

**Special notes for your reviewer**:
/invite @rfranzke

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
