### PR TITLE
Deactivate leader election, health and readiness checks when running `make *-debug`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -312,7 +312,7 @@ kind2-up kind2-down gardenlet-kind2-up gardenlet-kind2-dev gardenlet-kind2-debug
 kind-extensions-up kind-extensions-down gardener-extensions-up gardener-extensions-down: export KUBECONFIG = $(GARDENER_EXTENSIONS_KUBECONFIG)
 kind-ha-single-zone-up kind-ha-single-zone-down gardener-ha-single-zone-up register-kind-ha-single-zone-env tear-down-kind-ha-single-zone-env test-e2e-local-ha-single-zone ci-e2e-kind-ha-single-zone ci-e2e-kind-ha-single-zone-upgrade: export KUBECONFIG = $(GARDENER_LOCAL_HA_SINGLE_ZONE_KUBECONFIG)
 kind-ha-multi-zone-up kind-ha-multi-zone-down gardener-ha-multi-zone-up register-kind-ha-multi-zone-env tear-down-kind-ha-multi-zone-env test-e2e-local-ha-multi-zone ci-e2e-kind-ha-multi-zone ci-e2e-kind-ha-multi-zone-upgrade: export KUBECONFIG = $(GARDENER_LOCAL_HA_MULTI_ZONE_KUBECONFIG)
-kind-operator-up kind-operator-down operator-up operator-down test-e2e-local-operator ci-e2e-kind-operator: export KUBECONFIG = $(GARDENER_LOCAL_OPERATOR_KUBECONFIG)
+kind-operator-up kind-operator-down operator-up operator-dev operator-debug operator-down test-e2e-local-operator ci-e2e-kind-operator: export KUBECONFIG = $(GARDENER_LOCAL_OPERATOR_KUBECONFIG)
 
 kind-up: $(KIND) $(KUBECTL) $(HELM) $(YQ)
 	./hack/kind-up.sh --cluster-name gardener-local --environment $(KIND_ENV) --path-kubeconfig $(REPO_ROOT)/example/provider-local/seed-kind/base/kubeconfig --path-cluster-values $(REPO_ROOT)/example/gardener-local/kind/local/values.yaml
@@ -351,7 +351,7 @@ kind-operator-down: $(KIND)
 
 # speed-up skaffold deployments by building all images concurrently
 export SKAFFOLD_BUILD_CONCURRENCY = 0
-gardener%up gardener%dev gardener%debug gardenlet%up gardenlet%dev gardenlet%debug operator-up operator-dev  operator-debug: export SKAFFOLD_DEFAULT_REPO = localhost:5001
+gardener%up gardener%dev gardener%debug gardenlet%up gardenlet%dev gardenlet%debug operator-up operator-dev operator-debug: export SKAFFOLD_DEFAULT_REPO = localhost:5001
 gardener%up gardener%dev gardener%debug gardenlet%up gardenlet%dev gardenlet%debug operator-up operator-dev operator-debug: export SKAFFOLD_PUSH = true
 # use static label for skaffold to prevent rolling all gardener components on every `skaffold` invocation
 gardener%up gardener%dev gardener%debug gardener%down gardenlet%up gardenlet%dev gardenlet%debug gardenlet%down: export SKAFFOLD_LABEL = skaffold.dev/run-id=gardener-local

--- a/charts/gardener/controlplane/charts/runtime/templates/admission-controller/deployment.yaml
+++ b/charts/gardener/controlplane/charts/runtime/templates/admission-controller/deployment.yaml
@@ -78,6 +78,7 @@ spec:
         resources:
 {{ toYaml .Values.global.admission.resources | indent 10 }}
         {{- end }}
+        {{- if not .Values.global.admission.config.server.healthProbes.disable }}
         livenessProbe:
           httpGet:
             path: /healthz
@@ -92,6 +93,7 @@ spec:
             scheme: HTTP
           initialDelaySeconds: 10
           timeoutSeconds: 5
+        {{- end }}
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:

--- a/charts/gardener/controlplane/charts/runtime/templates/admission-controller/deployment.yaml
+++ b/charts/gardener/controlplane/charts/runtime/templates/admission-controller/deployment.yaml
@@ -78,7 +78,7 @@ spec:
         resources:
 {{ toYaml .Values.global.admission.resources | indent 10 }}
         {{- end }}
-        {{- if not .Values.global.admission.config.server.healthProbes.disable }}
+        {{- if .Values.global.admission.config.server.healthProbes.enable }}
         livenessProbe:
           httpGet:
             path: /healthz

--- a/charts/gardener/controlplane/charts/runtime/templates/apiserver/deployment.yaml
+++ b/charts/gardener/controlplane/charts/runtime/templates/apiserver/deployment.yaml
@@ -270,7 +270,7 @@ spec:
         - --log-level={{ .Values.global.apiserver.logLevel | default "info"  }}
         - --log-format={{ .Values.global.apiserver.logFormat | default "json"  }}
         - --v={{ .Values.global.apiserver.logVerbosity | default "2"  }}
-        {{- if not .Values.global.apiserver.livenessProbe.disable }}
+        {{- if .Values.global.apiserver.livenessProbe.enable }}
         livenessProbe:
           httpGet:
             scheme: HTTPS
@@ -282,7 +282,7 @@ spec:
           failureThreshold: {{ .Values.global.apiserver.livenessProbe.failureThreshold }}
           timeoutSeconds: {{ .Values.global.apiserver.livenessProbe.timeoutSeconds }}
         {{- end }}
-        {{- if not .Values.global.apiserver.readinessProbe.disable }}
+        {{- if .Values.global.apiserver.readinessProbe.enable }}
         readinessProbe:
           httpGet:
             scheme: HTTPS

--- a/charts/gardener/controlplane/charts/runtime/templates/apiserver/deployment.yaml
+++ b/charts/gardener/controlplane/charts/runtime/templates/apiserver/deployment.yaml
@@ -270,6 +270,7 @@ spec:
         - --log-level={{ .Values.global.apiserver.logLevel | default "info"  }}
         - --log-format={{ .Values.global.apiserver.logFormat | default "json"  }}
         - --v={{ .Values.global.apiserver.logVerbosity | default "2"  }}
+        {{- if not .Values.global.apiserver.livenessProbe.disable }}
         livenessProbe:
           httpGet:
             scheme: HTTPS
@@ -280,6 +281,8 @@ spec:
           successThreshold: {{ .Values.global.apiserver.livenessProbe.successThreshold }}
           failureThreshold: {{ .Values.global.apiserver.livenessProbe.failureThreshold }}
           timeoutSeconds: {{ .Values.global.apiserver.livenessProbe.timeoutSeconds }}
+        {{- end }}
+        {{- if not .Values.global.apiserver.readinessProbe.disable }}
         readinessProbe:
           httpGet:
             scheme: HTTPS
@@ -290,6 +293,7 @@ spec:
           successThreshold: {{ .Values.global.apiserver.readinessProbe.successThreshold }}
           failureThreshold: {{ .Values.global.apiserver.readinessProbe.failureThreshold }}
           timeoutSeconds: {{ .Values.global.apiserver.readinessProbe.timeoutSeconds }}
+        {{- end }}
         {{- if .Values.global.apiserver.resources }}
         resources:
 {{ toYaml .Values.global.apiserver.resources | indent 10 }}

--- a/charts/gardener/controlplane/charts/runtime/templates/controller-manager/deployment.yaml
+++ b/charts/gardener/controlplane/charts/runtime/templates/controller-manager/deployment.yaml
@@ -94,6 +94,7 @@ spec:
         dnsConfig:
 {{ toYaml .Values.global.controller.dnsConfig | indent 10 }}
         {{- end }}
+        {{- if not .Values.global.controller.config.server.healthProbes.disable }}
         livenessProbe:
           httpGet:
             path: /healthz
@@ -108,6 +109,7 @@ spec:
             scheme: HTTP
           initialDelaySeconds: 10
           timeoutSeconds: 5
+        {{- end }}
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:

--- a/charts/gardener/controlplane/charts/runtime/templates/controller-manager/deployment.yaml
+++ b/charts/gardener/controlplane/charts/runtime/templates/controller-manager/deployment.yaml
@@ -94,7 +94,7 @@ spec:
         dnsConfig:
 {{ toYaml .Values.global.controller.dnsConfig | indent 10 }}
         {{- end }}
-        {{- if not .Values.global.controller.config.server.healthProbes.disable }}
+        {{- if .Values.global.controller.config.server.healthProbes.enable }}
         livenessProbe:
           httpGet:
             path: /healthz

--- a/charts/gardener/controlplane/charts/runtime/templates/scheduler/deployment.yaml
+++ b/charts/gardener/controlplane/charts/runtime/templates/scheduler/deployment.yaml
@@ -77,6 +77,7 @@ spec:
         resources:
 {{ toYaml .Values.global.scheduler.resources | indent 10 }}
         {{- end }}
+        {{- if not .Values.global.scheduler.config.server.healthProbes.disable }}
         livenessProbe:
           httpGet:
             path: /healthz
@@ -91,6 +92,7 @@ spec:
             scheme: HTTP
           initialDelaySeconds: 10
           timeoutSeconds: 5
+        {{- end }}
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:

--- a/charts/gardener/controlplane/charts/runtime/templates/scheduler/deployment.yaml
+++ b/charts/gardener/controlplane/charts/runtime/templates/scheduler/deployment.yaml
@@ -77,7 +77,7 @@ spec:
         resources:
 {{ toYaml .Values.global.scheduler.resources | indent 10 }}
         {{- end }}
-        {{- if not .Values.global.scheduler.config.server.healthProbes.disable }}
+        {{- if .Values.global.scheduler.config.server.healthProbes.enable }}
         livenessProbe:
           httpGet:
             path: /healthz

--- a/charts/gardener/controlplane/values.yaml
+++ b/charts/gardener/controlplane/values.yaml
@@ -17,12 +17,16 @@ global:
       tag: latest
       pullPolicy: IfNotPresent
     livenessProbe:
+      # health probes should be disabled for debugging purposes only
+      disable: false
       initialDelaySeconds: 15
       periodSeconds: 10
       successThreshold: 1
       failureThreshold: 3
       timeoutSeconds: 15
     readinessProbe:
+      # health probes should be disabled for debugging purposes only
+      disable: false
       initialDelaySeconds: 15
       periodSeconds: 10
       successThreshold: 1
@@ -319,6 +323,8 @@ global:
               ...
               -----END RSA PRIVATE KEY-----
         healthProbes:
+          # health probes should be disabled for debugging purposes only
+          disable: false
           port: 2722
         metrics:
           port: 2723
@@ -444,6 +450,8 @@ global:
       logLevel: info
       server:
         healthProbes:
+          # health probes should be disabled for debugging purposes only
+          disable: false
           port: 2718
         metrics:
           port: 2719
@@ -489,6 +497,8 @@ global:
       logLevel: info
       server:
         healthProbes:
+          # health probes should be disabled for debugging purposes only
+          disable: false
           port: 10251
         metrics:
           port: 19251

--- a/charts/gardener/controlplane/values.yaml
+++ b/charts/gardener/controlplane/values.yaml
@@ -18,7 +18,7 @@ global:
       pullPolicy: IfNotPresent
     livenessProbe:
       # health probes should be disabled for debugging purposes only
-      disable: false
+      enable: true
       initialDelaySeconds: 15
       periodSeconds: 10
       successThreshold: 1
@@ -26,7 +26,7 @@ global:
       timeoutSeconds: 15
     readinessProbe:
       # health probes should be disabled for debugging purposes only
-      disable: false
+      enable: true
       initialDelaySeconds: 15
       periodSeconds: 10
       successThreshold: 1
@@ -324,7 +324,7 @@ global:
               -----END RSA PRIVATE KEY-----
         healthProbes:
           # health probes should be disabled for debugging purposes only
-          disable: false
+          enable: true
           port: 2722
         metrics:
           port: 2723
@@ -451,7 +451,7 @@ global:
       server:
         healthProbes:
           # health probes should be disabled for debugging purposes only
-          disable: false
+          enable: true
           port: 2718
         metrics:
           port: 2719
@@ -498,7 +498,7 @@ global:
       server:
         healthProbes:
           # health probes should be disabled for debugging purposes only
-          disable: false
+          enable: true
           port: 10251
         metrics:
           port: 19251

--- a/charts/gardener/gardenlet/templates/deployment.yaml
+++ b/charts/gardener/gardenlet/templates/deployment.yaml
@@ -102,6 +102,7 @@ spec:
         {{- end }}
         {{- end }}
         {{- end }}
+        {{- if not .Values.config.server.healthProbes.disable }}
         livenessProbe:
           httpGet:
             path: /healthz
@@ -116,6 +117,7 @@ spec:
             scheme: HTTP
           initialDelaySeconds: 10
           timeoutSeconds: 5
+        {{- end }}
         {{- if .Values.resources }}
         resources:
 {{ toYaml .Values.resources | indent 10 }}

--- a/charts/gardener/gardenlet/templates/deployment.yaml
+++ b/charts/gardener/gardenlet/templates/deployment.yaml
@@ -102,7 +102,7 @@ spec:
         {{- end }}
         {{- end }}
         {{- end }}
-        {{- if not .Values.config.server.healthProbes.disable }}
+        {{- if .Values.config.server.healthProbes.enable }}
         livenessProbe:
           httpGet:
             path: /healthz

--- a/charts/gardener/gardenlet/values.yaml
+++ b/charts/gardener/gardenlet/values.yaml
@@ -138,6 +138,8 @@ config:
   logFormat: json
   server:
     healthProbes:
+      # health probes should be disabled for debugging purposes only
+      disable: false
       port: 2728
     metrics:
       port: 2729

--- a/charts/gardener/gardenlet/values.yaml
+++ b/charts/gardener/gardenlet/values.yaml
@@ -139,7 +139,7 @@ config:
   server:
     healthProbes:
       # health probes should be disabled for debugging purposes only
-      disable: false
+      enable: true
       port: 2728
     metrics:
       port: 2729

--- a/charts/gardener/operator/templates/deployment.yaml
+++ b/charts/gardener/operator/templates/deployment.yaml
@@ -91,6 +91,7 @@ spec:
         {{- end }}
         {{- end }}
         {{- end }}
+        {{- if not .Values.config.server.healthProbes.disable }}
         livenessProbe:
           httpGet:
             path: /healthz
@@ -105,6 +106,7 @@ spec:
             scheme: HTTP
           initialDelaySeconds: 10
           timeoutSeconds: 5
+        {{- end }}
         {{- if .Values.resources }}
         resources:
 {{ toYaml .Values.resources | indent 10 }}

--- a/charts/gardener/operator/templates/deployment.yaml
+++ b/charts/gardener/operator/templates/deployment.yaml
@@ -91,7 +91,7 @@ spec:
         {{- end }}
         {{- end }}
         {{- end }}
-        {{- if not .Values.config.server.healthProbes.disable }}
+        {{- if .Values.config.server.healthProbes.enable }}
         livenessProbe:
           httpGet:
             path: /healthz

--- a/charts/gardener/operator/values.yaml
+++ b/charts/gardener/operator/values.yaml
@@ -42,7 +42,7 @@ config:
       port: 2750
     healthProbes:
       # health probes should be disabled for debugging purposes only
-      disable: false
+      enable: true
       port: 2751
     metrics:
       port: 2752

--- a/charts/gardener/operator/values.yaml
+++ b/charts/gardener/operator/values.yaml
@@ -41,6 +41,8 @@ config:
     webhooks:
       port: 2750
     healthProbes:
+      # health probes should be disabled for debugging purposes only
+      disable: false
       port: 2751
     metrics:
       port: 2752

--- a/docs/deployment/getting_started_locally.md
+++ b/docs/deployment/getting_started_locally.md
@@ -136,14 +136,11 @@ Please check your console output for the concrete port-forwarding on your machin
 > Note: Resuming or stopping only a single goroutine (Go Issue [25578](https://github.com/golang/go/issues/25578), [31132](https://github.com/golang/go/issues/31132)) is currently not supported, so the action will cause all the goroutines to get activated or paused.
 ([vscode-go wiki](https://github.com/golang/vscode-go/wiki/debugging#connecting-to-headless-delve-with-target-specified-at-server-start-up))
 
-This means that when a goroutine of gardenlet (or any other gardener-core component you try to debug) is paused on a breakpoint, all the other goroutines are paused. Hence, when the whole gardenlet process is paused, it can not renew its lease and can not respond to the liveness and readiness probes. Skaffold automatically increases `timeoutSeconds` of liveness and readiness probes to 600. In our local setups the gardener-core components should run with one replica only, so leases which are not renewed should not cause problems. Anyway, if you face problems when debugging, you could temporarily turn off the leader election e.g. by adding
+This means that when a goroutine of gardenlet (or any other gardener-core component you try to debug) is paused on a breakpoint, all the other goroutines are paused. Hence, when the whole gardenlet process is paused, it can not renew its lease and can not respond to the liveness and readiness probes. Skaffold automatically increases `timeoutSeconds` of liveness and readiness probes to 600. Anyway, we were facing problems when debugging that pods have been killed after a while.
 
-```
-  leaderElection:
-    leaderElect: false
-```
+Thus, leader election, health and readiness checks for `gardener-admission-controller`, `gardener-apiserver`, `gardener-controller-manager`, `gardener-scheduler`,`gardenlet` and `operator` are disabled when debugging.
 
-to `example/gardener-local/gardenlet/values.yaml` and disable liveness and readiness probes.
+If you have similar problems with other components which are not deployed by skaffold, you could temporarily turn off the leader election and disable liveness and readiness probes there too.
 
 ## Creating a `Shoot` Cluster
 

--- a/skaffold-operator.yaml
+++ b/skaffold-operator.yaml
@@ -253,12 +253,8 @@ profiles:
   - command: debug
   patches:
   - op: add
-    path: /deploy/helm/releases/0/setValueTemplates
+    path: /deploy/helm/releases/0/setValues
     value:
       replicaCount: 1
-      config:
-        leaderElection:
-          leaderElect: false
-        server:
-          healthProbes:
-            disable: true
+      config.leaderElection.leaderElect: false
+      config.server.healthProbes.enable: false

--- a/skaffold-operator.yaml
+++ b/skaffold-operator.yaml
@@ -247,3 +247,18 @@ deploy:
         replicaCount: 2
       createNamespace: true
       wait: true
+profiles:
+- name: debug
+  activation:
+  - command: debug
+  patches:
+  - op: add
+    path: /deploy/helm/releases/0/setValueTemplates
+    value:
+      replicaCount: 1
+      config:
+        leaderElection:
+          leaderElect: false
+        server:
+          healthProbes:
+            disable: true

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -516,6 +516,42 @@ profiles:
     value:
       global.admission.service.clusterIP: fd00:10:2::1000
       global.apiserver.featureGates.IPv6SingleStack: true
+- name: debug
+  activation:
+  - command: debug
+  patches:
+  - op: add
+    path: /deploy/helm/releases/0/setValueTemplates
+    value:
+      global:
+        apiserver:
+          replicaCount: 1
+          livenessProbe:
+            disable: true
+          readinessProbe:
+            disable: true
+        admission:
+          replicaCount: 1
+          config:
+            server:
+              healthProbes:
+                disable: true
+        controller:
+          replicaCount: 1
+          config:
+            leaderElection:
+              leaderElect: false
+            server:
+              healthProbes:
+                disable: true
+        scheduler:
+          replicaCount: 1
+          config:
+            leaderElection:
+              leaderElect: false
+            server:
+              healthProbes:
+                disable: true
 ---
 apiVersion: skaffold/v4beta3
 kind: Config
@@ -1122,7 +1158,6 @@ profiles:
     - bash
     - -ec
     - TIMEOUT=1200 hack/usage/wait-for.sh seed local-ha-multi-zone GardenletReady Bootstrapped SeedSystemComponentsHealthy ExtensionsReady BackupBucketsReady
-
 - name: ipv6
   activation:
   - env: IPFAMILY=ipv6
@@ -1130,3 +1165,18 @@ profiles:
   - op: add
     path: /deploy/helm/releases/0/valuesFiles/-
     value: example/gardener-local/gardenlet/values-ipv6.yaml
+- name: debug
+  activation:
+  - command: debug
+  patches:
+  - op: add
+    path: /deploy/helm/releases/0/setValueTemplates
+    value:
+      replicaCount: 1
+      config:
+        leaderElection:
+          leaderElect: false
+        server:
+          healthProbes:
+            disable: true
+

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -493,17 +493,11 @@ profiles:
 - name: extensions
   patches:
   - op: add
-    path: /deploy/helm/releases/0/setValueTemplates
+    path: /deploy/helm/releases/0/setValues
     value:
-      global:
-        apiserver:
-          clusterIdentity: gardener-extensions
-        scheduler:
-          config:
-            schedulers:
-              shoot:
-                candidateDeterminationStrategy: MinimalDistance
-                concurrentSyncs: 5
+      global.apiserver.clusterIdentity: gardener-extensions
+      global.scheduler.config.schedulers.shoot.candidateDeterminationStrategy: MinimalDistance
+      global.scheduler.config.schedulers.shoot.concurrentSyncs: 5
   - op: add
     path: /deploy/helm/releases/0/valuesFiles/-
     value: example/provider-extensions/garden/controlplane/values.yaml
@@ -521,37 +515,19 @@ profiles:
   - command: debug
   patches:
   - op: add
-    path: /deploy/helm/releases/0/setValueTemplates
+    path: /deploy/helm/releases/0/setValues
     value:
-      global:
-        apiserver:
-          replicaCount: 1
-          livenessProbe:
-            disable: true
-          readinessProbe:
-            disable: true
-        admission:
-          replicaCount: 1
-          config:
-            server:
-              healthProbes:
-                disable: true
-        controller:
-          replicaCount: 1
-          config:
-            leaderElection:
-              leaderElect: false
-            server:
-              healthProbes:
-                disable: true
-        scheduler:
-          replicaCount: 1
-          config:
-            leaderElection:
-              leaderElect: false
-            server:
-              healthProbes:
-                disable: true
+      global.apiserver.replicaCount: 1
+      global.apiserver.livenessProbe.enable: false
+      global.apiserver.readinessProbe.enable: false
+      global.admission.replicaCount: 1
+      global.admission.config.server.healthProbes.enable: false
+      global.controller.replicaCount: 1
+      global.controller.config.leaderElection.leaderElect: false
+      global.controller.config.server.healthProbes.enable: false
+      global.scheduler.replicaCount: 1
+      global.scheduler.config.leaderElection.leaderElect: false
+      global.scheduler.config.server.healthProbes.enable: false
 ---
 apiVersion: skaffold/v4beta3
 kind: Config
@@ -1170,13 +1146,8 @@ profiles:
   - command: debug
   patches:
   - op: add
-    path: /deploy/helm/releases/0/setValueTemplates
+    path: /deploy/helm/releases/0/setValues
     value:
       replicaCount: 1
-      config:
-        leaderElection:
-          leaderElect: false
-        server:
-          healthProbes:
-            disable: true
-
+      config.leaderElection.leaderElect: false
+      config.server.healthProbes.enable: false


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
This PR improves debugging experience by disabling leader election, health and readiness checks for `gardener-admission-controller`, `gardener-apiserver`, `gardener-controller-manager`, `gardener-scheduler`, `gardenlet` and `operator`  when running `make *-debug`.
Additionally, `replicas` are set to 1 for these deployments.

`gardener-resource-manager` is deployed by gardenlet and operator, thus it is not possible to use skaffold for debugging here. 

**Which issue(s) this PR fixes**:
Part of #6016

**Special notes for your reviewer**:
Improves #7755

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
Deactivate leader election, health and readiness checks when running `make *-debug.`
```
