### PR TITLE
Reintroduce seed zones admission checks

### DIFF
--- a/plugin/pkg/managedseed/shoot/admission.go
+++ b/plugin/pkg/managedseed/shoot/admission.go
@@ -100,7 +100,7 @@ func (v *Shoot) ValidateInitialization() error {
 
 var _ admission.ValidationInterface = &Shoot{}
 
-// Validate validates if the Shoot can be deleted. If the
+// Validate validates if the ManagedSeed can be deleted.
 func (v *Shoot) Validate(ctx context.Context, a admission.Attributes, _ admission.ObjectInterfaces) error {
 	// Wait until the caches have been synced
 	if v.readyFunc == nil {

--- a/plugin/pkg/managedseed/validator/admission_test.go
+++ b/plugin/pkg/managedseed/validator/admission_test.go
@@ -453,7 +453,7 @@ var _ = Describe("ManagedSeed", func() {
 					PointTo(MatchFields(IgnoreExtras, Fields{
 						"Type":   Equal(field.ErrorTypeInvalid),
 						"Field":  Equal("spec.gardenlet.config.seedConfig.spec.provider.zones"),
-						"Detail": ContainSubstring("seed provider zones must be equal to shoot zones"),
+						"Detail": ContainSubstring("[]string{\"foo\", \"bar\"}: cannot use zone in seed provider that is not available in referenced shoot"),
 					})),
 				))
 			})
@@ -698,7 +698,7 @@ var _ = Describe("ManagedSeed", func() {
 						PointTo(MatchFields(IgnoreExtras, Fields{
 							"Type":   Equal(field.ErrorTypeInvalid),
 							"Field":  Equal("spec.gardenlet.config.seedConfig.spec.provider.zones"),
-							"Detail": ContainSubstring("added zones must match the zones configured in the ManagedSeed's shoot cluster"),
+							"Detail": ContainSubstring("added zones must match zone names configured for workers in the referenced shoot cluster"),
 						})),
 					))
 				})
@@ -725,7 +725,7 @@ var _ = Describe("ManagedSeed", func() {
 						PointTo(MatchFields(IgnoreExtras, Fields{
 							"Type":   Equal(field.ErrorTypeInvalid),
 							"Field":  Equal("spec.gardenlet.config.seedConfig.spec.provider.zones"),
-							"Detail": ContainSubstring("[]string{\"zone-foobar\"}: added zones must match the zones configured in the ManagedSeed's shoot cluster"),
+							"Detail": ContainSubstring("[]string{\"zone-foobar\"}: added zones must match zone names configured for workers in the referenced shoot cluster"),
 						})),
 					))
 				})

--- a/plugin/pkg/seed/validator/admission_test.go
+++ b/plugin/pkg/seed/validator/admission_test.go
@@ -89,7 +89,7 @@ var _ = Describe("validator", func() {
 				newSeed.Spec.Provider.Zones = []string{"2"}
 			})
 
-			It("should allow zone removal there are no shoots", func() {
+			It("should allow zone removal when there are no shoots", func() {
 				attrs := admission.NewAttributesRecord(newSeed, oldSeed, core.Kind("Seed").WithVersion("version"), "", seed.Name, core.Resource("seeds").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, nil)
 
 				Expect(admissionHandler.Validate(context.TODO(), attrs, nil)).To(Succeed())

--- a/plugin/pkg/seed/validator/admission_test.go
+++ b/plugin/pkg/seed/validator/admission_test.go
@@ -78,6 +78,31 @@ var _ = Describe("validator", func() {
 			admissionHandler.SetInternalCoreInformerFactory(coreInformerFactory)
 		})
 
+		Context("Seed Update", func() {
+			var oldSeed, newSeed *core.Seed
+
+			BeforeEach(func() {
+				oldSeed = seedBase.DeepCopy()
+				newSeed = seedBase.DeepCopy()
+
+				oldSeed.Spec.Provider.Zones = []string{"1", "2"}
+				newSeed.Spec.Provider.Zones = []string{"2"}
+			})
+
+			It("should allow zone removal there are no shoots", func() {
+				attrs := admission.NewAttributesRecord(newSeed, oldSeed, core.Kind("Seed").WithVersion("version"), "", seed.Name, core.Resource("seeds").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, nil)
+
+				Expect(admissionHandler.Validate(context.TODO(), attrs, nil)).To(Succeed())
+			})
+
+			It("should forbid zone removal when there are shoots", func() {
+				Expect(coreInformerFactory.Core().InternalVersion().Shoots().Informer().GetStore().Add(&shoot)).To(Succeed())
+				attrs := admission.NewAttributesRecord(newSeed, oldSeed, core.Kind("Seed").WithVersion("version"), "", seed.Name, core.Resource("seeds").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, nil)
+
+				Expect(admissionHandler.Validate(context.TODO(), attrs, nil)).To(BeForbiddenError())
+			})
+		})
+
 		// The verification of protection is independent of the Cloud Provider (being checked before).
 		Context("Seed deletion", func() {
 			BeforeEach(func() {

--- a/plugin/pkg/shoot/managedseed/admission.go
+++ b/plugin/pkg/shoot/managedseed/admission.go
@@ -181,11 +181,11 @@ func (v *ManagedSeed) validateUpdate(ctx context.Context, a admission.Attributes
 		allErrs = append(allErrs, field.Invalid(field.NewPath("spec", "kubernetes", "enableStaticTokenKubeconfig"), shoot.Spec.Kubernetes.EnableStaticTokenKubeconfig, "shoot static token kubeconfig cannot be disabled when the seed secretRef is set"))
 	}
 
-	zoneValidationErrrs, err := v.validateWorkerZoneChanges(field.NewPath("spec", "providers", "workers"), shoot, seedTemplate)
+	zoneValidationErrs, err := v.validateWorkerZoneChanges(field.NewPath("spec", "providers", "workers"), shoot, seedTemplate)
 	if err != nil {
 		return apierrors.NewInternalError(err)
 	}
-	allErrs = append(allErrs, zoneValidationErrrs...)
+	allErrs = append(allErrs, zoneValidationErrs...)
 
 	if len(allErrs) > 0 {
 		return apierrors.NewInvalid(a.GetKind().GroupKind(), shoot.Name, allErrs)
@@ -195,7 +195,7 @@ func (v *ManagedSeed) validateUpdate(ctx context.Context, a admission.Attributes
 }
 
 // validateWorkerZoneChanges returns an error if worker zones for the given shoot were changed
-// while it still hosts shoot control-planes.
+// while they are still registered in the managedseed.
 func (v *ManagedSeed) validateWorkerZoneChanges(fldPath *field.Path, shoot *core.Shoot, seedTemplate *gardencorev1beta1.SeedTemplate) (field.ErrorList, error) {
 	allErrs := field.ErrorList{}
 

--- a/plugin/pkg/shoot/managedseed/admission.go
+++ b/plugin/pkg/shoot/managedseed/admission.go
@@ -33,11 +33,8 @@ import (
 	seedmanagementv1alpha1helper "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1/helper"
 	admissioninitializer "github.com/gardener/gardener/pkg/apiserver/admission/initializer"
 	gardencoreclientset "github.com/gardener/gardener/pkg/client/core/clientset/internalversion"
-	gardencoreinformers "github.com/gardener/gardener/pkg/client/core/informers/internalversion"
-	gardencorelisters "github.com/gardener/gardener/pkg/client/core/listers/core/internalversion"
 	seedmanagementclientset "github.com/gardener/gardener/pkg/client/seedmanagement/clientset/versioned"
 	"github.com/gardener/gardener/plugin/pkg/utils"
-	admissionutils "github.com/gardener/gardener/plugin/pkg/utils"
 )
 
 const (
@@ -57,7 +54,6 @@ type ManagedSeed struct {
 	*admission.Handler
 	coreClient           gardencoreclientset.Interface
 	seedManagementClient seedmanagementclientset.Interface
-	shootLister          gardencorelisters.ShootLister
 	readyFunc            admission.ReadyFunc
 }
 
@@ -91,14 +87,6 @@ func (v *ManagedSeed) SetSeedManagementClientset(c seedmanagementclientset.Inter
 	v.seedManagementClient = c
 }
 
-// SetInternalCoreInformerFactory gets Lister from SharedInformerFactory.
-func (v *ManagedSeed) SetInternalCoreInformerFactory(f gardencoreinformers.SharedInformerFactory) {
-	shootInformer := f.Core().InternalVersion().Shoots()
-	v.shootLister = shootInformer.Lister()
-
-	readyFuncs = append(readyFuncs, shootInformer.Informer().HasSynced)
-}
-
 // ValidateInitialization checks whether the plugin was correctly initialized.
 func (v *ManagedSeed) ValidateInitialization() error {
 	if v.coreClient == nil {
@@ -106,9 +94,6 @@ func (v *ManagedSeed) ValidateInitialization() error {
 	}
 	if v.seedManagementClient == nil {
 		return errors.New("missing garden seedmanagement client")
-	}
-	if v.shootLister == nil {
-		return errors.New("missing shoot lister")
 	}
 	return nil
 }
@@ -196,7 +181,7 @@ func (v *ManagedSeed) validateUpdate(ctx context.Context, a admission.Attributes
 		allErrs = append(allErrs, field.Invalid(field.NewPath("spec", "kubernetes", "enableStaticTokenKubeconfig"), shoot.Spec.Kubernetes.EnableStaticTokenKubeconfig, "shoot static token kubeconfig cannot be disabled when the seed secretRef is set"))
 	}
 
-	zoneValidationErrrs, err := v.validateWorkerZoneChanges(ctx, field.NewPath("spec", "providers", "workers"), shoot, oldShoot, seedTemplate)
+	zoneValidationErrrs, err := v.validateWorkerZoneChanges(field.NewPath("spec", "providers", "workers"), shoot, seedTemplate)
 	if err != nil {
 		return apierrors.NewInternalError(err)
 	}
@@ -211,38 +196,15 @@ func (v *ManagedSeed) validateUpdate(ctx context.Context, a admission.Attributes
 
 // validateWorkerZoneChanges returns an error if worker zones for the given shoot were changed
 // while it still hosts shoot control-planes.
-func (v *ManagedSeed) validateWorkerZoneChanges(ctx context.Context, fldPath *field.Path, shoot, oldShoot *core.Shoot, seedTemplate *gardencorev1beta1.SeedTemplate) (field.ErrorList, error) {
+func (v *ManagedSeed) validateWorkerZoneChanges(fldPath *field.Path, shoot *core.Shoot, seedTemplate *gardencorev1beta1.SeedTemplate) (field.ErrorList, error) {
 	allErrs := field.ErrorList{}
 
 	shootZones := gardencorehelper.GetAllZonesFromShoot(shoot)
 
-	// return if zones in shoot workers are unchanged
-	if shootZones.Equal(gardencorehelper.GetAllZonesFromShoot(oldShoot)) {
-		return allErrs, nil
-	}
-
-	// return if all zones in seedTemplate are available in shoot workers, i.e. no zone previously available
-	// in seed was removed from shoot workers.
-	if shootZones.HasAll(seedTemplate.Spec.Provider.Zones...) {
-		return allErrs, nil
-	}
-
-	managedSeed, err := utils.GetManagedSeed(ctx, v.seedManagementClient, shoot.GetNamespace(), shoot.GetName())
-	if err != nil {
-		return allErrs, apierrors.NewInternalError(fmt.Errorf("could not get ManagedSeed for shoot '%s/%s': %v", shoot.GetNamespace(), shoot.GetName(), err))
-	}
-
-	if managedSeed == nil {
-		return allErrs, nil
-	}
-
-	shoots, err := v.shootLister.List(labels.Everything())
-	if err != nil {
-		return allErrs, err
-	}
-
-	if admissionutils.IsSeedUsedByShoot(managedSeed.Name, shoots) {
-		allErrs = append(allErrs, field.Forbidden(fldPath, "cannot change zone information since shoot is registered as seed which is still used by shoot(s)"))
+	// Check if all zones in ManagedSeed are available in shoot workers.
+	// In case of a removal, zone(s) must first be deselected in ManagedSeed before they can be removed in the shoot.
+	if !shootZones.HasAll(seedTemplate.Spec.Provider.Zones...) {
+		allErrs = append(allErrs, field.Forbidden(fldPath, "shoot worker zone(s) must not be removed as long as registered in managedseed"))
 	}
 
 	return allErrs, nil

--- a/plugin/pkg/utils/miscellaneous.go
+++ b/plugin/pkg/utils/miscellaneous.go
@@ -20,7 +20,9 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apiserver/pkg/admission"
+	"k8s.io/utils/pointer"
 
 	"github.com/gardener/gardener/pkg/apis/core"
 	gardencorelisters "github.com/gardener/gardener/pkg/client/core/listers/core/internalversion"
@@ -72,4 +74,23 @@ func NewAttributesWithName(a admission.Attributes, name string) admission.Attrib
 		a.GetOperationOptions(),
 		a.IsDryRun(),
 		a.GetUserInfo())
+}
+
+// ValidateZoneRemovalFromSeeds returns an error when zones are removed from the old seed while it is still in use by
+// shoots.
+func ValidateZoneRemovalFromSeeds(oldSeedSpec, newSeedSpec *core.SeedSpec, seedName string, shootLister gardencorelisters.ShootLister, kind string) error {
+	if removedZones := sets.New[string](oldSeedSpec.Provider.Zones...).Difference(sets.New[string](newSeedSpec.Provider.Zones...)); removedZones.Len() > 0 {
+		shootList, err := GetFilteredShootList(shootLister, func(shoot *core.Shoot) bool {
+			return pointer.StringDeref(shoot.Spec.SeedName, "") == seedName
+		})
+		if err != nil {
+			return err
+		}
+
+		if len(shootList) > 0 {
+			return apierrors.NewForbidden(core.Resource(kind), seedName, fmt.Errorf("cannot remove zones %v from %s %s as there are %d Shoots scheduled to this Seed", sets.List(removedZones), kind, seedName, len(shootList)))
+		}
+	}
+
+	return nil
 }

--- a/plugin/pkg/utils/miscellaneous_test.go
+++ b/plugin/pkg/utils/miscellaneous_test.go
@@ -129,6 +129,9 @@ var _ = Describe("Miscellaneous", func() {
 				Spec: core.ShootSpec{
 					SeedName: &seedName,
 				},
+				Status: core.ShootStatus{
+					SeedName: &seedName,
+				},
 			}
 		})
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area high-availability
/kind technical-debt api-change

**What this PR does / why we need it**:
Gardener allowed zone name mismatches between shoot and seed specifications earlier. For instance, while a shoot worker configures zones [1,2,3] the registered seed cluster for it had to specify [central-1,central-2,central-3] because of special cloud provider characteristics. In the meantime it is assumed that this requirement is rather implemented by the respective provider extension ([example](https://github.com/gardener/gardener-extension-provider-azure/pull/602)) and Gardener can consequently add a name matching restriction again. Existing `ManagedSeed`s are not affected by this check, i.e. a given zone name mismatch can remain.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/6529

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
`Seed` and `ManagedSeed` API validation has been enhanced by the following checks:
(a) New `ManagedSeed`s can only use the very same zone(s) (`managedSeed.spec.gardenlet.config.seedConfig.spec.provider.zones`) that are available in the referenced `Shoot` (`shoot.spec.provider.workers[].zones`).
(b) Existing `ManagedSeed`s can only add additional zones that are available in the referenced shoot.
(c) Removing elements in `seed.spec.provider.zones` is denied if shoots are still scheduled to the affected seed.
These restrictions were removed in Gardener `v1.60` to compensate a zone mismatch issue in Azure that is in the meantime fixed by the Azure provider extension [v1.34](https://github.com/gardener/gardener-extension-provider-azure/releases/tag/v1.34.0).
⚠️ Before upgrading to this Gardener version, please make sure to check existing `ManagedSeed` objects. They should configure as many as zone as there are available in the referenced shoot - see check (c).
```