### PR TITLE
Use `GNU gzip`

### DIFF
--- a/docs/development/local_setup.md
+++ b/docs/development/local_setup.md
@@ -93,7 +93,7 @@ brew install parallel
 When running on macOS, install the GNU core utilities and friends:
 
 ```bash
-brew install coreutils gnu-sed gnu-tar grep
+brew install coreutils gnu-sed gnu-tar grep gzip
 ```
 
 This will create symbolic links for the GNU utilities with `g` prefix on your `PATH`, e.g., `gsed` or `gbase64`.
@@ -104,6 +104,7 @@ export PATH=$(brew --prefix)/opt/coreutils/libexec/gnubin:$PATH
 export PATH=$(brew --prefix)/opt/gnu-sed/libexec/gnubin:$PATH
 export PATH=$(brew --prefix)/opt/gnu-tar/libexec/gnubin:$PATH
 export PATH=$(brew --prefix)/opt/grep/libexec/gnubin:$PATH
+export PATH=$(brew --prefix)/opt/gzip/bin:$PATH
 ```
 
 ## [Windows Only] WSL2


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity documentation
/kind enhancement

**What this PR does / why we need it**:
Currently if `make generate` is executed on mac it generates a different controller registration than what is expected by the pipeline jobs. This is happening because of different `gzip` being used in mac and in the pipeline. By default gzip used in mac is 
```
$ gzip -V
Apple gzip 400
```
but gzip used in the pipeline is `GNU gzip`.
Enhance docs to suggest using `GNU gzip`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
