### PR TITLE
Fix secret manager adoption of existing secrets

### DIFF
--- a/docs/development/secrets_management.md
+++ b/docs/development/secrets_management.md
@@ -122,7 +122,7 @@ External components that want to reuse the `SecretsManager` should consider the 
 
 ## Migrating Existing Secrets To SecretsManager
 
-If you already have existing secrets which were not created with `SecretsManager`, then you can (optionally) migrate them by labeling them with `secrets-manager-use-data-for=<config-name>`.
+If you already have existing secrets which were not created with `SecretsManager`, then you can (optionally) migrate them by labeling them with `secrets-manager-use-data-for-name=<config-name>`.
 For example, if your `SecretsManager` generates a `CertificateConfigSecret` with name `foo` like this
 
 ```go
@@ -135,7 +135,7 @@ secret, err := k.secretsManager.Generate(
 )
 ```
 
-and you already have an existing secret in your system whose data should be kept instead of regenerated, then labeling it with `secrets-manager-use-data-for=foo` will instruct `SecretsManager` accordingly.
+and you already have an existing secret in your system whose data should be kept instead of regenerated, then labeling it with `secrets-manager-use-data-for-name=foo` will instruct `SecretsManager` accordingly.
 
 **⚠️ Caveat: You have to make sure that the existing `data` keys match with what `SecretsManager` uses:**
 

--- a/pkg/utils/secrets/manager/generate_test.go
+++ b/pkg/utils/secrets/manager/generate_test.go
@@ -775,7 +775,7 @@ var _ = Describe("Generate", func() {
 
 			BeforeEach(func() {
 				config = &secretsutils.RSASecretConfig{
-					Name: "foo",
+					Name: "kube-apiserver-etcd-encryption-key",
 					Bits: 4096,
 				}
 			})
@@ -825,7 +825,7 @@ var _ = Describe("Generate", func() {
 
 				By("Generate secret")
 				secret, err := m.Generate(ctx, config)
-				Expect(err).To(MatchError(ContainSubstring(`found more than one existing secret with "secrets-manager-use-data-for-name" label for config "foo"`)))
+				Expect(err).To(MatchError(ContainSubstring(`found more than one existing secret with "secrets-manager-use-data-for-name" label for config "kube-apiserver-etcd-encryption-key"`)))
 				Expect(secret).To(BeNil())
 			})
 		})


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind bug

**What this PR does / why we need it**:
Without this commit, if existing secrets named `kube-apiserver-etcd-encryption-key` or `service-account-key` shall be adopted, this will fail because the "special migration code" was executed first. Now, with reversed order, we first check for existing secrets explicitly labeled for adoption before executing the special code.

Also, the documentation was missing the `-name` suffix in the label key.

**Which issue(s) this PR fixes**:
Introduced with #7243 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
A bug has been fixed which prevented existing secrets from being adopted when they were named `kube-apiserver-etcd-encryption-key` or `service-account-key`.
```
