### PR TITLE
Validate updates of the `AuditPolicy` against the `k8s` version of `Shoot`s

### DIFF
--- a/pkg/admissioncontroller/webhook/admission/auditpolicy/handler_test.go
+++ b/pkg/admissioncontroller/webhook/admission/auditpolicy/handler_test.go
@@ -538,7 +538,7 @@ rules:
 					*cm = returnedCm
 					return nil
 				})
-				test(admissionv1.Create, nil, shootv1beta1K8sV124, false, statusCodeInvalid, "audit policy with apiVersion 'v1alpha1' is not supported for shoot 'fake-shoot-name' with kubernetes version >= 1.24.0", "")
+				test(admissionv1.Create, nil, shootv1beta1K8sV124, false, statusCodeInvalid, "audit policy with apiVersion 'v1alpha1' is not supported for shoot 'fake-shoot-name' with Kubernetes version >= 1.24.0", "")
 			})
 
 			It("references a valid auditPolicy/v1alpha1 (UPDATE kubernetes version)", func() {
@@ -554,7 +554,7 @@ rules:
 
 				newShoot := shootv1beta1.DeepCopy()
 				newShoot.Spec.Kubernetes.Version = "1.24.0"
-				test(admissionv1.Update, shootv1beta1, newShoot, false, statusCodeInvalid, "audit policy with apiVersion 'v1alpha1' is not supported for shoot 'fake-shoot-name' with kubernetes version >= 1.24.0", "")
+				test(admissionv1.Update, shootv1beta1, newShoot, false, statusCodeInvalid, "audit policy with apiVersion 'v1alpha1' is not supported for shoot 'fake-shoot-name' with Kubernetes version >= 1.24.0", "")
 			})
 
 			It("references a valid auditPolicy/v1beta1 (CREATE k8s >= 1.24.0)", func() {
@@ -567,7 +567,7 @@ rules:
 					*cm = returnedCm
 					return nil
 				})
-				test(admissionv1.Create, nil, shootv1beta1K8sV124, false, statusCodeInvalid, "audit policy with apiVersion 'v1beta1' is not supported for shoot 'fake-shoot-name' with kubernetes version >= 1.24.0", "")
+				test(admissionv1.Create, nil, shootv1beta1K8sV124, false, statusCodeInvalid, "audit policy with apiVersion 'v1beta1' is not supported for shoot 'fake-shoot-name' with Kubernetes version >= 1.24.0", "")
 			})
 
 			It("references a valid auditPolicy/v1beta1 (UPDATE kubernetes version)", func() {
@@ -583,7 +583,7 @@ rules:
 
 				newShoot := shootv1beta1.DeepCopy()
 				newShoot.Spec.Kubernetes.Version = "1.24.0"
-				test(admissionv1.Update, shootv1beta1, newShoot, false, statusCodeInvalid, "audit policy with apiVersion 'v1beta1' is not supported for shoot 'fake-shoot-name' with kubernetes version >= 1.24.0", "")
+				test(admissionv1.Update, shootv1beta1, newShoot, false, statusCodeInvalid, "audit policy with apiVersion 'v1beta1' is not supported for shoot 'fake-shoot-name' with Kubernetes version >= 1.24.0", "")
 			})
 
 		})
@@ -683,7 +683,7 @@ rules:
 					newCm := cm.DeepCopy()
 					newCm.Data["policy"] = validAuditPolicyV1beta1
 
-					test(admissionv1.Update, cm, newCm, false, statusCodeInvalid, "audit policy with apiVersion 'v1beta1' is not supported for shoot 'fake-shoot-name-2' with kubernetes version >= 1.24.0", "")
+					test(admissionv1.Update, cm, newCm, false, statusCodeInvalid, "audit policy with apiVersion 'v1beta1' is not supported for shoot 'fake-shoot-name-2' with Kubernetes version >= 1.24.0", "")
 				})
 			})
 		})

--- a/pkg/admissioncontroller/webhook/admission/auditpolicy/handler_test.go
+++ b/pkg/admissioncontroller/webhook/admission/auditpolicy/handler_test.go
@@ -538,7 +538,7 @@ rules:
 					*cm = returnedCm
 					return nil
 				})
-				test(admissionv1.Create, nil, shootv1beta1K8sV124, false, statusCodeInvalid, "audit policy with apiVersion 'v1alpha1' is not supported for kubernetes version >= 1.24.0", "")
+				test(admissionv1.Create, nil, shootv1beta1K8sV124, false, statusCodeInvalid, "audit policy with apiVersion 'v1alpha1' is not supported for shoot 'fake-shoot-name' with kubernetes version >= 1.24.0", "")
 			})
 
 			It("references a valid auditPolicy/v1alpha1 (UPDATE kubernetes version)", func() {
@@ -554,7 +554,7 @@ rules:
 
 				newShoot := shootv1beta1.DeepCopy()
 				newShoot.Spec.Kubernetes.Version = "1.24.0"
-				test(admissionv1.Update, shootv1beta1, newShoot, false, statusCodeInvalid, "audit policy with apiVersion 'v1alpha1' is not supported for kubernetes version >= 1.24.0", "")
+				test(admissionv1.Update, shootv1beta1, newShoot, false, statusCodeInvalid, "audit policy with apiVersion 'v1alpha1' is not supported for shoot 'fake-shoot-name' with kubernetes version >= 1.24.0", "")
 			})
 
 			It("references a valid auditPolicy/v1beta1 (CREATE k8s >= 1.24.0)", func() {
@@ -567,7 +567,7 @@ rules:
 					*cm = returnedCm
 					return nil
 				})
-				test(admissionv1.Create, nil, shootv1beta1K8sV124, false, statusCodeInvalid, "audit policy with apiVersion 'v1beta1' is not supported for kubernetes version >= 1.24.0", "")
+				test(admissionv1.Create, nil, shootv1beta1K8sV124, false, statusCodeInvalid, "audit policy with apiVersion 'v1beta1' is not supported for shoot 'fake-shoot-name' with kubernetes version >= 1.24.0", "")
 			})
 
 			It("references a valid auditPolicy/v1beta1 (UPDATE kubernetes version)", func() {
@@ -583,7 +583,7 @@ rules:
 
 				newShoot := shootv1beta1.DeepCopy()
 				newShoot.Spec.Kubernetes.Version = "1.24.0"
-				test(admissionv1.Update, shootv1beta1, newShoot, false, statusCodeInvalid, "audit policy with apiVersion 'v1beta1' is not supported for kubernetes version >= 1.24.0", "")
+				test(admissionv1.Update, shootv1beta1, newShoot, false, statusCodeInvalid, "audit policy with apiVersion 'v1beta1' is not supported for shoot 'fake-shoot-name' with kubernetes version >= 1.24.0", "")
 			})
 
 		})
@@ -659,7 +659,6 @@ rules:
 				})
 
 				It("holds audit policy which breaks validation rules", func() {
-					cm.DeepCopy()
 					newCm := cm.DeepCopy()
 					newCm.Data["policy"] = invalidAuditPolicy
 
@@ -667,11 +666,24 @@ rules:
 				})
 
 				It("holds audit policy with invalid YAML structure", func() {
-					cm.DeepCopy()
 					newCm := cm.DeepCopy()
 					newCm.Data["policy"] = missingKeyAuditPolicy
 
 					test(admissionv1.Update, cm, newCm, false, statusCodeInvalid, "did not find expected key", "")
+				})
+
+				It("holds audit policy with unsupported version for the kubernetes version of one of the shoots", func() {
+					patch := client.MergeFrom(shootv1beta1.DeepCopy())
+					shootv1beta1.Spec.Kubernetes.Version = "1.23"
+					Expect(fakeClient.Patch(ctx, shootv1beta1, patch)).To(Succeed())
+
+					shootv1beta1K8sV124.Name = "fake-shoot-name-2"
+					Expect(fakeClient.Create(ctx, shootv1beta1K8sV124)).To(Succeed())
+
+					newCm := cm.DeepCopy()
+					newCm.Data["policy"] = validAuditPolicyV1beta1
+
+					test(admissionv1.Update, cm, newCm, false, statusCodeInvalid, "audit policy with apiVersion 'v1beta1' is not supported for shoot 'fake-shoot-name-2' with kubernetes version >= 1.24.0", "")
 				})
 			})
 		})


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/area audit-logging
/kind bug

**What this PR does / why we need it**:
With this PR updates to the audit policy referenced by `Shoot`s are validated against the kubernetes versions of those `Shoot`s. Otherwise, users can update the audit policy to an `audit.k8s.io` version which is not supported by the current kubernetes version of the shoot. This causes errors on subsequent reconciliations as the `kube-apiserver` will not be able to start. An example on how this can happen is given in the details below

<details>

1. Create an audit policy `ConfigMap` in the `Project` namespace with the following content:
    ```
    kind: ConfigMap
    metadata:
      name: audit-everything
      namespace: garden-local
    data:
      policy: |
        apiVersion: audit.k8s.io/v1
        kind: Policy
        rules:
          - level: Metadata
    ``` 
2. Create a `Shoot` with k8s version >= 1.24 that references the `audit-everything` audit policy `ConfigMap`
3. Update the audit policy `ConfigMap` so that its `apiVersion` is `audit.k8s.io/v1beta1` which is not supported in k8s 1.24
    ```
     kind: ConfigMap
    metadata:
      name: audit-everything
      namespace: garden-local
    data:
      policy: |
        apiVersion: audit.k8s.io/v1beta1
        kind: Policy
        rules:
          - level: Metadata
    ```
4. Reconcile the shoot and observe that the `kube-apiserver` cannot start with the following error:
    ```
      I0216 22:08:29.298604   30814 flags.go:64] FLAG: --watch-cache="true"
      I0216 22:08:29.298606   30814 flags.go:64] FLAG: --watch-cache-sizes="[]"
      I0216 22:08:29.298977   30814 server.go:158] Version: v1.24.8
      I0216 22:08:29.299005   30814 server.go:160] "Golang settings" GOGC="" GOMAXPROCS="" GOTRACEBACK=""
      I0216 22:08:29.299474   30814 dynamic_serving_content.go:113] "Loaded a new cert/key pair" name="serving-cert::/srv/kubernetes/apiserver/tls.crt::/srv/kubernetes/apiserver/tls.key"
      I0216 22:08:29.559357   30814 dynamic_cafile_content.go:119] "Loaded a new CA Bundle and Verifier" name="client-ca-bundle::/srv/kubernetes/ca-client/bundle.crt"
      I0216 22:08:29.559430   30814 dynamic_cafile_content.go:119] "Loaded a new CA Bundle and Verifier" name="request-header::/srv/kubernetes/ca-front-proxy/bundle.crt"
      I0216 22:08:29.559732   30814 oidc.go:283] OIDC: No x509 certificates provided, will use host's root CA set
      I0216 22:08:29.559922   30814 shared_informer.go:255] Waiting for caches to sync for node_authorizer
      E0216 22:08:29.562310   30814 run.go:74] "command failed" err="loading audit policy file: failed decoding: no kind \"Policy\" is registered for version \"audit.k8s.io/v1beta1\" in scheme \"pkg/audit/scheme.go:30\": from file /etc/kubernetes/audit/audit-policy.yaml"
      ]
    ```

</details>

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
6. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Updates to the `AuditPolicy` referenced by `Shoot`s are now also validated against the Kubernetes versions of those shoot clusters. This fixes an issue where it was possible to specify an unsupported `audit.k8s.io` version when updating the `ConfigMap` which contains the `AuditPolicy`.
```
