### PR TITLE
refactor loki init container script turning it to a best effort init

### DIFF
--- a/charts/seed-bootstrap/charts/loki/templates/_helpers.tpl
+++ b/charts/seed-bootstrap/charts/loki/templates/_helpers.tpl
@@ -49,6 +49,18 @@ curator.yaml: |-
     MinFreePercentages: 10
     TargetFreePercentages: 15
     PageSizeForDeletionPercentages: 1
+loki-init.sh: |-
+  #!/bin/bash
+  set -o errexit
+  
+  function error() {
+      exit_code=$?
+      echo "${BASH_COMMAND} failed, exit code $exit_code"
+  }
+  
+  trap error ERR
+  
+  tune2fs -O large_dir $(mount | gawk '{if($3=="/data") {print $1}}')    
 {{- end -}}
 
 {{- define "loki.config.name" -}}

--- a/charts/seed-bootstrap/charts/loki/templates/statefulset.yaml
+++ b/charts/seed-bootstrap/charts/loki/templates/statefulset.yaml
@@ -44,9 +44,9 @@ spec:
       priorityClassName: {{ .Values.priorityClassName }}
       initContainers:
       - command:
-        - bash
-        - -c
-        - tune2fs -O large_dir $(mount | gawk '{if($3=="/data") {print $1}}')
+          - bash
+          - -c
+          - /loki-init.sh || true
         image: {{ index .Values.global.images "tune2fs" }}
         name: init-large-dir
         securityContext:
@@ -57,6 +57,9 @@ spec:
         volumeMounts:
         - mountPath: /data
           name: loki
+        - name: config
+          mountPath: /loki-init.sh
+          subPath: loki-init.sh
       containers:
 {{- if .Values.rbacSidecarEnabled }}
         - name: kube-rbac-proxy
@@ -152,7 +155,7 @@ spec:
             {{- toYaml .Values.resources.curator | nindent 12 }}
           volumeMounts:
             - name: config
-              mountPath: /etc/loki
+              mountPath: /etc/loki              
             - name: loki
               mountPath: "/data"
           securityContext:
@@ -162,6 +165,7 @@ spec:
         - name: config
           configMap:
             name: {{ include "loki.config.name" . }}
+            defaultMode: 0520
 {{- if .Values.rbacSidecarEnabled }}
         - name: kubeconfig
           projected:


### PR DESCRIPTION
/area logging
/kind flake

This PR improves the `loki` init container script by preventing it from failing. Changing the property of the file system is a best effort type of operation and may or may not succeed. In both cases the main container shall start and can and will function normally. Hence the init operation is not critical. 

```other developer
Improves testing flakiness of logging testmachinery test by making the loki init-container reliable. 
```
