### PR TITLE
Use `CreateOrGetAndStrategicMergePatch` for BackupBucket generated secret in garden

### DIFF
--- a/pkg/gardenlet/controller/backupbucket/reconciler.go
+++ b/pkg/gardenlet/controller/backupbucket/reconciler.go
@@ -366,7 +366,7 @@ func (r *Reconciler) syncGeneratedSecretToGarden(ctx context.Context, backupBuck
 		}
 		ownerRef := metav1.NewControllerRef(backupBucket, gardencorev1beta1.SchemeGroupVersion.WithKind("BackupBucket"))
 
-		if _, err := controllerutils.GetAndCreateOrMergePatch(ctx, r.GardenClient, gardenGeneratedSecret, func() error {
+		if _, err := controllerutils.CreateOrGetAndStrategicMergePatch(ctx, r.GardenClient, gardenGeneratedSecret, func() error {
 			gardenGeneratedSecret.OwnerReferences = []metav1.OwnerReference{*ownerRef}
 			controllerutil.AddFinalizer(gardenGeneratedSecret, finalizerName)
 			gardenGeneratedSecret.Data = seedGeneratedSecret.DeepCopy().Data

--- a/pkg/gardenlet/controller/backupbucket/reconciler.go
+++ b/pkg/gardenlet/controller/backupbucket/reconciler.go
@@ -350,28 +350,37 @@ func (r *Reconciler) reconcileBackupBucketExtensionSecret(ctx context.Context, e
 }
 
 func (r *Reconciler) syncGeneratedSecretToGarden(ctx context.Context, backupBucket *gardencorev1beta1.BackupBucket, extensionBackupBucket *extensionsv1alpha1.BackupBucket) error {
-	if extensionBackupBucket.Status.GeneratedSecretRef != nil {
-		seedGeneratedSecret, err := kubernetesutils.GetSecretByReference(ctx, r.SeedClient, extensionBackupBucket.Status.GeneratedSecretRef)
-		if err != nil {
-			return err
-		}
-
-		gardenGeneratedSecret := &corev1.Secret{
+	var (
+		gardenGeneratedSecret = &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      generateGeneratedBackupBucketSecretName(backupBucket.Name),
 				Namespace: r.GardenNamespace,
 			},
 		}
+		gardenGeneratedSecretRef *corev1.SecretReference
+	)
 
-		// Update the BackupBucket status here before going for the CreateOrGetAndStrategicMergePatch call, so that the SeedAuthorizer
-		// can add the entry for this secret in the graph. See https://github.com/gardener/gardener/issues/7705 for more details.
-		patch := client.MergeFrom(backupBucket.DeepCopy())
-		backupBucket.Status.GeneratedSecretRef = &corev1.SecretReference{
+	if extensionBackupBucket.Status.GeneratedSecretRef != nil {
+		gardenGeneratedSecretRef = &corev1.SecretReference{
 			Name:      gardenGeneratedSecret.Name,
 			Namespace: gardenGeneratedSecret.Namespace,
 		}
+	}
+
+	if extensionBackupBucket.Status.GeneratedSecretRef != nil || extensionBackupBucket.Status.ProviderStatus != nil {
+		patch := client.MergeFrom(backupBucket.DeepCopy())
+		// Update the BackupBucket status here before going for the CreateOrGetAndStrategicMergePatch call, so that the SeedAuthorizer
+		// can add the entry for this secret in the graph. See https://github.com/gardener/gardener/issues/7705 for more details.
+		backupBucket.Status.GeneratedSecretRef = gardenGeneratedSecretRef
 		backupBucket.Status.ProviderStatus = extensionBackupBucket.Status.ProviderStatus
 		if err := r.GardenClient.Status().Patch(ctx, backupBucket, patch); err != nil {
+			return err
+		}
+	}
+
+	if extensionBackupBucket.Status.GeneratedSecretRef != nil {
+		seedGeneratedSecret, err := kubernetesutils.GetSecretByReference(ctx, r.SeedClient, extensionBackupBucket.Status.GeneratedSecretRef)
+		if err != nil {
 			return err
 		}
 

--- a/pkg/provider-local/controller/backupbucket/actuator.go
+++ b/pkg/provider-local/controller/backupbucket/actuator.go
@@ -86,7 +86,6 @@ func (a *actuator) createBackupBucketGeneratedSecret(ctx context.Context, backup
 	}
 
 	if _, err := controllerutil.CreateOrUpdate(ctx, a.client, generatedSecret, func() error {
-		generatedSecret.Data = map[string][]byte{}
 		return nil
 	}); err != nil {
 		return err

--- a/pkg/provider-local/controller/backupbucket/actuator.go
+++ b/pkg/provider-local/controller/backupbucket/actuator.go
@@ -78,7 +78,7 @@ func (a *actuator) Delete(_ context.Context, log logr.Logger, bb *extensionsv1al
 }
 
 func (a *actuator) createBackupBucketGeneratedSecret(ctx context.Context, backupBucket *extensionsv1alpha1.BackupBucket) error {
-	var generatedSecret = &corev1.Secret{
+	generatedSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      v1beta1constants.SecretPrefixGeneratedBackupBucket + backupBucket.Name,
 			Namespace: v1beta1constants.GardenNamespace,
@@ -86,9 +86,7 @@ func (a *actuator) createBackupBucketGeneratedSecret(ctx context.Context, backup
 	}
 
 	if _, err := controllerutil.CreateOrUpdate(ctx, a.client, generatedSecret, func() error {
-		generatedSecret.Data = map[string][]byte{
-			"foo": []byte("bar"),
-		}
+		generatedSecret.Data = map[string][]byte{}
 		return nil
 	}); err != nil {
 		return err


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area backup
/kind bug

**What this PR does / why we need it**:
After https://github.com/gardener/gardener/pull/6837, While syncing the backupbucket generated secret from seed to garden, the controller is using `GetAndCreateOrMergePatch`, Previously this was `CreateOrGetAndStrategicMergePatch`, ref: 
https://github.com/gardener/gardener/blob/c3e2599f43a86565194e44066b28614b3b7262dd/pkg/gardenlet/controller/backupbucket/backup_bucket_actuator.go#L244

Due to this, the entry for this Secret is not added to the `seed-authorizer-graph` and while doing Get, 
```
{"level":"info","ts":"2023-03-24T11:05:05.651+0530","logger":"webhook.seedauthorizer","msg":"Denying authorization because no relationship is found between seed and object","seedName":"seed-foo","attributes":"authorizer.AttributesRecord{User:(*user.DefaultInfo)(0x14000992c40), Verb:\"get\", Namespace:\"garden\", APIGroup:\"\", APIVersion:\"v1\", Resource:\"secrets\", Subresource:\"\", Name:\"generated-bucket-4fdsd98sd98sdc-40ef-9b93-899dd3eadbd6 \", ResourceRequest:true, Path:\"\"}"}
```

This PR fixes this and switches the controller back to use `CreateOrGetAndStrategicMergePatch`, this way at https://github.com/gardener/gardener/blob/9c3976a0674469b4282dac537ab2d8e33cc5f5f1/pkg/gardenlet/controller/backupbucket/reconciler.go#L388-L390, when the Update call for BackupBucket is done, the graph is correctly populated.
```
{"level":"info","ts":"2023-03-24T11:09:17.185+0530","logger":"seed-authorizer-graph","msg":"Added","vertex":"Secret:garden/generated-bucket-4fdsd98sd98sdc-40ef-9b93-899dd3eadbd6 (43)"}
{"level":"info","ts":"2023-03-24T11:09:17.185+0530","logger":"seed-authorizer-graph","msg":"Added edge","from":"Secret:garden/generated-bucket-4fdsd98sd98sdc-40ef-9b93-899dd3eadbd6  (43)","to":"BackupBucket:4fdsd98sd98sdc-40ef-9b93-899dd3eadbd6 (47)"}
```

Also we now patch the `BackupBucket` status to have the secretRef before going for the `CreateOrGetAndStrategicMergePatch`, so that the case of gardenlet restart mentioned in https://github.com/gardener/gardener/pull/7708#issuecomment-1482425134 is also covered.

**Which issue(s) this PR fixes**:
Fixes #7705

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
A bug causing the gardenlet to be unable to access the BackupBucket generated secret in garden namespace is now fixed.
```
