### PR TITLE
Fix a minor regression in the "remote local setup" scenario

### DIFF
--- a/hack/local-development/start-extension-provider-local
+++ b/hack/local-development/start-extension-provider-local
@@ -37,6 +37,7 @@ trap cleanup_kubeconfig EXIT
 export LEADER_ELECTION_NAMESPACE=garden
 export GO111MODULE=on
 export GARDENER_SHOOT_CLIENT=external
+export PROVIDER_LOCAL_DISABLE_COREDNS_MUTATION=true
 
 # The namespace for the provider-local extension controller is required for various reasons
 # (heartbeats, secrets management, network policies, ...).
@@ -52,7 +53,7 @@ if [ "$USER" != root ]; then
   SUDO="sudo -E"
 fi
 
-PROVIDER_LOCAL_DISABLE_COREDNS_MUTATION=true $SUDO go run \
+$SUDO go run \
   -mod=vendor \
   -ldflags "$("$(dirname $0)"/../get-build-ld-flags.sh)" \
   "$REPO_ROOT/cmd/gardener-extension-provider-local/main.go" \

--- a/hack/local-development/start-extension-provider-local
+++ b/hack/local-development/start-extension-provider-local
@@ -52,7 +52,7 @@ if [ "$USER" != root ]; then
   SUDO="sudo -E"
 fi
 
-$SUDO PROVIDER_LOCAL_DISABLE_COREDNS_MUTATION=true go run \
+PROVIDER_LOCAL_DISABLE_COREDNS_MUTATION=true $SUDO go run \
   -mod=vendor \
   -ldflags "$("$(dirname $0)"/../get-build-ld-flags.sh)" \
   "$REPO_ROOT/cmd/gardener-extension-provider-local/main.go" \


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind regression

**What this PR does / why we need it**:

Fix a minor regression that was introduced in #7610 for the "remote local setup" scenario.

<details>
<summary>Change the order of $SUDO and environment variable assignment to avoid a bash error when SUDO is empty.</summary>

If the user is root, the SUDO variable will be empty and the following snippet:

```
SUDO=
$SUDO foo=bar ls
```

will fail with

```
-bash: foo=bar: command not found
```

man bash, "Simple Commands":

> A simple command is a sequence of optional variable assignments followed by
> blank-separated words and redirections, and terminated by a control operator.
> The first word specifies the command to be executed, and is passed as argument
> zero. The remaining words are passed as arguments to the invoked command.

Although `$SUDO` is resolved to blank, the variable assignment has to precede it.

If we switch the order, both cases work as expected and the environment variable is set on the program that comes after $SUDO:

```
$ SUDO=
$ foo=bar $SUDO env | grep foo
foo=bar
```

```
SUDO="sudo -E"
$ foo=bar $SUDO env | grep foo

Password:
foo=bar
```

Note that when the local setup is executed locally, the user is typically not root. When it is executed in the "remote local setup" pod, the user is root.

</details>

**Which issue(s) this PR fixes**:

Fixes https://github.com/gardener/gardener/pull/7610#issuecomment-1460806690

**Special notes for your reviewer**:

/cc @rfranzke 
fyi @jguipi @rickardsjp 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
