### PR TITLE
declare resource-id from resources from remote component

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -9,6 +9,8 @@ images:
   sourceRepository: github.com/gardener/gardener
   repository: eu.gcr.io/gardener-project/gardener/gardenlet
 - name: gardener-resource-manager
+  resourceId:
+    name: 'resource-manager'
   sourceRepository: github.com/gardener/gardener
   repository: eu.gcr.io/gardener-project/gardener/resource-manager
 
@@ -370,6 +372,8 @@ images:
       integrity_requirement: 'low'
       availability_requirement: 'low'
 - name: fluent-bit-plugin-installer
+  resourceId:
+    name: fluent-bit-to-loki
   sourceRepository: github.com/gardener/logging
   repository: eu.gcr.io/gardener-project/gardener/fluent-bit-to-loki
   tag: "v0.52.0"
@@ -438,6 +442,8 @@ images:
       availability_requirement: 'low'
       comment: network exposure is public due to the outbound connectivity, there is no exposed endpoint requiring auth.
 - name: telegraf
+  resourceId:
+    name: telegraf-iptables
   sourceRepository: github.com/gardener/logging
   repository: eu.gcr.io/gardener-project/gardener/telegraf-iptables
   tag: "v0.52.0"
@@ -648,6 +654,8 @@ images:
     - type: 'githubTeam'
       teamname: 'gardener/gardener-core-networking-maintainers'
 - name: apiserver-proxy-sidecar
+  resourceId:
+    name: apiserver-proxy
   sourceRepository: github.com/gardener/apiserver-proxy
   repository: eu.gcr.io/gardener-project/gardener/apiserver-proxy
   tag: "v0.11.0"

--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -10,7 +10,7 @@ images:
   repository: eu.gcr.io/gardener-project/gardener/gardenlet
 - name: gardener-resource-manager
   resourceId:
-    name: 'resource-manager'
+    name: resource-manager
   sourceRepository: github.com/gardener/gardener
   repository: eu.gcr.io/gardener-project/gardener/resource-manager
 


### PR DESCRIPTION
**How to categorize this PR?**
/area delivery
 /kind cleanup

**What this PR does / why we need it**:

[Component-CLI](https://github.com/gardener/component-cli) has has been deprecated, and is no longer actively maintained. Considering it contains a lot of custom and Gardener-specific logic for translating `charts/images.yaml` into component-descriptors, said logic was ported into default pipeline template at [cc-utils](https://github.com/gardener/cc-utils). In order to also somewhat simplify the implementation, resolution of referenced component-descriptors and implicity resource-matching was removed. There are some few cases where local resource-names and remote resources-names do not match. In those cases, an additional `resourceId`-Attribute needs to be added. `Component-CLI` will silently ignore/discard this new attribute, thus this change can already be accepted prior to switching from component-cli to its re-implementation.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
NONE