### PR TITLE
gardenlet: Deploy/destroy the owner DNSRecord unconditionally on Shoot deletion

### DIFF
--- a/pkg/gardenlet/controller/shoot/shoot/reconciler_delete.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler_delete.go
@@ -201,7 +201,7 @@ func (r *Reconciler) runDeleteShootFlow(ctx context.Context, o *operation.Operat
 		})
 		deployOwnerDomainDNSRecord = g.Add(flow.Task{
 			Name:         "Deploying owner domain DNS record",
-			Fn:           flow.TaskFn(botanist.DeployOwnerDNSResources).DoIf(cleanupShootResources),
+			Fn:           flow.TaskFn(botanist.DeployOwnerDNSResources),
 			Dependencies: flow.NewTaskIDs(ensureShootStateExists, deployReferencedResources),
 		})
 		deployInternalDomainDNSRecord = g.Add(flow.Task{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane-migration
/kind enhancement

**What this PR does / why we need it**:
When we set `spec.settings.ownerChecks.enabled=false` for our ManagedSeeds, we noticed that not all of the owner DNSRecords were deleted for the Shoots running on a given Seed. The reason is the following one. There might be Shoots without kube-apiserver Deployment and with Infrastructure that cannot be deleted for some reason (infrastructure dependency, invalid credentials, etc). For such cases the `deployOwnerDomainDNSRecord` won't be executed because of its condition: 
https://github.com/gardener/gardener/blob/341d364a215b91a714503b69949c72b57de6072c/pkg/gardenlet/controller/shoot/shoot/reconciler_delete.go#L202-L206
https://github.com/gardener/gardener/blob/341d364a215b91a714503b69949c72b57de6072c/pkg/gardenlet/controller/shoot/shoot/reconciler_delete.go#L144

However there is explicit deletion of the owner DNSRecord at later point in the step:
https://github.com/gardener/gardener/blob/341d364a215b91a714503b69949c72b57de6072c/pkg/gardenlet/controller/shoot/shoot/reconciler_delete.go#L604-L608
But it cannot reach to that step because the infrastructure cannot be deleted.

The `deployOwnerDomainDNSRecord` step can create or delete the owner DNSRecord based on the Seed setting for ownerChecks:
https://github.com/gardener/gardener/blob/268208e9d252351457c15a72a3862cdf3ba92cfe/pkg/operation/botanist/dnsresources.go#L27-L33

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/6302

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
When Seed's `spec.settings.ownerChecks.enabled=false` gardenlet is now able to delete the owner DNSRecord for a Shoot stuck in deletion where the kube-apiserver Deployment is missing but the Infrastructure is present and cannot be deleted for some reason (infrastructure dependency, invalid credentials).
```
