### PR TITLE
[operator] Manage `kube-state-metrics`

### DIFF
--- a/docs/development/priority-classes.md
+++ b/docs/development/priority-classes.md
@@ -26,7 +26,7 @@ When using the `gardener-operator` for managing the garden runtime and virtual c
 | `gardener-garden-system-400`      | 999999400 |                                                                                           |
 | `gardener-garden-system-300`      | 999999300 | `vpa-admission-controller`, `etcd-druid`                                                  |
 | `gardener-garden-system-200`      | 999999200 | `vpa-recommender`, `vpa-updater`, `hvpa-controller`                                       |
-| `gardener-garden-system-100`      | 999999100 |                                                                                           |
+| `gardener-garden-system-100`      | 999999100 | `kube-state-metrics`                                                                      |
 
 ## Seed Clusters
 

--- a/pkg/gardenlet/controller/seed/seed/components.go
+++ b/pkg/gardenlet/controller/seed/seed/components.go
@@ -63,9 +63,10 @@ func defaultKubeStateMetrics(
 	}
 
 	return kubestatemetrics.New(c, gardenNamespaceName, nil, kubestatemetrics.Values{
-		ClusterType: component.ClusterTypeSeed,
-		Image:       image.String(),
-		Replicas:    1,
+		ClusterType:       component.ClusterTypeSeed,
+		Image:             image.String(),
+		PriorityClassName: v1beta1constants.PriorityClassNameSeedSystem600,
+		Replicas:          1,
 	}), nil
 }
 

--- a/pkg/gardenlet/controller/seed/seed/components.go
+++ b/pkg/gardenlet/controller/seed/seed/components.go
@@ -36,7 +36,6 @@ import (
 	"github.com/gardener/gardener/pkg/operation/botanist/component/etcd"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/istio"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/kubeapiserver"
-	"github.com/gardener/gardener/pkg/operation/botanist/component/kubestatemetrics"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/networkpolicies"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/seedsystem"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/vpnauthzserver"
@@ -47,28 +46,6 @@ import (
 	"github.com/gardener/gardener/pkg/utils/images"
 	"github.com/gardener/gardener/pkg/utils/imagevector"
 )
-
-func defaultKubeStateMetrics(
-	c client.Client,
-	imageVector imagevector.ImageVector,
-	seedVersion *semver.Version,
-	gardenNamespaceName string,
-) (
-	component.DeployWaiter,
-	error,
-) {
-	image, err := imageVector.FindImage(images.ImageNameKubeStateMetrics, imagevector.TargetVersion(seedVersion.String()))
-	if err != nil {
-		return nil, err
-	}
-
-	return kubestatemetrics.New(c, gardenNamespaceName, nil, kubestatemetrics.Values{
-		ClusterType:       component.ClusterTypeSeed,
-		Image:             image.String(),
-		PriorityClassName: v1beta1constants.PriorityClassNameSeedSystem600,
-		Replicas:          1,
-	}), nil
-}
 
 func defaultIstio(
 	seedClient client.Client,

--- a/pkg/gardenlet/controller/seed/seed/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/seed/seed/reconciler_reconcile.go
@@ -829,10 +829,6 @@ func (r *Reconciler) runReconcileSeedFlow(
 	if err != nil {
 		return err
 	}
-	kubeStateMetrics, err := sharedcomponent.NewKubeStateMetrics(seedClient, r.GardenNamespace, kubernetesVersion, r.ImageVector, v1beta1constants.PriorityClassNameSeedSystem600)
-	if err != nil {
-		return err
-	}
 	dwdWeeder, dwdProber, err := defaultDependencyWatchdogs(seedClient, kubernetesVersion, r.ImageVector, seed.GetInfo().Spec.Settings, r.GardenNamespace)
 	if err != nil {
 		return err
@@ -855,7 +851,6 @@ func (r *Reconciler) runReconcileSeedFlow(
 		); err != nil {
 			return err
 		}
-
 	}
 
 	if features.DefaultFeatureGate.Enabled(features.FullNetworkPoliciesInRuntimeCluster) {
@@ -896,10 +891,6 @@ func (r *Reconciler) runReconcileSeedFlow(
 			Fn:   clusterautoscaler.NewBootstrapper(seedClient, r.GardenNamespace).Deploy,
 		})
 		_ = g.Add(flow.Task{
-			Name: "Deploying kube-state-metrics",
-			Fn:   kubeStateMetrics.Deploy,
-		})
-		_ = g.Add(flow.Task{
 			Name: "Deploying dependency-watchdog-weeder",
 			Fn:   dwdWeeder.Deploy,
 		})
@@ -937,7 +928,7 @@ func (r *Reconciler) runReconcileSeedFlow(
 		})
 	}
 
-	// When the seed is the garden cluster then the VPA is reconciled by the gardener-operator
+	// When the seed is the garden cluster then the following components are reconciled by the gardener-operator.
 	if !seedIsGarden {
 		vpa, err := sharedcomponent.NewVerticalPodAutoscaler(
 			seedClient,
@@ -980,6 +971,17 @@ func (r *Reconciler) runReconcileSeedFlow(
 			return err
 		}
 
+		kubeStateMetrics, err := sharedcomponent.NewKubeStateMetrics(
+			seedClient,
+			r.GardenNamespace,
+			kubernetesVersion,
+			r.ImageVector,
+			v1beta1constants.PriorityClassNameSeedSystem600,
+		)
+		if err != nil {
+			return err
+		}
+
 		var (
 			_ = g.Add(flow.Task{
 				Name: "Deploying Kubernetes vertical pod autoscaler",
@@ -992,6 +994,10 @@ func (r *Reconciler) runReconcileSeedFlow(
 			_ = g.Add(flow.Task{
 				Name: "Deploying ETCD Druid",
 				Fn:   etcdDruid.Deploy,
+			})
+			_ = g.Add(flow.Task{
+				Name: "Deploying kube-state-metrics",
+				Fn:   kubeStateMetrics.Deploy,
 			})
 		)
 	}

--- a/pkg/gardenlet/controller/seed/seed/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/seed/seed/reconciler_reconcile.go
@@ -829,7 +829,7 @@ func (r *Reconciler) runReconcileSeedFlow(
 	if err != nil {
 		return err
 	}
-	kubeStateMetrics, err := defaultKubeStateMetrics(seedClient, r.ImageVector, kubernetesVersion, r.GardenNamespace)
+	kubeStateMetrics, err := sharedcomponent.NewKubeStateMetrics(seedClient, r.GardenNamespace, kubernetesVersion, r.ImageVector, v1beta1constants.PriorityClassNameSeedSystem600)
 	if err != nil {
 		return err
 	}

--- a/pkg/operation/botanist/component/kubestatemetrics/kube_state_metrics.go
+++ b/pkg/operation/botanist/component/kubestatemetrics/kube_state_metrics.go
@@ -90,6 +90,8 @@ type Values struct {
 	ClusterType component.ClusterType
 	// Image is the container image.
 	Image string
+	// PriorityClassName is the name of the priority class.
+	PriorityClassName string
 	// Replicas is the number of replicas.
 	Replicas int32
 }

--- a/pkg/operation/botanist/component/kubestatemetrics/kube_state_metrics_test.go
+++ b/pkg/operation/botanist/component/kubestatemetrics/kube_state_metrics_test.go
@@ -32,7 +32,6 @@ import (
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
-	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/operation/botanist/component"
@@ -50,14 +49,14 @@ var _ = Describe("KubeStateMetrics", func() {
 	var (
 		ctx = context.TODO()
 
-		namespace = "some-namespace"
-		values    = Values{}
+		namespace         = "some-namespace"
+		image             = "some-image:some-tag"
+		priorityClassName = "some-priorityclass"
+		values            = Values{}
 
 		c   client.Client
 		sm  secretsmanager.Interface
 		ksm component.DeployWaiter
-
-		image = "some-image:some-tag"
 
 		managedResourceName   string
 		managedResource       *resourcesv1alpha1.ManagedResource
@@ -218,7 +217,6 @@ var _ = Describe("KubeStateMetrics", func() {
 					"component": "kube-state-metrics",
 					"type":      string(clusterType),
 				}
-				priorityClassName = v1beta1constants.PriorityClassNameSeedSystem600
 
 				deploymentLabels             map[string]string
 				podLabels                    map[string]string
@@ -253,7 +251,6 @@ var _ = Describe("KubeStateMetrics", func() {
 			}
 
 			if clusterType == component.ClusterTypeShoot {
-				priorityClassName = v1beta1constants.PriorityClassNameShootControlPlane100
 				deploymentLabels = map[string]string{
 					"component":           "kube-state-metrics",
 					"type":                string(clusterType),
@@ -486,8 +483,9 @@ var _ = Describe("KubeStateMetrics", func() {
 		Context("cluster type seed", func() {
 			BeforeEach(func() {
 				ksm = New(c, namespace, nil, Values{
-					ClusterType: component.ClusterTypeSeed,
-					Image:       image,
+					ClusterType:       component.ClusterTypeSeed,
+					Image:             image,
+					PriorityClassName: priorityClassName,
 				})
 				managedResourceName = "kube-state-metrics"
 			})
@@ -535,8 +533,9 @@ var _ = Describe("KubeStateMetrics", func() {
 		Context("cluster type shoot", func() {
 			BeforeEach(func() {
 				ksm = New(c, namespace, sm, Values{
-					ClusterType: component.ClusterTypeShoot,
-					Image:       image,
+					ClusterType:       component.ClusterTypeShoot,
+					Image:             image,
+					PriorityClassName: priorityClassName,
 				})
 				managedResourceName = "shoot-core-kube-state-metrics"
 			})

--- a/pkg/operation/botanist/component/kubestatemetrics/resources.go
+++ b/pkg/operation/botanist/component/kubestatemetrics/resources.go
@@ -220,9 +220,7 @@ func (k *kubeStateMetrics) reconcileDeployment(
 		)
 	}
 
-	priorityClassName := v1beta1constants.PriorityClassNameSeedSystem600
 	if k.values.ClusterType == component.ClusterTypeShoot {
-		priorityClassName = v1beta1constants.PriorityClassNameShootControlPlane100
 		deploymentLabels[v1beta1constants.GardenRole] = v1beta1constants.LabelMonitoring
 		podLabels = utils.MergeStringMaps(podLabels, deploymentLabels, map[string]string{
 			gardenerutils.NetworkPolicyLabel(v1beta1constants.DeploymentNameKubeAPIServer, kubeapiserverconstants.Port): v1beta1constants.LabelNetworkPolicyAllowed,
@@ -290,7 +288,7 @@ func (k *kubeStateMetrics) reconcileDeployment(
 					},
 				},
 			}},
-			PriorityClassName: priorityClassName,
+			PriorityClassName: k.values.PriorityClassName,
 		},
 	}
 

--- a/pkg/operation/botanist/component/shared/kube_state_metrics.go
+++ b/pkg/operation/botanist/component/shared/kube_state_metrics.go
@@ -1,0 +1,49 @@
+// Copyright 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package shared
+
+import (
+	"github.com/Masterminds/semver"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/gardener/gardener/pkg/operation/botanist/component"
+	"github.com/gardener/gardener/pkg/operation/botanist/component/kubestatemetrics"
+	"github.com/gardener/gardener/pkg/utils/images"
+	"github.com/gardener/gardener/pkg/utils/imagevector"
+)
+
+// NewKubeStateMetrics instantiates a new `kube-state-metrics` component.
+func NewKubeStateMetrics(
+	c client.Client,
+	gardenNamespaceName string,
+	runtimeVersion *semver.Version,
+	imageVector imagevector.ImageVector,
+	priorityClassName string,
+) (
+	component.DeployWaiter,
+	error,
+) {
+	image, err := imageVector.FindImage(images.ImageNameKubeStateMetrics, imagevector.TargetVersion(runtimeVersion.String()))
+	if err != nil {
+		return nil, err
+	}
+
+	return kubestatemetrics.New(c, gardenNamespaceName, nil, kubestatemetrics.Values{
+		ClusterType:       component.ClusterTypeSeed,
+		Image:             image.String(),
+		PriorityClassName: priorityClassName,
+		Replicas:          1,
+	}), nil
+}

--- a/pkg/operation/botanist/kubestatemetrics.go
+++ b/pkg/operation/botanist/kubestatemetrics.go
@@ -17,6 +17,7 @@ package botanist
 import (
 	"context"
 
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/operation/botanist/component"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/kubestatemetrics"
 	"github.com/gardener/gardener/pkg/utils/images"
@@ -35,9 +36,10 @@ func (b *Botanist) DefaultKubeStateMetrics() (kubestatemetrics.Interface, error)
 		b.Shoot.SeedNamespace,
 		b.SecretsManager,
 		kubestatemetrics.Values{
-			ClusterType: component.ClusterTypeShoot,
-			Image:       image.String(),
-			Replicas:    b.Shoot.GetReplicas(1),
+			ClusterType:       component.ClusterTypeShoot,
+			Image:             image.String(),
+			PriorityClassName: v1beta1constants.PriorityClassNameShootControlPlane100,
+			Replicas:          b.Shoot.GetReplicas(1),
 		},
 	), nil
 }

--- a/pkg/operator/controller/garden/components.go
+++ b/pkg/operator/controller/garden/components.go
@@ -393,3 +393,13 @@ func fetchKubeconfigFromSecret(ctx context.Context, c client.Client, key client.
 
 	return kubeconfig, nil
 }
+
+func (r *Reconciler) newKubeStateMetrics() (component.DeployWaiter, error) {
+	return sharedcomponent.NewKubeStateMetrics(
+		r.RuntimeClientSet.Client(),
+		r.GardenNamespace,
+		r.RuntimeVersion,
+		r.ImageVector,
+		v1beta1constants.PriorityClassNameGardenSystem100,
+	)
+}

--- a/pkg/operator/controller/garden/reconciler_delete.go
+++ b/pkg/operator/controller/garden/reconciler_delete.go
@@ -101,23 +101,17 @@ func (r *Reconciler) delete(
 	var (
 		g = flow.NewGraph("Garden deletion")
 
-		destroyKubeStateMetrics = g.Add(flow.Task{
+		_ = g.Add(flow.Task{
 			Name: "Destroying Kube State Metrics",
 			Fn:   component.OpDestroyAndWait(kubeStateMetrics).Destroy,
 		})
-		syncPointObservabilityComponentsDestroyed = flow.NewTaskIDs(
-			destroyKubeStateMetrics,
-		)
-
 		destroyKubeAPIServerService = g.Add(flow.Task{
-			Name:         "Destroying Kubernetes API Server service",
-			Fn:           component.OpDestroyAndWait(kubeAPIServerService).Destroy,
-			Dependencies: flow.NewTaskIDs(syncPointObservabilityComponentsDestroyed),
+			Name: "Destroying Kubernetes API Server service",
+			Fn:   component.OpDestroyAndWait(kubeAPIServerService).Destroy,
 		})
 		destroyKubeAPIServer = g.Add(flow.Task{
-			Name:         "Destroying Kubernetes API Server",
-			Fn:           component.OpDestroyAndWait(kubeAPIServer).Destroy,
-			Dependencies: flow.NewTaskIDs(syncPointObservabilityComponentsDestroyed),
+			Name: "Destroying Kubernetes API Server",
+			Fn:   component.OpDestroyAndWait(kubeAPIServer).Destroy,
 		})
 		destroyEtcd = g.Add(flow.Task{
 			Name: "Destroying main and events ETCDs of virtual garden",
@@ -132,7 +126,6 @@ func (r *Reconciler) delete(
 			Dependencies: flow.NewTaskIDs(destroyKubeAPIServer),
 		})
 		syncPointVirtualGardenControlPlaneDestroyed = flow.NewTaskIDs(
-			syncPointObservabilityComponentsDestroyed,
 			destroyKubeAPIServerService,
 			destroyEtcd,
 		)

--- a/pkg/operator/controller/garden/reconciler_reconcile.go
+++ b/pkg/operator/controller/garden/reconciler_reconcile.go
@@ -248,15 +248,12 @@ func (r *Reconciler) reconcile(
 				DoIf(helper.GetETCDEncryptionKeyRotationPhase(garden.Status.Credentials) == gardencorev1beta1.RotationCompleting),
 			Dependencies: flow.NewTaskIDs(initializeVirtualClusterClient),
 		})
-		syncPointControlPlaneComponents = flow.NewTaskIDs(
-			syncPointSystemComponents,
-			initializeVirtualClusterClient,
-		)
 
+		// observability components
 		_ = g.Add(flow.Task{
 			Name:         "Deploying Kube State Metrics",
 			Fn:           kubeStateMetrics.Deploy,
-			Dependencies: flow.NewTaskIDs(syncPointControlPlaneComponents),
+			Dependencies: flow.NewTaskIDs(deployGardenerResourceManager),
 		})
 	)
 

--- a/skaffold-operator.yaml
+++ b/skaffold-operator.yaml
@@ -69,6 +69,7 @@ build:
         - pkg/operation/botanist/component/kubeapiserver/constants
         - pkg/operation/botanist/component/kubeapiserverexposure
         - pkg/operation/botanist/component/kubescheduler
+        - pkg/operation/botanist/component/kubestatemetrics
         - pkg/operation/botanist/component/resourcemanager
         - pkg/operation/botanist/component/resourcemanager/constants
         - pkg/operation/botanist/component/shared

--- a/test/e2e/operator/garden/create_delete.go
+++ b/test/e2e/operator/garden/create_delete.go
@@ -89,6 +89,7 @@ var _ = Describe("Garden Tests", Label("Garden", "default"), func() {
 				healthyManagedResource("hvpa"),
 				healthyManagedResource("vpa"),
 				healthyManagedResource("etcd-druid"),
+				healthyManagedResource("kube-state-metrics"),
 			))
 		}).WithPolling(2 * time.Second).Should(Succeed())
 

--- a/test/integration/gardenlet/seed/seed/seed_test.go
+++ b/test/integration/gardenlet/seed/seed/seed_test.go
@@ -484,7 +484,6 @@ var _ = Describe("Seed controller tests", func() {
 						MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("cluster-autoscaler")})}),
 						MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("dependency-watchdog-weeder")})}),
 						MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("dependency-watchdog-prober")})}),
-						MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("kube-state-metrics")})}),
 						MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("nginx-ingress")})}),
 						MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("system")})}),
 					}
@@ -494,6 +493,7 @@ var _ = Describe("Seed controller tests", func() {
 							MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("vpa")})}),
 							MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("hvpa")})}),
 							MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("etcd-druid")})}),
+							MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("kube-state-metrics")})}),
 						)
 					}
 

--- a/test/integration/operator/garden/garden_test.go
+++ b/test/integration/operator/garden/garden_test.go
@@ -272,7 +272,7 @@ var _ = Describe("Garden controller tests", func() {
 			managedResourceList := &resourcesv1alpha1.ManagedResourceList{}
 			g.Expect(testClient.List(ctx, managedResourceList, client.InNamespace(testNamespace.Name))).To(Succeed())
 			return managedResourceList.Items
-		}).Should(ConsistOf(
+		}).Should(ContainElements(
 			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("garden-system")})}),
 			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("vpa")})}),
 			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("hvpa")})}),
@@ -367,6 +367,15 @@ var _ = Describe("Garden controller tests", func() {
 			}
 			g.Expect(testClient.Status().Patch(ctx, deployment, patch)).To(Succeed())
 		}).Should(Succeed())
+
+		By("Verify that the observability components have been deployed")
+		Eventually(func(g Gomega) []resourcesv1alpha1.ManagedResource {
+			managedResourceList := &resourcesv1alpha1.ManagedResourceList{}
+			g.Expect(testClient.List(ctx, managedResourceList, client.InNamespace(testNamespace.Name))).To(Succeed())
+			return managedResourceList.Items
+		}).Should(ContainElements(
+			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("kube-state-metrics")})}),
+		))
 
 		By("Wait for Reconciled condition to be set to True")
 		Eventually(func(g Gomega) []gardencorev1beta1.Condition {

--- a/test/integration/operator/garden/garden_test.go
+++ b/test/integration/operator/garden/garden_test.go
@@ -267,16 +267,17 @@ var _ = Describe("Garden controller tests", func() {
 			g.Expect(testClient.Status().Patch(ctx, deployment, patch)).To(Succeed())
 		}).Should(Succeed())
 
-		By("Verify that the garden system components have been deployed")
+		By("Verify that the relevant ManagedResources have been deployed")
 		Eventually(func(g Gomega) []resourcesv1alpha1.ManagedResource {
 			managedResourceList := &resourcesv1alpha1.ManagedResourceList{}
 			g.Expect(testClient.List(ctx, managedResourceList, client.InNamespace(testNamespace.Name))).To(Succeed())
 			return managedResourceList.Items
-		}).Should(ContainElements(
+		}).Should(ConsistOf(
 			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("garden-system")})}),
 			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("vpa")})}),
 			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("hvpa")})}),
 			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("etcd-druid")})}),
+			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("kube-state-metrics")})}),
 		))
 
 		By("Verify that the virtual garden control plane components have been deployed")
@@ -367,15 +368,6 @@ var _ = Describe("Garden controller tests", func() {
 			}
 			g.Expect(testClient.Status().Patch(ctx, deployment, patch)).To(Succeed())
 		}).Should(Succeed())
-
-		By("Verify that the observability components have been deployed")
-		Eventually(func(g Gomega) []resourcesv1alpha1.ManagedResource {
-			managedResourceList := &resourcesv1alpha1.ManagedResourceList{}
-			g.Expect(testClient.List(ctx, managedResourceList, client.InNamespace(testNamespace.Name))).To(Succeed())
-			return managedResourceList.Items
-		}).Should(ContainElements(
-			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("kube-state-metrics")})}),
-		))
 
 		By("Wait for Reconciled condition to be set to True")
 		Eventually(func(g Gomega) []gardencorev1beta1.Condition {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity delivery
/kind enhancement

**What this PR does / why we need it**:
With this PR, `gardener-operator` is enhanced to manage `kube-state-metrics`.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/7016

**Special notes for your reviewer**:
/cc @ScheererJ @timuthy @istvanballok @rickardsjp 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
The `gardener-operator` does now also manage `kube-state-metrics`.
```
