### PR TITLE
Add `make gardener-dev` as a skaffold-based dev experience

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -342,6 +342,8 @@ kind-operator-down: $(KIND)
 
 # speed-up skaffold deployments by building all images concurrently
 export SKAFFOLD_BUILD_CONCURRENCY = 0
+gardener%up gardenlet%up operator-up: export SKAFFOLD_DEFAULT_REPO = localhost:5001
+gardener%up gardenlet%up operator-up: export SKAFFOLD_PUSH = true
 # use static label for skaffold to prevent rolling all gardener components on every `skaffold` invocation
 gardener-up gardener-down gardener-ha-single-zone-up gardener-ha-single-zone-down gardener-ha-multi-zone-up gardener-ha-multi-zone-down gardenlet-kind2-up gardenlet-kind2-down: export SKAFFOLD_LABEL = skaffold.dev/run-id=gardener-local
 gardener-extensions-up gardener-extensions-down: export SKAFFOLD_LABEL = skaffold.dev/run-id=gardener-extensions
@@ -350,7 +352,7 @@ gardener-extensions-up gardener-extensions-down: export SKAFFOLD_LABEL = skaffol
 gardener-up gardener-extensions-up gardener-ha-single-zone-up gardener-ha-multi-zone-up gardenlet-kind2-up operator-up: export LD_FLAGS = $(shell $(REPO_ROOT)/hack/get-build-ld-flags.sh)
 
 gardener-up: $(SKAFFOLD) $(HELM) $(KUBECTL) $(YQ)
-	SKAFFOLD_DEFAULT_REPO=localhost:5001 SKAFFOLD_PUSH=true $(SKAFFOLD) run
+	$(SKAFFOLD) run
 gardener-down: $(SKAFFOLD) $(HELM) $(KUBECTL)
 	./hack/gardener-down.sh
 
@@ -370,7 +372,7 @@ tear-down-local-env: $(KUBECTL)
 gardenlet-kind2-up: $(SKAFFOLD) $(HELM)
 	$(SKAFFOLD) deploy -m kind2-env -p kind2 --kubeconfig=$(GARDENER_LOCAL_KUBECONFIG)
 	@# define GARDENER_LOCAL_KUBECONFIG so that it can be used by skaffold when checking whether the seed managed by this gardenlet is ready
-	GARDENER_LOCAL_KUBECONFIG=$(GARDENER_LOCAL_KUBECONFIG) SKAFFOLD_DEFAULT_REPO=localhost:5001 SKAFFOLD_PUSH=true $(SKAFFOLD) run -m provider-local,gardenlet -p kind2
+	GARDENER_LOCAL_KUBECONFIG=$(GARDENER_LOCAL_KUBECONFIG) $(SKAFFOLD) run -m provider-local,gardenlet -p kind2
 gardenlet-kind2-down: $(SKAFFOLD) $(HELM)
 	$(SKAFFOLD) delete -m kind2-env -p kind2 --kubeconfig=$(GARDENER_LOCAL_KUBECONFIG)
 	$(SKAFFOLD) delete -m gardenlet,kind2-env -p kind2
@@ -380,7 +382,7 @@ tear-down-kind2-env: $(KUBECTL)
 	$(KUBECTL) delete -k $(REPO_ROOT)/example/provider-local/seed-kind2/local
 
 gardener-ha-single-zone-up: $(SKAFFOLD) $(HELM) $(KUBECTL)
-	SKAFFOLD_DEFAULT_REPO=localhost:5001 SKAFFOLD_PUSH=true $(SKAFFOLD) run -p ha-single-zone
+	$(SKAFFOLD) run -p ha-single-zone
 gardener-ha-single-zone-down: $(SKAFFOLD) $(HELM) $(KUBECTL)
 	./hack/gardener-down.sh --skaffold-profile ha-single-zone
 register-kind-ha-single-zone-env: $(KUBECTL)
@@ -392,7 +394,7 @@ tear-down-kind-ha-single-zone-env: $(KUBECTL)
 	$(KUBECTL) delete -k $(REPO_ROOT)/example/provider-local/garden/local
 
 gardener-ha-multi-zone-up: $(SKAFFOLD) $(HELM) $(KUBECTL)
-	SKAFFOLD_DEFAULT_REPO=localhost:5001 SKAFFOLD_PUSH=true $(SKAFFOLD) run -p ha-multi-zone
+	$(SKAFFOLD) run -p ha-multi-zone
 gardener-ha-multi-zone-down: $(SKAFFOLD) $(HELM) $(KUBECTL)
 	./hack/gardener-down.sh --skaffold-profile ha-multi-zone
 register-kind-ha-multi-zone-env: $(KUBECTL)
@@ -404,7 +406,7 @@ tear-down-kind-ha-multi-zone-env: $(KUBECTL)
 	$(KUBECTL) delete -k $(REPO_ROOT)/example/provider-local/garden/local
 
 operator-up: $(SKAFFOLD) $(HELM) $(KUBECTL)
-	SKAFFOLD_DEFAULT_REPO=localhost:5001 SKAFFOLD_PUSH=true $(SKAFFOLD) run -f skaffold-operator.yaml
+	$(SKAFFOLD) run -f skaffold-operator.yaml
 operator-down: $(SKAFFOLD) $(HELM) $(KUBECTL)
 	$(KUBECTL) delete garden --all --ignore-not-found --wait --timeout 5m
 	$(SKAFFOLD) delete -f skaffold-operator.yaml

--- a/Makefile
+++ b/Makefile
@@ -339,15 +339,22 @@ kind-operator-down: $(KIND)
 
 # speed-up skaffold deployments by building all images concurrently
 export SKAFFOLD_BUILD_CONCURRENCY = 0
-gardener%up gardenlet%up operator-up: export SKAFFOLD_DEFAULT_REPO = localhost:5001
-gardener%up gardenlet%up operator-up: export SKAFFOLD_PUSH = true
+gardener%up gardener%dev gardenlet%up gardenlet%dev operator-up operator-dev: export SKAFFOLD_DEFAULT_REPO = localhost:5001
+gardener%up gardener%dev gardenlet%up gardenlet%dev operator-up operator-dev: export SKAFFOLD_PUSH = true
 # use static label for skaffold to prevent rolling all gardener components on every `skaffold` invocation
-gardener%up gardener%down gardenlet%up gardenlet%down: export SKAFFOLD_LABEL = skaffold.dev/run-id=gardener-local
+gardener%up gardener%dev gardener%down gardenlet%up gardenlet%dev gardenlet%down: export SKAFFOLD_LABEL = skaffold.dev/run-id=gardener-local
 # set ldflags for skaffold
-gardener%up gardenlet%up operator-up: export LD_FLAGS = $(shell $(REPO_ROOT)/hack/get-build-ld-flags.sh)
+gardener%up gardener%dev gardenlet%up gardenlet%dev operator-up operator-dev: export LD_FLAGS = $(shell $(REPO_ROOT)/hack/get-build-ld-flags.sh)
+# skaffold dev cleans up deployed modules by default, disable this
+gardener%dev gardenlet%dev operator-dev: export SKAFFOLD_CLEANUP = false
+# skaffold dev triggers new builds and deployments immediately on file changes by default,
+# this is too heavy in a large project like gardener, so trigger new builds and deployments manually instead.
+gardener%dev gardenlet%dev operator-dev: export SKAFFOLD_TRIGGER = manual
 
 gardener-up: $(SKAFFOLD) $(HELM) $(KUBECTL) $(YQ)
 	$(SKAFFOLD) run
+gardener-dev: $(SKAFFOLD) $(HELM) $(KUBECTL) $(YQ)
+	$(SKAFFOLD) dev
 gardener-down: $(SKAFFOLD) $(HELM) $(KUBECTL)
 	./hack/gardener-down.sh
 
@@ -372,6 +379,10 @@ gardenlet-kind2-up: $(SKAFFOLD) $(HELM)
 	$(SKAFFOLD) deploy -m kind2-env -p kind2 --kubeconfig=$(GARDENER_LOCAL_KUBECONFIG)
 	@# define GARDENER_LOCAL_KUBECONFIG so that it can be used by skaffold when checking whether the seed managed by this gardenlet is ready
 	GARDENER_LOCAL_KUBECONFIG=$(GARDENER_LOCAL_KUBECONFIG) $(SKAFFOLD) run -m provider-local,gardenlet -p kind2
+gardenlet-kind2-dev: $(SKAFFOLD) $(HELM)
+	$(SKAFFOLD) deploy -m kind2-env -p kind2 --kubeconfig=$(GARDENER_LOCAL_KUBECONFIG)
+	@# define GARDENER_LOCAL_KUBECONFIG so that it can be used by skaffold when checking whether the seed managed by this gardenlet is ready
+	GARDENER_LOCAL_KUBECONFIG=$(GARDENER_LOCAL_KUBECONFIG) $(SKAFFOLD) dev -m provider-local,gardenlet -p kind2
 gardenlet-kind2-down: $(SKAFFOLD) $(HELM)
 	$(SKAFFOLD) delete -m kind2-env -p kind2 --kubeconfig=$(GARDENER_LOCAL_KUBECONFIG)
 	$(SKAFFOLD) delete -m gardenlet,kind2-env -p kind2
@@ -382,6 +393,8 @@ tear-down-kind2-env: $(KUBECTL)
 
 gardener-ha-single-zone-up: $(SKAFFOLD) $(HELM) $(KUBECTL)
 	$(SKAFFOLD) run -p ha-single-zone
+gardener-ha-single-zone-dev: $(SKAFFOLD) $(HELM) $(KUBECTL)
+	$(SKAFFOLD) dev -p ha-single-zone
 gardener-ha-single-zone-down: $(SKAFFOLD) $(HELM) $(KUBECTL)
 	./hack/gardener-down.sh --skaffold-profile ha-single-zone
 register-kind-ha-single-zone-env: $(KUBECTL)
@@ -394,6 +407,8 @@ tear-down-kind-ha-single-zone-env: $(KUBECTL)
 
 gardener-ha-multi-zone-up: $(SKAFFOLD) $(HELM) $(KUBECTL)
 	$(SKAFFOLD) run -p ha-multi-zone
+gardener-ha-multi-zone-dev: $(SKAFFOLD) $(HELM) $(KUBECTL)
+	$(SKAFFOLD) dev -p ha-multi-zone
 gardener-ha-multi-zone-down: $(SKAFFOLD) $(HELM) $(KUBECTL)
 	./hack/gardener-down.sh --skaffold-profile ha-multi-zone
 register-kind-ha-multi-zone-env: $(KUBECTL)
@@ -408,6 +423,8 @@ operator-%: export SKAFFOLD_FILENAME = skaffold-operator.yaml
 
 operator-up: $(SKAFFOLD) $(HELM) $(KUBECTL)
 	$(SKAFFOLD) run
+operator-dev: $(SKAFFOLD) $(HELM) $(KUBECTL)
+	$(SKAFFOLD) dev
 operator-down: $(SKAFFOLD) $(HELM) $(KUBECTL)
 	$(KUBECTL) delete garden --all --ignore-not-found --wait --timeout 5m
 	$(SKAFFOLD) delete

--- a/Makefile
+++ b/Makefile
@@ -404,11 +404,13 @@ tear-down-kind-ha-multi-zone-env: $(KUBECTL)
 	$(KUBECTL) delete -k $(REPO_ROOT)/example/provider-local/seed-kind-ha-multi-zone/local
 	$(KUBECTL) delete -k $(REPO_ROOT)/example/provider-local/garden/local
 
+operator-%: export SKAFFOLD_FILENAME = skaffold-operator.yaml
+
 operator-up: $(SKAFFOLD) $(HELM) $(KUBECTL)
-	$(SKAFFOLD) run -f skaffold-operator.yaml
+	$(SKAFFOLD) run
 operator-down: $(SKAFFOLD) $(HELM) $(KUBECTL)
 	$(KUBECTL) delete garden --all --ignore-not-found --wait --timeout 5m
-	$(SKAFFOLD) delete -f skaffold-operator.yaml
+	$(SKAFFOLD) delete
 
 test-e2e-local: $(GINKGO)
 	./hack/test-e2e-local.sh --procs=$(PARALLEL_E2E_TESTS) --label-filter="default" ./test/e2e/gardener/...

--- a/docs/concepts/operator.md
+++ b/docs/concepts/operator.md
@@ -84,17 +84,24 @@ Please refer to [this document](../usage/shoot_credentials_rotation.md#gardener-
 
 ## Local Development
 
-The easiest setup is using a local [KinD](https://kind.sigs.k8s.io/) cluster and the [Skaffold](https://skaffold.dev/) based approach to deploy the `gardener-operator`.
+The easiest setup is using a local [KinD](https://kind.sigs.k8s.io/) cluster and the [Skaffold](https://skaffold.dev/) based approach to deploy and develop the `gardener-operator`.
 
 ```shell
+# prepare a kind cluster
 make kind-operator-up
+
+# deploy gardener-operator
+# option 1: one-time build and deployment
 make operator-up
+# option 2: full dev loop, press any key to build and deploy new changes
+make operator-dev
 
 # now you can create Garden resources, for example
 kubectl create -f example/operator/20-garden.yaml
 # alternatively, you can run the e2e test
 make test-e2e-local-operator
 
+# clean up
 make operator-down
 make kind-operator-down
 ```
@@ -104,12 +111,12 @@ An alternative approach is to start the process locally and manually deploy the 
 
 ```shell
 kubectl create -f example/operator/10-crd-operator.gardener.cloud_gardens.yaml
-make KUBECONFIG=... start-operator
+make start-operator KUBECONFIG=...
 
 # now you can create Garden resources, for example
 kubectl create -f example/operator/20-garden.yaml
 # alternatively, you can run the e2e test
-make KUBECONFIG=... test-e2e-local-operator
+make test-e2e-local-operator KUBECONFIG=...
 ```
 
 ## Implementation Details

--- a/docs/deployment/getting_started_locally.md
+++ b/docs/deployment/getting_started_locally.md
@@ -92,6 +92,28 @@ make gardener-up
 This will first build the base image (which might take a bit if you do it for the first time).
 Afterwards, the Gardener resources will be deployed into the cluster.
 
+## Developing Gardener
+
+```bash
+make gardener-dev
+```
+
+This is similar to `make gardener-up` but additionally starts a [skaffold dev loop](https://skaffold.dev/docs/workflows/dev/).
+After the initial deployment, skaffold starts watching source files.
+Once it has detected changes, press any key to trigger a new build and deployment of the changed components.
+
+Tip: you can set the `SKAFFOLD_MODULE` environment variable to select specific modules of the skaffold configuration (see [`skaffold.yaml`](../../skaffold.yaml)) that skaffold should watch, build, and deploy.
+This significantly reduces turnaround times during development.
+
+For example, if you want to develop changes to gardenlet:
+
+```bash
+# initial deployment of all components
+make gardener-up
+# start iterating on gardenlet without deploying other components
+make gardener-dev SKAFFOLD_MODULE=gardenlet
+```
+
 ## Creating a `Shoot` Cluster
 
 You can wait for the `Seed` to be ready by running:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancment

**What this PR does / why we need it**:

Developers can now use `make gardener-dev` to start a skaffold-based dev loop which can trigger new builds and deployments when changing source files.
Specific skaffold modules can be selected by setting `SKAFFOLD_MODULE` to reduce turnaround times.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/6016

**Special notes for your reviewer**:

With https://github.com/gardener/gardener/pull/7633, it is finally possible to select specific skaffold modules, because we are now using named image references instead of `{{.IMAGE_TAG1}}` etc.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature developer
Developers can now use `make gardener-dev` to start a skaffold-based dev loop which can trigger new builds and deployments when changing source files. See the [documentation](https://github.com/gardener/gardener/blob/master/docs/deployment/getting_started_locally.md#developing-gardener) for more details.
```
