### PR TITLE
Increase fluent-bit memory request and limit

### DIFF
--- a/charts/seed-bootstrap/charts/fluent-bit/templates/fluent-bit-daemonset.yaml
+++ b/charts/seed-bootstrap/charts/fluent-bit/templates/fluent-bit-daemonset.yaml
@@ -52,10 +52,10 @@ spec:
               fieldPath: spec.nodeName
         resources:
           limits:
-            memory: 400Mi
+            memory: 650Mi
           requests:
             cpu: 150m
-            memory: 150Mi
+            memory: 200Mi
         ports:
         - name: metrics
           containerPort: {{ .Values.ports.metrics }}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area logging
/kind enhancement

**What this PR does / why we need it**:
The fluent-bit memory limit is increased from 400MB to 650MB.
Also, the memory request is increased from 150MB to 200MB.

Fluent-bit and the integration tests were tested on nodes with max 100 pods. Now the pods on a node are increased to 200. On the etcd pool, where the pods are about 30, the fluent-bit normally works with 220-270MB of memory. On the others is using 400-450MB. With a limit of 400MB this means that they will be stuck in `CrashLoopBackOff`.
 
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Fluent-bit daemon set memory limit increased to 650MB and request to 200MB.
```
