### PR TITLE
Disable `SeedValidator` plugin in Shoot Scheduler integration test

### DIFF
--- a/test/integration/scheduler/shoot/shoot_suite_test.go
+++ b/test/integration/scheduler/shoot/shoot_suite_test.go
@@ -69,7 +69,7 @@ var _ = BeforeSuite(func() {
 	testEnv = &gardenerenvtest.GardenerTestEnvironment{
 		GardenerAPIServer: &gardenerenvtest.GardenerAPIServer{
 			Args: []string{
-				"--disable-admission-plugins=DeletionConfirmation,ResourceReferenceManager,ExtensionValidator,ShootQuotaValidator",
+				"--disable-admission-plugins=DeletionConfirmation,ResourceReferenceManager,ExtensionValidator,ShootQuotaValidator,SeedValidator",
 				"--feature-gates=HAControlPlanes=true"},
 		},
 	}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind flake

**What this PR does / why we need it**:
This PR fixes the `Scheduler Shoot Integration Test Suite` flake.

Failures from test grid:
https://prow.gardener.cloud/view/gs/gardener-prow/logs/ci-gardener-integration/1634002818098532352
https://prow.gardener.cloud/view/gs/gardener-prow/logs/ci-gardener-integration/1629833973876133888
https://prow.gardener.cloud/view/gs/gardener-prow/logs/ci-gardener-integration/1629592379352682496
https://prow.gardener.cloud/view/gs/gardener-prow/logs/ci-gardener-integration/1629531980766908416
https://prow.gardener.cloud/view/gs/gardener-prow/logs/ci-gardener-integration/1625484629534314496

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Similar to 16aec6175acf5419656aad89539984d8727f9fd1

After:
```
stress -ignore "unable to grab random port" -p 32 ./test/integration/scheduler/shoot/shoot.test -ginkgo.v -ginkgo.show-node-events
5s: 0 runs so far, 0 failures
.
.
19m20s: 1010 runs so far, 0 failures
19m25s: 1011 runs so far, 0 failures
.
21m40s: 1123 runs so far, 0 failures
21m45s: 1123 runs so far, 0 failures
```

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
