### PR TITLE
Switch from Loki to logging service in testmachinery

### DIFF
--- a/test/testmachinery/shoots/logging/utils.go
+++ b/test/testmachinery/shoots/logging/utils.go
@@ -165,15 +165,15 @@ func getCluster(number int) *extensionsv1alpha1.Cluster {
 	}
 }
 
-func getLokiShootService(number int) *corev1.Service {
+func getLoggingShootService(number int) *corev1.Service {
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      lokiName,
+			Name:      "logging",
 			Namespace: fmt.Sprintf("%s%v", simulatedShootNamespacePrefix, number),
 		},
 		Spec: corev1.ServiceSpec{
 			Type:         corev1.ServiceType(corev1.ServiceTypeExternalName),
-			ExternalName: "loki-shoots.garden.svc.cluster.local",
+			ExternalName: "logging-shoot.garden.svc.cluster.local",
 		},
 	}
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area logging
/kind technical-debt

**What this PR does / why we need it**:
By switching fluent-bit outputs from `loki` to `logging` service([PR](https://github.com/gardener/gardener/pull/7731)) we forget to do so for the `testmachinery`.
Currently, fluent-bit in the test is failing to send logs to both Loki instances because the logging service is missing:
```text
level=warn caller=client.go:323 ts=2023-04-12T12:07:47.511198747Z id=0 component=client host=logging.shoot--logging--test-74.svc:3100 msg="error sending batch, will retry" status=-1 error="Post \"http://logging.shoot--logging--test-74.svc:3100/loki/api/v1/push\": dial tcp: lookup logging.shoot--logging--test-74.svc on 172.24.0.10:53: no such host"
```
This PR fixes this mistake.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
The logging integration test is now switched from the `loki` Service to `logging` Service.
```
