### PR TITLE
Clean up the deletion logic for the `loki` PriorityClass

### DIFF
--- a/pkg/gardenlet/controller/seed/seed/reconciler_reconcile_test.go
+++ b/pkg/gardenlet/controller/seed/seed/reconciler_reconcile_test.go
@@ -24,60 +24,19 @@ import (
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	schedulingv1 "k8s.io/api/scheduling/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	"github.com/gardener/gardener/pkg/client/kubernetes"
 	. "github.com/gardener/gardener/pkg/gardenlet/controller/seed/seed"
 	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
-	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 )
 
 var _ = Describe("Reconcile", func() {
-	var (
-		ctx        context.Context
-		seedClient client.Client
-	)
-
-	BeforeEach(func() {
-		ctx = context.Background()
-		seedClient = fakeclient.NewClientBuilder().WithScheme(kubernetes.SeedScheme).Build()
-	})
-
-	Describe("#CleanupLegacyLokiPriorityClass", func() {
-		Context("when there is no legacy loki priority class in the cluster", func() {
-			It("should not return an error when attempting to clean the loki priority class that does not exist", func() {
-				Expect(CleanupLegacyLokiPriorityClass(ctx, seedClient)).To(Succeed())
-			})
-		})
-
-		Context("when there is legacy loki priority class in the cluster", func() {
-			var lokiPriorityClass = &schedulingv1.PriorityClass{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "loki",
-				},
-				Value: 1,
-			}
-
-			BeforeEach(func() {
-				Expect(seedClient.Create(ctx, lokiPriorityClass)).To(Succeed())
-			})
-
-			It("should delete the legacy loki priority class", func() {
-				Expect(CleanupLegacyLokiPriorityClass(ctx, seedClient)).To(Succeed())
-
-				err := seedClient.Get(ctx, client.ObjectKeyFromObject(lokiPriorityClass), &schedulingv1.PriorityClass{})
-				Expect(err).To(BeNotFoundError())
-			})
-		})
-	})
 
 	Describe("#ResizeOrDeleteLokiDataVolumeIfStorageNotTheSame", func() {
 		const (


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind cleanup

**What this PR does / why we need it**:
The deletion logic for the `loki` PriorityClass was introduced in 1.64 with https://github.com/gardener/gardener/pull/7433.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/5634

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
