### PR TITLE
Do not use `sudo` in `kind-up.sh` when running as root

### DIFF
--- a/hack/kind-up.sh
+++ b/hack/kind-up.sh
@@ -26,6 +26,10 @@ DEPLOY_REGISTRY=true
 MULTI_ZONAL=false
 CHART=$(dirname "$0")/../example/gardener-local/kind/cluster
 ADDITIONAL_ARGS=""
+SUDO=""
+if [[ "$(id -u)" != "0" ]]; then
+  SUDO="sudo "
+fi
 
 parse_flags() {
   while test $# -gt 0; do
@@ -103,12 +107,12 @@ setup_loopback_device() {
     LOOPBACK_IP_ADDRESSES+=(::10 ::11 ::12)
   fi
   echo "Checking loopback device ${LOOPBACK_DEVICE}..."
-  for address in ${LOOPBACK_IP_ADDRESSES[@]}; do
+  for address in "${LOOPBACK_IP_ADDRESSES[@]}"; do
     if ip address show dev ${LOOPBACK_DEVICE} | grep -q $address; then
       echo "IP address $address already assigned to ${LOOPBACK_DEVICE}."
     else
       echo "Adding IP address $address to ${LOOPBACK_DEVICE}..."
-      sudo ip address add $address dev ${LOOPBACK_DEVICE}
+      ${SUDO}ip address add "$address" dev "${LOOPBACK_DEVICE}"
     fi
   done
   echo "Setting up loopback device ${LOOPBACK_DEVICE} completed."


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind bug

**What this PR does / why we need it**:
Apparently, the [latest krte image](https://github.com/gardener/ci-infra/pull/694) does not contain `sudo` anymore, so the tests which require multiple loopback devices fail atm. ([ref](https://prow.gardener.cloud/view/gs/gardener-prow/logs/ci-gardener-e2e-kind-ha-multi-zone-release-v1-69/1649350115955052544#1:build-log.txt%3A50), [ref](https://prow.gardener.cloud/view/gs/gardener-prow/logs/ci-gardener-e2e-kind-ha-multi-zone/1649366976855805952#1:build-log.txt%3A50))
With this PR `kind-up.sh` is using `sudo` only if it is not running as root.

Additionally, an error raised by shell-check was fixed.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
