### PR TITLE
Fix local development scenario

### DIFF
--- a/extensions/pkg/webhook/handler_shootclient.go
+++ b/extensions/pkg/webhook/handler_shootclient.go
@@ -121,7 +121,7 @@ func (h *handlerShootClient) Handle(ctx context.Context, req admission.Request) 
 		}
 
 		if len(shootNamespace) == 0 {
-			return fmt.Errorf("could not find shoot namespace for webhook request")
+			return fmt.Errorf("could not find shoot namespace for webhook request from remote address %s", remoteAddr)
 		}
 
 		_, shootClient, err := util.NewClientForShoot(ctx, h.client, shootNamespace, client.Options{}, extensionsconfig.RESTOptions{})

--- a/hack/local-development/start-extension-provider-local
+++ b/hack/local-development/start-extension-provider-local
@@ -38,12 +38,11 @@ export LEADER_ELECTION_NAMESPACE=garden
 export GO111MODULE=on
 export GARDENER_SHOOT_CLIENT=external
 
-# The namespace for the provider-local extension controller is required because it is where
-# gardenlet will look for the gardener-extension-heartbeat lease resource during shoot
-# health checks.
-HEARTBEAT_NAMESPACE="$(kubectl get namespaces -l controllerregistration.core.gardener.cloud/name=provider-local -o jsonpath='{.items[0].metadata.name}')"
-if [ -z "$HEARTBEAT_NAMESPACE" ]; then
-  echo "Could not find namespace for provider-local extension controller heartbeats"
+# The namespace for the provider-local extension controller is required for various reasons
+# (heartbeats, secrets management, network policies, ...).
+EXTENSION_NAMESPACE="$(kubectl get namespaces -l controllerregistration.core.gardener.cloud/name=provider-local -o jsonpath='{.items[0].metadata.name}')"
+if [ -z "$EXTENSION_NAMESPACE" ]; then
+  echo "gardenlet has not yet created the namespace for the extension, cannot start provider-local"
   exit 1
 fi
 
@@ -51,12 +50,6 @@ fi
 SUDO=
 if [ "$USER" != root ]; then
   SUDO="sudo -E"
-fi
-
-namespace="$(kubectl --kubeconfig "$kubeconfig" get ns -l controllerregistration.core.gardener.cloud/name=provider-local -o jsonpath={..metadata.name})"
-if [[ -z "$namespace" ]]; then
-  echo "gardenlet has not yet created the namespace for the extension, cannot start provider-local"
-  exit 1
 fi
 
 $SUDO PROVIDER_LOCAL_DISABLE_COREDNS_MUTATION=true go run \
@@ -70,14 +63,14 @@ $SUDO PROVIDER_LOCAL_DISABLE_COREDNS_MUTATION=true go run \
   --webhook-config-server-port="${WEBHOOK_SERVER_PORT}" \
   --webhook-config-url=$(get_host_address):${WEBHOOK_SERVER_PORT} \
   --webhook-config-cert-dir="${WEBHOOK_CERT_DIR}" \
-  --webhook-config-namespace="$namespace" \
+  --webhook-config-namespace="${EXTENSION_NAMESPACE}" \
   --service-host-ip="${SERVICE_HOST_IP}" \
   --service-zone-0-ip="${SERVICE_ZONE_0_IP}" \
   --service-zone-1-ip="${SERVICE_ZONE_1_IP}" \
   --service-zone-2-ip="${SERVICE_ZONE_2_IP}" \
   --metrics-bind-address="${METRICS_BIND_ADDRESS}" \
   --health-bind-address="${HEALTH_BIND_ADDRESS}" \
-  --heartbeat-namespace="${HEARTBEAT_NAMESPACE}" \
+  --heartbeat-namespace="${EXTENSION_NAMESPACE}" \
   --gardener-version="$(cat "$(dirname $0)/../../VERSION")" \
   --backupbucket-local-dir="$ETCD_BACKUP_DIR" \
   --backupbucket-container-mount-path="$CONTAINER_PATH"

--- a/hack/local-development/start-extension-provider-local
+++ b/hack/local-development/start-extension-provider-local
@@ -59,7 +59,7 @@ if [[ -z "$namespace" ]]; then
   exit 1
 fi
 
-$SUDO go run \
+$SUDO PROVIDER_LOCAL_DISABLE_COREDNS_MUTATION=true go run \
   -mod=vendor \
   -ldflags "$("$(dirname $0)"/../get-build-ld-flags.sh)" \
   "$REPO_ROOT/cmd/gardener-extension-provider-local/main.go" \

--- a/hack/local-development/start-extension-provider-local
+++ b/hack/local-development/start-extension-provider-local
@@ -53,6 +53,12 @@ if [ "$USER" != root ]; then
   SUDO="sudo -E"
 fi
 
+namespace="$(kubectl --kubeconfig "$kubeconfig" get ns -l controllerregistration.core.gardener.cloud/name=provider-local -o jsonpath={..metadata.name})"
+if [[ -z "$namespace" ]]; then
+  echo "gardenlet has not yet created the namespace for the extension, cannot start provider-local"
+  exit 1
+fi
+
 $SUDO go run \
   -mod=vendor \
   -ldflags "$("$(dirname $0)"/../get-build-ld-flags.sh)" \
@@ -64,6 +70,7 @@ $SUDO go run \
   --webhook-config-server-port="${WEBHOOK_SERVER_PORT}" \
   --webhook-config-url=$(get_host_address):${WEBHOOK_SERVER_PORT} \
   --webhook-config-cert-dir="${WEBHOOK_CERT_DIR}" \
+  --webhook-config-namespace="$namespace" \
   --service-host-ip="${SERVICE_HOST_IP}" \
   --service-zone-0-ip="${SERVICE_ZONE_0_IP}" \
   --service-zone-1-ip="${SERVICE_ZONE_1_IP}" \

--- a/pkg/provider-local/webhook/dnsconfig/mutator.go
+++ b/pkg/provider-local/webhook/dnsconfig/mutator.go
@@ -44,6 +44,10 @@ func (m *mutator) Mutate(ctx context.Context, newObj, oldObj client.Object) erro
 		podSpec *corev1.PodSpec
 	)
 
+	if newObj.GetDeletionTimestamp() != nil {
+		return nil
+	}
+
 	switch obj := newObj.(type) {
 	case *corev1.Pod:
 		if oldObj != nil {

--- a/pkg/provider-local/webhook/shoot/add.go
+++ b/pkg/provider-local/webhook/shoot/add.go
@@ -15,6 +15,8 @@
 package shoot
 
 import (
+	"os"
+
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -41,16 +43,33 @@ func AddToManagerWithOptions(mgr manager.Manager, _ AddOptions) (*extensionswebh
 
 	failurePolicy := admissionregistrationv1.Fail
 
-	return shoot.New(mgr, shoot.Args{
-		Types: []extensionswebhook.Type{
-			{Obj: &corev1.Node{}},
-			{Obj: &corev1.ConfigMap{}},
-			{Obj: &corev1.Service{}},
-			{Obj: &appsv1.Deployment{}},
-		},
-		MutatorWithShootClient: NewMutator(),
-		FailurePolicy:          &failurePolicy,
-	})
+	args := shoot.Args{
+		Types:         []extensionswebhook.Type{{Obj: &corev1.ConfigMap{}}},
+		Mutator:       NewMutator(),
+		FailurePolicy: &failurePolicy,
+	}
+
+	// With https://github.com/gardener/gardener/pull/7578, provider-local temporarily mutates the CoreDNS configuration
+	// since the cluster network is not working properly in the shoots. However, this breaks the development setup
+	// (https://github.com/gardener/gardener/blob/master/docs/development/getting_started_locally.md) because it is not
+	// possible to determine the shoot namespace when running out of the seed cluster. Hence, `MutatorWithShootClient`
+	// cannot be used.
+	// Since all this is just a temporary workaround and was motivated by fixing flaky e2e tests, we can also work
+	// without it for development scenarios for the time being.
+	// So when the `PROVIDER_LOCAL_DISABLE_COREDNS_MUTATION` environment variable is not set then we enable the webhook
+	// (default scenario), otherwise we continue with above mutator (only for the local development scenario from
+	// above).
+	if os.Getenv("PROVIDER_LOCAL_DISABLE_COREDNS_MUTATION") == "" {
+		args.Mutator = nil
+		args.MutatorWithShootClient = NewMutatorWithShootClient(NewMutator())
+		args.Types = append(args.Types,
+			extensionswebhook.Type{Obj: &corev1.Node{}},
+			extensionswebhook.Type{Obj: &corev1.Service{}},
+			extensionswebhook.Type{Obj: &appsv1.Deployment{}},
+		)
+	}
+
+	return shoot.New(mgr, args)
 }
 
 // AddToManager creates a webhook with the default options and adds it to the manager.

--- a/pkg/provider-local/webhook/shoot/coredns.go
+++ b/pkg/provider-local/webhook/shoot/coredns.go
@@ -29,9 +29,9 @@ import (
 	"github.com/gardener/gardener/pkg/utils"
 )
 
-func (m *mutator) mutateCoreDNSDeployment(ctx context.Context, client client.Client, deployment *appsv1.Deployment) error {
-	nodeList := corev1.NodeList{}
-	if err := client.List(ctx, &nodeList); err != nil {
+func (m *mutatorWithShootClient) mutateCoreDNSDeployment(ctx context.Context, client client.Client, deployment *appsv1.Deployment) error {
+	nodeList := &corev1.NodeList{}
+	if err := client.List(ctx, nodeList); err != nil {
 		return fmt.Errorf("failed to list the nodes")
 	}
 
@@ -70,14 +70,14 @@ func (m *mutator) mutateCoreDNSDeployment(ctx context.Context, client client.Cli
 	return nil
 }
 
-func (m *mutator) mutateCoreDNSHpa(ctx context.Context, shootClient client.Client) error {
+func (m *mutatorWithShootClient) mutateCoreDNSHpa(ctx context.Context, shootClient client.Client) error {
 	hpa := autoscalingv2.HorizontalPodAutoscaler{}
 	if err := shootClient.Get(ctx, types.NamespacedName{Name: "coredns", Namespace: metav1.NamespaceSystem}, &hpa); client.IgnoreNotFound(err) != nil {
 		return err
 	}
 
-	nodeList := corev1.NodeList{}
-	if err := shootClient.List(ctx, &nodeList); err != nil {
+	nodeList := &corev1.NodeList{}
+	if err := shootClient.List(ctx, nodeList); err != nil {
 		return fmt.Errorf("failed to list the nodes")
 	}
 
@@ -94,7 +94,7 @@ func (m *mutator) mutateCoreDNSHpa(ctx context.Context, shootClient client.Clien
 	return shootClient.Patch(ctx, &hpa, patch)
 }
 
-func (m *mutator) mutateCoreDNSService(_ context.Context, service *corev1.Service) error {
+func (m *mutatorWithShootClient) mutateCoreDNSService(_ context.Context, service *corev1.Service) error {
 	serviceInternalTrafficPolicy := corev1.ServiceInternalTrafficPolicyLocal
 	service.Spec.InternalTrafficPolicy = &serviceInternalTrafficPolicy
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind bug regression

**What this PR does / why we need it**:
This PR fixes several issues preventing the local development scenario from working properly:

- After https://github.com/gardener/gardener/pull/7589, `provider-local` could not be started anymore, see https://github.com/gardener/gardener/issues/7607.
- After https://github.com/gardener/gardener/pull/7578, a created shoot could not get created successfully anymore because a locally running `provider-local` is unable to use the [`MutatorWithShootClient`](https://github.com/gardener/gardener/blob/04d981b72c4c74a29af6e48d700d043c56d61b74/extensions/pkg/webhook/mutator.go#L33-L37) interface.
- Not recently introduced, but the `dnsconfig` webhook of `provider-local` was always trying to mutate even if the object was about to be deleted. This (combined with other issues) has caused trouble when deleting a `Seed`, see https://github.com/gardener/gardener/issues/7237.

**Which issue(s) this PR fixes**:
Fixes #7237
Fixes #7607

**Special notes for your reviewer**:
/cc @ialidzhikov @Kostov6 @acumino 
**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```
NONE
```
