### PR TITLE
Move `dropEnableBasicAuthenticationField` and `setKubernetesDashboardAuthMode` functions to `Canonicalize`

### DIFF
--- a/pkg/registry/core/shoot/strategy.go
+++ b/pkg/registry/core/shoot/strategy.go
@@ -83,8 +83,6 @@ func (shootStrategy) PrepareForUpdate(ctx context.Context, obj, old runtime.Obje
 	}
 
 	dropDisabledFields(newShoot, oldShoot)
-	dropEnableBasicAuthenticationField(newShoot)
-	setKubernetesDashboardAuthMode(newShoot)
 }
 
 // dropDisabledFields removes disabled fields from shoot.
@@ -93,23 +91,6 @@ func dropDisabledFields(newShoot, oldShoot *core.Shoot) {
 	oldShootIsHA := oldShoot != nil && helper.IsHAControlPlaneConfigured(oldShoot)
 	if !utilfeature.DefaultFeatureGate.Enabled(features.HAControlPlanes) && !oldShootIsHA && newShoot.Spec.ControlPlane != nil {
 		newShoot.Spec.ControlPlane.HighAvailability = nil
-	}
-}
-
-// dropEnableBasicAuthenticationField sets the enableBasicAuthentication to nil.
-func dropEnableBasicAuthenticationField(shoot *core.Shoot) {
-	if shoot.Spec.Kubernetes.KubeAPIServer != nil {
-		shoot.Spec.Kubernetes.KubeAPIServer.EnableBasicAuthentication = nil
-	}
-}
-
-// setKubernetesDashboardAuthMode sets the kubernetes-dashboard authentication mode to "token", if its current value is not "token" (for example "basic").
-func setKubernetesDashboardAuthMode(shoot *core.Shoot) {
-	if shoot.Spec.Addons != nil && shoot.Spec.Addons.KubernetesDashboard != nil {
-		if authMode := shoot.Spec.Addons.KubernetesDashboard.AuthenticationMode; authMode != nil && *authMode != core.KubernetesDashboardAuthModeToken {
-			defaultAuthMode := core.KubernetesDashboardAuthModeToken
-			shoot.Spec.Addons.KubernetesDashboard.AuthenticationMode = &defaultAuthMode
-		}
 	}
 }
 
@@ -190,6 +171,8 @@ func (shootStrategy) Canonicalize(obj runtime.Object) {
 	if versionutils.ConstraintK8sGreaterEqual125.Check(semver.MustParse(shoot.Spec.Kubernetes.Version)) {
 		cleanupAdmissionPlugins(shoot)
 	}
+	dropEnableBasicAuthenticationField(shoot)
+	setKubernetesDashboardAuthMode(shoot)
 }
 
 func cleanupAdmissionPlugins(shoot *core.Shoot) {
@@ -205,6 +188,23 @@ func cleanupAdmissionPlugins(shoot *core.Shoot) {
 	}
 
 	shoot.Spec.Kubernetes.KubeAPIServer.AdmissionPlugins = admissionPlugins
+}
+
+// dropEnableBasicAuthenticationField sets the enableBasicAuthentication to nil.
+func dropEnableBasicAuthenticationField(shoot *core.Shoot) {
+	if shoot.Spec.Kubernetes.KubeAPIServer != nil {
+		shoot.Spec.Kubernetes.KubeAPIServer.EnableBasicAuthentication = nil
+	}
+}
+
+// setKubernetesDashboardAuthMode sets the kubernetes-dashboard authentication mode to "token", if its current value is not "token" (for example "basic").
+func setKubernetesDashboardAuthMode(shoot *core.Shoot) {
+	if shoot.Spec.Addons != nil && shoot.Spec.Addons.KubernetesDashboard != nil {
+		if authMode := shoot.Spec.Addons.KubernetesDashboard.AuthenticationMode; authMode != nil && *authMode != core.KubernetesDashboardAuthModeToken {
+			defaultAuthMode := core.KubernetesDashboardAuthModeToken
+			shoot.Spec.Addons.KubernetesDashboard.AuthenticationMode = &defaultAuthMode
+		}
+	}
 }
 
 func (shootStrategy) AllowCreateOnUpdate() bool {

--- a/pkg/registry/core/shoot/strategy.go
+++ b/pkg/registry/core/shoot/strategy.go
@@ -67,8 +67,6 @@ func (shootStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object) {
 	shoot.Status = core.ShootStatus{}
 
 	dropDisabledFields(shoot, nil)
-	dropEnableBasicAuthenticationField(shoot)
-	setKubernetesDashboardAuthMode(shoot)
 }
 
 func (shootStrategy) PrepareForUpdate(ctx context.Context, obj, old runtime.Object) {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind bug

**What this PR does / why we need it**:
https://github.com/gardener/gardener/pull/7534 added code to drop `EnableBasicAuthenticationField` and setting `kubernetesDashboardAuthMode` in the Shoot spec in `PrepareForCreate` and `PrepareForUpdate` functions in the shoot strategy.

Now the shoots which got deleted in gardener `v1.65`, but in the meanwhile gardener-apiserver was updated to `v1.66`, In the final step of deletion, gardenlet tries to remove the finalizer, which calls `PrepareForUpdate` logic and this fails validation because no spec change is allowed during deletion.

This PR moves these functions to `Canonicalize()` in the strategy. Canonicalize is called only after validation. [Ref](https://github.com/gardener/gardener/blob/4caee5fd5f34779b117a501ff3f3c90f3c3c4e3f/vendor/k8s.io/apiserver/pkg/registry/rest/update.go#L129-L163)

Steps to reproduce:
1. Create a shoot in `v1.65`, the fields `enableBasicAuthenticationField` in the kubeApiserver in shoot spec will be defaulted.
2. Stop the gardenlet.
3. Delete the Shoot.
4. Upgrade gardener-apiserver to `v1.66`.
5. Start gardenlet again. Make sure the deletion fails with:
```
{"level":"info","ts":"2023-03-17T00:00:18.527Z","msg":"The `.status.lastOperation` indicates a successful deletion, deletion accepted","controller":"shoot","object":{"name":"local","namespace":"garden-local"},"namespace":"garden-local","name":"local","reconcileID":"8ebada43-dd9f-4135-9b2e-c86b51f2d8a8","operation":"delete"}
{"level":"info","ts":"2023-03-17T00:00:18.584Z","msg":"Removing finalizer","controller":"shoot","object":{"name":"local","namespace":"garden-local"},"namespace":"garden-local","name":"local","reconcileID":"8ebada43-dd9f-4135-9b2e-c86b51f2d8a8","operation":"delete"}
{"level":"error","ts":"2023-03-17T00:00:18.638Z","msg":"Reconciler error","controller":"shoot","object":{"name":"local","namespace":"garden-local"},"namespace":"garden-local","name":"local","reconcileID":"8ebada43-dd9f-4135-9b2e-c86b51f2d8a8","error":"failed to remove finalizer: Shoot.core.gardener.cloud \"local\" is invalid: spec: Invalid value: core.ShootSpec{Addons:(*core.Addons)(0xc17461ef90), CloudProfileName:\"aws\", DNS:(*core.DNS)(0xc153dcf340), Extensions:[]core.Extension{core.Extension{Type:\"shoot-dns-service\", ProviderConfig:(*runtime.RawExtension)(0xc18bd1e240), Disabled:(*bool)(nil)}}, Hibernation:(*core.Hibernation)(0xc153dcf360), Kubernetes:core.Kubernetes{AllowPrivilegedContainers:(*bool)(0xc1b9dbf4cc), ClusterAutoscaler:(*core.ClusterAutoscaler)(nil), KubeAPIServer:(*core.KubeAPIServerConfig)(0xc170a8d720), KubeControllerManager:(*core.KubeControllerManagerConfig)(0xc18bd1e2d0), KubeScheduler:(*core.KubeSchedulerConfig)(0xc187741a28), KubeProxy:(*core.KubeProxyConfig)(0xc187741a70), Kubelet:(*core.KubeletConfig)(0xc1806bc5b0), Version:\"1.24.8\", VerticalPodAutoscaler:(*core.VerticalPodAutoscaler)(0xc16cdf03c0), EnableStaticTokenKubeconfig:(*bool)(0xc1b9dbf6ec)}, Networking:core.Networking{Type:\"calico\", ProviderConfig:(*runtime.RawExtension)(0xc18bd1e480), Pods:(*string)(0xc17461f180), Nodes:(*string)(0xc17461f190), Services:(*string)(0xc17461f1a0), IPFamilies:[]core.IPFamily{\"IPv4\"}}, Maintenance:(*core.Maintenance)(0xc187741ae8), Monitoring:(*core.Monitoring)(nil), Provider:core.Provider{Type:\"aws\", ControlPlaneConfig:(*runtime.RawExtension)(0xc18bd1e4b0), InfrastructureConfig:(*runtime.RawExtension)(0xc18bd1e4e0), Workers:[]core.Worker{core.Worker{Annotations:map[string]string(nil), CABundle:(*string)(nil), CRI:(*core.CRI)(0xc18bd1e510), Kubernetes:(*core.WorkerKubernetes)(0xc17461f430), Labels:map[string]string{\"hana-cloud.workload-class/default\":\"1\", \"node-role.kubernetes.io/default\":\"\"}, Name:\"default\", Machine:core.Machine{Type:\"m5.2xlarge\", Image:(*core.ShootMachineImage)(0xc18bd1e5d0), Architecture:(*string)(0xc17461f210)}, Maximum:10, Minimum:1, MaxSurge:(*intstr.IntOrString)(0xc153dcf400), MaxUnavailable:(*intstr.IntOrString)(0xc153dcf420), ProviderConfig:(*runtime.RawExtension)(nil), SystemComponents:(*core.WorkerSystemComponents)(0xc1b9dbf7a8), Taints:[]v1.Taint(nil), Volume:(*core.Volume)(0xc18bd1e5a0), DataVolumes:[]core.DataVolume(nil), KubeletDataVolumeName:(*string)(nil), Zones:[]string{\"eu-central-1a\"}, MachineControllerManagerSettings:(*core.MachineControllerManagerSettings)(nil)}}, WorkersSettings:(*core.WorkersSettings)(0xc146486af8)}, Purpose:(*core.ShootPurpose)(0xc17461f230), Region:\"eu-central-1\", SecretBindingName:\"reg-aws\", SeedName:(*string)(0xc17461e160), SeedSelector:(*core.SeedSelector)(nil), Resources:[]core.NamedResourceReference{core.NamedResourceReference{Name:\"shoot-dns-service-reg-dns\", ResourceRef:v1.CrossVersionObjectReference{Kind:\"Secret\", Name:\"reg-dns\", APIVersion:\"v1\"}}}, Tolerations:[]core.Toleration(nil), ExposureClassName:(*string)(nil), SystemComponents:(*core.SystemComponents)(0xc17461f250), ControlPlane:(*core.ControlPlane)(nil)}: field is immutable","stacktrace":"sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\t/go/src/github.com/gardener/gardener/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:329\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/go/src/github.com/gardener/gardener/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:274\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2\n\t/go/src/github.com/gardener/gardener/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:235"}
```
And the Shoot status shows:
```
k get shoots -A
NAMESPACE      NAME     CLOUDPROFILE   PROVIDER   REGION   K8S VERSION   HIBERNATION   LAST OPERATION            STATUS    AGE
garden-local   local   local          local      local    1.26.0        Awake         Delete Succeeded (100%)   healthy   20m
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @ialidzhikov @dimitar-kostadinov 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
7. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
A bug causing Shoot deletion to fail if the gardener-apiserver is upgraded during deletion is now fixed.
```
