### PR TITLE
List only the resources in the current namespace for `deletecollection` request for Shootstates

### DIFF
--- a/plugin/pkg/global/deletionconfirmation/admission.go
+++ b/plugin/pkg/global/deletionconfirmation/admission.go
@@ -184,7 +184,7 @@ func (d *DeletionConfirmation) Validate(ctx context.Context, a admission.Attribu
 
 	case core.Kind("ShootState"):
 		listFunc = func() ([]client.Object, error) {
-			list, err := d.shootStateLister.List(labels.Everything())
+			list, err := d.shootStateLister.ShootStates(a.GetNamespace()).List(labels.Everything())
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/area security
/kind bug

**What this PR does / why we need it**:
The `DELETECOLLECTION` sends a request with an empty resource name. We then try to list the resources and check if all of them have the deletion confirmation annotation. But while listing, we were not using the namespace in the request, so it was trying to look for all resources in all namespaces in the current namespace. This caused errors like,
```
panic: shootstates.core.gardener.cloud "Unknown" is forbidden: 5 errors occurred:
	* shootstates.core.gardener.cloud "bazz" not found
	* shootstates.core.gardener.cloud "foo" not found
	* shootstates.core.gardener.cloud "bar" not found
```
This PR fixes this issue by listing only the resources in the namespace of the request.

**Which issue(s) this PR fixes**:
Fixes #7776

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
A bug causing `kube-controller-manager` to fail to clean up `ShootState` resources is now fixed.
```
