### PR TITLE
CVE Rescoring for nginx-ingress-controller-seed & ingress-default-backend

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -37,20 +37,57 @@ images:
   repository: registry.k8s.io/ingress-nginx/controller
   tag: "v0.49.3"
   targetVersion: "< 1.22"
+  labels:
+  - name: 'gardener.cloud/cve-categorisation'
+    value:
+      network_exposure: 'public'
+      authentication_enforced: true
+      user_interaction: 'end-user'
+      confidentiality_requirement: 'low'
+      integrity_requirement: 'low'
+      availability_requirement: 'low'
 - name: nginx-ingress-controller-seed
   sourceRepository: github.com/kubernetes/ingress-nginx
   repository: registry.k8s.io/ingress-nginx/controller-chroot
   tag: "v1.4.0"
   targetVersion: "1.22.x"
+  labels:
+  - name: 'gardener.cloud/cve-categorisation'
+    value:
+      network_exposure: 'public'
+      authentication_enforced: true
+      user_interaction: 'end-user'
+      confidentiality_requirement: 'low'
+      integrity_requirement: 'low'
+      availability_requirement: 'low'
 - name: nginx-ingress-controller-seed
   sourceRepository: github.com/kubernetes/ingress-nginx
   repository: registry.k8s.io/ingress-nginx/controller-chroot
   tag: "v1.6.4"
   targetVersion: ">= 1.23"
+  labels:
+  - name: 'gardener.cloud/cve-categorisation'
+    value:
+      network_exposure: 'public'
+      authentication_enforced: true
+      user_interaction: 'end-user'
+      confidentiality_requirement: 'low'
+      integrity_requirement: 'low'
+      availability_requirement: 'low'
 - name: ingress-default-backend
   sourceRepository: github.com/gardener/ingress-default-backend
   repository: eu.gcr.io/gardener-project/gardener/ingress-default-backend
   tag: "0.14.0"
+  labels:
+  - name: 'gardener.cloud/cve-categorisation'
+    value:
+      network_exposure: 'private'
+      authentication_enforced: false
+      user_interaction: 'end-user'
+      confidentiality_requirement: 'none'
+      integrity_requirement: 'none'
+      availability_requirement: 'none'
+      comment: Show static page when no path is found
 
 # Seed controlplane
 #   hyperkube is used for kubectl + kubelet binaries on the worker nodes

--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -81,7 +81,7 @@ images:
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:
-      network_exposure: 'private'
+      network_exposure: 'public'
       authentication_enforced: false
       user_interaction: 'end-user'
       confidentiality_requirement: 'none'

--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -81,7 +81,7 @@ images:
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:
-      network_exposure: 'public'
+      network_exposure: 'private'
       authentication_enforced: false
       user_interaction: 'end-user'
       confidentiality_requirement: 'none'


### PR DESCRIPTION
**How to categorize this PR?**

<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind enhancement

**What this PR does / why we need it**:

Add CVE re-scoring configuration to  `nginx-ingress-controller-seed` &` ingress-default-backend`

**Special notes for your reviewer**:

Similar to https://github.com/gardener/gardener/pull/7289

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
