### PR TITLE
Drop no longer needed `shoot-core/network-policies` Helm chart

### DIFF
--- a/charts/shoot-core/components/charts/network-policies/Chart.yaml
+++ b/charts/shoot-core/components/charts/network-policies/Chart.yaml
@@ -1,4 +1,0 @@
-apiVersion: v1
-description: A Helm chart for networkpolicies that Gardener deploys into shoots.
-name: network-policies
-version: 0.1.0

--- a/charts/shoot-core/components/charts/network-policies/charts/utils-templates
+++ b/charts/shoot-core/components/charts/network-policies/charts/utils-templates
@@ -1,1 +1,0 @@
-../../../../../utils-templates

--- a/charts/shoot-core/components/charts/network-policies/templates/allow-from-seed.yaml
+++ b/charts/shoot-core/components/charts/network-policies/templates/allow-from-seed.yaml
@@ -1,8 +1,0 @@
-# TODO(rfranzke): Delete this Helm chart in a future version.
-kind: NetworkPolicy
-apiVersion: networking.k8s.io/v1
-metadata:
-  name: gardener.cloud--allow-from-seed
-  namespace: kube-system
-  annotations:
-    resources.gardener.cloud/mode: Ignore

--- a/charts/shoot-core/components/charts/network-policies/templates/allow-from-to-nginx.yaml
+++ b/charts/shoot-core/components/charts/network-policies/templates/allow-from-to-nginx.yaml
@@ -1,8 +1,0 @@
-# TODO(rfranzke): Delete this Helm chart in a future version.
-kind: NetworkPolicy
-apiVersion: networking.k8s.io/v1
-metadata:
-  name: gardener.cloud--allow-to-from-nginx
-  namespace: kube-system
-  annotations:
-    resources.gardener.cloud/mode: Ignore

--- a/charts/shoot-core/components/charts/network-policies/templates/allow-to-api-server.yaml
+++ b/charts/shoot-core/components/charts/network-policies/templates/allow-to-api-server.yaml
@@ -1,8 +1,0 @@
-# TODO(rfranzke): Delete this Helm chart in a future version.
-kind: NetworkPolicy
-apiVersion: networking.k8s.io/v1
-metadata:
-  name: gardener.cloud--allow-to-apiserver
-  namespace: kube-system
-  annotations:
-    resources.gardener.cloud/mode: Ignore

--- a/charts/shoot-core/components/charts/network-policies/templates/allow-to-dns.yaml
+++ b/charts/shoot-core/components/charts/network-policies/templates/allow-to-dns.yaml
@@ -1,8 +1,0 @@
-# TODO(rfranzke): Delete this Helm chart in a future version.
-kind: NetworkPolicy
-apiVersion: networking.k8s.io/v1
-metadata:
-  name: gardener.cloud--allow-to-dns
-  namespace: kube-system
-  annotations:
-    resources.gardener.cloud/mode: Ignore

--- a/charts/shoot-core/components/charts/network-policies/templates/allow-to-kubelet.yaml
+++ b/charts/shoot-core/components/charts/network-policies/templates/allow-to-kubelet.yaml
@@ -1,8 +1,0 @@
-# TODO(rfranzke): Delete this Helm chart in a future version.
-kind: NetworkPolicy
-apiVersion: networking.k8s.io/v1
-metadata:
-  name: gardener.cloud--allow-to-kubelet
-  namespace: kube-system
-  annotations:
-    resources.gardener.cloud/mode: Ignore

--- a/charts/shoot-core/components/charts/network-policies/templates/allow-to-public-networks.yaml
+++ b/charts/shoot-core/components/charts/network-policies/templates/allow-to-public-networks.yaml
@@ -1,8 +1,0 @@
-# TODO(rfranzke): Delete this Helm chart in a future version.
-kind: NetworkPolicy
-apiVersion: networking.k8s.io/v1
-metadata:
-  name: gardener.cloud--allow-to-public-networks
-  namespace: kube-system
-  annotations:
-    resources.gardener.cloud/mode: Ignore

--- a/charts/shoot-core/components/requirements.yaml
+++ b/charts/shoot-core/components/requirements.yaml
@@ -7,10 +7,6 @@ dependencies:
   repository: http://localhost:10191
   version: 0.1.0
   condition: monitoring.enabled
-- name: network-policies
-  repository: http://localhost:10191
-  version: 0.1.0
-  condition: network-policies.enabled
 - name: podsecuritypolicies
   repository: http://localhost:10191
   version: 0.1.0

--- a/charts/shoot-core/components/values.yaml
+++ b/charts/shoot-core/components/values.yaml
@@ -17,8 +17,6 @@ monitoring:
   node-exporter:
     images:
       node-exporter: image-repository:image-tag
-network-policies:
-  enabled: true
 podsecuritypolicies:
   enabled: true
   allowPrivilegedContainers: false

--- a/pkg/operation/botanist/addons.go
+++ b/pkg/operation/botanist/addons.go
@@ -75,7 +75,6 @@ func (b *Botanist) generateCoreAddonsChart() (*chartrenderer.RenderedChart, erro
 			"node-exporter":     nodeExporter,
 			"blackbox-exporter": blackboxExporter,
 		}, b.Operation.IsShootMonitoringEnabled()),
-		"network-policies":    common.GenerateAddonConfig(nil, true),
 		"podsecuritypolicies": common.GenerateAddonConfig(podSecurityPolicies, !b.Shoot.PSPDisabled),
 	}
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
This PR drops the `shoot-core/network-policies` Helm chart which was refactored with https://github.com/gardener/gardener/pull/7401 and released with `v1.64`.

**Which issue(s) this PR fixes**:
Part of #2754

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
