### PR TITLE
Remove containerd conf.d import

### DIFF
--- a/docs/usage/custom-containerd-config.md
+++ b/docs/usage/custom-containerd-config.md
@@ -3,16 +3,330 @@ title: Custom containerd Configuration
 ---
 
 # Custom `containerd` Configuration
+In case a `Shoot` cluster uses `containerd` (see [Kubernetes dockershim Removal](https://github.com/gardener/gardener/blob/master/docs/usage/docker-shim-removal.md)) for more information), it is possible to make the `containerd` process use custom configuration by modifying `/etc/containerd/config.toml`
 
-In case a `Shoot` cluster uses `containerd` (see [Kubernetes dockershim Removal](docker-shim-removal.md)) for more information), it is possible to make the `containerd` process load custom configuration files.
-Gardener initializes `containerd` with the following statement:
+One way of doing it is by using `sed`
 
-```toml
-imports = ["/etc/containerd/conf.d/*.toml"]
+## Setup
+For the approach described below to work the config file should follow a specific format that `containerd config dump` applies. 
+### Formatting
+To format the config file the following should be executed
+```bash
+containerd config dump > /etc/containerd/config_formatted.toml && mv /etc/containerd/config_formatted.toml /etc/containerd/config.toml
 ```
 
-This means that all `*.toml` files in the `/etc/containerd/conf.d` directory will be imported and merged with the default configuration.
-To prevent unintended configuration overwrites, please be aware that containerd merges config sections, not individual keys (see [here](https://github.com/containerd/containerd/issues/5837#issuecomment-894840240) and [here](https://github.com/gardener/gardener/pull/7316)).
-Please consult the [upstream `containerd` documentation](https://github.com/containerd/containerd/blob/main/docs/man/containerd-config.toml.5.md#format) for more information.
+## Working with the configuration
+Example config file `cdexample`:
+```toml
+required_plugins = []
+root = "/var/lib/containerd"
+state = "/run/containerd"
+version = 2
 
-> ⚠️ Note that this only applies to nodes which were newly created after `gardener/gardener@v1.51` was deployed. Existing nodes are not affected. 
+[cgroup]
+  path = ""
+
+[debug]
+  address = ""
+  format = ""
+
+[plugins]
+
+  [plugins."io.containerd.grpc.v1.cri"]
+    device_ownership_from_security_context = false
+
+    [plugins."io.containerd.grpc.v1.cri".registry]
+      config_path = ""
+
+       [plugins."io.containerd.grpc.v1.cri".registry.auths]
+
+  [plugins."io.containerd.gc.v1.scheduler"]
+    deletion_threshold = 0
+    mutation_threshold = 100
+```
+### Explanation of placeholders: 
+``` 
+<<section_selector>> = \[<<section>>\] # selects only direct fields of <<section>>
+					 = \[<<section>>   # selects direct fields and child sections/fields of <<section>>
+					 = 1               # selects root fields
+
+<<section/new_subsection>> = toml table
+<<field>>                  = toml key = value pair
+<<field_regex>>            = any BRE(basic regular expression) that matches a field
+```
+### Specifics
+In `<<section_selector>>` \[ , \] and . should be escaped(see examples). For more information about special characters consult [this](https://www.regular-expressions.info/characters.html) and [this](https://www.gnu.org/software/sed/manual/html_node/BRE-vs-ERE.html). By default `sed` uses BRE(basic regular expressions). For more indepth understanding visit [sed's manual](https://www.gnu.org/software/sed/manual/sed.html)
+### Printing a section
+`sed -n /<<section_selector>>/,/^$/p /etc/containerd/config.toml`
+
+``` bash
+sed -n '1,/^$/p' cdexample
+# Result:
+# required_plugins = []
+# root = "/var/lib/containerd"
+# state = "/run/containerd"
+# version = 2
+#
+```
+
+```bash 
+sed -n '/\[plugins\."io\.containerd\.grpc\.v1\.cri"\]/,/^$/p' cdexample
+# Result:
+#   [plugins."io.containerd.grpc.v1.cri"]
+#     device_ownership_from_security_context = false
+#
+```
+
+```bash
+sed -n '/\[plugins\."io\.containerd\.grpc\.v1\.cri"/,/^$/p' cdexample
+# Result:
+#   [plugins."io.containerd.grpc.v1.cri"]
+#     device_ownership_from_security_context = false
+#
+#     [plugins."io.containerd.grpc.v1.cri".registry]
+#       config_path = ""
+#
+#        [plugins."io.containerd.grpc.v1.cri".registry.auths]
+#
+```
+
+### Deleting a section
+`sed -i '/<<section_selector>>/,/^$/d' /etc/containerd/config.toml
+
+```bash
+sed -i '/\[plugins\."io\.containerd\.grpc\.v1\.cri"\]/,/^$/d' cdexample
+# Result:
+# required_plugins = []
+# root = "/var/lib/containerd"
+# state = "/run/containerd"
+# version = 2
+#
+# [cgroup]
+#   path = ""
+#
+# [debug]
+#   address = ""
+#   format = ""
+#
+# [plugins]
+#
+#     [plugins."io.containerd.grpc.v1.cri".registry]
+#       config_path = ""
+#
+#        [plugins."io.containerd.grpc.v1.cri".registry.auths]
+#
+#   [plugins."io.containerd.gc.v1.scheduler"]
+#     deletion_threshold = 0
+#     mutation_threshold = 100
+```
+
+``` bash
+sed -i '/\[plugins\."io.containerd\.grpc\.v1\.cri"/,/^$/d' cdexample 
+# Result:
+# required_plugins = []
+# root = "/var/lib/containerd"
+# state = "/run/containerd"
+# version = 2
+#
+# [cgroup]
+#   path = ""
+#
+# [debug]
+#   address = ""
+#   format = ""
+#
+# [plugins]
+#
+#   [plugins."io.containerd.gc.v1.scheduler"]
+#     deletion_threshold = 0
+#     mutation_threshold = 100
+
+```
+
+### Editing a section
+#### Adding a field
+`sed -i '/<<section>>/a<<field>>' /etc/containerd/config.toml`
+Note: even if the added/edited fields are not indented properly this will not cause invalid toml. Only reaplying the formatting command above is nessesary when adding a new section and it's fields 
+
+**Exception: If you want to add at a root field use `sed -i '1i<<field>>'
+
+```bash
+sed -i '1ifoo=bar' cdexample
+# Result:
+# foo=bar
+# required_plugins = []
+# root = "/var/lib/containerd"
+....
+
+```
+
+```bash
+sed -i '/\[plugins\."io\.containerd\.grpc\.v1\.cri"\]/afoo=bar' cdexample
+# Result:
+# required_plugins = []
+# root = "/var/lib/containerd"
+# state = "/run/containerd"
+# version = 2
+#
+# [cgroup]
+#   path = ""
+#
+# [debug]
+#   address = ""
+#   format = ""
+#
+# [plugins]
+#
+#   [plugins."io.containerd.grpc.v1.cri"]
+# foo=bar
+#     device_ownership_from_security_context = false
+#
+#     [plugins."io.containerd.grpc.v1.cri".registry]
+#       config_path = ""
+#
+#        [plugins."io.containerd.grpc.v1.cri".registry.auths]
+#
+#   [plugins."io.containerd.gc.v1.scheduler"]
+#     deletion_threshold = 0
+#     mutation_threshold = 100
+```
+#### Removing a field
+`sed -i '/<<section>>/,/^$/s/.*<<field_regex>>.*//' /etc/containerd/config.toml`
+
+```bash
+sed -i '/\[plugins\."io\.containerd\.grpc\.v1\.cri"\]/,/^$/s/.*security.*//' cdexample 
+# Result:
+# required_plugins = []
+# root = "/var/lib/containerd"
+# state = "/run/containerd"
+# version = 2
+#
+# [cgroup]
+#   path = ""
+#
+# [debug]
+#   address = ""
+#   format = ""
+#
+# [plugins]
+#
+#   [plugins."io.containerd.grpc.v1.cri"]
+#
+#
+#     [plugins."io.containerd.grpc.v1.cri".registry]
+#       config_path = ""
+#
+#        [plugins."io.containerd.grpc.v1.cri".registry.auths]
+#
+#   [plugins."io.containerd.gc.v1.scheduler"]
+#     deletion_threshold = 0
+#     mutation_threshold = 100
+```
+#### Editing a field 
+`sed -i '/<<section>>/,/^$/s/.*<<field_regex>>.*/<<new_field>>/' /etc/containerd/config.toml`
+
+```bash
+sed -i '/\[plugins\."io\.containerd\.grpc\.v1\.cri"\]/,/^$/s/.*security.*/device_ownership_from_security_context = true/' cdexample 
+# Result:
+# required_plugins = []
+# root = "/var/lib/containerd"
+# state = "/run/containerd"
+# version = 2
+#
+# [cgroup]
+#   path = ""
+#
+# [debug]
+#   address = ""
+#   format = ""
+#
+# [plugins]
+#
+#   [plugins."io.containerd.grpc.v1.cri"]
+# device_ownership_from_security_context = true
+#
+#     [plugins."io.containerd.grpc.v1.cri".registry]
+#       config_path = ""
+#
+#        [plugins."io.containerd.grpc.v1.cri".registry.auths]
+#
+#   [plugins."io.containerd.gc.v1.scheduler"]
+#     deletion_threshold = 0
+#     mutation_threshold = 100
+```
+### Adding a section
+
+**NOTE:After adding all sections and fields run the formatting script above again**
+
+#### Adding a top level section
+`sed -i '$a<<section>>' /etc/containerd/config.toml`
+
+```bash
+sed -i '$a[proxy_plugins]' cdexample 
+# Result:
+# required_plugins = []
+# root = "/var/lib/containerd"
+# state = "/run/containerd"
+# version = 2
+#
+# [cgroup]
+#   path = ""
+#
+# [debug]
+#   address = ""
+#   format = ""
+#
+# [plugins]
+#
+#   [plugins."io.containerd.grpc.v1.cri"]
+#     device_ownership_from_security_context = false
+#
+#     [plugins."io.containerd.grpc.v1.cri".registry]
+#       config_path = ""
+#
+#        [plugins."io.containerd.grpc.v1.cri".registry.auths]
+#
+#   [plugins."io.containerd.gc.v1.scheduler"]
+#     deletion_threshold = 0
+#     mutation_threshold = 100
+# [proxy_plugins]
+```
+#### Adding a subsection
+`sed -i '/<<section>>/a<<new_subsection>>' /etc/containerd/config.toml`
+
+```bash
+sed -i '/\[proxy_plugins\]/a[proxy_plugins."fuse-overlayfs"]' cdexample 
+# Result:
+# required_plugins = []
+# root = "/var/lib/containerd"
+# state = "/run/containerd"
+# version = 2
+#
+# [cgroup]
+#   path = ""
+#
+# [debug]
+#   address = ""
+#   format = ""
+#
+# [plugins]
+#
+#   [plugins."io.containerd.grpc.v1.cri"]
+#     device_ownership_from_security_context = false
+#
+#     [plugins."io.containerd.grpc.v1.cri".registry]
+#       config_path = ""
+#
+#        [plugins."io.containerd.grpc.v1.cri".registry.auths]
+#
+#   [plugins."io.containerd.gc.v1.scheduler"]
+#     deletion_threshold = 0
+#     mutation_threshold = 100
+# [proxy_plugins]
+# [proxy_plugins."fuse-overlayfs"]
+```
+#### Adding a fields
+Use the same steps as described in Editing a section
+
+## Validation
+After applying the custom configuration run the formatting commands above and make sure the config file has the expected content

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/containerd/templates/scripts/init.tpl.sh
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/containerd/templates/scripts/init.tpl.sh
@@ -7,27 +7,8 @@ if [ ! -s "$FILE" ]; then
 fi
 
 # use injected image as sandbox image
-sandbox_image_line="$(grep sandbox_image $FILE | sed -e 's/^[ ]*//')"
 pause_image={{ .pauseContainerImage }}
-sed -i  "s|$sandbox_image_line|sandbox_image = \"$pause_image\"|g" $FILE
-
-# allow to import custom configuration files
-CUSTOM_CONFIG_DIR=/etc/containerd/conf.d
-CUSTOM_CONFIG_FILES="$CUSTOM_CONFIG_DIR/*.toml"
-mkdir -p $CUSTOM_CONFIG_DIR
-if ! grep -E "^imports" $FILE >/dev/null ; then
-  # imports directive not present -> add it to the top
-  existing_content="$(cat "$FILE")"
-  cat <<EOF > $FILE
-imports = ["$CUSTOM_CONFIG_FILES"]
-$existing_content
-EOF
-elif ! grep -F "$CUSTOM_CONFIG_FILES" $FILE >/dev/null ; then
-  # imports directive present, but does not contain conf.d -> append conf.d to imports
-  existing_imports="$(grep -E "^imports" $FILE | sed -E 's#imports = \[(.*)\]#\1#g')"
-  [ -z "$existing_imports" ] || existing_imports="$existing_imports, "
-  sed -Ei 's#imports = \[(.*)\]#imports = ['"$existing_imports"'"'"$CUSTOM_CONFIG_FILES"'"]#g' $FILE
-fi
+sed -i  "s|sandbox_image.*$|sandbox_image = \"$pause_image\"|" $FILE
 
 BIN_PATH={{ .binaryPath }}
 mkdir -p $BIN_PATH


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind enhancement

**What this PR does / why we need it**:
Removes containerd conf.d import and proposes configuration of `config.toml` by using `sed`

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener/issues/7838

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking user
Custom configuration of `containerd` on shoot clusters is no longer done via import of toml file in `conf.d` directory. See https://gardener.cloud/docs/gardener/usage/custom-containerd-config/ for the updated approach
```
