### PR TITLE
Readd wrongly removed unit test

### DIFF
--- a/plugin/pkg/managedseed/validator/admission_test.go
+++ b/plugin/pkg/managedseed/validator/admission_test.go
@@ -370,6 +370,21 @@ var _ = Describe("ManagedSeed", func() {
 							Kind: "nginx",
 						},
 					},
+					Networks: gardencorev1beta1.SeedNetworks{
+						Nodes:    pointer.String("10.251.0.0/16"),
+						Pods:     "100.97.0.0/11",
+						Services: "100.65.0.0/13",
+					},
+					Provider: gardencorev1beta1.SeedProvider{
+						Type:   "bar-provider",
+						Region: "bar-region",
+						Zones:  []string{"foo", "bar"},
+					},
+					Settings: &gardencorev1beta1.SeedSettings{
+						VerticalPodAutoscaler: &gardencorev1beta1.SeedSettingVerticalPodAutoscaler{
+							Enabled: true,
+						},
+					},
 				}
 
 				managedSeed.Spec.Gardenlet.Config = &gardenletv1alpha1.GardenletConfiguration{
@@ -390,8 +405,39 @@ var _ = Describe("ManagedSeed", func() {
 				Expect(err).To(BeInvalidError())
 				Expect(getErrorList(err)).To(ConsistOf(
 					PointTo(MatchFields(IgnoreExtras, Fields{
-						"Type":  Equal(field.ErrorTypeInvalid),
-						"Field": Equal("spec.gardenlet.config.seedConfig.spec.ingress.domain"),
+						"Type":   Equal(field.ErrorTypeInvalid),
+						"Field":  Equal("spec.gardenlet.config.seedConfig.spec.ingress.domain"),
+						"Detail": ContainSubstring("seed ingress domain must be equal to shoot DNS domain"),
+					})),
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":   Equal(field.ErrorTypeInvalid),
+						"Field":  Equal("spec.gardenlet.config.seedConfig.spec.networks.nodes"),
+						"Detail": ContainSubstring("seed nodes CIDR must be equal to shoot nodes CIDR"),
+					})),
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":   Equal(field.ErrorTypeInvalid),
+						"Field":  Equal("spec.gardenlet.config.seedConfig.spec.networks.pods"),
+						"Detail": ContainSubstring("seed pods CIDR must be equal to shoot pods CIDR"),
+					})),
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":   Equal(field.ErrorTypeInvalid),
+						"Field":  Equal("spec.gardenlet.config.seedConfig.spec.networks.services"),
+						"Detail": ContainSubstring("seed services CIDR must be equal to shoot services CIDR"),
+					})),
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":   Equal(field.ErrorTypeInvalid),
+						"Field":  Equal("spec.gardenlet.config.seedConfig.spec.provider.type"),
+						"Detail": ContainSubstring("seed provider type must be equal to shoot provider type"),
+					})),
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":   Equal(field.ErrorTypeInvalid),
+						"Field":  Equal("spec.gardenlet.config.seedConfig.spec.provider.region"),
+						"Detail": ContainSubstring("seed provider region must be equal to shoot region"),
+					})),
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":   Equal(field.ErrorTypeInvalid),
+						"Field":  Equal("spec.gardenlet.config.seedConfig.spec.settings.verticalPodAutoscaler.enabled"),
+						"Detail": ContainSubstring("seed VPA is not supported for managed seeds - use the shoot VPA"),
 					})),
 				))
 			})


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind bug

**What this PR does / why we need it**:
https://github.com/gardener/gardener/pull/7529 wrongly removed the unit test from https://github.com/gardener/gardener/commit/bb2583c49bee1e9bcfa314e232d2bd8cc511e04e#diff-c263232e9b57bca8b49a62d8c304b86de45c6fa7330969f9c7b22c43f31a29edL407-L477. Although the dropped IT was suffixed with `(w/o ingress)`, it contains test cases/expectations that are not only related to ingress. Currently there is no uni tests that covers the added test cases.

**Which issue(s) this PR fixes**:
Follow-up after https://github.com/gardener/gardener/pull/7529

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
