### PR TITLE
Consider replicas for Istio `deployment`

### DIFF
--- a/pkg/operation/botanist/component/istio/charts/istio/istio-ingress/templates/deployment.yaml
+++ b/pkg/operation/botanist/component/istio/charts/istio/istio-ingress/templates/deployment.yaml
@@ -7,6 +7,7 @@ metadata:
     app.kubernetes.io/version: {{ .Values.ingressVersion }}
 {{ .Values.labels | toYaml | indent 4 }}
 spec:
+  replicas: {{ .Values.replicas }}
   revisionHistoryLimit: 1
   selector:
     matchLabels:

--- a/pkg/operation/botanist/component/istio/charts/istio/istio-ingress/values.yaml
+++ b/pkg/operation/botanist/component/istio/charts/istio/istio-ingress/values.yaml
@@ -19,6 +19,7 @@ ports: []
 serviceName: istio-ingressgateway
 ingressVersion: "1.17.1"
 #externalTrafficPolicy: Cluster
+replicas: 2
 minReplicas: 2
 maxReplicas: 5
 

--- a/pkg/operation/botanist/component/istio/ingress_gateway.go
+++ b/pkg/operation/botanist/component/istio/ingress_gateway.go
@@ -80,6 +80,10 @@ func (i *istiod) generateIstioIngressGatewayChart() (*chartrenderer.RenderedChar
 		}
 
 		if istioIngressGateway.MinReplicas != nil {
+			// Apply minReplicas here to deploy the Ingress-Gateway with the intended number of replicas from the beginning (creation).
+			// Otherwise, we would need to wait until HPA scales up the deployment which then again can trigger unnecessary rolling updates
+			// when additional configuration is added by registered webhooks, e.g. high-availability-config webhook.
+			values["replicas"] = *istioIngressGateway.MinReplicas
 			values["minReplicas"] = *istioIngressGateway.MinReplicas
 		}
 		if istioIngressGateway.MaxReplicas != nil {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area scalability
/kind enhancement

**What this PR does / why we need it**:
This PR changes the Ingress-Gateway `deployment`s to consider the `minReplicas` count, i.e. `deployment.spec.replicas`. As a consequence, when the `deployment` is created, it already contains the initial desired replicas.

Earlier, HPA scaled up the `deployment` to `minReplicas` a short time after creation which resulted in another rolling-update because the [High Availability Config](https://github.com/gardener/gardener/blob/master/docs/concepts/resource-manager.md#high-availability-config) webhook added configuration that is only relevant for components with `replicas >= 1`.

**The following `replicaset`s in the local setup serve as an example:**

_Before, without setting `deployment.spec.replicas: <minReplicas>`_
```
istio-ingress--0                            istio-ingressgateway-5568d5d695                0         0         0       5m28s
istio-ingress--0                            istio-ingressgateway-5f7df45f85                2         2         2       2m17s
istio-ingress--1                            istio-ingressgateway-74cdf9f8fb                2         2         2       2m18s
istio-ingress--1                            istio-ingressgateway-7f8fb5cfdf                0         0         0       5m28s
istio-ingress--2                            istio-ingressgateway-57f5469b8f                2         2         2       2m18s
istio-ingress--2                            istio-ingressgateway-59d7f4f95c                0         0         0       5m28s
istio-ingress                               istio-ingressgateway-5b759447db                6         6         6       2m17s
istio-ingress                               istio-ingressgateway-8c6b9df77                 0         0         0       5m28s
```

_With the changes of this PR applied_
```
istio-ingress--0                            istio-ingressgateway-5f7df45f85                2         2         2       2m39s
istio-ingress--1                            istio-ingressgateway-74cdf9f8fb                2         2         2       2m39s
istio-ingress--2                            istio-ingressgateway-57f5469b8f                2         2         2       2m39s
istio-ingress                               istio-ingressgateway-5b759447db                6         6         6       2m39s
```

**Special notes for your reviewer**:
/cc @ScheererJ

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The Istio Ingress-Gateway deployment was refined to speed up seed bootstrapping times.
```
