### PR TITLE
[operator] Add missing validation for `Garden` credentials rotation operation annotations

### DIFF
--- a/pkg/apis/operator/v1alpha1/types.go
+++ b/pkg/apis/operator/v1alpha1/types.go
@@ -232,6 +232,10 @@ var AvailableOperationAnnotations = sets.New[string](
 	v1beta1constants.GardenerOperationReconcile,
 	v1beta1constants.OperationRotateCAStart,
 	v1beta1constants.OperationRotateCAComplete,
+	v1beta1constants.OperationRotateServiceAccountKeyStart,
+	v1beta1constants.OperationRotateServiceAccountKeyComplete,
+	v1beta1constants.OperationRotateETCDEncryptionKeyStart,
+	v1beta1constants.OperationRotateETCDEncryptionKeyComplete,
 	v1beta1constants.OperationRotateCredentialsStart,
 	v1beta1constants.OperationRotateCredentialsComplete,
 )

--- a/pkg/apis/operator/v1alpha1/validation/validation.go
+++ b/pkg/apis/operator/v1alpha1/validation/validation.go
@@ -78,12 +78,24 @@ func validateOperationContext(operation string, garden *operatorv1alpha1.Garden,
 		if phase := helper.GetCARotationPhase(garden.Status.Credentials); len(phase) > 0 && phase != gardencorev1beta1.RotationCompleted {
 			allErrs = append(allErrs, field.Forbidden(fldPath, "cannot start rotation of all credentials if .status.credentials.rotation.certificateAuthorities.phase is not 'Completed'"))
 		}
+		if phase := helper.GetServiceAccountKeyRotationPhase(garden.Status.Credentials); len(phase) > 0 && phase != gardencorev1beta1.RotationCompleted {
+			allErrs = append(allErrs, field.Forbidden(fldPath, "cannot start rotation of all credentials if .status.credentials.rotation.serviceAccountKey.phase is not 'Completed'"))
+		}
+		if phase := helper.GetETCDEncryptionKeyRotationPhase(garden.Status.Credentials); len(phase) > 0 && phase != gardencorev1beta1.RotationCompleted {
+			allErrs = append(allErrs, field.Forbidden(fldPath, "cannot start rotation of all credentials if .status.credentials.rotation.etcdEncryptionKey.phase is not 'Completed'"))
+		}
 	case v1beta1constants.OperationRotateCredentialsComplete:
 		if garden.DeletionTimestamp != nil {
 			allErrs = append(allErrs, field.Forbidden(fldPath, "cannot complete rotation of all credentials if garden has deletion timestamp"))
 		}
 		if helper.GetCARotationPhase(garden.Status.Credentials) != gardencorev1beta1.RotationPrepared {
 			allErrs = append(allErrs, field.Forbidden(fldPath, "cannot complete rotation of all credentials if .status.credentials.rotation.certificateAuthorities.phase is not 'Prepared'"))
+		}
+		if helper.GetServiceAccountKeyRotationPhase(garden.Status.Credentials) != gardencorev1beta1.RotationPrepared {
+			allErrs = append(allErrs, field.Forbidden(fldPath, "cannot complete rotation of all credentials if .status.credentials.rotation.serviceAccountKey.phase is not 'Prepared'"))
+		}
+		if helper.GetETCDEncryptionKeyRotationPhase(garden.Status.Credentials) != gardencorev1beta1.RotationPrepared {
+			allErrs = append(allErrs, field.Forbidden(fldPath, "cannot complete rotation of all credentials if .status.credentials.rotation.etcdEncryptionKey.phase is not 'Prepared'"))
 		}
 
 	case v1beta1constants.OperationRotateCAStart:
@@ -99,6 +111,36 @@ func validateOperationContext(operation string, garden *operatorv1alpha1.Garden,
 		}
 		if helper.GetCARotationPhase(garden.Status.Credentials) != gardencorev1beta1.RotationPrepared {
 			allErrs = append(allErrs, field.Forbidden(fldPath, "cannot complete CA rotation if .status.credentials.rotation.certificateAuthorities.phase is not 'Prepared'"))
+		}
+
+	case v1beta1constants.OperationRotateServiceAccountKeyStart:
+		if garden.DeletionTimestamp != nil {
+			allErrs = append(allErrs, field.Forbidden(fldPath, "cannot start service account key rotation if garden has deletion timestamp"))
+		}
+		if phase := helper.GetServiceAccountKeyRotationPhase(garden.Status.Credentials); len(phase) > 0 && phase != gardencorev1beta1.RotationCompleted {
+			allErrs = append(allErrs, field.Forbidden(fldPath, "cannot start service account key rotation if .status.credentials.rotation.serviceAccountKey.phase is not 'Completed'"))
+		}
+	case v1beta1constants.OperationRotateServiceAccountKeyComplete:
+		if garden.DeletionTimestamp != nil {
+			allErrs = append(allErrs, field.Forbidden(fldPath, "cannot complete service account key rotation if garden has deletion timestamp"))
+		}
+		if helper.GetServiceAccountKeyRotationPhase(garden.Status.Credentials) != gardencorev1beta1.RotationPrepared {
+			allErrs = append(allErrs, field.Forbidden(fldPath, "cannot complete service account key rotation if .status.credentials.rotation.serviceAccountKey.phase is not 'Prepared'"))
+		}
+
+	case v1beta1constants.OperationRotateETCDEncryptionKeyStart:
+		if garden.DeletionTimestamp != nil {
+			allErrs = append(allErrs, field.Forbidden(fldPath, "cannot start ETCD encryption key rotation if garden has deletion timestamp"))
+		}
+		if phase := helper.GetETCDEncryptionKeyRotationPhase(garden.Status.Credentials); len(phase) > 0 && phase != gardencorev1beta1.RotationCompleted {
+			allErrs = append(allErrs, field.Forbidden(fldPath, "cannot start ETCD encryption key rotation if .status.credentials.rotation.etcdEncryptionKey.phase is not 'Completed'"))
+		}
+	case v1beta1constants.OperationRotateETCDEncryptionKeyComplete:
+		if garden.DeletionTimestamp != nil {
+			allErrs = append(allErrs, field.Forbidden(fldPath, "cannot complete ETCD encryption key rotation if garden has deletion timestamp"))
+		}
+		if helper.GetETCDEncryptionKeyRotationPhase(garden.Status.Credentials) != gardencorev1beta1.RotationPrepared {
+			allErrs = append(allErrs, field.Forbidden(fldPath, "cannot complete ETCD encryption key rotation if .status.credentials.rotation.etcdEncryptionKey.phase is not 'Prepared'"))
 		}
 	}
 

--- a/pkg/apis/operator/v1alpha1/validation/validation.go
+++ b/pkg/apis/operator/v1alpha1/validation/validation.go
@@ -22,6 +22,7 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	operatorv1alpha1 "github.com/gardener/gardener/pkg/apis/operator/v1alpha1"
+	"github.com/gardener/gardener/pkg/apis/operator/v1alpha1/helper"
 )
 
 // ValidateGarden contains functionality for performing extended validation of a Garden object which is not possible
@@ -74,14 +75,14 @@ func validateOperationContext(operation string, garden *operatorv1alpha1.Garden,
 		if garden.DeletionTimestamp != nil {
 			allErrs = append(allErrs, field.Forbidden(fldPath, "cannot start rotation of all credentials if garden has deletion timestamp"))
 		}
-		if phase := getCARotationPhase(garden.Status.Credentials); len(phase) > 0 && phase != gardencorev1beta1.RotationCompleted {
+		if phase := helper.GetCARotationPhase(garden.Status.Credentials); len(phase) > 0 && phase != gardencorev1beta1.RotationCompleted {
 			allErrs = append(allErrs, field.Forbidden(fldPath, "cannot start rotation of all credentials if .status.credentials.rotation.certificateAuthorities.phase is not 'Completed'"))
 		}
 	case v1beta1constants.OperationRotateCredentialsComplete:
 		if garden.DeletionTimestamp != nil {
 			allErrs = append(allErrs, field.Forbidden(fldPath, "cannot complete rotation of all credentials if garden has deletion timestamp"))
 		}
-		if getCARotationPhase(garden.Status.Credentials) != gardencorev1beta1.RotationPrepared {
+		if helper.GetCARotationPhase(garden.Status.Credentials) != gardencorev1beta1.RotationPrepared {
 			allErrs = append(allErrs, field.Forbidden(fldPath, "cannot complete rotation of all credentials if .status.credentials.rotation.certificateAuthorities.phase is not 'Prepared'"))
 		}
 
@@ -89,24 +90,17 @@ func validateOperationContext(operation string, garden *operatorv1alpha1.Garden,
 		if garden.DeletionTimestamp != nil {
 			allErrs = append(allErrs, field.Forbidden(fldPath, "cannot start CA rotation if garden has deletion timestamp"))
 		}
-		if phase := getCARotationPhase(garden.Status.Credentials); len(phase) > 0 && phase != gardencorev1beta1.RotationCompleted {
+		if phase := helper.GetCARotationPhase(garden.Status.Credentials); len(phase) > 0 && phase != gardencorev1beta1.RotationCompleted {
 			allErrs = append(allErrs, field.Forbidden(fldPath, "cannot start CA rotation if .status.credentials.rotation.certificateAuthorities.phase is not 'Completed'"))
 		}
 	case v1beta1constants.OperationRotateCAComplete:
 		if garden.DeletionTimestamp != nil {
 			allErrs = append(allErrs, field.Forbidden(fldPath, "cannot complete CA rotation if garden has deletion timestamp"))
 		}
-		if getCARotationPhase(garden.Status.Credentials) != gardencorev1beta1.RotationPrepared {
+		if helper.GetCARotationPhase(garden.Status.Credentials) != gardencorev1beta1.RotationPrepared {
 			allErrs = append(allErrs, field.Forbidden(fldPath, "cannot complete CA rotation if .status.credentials.rotation.certificateAuthorities.phase is not 'Prepared'"))
 		}
 	}
 
 	return allErrs
-}
-
-func getCARotationPhase(credentials *operatorv1alpha1.Credentials) gardencorev1beta1.CredentialsRotationPhase {
-	if credentials != nil && credentials.Rotation != nil && credentials.Rotation.CertificateAuthorities != nil {
-		return credentials.Rotation.CertificateAuthorities.Phase
-	}
-	return ""
 }

--- a/pkg/apis/operator/v1alpha1/validation/validation_test.go
+++ b/pkg/apis/operator/v1alpha1/validation/validation_test.go
@@ -58,6 +58,10 @@ var _ = Describe("Validation Tests", func() {
 				Entry("complete all rotations", "rotate-credentials-complete"),
 				Entry("start CA rotation", "rotate-ca-start"),
 				Entry("complete CA rotation", "rotate-ca-complete"),
+				Entry("start ServiceAccount key rotation", "rotate-serviceaccount-key-start"),
+				Entry("complete ServiceAccount key rotation", "rotate-serviceaccount-key-complete"),
+				Entry("start ETCD encryption key rotation", "rotate-etcd-encryption-key-start"),
+				Entry("complete ETCD encryption key rotation", "rotate-etcd-encryption-key-complete"),
 			)
 
 			DescribeTable("starting rotation of all credentials",
@@ -85,10 +89,46 @@ var _ = Describe("Validation Tests", func() {
 						},
 					},
 				}),
+				Entry("sa rotation phase is preparing", false, operatorv1alpha1.GardenStatus{
+					Credentials: &operatorv1alpha1.Credentials{
+						Rotation: &operatorv1alpha1.CredentialsRotation{
+							ServiceAccountKey: &gardencorev1beta1.ServiceAccountKeyRotation{
+								Phase: gardencorev1beta1.RotationPreparing,
+							},
+						},
+					},
+				}),
+				Entry("etcd key rotation phase is preparing", false, operatorv1alpha1.GardenStatus{
+					Credentials: &operatorv1alpha1.Credentials{
+						Rotation: &operatorv1alpha1.CredentialsRotation{
+							ETCDEncryptionKey: &gardencorev1beta1.ETCDEncryptionKeyRotation{
+								Phase: gardencorev1beta1.RotationPreparing,
+							},
+						},
+					},
+				}),
 				Entry("ca rotation phase is prepared", false, operatorv1alpha1.GardenStatus{
 					Credentials: &operatorv1alpha1.Credentials{
 						Rotation: &operatorv1alpha1.CredentialsRotation{
 							CertificateAuthorities: &gardencorev1beta1.CARotation{
+								Phase: gardencorev1beta1.RotationPrepared,
+							},
+						},
+					},
+				}),
+				Entry("sa rotation phase is prepared", false, operatorv1alpha1.GardenStatus{
+					Credentials: &operatorv1alpha1.Credentials{
+						Rotation: &operatorv1alpha1.CredentialsRotation{
+							ServiceAccountKey: &gardencorev1beta1.ServiceAccountKeyRotation{
+								Phase: gardencorev1beta1.RotationPrepared,
+							},
+						},
+					},
+				}),
+				Entry("etcd key rotation phase is prepared", false, operatorv1alpha1.GardenStatus{
+					Credentials: &operatorv1alpha1.Credentials{
+						Rotation: &operatorv1alpha1.CredentialsRotation{
+							ETCDEncryptionKey: &gardencorev1beta1.ETCDEncryptionKeyRotation{
 								Phase: gardencorev1beta1.RotationPrepared,
 							},
 						},
@@ -103,10 +143,46 @@ var _ = Describe("Validation Tests", func() {
 						},
 					},
 				}),
+				Entry("sa rotation phase is completing", false, operatorv1alpha1.GardenStatus{
+					Credentials: &operatorv1alpha1.Credentials{
+						Rotation: &operatorv1alpha1.CredentialsRotation{
+							ServiceAccountKey: &gardencorev1beta1.ServiceAccountKeyRotation{
+								Phase: gardencorev1beta1.RotationCompleting,
+							},
+						},
+					},
+				}),
+				Entry("etcd key rotation phase is completing", false, operatorv1alpha1.GardenStatus{
+					Credentials: &operatorv1alpha1.Credentials{
+						Rotation: &operatorv1alpha1.CredentialsRotation{
+							ETCDEncryptionKey: &gardencorev1beta1.ETCDEncryptionKeyRotation{
+								Phase: gardencorev1beta1.RotationCompleting,
+							},
+						},
+					},
+				}),
 				Entry("ca rotation phase is completed", true, operatorv1alpha1.GardenStatus{
 					Credentials: &operatorv1alpha1.Credentials{
 						Rotation: &operatorv1alpha1.CredentialsRotation{
 							CertificateAuthorities: &gardencorev1beta1.CARotation{
+								Phase: gardencorev1beta1.RotationCompleted,
+							},
+						},
+					},
+				}),
+				Entry("sa rotation phase is completed", true, operatorv1alpha1.GardenStatus{
+					Credentials: &operatorv1alpha1.Credentials{
+						Rotation: &operatorv1alpha1.CredentialsRotation{
+							ServiceAccountKey: &gardencorev1beta1.ServiceAccountKeyRotation{
+								Phase: gardencorev1beta1.RotationCompleted,
+							},
+						},
+					},
+				}),
+				Entry("etcd key rotation phase is completed", true, operatorv1alpha1.GardenStatus{
+					Credentials: &operatorv1alpha1.Credentials{
+						Rotation: &operatorv1alpha1.CredentialsRotation{
+							ETCDEncryptionKey: &gardencorev1beta1.ETCDEncryptionKeyRotation{
 								Phase: gardencorev1beta1.RotationCompleted,
 							},
 						},
@@ -136,6 +212,42 @@ var _ = Describe("Validation Tests", func() {
 							CertificateAuthorities: &gardencorev1beta1.CARotation{
 								Phase: gardencorev1beta1.RotationPreparing,
 							},
+							ServiceAccountKey: &gardencorev1beta1.ServiceAccountKeyRotation{
+								Phase: gardencorev1beta1.RotationPrepared,
+							},
+							ETCDEncryptionKey: &gardencorev1beta1.ETCDEncryptionKeyRotation{
+								Phase: gardencorev1beta1.RotationPrepared,
+							},
+						},
+					},
+				}),
+				Entry("sa rotation phase is preparing", false, operatorv1alpha1.GardenStatus{
+					Credentials: &operatorv1alpha1.Credentials{
+						Rotation: &operatorv1alpha1.CredentialsRotation{
+							CertificateAuthorities: &gardencorev1beta1.CARotation{
+								Phase: gardencorev1beta1.RotationPrepared,
+							},
+							ServiceAccountKey: &gardencorev1beta1.ServiceAccountKeyRotation{
+								Phase: gardencorev1beta1.RotationPreparing,
+							},
+							ETCDEncryptionKey: &gardencorev1beta1.ETCDEncryptionKeyRotation{
+								Phase: gardencorev1beta1.RotationPrepared,
+							},
+						},
+					},
+				}),
+				Entry("etcd key rotation phase is preparing", false, operatorv1alpha1.GardenStatus{
+					Credentials: &operatorv1alpha1.Credentials{
+						Rotation: &operatorv1alpha1.CredentialsRotation{
+							CertificateAuthorities: &gardencorev1beta1.CARotation{
+								Phase: gardencorev1beta1.RotationPrepared,
+							},
+							ServiceAccountKey: &gardencorev1beta1.ServiceAccountKeyRotation{
+								Phase: gardencorev1beta1.RotationPrepared,
+							},
+							ETCDEncryptionKey: &gardencorev1beta1.ETCDEncryptionKeyRotation{
+								Phase: gardencorev1beta1.RotationPreparing,
+							},
 						},
 					},
 				}),
@@ -143,6 +255,12 @@ var _ = Describe("Validation Tests", func() {
 					Credentials: &operatorv1alpha1.Credentials{
 						Rotation: &operatorv1alpha1.CredentialsRotation{
 							CertificateAuthorities: &gardencorev1beta1.CARotation{
+								Phase: gardencorev1beta1.RotationPrepared,
+							},
+							ServiceAccountKey: &gardencorev1beta1.ServiceAccountKeyRotation{
+								Phase: gardencorev1beta1.RotationPrepared,
+							},
+							ETCDEncryptionKey: &gardencorev1beta1.ETCDEncryptionKeyRotation{
 								Phase: gardencorev1beta1.RotationPrepared,
 							},
 						},
@@ -154,6 +272,42 @@ var _ = Describe("Validation Tests", func() {
 							CertificateAuthorities: &gardencorev1beta1.CARotation{
 								Phase: gardencorev1beta1.RotationCompleting,
 							},
+							ServiceAccountKey: &gardencorev1beta1.ServiceAccountKeyRotation{
+								Phase: gardencorev1beta1.RotationPrepared,
+							},
+							ETCDEncryptionKey: &gardencorev1beta1.ETCDEncryptionKeyRotation{
+								Phase: gardencorev1beta1.RotationPrepared,
+							},
+						},
+					},
+				}),
+				Entry("sa rotation phase is completing", false, operatorv1alpha1.GardenStatus{
+					Credentials: &operatorv1alpha1.Credentials{
+						Rotation: &operatorv1alpha1.CredentialsRotation{
+							CertificateAuthorities: &gardencorev1beta1.CARotation{
+								Phase: gardencorev1beta1.RotationPrepared,
+							},
+							ServiceAccountKey: &gardencorev1beta1.ServiceAccountKeyRotation{
+								Phase: gardencorev1beta1.RotationCompleting,
+							},
+							ETCDEncryptionKey: &gardencorev1beta1.ETCDEncryptionKeyRotation{
+								Phase: gardencorev1beta1.RotationPrepared,
+							},
+						},
+					},
+				}),
+				Entry("etcd key rotation phase is completing", false, operatorv1alpha1.GardenStatus{
+					Credentials: &operatorv1alpha1.Credentials{
+						Rotation: &operatorv1alpha1.CredentialsRotation{
+							CertificateAuthorities: &gardencorev1beta1.CARotation{
+								Phase: gardencorev1beta1.RotationPrepared,
+							},
+							ServiceAccountKey: &gardencorev1beta1.ServiceAccountKeyRotation{
+								Phase: gardencorev1beta1.RotationPrepared,
+							},
+							ETCDEncryptionKey: &gardencorev1beta1.ETCDEncryptionKeyRotation{
+								Phase: gardencorev1beta1.RotationCompleting,
+							},
 						},
 					},
 				}),
@@ -161,6 +315,42 @@ var _ = Describe("Validation Tests", func() {
 					Credentials: &operatorv1alpha1.Credentials{
 						Rotation: &operatorv1alpha1.CredentialsRotation{
 							CertificateAuthorities: &gardencorev1beta1.CARotation{
+								Phase: gardencorev1beta1.RotationCompleted,
+							},
+							ServiceAccountKey: &gardencorev1beta1.ServiceAccountKeyRotation{
+								Phase: gardencorev1beta1.RotationPrepared,
+							},
+							ETCDEncryptionKey: &gardencorev1beta1.ETCDEncryptionKeyRotation{
+								Phase: gardencorev1beta1.RotationPrepared,
+							},
+						},
+					},
+				}),
+				Entry("sa rotation phase is completed", false, operatorv1alpha1.GardenStatus{
+					Credentials: &operatorv1alpha1.Credentials{
+						Rotation: &operatorv1alpha1.CredentialsRotation{
+							CertificateAuthorities: &gardencorev1beta1.CARotation{
+								Phase: gardencorev1beta1.RotationPrepared,
+							},
+							ServiceAccountKey: &gardencorev1beta1.ServiceAccountKeyRotation{
+								Phase: gardencorev1beta1.RotationCompleted,
+							},
+							ETCDEncryptionKey: &gardencorev1beta1.ETCDEncryptionKeyRotation{
+								Phase: gardencorev1beta1.RotationPrepared,
+							},
+						},
+					},
+				}),
+				Entry("etcd key rotation phase is completed", false, operatorv1alpha1.GardenStatus{
+					Credentials: &operatorv1alpha1.Credentials{
+						Rotation: &operatorv1alpha1.CredentialsRotation{
+							CertificateAuthorities: &gardencorev1beta1.CARotation{
+								Phase: gardencorev1beta1.RotationPrepared,
+							},
+							ServiceAccountKey: &gardencorev1beta1.ServiceAccountKeyRotation{
+								Phase: gardencorev1beta1.RotationPrepared,
+							},
+							ETCDEncryptionKey: &gardencorev1beta1.ETCDEncryptionKeyRotation{
 								Phase: gardencorev1beta1.RotationCompleted,
 							},
 						},
@@ -269,6 +459,221 @@ var _ = Describe("Validation Tests", func() {
 					Credentials: &operatorv1alpha1.Credentials{
 						Rotation: &operatorv1alpha1.CredentialsRotation{
 							CertificateAuthorities: &gardencorev1beta1.CARotation{
+								Phase: gardencorev1beta1.RotationCompleted,
+							},
+						},
+					},
+				}),
+			)
+
+			DescribeTable("starting service account key rotation",
+				func(allowed bool, status operatorv1alpha1.GardenStatus) {
+					metav1.SetMetaDataAnnotation(&garden.ObjectMeta, "gardener.cloud/operation", "rotate-serviceaccount-key-start")
+					garden.Status = status
+
+					matcher := BeEmpty()
+					if !allowed {
+						matcher = ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+							"Type":  Equal(field.ErrorTypeForbidden),
+							"Field": Equal("metadata.annotations[gardener.cloud/operation]"),
+						})))
+					}
+
+					Expect(ValidateGarden(garden)).To(matcher)
+				},
+				Entry("rotation phase is preparing", false, operatorv1alpha1.GardenStatus{
+					Credentials: &operatorv1alpha1.Credentials{
+						Rotation: &operatorv1alpha1.CredentialsRotation{
+							ServiceAccountKey: &gardencorev1beta1.ServiceAccountKeyRotation{
+								Phase: gardencorev1beta1.RotationPreparing,
+							},
+						},
+					},
+				}),
+				Entry("rotation phase is prepared", false, operatorv1alpha1.GardenStatus{
+					Credentials: &operatorv1alpha1.Credentials{
+						Rotation: &operatorv1alpha1.CredentialsRotation{
+							ServiceAccountKey: &gardencorev1beta1.ServiceAccountKeyRotation{
+								Phase: gardencorev1beta1.RotationPrepared,
+							},
+						},
+					},
+				}),
+				Entry("rotation phase is completing", false, operatorv1alpha1.GardenStatus{
+					Credentials: &operatorv1alpha1.Credentials{
+						Rotation: &operatorv1alpha1.CredentialsRotation{
+							ServiceAccountKey: &gardencorev1beta1.ServiceAccountKeyRotation{
+								Phase: gardencorev1beta1.RotationCompleting,
+							},
+						},
+					},
+				}),
+				Entry("rotation phase is completed", true, operatorv1alpha1.GardenStatus{
+					Credentials: &operatorv1alpha1.Credentials{
+						Rotation: &operatorv1alpha1.CredentialsRotation{
+							ServiceAccountKey: &gardencorev1beta1.ServiceAccountKeyRotation{
+								Phase: gardencorev1beta1.RotationCompleted,
+							},
+						},
+					},
+				}),
+			)
+
+			DescribeTable("completing service account key rotation",
+				func(allowed bool, status operatorv1alpha1.GardenStatus) {
+					metav1.SetMetaDataAnnotation(&garden.ObjectMeta, "gardener.cloud/operation", "rotate-serviceaccount-key-complete")
+					garden.Status = status
+
+					matcher := BeEmpty()
+					if !allowed {
+						matcher = ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+							"Type":  Equal(field.ErrorTypeForbidden),
+							"Field": Equal("metadata.annotations[gardener.cloud/operation]"),
+						})))
+					}
+
+					Expect(ValidateGarden(garden)).To(matcher)
+				},
+
+				Entry("rotation phase is preparing", false, operatorv1alpha1.GardenStatus{
+					Credentials: &operatorv1alpha1.Credentials{
+						Rotation: &operatorv1alpha1.CredentialsRotation{
+							ServiceAccountKey: &gardencorev1beta1.ServiceAccountKeyRotation{
+								Phase: gardencorev1beta1.RotationPreparing,
+							},
+						},
+					},
+				}),
+				Entry("rotation phase is prepared", true, operatorv1alpha1.GardenStatus{
+					Credentials: &operatorv1alpha1.Credentials{
+						Rotation: &operatorv1alpha1.CredentialsRotation{
+							ServiceAccountKey: &gardencorev1beta1.ServiceAccountKeyRotation{
+								Phase: gardencorev1beta1.RotationPrepared,
+							},
+						},
+					},
+				}),
+				Entry("rotation phase is completing", false, operatorv1alpha1.GardenStatus{
+					Credentials: &operatorv1alpha1.Credentials{
+						Rotation: &operatorv1alpha1.CredentialsRotation{
+							ServiceAccountKey: &gardencorev1beta1.ServiceAccountKeyRotation{
+								Phase: gardencorev1beta1.RotationCompleting,
+							},
+						},
+					},
+				}),
+				Entry("rotation phase is completed", false, operatorv1alpha1.GardenStatus{
+					Credentials: &operatorv1alpha1.Credentials{
+						Rotation: &operatorv1alpha1.CredentialsRotation{
+							ServiceAccountKey: &gardencorev1beta1.ServiceAccountKeyRotation{
+								Phase: gardencorev1beta1.RotationCompleted,
+							},
+						},
+					},
+				}),
+			)
+
+			DescribeTable("starting ETCD encryption key rotation",
+				func(allowed bool, status operatorv1alpha1.GardenStatus) {
+					metav1.SetMetaDataAnnotation(&garden.ObjectMeta, "gardener.cloud/operation", "rotate-etcd-encryption-key-start")
+					garden.Status = status
+
+					matcher := BeEmpty()
+					if !allowed {
+						matcher = ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+							"Type":  Equal(field.ErrorTypeForbidden),
+							"Field": Equal("metadata.annotations[gardener.cloud/operation]"),
+						})))
+					}
+
+					Expect(ValidateGarden(garden)).To(matcher)
+				},
+
+				Entry("rotation phase is prepare", false, operatorv1alpha1.GardenStatus{
+					Credentials: &operatorv1alpha1.Credentials{
+						Rotation: &operatorv1alpha1.CredentialsRotation{
+							ETCDEncryptionKey: &gardencorev1beta1.ETCDEncryptionKeyRotation{
+								Phase: gardencorev1beta1.RotationPreparing,
+							},
+						},
+					},
+				}),
+				Entry("rotation phase is prepared", false, operatorv1alpha1.GardenStatus{
+					Credentials: &operatorv1alpha1.Credentials{
+						Rotation: &operatorv1alpha1.CredentialsRotation{
+							ETCDEncryptionKey: &gardencorev1beta1.ETCDEncryptionKeyRotation{
+								Phase: gardencorev1beta1.RotationPrepared,
+							},
+						},
+					},
+				}),
+				Entry("rotation phase is complete", false, operatorv1alpha1.GardenStatus{
+					Credentials: &operatorv1alpha1.Credentials{
+						Rotation: &operatorv1alpha1.CredentialsRotation{
+							ETCDEncryptionKey: &gardencorev1beta1.ETCDEncryptionKeyRotation{
+								Phase: gardencorev1beta1.RotationCompleting,
+							},
+						},
+					},
+				}),
+				Entry("rotation phase is completed", true, operatorv1alpha1.GardenStatus{
+					Credentials: &operatorv1alpha1.Credentials{
+						Rotation: &operatorv1alpha1.CredentialsRotation{
+							ETCDEncryptionKey: &gardencorev1beta1.ETCDEncryptionKeyRotation{
+								Phase: gardencorev1beta1.RotationCompleted,
+							},
+						},
+					},
+				}),
+			)
+
+			DescribeTable("completing ETCD encryption key rotation",
+				func(allowed bool, status operatorv1alpha1.GardenStatus) {
+					metav1.SetMetaDataAnnotation(&garden.ObjectMeta, "gardener.cloud/operation", "rotate-etcd-encryption-key-complete")
+					garden.Status = status
+
+					matcher := BeEmpty()
+					if !allowed {
+						matcher = ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+							"Type":  Equal(field.ErrorTypeForbidden),
+							"Field": Equal("metadata.annotations[gardener.cloud/operation]"),
+						})))
+					}
+
+					Expect(ValidateGarden(garden)).To(matcher)
+				},
+
+				Entry("rotation phase is prepare", false, operatorv1alpha1.GardenStatus{
+					Credentials: &operatorv1alpha1.Credentials{
+						Rotation: &operatorv1alpha1.CredentialsRotation{
+							ETCDEncryptionKey: &gardencorev1beta1.ETCDEncryptionKeyRotation{
+								Phase: gardencorev1beta1.RotationPreparing,
+							},
+						},
+					},
+				}),
+				Entry("rotation phase is prepared", true, operatorv1alpha1.GardenStatus{
+					Credentials: &operatorv1alpha1.Credentials{
+						Rotation: &operatorv1alpha1.CredentialsRotation{
+							ETCDEncryptionKey: &gardencorev1beta1.ETCDEncryptionKeyRotation{
+								Phase: gardencorev1beta1.RotationPrepared,
+							},
+						},
+					},
+				}),
+				Entry("rotation phase is complete", false, operatorv1alpha1.GardenStatus{
+					Credentials: &operatorv1alpha1.Credentials{
+						Rotation: &operatorv1alpha1.CredentialsRotation{
+							ETCDEncryptionKey: &gardencorev1beta1.ETCDEncryptionKeyRotation{
+								Phase: gardencorev1beta1.RotationCompleting,
+							},
+						},
+					},
+				}),
+				Entry("rotation phase is completed", false, operatorv1alpha1.GardenStatus{
+					Credentials: &operatorv1alpha1.Credentials{
+						Rotation: &operatorv1alpha1.CredentialsRotation{
+							ETCDEncryptionKey: &gardencorev1beta1.ETCDEncryptionKeyRotation{
 								Phase: gardencorev1beta1.RotationCompleted,
 							},
 						},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind enhancement

**What this PR does / why we need it**:
Add missing validation for `Garden` credentials rotation operation annotations.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/7016

**Special notes for your reviewer**:
Left-over from #7573

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
