### PR TITLE
[operator] Consider name prefix for KAPI server certificate

### DIFF
--- a/pkg/operation/botanist/component/kubeapiserver/secrets.go
+++ b/pkg/operation/botanist/component/kubeapiserver/secrets.go
@@ -259,11 +259,12 @@ func aesKeyFromSecretData(data map[string][]byte) apiserverconfigv1.Key {
 
 func (k *kubeAPIServer) reconcileSecretServer(ctx context.Context) (*corev1.Secret, error) {
 	var (
-		ipAddresses = append([]net.IP{}, k.values.ServerCertificate.ExtraIPAddresses...)
-		dnsNames    = []string{
-			v1beta1constants.DeploymentNameKubeAPIServer,
-			fmt.Sprintf("%s.%s", v1beta1constants.DeploymentNameKubeAPIServer, k.namespace),
-			fmt.Sprintf("%s.%s.svc", v1beta1constants.DeploymentNameKubeAPIServer, k.namespace),
+		ipAddresses    = append([]net.IP{}, k.values.ServerCertificate.ExtraIPAddresses...)
+		deploymentName = k.values.NamePrefix + v1beta1constants.DeploymentNameKubeAPIServer
+		dnsNames       = []string{
+			deploymentName,
+			fmt.Sprintf("%s.%s", deploymentName, k.namespace),
+			fmt.Sprintf("%s.%s.svc", deploymentName, k.namespace),
 		}
 	)
 
@@ -277,7 +278,7 @@ func (k *kubeAPIServer) reconcileSecretServer(ctx context.Context) (*corev1.Secr
 
 	return k.secretsManager.Generate(ctx, &secretsutils.CertificateSecretConfig{
 		Name:                        secretNameServer,
-		CommonName:                  v1beta1constants.DeploymentNameKubeAPIServer,
+		CommonName:                  deploymentName,
 		IPAddresses:                 append(ipAddresses, k.values.ServerCertificate.ExtraIPAddresses...),
 		DNSNames:                    append(dnsNames, k.values.ServerCertificate.ExtraDNSNames...),
 		CertType:                    secretsutils.ServerCert,


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind enhancement

**What this PR does / why we need it**:
Consider name prefix for KAPI server certificate.

**Which issue(s) this PR fixes**:
Part of #7016 

**Special notes for your reviewer**:
/cc @timuthy 
Introduced with #7730 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
