### PR TITLE
Allow `blackbox-exporter` to scrape `kube-apiserver` via `istio-ingressgateway`

### DIFF
--- a/charts/seed-monitoring/charts/core/charts/prometheus/templates/prometheus.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/templates/prometheus.yaml
@@ -58,9 +58,11 @@ spec:
         app: prometheus
         role: monitoring
         networking.gardener.cloud/to-dns: allowed
-        networking.gardener.cloud/to-public-networks: allowed
         networking.gardener.cloud/to-runtime-apiserver: allowed
         networking.resources.gardener.cloud/to-all-scrape-targets: allowed
+        # needed for blackbox-exporter sidecar container to talk to shoot API server via istio-ingressgateway
+        networking.gardener.cloud/to-public-networks: allowed
+        networking.resources.gardener.cloud/to-all-istio-ingresses-istio-ingressgateway-tcp-9443: allowed
     spec:
       # used to talk to Seed's API server.
       serviceAccountName: prometheus

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -479,6 +479,9 @@ const (
 	// LabelNetworkPolicyShootNamespaceAlias is a constant for the alias for shoot namespaces used in NetworkPolicy
 	// labels.
 	LabelNetworkPolicyShootNamespaceAlias = "all-shoots"
+	// LabelNetworkPolicyIstioIngressNamespaceAlias is a constant for the alias for shoot namespaces used in
+	// NetworkPolicy labels.
+	LabelNetworkPolicyIstioIngressNamespaceAlias = "all-istio-ingresses"
 
 	// LabelApp is a constant for a label key.
 	LabelApp = "app"

--- a/pkg/operation/botanist/component/istio/charts/istio/istio-ingress/templates/service.yaml
+++ b/pkg/operation/botanist/component/istio/charts/istio/istio-ingress/templates/service.yaml
@@ -7,6 +7,8 @@ metadata:
     service.alpha.kubernetes.io/aws-load-balancer-type: "nlb"
     service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
     networking.resources.gardener.cloud/from-world-to-ports: '[{"port":8132,"protocol":"TCP"},{"port":8443,"protocol":"TCP"},{"port":9443,"protocol":"TCP"}]'
+    networking.resources.gardener.cloud/namespace-selectors: '[{"matchLabels":{"gardener.cloud/role":"shoot"}}]'
+    networking.resources.gardener.cloud/pod-label-selector-namespace-alias: all-istio-ingresses
 {{- if .Values.annotations }}
 {{ .Values.annotations | toYaml | indent 4 }}
 {{- end }}

--- a/pkg/operation/botanist/component/istio/istio_test.go
+++ b/pkg/operation/botanist/component/istio/istio_test.go
@@ -1607,6 +1607,8 @@ metadata:
     service.alpha.kubernetes.io/aws-load-balancer-type: "nlb"
     service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
     networking.resources.gardener.cloud/from-world-to-ports: '[{"port":8132,"protocol":"TCP"},{"port":8443,"protocol":"TCP"},{"port":9443,"protocol":"TCP"}]'
+    networking.resources.gardener.cloud/namespace-selectors: '[{"matchLabels":{"gardener.cloud/role":"shoot"}}]'
+    networking.resources.gardener.cloud/pod-label-selector-namespace-alias: all-istio-ingresses
     foo: bar
     
   labels:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind regression

**What this PR does / why we need it**:
After https://github.com/gardener/gardener/pull/7515/commits/c2f57291815cb291eb67134249cf0809fbfd40ea (#7515), the network path from `blackbox-exporter` to `kube-apiserver` via `istio-ingressgateway` was no longer allowed. 

**Special notes for your reviewer**:
/cc @timuthy @ScheererJ @istvanballok @rickardsjp 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
A bug has been fixed which prevented `blackbox-exporter` to scrape the `kube-apiserver`s of shoot clusters via the `istio-ingressgateway`. As a result, its "external probe" was always failing.
```
