### PR TITLE
Update architecture.md to remove extra parenthesis

### DIFF
--- a/docs/concepts/architecture.md
+++ b/docs/concepts/architecture.md
@@ -14,7 +14,7 @@ We provide a central operator UI, which we call the "Gardener Dashboard". It tal
 
 * Create a namespace in the "seed" cluster for the "shoot" cluster, which will host the "shoot" cluster control plane.
 * Generate secrets and credentials, which the worker nodes will need to talk to the control plane.
-* Create the infrastructure (using [Terraform](https://www.terraform.io/)), which basically consists out of the network setup).
+* Create the infrastructure (using [Terraform](https://www.terraform.io/)), which basically consists out of the network setup.
 * Deploy the "shoot" cluster control plane into the "shoot" namespace in the "seed" cluster, containing the "machine-controller-manager" pod.
 * Create machine CRDs in the "seed" cluster, describing the configuration and the number of worker machines for the "shoot" (the machine-controller-manager watches the CRDs and creates virtual machines out of it).
 * Wait for the "shoot" cluster API server to become responsive (pods will be scheduled, persistent volumes and load balancers are created by Kubernetes via the respective cloud provider).


### PR DESCRIPTION
A close parenthesis was included without an open paren.  Removed it to improve readability.

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area documentation
/kind cleanup

**What this PR does / why we need it**:
fixes a typo

**Which issue(s) this PR fixes**:
Fixes # 
none

**Special notes for your reviewer**:
simple typo fix.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       doc
- target_group:   operator
-->
```documentation operator 
NONE
```
