### PR TITLE
Minor cosmetics

### DIFF
--- a/charts/seed-monitoring/charts/core/charts/prometheus/templates/prometheus-vpa.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/templates/prometheus-vpa.yaml
@@ -13,7 +13,7 @@ spec:
   resourcePolicy:
     containerPolicies:
     # Due to CVE-2019-5736 runC is initially loaded into memory when the container starts.
-    # After some time VPA recommends less memory (2,3Mb) than the size of of runC binary (about 10Mb).
+    # After some time VPA recommends less memory (2,3Mb) than the size of runC binary (about 10Mb).
     # This results in an error when trying to start the container:
     # failed to write 2485760 to memory.limit_in_bytes in /sys/fs/cgroup/memory/kubepods/prometheus-config-reloader/memory.limit_in_bytes: device or resource busy
     # https://github.com/lxc/lxc/commit/6400238d08cdf1ca20d49bafb85f4e224348bf9d

--- a/charts/seed-monitoring/charts/grafana/dashboards/owners/istio/apiserver-proxy-dashboard.json
+++ b/charts/seed-monitoring/charts/grafana/dashboards/owners/istio/apiserver-proxy-dashboard.json
@@ -902,7 +902,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": null,
-      "description": "The amount of of failures when the `apiserver-proxy`  tries to connect to the upstream Shoot Kube API Server",
+      "description": "The amount of failures when the `apiserver-proxy`  tries to connect to the upstream Shoot Kube API Server",
       "fieldConfig": {
         "defaults": {
           "custom": {

--- a/charts/seed-monitoring/charts/grafana/dashboards/owners/kubernetes-daemonsets-dashboard.json
+++ b/charts/seed-monitoring/charts/grafana/dashboards/owners/kubernetes-daemonsets-dashboard.json
@@ -709,7 +709,7 @@
           "refId": "A"
         }
       ],
-      "title": "Drill down to to Pod Dashboard",
+      "title": "Drill down to Pod Dashboard",
       "transform": "timeseries_to_rows",
       "type": "table"
     }

--- a/charts/seed-monitoring/charts/grafana/dashboards/owners/kubernetes-deployments-dashboard.json
+++ b/charts/seed-monitoring/charts/grafana/dashboards/owners/kubernetes-deployments-dashboard.json
@@ -844,7 +844,7 @@
           "refId": "A"
         }
       ],
-      "title": "Drill down to to Pod Dashboard",
+      "title": "Drill down to Pod Dashboard",
       "transform": "timeseries_to_rows",
       "type": "table-old"
     }

--- a/charts/seed-monitoring/charts/grafana/dashboards/owners/kubernetes-statefulsets-dashboard.json
+++ b/charts/seed-monitoring/charts/grafana/dashboards/owners/kubernetes-statefulsets-dashboard.json
@@ -838,7 +838,7 @@
           "refId": "A"
         }
       ],
-      "title": "Drill down to to Pod Dashboard",
+      "title": "Drill down to Pod Dashboard",
       "transform": "timeseries_to_rows",
       "type": "table-old"
     }

--- a/charts/seed-monitoring/charts/grafana/dashboards/owners/vpn-seed-server/vpn-seed-server-dashboard.json
+++ b/charts/seed-monitoring/charts/grafana/dashboards/owners/vpn-seed-server/vpn-seed-server-dashboard.json
@@ -24,7 +24,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": null,
-      "description": "Traffic for all VPN tunnels of all VPN clients of all all Kube-apiservers pods",
+      "description": "Traffic for all VPN tunnels of all VPN clients of all Kube-apiservers pods",
       "fieldConfig": {
         "defaults": {},
         "overrides": []

--- a/docs/api-reference/core.md
+++ b/docs/api-reference/core.md
@@ -4544,7 +4544,7 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>Location is the time location in which both start and and shall be evaluated.</p>
+<p>Location is the time location in which both start and shall be evaluated.</p>
 </td>
 </tr>
 </tbody>

--- a/docs/usage/control_plane_migration.md
+++ b/docs/usage/control_plane_migration.md
@@ -12,7 +12,7 @@ Also, the involved Seeds need to have enabled `BackupBucket`s.
 
 ## Shoot Control Plane Migration
 
-Triggering the migration is done by changing the `Shoot`'s `.spec.seedName` to a `Seed` that differs from the `.status.seedName`, we call this `Seed` a `"Destination Seed"`. This action can only be performed by an operator with the necessary RBAC. If the Destination `Seed` does not have a backup and restore configuration, the the change to `spec.seedName` is rejected. Additionally, this Seed must not be set for deletion and must be healthy.
+Triggering the migration is done by changing the `Shoot`'s `.spec.seedName` to a `Seed` that differs from the `.status.seedName`, we call this `Seed` a `"Destination Seed"`. This action can only be performed by an operator with the necessary RBAC. If the Destination `Seed` does not have a backup and restore configuration, the change to `spec.seedName` is rejected. Additionally, this Seed must not be set for deletion and must be healthy.
 
 If the `Shoot` has different `.spec.seedName` and `.status.seedName`, a process is started to prepare the Control Plane for migration:
 

--- a/example/provider-extensions/kyverno-policies/gardener-image-pull-policy.yaml
+++ b/example/provider-extensions/kyverno-policies/gardener-image-pull-policy.yaml
@@ -7,7 +7,7 @@ metadata:
     policies.kyverno.io/category: Other
     policies.kyverno.io/subject: Pod
     policies.kyverno.io/description: >-
-      Locally built Gardener images are pushed to a container registry on the the seed.
+      Locally built Gardener images are pushed to a container registry on the seed.
       This registry requires an imagePullSecret, which cannot to gardener components by gardener itself.   
 spec:
   failurePolicy: Ignore

--- a/extensions/pkg/controller/cmd/options.go
+++ b/extensions/pkg/controller/cmd/options.go
@@ -230,11 +230,11 @@ func (m *ManagerOptions) AddFlags(fs *pflag.FlagSet) {
 
 // Complete implements Completer.Complete.
 func (m *ManagerOptions) Complete() error {
-	if !sets.New[string](logger.AllLogLevels...).Has(m.LogLevel) {
+	if !sets.New(logger.AllLogLevels...).Has(m.LogLevel) {
 		return fmt.Errorf("invalid --%s: %s", LogLevelFlag, m.LogLevel)
 	}
 
-	if !sets.New[string](logger.AllLogFormats...).Has(m.LogFormat) {
+	if !sets.New(logger.AllLogFormats...).Has(m.LogFormat) {
 		return fmt.Errorf("invalid --%s: %s", LogFormatFlag, m.LogFormat)
 	}
 

--- a/extensions/pkg/terraformer/state.go
+++ b/extensions/pkg/terraformer/state.go
@@ -66,7 +66,7 @@ func (t *terraformer) GetStateOutputVariables(ctx context.Context, variables ...
 	var (
 		output = make(map[string]string)
 
-		wantedVariables = sets.New[string](variables...)
+		wantedVariables = sets.New(variables...)
 		foundVariables  = sets.New[string]()
 	)
 

--- a/pkg/admissioncontroller/apis/config/validation/admissioncontrollerconfiguration.go
+++ b/pkg/admissioncontroller/apis/config/validation/admissioncontrollerconfiguration.go
@@ -28,10 +28,10 @@ import (
 func ValidateAdmissionControllerConfiguration(config *admissioncontrollerconfig.AdmissionControllerConfiguration) field.ErrorList {
 	allErrs := field.ErrorList{}
 
-	if !sets.New[string](logger.AllLogLevels...).Has(config.LogLevel) {
+	if !sets.New(logger.AllLogLevels...).Has(config.LogLevel) {
 		allErrs = append(allErrs, field.NotSupported(field.NewPath("logLevel"), config.LogLevel, logger.AllLogLevels))
 	}
-	if !sets.New[string](logger.AllLogFormats...).Has(config.LogFormat) {
+	if !sets.New(logger.AllLogFormats...).Has(config.LogFormat) {
 		allErrs = append(allErrs, field.NotSupported(field.NewPath("logFormat"), config.LogFormat, logger.AllLogFormats))
 	}
 
@@ -45,13 +45,13 @@ func ValidateAdmissionControllerConfiguration(config *admissioncontrollerconfig.
 // ValidateResourceAdmissionConfiguration validates the given `ResourceAdmissionConfiguration`.
 func validateResourceAdmissionConfiguration(config *admissioncontrollerconfig.ResourceAdmissionConfiguration, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
-	validValues := sets.New[string](string(admissioncontrollerconfig.AdmissionModeBlock), string(admissioncontrollerconfig.AdmissionModeLog))
+	validValues := sets.New(string(admissioncontrollerconfig.AdmissionModeBlock), string(admissioncontrollerconfig.AdmissionModeLog))
 
 	if config.OperationMode != nil && !validValues.Has(string(*config.OperationMode)) {
 		allErrs = append(allErrs, field.NotSupported(fldPath.Child("mode"), string(*config.OperationMode), validValues.UnsortedList()))
 	}
 
-	allowedSubjectKinds := sets.New[string](rbacv1.UserKind, rbacv1.GroupKind, rbacv1.ServiceAccountKind)
+	allowedSubjectKinds := sets.New(rbacv1.UserKind, rbacv1.GroupKind, rbacv1.ServiceAccountKind)
 
 	for i, subject := range config.UnrestrictedSubjects {
 		fld := fldPath.Child("unrestrictedSubjects").Index(i)

--- a/pkg/apis/authentication/types_adminkubeconfigrequest.go
+++ b/pkg/apis/authentication/types_adminkubeconfigrequest.go
@@ -40,7 +40,7 @@ type AdminKubeconfigRequest struct {
 type AdminKubeconfigRequestStatus struct {
 	// Kubeconfig contains the kubeconfig with cluster-admin privileges for the shoot cluster.
 	Kubeconfig []byte
-	// ExpirationTimestamp is the expiration timestamp of of the returned credential.
+	// ExpirationTimestamp is the expiration timestamp of the returned credential.
 	ExpirationTimestamp metav1.Time
 }
 

--- a/pkg/apis/core/helper/helpers.go
+++ b/pkg/apis/core/helper/helpers.go
@@ -456,7 +456,7 @@ func SecretBindingHasType(secretBinding *core.SecretBinding, providerType string
 		return false
 	}
 
-	return sets.New[string](types...).Has(providerType)
+	return sets.New(types...).Has(providerType)
 }
 
 // GetAllZonesFromShoot returns the set of all availability zones defined in the worker pools of the Shoot specification.

--- a/pkg/apis/core/types_shoot.go
+++ b/pkg/apis/core/types_shoot.go
@@ -410,7 +410,7 @@ type HibernationSchedule struct {
 	Start *string
 	// End is a Cron spec at which time a Shoot will be woken up.
 	End *string
-	// Location is the time location in which both start and and shall be evaluated.
+	// Location is the time location in which both start and shall be evaluated.
 	Location *string
 }
 

--- a/pkg/apis/core/v1alpha1/generated.proto
+++ b/pkg/apis/core/v1alpha1/generated.proto
@@ -870,7 +870,7 @@ message HibernationSchedule {
   // +optional
   optional string end = 2;
 
-  // Location is the time location in which both start and and shall be evaluated.
+  // Location is the time location in which both start and shall be evaluated.
   // +optional
   optional string location = 3;
 }

--- a/pkg/apis/core/v1alpha1/types_shoot.go
+++ b/pkg/apis/core/v1alpha1/types_shoot.go
@@ -488,7 +488,7 @@ type HibernationSchedule struct {
 	// End is a Cron spec at which time a Shoot will be woken up.
 	// +optional
 	End *string `json:"end,omitempty" protobuf:"bytes,2,opt,name=end"`
-	// Location is the time location in which both start and and shall be evaluated.
+	// Location is the time location in which both start and shall be evaluated.
 	// +optional
 	Location *string `json:"location,omitempty" protobuf:"bytes,3,opt,name=location"`
 }

--- a/pkg/apis/core/v1beta1/generated.proto
+++ b/pkg/apis/core/v1beta1/generated.proto
@@ -869,7 +869,7 @@ message HibernationSchedule {
   // +optional
   optional string end = 2;
 
-  // Location is the time location in which both start and and shall be evaluated.
+  // Location is the time location in which both start and shall be evaluated.
   // +optional
   optional string location = 3;
 }

--- a/pkg/apis/core/v1beta1/helper/helper.go
+++ b/pkg/apis/core/v1beta1/helper/helper.go
@@ -1090,7 +1090,7 @@ func SecretBindingHasType(secretBinding *gardencorev1beta1.SecretBinding, provid
 		return false
 	}
 
-	return sets.New[string](types...).Has(providerType)
+	return sets.New(types...).Has(providerType)
 }
 
 // AddTypeToSecretBinding adds the given provider type to the SecretBinding.
@@ -1103,7 +1103,7 @@ func AddTypeToSecretBinding(secretBinding *gardencorev1beta1.SecretBinding, prov
 	}
 
 	types := GetSecretBindingTypes(secretBinding)
-	if !sets.New[string](types...).Has(providerType) {
+	if !sets.New(types...).Has(providerType) {
 		types = append(types, providerType)
 	}
 	secretBinding.Provider.Type = strings.Join(types, ",")

--- a/pkg/apis/core/v1beta1/types_shoot.go
+++ b/pkg/apis/core/v1beta1/types_shoot.go
@@ -500,7 +500,7 @@ type HibernationSchedule struct {
 	// End is a Cron spec at which time a Shoot will be woken up.
 	// +optional
 	End *string `json:"end,omitempty" protobuf:"bytes,2,opt,name=end"`
-	// Location is the time location in which both start and and shall be evaluated.
+	// Location is the time location in which both start and shall be evaluated.
 	// +optional
 	Location *string `json:"location,omitempty" protobuf:"bytes,3,opt,name=location"`
 }

--- a/pkg/apis/core/validation/cloudprofile.go
+++ b/pkg/apis/core/validation/cloudprofile.go
@@ -185,7 +185,7 @@ func validateKubernetesSettings(kubernetes core.KubernetesSettings, fldPath *fie
 	return allErrs
 }
 
-var supportedVersionClassifications = sets.New[string](string(core.ClassificationPreview), string(core.ClassificationSupported), string(core.ClassificationDeprecated))
+var supportedVersionClassifications = sets.New(string(core.ClassificationPreview), string(core.ClassificationSupported), string(core.ClassificationDeprecated))
 
 func validateExpirableVersion(version core.ExpirableVersion, allVersions []core.ExpirableVersion, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}

--- a/pkg/apis/core/validation/controllerregistration.go
+++ b/pkg/apis/core/validation/controllerregistration.go
@@ -30,13 +30,13 @@ import (
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 )
 
-var availablePolicies = sets.New[string](
+var availablePolicies = sets.New(
 	string(core.ControllerDeploymentPolicyOnDemand),
 	string(core.ControllerDeploymentPolicyAlways),
 	string(core.ControllerDeploymentPolicyAlwaysExceptNoShoots),
 )
 
-var availableExtensionStrategies = sets.New[string](
+var availableExtensionStrategies = sets.New(
 	string(core.BeforeKubeAPIServer),
 	string(core.AfterKubeAPIServer),
 )
@@ -52,7 +52,7 @@ func ValidateControllerRegistration(controllerRegistration *core.ControllerRegis
 }
 
 // SupportedExtensionKinds contains all supported extension kinds.
-var SupportedExtensionKinds = sets.New[string](
+var SupportedExtensionKinds = sets.New(
 	extensionsv1alpha1.BackupBucketResource,
 	extensionsv1alpha1.BackupEntryResource,
 	extensionsv1alpha1.BastionResource,

--- a/pkg/apis/core/validation/project.go
+++ b/pkg/apis/core/validation/project.go
@@ -159,7 +159,7 @@ func ValidateSubject(subject rbacv1.Subject, fldPath *field.Path) field.ErrorLis
 	return allErrs
 }
 
-var supportedRoles = sets.New[string](
+var supportedRoles = sets.New(
 	core.ProjectMemberOwner,
 	core.ProjectMemberAdmin,
 	core.ProjectMemberViewer,

--- a/pkg/apis/core/validation/seed.go
+++ b/pkg/apis/core/validation/seed.go
@@ -30,10 +30,10 @@ import (
 )
 
 var (
-	availableIngressKinds = sets.New[string](
+	availableIngressKinds = sets.New(
 		v1beta1constants.IngressKindNginx,
 	)
-	availableExternalTrafficPolicies = sets.New[string](
+	availableExternalTrafficPolicies = sets.New(
 		string(corev1.ServiceExternalTrafficPolicyTypeCluster),
 		string(corev1.ServiceExternalTrafficPolicyTypeLocal),
 	)
@@ -168,7 +168,7 @@ func ValidateSeedSpec(seedSpec *core.SeedSpec, fldPath *field.Path, inTemplate b
 				allErrs = append(allErrs, field.Forbidden(fldPath.Child("settings", "loadBalancerServices", "zones"), "zone-specific load balancer settings only allowed with at least two zones in spec.provider.zones"))
 			}
 
-			zones := sets.New[string](seedSpec.Provider.Zones...)
+			zones := sets.New(seedSpec.Provider.Zones...)
 			specifiedZones := sets.New[string]()
 
 			for i, zoneSettings := range seedSpec.Settings.LoadBalancerServices.Zones {

--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -1491,7 +1491,7 @@ func validateKubeletConfigReserved(reserved *core.KubeletConfigReserved, fldPath
 	return allErrs
 }
 
-var reservedTaintKeys = sets.NewString(v1beta1constants.TaintNodeCriticalComponentsNotReady)
+var reservedTaintKeys = sets.New(v1beta1constants.TaintNodeCriticalComponentsNotReady)
 
 func validateClusterAutoscalerIgnoreTaints(ignoredTaints []string, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}

--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -54,22 +54,22 @@ import (
 )
 
 var (
-	availableProxyModes = sets.New[string](
+	availableProxyModes = sets.New(
 		string(core.ProxyModeIPTables),
 		string(core.ProxyModeIPVS),
 	)
-	availableKubernetesDashboardAuthenticationModes = sets.New[string](
+	availableKubernetesDashboardAuthenticationModes = sets.New(
 		core.KubernetesDashboardAuthModeToken,
 	)
-	availableNginxIngressExternalTrafficPolicies = sets.New[string](
+	availableNginxIngressExternalTrafficPolicies = sets.New(
 		string(corev1.ServiceExternalTrafficPolicyTypeCluster),
 		string(corev1.ServiceExternalTrafficPolicyTypeLocal),
 	)
-	availableShootOperations = sets.New[string](
+	availableShootOperations = sets.New(
 		v1beta1constants.ShootOperationMaintain,
 		v1beta1constants.ShootOperationRetry,
 	).Union(availableShootMaintenanceOperations)
-	availableShootMaintenanceOperations = sets.New[string](
+	availableShootMaintenanceOperations = sets.New(
 		v1beta1constants.GardenerOperationReconcile,
 		v1beta1constants.OperationRotateCAStart,
 		v1beta1constants.OperationRotateCAComplete,
@@ -77,7 +77,7 @@ var (
 		v1beta1constants.ShootOperationRotateObservabilityCredentials,
 		v1beta1constants.ShootOperationRotateSSHKeypair,
 	).Union(forbiddenShootOperationsWhenHibernated)
-	forbiddenShootOperationsWhenHibernated = sets.New[string](
+	forbiddenShootOperationsWhenHibernated = sets.New(
 		v1beta1constants.OperationRotateCredentialsStart,
 		v1beta1constants.OperationRotateCredentialsComplete,
 		v1beta1constants.OperationRotateETCDEncryptionKeyStart,
@@ -85,33 +85,33 @@ var (
 		v1beta1constants.OperationRotateServiceAccountKeyStart,
 		v1beta1constants.OperationRotateServiceAccountKeyComplete,
 	)
-	availableShootPurposes = sets.New[string](
+	availableShootPurposes = sets.New(
 		string(core.ShootPurposeEvaluation),
 		string(core.ShootPurposeTesting),
 		string(core.ShootPurposeDevelopment),
 		string(core.ShootPurposeProduction),
 	)
-	availableWorkerCRINames = sets.New[string](
+	availableWorkerCRINames = sets.New(
 		string(core.CRINameContainerD),
 		string(core.CRINameDocker),
 	)
-	availableClusterAutoscalerExpanderModes = sets.New[string](
+	availableClusterAutoscalerExpanderModes = sets.New(
 		string(core.ClusterAutoscalerExpanderLeastWaste),
 		string(core.ClusterAutoscalerExpanderMostPods),
 		string(core.ClusterAutoscalerExpanderPriority),
 		string(core.ClusterAutoscalerExpanderRandom),
 	)
-	availableCoreDNSAutoscalingModes = sets.New[string](
+	availableCoreDNSAutoscalingModes = sets.New(
 		string(core.CoreDNSAutoscalingModeClusterProportional),
 		string(core.CoreDNSAutoscalingModeHorizontal),
 	)
-	availableSchedulingProfiles = sets.New[string](
+	availableSchedulingProfiles = sets.New(
 		string(core.SchedulingProfileBalanced),
 		string(core.SchedulingProfileBinPacking),
 	)
 
 	// asymmetric algorithms from https://datatracker.ietf.org/doc/html/rfc7518#section-3.1
-	availableOIDCSigningAlgs = sets.New[string](
+	availableOIDCSigningAlgs = sets.New(
 		"RS256",
 		"RS384",
 		"RS512",
@@ -238,7 +238,7 @@ func ValidateShootSpec(meta metav1.ObjectMeta, spec *core.ShootSpec, fldPath *fi
 	if purpose := spec.Purpose; purpose != nil {
 		allowedShootPurposes := availableShootPurposes
 		if meta.Namespace == v1beta1constants.GardenNamespace || inTemplate {
-			allowedShootPurposes = sets.New[string](append(sets.List(availableShootPurposes), string(core.ShootPurposeInfrastructure))...)
+			allowedShootPurposes = sets.New(append(sets.List(availableShootPurposes), string(core.ShootPurposeInfrastructure))...)
 		}
 
 		if !allowedShootPurposes.Has(string(*purpose)) {

--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -5589,7 +5589,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 			Entry("invalid spec", sets.New[string](), "foo", ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 				"Type": Equal(field.ErrorTypeInvalid),
 			})))),
-			Entry("duplicate spec", sets.New[string]("* * * * *"), "* * * * *", ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+			Entry("duplicate spec", sets.New("* * * * *"), "* * * * *", ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 				"Type": Equal(field.ErrorTypeDuplicate),
 			})))),
 		)

--- a/pkg/apis/core/validation/utils.go
+++ b/pkg/apis/core/validation/utils.go
@@ -116,7 +116,7 @@ func getPercentValue(intOrStringValue intstr.IntOrString) (int, bool) {
 	return value, true
 }
 
-var availableFailureTolerance = sets.New[string](
+var availableFailureTolerance = sets.New(
 	string(core.FailureToleranceTypeNode),
 	string(core.FailureToleranceTypeZone),
 )
@@ -155,7 +155,7 @@ func shootReconciliationSuccessful(shoot *core.Shoot) (bool, string) {
 	return false, fmt.Sprintf("last operation was %s, not Reconcile", shoot.Status.LastOperation.Type)
 }
 
-var availableIPFamilies = sets.New[string](
+var availableIPFamilies = sets.New(
 	string(core.IPFamilyIPv4),
 	string(core.IPFamilyIPv6),
 )

--- a/pkg/apis/extensions/validation/bastion_test.go
+++ b/pkg/apis/extensions/validation/bastion_test.go
@@ -114,7 +114,7 @@ var _ = Describe("Bastion validation tests", func() {
 			}))))
 		})
 
-		It("should allow updating the the ingress", func() {
+		It("should allow updating the ingress", func() {
 			newBastion := prepareBastionForUpdate(bastion)
 			newBastion.Spec.Ingress[0].IPBlock.CIDR = "8.8.8.8/8"
 

--- a/pkg/apis/extensions/validation/network.go
+++ b/pkg/apis/extensions/validation/network.go
@@ -118,7 +118,7 @@ func ValidateNetworkStatusUpdate(newStatus, oldStatus *extensionsv1alpha1.Networ
 	return allErrs
 }
 
-var availableIPFamilies = sets.New[string](
+var availableIPFamilies = sets.New(
 	string(extensionsv1alpha1.IPFamilyIPv4),
 	string(extensionsv1alpha1.IPFamilyIPv6),
 )

--- a/pkg/apis/operator/v1alpha1/types.go
+++ b/pkg/apis/operator/v1alpha1/types.go
@@ -393,7 +393,7 @@ const (
 )
 
 // AvailableOperationAnnotations is the set of available operation annotations for Garden resources.
-var AvailableOperationAnnotations = sets.New[string](
+var AvailableOperationAnnotations = sets.New(
 	v1beta1constants.GardenerOperationReconcile,
 	v1beta1constants.OperationRotateCAStart,
 	v1beta1constants.OperationRotateCAComplete,

--- a/pkg/apis/settings/validation/validation.go
+++ b/pkg/apis/settings/validation/validation.go
@@ -28,9 +28,9 @@ import (
 
 var (
 	// See https://tools.ietf.org/html/rfc7518#section-3.1 (without "none")
-	validSigningAlgs = sets.New[string]("RS256", "RS384", "RS512", "ES256", "ES384", "ES512", "PS256", "PS384", "PS512")
+	validSigningAlgs = sets.New("RS256", "RS384", "RS512", "ES256", "ES384", "ES512", "PS256", "PS384", "PS512")
 	// used by oidc-provider
-	forbiddenKeys = sets.New[string]("idp-issuer-url", "client-id", "client-secret", "idp-certificate-authority", "idp-certificate-authority-data", "id-token", "refresh-token")
+	forbiddenKeys = sets.New("idp-issuer-url", "client-id", "client-secret", "idp-certificate-authority", "idp-certificate-authority-data", "id-token", "refresh-token")
 )
 
 func validateOpenIDConnectPresetSpec(spec *settings.OpenIDConnectPresetSpec, fldPath *field.Path) field.ErrorList {

--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -118,11 +118,11 @@ func (o *ExtraOptions) Validate() []error {
 		allErrors = append(allErrors, fmt.Errorf("--shoot-credentials-rotation-interval must be between 24 hours and 2^32 seconds"))
 	}
 
-	if !sets.New[string](logger.AllLogLevels...).Has(o.LogLevel) {
+	if !sets.New(logger.AllLogLevels...).Has(o.LogLevel) {
 		allErrors = append(allErrors, fmt.Errorf("invalid --log-level: %s", o.LogLevel))
 	}
 
-	if !sets.New[string](logger.AllLogFormats...).Has(o.LogFormat) {
+	if !sets.New(logger.AllLogFormats...).Has(o.LogFormat) {
 		allErrors = append(allErrors, fmt.Errorf("invalid --log-format: %s", o.LogFormat))
 	}
 

--- a/pkg/controllermanager/apis/config/validation/validation.go
+++ b/pkg/controllermanager/apis/config/validation/validation.go
@@ -28,13 +28,13 @@ func ValidateControllerManagerConfiguration(conf *config.ControllerManagerConfig
 	allErrs := field.ErrorList{}
 
 	if conf.LogLevel != "" {
-		if !sets.New[string](logger.AllLogLevels...).Has(conf.LogLevel) {
+		if !sets.New(logger.AllLogLevels...).Has(conf.LogLevel) {
 			allErrs = append(allErrs, field.NotSupported(field.NewPath("logLevel"), conf.LogLevel, logger.AllLogLevels))
 		}
 	}
 
 	if conf.LogFormat != "" {
-		if !sets.New[string](logger.AllLogFormats...).Has(conf.LogFormat) {
+		if !sets.New(logger.AllLogFormats...).Has(conf.LogFormat) {
 			allErrs = append(allErrs, field.NotSupported(field.NewPath("logFormat"), conf.LogFormat, logger.AllLogFormats))
 		}
 	}

--- a/pkg/controllermanager/controller/cloudprofile/reconciler.go
+++ b/pkg/controllermanager/controller/cloudprofile/reconciler.go
@@ -60,7 +60,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	// no Shoots and Seed are assigned to the CloudProfile anymore. If this is the case then the controller will remove
 	// the finalizers from the CloudProfile so that it can be garbage collected.
 	if cloudProfile.DeletionTimestamp != nil {
-		if !sets.New[string](cloudProfile.Finalizers...).Has(gardencorev1beta1.GardenerName) {
+		if !sets.New(cloudProfile.Finalizers...).Has(gardencorev1beta1.GardenerName) {
 			return reconcile.Result{}, nil
 		}
 

--- a/pkg/controllermanager/controller/controllerregistration/seed/reconciler_test.go
+++ b/pkg/controllermanager/controller/controllerregistration/seed/reconciler_test.go
@@ -456,7 +456,7 @@ var _ = Describe("Reconciler", func() {
 		It("should correctly compute the result", func() {
 			kindTypes, bs := computeKindTypesForBackupBuckets(backupBucketList)
 
-			Expect(kindTypes).To(Equal(sets.New[string](
+			Expect(kindTypes).To(Equal(sets.New(
 				extensionsv1alpha1.BackupBucketResource+"/"+backupBucket1.Spec.Provider.Type,
 				extensionsv1alpha1.BackupBucketResource+"/"+backupBucket2.Spec.Provider.Type,
 			)))
@@ -474,7 +474,7 @@ var _ = Describe("Reconciler", func() {
 		It("should correctly compute the result", func() {
 			kindTypes := computeKindTypesForBackupEntries(nopLogger, backupEntryList, buckets)
 
-			Expect(kindTypes).To(Equal(sets.New[string](
+			Expect(kindTypes).To(Equal(sets.New(
 				extensionsv1alpha1.BackupEntryResource + "/" + backupBucket1.Spec.Provider.Type,
 			)))
 		})
@@ -495,7 +495,7 @@ var _ = Describe("Reconciler", func() {
 
 			kindTypes := computeKindTypesForShoots(ctx, nopLogger, nil, shootList, seed, controllerRegistrationList, internalDomain, nil)
 
-			Expect(kindTypes).To(Equal(sets.New[string](
+			Expect(kindTypes).To(Equal(sets.New(
 				// seed types
 				extensionsv1alpha1.BackupBucketResource+"/"+type8,
 				extensionsv1alpha1.BackupEntryResource+"/"+type8,
@@ -556,7 +556,7 @@ var _ = Describe("Reconciler", func() {
 
 			kindTypes := computeKindTypesForShoots(ctx, nopLogger, nil, shootList, seed, controllerRegistrationList, internalDomain, nil)
 
-			Expect(kindTypes).To(Equal(sets.New[string](
+			Expect(kindTypes).To(Equal(sets.New(
 				// seed types
 				extensionsv1alpha1.BackupBucketResource+"/"+type8,
 				extensionsv1alpha1.BackupEntryResource+"/"+type8,
@@ -591,7 +591,7 @@ var _ = Describe("Reconciler", func() {
 				},
 			}
 
-			expected := sets.New[string](gardenerutils.ExtensionsID(extensionsv1alpha1.DNSRecordResource, providerType))
+			expected := sets.New(gardenerutils.ExtensionsID(extensionsv1alpha1.DNSRecordResource, providerType))
 			actual := computeKindTypesForSeed(seed)
 			Expect(actual).To(Equal(expected))
 		})
@@ -637,14 +637,14 @@ var _ = Describe("Reconciler", func() {
 
 	Describe("#computeWantedControllerRegistrationNames", func() {
 		It("should correctly compute the result w/o error", func() {
-			wantedKindTypeCombinations := sets.New[string](
+			wantedKindTypeCombinations := sets.New(
 				extensionsv1alpha1.NetworkResource+"/"+type2,
 				extensionsv1alpha1.ControlPlaneResource+"/"+type3,
 			)
 
 			names, err := computeWantedControllerRegistrationNames(wantedKindTypeCombinations, controllerInstallationList, controllerRegistrations, len(shootList), seedObjectMeta)
 
-			Expect(names).To(Equal(sets.New[string](controllerRegistration1.Name, controllerRegistration2.Name, controllerRegistration3.Name, controllerRegistration4.Name, controllerRegistration7.Name, controllerRegistration8.Name)))
+			Expect(names).To(Equal(sets.New(controllerRegistration1.Name, controllerRegistration2.Name, controllerRegistration3.Name, controllerRegistration4.Name, controllerRegistration7.Name, controllerRegistration8.Name)))
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -653,7 +653,7 @@ var _ = Describe("Reconciler", func() {
 
 			names, err := computeWantedControllerRegistrationNames(wantedKindTypeCombinations, controllerInstallationList, controllerRegistrations, 0, seedObjectMeta)
 
-			Expect(names).To(Equal(sets.New[string](controllerRegistration4.Name, controllerRegistration7.Name)))
+			Expect(names).To(Equal(sets.New(controllerRegistration4.Name, controllerRegistration7.Name)))
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -662,7 +662,7 @@ var _ = Describe("Reconciler", func() {
 
 			names, err := computeWantedControllerRegistrationNames(wantedKindTypeCombinations, controllerInstallationList, controllerRegistrations, 0, seedObjectMeta)
 
-			Expect(names).To(Equal(sets.New[string](controllerRegistration4.Name, controllerRegistration7.Name)))
+			Expect(names).To(Equal(sets.New(controllerRegistration4.Name, controllerRegistration7.Name)))
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -674,7 +674,7 @@ var _ = Describe("Reconciler", func() {
 
 			names, err := computeWantedControllerRegistrationNames(wantedKindTypeCombinations, controllerInstallationList, controllerRegistrations, 0, *seedObjectMetaCopy)
 
-			Expect(names).To(Equal(sets.New[string](controllerRegistration7.Name)))
+			Expect(names).To(Equal(sets.New(controllerRegistration7.Name)))
 			Expect(err).NotTo(HaveOccurred())
 		})
 	})
@@ -726,7 +726,7 @@ var _ = Describe("Reconciler", func() {
 		Describe("#deployNeededInstallations", func() {
 			It("should return an error when cannot get controller installation", func() {
 				var (
-					wantedControllerRegistrations  = sets.New[string](controllerRegistration2.Name)
+					wantedControllerRegistrations  = sets.New(controllerRegistration2.Name)
 					registrationNameToInstallation = map[string]*gardencorev1beta1.ControllerInstallation{
 						controllerRegistration1.Name: controllerInstallation1,
 						controllerRegistration2.Name: controllerInstallation2,
@@ -746,7 +746,7 @@ var _ = Describe("Reconciler", func() {
 				installation2 := controllerInstallation2.DeepCopy()
 				installation2.DeletionTimestamp = &now
 				var (
-					wantedControllerRegistrations  = sets.New[string](controllerRegistration2.Name)
+					wantedControllerRegistrations  = sets.New(controllerRegistration2.Name)
 					registrationNameToInstallation = map[string]*gardencorev1beta1.ControllerInstallation{
 						controllerRegistration1.Name: controllerInstallation1,
 						controllerRegistration2.Name: installation2,
@@ -760,7 +760,7 @@ var _ = Describe("Reconciler", func() {
 
 			It("should correctly deploy needed controller installations", func() {
 				var (
-					wantedControllerRegistrations  = sets.New[string](controllerRegistration2.Name, controllerRegistration3.Name, controllerRegistration4.Name)
+					wantedControllerRegistrations  = sets.New(controllerRegistration2.Name, controllerRegistration3.Name, controllerRegistration4.Name)
 					registrationNameToInstallation = map[string]*gardencorev1beta1.ControllerInstallation{
 						controllerRegistration1.Name: controllerInstallation1,
 						controllerRegistration2.Name: controllerInstallation2,
@@ -799,7 +799,7 @@ var _ = Describe("Reconciler", func() {
 				registration1 := controllerRegistration1.DeepCopy()
 				registration1.DeletionTimestamp = &now
 				var (
-					wantedControllerRegistrations  = sets.New[string](registration1.Name, controllerRegistration2.Name)
+					wantedControllerRegistrations  = sets.New(registration1.Name, controllerRegistration2.Name)
 					registrationNameToInstallation = map[string]*gardencorev1beta1.ControllerInstallation{
 						registration1.Name:           controllerInstallation1,
 						controllerRegistration2.Name: controllerInstallation2,
@@ -831,7 +831,7 @@ var _ = Describe("Reconciler", func() {
 				registration2 := controllerRegistration2.DeepCopy()
 				registration2.DeletionTimestamp = &now
 				var (
-					wantedControllerRegistrations  = sets.New[string](registration1.Name, registration2.Name)
+					wantedControllerRegistrations  = sets.New(registration1.Name, registration2.Name)
 					registrationNameToInstallation = map[string]*gardencorev1beta1.ControllerInstallation{
 						registration1.Name: controllerInstallation1,
 						registration2.Name: nil,
@@ -867,7 +867,7 @@ var _ = Describe("Reconciler", func() {
 
 			It("should correctly delete unneeded controller installations", func() {
 				var (
-					wantedControllerRegistrationNames = sets.New[string](controllerRegistration2.Name)
+					wantedControllerRegistrationNames = sets.New(controllerRegistration2.Name)
 					registrationNameToInstallation    = map[string]*gardencorev1beta1.ControllerInstallation{
 						controllerRegistration1.Name: controllerInstallation1,
 						controllerRegistration2.Name: controllerInstallation2,

--- a/pkg/controllermanager/controller/exposureclass/reconciler.go
+++ b/pkg/controllermanager/controller/exposureclass/reconciler.go
@@ -62,7 +62,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 
 	if exposureClass.DeletionTimestamp != nil {
 		// Ignore the exposure class if it has no gardener finalizer.
-		if !sets.New[string](exposureClass.Finalizers...).Has(gardencorev1beta1.GardenerName) {
+		if !sets.New(exposureClass.Finalizers...).Has(gardencorev1beta1.GardenerName) {
 			return reconcile.Result{}, nil
 		}
 

--- a/pkg/controllermanager/controller/project/stale/reconciler.go
+++ b/pkg/controllermanager/controller/project/stale/reconciler.go
@@ -215,7 +215,7 @@ func (r *Reconciler) relevantSecretBindingsInUse(ctx context.Context, isSecretBi
 		}
 
 		if _, ok := namespaceToSecretBindingNames[secretBinding.Namespace]; !ok {
-			namespaceToSecretBindingNames[secretBinding.Namespace] = sets.New[string](secretBinding.Name)
+			namespaceToSecretBindingNames[secretBinding.Namespace] = sets.New(secretBinding.Name)
 		} else {
 			namespaceToSecretBindingNames[secretBinding.Namespace].Insert(secretBinding.Name)
 		}

--- a/pkg/controllermanager/controller/quota/reconciler.go
+++ b/pkg/controllermanager/controller/quota/reconciler.go
@@ -60,7 +60,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	// it has to be ensured that no SecretBindings are depending on the Quota anymore.
 	// When this happens the controller will remove the finalizers from the Quota so that it can be garbage collected.
 	if quota.DeletionTimestamp != nil {
-		if !sets.New[string](quota.Finalizers...).Has(gardencorev1beta1.GardenerName) {
+		if !sets.New(quota.Finalizers...).Has(gardencorev1beta1.GardenerName) {
 			return reconcile.Result{}, nil
 		}
 

--- a/pkg/controllermanager/controller/seed/secrets/reconciler.go
+++ b/pkg/controllermanager/controller/seed/secrets/reconciler.go
@@ -95,7 +95,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 
 func (r *Reconciler) cleanupStaleSecrets(ctx context.Context, existingSecrets []string, namespace string) error {
 	var fns []flow.TaskFn
-	exclude := sets.New[string](existingSecrets...)
+	exclude := sets.New(existingSecrets...)
 
 	secretList := &corev1.SecretList{}
 	if err := r.Client.List(ctx, secretList, client.InNamespace(namespace), client.MatchingLabelsSelector{Selector: gardenRoleSelector}); err != nil {

--- a/pkg/gardenlet/apis/config/validation/validation.go
+++ b/pkg/gardenlet/apis/config/validation/validation.go
@@ -74,13 +74,13 @@ func ValidateGardenletConfiguration(cfg *config.GardenletConfiguration, fldPath 
 	}
 
 	if cfg.LogLevel != "" {
-		if !sets.New[string](logger.AllLogLevels...).Has(cfg.LogLevel) {
+		if !sets.New(logger.AllLogLevels...).Has(cfg.LogLevel) {
 			allErrs = append(allErrs, field.NotSupported(field.NewPath("logLevel"), cfg.LogLevel, logger.AllLogLevels))
 		}
 	}
 
 	if cfg.LogFormat != "" {
-		if !sets.New[string](logger.AllLogFormats...).Has(cfg.LogFormat) {
+		if !sets.New(logger.AllLogFormats...).Has(cfg.LogFormat) {
 			allErrs = append(allErrs, field.NotSupported(field.NewPath("logFormat"), cfg.LogFormat, logger.AllLogFormats))
 		}
 	}
@@ -228,7 +228,7 @@ func ValidateManagedSeedControllerConfiguration(cfg *config.ManagedSeedControlle
 	return allErrs
 }
 
-var availableShootPurposes = sets.New[string](
+var availableShootPurposes = sets.New(
 	string(gardencore.ShootPurposeEvaluation),
 	string(gardencore.ShootPurposeTesting),
 	string(gardencore.ShootPurposeDevelopment),

--- a/pkg/gardenlet/controller/backupbucket/reconciler.go
+++ b/pkg/gardenlet/controller/backupbucket/reconciler.go
@@ -261,7 +261,7 @@ func (r *Reconciler) deleteBackupBucket(
 	reconcile.Result,
 	error,
 ) {
-	if !sets.New[string](backupBucket.Finalizers...).Has(gardencorev1beta1.GardenerName) {
+	if !sets.New(backupBucket.Finalizers...).Has(gardencorev1beta1.GardenerName) {
 		return reconcile.Result{}, nil
 	}
 

--- a/pkg/gardenlet/controller/backupentry/reconciler.go
+++ b/pkg/gardenlet/controller/backupentry/reconciler.go
@@ -279,7 +279,7 @@ func (r *Reconciler) deleteBackupEntry(
 	reconcile.Result,
 	error,
 ) {
-	if !sets.New[string](backupEntry.Finalizers...).Has(gardencorev1beta1.GardenerName) {
+	if !sets.New(backupEntry.Finalizers...).Has(gardencorev1beta1.GardenerName) {
 		log.V(1).Info("Do not need to do anything as the BackupEntry does not have my finalizer")
 		return reconcile.Result{}, nil
 	}
@@ -380,7 +380,7 @@ func (r *Reconciler) migrateBackupEntry(
 	reconcile.Result,
 	error,
 ) {
-	if !sets.New[string](backupEntry.Finalizers...).Has(gardencorev1beta1.GardenerName) {
+	if !sets.New(backupEntry.Finalizers...).Has(gardencorev1beta1.GardenerName) {
 		log.V(1).Info("Do not need to do anything as the BackupEntry does not have my finalizer")
 		return reconcile.Result{}, nil
 	}

--- a/pkg/gardenlet/controller/bastion/reconciler.go
+++ b/pkg/gardenlet/controller/bastion/reconciler.go
@@ -213,7 +213,7 @@ func (r *Reconciler) cleanupBastion(
 	bastion *operationsv1alpha1.Bastion,
 	shoot *gardencorev1beta1.Shoot,
 ) error {
-	if !sets.New[string](bastion.Finalizers...).Has(finalizerName) {
+	if !sets.New(bastion.Finalizers...).Has(finalizerName) {
 		return nil
 	}
 

--- a/pkg/gardenlet/controller/controllerinstallation/required/add_test.go
+++ b/pkg/gardenlet/controller/controllerinstallation/required/add_test.go
@@ -206,7 +206,7 @@ var _ = Describe("Add", func() {
 			Expect(fakeSeedClient.Create(ctx, infrastructure2)).To(Succeed())
 
 			Expect(mapFn(ctx, log, nil, nil)).To(BeEmpty())
-			Expect(reconciler.KindToRequiredTypes).To(HaveKeyWithValue(extensionsv1alpha1.InfrastructureResource, sets.New[string](type1, type2)))
+			Expect(reconciler.KindToRequiredTypes).To(HaveKeyWithValue(extensionsv1alpha1.InfrastructureResource, sets.New(type1, type2)))
 		})
 
 		It("should do nothing when there are no controllerinstallation resources", func() {
@@ -217,7 +217,7 @@ var _ = Describe("Add", func() {
 			Expect(fakeSeedClient.Create(ctx, infrastructure2)).To(Succeed())
 
 			Expect(mapFn(ctx, log, nil, nil)).To(BeEmpty())
-			Expect(reconciler.KindToRequiredTypes).To(HaveKeyWithValue(extensionsv1alpha1.InfrastructureResource, sets.New[string](type1, type2)))
+			Expect(reconciler.KindToRequiredTypes).To(HaveKeyWithValue(extensionsv1alpha1.InfrastructureResource, sets.New(type1, type2)))
 		})
 
 		It("should return the expected names of controllerinstallations", func() {
@@ -236,7 +236,7 @@ var _ = Describe("Add", func() {
 				reconcile.Request{NamespacedName: types.NamespacedName{Name: controllerInstallation1.Name}},
 				reconcile.Request{NamespacedName: types.NamespacedName{Name: controllerInstallation2.Name}},
 			))
-			Expect(reconciler.KindToRequiredTypes).To(HaveKeyWithValue(extensionsv1alpha1.InfrastructureResource, sets.New[string](type1, type2)))
+			Expect(reconciler.KindToRequiredTypes).To(HaveKeyWithValue(extensionsv1alpha1.InfrastructureResource, sets.New(type1, type2)))
 		})
 	})
 })

--- a/pkg/gardenlet/controller/shootstate/extensions/add.go
+++ b/pkg/gardenlet/controller/shootstate/extensions/add.go
@@ -95,7 +95,7 @@ func (r *Reconciler) ObjectPredicate() predicate.Predicate {
 	}
 }
 
-var invalidOperationAnnotations = sets.New[string](
+var invalidOperationAnnotations = sets.New(
 	v1beta1constants.GardenerOperationWaitForState,
 	v1beta1constants.GardenerOperationRestore,
 	v1beta1constants.GardenerOperationMigrate,

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -3287,7 +3287,7 @@ func schema_pkg_apis_core_v1alpha1_HibernationSchedule(ref common.ReferenceCallb
 					},
 					"location": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Location is the time location in which both start and and shall be evaluated.",
+							Description: "Location is the time location in which both start and shall be evaluated.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -11030,7 +11030,7 @@ func schema_pkg_apis_core_v1beta1_HibernationSchedule(ref common.ReferenceCallba
 					},
 					"location": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Location is the time location in which both start and and shall be evaluated.",
+							Description: "Location is the time location in which both start and shall be evaluated.",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/pkg/operation/botanist/component/kubeapiserver/deployment.go
+++ b/pkg/operation/botanist/component/kubeapiserver/deployment.go
@@ -494,8 +494,14 @@ func (k *kubeAPIServer) computeKubeAPIServerCommand() []string {
 	var out []string
 
 	out = append(out, "/usr/local/bin/kube-apiserver")
-	out = append(out, "--enable-admission-plugins="+strings.Join(k.admissionPluginNames(), ","))
-	out = append(out, "--disable-admission-plugins="+strings.Join(k.disabledAdmissionPluginNames(), ","))
+
+	if len(k.values.EnabledAdmissionPlugins) > 0 {
+		out = append(out, "--enable-admission-plugins="+strings.Join(k.admissionPluginNames(), ","))
+	}
+	if len(k.values.DisabledAdmissionPlugins) > 0 {
+		out = append(out, "--disable-admission-plugins="+strings.Join(k.disabledAdmissionPluginNames(), ","))
+	}
+
 	out = append(out, fmt.Sprintf("--admission-control-config-file=%s/%s", volumeMountPathAdmissionConfiguration, configMapAdmissionDataKey))
 	out = append(out, "--anonymous-auth="+strconv.FormatBool(k.values.AnonymousAuthenticationEnabled))
 

--- a/pkg/operation/botanist/component/kubeapiserver/kube_apiserver_test.go
+++ b/pkg/operation/botanist/component/kubeapiserver/kube_apiserver_test.go
@@ -2520,7 +2520,6 @@ rules:
 					Expect(deployment.Spec.Template.Spec.Containers[0].Command).To(ConsistOf(
 						"/usr/local/bin/kube-apiserver",
 						"--enable-admission-plugins="+admissionPlugin1+","+admissionPlugin2,
-						"--disable-admission-plugins=",
 						"--admission-control-config-file=/etc/kubernetes/admission/admission-configuration.yaml",
 						"--anonymous-auth=false",
 						"--audit-log-path=/var/lib/audit.log",

--- a/pkg/operation/care/checker.go
+++ b/pkg/operation/care/checker.go
@@ -40,28 +40,28 @@ import (
 )
 
 var (
-	requiredControlPlaneDeployments = sets.New[string](
+	requiredControlPlaneDeployments = sets.New(
 		v1beta1constants.DeploymentNameGardenerResourceManager,
 		v1beta1constants.DeploymentNameKubeAPIServer,
 		v1beta1constants.DeploymentNameKubeControllerManager,
 		v1beta1constants.DeploymentNameKubeScheduler,
 	)
 
-	requiredControlPlaneEtcds = sets.New[string](
+	requiredControlPlaneEtcds = sets.New(
 		v1beta1constants.ETCDMain,
 		v1beta1constants.ETCDEvents,
 	)
 
-	requiredMonitoringSeedDeployments = sets.New[string](
+	requiredMonitoringSeedDeployments = sets.New(
 		v1beta1constants.DeploymentNameGrafana,
 		v1beta1constants.DeploymentNameKubeStateMetrics,
 	)
 
-	requiredLoggingStatefulSets = sets.New[string](
+	requiredLoggingStatefulSets = sets.New(
 		v1beta1constants.StatefulSetNameLoki,
 	)
 
-	requiredLoggingDeployments = sets.New[string](
+	requiredLoggingDeployments = sets.New(
 		v1beta1constants.DeploymentNameEventLogger,
 	)
 )
@@ -347,7 +347,7 @@ func computeRequiredControlPlaneDeployments(shoot *gardencorev1beta1.Shoot) (set
 		return nil, err
 	}
 
-	requiredControlPlaneDeployments := sets.New[string](requiredControlPlaneDeployments.UnsortedList()...)
+	requiredControlPlaneDeployments := sets.New(requiredControlPlaneDeployments.UnsortedList()...)
 	if shootWantsClusterAutoscaler {
 		requiredControlPlaneDeployments.Insert(v1beta1constants.DeploymentNameClusterAutoscaler)
 	}
@@ -364,7 +364,7 @@ func computeRequiredControlPlaneDeployments(shoot *gardencorev1beta1.Shoot) (set
 // computeRequiredMonitoringStatefulSets determine the required monitoring statefulsets
 // which should exist next to the control plane.
 func computeRequiredMonitoringStatefulSets(wantsAlertmanager bool) sets.Set[string] {
-	var requiredMonitoringStatefulSets = sets.New[string](v1beta1constants.StatefulSetNamePrometheus)
+	var requiredMonitoringStatefulSets = sets.New(v1beta1constants.StatefulSetNamePrometheus)
 	if wantsAlertmanager {
 		requiredMonitoringStatefulSets.Insert(v1beta1constants.StatefulSetNameAlertManager)
 	}

--- a/pkg/operation/care/seed_health.go
+++ b/pkg/operation/care/seed_health.go
@@ -42,7 +42,7 @@ import (
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 )
 
-var requiredManagedResourcesSeed = sets.New[string](
+var requiredManagedResourcesSeed = sets.New(
 	etcd.Druid,
 	clusterautoscaler.ManagedResourceControlName,
 	kubestatemetrics.ManagedResourceName,

--- a/pkg/operation/istio_config.go
+++ b/pkg/operation/istio_config.go
@@ -103,7 +103,7 @@ func (o *Operation) singleZoneIfPinned() *string {
 		return nil
 	}
 	if v, ok := o.SeedNamespaceObject.Annotations[resourcesv1alpha1.HighAvailabilityConfigZones]; ok {
-		zones := sets.List(sets.New[string](strings.Split(v, ",")...).Delete(""))
+		zones := sets.List(sets.New(strings.Split(v, ",")...).Delete(""))
 		if len(zones) == 1 {
 			return &zones[0]
 		}

--- a/pkg/operator/apis/config/validation/validation.go
+++ b/pkg/operator/apis/config/validation/validation.go
@@ -30,11 +30,11 @@ import (
 func ValidateOperatorConfiguration(conf *config.OperatorConfiguration) field.ErrorList {
 	allErrs := field.ErrorList{}
 
-	if conf.LogLevel != "" && !sets.New[string](logger.AllLogLevels...).Has(conf.LogLevel) {
+	if conf.LogLevel != "" && !sets.New(logger.AllLogLevels...).Has(conf.LogLevel) {
 		allErrs = append(allErrs, field.NotSupported(field.NewPath("logLevel"), conf.LogLevel, logger.AllLogLevels))
 	}
 
-	if conf.LogFormat != "" && !sets.New[string](logger.AllLogFormats...).Has(conf.LogFormat) {
+	if conf.LogFormat != "" && !sets.New(logger.AllLogFormats...).Has(conf.LogFormat) {
 		allErrs = append(allErrs, field.NotSupported(field.NewPath("logFormat"), conf.LogFormat, logger.AllLogFormats))
 	}
 

--- a/pkg/resourcemanager/apis/config/validation/validation.go
+++ b/pkg/resourcemanager/apis/config/validation/validation.go
@@ -39,10 +39,10 @@ func ValidateResourceManagerConfiguration(conf *config.ResourceManagerConfigurat
 	allErrs = append(allErrs, validateServerConfiguration(conf.Server, field.NewPath("server"))...)
 	allErrs = append(allErrs, componentbaseconfigvalidation.ValidateLeaderElectionConfiguration(&conf.LeaderElection, field.NewPath("leaderElection"))...)
 
-	if !sets.New[string](logger.AllLogLevels...).Has(conf.LogLevel) {
+	if !sets.New(logger.AllLogLevels...).Has(conf.LogLevel) {
 		allErrs = append(allErrs, field.NotSupported(field.NewPath("logLevel"), conf.LogLevel, logger.AllLogLevels))
 	}
-	if !sets.New[string](logger.AllLogFormats...).Has(conf.LogFormat) {
+	if !sets.New(logger.AllLogFormats...).Has(conf.LogFormat) {
 		allErrs = append(allErrs, field.NotSupported(field.NewPath("logFormat"), conf.LogFormat, logger.AllLogFormats))
 	}
 

--- a/pkg/resourcemanager/controller/csrapprover/reconciler.go
+++ b/pkg/resourcemanager/controller/csrapprover/reconciler.go
@@ -161,7 +161,7 @@ func (r *Reconciler) mustApprove(ctx context.Context, csr *certificatesv1.Certif
 		}
 	}
 
-	if !sets.New[string](hostNames...).Equal(sets.New[string](x509cr.DNSNames...)) {
+	if !sets.New(hostNames...).Equal(sets.New(x509cr.DNSNames...)) {
 		return "DNS names in CSR do not match addresses of type 'Hostname' or 'InternalDNS' or 'ExternalDNS' in node object", false, nil
 	}
 
@@ -170,7 +170,7 @@ func (r *Reconciler) mustApprove(ctx context.Context, csr *certificatesv1.Certif
 		ipAddressesInCSR = append(ipAddressesInCSR, ip.String())
 	}
 
-	if !sets.New[string](ipAddresses...).Equal(sets.New[string](ipAddressesInCSR...)) {
+	if !sets.New(ipAddresses...).Equal(sets.New(ipAddressesInCSR...)) {
 		return "IP addresses in CSR do not match addresses of type 'InternalIP' or 'ExternalIP' in node object", false, nil
 	}
 

--- a/pkg/resourcemanager/controller/managedresource/reconciler.go
+++ b/pkg/resourcemanager/controller/managedresource/reconciler.go
@@ -67,7 +67,7 @@ import (
 
 var (
 	deletePropagationForeground = metav1.DeletePropagationForeground
-	foregroundDeletionAPIGroups = sets.New[string](appsv1.GroupName, extensionsv1beta1.GroupName, batchv1.GroupName)
+	foregroundDeletionAPIGroups = sets.New(appsv1.GroupName, extensionsv1beta1.GroupName, batchv1.GroupName)
 )
 
 // Reconciler manages the resources reference by ManagedResources.
@@ -640,7 +640,7 @@ func ignore(meta metav1.Object) bool {
 
 func deleteOnInvalidUpdate(obj *unstructured.Unstructured, err error) bool {
 	isImmutableConfigMapOrSecret := false
-	if obj.GetAPIVersion() == "v1" && sets.New[string]("ConfigMap", "Secret").Has(obj.GetKind()) {
+	if obj.GetAPIVersion() == "v1" && sets.New("ConfigMap", "Secret").Has(obj.GetKind()) {
 		cause, ok := apierrors.StatusCause(err, metav1.CauseType(field.ErrorTypeForbidden))
 		if ok && strings.Contains(cause.Message, "field is immutable when `immutable` is set") {
 			isImmutableConfigMapOrSecret = true
@@ -656,7 +656,7 @@ func keepObject(meta metav1.Object) bool {
 
 func isGarbageCollectableResource(obj *unstructured.Unstructured) bool {
 	return keyExistsAndValueTrue(obj.GetLabels(), references.LabelKeyGarbageCollectable) &&
-		obj.GetAPIVersion() == "v1" && sets.New[string]("ConfigMap", "Secret").Has(obj.GetKind())
+		obj.GetAPIVersion() == "v1" && sets.New("ConfigMap", "Secret").Has(obj.GetKind())
 }
 
 func keyExistsAndValueTrue(kv map[string]string, key string) bool {

--- a/pkg/resourcemanager/controller/networkpolicy/reconciler.go
+++ b/pkg/resourcemanager/controller/networkpolicy/reconciler.go
@@ -125,7 +125,7 @@ func (r *Reconciler) fetchRelevantNamespaceNames(ctx context.Context, service *c
 		}
 	}
 
-	namespaceNames := sets.New[string](service.Namespace)
+	namespaceNames := sets.New(service.Namespace)
 
 	for _, n := range namespaceSelectors {
 		namespaceSelector := n

--- a/pkg/resourcemanager/webhook/highavailabilityconfig/handler.go
+++ b/pkg/resourcemanager/webhook/highavailabilityconfig/handler.go
@@ -91,7 +91,7 @@ func (h *Handler) Handle(ctx context.Context, req admission.Request) admission.R
 	}
 
 	if v, ok := namespace.Annotations[resourcesv1alpha1.HighAvailabilityConfigZones]; ok {
-		zones = sets.List(sets.New[string](strings.Split(v, ",")...).Delete(""))
+		zones = sets.List(sets.New(strings.Split(v, ",")...).Delete(""))
 	}
 
 	if v, err := strconv.ParseBool(namespace.Annotations[resourcesv1alpha1.HighAvailabilityConfigZonePinning]); err == nil {

--- a/pkg/scheduler/apis/config/validation/validation.go
+++ b/pkg/scheduler/apis/config/validation/validation.go
@@ -29,13 +29,13 @@ func ValidateConfiguration(config *schedulerconfig.SchedulerConfiguration) field
 	allErrs = append(allErrs, validateStrategy(config.Schedulers.Shoot.Strategy, field.NewPath("schedulers", "shoot", "strategy"))...)
 
 	if config.LogLevel != "" {
-		if !sets.New[string](logger.AllLogLevels...).Has(config.LogLevel) {
+		if !sets.New(logger.AllLogLevels...).Has(config.LogLevel) {
 			allErrs = append(allErrs, field.NotSupported(field.NewPath("logLevel"), config.LogLevel, logger.AllLogLevels))
 		}
 	}
 
 	if config.LogFormat != "" {
-		if !sets.New[string](logger.AllLogFormats...).Has(config.LogFormat) {
+		if !sets.New(logger.AllLogFormats...).Has(config.LogFormat) {
 			allErrs = append(allErrs, field.NotSupported(field.NewPath("logFormat"), config.LogFormat, logger.AllLogFormats))
 		}
 	}

--- a/pkg/utils/gardener/shoot_test.go
+++ b/pkg/utils/gardener/shoot_test.go
@@ -1159,7 +1159,7 @@ var _ = Describe("Shoot", func() {
 		It("should compute the correct list of required extensions", func() {
 			result := ComputeRequiredExtensions(shoot, seed, controllerRegistrationList, internalDomain, externalDomain)
 
-			Expect(result).To(Equal(sets.New[string](
+			Expect(result).To(Equal(sets.New(
 				ExtensionsID(extensionsv1alpha1.BackupBucketResource, backupProvider),
 				ExtensionsID(extensionsv1alpha1.BackupEntryResource, backupProvider),
 				ExtensionsID(extensionsv1alpha1.ControlPlaneResource, seedProvider),
@@ -1181,7 +1181,7 @@ var _ = Describe("Shoot", func() {
 
 			result := ComputeRequiredExtensions(shoot, seed, controllerRegistrationList, internalDomain, externalDomain)
 
-			Expect(result).To(Equal(sets.New[string](
+			Expect(result).To(Equal(sets.New(
 				ExtensionsID(extensionsv1alpha1.ControlPlaneResource, seedProvider),
 				ExtensionsID(extensionsv1alpha1.ControlPlaneResource, shootProvider),
 				ExtensionsID(extensionsv1alpha1.InfrastructureResource, shootProvider),
@@ -1204,7 +1204,7 @@ var _ = Describe("Shoot", func() {
 
 			result := ComputeRequiredExtensions(shoot, seed, controllerRegistrationList, internalDomain, externalDomain)
 
-			Expect(result).To(Equal(sets.New[string](
+			Expect(result).To(Equal(sets.New(
 				ExtensionsID(extensionsv1alpha1.BackupBucketResource, backupProvider),
 				ExtensionsID(extensionsv1alpha1.BackupEntryResource, backupProvider),
 				ExtensionsID(extensionsv1alpha1.ControlPlaneResource, seedProvider),

--- a/pkg/utils/test/test_resources.go
+++ b/pkg/utils/test/test_resources.go
@@ -72,7 +72,7 @@ func ReadTestResources(scheme *runtime.Scheme, namespaceName, path string) ([]cl
 	}
 
 	// file extensions that may contain Webhooks
-	resourceExtensions := sets.New[string](".json", ".yaml", ".yml")
+	resourceExtensions := sets.New(".json", ".yaml", ".yml")
 
 	var objects []client.Object
 	for _, file := range files {

--- a/plugin/pkg/bastion/validator/admission.go
+++ b/plugin/pkg/bastion/validator/admission.go
@@ -46,7 +46,7 @@ func Register(plugins *admission.Plugins) {
 	})
 }
 
-// Bastion contains listers and and admission handler.
+// Bastion contains listers and admission handler.
 type Bastion struct {
 	*admission.Handler
 	coreClient gardencoreclientset.Interface

--- a/plugin/pkg/global/customverbauthorizer/admission.go
+++ b/plugin/pkg/global/customverbauthorizer/admission.go
@@ -220,7 +220,7 @@ func userIsOwner(userInfo user.Info, owner *rbacv1.Subject) bool {
 		return owner.Name == userInfo.GetName()
 
 	case rbacv1.GroupKind:
-		return sets.New[string](userInfo.GetGroups()...).Has(owner.Name)
+		return sets.New(userInfo.GetGroups()...).Has(owner.Name)
 	}
 
 	return false

--- a/plugin/pkg/global/resourcereferencemanager/admission.go
+++ b/plugin/pkg/global/resourcereferencemanager/admission.go
@@ -66,7 +66,7 @@ func Register(plugins *admission.Plugins) {
 	})
 }
 
-// ReferenceManager contains listers and and admission handler.
+// ReferenceManager contains listers and admission handler.
 type ReferenceManager struct {
 	*admission.Handler
 	gardenCoreClient           internalversion.Interface

--- a/plugin/pkg/managedseed/shoot/admission.go
+++ b/plugin/pkg/managedseed/shoot/admission.go
@@ -46,7 +46,7 @@ func Register(plugins *admission.Plugins) {
 	})
 }
 
-// Shoot contains listers and and admission handler.
+// Shoot contains listers and admission handler.
 type Shoot struct {
 	*admission.Handler
 	shootLister          gardencorelisters.ShootLister

--- a/plugin/pkg/managedseed/validator/admission.go
+++ b/plugin/pkg/managedseed/validator/admission.go
@@ -301,7 +301,7 @@ func (v *ManagedSeed) validateManagedSeedUpdate(oldManagedSeed, newManagedSeed *
 	}
 
 	shootZones := helper.GetAllZonesFromShoot(shoot)
-	newZones := sets.New[string](newSeedSpec.Provider.Zones...).Difference(sets.New[string](oldSeedSpec.Provider.Zones...))
+	newZones := sets.New(newSeedSpec.Provider.Zones...).Difference(sets.New(oldSeedSpec.Provider.Zones...))
 
 	// Newly added zones should match the ones found in the shoot cluster.
 	// Zone names were allowed to deviate from the zones configured for shoot clusters, see https://github.com/gardener/gardener/commit/8d28452e7f718d0041fbe82eb83543e3a87ea8ad.

--- a/plugin/pkg/shoot/dns/admission.go
+++ b/plugin/pkg/shoot/dns/admission.go
@@ -55,7 +55,7 @@ func Register(plugins *admission.Plugins) {
 	})
 }
 
-// DNS contains listers and and admission handler.
+// DNS contains listers and admission handler.
 type DNS struct {
 	*admission.Handler
 	secretLister  kubecorev1listers.SecretLister
@@ -162,7 +162,7 @@ func (d *DNS) Admit(ctx context.Context, a admission.Attributes, o admission.Obj
 
 	switch a.GetOperation() {
 	case admission.Create:
-		// If shoot uses deafult domain validate domain even though shoot can be assigned to seed
+		// If shoot uses default domain, validate domain even though shoot can be assigned to seed
 		// having dns disabled later on
 		if isShootDomainSet(shoot) && !helper.ShootUsesUnmanagedDNS(shoot) {
 			if err := checkDefaultDomainFormat(a, shoot, d.projectLister, defaultDomains); err != nil {

--- a/plugin/pkg/shoot/exposureclass/admission.go
+++ b/plugin/pkg/shoot/exposureclass/admission.go
@@ -190,7 +190,7 @@ func uniteSeedSelectors(shootSeedSelector *core.SeedSelector, exposureClassSeedS
 }
 
 func uniteTolerations(shootTolerations []core.Toleration, exposureClassTolerations []core.Toleration) ([]core.Toleration, error) {
-	shootTolerationsKeys := sets.NewString()
+	shootTolerationsKeys := sets.New[string]()
 	for _, toleration := range shootTolerations {
 		shootTolerationsKeys.Insert(toleration.Key)
 	}

--- a/plugin/pkg/shoot/oidc/clusteropenidconnectpreset/admission.go
+++ b/plugin/pkg/shoot/oidc/clusteropenidconnectpreset/admission.go
@@ -48,7 +48,7 @@ func Register(plugins *admission.Plugins) {
 	})
 }
 
-// ClusterOpenIDConnectPreset contains listers and and admission handler.
+// ClusterOpenIDConnectPreset contains listers and admission handler.
 type ClusterOpenIDConnectPreset struct {
 	*admission.Handler
 

--- a/plugin/pkg/shoot/oidc/openidconnectpreset/admission.go
+++ b/plugin/pkg/shoot/oidc/openidconnectpreset/admission.go
@@ -46,7 +46,7 @@ func Register(plugins *admission.Plugins) {
 	})
 }
 
-// OpenIDConnectPreset contains listers and and admission handler.
+// OpenIDConnectPreset contains listers and admission handler.
 type OpenIDConnectPreset struct {
 	*admission.Handler
 

--- a/plugin/pkg/shoot/quotavalidator/admission.go
+++ b/plugin/pkg/shoot/quotavalidator/admission.go
@@ -59,7 +59,7 @@ func Register(plugins *admission.Plugins) {
 	})
 }
 
-// QuotaValidator contains listers and and admission handler.
+// QuotaValidator contains listers and admission handler.
 type QuotaValidator struct {
 	*admission.Handler
 	shootLister         gardencorelisters.ShootLister

--- a/plugin/pkg/shoot/validator/admission.go
+++ b/plugin/pkg/shoot/validator/admission.go
@@ -65,7 +65,7 @@ func Register(plugins *admission.Plugins) {
 	})
 }
 
-// ValidateShoot contains listers and and admission handler.
+// ValidateShoot contains listers and admission handler.
 type ValidateShoot struct {
 	*admission.Handler
 	authorizer          authorizer.Authorizer

--- a/plugin/pkg/shoot/validator/admission.go
+++ b/plugin/pkg/shoot/validator/admission.go
@@ -424,7 +424,7 @@ func (c *validationContext) validateScheduling(ctx context.Context, a admission.
 			}
 
 			if seedSelector.ProviderTypes != nil {
-				if !sets.New[string](seedSelector.ProviderTypes...).HasAny(c.seed.Spec.Provider.Type, "*") {
+				if !sets.New(seedSelector.ProviderTypes...).HasAny(c.seed.Spec.Provider.Type, "*") {
 					return admission.NewForbidden(a, fmt.Errorf("cannot schedule shoot '%s' on seed '%s' because none of the provider types in the seed selector of cloud profile '%s' is matching the provider type of the seed", c.shoot.Name, c.seed.Name, c.cloudProfile.Name))
 				}
 			}
@@ -563,8 +563,8 @@ func (c *validationContext) validateDeletion(a admission.Attributes) error {
 
 	// Allow removal of `gardener` finalizer only if the Shoot deletion has completed successfully
 	if len(c.shoot.Status.TechnicalID) > 0 && c.shoot.Status.LastOperation != nil {
-		oldFinalizers := sets.New[string](c.oldShoot.Finalizers...)
-		newFinalizers := sets.New[string](c.shoot.Finalizers...)
+		oldFinalizers := sets.New(c.oldShoot.Finalizers...)
+		newFinalizers := sets.New(c.shoot.Finalizers...)
 
 		if oldFinalizers.Has(core.GardenerName) && !newFinalizers.Has(core.GardenerName) {
 			lastOperation := c.shoot.Status.LastOperation

--- a/plugin/pkg/shoot/validator/admission_test.go
+++ b/plugin/pkg/shoot/validator/admission_test.go
@@ -468,7 +468,7 @@ var _ = Describe("validator", func() {
 
 				// set old shoot for update and add gardener finalizer to it
 				oldShoot = shoot.DeepCopy()
-				finalizers := sets.New[string](oldShoot.GetFinalizers()...)
+				finalizers := sets.New(oldShoot.GetFinalizers()...)
 				finalizers.Insert(core.GardenerName)
 				oldShoot.SetFinalizers(finalizers.UnsortedList())
 			})

--- a/plugin/pkg/utils/miscellaneous.go
+++ b/plugin/pkg/utils/miscellaneous.go
@@ -78,7 +78,7 @@ func NewAttributesWithName(a admission.Attributes, name string) admission.Attrib
 // ValidateZoneRemovalFromSeeds returns an error when zones are removed from the old seed while it is still in use by
 // shoots.
 func ValidateZoneRemovalFromSeeds(oldSeedSpec, newSeedSpec *core.SeedSpec, seedName string, shootLister gardencorelisters.ShootLister, kind string) error {
-	if removedZones := sets.New[string](oldSeedSpec.Provider.Zones...).Difference(sets.New[string](newSeedSpec.Provider.Zones...)); removedZones.Len() > 0 {
+	if removedZones := sets.New(oldSeedSpec.Provider.Zones...).Difference(sets.New(newSeedSpec.Provider.Zones...)); removedZones.Len() > 0 {
 		shoots, err := shootLister.List(labels.Everything())
 		if err != nil {
 			return err

--- a/test/framework/test_description.go
+++ b/test/framework/test_description.go
@@ -31,7 +31,7 @@ type TestDescription struct {
 // NewTestDescription creates a new test description
 func NewTestDescription(baseLabel string) TestDescription {
 	return TestDescription{
-		labels: sets.New[string](baseLabel),
+		labels: sets.New(baseLabel),
 	}
 }
 

--- a/test/integration/scheduler/shoot/shoot_test.go
+++ b/test/integration/scheduler/shoot/shoot_test.go
@@ -62,7 +62,7 @@ var _ = Describe("Scheduler tests", func() {
 			}).Should(PointTo(Equal(seed.Name)))
 		})
 
-		It("should pass because there is a a seed with < 3 zones for non-HA shoot", func() {
+		It("should pass because there is a seed with < 3 zones for non-HA shoot", func() {
 			cloudProfile := createCloudProfile(providerType, "some-region")
 			seed := createSeed(providerType, "some-region", []string{"1"})
 			shoot := createShoot(providerType, cloudProfile.Name, "some-region", pointer.String("somedns.example.com"), nil)
@@ -72,7 +72,7 @@ var _ = Describe("Scheduler tests", func() {
 			}).Should(PointTo(Equal(seed.Name)))
 		})
 
-		It("should pass because there is a a seed with >= 3 zones for non-HA shoot", func() {
+		It("should pass because there is a seed with >= 3 zones for non-HA shoot", func() {
 			cloudProfile := createCloudProfile(providerType, "some-region")
 			seed := createSeed(providerType, "some-region", []string{"1", "2", "3"})
 			shoot := createShoot(providerType, cloudProfile.Name, "some-region", pointer.String("somedns.example.com"), nil)
@@ -82,7 +82,7 @@ var _ = Describe("Scheduler tests", func() {
 			}).Should(PointTo(Equal(seed.Name)))
 		})
 
-		It("should pass because there is a a seed with < 3 zones for shoot with failure tolerance type 'node'", func() {
+		It("should pass because there is a seed with < 3 zones for shoot with failure tolerance type 'node'", func() {
 			cloudProfile := createCloudProfile(providerType, "some-region")
 			seed := createSeed(providerType, "some-region", []string{"1", "2"})
 			shoot := createShoot(providerType, cloudProfile.Name, "some-region", pointer.String("somedns.example.com"), getControlPlaneWithType("node"))
@@ -92,7 +92,7 @@ var _ = Describe("Scheduler tests", func() {
 			}).Should(PointTo(Equal(seed.Name)))
 		})
 
-		It("should pass because there is a a seed with >= 3 zones for shoot with failure tolerance type 'node'", func() {
+		It("should pass because there is a seed with >= 3 zones for shoot with failure tolerance type 'node'", func() {
 			cloudProfile := createCloudProfile(providerType, "some-region")
 			seed := createSeed(providerType, "some-region", []string{"1", "2", "3"})
 			shoot := createShoot(providerType, cloudProfile.Name, "some-region", pointer.String("somedns.example.com"), getControlPlaneWithType("node"))
@@ -112,7 +112,7 @@ var _ = Describe("Scheduler tests", func() {
 			}).Should(BeNil())
 		})
 
-		It("should pass because there is a a seed with >= 3 zones for shoot with failure tolerance type 'zone'", func() {
+		It("should pass because there is a seed with >= 3 zones for shoot with failure tolerance type 'zone'", func() {
 			cloudProfile := createCloudProfile(providerType, "some-region")
 			seed := createSeed(providerType, "some-region", []string{"1", "2", "3"})
 			shoot := createShoot(providerType, cloudProfile.Name, "some-region", pointer.String("somedns.example.com"), getControlPlaneWithType("zone"))

--- a/test/start-envtest/main.go
+++ b/test/start-envtest/main.go
@@ -81,7 +81,7 @@ const (
 	typeGardener   = "gardener"
 )
 
-var supportedTypes = sets.New[string](typeKubernetes, typeGardener)
+var supportedTypes = sets.New(typeKubernetes, typeGardener)
 
 type options struct {
 	environmentType string


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind cleanup

**What this PR does / why we need it**:
This PR does some minor cosmetic changes:
1. Add the kubeapiserver commands for admissionplugins only if they are present
2. Fix wrong spellings and repeated words
3. Fix `unnecessary type arguments` error for sets
4. Replace usages of `sets.NewString` with `sets.New[string]`

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
5. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
