### PR TITLE
`hack/check-license-header.sh` ignores folders related to development

### DIFF
--- a/hack/add-license-header.sh
+++ b/hack/add-license-header.sh
@@ -13,12 +13,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 set -e
 
-echo "> Adding Apache License header to all go files where it is not present."
+echo "> Adding Apache License header to all go files where it is not present"
 
-YEAR=`date +"%Y"`
-
-addlicense -c "SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file." \
- -y "${YEAR}" -l apache -ignore "vendor/**" -ignore "**/*.md" -ignore "**/*.html" -ignore "**/*.yaml" -ignore "**/Dockerfile" --ignore "hack/tools/gomegacheck/**" --ignore "pkg/operation/botanist/**/*.sh" .
+addlicense \
+  -c "SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file." \
+  -y "$(date +"%Y")" \
+  -l apache \
+  -ignore ".idea/**" \
+  -ignore ".vscode/**" \
+  -ignore "dev/**" \
+  -ignore "vendor/**" \
+  -ignore "**/*.md" \
+  -ignore "**/*.html" \
+  -ignore "**/*.yaml" \
+  -ignore "**/Dockerfile" \
+  -ignore "hack/tools/gomegacheck/**" \
+  -ignore "pkg/operation/botanist/**/*.sh" \
+  .

--- a/hack/check-license-header.sh
+++ b/hack/check-license-header.sh
@@ -18,7 +18,16 @@ set -e
 
 echo "> Checking if license header is present in all required files."
 
-missing_license_header_files="$(addlicense -check -ignore "vendor/**" -ignore "**/*.md" -ignore "**/*.html" -ignore "**/*.yaml" -ignore "**/Dockerfile" --ignore "hack/tools/gomegacheck/**" --ignore "pkg/operation/botanist/**/*.sh" .)" || true
+missing_license_header_files="$(addlicense -check \
+  -ignore ".idea/**" \
+  -ignore "dev/**" \
+  -ignore "vendor/**" \
+  -ignore "**/*.md" \
+  -ignore "**/*.html" \
+  -ignore "**/*.yaml" \
+  -ignore "**/Dockerfile" \
+  -ignore "hack/tools/gomegacheck/**" \
+  -ignore "pkg/operation/botanist/**/*.sh" .)" || true
 
 if [[ "$missing_license_header_files" ]]; then
   echo "Files with no license header detected:"

--- a/hack/check-license-header.sh
+++ b/hack/check-license-header.sh
@@ -13,13 +13,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 set -e
 
-echo "> Checking if license header is present in all required files."
+echo "> Checking if license header is present in all required files"
 
-missing_license_header_files="$(addlicense -check \
+missing_license_header_files="$(addlicense \
+  -check \
   -ignore ".idea/**" \
+  -ignore ".vscode/**" \
   -ignore "dev/**" \
   -ignore "vendor/**" \
   -ignore "**/*.md" \
@@ -27,7 +28,8 @@ missing_license_header_files="$(addlicense -check \
   -ignore "**/*.yaml" \
   -ignore "**/Dockerfile" \
   -ignore "hack/tools/gomegacheck/**" \
-  -ignore "pkg/operation/botanist/**/*.sh" .)" || true
+  -ignore "pkg/operation/botanist/**/*.sh" \
+  .)" || true
 
 if [[ "$missing_license_header_files" ]]; then
   echo "Files with no license header detected:"


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
Follow-up of #7680 
/cc @acumino @oliver-goetz 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
