### PR TITLE
Ensure underlying informer is started in single-object cache

### DIFF
--- a/pkg/client/kubernetes/cache/single_object.go
+++ b/pkg/client/kubernetes/cache/single_object.go
@@ -229,12 +229,12 @@ func (s *singleObject) createAndStartCache(log logr.Logger, key client.ObjectKey
 		return nil, fmt.Errorf("failed waiting for cache to be synced")
 	}
 
-	// The controller-runtime starts informers (which start the real WATCH on the API servers) only lazy with the first
-	// call on the cache. Hence, after we have started the cache above and waited for its sync, in fact no informer was
-	// started yet.
+	// The controller-runtime starts informers (which start the real WATCH on the API servers) only lazily with the
+	// first call on the cache. Hence, after we have started the cache above and waited for its sync, in fact no
+	// informer was started yet.
 	// Hence, when we newly start a cache here, we need to perform a call on such cache to make it starting the
 	// underlying informer. This is blocking because it implicitly waits for this informer to be synced. That's why we
-	// use a context with a small timeout.
+	// use a context with a small timeout, especially to exit early in case of any permission errors.
 	if _, err := cache.GetInformerForKind(waitForSyncCtx, s.gvk); err != nil {
 		cancel()
 		return nil, fmt.Errorf("failed getting informer: %w", err)

--- a/pkg/client/kubernetes/cache/single_object.go
+++ b/pkg/client/kubernetes/cache/single_object.go
@@ -42,6 +42,7 @@ type singleObject struct {
 	restConfig *rest.Config
 	newCache   cache.NewCacheFunc
 	opts       func() cache.Options
+	gvk        schema.GroupVersionKind
 
 	started   bool
 	startWait chan struct{} // startWait is a channel that is closed after the cache has been started
@@ -70,6 +71,7 @@ func NewSingleObject(
 	restConfig *rest.Config,
 	newCache cache.NewCacheFunc,
 	opts cache.Options,
+	gvk schema.GroupVersionKind,
 	clock clock.Clock,
 	maxIdleTime time.Duration,
 	garbageCollectionInterval time.Duration,
@@ -79,6 +81,7 @@ func NewSingleObject(
 		restConfig:                restConfig,
 		newCache:                  newCache,
 		opts:                      func() cache.Options { return opts },
+		gvk:                       gvk,
 		startWait:                 make(chan struct{}),
 		store:                     make(map[client.ObjectKey]*objectCache),
 		clock:                     clock,
@@ -172,10 +175,12 @@ func (s *singleObject) getOrCreateCache(key client.ObjectKey) (cache.Cache, erro
 		log.V(1).Info("Cache not found, creating it")
 
 		var err error
-		cache, err = s.createAndStartCache(key)
+		cache, err = s.createAndStartCache(log, key)
 		if err != nil {
 			return nil, err
 		}
+	} else {
+		log.V(1).Info("Cache found, accessing it")
 	}
 
 	now := s.clock.Now().UTC()
@@ -185,9 +190,7 @@ func (s *singleObject) getOrCreateCache(key client.ObjectKey) (cache.Cache, erro
 	return cache.cache, nil
 }
 
-func (s *singleObject) createAndStartCache(key client.ObjectKey) (*objectCache, error) {
-	log := s.log.WithValues("key", key)
-
+func (s *singleObject) createAndStartCache(log logr.Logger, key client.ObjectKey) (*objectCache, error) {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 
@@ -217,10 +220,24 @@ func (s *singleObject) createAndStartCache(key client.ObjectKey) (*objectCache, 
 		}
 	}()
 
+	waitForSyncCtx, waitForSyncCancel := context.WithTimeout(s.parentCtx, 5*time.Second)
+	defer waitForSyncCancel()
+
 	log.V(1).Info("Waiting for cache to be synced")
-	if !cache.WaitForCacheSync(s.parentCtx) {
+	if !cache.WaitForCacheSync(waitForSyncCtx) {
 		cancel()
 		return nil, fmt.Errorf("failed waiting for cache to be synced")
+	}
+
+	// The controller-runtime starts informers (which start the real WATCH on the API servers) only lazy with the first
+	// call on the cache. Hence, after we have started the cache above and waited for its sync, in fact no informer was
+	// started yet.
+	// Hence, when we newly start a cache here, we need to perform a call on such cache to make it starting the
+	// underlying informer. This is blocking because it implicitly waits for this informer to be synced. That's why we
+	// use a context with a small timeout.
+	if _, err := cache.GetInformerForKind(waitForSyncCtx, s.gvk); err != nil {
+		cancel()
+		return nil, fmt.Errorf("failed getting informer: %w", err)
 	}
 
 	log.V(1).Info("Cache was synced successfully")


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind bug

**What this PR does / why we need it**:
The controller-runtime starts informers (which start the real WATCH on the API servers) only lazy with the first call on the cache, see https://github.com/gardener/gardener/blob/870eb7f0218728f5071420bee5b41c96192b14ce/vendor/sigs.k8s.io/controller-runtime/pkg/cache/internal/informers_map.go#L206-L211
Hence, after we have started the cache in the `createAndStartCache` function and waited for its sync, in fact no informer was started yet.
Hence, when we newly start a cache there, we need to perform a call on such cache to make it starting the underlying informer. This is blocking because it implicitly waits for this informer to be synced. That's why we use a context with a small timeout.

Without this, clients calling `Get` might wait (and block) forever.

**Which issue(s) this PR fixes**:
Introduced with #7632

**Special notes for your reviewer**:
/cc @ScheererJ @timuthy @oliver-goetz 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
