### PR TITLE
Fix excessive memory usage by `managedresources.NewRegistry`

### DIFF
--- a/pkg/utils/managedresources/registry.go
+++ b/pkg/utils/managedresources/registry.go
@@ -57,7 +57,7 @@ func NewRegistry(scheme *runtime.Scheme, codec serializer.CodecFactory, serializ
 	// for the map in https://github.com/kubernetes/apimachinery/blob/v0.26.1/pkg/runtime/serializer/versioning/versioning.go#L94
 	sort.Slice(groupVersions, func(i, j int) bool {
 		if groupVersions[i].Group == groupVersions[j].Group {
-			return groupVersions[i].Version == groupVersions[j].Version
+			return groupVersions[i].Version < groupVersions[j].Version
 		}
 		return groupVersions[i].Group < groupVersions[j].Group
 	})

--- a/pkg/utils/managedresources/registry.go
+++ b/pkg/utils/managedresources/registry.go
@@ -17,12 +17,14 @@ package managedresources
 import (
 	"fmt"
 	"reflect"
+	"sort"
 	"strings"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apimachinery/pkg/runtime/serializer/json"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 )
@@ -43,14 +45,26 @@ type object struct {
 // NewRegistry returns a new registry for resources. The given scheme, codec, and serializer must know all the resource
 // types that will later be added to the registry.
 func NewRegistry(scheme *runtime.Scheme, codec serializer.CodecFactory, serializer *json.Serializer) *Registry {
-	var groupVersions []schema.GroupVersion
+	var groupVersions schema.GroupVersions
 	for k := range scheme.AllKnownTypes() {
 		groupVersions = append(groupVersions, k.GroupVersion())
 	}
 
+	// Use set to remove duplicates
+	groupVersions = sets.New(groupVersions...).UnsortedList()
+
+	// Sort groupVersions to ensure groupVersions.Identifier() is stable key
+	// for the map in https://github.com/kubernetes/apimachinery/blob/v0.26.1/pkg/runtime/serializer/versioning/versioning.go#L94
+	sort.Slice(groupVersions, func(i, j int) bool {
+		if groupVersions[i].Group == groupVersions[j].Group {
+			return groupVersions[i].Version == groupVersions[j].Version
+		}
+		return groupVersions[i].Group < groupVersions[j].Group
+	})
+
 	return &Registry{
 		scheme:       scheme,
-		codec:        codec.CodecForVersions(serializer, serializer, schema.GroupVersions(groupVersions), schema.GroupVersions(groupVersions)),
+		codec:        codec.CodecForVersions(serializer, serializer, groupVersions, groupVersions),
 		nameToObject: make(map[string]*object),
 	}
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area performance quality
/kind bug

**What this PR does / why we need it**:
Fix excessive memory usage by `managedresources.NewRegistry`

Controllers, that are creating new registries dynamically, e.g. on each reconciliation, creates new codecs each time. 
k8s.io/apimachinery generates identifiers and store them into a global map, [ref](https://github.com/kubernetes/kubernetes/blob/3cf9f66e90d560ac080687610933c712bcf37b39/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/versioning/versioning.go#L108-L121).

The identifier is string joined from all available groups and version in the scheme, [ref](https://github.com/kubernetes/kubernetes/blob/3cf9f66e90d560ac080687610933c712bcf37b39/staging/src/k8s.io/apimachinery/pkg/runtime/schema/group_version.go#L245-L252). 

For the `SeedScheme` and `ShootScheme` it turns out there are ~800 `GroupVersion` entries, as a lot of them are duplicated and not in the same order. This way, the joined string is different every time, hence the identifier is never found in the global map. The result is that this map grows every time new registry is created. 

By sorting and making the elements in the `groupVersions` unique, the identifier for given scheme will be always the same, and this way the global map will not grow indefinitely.  

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
There are some other options this issue to be fixed, but they are not backward compatible. 
For example, `managedresources.NewRegistry` to accept `runtime.Codec` instead of `serializer.CodecFactory`. 
Then the users of `NewRegistry` will have to take care to create the codec themselves and they will eventually single codec for the controller/program. 

In this case, it would be nice https://github.com/gardener/gardener/blob/master/pkg/client/kubernetes/types.go to provide pre-created Shoot and Seed `runtime.Codec`s, but there are already exposed variable `(Shoot|Seed)Codec` which are of type `CodecFactory`. 


**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix developer
A bug in `managedresources.NewRegistry` that was leading to excessive memory usage when this function is called multiple times has been fixed. 
```
