### PR TITLE
Deprecate the Seed `.spec.settings.ownerChecks` field in gardener core API

### DIFF
--- a/docs/api-reference/core.md
+++ b/docs/api-reference/core.md
@@ -9075,6 +9075,9 @@ Defaults to &ldquo;Cluster&rdquo;.</p>
 </p>
 <p>
 <p>SeedSettingOwnerChecks controls certain owner checks settings for shoots scheduled on this seed.</p>
+<p>Deprecated: This field is deprecated. The &ldquo;bad-case&rdquo; control plane migration is being removed in favor of the HA Shoot control planes (see <a href="https://github.com/gardener/gardener/issues/6302">https://github.com/gardener/gardener/issues/6302</a>).
+The field will be locked to false in a future version of Gardener. In this way gardenlet will clean up all owner DNSRecords. Finally, the field will be removed from the API.
+Set this field to false to be prepared for the above-mentioned locking.</p>
 </p>
 <table>
 <thead>
@@ -9279,6 +9282,9 @@ SeedSettingOwnerChecks
 <td>
 <em>(Optional)</em>
 <p>SeedSettingOwnerChecks controls certain owner checks settings for shoots scheduled on this seed.</p>
+<p>Deprecated: This field is deprecated. The &ldquo;bad-case&rdquo; control plane migration is being removed in favor of the HA Shoot control planes (see <a href="https://github.com/gardener/gardener/issues/6302">https://github.com/gardener/gardener/issues/6302</a>).
+The field will be locked to false in a future version of Gardener. In this way gardenlet will clean up all owner DNSRecords. Finally, the field will be removed from the API.
+Set this field to false to be prepared for the above-mentioned locking.</p>
 </td>
 </tr>
 <tr>

--- a/docs/usage/seed_settings.md
+++ b/docs/usage/seed_settings.md
@@ -111,6 +111,8 @@ By setting the `.spec.settings.verticalPodAutoscaler.enabled=false`, you can dis
 
 ## Owner Checks
 
+> Note: The owner checks are deprecated. The "bad-case" control plane migration is being removed in favor of the HA Shoot control planes (see https://github.com/gardener/gardener/issues/6302). The field will be locked to `false` in a future version of Gardener. In this way gardenlet will clean up all owner DNSRecords. Finally, the field will be removed from the API. Set this field to `false` to be prepared for the above-mentioned locking.
+
 When a shoot is scheduled to a seed and actually reconciled, Gardener appoints the seed as the current "owner" of the shoot by creating a special "owner DNS record" and checking against it if the seed still owns the shoot in order to guard against "split brain scenario" during control plane migration, as described in [GEP-17 Shoot Control Plane Migration "Bad Case" Scenario](../proposals/17-shoot-control-plane-migration-bad-case.md).
 This mechanism relies on the DNS resolution of TXT DNS records being possible and highly reliable, since if the owner check fails, the shoot will be effectively disabled for the duration of the failure.
 In environments where resolving TXT DNS records is either not possible or not considered reliable enough, it may be necessary to disable the owner check mechanism, in order to avoid shoots failing to reconcile or temporary outages due to transient DNS failures.

--- a/pkg/apis/core/types_seed.go
+++ b/pkg/apis/core/types_seed.go
@@ -203,6 +203,10 @@ type SeedSettings struct {
 	// VerticalPodAutoscaler controls certain settings for the vertical pod autoscaler components deployed in the seed.
 	VerticalPodAutoscaler *SeedSettingVerticalPodAutoscaler
 	// SeedSettingOwnerChecks controls certain owner checks settings for shoots scheduled on this seed.
+	//
+	// Deprecated: This field is deprecated. The "bad-case" control plane migration is being removed in favor of the HA Shoot control planes (see https://github.com/gardener/gardener/issues/6302).
+	// The field will be locked to false in a future version of Gardener. In this way gardenlet will clean up all owner DNSRecords. Finally, the field will be removed from the API.
+	// Set this field to false to be prepared for the above-mentioned locking.
 	OwnerChecks *SeedSettingOwnerChecks
 	// DependencyWatchdog controls certain settings for the dependency-watchdog components deployed in the seed.
 	DependencyWatchdog *SeedSettingDependencyWatchdog
@@ -262,6 +266,10 @@ type SeedSettingVerticalPodAutoscaler struct {
 }
 
 // SeedSettingOwnerChecks controls certain owner checks settings for shoots scheduled on this seed.
+//
+// Deprecated: This field is deprecated. The "bad-case" control plane migration is being removed in favor of the HA Shoot control planes (see https://github.com/gardener/gardener/issues/6302).
+// The field will be locked to false in a future version of Gardener. In this way gardenlet will clean up all owner DNSRecords. Finally, the field will be removed from the API.
+// Set this field to false to be prepared for the above-mentioned locking.
 type SeedSettingOwnerChecks struct {
 	// Enabled controls whether owner checks are enabled for shoots scheduled on this seed. It
 	// is enabled by default because it is a prerequisite for control plane migration.

--- a/pkg/apis/core/v1alpha1/generated.proto
+++ b/pkg/apis/core/v1alpha1/generated.proto
@@ -2219,6 +2219,10 @@ message SeedSettingLoadBalancerServicesZones {
 }
 
 // SeedSettingOwnerChecks controls certain owner checks settings for shoots scheduled on this seed.
+//
+// Deprecated: This field is deprecated. The "bad-case" control plane migration is being removed in favor of the HA Shoot control planes (see https://github.com/gardener/gardener/issues/6302).
+// The field will be locked to false in a future version of Gardener. In this way gardenlet will clean up all owner DNSRecords. Finally, the field will be removed from the API.
+// Set this field to false to be prepared for the above-mentioned locking.
 message SeedSettingOwnerChecks {
   // Enabled controls whether owner checks are enabled for shoots scheduled on this seed. It
   // is enabled by default because it is a prerequisite for control plane migration.
@@ -2268,6 +2272,10 @@ message SeedSettings {
   optional SeedSettingVerticalPodAutoscaler verticalPodAutoscaler = 5;
 
   // SeedSettingOwnerChecks controls certain owner checks settings for shoots scheduled on this seed.
+  //
+  // Deprecated: This field is deprecated. The "bad-case" control plane migration is being removed in favor of the HA Shoot control planes (see https://github.com/gardener/gardener/issues/6302).
+  // The field will be locked to false in a future version of Gardener. In this way gardenlet will clean up all owner DNSRecords. Finally, the field will be removed from the API.
+  // Set this field to false to be prepared for the above-mentioned locking.
   // +optional
   optional SeedSettingOwnerChecks ownerChecks = 6;
 

--- a/pkg/apis/core/v1alpha1/types_seed.go
+++ b/pkg/apis/core/v1alpha1/types_seed.go
@@ -229,6 +229,10 @@ type SeedSettings struct {
 	// +optional
 	VerticalPodAutoscaler *SeedSettingVerticalPodAutoscaler `json:"verticalPodAutoscaler,omitempty" protobuf:"bytes,5,opt,name=verticalPodAutoscaler"`
 	// SeedSettingOwnerChecks controls certain owner checks settings for shoots scheduled on this seed.
+	//
+	// Deprecated: This field is deprecated. The "bad-case" control plane migration is being removed in favor of the HA Shoot control planes (see https://github.com/gardener/gardener/issues/6302).
+	// The field will be locked to false in a future version of Gardener. In this way gardenlet will clean up all owner DNSRecords. Finally, the field will be removed from the API.
+	// Set this field to false to be prepared for the above-mentioned locking.
 	// +optional
 	OwnerChecks *SeedSettingOwnerChecks `json:"ownerChecks,omitempty" protobuf:"bytes,6,opt,name=ownerChecks"`
 	// DependencyWatchdog controls certain settings for the dependency-watchdog components deployed in the seed.
@@ -295,6 +299,10 @@ type SeedSettingVerticalPodAutoscaler struct {
 }
 
 // SeedSettingOwnerChecks controls certain owner checks settings for shoots scheduled on this seed.
+//
+// Deprecated: This field is deprecated. The "bad-case" control plane migration is being removed in favor of the HA Shoot control planes (see https://github.com/gardener/gardener/issues/6302).
+// The field will be locked to false in a future version of Gardener. In this way gardenlet will clean up all owner DNSRecords. Finally, the field will be removed from the API.
+// Set this field to false to be prepared for the above-mentioned locking.
 type SeedSettingOwnerChecks struct {
 	// Enabled controls whether owner checks are enabled for shoots scheduled on this seed. It
 	// is enabled by default because it is a prerequisite for control plane migration.

--- a/pkg/apis/core/v1beta1/generated.proto
+++ b/pkg/apis/core/v1beta1/generated.proto
@@ -2227,6 +2227,10 @@ message SeedSettingLoadBalancerServicesZones {
 }
 
 // SeedSettingOwnerChecks controls certain owner checks settings for shoots scheduled on this seed.
+//
+// Deprecated: This field is deprecated. The "bad-case" control plane migration is being removed in favor of the HA Shoot control planes (see https://github.com/gardener/gardener/issues/6302).
+// The field will be locked to false in a future version of Gardener. In this way gardenlet will clean up all owner DNSRecords. Finally, the field will be removed from the API.
+// Set this field to false to be prepared for the above-mentioned locking.
 message SeedSettingOwnerChecks {
   // Enabled controls whether owner checks are enabled for shoots scheduled on this seed. It
   // is enabled by default because it is a prerequisite for control plane migration.
@@ -2276,6 +2280,10 @@ message SeedSettings {
   optional SeedSettingVerticalPodAutoscaler verticalPodAutoscaler = 5;
 
   // SeedSettingOwnerChecks controls certain owner checks settings for shoots scheduled on this seed.
+  //
+  // Deprecated: This field is deprecated. The "bad-case" control plane migration is being removed in favor of the HA Shoot control planes (see https://github.com/gardener/gardener/issues/6302).
+  // The field will be locked to false in a future version of Gardener. In this way gardenlet will clean up all owner DNSRecords. Finally, the field will be removed from the API.
+  // Set this field to false to be prepared for the above-mentioned locking.
   // +optional
   optional SeedSettingOwnerChecks ownerChecks = 6;
 

--- a/pkg/apis/core/v1beta1/types_seed.go
+++ b/pkg/apis/core/v1beta1/types_seed.go
@@ -246,6 +246,10 @@ type SeedSettings struct {
 	// +optional
 	VerticalPodAutoscaler *SeedSettingVerticalPodAutoscaler `json:"verticalPodAutoscaler,omitempty" protobuf:"bytes,5,opt,name=verticalPodAutoscaler"`
 	// SeedSettingOwnerChecks controls certain owner checks settings for shoots scheduled on this seed.
+	//
+	// Deprecated: This field is deprecated. The "bad-case" control plane migration is being removed in favor of the HA Shoot control planes (see https://github.com/gardener/gardener/issues/6302).
+	// The field will be locked to false in a future version of Gardener. In this way gardenlet will clean up all owner DNSRecords. Finally, the field will be removed from the API.
+	// Set this field to false to be prepared for the above-mentioned locking.
 	// +optional
 	OwnerChecks *SeedSettingOwnerChecks `json:"ownerChecks,omitempty" protobuf:"bytes,6,opt,name=ownerChecks"`
 	// DependencyWatchdog controls certain settings for the dependency-watchdog components deployed in the seed.
@@ -312,6 +316,10 @@ type SeedSettingVerticalPodAutoscaler struct {
 }
 
 // SeedSettingOwnerChecks controls certain owner checks settings for shoots scheduled on this seed.
+//
+// Deprecated: This field is deprecated. The "bad-case" control plane migration is being removed in favor of the HA Shoot control planes (see https://github.com/gardener/gardener/issues/6302).
+// The field will be locked to false in a future version of Gardener. In this way gardenlet will clean up all owner DNSRecords. Finally, the field will be removed from the API.
+// Set this field to false to be prepared for the above-mentioned locking.
 type SeedSettingOwnerChecks struct {
 	// Enabled controls whether owner checks are enabled for shoots scheduled on this seed. It
 	// is enabled by default because it is a prerequisite for control plane migration.

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -6699,7 +6699,7 @@ func schema_pkg_apis_core_v1alpha1_SeedSettingOwnerChecks(ref common.ReferenceCa
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "SeedSettingOwnerChecks controls certain owner checks settings for shoots scheduled on this seed.",
+				Description: "SeedSettingOwnerChecks controls certain owner checks settings for shoots scheduled on this seed.\n\nDeprecated: This field is deprecated. The \"bad-case\" control plane migration is being removed in favor of the HA Shoot control planes (see https://github.com/gardener/gardener/issues/6302). The field will be locked to false in a future version of Gardener. In this way gardenlet will clean up all owner DNSRecords. Finally, the field will be removed from the API. Set this field to false to be prepared for the above-mentioned locking.",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"enabled": {
@@ -6816,7 +6816,7 @@ func schema_pkg_apis_core_v1alpha1_SeedSettings(ref common.ReferenceCallback) co
 					},
 					"ownerChecks": {
 						SchemaProps: spec.SchemaProps{
-							Description: "SeedSettingOwnerChecks controls certain owner checks settings for shoots scheduled on this seed.",
+							Description: "SeedSettingOwnerChecks controls certain owner checks settings for shoots scheduled on this seed.\n\nDeprecated: This field is deprecated. The \"bad-case\" control plane migration is being removed in favor of the HA Shoot control planes (see https://github.com/gardener/gardener/issues/6302). The field will be locked to false in a future version of Gardener. In this way gardenlet will clean up all owner DNSRecords. Finally, the field will be removed from the API. Set this field to false to be prepared for the above-mentioned locking.",
 							Ref:         ref("github.com/gardener/gardener/pkg/apis/core/v1alpha1.SeedSettingOwnerChecks"),
 						},
 					},
@@ -14457,7 +14457,7 @@ func schema_pkg_apis_core_v1beta1_SeedSettingOwnerChecks(ref common.ReferenceCal
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "SeedSettingOwnerChecks controls certain owner checks settings for shoots scheduled on this seed.",
+				Description: "SeedSettingOwnerChecks controls certain owner checks settings for shoots scheduled on this seed.\n\nDeprecated: This field is deprecated. The \"bad-case\" control plane migration is being removed in favor of the HA Shoot control planes (see https://github.com/gardener/gardener/issues/6302). The field will be locked to false in a future version of Gardener. In this way gardenlet will clean up all owner DNSRecords. Finally, the field will be removed from the API. Set this field to false to be prepared for the above-mentioned locking.",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"enabled": {
@@ -14574,7 +14574,7 @@ func schema_pkg_apis_core_v1beta1_SeedSettings(ref common.ReferenceCallback) com
 					},
 					"ownerChecks": {
 						SchemaProps: spec.SchemaProps{
-							Description: "SeedSettingOwnerChecks controls certain owner checks settings for shoots scheduled on this seed.",
+							Description: "SeedSettingOwnerChecks controls certain owner checks settings for shoots scheduled on this seed.\n\nDeprecated: This field is deprecated. The \"bad-case\" control plane migration is being removed in favor of the HA Shoot control planes (see https://github.com/gardener/gardener/issues/6302). The field will be locked to false in a future version of Gardener. In this way gardenlet will clean up all owner DNSRecords. Finally, the field will be removed from the API. Set this field to false to be prepared for the above-mentioned locking.",
 							Ref:         ref("github.com/gardener/gardener/pkg/apis/core/v1beta1.SeedSettingOwnerChecks"),
 						},
 					},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind api-change

**What this PR does / why we need it**:
Deprecates the Seed `.spec.settings.ownerChecks` field and the `SeedSettingOwnerChecks` type in the gardener API, so that they can be removed in a future Gardener release.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/6302

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The `.spec.settings.ownerChecks` field of the Seed configuration is deprecated. The "bad-case" control plane migration is being removed in favor of the HA Shoot control planes (see https://github.com/gardener/gardener/issues/6302). The field will be locked to `false` in a future version of Gardener. In this way gardenlet will clean up all owner DNSRecords. Finally, the field will be removed from the API. Set this field to `false` to be prepared for the above-mentioned locking.
```
