### PR TITLE
gardenlet: Prevent panic on startup when there is a terminating Namespace

### DIFF
--- a/cmd/gardenlet/app/app.go
+++ b/cmd/gardenlet/app/app.go
@@ -610,6 +610,11 @@ func migrationTasksForShootVPARecommenders(cl client.Client, shootNamespaces []c
 	for _, ns := range shootNamespaces {
 		namespace := ns
 
+		// It is forbidden to create a new resource in already terminating Namespace.
+		if namespace.DeletionTimestamp != nil {
+			continue
+		}
+
 		taskFns = append(taskFns, func(ctx context.Context) error {
 			service := &corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind bug
/kind regression

**What this PR does / why we need it**:
When there is already a terminating Namespace in the Seed cluster, gardenlet fails to startup with:
```
panic: 1 error occurred:
	* services "vpa-recommender" is forbidden: unable to create new content in namespace shoot--foo--bar because it is being terminated



goroutine 1 [running]:
main.main()
	/go/src/github.com/gardener/gardener/cmd/gardenlet/main.go:30 +0x5a
```

In K8s, it is forbidden to create a new resource in already Terminating namespace.
The issue was introduced with https://github.com/gardener/gardener/pull/7636.

**Which issue(s) this PR fixes**:
See above

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
A panic causing gardenlet to fail to startup when there is already a terminating Shoot namespace in the Seed is now fixed.
```
