### PR TITLE
Enable `FullNetworkPoliciesInRuntimeCluster` feature gate locally

### DIFF
--- a/example/gardener-local/gardenlet/values.yaml
+++ b/example/gardener-local/gardenlet/values.yaml
@@ -36,8 +36,7 @@ config:
     CopyEtcdBackupsDuringControlPlaneMigration: true
     DefaultSeccompProfile: true
     CoreDNSQueryRewriting: true
-    # TODO(rfranzke): Enable FullNetworkPoliciesInRuntimeCluster once `networking-calico` extension (used in local setup) supports the feature gate.
-    FullNetworkPoliciesInRuntimeCluster: false
+    FullNetworkPoliciesInRuntimeCluster: true
   logging:
     enabled: true
     loki:

--- a/example/provider-local/garden/base/kustomization.yaml
+++ b/example/provider-local/garden/base/kustomization.yaml
@@ -7,8 +7,7 @@ resources:
 - project.yaml
 - secret-backup.yaml
 - secretbinding.yaml
-- https://raw.githubusercontent.com/gardener/gardener-extension-networking-calico/v1.26.0/example/controller-registration.yaml
+- https://raw.githubusercontent.com/gardener/gardener-extension-networking-calico/v1.31.1/example/controller-registration.yaml
 
 patchesStrategicMerge:
 - patch-controller-registrations.yaml
-- patch-controller-deployment.yaml

--- a/example/provider-local/garden/base/patch-controller-deployment.yaml
+++ b/example/provider-local/garden/base/patch-controller-deployment.yaml
@@ -1,8 +1,0 @@
-apiVersion: core.gardener.cloud/v1beta1
-kind: ControllerDeployment
-metadata:
-  name: networking-calico
-providerConfig:
-  values:
-    image:
-      tag: v1.27.0


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
This PR enables the `FullNetworkPoliciesInRuntimeCluster` feature gate (introduced with https://github.com/gardener/gardener/pull/7589) for the local setup with a version of `gardener-extension-networking-calico` including https://github.com/gardener/gardener-extension-networking-calico/pull/247.

/cc @ScheererJ 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
