### PR TITLE
Migration step 2 for deploying `cluster-identity` managed resource on the seed conditionally

### DIFF
--- a/cmd/gardener-apiserver/app/gardener_apiserver.go
+++ b/cmd/gardener-apiserver/app/gardener_apiserver.go
@@ -333,7 +333,7 @@ func (o *Options) Run(ctx context.Context) error {
 			return err
 		} else if err == nil {
 			// Set immutable flag to true and origin to gardener-apiserver if cluster-identity config map is not immutable, its origin is empty and the cluster-identity is equal the one set by gardener-apiserver
-			if clusterIdentity.Immutable != nil && *clusterIdentity.Immutable {
+			if pointer.BoolDeref(clusterIdentity.Immutable, false) {
 				return nil
 			}
 			if clusterIdentity.Data[v1beta1constants.ClusterIdentityOrigin] == "" && clusterIdentity.Data[v1beta1constants.ClusterIdentity] == o.ExtraOptions.ClusterIdentity {

--- a/pkg/gardenlet/controller/seed/seed/reconciler_delete.go
+++ b/pkg/gardenlet/controller/seed/seed/reconciler_delete.go
@@ -313,21 +313,6 @@ func (r *Reconciler) runDeleteSeedFlow(
 			})
 		)
 		syncPointCleanedUp.Insert(destroyClusterIdentity)
-	} else {
-		// This is the migration scenario for the "cluster-identity" managed resource.
-		// In the first step the "cluster-identity" config map is annotated with "resources.gardener.cloud/mode: Ignore"
-		// In the second step (next release) the migration managed resource will be destroyed.
-		// In the last step the migration scenario will be removed entirely.
-		// TODO(oliver-goetz): Remove this migration scenario in a future release at the second step of migration.
-		var (
-			clusterIdentity = clusteridentity.NewIgnoredManagedResourceForSeed(seedClient, r.GardenNamespace, "")
-
-			destroyClusterIdentity = g.Add(flow.Task{
-				Name: "Destroying cluster-identity migration",
-				Fn:   component.OpDestroyAndWait(clusterIdentity).Destroy,
-			})
-		)
-		syncPointCleanedUp.Insert(destroyClusterIdentity)
 	}
 
 	// When the seed is the garden cluster then these components are reconciled by the gardener-operator.

--- a/pkg/gardenlet/controller/seed/seed/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/seed/seed/reconciler_reconcile.go
@@ -963,9 +963,10 @@ func (r *Reconciler) runReconcileSeedFlow(
 		// In the second step (next release) the migration managed resource will be destroyed.
 		// In the last step the migration scenario will be removed entirely.
 		// TODO(oliver-goetz): Remove this migration scenario in a future release.
+		clusterIdentity := clusteridentity.NewIgnoredManagedResourceForSeed(seedClient, r.GardenNamespace, "")
 		_ = g.Add(flow.Task{
-			Name: "Deploying cluster-identity migration",
-			Fn:   clusteridentity.NewIgnoredManagedResourceForSeed(seedClient, r.GardenNamespace, *seed.GetInfo().Status.ClusterIdentity).Deploy,
+			Name: "Destroying cluster-identity migration",
+			Fn:   component.OpDestroyAndWait(clusterIdentity).Destroy,
 		})
 	}
 

--- a/pkg/operation/botanist/component/clusteridentity/clusteridentity.go
+++ b/pkg/operation/botanist/component/clusteridentity/clusteridentity.go
@@ -199,6 +199,5 @@ func IsClusterIdentityEmptyOrFromOrigin(ctx context.Context, c client.Client, or
 		}
 		return false, err
 	}
-	// TODO(oliver-goetz): do not treat an empty origin as foreign origin anymore in a future release when shoot clusters have been reconciled at least once
-	return clusterIdentity.Data[v1beta1constants.ClusterIdentityOrigin] == origin, nil
+	return clusterIdentity.Data[v1beta1constants.ClusterIdentityOrigin] == origin || clusterIdentity.Data[v1beta1constants.ClusterIdentityOrigin] == "", nil
 }

--- a/test/integration/gardenlet/seed/seed/seed_test.go
+++ b/test/integration/gardenlet/seed/seed/seed_test.go
@@ -445,8 +445,6 @@ var _ = Describe("Seed controller tests", func() {
 					By("Verify that the seed system components have been deployed")
 					expectedManagedResources := []gomegatypes.GomegaMatcher{
 						MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("cluster-autoscaler")})}),
-						// TODO(oliver-goetz): "cluster-identity" managed resource won't be created by gardenlet anymore in the test scenario in the future.
-						MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("cluster-identity")})}),
 						MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("dependency-watchdog-endpoint")})}),
 						MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("dependency-watchdog-probe")})}),
 						MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("global-network-policies")})}),


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind technical-debt

**What this PR does / why we need it**:
This PR represents the second step of the migration scenario defined in https://github.com/gardener/gardener/pull/7436.

For recap, these are the migration steps.
1. Annotate the content of `cluster-identity`  managed resource of the seed with `resources.gardener.cloud/mode: Ignore` if `cluster-identity` config map is already existing.
  Switch `cluster-identity` config maps originated by the shoots to immutable.
2. Delete `cluster-identity` config map in the same case.
    Switch `cluster-identity` config maps originated by gardener-apiserver and the seeds to immutable. 
3. Remove the migration code.


**Which issue(s) this PR fixes**:
Part of #6896 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
