### PR TITLE
Fix early exit of `check-apidiff.sh`

### DIFF
--- a/hack/check-apidiff.sh
+++ b/hack/check-apidiff.sh
@@ -30,10 +30,10 @@ temp=0
 # PULL_BASE_SHA env variable is set by default in prow presubmit jobs
 if [ -n "${PULL_BASE_SHA:-}" ]; then
   echo "invoking: go-apidiff ${PULL_BASE_SHA} --print-compatible --repo-path=."
-  go-apidiff ${PULL_BASE_SHA} --print-compatible --repo-path=. >${tmpDir}/output.txt
+  go-apidiff ${PULL_BASE_SHA} --print-compatible --repo-path=. >${tmpDir}/output.txt || true
 else
   echo "invoking: go-apidiff master --print-compatible --repo-path=."
-  go-apidiff master --print-compatible --repo-path=. >${tmpDir}/output.txt
+  go-apidiff master --print-compatible --repo-path=. >${tmpDir}/output.txt || true
 fi
 
 exported_pkg=(


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind bug

**What this PR does / why we need it**:

`pull-gardener-apidiff` exits early and doesn't output the breaking changes anymore: https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/7561/pull-gardener-apidiff/1639160906803843072

Broken by https://github.com/gardener/gardener/pull/7654
