### PR TITLE
Provide value`gardener.seed.name` for controller registration helm charts. 

### DIFF
--- a/pkg/gardenlet/controller/controllerinstallation/controllerinstallation/reconciler.go
+++ b/pkg/gardenlet/controller/controllerinstallation/controllerinstallation/reconciler.go
@@ -194,7 +194,8 @@ func (r *Reconciler) reconcile(
 				"clusterIdentity": r.GardenClusterIdentity,
 			},
 			"seed": map[string]interface{}{
-				"identity":        seed.Name, // 'identity' value is deprecated to be replaced by 'clusterIdentity'. Should be removed in a future version.
+				"identity":        seed.Name, // 'identity' value is deprecated to be replaced either by 'clusterIdentity' or 'name'. Should be removed in a future version.
+				"name":            seed.Name,
 				"clusterIdentity": seedClusterIdentity,
 				"annotations":     seed.Annotations,
 				"labels":          seed.Labels,

--- a/test/integration/gardenlet/controllerinstallation/controllerinstallation/controllerinstallation_test.go
+++ b/test/integration/gardenlet/controllerinstallation/controllerinstallation/controllerinstallation_test.go
@@ -204,6 +204,7 @@ var _ = Describe("ControllerInstallation controller tests", func() {
       ` + testID + `: ` + testRunID + `
       dnsrecord.extensions.gardener.cloud/` + seed.Spec.DNS.Provider.Type + `: "true"
       provider.extensions.gardener.cloud/` + seed.Spec.Provider.Type + `: "true"
+    name: ` + seed.Name + `
     networks:
       ipFamilies:
       - IPv4


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement

**What this PR does / why we need it**:
The value `gardener.seed.identity` is deprecated, as "identity" implies global uniqueness. Instead it is recommended to use the value `gardener.seed.clusterIdentity`. For the dns-shoot-service we would prefer to continue with using the seed name as part of the the DNSOwner id, as it has contains the `gardener.garden.clusterIdentity` to make it unique. 
With introducing `gardener.seed.name`, we can still use the seed name for better readability.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Related to #2851

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature developer
The Helm chart values provided when extension controllers are deployed are now including the new value `gardener.seed.name`. 
```
