### PR TITLE
Expose `kube-apiservers` of `Shoots` with trusted wildcard certificate

### DIFF
--- a/pkg/gardenlet/controller/shoot/shoot/reconciler_delete.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler_delete.go
@@ -534,6 +534,11 @@ func (r *Reconciler) runDeleteShootFlow(ctx context.Context, o *operation.Operat
 			Dependencies: flow.NewTaskIDs(waitUntilKubeAPIServerDeleted),
 		})
 		_ = g.Add(flow.Task{
+			Name:         "Destroying Kubernetes API server ingress with trusted certificate",
+			Fn:           flow.TaskFn(botanist.DestroyKubeAPIServerIngress),
+			Dependencies: flow.NewTaskIDs(waitUntilKubeAPIServerDeleted),
+		})
+		_ = g.Add(flow.Task{
 			Name:         "Destroying Kubernetes API server service",
 			Fn:           flow.TaskFn(botanist.Shoot.Components.ControlPlane.KubeAPIServerService.Destroy).RetryUntilTimeout(defaultInterval, defaultTimeout),
 			Dependencies: flow.NewTaskIDs(waitUntilKubeAPIServerDeleted, destroyKubeAPIServerSNI),

--- a/pkg/gardenlet/controller/shoot/shoot/reconciler_delete.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler_delete.go
@@ -535,7 +535,7 @@ func (r *Reconciler) runDeleteShootFlow(ctx context.Context, o *operation.Operat
 		})
 		_ = g.Add(flow.Task{
 			Name:         "Destroying Kubernetes API server ingress with trusted certificate",
-			Fn:           flow.TaskFn(botanist.DestroyKubeAPIServerIngress),
+			Fn:           flow.TaskFn(botanist.Shoot.Components.ControlPlane.KubeAPIServerIngress.Destroy),
 			Dependencies: flow.NewTaskIDs(waitUntilKubeAPIServerDeleted),
 		})
 		_ = g.Add(flow.Task{

--- a/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
@@ -172,6 +172,11 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 			Fn:           flow.TaskFn(botanist.InitializeSecretsManagement).RetryUntilTimeout(defaultInterval, defaultTimeout),
 			Dependencies: flow.NewTaskIDs(deployNamespace, ensureShootStateExists),
 		})
+		_ = g.Add(flow.Task{
+			Name:         "Deploying Kubernetes API server ingress with trusted certificate in the Seed cluster",
+			Fn:           flow.TaskFn(botanist.DeployKubeAPIServerIngress),
+			Dependencies: flow.NewTaskIDs(initializeSecretsManagement),
+		})
 		deployReferencedResources = g.Add(flow.Task{
 			Name:         "Deploying referenced resources",
 			Fn:           flow.TaskFn(botanist.DeployReferencedResources).RetryUntilTimeout(defaultInterval, defaultTimeout),

--- a/pkg/operation/botanist/botanist.go
+++ b/pkg/operation/botanist/botanist.go
@@ -130,6 +130,10 @@ func New(ctx context.Context, o *operation.Operation) (*Botanist, error) {
 	if err != nil {
 		return nil, err
 	}
+	o.Shoot.Components.ControlPlane.KubeAPIServerIngress, err = b.DefaultKubeAPIServerIngress()
+	if err != nil {
+		return nil, err
+	}
 	o.Shoot.Components.ControlPlane.KubeAPIServerService = b.DefaultKubeAPIServerService(sniPhase)
 	o.Shoot.Components.ControlPlane.KubeAPIServerSNI = b.DefaultKubeAPIServerSNI()
 	o.Shoot.Components.ControlPlane.KubeAPIServerSNIPhase = sniPhase

--- a/pkg/operation/botanist/component/kubeapiserverexposure/kube_apiserver_ingress.go
+++ b/pkg/operation/botanist/component/kubeapiserverexposure/kube_apiserver_ingress.go
@@ -1,0 +1,103 @@
+// Copyright 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubeapiserverexposure
+
+import (
+	"context"
+
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/gardener/gardener/pkg/controllerutils"
+	"github.com/gardener/gardener/pkg/operation/botanist/component"
+	kubeapiserverconstants "github.com/gardener/gardener/pkg/operation/botanist/component/kubeapiserver/constants"
+	"github.com/gardener/gardener/pkg/utils"
+)
+
+const (
+	nginxIngressSSLPassthrough = "nginx.ingress.kubernetes.io/ssl-passthrough"
+)
+
+// IngressValues configure the kube-apiserver ingress.
+type IngressValues struct {
+	// Host is the host where the kube-apiserver should be exposed.
+	Host string
+	// IngressClassName is the name of the ingress class.
+	IngressClassName *string
+	// ServiceName is the name of the service the ingress is using
+	ServiceName string
+}
+
+// NewIngress creates a new instance of Deployer for the ingress used to expose the kube-apiserver.
+func NewIngress(c client.Client, objectKey client.ObjectKey, values IngressValues) component.Deployer {
+	return &ingress{client: c, objectKey: objectKey, values: values}
+}
+
+type ingress struct {
+	client    client.Client
+	objectKey client.ObjectKey
+	values    IngressValues
+}
+
+func (i *ingress) Deploy(ctx context.Context) error {
+	ingress := i.emptyIngress()
+
+	if _, err := controllerutils.GetAndCreateOrMergePatch(ctx, i.client, ingress, func() error {
+		metav1.SetMetaDataAnnotation(&ingress.ObjectMeta, nginxIngressSSLPassthrough, "true")
+		ingress.Labels = utils.MergeStringMaps(ingress.Labels, getLabels())
+		pathType := networkingv1.PathTypePrefix
+		ingress.Spec = networkingv1.IngressSpec{
+			IngressClassName: i.values.IngressClassName,
+			Rules: []networkingv1.IngressRule{
+				{
+					Host: i.values.Host,
+					IngressRuleValue: networkingv1.IngressRuleValue{
+						HTTP: &networkingv1.HTTPIngressRuleValue{
+							Paths: []networkingv1.HTTPIngressPath{
+								{
+									Backend: networkingv1.IngressBackend{
+										Service: &networkingv1.IngressServiceBackend{
+											Name: i.values.ServiceName,
+											Port: networkingv1.ServiceBackendPort{
+												Number: kubeapiserverconstants.Port,
+											},
+										},
+									},
+									Path:     "/",
+									PathType: &pathType,
+								},
+							},
+						},
+					},
+				},
+			},
+			TLS: []networkingv1.IngressTLS{{Hosts: []string{i.values.Host}}},
+		}
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (i *ingress) Destroy(ctx context.Context) error {
+	return client.IgnoreNotFound(i.client.Delete(ctx, i.emptyIngress()))
+}
+
+func (i *ingress) emptyIngress() *networkingv1.Ingress {
+	return &networkingv1.Ingress{ObjectMeta: metav1.ObjectMeta{Name: i.objectKey.Name, Namespace: i.objectKey.Namespace}}
+}

--- a/pkg/operation/botanist/component/kubeapiserverexposure/kube_apiserver_ingress_test.go
+++ b/pkg/operation/botanist/component/kubeapiserverexposure/kube_apiserver_ingress_test.go
@@ -35,11 +35,12 @@ var _ = Describe("#Ingress", func() {
 		ctx context.Context
 		c   client.Client
 
-		ingressObjKey   client.ObjectKey
-		ingressClass    string
-		pathType        networkingv1.PathType
-		expected        *networkingv1.Ingress
-		defaultDeployer component.Deployer
+		ingressObjKey    client.ObjectKey
+		ingressNamespace string
+		ingressClass     string
+		pathType         networkingv1.PathType
+		expected         *networkingv1.Ingress
+		defaultDeployer  component.Deployer
 	)
 
 	BeforeEach(func() {
@@ -48,7 +49,8 @@ var _ = Describe("#Ingress", func() {
 		Expect(networkingv1.AddToScheme(s)).To(Succeed())
 		c = fake.NewClientBuilder().WithScheme(s).Build()
 
-		ingressObjKey = client.ObjectKey{Name: "foo", Namespace: "bar"}
+		ingressNamespace = "bar"
+		ingressObjKey = client.ObjectKey{Name: "kube-apiserver", Namespace: ingressNamespace}
 		pathType = networkingv1.PathTypePrefix
 		ingressClass = "foo-bar-ingress"
 		expected = &networkingv1.Ingress{
@@ -98,10 +100,10 @@ var _ = Describe("#Ingress", func() {
 	})
 
 	JustBeforeEach(func() {
-		defaultDeployer = NewIngress(c, ingressObjKey, IngressValues{
+		defaultDeployer = NewIngress(c, ingressNamespace, IngressValues{
 			Host:             "foo.bar.example.com",
 			IngressClassName: &ingressClass,
-			ServiceName:      ingressObjKey.Name,
+			ServiceName:      "foo",
 		})
 	})
 

--- a/pkg/operation/botanist/component/kubeapiserverexposure/kube_apiserver_ingress_test.go
+++ b/pkg/operation/botanist/component/kubeapiserverexposure/kube_apiserver_ingress_test.go
@@ -1,0 +1,130 @@
+// Copyright 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubeapiserverexposure_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/gardener/gardener/pkg/operation/botanist/component"
+	. "github.com/gardener/gardener/pkg/operation/botanist/component/kubeapiserverexposure"
+	. "github.com/gardener/gardener/pkg/utils/test/matchers"
+)
+
+var _ = Describe("#Ingress", func() {
+	var (
+		ctx context.Context
+		c   client.Client
+
+		ingressObjKey   client.ObjectKey
+		ingressClass    string
+		pathType        networkingv1.PathType
+		expected        *networkingv1.Ingress
+		defaultDeployer component.Deployer
+	)
+
+	BeforeEach(func() {
+		ctx = context.TODO()
+		s := runtime.NewScheme()
+		Expect(networkingv1.AddToScheme(s)).To(Succeed())
+		c = fake.NewClientBuilder().WithScheme(s).Build()
+
+		ingressObjKey = client.ObjectKey{Name: "foo", Namespace: "bar"}
+		pathType = networkingv1.PathTypePrefix
+		ingressClass = "foo-bar-ingress"
+		expected = &networkingv1.Ingress{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: networkingv1.SchemeGroupVersion.String(),
+				Kind:       "Ingress",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      ingressObjKey.Name,
+				Namespace: ingressObjKey.Namespace,
+				Annotations: map[string]string{
+					"nginx.ingress.kubernetes.io/ssl-passthrough": "true",
+				},
+				Labels: map[string]string{
+					"app":  "kubernetes",
+					"role": "apiserver",
+				},
+			},
+			Spec: networkingv1.IngressSpec{
+				IngressClassName: &ingressClass,
+				Rules: []networkingv1.IngressRule{
+					{
+						Host: "foo.bar.example.com",
+						IngressRuleValue: networkingv1.IngressRuleValue{
+							HTTP: &networkingv1.HTTPIngressRuleValue{
+								Paths: []networkingv1.HTTPIngressPath{
+									{
+										Backend: networkingv1.IngressBackend{
+											Service: &networkingv1.IngressServiceBackend{
+												Name: "foo",
+												Port: networkingv1.ServiceBackendPort{
+													Number: 443,
+												},
+											},
+										},
+										Path:     "/",
+										PathType: &pathType,
+									},
+								},
+							},
+						},
+					},
+				},
+				TLS: []networkingv1.IngressTLS{{Hosts: []string{"foo.bar.example.com"}}},
+			},
+		}
+	})
+
+	JustBeforeEach(func() {
+		defaultDeployer = NewIngress(c, ingressObjKey, IngressValues{
+			Host:             "foo.bar.example.com",
+			IngressClassName: &ingressClass,
+			ServiceName:      ingressObjKey.Name,
+		})
+	})
+
+	Context("Deploy", func() {
+		It("should create the expected ingress object", func() {
+			Expect(defaultDeployer.Deploy(ctx)).To(Succeed())
+
+			actual := &networkingv1.Ingress{}
+			Expect(c.Get(ctx, ingressObjKey, actual)).To(Succeed())
+			Expect(actual.Annotations).To(DeepEqual(expected.Annotations))
+			Expect(actual.Labels).To(DeepEqual(expected.Labels))
+			Expect(actual.Spec).To(DeepEqual(expected.Spec))
+		})
+	})
+
+	Context("Destroy", func() {
+		It("should delete the ingress object", func() {
+			Expect(c.Create(ctx, expected)).To(Succeed())
+			Expect(c.Get(ctx, ingressObjKey, &networkingv1.Ingress{})).To(Succeed())
+
+			Expect(defaultDeployer.Destroy(ctx)).To(Succeed())
+
+			Expect(c.Get(ctx, ingressObjKey, &networkingv1.Ingress{})).To(BeNotFoundError())
+		})
+	})
+})

--- a/pkg/operation/botanist/kubeapiserver.go
+++ b/pkg/operation/botanist/kubeapiserver.go
@@ -546,6 +546,11 @@ func (b *Botanist) computeKubeAPIServerSNIConfig() kubeapiserver.SNIConfig {
 		}
 	}
 
+	// Add control plane wildcard certificate to TLS SNI config if it is available.
+	if b.ControlPlaneWildcardCert != nil {
+		config.TLS = append(config.TLS, kubeapiserver.TLSSNIConfig{SecretName: &b.ControlPlaneWildcardCert.Name, DomainPatterns: []string{b.ComputeKubeAPIServerHost()}})
+	}
+
 	return config
 }
 

--- a/pkg/operation/botanist/kubeapiserverexposure.go
+++ b/pkg/operation/botanist/kubeapiserverexposure.go
@@ -173,16 +173,7 @@ func (b *Botanist) DefaultKubeAPIServerIngress() (component.Deployer, error) {
 func (b *Botanist) DeployKubeAPIServerIngress(ctx context.Context) error {
 	// Do not deploy ingress if there is no wildcard certificate
 	if b.ControlPlaneWildcardCert == nil {
-		return b.DestroyKubeAPIServerIngress(ctx)
+		return b.Shoot.Components.ControlPlane.KubeAPIServerIngress.Destroy(ctx)
 	}
 	return b.Shoot.Components.ControlPlane.KubeAPIServerIngress.Deploy(ctx)
-}
-
-// DestroyKubeAPIServerIngress destroys the ingress for the kube-apiserver.
-func (b *Botanist) DestroyKubeAPIServerIngress(ctx context.Context) error {
-	return kubeapiserverexposure.NewIngress(
-		b.SeedClientSet.Client(),
-		b.Shoot.SeedNamespace,
-		kubeapiserverexposure.IngressValues{},
-	).Destroy(ctx)
 }

--- a/pkg/operation/botanist/kubeapiserverexposure.go
+++ b/pkg/operation/botanist/kubeapiserverexposure.go
@@ -152,31 +152,37 @@ func (b *Botanist) setAPIServerServiceClusterIP(clusterIP string) {
 	)
 }
 
-// DeployKubeAPIServerIngress deploys ingress for the kube-apiserver.
+// DefaultKubeAPIServerIngress returns a deployer for the kube-apiserver ingress.
+func (b *Botanist) DefaultKubeAPIServerIngress() (component.Deployer, error) {
+	ingressClass, err := gardenerutils.ComputeNginxIngressClassForSeed(b.Seed.GetInfo(), b.Seed.GetInfo().Status.KubernetesVersion)
+	if err != nil {
+		return nil, err
+	}
+
+	return kubeapiserverexposure.NewIngress(
+		b.SeedClientSet.Client(),
+		b.Shoot.SeedNamespace,
+		kubeapiserverexposure.IngressValues{
+			ServiceName:      v1beta1constants.DeploymentNameKubeAPIServer,
+			Host:             b.ComputeKubeAPIServerHost(),
+			IngressClassName: &ingressClass,
+		}), nil
+}
+
+// DeployKubeAPIServerIngress deploys the ingress for the kube-apiserver.
 func (b *Botanist) DeployKubeAPIServerIngress(ctx context.Context) error {
 	// Do not deploy ingress if there is no wildcard certificate
 	if b.ControlPlaneWildcardCert == nil {
 		return b.DestroyKubeAPIServerIngress(ctx)
 	}
-	ingressClass, err := gardenerutils.ComputeNginxIngressClassForSeed(b.Seed.GetInfo(), b.Seed.GetInfo().Status.KubernetesVersion)
-	if err != nil {
-		return err
-	}
-	return kubeapiserverexposure.NewIngress(
-		b.SeedClientSet.Client(),
-		client.ObjectKey{Name: v1beta1constants.DeploymentNameKubeAPIServer, Namespace: b.Shoot.SeedNamespace},
-		kubeapiserverexposure.IngressValues{
-			ServiceName:      v1beta1constants.DeploymentNameKubeAPIServer,
-			Host:             b.ComputeKubeAPIServerHost(),
-			IngressClassName: &ingressClass,
-		}).Deploy(ctx)
+	return b.Shoot.Components.ControlPlane.KubeAPIServerIngress.Deploy(ctx)
 }
 
-// DestroyKubeAPIServerIngress deploys ingress for the kube-apiserver.
+// DestroyKubeAPIServerIngress destroys the ingress for the kube-apiserver.
 func (b *Botanist) DestroyKubeAPIServerIngress(ctx context.Context) error {
 	return kubeapiserverexposure.NewIngress(
 		b.SeedClientSet.Client(),
-		client.ObjectKey{Name: v1beta1constants.DeploymentNameKubeAPIServer, Namespace: b.Shoot.SeedNamespace},
+		b.Shoot.SeedNamespace,
 		kubeapiserverexposure.IngressValues{},
 	).Destroy(ctx)
 }

--- a/pkg/operation/common/types.go
+++ b/pkg/operation/common/types.go
@@ -18,8 +18,8 @@ const (
 	// VPNTunnel dictates that VPN is used as a tunnel between seed and shoot networks.
 	VPNTunnel string = "vpn-shoot"
 
-	// KubeAPIServerUsersPrefix is a constant for a prefix used for the users KubeAPIServer instance using a TLS certificate from a trusted origin.
-	KubeAPIServerUsersPrefix = "api"
+	// KubeAPIServerPrefix is a constant for a prefix used for the users KubeAPIServer instance which uses a TLS certificate from a trusted origin.
+	KubeAPIServerPrefix = "api"
 
 	// GrafanaUsersPrefix is a constant for a prefix used for the users Grafana instance.
 	GrafanaUsersPrefix = "gu"

--- a/pkg/operation/common/types.go
+++ b/pkg/operation/common/types.go
@@ -18,7 +18,7 @@ const (
 	// VPNTunnel dictates that VPN is used as a tunnel between seed and shoot networks.
 	VPNTunnel string = "vpn-shoot"
 
-	// KubeAPIServerPrefix is a constant for a prefix used for the users KubeAPIServer instance which uses a TLS certificate from a trusted origin.
+	// KubeAPIServerPrefix is a constant for a prefix used for the KubeAPIServer instance which uses a TLS certificate from a trusted origin.
 	KubeAPIServerPrefix = "api"
 
 	// GrafanaUsersPrefix is a constant for a prefix used for the users Grafana instance.

--- a/pkg/operation/common/types.go
+++ b/pkg/operation/common/types.go
@@ -18,6 +18,9 @@ const (
 	// VPNTunnel dictates that VPN is used as a tunnel between seed and shoot networks.
 	VPNTunnel string = "vpn-shoot"
 
+	// KubeAPIServerUsersPrefix is a constant for a prefix used for the users KubeAPIServer instance using a TLS certificate from a trusted origin.
+	KubeAPIServerUsersPrefix = "api"
+
 	// GrafanaUsersPrefix is a constant for a prefix used for the users Grafana instance.
 	GrafanaUsersPrefix = "gu"
 

--- a/pkg/operation/operation.go
+++ b/pkg/operation/operation.go
@@ -580,7 +580,7 @@ func (o *Operation) WantsGrafana() bool {
 
 // ComputeKubeAPIServerHost computes the host with a TLS certificate from a trusted origin for KubeAPIServer.
 func (o *Operation) ComputeKubeAPIServerHost() string {
-	return o.ComputeIngressHost(common.KubeAPIServerUsersPrefix)
+	return o.ComputeIngressHost(common.KubeAPIServerPrefix)
 }
 
 // ComputeGrafanaHost computes the host for Grafana.

--- a/pkg/operation/operation.go
+++ b/pkg/operation/operation.go
@@ -578,6 +578,11 @@ func (o *Operation) WantsGrafana() bool {
 	return o.Shoot.Purpose != gardencorev1beta1.ShootPurposeTesting && (helper.IsMonitoringEnabled(o.Config) || helper.IsLokiEnabled(o.Config))
 }
 
+// ComputeKubeAPIServerHost computes the host with a TLS certificate from a trusted origin for KubeAPIServer.
+func (o *Operation) ComputeKubeAPIServerHost() string {
+	return o.ComputeIngressHost(common.KubeAPIServerUsersPrefix)
+}
+
 // ComputeGrafanaHost computes the host for Grafana.
 func (o *Operation) ComputeGrafanaHost() string {
 	return o.ComputeIngressHost(common.GrafanaUsersPrefix)

--- a/pkg/operation/shoot/types.go
+++ b/pkg/operation/shoot/types.go
@@ -119,6 +119,7 @@ type ControlPlane struct {
 	EtcdMain              etcd.Interface
 	EtcdEvents            etcd.Interface
 	EtcdCopyBackupsTask   etcdcopybackupstask.Interface
+	KubeAPIServerIngress  component.Deployer
 	KubeAPIServerService  component.DeployWaiter
 	KubeAPIServerSNI      component.DeployWaiter
 	KubeAPIServerSNIPhase component.Phase


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement

**What this PR does / why we need it**:
This PR exposes the `kube-apiservers` of `Shoot` with the trusted wildcard certificate via Ingress if it exists. 
Their addresses look like: `https://api-<project-name>--<shoot-name>.<seed-ingress-domain>`.
If there is no wildcard certificate on the seed the ingress object is not created.
This endpoint **should not** be used by end-users - they should continue using the URL provided by Gardener in their kubeconfigs.

**Which issue(s) this PR fixes**:
Fixes #7233 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
NONE
```
