### PR TITLE
Promote the bin-packing scheduling profile to stable

### DIFF
--- a/docs/usage/shoot_scheduling_profiles.md
+++ b/docs/usage/shoot_scheduling_profiles.md
@@ -18,15 +18,13 @@ As of today, Gardener supports two predefined scheduling profiles:
    
    The kube-scheduler is started without any profiles. In such case, by default, one profile with the scheduler name `default-scheduler` is created. This profile includes the default plugins. If a Pod doesn't specify the `.spec.schedulerName` field, kube-apiserver sets it to `default-scheduler`. Then, the Pod gets scheduled by the `default-scheduler` accordingly.
   
-- `bin-packing` (alpha)
+- `bin-packing`
 
    **Overview**
 
    The `bin-packing` profile scores Nodes based on the allocation of resources. It prioritizes Nodes with the most allocated resources. By favoring the Nodes with the most allocation, some of the other Nodes become under-utilized over time (because new Pods keep being scheduled to the most allocated Nodes). Then, the cluster-autoscaler identifies such under-utilized Nodes and removes them from the cluster. In this way, this profile provides a greater overall resource utilization (compared to the `balanced` profile).
 
    > **Note:** The decision of when to remove a Node is a trade-off between optimizing for utilization or the availability of resources. Removing under-utilized Nodes improves cluster utilization, but new workloads might have to wait for resources to be provisioned again before they can run.
-
-   > **Note:** The `bin-packing` profile is considered as an alpha feature. Use it only for evaluation purposes.
 
    **How it works?**
    


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area auto-scaling
/kind enhancement

**What this PR does / why we need it**:
We use it for our ManagedSeeds since some time and we haven't noticed any issue so far.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
