### PR TITLE
Add webhook handlers to all GOP instances

### DIFF
--- a/skaffold-operator.yaml
+++ b/skaffold-operator.yaml
@@ -244,5 +244,6 @@ deploy:
             tag: '{{.IMAGE_TAG_eu_gcr_io_gardener_project_gardener_resource_manager}}@{{.IMAGE_DIGEST_eu_gcr_io_gardener_project_gardener_resource_manager}}'
         hostAliases[0].ip: "10.2.10.2"
         hostAliases[0].hostnames[0]: api.virtual-garden.local.gardener.cloud
+        replicaCount: 2
       createNamespace: true
       wait: true


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/area ipcei
/kind bug

**What this PR does / why we need it**:
Earlier, webhook handlers were only added when the Gardener Operator instance gained leadership. This caused `404` responses if webhook requests were sent to non-leaders.

**Special notes for your reviewer**:
/cc @rfranzke

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
A bug has been fixed for the Gardener Operator that occasionally caused "404 not-found" errors when `garden` resources where applied and the operator ran with multiple replicas.
```
