### PR TITLE
Add `make gardener-debug` as a skaffold-based debugging experience

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -351,22 +351,28 @@ kind-operator-down: $(KIND)
 
 # speed-up skaffold deployments by building all images concurrently
 export SKAFFOLD_BUILD_CONCURRENCY = 0
-gardener%up gardener%dev gardenlet%up gardenlet%dev operator-up operator-dev: export SKAFFOLD_DEFAULT_REPO = localhost:5001
-gardener%up gardener%dev gardenlet%up gardenlet%dev operator-up operator-dev: export SKAFFOLD_PUSH = true
+gardener%up gardener%dev gardenlet%up gardenlet%dev operator-up operator-dev gardener%debug gardenlet%debug operator-debug: export SKAFFOLD_DEFAULT_REPO = localhost:5001
+gardener%up gardener%dev gardenlet%up gardenlet%dev operator-up operator-dev gardener%debug gardenlet%debug operator-debug: export SKAFFOLD_PUSH = true
 # use static label for skaffold to prevent rolling all gardener components on every `skaffold` invocation
-gardener%up gardener%dev gardener%down gardenlet%up gardenlet%dev gardenlet%down: export SKAFFOLD_LABEL = skaffold.dev/run-id=gardener-local
+gardener%up gardener%dev gardener%debug gardener%down gardenlet%up gardenlet%dev gardenlet%down: export SKAFFOLD_LABEL = skaffold.dev/run-id=gardener-local
 # set ldflags for skaffold
-gardener%up gardener%dev gardenlet%up gardenlet%dev operator-up operator-dev: export LD_FLAGS = $(shell $(REPO_ROOT)/hack/get-build-ld-flags.sh)
-# skaffold dev cleans up deployed modules by default, disable this
-gardener%dev gardenlet%dev operator-dev: export SKAFFOLD_CLEANUP = false
+gardener%up gardener%dev gardenlet%up gardenlet%dev operator-up operator-dev gardener%debug gardenlet%debug operator-debug: export LD_FLAGS = $(shell $(REPO_ROOT)/hack/get-build-ld-flags.sh)
+# skaffold dev and debug clean up deployed modules by default, disable this
+gardener%dev gardenlet%dev operator-dev gardener%debug gardenlet%debug operator-debug: export SKAFFOLD_CLEANUP = false
 # skaffold dev triggers new builds and deployments immediately on file changes by default,
 # this is too heavy in a large project like gardener, so trigger new builds and deployments manually instead.
 gardener%dev gardenlet%dev operator-dev: export SKAFFOLD_TRIGGER = manual
+# Artifacts might be already built when you decide to start debugging.
+# However, these artifacts do not include the gcflags which `skaffold debug` sets automatically, so delve would not work.
+# Disabling the skaffold cache for debugging ensures that you run artifacts with gcflags required for debugging.
+gardener%debug gardenlet%debug operator-debug: export SKAFFOLD_CACHE_ARTIFACTS = false
 
 gardener-up: $(SKAFFOLD) $(HELM) $(KUBECTL) $(YQ)
 	$(SKAFFOLD) run
 gardener-dev: $(SKAFFOLD) $(HELM) $(KUBECTL) $(YQ)
 	$(SKAFFOLD) dev
+gardener-debug: $(SKAFFOLD) $(HELM) $(KUBECTL) $(YQ)
+	$(SKAFFOLD) debug
 gardener-down: $(SKAFFOLD) $(HELM) $(KUBECTL)
 	./hack/gardener-down.sh
 
@@ -394,6 +400,10 @@ gardenlet-kind2-dev: $(SKAFFOLD) $(HELM)
 	$(SKAFFOLD) deploy -m kind2-env -p kind2 --kubeconfig=$(GARDENER_LOCAL_KUBECONFIG)
 	@# define GARDENER_LOCAL_KUBECONFIG so that it can be used by skaffold when checking whether the seed managed by this gardenlet is ready
 	GARDENER_LOCAL_KUBECONFIG=$(GARDENER_LOCAL_KUBECONFIG) $(SKAFFOLD) dev -m gardenlet -p kind2
+gardenlet-kind2-debug: $(SKAFFOLD) $(HELM)
+	$(SKAFFOLD) deploy -m kind2-env -p kind2 --kubeconfig=$(GARDENER_LOCAL_KUBECONFIG)
+	@# define GARDENER_LOCAL_KUBECONFIG so that it can be used by skaffold when checking whether the seed managed by this gardenlet is ready
+	GARDENER_LOCAL_KUBECONFIG=$(GARDENER_LOCAL_KUBECONFIG) $(SKAFFOLD) debug -m gardenlet -p kind2
 gardenlet-kind2-down: $(SKAFFOLD) $(HELM)
 	$(SKAFFOLD) delete -m kind2-env -p kind2 --kubeconfig=$(GARDENER_LOCAL_KUBECONFIG)
 	$(SKAFFOLD) delete -m gardenlet,kind2-env -p kind2
@@ -408,6 +418,8 @@ gardener-ha-single-zone-up: $(SKAFFOLD) $(HELM) $(KUBECTL)
 	$(SKAFFOLD) run
 gardener-ha-single-zone-dev: $(SKAFFOLD) $(HELM) $(KUBECTL)
 	$(SKAFFOLD) dev
+gardener-ha-single-zone-debug: $(SKAFFOLD) $(HELM) $(KUBECTL)
+	$(SKAFFOLD) debug
 gardener-ha-single-zone-down: $(SKAFFOLD) $(HELM) $(KUBECTL)
 	./hack/gardener-down.sh
 register-kind-ha-single-zone-env: $(KUBECTL)
@@ -424,6 +436,8 @@ gardener-ha-multi-zone-up: $(SKAFFOLD) $(HELM) $(KUBECTL)
 	$(SKAFFOLD) run
 gardener-ha-multi-zone-dev: $(SKAFFOLD) $(HELM) $(KUBECTL)
 	$(SKAFFOLD) dev
+gardener-ha-multi-zone-debug: $(SKAFFOLD) $(HELM) $(KUBECTL)
+	$(SKAFFOLD) debug
 gardener-ha-multi-zone-down: $(SKAFFOLD) $(HELM) $(KUBECTL)
 	./hack/gardener-down.sh
 register-kind-ha-multi-zone-env: $(KUBECTL)
@@ -440,6 +454,8 @@ operator-up: $(SKAFFOLD) $(HELM) $(KUBECTL)
 	$(SKAFFOLD) run
 operator-dev: $(SKAFFOLD) $(HELM) $(KUBECTL)
 	$(SKAFFOLD) dev
+operator-debug: $(SKAFFOLD) $(HELM) $(KUBECTL)
+	$(SKAFFOLD) debug
 operator-down: $(SKAFFOLD) $(HELM) $(KUBECTL)
 	$(KUBECTL) delete garden --all --ignore-not-found --wait --timeout 5m
 	$(SKAFFOLD) delete

--- a/Makefile
+++ b/Makefile
@@ -307,8 +307,8 @@ verify-extended: check-generate check format test-cov test-cov-clean test-integr
 #####################################################################
 
 kind-% kind2-% gardener-%: export IPFAMILY := $(IPFAMILY)
-kind-up kind-down gardener-up gardener-down register-local-env tear-down-local-env register-kind2-env tear-down-kind2-env test-e2e-local-simple test-e2e-local-migration test-e2e-local ci-e2e-kind ci-e2e-kind-upgrade: export KUBECONFIG = $(GARDENER_LOCAL_KUBECONFIG)
-kind2-up kind2-down gardenlet-kind2-up gardenlet-kind2-down: export KUBECONFIG = $(GARDENER_LOCAL2_KUBECONFIG)
+kind-up kind-down gardener-up gardener-dev gardener-debug gardener-down register-local-env tear-down-local-env register-kind2-env tear-down-kind2-env test-e2e-local-simple test-e2e-local-migration test-e2e-local ci-e2e-kind ci-e2e-kind-upgrade: export KUBECONFIG = $(GARDENER_LOCAL_KUBECONFIG)
+kind2-up kind2-down gardenlet-kind2-up gardenlet-kind2-dev gardenlet-kind2-debug gardenlet-kind2-down: export KUBECONFIG = $(GARDENER_LOCAL2_KUBECONFIG)
 kind-extensions-up kind-extensions-down gardener-extensions-up gardener-extensions-down: export KUBECONFIG = $(GARDENER_EXTENSIONS_KUBECONFIG)
 kind-ha-single-zone-up kind-ha-single-zone-down gardener-ha-single-zone-up register-kind-ha-single-zone-env tear-down-kind-ha-single-zone-env ci-e2e-kind-ha-single-zone ci-e2e-kind-ha-single-zone-upgrade: export KUBECONFIG = $(GARDENER_LOCAL_HA_SINGLE_ZONE_KUBECONFIG)
 kind-ha-multi-zone-up kind-ha-multi-zone-down gardener-ha-multi-zone-up register-kind-ha-multi-zone-env tear-down-kind-ha-multi-zone-env ci-e2e-kind-ha-multi-zone ci-e2e-kind-ha-multi-zone-upgrade: export KUBECONFIG = $(GARDENER_LOCAL_HA_MULTI_ZONE_KUBECONFIG)
@@ -351,14 +351,14 @@ kind-operator-down: $(KIND)
 
 # speed-up skaffold deployments by building all images concurrently
 export SKAFFOLD_BUILD_CONCURRENCY = 0
-gardener%up gardener%dev gardenlet%up gardenlet%dev operator-up operator-dev gardener%debug gardenlet%debug operator-debug: export SKAFFOLD_DEFAULT_REPO = localhost:5001
-gardener%up gardener%dev gardenlet%up gardenlet%dev operator-up operator-dev gardener%debug gardenlet%debug operator-debug: export SKAFFOLD_PUSH = true
+gardener%up gardener%dev gardener%debug gardenlet%up gardenlet%dev gardenlet%debug operator-up operator-dev  operator-debug: export SKAFFOLD_DEFAULT_REPO = localhost:5001
+gardener%up gardener%dev gardener%debug gardenlet%up gardenlet%dev gardenlet%debug operator-up operator-dev operator-debug: export SKAFFOLD_PUSH = true
 # use static label for skaffold to prevent rolling all gardener components on every `skaffold` invocation
-gardener%up gardener%dev gardener%debug gardener%down gardenlet%up gardenlet%dev gardenlet%down: export SKAFFOLD_LABEL = skaffold.dev/run-id=gardener-local
+gardener%up gardener%dev gardener%debug gardener%down gardenlet%up gardenlet%dev gardenlet%debug gardenlet%down: export SKAFFOLD_LABEL = skaffold.dev/run-id=gardener-local
 # set ldflags for skaffold
-gardener%up gardener%dev gardenlet%up gardenlet%dev operator-up operator-dev gardener%debug gardenlet%debug operator-debug: export LD_FLAGS = $(shell $(REPO_ROOT)/hack/get-build-ld-flags.sh)
+gardener%up gardener%dev gardener%debug gardenlet%up gardenlet%dev gardenlet%debug operator-up operator-dev operator-debug: export LD_FLAGS = $(shell $(REPO_ROOT)/hack/get-build-ld-flags.sh)
 # skaffold dev and debug clean up deployed modules by default, disable this
-gardener%dev gardenlet%dev operator-dev gardener%debug gardenlet%debug operator-debug: export SKAFFOLD_CLEANUP = false
+gardener%dev gardener%debug gardenlet%dev gardenlet%debug operator-dev operator-debug: export SKAFFOLD_CLEANUP = false
 # skaffold dev triggers new builds and deployments immediately on file changes by default,
 # this is too heavy in a large project like gardener, so trigger new builds and deployments manually instead.
 gardener%dev gardenlet%dev operator-dev: export SKAFFOLD_TRIGGER = manual

--- a/docs/deployment/getting_started_locally.md
+++ b/docs/deployment/getting_started_locally.md
@@ -136,14 +136,14 @@ Please check your console output for the concrete port-forwarding on your machin
 > Note: Resuming or stopping only a single goroutine (Go Issue [25578](https://github.com/golang/go/issues/25578), [31132](https://github.com/golang/go/issues/31132)) is currently not supported, so the action will cause all the goroutines to get activated or paused.
 ([vscode-go wiki](https://github.com/golang/vscode-go/wiki/debugging#connecting-to-headless-delve-with-target-specified-at-server-start-up))
 
-This means that when a goroutine of gardenlet (or any other gardener-core component you try to debug) is paused on a breakpoint, all the other goroutines are paused. Hence, when the whole gardenlet process is paused, it can not renew its lease and can not respond to the liveness and readiness probes. Skaffold automatically increases `timeoutSeconds` of liveness and readiness probes to 600. In our local setups the gardener-core components should run with one replica only, so leases which are not renewed should cause problems. Anyway, if you face problems when debugging, you could temporarily turn off the leader election e.g. by adding
+This means that when a goroutine of gardenlet (or any other gardener-core component you try to debug) is paused on a breakpoint, all the other goroutines are paused. Hence, when the whole gardenlet process is paused, it can not renew its lease and can not respond to the liveness and readiness probes. Skaffold automatically increases `timeoutSeconds` of liveness and readiness probes to 600. In our local setups the gardener-core components should run with one replica only, so leases which are not renewed should not cause problems. Anyway, if you face problems when debugging, you could temporarily turn off the leader election e.g. by adding
 
 ```
   leaderElection:
     leaderElect: false
 ```
 
-to `example/gardener-local/gardenlet/values.yaml` and disabling the various probes.
+to `example/gardener-local/gardenlet/values.yaml` and disable liveness and readiness probes.
 
 ## Creating a `Shoot` Cluster
 

--- a/docs/deployment/getting_started_locally.md
+++ b/docs/deployment/getting_started_locally.md
@@ -108,6 +108,31 @@ make gardener-up
 make gardener-dev SKAFFOLD_MODULE=gardenlet
 ```
 
+## Debugging Gardener
+
+```bash
+make gardener-debug
+```
+
+This is using skaffold debugging features. In the Gardener case, Go debugging using [Delve](https://github.com/go-delve/delve) is the most relevant use case.
+Please see the [skaffold debugging documentation](https://skaffold.dev/docs/workflows/debug/) how to setup your IDE accordingly.
+
+`SKAFFOLD_MODULE` environment variable is working the same way as described for [Developing Gardener](#developing-gardener). However, skaffold is not watching for changes when debugging,
+because it would like to avoid interrupting your debugging session.
+
+For example, if you want to debug gardenlet:
+
+```bash
+# initial deployment of all components
+make gardener-up
+# start debugging gardenlet without deploying other components
+make gardener-debug SKAFFOLD_MODULE=gardenlet
+```
+
+In debugging flow, skaffold builds your container images, reconfigures your pods and creates port forwardings for the `Delve` debugging ports to your localhost.
+The default port is `56268`. If you debug multiple pods at the same time, the port of the second pod will be forwarded to `56269` and so on.
+Please check your console output for the concrete port-forwarding on your machine.
+
 ## Creating a `Shoot` Cluster
 
 You can wait for the `Seed` to be ready by running:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
Similar to the dev-flow of #7659, developers can now use `make gardener-debug` to start a skaffold-based debugging loop which allows remote debugging of Gardener Core pods using Delve.
Specific skaffold modules can be selected by setting `SKAFFOLD_MODULE` to reduce load on laptops.

**Which issue(s) this PR fixes**:
Part of #6016 

**Special notes for your reviewer**:
[skaffold debugging documentation](https://skaffold.dev/docs/workflows/debug/)

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature developer
Developers can now use `make gardener-debug` to start a skaffold-based debugging loop which allows remote debugging of Gardener Core pods using Delve. See the [documentation](https://github.com/gardener/gardener/blob/master/docs/deployment/getting_started_locally.md#debugging-gardener) for more details.
```
