### PR TITLE
adapt hash library to control machine rollout

### DIFF
--- a/extensions/pkg/controller/worker/machines.go
+++ b/extensions/pkg/controller/worker/machines.go
@@ -120,6 +120,11 @@ func (m MachineDeployments) HasSecret(secretName string) bool {
 
 // WorkerPoolHash returns a hash value for a given worker pool and a given cluster resource.
 func WorkerPoolHash(pool extensionsv1alpha1.WorkerPool, cluster *extensionscontroller.Cluster, additionalData ...string) (string, error) {
+	return WorkerPoolHashWithProviderConfigOption(pool, cluster, true, additionalData...)
+}
+
+// WorkerPoolHashWithProviderConfigOption returns a hash value for a given worker pool and a given cluster resource.
+func WorkerPoolHashWithProviderConfigOption(pool extensionsv1alpha1.WorkerPool, cluster *extensionscontroller.Cluster, includeProviderConfig bool, additionalData ...string) (string, error) {
 	kubernetesVersion := cluster.Shoot.Spec.Kubernetes.Version
 	if pool.KubernetesVersion != nil {
 		kubernetesVersion = *pool.KubernetesVersion
@@ -143,8 +148,10 @@ func WorkerPoolHash(pool extensionsv1alpha1.WorkerPool, cluster *extensionscontr
 		}
 	}
 
-	if pool.ProviderConfig != nil && pool.ProviderConfig.Raw != nil {
-		data = append(data, string(pool.ProviderConfig.Raw))
+	if includeProviderConfig {
+		if pool.ProviderConfig != nil && pool.ProviderConfig.Raw != nil {
+			data = append(data, string(pool.ProviderConfig.Raw))
+		}
 	}
 
 	data = append(data, additionalData...)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement

**What this PR does / why we need it**:

Adapt the extension library by adding a function similar to `WorkerPoolHash` with an option to include or not the `providerConfig`. The `WorkerPoolHash` should remain unchanged to preserve backwards compatibility

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature developer
A new function has been added to the extension library that allows to calculate the worker pool hash without using the respective `ProviderConfig`. Extensions can use it to implement fine-grained roll-out behavior for the workers
```
