### PR TITLE
multiple excutions of kind-up do not lead to kind misconfiguration

### DIFF
--- a/hack/kind-up.sh
+++ b/hack/kind-up.sh
@@ -144,15 +144,20 @@ kind create cluster \
 # See containerd CRI: https://github.com/containerd/containerd/commit/687469d3cee18bf0e12defa5c6d0c7b9139a2dbd
 if [ -f "/sys/fs/cgroup/cgroup.controllers" ]; then
     echo "Host uses cgroupsv2"
-    cat << 'EOF' >>adjust_cri_base.sh
+    cat << 'EOF' > adjust_cri_base.sh
 #!/bin/bash
 if [ -f /etc/containerd/cri-base.json ]; then
-    cat /etc/containerd/cri-base.json | jq '.linux.namespaces += [{
-        "type": "cgroup"
-    }]' > /etc/containerd/cri-base.tmp.json && cp /etc/containerd/cri-base.tmp.json /etc/containerd/cri-base.json
-    echo "Adjusted kind node /etc/containerd/cri-base.json to create containers with a cgroup namespace"
+  key=$(cat /etc/containerd/cri-base.json | jq '.linux.namespaces | map(select(.type == "cgroup"))[0]')
+  if [ "$key" = "null" ]; then
+      echo "Adjusting kind node /etc/containerd/cri-base.json to create containers with a cgroup namespace";
+      cat /etc/containerd/cri-base.json | jq '.linux.namespaces += [{
+          "type": "cgroup"
+      }]' > /etc/containerd/cri-base.tmp.json && cp /etc/containerd/cri-base.tmp.json /etc/containerd/cri-base.json
+    else
+      echo "cgroup namespace already configured for kind node";
+  fi
 else
-    echo "/etc/containerd/cri-base.json not found in kind container"
+    echo "cannot configure cgroup namespace for kind containers: /etc/containerd/cri-base.json not found in kind container"
 fi
 EOF
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind bug

**What this PR does / why we need it**:

#7780 introduced a regression for e2e tests that require multiple kind clusters. thanks @istvanballok .
Please see this [comment](https://github.com/gardener/gardener/pull/7780#discussion_r1171419580).

- only add the configuration if it does not exist yet
- overwrite current configuration script (previously append)


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
