### PR TITLE
Deploy CA before worker pools are ready

### DIFF
--- a/docs/api-reference/extensions.md
+++ b/docs/api-reference/extensions.md
@@ -4294,6 +4294,19 @@ DefaultStatus
 the cluster-autoscaler properly.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>machineDeploymentsLastUpdateTime</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#time-v1-meta">
+Kubernetes meta/v1.Time
+</a>
+</em>
+</td>
+<td>
+<p>MachineDeploymentsLastUpdateTime is the timestamp when the status.MachineDeployments slice was last updated.</p>
+</td>
+</tr>
 </tbody>
 </table>
 <hr/>

--- a/docs/api-reference/extensions.md
+++ b/docs/api-reference/extensions.md
@@ -4304,6 +4304,7 @@ Kubernetes meta/v1.Time
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>MachineDeploymentsLastUpdateTime is the timestamp when the status.MachineDeployments slice was last updated.</p>
 </td>
 </tr>

--- a/docs/extensions/worker.md
+++ b/docs/extensions/worker.md
@@ -278,7 +278,7 @@ Our cluster-autoscaler only needs to know the minimum and maximum number of repl
 Gardener deploys this autoscaler if there is at least one worker pool that specifies `max>min`.
 In order to know how it needs to configure it, the provider-specific `Worker` extension controller must expose which `MachineDeployment`s it has created and how the `min`/`max` numbers should look like.
 
-Consequently, your controller should write this information into the `Worker` resource's `.status.machineDeployments` field:
+Consequently, your controller should write this information into the `Worker` resource's `.status.machineDeployments` field. It should also update the `.status.machineDeploymentsLastUpdateTime` field along with `.status.machineDeployments`, so that gardener is able to deploy cluster-autoscaler right after the Worker status is updated with the latest machine deployments and does not wait for the Worker reconciliation to be completed:
 
 ```yaml
 ---
@@ -298,6 +298,7 @@ status:
   - name: shoot--foo--bar-cpu-worker-z2
     minimum: 1
     maximum: 2
+  machineDeploymentsLastUpdateTime: <pointer to a metav1.Time value>
 ```
 
 In order to support a new worker provider, you need to write a controller that watches all `Worker`s with `.spec.type=<my-provider-name>`.

--- a/docs/extensions/worker.md
+++ b/docs/extensions/worker.md
@@ -278,7 +278,7 @@ Our cluster-autoscaler only needs to know the minimum and maximum number of repl
 Gardener deploys this autoscaler if there is at least one worker pool that specifies `max>min`.
 In order to know how it needs to configure it, the provider-specific `Worker` extension controller must expose which `MachineDeployment`s it has created and how the `min`/`max` numbers should look like.
 
-Consequently, your controller should write this information into the `Worker` resource's `.status.machineDeployments` field. It should also update the `.status.machineDeploymentsLastUpdateTime` field along with `.status.machineDeployments`, so that gardener is able to deploy cluster-autoscaler right after the Worker status is updated with the latest machine deployments and does not wait for the Worker reconciliation to be completed:
+Consequently, your controller should write this information into the `Worker` resource's `.status.machineDeployments` field. It should also update the `.status.machineDeploymentsLastUpdateTime` field along with `.status.machineDeployments`, so that gardener is able to deploy Cluster-Autoscaler right after the status is updated with the latest `MachineDeployment`s and does not wait for the reconciliation to be completed:
 
 ```yaml
 ---
@@ -298,7 +298,7 @@ status:
   - name: shoot--foo--bar-cpu-worker-z2
     minimum: 1
     maximum: 2
-  machineDeploymentsLastUpdateTime: <pointer to a metav1.Time value>
+  machineDeploymentsLastUpdateTime: "2023-05-01T12:44:27Z"
 ```
 
 In order to support a new worker provider, you need to write a controller that watches all `Worker`s with `.spec.type=<my-provider-name>`.

--- a/example/seed-crds/10-crd-extensions.gardener.cloud_workers.yaml
+++ b/example/seed-crds/10-crd-extensions.gardener.cloud_workers.yaml
@@ -447,6 +447,11 @@ spec:
                   - name
                   type: object
                 type: array
+              machineDeploymentsLastUpdateTime:
+                description: MachineDeploymentsLastUpdateTime is the timestamp when
+                  the status.MachineDeployments slice was last updated.
+                format: date-time
+                type: string
               observedGeneration:
                 description: ObservedGeneration is the most recent generation observed
                   for this resource.

--- a/pkg/apis/extensions/v1alpha1/types_worker.go
+++ b/pkg/apis/extensions/v1alpha1/types_worker.go
@@ -211,6 +211,7 @@ type WorkerStatus struct {
 	// +patchStrategy=merge
 	MachineDeployments []MachineDeployment `json:"machineDeployments,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
 	// MachineDeploymentsLastUpdateTime is the timestamp when the status.MachineDeployments slice was last updated.
+	// +optional
 	MachineDeploymentsLastUpdateTime *metav1.Time `json:"machineDeploymentsLastUpdateTime,omitempty"`
 }
 

--- a/pkg/apis/extensions/v1alpha1/types_worker.go
+++ b/pkg/apis/extensions/v1alpha1/types_worker.go
@@ -210,6 +210,8 @@ type WorkerStatus struct {
 	// +patchMergeKey=name
 	// +patchStrategy=merge
 	MachineDeployments []MachineDeployment `json:"machineDeployments,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
+	// MachineDeploymentsLastUpdateTime is the timestamp when the status.MachineDeployments slice was last updated.
+	MachineDeploymentsLastUpdateTime *metav1.Time `json:"machineDeploymentsLastUpdateTime,omitempty"`
 }
 
 // MachineDeployment is a created machine deployment.

--- a/pkg/apis/extensions/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/extensions/v1alpha1/zz_generated.deepcopy.go
@@ -1760,6 +1760,10 @@ func (in *WorkerStatus) DeepCopyInto(out *WorkerStatus) {
 		*out = make([]MachineDeployment, len(*in))
 		copy(*out, *in)
 	}
+	if in.MachineDeploymentsLastUpdateTime != nil {
+		in, out := &in.MachineDeploymentsLastUpdateTime, &out.MachineDeploymentsLastUpdateTime
+		*out = (*in).DeepCopy()
+	}
 	return
 }
 

--- a/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
@@ -608,7 +608,7 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 		})
 		waitUntilWorkerStatusUpdate = g.Add(flow.Task{
 			Name:         "Waiting until worker resource status is updated with latest machine deployments",
-			Fn:           botanist.Shoot.Components.Extensions.Worker.WaitUntilWorkerStatusMachineDeploymentsUpdate,
+			Fn:           botanist.Shoot.Components.Extensions.Worker.WaitUntilWorkerStatusMachineDeploymentsUpdated,
 			Dependencies: flow.NewTaskIDs(deployWorker),
 		})
 		deployClusterAutoscaler = g.Add(flow.Task{

--- a/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
@@ -624,7 +624,7 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 		waitUntilWorkerReady = g.Add(flow.Task{
 			Name:         "Waiting until shoot worker nodes have been reconciled",
 			Fn:           flow.TaskFn(botanist.Shoot.Components.Extensions.Worker.Wait).SkipIf(skipReadiness),
-			Dependencies: flow.NewTaskIDs(deployWorker, deployManagedResourceForCloudConfigExecutor),
+			Dependencies: flow.NewTaskIDs(deployWorker, waitUntilWorkerStatusUpdate, deployManagedResourceForCloudConfigExecutor),
 		})
 		nginxLBReady = g.Add(flow.Task{
 			Name:         "Waiting until nginx ingress LoadBalancer is ready",

--- a/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
@@ -606,6 +606,16 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 			Fn:           flow.TaskFn(botanist.DeployWorker).RetryUntilTimeout(defaultInterval, defaultTimeout),
 			Dependencies: flow.NewTaskIDs(deployCloudProviderSecret, deployReferencedResources, waitUntilInfrastructureReady, initializeShootClients, waitUntilOperatingSystemConfigReady, waitUntilNetworkIsReady, createNewServiceAccountSecrets),
 		})
+		waitUntilWorkerStatusUpdate = g.Add(flow.Task{
+			Name:         "Waiting until worker resource status is updated with latest machine deployments",
+			Fn:           botanist.Shoot.Components.Extensions.Worker.WaitUntilWorkerStatusMachineDeploymentsUpdate,
+			Dependencies: flow.NewTaskIDs(deployWorker),
+		})
+		deployClusterAutoscaler = g.Add(flow.Task{
+			Name:         "Deploying cluster autoscaler",
+			Fn:           flow.TaskFn(botanist.DeployClusterAutoscaler).RetryUntilTimeout(defaultInterval, defaultTimeout),
+			Dependencies: flow.NewTaskIDs(waitUntilWorkerStatusUpdate, deployManagedResourcesForAddons, deployManagedResourceForCloudConfigExecutor),
+		})
 		_ = g.Add(flow.Task{
 			Name:         "Reconciling Grafana for Shoot in Seed for the logging stack",
 			Fn:           flow.TaskFn(botanist.DeploySeedGrafana).RetryUntilTimeout(defaultInterval, 2*time.Minute),
@@ -678,11 +688,6 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 			Fn:           flow.TaskFn(botanist.DeploySeedGrafana).RetryUntilTimeout(defaultInterval, 2*time.Minute),
 			Dependencies: flow.NewTaskIDs(deploySeedMonitoring),
 		})
-		deployClusterAutoscaler = g.Add(flow.Task{
-			Name:         "Deploying cluster autoscaler",
-			Fn:           flow.TaskFn(botanist.DeployClusterAutoscaler).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			Dependencies: flow.NewTaskIDs(waitUntilWorkerReady, deployManagedResourcesForAddons, deployManagedResourceForCloudConfigExecutor),
-		})
 
 		deployExtensionResourcesAfterKAPI = g.Add(flow.Task{
 			Name:         deployExtensionAfterKAPIMsg,
@@ -698,7 +703,7 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 		hibernateControlPlane = g.Add(flow.Task{
 			Name:         "Hibernating control plane",
 			Fn:           flow.TaskFn(botanist.HibernateControlPlane).RetryUntilTimeout(defaultInterval, 2*time.Minute).DoIf(o.Shoot.HibernationEnabled),
-			Dependencies: flow.NewTaskIDs(initializeShootClients, deploySeedMonitoring, deploySeedLogging, deployClusterAutoscaler, waitUntilExtensionResourcesAfterKAPIReady),
+			Dependencies: flow.NewTaskIDs(initializeShootClients, deploySeedMonitoring, deploySeedLogging, deployClusterAutoscaler, waitUntilWorkerReady, waitUntilExtensionResourcesAfterKAPIReady),
 		})
 
 		// logic is inverted here

--- a/pkg/operation/botanist/component/extensions/crds/assets/crd-extensions.gardener.cloud_workers.yaml
+++ b/pkg/operation/botanist/component/extensions/crds/assets/crd-extensions.gardener.cloud_workers.yaml
@@ -449,6 +449,11 @@ spec:
                   - name
                   type: object
                 type: array
+              machineDeploymentsLastUpdateTime:
+                description: MachineDeploymentsLastUpdateTime is the timestamp when
+                  the status.MachineDeployments slice was last updated.
+                format: date-time
+                type: string
               observedGeneration:
                 description: ObservedGeneration is the most recent generation observed
                   for this resource.

--- a/pkg/operation/botanist/component/extensions/worker/mock/mocks.go
+++ b/pkg/operation/botanist/component/extensions/worker/mock/mocks.go
@@ -186,16 +186,16 @@ func (mr *MockInterfaceMockRecorder) WaitMigrate(arg0 interface{}) *gomock.Call 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitMigrate", reflect.TypeOf((*MockInterface)(nil).WaitMigrate), arg0)
 }
 
-// WaitUntilWorkerStatusMachineDeploymentsUpdate mocks base method.
-func (m *MockInterface) WaitUntilWorkerStatusMachineDeploymentsUpdate(arg0 context.Context) error {
+// WaitUntilWorkerStatusMachineDeploymentsUpdated mocks base method.
+func (m *MockInterface) WaitUntilWorkerStatusMachineDeploymentsUpdated(arg0 context.Context) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WaitUntilWorkerStatusMachineDeploymentsUpdate", arg0)
+	ret := m.ctrl.Call(m, "WaitUntilWorkerStatusMachineDeploymentsUpdated", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// WaitUntilWorkerStatusMachineDeploymentsUpdate indicates an expected call of WaitUntilWorkerStatusMachineDeploymentsUpdate.
-func (mr *MockInterfaceMockRecorder) WaitUntilWorkerStatusMachineDeploymentsUpdate(arg0 interface{}) *gomock.Call {
+// WaitUntilWorkerStatusMachineDeploymentsUpdated indicates an expected call of WaitUntilWorkerStatusMachineDeploymentsUpdated.
+func (mr *MockInterfaceMockRecorder) WaitUntilWorkerStatusMachineDeploymentsUpdated(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitUntilWorkerStatusMachineDeploymentsUpdate", reflect.TypeOf((*MockInterface)(nil).WaitUntilWorkerStatusMachineDeploymentsUpdate), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitUntilWorkerStatusMachineDeploymentsUpdated", reflect.TypeOf((*MockInterface)(nil).WaitUntilWorkerStatusMachineDeploymentsUpdated), arg0)
 }

--- a/pkg/operation/botanist/component/extensions/worker/mock/mocks.go
+++ b/pkg/operation/botanist/component/extensions/worker/mock/mocks.go
@@ -185,3 +185,17 @@ func (mr *MockInterfaceMockRecorder) WaitMigrate(arg0 interface{}) *gomock.Call 
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitMigrate", reflect.TypeOf((*MockInterface)(nil).WaitMigrate), arg0)
 }
+
+// WaitUntilWorkerStatusMachineDeploymentsUpdate mocks base method.
+func (m *MockInterface) WaitUntilWorkerStatusMachineDeploymentsUpdate(arg0 context.Context) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WaitUntilWorkerStatusMachineDeploymentsUpdate", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// WaitUntilWorkerStatusMachineDeploymentsUpdate indicates an expected call of WaitUntilWorkerStatusMachineDeploymentsUpdate.
+func (mr *MockInterfaceMockRecorder) WaitUntilWorkerStatusMachineDeploymentsUpdate(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitUntilWorkerStatusMachineDeploymentsUpdate", reflect.TypeOf((*MockInterface)(nil).WaitUntilWorkerStatusMachineDeploymentsUpdate), arg0)
+}

--- a/pkg/operation/botanist/component/extensions/worker/worker.go
+++ b/pkg/operation/botanist/component/extensions/worker/worker.go
@@ -60,7 +60,7 @@ type Interface interface {
 	SetInfrastructureProviderStatus(*runtime.RawExtension)
 	SetWorkerNameToOperatingSystemConfigsMap(map[string]*operatingsystemconfig.OperatingSystemConfigs)
 	MachineDeployments() []extensionsv1alpha1.MachineDeployment
-	WaitUntilWorkerStatusMachineDeploymentsUpdate(ctx context.Context) error
+	WaitUntilWorkerStatusMachineDeploymentsUpdated(ctx context.Context) error
 }
 
 // Values contains the values used to create a Worker resources.
@@ -305,13 +305,13 @@ func (w *worker) Wait(ctx context.Context) error {
 	)
 }
 
-// WaitUntilWorkerStatusMachineDeploymentsUpdate waits until the worker status is updated with the latest machineDeployment slice.
-func (w *worker) WaitUntilWorkerStatusMachineDeploymentsUpdate(ctx context.Context) error {
+// WaitUntilWorkerStatusMachineDeploymentsUpdated waits until the worker status is updated with the latest machineDeployment slice.
+func (w *worker) WaitUntilWorkerStatusMachineDeploymentsUpdated(ctx context.Context) error {
 	return extensions.WaitUntilObjectReadyWithHealthFunction(
 		ctx,
 		w.client,
 		w.log,
-		w.checkWorkerStatusMachineDeployments,
+		w.checkWorkerStatusMachineDeploymentsUpdated,
 		w.worker,
 		extensionsv1alpha1.WorkerResource,
 		w.waitInterval,
@@ -378,10 +378,10 @@ func (w *worker) findNodeTemplateAndMachineTypeByPoolName(ctx context.Context, o
 	return nil, ""
 }
 
-// CheckWorkerStatusMachineDeployments checks if the status of the worker is updated or not during its reconciliation.
+// checkWorkerStatusMachineDeploymentsUpdated checks if the status of the worker is updated or not during its reconciliation.
 // It is updated if
 // * The status.MachineDeploymentsLastUpdateTime > the value of the time stamp stored in worker struct before the reconciliation begins.
-func (w *worker) checkWorkerStatusMachineDeployments(o client.Object) error {
+func (w *worker) checkWorkerStatusMachineDeploymentsUpdated(o client.Object) error {
 	obj, ok := o.(*extensionsv1alpha1.Worker)
 	if !ok {
 		return fmt.Errorf("expected *extensionsv1alpha1.Worker but got %T", o)

--- a/pkg/operation/botanist/component/extensions/worker/worker.go
+++ b/pkg/operation/botanist/component/extensions/worker/worker.go
@@ -391,6 +391,7 @@ func (w *worker) checkWorkerStatusMachineDeployments(o client.Object) error {
 		return nil
 	}
 
+	// TODO(rishabh-11): Remove this check in a future release when it's ensured that all extensions were upgraded and follow the contract to maintain `MachineDeploymentsLastUpdateTime`.
 	if obj.Status.MachineDeploymentsLastUpdateTime == nil {
 		return health.CheckExtensionObject(o)
 	}

--- a/pkg/operation/botanist/component/extensions/worker/worker.go
+++ b/pkg/operation/botanist/component/extensions/worker/worker.go
@@ -310,7 +310,7 @@ func (w *worker) WaitUntilWorkerStatusMachineDeploymentsUpdate(ctx context.Conte
 		ctx,
 		w.client,
 		w.log,
-		w.CheckWorkerStatusMachineDeployments,
+		w.checkWorkerStatusMachineDeployments,
 		w.worker,
 		extensionsv1alpha1.WorkerResource,
 		w.waitInterval,
@@ -380,7 +380,7 @@ func (w *worker) findNodeTemplateAndMachineTypeByPoolName(ctx context.Context, o
 // CheckWorkerStatusMachineDeployments checks if the status of the worker is updated or not during its reconciliation.
 // It is updated if
 // * The status.MachineDeploymentsLastUpdateTime > the value of the time stamp stored in worker struct before the reconciliation begins.
-func (w *worker) CheckWorkerStatusMachineDeployments(o client.Object) error {
+func (w *worker) checkWorkerStatusMachineDeployments(o client.Object) error {
 	obj, ok := o.(*extensionsv1alpha1.Worker)
 	if !ok {
 		return fmt.Errorf("expected *extensionsv1alpha1.Worker but got %T", o)

--- a/pkg/operation/botanist/component/extensions/worker/worker_test.go
+++ b/pkg/operation/botanist/component/extensions/worker/worker_test.go
@@ -540,16 +540,16 @@ var _ = Describe("Worker", func() {
 		})
 	})
 
-	Describe("#WaitUntilWorkerStatusMachineDeploymentsUpdate", func() {
+	Describe("#WaitUntilWorkerStatusMachineDeploymentsUpdated", func() {
 		It("should return error when no resources are found", func() {
-			Expect(defaultDepWaiter.WaitUntilWorkerStatusMachineDeploymentsUpdate(ctx)).To(HaveOccurred())
+			Expect(defaultDepWaiter.WaitUntilWorkerStatusMachineDeploymentsUpdated(ctx)).To(HaveOccurred())
 		})
 
 		It("should return error when status.machineDeploymentsLastUpdateTime remains nil", func() {
 			obj := w.DeepCopy()
 			Expect(c.Create(ctx, obj)).To(Succeed(), "creating worker succeeds")
 
-			Expect(defaultDepWaiter.WaitUntilWorkerStatusMachineDeploymentsUpdate(ctx)).To(HaveOccurred(), "worker status is not updated")
+			Expect(defaultDepWaiter.WaitUntilWorkerStatusMachineDeploymentsUpdated(ctx)).To(HaveOccurred(), "worker status is not updated")
 		})
 
 		It("should return error when status.machineDeploymentsLastUpdateTime is not updated", func() {
@@ -560,7 +560,7 @@ var _ = Describe("Worker", func() {
 			// this will populate the machineDeploymentsLastUpdateTime in the worker struct
 			Expect(defaultDepWaiter.Deploy(ctx)).To(Succeed())
 
-			Expect(defaultDepWaiter.WaitUntilWorkerStatusMachineDeploymentsUpdate(ctx)).To(HaveOccurred(), "worker status is not updated")
+			Expect(defaultDepWaiter.WaitUntilWorkerStatusMachineDeploymentsUpdated(ctx)).To(HaveOccurred(), "worker status is not updated")
 		})
 
 		It("should return no error when status.machineDeploymentsLastUpdateTime is added for the first time", func() {
@@ -583,8 +583,8 @@ var _ = Describe("Worker", func() {
 			w.Status.MachineDeploymentsLastUpdateTime = &metav1Now
 			Expect(c.Patch(ctx, w, patch)).To(Succeed(), "patching worker succeeds")
 
-			By("WaitUntilWorkerStatusMachineDeploymentsUpdate")
-			Expect(defaultDepWaiter.WaitUntilWorkerStatusMachineDeploymentsUpdate(ctx)).To(Succeed(), "worker status is updated with latest machine deployments")
+			By("WaitUntilWorkerStatusMachineDeploymentsUpdated")
+			Expect(defaultDepWaiter.WaitUntilWorkerStatusMachineDeploymentsUpdated(ctx)).To(Succeed(), "worker status is updated with latest machine deployments")
 		})
 
 		It("should return no error when status.machineDeploymentsLastUpdateTime is updated", func() {
@@ -612,8 +612,8 @@ var _ = Describe("Worker", func() {
 			w.Status.MachineDeploymentsLastUpdateTime = &lastUpdateTime
 			Expect(c.Patch(ctx, w, patch)).To(Succeed(), "patching worker succeeds")
 
-			By("WaitUntilWorkerStatusMachineDeploymentsUpdate")
-			Expect(defaultDepWaiter.WaitUntilWorkerStatusMachineDeploymentsUpdate(ctx)).To(Succeed(), "worker status is updated with latest machine deployments")
+			By("WaitUntilWorkerStatusMachineDeploymentsUpdated")
+			Expect(defaultDepWaiter.WaitUntilWorkerStatusMachineDeploymentsUpdated(ctx)).To(Succeed(), "worker status is updated with latest machine deployments")
 		})
 
 		// TODO(rishabh-11): Remove this test in a future release when it's ensured that all extensions were upgraded and follow the contract to maintain `MachineDeploymentsLastUpdateTime.
@@ -639,8 +639,8 @@ var _ = Describe("Worker", func() {
 			}
 			Expect(c.Patch(ctx, w, patch)).To(Succeed(), "patching worker succeeds")
 
-			By("WaitUntilWorkerStatusMachineDeploymentsUpdate")
-			Expect(defaultDepWaiter.WaitUntilWorkerStatusMachineDeploymentsUpdate(ctx)).To(Succeed(), "worker status is updated with latest machine deployments")
+			By("WaitUntilWorkerStatusMachineDeploymentsUpdated")
+			Expect(defaultDepWaiter.WaitUntilWorkerStatusMachineDeploymentsUpdated(ctx)).To(Succeed(), "worker status is updated with latest machine deployments")
 		})
 	})
 

--- a/pkg/operation/botanist/component/extensions/worker/worker_test.go
+++ b/pkg/operation/botanist/component/extensions/worker/worker_test.go
@@ -577,7 +577,7 @@ var _ = Describe("Worker", func() {
 			patch := client.MergeFrom(w.DeepCopy())
 			// remove operation annotation, add up-to-date timestamp annotation
 			w.ObjectMeta.Annotations = map[string]string{
-				v1beta1constants.GardenerTimestamp: now.UTC().String(),
+				v1beta1constants.GardenerTimestamp: now.UTC().Format(time.RFC3339Nano),
 			}
 			// update the MachineDeploymentsLastUpdateTime in the worker status
 			w.Status.MachineDeploymentsLastUpdateTime = &metav1Now
@@ -605,7 +605,7 @@ var _ = Describe("Worker", func() {
 			patch := client.MergeFrom(w.DeepCopy())
 			// remove operation annotation, add up-to-date timestamp annotation
 			w.ObjectMeta.Annotations = map[string]string{
-				v1beta1constants.GardenerTimestamp: now.UTC().String(),
+				v1beta1constants.GardenerTimestamp: now.UTC().Format(time.RFC3339Nano),
 			}
 			// update the MachineDeploymentsLastUpdateTime in the worker status
 			lastUpdateTime := metav1.NewTime(metav1Now.Add(1 * time.Second))
@@ -632,7 +632,7 @@ var _ = Describe("Worker", func() {
 			w.Status.LastError = nil
 			// remove operation annotation, add up-to-date timestamp annotation
 			w.ObjectMeta.Annotations = map[string]string{
-				v1beta1constants.GardenerTimestamp: now.UTC().String(),
+				v1beta1constants.GardenerTimestamp: now.UTC().Format(time.RFC3339Nano),
 			}
 			w.Status.LastOperation = &gardencorev1beta1.LastOperation{
 				State: gardencorev1beta1.LastOperationStateSucceeded,


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/area ops-productivity
/kind enhancement

**What this PR does / why we need it**:
As discussed in issue #7057, this PR will enhance the current shoot reconciliation flow to deploy Cluster Autoscaler before the `workers become ready`. Here `workers become ready` means that all the machine deployments in the cluster should have the desired number of machines in the `Running` state. This PR will deploy CA after the worker and machine deployment resources are updated.

**Which issue(s) this PR fixes**:
Fixes #7057 

**Special notes for your reviewer**:
This solution was tested using the [Hard Way setup](https://pages.github.tools.sap/kubernetes/onboarding-website/setup/localsetup/hardlocalsetup/) of gardener using an AWS shoot(k8s version `1.23.17`) on the dev landscape. The following scenarios were tested:- 

1. Creation of a Cluster
2. Update the existing worker to increase its min and max limits
3. Addition of a worker to get schedule the existing un-schedulable pods
4. There is a worker pool in the cluster with some workload on it, additional workload comes, but machines in that worker are not coming up; add a new worker pool and check that CA scales it up.
5. Rolling update scenario by changing the machine image in one of the workers
6. Hibernation/waking up of the cluster
7. Deletion of the cluster

Things to keep in mind about CA behaviour:-
1. CA does nothing productive until all the node groups(machine deployments) specified in the `--nodes` flag is present in the cluster. It simply keeps on giving error logs which say, `machine deployment [xyz] not found.`
2. If a node group has `min > 0`, then it will be considered for scale-up only if it follows the criteria mentioned [here](https://github.com/gardener/autoscaler/blob/1198fbcd90074d4f7d74b46ebdc7ae054367721b/cluster-autoscaler/clusterstate/clusterstate.go#L385-L398)

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
9. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Gardener now deploys the [cluster-autoscaler](https://github.com/gardener/autoscaler) earlier in the shoot reconciliation flow without checking if the worker pools are ready.
```
```other developer
Introduced a new field called `machineDeploymentsLastUpdateTime` in the `Worker` status to keep track of the time when the status of the Worker resource was last updated with the latest machine deployments.
```