### PR TITLE
Also add `.cluster.local` suffix to KAPI server cert SANS

### DIFF
--- a/example/90-shoot.yaml
+++ b/example/90-shoot.yaml
@@ -188,6 +188,8 @@ spec:
   #     maxNonMutatingInflight: 400
   #     maxMutatingInflight: 200
   #   enableAnonymousAuthentication: false # See: https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/
+  #   apiAudiences:
+  #   - foo
   #   serviceAccountConfig:
   #     issuer: foo
   #     acceptedIssuers:

--- a/pkg/operation/botanist/component/kubeapiserver/secrets.go
+++ b/pkg/operation/botanist/component/kubeapiserver/secrets.go
@@ -261,11 +261,7 @@ func (k *kubeAPIServer) reconcileSecretServer(ctx context.Context) (*corev1.Secr
 	var (
 		ipAddresses    = append([]net.IP{}, k.values.ServerCertificate.ExtraIPAddresses...)
 		deploymentName = k.values.NamePrefix + v1beta1constants.DeploymentNameKubeAPIServer
-		dnsNames       = []string{
-			deploymentName,
-			fmt.Sprintf("%s.%s", deploymentName, k.namespace),
-			fmt.Sprintf("%s.%s.svc", deploymentName, k.namespace),
-		}
+		dnsNames       = kubernetesutils.DNSNamesForService(deploymentName, k.namespace)
 	)
 
 	if k.values.SNI.PodMutatorEnabled || (k.values.VPN.Enabled && k.values.VPN.HighAvailabilityEnabled) {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind enhancement

**What this PR does / why we need it**:
This PR adds the `.cluster.local` suffix to the server certificate of `kube-apiserver`.

**Special notes for your reviewer**:
Earlier, it was only possible to communicate with the API server via `<service-name>`, `<service-name>.<namespace>`, `<service-name>.<namespace>.svc`, but not via `<service-name>.<namespace>.svc.cluster.local`.

/cc @timuthy 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
The server certificate of the `kube-apiserver` deployment now contains the `<service-name>.<namespace>.svc.cluster.local` SAN.
```
