### PR TITLE
Remove migration code for conditional deployment of `cluster-identity`

### DIFF
--- a/pkg/gardenlet/controller/seed/seed/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/seed/seed/reconciler_reconcile.go
@@ -914,17 +914,6 @@ func (r *Reconciler) runReconcileSeedFlow(
 			Name: "Deploying cluster-identity",
 			Fn:   clusteridentity.NewForSeed(seedClient, r.GardenNamespace, *seed.GetInfo().Status.ClusterIdentity).Deploy,
 		})
-	} else {
-		// This is the migration scenario for the "cluster-identity" managed resource.
-		// In the first step the "cluster-identity" config map is annotated with "resources.gardener.cloud/mode: Ignore"
-		// In the second step (next release) the migration managed resource will be destroyed.
-		// In the last step the migration scenario will be removed entirely.
-		// TODO(oliver-goetz): Remove this migration scenario in a future release.
-		clusterIdentity := clusteridentity.NewIgnoredManagedResourceForSeed(seedClient, r.GardenNamespace, "")
-		_ = g.Add(flow.Task{
-			Name: "Destroying cluster-identity migration",
-			Fn:   component.OpDestroyAndWait(clusterIdentity).Destroy,
-		})
 	}
 
 	// When the seed is the garden cluster then the following components are reconciled by the gardener-operator.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind cleanup

**What this PR does / why we need it**:
This PR represents the third step of the migration scenario defined in https://github.com/gardener/gardener/pull/7436.

For recap, these are the migration steps.
1. Annotate the content of `cluster-identity`  managed resource of the seed with `resources.gardener.cloud/mode: Ignore` if `cluster-identity` config map is already existing.
  Switch `cluster-identity` config maps originated by the shoots to immutable.
2. Delete `cluster-identity` config map in the same case.
    Switch `cluster-identity` config maps originated by gardener-apiserver and the seeds to immutable. 
3. Remove the migration code.

**Which issue(s) this PR fixes**:
Fixes #6896 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
