### PR TITLE
Add back `--use-env` in `prepare-envtest.sh`

### DIFF
--- a/hack/prepare-envtest.sh
+++ b/hack/prepare-envtest.sh
@@ -26,7 +26,8 @@ if ! command -v setup-envtest &> /dev/null ; then
   exit 1
 fi
 
-export KUBEBUILDER_ASSETS="$(setup-envtest use -p path ${ENVTEST_K8S_VERSION})"
+# --use-env allows overwriting the envtest tools path via the KUBEBUILDER_ASSETS env var just like it was before
+export KUBEBUILDER_ASSETS="$(setup-envtest use --use-env -p path ${ENVTEST_K8S_VERSION})"
 echo "using envtest tools installed at '$KUBEBUILDER_ASSETS'"
 
 source "$(dirname "$0")/test-integration.env"

--- a/hack/prepare-envtest.sh
+++ b/hack/prepare-envtest.sh
@@ -26,7 +26,7 @@ if ! command -v setup-envtest &> /dev/null ; then
   exit 1
 fi
 
-# --use-env allows overwriting the envtest tools path via the KUBEBUILDER_ASSETS env var just like it was before
+# --use-env allows overwriting the envtest tools path via the KUBEBUILDER_ASSETS env var
 export KUBEBUILDER_ASSETS="$(setup-envtest use --use-env -p path ${ENVTEST_K8S_VERSION})"
 echo "using envtest tools installed at '$KUBEBUILDER_ASSETS'"
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind regression

**What this PR does / why we need it**:

The `--use-env` argument for `setup-envtest` went missing in https://github.com/gardener/gardener/pull/6948.
This PR adds the arg back so that one can overwrite the assets directory via `KUBEBUILDER_ASSETS` as it was before.

