### PR TITLE
[CPM] Adds restoration of `etcd-main` for HA shoots

### DIFF
--- a/pkg/operation/botanist/component/etcd/etcd.go
+++ b/pkg/operation/botanist/component/etcd/etcd.go
@@ -113,6 +113,10 @@ type Interface interface {
 	RolloutPeerCA(context.Context) error
 	// GetValues returns the current configuration values of the deployer.
 	GetValues() Values
+	// GetReplicas gets the Replicas field in the Values.
+	GetReplicas() *int32
+	// SetReplicas sets the Replicas field in the Values.
+	SetReplicas(*int32)
 }
 
 // New creates a new instance of DeployWaiter for the Etcd.
@@ -808,9 +812,11 @@ func (e *etcd) RolloutPeerCA(ctx context.Context) error {
 	return err
 }
 
-func (e *etcd) GetValues() Values {
-	return e.values
-}
+func (e *etcd) GetValues() Values { return e.values }
+
+func (e *etcd) GetReplicas() *int32 { return e.values.Replicas }
+
+func (e *etcd) SetReplicas(replicas *int32) { e.values.Replicas = replicas }
 
 func (e *etcd) podLabelSelector() labels.Selector {
 	app, _ := labels.NewRequirement(v1beta1constants.LabelApp, selection.Equals, []string{LabelAppValue})

--- a/pkg/operation/botanist/component/etcd/mock/mocks.go
+++ b/pkg/operation/botanist/component/etcd/mock/mocks.go
@@ -95,6 +95,20 @@ func (mr *MockInterfaceMockRecorder) Get(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockInterface)(nil).Get), arg0)
 }
 
+// GetReplicas mocks base method.
+func (m *MockInterface) GetReplicas() *int32 {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetReplicas")
+	ret0, _ := ret[0].(*int32)
+	return ret0
+}
+
+// GetReplicas indicates an expected call of GetReplicas.
+func (mr *MockInterfaceMockRecorder) GetReplicas() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetReplicas", reflect.TypeOf((*MockInterface)(nil).GetReplicas))
+}
+
 // GetValues mocks base method.
 func (m *MockInterface) GetValues() etcd.Values {
 	m.ctrl.T.Helper()
@@ -174,6 +188,18 @@ func (m *MockInterface) SetHVPAConfig(arg0 *etcd.HVPAConfig) {
 func (mr *MockInterfaceMockRecorder) SetHVPAConfig(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetHVPAConfig", reflect.TypeOf((*MockInterface)(nil).SetHVPAConfig), arg0)
+}
+
+// SetReplicas mocks base method.
+func (m *MockInterface) SetReplicas(arg0 *int32) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetReplicas", arg0)
+}
+
+// SetReplicas indicates an expected call of SetReplicas.
+func (mr *MockInterfaceMockRecorder) SetReplicas(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetReplicas", reflect.TypeOf((*MockInterface)(nil).SetReplicas), arg0)
 }
 
 // Snapshot mocks base method.

--- a/pkg/operation/botanist/etcd.go
+++ b/pkg/operation/botanist/etcd.go
@@ -234,9 +234,11 @@ func (b *Botanist) isRestorationOfMultiNodeMainEtcdRequired(ctx context.Context)
 }
 
 func (b *Botanist) restoreMultiNodeMainEtcd(ctx context.Context) error {
-	desiredReplicas := b.Shoot.Components.ControlPlane.EtcdMain.GetReplicas()
+	originalReplicas := b.Shoot.Components.ControlPlane.EtcdMain.GetReplicas()
 	defer func() {
-		b.Shoot.Components.ControlPlane.EtcdMain.SetReplicas(desiredReplicas)
+		// Revert the original replica count for the etcd. This is done in case a step
+		// is added to the reconciliation flow that depends on the etcd's replica count.
+		b.Shoot.Components.ControlPlane.EtcdMain.SetReplicas(originalReplicas)
 	}()
 
 	b.Shoot.Components.ControlPlane.EtcdMain.SetReplicas(pointer.Int32(1))

--- a/pkg/operation/botanist/etcd_test.go
+++ b/pkg/operation/botanist/etcd_test.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"time"
 
+	druidv1alpha1 "github.com/gardener/etcd-druid/api/v1alpha1"
 	hvpav1alpha1 "github.com/gardener/hvpa-controller/api/v1alpha1"
 	"github.com/go-logr/logr"
 	"github.com/golang/mock/gomock"
@@ -28,7 +29,9 @@ import (
 	. "github.com/onsi/gomega/gstruct"
 	gomegatypes "github.com/onsi/gomega/types"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	kubernetesscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/utils/pointer"
@@ -401,6 +404,91 @@ var _ = Describe("Etcd", func() {
 				expectGetBackupSecret()
 
 				Expect(botanist.DeployEtcd(ctx)).To(HaveOccurred())
+			})
+
+			Context("cpm restore phase", func() {
+				BeforeEach(func() {
+					botanist.Shoot.GetInfo().Spec.ControlPlane = &gardencorev1beta1.ControlPlane{
+						HighAvailability: &gardencorev1beta1.HighAvailability{
+							FailureTolerance: gardencorev1beta1.FailureTolerance{
+								Type: gardencorev1beta1.FailureToleranceTypeNode,
+							},
+						},
+					}
+					botanist.Shoot.GetInfo().Status.LastOperation = &gardencorev1beta1.LastOperation{
+						Type: gardencorev1beta1.LastOperationTypeRestore,
+					}
+
+					expectSetBackupConfig()
+					expectGetBackupSecret()
+				})
+
+				It("should properly restore multi-node main etcd from backup if etcd does not exist", func() {
+					gomock.InOrder(
+						etcdMain.EXPECT().Get(ctx).Return(nil, apierrors.NewNotFound(schema.GroupResource{}, "")),
+						etcdMain.EXPECT().GetReplicas().Return(pointer.Int32(3)),
+						etcdMain.EXPECT().SetReplicas(pointer.Int32(1)),
+						etcdMain.EXPECT().Deploy(ctx),
+						etcdMain.EXPECT().Wait(ctx),
+						etcdMain.EXPECT().Scale(ctx, int32(3)),
+						etcdMain.EXPECT().SetReplicas(pointer.Int32(3)),
+					)
+
+					etcdEvents.EXPECT().Deploy(ctx)
+					Expect(botanist.DeployEtcd(ctx)).To(Succeed())
+				})
+
+				It("should properly restore multi-node main etcd from backup if it is deployed with 1 replica", func() {
+					etcdMain.EXPECT().Get(ctx).DoAndReturn(func(ctx context.Context) (*druidv1alpha1.Etcd, error) {
+						return &druidv1alpha1.Etcd{
+							Spec: druidv1alpha1.EtcdSpec{
+								Replicas: 1,
+							},
+						}, nil
+					})
+					gomock.InOrder(
+						etcdMain.EXPECT().GetReplicas().Return(pointer.Int32(3)),
+						etcdMain.EXPECT().SetReplicas(pointer.Int32(1)),
+						etcdMain.EXPECT().Deploy(ctx),
+						etcdMain.EXPECT().Wait(ctx),
+						etcdMain.EXPECT().Scale(ctx, int32(3)),
+						etcdMain.EXPECT().SetReplicas(pointer.Int32(3)),
+					)
+
+					etcdEvents.EXPECT().Deploy(ctx)
+
+					Expect(botanist.DeployEtcd(ctx)).To(Succeed())
+				})
+
+				It("should not try to restore multi-node etcd from backup if it has alrady been scaled up", func() {
+					etcdMain.EXPECT().Get(ctx).DoAndReturn(func(ctx context.Context) (*druidv1alpha1.Etcd, error) {
+						return &druidv1alpha1.Etcd{
+							Spec: druidv1alpha1.EtcdSpec{
+								Replicas: 3,
+							},
+						}, nil
+					})
+					etcdMain.EXPECT().Deploy(ctx)
+					etcdEvents.EXPECT().Deploy(ctx)
+
+					Expect(botanist.DeployEtcd(ctx)).To(Succeed())
+				})
+
+				It("should not try to restore multi-node etcd from backup if it has alrady been scaled down and the shoot is hibernated", func() {
+					botanist.Shoot.HibernationEnabled = true
+
+					etcdMain.EXPECT().Get(ctx).DoAndReturn(func(ctx context.Context) (*druidv1alpha1.Etcd, error) {
+						return &druidv1alpha1.Etcd{
+							Spec: druidv1alpha1.EtcdSpec{
+								Replicas: 0,
+							},
+						}, nil
+					})
+					etcdMain.EXPECT().Deploy(ctx)
+					etcdEvents.EXPECT().Deploy(ctx)
+
+					Expect(botanist.DeployEtcd(ctx)).To(Succeed())
+				})
 			})
 		})
 	})


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane-migration
/kind enhancement

**What this PR does / why we need it**:
This PR adds a step to the reconciliation flow so that during the `restore` phase of control plane migration, the `etcd-main` resource is first deployed with 1 replica when the `Shoot` cluster has an HA control plane. This is needed so that proper restoration of the `etcd` from backup can occur. If the `etcd-main` is deployed directly with 3 replicas, it will never be able to elect a leader and be stuck in a permanent quorum loss.
For hibernated clusters the same process must take place during restoration. This means that the `etcd-main` `Etcd` resource will be deployed with 1 replica, then scaled to 3 replicas. Later on in the flow it will be scaled down to 0 replicas by the [`hibernateControlPlane`](https://github.com/gardener/gardener/blob/7c647ba75fa5bd6bd9db590c43f91b6b764722a7/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go#L693-L697) step.

For more info check: https://github.com/gardener/etcd-druid/issues/479#issuecomment-1365793557

**Which issue(s) this PR fixes**:
Part of #6529
Fixes https://github.com/gardener/etcd-druid/issues/479

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
It is now possible to perform control plane migration for HA shoot clusters. 
```
