### PR TITLE
Remove Loki metrics named port

### DIFF
--- a/charts/seed-bootstrap/charts/fluent-bit/templates/fluent-bit-daemonset.yaml
+++ b/charts/seed-bootstrap/charts/fluent-bit/templates/fluent-bit-daemonset.yaml
@@ -24,8 +24,8 @@ spec:
 {{ toYaml .Values.labels | indent 8 }}
         networking.gardener.cloud/to-dns: allowed
         networking.gardener.cloud/to-runtime-apiserver: allowed
-        networking.resources.gardener.cloud/to-logging-tcp-metrics: allowed
-        networking.resources.gardener.cloud/to-all-shoots-loki-tcp-metrics: allowed
+        networking.resources.gardener.cloud/to-logging-tcp-3100: allowed
+        networking.resources.gardener.cloud/to-all-shoots-loki-tcp-3100: allowed
     spec:
       initContainers:
       - name: install-plugin

--- a/charts/seed-bootstrap/charts/loki/templates/logging-service.yaml
+++ b/charts/seed-bootstrap/charts/loki/templates/logging-service.yaml
@@ -9,7 +9,7 @@ metadata:
 {{ toYaml .Values.labels | indent 4 }}
 {{- if or .Values.annotations .Values.clusterType }}
   annotations:
-    networking.resources.gardener.cloud/from-policy-allowed-ports: '[{"port":"metrics","protocol":"TCP"}{{ if .Values.rbacSidecarEnabled }},{"port":{{ .Values.telegraf.port }},"protocol":"TCP"}{{ end }}]'
+    networking.resources.gardener.cloud/from-policy-allowed-ports: '[{"port":{{ .Values.service.port }},"protocol":"TCP"}{{ if .Values.rbacSidecarEnabled }},{"port":{{ .Values.telegraf.port }},"protocol":"TCP"}{{ end }}]'
 {{- if eq .Values.clusterType "seed" }}
     networking.resources.gardener.cloud/from-policy-pod-label-selector: all-seed-scrape-targets
 {{- else if eq .Values.clusterType "shoot" }}
@@ -27,7 +27,7 @@ spec:
   - port: {{ .Values.service.port }}
     protocol: TCP
     name: metrics
-    targetPort: metrics
+    targetPort: {{ .Values.service.port }}
 {{- if .Values.rbacSidecarEnabled }}
   - port: {{ .Values.kubeRBACProxy.port }}
     protocol: TCP

--- a/charts/seed-bootstrap/charts/loki/templates/service.yaml
+++ b/charts/seed-bootstrap/charts/loki/templates/service.yaml
@@ -9,7 +9,7 @@ metadata:
 {{ toYaml .Values.labels | indent 4 }}
 {{- if or .Values.annotations .Values.clusterType }}
   annotations:
-    networking.resources.gardener.cloud/from-policy-allowed-ports: '[{"port":"metrics","protocol":"TCP"}{{ if .Values.rbacSidecarEnabled }},{"port":{{ .Values.telegraf.port }},"protocol":"TCP"}{{ end }}]'
+    networking.resources.gardener.cloud/from-policy-allowed-ports: '[{"port":{{ .Values.service.port }},"protocol":"TCP"}{{ if .Values.rbacSidecarEnabled }},{"port":{{ .Values.telegraf.port }},"protocol":"TCP"}{{ end }}]'
 {{- if eq .Values.clusterType "seed" }}
     networking.resources.gardener.cloud/from-policy-pod-label-selector: all-seed-scrape-targets
 {{- else if eq .Values.clusterType "shoot" }}
@@ -27,7 +27,7 @@ spec:
   - port: {{ .Values.service.port }}
     protocol: TCP
     name: metrics
-    targetPort: metrics
+    targetPort: {{ .Values.service.port }}
 {{- if .Values.rbacSidecarEnabled }}
   - port: {{ .Values.kubeRBACProxy.port }}
     protocol: TCP

--- a/charts/seed-bootstrap/templates/grafana/grafana-deployment.yaml
+++ b/charts/seed-bootstrap/templates/grafana/grafana-deployment.yaml
@@ -31,7 +31,7 @@ spec:
         networking.gardener.cloud/to-seed-prometheus: allowed
         networking.resources.gardener.cloud/to-aggregate-prometheus-web-tcp-9090: allowed
         networking.resources.gardener.cloud/to-seed-prometheus-web-tcp-9090: allowed
-        networking.resources.gardener.cloud/to-logging-tcp-metrics: allowed
+        networking.resources.gardener.cloud/to-logging-tcp-3100: allowed
     spec:
       automountServiceAccountToken: false
       priorityClassName: gardener-system-600

--- a/charts/seed-monitoring/charts/grafana/templates/grafana-deployment.yaml
+++ b/charts/seed-monitoring/charts/grafana/templates/grafana-deployment.yaml
@@ -28,7 +28,7 @@ spec:
         gardener.cloud/role: monitoring
         component: grafana
         networking.gardener.cloud/to-dns: allowed
-        networking.resources.gardener.cloud/to-logging-tcp-metrics: allowed
+        networking.resources.gardener.cloud/to-logging-tcp-3100: allowed
         networking.resources.gardener.cloud/to-prometheus-web-tcp-9090: allowed
     spec:
       priorityClassName: gardener-system-100


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area logging
/kind bug

**What this PR does / why we need it**:
Currently there is an issue in Cilium with the named ports: Ref: https://github.com/cilium/cilium/issues/24779
This issue is causing troubles with the network policies and the connection FluentBit-Loki-Grafana is broken

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
@vlvasilev 
@dimityrmirchev 
@axel7born 
@DockToFuture 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
An issue causing the garden/grafana Pod to fail to reach to the garden/loki Pod on cilium Seed clusters is now mitigated.
```
