### PR TITLE
Cleanup deprecated functions and interface in generic `Worker` actuator

### DIFF
--- a/extensions/pkg/controller/worker/genericactuator/actuator.go
+++ b/extensions/pkg/controller/worker/genericactuator/actuator.go
@@ -210,27 +210,6 @@ func (a *genericActuator) cleanupMachineClassSecrets(ctx context.Context, logger
 	return nil
 }
 
-// updateCloudCredentialsInAllMachineClassSecrets updates the cloud credentials
-// for all existing machine class secrets.
-func (a *genericActuator) updateCloudCredentialsInAllMachineClassSecrets(ctx context.Context, logger logr.Logger, cloudCredentials map[string][]byte, namespace string) error {
-	logger.Info("Updating cloud credentials for existing machine class secrets")
-	secretList, err := a.listMachineClassSecrets(ctx, namespace)
-	if err != nil {
-		return fmt.Errorf("failed to list machine class secrets in namespace %s: %w", namespace, err)
-	}
-
-	for _, secret := range secretList.Items {
-		secretCopy := secret.DeepCopy()
-		for key, value := range cloudCredentials {
-			secretCopy.Data[key] = value
-		}
-		if err := a.client.Patch(ctx, secretCopy, client.MergeFrom(&secret)); err != nil {
-			return fmt.Errorf("failed to patch secret %s/%s with cloud credentials: %w", namespace, secret.Name, err)
-		}
-	}
-	return nil
-}
-
 // shallowDeleteMachineClassSecrets deletes all unused machine class secrets (i.e., those which are not part
 // of the provided list <usedSecrets>) without waiting for MCM to do this.
 func (a *genericActuator) shallowDeleteMachineClassSecrets(ctx context.Context, log logr.Logger, namespace string, wantedMachineDeployments worker.MachineDeployments) error {

--- a/extensions/pkg/controller/worker/genericactuator/actuator_delete.go
+++ b/extensions/pkg/controller/worker/genericactuator/actuator_delete.go
@@ -126,12 +126,6 @@ func (a *genericActuator) Delete(ctx context.Context, log logr.Logger, worker *e
 		return fmt.Errorf("failed deleting machine-controller-manager: %w", err)
 	}
 
-	// Cleanup machine dependencies.
-	// TODO(dkistner): Remove in a future release.
-	if err := workerDelegate.CleanupMachineDependencies(ctx); err != nil {
-		return fmt.Errorf("failed to cleanup machine dependencies: %w", err)
-	}
-
 	// Call post deletion hook after Worker deletion has happened.
 	if err := workerDelegate.PostDeleteHook(ctx); err != nil {
 		return fmt.Errorf("post worker deletion hook failed: %w", err)

--- a/extensions/pkg/controller/worker/genericactuator/actuator_delete.go
+++ b/extensions/pkg/controller/worker/genericactuator/actuator_delete.go
@@ -75,17 +75,6 @@ func (a *genericActuator) Delete(ctx context.Context, log logr.Logger, worker *e
 		return fmt.Errorf("failed while waiting for the machine class credentials secret to be acquired: %w", err)
 	}
 
-	if workerCredentialsDelegate, ok := workerDelegate.(WorkerCredentialsDelegate); ok {
-		// Update cloud credentials for all existing machine class secrets
-		cloudCredentials, err := workerCredentialsDelegate.GetMachineControllerManagerCloudCredentials(ctx)
-		if err != nil {
-			return fmt.Errorf("failed to get the cloud credentials in namespace %s: %w", worker.Namespace, err)
-		}
-		if err = a.updateCloudCredentialsInAllMachineClassSecrets(ctx, log, cloudCredentials, worker.Namespace); err != nil {
-			return fmt.Errorf("failed to update cloud credentials in machine class secrets for namespace %s: %w", worker.Namespace, err)
-		}
-	}
-
 	// Mark all existing machines to become forcefully deleted.
 	log.Info("Marking all machines to become forcefully deleted")
 	if err := a.markAllMachinesForcefulDeletion(ctx, log, worker.Namespace); err != nil {
@@ -274,21 +263,16 @@ func (a *genericActuator) waitUntilCredentialsSecretAcquiredOrReleased(ctx conte
 		// deprecated WorkerCredentialsDelegate interface, i.e. machine classes reference a separate
 		// Secret for cloud provider credentials.
 		if !acquiredOrReleased {
-			_, ok := workerDelegate.(WorkerCredentialsDelegate)
-			if ok {
-				acquiredOrReleased = true
-			} else {
-				secret, err := kubernetesutils.GetSecretByReference(ctx, a.client, &worker.Spec.SecretRef)
-				if err != nil {
-					return retryutils.SevereError(fmt.Errorf("could not get the secret referenced by worker: %+v", err))
-				}
+			secret, err := kubernetesutils.GetSecretByReference(ctx, a.client, &worker.Spec.SecretRef)
+			if err != nil {
+				return retryutils.SevereError(fmt.Errorf("could not get the secret referenced by worker: %+v", err))
+			}
 
-				// We need to check for both mcmFinalizer and mcmProviderFinalizer:
-				// - mcmFinalizer is the finalizer used by machine controller manager and its in-tree providers
-				// - mcmProviderFinalizer is the finalizer used by out-of-tree machine controller providers
-				if (controllerutil.ContainsFinalizer(secret, mcmFinalizer) || controllerutil.ContainsFinalizer(secret, mcmProviderFinalizer)) == acquired {
-					acquiredOrReleased = true
-				}
+			// We need to check for both mcmFinalizer and mcmProviderFinalizer:
+			// - mcmFinalizer is the finalizer used by machine controller manager and its in-tree providers
+			// - mcmProviderFinalizer is the finalizer used by out-of-tree machine controller providers
+			if (controllerutil.ContainsFinalizer(secret, mcmFinalizer) || controllerutil.ContainsFinalizer(secret, mcmProviderFinalizer)) == acquired {
+				acquiredOrReleased = true
 			}
 		}
 

--- a/extensions/pkg/controller/worker/genericactuator/actuator_delete.go
+++ b/extensions/pkg/controller/worker/genericactuator/actuator_delete.go
@@ -259,9 +259,6 @@ func (a *genericActuator) waitUntilCredentialsSecretAcquiredOrReleased(ctx conte
 	acquiredOrReleased := false
 	return retryutils.UntilTimeout(ctx, 5*time.Second, 5*time.Minute, func(ctx context.Context) (bool, error) {
 		// Check whether the finalizer of the machine class credentials secret has been added or removed.
-		// This check is only applicable when the given workerDelegate does not implement the
-		// deprecated WorkerCredentialsDelegate interface, i.e. machine classes reference a separate
-		// Secret for cloud provider credentials.
 		if !acquiredOrReleased {
 			secret, err := kubernetesutils.GetSecretByReference(ctx, a.client, &worker.Spec.SecretRef)
 			if err != nil {

--- a/extensions/pkg/controller/worker/genericactuator/actuator_reconcile.go
+++ b/extensions/pkg/controller/worker/genericactuator/actuator_reconcile.go
@@ -82,12 +82,6 @@ func (a *genericActuator) Reconcile(ctx context.Context, log logr.Logger, worker
 		}
 	}
 
-	// Deploy machine dependencies.
-	// TODO(dkistner): Remove in a future release.
-	if err := workerDelegate.DeployMachineDependencies(ctx); err != nil {
-		return fmt.Errorf("failed to deploy machine dependencies: %w", err)
-	}
-
 	// Deploy the machine-controller-manager into the cluster.
 	if err := a.deployMachineControllerManager(ctx, log, worker, cluster, workerDelegate, mcmReplicaFunc); err != nil {
 		return err
@@ -218,12 +212,6 @@ func (a *genericActuator) Reconcile(ctx context.Context, log logr.Logger, worker
 
 	if err := a.updateWorkerStatusMachineDeployments(ctx, worker, wantedMachineDeployments); err != nil {
 		return fmt.Errorf("failed to update the machine deployments in worker status: %w", err)
-	}
-
-	// Cleanup machine dependencies.
-	// TODO(dkistner): Remove in a future release.
-	if err := workerDelegate.CleanupMachineDependencies(ctx); err != nil {
-		return fmt.Errorf("failed to cleanup machine dependencies: %w", err)
 	}
 
 	// Call post reconcilation hook after Worker reconciliation has happened.

--- a/extensions/pkg/controller/worker/genericactuator/actuator_reconcile.go
+++ b/extensions/pkg/controller/worker/genericactuator/actuator_reconcile.go
@@ -117,17 +117,6 @@ func (a *genericActuator) Reconcile(ctx context.Context, log logr.Logger, worker
 		return fmt.Errorf("failed to deploy the machine classes: %w", err)
 	}
 
-	if workerCredentialsDelegate, ok := workerDelegate.(WorkerCredentialsDelegate); ok {
-		// Update cloud credentials for all existing machine class secrets
-		cloudCredentials, err := workerCredentialsDelegate.GetMachineControllerManagerCloudCredentials(ctx)
-		if err != nil {
-			return fmt.Errorf("failed to get the cloud credentials in namespace %s: %w", worker.Namespace, err)
-		}
-		if err = a.updateCloudCredentialsInAllMachineClassSecrets(ctx, log, cloudCredentials, worker.Namespace); err != nil {
-			return fmt.Errorf("failed to update cloud credentials in machine class secrets for namespace %s: %w", worker.Namespace, err)
-		}
-	}
-
 	// Update the machine images in the worker provider status.
 	if err := workerDelegate.UpdateMachineImagesStatus(ctx); err != nil {
 		return fmt.Errorf("failed to update the machine image status: %w", err)

--- a/extensions/pkg/controller/worker/genericactuator/actuator_test.go
+++ b/extensions/pkg/controller/worker/genericactuator/actuator_test.go
@@ -26,7 +26,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -222,86 +221,6 @@ var _ = Describe("Actuator", func() {
 			Entry("should be stuck - machine set does not have matching matching class", []machinev1alpha1.MachineSet{machineSetOtherMachineClass}, machineDeployments, true),
 			Entry("should be stuck - no machine set with matching owner reference", []machinev1alpha1.MachineSet{machineSetOtherOwner}, machineDeployments, true),
 		)
-	})
-
-	Describe("#updateCloudCredentialsForUnwantedMachineDeployments", func() {
-		const (
-			workerNamespace           = "test-ns"
-			machineClassSecretName1   = "machine-class-secret1"
-			machineClassSecretName2   = "machine-class-secret2"
-			nonMachineClassSecretName = "non-machine-class-secret"
-		)
-
-		var (
-			all    []runtime.Object
-			logger = log.Log.WithName("test")
-
-			usernameKey   = "username"
-			usernameValue = []byte("username")
-
-			cloudCredentials = map[string][]byte{
-				usernameKey: usernameValue,
-			}
-			machineClassSecret1 = &corev1.Secret{
-				Data: map[string][]byte{
-					"key": []byte("value"),
-				},
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      machineClassSecretName1,
-					Namespace: workerNamespace,
-					Labels:    map[string]string{"gardener.cloud/purpose": "machineclass"},
-				},
-			}
-			machineClassSecret2 = &corev1.Secret{
-				Data: map[string][]byte{
-					usernameKey: []byte("outadated-username"),
-				},
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      machineClassSecretName2,
-					Namespace: workerNamespace,
-					Labels:    map[string]string{"gardener.cloud/purpose": "machineclass"},
-				},
-			}
-			nonMachineClassSecret = &corev1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      nonMachineClassSecretName,
-					Namespace: workerNamespace,
-				},
-			}
-		)
-
-		BeforeEach(func() {
-			all = []runtime.Object{
-				machineClassSecret1,
-				machineClassSecret2,
-				nonMachineClassSecret,
-			}
-		})
-
-		It("should update the cloud credentials for all machine class secret", func() {
-			a := &genericActuator{client: fake.NewClientBuilder().WithRuntimeObjects(all...).Build()}
-			secret1 := &corev1.Secret{}
-			secret2 := &corev1.Secret{}
-			secret3 := &corev1.Secret{}
-
-			Expect(a.updateCloudCredentialsInAllMachineClassSecrets(context.TODO(), logger, cloudCredentials, workerNamespace)).ToNot(HaveOccurred())
-			Expect(a.client.Get(context.TODO(), client.ObjectKey{Name: machineClassSecretName1, Namespace: workerNamespace}, secret1)).ToNot(HaveOccurred())
-			Expect(a.client.Get(context.TODO(), client.ObjectKey{Name: machineClassSecretName2, Namespace: workerNamespace}, secret2)).ToNot(HaveOccurred())
-			Expect(a.client.Get(context.TODO(), client.ObjectKey{Name: nonMachineClassSecretName, Namespace: workerNamespace}, secret3)).ToNot(HaveOccurred())
-
-			for key, value := range cloudCredentials {
-				v, ok := secret1.Data[key]
-				Expect(ok).To(BeTrue())
-				Expect(v).To(Equal(value))
-
-				v, ok = secret2.Data[key]
-				Expect(ok).To(BeTrue())
-				Expect(v).To(Equal(value))
-
-				_, ok = secret3.Data[key]
-				Expect(ok).To(BeFalse())
-			}
-		})
 	})
 
 	Describe("#restoreMachineSetsAndMachines", func() {

--- a/extensions/pkg/controller/worker/genericactuator/interface.go
+++ b/extensions/pkg/controller/worker/genericactuator/interface.go
@@ -51,16 +51,6 @@ type WorkerDelegate interface {
 	// in case the required version has been removed from the `CloudProfile`.
 	UpdateMachineImagesStatus(context.Context) error
 
-	// DeployMachineDependencies is a hook to create external machine dependencies.
-	// Deprecated: Use PreReconcileHook() instead.
-	// TODO(dkistner): Remove in a future release.
-	DeployMachineDependencies(context.Context) error
-
-	// CleanupMachineDependencies is a hook to cleanup external machine dependencies.
-	// Deprecated: Use PostReconcileHook() and PostDeleteHook() instead.
-	// TODO(dkistner): Remove in a future release.
-	CleanupMachineDependencies(context.Context) error
-
 	// PreReconcileHook is a hook called at the beginning of the worker reconciliation flow.
 	PreReconcileHook(context.Context) error
 	// PostReconcileHook is a hook called at the end of the worker reconciliation flow.

--- a/extensions/pkg/controller/worker/genericactuator/interface.go
+++ b/extensions/pkg/controller/worker/genericactuator/interface.go
@@ -61,18 +61,6 @@ type WorkerDelegate interface {
 	PostDeleteHook(context.Context) error
 }
 
-// WorkerCredentialsDelegate is an interface that can optionally be implemented to be
-// used during the Worker reconciliation to keep all machine class secrets up to date.
-// DEPRECATED: extensions should instead provide credentials only (!) via the machine class field .spec.credentialsSecretRef
-// referencing the Worker's secret reference (spec.SecretRef). This way all machine classes
-// reference the same secret - there is no need anymore to update all machine class secrets.
-// please see [here](https://github.com/gardener/machine-controller-manager/pull/578) for more details
-type WorkerCredentialsDelegate interface {
-	// GetMachineControllerManagerCloudCredentials should return the IaaS credentials
-	// with the secret keys used by the machine-controller-manager.
-	GetMachineControllerManagerCloudCredentials(context.Context) (map[string][]byte, error)
-}
-
 // DelegateFactory acts upon Worker resources.
 type DelegateFactory interface {
 	// WorkerDelegate returns a worker delegate interface that is used for the Worker reconciliation

--- a/pkg/provider-local/controller/worker/machines.go
+++ b/pkg/provider-local/controller/worker/machines.go
@@ -132,12 +132,6 @@ func (w *workerDelegate) generateMachineConfig() error {
 	return nil
 }
 
-// TODO(dkistner): Remove in a future release.
-func (w *workerDelegate) DeployMachineDependencies(_ context.Context) error { return nil }
-
-// TODO(dkistner): Remove in a future release.
-func (w *workerDelegate) CleanupMachineDependencies(_ context.Context) error { return nil }
-
 func (w *workerDelegate) PreReconcileHook(_ context.Context) error  { return nil }
 func (w *workerDelegate) PostReconcileHook(_ context.Context) error { return nil }
 func (w *workerDelegate) PreDeleteHook(_ context.Context) error     { return nil }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind cleanup

**What this PR does / why we need it**:
- Drop deprecated `{Deploy,Cleanup}MachineDependencies` from `WorkerDelegate` interface (deprecated with https://github.com/gardener/gardener/pull/6290)
- Drop deprecated `WorkerCredentialsDelegate` interface (deprecated with https://github.com/gardener/gardener/pull/3308)

**Special notes for your reviewer**:
FYI @dkistner @danielfoehrKn 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking dependency
The deprecated `{Deploy,Cleanup}MachineDependencies` methods have been dropped from the `WorkerDelegate` interface. Similar, the deprecated `WorkerCredentialsDelegate` interface has been dropped.
```
