### PR TITLE
Remove trailing whitespace in local setup coredns configuration.

### DIFF
--- a/hack/kind-up.sh
+++ b/hack/kind-up.sh
@@ -215,11 +215,11 @@ kubectl get nodes -o name |\
 # Inject garden.local.gardener.cloud into coredns config (after ready plugin, before kubernetes plugin)
 kubectl -n kube-system get configmap coredns -ojson | \
   yq '.data.Corefile' | \
-  sed '0,/ready.*$/s//&'" \n\
-    hosts { \n\
-      $garden_cluster_ip garden.local.gardener.cloud \n\
-      fallthrough \n\
-    } \
+  sed '0,/ready.*$/s//&'"\n\
+    hosts {\n\
+      $garden_cluster_ip garden.local.gardener.cloud\n\
+      fallthrough\n\
+    }\
 "'/' | \
   kubectl -n kube-system create configmap coredns --from-file Corefile=/dev/stdin --dry-run=client -oyaml | \
   kubectl -n kube-system patch configmap coredns --patch-file /dev/stdin


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind cleanup

**What this PR does / why we need it**:
Remove trailing whitespace in local setup coredns configuration.

Trailing whitespace causes issues with multi-line detection in kubectl. Removing these unnecessary characters makes the output better readable.

**Which issue(s) this PR fixes**:
None.

**Special notes for your reviewer**:
Before:
```
# kubectl -n kube-system get cm coredns -o yaml
apiVersion: v1
data:
  Corefile: ".:53 {\n    errors\n    health {\n       lameduck 5s\n    }\n    ready
    \n    hosts { \n      172.18.0.2 garden.local.gardener.cloud \n      fallthrough
    \n    } \n    kubernetes cluster.local in-addr.arpa ip6.arpa {\n       pods insecure\n
    \      fallthrough in-addr.arpa ip6.arpa\n       ttl 30\n    }\n    prometheus
    :9153\n    forward . /etc/resolv.conf {\n       max_concurrent 1000\n    }\n    cache
    30\n    loop\n    reload\n    loadbalance\n}\n\n"
kind: ConfigMap
metadata:
...
  name: coredns
  namespace: kube-system
...
```

After:
```
# kubectl -n kube-system get cm coredns -o yaml
apiVersion: v1
data:
  Corefile: |+
    .:53 {
        errors
        health {
           lameduck 5s
        }
        ready
        hosts {
          172.18.0.2 garden.local.gardener.cloud
          fallthrough
        }
        kubernetes cluster.local in-addr.arpa ip6.arpa {
           pods insecure
           fallthrough in-addr.arpa ip6.arpa
           ttl 30
        }
        prometheus :9153
        forward . /etc/resolv.conf {
           max_concurrent 1000
        }
        cache 30
        loop
        reload
        loadbalance
    }

kind: ConfigMap
metadata:
...
  name: coredns
  namespace: kube-system
...
```

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
