### PR TITLE
Enable memory-saver mode for VPA recommender

### DIFF
--- a/pkg/operation/botanist/component/vpa/recommender.go
+++ b/pkg/operation/botanist/component/vpa/recommender.go
@@ -204,6 +204,7 @@ func (v *vpa) reconcileRecommenderDeployment(deployment *appsv1.Deployment, serv
 						fmt.Sprintf("--recommender-interval=%s", durationDeref(v.values.Recommender.Interval, gardencorev1beta1.DefaultRecommenderInterval).Duration),
 						"--kube-api-qps=100",
 						"--kube-api-burst=120",
+						"--memory-saver=true",
 					},
 					LivenessProbe: newDefaultLivenessProbe(),
 					Ports: []corev1.ContainerPort{

--- a/pkg/operation/botanist/component/vpa/vpa_test.go
+++ b/pkg/operation/botanist/component/vpa/vpa_test.go
@@ -646,6 +646,7 @@ var _ = Describe("VPA", func() {
 									fmt.Sprintf("--recommender-interval=%s", flagRecommenderIntervalValue),
 									"--kube-api-qps=100",
 									"--kube-api-burst=120",
+									"--memory-saver=true",
 								},
 								LivenessProbe: livenessProbeVpa,
 								Ports: []corev1.ContainerPort{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area auto-scaling
/kind enhancement

**What this PR does / why we need it**:
Enable memory-saver mode for VPA recommender. This makes the recommender keep only those `ContainerState`s for which a VPA already exists. Running in non-memory-saver mode allows people to deploy a VPA for a Pod that has been running for a while already and immediately get reasonable recommendations. That's not the use-case we're optimizing for, instead we're more interested in running a resource-efficient recommender.

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Enable memory-saver mode for the VPA recommender. It stops tracking resource consumption for Containers without matching VPAs and frees up memory.
```
