### PR TITLE
Bump `nginx-ingress-controller-seed` to `v1.7.0` for `1.24.x+` seeds

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -64,7 +64,21 @@ images:
   sourceRepository: github.com/kubernetes/ingress-nginx
   repository: registry.k8s.io/ingress-nginx/controller-chroot
   tag: "v1.6.4"
-  targetVersion: ">= 1.23"
+  targetVersion: "1.23.x"
+  labels:
+  - name: 'gardener.cloud/cve-categorisation'
+    value:
+      network_exposure: 'public'
+      authentication_enforced: true
+      user_interaction: 'end-user'
+      confidentiality_requirement: 'low'
+      integrity_requirement: 'low'
+      availability_requirement: 'low'
+- name: nginx-ingress-controller-seed
+  sourceRepository: github.com/kubernetes/ingress-nginx
+  repository: registry.k8s.io/ingress-nginx/controller-chroot
+  tag: "v1.7.0"
+  targetVersion: ">= 1.24"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane open-source
/kind enhancement

**What this PR does / why we need it**:
Bump `nginx-ingress-controller-seed` to `v1.7.0` for `1.24.x+` seeds
See compatibility matrix: https://github.com/kubernetes/ingress-nginx#supported-versions-table

https://github.com/kubernetes/ingress-nginx/releases/tag/controller-v1.7.0


**Which issue(s) this PR fixes**:
```
nginx-ingress-controller:v1.6.4
curl:7.87.0-r1 - CVE-2023-23914 (9.1), CVE-2023-23915 (6.5), CVE-2023-23916 (7.5)
golang-runtime:1.19.4 - CVE-2022-41722 (7.5), CVE-2022-41723 (7.5), CVE-2022-41724 (7.5), CVE-2022-41725 (7.5), CVE-2023-24532 (5.3)
nginx:1.21.6 - CVE-2022-41741 (7.8), CVE-2022-41742 (7.1)
openssl:3.0.7-r0 - CVE-2022-3996 (7.5), CVE-2022-4203 (4.9), CVE-2022-4304 (5.9)
runc:v1.1.4 - CVE-2023-27561 (7.0)
thrift:0.12.0 - CVE-2019-0205 (7.5), CVE-2019-0210 (7.5), CVE-2020-13949 (7.5)
```

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
`nginx-ingress-controller-seed` image is updated to `v1.7.0` for `1.24.x+` seeds.
```
