### PR TITLE
Add annotations from `seedConfig` to `Seed` object

### DIFF
--- a/cmd/gardenlet/app/app.go
+++ b/cmd/gardenlet/app/app.go
@@ -451,6 +451,7 @@ func (g *garden) registerSeed(ctx context.Context, gardenClient client.Client) e
 	}
 
 	if _, err := controllerutils.GetAndCreateOrMergePatch(ctx, gardenClient, seed, func() error {
+		seed.Annotations = utils.MergeStringMaps(seed.Annotations, g.config.SeedConfig.Annotations)
 		seed.Labels = utils.MergeStringMaps(map[string]string{
 			v1beta1constants.GardenRole: v1beta1constants.GardenRoleSeed,
 		}, g.config.SeedConfig.Labels)

--- a/docs/deployment/deploy_gardenlet_manually.md
+++ b/docs/deployment/deploy_gardenlet_manually.md
@@ -293,10 +293,14 @@ The field `seedConfig.spec.provider.type` specifies the infrastructure provider 
 For all supported infrastructure providers, see [Known Extension Implementations](../../extensions/README.md#known-extension-implementations).
 
     ```yaml
-    ....
+    # ...
     seedConfig:
       metadata:
         name: sweet-seed
+        labels:
+          environment: evaluation
+        annotations:
+          custom.gardener.cloud/option: special
       spec:
         dns:
           provider:
@@ -319,6 +323,14 @@ For all supported infrastructure providers, see [Known Extension Implementations
           region: eu-west-1
           type: <provider>
     ```
+
+Apart from the seed's name, `seedConfig.metadata` can optionally contain `labels` and `annotations`.
+gardenlet will set the labels of the registered `Seed` object to the labels given in the `seedConfig` plus `gardener.cloud/role=seed`.
+Any custom labels on the `Seed` object will be removed on the next restart of gardenlet.
+If a label is removed from the `seedConfig` it is removed from the `Seed` object as well.
+In contrast to labels, annotations in the `seedConfig` are added to existing annotations on the `Seed` object.
+Thus, custom annotations that are added to the `Seed` object during runtime are not removed by gardenlet on restarts.
+Furthermore, if an annotation is removed from the `seedConfig`, gardenlet does **not** remove it from the `Seed` object.
 
 ### Optional: Enable HA Mode
 
@@ -360,7 +372,7 @@ data:
 Configure the `Seed` resource in the `seedConfig` section of your gardenlet configuration to use backup and restore:
 
 ```yaml
-...
+# ...
 seedConfig:
   metadata:
     name: sweet-seed
@@ -383,11 +395,11 @@ The `gardenlet-values.yaml` looks something like this
 (with automatic Seed registration and backup for shoot clusters enabled):
 
 ```yaml
-<default config>
-...
+# <default config>
+# ...
 config:
   gardenClientConnection:
-    ...
+    # ...
     bootstrapKubeconfig:
       name: gardenlet-bootstrap-kubeconfig
       namespace: garden
@@ -398,14 +410,14 @@ config:
             certificate-authority-data: <dummy>
             server: <my-garden-cluster-endpoint>
           name: my-kubernetes-cluster
-        ....
+        # ...
 
     kubeconfigSecret:
       name: gardenlet-kubeconfig
       namespace: garden
-  ...
-  <default config>
-  ...
+  # ...
+  # <default config>
+  # ...
   seedConfig:
     metadata:
       name: sweet-seed


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind enhancement

**What this PR does / why we need it**:

Add annotations from `seedConfig` to `Seed` object on registration and document the behavior of `seedConfig.metadata.{labels,annotations}`.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Annotations in `GardenletConfiguration.seedConfig.metadata.annotations` are added to the `Seed` object during registration. If an annotation is removed from `seedConfig`, it is **not** removed from the `Seed` object.
```
