### PR TITLE
Fix grafana dashboards

### DIFF
--- a/charts/seed-monitoring/charts/grafana/dashboards/owners/cluster-overview-dashboard.json
+++ b/charts/seed-monitoring/charts/grafana/dashboards/owners/cluster-overview-dashboard.json
@@ -190,7 +190,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "absent(up{job=\"kube-apiserver\"} == 1)",
+          "expr": "absent(up{job=\"kube-controller-manager\"} == 1)",
           "format": "time_series",
           "instant": true,
           "intervalFactor": 10,

--- a/charts/seed-monitoring/charts/grafana/dashboards/owners/cluster-overview-dashboard.json
+++ b/charts/seed-monitoring/charts/grafana/dashboards/owners/cluster-overview-dashboard.json
@@ -856,7 +856,7 @@
       "gridPos": {
         "h": 3,
         "w": 4,
-        "x": 3,
+        "x": 0,
         "y": 12
       },
       "hideTimeOverride": false,
@@ -939,7 +939,7 @@
       "gridPos": {
         "h": 3,
         "w": 4,
-        "x": 7,
+        "x": 4,
         "y": 12
       },
       "id": 43,


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind bug

**What this PR does / why we need it**:
Fixes wrong job used for checking KCM `up`.
Corrects position of few tiles in the dashboard.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
We are checking for any more anomalies in the dashboards. Will mark the PR ready after that.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
A bug in grafana dashboards checking `kube-apiserver` job for `kube-controller-manager` up status is now fixed.
```
