### PR TITLE
Change registry of e2e-test-images/agnhost image

### DIFF
--- a/test/framework/resources/templates/logger-app.yaml.tpl
+++ b/test/framework/resources/templates/logger-app.yaml.tpl
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
       - name: logger
-        image: registry.k8s.io/e2e-test-images/agnhost:2.40
+        image: eu.gcr.io/gardener-project/3rd/agnhost:2.40 # Original image registry.k8s.io/e2e-test-images/agnhost:2.40
         command: ["/bin/sh"]
         args:
           - -c

--- a/test/framework/resources/templates/logger-app.yaml.tpl
+++ b/test/framework/resources/templates/logger-app.yaml.tpl
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
       - name: logger
-        image: eu.gcr.io/gardener-project/3rd/agnhost:2.40 # Original image registry.k8s.io/e2e-test-images/agnhost:2.40
+        image: eu.gcr.io/gardener-project/3rd/agnhost:2.40
         command: ["/bin/sh"]
         args:
           - -c

--- a/test/framework/resources/templates/vpntunnel.yaml.tpl
+++ b/test/framework/resources/templates/vpntunnel.yaml.tpl
@@ -27,7 +27,7 @@ spec:
               sleep 3600;
             done
       - name: logger
-        image: eu.gcr.io/gardener-project/3rd/agnhost:2.40
+        image: registry.k8s.io/e2e-test-images/agnhost:2.40
         args:
           - logs-generator
           - --logtostderr

--- a/test/framework/resources/templates/vpntunnel.yaml.tpl
+++ b/test/framework/resources/templates/vpntunnel.yaml.tpl
@@ -27,7 +27,7 @@ spec:
               sleep 3600;
             done
       - name: logger
-        image: eu.gcr.io/gardener-project/3rd/agnhost:2.40 # Original image registry.k8s.io/e2e-test-images/agnhost:2.40
+        image: eu.gcr.io/gardener-project/3rd/agnhost:2.40
         args:
           - logs-generator
           - --logtostderr

--- a/test/framework/resources/templates/vpntunnel.yaml.tpl
+++ b/test/framework/resources/templates/vpntunnel.yaml.tpl
@@ -27,7 +27,7 @@ spec:
               sleep 3600;
             done
       - name: logger
-        image: registry.k8s.io/e2e-test-images/agnhost:2.40
+        image: eu.gcr.io/gardener-project/3rd/agnhost:2.40 # Original image registry.k8s.io/e2e-test-images/agnhost:2.40
         args:
           - logs-generator
           - --logtostderr


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security testing 
/kind technical-debt

**What this PR does / why we need it**:
Change registry of `e2e-test-images/agnhost` image.

This is needed as the test is failing in environments, where the image needs to be signed with particular keys. 
/cc @vlvasilev 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
