### PR TITLE
nginx ingress controller - add network policy label for communication to public networks

### DIFF
--- a/pkg/operation/botanist/component/nginxingress/nginxingress.go
+++ b/pkg/operation/botanist/component/nginxingress/nginxingress.go
@@ -419,6 +419,7 @@ func (n *nginxIngress) computeResourcesData() (map[string][]byte, error) {
 						Labels: utils.MergeStringMaps(getLabels(LabelValueController, labelValueAddons), map[string]string{
 							v1beta1constants.LabelNetworkPolicyToDNS:                                        v1beta1constants.LabelNetworkPolicyAllowed,
 							v1beta1constants.LabelNetworkPolicyToRuntimeAPIServer:                           v1beta1constants.LabelNetworkPolicyAllowed,
+							v1beta1constants.LabelNetworkPolicyToPublicNetworks:                             v1beta1constants.LabelNetworkPolicyAllowed,
 							gardenerutils.NetworkPolicyLabel(serviceNameBackend, int(containerPortBackend)): v1beta1constants.LabelNetworkPolicyAllowed,
 						}),
 						Annotations: map[string]string{

--- a/pkg/operation/botanist/component/nginxingress/nginxingress_test.go
+++ b/pkg/operation/botanist/component/nginxingress/nginxingress_test.go
@@ -471,6 +471,7 @@ spec:
         app: nginx-ingress
         component: controller
         networking.gardener.cloud/to-dns: allowed
+        networking.gardener.cloud/to-public-networks: allowed
         networking.gardener.cloud/to-runtime-apiserver: allowed
         networking.resources.gardener.cloud/to-nginx-ingress-k8s-backend-tcp-8080: allowed
         release: addons


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area regression networking security
/kind bug

**What this PR does / why we need it**:
The `nginx-ingress-controller` deployment is missing the `networking.gardener.cloud/to-public-networks=allowed` pod label.

For the web terminal feature of the gardener dashboard the [terminal-bootstrap](https://github.com/gardener/dashboard/tree/master/packages/terminal-bootstrap) component makes sure to create an ingress and headless service for the external kube-apiserver of a `Seed` (not managed by gardener), similar like it is now done for `Shoot` clusters with #7712

If this network policy label is not set, the request will timeout on nginx ingress controller and the following error message can be found in the logs:

```
[error] 119#119: *2151733 upstream timed out (110: Operation timed out) while connecting to upstream, client: 127.0.0.1, server: my-kube-apiserver.ingress.my-seed.example.com, request: "GET /api/v1 HTTP/2.0", upstream: "https://1.2.3.4:443/api/v1", host: "my-kube-apiserver.ingress.my-seed.example.com"
``` 
 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
