### PR TITLE
Add hint about the optional nature of the apidiff check

### DIFF
--- a/hack/check-apidiff.sh
+++ b/hack/check-apidiff.sh
@@ -75,6 +75,21 @@ done <"${tmpDir}/output.txt"
 if [[ $retval -eq 1 ]]; then
   echo >&2 "FAIL: contains compatible/incompatible changes:"
   cat ${tmpDir}/result.txt
+
+  cat <<EOF
+
+The apidiff check failed – don't worry!
+This check is optional and hence not required to pass before merging a PR.
+
+The apidiff check makes changes to the go packages' API surface visible.
+For example, other repositories rely on a stable API of the extensions library located in gardener/gardener/extensions.
+When introducing incompatible changes in the extensions library, those dependants need to adapt to these changes when upgrading their go dependencies.
+To make this process easier for your fellow developers, try to keep incompatible changes limited.
+For all other cases, please check all incompatible changes listed above and add a friendly release note about them to your PR.
+Even better: you could explain how to adapt to the breaking changes in your PR's description or add a short doc.
+
+If your PR only contains compatible API changes, no action is required. You're good to go!
+EOF
 fi
 
 exit $retval

--- a/hack/check-apidiff.sh
+++ b/hack/check-apidiff.sh
@@ -20,7 +20,7 @@ set -o pipefail
 
 tmpDir=$(mktemp -d)
 function cleanup_output {
-    rm -rf "$tmpDir"
+  rm -rf "$tmpDir"
 }
 trap cleanup_output EXIT
 
@@ -29,52 +29,52 @@ temp=0
 
 # PULL_BASE_SHA env variable is set by default in prow presubmit jobs
 if [ -n "${PULL_BASE_SHA:-}" ]; then
-    echo "invoking: go-apidiff ${PULL_BASE_SHA} --print-compatible --repo-path=."
-    go-apidiff ${PULL_BASE_SHA} --print-compatible --repo-path=. > ${tmpDir}/output.txt
+  echo "invoking: go-apidiff ${PULL_BASE_SHA} --print-compatible --repo-path=."
+  go-apidiff ${PULL_BASE_SHA} --print-compatible --repo-path=. >${tmpDir}/output.txt
 else
-    echo "invoking: go-apidiff master --print-compatible --repo-path=."
-    go-apidiff master --print-compatible --repo-path=. > ${tmpDir}/output.txt
+  echo "invoking: go-apidiff master --print-compatible --repo-path=."
+  go-apidiff master --print-compatible --repo-path=. >${tmpDir}/output.txt
 fi
 
 exported_pkg=(
-"gardener/gardener/extensions/"
-"gardener/gardener/pkg/api/"
-"gardener/gardener/pkg/apis/"
-"gardener/gardener/pkg/chartrenderer/"
-"gardener/gardener/pkg/client/"
-"gardener/gardener/pkg/controllerutils/"
-"gardener/gardener/pkg/extensions/"
-"gardener/gardener/pkg/gardenlet/apis/config/"
-"gardener/gardener/pkg/logger/"
-"gardener/gardener/pkg/mock/controller-runtime/client/"
-"gardener/gardener/pkg/operation/botanist/component/extensions/operatingsystemconfig/"
-"gardener/gardener/pkg/resourcemanager/controller/garbagecollector/references/"
-"gardener/gardener/pkg/scheduler/"
-"gardener/gardener/pkg/utils/"
-"gardener/gardener/test/framework/"
+  "gardener/gardener/extensions/"
+  "gardener/gardener/pkg/api/"
+  "gardener/gardener/pkg/apis/"
+  "gardener/gardener/pkg/chartrenderer/"
+  "gardener/gardener/pkg/client/"
+  "gardener/gardener/pkg/controllerutils/"
+  "gardener/gardener/pkg/extensions/"
+  "gardener/gardener/pkg/gardenlet/apis/config/"
+  "gardener/gardener/pkg/logger/"
+  "gardener/gardener/pkg/mock/controller-runtime/client/"
+  "gardener/gardener/pkg/operation/botanist/component/extensions/operatingsystemconfig/"
+  "gardener/gardener/pkg/resourcemanager/controller/garbagecollector/references/"
+  "gardener/gardener/pkg/scheduler/"
+  "gardener/gardener/pkg/utils/"
+  "gardener/gardener/test/framework/"
 )
 
 # check the changes only for the package that is in the exported_pkg list
 while IFS= read -r line; do
-    if [[ $line =~ ^"github.com/gardener/gardener" ]]; then
-        temp=0
-        for x in ${exported_pkg[*]}; do
-            if [[ $line =~ $x ]]; then
-                retval=1
-                temp=1
-                echo "$line" >>  ${tmpDir}/result.txt
-            fi
-        done
-    else
-        if [[ $temp -eq 1 ]]; then
-            echo "$line" >>  ${tmpDir}/result.txt
-        fi
+  if [[ $line =~ ^"github.com/gardener/gardener" ]]; then
+    temp=0
+    for x in ${exported_pkg[*]}; do
+      if [[ $line =~ $x ]]; then
+        retval=1
+        temp=1
+        echo "$line" >>${tmpDir}/result.txt
+      fi
+    done
+  else
+    if [[ $temp -eq 1 ]]; then
+      echo "$line" >>${tmpDir}/result.txt
     fi
-done < "${tmpDir}/output.txt"
+  fi
+done <"${tmpDir}/output.txt"
 
 if [[ $retval -eq 1 ]]; then
-    echo >&2 "FAIL: contains compatible/incompatible changes:"
-    cat ${tmpDir}/result.txt
+  echo >&2 "FAIL: contains compatible/incompatible changes:"
+  cat ${tmpDir}/result.txt
 fi
 
 exit $retval

--- a/hack/check-apidiff.sh
+++ b/hack/check-apidiff.sh
@@ -27,14 +27,13 @@ trap cleanup_output EXIT
 retval=0
 temp=0
 
-BASE_SHA=${PULL_BASE_SHA:-} # PULL_BASE_SHA env variable is set by default in prow presubmit jobs
-
-if [ ! -z ${BASE_SHA} ]; then
+# PULL_BASE_SHA env variable is set by default in prow presubmit jobs
+if [ -n "${PULL_BASE_SHA:-}" ]; then
     echo "invoking: go-apidiff ${PULL_BASE_SHA} --print-compatible --repo-path=."
-    echo "$(go-apidiff ${PULL_BASE_SHA} --print-compatible --repo-path=.)" > ${tmpDir}/output.txt
+    go-apidiff ${PULL_BASE_SHA} --print-compatible --repo-path=. > ${tmpDir}/output.txt
 else
     echo "invoking: go-apidiff master --print-compatible --repo-path=."
-    echo "$(go-apidiff master --print-compatible --repo-path=.)" > ${tmpDir}/output.txt
+    go-apidiff master --print-compatible --repo-path=. > ${tmpDir}/output.txt
 fi
 
 exported_pkg=(


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area open-source
/kind enhancement

**What this PR does / why we need it**:

Add a hint about the optional nature of the apidiff check to the job output.
New contributors are often confused, about what they should do about a failing `pull-gardener-apidiff` test.
When checking such a failure, they are now presented with a short explanation.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
