### PR TITLE
Suppress the event-logger `nest` filter's warnings

### DIFF
--- a/pkg/operation/botanist/component/logging/eventlogger/logging.go
+++ b/pkg/operation/botanist/component/logging/eventlogger/logging.go
@@ -25,7 +25,7 @@ const (
     Match               kubernetes.*` + v1beta1constants.DeploymentNameEventLogger + `*` + name + `*
     Operation           lift
     Nested_under        log
-    log_level           error
+    Log_Level           error
 
 [FILTER]
     Name                record_modifier

--- a/pkg/operation/botanist/component/logging/eventlogger/logging.go
+++ b/pkg/operation/botanist/component/logging/eventlogger/logging.go
@@ -25,6 +25,7 @@ const (
     Match               kubernetes.*` + v1beta1constants.DeploymentNameEventLogger + `*` + name + `*
     Operation           lift
     Nested_under        log
+    log_level           error
 
 [FILTER]
     Name                record_modifier

--- a/pkg/operation/botanist/component/logging/eventlogger/logging_test.go
+++ b/pkg/operation/botanist/component/logging/eventlogger/logging_test.go
@@ -33,6 +33,7 @@ var _ = Describe("Logging", func() {
     Match               kubernetes.*event-logger*event-logger*
     Operation           lift
     Nested_under        log
+    Log_Level           error
 
 [FILTER]
     Name                record_modifier


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area logging
/kind enhancement

**What this PR does / why we need it**:
When `event-logger` pod gets an error during its work with the `go-client` library it writes a log in non-JSON format.
This non-JSON can't be `lifted` by the event-logger `nest` filter in the `fluent-bit`. This triggers warning which flood the fluent-bit logs with meaningless warnings. This PR changes the log level of this `nest` filter to error in order to suppress the redundant warning messages

**Which issue(s) this PR fixes**:
Fixes [#7672](https://github.com/gardener/gardener/issues/7672)

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Suppress the event-logger `nest` filter's warnings in the fluent-bit.
```
