### PR TITLE
Rename httpAccessLogs to httpAccessVerbosity in the shoot example

### DIFF
--- a/example/90-shoot.yaml
+++ b/example/90-shoot.yaml
@@ -202,7 +202,7 @@ spec:
   #     maxTokenExpiration: 45d
   #   logging:
   #     verbosity: 2
-  #     httpAccessLogs: 3
+  #     httpAccessVerbosity: 3
   #   defaultNotReadyTolerationSeconds: 300
   #   defaultUnreachableTolerationSeconds: 300
   # kubeControllerManager:

--- a/example/operator/20-garden.yaml
+++ b/example/operator/20-garden.yaml
@@ -119,7 +119,7 @@ spec:
     #     maxTokenExpiration: 45d
     #   logging:
     #     verbosity: 2
-    #     httpAccessLogs: 3
+    #     httpAccessVerbosity: 3
     #   defaultNotReadyTolerationSeconds: 300
     #   defaultUnreachableTolerationSeconds: 300
     #   sni:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area logging
/kind enhancement

**What this PR does / why we need it**:
The field for enabling http access logs is `httpAccessVerbosity` in the source code but in the shoot example is `httpAccessLogs`. This PR resolves this discrepancy.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
