### PR TITLE
[ci:component:github.com/gardener/hvpa-controller:v0.11.0->v0.12.0]

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -570,7 +570,7 @@ images:
 - name: hvpa-controller
   sourceRepository: github.com/gardener/hvpa-controller
   repository: eu.gcr.io/gardener-project/gardener/hvpa-controller
-  tag: "v0.11.0"
+  tag: "v0.12.0"
   labels:
     - name: 'gardener.cloud/cve-categorisation'
       value:

--- a/pkg/operation/botanist/component/hvpa/hvpa.go
+++ b/pkg/operation/botanist/component/hvpa/hvpa.go
@@ -145,6 +145,17 @@ func (h *hvpa) Deploy(ctx context.Context) error {
 					Resources: []string{"jobs"},
 					Verbs:     []string{"get", "list", "patch", "update", "watch"},
 				},
+				{
+					APIGroups: []string{"coordination.k8s.io"},
+					Resources: []string{"leases"},
+					Verbs:     []string{"create"},
+				},
+				{
+					APIGroups:     []string{"coordination.k8s.io"},
+					Resources:     []string{"leases"},
+					ResourceNames: []string{"hvpa-controller"},
+					Verbs:         []string{"get", "watch", "update"},
+				},
 			},
 		}
 		clusterRoleBinding = &rbacv1.ClusterRoleBinding{
@@ -210,6 +221,7 @@ func (h *hvpa) Deploy(ctx context.Context) error {
 							Command: []string{
 								"./manager",
 								"--logtostderr=true",
+								"--leader-elect=true",
 								"--enable-detailed-metrics=true",
 								fmt.Sprintf("--metrics-bind-address=:%d", portMetrics),
 								"--v=2",

--- a/pkg/operation/botanist/component/hvpa/hvpa_test.go
+++ b/pkg/operation/botanist/component/hvpa/hvpa_test.go
@@ -138,6 +138,17 @@ var _ = Describe("HVPA", func() {
 					Resources: []string{"jobs"},
 					Verbs:     []string{"get", "list", "patch", "update", "watch"},
 				},
+				{
+					APIGroups: []string{"coordination.k8s.io"},
+					Resources: []string{"leases"},
+					Verbs:     []string{"create"},
+				},
+				{
+					APIGroups:     []string{"coordination.k8s.io"},
+					Resources:     []string{"leases"},
+					ResourceNames: []string{"hvpa-controller"},
+					Verbs:         []string{"get", "watch", "update"},
+				},
 			},
 		}
 		clusterRoleBinding = &rbacv1.ClusterRoleBinding{
@@ -223,6 +234,7 @@ var _ = Describe("HVPA", func() {
 							Command: []string{
 								"./manager",
 								"--logtostderr=true",
+								"--leader-elect=true",
 								"--enable-detailed-metrics=true",
 								"--metrics-bind-address=:9569",
 								"--v=2",

--- a/pkg/operation/botanist/component/hvpa/templates/crd.tpl.yaml
+++ b/pkg/operation/botanist/component/hvpa/templates/crd.tpl.yaml
@@ -1,11 +1,13 @@
+# source: https://github.com/gardener/hvpa-controller/blob/v0.12.0/config/crd/output/crds.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: hvpas.autoscaling.k8s.io
   annotations:
-    api-approved.kubernetes.io: "unapproved, temporarily squatting" # see https://github.com/kubernetes/enhancements/tree/master/keps/sig-api-machinery/2337-k8s.io-group-protection
+    api-approved.kubernetes.io: unapproved, temporarily squatting
+    controller-gen.kubebuilder.io/version: v0.9.2
   labels:
     gardener.cloud/role: hvpa
+  name: hvpas.autoscaling.k8s.io
 spec:
   group: autoscaling.k8s.io
   names:
@@ -15,1325 +17,1327 @@ spec:
     singular: hvpa
   scope: Namespaced
   versions:
-    - name: v1alpha1
-      schema:
-        openAPIV3Schema:
-          description: Hvpa is the Schema for the hvpas API
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
-                of an object. Servers should convert recognized schemas to the latest
-                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this
-                object represents. Servers may infer this from the endpoint the client
-                submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: HvpaSpec defines the desired state of Hvpa
-              properties:
-                hpa:
-                  description: Hpa defines the spec of HPA
-                  properties:
-                    deploy:
-                      description: Deploy defines whether the HPA is deployed or not
-                      type: boolean
-                    scaleDown:
-                      description: ScaleDown defines the parameters for scale down
-                      properties:
-                        minChange:
-                          description: MinChange is the minimum change in the resource
-                            on which HVPA acts HVPA uses minimum of the Value and Percentage
-                            value
-                          properties:
-                            cpu:
-                              description: Scale parameters for CPU
-                              properties:
-                                percentage:
-                                  description: Percentage is the percentage of currently
-                                    allocated value to be used for scaling
-                                  format: int32
-                                  type: integer
-                                value:
-                                  description: Value is the absolute value of the scaling
-                                  type: string
-                              type: object
-                            memory:
-                              description: Scale parameters for memory
-                              properties:
-                                percentage:
-                                  description: Percentage is the percentage of currently
-                                    allocated value to be used for scaling
-                                  format: int32
-                                  type: integer
-                                value:
-                                  description: Value is the absolute value of the scaling
-                                  type: string
-                              type: object
-                            replicas:
-                              description: Scale patameters for replicas
-                              properties:
-                                percentage:
-                                  description: Percentage is the percentage of currently
-                                    allocated value to be used for scaling
-                                  format: int32
-                                  type: integer
-                                value:
-                                  description: Value is the absolute value of the scaling
-                                  type: string
-                              type: object
-                          type: object
-                        stabilizationDuration:
-                          description: StabilizationDuration defines the minimum delay
-                            in minutes between 2 consecutive scale operations Valid
-                            time units are "ns", "us" (or "µs"), "ms", "s", "m", "h"
-                          type: string
-                        updatePolicy:
-                          description: Describes the rules on when changes are applied.
-                            If not specified, all fields in the `UpdatePolicy` are set
-                            to their default values.
-                          properties:
-                            updateMode:
-                              description: Controls when autoscaler applies changes
-                                to the resources. The default is 'Auto'.
-                              type: string
-                          type: object
-                      type: object
-                    scaleUp:
-                      description: ScaleUp defines the parameters for scale up
-                      properties:
-                        minChange:
-                          description: MinChange is the minimum change in the resource
-                            on which HVPA acts HVPA uses minimum of the Value and Percentage
-                            value
-                          properties:
-                            cpu:
-                              description: Scale parameters for CPU
-                              properties:
-                                percentage:
-                                  description: Percentage is the percentage of currently
-                                    allocated value to be used for scaling
-                                  format: int32
-                                  type: integer
-                                value:
-                                  description: Value is the absolute value of the scaling
-                                  type: string
-                              type: object
-                            memory:
-                              description: Scale parameters for memory
-                              properties:
-                                percentage:
-                                  description: Percentage is the percentage of currently
-                                    allocated value to be used for scaling
-                                  format: int32
-                                  type: integer
-                                value:
-                                  description: Value is the absolute value of the scaling
-                                  type: string
-                              type: object
-                            replicas:
-                              description: Scale patameters for replicas
-                              properties:
-                                percentage:
-                                  description: Percentage is the percentage of currently
-                                    allocated value to be used for scaling
-                                  format: int32
-                                  type: integer
-                                value:
-                                  description: Value is the absolute value of the scaling
-                                  type: string
-                              type: object
-                          type: object
-                        stabilizationDuration:
-                          description: StabilizationDuration defines the minimum delay
-                            in minutes between 2 consecutive scale operations Valid
-                            time units are "ns", "us" (or "µs"), "ms", "s", "m", "h"
-                          type: string
-                        updatePolicy:
-                          description: Describes the rules on when changes are applied.
-                            If not specified, all fields in the `UpdatePolicy` are set
-                            to their default values.
-                          properties:
-                            updateMode:
-                              description: Controls when autoscaler applies changes
-                                to the resources. The default is 'Auto'.
-                              type: string
-                          type: object
-                      type: object
-                    selector:
-                      description: 'Selector is a label query that should match HPA.
-                        Must match in order to be controlled. If empty, defaulted to
-                        labels on HPA template. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors'
-                      properties:
-                        matchExpressions:
-                          description: matchExpressions is a list of label selector
-                            requirements. The requirements are ANDed.
-                          items:
-                            description: A label selector requirement is a selector
-                              that contains values, a key, and an operator that relates
-                              the key and values.
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Hvpa is the Schema for the hvpas API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: HvpaSpec defines the desired state of Hvpa
+            properties:
+              hpa:
+                description: Hpa defines the spec of HPA
+                properties:
+                  deploy:
+                    description: Deploy defines whether the HPA is deployed or not
+                    type: boolean
+                  scaleDown:
+                    description: ScaleDown defines the parameters for scale down
+                    properties:
+                      minChange:
+                        description: MinChange is the minimum change in the resource
+                          on which HVPA acts HVPA uses minimum of the Value and Percentage
+                          value
+                        properties:
+                          cpu:
+                            description: Scale parameters for CPU
                             properties:
-                              key:
-                                description: key is the label key that the selector
-                                  applies to.
+                              percentage:
+                                description: Percentage is the percentage of currently
+                                  allocated value to be used for scaling
+                                format: int32
+                                type: integer
+                              value:
+                                description: Value is the absolute value of the scaling
                                 type: string
-                              operator:
-                                description: operator represents a key's relationship
-                                  to a set of values. Valid operators are In, NotIn,
-                                  Exists and DoesNotExist.
-                                type: string
-                              values:
-                                description: values is an array of string values. If
-                                  the operator is In or NotIn, the values array must
-                                  be non-empty. If the operator is Exists or DoesNotExist,
-                                  the values array must be empty. This array is replaced
-                                  during a strategic merge patch.
-                                items:
-                                  type: string
-                                type: array
-                            required:
-                              - key
-                              - operator
                             type: object
-                          type: array
-                        matchLabels:
-                          additionalProperties:
+                          memory:
+                            description: Scale parameters for memory
+                            properties:
+                              percentage:
+                                description: Percentage is the percentage of currently
+                                  allocated value to be used for scaling
+                                format: int32
+                                type: integer
+                              value:
+                                description: Value is the absolute value of the scaling
+                                type: string
+                            type: object
+                          replicas:
+                            description: Scale patameters for replicas
+                            properties:
+                              percentage:
+                                description: Percentage is the percentage of currently
+                                  allocated value to be used for scaling
+                                format: int32
+                                type: integer
+                              value:
+                                description: Value is the absolute value of the scaling
+                                type: string
+                            type: object
+                        type: object
+                      stabilizationDuration:
+                        description: StabilizationDuration defines the minimum delay
+                          in minutes between 2 consecutive scale operations Valid
+                          time units are "ns", "us" (or "µs"), "ms", "s", "m", "h"
+                        type: string
+                      updatePolicy:
+                        description: Describes the rules on when changes are applied.
+                          If not specified, all fields in the `UpdatePolicy` are set
+                          to their default values.
+                        properties:
+                          updateMode:
+                            description: Controls when autoscaler applies changes
+                              to the resources. The default is 'Auto'.
                             type: string
-                          description: matchLabels is a map of {key,value} pairs. A
-                            single {key,value} in the matchLabels map is equivalent
-                            to an element of matchExpressions, whose key field is "key",
-                            the operator is "In", and the values array contains only
-                            "value". The requirements are ANDed.
-                          type: object
-                      type: object
-                    template:
-                      description: Template is the object that describes the HPA that
-                        will be created.
-                      properties:
-                        metadata:
-                          description: Metadata of the pods created from this template.
-                          type: object
-                          x-kubernetes-preserve-unknown-fields: true
-                        spec:
-                          description: Spec defines the behavior of a HPA.
+                        type: object
+                    type: object
+                  scaleUp:
+                    description: ScaleUp defines the parameters for scale up
+                    properties:
+                      minChange:
+                        description: MinChange is the minimum change in the resource
+                          on which HVPA acts HVPA uses minimum of the Value and Percentage
+                          value
+                        properties:
+                          cpu:
+                            description: Scale parameters for CPU
+                            properties:
+                              percentage:
+                                description: Percentage is the percentage of currently
+                                  allocated value to be used for scaling
+                                format: int32
+                                type: integer
+                              value:
+                                description: Value is the absolute value of the scaling
+                                type: string
+                            type: object
+                          memory:
+                            description: Scale parameters for memory
+                            properties:
+                              percentage:
+                                description: Percentage is the percentage of currently
+                                  allocated value to be used for scaling
+                                format: int32
+                                type: integer
+                              value:
+                                description: Value is the absolute value of the scaling
+                                type: string
+                            type: object
+                          replicas:
+                            description: Scale patameters for replicas
+                            properties:
+                              percentage:
+                                description: Percentage is the percentage of currently
+                                  allocated value to be used for scaling
+                                format: int32
+                                type: integer
+                              value:
+                                description: Value is the absolute value of the scaling
+                                type: string
+                            type: object
+                        type: object
+                      stabilizationDuration:
+                        description: StabilizationDuration defines the minimum delay
+                          in minutes between 2 consecutive scale operations Valid
+                          time units are "ns", "us" (or "µs"), "ms", "s", "m", "h"
+                        type: string
+                      updatePolicy:
+                        description: Describes the rules on when changes are applied.
+                          If not specified, all fields in the `UpdatePolicy` are set
+                          to their default values.
+                        properties:
+                          updateMode:
+                            description: Controls when autoscaler applies changes
+                              to the resources. The default is 'Auto'.
+                            type: string
+                        type: object
+                    type: object
+                  selector:
+                    description: 'Selector is a label query that should match HPA.
+                      Must match in order to be controlled. If empty, defaulted to
+                      labels on HPA template. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors'
+                    properties:
+                      matchExpressions:
+                        description: matchExpressions is a list of label selector
+                          requirements. The requirements are ANDed.
+                        items:
+                          description: A label selector requirement is a selector
+                            that contains values, a key, and an operator that relates
+                            the key and values.
                           properties:
-                            maxReplicas:
-                              description: maxReplicas is the upper limit for the number
-                                of replicas to which the autoscaler can scale up. It
-                                cannot be less that minReplicas.
+                            key:
+                              description: key is the label key that the selector
+                                applies to.
+                              type: string
+                            operator:
+                              description: operator represents a key's relationship
+                                to a set of values. Valid operators are In, NotIn,
+                                Exists and DoesNotExist.
+                              type: string
+                            values:
+                              description: values is an array of string values. If
+                                the operator is In or NotIn, the values array must
+                                be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. This array is replaced
+                                during a strategic merge patch.
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - key
+                          - operator
+                          type: object
+                        type: array
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: matchLabels is a map of {key,value} pairs. A
+                          single {key,value} in the matchLabels map is equivalent
+                          to an element of matchExpressions, whose key field is "key",
+                          the operator is "In", and the values array contains only
+                          "value". The requirements are ANDed.
+                        type: object
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  template:
+                    description: Template is the object that describes the HPA that
+                      will be created.
+                    properties:
+                      metadata:
+                        description: Metadata of the pods created from this template.
+                        type: object
+                        x-kubernetes-preserve-unknown-fields: true
+                      spec:
+                        description: Spec defines the behavior of a HPA.
+                        properties:
+                          maxReplicas:
+                            description: maxReplicas is the upper limit for the number
+                              of replicas to which the autoscaler can scale up. It
+                              cannot be less that minReplicas.
+                            format: int32
+                            type: integer
+                          metrics:
+                            description: metrics contains the specifications for which
+                              to use to calculate the desired replica count (the maximum
+                              replica count across all metrics will be used).  The
+                              desired replica count is calculated multiplying the
+                              ratio between the target value and the current value
+                              by the current number of pods.  Ergo, metrics used must
+                              decrease as the pod count is increased, and vice-versa.  See
+                              the individual metric source types for more information
+                              about how each type of metric must respond. If not set,
+                              the default metric will be set to 80% average CPU utilization.
+                            items:
+                              description: MetricSpec specifies how to scale based
+                                on a single metric (only `type` and one other matching
+                                field should be set at once).
+                              properties:
+                                containerResource:
+                                  description: container resource refers to a resource
+                                    metric (such as those specified in requests and
+                                    limits) known to Kubernetes describing a single
+                                    container in each pod of the current scale target
+                                    (e.g. CPU or memory). Such metrics are built in
+                                    to Kubernetes, and have special scaling options
+                                    on top of those available to normal per-pod metrics
+                                    using the "pods" source. This is an alpha feature
+                                    and can be enabled by the HPAContainerMetrics
+                                    feature flag.
+                                  properties:
+                                    container:
+                                      description: container is the name of the container
+                                        in the pods of the scaling target
+                                      type: string
+                                    name:
+                                      description: name is the name of the resource
+                                        in question.
+                                      type: string
+                                    targetAverageUtilization:
+                                      description: targetAverageUtilization is the
+                                        target value of the average of the resource
+                                        metric across all relevant pods, represented
+                                        as a percentage of the requested value of
+                                        the resource for the pods.
+                                      format: int32
+                                      type: integer
+                                    targetAverageValue:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: targetAverageValue is the target
+                                        value of the average of the resource metric
+                                        across all relevant pods, as a raw value (instead
+                                        of as a percentage of the request), similar
+                                        to the "pods" metric source type.
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - container
+                                  - name
+                                  type: object
+                                external:
+                                  description: external refers to a global metric
+                                    that is not associated with any Kubernetes object.
+                                    It allows autoscaling based on information coming
+                                    from components running outside of cluster (for
+                                    example length of queue in cloud messaging service,
+                                    or QPS from loadbalancer running outside of cluster).
+                                  properties:
+                                    metricName:
+                                      description: metricName is the name of the metric
+                                        in question.
+                                      type: string
+                                    metricSelector:
+                                      description: metricSelector is used to identify
+                                        a specific time series within a given metric.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a
+                                                  key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists
+                                                  and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of
+                                                  string values. If the operator is
+                                                  In or NotIn, the values array must
+                                                  be non-empty. If the operator is
+                                                  Exists or DoesNotExist, the values
+                                                  array must be empty. This array
+                                                  is replaced during a strategic merge
+                                                  patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator
+                                            is "In", and the values array contains
+                                            only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    targetAverageValue:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: targetAverageValue is the target
+                                        per-pod value of global metric (as a quantity).
+                                        Mutually exclusive with TargetValue.
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    targetValue:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: targetValue is the target value
+                                        of the metric (as a quantity). Mutually exclusive
+                                        with TargetAverageValue.
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - metricName
+                                  type: object
+                                object:
+                                  description: object refers to a metric describing
+                                    a single kubernetes object (for example, hits-per-second
+                                    on an Ingress object).
+                                  properties:
+                                    averageValue:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: averageValue is the target value
+                                        of the average of the metric across all relevant
+                                        pods (as a quantity)
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    metricName:
+                                      description: metricName is the name of the metric
+                                        in question.
+                                      type: string
+                                    selector:
+                                      description: selector is the string-encoded
+                                        form of a standard kubernetes label selector
+                                        for the given metric When set, it is passed
+                                        as an additional parameter to the metrics
+                                        server for more specific metrics scoping When
+                                        unset, just the metricName will be used to
+                                        gather metrics.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a
+                                                  key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists
+                                                  and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of
+                                                  string values. If the operator is
+                                                  In or NotIn, the values array must
+                                                  be non-empty. If the operator is
+                                                  Exists or DoesNotExist, the values
+                                                  array must be empty. This array
+                                                  is replaced during a strategic merge
+                                                  patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator
+                                            is "In", and the values array contains
+                                            only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    target:
+                                      description: target is the described Kubernetes
+                                        object.
+                                      properties:
+                                        apiVersion:
+                                          description: API version of the referent
+                                          type: string
+                                        kind:
+                                          description: 'Kind of the referent; More
+                                            info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"'
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent; More
+                                            info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                                          type: string
+                                      required:
+                                      - kind
+                                      - name
+                                      type: object
+                                    targetValue:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: targetValue is the target value
+                                        of the metric (as a quantity).
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - metricName
+                                  - target
+                                  - targetValue
+                                  type: object
+                                pods:
+                                  description: pods refers to a metric describing
+                                    each pod in the current scale target (for example,
+                                    transactions-processed-per-second).  The values
+                                    will be averaged together before being compared
+                                    to the target value.
+                                  properties:
+                                    metricName:
+                                      description: metricName is the name of the metric
+                                        in question
+                                      type: string
+                                    selector:
+                                      description: selector is the string-encoded
+                                        form of a standard kubernetes label selector
+                                        for the given metric When set, it is passed
+                                        as an additional parameter to the metrics
+                                        server for more specific metrics scoping When
+                                        unset, just the metricName will be used to
+                                        gather metrics.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a
+                                                  key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists
+                                                  and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of
+                                                  string values. If the operator is
+                                                  In or NotIn, the values array must
+                                                  be non-empty. If the operator is
+                                                  Exists or DoesNotExist, the values
+                                                  array must be empty. This array
+                                                  is replaced during a strategic merge
+                                                  patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator
+                                            is "In", and the values array contains
+                                            only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    targetAverageValue:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: targetAverageValue is the target
+                                        value of the average of the metric across
+                                        all relevant pods (as a quantity)
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - metricName
+                                  - targetAverageValue
+                                  type: object
+                                resource:
+                                  description: resource refers to a resource metric
+                                    (such as those specified in requests and limits)
+                                    known to Kubernetes describing each pod in the
+                                    current scale target (e.g. CPU or memory). Such
+                                    metrics are built in to Kubernetes, and have special
+                                    scaling options on top of those available to normal
+                                    per-pod metrics using the "pods" source.
+                                  properties:
+                                    name:
+                                      description: name is the name of the resource
+                                        in question.
+                                      type: string
+                                    targetAverageUtilization:
+                                      description: targetAverageUtilization is the
+                                        target value of the average of the resource
+                                        metric across all relevant pods, represented
+                                        as a percentage of the requested value of
+                                        the resource for the pods.
+                                      format: int32
+                                      type: integer
+                                    targetAverageValue:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: targetAverageValue is the target
+                                        value of the average of the resource metric
+                                        across all relevant pods, as a raw value (instead
+                                        of as a percentage of the request), similar
+                                        to the "pods" metric source type.
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - name
+                                  type: object
+                                type:
+                                  description: 'type is the type of metric source.  It
+                                    should be one of "ContainerResource", "External",
+                                    "Object", "Pods" or "Resource", each mapping to
+                                    a matching field in the object. Note: "ContainerResource"
+                                    type is available on when the feature-gate HPAContainerMetrics
+                                    is enabled'
+                                  type: string
+                              required:
+                              - type
+                              type: object
+                            type: array
+                          minReplicas:
+                            description: minReplicas is the lower limit for the number
+                              of replicas to which the autoscaler can scale down.
+                              It defaults to 1 pod.
+                            format: int32
+                            type: integer
+                        required:
+                        - maxReplicas
+                        type: object
+                    type: object
+                type: object
+              maintenanceTimeWindow:
+                description: MaintenanceTimeWindow contains information about the
+                  time window for maintenance operations.
+                properties:
+                  begin:
+                    description: Begin is the beginning of the time window in the
+                      format HHMMSS+ZONE, e.g. "220000+0100".
+                    type: string
+                  end:
+                    description: End is the end of the time window in the format HHMMSS+ZONE,
+                      e.g. "220000+0100".
+                    type: string
+                required:
+                - begin
+                - end
+                type: object
+              replicas:
+                description: Replicas is the number of replicas of target resource
+                format: int32
+                type: integer
+              targetRef:
+                description: TargetRef points to the controller managing the set of
+                  pods for the autoscaler to control
+                properties:
+                  apiVersion:
+                    description: API version of the referent
+                    type: string
+                  kind:
+                    description: 'Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"'
+                    type: string
+                  name:
+                    description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                    type: string
+                required:
+                - kind
+                - name
+                type: object
+              vpa:
+                description: Vpa defines the spec of VPA
+                properties:
+                  deploy:
+                    description: Deploy defines whether the VPA is deployed or not
+                    type: boolean
+                  limitsRequestsGapScaleParams:
+                    description: LimitsRequestsGapScaleParams is the scaling thresholds
+                      for limits
+                    properties:
+                      cpu:
+                        description: Scale parameters for CPU
+                        properties:
+                          percentage:
+                            description: Percentage is the percentage of currently
+                              allocated value to be used for scaling
+                            format: int32
+                            type: integer
+                          value:
+                            description: Value is the absolute value of the scaling
+                            type: string
+                        type: object
+                      memory:
+                        description: Scale parameters for memory
+                        properties:
+                          percentage:
+                            description: Percentage is the percentage of currently
+                              allocated value to be used for scaling
+                            format: int32
+                            type: integer
+                          value:
+                            description: Value is the absolute value of the scaling
+                            type: string
+                        type: object
+                      replicas:
+                        description: Scale patameters for replicas
+                        properties:
+                          percentage:
+                            description: Percentage is the percentage of currently
+                              allocated value to be used for scaling
+                            format: int32
+                            type: integer
+                          value:
+                            description: Value is the absolute value of the scaling
+                            type: string
+                        type: object
+                    type: object
+                  scaleDown:
+                    description: ScaleDown defines the parameters for scale down
+                    properties:
+                      minChange:
+                        description: MinChange is the minimum change in the resource
+                          on which HVPA acts HVPA uses minimum of the Value and Percentage
+                          value
+                        properties:
+                          cpu:
+                            description: Scale parameters for CPU
+                            properties:
+                              percentage:
+                                description: Percentage is the percentage of currently
+                                  allocated value to be used for scaling
+                                format: int32
+                                type: integer
+                              value:
+                                description: Value is the absolute value of the scaling
+                                type: string
+                            type: object
+                          memory:
+                            description: Scale parameters for memory
+                            properties:
+                              percentage:
+                                description: Percentage is the percentage of currently
+                                  allocated value to be used for scaling
+                                format: int32
+                                type: integer
+                              value:
+                                description: Value is the absolute value of the scaling
+                                type: string
+                            type: object
+                          replicas:
+                            description: Scale patameters for replicas
+                            properties:
+                              percentage:
+                                description: Percentage is the percentage of currently
+                                  allocated value to be used for scaling
+                                format: int32
+                                type: integer
+                              value:
+                                description: Value is the absolute value of the scaling
+                                type: string
+                            type: object
+                        type: object
+                      stabilizationDuration:
+                        description: StabilizationDuration defines the minimum delay
+                          in minutes between 2 consecutive scale operations Valid
+                          time units are "ns", "us" (or "µs"), "ms", "s", "m", "h"
+                        type: string
+                      updatePolicy:
+                        description: Describes the rules on when changes are applied.
+                          If not specified, all fields in the `UpdatePolicy` are set
+                          to their default values.
+                        properties:
+                          updateMode:
+                            description: Controls when autoscaler applies changes
+                              to the resources. The default is 'Auto'.
+                            type: string
+                        type: object
+                    type: object
+                  scaleUp:
+                    description: ScaleUp defines the parameters for scale up
+                    properties:
+                      minChange:
+                        description: MinChange is the minimum change in the resource
+                          on which HVPA acts HVPA uses minimum of the Value and Percentage
+                          value
+                        properties:
+                          cpu:
+                            description: Scale parameters for CPU
+                            properties:
+                              percentage:
+                                description: Percentage is the percentage of currently
+                                  allocated value to be used for scaling
+                                format: int32
+                                type: integer
+                              value:
+                                description: Value is the absolute value of the scaling
+                                type: string
+                            type: object
+                          memory:
+                            description: Scale parameters for memory
+                            properties:
+                              percentage:
+                                description: Percentage is the percentage of currently
+                                  allocated value to be used for scaling
+                                format: int32
+                                type: integer
+                              value:
+                                description: Value is the absolute value of the scaling
+                                type: string
+                            type: object
+                          replicas:
+                            description: Scale patameters for replicas
+                            properties:
+                              percentage:
+                                description: Percentage is the percentage of currently
+                                  allocated value to be used for scaling
+                                format: int32
+                                type: integer
+                              value:
+                                description: Value is the absolute value of the scaling
+                                type: string
+                            type: object
+                        type: object
+                      stabilizationDuration:
+                        description: StabilizationDuration defines the minimum delay
+                          in minutes between 2 consecutive scale operations Valid
+                          time units are "ns", "us" (or "µs"), "ms", "s", "m", "h"
+                        type: string
+                      updatePolicy:
+                        description: Describes the rules on when changes are applied.
+                          If not specified, all fields in the `UpdatePolicy` are set
+                          to their default values.
+                        properties:
+                          updateMode:
+                            description: Controls when autoscaler applies changes
+                              to the resources. The default is 'Auto'.
+                            type: string
+                        type: object
+                    type: object
+                  selector:
+                    description: 'Selector is a label query that should match VPA.
+                      Must match in order to be controlled. If empty, defaulted to
+                      labels on VPA template. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors'
+                    properties:
+                      matchExpressions:
+                        description: matchExpressions is a list of label selector
+                          requirements. The requirements are ANDed.
+                        items:
+                          description: A label selector requirement is a selector
+                            that contains values, a key, and an operator that relates
+                            the key and values.
+                          properties:
+                            key:
+                              description: key is the label key that the selector
+                                applies to.
+                              type: string
+                            operator:
+                              description: operator represents a key's relationship
+                                to a set of values. Valid operators are In, NotIn,
+                                Exists and DoesNotExist.
+                              type: string
+                            values:
+                              description: values is an array of string values. If
+                                the operator is In or NotIn, the values array must
+                                be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. This array is replaced
+                                during a strategic merge patch.
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - key
+                          - operator
+                          type: object
+                        type: array
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: matchLabels is a map of {key,value} pairs. A
+                          single {key,value} in the matchLabels map is equivalent
+                          to an element of matchExpressions, whose key field is "key",
+                          the operator is "In", and the values array contains only
+                          "value". The requirements are ANDed.
+                        type: object
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  template:
+                    description: Template is the object that describes the VPA that
+                      will be created.
+                    properties:
+                      metadata:
+                        description: Metadata of the pods created from this template.
+                        type: object
+                        x-kubernetes-preserve-unknown-fields: true
+                      spec:
+                        description: Spec defines the behavior of a VPA.
+                        properties:
+                          resourcePolicy:
+                            description: Controls how the autoscaler computes recommended
+                              resources. The resource policy may be used to set constraints
+                              on the recommendations for individual containers. If
+                              not specified, the autoscaler computes recommended resources
+                              for all containers in the pod, without additional constraints.
+                            properties:
+                              containerPolicies:
+                                description: Per-container resource policies.
+                                items:
+                                  description: ContainerResourcePolicy controls how
+                                    autoscaler computes the recommended resources
+                                    for a specific container.
+                                  properties:
+                                    containerName:
+                                      description: Name of the container or DefaultContainerResourcePolicy,
+                                        in which case the policy is used by the containers
+                                        that don't have their own policy specified.
+                                      type: string
+                                    controlledResources:
+                                      description: Specifies the type of recommendations
+                                        that will be computed (and possibly applied)
+                                        by VPA. If not specified, the default of [ResourceCPU,
+                                        ResourceMemory] will be used.
+                                      items:
+                                        description: ResourceName is the name identifying
+                                          various resources in a ResourceList.
+                                        type: string
+                                      type: array
+                                    controlledValues:
+                                      description: Specifies which resource values
+                                        should be controlled. The default is "RequestsAndLimits".
+                                      type: string
+                                    maxAllowed:
+                                      additionalProperties:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      description: Specifies the maximum amount of
+                                        resources that will be recommended for the
+                                        container. The default is no maximum.
+                                      type: object
+                                    minAllowed:
+                                      additionalProperties:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      description: Specifies the minimal amount of
+                                        resources that will be recommended for the
+                                        container. The default is no minimum.
+                                      type: object
+                                    mode:
+                                      description: Whether autoscaler is enabled for
+                                        the container. The default is "Auto".
+                                      type: string
+                                  type: object
+                                type: array
+                            type: object
+                        type: object
+                    type: object
+                type: object
+              weightBasedScalingIntervals:
+                description: WeightBasedScalingIntervals defines the intervals of
+                  replica counts, and the weights for scaling a deployment vertically
+                  If there are overlapping intervals, then the vpaWeight will be taken
+                  from the first matching interval
+                items:
+                  description: WeightBasedScalingInterval defines the interval of
+                    replica counts in which VpaWeight is applied to VPA scaling
+                  properties:
+                    lastReplicaCount:
+                      description: LastReplicaCount is the number of replicas till
+                        which VpaWeight is applied to VPA scaling If this field is
+                        not provided, it will default to maxReplicas of HPA
+                      format: int32
+                      type: integer
+                    startReplicaCount:
+                      description: StartReplicaCount is the number of replicas from
+                        which VpaWeight is applied to VPA scaling If this field is
+                        not provided, it will default to minReplicas of HPA
+                      format: int32
+                      type: integer
+                    vpaWeight:
+                      description: VpaWeight defines the weight (in percentage) to
+                        be given to VPA's recommendationd for the interval of number
+                        of replicas provided
+                      format: int32
+                      maximum: 100
+                      minimum: 0
+                      type: integer
+                  type: object
+                type: array
+            required:
+            - targetRef
+            type: object
+          status:
+            description: HvpaStatus defines the observed state of Hvpa
+            properties:
+              hpaScaleDownUpdatePolicy:
+                description: Current HPA UpdatePolicy set in the spec
+                properties:
+                  updateMode:
+                    description: Controls when autoscaler applies changes to the resources.
+                      The default is 'Auto'.
+                    type: string
+                type: object
+              hpaScaleUpUpdatePolicy:
+                description: Current HPA UpdatePolicy set in the spec
+                properties:
+                  updateMode:
+                    description: Controls when autoscaler applies changes to the resources.
+                      The default is 'Auto'.
+                    type: string
+                type: object
+              hpaWeight:
+                format: int32
+                type: integer
+              lastBlockedScaling:
+                items:
+                  description: BlockedScaling defines the details for blocked scaling
+                  properties:
+                    reason:
+                      description: BlockingReason defines the reason for blocking.
+                      type: string
+                    scalingStatus:
+                      description: ScalingStatus defines the status of scaling
+                      properties:
+                        hpaStatus:
+                          description: HpaStatus defines the status of HPA
+                          properties:
+                            currentReplicas:
                               format: int32
                               type: integer
-                            metrics:
-                              description: metrics contains the specifications for which
-                                to use to calculate the desired replica count (the maximum
-                                replica count across all metrics will be used).  The
-                                desired replica count is calculated multiplying the
-                                ratio between the target value and the current value
-                                by the current number of pods.  Ergo, metrics used must
-                                decrease as the pod count is increased, and vice-versa.  See
-                                the individual metric source types for more information
-                                about how each type of metric must respond. If not set,
-                                the default metric will be set to 80% average CPU utilization.
+                            desiredReplicas:
+                              format: int32
+                              type: integer
+                          type: object
+                        lastScaleTime:
+                          format: date-time
+                          type: string
+                        vpaStatus:
+                          description: VerticalPodAutoscalerStatus describes the runtime
+                            state of the autoscaler.
+                          properties:
+                            conditions:
+                              description: Conditions is the set of conditions required
+                                for this autoscaler to scale its target, and indicates
+                                whether or not those conditions are met.
                               items:
-                                description: MetricSpec specifies how to scale based
-                                  on a single metric (only `type` and one other matching
-                                  field should be set at once).
+                                description: VerticalPodAutoscalerCondition describes
+                                  the state of a VerticalPodAutoscaler at a certain
+                                  point.
                                 properties:
-                                  containerResource:
-                                    description: container resource refers to a resource
-                                      metric (such as those specified in requests and
-                                      limits) known to Kubernetes describing a single
-                                      container in each pod of the current scale target
-                                      (e.g. CPU or memory). Such metrics are built in
-                                      to Kubernetes, and have special scaling options
-                                      on top of those available to normal per-pod metrics
-                                      using the "pods" source. This is an alpha feature
-                                      and can be enabled by the HPAContainerMetrics
-                                      feature flag.
-                                    properties:
-                                      container:
-                                        description: container is the name of the container
-                                          in the pods of the scaling target
-                                        type: string
-                                      name:
-                                        description: name is the name of the resource
-                                          in question.
-                                        type: string
-                                      targetAverageUtilization:
-                                        description: targetAverageUtilization is the
-                                          target value of the average of the resource
-                                          metric across all relevant pods, represented
-                                          as a percentage of the requested value of
-                                          the resource for the pods.
-                                        format: int32
-                                        type: integer
-                                      targetAverageValue:
-                                        anyOf:
-                                          - type: integer
-                                          - type: string
-                                        description: targetAverageValue is the target
-                                          value of the average of the resource metric
-                                          across all relevant pods, as a raw value (instead
-                                          of as a percentage of the request), similar
-                                          to the "pods" metric source type.
-                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                        x-kubernetes-int-or-string: true
-                                    required:
-                                      - container
-                                      - name
-                                    type: object
-                                  external:
-                                    description: external refers to a global metric
-                                      that is not associated with any Kubernetes object.
-                                      It allows autoscaling based on information coming
-                                      from components running outside of cluster (for
-                                      example length of queue in cloud messaging service,
-                                      or QPS from loadbalancer running outside of cluster).
-                                    properties:
-                                      metricName:
-                                        description: metricName is the name of the metric
-                                          in question.
-                                        type: string
-                                      metricSelector:
-                                        description: metricSelector is used to identify
-                                          a specific time series within a given metric.
-                                        properties:
-                                          matchExpressions:
-                                            description: matchExpressions is a list
-                                              of label selector requirements. The requirements
-                                              are ANDed.
-                                            items:
-                                              description: A label selector requirement
-                                                is a selector that contains values,
-                                                a key, and an operator that relates
-                                                the key and values.
-                                              properties:
-                                                key:
-                                                  description: key is the label key
-                                                    that the selector applies to.
-                                                  type: string
-                                                operator:
-                                                  description: operator represents a
-                                                    key's relationship to a set of values.
-                                                    Valid operators are In, NotIn, Exists
-                                                    and DoesNotExist.
-                                                  type: string
-                                                values:
-                                                  description: values is an array of
-                                                    string values. If the operator is
-                                                    In or NotIn, the values array must
-                                                    be non-empty. If the operator is
-                                                    Exists or DoesNotExist, the values
-                                                    array must be empty. This array
-                                                    is replaced during a strategic merge
-                                                    patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              required:
-                                                - key
-                                                - operator
-                                              type: object
-                                            type: array
-                                          matchLabels:
-                                            additionalProperties:
-                                              type: string
-                                            description: matchLabels is a map of {key,value}
-                                              pairs. A single {key,value} in the matchLabels
-                                              map is equivalent to an element of matchExpressions,
-                                              whose key field is "key", the operator
-                                              is "In", and the values array contains
-                                              only "value". The requirements are ANDed.
-                                            type: object
-                                        type: object
-                                      targetAverageValue:
-                                        anyOf:
-                                          - type: integer
-                                          - type: string
-                                        description: targetAverageValue is the target
-                                          per-pod value of global metric (as a quantity).
-                                          Mutually exclusive with TargetValue.
-                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                        x-kubernetes-int-or-string: true
-                                      targetValue:
-                                        anyOf:
-                                          - type: integer
-                                          - type: string
-                                        description: targetValue is the target value
-                                          of the metric (as a quantity). Mutually exclusive
-                                          with TargetAverageValue.
-                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                        x-kubernetes-int-or-string: true
-                                    required:
-                                      - metricName
-                                    type: object
-                                  object:
-                                    description: object refers to a metric describing
-                                      a single kubernetes object (for example, hits-per-second
-                                      on an Ingress object).
-                                    properties:
-                                      averageValue:
-                                        anyOf:
-                                          - type: integer
-                                          - type: string
-                                        description: averageValue is the target value
-                                          of the average of the metric across all relevant
-                                          pods (as a quantity)
-                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                        x-kubernetes-int-or-string: true
-                                      metricName:
-                                        description: metricName is the name of the metric
-                                          in question.
-                                        type: string
-                                      selector:
-                                        description: selector is the string-encoded
-                                          form of a standard kubernetes label selector
-                                          for the given metric When set, it is passed
-                                          as an additional parameter to the metrics
-                                          server for more specific metrics scoping When
-                                          unset, just the metricName will be used to
-                                          gather metrics.
-                                        properties:
-                                          matchExpressions:
-                                            description: matchExpressions is a list
-                                              of label selector requirements. The requirements
-                                              are ANDed.
-                                            items:
-                                              description: A label selector requirement
-                                                is a selector that contains values,
-                                                a key, and an operator that relates
-                                                the key and values.
-                                              properties:
-                                                key:
-                                                  description: key is the label key
-                                                    that the selector applies to.
-                                                  type: string
-                                                operator:
-                                                  description: operator represents a
-                                                    key's relationship to a set of values.
-                                                    Valid operators are In, NotIn, Exists
-                                                    and DoesNotExist.
-                                                  type: string
-                                                values:
-                                                  description: values is an array of
-                                                    string values. If the operator is
-                                                    In or NotIn, the values array must
-                                                    be non-empty. If the operator is
-                                                    Exists or DoesNotExist, the values
-                                                    array must be empty. This array
-                                                    is replaced during a strategic merge
-                                                    patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              required:
-                                                - key
-                                                - operator
-                                              type: object
-                                            type: array
-                                          matchLabels:
-                                            additionalProperties:
-                                              type: string
-                                            description: matchLabels is a map of {key,value}
-                                              pairs. A single {key,value} in the matchLabels
-                                              map is equivalent to an element of matchExpressions,
-                                              whose key field is "key", the operator
-                                              is "In", and the values array contains
-                                              only "value". The requirements are ANDed.
-                                            type: object
-                                        type: object
-                                      target:
-                                        description: target is the described Kubernetes
-                                          object.
-                                        properties:
-                                          apiVersion:
-                                            description: API version of the referent
-                                            type: string
-                                          kind:
-                                            description: 'Kind of the referent; More
-                                              info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"'
-                                            type: string
-                                          name:
-                                            description: 'Name of the referent; More
-                                              info: http://kubernetes.io/docs/user-guide/identifiers#names'
-                                            type: string
-                                        required:
-                                          - kind
-                                          - name
-                                        type: object
-                                      targetValue:
-                                        anyOf:
-                                          - type: integer
-                                          - type: string
-                                        description: targetValue is the target value
-                                          of the metric (as a quantity).
-                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                        x-kubernetes-int-or-string: true
-                                    required:
-                                      - metricName
-                                      - target
-                                      - targetValue
-                                    type: object
-                                  pods:
-                                    description: pods refers to a metric describing
-                                      each pod in the current scale target (for example,
-                                      transactions-processed-per-second).  The values
-                                      will be averaged together before being compared
-                                      to the target value.
-                                    properties:
-                                      metricName:
-                                        description: metricName is the name of the metric
-                                          in question
-                                        type: string
-                                      selector:
-                                        description: selector is the string-encoded
-                                          form of a standard kubernetes label selector
-                                          for the given metric When set, it is passed
-                                          as an additional parameter to the metrics
-                                          server for more specific metrics scoping When
-                                          unset, just the metricName will be used to
-                                          gather metrics.
-                                        properties:
-                                          matchExpressions:
-                                            description: matchExpressions is a list
-                                              of label selector requirements. The requirements
-                                              are ANDed.
-                                            items:
-                                              description: A label selector requirement
-                                                is a selector that contains values,
-                                                a key, and an operator that relates
-                                                the key and values.
-                                              properties:
-                                                key:
-                                                  description: key is the label key
-                                                    that the selector applies to.
-                                                  type: string
-                                                operator:
-                                                  description: operator represents a
-                                                    key's relationship to a set of values.
-                                                    Valid operators are In, NotIn, Exists
-                                                    and DoesNotExist.
-                                                  type: string
-                                                values:
-                                                  description: values is an array of
-                                                    string values. If the operator is
-                                                    In or NotIn, the values array must
-                                                    be non-empty. If the operator is
-                                                    Exists or DoesNotExist, the values
-                                                    array must be empty. This array
-                                                    is replaced during a strategic merge
-                                                    patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              required:
-                                                - key
-                                                - operator
-                                              type: object
-                                            type: array
-                                          matchLabels:
-                                            additionalProperties:
-                                              type: string
-                                            description: matchLabels is a map of {key,value}
-                                              pairs. A single {key,value} in the matchLabels
-                                              map is equivalent to an element of matchExpressions,
-                                              whose key field is "key", the operator
-                                              is "In", and the values array contains
-                                              only "value". The requirements are ANDed.
-                                            type: object
-                                        type: object
-                                      targetAverageValue:
-                                        anyOf:
-                                          - type: integer
-                                          - type: string
-                                        description: targetAverageValue is the target
-                                          value of the average of the metric across
-                                          all relevant pods (as a quantity)
-                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                        x-kubernetes-int-or-string: true
-                                    required:
-                                      - metricName
-                                      - targetAverageValue
-                                    type: object
-                                  resource:
-                                    description: resource refers to a resource metric
-                                      (such as those specified in requests and limits)
-                                      known to Kubernetes describing each pod in the
-                                      current scale target (e.g. CPU or memory). Such
-                                      metrics are built in to Kubernetes, and have special
-                                      scaling options on top of those available to normal
-                                      per-pod metrics using the "pods" source.
-                                    properties:
-                                      name:
-                                        description: name is the name of the resource
-                                          in question.
-                                        type: string
-                                      targetAverageUtilization:
-                                        description: targetAverageUtilization is the
-                                          target value of the average of the resource
-                                          metric across all relevant pods, represented
-                                          as a percentage of the requested value of
-                                          the resource for the pods.
-                                        format: int32
-                                        type: integer
-                                      targetAverageValue:
-                                        anyOf:
-                                          - type: integer
-                                          - type: string
-                                        description: targetAverageValue is the target
-                                          value of the average of the resource metric
-                                          across all relevant pods, as a raw value (instead
-                                          of as a percentage of the request), similar
-                                          to the "pods" metric source type.
-                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                        x-kubernetes-int-or-string: true
-                                    required:
-                                      - name
-                                    type: object
+                                  lastTransitionTime:
+                                    description: lastTransitionTime is the last time
+                                      the condition transitioned from one status to
+                                      another
+                                    format: date-time
+                                    type: string
+                                  message:
+                                    description: message is a human-readable explanation
+                                      containing details about the transition
+                                    type: string
+                                  reason:
+                                    description: reason is the reason for the condition's
+                                      last transition.
+                                    type: string
+                                  status:
+                                    description: status is the status of the condition
+                                      (True, False, Unknown)
+                                    type: string
                                   type:
-                                    description: 'type is the type of metric source.  It
-                                      should be one of "ContainerResource", "External",
-                                      "Object", "Pods" or "Resource", each mapping to
-                                      a matching field in the object. Note: "ContainerResource"
-                                      type is available on when the feature-gate HPAContainerMetrics
-                                      is enabled'
+                                    description: type describes the current condition
                                     type: string
                                 required:
-                                  - type
+                                - status
+                                - type
                                 type: object
                               type: array
-                            minReplicas:
-                              description: minReplicas is the lower limit for the number
-                                of replicas to which the autoscaler can scale down.
-                                It defaults to 1 pod.
-                              format: int32
-                              type: integer
-                          required:
-                            - maxReplicas
-                          type: object
-                      type: object
-                  type: object
-                maintenanceTimeWindow:
-                  description: MaintenanceTimeWindow contains information about the
-                    time window for maintenance operations.
-                  properties:
-                    begin:
-                      description: Begin is the beginning of the time window in the
-                        format HHMMSS+ZONE, e.g. "220000+0100".
-                      type: string
-                    end:
-                      description: End is the end of the time window in the format HHMMSS+ZONE,
-                        e.g. "220000+0100".
-                      type: string
-                  required:
-                    - begin
-                    - end
-                  type: object
-                replicas:
-                  description: Replicas is the number of replicas of target resource
-                  format: int32
-                  type: integer
-                targetRef:
-                  description: TargetRef points to the controller managing the set of
-                    pods for the autoscaler to control
-                  properties:
-                    apiVersion:
-                      description: API version of the referent
-                      type: string
-                    kind:
-                      description: 'Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"'
-                      type: string
-                    name:
-                      description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
-                      type: string
-                  required:
-                    - kind
-                    - name
-                  type: object
-                vpa:
-                  description: Vpa defines the spec of VPA
-                  properties:
-                    deploy:
-                      description: Deploy defines whether the VPA is deployed or not
-                      type: boolean
-                    limitsRequestsGapScaleParams:
-                      description: LimitsRequestsGapScaleParams is the scaling thresholds
-                        for limits
-                      properties:
-                        cpu:
-                          description: Scale parameters for CPU
-                          properties:
-                            percentage:
-                              description: Percentage is the percentage of currently
-                                allocated value to be used for scaling
-                              format: int32
-                              type: integer
-                            value:
-                              description: Value is the absolute value of the scaling
-                              type: string
-                          type: object
-                        memory:
-                          description: Scale parameters for memory
-                          properties:
-                            percentage:
-                              description: Percentage is the percentage of currently
-                                allocated value to be used for scaling
-                              format: int32
-                              type: integer
-                            value:
-                              description: Value is the absolute value of the scaling
-                              type: string
-                          type: object
-                        replicas:
-                          description: Scale patameters for replicas
-                          properties:
-                            percentage:
-                              description: Percentage is the percentage of currently
-                                allocated value to be used for scaling
-                              format: int32
-                              type: integer
-                            value:
-                              description: Value is the absolute value of the scaling
-                              type: string
-                          type: object
-                      type: object
-                    scaleDown:
-                      description: ScaleDown defines the parameters for scale down
-                      properties:
-                        minChange:
-                          description: MinChange is the minimum change in the resource
-                            on which HVPA acts HVPA uses minimum of the Value and Percentage
-                            value
-                          properties:
-                            cpu:
-                              description: Scale parameters for CPU
+                            recommendation:
+                              description: The most recently computed amount of resources
+                                recommended by the autoscaler for the controlled pods.
                               properties:
-                                percentage:
-                                  description: Percentage is the percentage of currently
-                                    allocated value to be used for scaling
-                                  format: int32
-                                  type: integer
-                                value:
-                                  description: Value is the absolute value of the scaling
-                                  type: string
-                              type: object
-                            memory:
-                              description: Scale parameters for memory
-                              properties:
-                                percentage:
-                                  description: Percentage is the percentage of currently
-                                    allocated value to be used for scaling
-                                  format: int32
-                                  type: integer
-                                value:
-                                  description: Value is the absolute value of the scaling
-                                  type: string
-                              type: object
-                            replicas:
-                              description: Scale patameters for replicas
-                              properties:
-                                percentage:
-                                  description: Percentage is the percentage of currently
-                                    allocated value to be used for scaling
-                                  format: int32
-                                  type: integer
-                                value:
-                                  description: Value is the absolute value of the scaling
-                                  type: string
-                              type: object
-                          type: object
-                        stabilizationDuration:
-                          description: StabilizationDuration defines the minimum delay
-                            in minutes between 2 consecutive scale operations Valid
-                            time units are "ns", "us" (or "µs"), "ms", "s", "m", "h"
-                          type: string
-                        updatePolicy:
-                          description: Describes the rules on when changes are applied.
-                            If not specified, all fields in the `UpdatePolicy` are set
-                            to their default values.
-                          properties:
-                            updateMode:
-                              description: Controls when autoscaler applies changes
-                                to the resources. The default is 'Auto'.
-                              type: string
-                          type: object
-                      type: object
-                    scaleUp:
-                      description: ScaleUp defines the parameters for scale up
-                      properties:
-                        minChange:
-                          description: MinChange is the minimum change in the resource
-                            on which HVPA acts HVPA uses minimum of the Value and Percentage
-                            value
-                          properties:
-                            cpu:
-                              description: Scale parameters for CPU
-                              properties:
-                                percentage:
-                                  description: Percentage is the percentage of currently
-                                    allocated value to be used for scaling
-                                  format: int32
-                                  type: integer
-                                value:
-                                  description: Value is the absolute value of the scaling
-                                  type: string
-                              type: object
-                            memory:
-                              description: Scale parameters for memory
-                              properties:
-                                percentage:
-                                  description: Percentage is the percentage of currently
-                                    allocated value to be used for scaling
-                                  format: int32
-                                  type: integer
-                                value:
-                                  description: Value is the absolute value of the scaling
-                                  type: string
-                              type: object
-                            replicas:
-                              description: Scale patameters for replicas
-                              properties:
-                                percentage:
-                                  description: Percentage is the percentage of currently
-                                    allocated value to be used for scaling
-                                  format: int32
-                                  type: integer
-                                value:
-                                  description: Value is the absolute value of the scaling
-                                  type: string
-                              type: object
-                          type: object
-                        stabilizationDuration:
-                          description: StabilizationDuration defines the minimum delay
-                            in minutes between 2 consecutive scale operations Valid
-                            time units are "ns", "us" (or "µs"), "ms", "s", "m", "h"
-                          type: string
-                        updatePolicy:
-                          description: Describes the rules on when changes are applied.
-                            If not specified, all fields in the `UpdatePolicy` are set
-                            to their default values.
-                          properties:
-                            updateMode:
-                              description: Controls when autoscaler applies changes
-                                to the resources. The default is 'Auto'.
-                              type: string
-                          type: object
-                      type: object
-                    selector:
-                      description: 'Selector is a label query that should match VPA.
-                        Must match in order to be controlled. If empty, defaulted to
-                        labels on VPA template. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors'
-                      properties:
-                        matchExpressions:
-                          description: matchExpressions is a list of label selector
-                            requirements. The requirements are ANDed.
-                          items:
-                            description: A label selector requirement is a selector
-                              that contains values, a key, and an operator that relates
-                              the key and values.
-                            properties:
-                              key:
-                                description: key is the label key that the selector
-                                  applies to.
-                                type: string
-                              operator:
-                                description: operator represents a key's relationship
-                                  to a set of values. Valid operators are In, NotIn,
-                                  Exists and DoesNotExist.
-                                type: string
-                              values:
-                                description: values is an array of string values. If
-                                  the operator is In or NotIn, the values array must
-                                  be non-empty. If the operator is Exists or DoesNotExist,
-                                  the values array must be empty. This array is replaced
-                                  during a strategic merge patch.
-                                items:
-                                  type: string
-                                type: array
-                            required:
-                              - key
-                              - operator
-                            type: object
-                          type: array
-                        matchLabels:
-                          additionalProperties:
-                            type: string
-                          description: matchLabels is a map of {key,value} pairs. A
-                            single {key,value} in the matchLabels map is equivalent
-                            to an element of matchExpressions, whose key field is "key",
-                            the operator is "In", and the values array contains only
-                            "value". The requirements are ANDed.
-                          type: object
-                      type: object
-                    template:
-                      description: Template is the object that describes the VPA that
-                        will be created.
-                      properties:
-                        metadata:
-                          description: Metadata of the pods created from this template.
-                          type: object
-                          x-kubernetes-preserve-unknown-fields: true
-                        spec:
-                          description: Spec defines the behavior of a VPA.
-                          properties:
-                            resourcePolicy:
-                              description: Controls how the autoscaler computes recommended
-                                resources. The resource policy may be used to set constraints
-                                on the recommendations for individual containers. If
-                                not specified, the autoscaler computes recommended resources
-                                for all containers in the pod, without additional constraints.
-                              properties:
-                                containerPolicies:
-                                  description: Per-container resource policies.
+                                containerRecommendations:
+                                  description: Resources recommended by the autoscaler
+                                    for each container.
                                   items:
-                                    description: ContainerResourcePolicy controls how
-                                      autoscaler computes the recommended resources
-                                      for a specific container.
+                                    description: RecommendedContainerResources is
+                                      the recommendation of resources computed by
+                                      autoscaler for a specific container. Respects
+                                      the container resource policy if present in
+                                      the spec. In particular the recommendation is
+                                      not produced for containers with `ContainerScalingMode`
+                                      set to 'Off'.
                                     properties:
                                       containerName:
-                                        description: Name of the container or DefaultContainerResourcePolicy,
-                                          in which case the policy is used by the containers
-                                          that don't have their own policy specified.
+                                        description: Name of the container.
                                         type: string
-                                      controlledResources:
-                                        description: Specifies the type of recommendations
-                                          that will be computed (and possibly applied)
-                                          by VPA. If not specified, the default of [ResourceCPU,
-                                          ResourceMemory] will be used.
-                                        items:
-                                          description: ResourceName is the name identifying
-                                            various resources in a ResourceList.
-                                          type: string
-                                        type: array
-                                      controlledValues:
-                                        description: Specifies which resource values
-                                          should be controlled. The default is "RequestsAndLimits".
-                                        type: string
-                                      maxAllowed:
+                                      lowerBound:
                                         additionalProperties:
                                           anyOf:
-                                            - type: integer
-                                            - type: string
+                                          - type: integer
+                                          - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
-                                        description: Specifies the maximum amount of
-                                          resources that will be recommended for the
-                                          container. The default is no maximum.
+                                        description: Minimum recommended amount of
+                                          resources. Observes ContainerResourcePolicy.
+                                          This amount is not guaranteed to be sufficient
+                                          for the application to operate in a stable
+                                          way, however running with less resources
+                                          is likely to have significant impact on
+                                          performance/availability.
                                         type: object
-                                      minAllowed:
+                                      target:
                                         additionalProperties:
                                           anyOf:
-                                            - type: integer
-                                            - type: string
+                                          - type: integer
+                                          - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
-                                        description: Specifies the minimal amount of
-                                          resources that will be recommended for the
-                                          container. The default is no minimum.
+                                        description: Recommended amount of resources.
+                                          Observes ContainerResourcePolicy.
                                         type: object
-                                      mode:
-                                        description: Whether autoscaler is enabled for
-                                          the container. The default is "Auto".
-                                        enum:
-                                          - Auto
-                                          - "Off"
-                                        type: string
+                                      uncappedTarget:
+                                        additionalProperties:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        description: The most recent recommended resources
+                                          target computed by the autoscaler for the
+                                          controlled pods, based only on actual resource
+                                          usage, not taking into account the ContainerResourcePolicy.
+                                          May differ from the Recommendation if the
+                                          actual resource usage causes the target
+                                          to violate the ContainerResourcePolicy (lower
+                                          than MinAllowed or higher that MaxAllowed).
+                                          Used only as status indication, will not
+                                          affect actual resource assignment.
+                                        type: object
+                                      upperBound:
+                                        additionalProperties:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        description: Maximum recommended amount of
+                                          resources. Observes ContainerResourcePolicy.
+                                          Any resources allocated beyond this value
+                                          are likely wasted. This value may be larger
+                                          than the maximum amount of application is
+                                          actually capable of consuming.
+                                        type: object
+                                    required:
+                                    - target
                                     type: object
                                   type: array
                               type: object
                           type: object
                       type: object
                   type: object
-                weightBasedScalingIntervals:
-                  description: WeightBasedScalingIntervals defines the intervals of
-                    replica counts, and the weights for scaling a deployment vertically
-                    If there are overlapping intervals, then the vpaWeight will be taken
-                    from the first matching interval
-                  items:
-                    description: WeightBasedScalingInterval defines the interval of
-                      replica counts in which VpaWeight is applied to VPA scaling
+                type: array
+              lastError:
+                description: LastError has details of any errors that occurred
+                properties:
+                  description:
+                    description: Description of the error
+                    type: string
+                  lastOperation:
+                    description: LastOperation is the type of operation for which
+                      error occurred
+                    type: string
+                  lastUpdateTime:
+                    description: Time at which the error occurred
+                    format: date-time
+                    type: string
+                type: object
+              lastScaling:
+                description: ScalingStatus defines the status of scaling
+                properties:
+                  hpaStatus:
+                    description: HpaStatus defines the status of HPA
                     properties:
-                      lastReplicaCount:
-                        description: LastReplicaCount is the number of replicas till
-                          which VpaWeight is applied to VPA scaling If this field is
-                          not provided, it will default to maxReplicas of HPA
+                      currentReplicas:
                         format: int32
                         type: integer
-                      startReplicaCount:
-                        description: StartReplicaCount is the number of replicas from
-                          which VpaWeight is applied to VPA scaling If this field is
-                          not provided, it will default to minReplicas of HPA
+                      desiredReplicas:
                         format: int32
-                        type: integer
-                      vpaWeight:
-                        description: VpaWeight defines the weight (in percentage) to
-                          be given to VPA's recommendationd for the interval of number
-                          of replicas provided
-                        format: int32
-                        maximum: 100
-                        minimum: 0
                         type: integer
                     type: object
-                  type: array
-              required:
-                - targetRef
-              type: object
-            status:
-              description: HvpaStatus defines the observed state of Hvpa
-              properties:
-                hpaScaleDownUpdatePolicy:
-                  description: Current HPA UpdatePolicy set in the spec
-                  properties:
-                    updateMode:
-                      description: Controls when autoscaler applies changes to the resources.
-                        The default is 'Auto'.
-                      type: string
-                  type: object
-                hpaScaleUpUpdatePolicy:
-                  description: Current HPA UpdatePolicy set in the spec
-                  properties:
-                    updateMode:
-                      description: Controls when autoscaler applies changes to the resources.
-                        The default is 'Auto'.
-                      type: string
-                  type: object
-                hpaWeight:
-                  format: int32
-                  type: integer
-                lastBlockedScaling:
-                  items:
-                    description: BlockedScaling defines the details for blocked scaling
+                  lastScaleTime:
+                    format: date-time
+                    type: string
+                  vpaStatus:
+                    description: VerticalPodAutoscalerStatus describes the runtime
+                      state of the autoscaler.
                     properties:
-                      reason:
-                        description: BlockingReason defines the reason for blocking.
-                        type: string
-                      scalingStatus:
-                        description: ScalingStatus defines the status of scaling
+                      conditions:
+                        description: Conditions is the set of conditions required
+                          for this autoscaler to scale its target, and indicates whether
+                          or not those conditions are met.
+                        items:
+                          description: VerticalPodAutoscalerCondition describes the
+                            state of a VerticalPodAutoscaler at a certain point.
+                          properties:
+                            lastTransitionTime:
+                              description: lastTransitionTime is the last time the
+                                condition transitioned from one status to another
+                              format: date-time
+                              type: string
+                            message:
+                              description: message is a human-readable explanation
+                                containing details about the transition
+                              type: string
+                            reason:
+                              description: reason is the reason for the condition's
+                                last transition.
+                              type: string
+                            status:
+                              description: status is the status of the condition (True,
+                                False, Unknown)
+                              type: string
+                            type:
+                              description: type describes the current condition
+                              type: string
+                          required:
+                          - status
+                          - type
+                          type: object
+                        type: array
+                      recommendation:
+                        description: The most recently computed amount of resources
+                          recommended by the autoscaler for the controlled pods.
                         properties:
-                          hpaStatus:
-                            description: HpaStatus defines the status of HPA
-                            properties:
-                              currentReplicas:
-                                format: int32
-                                type: integer
-                              desiredReplicas:
-                                format: int32
-                                type: integer
-                            type: object
-                          lastScaleTime:
-                            format: date-time
-                            type: string
-                          vpaStatus:
-                            description: VerticalPodAutoscalerStatus describes the runtime
-                              state of the autoscaler.
-                            properties:
-                              conditions:
-                                description: Conditions is the set of conditions required
-                                  for this autoscaler to scale its target, and indicates
-                                  whether or not those conditions are met.
-                                items:
-                                  description: VerticalPodAutoscalerCondition describes
-                                    the state of a VerticalPodAutoscaler at a certain
-                                    point.
-                                  properties:
-                                    lastTransitionTime:
-                                      description: lastTransitionTime is the last time
-                                        the condition transitioned from one status to
-                                        another
-                                      format: date-time
-                                      type: string
-                                    message:
-                                      description: message is a human-readable explanation
-                                        containing details about the transition
-                                      type: string
-                                    reason:
-                                      description: reason is the reason for the condition's
-                                        last transition.
-                                      type: string
-                                    status:
-                                      description: status is the status of the condition
-                                        (True, False, Unknown)
-                                      type: string
-                                    type:
-                                      description: type describes the current condition
-                                      type: string
-                                  required:
-                                    - status
-                                    - type
+                          containerRecommendations:
+                            description: Resources recommended by the autoscaler for
+                              each container.
+                            items:
+                              description: RecommendedContainerResources is the recommendation
+                                of resources computed by autoscaler for a specific
+                                container. Respects the container resource policy
+                                if present in the spec. In particular the recommendation
+                                is not produced for containers with `ContainerScalingMode`
+                                set to 'Off'.
+                              properties:
+                                containerName:
+                                  description: Name of the container.
+                                  type: string
+                                lowerBound:
+                                  additionalProperties:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: Minimum recommended amount of resources.
+                                    Observes ContainerResourcePolicy. This amount
+                                    is not guaranteed to be sufficient for the application
+                                    to operate in a stable way, however running with
+                                    less resources is likely to have significant impact
+                                    on performance/availability.
                                   type: object
-                                type: array
-                              recommendation:
-                                description: The most recently computed amount of resources
-                                  recommended by the autoscaler for the controlled pods.
-                                properties:
-                                  containerRecommendations:
-                                    description: Resources recommended by the autoscaler
-                                      for each container.
-                                    items:
-                                      description: RecommendedContainerResources is
-                                        the recommendation of resources computed by
-                                        autoscaler for a specific container. Respects
-                                        the container resource policy if present in
-                                        the spec. In particular the recommendation is
-                                        not produced for containers with `ContainerScalingMode`
-                                        set to 'Off'.
-                                      properties:
-                                        containerName:
-                                          description: Name of the container.
-                                          type: string
-                                        lowerBound:
-                                          additionalProperties:
-                                            anyOf:
-                                              - type: integer
-                                              - type: string
-                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                            x-kubernetes-int-or-string: true
-                                          description: Minimum recommended amount of
-                                            resources. Observes ContainerResourcePolicy.
-                                            This amount is not guaranteed to be sufficient
-                                            for the application to operate in a stable
-                                            way, however running with less resources
-                                            is likely to have significant impact on
-                                            performance/availability.
-                                          type: object
-                                        target:
-                                          additionalProperties:
-                                            anyOf:
-                                              - type: integer
-                                              - type: string
-                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                            x-kubernetes-int-or-string: true
-                                          description: Recommended amount of resources.
-                                            Observes ContainerResourcePolicy.
-                                          type: object
-                                        uncappedTarget:
-                                          additionalProperties:
-                                            anyOf:
-                                              - type: integer
-                                              - type: string
-                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                            x-kubernetes-int-or-string: true
-                                          description: The most recent recommended resources
-                                            target computed by the autoscaler for the
-                                            controlled pods, based only on actual resource
-                                            usage, not taking into account the ContainerResourcePolicy.
-                                            May differ from the Recommendation if the
-                                            actual resource usage causes the target
-                                            to violate the ContainerResourcePolicy (lower
-                                            than MinAllowed or higher that MaxAllowed).
-                                            Used only as status indication, will not
-                                            affect actual resource assignment.
-                                          type: object
-                                        upperBound:
-                                          additionalProperties:
-                                            anyOf:
-                                              - type: integer
-                                              - type: string
-                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                            x-kubernetes-int-or-string: true
-                                          description: Maximum recommended amount of
-                                            resources. Observes ContainerResourcePolicy.
-                                            Any resources allocated beyond this value
-                                            are likely wasted. This value may be larger
-                                            than the maximum amount of application is
-                                            actually capable of consuming.
-                                          type: object
-                                      required:
-                                        - target
-                                      type: object
-                                    type: array
-                                type: object
-                            type: object
+                                target:
+                                  additionalProperties:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: Recommended amount of resources. Observes
+                                    ContainerResourcePolicy.
+                                  type: object
+                                uncappedTarget:
+                                  additionalProperties:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: The most recent recommended resources
+                                    target computed by the autoscaler for the controlled
+                                    pods, based only on actual resource usage, not
+                                    taking into account the ContainerResourcePolicy.
+                                    May differ from the Recommendation if the actual
+                                    resource usage causes the target to violate the
+                                    ContainerResourcePolicy (lower than MinAllowed
+                                    or higher that MaxAllowed). Used only as status
+                                    indication, will not affect actual resource assignment.
+                                  type: object
+                                upperBound:
+                                  additionalProperties:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: Maximum recommended amount of resources.
+                                    Observes ContainerResourcePolicy. Any resources
+                                    allocated beyond this value are likely wasted.
+                                    This value may be larger than the maximum amount
+                                    of application is actually capable of consuming.
+                                  type: object
+                              required:
+                              - target
+                              type: object
+                            type: array
                         type: object
                     type: object
-                  type: array
-                lastError:
-                  description: LastError has details of any errors that occurred
-                  properties:
-                    description:
-                      description: Description of the error
-                      type: string
-                    lastOperation:
-                      description: LastOperation is the type of operation for which
-                        error occurred
-                      type: string
-                    lastUpdateTime:
-                      description: Time at which the error occurred
-                      format: date-time
-                      type: string
-                  type: object
-                lastScaling:
-                  description: ScalingStatus defines the status of scaling
-                  properties:
-                    hpaStatus:
-                      description: HpaStatus defines the status of HPA
-                      properties:
-                        currentReplicas:
-                          format: int32
-                          type: integer
-                        desiredReplicas:
-                          format: int32
-                          type: integer
-                      type: object
-                    lastScaleTime:
-                      format: date-time
-                      type: string
-                    vpaStatus:
-                      description: VerticalPodAutoscalerStatus describes the runtime
-                        state of the autoscaler.
-                      properties:
-                        conditions:
-                          description: Conditions is the set of conditions required
-                            for this autoscaler to scale its target, and indicates whether
-                            or not those conditions are met.
-                          items:
-                            description: VerticalPodAutoscalerCondition describes the
-                              state of a VerticalPodAutoscaler at a certain point.
-                            properties:
-                              lastTransitionTime:
-                                description: lastTransitionTime is the last time the
-                                  condition transitioned from one status to another
-                                format: date-time
-                                type: string
-                              message:
-                                description: message is a human-readable explanation
-                                  containing details about the transition
-                                type: string
-                              reason:
-                                description: reason is the reason for the condition's
-                                  last transition.
-                                type: string
-                              status:
-                                description: status is the status of the condition (True,
-                                  False, Unknown)
-                                type: string
-                              type:
-                                description: type describes the current condition
-                                type: string
-                            required:
-                              - status
-                              - type
-                            type: object
-                          type: array
-                        recommendation:
-                          description: The most recently computed amount of resources
-                            recommended by the autoscaler for the controlled pods.
-                          properties:
-                            containerRecommendations:
-                              description: Resources recommended by the autoscaler for
-                                each container.
-                              items:
-                                description: RecommendedContainerResources is the recommendation
-                                  of resources computed by autoscaler for a specific
-                                  container. Respects the container resource policy
-                                  if present in the spec. In particular the recommendation
-                                  is not produced for containers with `ContainerScalingMode`
-                                  set to 'Off'.
-                                properties:
-                                  containerName:
-                                    description: Name of the container.
-                                    type: string
-                                  lowerBound:
-                                    additionalProperties:
-                                      anyOf:
-                                        - type: integer
-                                        - type: string
-                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                      x-kubernetes-int-or-string: true
-                                    description: Minimum recommended amount of resources.
-                                      Observes ContainerResourcePolicy. This amount
-                                      is not guaranteed to be sufficient for the application
-                                      to operate in a stable way, however running with
-                                      less resources is likely to have significant impact
-                                      on performance/availability.
-                                    type: object
-                                  target:
-                                    additionalProperties:
-                                      anyOf:
-                                        - type: integer
-                                        - type: string
-                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                      x-kubernetes-int-or-string: true
-                                    description: Recommended amount of resources. Observes
-                                      ContainerResourcePolicy.
-                                    type: object
-                                  uncappedTarget:
-                                    additionalProperties:
-                                      anyOf:
-                                        - type: integer
-                                        - type: string
-                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                      x-kubernetes-int-or-string: true
-                                    description: The most recent recommended resources
-                                      target computed by the autoscaler for the controlled
-                                      pods, based only on actual resource usage, not
-                                      taking into account the ContainerResourcePolicy.
-                                      May differ from the Recommendation if the actual
-                                      resource usage causes the target to violate the
-                                      ContainerResourcePolicy (lower than MinAllowed
-                                      or higher that MaxAllowed). Used only as status
-                                      indication, will not affect actual resource assignment.
-                                    type: object
-                                  upperBound:
-                                    additionalProperties:
-                                      anyOf:
-                                        - type: integer
-                                        - type: string
-                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                      x-kubernetes-int-or-string: true
-                                    description: Maximum recommended amount of resources.
-                                      Observes ContainerResourcePolicy. Any resources
-                                      allocated beyond this value are likely wasted.
-                                      This value may be larger than the maximum amount
-                                      of application is actually capable of consuming.
-                                    type: object
-                                required:
-                                  - target
-                                type: object
-                              type: array
-                          type: object
-                      type: object
-                  type: object
-                overrideScaleUpStabilization:
-                  description: Override scale up stabilization window
-                  type: boolean
-                replicas:
-                  description: Replicas is the number of replicas of the target resource.
-                  format: int32
-                  type: integer
-                targetSelector:
-                  description: TargetSelector is the string form of the label selector
-                    of HPA. This is required for HPA to work with scale subresource.
-                  type: string
-                vpaScaleDownUpdatePolicy:
-                  description: Current VPA UpdatePolicy set in the spec
-                  properties:
-                    updateMode:
-                      description: Controls when autoscaler applies changes to the resources.
-                        The default is 'Auto'.
-                      type: string
-                  type: object
-                vpaScaleUpUpdatePolicy:
-                  description: Current VPA UpdatePolicy set in the spec
-                  properties:
-                    updateMode:
-                      description: Controls when autoscaler applies changes to the resources.
-                        The default is 'Auto'.
-                      type: string
-                  type: object
-                vpaWeight:
-                  format: int32
-                  type: integer
-              type: object
-          type: object
-      served: true
-      storage: true
-      subresources:
-        scale:
-          labelSelectorPath: .status.targetSelector
-          specReplicasPath: .spec.replicas
-          statusReplicasPath: .status.replicas
-        status: {}
+                type: object
+              overrideScaleUpStabilization:
+                description: Override scale up stabilization window
+                type: boolean
+              replicas:
+                description: Replicas is the number of replicas of the target resource.
+                format: int32
+                type: integer
+              targetSelector:
+                description: TargetSelector is the string form of the label selector
+                  of HPA. This is required for HPA to work with scale subresource.
+                type: string
+              vpaScaleDownUpdatePolicy:
+                description: Current VPA UpdatePolicy set in the spec
+                properties:
+                  updateMode:
+                    description: Controls when autoscaler applies changes to the resources.
+                      The default is 'Auto'.
+                    type: string
+                type: object
+              vpaScaleUpUpdatePolicy:
+                description: Current VPA UpdatePolicy set in the spec
+                properties:
+                  updateMode:
+                    description: Controls when autoscaler applies changes to the resources.
+                      The default is 'Auto'.
+                    type: string
+                type: object
+              vpaWeight:
+                format: int32
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      scale:
+        labelSelectorPath: .status.targetSelector
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
+      status: {}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area auto-scaling
/kind enhancement

**What this PR does / why we need it**:
Update HVPA to v0.12.0

**Which issue(s) this PR fixes**:
part of #6893

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
``` feature operator github.com/gardener/hvpa-controller #121 @voelzmo
HVPA supports k8s versions >= 1.25 by switching to `k8s.io/autoscaling/v2` when necessary for all API calls.
```

``` feature operator github.com/gardener/hvpa-controller #122 @voelzmo
Added a LeaderElectionID to the controller options, allowing to run multiple instances of HVPA with leader election when `--leader-elect=true` is passed as commandline arg
```
