### PR TITLE
Support specifying resources to store in `etcd-events` for `kube-apiserver`

### DIFF
--- a/pkg/operation/botanist/component/kubeapiserver/kube_apiserver.go
+++ b/pkg/operation/botanist/component/kubeapiserver/kube_apiserver.go
@@ -161,6 +161,9 @@ type Values struct {
 	OIDC *gardencorev1beta1.OIDCConfig
 	// Requests contains configuration for the kube-apiserver requests.
 	Requests *gardencorev1beta1.KubeAPIServerRequests
+	// ResourcesToStoreInETCDEvents is a list of resources which should be stored in the etcd-events instead of the
+	// etcd-main. The `events` resource in the `core` group is always stored in etcd-events.
+	ResourcesToStoreInETCDEvents []schema.GroupResource
 	// RuntimeConfig is the set of runtime configurations.
 	RuntimeConfig map[string]bool
 	// RuntimeVersion is the Kubernetes version of the runtime cluster.

--- a/pkg/operation/botanist/component/kubeapiserver/kube_apiserver_test.go
+++ b/pkg/operation/botanist/component/kubeapiserver/kube_apiserver_test.go
@@ -2909,6 +2909,23 @@ rules:
 					Expect(deployment.Spec.Template.Spec.Containers[0].Command).NotTo(ContainElement(ContainSubstring("--advertise-address=")))
 				})
 
+				It("should configure the correct etcd overrides for etcd-events", func() {
+					var (
+						resourcesToStoreInETCDEvents = []schema.GroupResource{
+							{Group: "networking.k8s.io", Resource: "networkpolicies"},
+							{Group: "", Resource: "events"},
+							{Group: "apps", Resource: "daemonsets"},
+						}
+					)
+
+					kapi = New(kubernetesInterface, namespace, sm, Values{ResourcesToStoreInETCDEvents: resourcesToStoreInETCDEvents, Images: images, RuntimeVersion: runtimeVersion, Version: version})
+					deployAndRead()
+
+					Expect(deployment.Spec.Template.Spec.Containers[0].Command).To(ContainElement(
+						"--etcd-servers-overrides=networking.k8s.io/networkpolicies#https://etcd-events-client:2379,/events#https://etcd-events-client:2379,apps/daemonsets#https://etcd-events-client:2379",
+					))
+				})
+
 				It("should configure the api audiences if provided", func() {
 					var (
 						apiAudience1 = "foo"


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind enhancement

**What this PR does / why we need it**:
This PR allows to configure the `kubeapiserver` component with resources that should be stored in `etcd-events` instead of `etcd-main`. By default (and not configurable), the `events` resource in the `core` group is always stored in `etcd-events` (just like today).

Note that this PR does not yet expose this via the `Shoot` resource in any way. This can be done separately, but it is not planned for `Shoot`s to support this yet.
Generally, this is a prerequisite for `gardener-operator` managing the `kube-apiserver` deployment.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
