### PR TITLE
Fix prow (kind) Gardener setup on cgroupsv2

### DIFF
--- a/hack/kind-up.sh
+++ b/hack/kind-up.sh
@@ -139,6 +139,33 @@ kind create cluster \
   --image "kindest/node:v1.24.7" \
   --config <(helm template $CHART --values "$PATH_CLUSTER_VALUES" $ADDITIONAL_ARGS --set "environment=$ENVIRONMENT" --set "gardener.repositoryRoot"=$(dirname "$0")/..)
 
+# adjust Kind's CRI default OCI runtime spec for new containers to include the cgroup namespace
+# this is required for nesting kubelets on cgroupsv2, as the kindest-node entrypoint script assumes an existing cgroupns when the host kernel uses cgroupsv2
+# See containerd CRI: https://github.com/containerd/containerd/commit/687469d3cee18bf0e12defa5c6d0c7b9139a2dbd
+if [ -f "/sys/fs/cgroup/cgroup.controllers" ]; then
+    echo "Host uses cgroupsv2"
+    cat << 'EOF' >>adjust_cri_base.sh
+#!/bin/bash
+if [ -f /etc/containerd/cri-base.json ]; then
+    cat /etc/containerd/cri-base.json | jq '.linux.namespaces += [{
+        "type": "cgroup"
+    }]' > /etc/containerd/cri-base.tmp.json && cp /etc/containerd/cri-base.tmp.json /etc/containerd/cri-base.json
+    echo "Adjusted kind node /etc/containerd/cri-base.json to create containers with a cgroup namespace"
+else
+    echo "/etc/containerd/cri-base.json not found in kind container"
+fi
+EOF
+
+    for node_name in $(kubectl get nodes -o name | cut -d/ -f2)
+    do
+        echo "Adjusting containerd config for kind node $node_name"
+
+        # copy script to the kind's docker container and execute it
+        docker cp adjust_cri_base.sh "$node_name":/etc/containerd/adjust_cri_base.sh
+        docker exec "$node_name" bash -c "chmod +x /etc/containerd/adjust_cri_base.sh && /etc/containerd/adjust_cri_base.sh && systemctl restart containerd"
+    done
+fi
+
 # workaround https://kind.sigs.k8s.io/docs/user/known-issues/#pod-errors-due-to-too-many-open-files
 kubectl get nodes -o name |\
   cut -d/ -f2 |\


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/area testing
/kind bug

**What this PR does / why we need it**:
Gardeners E2E tests use prow and kind which currently fails on cgroupsv2 enabled hosts.
This is because kubelets from Gardener machine pods "interfere" with kind's kubelet (similar to whats described [in this blogpost](https://d2iq.com/blog/running-kind-inside-a-kubernetes-cluster-for-continuous-integration), but on an inception level deeper). This is because all machine-pods see the same cgroup hierarchy due to a lack of a cgroup namespace. 

The machine-pods use kindest-node as the machine image, which on cgroupsv1 fixes the cgroup hierarchy to appear as a virtualised cgroup hierarchy akin to using a cgroups namespace. However, [kindest-node's entrypoint script on cgroupsv2, assumes that the container was started using a cgroup ns](https://github.com/kubernetes-sigs/kind/blob/822f4968ac67245e6b38c0da66d440de85a15abc/images/base/files/usr/local/bin/entrypoint#L206), however, that is not the case for [privileged pods on cgroupsv2 in Kubernetes](https://github.com/containerd/containerd/commit/687469d3cee18bf0e12defa5c6d0c7b9139a2dbd). 
Hence, this fix ensures that all containers are per-default started using a cgroup namespace.


**Which issue(s) this PR fixes**:
Part of #6016

**Special notes for your reviewer**:

- Using a cgroup namespace per default deviates from the standard Kubernetes behaviour for privileged pods on cgroupsv2 (any non-priv. container has a cgroup namespace enabled). There might be privileged pods that rely on a non-virtualised cgroup hierarchy, where this could cause problems. But I am not aware of any Gardener component where this is the case. 
- tested as a prow CI pod, but not in the local setup when running in docker-for-desktop or similar.


**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The nested kubelet in the Gardener e2e tests (in prow/kind) now work on hosts using cgroupsv2
```
