### PR TITLE
Fix the network policy for "cache Prometheus -> node-exporter"

### DIFF
--- a/charts/seed-bootstrap/templates/prometheus/networkpolicy.yaml
+++ b/charts/seed-bootstrap/templates/prometheus/networkpolicy.yaml
@@ -14,13 +14,7 @@ spec:
       app: prometheus
       role: monitoring
   egress:
-  - to:
-    - podSelector:
-        matchLabels:
-          component: node-exporter
-      namespaceSelector:
-        matchLabels:
-          kubernetes.io/metadata.name: kube-system
+  - to: []
     ports:
     - port: 16909
       protocol: TCP

--- a/charts/seed-bootstrap/templates/prometheus/networkpolicy.yaml
+++ b/charts/seed-bootstrap/templates/prometheus/networkpolicy.yaml
@@ -14,6 +14,9 @@ spec:
       app: prometheus
       role: monitoring
   egress:
+  # A podselector to select the node-exporter pods in the kube-system namespace does not work here
+  # because the node-exporter uses the host network. Network policies are currently not supported
+  # with pods in the host network.
   - to: []
     ports:
     - port: 16909


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind bug

**What this PR does / why we need it**:

The node-exporter pod has "hostNetwork: true". The node-exporter is using the host's network and it does not use the pod networking feature of Kubernetes.

Network policies do not seem to work in that case as intuitively expected, at least with the Calico CNI plugin: even though the pod selector is correctly configured in the network policy's egress/to section, the network path is still blocked.

When the traffic is not restricted by the destination (only by the port), the network path is allowed. Unfortunately it seems that (at least currently) the destination can not be restricted by using pod selectors.

**Which issue(s) this PR fixes**:

Fixes a minor regression that was introduced in this [commit](https://github.com/gardener/gardener/pull/7636/commits/1818e3e6ce7617f3b14f7112ece01af7781e4267) in #7636.

**Special notes for your reviewer**:

/cc @ScheererJ @rfranzke 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
An issue causing the "cache" Prometheus in the (managed) seed's garden namespace to fail when scraping the node-exporter-s in the kube-system namespace has been fixed.
```
