### PR TITLE
Drop ingress `NetworkPolicy` rule from `seed-prometheus` for shoot components

### DIFF
--- a/charts/seed-monitoring/charts/core/charts/prometheus/templates/allow-from-prometheus-network-policy.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/templates/allow-from-prometheus-network-policy.yaml
@@ -18,13 +18,6 @@ spec:
           app: prometheus
           gardener.cloud/role: monitoring
           role: monitoring
-    - podSelector:
-        matchLabels:
-          app: seed-prometheus
-          role: monitoring
-      namespaceSelector:
-        matchLabels:
-          role: garden
     ports:
     - port: metrics
       protocol: TCP


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking security
/kind cleanup

**What this PR does / why we need it**:
Today, `seed-prometheus` is allowed to scrape shoot control plane components labeled with `networking.gardener.cloud/from-prometheus=allowed`. However, there is no scrape target in shoot namespaces for the `seed-prometheus`. Hence, this rule can be dropped.

Only the `aggregate-prometheus` talks to Prometheis in shoot namespaces via https://github.com/gardener/gardener/blob/f47324ffb76cd9d923ac172c0959857fa7e85624/charts/seed-bootstrap/templates/aggregate-prometheus/config.yaml#L39-L60

**Which issue(s) this PR fixes**:
Part of #7352 

**Special notes for your reviewer**:
/cc @istvanballok @rickardsjp 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
