### PR TITLE
Nit: Fix typo

### DIFF
--- a/docs/usage/custom-containerd-config.md
+++ b/docs/usage/custom-containerd-config.md
@@ -5,7 +5,7 @@ title: Custom containerd Configuration
 # Custom `containerd` Configuration
 
 In case a `Shoot` cluster uses `containerd` (see [Kubernetes dockershim Removal](docker-shim-removal.md)) for more information), it is possible to make the `containerd` process load custom configuration files.
-Gardener initializes `contaienerd` with the following statement:
+Gardener initializes `containerd` with the following statement:
 
 ```toml
 imports = ["/etc/containerd/conf.d/*.toml"]

--- a/docs/usage/topology_aware_routing.md
+++ b/docs/usage/topology_aware_routing.md
@@ -93,7 +93,7 @@ The `gardener-apiserver` Service is topology-aware. It is consumed by `virtual-g
 
 ##### gardener-admission-controller
 
-The `gardener-admission-controller` Service is topology-aware. It is consumed by `virtual-garden-kube-apiserver` and `virtual-garden-kube-apiserver` for the webhook communication.
+The `gardener-admission-controller` Service is topology-aware. It is consumed by `virtual-garden-kube-apiserver` and `gardener-apiserver` for the webhook communication.
 
 ## How to enable the topology-aware routing for a Seed cluster?
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind enhancement

**What this PR does / why we need it**:
The `gardener-admission-controller` Service is consumed by `virtual-garden-kube-apiserver` and `gardener-apiserver` (not `virtual-garden-kube-apiserver` and `virtual-garden-kube-apiserver`).

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
