### PR TITLE
Fix broken grafana dashboard for `state-metrics-seed`

### DIFF
--- a/charts/seed-monitoring/charts/grafana/dashboards/owners/cluster-overview-dashboard.json
+++ b/charts/seed-monitoring/charts/grafana/dashboards/owners/cluster-overview-dashboard.json
@@ -1341,7 +1341,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "absent(up{job=\"kube-state-metrics-seed\",type=\"seed\"} == 1)",
+          "expr": "absent(count({exported_job=\"kube-state-metrics\"}))",
           "format": "time_series",
           "instant": true,
           "intervalFactor": 10,


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind regression

**What this PR does / why we need it**:
This PR fixes an issue causing the `state-metrics-seed` status to show down falsely.

Introduced in - https://github.com/gardener/gardener/pull/6771

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
An issue causing `state-metrics-seed` status to show down falsely has been fixed.
```
