### PR TITLE
Wait for `CSINode` object before scheduling workload pods

### DIFF
--- a/docs/usage/node-readiness.md
+++ b/docs/usage/node-readiness.md
@@ -21,8 +21,9 @@ If there are `DaemonSets` that contain the `node.gardener.cloud/critical-compone
 
 Additionally, the `Node` controller checks for the readiness of `csi-driver-node` components if a respective Pod indicates that it uses such a driver.
 This is achieved through a well-defined annotation prefix (`node.gardener.cloud/wait-for-csi-node-`).
-E. g. for an Openstack Cinder CSI Driver, the `csi-driver-node` Pod is annotated with `node.gardener.cloud/wait-for-csi-node-cinder=cinder.csi.openstack.org`.
-The annotation key's suffix is arbitrarily chosen (in this case `cinder`) and the annotation value needs to match the actual driver name as specified in the `CSINode` object.
+For example, the `csi-driver-node` Pod for Openstack Cinder is annotated with `node.gardener.cloud/wait-for-csi-node-cinder=cinder.csi.openstack.org`.
+A key prefix is used instead of a "regular" annotation to allow for multiple CSI drivers being registered by one `csi-driver-node` Pod.
+The annotation key's suffix can be chosen arbitrarily (in this case `cinder`) and the annotation value needs to match the actual driver name as specified in the `CSINode` object.
 The `Node` controller will verify that the used driver is properly registered in this object before removing the `node.gardener.cloud/critical-components-not-ready` taint.
 Note that the `csi-driver-node` Pod still needs to be labelled and tolerate the taint as described above to be considered in this additional check.
 

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -807,4 +807,7 @@ const (
 	TaintNodeCriticalComponentsNotReady = "node.gardener.cloud/critical-components-not-ready"
 	// LabelNodeCriticalComponent is the label key for marking node-critical component pods.
 	LabelNodeCriticalComponent = "node.gardener.cloud/critical-component"
+	// AnnotationWaitForCSINode is the annotation key for csi-driver-node pods,
+	// indicating they use the driver specified in the value.
+	AnnotationPrefixWaitForCSINode = "node.gardener.cloud/wait-for-csi-node-"
 )

--- a/test/e2e/gardener/shoot/internal/node/node.go
+++ b/test/e2e/gardener/shoot/internal/node/node.go
@@ -172,9 +172,8 @@ func createOrUpdateNodeCriticalManagedResource(ctx context.Context, seedClient, 
 
 func patchCSINodeObjectWithRequiredDriver(ctx context.Context, shootClient client.Client) {
 	csiNodeList := &storagev1.CSINodeList{}
-
 	Expect(shootClient.List(ctx, csiNodeList)).To(Succeed())
-	Expect(len(csiNodeList.Items)).To(Equal(1))
+	Expect(csiNodeList.Items).To(HaveLen(1))
 
 	csiNode := csiNodeList.Items[0].DeepCopy()
 	csiNode.Spec.Drivers = []storagev1.CSINodeDriver{


### PR DESCRIPTION
**How to categorize this PR?**

/area robustness
/kind enhancement

**What this PR does / why we need it**:

Building upon #7406, this PR extends the `node` controller in the gardener-resource-manager to also take the readiness of CSI Drivers into consideration. See the proposal issue or documentation for more details.

**Which issue(s) this PR fixes**:
Contributes to #7117 

**Special notes for your reviewer**:

**Release note**:

```feature user
Gardener considers the readiness of CSI Drivers on the node before scheduling user workload. Please refer to the [documentation](https://github.com/gardener/gardener/blob/master/docs/usage/node-readiness.md) for more details.
```

```feature developer
Extensions should label `csi-driver-node` pods that they manage with `node.gardener.cloud/wait-for-csi-node-<suffix>=<driver-name>` to ensure user workload is only scheduled to nodes once the driver is properly registered. Please refer to the [documentation](https://github.com/gardener/gardener/blob/master/docs/usage/node-readiness.md) for more details.
```