### PR TITLE
gardener-apiserver: Fix the kubelet version constraint validation to cover the Shoot K8s version update

### DIFF
--- a/pkg/apis/core/helper/helpers.go
+++ b/pkg/apis/core/helper/helpers.go
@@ -213,6 +213,22 @@ func SeedSettingTopologyAwareRoutingEnabled(settings *core.SeedSettings) bool {
 	return settings != nil && settings.TopologyAwareRouting != nil && settings.TopologyAwareRouting.Enabled
 }
 
+// FindMachineImageVersion finds the machine image version in the <cloudProfile> for the given <name> and <version>.
+// In case no machine image version can be found with the given <name> or <version>, false is being returned.
+func FindMachineImageVersion(machineImages []core.MachineImage, name, version string) (core.MachineImageVersion, bool) {
+	for _, image := range machineImages {
+		if image.Name == name {
+			for _, imageVersion := range image.Versions {
+				if imageVersion.Version == version {
+					return imageVersion, true
+				}
+			}
+		}
+	}
+
+	return core.MachineImageVersion{}, false
+}
+
 // ShootUsesUnmanagedDNS returns true if the shoot's DNS section is marked as 'unmanaged'.
 func ShootUsesUnmanagedDNS(shoot *core.Shoot) bool {
 	if shoot.Spec.DNS == nil {

--- a/pkg/apis/core/helper/helpers_test.go
+++ b/pkg/apis/core/helper/helpers_test.go
@@ -532,6 +532,54 @@ var _ = Describe("helper", func() {
 		Entry("topology-aware routing disabled", &core.SeedSettings{TopologyAwareRouting: &core.SeedSettingTopologyAwareRouting{Enabled: false}}, false),
 	)
 
+	Describe("#FindMachineImageVersion", func() {
+		var machineImages []core.MachineImage
+
+		BeforeEach(func() {
+			machineImages = []core.MachineImage{
+				{
+					Name: "coreos",
+					Versions: []core.MachineImageVersion{
+						{
+							ExpirableVersion: core.ExpirableVersion{
+								Version: "0.0.2",
+							},
+						},
+						{
+							ExpirableVersion: core.ExpirableVersion{
+								Version: "0.0.3",
+							},
+						},
+					},
+				},
+			}
+		})
+
+		It("should find the machine image version when it exists", func() {
+			expected := core.MachineImageVersion{
+				ExpirableVersion: core.ExpirableVersion{
+					Version: "0.0.3",
+				},
+			}
+
+			actual, ok := FindMachineImageVersion(machineImages, "coreos", "0.0.3")
+			Expect(ok).To(BeTrue())
+			Expect(actual).To(Equal(expected))
+		})
+
+		It("should return false when machine image with the given name does not exist", func() {
+			actual, ok := FindMachineImageVersion(machineImages, "foo", "0.0.3")
+			Expect(ok).To(BeFalse())
+			Expect(actual).To(Equal(core.MachineImageVersion{}))
+		})
+
+		It("should return false when machine image version with the given version does not exist", func() {
+			actual, ok := FindMachineImageVersion(machineImages, "coreos", "0.0.4")
+			Expect(ok).To(BeFalse())
+			Expect(actual).To(Equal(core.MachineImageVersion{}))
+		})
+	})
+
 	classificationPreview := core.ClassificationPreview
 	classificationDeprecated := core.ClassificationDeprecated
 	classificationSupported := core.ClassificationSupported

--- a/pkg/apis/core/v1beta1/helper/helper.go
+++ b/pkg/apis/core/v1beta1/helper/helper.go
@@ -532,18 +532,18 @@ func DetermineMachineImageForName(cloudProfile *gardencorev1beta1.CloudProfile, 
 
 // FindMachineImageVersion finds the machine image version in the <cloudProfile> for the given <name> and <version>.
 // In case no machine image version can be found with the given <name> or <version>, false is being returned.
-func FindMachineImageVersion(cloudProfile *gardencorev1beta1.CloudProfile, name, version string) (bool, gardencorev1beta1.MachineImageVersion) {
-	for _, image := range cloudProfile.Spec.MachineImages {
+func FindMachineImageVersion(machineImages []gardencorev1beta1.MachineImage, name, version string) (gardencorev1beta1.MachineImageVersion, bool) {
+	for _, image := range machineImages {
 		if image.Name == name {
 			for _, imageVersion := range image.Versions {
 				if imageVersion.Version == version {
-					return true, imageVersion
+					return imageVersion, true
 				}
 			}
 		}
 	}
 
-	return false, gardencorev1beta1.MachineImageVersion{}
+	return gardencorev1beta1.MachineImageVersion{}, false
 }
 
 // ShootMachineImageVersionExists checks if the shoot machine image (name, version) exists in the machine image constraint and returns true if yes and the index in the versions slice

--- a/pkg/apis/core/v1beta1/helper/helper_test.go
+++ b/pkg/apis/core/v1beta1/helper/helper_test.go
@@ -910,25 +910,21 @@ var _ = Describe("helper", func() {
 	)
 
 	Describe("#FindMachineImageVersion", func() {
-		var cloudProfile *gardencorev1beta1.CloudProfile
+		var machineImages []gardencorev1beta1.MachineImage
 
 		BeforeEach(func() {
-			cloudProfile = &gardencorev1beta1.CloudProfile{
-				Spec: gardencorev1beta1.CloudProfileSpec{
-					MachineImages: []gardencorev1beta1.MachineImage{
+			machineImages = []gardencorev1beta1.MachineImage{
+				{
+					Name: "coreos",
+					Versions: []gardencorev1beta1.MachineImageVersion{
 						{
-							Name: "coreos",
-							Versions: []gardencorev1beta1.MachineImageVersion{
-								{
-									ExpirableVersion: gardencorev1beta1.ExpirableVersion{
-										Version: "0.0.2",
-									},
-								},
-								{
-									ExpirableVersion: gardencorev1beta1.ExpirableVersion{
-										Version: "0.0.3",
-									},
-								},
+							ExpirableVersion: gardencorev1beta1.ExpirableVersion{
+								Version: "0.0.2",
+							},
+						},
+						{
+							ExpirableVersion: gardencorev1beta1.ExpirableVersion{
+								Version: "0.0.3",
 							},
 						},
 					},
@@ -943,20 +939,20 @@ var _ = Describe("helper", func() {
 				},
 			}
 
-			found, actual := FindMachineImageVersion(cloudProfile, "coreos", "0.0.3")
-			Expect(found).To(BeTrue())
+			actual, ok := FindMachineImageVersion(machineImages, "coreos", "0.0.3")
+			Expect(ok).To(BeTrue())
 			Expect(actual).To(Equal(expected))
 		})
 
 		It("should return false when machine image with the given name does not exist", func() {
-			found, actual := FindMachineImageVersion(cloudProfile, "foo", "0.0.3")
-			Expect(found).To(BeFalse())
+			actual, ok := FindMachineImageVersion(machineImages, "foo", "0.0.3")
+			Expect(ok).To(BeFalse())
 			Expect(actual).To(Equal(gardencorev1beta1.MachineImageVersion{}))
 		})
 
 		It("should return false when machine image version with the given version does not exist", func() {
-			found, actual := FindMachineImageVersion(cloudProfile, "coreos", "0.0.4")
-			Expect(found).To(BeFalse())
+			actual, ok := FindMachineImageVersion(machineImages, "coreos", "0.0.4")
+			Expect(ok).To(BeFalse())
 			Expect(actual).To(Equal(gardencorev1beta1.MachineImageVersion{}))
 		})
 	})

--- a/pkg/apis/core/validation/cloudprofile_test.go
+++ b/pkg/apis/core/validation/cloudprofile_test.go
@@ -617,7 +617,7 @@ var _ = Describe("CloudProfile Validation Tests ", func() {
 					}))))
 				})
 
-				It("should allow valid kubeletVersionConstraint constraint for machine image versions", func() {
+				It("should allow valid kubeletVersionConstraint for machine image versions", func() {
 					cloudProfile.Spec.MachineImages = []core.MachineImage{
 						{
 							Name: "some-machineimage",
@@ -644,7 +644,7 @@ var _ = Describe("CloudProfile Validation Tests ", func() {
 					Expect(errorList).To(BeEmpty())
 				})
 
-				It("should forbid invalid kubeletVersionConstraint constraint for machine image versions", func() {
+				It("should forbid invalid kubeletVersionConstraint for machine image versions", func() {
 					cloudProfile.Spec.MachineImages = []core.MachineImage{
 						{
 							Name: "some-machineimage",

--- a/pkg/controllermanager/controller/shoot/maintenance/reconciler_test.go
+++ b/pkg/controllermanager/controller/shoot/maintenance/reconciler_test.go
@@ -365,7 +365,7 @@ var _ = Describe("Shoot Maintenance", func() {
 			assertWorkerMachineImageVersion(&shoot.Spec.Provider.Workers[2], "CoreOs", "1.1.1")
 		})
 
-		It("should determine that the shoot worker machine images must not be maintained - found no machineImageVersion with matching kubeletVersionConstraint constraint (control plane K8s version)", func() {
+		It("should determine that the shoot worker machine images must not be maintained - found no machineImageVersion with matching kubeletVersionConstraint (control plane K8s version)", func() {
 			cloudProfile.Spec.MachineImages[0].Versions[1].KubeletVersionConstraint = pointer.String("< 1.26")
 			shoot.Spec.Kubernetes.Version = "1.26.0"
 
@@ -375,7 +375,7 @@ var _ = Describe("Shoot Maintenance", func() {
 			Expect(shoot.Spec.Provider.Workers[0].Machine.Image).To(Equal(expected))
 		})
 
-		It("should determine that the shoot worker machine images must be maintained - found machineImageVersion with matching kubeletVersionConstraint constraint (control plane K8s version)", func() {
+		It("should determine that the shoot worker machine images must be maintained - found machineImageVersion with matching kubeletVersionConstraint (control plane K8s version)", func() {
 			cloudProfile.Spec.MachineImages[0].Versions[1].KubeletVersionConstraint = pointer.String("< 1.26")
 			shoot.Spec.Kubernetes.Version = "1.25.1"
 
@@ -384,7 +384,7 @@ var _ = Describe("Shoot Maintenance", func() {
 			assertWorkerMachineImageVersion(&shoot.Spec.Provider.Workers[0], "CoreOs", "1.1.1")
 		})
 
-		It("should determine that the shoot worker machine images must not be maintained - found no machineImageVersion with matching kubeletVersionConstraint constraint (worker K8s version)", func() {
+		It("should determine that the shoot worker machine images must not be maintained - found no machineImageVersion with matching kubeletVersionConstraint (worker K8s version)", func() {
 			cloudProfile.Spec.MachineImages[0].Versions[1].KubeletVersionConstraint = pointer.String(">= 1.26")
 			shoot.Spec.Kubernetes.Version = "1.26.0"
 			shoot.Spec.Provider.Workers[0].Kubernetes = &gardencorev1beta1.WorkerKubernetes{
@@ -397,7 +397,7 @@ var _ = Describe("Shoot Maintenance", func() {
 			Expect(shoot.Spec.Provider.Workers[0].Machine.Image).To(Equal(expected))
 		})
 
-		It("should determine that the shoot worker machine images must be maintained - found machineImageVersion with matching kubeletVersionConstraint constraint (worker K8s version)", func() {
+		It("should determine that the shoot worker machine images must be maintained - found machineImageVersion with matching kubeletVersionConstraint (worker K8s version)", func() {
 			assertWorkerMachineImageVersion(&shoot.Spec.Provider.Workers[0], "CoreOs", "1.0.0")
 			cloudProfile.Spec.MachineImages[0].Versions[1].KubeletVersionConstraint = pointer.String(">= 1.26")
 			shoot.Spec.Kubernetes.Version = "1.27.0"

--- a/test/integration/controllermanager/shoot/maintenance/utils_test.go
+++ b/test/integration/controllermanager/shoot/maintenance/utils_test.go
@@ -46,8 +46,8 @@ func waitMachineImageVersionToBeExpiredInCloudProfile(cloudProfileName, imageNam
 		cloudProfile := &gardencorev1beta1.CloudProfile{}
 		g.Expect(mgrClient.Get(ctx, client.ObjectKey{Name: cloudProfileName}, cloudProfile)).To(Succeed())
 
-		found, machineImageVersion := v1beta1helper.FindMachineImageVersion(cloudProfile, imageName, imageVersion)
-		g.Expect(found).To(BeTrue())
+		machineImageVersion, ok := v1beta1helper.FindMachineImageVersion(cloudProfile.Spec.MachineImages, imageName, imageVersion)
+		g.Expect(ok).To(BeTrue())
 		g.Expect(machineImageVersion.Classification).To(PointTo(Equal(gardencorev1beta1.ClassificationDeprecated)))
 		g.Expect(machineImageVersion.ExpirationDate).NotTo(BeNil())
 		g.Expect(machineImageVersion.ExpirationDate.UTC()).To(Equal(expirationDate.UTC()))


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind bug

**What this PR does / why we need it**:
In https://github.com/gardener/gardener/pull/7265 I missed the following case:
1. Create K8s 1.25 Shoot with machine image version with containerd < 1.6.0 (gardenlinux@576.12.0)

2. Update the Shoot to K8s 1.26

Although the machine image has the proper kubeletVersionConstraint in the CloudProfile
```yaml
apiVersion: core.gardener.cloud/v1beta1
kind: CloudProfile
# ...
spec:
  machineImages:
  - name: gardenlinux
    versions:
    - version: 576.12.0 # comes with containerd@1.5.13
      kubeletVersionConstraint: "< 1.26"
```

the update request is not rejected by gardener-apiserver, the Shoot is updated to K8s 1.26 with machine image version that does not support kubelet@v1.26 (see https://kubernetes.io/blog/2022/12/09/kubernetes-v1-26-release/#cri-v1alpha2-removed).

The reason the validation to work for CREATE request and not to cover the above-described UPDATE request is the early exit  in:
https://github.com/gardener/gardener/blob/56d0d1f4bfca4ec85e44c3e3ed57ef6926710319/plugin/pkg/shoot/validator/admission.go#L1321-L1324
If there is no change to the pool's machine image and arch, the `validateMachineImagesConstraints` returns nil. However for the  kubelet version constraint validation we need the validation to execute always (not only on machine image change).

**Which issue(s) this PR fixes**:
See above

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
gardener-apiserver: The kubelet version constraint validation is now fixed to also cover the Shoot K8s version update. Previously it was possible to update the Shoot K8s version to a new minor version when the Shoot has a worker pool with machine image version which kubeletVersionConstraint does not match the new K8s version.
```
