### PR TITLE
Reformat gardener timestamp annotation

### DIFF
--- a/extensions/pkg/predicate/default_test.go
+++ b/extensions/pkg/predicate/default_test.go
@@ -118,14 +118,14 @@ var _ = Describe("Default", func() {
 				It("should return true when last operation has not succeeded and the timestamp changed", func() {
 					obj.Status.LastOperation = &gardencorev1beta1.LastOperation{State: gardencorev1beta1.LastOperationStateError}
 					oldObj := obj.DeepCopy()
-					obj.SetAnnotations(map[string]string{"gardener.cloud/timestamp": now.UTC().Add(time.Second).String()})
+					obj.SetAnnotations(map[string]string{"gardener.cloud/timestamp": now.UTC().Add(time.Second).Format(time.RFC3339Nano)})
 					Expect(pred.Update(event.UpdateEvent{ObjectNew: obj, ObjectOld: oldObj})).To(BeTrue())
 				})
 
 				It("should return false when last operation has succeeded and the timestamp changed", func() {
 					obj.Status.LastOperation = &gardencorev1beta1.LastOperation{State: gardencorev1beta1.LastOperationStateSucceeded}
 					oldObj := obj.DeepCopy()
-					obj.SetAnnotations(map[string]string{"gardener.cloud/timestamp": now.UTC().Add(time.Second).String()})
+					obj.SetAnnotations(map[string]string{"gardener.cloud/timestamp": now.UTC().Add(time.Second).Format(time.RFC3339Nano)})
 					Expect(pred.Update(event.UpdateEvent{ObjectNew: obj, ObjectOld: oldObj})).To(BeFalse())
 				})
 			})

--- a/pkg/controllermanager/controller/project/stale/reconciler_test.go
+++ b/pkg/controllermanager/controller/project/stale/reconciler_test.go
@@ -452,7 +452,7 @@ var _ = Describe("Reconciler", func() {
 					projectCopy := project.DeepCopy()
 					projectCopy.Annotations = map[string]string{
 						gardenerutils.ConfirmationDeletion: "true",
-						v1beta1constants.GardenerTimestamp: gardenerutils.TimeNow().UTC().String(),
+						v1beta1constants.GardenerTimestamp: gardenerutils.TimeNow().UTC().Format(time.RFC3339Nano),
 					}
 					k8sGardenRuntimeClient.EXPECT().Patch(gomock.Any(), projectCopy, gomock.Any())
 					k8sGardenRuntimeClient.EXPECT().Delete(gomock.Any(), projectCopy)

--- a/pkg/extensions/customresources.go
+++ b/pkg/extensions/customresources.go
@@ -399,7 +399,7 @@ func WaitUntilExtensionObjectsMigrated(
 func AnnotateObjectWithOperation(ctx context.Context, w client.Writer, obj client.Object, operation string) error {
 	patch := client.MergeFrom(obj.DeepCopyObject().(client.Object))
 	kubernetesutils.SetMetaDataAnnotation(obj, v1beta1constants.GardenerOperation, operation)
-	kubernetesutils.SetMetaDataAnnotation(obj, v1beta1constants.GardenerTimestamp, TimeNow().UTC().String())
+	kubernetesutils.SetMetaDataAnnotation(obj, v1beta1constants.GardenerTimestamp, TimeNow().UTC().Format(time.RFC3339Nano))
 	return w.Patch(ctx, obj, patch)
 }
 

--- a/pkg/extensions/customresources_test.go
+++ b/pkg/extensions/customresources_test.go
@@ -267,9 +267,9 @@ var _ = Describe("extensions", func() {
 				LastUpdateTime: metav1.Now(),
 			}
 			now = time.Now()
-			metav1.SetMetaDataAnnotation(&expected.ObjectMeta, v1beta1constants.GardenerTimestamp, now.UTC().String())
+			metav1.SetMetaDataAnnotation(&expected.ObjectMeta, v1beta1constants.GardenerTimestamp, now.UTC().Format(time.RFC3339Nano))
 			passedObj := expected.DeepCopy()
-			metav1.SetMetaDataAnnotation(&passedObj.ObjectMeta, v1beta1constants.GardenerTimestamp, now.Add(time.Millisecond).UTC().String())
+			metav1.SetMetaDataAnnotation(&passedObj.ObjectMeta, v1beta1constants.GardenerTimestamp, now.Add(time.Millisecond).UTC().Format(time.RFC3339Nano))
 
 			Expect(c.Create(ctx, expected)).ToNot(HaveOccurred(), "creating worker succeeds")
 			err := WaitUntilObjectReadyWithHealthFunction(
@@ -289,7 +289,7 @@ var _ = Describe("extensions", func() {
 				LastUpdateTime: metav1.Now(),
 			}
 			now = time.Now()
-			metav1.SetMetaDataAnnotation(&expected.ObjectMeta, v1beta1constants.GardenerTimestamp, now.UTC().String())
+			metav1.SetMetaDataAnnotation(&expected.ObjectMeta, v1beta1constants.GardenerTimestamp, now.UTC().Format(time.RFC3339Nano))
 			passedObj := expected.DeepCopy()
 
 			Expect(c.Create(ctx, expected)).ToNot(HaveOccurred(), "creating worker succeeds")
@@ -361,7 +361,7 @@ var _ = Describe("extensions", func() {
 			)()
 
 			expected.Annotations = map[string]string{
-				v1beta1constants.GardenerTimestamp: now.UTC().String(),
+				v1beta1constants.GardenerTimestamp: now.UTC().Format(time.RFC3339Nano),
 			}
 
 			mockNow.EXPECT().Do().Return(now.UTC()).AnyTimes()
@@ -579,7 +579,7 @@ var _ = Describe("extensions", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(expected.Annotations).To(Equal(map[string]string{
 					v1beta1constants.GardenerOperation: v1beta1constants.GardenerOperationRestore,
-					v1beta1constants.GardenerTimestamp: now.UTC().String(),
+					v1beta1constants.GardenerTimestamp: now.UTC().Format(time.RFC3339Nano),
 				}))
 				Expect(expected.Status.State).To(Equal(expectedState))
 			})
@@ -605,7 +605,7 @@ var _ = Describe("extensions", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(expected.Annotations).To(Equal(map[string]string{
 					v1beta1constants.GardenerOperation: v1beta1constants.GardenerOperationRestore,
-					v1beta1constants.GardenerTimestamp: now.UTC().String(),
+					v1beta1constants.GardenerTimestamp: now.UTC().Format(time.RFC3339Nano),
 				}))
 				Expect(expected.Status.State).To(BeNil())
 			})
@@ -658,7 +658,7 @@ var _ = Describe("extensions", func() {
 			expectedWithAnnotations := expected.DeepCopy()
 			expectedWithAnnotations.Annotations = map[string]string{
 				v1beta1constants.GardenerOperation: v1beta1constants.GardenerOperationMigrate,
-				v1beta1constants.GardenerTimestamp: now.UTC().String(),
+				v1beta1constants.GardenerTimestamp: now.UTC().Format(time.RFC3339Nano),
 			}
 
 			mc := mockclient.NewMockClient(ctrl)
@@ -869,7 +869,7 @@ var _ = Describe("extensions", func() {
 			expectedWithAnnotations := expected.DeepCopy()
 			expectedWithAnnotations.Annotations = map[string]string{
 				v1beta1constants.GardenerOperation: v1beta1constants.GardenerOperationMigrate,
-				v1beta1constants.GardenerTimestamp: now.UTC().String(),
+				v1beta1constants.GardenerTimestamp: now.UTC().Format(time.RFC3339Nano),
 			}
 
 			mc := mockclient.NewMockClient(ctrl)

--- a/pkg/gardenlet/controller/backupbucket/reconciler.go
+++ b/pkg/gardenlet/controller/backupbucket/reconciler.go
@@ -181,6 +181,10 @@ func (r *Reconciler) reconcileBackupBucket(
 		return reconcile.Result{}, err
 	}
 
+	// round the secret timestamp because extension.Status.LastOperation.LastUpdateTime
+	// is represented in time.RFC3339 format which does not include the Nano precision
+	secretLastUpdateTime = secretLastUpdateTime.Round(time.Second)
+
 	if err := r.SeedClient.Get(seedCtx, client.ObjectKeyFromObject(extensionBackupBucket), extensionBackupBucket); err != nil {
 		if !apierrors.IsNotFound(err) {
 			return reconcile.Result{}, err

--- a/pkg/gardenlet/controller/backupbucket/reconciler.go
+++ b/pkg/gardenlet/controller/backupbucket/reconciler.go
@@ -176,7 +176,7 @@ func (r *Reconciler) reconcileBackupBucket(
 		}
 	}
 
-	secretLastUpdateTime, err := time.Parse(time.RFC3339, extensionSecret.Annotations[v1beta1constants.GardenerTimestamp])
+	secretLastUpdateTime, err := time.Parse(time.RFC3339Nano, extensionSecret.Annotations[v1beta1constants.GardenerTimestamp])
 	if err != nil {
 		return reconcile.Result{}, err
 	}
@@ -231,7 +231,7 @@ func (r *Reconciler) reconcileBackupBucket(
 	if mustReconcileExtensionBackupBucket {
 		if _, err := controllerutils.GetAndCreateOrMergePatch(seedCtx, r.SeedClient, extensionBackupBucket, func() error {
 			metav1.SetMetaDataAnnotation(&extensionBackupBucket.ObjectMeta, v1beta1constants.GardenerOperation, v1beta1constants.GardenerOperationReconcile)
-			metav1.SetMetaDataAnnotation(&extensionBackupBucket.ObjectMeta, v1beta1constants.GardenerTimestamp, r.Clock.Now().UTC().String())
+			metav1.SetMetaDataAnnotation(&extensionBackupBucket.ObjectMeta, v1beta1constants.GardenerTimestamp, r.Clock.Now().UTC().Format(time.RFC3339Nano))
 
 			extensionBackupBucket.Spec = extensionBackupBucketSpec
 			return nil
@@ -349,7 +349,7 @@ func (r *Reconciler) emptyExtensionSecret(backupBucketName string) *corev1.Secre
 
 func (r *Reconciler) reconcileBackupBucketExtensionSecret(ctx context.Context, extensionSecret, gardenSecret *corev1.Secret, backupBucket *gardencorev1beta1.BackupBucket) error {
 	_, err := controllerutils.GetAndCreateOrMergePatch(ctx, r.SeedClient, extensionSecret, func() error {
-		metav1.SetMetaDataAnnotation(&extensionSecret.ObjectMeta, v1beta1constants.GardenerTimestamp, r.Clock.Now().UTC().Format(time.RFC3339))
+		metav1.SetMetaDataAnnotation(&extensionSecret.ObjectMeta, v1beta1constants.GardenerTimestamp, r.Clock.Now().UTC().Format(time.RFC3339Nano))
 		extensionSecret.Data = gardenSecret.Data
 		return nil
 	})

--- a/pkg/gardenlet/controller/backupbucket/reconciler.go
+++ b/pkg/gardenlet/controller/backupbucket/reconciler.go
@@ -181,9 +181,9 @@ func (r *Reconciler) reconcileBackupBucket(
 		return reconcile.Result{}, err
 	}
 
-	// round the secret timestamp because extension.Status.LastOperation.LastUpdateTime
+	// truncate the secret timestamp because extension.Status.LastOperation.LastUpdateTime
 	// is represented in time.RFC3339 format which does not include the Nano precision
-	secretLastUpdateTime = secretLastUpdateTime.Round(time.Second)
+	secretLastUpdateTime = secretLastUpdateTime.Truncate(time.Second)
 
 	if err := r.SeedClient.Get(seedCtx, client.ObjectKeyFromObject(extensionBackupBucket), extensionBackupBucket); err != nil {
 		if !apierrors.IsNotFound(err) {

--- a/pkg/gardenlet/controller/backupbucket/reconciler_test.go
+++ b/pkg/gardenlet/controller/backupbucket/reconciler_test.go
@@ -197,7 +197,6 @@ var _ = Describe("Controller", func() {
 	})
 
 	It("should not reconcile the extension BackupBucket if the secret data or extension spec hasn't changed", func() {
-		extensionBackupBucket.Status.LastOperation.LastUpdateTime = metav1.NewTime(time.Now().Add(time.Second * 10).UTC())
 		Expect(seedClient.Create(ctx, extensionSecret)).To(Succeed())
 		Expect(seedClient.Create(ctx, extensionBackupBucket)).To(Succeed())
 

--- a/pkg/gardenlet/controller/backupentry/reconciler.go
+++ b/pkg/gardenlet/controller/backupentry/reconciler.go
@@ -200,7 +200,7 @@ func (r *Reconciler) reconcileBackupEntry(
 		BackupBucketProviderStatus: backupBucket.Status.ProviderStatus,
 	}
 
-	secretLastUpdateTime, err := time.Parse(time.RFC3339, extensionSecret.Annotations[v1beta1constants.GardenerTimestamp])
+	secretLastUpdateTime, err := time.Parse(time.RFC3339Nano, extensionSecret.Annotations[v1beta1constants.GardenerTimestamp])
 	if err != nil {
 		return reconcile.Result{}, err
 	}
@@ -626,7 +626,7 @@ func (r *Reconciler) getGardenSecret(ctx context.Context, backupBucket *gardenco
 
 func (r *Reconciler) reconcileBackupEntryExtensionSecret(ctx context.Context, extensionSecret, gardenSecret *corev1.Secret) error {
 	if _, err := controllerutils.GetAndCreateOrMergePatch(ctx, r.SeedClient, extensionSecret, func() error {
-		metav1.SetMetaDataAnnotation(&extensionSecret.ObjectMeta, v1beta1constants.GardenerTimestamp, r.Clock.Now().UTC().Format(time.RFC3339))
+		metav1.SetMetaDataAnnotation(&extensionSecret.ObjectMeta, v1beta1constants.GardenerTimestamp, r.Clock.Now().UTC().Format(time.RFC3339Nano))
 		extensionSecret.Data = gardenSecret.DeepCopy().Data
 		return nil
 	}); err != nil {

--- a/pkg/gardenlet/controller/backupentry/reconciler.go
+++ b/pkg/gardenlet/controller/backupentry/reconciler.go
@@ -205,6 +205,10 @@ func (r *Reconciler) reconcileBackupEntry(
 		return reconcile.Result{}, err
 	}
 
+	// round the secret timestamp because extension.Status.LastOperation.LastUpdateTime
+	// is represented in time.RFC3339 format which does not include the Nano precision
+	secretLastUpdateTime = secretLastUpdateTime.Round(time.Second)
+
 	if err := r.SeedClient.Get(seedCtx, client.ObjectKeyFromObject(extensionBackupEntry), extensionBackupEntry); err != nil {
 		if !apierrors.IsNotFound(err) {
 			return reconcile.Result{}, err

--- a/pkg/gardenlet/controller/backupentry/reconciler.go
+++ b/pkg/gardenlet/controller/backupentry/reconciler.go
@@ -205,9 +205,9 @@ func (r *Reconciler) reconcileBackupEntry(
 		return reconcile.Result{}, err
 	}
 
-	// round the secret timestamp because extension.Status.LastOperation.LastUpdateTime
+	// truncate the secret timestamp because extension.Status.LastOperation.LastUpdateTime
 	// is represented in time.RFC3339 format which does not include the Nano precision
-	secretLastUpdateTime = secretLastUpdateTime.Round(time.Second)
+	secretLastUpdateTime = secretLastUpdateTime.Truncate(time.Second)
 
 	if err := r.SeedClient.Get(seedCtx, client.ObjectKeyFromObject(extensionBackupEntry), extensionBackupEntry); err != nil {
 		if !apierrors.IsNotFound(err) {

--- a/pkg/gardenlet/controller/backupentry/reconciler_test.go
+++ b/pkg/gardenlet/controller/backupentry/reconciler_test.go
@@ -219,7 +219,6 @@ var _ = Describe("Controller", func() {
 	})
 
 	It("should not reconcile the extension BackupEntry if the secret data or extension spec hasn't changed", func() {
-		extensionBackupEntry.Status.LastOperation.LastUpdateTime = metav1.NewTime(time.Now().Add(time.Second * 10).UTC())
 		Expect(seedClient.Create(ctx, extensionSecret)).To(Succeed())
 		Expect(seedClient.Create(ctx, extensionBackupEntry)).To(Succeed())
 

--- a/pkg/gardenlet/controller/backupentry/reconciler_test.go
+++ b/pkg/gardenlet/controller/backupentry/reconciler_test.go
@@ -148,12 +148,13 @@ var _ = Describe("Controller", func() {
 
 		Expect(gardenClient.Create(ctx, backupEntry)).To(Succeed())
 
+		now := fakeClock.Now().UTC()
 		extensionSecret = &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "entry-" + backupEntry.Name,
 				Namespace: gardenNamespaceName,
 				Annotations: map[string]string{
-					v1beta1constants.GardenerTimestamp: fakeClock.Now().UTC().Format(time.RFC3339),
+					v1beta1constants.GardenerTimestamp: now.Format(time.RFC3339Nano),
 				},
 			},
 			Data: gardenSecret.Data,
@@ -180,7 +181,7 @@ var _ = Describe("Controller", func() {
 				DefaultStatus: extensionsv1alpha1.DefaultStatus{
 					LastOperation: &gardencorev1beta1.LastOperation{
 						State:          gardencorev1beta1.LastOperationStateSucceeded,
-						LastUpdateTime: metav1.NewTime(fakeClock.Now().UTC()),
+						LastUpdateTime: metav1.NewTime(now),
 					},
 				},
 			},
@@ -218,6 +219,7 @@ var _ = Describe("Controller", func() {
 	})
 
 	It("should not reconcile the extension BackupEntry if the secret data or extension spec hasn't changed", func() {
+		extensionBackupEntry.Status.LastOperation.LastUpdateTime = metav1.NewTime(time.Now().Add(time.Second * 10).UTC())
 		Expect(seedClient.Create(ctx, extensionSecret)).To(Succeed())
 		Expect(seedClient.Create(ctx, extensionBackupEntry)).To(Succeed())
 
@@ -242,7 +244,7 @@ var _ = Describe("Controller", func() {
 		Expect(result).To(Equal(reconcile.Result{}))
 
 		Expect(seedClient.Get(ctx, client.ObjectKeyFromObject(extensionSecret), extensionSecret)).To(Succeed())
-		Expect(extensionSecret.Annotations).To(HaveKeyWithValue(v1beta1constants.GardenerTimestamp, fakeClock.Now().UTC().Format(time.RFC3339)))
+		Expect(extensionSecret.Annotations).To(HaveKeyWithValue(v1beta1constants.GardenerTimestamp, fakeClock.Now().UTC().Format(time.RFC3339Nano)))
 		Expect(seedClient.Get(ctx, client.ObjectKeyFromObject(extensionBackupEntry), extensionBackupEntry)).To(Succeed())
 		Expect(extensionBackupEntry.Annotations).To(HaveKey(v1beta1constants.GardenerOperation))
 	})
@@ -261,7 +263,7 @@ var _ = Describe("Controller", func() {
 	})
 
 	It("should reconcile the extension BackupEntry if the secret update timestamp is after the extension last update time", func() {
-		time := fakeClock.Now().Add(time.Second).UTC().Format(time.RFC3339)
+		time := fakeClock.Now().Add(time.Second).UTC().Format(time.RFC3339Nano)
 		metav1.SetMetaDataAnnotation(&extensionSecret.ObjectMeta, v1beta1constants.GardenerTimestamp, time)
 		Expect(seedClient.Create(ctx, extensionSecret)).To(Succeed())
 		Expect(seedClient.Create(ctx, extensionBackupEntry)).To(Succeed())

--- a/pkg/gardenlet/controller/bastion/reconciler.go
+++ b/pkg/gardenlet/controller/bastion/reconciler.go
@@ -178,7 +178,7 @@ func (r *Reconciler) reconcileBastion(
 	if mustReconcileExtensionBastion {
 		if _, err := controllerutils.GetAndCreateOrMergePatch(seedCtx, r.SeedClient, extensionBastion, func() error {
 			metav1.SetMetaDataAnnotation(&extensionBastion.ObjectMeta, v1beta1constants.GardenerOperation, v1beta1constants.GardenerOperationReconcile)
-			metav1.SetMetaDataAnnotation(&extensionBastion.ObjectMeta, v1beta1constants.GardenerTimestamp, r.Clock.Now().UTC().String())
+			metav1.SetMetaDataAnnotation(&extensionBastion.ObjectMeta, v1beta1constants.GardenerTimestamp, r.Clock.Now().UTC().Format(time.RFC3339Nano))
 
 			extensionBastion.Spec = extensionBastionSpec
 			return nil

--- a/pkg/operation/botanist/component/backupentry/backupentry.go
+++ b/pkg/operation/botanist/component/backupentry/backupentry.go
@@ -165,7 +165,7 @@ func (b *backupEntry) Restore(ctx context.Context, _ *gardencorev1beta1.ShootSta
 func (b *backupEntry) reconcile(ctx context.Context, backupEntry *gardencorev1beta1.BackupEntry, seedName *string, bucketName string, operation string) error {
 	_, err := controllerutils.GetAndCreateOrStrategicMergePatch(ctx, b.client, backupEntry, func() error {
 		metav1.SetMetaDataAnnotation(&backupEntry.ObjectMeta, v1beta1constants.GardenerOperation, operation)
-		metav1.SetMetaDataAnnotation(&backupEntry.ObjectMeta, v1beta1constants.GardenerTimestamp, TimeNow().UTC().String())
+		metav1.SetMetaDataAnnotation(&backupEntry.ObjectMeta, v1beta1constants.GardenerTimestamp, TimeNow().UTC().Format(time.RFC3339Nano))
 
 		if b.values.ShootPurpose != nil {
 			metav1.SetMetaDataAnnotation(&backupEntry.ObjectMeta, v1beta1constants.ShootPurpose, string(*b.values.ShootPurpose))

--- a/pkg/operation/botanist/component/backupentry/backupentry_test.go
+++ b/pkg/operation/botanist/component/backupentry/backupentry_test.go
@@ -93,7 +93,7 @@ var _ = Describe("BackupEntry", func() {
 				Name:      name,
 				Namespace: namespace,
 				Annotations: map[string]string{
-					v1beta1constants.GardenerTimestamp: now.UTC().String(),
+					v1beta1constants.GardenerTimestamp: now.UTC().Format(time.RFC3339Nano),
 					v1beta1constants.ShootPurpose:      string(shootPurpose),
 				},
 				OwnerReferences: []metav1.OwnerReference{*ownerRef},

--- a/pkg/operation/botanist/component/etcd/etcd.go
+++ b/pkg/operation/botanist/component/etcd/etcd.go
@@ -367,7 +367,7 @@ func (e *etcd) Deploy(ctx context.Context) error {
 
 	if _, err := controllerutils.GetAndCreateOrMergePatch(ctx, e.client, e.etcd, func() error {
 		metav1.SetMetaDataAnnotation(&e.etcd.ObjectMeta, v1beta1constants.GardenerOperation, v1beta1constants.GardenerOperationReconcile)
-		metav1.SetMetaDataAnnotation(&e.etcd.ObjectMeta, v1beta1constants.GardenerTimestamp, TimeNow().UTC().String())
+		metav1.SetMetaDataAnnotation(&e.etcd.ObjectMeta, v1beta1constants.GardenerTimestamp, TimeNow().UTC().Format(time.RFC3339Nano))
 
 		e.etcd.Labels = map[string]string{
 			v1beta1constants.LabelRole:  e.values.Role,
@@ -761,7 +761,7 @@ func (e *etcd) Scale(ctx context.Context, replicas int32) error {
 	}
 
 	etcdObj.Annotations[v1beta1constants.GardenerOperation] = v1beta1constants.GardenerOperationReconcile
-	etcdObj.Annotations[v1beta1constants.GardenerTimestamp] = TimeNow().UTC().String()
+	etcdObj.Annotations[v1beta1constants.GardenerTimestamp] = TimeNow().UTC().Format(time.RFC3339Nano)
 	etcdObj.Spec.Replicas = replicas
 
 	e.etcd = etcdObj
@@ -806,7 +806,7 @@ func (e *etcd) RolloutPeerCA(ctx context.Context) error {
 
 		e.etcd.Annotations = map[string]string{
 			v1beta1constants.GardenerOperation: v1beta1constants.GardenerOperationReconcile,
-			v1beta1constants.GardenerTimestamp: TimeNow().UTC().String(),
+			v1beta1constants.GardenerTimestamp: TimeNow().UTC().Format(time.RFC3339Nano),
 		}
 
 		var dataKey *string

--- a/pkg/operation/botanist/component/etcd/etcd_test.go
+++ b/pkg/operation/botanist/component/etcd/etcd_test.go
@@ -262,7 +262,7 @@ var _ = Describe("Etcd", func() {
 					Namespace: testNamespace,
 					Annotations: map[string]string{
 						"gardener.cloud/operation": "reconcile",
-						"gardener.cloud/timestamp": now.String(),
+						"gardener.cloud/timestamp": now.Format(time.RFC3339Nano),
 					},
 					Labels: map[string]string{
 						"gardener.cloud/role": "controlplane",
@@ -1633,7 +1633,7 @@ var _ = Describe("Etcd", func() {
 				Namespace: testNamespace,
 				Annotations: map[string]string{
 					"confirmation.gardener.cloud/deletion": "true",
-					"gardener.cloud/timestamp":             nowFunc().String(),
+					"gardener.cloud/timestamp":             nowFunc().Format(time.RFC3339Nano),
 				},
 			}}
 		})
@@ -1752,7 +1752,7 @@ var _ = Describe("Etcd", func() {
 				func(_ context.Context, etcd *druidv1alpha1.Etcd, patch client.Patch, _ ...client.PatchOption) error {
 					data, err := patch.Data(etcd)
 					Expect(err).ToNot(HaveOccurred())
-					Expect(string(data)).To(Equal(fmt.Sprintf(`{"metadata":{"annotations":{"gardener.cloud/operation":"reconcile","gardener.cloud/timestamp":"%s"}},"spec":{"replicas":1}}`, now.String())))
+					Expect(string(data)).To(Equal(fmt.Sprintf(`{"metadata":{"annotations":{"gardener.cloud/operation":"reconcile","gardener.cloud/timestamp":"%s"}},"spec":{"replicas":1}}`, now.Format(time.RFC3339Nano))))
 					return nil
 				})
 
@@ -1778,7 +1778,7 @@ var _ = Describe("Etcd", func() {
 				func(_ context.Context, etcd *druidv1alpha1.Etcd, patch client.Patch, _ ...client.PatchOption) error {
 					data, err := patch.Data(etcd)
 					Expect(err).ToNot(HaveOccurred())
-					Expect(string(data)).To(Equal(fmt.Sprintf(`{"metadata":{"annotations":{"gardener.cloud/operation":"reconcile","gardener.cloud/timestamp":"%s"}}}`, now.String())))
+					Expect(string(data)).To(Equal(fmt.Sprintf(`{"metadata":{"annotations":{"gardener.cloud/operation":"reconcile","gardener.cloud/timestamp":"%s"}}}`, now.Format(time.RFC3339Nano))))
 					return nil
 				})
 
@@ -1811,7 +1811,7 @@ var _ = Describe("Etcd", func() {
 			)
 
 			Expect(etcd.Scale(ctx, 1)).To(Succeed())
-			Expect(etcd.Scale(ctx, 1)).Should(MatchError(`object's "gardener.cloud/timestamp" annotation is not "0001-01-01 00:00:00 +0000 UTC" but "foo"`))
+			Expect(etcd.Scale(ctx, 1)).Should(MatchError(`object's "gardener.cloud/timestamp" annotation is not "0001-01-01T00:00:00Z" but "foo"`))
 		})
 
 		It("should fail because operation annotation is set", func() {
@@ -1930,7 +1930,7 @@ var _ = Describe("Etcd", func() {
 					func(_ context.Context, obj *druidv1alpha1.Etcd, patch client.Patch, _ ...client.PatchOption) error {
 						data, err := patch.Data(obj)
 						Expect(err).ToNot(HaveOccurred())
-						Expect(data).To(MatchJSON("{\"metadata\":{\"annotations\":{\"gardener.cloud/operation\":\"reconcile\",\"gardener.cloud/timestamp\":\"0001-01-01 00:00:00 +0000 UTC\"}},\"spec\":{\"etcd\":{\"peerUrlTls\":{\"tlsCASecretRef\":{\"name\":\"ca-etcd-peer\"}}}}}"))
+						Expect(data).To(MatchJSON("{\"metadata\":{\"annotations\":{\"gardener.cloud/operation\":\"reconcile\",\"gardener.cloud/timestamp\":\"0001-01-01T00:00:00Z\"}},\"spec\":{\"etcd\":{\"peerUrlTls\":{\"tlsCASecretRef\":{\"name\":\"ca-etcd-peer\"}}}}}"))
 						return nil
 					})
 

--- a/pkg/operation/botanist/component/etcd/waiter_test.go
+++ b/pkg/operation/botanist/component/etcd/waiter_test.go
@@ -112,7 +112,7 @@ var _ = Describe("#Wait", func() {
 				Namespace: testNamespace,
 				Annotations: map[string]string{
 					v1beta1constants.GardenerOperation: v1beta1constants.GardenerOperationReconcile,
-					v1beta1constants.GardenerTimestamp: now.UTC().String(),
+					v1beta1constants.GardenerTimestamp: now.UTC().Format(time.RFC3339Nano),
 				},
 			},
 			Spec: druidv1alpha1.EtcdSpec{},
@@ -154,7 +154,7 @@ var _ = Describe("#Wait", func() {
 		expected.Status.LastError = nil
 		// remove operation annotation, add old timestamp annotation
 		expected.ObjectMeta.Annotations = map[string]string{
-			v1beta1constants.GardenerTimestamp: now.Add(-time.Millisecond).UTC().String(),
+			v1beta1constants.GardenerTimestamp: now.Add(-time.Millisecond).UTC().Format(time.RFC3339Nano),
 		}
 		expected.Status.Ready = pointer.Bool(true)
 		Expect(c.Patch(ctx, expected, patch)).To(Succeed(), "patching etcd succeeds")
@@ -180,7 +180,7 @@ var _ = Describe("#Wait", func() {
 		expected.Status.LastError = nil
 		// remove operation annotation, add up-to-date timestamp annotation
 		expected.ObjectMeta.Annotations = map[string]string{
-			v1beta1constants.GardenerTimestamp: now.UTC().String(),
+			v1beta1constants.GardenerTimestamp: now.UTC().Format(time.RFC3339Nano),
 		}
 		expected.Status.Ready = pointer.Bool(true)
 		Expect(c.Patch(ctx, expected, patch)).To(Succeed(), "patching etcd succeeds")

--- a/pkg/operation/botanist/component/extensions/backupentry/backupentry.go
+++ b/pkg/operation/botanist/component/extensions/backupentry/backupentry.go
@@ -118,7 +118,7 @@ func (b *backupEntry) Deploy(ctx context.Context) error {
 func (b *backupEntry) deploy(ctx context.Context, operation string) (extensionsv1alpha1.Object, error) {
 	_, err := controllerutils.GetAndCreateOrMergePatch(ctx, b.client, b.backupEntry, func() error {
 		metav1.SetMetaDataAnnotation(&b.backupEntry.ObjectMeta, v1beta1constants.GardenerOperation, operation)
-		metav1.SetMetaDataAnnotation(&b.backupEntry.ObjectMeta, v1beta1constants.GardenerTimestamp, b.clock.Now().UTC().String())
+		metav1.SetMetaDataAnnotation(&b.backupEntry.ObjectMeta, v1beta1constants.GardenerTimestamp, b.clock.Now().UTC().Format(time.RFC3339Nano))
 
 		b.backupEntry.Spec = extensionsv1alpha1.BackupEntrySpec{
 			DefaultSpec: extensionsv1alpha1.DefaultSpec{

--- a/pkg/operation/botanist/component/extensions/backupentry/backupentry_test.go
+++ b/pkg/operation/botanist/component/extensions/backupentry/backupentry_test.go
@@ -113,7 +113,7 @@ var _ = Describe("#BackupEntry", func() {
 				Name: name,
 				Annotations: map[string]string{
 					v1beta1constants.GardenerOperation: v1beta1constants.GardenerOperationReconcile,
-					v1beta1constants.GardenerTimestamp: fakeClock.Now().UTC().String(),
+					v1beta1constants.GardenerTimestamp: fakeClock.Now().UTC().Format(time.RFC3339Nano),
 				},
 			},
 			Spec: extensionsv1alpha1.BackupEntrySpec{
@@ -174,7 +174,7 @@ var _ = Describe("#BackupEntry", func() {
 			expected.Status.LastError = nil
 			// remove operation annotation, add old timestamp annotation
 			expected.ObjectMeta.Annotations = map[string]string{
-				v1beta1constants.GardenerTimestamp: fakeClock.Now().Add(-time.Millisecond).UTC().String(),
+				v1beta1constants.GardenerTimestamp: fakeClock.Now().Add(-time.Millisecond).UTC().Format(time.RFC3339Nano),
 			}
 			expected.Status.LastOperation = &gardencorev1beta1.LastOperation{
 				State: gardencorev1beta1.LastOperationStateSucceeded,
@@ -195,7 +195,7 @@ var _ = Describe("#BackupEntry", func() {
 			expected.Status.LastError = nil
 			// remove operation annotation, add up-to-date timestamp annotation
 			expected.ObjectMeta.Annotations = map[string]string{
-				v1beta1constants.GardenerTimestamp: fakeClock.Now().UTC().String(),
+				v1beta1constants.GardenerTimestamp: fakeClock.Now().UTC().Format(time.RFC3339Nano),
 			}
 			expected.Status.LastOperation = &gardencorev1beta1.LastOperation{
 				State: gardencorev1beta1.LastOperationStateSucceeded,
@@ -229,7 +229,7 @@ var _ = Describe("#BackupEntry", func() {
 			expected = empty.DeepCopy()
 			expected.SetAnnotations(map[string]string{
 				gardenerutils.ConfirmationDeletion: "true",
-				v1beta1constants.GardenerTimestamp: fakeClock.Now().UTC().String(),
+				v1beta1constants.GardenerTimestamp: fakeClock.Now().UTC().Format(time.RFC3339Nano),
 			})
 
 			// add deletion confirmation and timestamp annotation
@@ -299,7 +299,7 @@ var _ = Describe("#BackupEntry", func() {
 			// deploy with wait-for-state annotation
 			obj := expected.DeepCopy()
 			metav1.SetMetaDataAnnotation(&obj.ObjectMeta, "gardener.cloud/operation", "wait-for-state")
-			metav1.SetMetaDataAnnotation(&obj.ObjectMeta, "gardener.cloud/timestamp", fakeClock.Now().UTC().String())
+			metav1.SetMetaDataAnnotation(&obj.ObjectMeta, "gardener.cloud/timestamp", fakeClock.Now().UTC().Format(time.RFC3339Nano))
 			obj.TypeMeta = metav1.TypeMeta{}
 			mc.EXPECT().Create(ctx, test.HasObjectKeyOf(obj)).
 				DoAndReturn(func(ctx context.Context, actual client.Object, opts ...client.CreateOption) error {
@@ -331,7 +331,7 @@ var _ = Describe("#BackupEntry", func() {
 
 			expectedCopy := empty.DeepCopy()
 			metav1.SetMetaDataAnnotation(&expectedCopy.ObjectMeta, v1beta1constants.GardenerOperation, v1beta1constants.GardenerOperationMigrate)
-			metav1.SetMetaDataAnnotation(&expectedCopy.ObjectMeta, v1beta1constants.GardenerTimestamp, fakeClock.Now().UTC().String())
+			metav1.SetMetaDataAnnotation(&expectedCopy.ObjectMeta, v1beta1constants.GardenerTimestamp, fakeClock.Now().UTC().Format(time.RFC3339Nano))
 			test.EXPECTPatch(ctx, mc, expectedCopy, empty, types.MergePatchType)
 
 			defaultDepWaiter = backupentry.New(log, mc, fakeClock, values, time.Millisecond, 250*time.Millisecond, 500*time.Millisecond)
@@ -347,7 +347,7 @@ var _ = Describe("#BackupEntry", func() {
 
 			expectedCopy := empty.DeepCopy()
 			metav1.SetMetaDataAnnotation(&expectedCopy.ObjectMeta, v1beta1constants.GardenerOperation, v1beta1constants.GardenerOperationMigrate)
-			metav1.SetMetaDataAnnotation(&expectedCopy.ObjectMeta, v1beta1constants.GardenerTimestamp, fakeClock.Now().UTC().String())
+			metav1.SetMetaDataAnnotation(&expectedCopy.ObjectMeta, v1beta1constants.GardenerTimestamp, fakeClock.Now().UTC().Format(time.RFC3339Nano))
 			test.EXPECTPatch(ctx, mc, expectedCopy, empty, types.MergePatchType)
 
 			defaultDepWaiter = backupentry.New(log, mc, fakeClock, values, time.Millisecond, 250*time.Millisecond, 500*time.Millisecond)

--- a/pkg/operation/botanist/component/extensions/containerruntime/containerruntime.go
+++ b/pkg/operation/botanist/component/extensions/containerruntime/containerruntime.go
@@ -108,7 +108,7 @@ func (c *containerRuntime) Deploy(ctx context.Context) error {
 func (c *containerRuntime) deploy(ctx context.Context, cr *extensionsv1alpha1.ContainerRuntime, coreCR gardencorev1beta1.ContainerRuntime, workerName, operation string) (extensionsv1alpha1.Object, error) {
 	_, err := controllerutils.GetAndCreateOrMergePatch(ctx, c.client, cr, func() error {
 		metav1.SetMetaDataAnnotation(&cr.ObjectMeta, v1beta1constants.GardenerOperation, operation)
-		metav1.SetMetaDataAnnotation(&cr.ObjectMeta, v1beta1constants.GardenerTimestamp, TimeNow().UTC().String())
+		metav1.SetMetaDataAnnotation(&cr.ObjectMeta, v1beta1constants.GardenerTimestamp, TimeNow().UTC().Format(time.RFC3339Nano))
 
 		cr.Spec.BinaryPath = extensionsv1alpha1.ContainerDRuntimeContainersBinFolder
 		cr.Spec.Type = coreCR.Type

--- a/pkg/operation/botanist/component/extensions/containerruntime/containerruntime_test.go
+++ b/pkg/operation/botanist/component/extensions/containerruntime/containerruntime_test.go
@@ -112,7 +112,7 @@ var _ = Describe("#ContainerRuntime", func() {
 						Namespace: namespace,
 						Annotations: map[string]string{
 							v1beta1constants.GardenerOperation: v1beta1constants.GardenerOperationReconcile,
-							v1beta1constants.GardenerTimestamp: now.UTC().String(),
+							v1beta1constants.GardenerTimestamp: now.UTC().Format(time.RFC3339Nano),
 						},
 					},
 					Spec: extensionsv1alpha1.ContainerRuntimeSpec{
@@ -198,7 +198,7 @@ var _ = Describe("#ContainerRuntime", func() {
 				patch := client.MergeFrom(expected[i].DeepCopy())
 				// remove operation annotation, add old timestamp annotation
 				expected[i].ObjectMeta.Annotations = map[string]string{
-					v1beta1constants.GardenerTimestamp: now.Add(-time.Millisecond).UTC().String(),
+					v1beta1constants.GardenerTimestamp: now.Add(-time.Millisecond).UTC().Format(time.RFC3339Nano),
 				}
 				// set last operation
 				expected[i].Status.LastOperation = &gardencorev1beta1.LastOperation{
@@ -226,7 +226,7 @@ var _ = Describe("#ContainerRuntime", func() {
 				patch := client.MergeFrom(expected[i].DeepCopy())
 				// remove operation annotation, add up-to-date timestamp annotation
 				expected[i].ObjectMeta.Annotations = map[string]string{
-					v1beta1constants.GardenerTimestamp: now.UTC().String(),
+					v1beta1constants.GardenerTimestamp: now.UTC().Format(time.RFC3339Nano),
 				}
 				// set last operation
 				expected[i].Status.LastOperation = &gardencorev1beta1.LastOperation{
@@ -279,7 +279,7 @@ var _ = Describe("#ContainerRuntime", func() {
 					Namespace: namespace,
 					Annotations: map[string]string{
 						gardenerutils.ConfirmationDeletion: "true",
-						v1beta1constants.GardenerTimestamp: now.UTC().String(),
+						v1beta1constants.GardenerTimestamp: now.UTC().Format(time.RFC3339Nano),
 					},
 				},
 			}
@@ -367,7 +367,7 @@ var _ = Describe("#ContainerRuntime", func() {
 
 			// deploy with wait-for-state annotation
 			expected[0].Annotations[v1beta1constants.GardenerOperation] = v1beta1constants.GardenerOperationWaitForState
-			expected[0].Annotations[v1beta1constants.GardenerTimestamp] = now.UTC().String()
+			expected[0].Annotations[v1beta1constants.GardenerTimestamp] = now.UTC().Format(time.RFC3339Nano)
 			mc.EXPECT().Create(ctx, test.HasObjectKeyOf(expected[0])).
 				DoAndReturn(func(ctx context.Context, actual client.Object, opts ...client.CreateOption) error {
 					Expect(actual).To(DeepEqual(expected[0]))

--- a/pkg/operation/botanist/component/extensions/controlplane/controlplane.go
+++ b/pkg/operation/botanist/component/extensions/controlplane/controlplane.go
@@ -129,7 +129,7 @@ func (c *controlPlane) deploy(ctx context.Context, operation string) (extensions
 
 	_, err := controllerutils.GetAndCreateOrMergePatch(ctx, c.client, c.controlPlane, func() error {
 		metav1.SetMetaDataAnnotation(&c.controlPlane.ObjectMeta, v1beta1constants.GardenerOperation, operation)
-		metav1.SetMetaDataAnnotation(&c.controlPlane.ObjectMeta, v1beta1constants.GardenerTimestamp, TimeNow().UTC().String())
+		metav1.SetMetaDataAnnotation(&c.controlPlane.ObjectMeta, v1beta1constants.GardenerTimestamp, TimeNow().UTC().Format(time.RFC3339Nano))
 
 		c.controlPlane.Spec = extensionsv1alpha1.ControlPlaneSpec{
 			DefaultSpec: extensionsv1alpha1.DefaultSpec{

--- a/pkg/operation/botanist/component/extensions/controlplane/controlplane_test.go
+++ b/pkg/operation/botanist/component/extensions/controlplane/controlplane_test.go
@@ -88,7 +88,7 @@ var _ = Describe("ControlPlane", func() {
 		cp = empty.DeepCopy()
 		cp.SetAnnotations(map[string]string{
 			v1beta1constants.GardenerOperation: v1beta1constants.GardenerOperationReconcile,
-			v1beta1constants.GardenerTimestamp: now.UTC().String(),
+			v1beta1constants.GardenerTimestamp: now.UTC().Format(time.RFC3339Nano),
 		})
 
 		cpSpec = extensionsv1alpha1.ControlPlaneSpec{
@@ -142,7 +142,7 @@ var _ = Describe("ControlPlane", func() {
 					Namespace: namespace,
 					Annotations: map[string]string{
 						"gardener.cloud/operation": "reconcile",
-						"gardener.cloud/timestamp": now.UTC().String(),
+						"gardener.cloud/timestamp": now.UTC().Format(time.RFC3339Nano),
 					},
 					ResourceVersion: "1",
 				},
@@ -174,7 +174,7 @@ var _ = Describe("ControlPlane", func() {
 					Namespace: namespace,
 					Annotations: map[string]string{
 						"gardener.cloud/operation": "reconcile",
-						"gardener.cloud/timestamp": now.UTC().String(),
+						"gardener.cloud/timestamp": now.UTC().Format(time.RFC3339Nano),
 					},
 					ResourceVersion: "1",
 				},
@@ -210,7 +210,7 @@ var _ = Describe("ControlPlane", func() {
 			patch := client.MergeFrom(cp.DeepCopy())
 			// remove operation annotation, add old timestamp annotation
 			cp.ObjectMeta.Annotations = map[string]string{
-				v1beta1constants.GardenerTimestamp: now.Add(-time.Millisecond).UTC().String(),
+				v1beta1constants.GardenerTimestamp: now.Add(-time.Millisecond).UTC().Format(time.RFC3339Nano),
 			}
 			cp.Status.LastOperation = &gardencorev1beta1.LastOperation{
 				State: gardencorev1beta1.LastOperationStateSucceeded,
@@ -233,7 +233,7 @@ var _ = Describe("ControlPlane", func() {
 			patch := client.MergeFrom(cp.DeepCopy())
 			// remove operation annotation, add up-to-date timestamp annotation
 			cp.ObjectMeta.Annotations = map[string]string{
-				v1beta1constants.GardenerTimestamp: now.UTC().String(),
+				v1beta1constants.GardenerTimestamp: now.UTC().Format(time.RFC3339Nano),
 			}
 			cp.Status.LastOperation = &gardencorev1beta1.LastOperation{
 				State: gardencorev1beta1.LastOperationStateSucceeded,
@@ -260,7 +260,7 @@ var _ = Describe("ControlPlane", func() {
 			patch := client.MergeFrom(cp.DeepCopy())
 			// remove operation annotation, add old timestamp annotation
 			cp.ObjectMeta.Annotations = map[string]string{
-				v1beta1constants.GardenerTimestamp: now.Add(-time.Millisecond).UTC().String(),
+				v1beta1constants.GardenerTimestamp: now.Add(-time.Millisecond).UTC().Format(time.RFC3339Nano),
 			}
 			cp.Status.LastOperation = &gardencorev1beta1.LastOperation{
 				State: gardencorev1beta1.LastOperationStateSucceeded,
@@ -287,7 +287,7 @@ var _ = Describe("ControlPlane", func() {
 			patch := client.MergeFrom(cp.DeepCopy())
 			// remove operation annotation, add up-to-date timestamp annotation
 			cp.ObjectMeta.Annotations = map[string]string{
-				v1beta1constants.GardenerTimestamp: now.UTC().String(),
+				v1beta1constants.GardenerTimestamp: now.UTC().Format(time.RFC3339Nano),
 			}
 			cp.Status.LastOperation = &gardencorev1beta1.LastOperation{
 				State: gardencorev1beta1.LastOperationStateSucceeded,
@@ -320,7 +320,7 @@ var _ = Describe("ControlPlane", func() {
 			obj := cp.DeepCopy()
 			obj.Annotations = map[string]string{
 				"confirmation.gardener.cloud/deletion": "true",
-				"gardener.cloud/timestamp":             now.UTC().String(),
+				"gardener.cloud/timestamp":             now.UTC().Format(time.RFC3339Nano),
 			}
 
 			mc := mockclient.NewMockClient(ctrl)
@@ -344,7 +344,7 @@ var _ = Describe("ControlPlane", func() {
 			obj.Name += "-exposure"
 			obj.Annotations = map[string]string{
 				"confirmation.gardener.cloud/deletion": "true",
-				"gardener.cloud/timestamp":             now.UTC().String(),
+				"gardener.cloud/timestamp":             now.UTC().Format(time.RFC3339Nano),
 			}
 
 			mc := mockclient.NewMockClient(ctrl)
@@ -423,7 +423,7 @@ var _ = Describe("ControlPlane", func() {
 			obj := cp.DeepCopy()
 			obj.Spec = cpSpec
 			metav1.SetMetaDataAnnotation(&obj.ObjectMeta, "gardener.cloud/operation", "wait-for-state")
-			metav1.SetMetaDataAnnotation(&obj.ObjectMeta, "gardener.cloud/timestamp", now.UTC().String())
+			metav1.SetMetaDataAnnotation(&obj.ObjectMeta, "gardener.cloud/timestamp", now.UTC().Format(time.RFC3339Nano))
 			mc.EXPECT().Create(ctx, test.HasObjectKeyOf(obj)).
 				DoAndReturn(func(ctx context.Context, actual client.Object, opts ...client.CreateOption) error {
 					Expect(actual).To(DeepEqual(obj))
@@ -466,7 +466,7 @@ var _ = Describe("ControlPlane", func() {
 			obj.Spec = cpSpec
 			obj.Spec.Purpose = &values.Purpose
 			metav1.SetMetaDataAnnotation(&obj.ObjectMeta, "gardener.cloud/operation", "wait-for-state")
-			metav1.SetMetaDataAnnotation(&obj.ObjectMeta, "gardener.cloud/timestamp", now.UTC().String())
+			metav1.SetMetaDataAnnotation(&obj.ObjectMeta, "gardener.cloud/timestamp", now.UTC().Format(time.RFC3339Nano))
 			mc.EXPECT().Create(ctx, test.HasObjectKeyOf(obj)).
 				DoAndReturn(func(ctx context.Context, actual client.Object, opts ...client.CreateOption) error {
 					Expect(actual).To(DeepEqual(obj))

--- a/pkg/operation/botanist/component/extensions/dnsrecord/dnsrecord.go
+++ b/pkg/operation/botanist/component/extensions/dnsrecord/dnsrecord.go
@@ -146,7 +146,7 @@ func (c *dnsRecord) deploy(ctx context.Context, operation string) (extensionsv1a
 		if c.values.AnnotateOperation || c.valuesDontMatchDNSRecord() {
 			metav1.SetMetaDataAnnotation(&c.dnsRecord.ObjectMeta, v1beta1constants.GardenerOperation, operation)
 		}
-		metav1.SetMetaDataAnnotation(&c.dnsRecord.ObjectMeta, v1beta1constants.GardenerTimestamp, TimeNow().UTC().String())
+		metav1.SetMetaDataAnnotation(&c.dnsRecord.ObjectMeta, v1beta1constants.GardenerTimestamp, TimeNow().UTC().Format(time.RFC3339Nano))
 
 		c.dnsRecord.Spec = extensionsv1alpha1.DNSRecordSpec{
 			DefaultSpec: extensionsv1alpha1.DefaultSpec{
@@ -188,7 +188,7 @@ func (c *dnsRecord) deploy(ctx context.Context, operation string) (extensionsv1a
 				// Otherwise, just update the timestamp annotation.
 				// If the object is still annotated with the operation annotation (e.g. not reconciled yet) this will send a watch
 				// event to the extension controller triggering a new reconciliation.
-				metav1.SetMetaDataAnnotation(&c.dnsRecord.ObjectMeta, v1beta1constants.GardenerTimestamp, TimeNow().UTC().String())
+				metav1.SetMetaDataAnnotation(&c.dnsRecord.ObjectMeta, v1beta1constants.GardenerTimestamp, TimeNow().UTC().Format(time.RFC3339Nano))
 			}
 			if err := c.client.Patch(ctx, c.dnsRecord, patch); err != nil {
 				return nil, err

--- a/pkg/operation/botanist/component/extensions/dnsrecord/dnsrecord_test.go
+++ b/pkg/operation/botanist/component/extensions/dnsrecord/dnsrecord_test.go
@@ -111,7 +111,7 @@ var _ = Describe("DNSRecord", func() {
 				Namespace: namespace,
 				Annotations: map[string]string{
 					v1beta1constants.GardenerOperation: v1beta1constants.GardenerOperationReconcile,
-					v1beta1constants.GardenerTimestamp: now.UTC().String(),
+					v1beta1constants.GardenerTimestamp: now.UTC().Format(time.RFC3339Nano),
 				},
 			},
 			Spec: extensionsv1alpha1.DNSRecordSpec{
@@ -174,7 +174,7 @@ var _ = Describe("DNSRecord", func() {
 					Namespace: namespace,
 					Annotations: map[string]string{
 						v1beta1constants.GardenerOperation: v1beta1constants.GardenerOperationReconcile,
-						v1beta1constants.GardenerTimestamp: now.UTC().String(),
+						v1beta1constants.GardenerTimestamp: now.UTC().Format(time.RFC3339Nano),
 					},
 					ResourceVersion: "1",
 				},
@@ -203,7 +203,7 @@ var _ = Describe("DNSRecord", func() {
 			By("Create existing DNSRecord")
 			existingDNS := dns.DeepCopy()
 			delete(existingDNS.Annotations, v1beta1constants.GardenerOperation)
-			metav1.SetMetaDataAnnotation(&existingDNS.ObjectMeta, v1beta1constants.GardenerTimestamp, now.UTC().Add(-time.Second).String())
+			metav1.SetMetaDataAnnotation(&existingDNS.ObjectMeta, v1beta1constants.GardenerTimestamp, now.UTC().Add(-time.Second).Format(time.RFC3339Nano))
 			Expect(c.Create(ctx, existingDNS)).To(Succeed())
 
 			By("Deploy DNSRecord again")
@@ -224,7 +224,7 @@ var _ = Describe("DNSRecord", func() {
 					Name:      name,
 					Namespace: namespace,
 					Annotations: map[string]string{
-						v1beta1constants.GardenerTimestamp: now.UTC().String(),
+						v1beta1constants.GardenerTimestamp: now.UTC().Format(time.RFC3339Nano),
 						v1beta1constants.GardenerOperation: v1beta1constants.GardenerOperationReconcile,
 					},
 					ResourceVersion: "2",
@@ -252,7 +252,7 @@ var _ = Describe("DNSRecord", func() {
 					Name:      name,
 					Namespace: namespace,
 					Annotations: map[string]string{
-						v1beta1constants.GardenerTimestamp: now.UTC().String(),
+						v1beta1constants.GardenerTimestamp: now.UTC().Format(time.RFC3339Nano),
 						v1beta1constants.GardenerOperation: v1beta1constants.GardenerOperationReconcile,
 					},
 					ResourceVersion: "1",
@@ -282,7 +282,7 @@ var _ = Describe("DNSRecord", func() {
 			By("Create existing DNSRecord")
 			existingDNS := dns.DeepCopy()
 			delete(existingDNS.Annotations, v1beta1constants.GardenerOperation)
-			metav1.SetMetaDataAnnotation(&existingDNS.ObjectMeta, v1beta1constants.GardenerTimestamp, now.UTC().Add(-time.Second).String())
+			metav1.SetMetaDataAnnotation(&existingDNS.ObjectMeta, v1beta1constants.GardenerTimestamp, now.UTC().Add(-time.Second).Format(time.RFC3339Nano))
 			Expect(c.Create(ctx, existingDNS)).To(Succeed())
 
 			By("Deploy DNSRecord again")
@@ -303,7 +303,7 @@ var _ = Describe("DNSRecord", func() {
 					Name:      name,
 					Namespace: namespace,
 					Annotations: map[string]string{
-						v1beta1constants.GardenerTimestamp: now.UTC().String(),
+						v1beta1constants.GardenerTimestamp: now.UTC().Format(time.RFC3339Nano),
 					},
 					ResourceVersion: "2",
 				},
@@ -316,7 +316,7 @@ var _ = Describe("DNSRecord", func() {
 			By("Create existing DNSRecord")
 			existingDNS := dns.DeepCopy()
 			delete(existingDNS.Annotations, v1beta1constants.GardenerOperation)
-			metav1.SetMetaDataAnnotation(&existingDNS.ObjectMeta, v1beta1constants.GardenerTimestamp, now.UTC().Add(-time.Second).String())
+			metav1.SetMetaDataAnnotation(&existingDNS.ObjectMeta, v1beta1constants.GardenerTimestamp, now.UTC().Add(-time.Second).Format(time.RFC3339Nano))
 			Expect(c.Create(ctx, existingDNS)).To(Succeed())
 
 			By("Deploy DNSRecord again with changed values")
@@ -341,7 +341,7 @@ var _ = Describe("DNSRecord", func() {
 					Name:      name,
 					Namespace: namespace,
 					Annotations: map[string]string{
-						v1beta1constants.GardenerTimestamp: now.UTC().String(),
+						v1beta1constants.GardenerTimestamp: now.UTC().Format(time.RFC3339Nano),
 						v1beta1constants.GardenerOperation: v1beta1constants.GardenerOperationReconcile,
 					},
 					ResourceVersion: "2",
@@ -386,7 +386,7 @@ var _ = Describe("DNSRecord", func() {
 						Namespace: namespace,
 						Annotations: map[string]string{
 							v1beta1constants.GardenerOperation: v1beta1constants.GardenerOperationReconcile,
-							v1beta1constants.GardenerTimestamp: now.UTC().String(),
+							v1beta1constants.GardenerTimestamp: now.UTC().Format(time.RFC3339Nano),
 						},
 					},
 					Spec: dns.Spec,
@@ -408,7 +408,7 @@ var _ = Describe("DNSRecord", func() {
 			It("should deploy the DNSRecord resource if the DNSRecord is not Succeeded", func() {
 				existingDNS := dns.DeepCopy()
 				delete(existingDNS.Annotations, v1beta1constants.GardenerOperation)
-				metav1.SetMetaDataAnnotation(&existingDNS.ObjectMeta, v1beta1constants.GardenerTimestamp, now.UTC().Add(-time.Second).String())
+				metav1.SetMetaDataAnnotation(&existingDNS.ObjectMeta, v1beta1constants.GardenerTimestamp, now.UTC().Add(-time.Second).Format(time.RFC3339Nano))
 				existingDNS.Status.LastOperation = &gardencorev1beta1.LastOperation{
 					State: gardencorev1beta1.LastOperationStateError,
 				}
@@ -433,10 +433,10 @@ var _ = Describe("DNSRecord", func() {
 			It("should only update the timestamp annotation if the DNSRecord exists with the same values", func() {
 				delete(dns.Annotations, v1beta1constants.GardenerOperation)
 				// set old timestamp (e.g. added on creation / earlier Deploy call)
-				metav1.SetMetaDataAnnotation(&dns.ObjectMeta, v1beta1constants.GardenerTimestamp, now.UTC().Add(-time.Second).String())
+				metav1.SetMetaDataAnnotation(&dns.ObjectMeta, v1beta1constants.GardenerTimestamp, now.UTC().Add(-time.Second).Format(time.RFC3339Nano))
 
 				expectedDNSRecord.Annotations = map[string]string{
-					v1beta1constants.GardenerTimestamp: now.UTC().String(),
+					v1beta1constants.GardenerTimestamp: now.UTC().Format(time.RFC3339Nano),
 				}
 
 				Expect(c.Create(ctx, dns)).To(Succeed())
@@ -451,7 +451,7 @@ var _ = Describe("DNSRecord", func() {
 			DescribeTable("should reconcile the DNSRecord if desired values differ from current state", func(modifyValues func(), modifyExpected func()) {
 				delete(dns.Annotations, v1beta1constants.GardenerOperation)
 				// set old timestamp (e.g. added on creation / earlier Deploy call)
-				metav1.SetMetaDataAnnotation(&dns.ObjectMeta, v1beta1constants.GardenerTimestamp, now.UTC().Add(-time.Second).String())
+				metav1.SetMetaDataAnnotation(&dns.ObjectMeta, v1beta1constants.GardenerTimestamp, now.UTC().Add(-time.Second).Format(time.RFC3339Nano))
 				Expect(c.Create(ctx, dns)).To(Succeed())
 
 				modifyValues()
@@ -481,7 +481,7 @@ var _ = Describe("DNSRecord", func() {
 
 		It("should fail if the resource is not ready", func() {
 			dns.ObjectMeta.Annotations = map[string]string{
-				v1beta1constants.GardenerTimestamp: now.UTC().String(),
+				v1beta1constants.GardenerTimestamp: now.UTC().Format(time.RFC3339Nano),
 			}
 			dns.Status.LastError = &gardencorev1beta1.LastError{
 				Description: "Some error",
@@ -496,7 +496,7 @@ var _ = Describe("DNSRecord", func() {
 
 			patch := client.MergeFrom(dns.DeepCopy())
 			dns.ObjectMeta.Annotations = map[string]string{
-				v1beta1constants.GardenerTimestamp: now.Add(-time.Millisecond).UTC().String(),
+				v1beta1constants.GardenerTimestamp: now.Add(-time.Millisecond).UTC().Format(time.RFC3339Nano),
 			}
 			dns.Status.LastOperation = &gardencorev1beta1.LastOperation{
 				State: gardencorev1beta1.LastOperationStateSucceeded,
@@ -511,7 +511,7 @@ var _ = Describe("DNSRecord", func() {
 
 			patch := client.MergeFrom(dns.DeepCopy())
 			dns.ObjectMeta.Annotations = map[string]string{
-				v1beta1constants.GardenerTimestamp: now.UTC().String(),
+				v1beta1constants.GardenerTimestamp: now.UTC().Format(time.RFC3339Nano),
 			}
 			dns.Status.LastOperation = &gardencorev1beta1.LastOperation{
 				State: gardencorev1beta1.LastOperationStateSucceeded,
@@ -530,7 +530,7 @@ var _ = Describe("DNSRecord", func() {
 					Namespace: namespace,
 					Annotations: map[string]string{
 						"confirmation.gardener.cloud/deletion": "true",
-						v1beta1constants.GardenerTimestamp:     now.UTC().String(),
+						v1beta1constants.GardenerTimestamp:     now.UTC().Format(time.RFC3339Nano),
 					},
 				},
 			}
@@ -577,7 +577,7 @@ var _ = Describe("DNSRecord", func() {
 					Namespace: namespace,
 					Annotations: map[string]string{
 						"confirmation.gardener.cloud/deletion": "true",
-						v1beta1constants.GardenerTimestamp:     now.UTC().String(),
+						v1beta1constants.GardenerTimestamp:     now.UTC().Format(time.RFC3339Nano),
 					},
 				},
 			}

--- a/pkg/operation/botanist/component/extensions/extension/extension.go
+++ b/pkg/operation/botanist/component/extensions/extension/extension.go
@@ -164,7 +164,7 @@ func (e *extension) DeployBeforeKubeAPIServer(ctx context.Context) error {
 func (e *extension) deploy(ctx context.Context, ext *extensionsv1alpha1.Extension, extType string, providerConfig *runtime.RawExtension, operation string) (extensionsv1alpha1.Object, error) {
 	_, err := controllerutils.GetAndCreateOrMergePatch(ctx, e.client, ext, func() error {
 		metav1.SetMetaDataAnnotation(&ext.ObjectMeta, v1beta1constants.GardenerOperation, operation)
-		metav1.SetMetaDataAnnotation(&ext.ObjectMeta, v1beta1constants.GardenerTimestamp, TimeNow().UTC().String())
+		metav1.SetMetaDataAnnotation(&ext.ObjectMeta, v1beta1constants.GardenerTimestamp, TimeNow().UTC().Format(time.RFC3339Nano))
 		ext.Spec.Type = extType
 		ext.Spec.ProviderConfig = providerConfig
 		return nil

--- a/pkg/operation/botanist/component/extensions/extension/extension_test.go
+++ b/pkg/operation/botanist/component/extensions/extension/extension_test.go
@@ -245,7 +245,7 @@ var _ = Describe("Extension", func() {
 			patch := client.MergeFrom(beforeExtension.DeepCopy())
 			// remove operation annotation, add old timestamp annotation
 			beforeExtension.ObjectMeta.Annotations = map[string]string{
-				v1beta1constants.GardenerTimestamp: now.Add(-time.Millisecond).UTC().String(),
+				v1beta1constants.GardenerTimestamp: now.Add(-time.Millisecond).UTC().Format(time.RFC3339Nano),
 			}
 			// set last operation
 			beforeExtension.Status.LastOperation = &gardencorev1beta1.LastOperation{
@@ -295,7 +295,7 @@ var _ = Describe("Extension", func() {
 			patch := client.MergeFrom(defaultExtension.DeepCopy())
 			// remove operation annotation, add old timestamp annotation
 			defaultExtension.ObjectMeta.Annotations = map[string]string{
-				v1beta1constants.GardenerTimestamp: now.Add(-time.Millisecond).UTC().String(),
+				v1beta1constants.GardenerTimestamp: now.Add(-time.Millisecond).UTC().Format(time.RFC3339Nano),
 			}
 			// set last operation
 			defaultExtension.Status.LastOperation = &gardencorev1beta1.LastOperation{

--- a/pkg/operation/botanist/component/extensions/infrastructure/infrastructure.go
+++ b/pkg/operation/botanist/component/extensions/infrastructure/infrastructure.go
@@ -137,8 +137,7 @@ func (i *infrastructure) deploy(ctx context.Context, operation string) (extensio
 			metav1.SetMetaDataAnnotation(&i.infrastructure.ObjectMeta, v1beta1constants.GardenerOperation, operation)
 		}
 
-		metav1.SetMetaDataAnnotation(&i.infrastructure.ObjectMeta, v1beta1constants.GardenerTimestamp, TimeNow().UTC().String())
-
+		metav1.SetMetaDataAnnotation(&i.infrastructure.ObjectMeta, v1beta1constants.GardenerTimestamp, TimeNow().UTC().Format(time.RFC3339Nano))
 		i.infrastructure.Spec = extensionsv1alpha1.InfrastructureSpec{
 			DefaultSpec: extensionsv1alpha1.DefaultSpec{
 				Type:           i.values.Type,

--- a/pkg/operation/botanist/component/extensions/infrastructure/infrastructure_test.go
+++ b/pkg/operation/botanist/component/extensions/infrastructure/infrastructure_test.go
@@ -121,7 +121,7 @@ var _ = Describe("#Interface", func() {
 				Namespace: namespace,
 				Annotations: map[string]string{
 					v1beta1constants.GardenerOperation: v1beta1constants.GardenerOperationReconcile,
-					v1beta1constants.GardenerTimestamp: now.UTC().String(),
+					v1beta1constants.GardenerTimestamp: now.UTC().Format(time.RFC3339Nano),
 				},
 			},
 			Spec: extensionsv1alpha1.InfrastructureSpec{
@@ -170,7 +170,7 @@ var _ = Describe("#Interface", func() {
 			expected.Spec.SSHPublicKey = []byte("")
 			Expect(c.Get(ctx, client.ObjectKeyFromObject(expected), actual)).To(Succeed())
 			expected.SetAnnotations(map[string]string{
-				v1beta1constants.GardenerTimestamp: now.UTC().String(),
+				v1beta1constants.GardenerTimestamp: now.UTC().Format(time.RFC3339Nano),
 			})
 			Expect(actual).To(DeepEqual(expected))
 		})
@@ -222,7 +222,7 @@ var _ = Describe("#Interface", func() {
 			expected.Status.LastError = nil
 			// remove operation annotation, add old timestamp annotation
 			expected.ObjectMeta.Annotations = map[string]string{
-				v1beta1constants.GardenerTimestamp: now.Add(-time.Millisecond).UTC().String(),
+				v1beta1constants.GardenerTimestamp: now.Add(-time.Millisecond).UTC().Format(time.RFC3339Nano),
 			}
 			expected.Status.LastOperation = &gardencorev1beta1.LastOperation{
 				State: gardencorev1beta1.LastOperationStateSucceeded,
@@ -250,7 +250,7 @@ var _ = Describe("#Interface", func() {
 			expected.Status.LastError = nil
 			// remove operation annotation, add up-to-date timestamp annotation
 			expected.ObjectMeta.Annotations = map[string]string{
-				v1beta1constants.GardenerTimestamp: now.UTC().String(),
+				v1beta1constants.GardenerTimestamp: now.UTC().Format(time.RFC3339Nano),
 			}
 			expected.Status.LastOperation = &gardencorev1beta1.LastOperation{
 				State: gardencorev1beta1.LastOperationStateSucceeded,
@@ -305,7 +305,7 @@ var _ = Describe("#Interface", func() {
 			expected = empty.DeepCopy()
 			expected.SetAnnotations(map[string]string{
 				gardenerutils.ConfirmationDeletion: "true",
-				v1beta1constants.GardenerTimestamp: now.UTC().String(),
+				v1beta1constants.GardenerTimestamp: now.UTC().Format(time.RFC3339Nano),
 			})
 
 			// add deletion confirmation and timestamp annotation
@@ -369,7 +369,7 @@ var _ = Describe("#Interface", func() {
 			// deploy with wait-for-state annotation
 			obj := expected.DeepCopy()
 			metav1.SetMetaDataAnnotation(&obj.ObjectMeta, "gardener.cloud/operation", "wait-for-state")
-			metav1.SetMetaDataAnnotation(&obj.ObjectMeta, "gardener.cloud/timestamp", now.UTC().String())
+			metav1.SetMetaDataAnnotation(&obj.ObjectMeta, "gardener.cloud/timestamp", now.UTC().Format(time.RFC3339Nano))
 			obj.TypeMeta = metav1.TypeMeta{}
 			mc.EXPECT().Create(ctx, test.HasObjectKeyOf(obj)).
 				DoAndReturn(func(ctx context.Context, actual client.Object, opts ...client.CreateOption) error {
@@ -408,7 +408,7 @@ var _ = Describe("#Interface", func() {
 			Expect(c.Get(ctx, client.ObjectKeyFromObject(expected), actual)).To(Succeed())
 			expected.SetResourceVersion("2")
 			metav1.SetMetaDataAnnotation(&expected.ObjectMeta, v1beta1constants.GardenerOperation, v1beta1constants.GardenerOperationMigrate)
-			metav1.SetMetaDataAnnotation(&expected.ObjectMeta, v1beta1constants.GardenerTimestamp, now.UTC().String())
+			metav1.SetMetaDataAnnotation(&expected.ObjectMeta, v1beta1constants.GardenerTimestamp, now.UTC().Format(time.RFC3339Nano))
 			Expect(actual).To(DeepEqual(expected))
 		})
 

--- a/pkg/operation/botanist/component/extensions/network/network.go
+++ b/pkg/operation/botanist/component/extensions/network/network.go
@@ -176,7 +176,7 @@ func (n *network) WaitCleanup(ctx context.Context) error {
 func (n *network) deploy(ctx context.Context, operation string) (extensionsv1alpha1.Object, error) {
 	_, err := controllerutils.GetAndCreateOrMergePatch(ctx, n.client, n.network, func() error {
 		metav1.SetMetaDataAnnotation(&n.network.ObjectMeta, v1beta1constants.GardenerOperation, operation)
-		metav1.SetMetaDataAnnotation(&n.network.ObjectMeta, v1beta1constants.GardenerTimestamp, TimeNow().UTC().String())
+		metav1.SetMetaDataAnnotation(&n.network.ObjectMeta, v1beta1constants.GardenerTimestamp, TimeNow().UTC().Format(time.RFC3339Nano))
 
 		n.network.Spec = extensionsv1alpha1.NetworkSpec{
 			DefaultSpec: extensionsv1alpha1.DefaultSpec{

--- a/pkg/operation/botanist/component/extensions/network/network_test.go
+++ b/pkg/operation/botanist/component/extensions/network/network_test.go
@@ -115,7 +115,7 @@ var _ = Describe("#Network", func() {
 				Namespace: networkNs,
 				Annotations: map[string]string{
 					v1beta1constants.GardenerOperation: v1beta1constants.GardenerOperationReconcile,
-					v1beta1constants.GardenerTimestamp: now.UTC().String(),
+					v1beta1constants.GardenerTimestamp: now.UTC().Format(time.RFC3339Nano),
 				},
 			},
 			Spec: extensionsv1alpha1.NetworkSpec{
@@ -182,7 +182,7 @@ var _ = Describe("#Network", func() {
 			expected.Status.LastError = nil
 			// remove operation annotation, add old timestamp annotation
 			expected.ObjectMeta.Annotations = map[string]string{
-				v1beta1constants.GardenerTimestamp: now.Add(-time.Millisecond).UTC().String(),
+				v1beta1constants.GardenerTimestamp: now.Add(-time.Millisecond).UTC().Format(time.RFC3339Nano),
 			}
 			expected.Status.LastOperation = &gardencorev1beta1.LastOperation{
 				State: gardencorev1beta1.LastOperationStateSucceeded,
@@ -208,7 +208,7 @@ var _ = Describe("#Network", func() {
 			expected.Status.LastError = nil
 			// remove operation annotation, add up-to-date timestamp annotation
 			expected.ObjectMeta.Annotations = map[string]string{
-				v1beta1constants.GardenerTimestamp: now.UTC().String(),
+				v1beta1constants.GardenerTimestamp: now.UTC().Format(time.RFC3339Nano),
 			}
 			expected.Status.LastOperation = &gardencorev1beta1.LastOperation{
 				State: gardencorev1beta1.LastOperationStateSucceeded,
@@ -245,7 +245,7 @@ var _ = Describe("#Network", func() {
 					Namespace: networkNs,
 					Annotations: map[string]string{
 						gardenerutils.ConfirmationDeletion: "true",
-						v1beta1constants.GardenerTimestamp: now.UTC().String(),
+						v1beta1constants.GardenerTimestamp: now.UTC().Format(time.RFC3339Nano),
 					},
 				}}
 
@@ -308,7 +308,7 @@ var _ = Describe("#Network", func() {
 			// deploy with wait-for-state annotation
 			obj := expected.DeepCopy()
 			metav1.SetMetaDataAnnotation(&obj.ObjectMeta, "gardener.cloud/operation", "wait-for-state")
-			metav1.SetMetaDataAnnotation(&obj.ObjectMeta, "gardener.cloud/timestamp", now.UTC().String())
+			metav1.SetMetaDataAnnotation(&obj.ObjectMeta, "gardener.cloud/timestamp", now.UTC().Format(time.RFC3339Nano))
 			obj.TypeMeta = metav1.TypeMeta{}
 			mc.EXPECT().Create(ctx, test.HasObjectKeyOf(obj)).
 				DoAndReturn(func(ctx context.Context, actual client.Object, opts ...client.CreateOption) error {
@@ -342,7 +342,7 @@ var _ = Describe("#Network", func() {
 
 			expectedCopy := empty.DeepCopy()
 			metav1.SetMetaDataAnnotation(&expectedCopy.ObjectMeta, v1beta1constants.GardenerOperation, v1beta1constants.GardenerOperationMigrate)
-			metav1.SetMetaDataAnnotation(&expectedCopy.ObjectMeta, v1beta1constants.GardenerTimestamp, now.UTC().String())
+			metav1.SetMetaDataAnnotation(&expectedCopy.ObjectMeta, v1beta1constants.GardenerTimestamp, now.UTC().Format(time.RFC3339Nano))
 			test.EXPECTPatch(ctx, mc, expectedCopy, empty, types.MergePatchType)
 
 			defaultDepWaiter = network.New(log, mc, values, time.Millisecond, 250*time.Millisecond, 500*time.Millisecond)
@@ -359,7 +359,7 @@ var _ = Describe("#Network", func() {
 
 			expectedCopy := empty.DeepCopy()
 			metav1.SetMetaDataAnnotation(&expectedCopy.ObjectMeta, v1beta1constants.GardenerOperation, v1beta1constants.GardenerOperationMigrate)
-			metav1.SetMetaDataAnnotation(&expectedCopy.ObjectMeta, v1beta1constants.GardenerTimestamp, now.UTC().String())
+			metav1.SetMetaDataAnnotation(&expectedCopy.ObjectMeta, v1beta1constants.GardenerTimestamp, now.UTC().Format(time.RFC3339Nano))
 			test.EXPECTPatch(ctx, mc, expectedCopy, empty, types.MergePatchType)
 
 			defaultDepWaiter = network.New(log, mc, values, time.Millisecond, 250*time.Millisecond, 500*time.Millisecond)

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/operatingsystemconfig.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/operatingsystemconfig.go
@@ -681,7 +681,7 @@ func (d *deployer) deploy(ctx context.Context, operation string) (extensionsv1al
 	// to be owned by gardenlet exclusively.
 	_, err = controllerutils.GetAndCreateOrMergePatch(ctx, d.client, d.osc, func() error {
 		metav1.SetMetaDataAnnotation(&d.osc.ObjectMeta, v1beta1constants.GardenerOperation, operation)
-		metav1.SetMetaDataAnnotation(&d.osc.ObjectMeta, v1beta1constants.GardenerTimestamp, TimeNow().UTC().String())
+		metav1.SetMetaDataAnnotation(&d.osc.ObjectMeta, v1beta1constants.GardenerTimestamp, TimeNow().UTC().Format(time.RFC3339Nano))
 		metav1.SetMetaDataLabel(&d.osc.ObjectMeta, v1beta1constants.LabelWorkerPool, d.worker.Name)
 
 		d.osc.Spec.Type = d.worker.Machine.Image.Name

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/operatingsystemconfig_test.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/operatingsystemconfig_test.go
@@ -258,7 +258,7 @@ var _ = Describe("OperatingSystemConfig", func() {
 						Namespace: namespace,
 						Annotations: map[string]string{
 							v1beta1constants.GardenerOperation: v1beta1constants.GardenerOperationReconcile,
-							v1beta1constants.GardenerTimestamp: now.UTC().String(),
+							v1beta1constants.GardenerTimestamp: now.UTC().Format(time.RFC3339Nano),
 						},
 						Labels: map[string]string{
 							"worker.gardener.cloud/pool": worker.Name,
@@ -282,7 +282,7 @@ var _ = Describe("OperatingSystemConfig", func() {
 						Namespace: namespace,
 						Annotations: map[string]string{
 							v1beta1constants.GardenerOperation: v1beta1constants.GardenerOperationReconcile,
-							v1beta1constants.GardenerTimestamp: now.UTC().String(),
+							v1beta1constants.GardenerTimestamp: now.UTC().Format(time.RFC3339Nano),
 						},
 						Labels: map[string]string{
 							"worker.gardener.cloud/pool": worker.Name,
@@ -485,7 +485,7 @@ var _ = Describe("OperatingSystemConfig", func() {
 					// deploy with wait-for-state annotation
 					obj := expected[i].DeepCopy()
 					metav1.SetMetaDataAnnotation(&obj.ObjectMeta, "gardener.cloud/operation", "wait-for-state")
-					metav1.SetMetaDataAnnotation(&obj.ObjectMeta, "gardener.cloud/timestamp", now.UTC().String())
+					metav1.SetMetaDataAnnotation(&obj.ObjectMeta, "gardener.cloud/timestamp", now.UTC().Format(time.RFC3339Nano))
 					obj.TypeMeta = metav1.TypeMeta{}
 					mc.EXPECT().Create(ctx, test.HasObjectKeyOf(obj)).
 						DoAndReturn(func(ctx context.Context, actual client.Object, opts ...client.CreateOption) error {
@@ -558,7 +558,7 @@ var _ = Describe("OperatingSystemConfig", func() {
 					patch := client.MergeFrom(expected[i].DeepCopy())
 					// remove operation annotation, add old timestamp annotation
 					expected[i].ObjectMeta.Annotations = map[string]string{
-						v1beta1constants.GardenerTimestamp: now.Add(-time.Millisecond).UTC().String(),
+						v1beta1constants.GardenerTimestamp: now.Add(-time.Millisecond).UTC().Format(time.RFC3339Nano),
 					}
 					// set last operation
 					expected[i].Status.LastOperation = &gardencorev1beta1.LastOperation{
@@ -610,7 +610,7 @@ var _ = Describe("OperatingSystemConfig", func() {
 					patch := client.MergeFrom(expected[i].DeepCopy())
 					// remove operation annotation, add up-to-date timestamp annotation
 					expected[i].ObjectMeta.Annotations = map[string]string{
-						v1beta1constants.GardenerTimestamp: now.UTC().String(),
+						v1beta1constants.GardenerTimestamp: now.UTC().Format(time.RFC3339Nano),
 					}
 					// set last operation
 					expected[i].Status.LastOperation = &gardencorev1beta1.LastOperation{
@@ -745,7 +745,7 @@ var _ = Describe("OperatingSystemConfig", func() {
 						Namespace: namespace,
 						Annotations: map[string]string{
 							gardenerutils.ConfirmationDeletion: "true",
-							v1beta1constants.GardenerTimestamp: now.UTC().String(),
+							v1beta1constants.GardenerTimestamp: now.UTC().Format(time.RFC3339Nano),
 						},
 					},
 				}

--- a/pkg/operation/botanist/component/extensions/worker/worker.go
+++ b/pkg/operation/botanist/component/extensions/worker/worker.go
@@ -231,7 +231,7 @@ func (w *worker) deploy(ctx context.Context, operation string) (extensionsv1alph
 	// to be owned by gardenlet exclusively.
 	_, err := controllerutils.GetAndCreateOrMergePatch(ctx, w.client, w.worker, func() error {
 		metav1.SetMetaDataAnnotation(&w.worker.ObjectMeta, v1beta1constants.GardenerOperation, operation)
-		metav1.SetMetaDataAnnotation(&w.worker.ObjectMeta, v1beta1constants.GardenerTimestamp, TimeNow().UTC().String())
+		metav1.SetMetaDataAnnotation(&w.worker.ObjectMeta, v1beta1constants.GardenerTimestamp, TimeNow().UTC().Format(time.RFC3339Nano))
 
 		w.worker.Spec = extensionsv1alpha1.WorkerSpec{
 			DefaultSpec: extensionsv1alpha1.DefaultSpec{

--- a/pkg/operation/botanist/component/extensions/worker/worker_test.go
+++ b/pkg/operation/botanist/component/extensions/worker/worker_test.go
@@ -249,7 +249,7 @@ var _ = Describe("Worker", func() {
 		w = empty.DeepCopy()
 		w.SetAnnotations(map[string]string{
 			v1beta1constants.GardenerOperation: v1beta1constants.GardenerOperationReconcile,
-			v1beta1constants.GardenerTimestamp: now.UTC().String(),
+			v1beta1constants.GardenerTimestamp: now.UTC().Format(time.RFC3339Nano),
 		})
 
 		wSpec = extensionsv1alpha1.WorkerSpec{
@@ -366,7 +366,7 @@ var _ = Describe("Worker", func() {
 					Namespace: namespace,
 					Annotations: map[string]string{
 						"gardener.cloud/operation": "reconcile",
-						"gardener.cloud/timestamp": now.UTC().String(),
+						"gardener.cloud/timestamp": now.UTC().Format(time.RFC3339Nano),
 					},
 					ResourceVersion: "1",
 				},
@@ -413,7 +413,7 @@ var _ = Describe("Worker", func() {
 					Namespace: namespace,
 					Annotations: map[string]string{
 						"gardener.cloud/operation": "reconcile",
-						"gardener.cloud/timestamp": now.UTC().String(),
+						"gardener.cloud/timestamp": now.UTC().Format(time.RFC3339Nano),
 					},
 					ResourceVersion: "2",
 				},
@@ -460,7 +460,7 @@ var _ = Describe("Worker", func() {
 					Namespace: namespace,
 					Annotations: map[string]string{
 						"gardener.cloud/operation": "reconcile",
-						"gardener.cloud/timestamp": now.UTC().String(),
+						"gardener.cloud/timestamp": now.UTC().Format(time.RFC3339Nano),
 					},
 					ResourceVersion: "2",
 				},
@@ -500,7 +500,7 @@ var _ = Describe("Worker", func() {
 			w.Status.LastError = nil
 			// remove operation annotation, add old timestamp annotation
 			w.ObjectMeta.Annotations = map[string]string{
-				v1beta1constants.GardenerTimestamp: now.Add(-time.Millisecond).UTC().String(),
+				v1beta1constants.GardenerTimestamp: now.Add(-time.Millisecond).UTC().Format(time.RFC3339Nano),
 			}
 			w.Status.LastOperation = &gardencorev1beta1.LastOperation{
 				State: gardencorev1beta1.LastOperationStateSucceeded,
@@ -526,7 +526,7 @@ var _ = Describe("Worker", func() {
 			w.Status.LastError = nil
 			// remove operation annotation, add up-to-date timestamp annotation
 			w.ObjectMeta.Annotations = map[string]string{
-				v1beta1constants.GardenerTimestamp: now.UTC().String(),
+				v1beta1constants.GardenerTimestamp: now.UTC().Format(time.RFC3339Nano),
 			}
 			w.Status.LastOperation = &gardencorev1beta1.LastOperation{
 				State: gardencorev1beta1.LastOperationStateSucceeded,
@@ -559,7 +559,7 @@ var _ = Describe("Worker", func() {
 			obj := w.DeepCopy()
 			obj.Annotations = map[string]string{
 				"confirmation.gardener.cloud/deletion": "true",
-				"gardener.cloud/timestamp":             now.UTC().String(),
+				"gardener.cloud/timestamp":             now.UTC().Format(time.RFC3339Nano),
 			}
 
 			mc := mockclient.NewMockClient(ctrl)
@@ -621,7 +621,7 @@ var _ = Describe("Worker", func() {
 			obj := w.DeepCopy()
 			obj.Spec = wSpec
 			metav1.SetMetaDataAnnotation(&obj.ObjectMeta, "gardener.cloud/operation", "wait-for-state")
-			metav1.SetMetaDataAnnotation(&obj.ObjectMeta, "gardener.cloud/timestamp", now.UTC().String())
+			metav1.SetMetaDataAnnotation(&obj.ObjectMeta, "gardener.cloud/timestamp", now.UTC().Format(time.RFC3339Nano))
 			obj.TypeMeta = metav1.TypeMeta{}
 			mc.EXPECT().Create(ctx, test.HasObjectKeyOf(obj)).
 				DoAndReturn(func(ctx context.Context, actual client.Object, opts ...client.CreateOption) error {

--- a/pkg/operation/botanist/dnsrecord_test.go
+++ b/pkg/operation/botanist/dnsrecord_test.go
@@ -251,7 +251,7 @@ var _ = Describe("dnsrecord", func() {
 					ResourceVersion: "1",
 					Annotations: map[string]string{
 						v1beta1constants.GardenerOperation: v1beta1constants.GardenerOperationReconcile,
-						v1beta1constants.GardenerTimestamp: now.UTC().String(),
+						v1beta1constants.GardenerTimestamp: now.UTC().Format(time.RFC3339Nano),
 					},
 				},
 				Spec: extensionsv1alpha1.DNSRecordSpec{
@@ -366,7 +366,7 @@ var _ = Describe("dnsrecord", func() {
 					ResourceVersion: "1",
 					Annotations: map[string]string{
 						v1beta1constants.GardenerOperation: v1beta1constants.GardenerOperationReconcile,
-						v1beta1constants.GardenerTimestamp: now.UTC().String(),
+						v1beta1constants.GardenerTimestamp: now.UTC().Format(time.RFC3339Nano),
 					},
 				},
 				Spec: extensionsv1alpha1.DNSRecordSpec{

--- a/pkg/operation/botanist/nginxingress_test.go
+++ b/pkg/operation/botanist/nginxingress_test.go
@@ -326,7 +326,7 @@ var _ = Describe("NginxIngress", func() {
 					ResourceVersion: "1",
 					Annotations: map[string]string{
 						v1beta1constants.GardenerOperation: v1beta1constants.GardenerOperationReconcile,
-						v1beta1constants.GardenerTimestamp: now.UTC().String(),
+						v1beta1constants.GardenerTimestamp: now.UTC().Format(time.RFC3339Nano),
 					},
 				},
 				Spec: extensionsv1alpha1.DNSRecordSpec{

--- a/pkg/operation/operation_test.go
+++ b/pkg/operation/operation_test.go
@@ -185,7 +185,7 @@ var _ = Describe("operation", func() {
 					&gardener.TimeNow, mockNow.Do,
 				)()
 
-				shootState.Annotations = map[string]string{gardener.ConfirmationDeletion: "true", v1beta1constants.GardenerTimestamp: now.UTC().String()}
+				shootState.Annotations = map[string]string{gardener.ConfirmationDeletion: "true", v1beta1constants.GardenerTimestamp: now.UTC().Format(time.RFC3339Nano)}
 				gomock.InOrder(
 					gardenClient.EXPECT().Patch(gomock.Any(), gomock.Any(), gomock.Any()),
 					gardenClient.EXPECT().Delete(ctx, shootState).Return(nil),

--- a/pkg/utils/gardener/deletion_confirmation.go
+++ b/pkg/utils/gardener/deletion_confirmation.go
@@ -58,7 +58,7 @@ func CheckIfDeletionIsConfirmed(obj client.Object) error {
 func ConfirmDeletion(ctx context.Context, w client.Writer, obj client.Object) error {
 	patch := client.MergeFrom(obj.DeepCopyObject().(client.Object))
 	kubernetesutils.SetMetaDataAnnotation(obj, ConfirmationDeletion, "true")
-	kubernetesutils.SetMetaDataAnnotation(obj, v1beta1constants.GardenerTimestamp, TimeNow().UTC().String())
+	kubernetesutils.SetMetaDataAnnotation(obj, v1beta1constants.GardenerTimestamp, TimeNow().UTC().Format(time.RFC3339Nano))
 	return w.Patch(ctx, obj, patch)
 }
 

--- a/pkg/utils/gardener/deletion_confirmation_test.go
+++ b/pkg/utils/gardener/deletion_confirmation_test.go
@@ -94,7 +94,7 @@ var _ = Describe("DeletionConfirmation", func() {
 			)()
 			mockNow.EXPECT().Do().Return(now.UTC()).AnyTimes()
 
-			expectedAnnotations := map[string]string{ConfirmationDeletion: "true", v1beta1constants.GardenerTimestamp: now.UTC().String()}
+			expectedAnnotations := map[string]string{ConfirmationDeletion: "true", v1beta1constants.GardenerTimestamp: now.UTC().Format(time.RFC3339Nano)}
 
 			Expect(ConfirmDeletion(ctx, c, obj)).To(Succeed())
 
@@ -111,7 +111,7 @@ var _ = Describe("DeletionConfirmation", func() {
 			obj.SetAnnotations(map[string]string{"foo": "bar"})
 			Expect(c.Update(ctx, obj)).To(Succeed())
 
-			expectedAnnotations := map[string]string{"foo": "bar", ConfirmationDeletion: "true", v1beta1constants.GardenerTimestamp: now.UTC().String()}
+			expectedAnnotations := map[string]string{"foo": "bar", ConfirmationDeletion: "true", v1beta1constants.GardenerTimestamp: now.UTC().Format(time.RFC3339Nano)}
 
 			Expect(ConfirmDeletion(ctx, c, obj)).To(Succeed())
 

--- a/test/integration/gardenlet/backupbucket/backupbucket_test.go
+++ b/test/integration/gardenlet/backupbucket/backupbucket_test.go
@@ -53,7 +53,7 @@ var _ = Describe("BackupBucket controller tests", func() {
 	BeforeEach(func() {
 		DeferCleanup(test.WithVar(&backupbucket.RequeueDurationWhenResourceDeletionStillPresent, 30*time.Millisecond))
 
-		fakeClock.SetTime(time.Now().Round(time.Second))
+		fakeClock.SetTime(time.Now().Truncate(time.Second))
 
 		reconcileExtensionBackupBucket = func(makeReady bool) {
 			// These should be done by the extension controller, we are faking it here for the tests.

--- a/test/integration/gardenlet/backupbucket/backupbucket_test.go
+++ b/test/integration/gardenlet/backupbucket/backupbucket_test.go
@@ -53,7 +53,7 @@ var _ = Describe("BackupBucket controller tests", func() {
 	BeforeEach(func() {
 		DeferCleanup(test.WithVar(&backupbucket.RequeueDurationWhenResourceDeletionStillPresent, 30*time.Millisecond))
 
-		fakeClock.SetTime(time.Now())
+		fakeClock.SetTime(time.Now().Round(time.Second))
 
 		reconcileExtensionBackupBucket = func(makeReady bool) {
 			// These should be done by the extension controller, we are faking it here for the tests.
@@ -101,7 +101,7 @@ var _ = Describe("BackupBucket controller tests", func() {
 					ProviderStatus:     providerStatus,
 					LastOperation: &gardencorev1beta1.LastOperation{
 						State:          lastOperationState,
-						LastUpdateTime: metav1.NewTime(fakeClock.Now().Add(time.Second * 10)),
+						LastUpdateTime: metav1.NewTime(fakeClock.Now()),
 					},
 				},
 				GeneratedSecretRef: &corev1.SecretReference{

--- a/test/integration/gardenlet/backupbucket/backupbucket_test.go
+++ b/test/integration/gardenlet/backupbucket/backupbucket_test.go
@@ -101,7 +101,7 @@ var _ = Describe("BackupBucket controller tests", func() {
 					ProviderStatus:     providerStatus,
 					LastOperation: &gardencorev1beta1.LastOperation{
 						State:          lastOperationState,
-						LastUpdateTime: metav1.NewTime(fakeClock.Now()),
+						LastUpdateTime: metav1.NewTime(fakeClock.Now().Add(time.Second * 10)),
 					},
 				},
 				GeneratedSecretRef: &corev1.SecretReference{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind enhancement

**What this PR does / why we need it**:
This PR changes the format of the `gardener.cloud/timestamp` annotation to `time.RFC3339Nano` and unifies the format across different resources. The previously used format is meant for debugging as stated in the [documentation](https://pkg.go.dev/time#Time.String). `Backupbucket` and `Backupentry` were already using `time.RFC3339` format which should be backwards compatible with `time.RFC3339Nano` (see an example [here](https://go.dev/play/p/MiukYosIkkR)).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
cc @rfranzke 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking developer
The `gardener.cloud/timestamp` annotation is now formatted as `time.RFC3339Nano`.
```
