### PR TITLE
Add annotations to Nginx-Ingress LB service

### DIFF
--- a/pkg/gardenlet/controller/seed/seed/nginxingress.go
+++ b/pkg/gardenlet/controller/seed/seed/nginxingress.go
@@ -52,7 +52,7 @@ func defaultNginxIngress(
 	kubernetesVersion *semver.Version,
 	ingressClass string,
 	config map[string]string,
-	lbAnnotations map[string]string,
+	loadBalancerAnnotations map[string]string,
 	gardenNamespaceName string,
 ) (
 	component.DeployWaiter,
@@ -73,7 +73,7 @@ func defaultNginxIngress(
 		KubernetesVersion:       kubernetesVersion,
 		IngressClass:            ingressClass,
 		ConfigData:              config,
-		LoadBalancerAnnotations: lbAnnotations,
+		LoadBalancerAnnotations: loadBalancerAnnotations,
 	}
 
 	return nginxingress.New(c, gardenNamespaceName, values), nil

--- a/pkg/gardenlet/controller/seed/seed/nginxingress.go
+++ b/pkg/gardenlet/controller/seed/seed/nginxingress.go
@@ -52,6 +52,7 @@ func defaultNginxIngress(
 	kubernetesVersion *semver.Version,
 	ingressClass string,
 	config map[string]string,
+	lbAnnotations map[string]string,
 	gardenNamespaceName string,
 ) (
 	component.DeployWaiter,
@@ -67,11 +68,12 @@ func defaultNginxIngress(
 	}
 
 	values := nginxingress.Values{
-		ImageController:     imageController.String(),
-		ImageDefaultBackend: imageDefaultBackend.String(),
-		KubernetesVersion:   kubernetesVersion,
-		IngressClass:        ingressClass,
-		ConfigData:          config,
+		ImageController:         imageController.String(),
+		ImageDefaultBackend:     imageDefaultBackend.String(),
+		KubernetesVersion:       kubernetesVersion,
+		IngressClass:            ingressClass,
+		ConfigData:              config,
+		LoadBalancerAnnotations: lbAnnotations,
 	}
 
 	return nginxingress.New(c, gardenNamespaceName, values), nil

--- a/pkg/gardenlet/controller/seed/seed/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/seed/seed/reconciler_reconcile.go
@@ -1281,7 +1281,7 @@ func waitForNginxIngressServiceAndGetDNSComponent(
 			return nil, err
 		}
 
-		nginxIngress, err := defaultNginxIngress(seedClient, imageVector, kubernetesVersion, ingressClass, providerConfig, gardenNamespaceName)
+		nginxIngress, err := defaultNginxIngress(seedClient, imageVector, kubernetesVersion, ingressClass, providerConfig, seed.GetLoadBalancerServiceAnnotations(), gardenNamespaceName)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/operation/botanist/component/nginxingress/nginxingress.go
+++ b/pkg/operation/botanist/component/nginxingress/nginxingress.go
@@ -93,6 +93,8 @@ type Values struct {
 	IngressClass string
 	// ConfigData contains the configuration details for the nginx-ingress controller
 	ConfigData map[string]string
+	// LoadBalancerAnnotations are the annotations added to the nginx-ingress load balancer service.
+	LoadBalancerAnnotations map[string]string
 }
 
 // New creates a new instance of DeployWaiter for nginx-ingress
@@ -177,9 +179,10 @@ func (n *nginxIngress) computeResourcesData() (map[string][]byte, error) {
 
 		serviceController = &corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      serviceNameController,
-				Namespace: n.namespace,
-				Labels:    getLabels(LabelValueController, ""),
+				Name:        serviceNameController,
+				Namespace:   n.namespace,
+				Annotations: n.values.LoadBalancerAnnotations,
+				Labels:      getLabels(LabelValueController, ""),
 			},
 			Spec: corev1.ServiceSpec{
 				Type: corev1.ServiceTypeLoadBalancer,

--- a/pkg/operation/botanist/component/nginxingress/nginxingress_test.go
+++ b/pkg/operation/botanist/component/nginxingress/nginxingress_test.go
@@ -62,10 +62,15 @@ var _ = Describe("Nginx Ingress", func() {
 			"dash": "false",
 		}
 
+		loadBalancerAnnotations = map[string]string{
+			"some": "value",
+		}
+
 		values = Values{
-			ImageController:     imageController,
-			ImageDefaultBackend: imageDefaultBackend,
-			ConfigData:          configMapData,
+			ImageController:         imageController,
+			ImageDefaultBackend:     imageDefaultBackend,
+			ConfigData:              configMapData,
+			LoadBalancerAnnotations: loadBalancerAnnotations,
 		}
 
 		configMapName = "nginx-ingress-controller-" + utils.ComputeConfigMapChecksum(configMapData)[:8]
@@ -275,6 +280,7 @@ kind: Service
 metadata:
   annotations:
     networking.resources.gardener.cloud/from-world-to-ports: '[{"protocol":"TCP","port":80},{"protocol":"TCP","port":443}]'
+    some: value
   creationTimestamp: null
   labels:
     app: nginx-ingress


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind enhancement

**What this PR does / why we need it**:
The Seed API allows to configure annotations for load balancer services via `seed.spec.settings.loadBalancerServices.annotations`. Earlier these annotations were not considered for Nginx-Ingress services of type Load Balancer which is however intended with regards to the API field and description:

```
// LoadBalancerServices controls certain settings for services of type load balancer that are created in the seed.
```

[ref](https://github.com/gardener/gardener/blob/454ad5ba2d67e99bbd4d0ce278b8fef838cb6ff6/pkg/apis/core/v1beta1/types_seed.go#L242)

/cc @RaphaelVogel

**Which issue(s) this PR fixes**:
Fixes #7820

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Annotations in `seed.spec.settings.loadBalancerServices.annotations` are now applied to the Nginx-Ingress load balancer service in the seed cluster.
```
