### PR TITLE
Align downtime validator with `kube-apiserver` readiness probe

### DIFF
--- a/hack/ci-e2e-kind-upgrade.sh
+++ b/hack/ci-e2e-kind-upgrade.sh
@@ -205,7 +205,10 @@ kubectl wait seed $SEED_NAME --timeout=5m --for=jsonpath="{.status.gardener.vers
 # In a multi-zone setup, 6 istio-ingressgateway pods will be running, and it will take 18 minutes to complete the rollout.
 TIMEOUT=1200 ./hack/usage/wait-for.sh seed "$SEED_NAME" GardenletReady Bootstrapped SeedSystemComponentsHealthy ExtensionsReady BackupBucketsReady
 
-# Sleep for 60 seconds to allow for potential downtime detection during post-upgrade stabilization.
+# The downtime validator considers downtime after 3 consecutive failures, taking a total of 30 seconds.
+# Therefore, we're waiting for double that amount of time (60s) to detect if there is any downtime after the upgrade process.
+# By waiting for double the amount of time (60 seconds) post-upgrade, the script accounts for the possibility of missing the last 30-second window,
+# thus ensuring that any potential downtime after the post-upgrade is detected.
 sleep 60
 
 echo "Running gardener post-upgrade tests"

--- a/hack/ci-e2e-kind-upgrade.sh
+++ b/hack/ci-e2e-kind-upgrade.sh
@@ -205,6 +205,9 @@ kubectl wait seed $SEED_NAME --timeout=5m --for=jsonpath="{.status.gardener.vers
 # In a multi-zone setup, 6 istio-ingressgateway pods will be running, and it will take 18 minutes to complete the rollout.
 TIMEOUT=1200 ./hack/usage/wait-for.sh seed "$SEED_NAME" GardenletReady Bootstrapped SeedSystemComponentsHealthy ExtensionsReady BackupBucketsReady
 
+# Sleep for 60 seconds to allow for potential downtime detection during post-upgrade stabilization.
+sleep 60
+
 echo "Running gardener post-upgrade tests"
 make test-post-upgrade GARDENER_PREVIOUS_RELEASE=$GARDENER_PREVIOUS_RELEASE GARDENER_NEXT_RELEASE=$GARDENER_NEXT_RELEASE
 

--- a/test/utils/shoots/update/highavailability/upgrade.go
+++ b/test/utils/shoots/update/highavailability/upgrade.go
@@ -160,7 +160,7 @@ func DeployZeroDownTimeValidatorJob(ctx context.Context, c client.Client, testNa
 									"else failed=$((failed+1)); " +
 									"echo $(date +'%Y-%m-%dT%H:%M:%S.%3N%z') ERROR: kube-apiserver is unhealthy and retrying.; " +
 									"fi; " +
-									"sleep 1; " +
+									"sleep 10; " +
 									"done; " +
 									"echo $(date +'%Y-%m-%dT%H:%M:%S.%3N%z') ERROR: kube-apiserver is still unhealthy after $failed attempts. Considered as downtime.; " +
 									"exit 1; "},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing 
/kind flake test

**What this PR does / why we need it**:

This PR includes two changes to fix downtime validator flakiness:

1. Update the downtime validator threshold to match the `kube-apiserver `readiness probe configuration. The `kube-apiserver` is considered not ready after 3 consecutive failures, which would take approximately **30 seconds** (`3 failures * 10 seconds per check`). By adjusting the threshold in the downtime validator, we ensure that the validator's downtime detection is more consistent with the kube-apiserver's readiness status.

2. Add a 60-second sleep period in the upgrade script to accommodate downtime monitoring during the post-upgrade stabilization process. This pause allows time for detecting any downtime that may occur as the system stabilizes after the upgrade.

Changes:
- Align downtime validator threshold with kube-apiserver readiness probe configuration `30 seconds`
- Add a 60-second sleep period in the upgrade script for potential downtime detection during post-upgrade stabilization

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
cc: @rfranzke 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
