### PR TITLE
Create a unified logging service definition in the logging stack 

### DIFF
--- a/charts/seed-bootstrap/charts/loki/templates/logging-service.yaml
+++ b/charts/seed-bootstrap/charts/loki/templates/logging-service.yaml
@@ -1,9 +1,9 @@
-# This service is to be soon removed by the unified logging service.
+# This service duplicates the soon to be removed loki service.
 # That serves the migration plan described at https://github.com/gardener/gardener/issues/7585
 apiVersion: v1
 kind: Service
 metadata:
-  name: loki
+  name: logging
   namespace: {{ .Release.Namespace }}
   labels:
 {{ toYaml .Values.labels | indent 4 }}

--- a/pkg/operation/botanist/logging_test.go
+++ b/pkg/operation/botanist/logging_test.go
@@ -168,6 +168,8 @@ var _ = Describe("Logging", func() {
 				c.EXPECT().Delete(ctx, &hvpav1alpha1.Hvpa{ObjectMeta: metav1.ObjectMeta{Name: "loki", Namespace: seedNamespace}}),
 				c.EXPECT().Delete(ctx, &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "loki-config", Namespace: seedNamespace}}),
 				c.EXPECT().Delete(ctx, &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "loki", Namespace: seedNamespace}}),
+				c.EXPECT().Delete(ctx, &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "logging",
+					Namespace: seedNamespace}}),
 				c.EXPECT().Delete(ctx, &appsv1.StatefulSet{ObjectMeta: metav1.ObjectMeta{Name: "loki", Namespace: seedNamespace}}),
 				c.EXPECT().Delete(ctx, &corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{Name: "loki-loki-0", Namespace: seedNamespace}}),
 			)
@@ -191,6 +193,8 @@ var _ = Describe("Logging", func() {
 				c.EXPECT().Delete(ctx, &hvpav1alpha1.Hvpa{ObjectMeta: metav1.ObjectMeta{Name: "loki", Namespace: seedNamespace}}),
 				c.EXPECT().Delete(ctx, &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "loki-config", Namespace: seedNamespace}}),
 				c.EXPECT().Delete(ctx, &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "loki", Namespace: seedNamespace}}),
+				c.EXPECT().Delete(ctx, &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "logging",
+					Namespace: seedNamespace}}),
 				c.EXPECT().Delete(ctx, &appsv1.StatefulSet{ObjectMeta: metav1.ObjectMeta{Name: "loki", Namespace: seedNamespace}}),
 				c.EXPECT().Delete(ctx, &corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{Name: "loki-loki-0", Namespace: seedNamespace}}),
 			)
@@ -267,6 +271,8 @@ var _ = Describe("Logging", func() {
 				c.EXPECT().Delete(ctx, &hvpav1alpha1.Hvpa{ObjectMeta: metav1.ObjectMeta{Name: "loki", Namespace: seedNamespace}}),
 				c.EXPECT().Delete(ctx, &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "loki-config", Namespace: seedNamespace}}),
 				c.EXPECT().Delete(ctx, &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "loki", Namespace: seedNamespace}}),
+				c.EXPECT().Delete(ctx, &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "logging",
+					Namespace: seedNamespace}}),
 				c.EXPECT().Delete(ctx, &appsv1.StatefulSet{ObjectMeta: metav1.ObjectMeta{Name: "loki", Namespace: seedNamespace}}),
 				c.EXPECT().Delete(ctx, &corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{Name: "loki-loki-0", Namespace: seedNamespace}}),
 			)

--- a/pkg/operation/common/utils.go
+++ b/pkg/operation/common/utils.go
@@ -105,6 +105,7 @@ func DeleteLoki(ctx context.Context, k8sClient client.Client, namespace string) 
 		&hvpav1alpha1.Hvpa{ObjectMeta: metav1.ObjectMeta{Name: "loki", Namespace: namespace}},
 		&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "loki-config", Namespace: namespace}},
 		&corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "loki", Namespace: namespace}},
+		&corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "logging", Namespace: namespace}},
 		&appsv1.StatefulSet{ObjectMeta: metav1.ObjectMeta{Name: "loki", Namespace: namespace}},
 		&corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{Name: "loki-loki-0", Namespace: namespace}},
 	}

--- a/pkg/operation/common/utils_test.go
+++ b/pkg/operation/common/utils_test.go
@@ -216,6 +216,8 @@ var _ = Describe("common", func() {
 			&hvpav1alpha1.Hvpa{ObjectMeta: metav1.ObjectMeta{Name: "loki", Namespace: v1beta1constants.GardenNamespace}},
 			&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "loki-config", Namespace: v1beta1constants.GardenNamespace}},
 			&corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "loki", Namespace: v1beta1constants.GardenNamespace}},
+			&corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "logging",
+				Namespace: v1beta1constants.GardenNamespace}},
 			&appsv1.StatefulSet{ObjectMeta: metav1.ObjectMeta{Name: "loki", Namespace: v1beta1constants.GardenNamespace}},
 			&corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{Name: "loki-loki-0", Namespace: v1beta1constants.GardenNamespace}},
 		}


### PR DESCRIPTION
**How to categorize this PR?**
/area logging
/kind task

**What this PR does / why we need it**:

This PR introduces a unified logging service definition in the seed cluster logging stacks. The purpose is to allow in the subsequent gardener release to switch the `fluent-bit` log shippers to use it as the target in the `output` plugin.

The end result after both changes is that `fluent-bits` will be able to ship logs to both `loki` and `vali` backends. In this way we handle the situation in time when we may have both migrated (vali) and non-migrated (loki) shoots running on the same seed. Since those share the same `logging` service both are addressable from the `fluent-bit`

**Which issue(s) this PR fixes**:
Part of #7585

**Special notes for your reviewer**:

The PR only brings the service definition without changing current logging streams end points. In the next gardener release we will switch the fluent-bits to target the service

**Release note**:
```other operator
NONE
```
