### PR TITLE
Set `large_dir` option on the loki data disk

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -321,7 +321,7 @@ images:
 - name: fluent-bit-plugin-installer
   sourceRepository: github.com/gardener/logging
   repository: eu.gcr.io/gardener-project/gardener/fluent-bit-to-loki
-  tag: "v0.49.0"
+  tag: "v0.52.0"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:
@@ -348,7 +348,7 @@ images:
 - name: loki-curator
   sourceRepository: github.com/gardener/logging
   repository: eu.gcr.io/gardener-project/gardener/loki-curator
-  tag: "v0.49.0"
+  tag: "v0.52.0"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:
@@ -389,7 +389,7 @@ images:
 - name: telegraf
   sourceRepository: github.com/gardener/logging
   repository: eu.gcr.io/gardener-project/gardener/telegraf-iptables
-  tag: "v0.49.0"
+  tag: "v0.52.0"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:
@@ -405,7 +405,7 @@ images:
 - name: event-logger
   sourceRepository: github.com/gardener/logging
   repository: eu.gcr.io/gardener-project/gardener/event-logger
-  tag: "v0.49.0"
+  tag: "v0.52.0"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:
@@ -414,6 +414,19 @@ images:
       user_interaction: 'gardener-operator'
       confidentiality_requirement: 'high'
       integrity_requirement: 'high'
+      availability_requirement: 'low'
+- name: tune2fs
+  sourceRepository: github.com/gardener/logging
+  repository: eu.gcr.io/gardener-project/gardener/tune2fs
+  tag: "v0.52.0"
+  labels:
+  - name: 'gardener.cloud/cve-categorisation'
+    value:
+      network_exposure: 'private'
+      authentication_enforced: false
+      user_interaction: 'gardener-operator'
+      confidentiality_requirement: 'none'
+      integrity_requirement: 'none'
       availability_requirement: 'low'
 
 # VPA

--- a/charts/seed-bootstrap/charts/loki/templates/hvpa.yaml
+++ b/charts/seed-bootstrap/charts/loki/templates/hvpa.yaml
@@ -81,6 +81,9 @@ spec:
               mode: "Off"
             - containerName: telegraf
               mode: "Off"
+            - containerName: init-large-dir
+              mode: "Off"
+
 {{- end }}
   weightBasedScalingIntervals:
     - vpaWeight: 100

--- a/charts/seed-bootstrap/charts/loki/templates/statefulset.yaml
+++ b/charts/seed-bootstrap/charts/loki/templates/statefulset.yaml
@@ -42,6 +42,21 @@ spec:
         fsGroup: 10001
         fsGroupChangePolicy: "OnRootMismatch"
       priorityClassName: {{ .Values.priorityClassName }}
+      initContainers:
+      - command:
+        - bash
+        - -c
+        - tune2fs -O large_dir $(mount | gawk '{if($3=="/data") {print $1}}')
+        image: {{ index .Values.global.images "tune2fs" }}
+        name: init-large-dir
+        securityContext:
+          privileged: true
+          runAsUser: 0
+          runAsNonRoot: false
+          runAsGroup: 0
+        volumeMounts:
+        - mountPath: /data
+          name: loki
       containers:
 {{- if .Values.rbacSidecarEnabled }}
         - name: kube-rbac-proxy

--- a/charts/seed-bootstrap/charts/loki/values.yaml
+++ b/charts/seed-bootstrap/charts/loki/values.yaml
@@ -4,6 +4,7 @@ global:
     loki-curator: image-repository:image-tag
     kube-rbac-proxy: image-repository:image-tag
     telegraf: image-repository:image-tag
+    tune2fs: image-repository:image-tag
   fluentbit:
     labels:
       gardener.cloud/role: logging

--- a/pkg/gardenlet/controller/seed/seed/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/seed/seed/reconciler_reconcile.go
@@ -352,6 +352,7 @@ func (r *Reconciler) runReconcileSeedFlow(
 			images.ImageNameConfigmapReloader,
 			images.ImageNameLoki,
 			images.ImageNameLokiCurator,
+			images.ImageNameTune2fs,
 			images.ImageNameFluentBit,
 			images.ImageNameFluentBitPluginInstaller,
 			images.ImageNameGrafana,

--- a/pkg/operation/botanist/logging.go
+++ b/pkg/operation/botanist/logging.go
@@ -51,6 +51,7 @@ func (b *Botanist) DeploySeedLogging(ctx context.Context) error {
 		images.ImageNameLokiCurator,
 		images.ImageNameKubeRbacProxy,
 		images.ImageNameTelegraf,
+		images.ImageNameTune2fs,
 	)
 	if err != nil {
 		return err

--- a/pkg/operation/botanist/logging_test.go
+++ b/pkg/operation/botanist/logging_test.go
@@ -123,6 +123,7 @@ var _ = Describe("Logging", func() {
 					{Name: "loki-curator"},
 					{Name: "kube-rbac-proxy"},
 					{Name: "telegraf"},
+					{Name: "tune2fs"},
 				},
 			},
 		}
@@ -337,6 +338,7 @@ var _ = Describe("Logging", func() {
 					{Name: "loki-curator"},
 					{Name: "kube-rbac-proxy"},
 					{Name: "telegraf"},
+					{Name: "tune2fs"},
 				}
 
 				Expect(botanist.DeploySeedLogging(ctx)).ToNot(Succeed())

--- a/pkg/utils/images/images.go
+++ b/pkg/utils/images/images.go
@@ -107,6 +107,8 @@ const (
 	ImageNamePromtail = "promtail"
 	// ImageNameTelegraf is a constant for an image in the image vector with name 'telegraf'.
 	ImageNameTelegraf = "telegraf"
+	// ImageNameTune2fs is a constant for an image in the image vector with name 'tune2fs'.
+	ImageNameTune2fs = "tune2fs"
 	// ImageNameVpaAdmissionController is a constant for an image in the image vector with name 'vpa-admission-controller'.
 	ImageNameVpaAdmissionController = "vpa-admission-controller"
 	// ImageNameVpaRecommender is a constant for an image in the image vector with name 'vpa-recommender'.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area logging
/kind enhancement

**What this PR does / why we need it**:
As increasing the number of components in one seed the combinations of different labels per container are increased too. So the chunk dir(Loki stores the actual logs there), mainly of the central Loki, has exceeded the number of maximum files according to its index_tree capacity. This PR introduces a Loki init container that enables the `large_dir` filesystem feature on the Loki data disk.

**Which issue(s) this PR fixes**:
Fixes #7651 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Minimal Loki init container with `tunef2s` now enables the `large_dir` filesystem feature on Loki PV.
```
