### PR TITLE
Fixes `docs/deployment/content/remote-local-setup.yaml`

### DIFF
--- a/docs/deployment/content/remote-local-setup.yaml
+++ b/docs/deployment/content/remote-local-setup.yaml
@@ -21,7 +21,7 @@ spec:
         - |
           set -ex
           cd
-          apk add bash bash-completion curl fzf g++ git jq less lsof make mandoc mc procps tmux tmux-doc yq vim go
+          apk add bash bash-completion curl fzf g++ git jq less lsof make mandoc mc procps sed tmux tmux-doc yq vim go
           apk add --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main mount
           apk add --repository=http://dl-cdn.alpinelinux.org/alpine/edge/k9s k9s
           echo golang            && curl -sLO "https://go.dev/dl/$(curl -sL https://golang.org/VERSION?m=text).linux-amd64.tar.gz" && tar -C /usr/local -xzf go1.*.linux-amd64.tar.gz


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind bug

**What this PR does / why we need it**:
This PR adds `sed` to the list of programs to install via `apk add` when the container inside [docs/deployment/content/remote-local-setup.yaml](https://github.com/plkokanov/gardener/blob/e82dd100a7639c414ac554752cdbd91ccc880920/docs/deployment/content/remote-local-setup.yaml) is started.
Without this the following code does not change the `coredns` configmap when setting up the [kind](https://kind.sigs.k8s.io/) clusters via the `kind-*-up` make targets (e.g. `make kind-up`):
https://github.com/gardener/gardener/blob/20e3c5dbd33df1aefa0ead8f1bbad38e23c4b477/hack/kind-up.sh#L215-L225
Not changing the  configmap results in the `gardenlet` pods deployed when running the`make gardener-*-up` make targets to get stuck in a `CrashLoopBackOff` with the following error:
```
panic: failed during bootstrapping: unable to bootstrap client from bootstrap kubeconfig: error discovering kubernetes version: Get "https://garden.local.gardener.cloud:6443/version": dial tcp: lookup garden.local.gardener.cloud on 10.2.0.10:53: no such host

goroutine 1 [running]:
main.main()
        github.com/gardener/gardener/cmd/gardenlet/main.go:30 +0x92
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Fixed an issue that would cause the `gardenlet` to run into `CrashLoopBackoff` when following the docs/development/getting_started_locally.md#remote-local-setup guide.
```
