### PR TITLE
Fix a minor formatting issue in the network policies annotation

### DIFF
--- a/pkg/resourcemanager/controller/networkpolicy/reconciler.go
+++ b/pkg/resourcemanager/controller/networkpolicy/reconciler.go
@@ -339,7 +339,7 @@ func (r *Reconciler) reconcileIngressFromWorldPolicy(ctx context.Context, servic
 		metav1.SetMetaDataLabel(&networkPolicy.ObjectMeta, resourcesv1alpha1.NetworkingServiceNamespace, service.Namespace)
 
 		metav1.SetMetaDataAnnotation(&networkPolicy.ObjectMeta, v1beta1constants.GardenerDescription, fmt.Sprintf("Allows "+
-			"ingress traffic from everywhere to ports %v for pods selected by the %s service selector.", ports,
+			"ingress traffic from everywhere to ports %v for pods selected by the %s service selector.", asSliceOfPointers(ports),
 			client.ObjectKeyFromObject(service)))
 
 		networkPolicy.Spec.Ingress = []networkingv1.NetworkPolicyIngressRule{{
@@ -357,6 +357,15 @@ func (r *Reconciler) reconcileIngressFromWorldPolicy(ctx context.Context, servic
 		return nil
 	})
 	return err
+}
+
+func asSliceOfPointers(portValues []networkingv1.NetworkPolicyPort) []*networkingv1.NetworkPolicyPort {
+	// 'func (this *NetworkPolicyPort) String() string' is called by fmt.Printf("%v", ports) only for a slice of pointers, not for a slice of values
+	var portPointers []*networkingv1.NetworkPolicyPort
+	for _, v := range portValues {
+		portPointers = append(portPointers, &v)
+	}
+	return portPointers
 }
 
 func (r *Reconciler) portsExposedByIngressResources(ctx context.Context, service *corev1.Service) ([]networkingv1.NetworkPolicyPort, error) {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind bug

**What this PR does / why we need it**:

The generated network policies have a `gardener.cloud/description` annotation
that contains a human readable description of the network policy.

For the `ingress-*-from-world` policies, a `kubectl get netpol -w` list+watch
request revealed that they are continuously updated (as observed in the local
setup). The slice of ports is formatted with `"%v"` for the description
annotation, but `fmt.Printf` did not use the generated `String()` function as
expected.

`fmt.Printf` used the default serialisation of the port struct, like
`{0x0123456789 10250 <nil>}`, and as the pointer to the protocol field changes
in each iteration, each iteration yielded a new string representation and hence
an update for the network policy, with no meaningful change.

This PR changes the formatting to show only the protocol and the port numbers, like
`[TCP/10250]`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

/cc @rfranzke 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
