### PR TITLE
Add a periodSeconds and a failureThreshold to the startup probe

### DIFF
--- a/docs/development/content/remote-local-setup.yaml
+++ b/docs/development/content/remote-local-setup.yaml
@@ -97,6 +97,8 @@ spec:
             command:
             - cat
             - /tmp/ready
+          failureThreshold: 30
+          periodSeconds: 10
         resources:
           requests: {cpu: 8, memory: 16G}
           limits:   {cpu: 8, memory: 16G}


### PR DESCRIPTION
**How to categorize this PR?**
/area usability

**What this PR does / why we need it**:
This PR adds a failureThreshold and periodSeconds to the startup probe, which resolves the issue of the remote-local-setup deployment constantly entering a CrashLoopBackOff state due to insufficient time for all commands to complete. To improve stability, the pod will now wait until it is fully ready before starting up."

**Which issue(s) this PR fixes**:
-

**Special notes for your reviewer**:

**Release note**:
```other operator
NONE
```
