### PR TITLE
Protect `Secret`s/`ConfigMap`s referenced in `.spec.resources` of `Shoot`s with finalizer

### DIFF
--- a/pkg/controllermanager/controller/shoot/reference/reconciler.go
+++ b/pkg/controllermanager/controller/shoot/reference/reconciler.go
@@ -136,8 +136,7 @@ func (r *Reconciler) handleReferencedSecrets(ctx context.Context, log logr.Logge
 		name := secretName
 		fns = append(fns, func(ctx context.Context) error {
 			secret := &corev1.Secret{}
-			s := shoot
-			if err := c.Get(ctx, kubernetesutils.Key(s.Namespace, name), secret); err != nil {
+			if err := c.Get(ctx, kubernetesutils.Key(shoot.Namespace, name), secret); err != nil {
 				return err
 			}
 
@@ -177,8 +176,7 @@ func (r *Reconciler) handleReferencedConfigMap(ctx context.Context, log logr.Log
 		name := configMapName
 		fns = append(fns, func(ctx context.Context) error {
 			configMap := &corev1.ConfigMap{}
-			s := shoot
-			if err := c.Get(ctx, kubernetesutils.Key(s.Namespace, name), configMap); err != nil {
+			if err := c.Get(ctx, kubernetesutils.Key(shoot.Namespace, name), configMap); err != nil {
 				return err
 			}
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind enhancement

**What this PR does / why we need it**:
Similar to other `Secret`/`ConfigMap` references in the `Shoot`, with this PR we are now also protecting those referenced in `.spec.resources` of `Shoot`s with a finalizer. This makes sure that such resources do not disappear from the system as long as they are still referenced somewhere.

**Which issue(s) this PR fixes**:
Fixes #7846

**Special notes for your reviewer**:
/cc @timuthy 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
`Secret`s/`ConfigMap`s referenced in `.spec.resources` of `Shoot`s are now protected with a finalizer to ensure they do not disappear from the system as long as they are still referenced somewhere.
```
