### PR TITLE
Change `update-local-ca-certificates` script path

### DIFF
--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/rootcertificates/component.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/rootcertificates/component.go
@@ -32,7 +32,7 @@ import (
 
 const (
 	pathLocalSSLCerts             = "/var/lib/ca-certificates-local"
-	pathUpdateLocalCaCertificates = "/etc/ssl/update-local-ca-certificates.sh"
+	pathUpdateLocalCaCertificates = "/var/lib/ssl/update-local-ca-certificates.sh"
 )
 
 var (

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/rootcertificates/component_test.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/rootcertificates/component_test.go
@@ -70,7 +70,7 @@ ConditionPathIsReadWrite=/var/lib/ca-certificates-local
 ConditionPathExists=!/var/lib/kubelet/kubeconfig-real
 [Service]
 Type=oneshot
-ExecStart=/etc/ssl/update-local-ca-certificates.sh
+ExecStart=/var/lib/ssl/update-local-ca-certificates.sh
 ExecStartPost=/bin/systemctl restart docker.service
 [Install]
 WantedBy=multi-user.target`),
@@ -78,7 +78,7 @@ WantedBy=multi-user.target`),
 			))
 			Expect(files).To(ConsistOf(
 				extensionsv1alpha1.File{
-					Path:        "/etc/ssl/update-local-ca-certificates.sh",
+					Path:        "/var/lib/ssl/update-local-ca-certificates.sh",
 					Permissions: pointer.Int32(0744),
 					Content: extensionsv1alpha1.FileContent{
 						Inline: &extensionsv1alpha1.FileContentInline{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/area compliance
/kind enhancement

**What this PR does / why we need it**:
This PR change the path of `update-local-ca-certificates.sh` script from `/etc/ssl` to `/var/lib/ssl` on our worker nodes. The `/etc/ssl` directory is mounted by the `kube-apiserver` pods, where it is ill-advised to have files with execute permission. The `update-local-ca-certificates.sh` script is only used by the `updatecacerts` service, removing it from `kube-apiserver` pods would not cause changes to functionality.
This PR is in sync with Kubernetes' STIG. See rule [242458](https://www.stigviewer.com/stig/kubernetes/2022-12-02/finding/V-242458) for more details.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Change the path of `update-local-ca-certificates.sh` script from `/etc/ssl` to `/var/lib/ssl` on our worker nodes.
```
