### PR TITLE
Add shoot webhook to modify coreDNS config in provider-local setup

### DIFF
--- a/example/90-shoot.yaml
+++ b/example/90-shoot.yaml
@@ -43,7 +43,7 @@ spec:
           version: <some-image-version>
         # providerConfig:
         #   <some-machine-image-specific-configuration>
-        # architecture: <some-cpu-architecture>
+      # architecture: <some-cpu-architecture>
       volume:
         type: gp2
         size: 20Gi

--- a/pkg/operation/botanist/component/vpnshoot/vpnshoot.go
+++ b/pkg/operation/botanist/component/vpnshoot/vpnshoot.go
@@ -244,7 +244,6 @@ func (v *vpnShoot) computeResourcesData(secretCAVPN *corev1.Secret, secretsVPNSh
 			Data: secretVPNSeedServerTLSAuth.Data,
 		}
 		secretDH           *corev1.Secret
-		service            *corev1.Service
 		clusterRole        *rbacv1.ClusterRole
 		clusterRoleBinding *rbacv1.ClusterRoleBinding
 	)
@@ -481,7 +480,6 @@ func (v *vpnShoot) computeResourcesData(secretCAVPN *corev1.Secret, secretsVPNSh
 		deploymentOrStatefulSet,
 		clusterRole,
 		clusterRoleBinding,
-		service,
 		vpa,
 		podSecurityPolicy,
 		clusterRolePSP,

--- a/pkg/provider-local/webhook/shoot/add.go
+++ b/pkg/provider-local/webhook/shoot/add.go
@@ -16,6 +16,7 @@ package shoot
 
 import (
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -41,9 +42,14 @@ func AddToManagerWithOptions(mgr manager.Manager, _ AddOptions) (*extensionswebh
 	failurePolicy := admissionregistrationv1.Fail
 
 	return shoot.New(mgr, shoot.Args{
-		Types:         []extensionswebhook.Type{{Obj: &corev1.ConfigMap{}}},
-		Mutator:       NewMutator(),
-		FailurePolicy: &failurePolicy,
+		Types: []extensionswebhook.Type{
+			{Obj: &corev1.Node{}},
+			{Obj: &corev1.ConfigMap{}},
+			{Obj: &corev1.Service{}},
+			{Obj: &appsv1.Deployment{}},
+		},
+		MutatorWithShootClient: NewMutator(),
+		FailurePolicy:          &failurePolicy,
 	})
 }
 

--- a/pkg/provider-local/webhook/shoot/coredns.go
+++ b/pkg/provider-local/webhook/shoot/coredns.go
@@ -1,0 +1,111 @@
+// Copyright (c) 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package shoot
+
+import (
+	"context"
+	"fmt"
+
+	appsv1 "k8s.io/api/apps/v1"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
+	"github.com/gardener/gardener/pkg/utils"
+)
+
+func (m *mutator) mutateCoreDNSDeployment(ctx context.Context, client client.Client, deployment *appsv1.Deployment) error {
+	nodeList := corev1.NodeList{}
+	if err := client.List(ctx, &nodeList); err != nil {
+		return fmt.Errorf("failed to list the nodes")
+	}
+
+	addPodAntiAffinity := func(podAffinityTerms []corev1.WeightedPodAffinityTerm, podAffinityTerm corev1.WeightedPodAffinityTerm) []corev1.WeightedPodAffinityTerm {
+		for _, affinityTerms := range podAffinityTerms {
+			if affinityTerms.PodAffinityTerm.TopologyKey == corev1.LabelHostname {
+				return podAffinityTerms
+			}
+		}
+
+		return append(podAffinityTerms, podAffinityTerm)
+	}
+
+	if len(nodeList.Items) > 1 {
+		if deployment.Spec.Template.Spec.Affinity == nil {
+			deployment.Spec.Template.Spec.Affinity = &corev1.Affinity{}
+		}
+
+		if deployment.Spec.Template.Spec.Affinity.PodAntiAffinity == nil {
+			deployment.Spec.Template.Spec.Affinity.PodAntiAffinity = &corev1.PodAntiAffinity{}
+		}
+
+		labelSelector := metav1.LabelSelector{MatchLabels: deployment.Spec.Template.Labels}
+		podAffinityTerm := corev1.WeightedPodAffinityTerm{
+			Weight: 100,
+			PodAffinityTerm: corev1.PodAffinityTerm{
+				LabelSelector: &labelSelector,
+				TopologyKey:   corev1.LabelHostname,
+			},
+		}
+
+		podAffinityTerms := addPodAntiAffinity(deployment.Spec.Template.Spec.Affinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution, podAffinityTerm)
+		deployment.Spec.Template.Spec.Affinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution = podAffinityTerms
+	}
+
+	return nil
+}
+
+func (m *mutator) mutateCoreDNSHpa(ctx context.Context, shootClient client.Client) error {
+	hpa := autoscalingv2.HorizontalPodAutoscaler{}
+	if err := shootClient.Get(ctx, types.NamespacedName{Name: "coredns", Namespace: metav1.NamespaceSystem}, &hpa); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+
+		return err
+	}
+
+	nodeList := corev1.NodeList{}
+	if err := shootClient.List(ctx, &nodeList); err != nil {
+		return fmt.Errorf("failed to list the nodes")
+	}
+
+	requiredReplicas := 2
+	if len(nodeList.Items) > 2 {
+		requiredReplicas = len(nodeList.Items)
+	}
+
+	patch := client.MergeFrom(hpa.DeepCopy())
+	hpa.Annotations = utils.MergeStringMaps(hpa.Annotations, map[string]string{
+		resourcesv1alpha1.HighAvailabilityConfigReplicas: fmt.Sprintf("%v", requiredReplicas),
+	})
+
+	if err := shootClient.Patch(ctx, &hpa, patch); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *mutator) mutateCoreDNSService(_ context.Context, service *corev1.Service) error {
+	serviceInternalTrafficPolicy := corev1.ServiceInternalTrafficPolicyLocal
+	service.Spec.InternalTrafficPolicy = &serviceInternalTrafficPolicy
+
+	return nil
+}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind flake

**What this PR does / why we need it**:
This PR is an intermediate fix for https://github.com/gardener/gardener/issues/7530 issues. It adds a shoot webhook to set  `CoreDNS` replica equal to no of nodes, and set `internalTrafficPolicy` to Local in `kube-dns` service.
This is required so domain resolution traffic is always routed to coreDNS pods running on the same node.

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener/issues/7530

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
