### PR TITLE
Remove unused tenants config from fluent-bit

### DIFF
--- a/pkg/gardenlet/controller/seed/seed/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/seed/seed/reconciler_reconcile.go
@@ -19,7 +19,6 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
-	"regexp"
 	"strings"
 	"time"
 
@@ -478,9 +477,8 @@ func (r *Reconciler) runReconcileSeedFlow(
 		fluentBitConfigurationsOverwrites = map[string]interface{}{}
 		lokiValues                        = map[string]interface{}{}
 
-		filters               = strings.Builder{}
-		parsers               = strings.Builder{}
-		userAllowedComponents []string
+		filters = strings.Builder{}
+		parsers = strings.Builder{}
 	)
 	lokiValues["enabled"] = loggingEnabled
 
@@ -582,19 +580,7 @@ func (r *Reconciler) runReconcileSeedFlow(
 
 			filters.WriteString(fmt.Sprintln(loggingConfig.Filters))
 			parsers.WriteString(fmt.Sprintln(loggingConfig.Parsers))
-
-			if loggingConfig.UserExposed {
-				userAllowedComponents = append(userAllowedComponents, loggingConfig.PodPrefixes...)
-			}
 		}
-
-		loggingRewriteTagFilter := `[FILTER]
-    Name          modify
-    Match         kubernetes.*
-    Condition     Key_value_matches tag ^kubernetes\.var\.log\.containers\.(` + strings.Join(userAllowedComponents, "|") + `)-.+?_
-    Add           __gardener_multitenant_id__ operator;user
-`
-		filters.WriteString(fmt.Sprintln(loggingRewriteTagFilter))
 
 		// Read extension provider specific logging configuration
 		existingConfigMaps := &corev1.ConfigMapList{}
@@ -606,34 +592,10 @@ func (r *Reconciler) runReconcileSeedFlow(
 
 		// Need stable order before passing the dashboards to Grafana config to avoid unnecessary changes
 		kubernetesutils.ByName().Sort(existingConfigMaps)
-		modifyFilter := `
-    Name          modify
-    Match         kubernetes.*
-    Condition     Key_value_matches tag __PLACE_HOLDER__
-    Add           __gardener_multitenant_id__ operator;user
-`
+
 		// Read all filters and parsers coming from the extension provider configurations
 		for _, cm := range existingConfigMaps.Items {
-			// Remove the extensions rewrite_tag filters.
-			// TODO (vlvasilev): When all custom rewrite_tag filters are removed from the extensions this code snipped must be removed
-			flbFilters := cm.Data[v1beta1constants.FluentBitConfigMapKubernetesFilter]
-			tokens := strings.Split(flbFilters, "[FILTER]")
-			var sb strings.Builder
-			for _, token := range tokens {
-				if strings.Contains(token, "rewrite_tag") {
-					result := regexp.MustCompile(`\$tag\s+(.+?)\s+user-exposed\.\$TAG\s+true`).FindAllStringSubmatch(token, 1)
-					if len(result) < 1 || len(result[0]) < 2 {
-						continue
-					}
-					token = strings.Replace(modifyFilter, "__PLACE_HOLDER__", result[0][1], 1)
-				}
-				// In case we are processing the first token
-				if strings.TrimSpace(token) != "" {
-					sb.WriteString("[FILTER]")
-				}
-				sb.WriteString(token)
-			}
-			filters.WriteString(fmt.Sprintln(strings.TrimRight(sb.String(), " ")))
+			filters.WriteString(fmt.Sprintln(cm.Data[v1beta1constants.FluentBitConfigMapKubernetesFilter]))
 			parsers.WriteString(fmt.Sprintln(cm.Data[v1beta1constants.FluentBitConfigMapParser]))
 		}
 

--- a/pkg/operation/botanist/component/clusterautoscaler/logging.go
+++ b/pkg/operation/botanist/component/clusterautoscaler/logging.go
@@ -39,10 +39,5 @@ const (
 
 // CentralLoggingConfiguration returns a fluent-bit parser and filter for the cluster-autoscaler logs.
 func CentralLoggingConfiguration() (component.CentralLoggingConfig, error) {
-	return component.CentralLoggingConfig{
-		Filters:     loggingFilter,
-		Parsers:     loggingParser,
-		UserExposed: true,
-		PodPrefixes: []string{v1beta1constants.DeploymentNameClusterAutoscaler},
-	}, nil
+	return component.CentralLoggingConfig{Filters: loggingFilter, Parsers: loggingParser}, nil
 }

--- a/pkg/operation/botanist/component/clusterautoscaler/logging_test.go
+++ b/pkg/operation/botanist/component/clusterautoscaler/logging_test.go
@@ -42,8 +42,6 @@ var _ = Describe("Logging", func() {
     Parser              clusterAutoscalerParser
     Reserve_Data        True
 `))
-			Expect(loggingConfig.UserExposed).To(BeTrue())
-			Expect(loggingConfig.PodPrefixes).To(ConsistOf("cluster-autoscaler"))
 		})
 	})
 })

--- a/pkg/operation/botanist/component/coredns/logging_test.go
+++ b/pkg/operation/botanist/component/coredns/logging_test.go
@@ -50,8 +50,6 @@ var _ = Describe("Logging", func() {
     Parser              coreDNSParser2
     Reserve_Data        True
 `))
-			Expect(loggingConfig.PodPrefixes).To(BeEmpty())
-			Expect(loggingConfig.UserExposed).To(BeFalse())
 		})
 	})
 })

--- a/pkg/operation/botanist/component/dependencywatchdog/logging_test.go
+++ b/pkg/operation/botanist/component/dependencywatchdog/logging_test.go
@@ -42,9 +42,6 @@ var _ = Describe("Logging", func() {
     Parser              dependencyWatchdogParser
     Reserve_Data        True
 `))
-			Expect(loggingConfig.PodPrefixes).To(BeEmpty())
-			Expect(loggingConfig.UserExposed).To(BeFalse())
-
 		})
 	})
 })

--- a/pkg/operation/botanist/component/etcd/logging_test.go
+++ b/pkg/operation/botanist/component/etcd/logging_test.go
@@ -56,8 +56,6 @@ var _ = Describe("Logging", func() {
     Parser              backupRestoreParser
     Reserve_Data        True
 `))
-			Expect(loggingConfig.PodPrefixes).To(BeEmpty())
-			Expect(loggingConfig.UserExposed).To(BeFalse())
 		})
 	})
 })

--- a/pkg/operation/botanist/component/hvpa/logging_test.go
+++ b/pkg/operation/botanist/component/hvpa/logging_test.go
@@ -42,8 +42,6 @@ var _ = Describe("Logging", func() {
     Parser              hvpaParser
     Reserve_Data        True
 `))
-			Expect(loggingConfig.PodPrefixes).To(BeEmpty())
-			Expect(loggingConfig.UserExposed).To(BeFalse())
 		})
 	})
 })

--- a/pkg/operation/botanist/component/kubeapiserver/logging.go
+++ b/pkg/operation/botanist/component/kubeapiserver/logging.go
@@ -61,9 +61,7 @@ const (
 // CentralLoggingConfiguration returns a fluent-bit parser and filter for the kube-apiserver logs.
 func CentralLoggingConfiguration() (component.CentralLoggingConfig, error) {
 	return component.CentralLoggingConfig{
-		Filters:     fmt.Sprintf("%s\n%s\n%s", loggingFilterAPIServer, loggingFilterAPIProxyMutator, loggingModifyFilterAPIProxyMutator),
-		Parsers:     fmt.Sprintf("%s\n%s", loggingParserAPIServer, loggingParserAPIProxyMutator),
-		UserExposed: true,
-		PodPrefixes: []string{v1beta1constants.DeploymentNameKubeAPIServer},
+		Filters: fmt.Sprintf("%s\n%s\n%s", loggingFilterAPIServer, loggingFilterAPIProxyMutator, loggingModifyFilterAPIProxyMutator),
+		Parsers: fmt.Sprintf("%s\n%s", loggingParserAPIServer, loggingParserAPIProxyMutator),
 	}, nil
 }

--- a/pkg/operation/botanist/component/kubeapiserver/logging_test.go
+++ b/pkg/operation/botanist/component/kubeapiserver/logging_test.go
@@ -59,8 +59,6 @@ var _ = Describe("Logging", func() {
     Match               kubernetes.*kube-apiserver*apiserver-proxy-pod-mutator*
     Copy                level    severity
 `))
-			Expect(loggingConfig.UserExposed).To(BeTrue())
-			Expect(loggingConfig.PodPrefixes).To(ConsistOf("kube-apiserver"))
 		})
 	})
 })

--- a/pkg/operation/botanist/component/kubecontrollermanager/logging.go
+++ b/pkg/operation/botanist/component/kubecontrollermanager/logging.go
@@ -15,7 +15,6 @@
 package kubecontrollermanager
 
 import (
-	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/operation/botanist/component"
 )
 
@@ -39,10 +38,5 @@ const (
 
 // CentralLoggingConfiguration returns a fluent-bit parser and filter for the kube-controller-manager logs.
 func CentralLoggingConfiguration() (component.CentralLoggingConfig, error) {
-	return component.CentralLoggingConfig{
-		Filters:     loggingFilter,
-		Parsers:     loggingParser,
-		UserExposed: true,
-		PodPrefixes: []string{v1beta1constants.DeploymentNameKubeControllerManager},
-	}, nil
+	return component.CentralLoggingConfig{Filters: loggingFilter, Parsers: loggingParser}, nil
 }

--- a/pkg/operation/botanist/component/kubecontrollermanager/logging_test.go
+++ b/pkg/operation/botanist/component/kubecontrollermanager/logging_test.go
@@ -42,8 +42,6 @@ var _ = Describe("Logging", func() {
     Parser              kubeControllerManagerParser
     Reserve_Data        True
 `))
-			Expect(loggingConfig.UserExposed).To(BeTrue())
-			Expect(loggingConfig.PodPrefixes).To(ConsistOf("kube-controller-manager"))
 		})
 	})
 })

--- a/pkg/operation/botanist/component/kubeproxy/logging_test.go
+++ b/pkg/operation/botanist/component/kubeproxy/logging_test.go
@@ -42,8 +42,6 @@ var _ = Describe("Logging", func() {
     Parser              kubeProxyParser
     Reserve_Data        True
 `))
-			Expect(loggingConfig.PodPrefixes).To(BeEmpty())
-			Expect(loggingConfig.UserExposed).To(BeFalse())
 		})
 	})
 })

--- a/pkg/operation/botanist/component/kubernetesdashboard/logging.go
+++ b/pkg/operation/botanist/component/kubernetesdashboard/logging.go
@@ -15,7 +15,6 @@
 package kubernetesdashboard
 
 import (
-	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/operation/botanist/component"
 )
 
@@ -39,10 +38,5 @@ const (
 
 // CentralLoggingConfiguration returns a fluent-bit parser and filter for the kubernetesDashboard logs.
 func CentralLoggingConfiguration() (component.CentralLoggingConfig, error) {
-	return component.CentralLoggingConfig{
-		Filters:     loggingFilter,
-		Parsers:     loggingParser,
-		UserExposed: true,
-		PodPrefixes: []string{v1beta1constants.DeploymentNameKubernetesDashboard, v1beta1constants.DeploymentNameDashboardMetricsScraper},
-	}, nil
+	return component.CentralLoggingConfig{Filters: loggingFilter, Parsers: loggingParser}, nil
 }

--- a/pkg/operation/botanist/component/kubernetesdashboard/logging_test.go
+++ b/pkg/operation/botanist/component/kubernetesdashboard/logging_test.go
@@ -42,8 +42,6 @@ var _ = Describe("Logging", func() {
     Parser              kubernetesDashboardParser
     Reserve_Data        True
 `))
-			Expect(loggingConfig.UserExposed).To(BeTrue())
-			Expect(loggingConfig.PodPrefixes).To(ConsistOf("kubernetes-dashboard", "dashboard-metrics-scraper"))
 		})
 	})
 })

--- a/pkg/operation/botanist/component/kubescheduler/logging.go
+++ b/pkg/operation/botanist/component/kubescheduler/logging.go
@@ -39,6 +39,5 @@ const (
 
 // CentralLoggingConfiguration returns a fluent-bit parser and filter for the kube-scheduler logs.
 func CentralLoggingConfiguration() (component.CentralLoggingConfig, error) {
-	return component.CentralLoggingConfig{Filters:     loggingFilter,Parsers:     loggingParser,
-	}, nil
+	return component.CentralLoggingConfig{Filters: loggingFilter, Parsers: loggingParser}, nil
 }

--- a/pkg/operation/botanist/component/kubescheduler/logging.go
+++ b/pkg/operation/botanist/component/kubescheduler/logging.go
@@ -39,10 +39,6 @@ const (
 
 // CentralLoggingConfiguration returns a fluent-bit parser and filter for the kube-scheduler logs.
 func CentralLoggingConfiguration() (component.CentralLoggingConfig, error) {
-	return component.CentralLoggingConfig{
-		Filters:     loggingFilter,
-		Parsers:     loggingParser,
-		UserExposed: true,
-		PodPrefixes: []string{v1beta1constants.DeploymentNameKubeScheduler},
+	return component.CentralLoggingConfig{Filters:     loggingFilter,Parsers:     loggingParser,
 	}, nil
 }

--- a/pkg/operation/botanist/component/kubescheduler/logging_test.go
+++ b/pkg/operation/botanist/component/kubescheduler/logging_test.go
@@ -42,8 +42,6 @@ var _ = Describe("Logging", func() {
     Parser              kubeSchedulerParser
     Reserve_Data        True
 `))
-			Expect(loggingConfig.UserExposed).To(BeTrue())
-			Expect(loggingConfig.PodPrefixes).To(ConsistOf("kube-scheduler"))
 		})
 	})
 })

--- a/pkg/operation/botanist/component/kubestatemetrics/logging_test.go
+++ b/pkg/operation/botanist/component/kubestatemetrics/logging_test.go
@@ -42,7 +42,6 @@ var _ = Describe("Logging", func() {
     Parser              kubeStateMetricsParser
     Reserve_Data        True
 `))
-			Expect(loggingConfig.UserExposed).To(BeFalse())
 		})
 	})
 })

--- a/pkg/operation/botanist/component/logging/eventlogger/logging.go
+++ b/pkg/operation/botanist/component/logging/eventlogger/logging.go
@@ -35,10 +35,5 @@ const (
 
 // CentralLoggingConfiguration returns a fluent-bit parser and filter for the event-logger logs.
 func CentralLoggingConfiguration() (component.CentralLoggingConfig, error) {
-	return component.CentralLoggingConfig{
-		Filters:     filter,
-		Parsers:     "",
-		UserExposed: false,
-		PodPrefixes: []string{},
-	}, nil
+	return component.CentralLoggingConfig{Filters: filter, Parsers: ""}, nil
 }

--- a/pkg/operation/botanist/component/logging/eventlogger/logging_test.go
+++ b/pkg/operation/botanist/component/logging/eventlogger/logging_test.go
@@ -39,7 +39,6 @@ var _ = Describe("Logging", func() {
     Match               kubernetes.*event-logger*event-logger*
     Record              job event-logging
 `))
-			Expect(loggingConfig.UserExposed).To(BeFalse())
 		})
 	})
 })

--- a/pkg/operation/botanist/component/machinecontrollermanager/logging.go
+++ b/pkg/operation/botanist/component/machinecontrollermanager/logging.go
@@ -39,10 +39,5 @@ const (
 
 // CentralLoggingConfiguration returns a fluent-bit parser and filter for the machine-controller-manager logs.
 func CentralLoggingConfiguration() (component.CentralLoggingConfig, error) {
-	return component.CentralLoggingConfig{
-		Filters:     loggingFilter,
-		Parsers:     loggingParser,
-		UserExposed: true,
-		PodPrefixes: []string{v1beta1constants.DeploymentNameMachineControllerManager},
-	}, nil
+	return component.CentralLoggingConfig{Filters: loggingFilter, Parsers: loggingParser}, nil
 }

--- a/pkg/operation/botanist/component/machinecontrollermanager/logging_test.go
+++ b/pkg/operation/botanist/component/machinecontrollermanager/logging_test.go
@@ -42,8 +42,6 @@ var _ = Describe("Logging", func() {
     Parser              machineControllerManagerParser
     Reserve_Data        True
 `))
-			Expect(loggingConfig.UserExposed).To(BeTrue())
-			Expect(loggingConfig.PodPrefixes).To(ConsistOf("machine-controller-manager"))
 		})
 	})
 })

--- a/pkg/operation/botanist/component/metricsserver/logging_test.go
+++ b/pkg/operation/botanist/component/metricsserver/logging_test.go
@@ -42,8 +42,6 @@ var _ = Describe("Logging", func() {
     Parser              metricsServerParser
     Reserve_Data        True
 `))
-			Expect(loggingConfig.PodPrefixes).To(BeEmpty())
-			Expect(loggingConfig.UserExposed).To(BeFalse())
 		})
 	})
 })

--- a/pkg/operation/botanist/component/nodeproblemdetector/logging_test.go
+++ b/pkg/operation/botanist/component/nodeproblemdetector/logging_test.go
@@ -42,8 +42,6 @@ var _ = Describe("Logging", func() {
     Parser              nodeProblemDetector
     Reserve_Data        True
 `))
-			Expect(loggingConfig.PodPrefixes).To(BeEmpty())
-			Expect(loggingConfig.UserExposed).To(BeFalse())
 		})
 	})
 })

--- a/pkg/operation/botanist/component/types.go
+++ b/pkg/operation/botanist/component/types.go
@@ -44,8 +44,4 @@ type CentralLoggingConfig struct {
 	Filters string
 	// Parser contains the parsers for specific component.
 	Parsers string
-	// UserExposed defines if the component is exposed to the end-user.
-	UserExposed bool
-	// PodPrefixes is the list of prefixes of the pod names when logging config is user-exposed.
-	PodPrefixes []string
 }

--- a/pkg/operation/botanist/component/vpa/logging.go
+++ b/pkg/operation/botanist/component/vpa/logging.go
@@ -38,10 +38,5 @@ const (
 
 // CentralLoggingConfiguration returns a fluent-bit parser and filter for the VPA logs.
 func CentralLoggingConfiguration() (component.CentralLoggingConfig, error) {
-	return component.CentralLoggingConfig{
-		Filters:     loggingFilter,
-		Parsers:     loggingParser,
-		UserExposed: true,
-		PodPrefixes: []string{admissionController, recommender, updater},
-	}, nil
+	return component.CentralLoggingConfig{Filters: loggingFilter, Parsers: loggingParser}, nil
 }

--- a/pkg/operation/botanist/component/vpa/logging_test.go
+++ b/pkg/operation/botanist/component/vpa/logging_test.go
@@ -42,8 +42,6 @@ var _ = Describe("Logging", func() {
     Parser              vpaParser
     Reserve_Data        True
 `))
-			Expect(loggingConfig.UserExposed).To(BeTrue())
-			Expect(loggingConfig.PodPrefixes).To(ConsistOf("vpa-admission-controller", "vpa-recommender", "vpa-updater"))
 		})
 	})
 })

--- a/pkg/operation/botanist/component/vpnseedserver/logging_test.go
+++ b/pkg/operation/botanist/component/vpnseedserver/logging_test.go
@@ -56,8 +56,6 @@ var _ = Describe("Logging", func() {
     Parser              vpnSeedServerEnvoyProxyParser
     Reserve_Data        True
 `))
-			Expect(loggingConfig.PodPrefixes).To(BeEmpty())
-			Expect(loggingConfig.UserExposed).To(BeFalse())
 		})
 	})
 })

--- a/pkg/operation/botanist/component/vpnshoot/logging_test.go
+++ b/pkg/operation/botanist/component/vpnshoot/logging_test.go
@@ -41,8 +41,6 @@ var _ = Describe("Logging", func() {
     Parser              vpnShootParser
     Reserve_Data        True
 `))
-			Expect(loggingConfig.PodPrefixes).To(BeEmpty())
-			Expect(loggingConfig.UserExposed).To(BeFalse())
 		})
 	})
 })


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area logging
/kind cleanup

**What this PR does / why we need it**:
As the user tenant is no longer used in fluent-bit we do not need this separation between users and operators anymore.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/7580

**Special notes for your reviewer**:
@vlvasilev @ialidzhikov 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
