### PR TITLE
Fixes potential leaks of `ShootState`s

### DIFF
--- a/pkg/gardenlet/controller/shoot/shoot/reconciler.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler.go
@@ -873,8 +873,9 @@ func checkIfSeedNamespaceExists(ctx context.Context, o *operation.Operation, bot
 	botanist.SeedNamespaceObject = &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: o.Shoot.SeedNamespace}}
 	if err := botanist.SeedClientSet.APIReader().Get(ctx, client.ObjectKeyFromObject(botanist.SeedNamespaceObject), botanist.SeedNamespaceObject); err != nil {
 		if apierrors.IsNotFound(err) {
-			o.Logger.Info("Did not find namespace in the Seed cluster - nothing to be done", "namespace", client.ObjectKeyFromObject(o.SeedNamespaceObject))
-			return errorsutils.Cancel()
+			o.Logger.Info("Did not find namespace in the Seed cluster", "namespace", client.ObjectKeyFromObject(o.SeedNamespaceObject))
+			botanist.SeedNamespaceObject = nil
+			return nil
 		}
 		return err
 	}

--- a/pkg/gardenlet/controller/shoot/shoot/reconciler_delete.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler_delete.go
@@ -136,14 +136,11 @@ func (r *Reconciler) runDeleteShootFlow(ctx context.Context, o *operation.Operat
 	)
 
 	if err != nil {
-		if errors.WasCanceled(err) {
-			return nil
-		}
 		return v1beta1helper.NewWrappedLastErrors(v1beta1helper.FormatLastErrDescription(err), err)
 	}
 
 	var (
-		nonTerminatingNamespace = botanist.SeedNamespaceObject.Status.Phase != corev1.NamespaceTerminating
+		nonTerminatingNamespace = botanist.SeedNamespaceObject != nil && botanist.SeedNamespaceObject.Status.Phase != corev1.NamespaceTerminating
 		cleanupShootResources   = nonTerminatingNamespace && kubeAPIServerDeploymentFound && infrastructure != nil
 		defaultInterval         = 5 * time.Second
 		defaultTimeout          = 30 * time.Second

--- a/pkg/gardenlet/controller/shoot/shoot/reconciler_migrate.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler_migrate.go
@@ -268,7 +268,7 @@ func (r *Reconciler) runMigrateShootFlow(ctx context.Context, o *operation.Opera
 		})
 		deleteKubeAPIServer = g.Add(flow.Task{
 			Name:         "Deleting kube-apiserver deployment",
-			Fn:           flow.TaskFn(botanist.DeleteKubeAPIServer),
+			Fn:           flow.TaskFn(botanist.DeleteKubeAPIServer).RetryUntilTimeout(defaultInterval, defaultTimeout),
 			Dependencies: flow.NewTaskIDs(waitForManagedResourcesDeletion, waitUntilEtcdReady, waitUntilControlPlaneDeleted, waitUntilShootManagedResourcesDeleted),
 		})
 		waitUntilKubeAPIServerDeleted = g.Add(flow.Task{

--- a/pkg/operation/botanist/dnsresources.go
+++ b/pkg/operation/botanist/dnsresources.go
@@ -37,11 +37,11 @@ func (b *Botanist) DestroyOwnerDNSResources(ctx context.Context) error {
 	return b.DestroyOwnerDNSRecord(ctx)
 }
 
-// MigrateOwnerDNSResources migrates or deletes the owner DNSRecord resource depending on whether
+// MigrateOrDestroyOwnerDNSResources migrates or destroys the owner DNSRecord resource depending on whether
 // the 'ownerChecks' setting is enabled.
 // * If the ownerChecks is enabled, the DNSRecord resource is migrated.
-// * Otherwise, it is deleted.
-func (b *Botanist) MigrateOwnerDNSResources(ctx context.Context) error {
+// * Otherwise, it is destroyed.
+func (b *Botanist) MigrateOrDestroyOwnerDNSResources(ctx context.Context) error {
 	if v1beta1helper.SeedSettingOwnerChecksEnabled(b.Seed.GetInfo().Spec.Settings) {
 		return b.MigrateOwnerDNSRecord(ctx)
 	} else {

--- a/pkg/operation/botanist/dnsresources_test.go
+++ b/pkg/operation/botanist/dnsresources_test.go
@@ -221,7 +221,7 @@ var _ = Describe("dnsrecord", func() {
 				ownerDNSRecord.EXPECT().Migrate(ctx),
 				ownerDNSRecord.EXPECT().WaitMigrate(ctx),
 			)
-			Expect(b.MigrateOwnerDNSResources(ctx)).To(Succeed())
+			Expect(b.MigrateOrDestroyOwnerDNSResources(ctx)).To(Succeed())
 		})
 
 		It("should delete the owner DNSRecord resource if owner checks are disabled", func() {
@@ -234,7 +234,7 @@ var _ = Describe("dnsrecord", func() {
 				ownerDNSRecord.EXPECT().Destroy(ctx),
 				ownerDNSRecord.EXPECT().WaitCleanup(ctx),
 			)
-			Expect(b.MigrateOwnerDNSResources(ctx)).To(Succeed())
+			Expect(b.MigrateOrDestroyOwnerDNSResources(ctx)).To(Succeed())
 		})
 	})
 })

--- a/pkg/operation/common/utils.go
+++ b/pkg/operation/common/utils.go
@@ -210,16 +210,14 @@ func DeleteGrafana(ctx context.Context, k8sClient kubernetes.Interface, namespac
 		return err
 	}
 
-	if err := k8sClient.Client().Delete(
-		ctx,
-		&corev1.Service{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "grafana",
-				Namespace: namespace,
-			}},
-	); client.IgnoreNotFound(err) != nil {
-		return err
-	}
-
-	return nil
+	return client.IgnoreNotFound(
+		k8sClient.Client().Delete(
+			ctx,
+			&corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "grafana",
+					Namespace: namespace,
+				}},
+		),
+	)
 }

--- a/pkg/utils/errors/errors_test.go
+++ b/pkg/utils/errors/errors_test.go
@@ -155,19 +155,6 @@ var _ = Describe("Errors", func() {
 			Expect(err).To(Equal(expectedErr))
 		})
 
-		It("Should return a cancelError when manually canceled", func() {
-			errID := "x1"
-			err := errorsutils.HandleErrors(errorContext,
-				nil,
-				nil,
-				errorsutils.ToExecute(errID, func() error {
-					return errorsutils.Cancel()
-				}),
-			)
-
-			Expect(errorsutils.WasCanceled(errorsutils.Unwrap(err))).To(BeTrue())
-		})
-
 		It("Should stop execution on error", func() {
 			expectedErr := fmt.Errorf("Err1")
 			f1 := errorsmock.NewMockTaskFunc(ctrl)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane-migration
/kind bug

**What this PR does / why we need it**:
This PR fixes a potential leak of `ShootState` resources when the cluster is deleted. The leak could happen if at the end of the deletion flow, the shoot's seed `Namespace` gets deleted then some error occurs and the `ShootState` does not get deleted. When the deletion is retried, there was a check whether the shoot's seed `Namespace` exists or not. If it did not exist, the reconciliation flow exits early and nothing else is done as it incorrectly assumes that all resources have been cleaned up. More details can be found in the corresponding issue - #7784 

The early check and exit is now removed. This has the benefit of not only fixing the potential leak of `ShootState`s but other problems that could occur due to this early exit. For instance: https://github.com/gardener/gardener/issues/7784#issuecomment-1506755764

The check is also removed from the migration flow for consistency.

If you want to test this PR you could introduce a dummy error at the end of the deletion and migration flows (after the shoot's seed `Namespace` is removed) so that they are retried

**Which issue(s) this PR fixes**:
Fixes #7784 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fixed potential leaks of `ShootState`s that could happen when a `Shoot` cluster is deleted. This is achieved by no longer exiting early from the deletion flow if the shoot's seed `Namespace` has been deleted. The same logic has been applied to the migration flow for consistency.
```