### PR TITLE
Promotes `SeedChange` and `CopyEtcdBackupsDuringControlPlaneMigration` feature gates to GA

### DIFF
--- a/docs/deployment/feature_gates.md
+++ b/docs/deployment/feature_gates.md
@@ -28,8 +28,6 @@ The following tables are a summary of the feature gates that you can set on diff
 | APIServerSNI                               | `false` | `Alpha` | `1.7`  | `1.18` |
 | APIServerSNI                               | `true`  | `Beta`  | `1.19` |        |
 | APIServerSNI (deprecated)                  | `true`  | `Beta`  | `1.48` |        |
-| SeedChange                                 | `false` | `Alpha` | `1.12` | `1.52` |
-| SeedChange                                 | `true`  | `Beta`  | `1.53` |        |
 | CopyEtcdBackupsDuringControlPlaneMigration | `false` | `Alpha` | `1.37` | `1.52` |
 | CopyEtcdBackupsDuringControlPlaneMigration | `true`  | `Beta`  | `1.53` |        |
 | HAControlPlanes                            | `false` | `Alpha` | `1.49` |        |
@@ -112,6 +110,9 @@ The following tables are a summary of the feature gates that you can set on diff
 | ReversedVPN                                  | `true`  | `Beta`       | `1.42` | `1.62` |
 | ReversedVPN                                  | `true`  | `GA`         | `1.63` |        |
 | ForceRestore                                 | `false` | `Removed`    | `1.66` |        |
+| SeedChange                                   | `false` | `Alpha`      | `1.12` | `1.52` |
+| SeedChange                                   | `true`  | `Beta`       | `1.53` | `1.68` |
+| SeedChange                                   | `true`  | `GA`         | `1.69` |        |
 
 ## Using a Feature
 

--- a/docs/deployment/feature_gates.md
+++ b/docs/deployment/feature_gates.md
@@ -28,8 +28,6 @@ The following tables are a summary of the feature gates that you can set on diff
 | APIServerSNI                               | `false` | `Alpha` | `1.7`  | `1.18` |
 | APIServerSNI                               | `true`  | `Beta`  | `1.19` |        |
 | APIServerSNI (deprecated)                  | `true`  | `Beta`  | `1.48` |        |
-| CopyEtcdBackupsDuringControlPlaneMigration | `false` | `Alpha` | `1.37` | `1.52` |
-| CopyEtcdBackupsDuringControlPlaneMigration | `true`  | `Beta`  | `1.53` |        |
 | HAControlPlanes                            | `false` | `Alpha` | `1.49` |        |
 | DefaultSeccompProfile                      | `false` | `Alpha` | `1.54` |        |
 | CoreDNSQueryRewriting                      | `false` | `Alpha` | `1.55` |        |
@@ -113,6 +111,9 @@ The following tables are a summary of the feature gates that you can set on diff
 | SeedChange                                   | `false` | `Alpha`      | `1.12` | `1.52` |
 | SeedChange                                   | `true`  | `Beta`       | `1.53` | `1.68` |
 | SeedChange                                   | `true`  | `GA`         | `1.69` |        |
+| CopyEtcdBackupsDuringControlPlaneMigration   | `false` | `Alpha`      | `1.37` | `1.52` |
+| CopyEtcdBackupsDuringControlPlaneMigration   | `true`  | `Beta`       | `1.53` | `1.68` |
+| CopyEtcdBackupsDuringControlPlaneMigration   | `true`  | `GA`         | `1.69` |        |
 
 ## Using a Feature
 

--- a/example/20-componentconfig-gardenlet.yaml
+++ b/example/20-componentconfig-gardenlet.yaml
@@ -111,7 +111,6 @@ featureGates:
   HVPAForShootedSeed: true
   ManagedIstio: true
   APIServerSNI: true
-  CopyEtcdBackupsDuringControlPlaneMigration: true
   DefaultSeccompProfile: true
   CoreDNSQueryRewriting: true
 # seedConfig:

--- a/example/gardener-local/controlplane/values.yaml
+++ b/example/gardener-local/controlplane/values.yaml
@@ -158,7 +158,6 @@ global:
         maxSize: 0
         policy: ""
     featureGates:
-      SeedChange: true
       HAControlPlanes: true
       IPv6SingleStack: true
       MutableShootSpecNetworkingNodes: true

--- a/example/gardener-local/gardenlet/values.yaml
+++ b/example/gardener-local/gardenlet/values.yaml
@@ -33,7 +33,6 @@ config:
     HVPAForShootedSeed: true
     ManagedIstio: true
     APIServerSNI: true
-    CopyEtcdBackupsDuringControlPlaneMigration: true
     DefaultSeccompProfile: true
     CoreDNSQueryRewriting: true
     FullNetworkPoliciesInRuntimeCluster: true

--- a/hack/local-development/start-apiserver
+++ b/hack/local-development/start-apiserver
@@ -57,7 +57,7 @@ apiserver_flags="
   --secure-port=8443 \
   --tls-cert-file $TLS_CERT_FILE \
   --tls-private-key-file $TLS_KEY_FILE \
-  --feature-gates HAControlPlanes=true,SeedChange=true,IPv6SingleStack=true,MutableShootSpecNetworkingNodes=true \
+  --feature-gates HAControlPlanes=true,IPv6SingleStack=true,MutableShootSpecNetworkingNodes=true \
   --shoot-admin-kubeconfig-max-expiration=24h \
   --enable-admission-plugins=ShootVPAEnabledByDefault \
   --v 2"

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -76,6 +76,7 @@ const (
 	// owner: @plkokanov
 	// alpha: v1.37.0
 	// beta: v1.53.0
+	// GA: v1.69.0
 	CopyEtcdBackupsDuringControlPlaneMigration featuregate.Feature = "CopyEtcdBackupsDuringControlPlaneMigration"
 
 	// HAControlPlanes allows shoot control planes to be run in high availability mode.
@@ -118,7 +119,7 @@ var allFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	APIServerSNI:       {Default: true, PreRelease: featuregate.Deprecated, LockToDefault: true},
 	SeedChange:         {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
 	ReversedVPN:        {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
-	CopyEtcdBackupsDuringControlPlaneMigration: {Default: true, PreRelease: featuregate.Beta},
+	CopyEtcdBackupsDuringControlPlaneMigration: {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
 	HAControlPlanes:                     {Default: false, PreRelease: featuregate.Alpha},
 	DefaultSeccompProfile:               {Default: false, PreRelease: featuregate.Alpha},
 	CoreDNSQueryRewriting:               {Default: false, PreRelease: featuregate.Alpha},

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -61,6 +61,7 @@ const (
 	// owner: @plkokanov
 	// alpha: v1.12.0
 	// beta: v1.53.0
+	// GA: v1.69.0
 	SeedChange featuregate.Feature = "SeedChange"
 
 	// ReversedVPN moves the openvpn server to the seed.
@@ -115,7 +116,7 @@ var allFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	HVPAForShootedSeed: {Default: false, PreRelease: featuregate.Alpha},
 	ManagedIstio:       {Default: true, PreRelease: featuregate.Deprecated, LockToDefault: true},
 	APIServerSNI:       {Default: true, PreRelease: featuregate.Deprecated, LockToDefault: true},
-	SeedChange:         {Default: true, PreRelease: featuregate.Beta},
+	SeedChange:         {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
 	ReversedVPN:        {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
 	CopyEtcdBackupsDuringControlPlaneMigration: {Default: true, PreRelease: featuregate.Beta},
 	HAControlPlanes:                     {Default: false, PreRelease: featuregate.Alpha},

--- a/pkg/operation/botanist/backupentry.go
+++ b/pkg/operation/botanist/backupentry.go
@@ -24,8 +24,6 @@ import (
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
-	"github.com/gardener/gardener/pkg/features"
-	gardenletfeatures "github.com/gardener/gardener/pkg/gardenlet/features"
 	corebackupentry "github.com/gardener/gardener/pkg/operation/botanist/component/backupentry"
 )
 
@@ -94,11 +92,10 @@ func (b *Botanist) DeploySourceBackupEntry(ctx context.Context) error {
 	return b.Shoot.Components.SourceBackupEntry.Deploy(ctx)
 }
 
-// DestroySourceBackupEntry destroys the source BackupEntry. It returns nil if the CopyEtcdBackupsDuringControlPlaneMigration feature gate
-// is disabled or the Seed backup is not enabled or the Shoot is not in restore phase.
+// DestroySourceBackupEntry destroys the source BackupEntry. It returns nil if the
+// Seed backup is not enabled or the Shoot is not in restore phase.
 func (b *Botanist) DestroySourceBackupEntry(ctx context.Context) error {
-	if !gardenletfeatures.FeatureGate.Enabled(features.CopyEtcdBackupsDuringControlPlaneMigration) ||
-		b.Seed.GetInfo().Spec.Backup == nil || !b.isRestorePhase() {
+	if b.Seed.GetInfo().Spec.Backup == nil || !b.isRestorePhase() {
 		return nil
 	}
 

--- a/pkg/operation/botanist/backupentry_test.go
+++ b/pkg/operation/botanist/backupentry_test.go
@@ -23,14 +23,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
-	"github.com/gardener/gardener/pkg/features"
-	gardenletfeatures "github.com/gardener/gardener/pkg/gardenlet/features"
 	"github.com/gardener/gardener/pkg/operation"
 	. "github.com/gardener/gardener/pkg/operation/botanist"
 	mockbackupentry "github.com/gardener/gardener/pkg/operation/botanist/component/backupentry/mock"
 	"github.com/gardener/gardener/pkg/operation/seed"
 	shootpkg "github.com/gardener/gardener/pkg/operation/shoot"
-	"github.com/gardener/gardener/pkg/utils/test"
 )
 
 var _ = Describe("BackupEntry", func() {
@@ -87,15 +84,7 @@ var _ = Describe("BackupEntry", func() {
 	})
 
 	Describe("#DestroySourceBackupEntry", func() {
-		It("shouldn't destroy the SourceBackupEntry component when CopyEtcdBackupsDuringControlPlaneMigration=false", func() {
-			defer test.WithFeatureGate(gardenletfeatures.FeatureGate, features.CopyEtcdBackupsDuringControlPlaneMigration, false)()
-
-			Expect(botanist.DestroySourceBackupEntry(ctx)).To(Succeed())
-		})
-
 		It("shouldn't destroy the SourceBackupEntry component when Seed backup is not enabled", func() {
-			defer test.WithFeatureGate(gardenletfeatures.FeatureGate, features.CopyEtcdBackupsDuringControlPlaneMigration, true)()
-
 			botanist.Seed.SetInfo(&gardencorev1beta1.Seed{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "seed",
@@ -110,8 +99,6 @@ var _ = Describe("BackupEntry", func() {
 		})
 
 		It("shouldn't destroy the SourceBackupEntry component when Shoot is not in restore phase", func() {
-			defer test.WithFeatureGate(gardenletfeatures.FeatureGate, features.CopyEtcdBackupsDuringControlPlaneMigration, true)()
-
 			botanist.Shoot.SetInfo(&gardencorev1beta1.Shoot{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "bar",
@@ -128,8 +115,6 @@ var _ = Describe("BackupEntry", func() {
 		})
 
 		It("should set force-deletion annotation and destroy the SourceBackupEntry component", func() {
-			defer test.WithFeatureGate(gardenletfeatures.FeatureGate, features.CopyEtcdBackupsDuringControlPlaneMigration, true)()
-
 			sourceBackupEntry.EXPECT().SetForceDeletionAnnotation(ctx)
 			sourceBackupEntry.EXPECT().Destroy(ctx)
 

--- a/pkg/operation/botanist/component/backupentry/backupentry.go
+++ b/pkg/operation/botanist/component/backupentry/backupentry.go
@@ -27,8 +27,6 @@ import (
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/extensions"
-	"github.com/gardener/gardener/pkg/features"
-	gardenletfeatures "github.com/gardener/gardener/pkg/gardenlet/features"
 	"github.com/gardener/gardener/pkg/operation/botanist/component"
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/kubernetes/health"
@@ -161,15 +159,7 @@ func (b *backupEntry) WaitMigrate(ctx context.Context) error {
 // Restore uses the garden client to update the BackupEntry and set the name of the new seed to which it shall be scheduled.
 // If the BackupEntry was deleted it will be recreated.
 func (b *backupEntry) Restore(ctx context.Context, _ *gardencorev1beta1.ShootState) error {
-	bucketName := b.values.BucketName
-	if !gardenletfeatures.FeatureGate.Enabled(features.CopyEtcdBackupsDuringControlPlaneMigration) {
-		if err := b.client.Get(ctx, kubernetesutils.Key(b.values.Namespace, b.values.Name), b.backupEntry); err == nil {
-			bucketName = b.backupEntry.Spec.BucketName
-		} else if client.IgnoreNotFound(err) != nil {
-			return err
-		}
-	}
-	return b.reconcile(ctx, b.backupEntry, b.values.SeedName, bucketName, v1beta1constants.GardenerOperationRestore)
+	return b.reconcile(ctx, b.backupEntry, b.values.SeedName, b.values.BucketName, v1beta1constants.GardenerOperationRestore)
 }
 
 func (b *backupEntry) reconcile(ctx context.Context, backupEntry *gardencorev1beta1.BackupEntry, seedName *string, bucketName string, operation string) error {

--- a/pkg/operation/botanist/component/backupentry/backupentry_test.go
+++ b/pkg/operation/botanist/component/backupentry/backupentry_test.go
@@ -30,8 +30,6 @@ import (
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
-	"github.com/gardener/gardener/pkg/features"
-	gardenletfeatures "github.com/gardener/gardener/pkg/gardenlet/features"
 	mocktime "github.com/gardener/gardener/pkg/mock/go/time"
 	. "github.com/gardener/gardener/pkg/operation/botanist/component/backupentry"
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
@@ -186,32 +184,8 @@ var _ = Describe("BackupEntry", func() {
 			defaultDepWaiter = New(log, c, values, time.Millisecond, 500*time.Millisecond)
 		})
 
-		It("should not change the BucketName of the BackupEntry when the CopyEtcdBackupsDuringControlPlaneMigration feature gate is disabled", func() {
+		It("should change the BucketName of the BackupEntry", func() {
 			defer test.WithVars(&TimeNow, mockNow.Do)()
-			defer test.WithFeatureGate(gardenletfeatures.FeatureGate, features.CopyEtcdBackupsDuringControlPlaneMigration, false)()
-			mockNow.EXPECT().Do().Return(now.UTC()).AnyTimes()
-
-			existing := expected.DeepCopy()
-			existing.ResourceVersion = ""
-			existing.Spec.BucketName = differentBucketName
-			existing.Spec.SeedName = &differentSeedName
-			Expect(c.Create(ctx, existing)).To(Succeed(), "restoring BackupEntry succeeds")
-
-			Expect(defaultDepWaiter.Restore(ctx, nil)).To(Succeed())
-
-			actual := &gardencorev1beta1.BackupEntry{}
-			Expect(c.Get(ctx, client.ObjectKey{Name: name, Namespace: namespace}, actual)).To(Succeed())
-
-			expected.ResourceVersion = "2"
-			expected.Spec.BucketName = differentBucketName
-			expected.Annotations[v1beta1constants.GardenerOperation] = v1beta1constants.GardenerOperationRestore
-
-			Expect(actual).To(DeepEqual(expected))
-		})
-
-		It("should change the BucketName of the BackupEntry when the CopyEtcdBackupsDuringControlPlaneMigration feature gate is enabled", func() {
-			defer test.WithVars(&TimeNow, mockNow.Do)()
-			defer test.WithFeatureGate(gardenletfeatures.FeatureGate, features.CopyEtcdBackupsDuringControlPlaneMigration, true)()
 			mockNow.EXPECT().Do().Return(now.UTC()).AnyTimes()
 
 			existing := expected.DeepCopy()

--- a/pkg/operation/botanist/migration.go
+++ b/pkg/operation/botanist/migration.go
@@ -21,8 +21,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
-	"github.com/gardener/gardener/pkg/features"
-	gardenletfeatures "github.com/gardener/gardener/pkg/gardenlet/features"
 	"github.com/gardener/gardener/pkg/operation/botanist/component"
 	"github.com/gardener/gardener/pkg/utils/flow"
 )
@@ -76,8 +74,7 @@ func (b *Botanist) runParallelTaskForEachComponent(ctx context.Context, componen
 
 // IsCopyOfBackupsRequired check if etcd backups need to be copied between seeds.
 func (b *Botanist) IsCopyOfBackupsRequired(ctx context.Context) (bool, error) {
-	if !gardenletfeatures.FeatureGate.Enabled(features.CopyEtcdBackupsDuringControlPlaneMigration) ||
-		b.Seed.GetInfo().Spec.Backup == nil || !b.isRestorePhase() {
+	if b.Seed.GetInfo().Spec.Backup == nil || !b.isRestorePhase() {
 		return false, nil
 	}
 

--- a/pkg/operation/botanist/migration_test.go
+++ b/pkg/operation/botanist/migration_test.go
@@ -208,7 +208,7 @@ var _ = Describe("migration", func() {
 			botanist.Shoot.Components.SourceBackupEntry = sourceBackupEntry
 		})
 
-		It("should return false if lastOpreation is not restore", func() {
+		It("should return false if lastOperation is not restore", func() {
 			botanist.Shoot.GetInfo().Status.LastOperation.Type = v1beta1.LastOperationTypeReconcile
 			copyRequired, err := botanist.IsCopyOfBackupsRequired(ctx)
 			Expect(err).NotTo(HaveOccurred())

--- a/pkg/operation/botanist/migration_test.go
+++ b/pkg/operation/botanist/migration_test.go
@@ -28,8 +28,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/gardener/gardener/pkg/apis/core/v1beta1"
-	"github.com/gardener/gardener/pkg/features"
-	gardenletfeatures "github.com/gardener/gardener/pkg/gardenlet/features"
 	"github.com/gardener/gardener/pkg/operation"
 	. "github.com/gardener/gardener/pkg/operation/botanist"
 	mockbackupentry "github.com/gardener/gardener/pkg/operation/botanist/component/backupentry/mock"
@@ -42,7 +40,6 @@ import (
 	mockcomponent "github.com/gardener/gardener/pkg/operation/botanist/component/mock"
 	"github.com/gardener/gardener/pkg/operation/seed"
 	shootpkg "github.com/gardener/gardener/pkg/operation/shoot"
-	"github.com/gardener/gardener/pkg/utils/test"
 )
 
 var _ = Describe("migration", func() {
@@ -211,142 +208,121 @@ var _ = Describe("migration", func() {
 			botanist.Shoot.Components.SourceBackupEntry = sourceBackupEntry
 		})
 
-		Context("CopyEtcdBackups feature gate disabled", func() {
-			It("should return false if CopyEtcdBackups feature gate is not enabled", func() {
-				defer test.WithFeatureGate(gardenletfeatures.FeatureGate, features.CopyEtcdBackupsDuringControlPlaneMigration, false)()
+		It("should return false if lastOpreation is not restore", func() {
+			botanist.Shoot.GetInfo().Status.LastOperation.Type = v1beta1.LastOperationTypeReconcile
+			copyRequired, err := botanist.IsCopyOfBackupsRequired(ctx)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(copyRequired).To(BeFalse())
+		})
+
+		It("should return false if seed backup is not set", func() {
+			botanist.Seed.GetInfo().Spec.Backup = nil
+			copyRequired, err := botanist.IsCopyOfBackupsRequired(ctx)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(copyRequired).To(BeFalse())
+		})
+
+		It("should return false if lastOperation is nil", func() {
+			botanist.Shoot.GetInfo().Status.LastOperation = nil
+			copyRequired, err := botanist.IsCopyOfBackupsRequired(ctx)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(copyRequired).To(BeFalse())
+		})
+
+		Context("Last operation is restore and etcd main exists", func() {
+			It("should return false if etcd main resource has been deployed", func() {
+				etcdMain.EXPECT().Get(ctx)
 				copyRequired, err := botanist.IsCopyOfBackupsRequired(ctx)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(copyRequired).To(BeFalse())
+			})
+
+			It("should return error if retrieval of etcd main resource fials", func() {
+				etcdMain.EXPECT().Get(ctx).Return(nil, fakeErr)
+				copyRequired, err := botanist.IsCopyOfBackupsRequired(ctx)
+				Expect(err).To(MatchError(fakeErr))
+				Expect(copyRequired).To(BeFalse())
+			})
+
+		})
+
+		Context("Last operation is restore and etcd main does not exist", func() {
+			BeforeEach(func() {
+				etcdMain.EXPECT().Get(ctx).Return(nil, apierrors.NewNotFound(schema.GroupResource{}, "etcd-main"))
+			})
+
+			It("should return an error if backupentry retrieval fails", func() {
+				backupEntry.EXPECT().Get(ctx).Return(nil, fakeErr)
+				copyRequired, err := botanist.IsCopyOfBackupsRequired(ctx)
+				Expect(err).To(MatchError(fakeErr))
+				Expect(copyRequired).To(BeFalse())
+			})
+
+			It("should return an error if backupentry is not found", func() {
+				backupEntryNotFoundErr := apierrors.NewNotFound(schema.GroupResource{}, "backupentry")
+				backupEntry.EXPECT().Get(ctx).Return(nil, backupEntryNotFoundErr)
+				copyRequired, err := botanist.IsCopyOfBackupsRequired(ctx)
+				Expect(err).To(MatchError(backupEntryNotFoundErr))
+				Expect(copyRequired).To(BeFalse())
+			})
+
+			It("should return true if backupentry.Spec.BucketName has not been switched to the new seed", func() {
+				backupEntry.EXPECT().Get(ctx).Return(&v1beta1.BackupEntry{
+					Spec: v1beta1.BackupEntrySpec{
+						BucketName: "old-seed",
+					},
+				}, nil)
+				copyRequired, err := botanist.IsCopyOfBackupsRequired(ctx)
+				Expect(err).To(Succeed())
+				Expect(copyRequired).To(BeTrue())
 			})
 		})
 
-		Context("CopyEtcdBackups feature gate enabled", func() {
-			var restoreFeatureGate func()
-
+		Context("Last operation is restore, etcd-main resource exists and backupentry.Spec.BucketName is switched to the new seed", func() {
 			BeforeEach(func() {
-				restoreFeatureGate = test.WithFeatureGate(gardenletfeatures.FeatureGate, features.CopyEtcdBackupsDuringControlPlaneMigration, true)
+				etcdMain.EXPECT().Get(ctx).Return(nil, apierrors.NewNotFound(schema.GroupResource{}, "etcd-main"))
+				backupEntry.EXPECT().Get(ctx).Return(&v1beta1.BackupEntry{
+					Spec: v1beta1.BackupEntrySpec{
+						BucketName: string(botanist.Seed.GetInfo().UID),
+					},
+				}, nil)
 			})
 
-			AfterEach(func() {
-				restoreFeatureGate()
-			})
-
-			It("should return false if lastOpreation is not restore", func() {
-				botanist.Shoot.GetInfo().Status.LastOperation.Type = v1beta1.LastOperationTypeReconcile
+			It("should return error if source backupentry does not exist", func() {
+				sourceBackupEntryNotFoundErr := apierrors.NewNotFound(schema.GroupResource{}, "source-backupentry")
+				sourceBackupEntry.EXPECT().Get(ctx).Return(nil, sourceBackupEntryNotFoundErr)
 				copyRequired, err := botanist.IsCopyOfBackupsRequired(ctx)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).To(MatchError(sourceBackupEntryNotFoundErr))
 				Expect(copyRequired).To(BeFalse())
 			})
 
-			It("should return false if seed backup is not set", func() {
-				botanist.Seed.GetInfo().Spec.Backup = nil
+			It("should return an error if source backupentry retrieval fails", func() {
+				sourceBackupEntry.EXPECT().Get(ctx).Return(nil, fakeErr)
 				copyRequired, err := botanist.IsCopyOfBackupsRequired(ctx)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).To(MatchError(fakeErr))
 				Expect(copyRequired).To(BeFalse())
 			})
 
-			It("should return false if lastOperation is nil", func() {
-				botanist.Shoot.GetInfo().Status.LastOperation = nil
+			It("should return an error if source backupentry and destination backupentry point to the same bucket", func() {
+				sourceBackupEntry.EXPECT().Get(ctx).Return(&v1beta1.BackupEntry{
+					Spec: v1beta1.BackupEntrySpec{
+						BucketName: string(botanist.Seed.GetInfo().UID),
+					},
+				}, nil)
 				copyRequired, err := botanist.IsCopyOfBackupsRequired(ctx)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).To(HaveOccurred())
 				Expect(copyRequired).To(BeFalse())
 			})
 
-			Context("Last operation is restore and etcd main exists", func() {
-				It("should return false if etcd main resource has been deployed", func() {
-					etcdMain.EXPECT().Get(ctx)
-					copyRequired, err := botanist.IsCopyOfBackupsRequired(ctx)
-					Expect(err).NotTo(HaveOccurred())
-					Expect(copyRequired).To(BeFalse())
-				})
-
-				It("should return error if retrieval of etcd main resource fials", func() {
-					etcdMain.EXPECT().Get(ctx).Return(nil, fakeErr)
-					copyRequired, err := botanist.IsCopyOfBackupsRequired(ctx)
-					Expect(err).To(MatchError(fakeErr))
-					Expect(copyRequired).To(BeFalse())
-				})
-
-			})
-
-			Context("Last operation is restore and etcd main does not exist", func() {
-				BeforeEach(func() {
-					etcdMain.EXPECT().Get(ctx).Return(nil, apierrors.NewNotFound(schema.GroupResource{}, "etcd-main"))
-				})
-
-				It("should return an error if backupentry retrieval fails", func() {
-					backupEntry.EXPECT().Get(ctx).Return(nil, fakeErr)
-					copyRequired, err := botanist.IsCopyOfBackupsRequired(ctx)
-					Expect(err).To(MatchError(fakeErr))
-					Expect(copyRequired).To(BeFalse())
-				})
-
-				It("should return an error if backupentry is not found", func() {
-					backupEntryNotFoundErr := apierrors.NewNotFound(schema.GroupResource{}, "backupentry")
-					backupEntry.EXPECT().Get(ctx).Return(nil, backupEntryNotFoundErr)
-					copyRequired, err := botanist.IsCopyOfBackupsRequired(ctx)
-					Expect(err).To(MatchError(backupEntryNotFoundErr))
-					Expect(copyRequired).To(BeFalse())
-				})
-
-				It("should return true if backupentry.Spec.BucketName has not been switched to the new seed", func() {
-					backupEntry.EXPECT().Get(ctx).Return(&v1beta1.BackupEntry{
-						Spec: v1beta1.BackupEntrySpec{
-							BucketName: "old-seed",
-						},
-					}, nil)
-					copyRequired, err := botanist.IsCopyOfBackupsRequired(ctx)
-					Expect(err).To(Succeed())
-					Expect(copyRequired).To(BeTrue())
-				})
-			})
-
-			Context("Last operation is restore, etcd-main resource exists and backupentry.Spec.BucketName is switched to the new seed", func() {
-				BeforeEach(func() {
-					etcdMain.EXPECT().Get(ctx).Return(nil, apierrors.NewNotFound(schema.GroupResource{}, "etcd-main"))
-					backupEntry.EXPECT().Get(ctx).Return(&v1beta1.BackupEntry{
-						Spec: v1beta1.BackupEntrySpec{
-							BucketName: string(botanist.Seed.GetInfo().UID),
-						},
-					}, nil)
-				})
-
-				It("should return error if source backupentry does not exist", func() {
-					sourceBackupEntryNotFoundErr := apierrors.NewNotFound(schema.GroupResource{}, "source-backupentry")
-					sourceBackupEntry.EXPECT().Get(ctx).Return(nil, sourceBackupEntryNotFoundErr)
-					copyRequired, err := botanist.IsCopyOfBackupsRequired(ctx)
-					Expect(err).To(MatchError(sourceBackupEntryNotFoundErr))
-					Expect(copyRequired).To(BeFalse())
-				})
-
-				It("should return an error if source backupentry retrieval fails", func() {
-					sourceBackupEntry.EXPECT().Get(ctx).Return(nil, fakeErr)
-					copyRequired, err := botanist.IsCopyOfBackupsRequired(ctx)
-					Expect(err).To(MatchError(fakeErr))
-					Expect(copyRequired).To(BeFalse())
-				})
-
-				It("should return an error if source backupentry and destination backupentry point to the same bucket", func() {
-					sourceBackupEntry.EXPECT().Get(ctx).Return(&v1beta1.BackupEntry{
-						Spec: v1beta1.BackupEntrySpec{
-							BucketName: string(botanist.Seed.GetInfo().UID),
-						},
-					}, nil)
-					copyRequired, err := botanist.IsCopyOfBackupsRequired(ctx)
-					Expect(err).To(HaveOccurred())
-					Expect(copyRequired).To(BeFalse())
-				})
-
-				It("should return true if source backupentry and destination backupentry point to different buckets", func() {
-					sourceBackupEntry.EXPECT().Get(ctx).Return(&v1beta1.BackupEntry{
-						Spec: v1beta1.BackupEntrySpec{
-							BucketName: "old-seed",
-						},
-					}, nil)
-					copyRequired, err := botanist.IsCopyOfBackupsRequired(ctx)
-					Expect(err).To(Succeed())
-					Expect(copyRequired).To(BeTrue())
-				})
+			It("should return true if source backupentry and destination backupentry point to different buckets", func() {
+				sourceBackupEntry.EXPECT().Get(ctx).Return(&v1beta1.BackupEntry{
+					Spec: v1beta1.BackupEntrySpec{
+						BucketName: "old-seed",
+					},
+				}, nil)
+				copyRequired, err := botanist.IsCopyOfBackupsRequired(ctx)
+				Expect(err).To(Succeed())
+				Expect(copyRequired).To(BeTrue())
 			})
 		})
 	})

--- a/plugin/pkg/shoot/validator/admission.go
+++ b/plugin/pkg/shoot/validator/admission.go
@@ -27,7 +27,6 @@ import (
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
-	apivalidation "k8s.io/apimachinery/pkg/api/validation"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
@@ -36,7 +35,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/apiserver/pkg/admission"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
-	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/utils/pointer"
 	"k8s.io/utils/strings/slices"
 
@@ -47,7 +45,6 @@ import (
 	gardencoreinformers "github.com/gardener/gardener/pkg/client/core/informers/internalversion"
 	gardencorelisters "github.com/gardener/gardener/pkg/client/core/listers/core/internalversion"
 	"github.com/gardener/gardener/pkg/controllerutils"
-	"github.com/gardener/gardener/pkg/features"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 	secretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager"
 	cidrvalidation "github.com/gardener/gardener/pkg/utils/validation/cidr"
@@ -384,12 +381,6 @@ func (c *validationContext) validateScheduling(ctx context.Context, a admission.
 			}
 
 			if shootIsBeingRescheduled {
-				if !utilfeature.DefaultFeatureGate.Enabled(features.SeedChange) {
-					if err := apivalidation.ValidateImmutableField(c.oldShoot.Spec.SeedName, c.shoot.Spec.SeedName, field.NewPath("spec", "seedName")).ToAggregate(); err != nil {
-						return err
-					}
-				}
-
 				newShootSpec := c.shoot.Spec
 				newShootSpec.SeedName = c.oldShoot.Spec.SeedName
 				if !reflect.DeepEqual(newShootSpec, c.oldShoot.Spec) {

--- a/test/integration/controllermanager/bastion/bastion_suite_test.go
+++ b/test/integration/controllermanager/bastion/bastion_suite_test.go
@@ -77,7 +77,6 @@ var _ = BeforeSuite(func() {
 		GardenerAPIServer: &gardenerenvtest.GardenerAPIServer{
 			Args: []string{
 				"--disable-admission-plugins=Bastion,DeletionConfirmation,ResourceReferenceManager,ExtensionValidator,ShootDNS,ShootQuotaValidator,ShootTolerationRestriction,ShootValidator",
-				"--feature-gates=SeedChange=true",
 			},
 		},
 	}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane-migration
/kind enhancement

**What this PR does / why we need it**:
Promotes `SeedChange` and `CopyEtcdBackupsDuringControlPlaneMigration` feature gates to GA and locks them `true` (promoted to beta in #6452).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The `SeedChange` and `CopyEtcdBackupsDuringControlPlaneMigration` feature gates have been promoted to GA and are now locked to `true`.
```
