### PR TITLE
Fix `ManagedSeed` controller integration test

### DIFF
--- a/test/integration/gardenlet/managedseed/managedseed_suite_test.go
+++ b/test/integration/gardenlet/managedseed/managedseed_suite_test.go
@@ -181,13 +181,11 @@ var _ = BeforeSuite(func() {
 	mgr, err := manager.New(restConfig, manager.Options{
 		Scheme:             testScheme,
 		MetricsBindAddress: "0",
-		Namespace:          gardenNamespaceGarden.Name,
 		NewCache: cache.BuilderWithOptions(cache.Options{
 			SelectorsByObject: map[client.Object]cache.ObjectSelector{
 				&seedmanagementv1alpha1.ManagedSeed{}: {Label: labels.SelectorFromSet(labels.Set{testID: testRunID})},
 				&gardencorev1beta1.Shoot{}:            {Label: labels.SelectorFromSet(labels.Set{testID: testRunID})},
 				&gardencorev1beta1.SecretBinding{}:    {Label: labels.SelectorFromSet(labels.Set{testID: testRunID})},
-				&corev1.Secret{}:                      {Label: labels.SelectorFromSet(labels.Set{testID: testRunID})},
 			},
 		}),
 	})


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind bug

**What this PR does / why we need it**:
The `ManagedSeed` controller test was wrongly asserting some things.
1. https://github.com/gardener/gardener/blob/d36d8944d19040f4f6ddd2043dbe93c401291a13/test/integration/gardenlet/managedseed/managedseed_test.go#L349-L350
 This passes in the envtest, because it's too quick.
  It doesn't pass against an actual cluster.
2. https://github.com/gardener/gardener/blob/d36d8944d19040f4f6ddd2043dbe93c401291a13/test/integration/gardenlet/managedseed/managedseed_test.go#L351
 The `gardenlet` should be expected to be not present in the `gardenNamespaceShoot` and not `gardenNamespaceGarden`. This passed because there was never a gardenlet deployment in `gardenNamespaceGarden`.

After fixing these two, the tests started to fail, turns out the manager cache was restricted to a single namespace.
https://github.com/gardener/gardener/blob/13025707f3e242409d278e596c45f3463d5027a7/test/integration/gardenlet/managedseed/managedseed_suite_test.go#L184-L191
Also, the Secret cache should not be restricted since the reconciler creates some secrets which won't have the test run labels. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @ary1992 @rfranzke 
Introduced with https://github.com/gardener/gardener/pull/7108

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
4. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
