### PR TITLE
Clarification on static token kubeconfig docs

### DIFF
--- a/docs/usage/shoot_access.md
+++ b/docs/usage/shoot_access.md
@@ -57,7 +57,7 @@ For further information on `(Cluster)OpenIDConnectPreset`, refer to [ClusterOpen
 
 ## Static Token kubeconfig
 
-> **Note:** Static token kubeconfig is deprekated for Shoot clusters using Kubernetes version >= 1.27
+> **Note:** Static token kubeconfig is deprecated for Shoot clusters using Kubernetes version >= 1.27
 
 This `kubeconfig` contains a [static token](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#static-token-file) and provides `cluster-admin` privileges.
 It is created by default and persisted in the `<shoot-name>.kubeconfig` secret in the project namespace in the garden cluster.

--- a/docs/usage/shoot_access.md
+++ b/docs/usage/shoot_access.md
@@ -57,7 +57,7 @@ For further information on `(Cluster)OpenIDConnectPreset`, refer to [ClusterOpen
 
 ## Static Token kubeconfig 
 
-> **Note:** Static token kubeconfig is not available for Shoot clusters created with Kubernetes version >= 1.27. The [`shoots/adminkubeconfig` subresource](#shootsadminkubeconfig-subresource) should be used instead.
+> **Note:** Static token kubeconfig is not available for Shoot clusters using Kubernetes version >= 1.27. The [`shoots/adminkubeconfig` subresource](#shootsadminkubeconfig-subresource) should be used instead.
 
 This `kubeconfig` contains a [static token](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#static-token-file) and provides `cluster-admin` privileges.
 It is created by default and persisted in the `<shoot-name>.kubeconfig` secret in the project namespace in the garden cluster.

--- a/docs/usage/shoot_access.md
+++ b/docs/usage/shoot_access.md
@@ -2,31 +2,6 @@
 
 After creation of a shoot cluster, end-users require a `kubeconfig` to access it. There are several options available to get to such `kubeconfig`.
 
-## Static Token kubeconfig
-
-This `kubeconfig` contains a [static token](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#static-token-file) and provides `cluster-admin` privileges.
-It is created by default and persisted in the `<shoot-name>.kubeconfig` secret in the project namespace in the garden cluster.
-
-```yaml
-apiVersion: core.gardener.cloud/v1beta1
-kind: Shoot
-...
-spec:
-  kubernetes:
-    enableStaticTokenKubeconfig: true
-...
-```
-
-It is **not** the recommended method to access the shoot cluster, as the static token `kubeconfig` has some security flaws associated with it:
-- The static token in the `kubeconfig` doesn't have any expiration date. Read [this document](shoot_credentials_rotation.md#kubeconfig) to learn how to rotate the static token.
-- The static token doesn't have any user identity associated with it. The user in that token will always be `system:cluster-admin`, irrespective of the person accessing the cluster. Hence, it is impossible to audit the events in cluster.
-
-When `enableStaticTokenKubeconfig` field is not explicitly set in the Shoot spec:
-- for Shoot clusters using Kubernetes version < 1.26 the field is defaulted to `true`.
-- for Shoot clusters using Kubernetes version >= 1.26 the field is defaulted to `false`.
-
-> **Note:** Starting with Kubernetes 1.27, the `enableStaticTokenKubeconfig` field will be locked to `false`. The [`shoots/adminkubeconfig` subresource](#shootsadminkubeconfig-subresource) should be used instead.
-
 ## `shoots/adminkubeconfig` Subresource
 
 The [`shoots/adminkubeconfig`](../proposals/16-adminkubeconfig-subresource.md) subresource allows users to dynamically generate temporary `kubeconfig`s that can be used to access shoot cluster with `cluster-admin` privileges. The credentials associated with this `kubeconfig` are client certificates which have a very short validity and must be renewed before they expire (by calling the subresource endpoint again).
@@ -79,3 +54,30 @@ If you want to use the same OIDC configuration for all your shoots by default, t
 Shoots have to "opt-in" for such defaulting by using the `oidc=enable` label.
 
 For further information on `(Cluster)OpenIDConnectPreset`, refer to [ClusterOpenIDConnectPreset and OpenIDConnectPreset](openidconnect-presets.md).
+
+## Static Token kubeconfig
+
+> **Note:** Static token kubeconfig is deprekated for Shoot clusters using Kubernetes version >= 1.27
+
+This `kubeconfig` contains a [static token](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#static-token-file) and provides `cluster-admin` privileges.
+It is created by default and persisted in the `<shoot-name>.kubeconfig` secret in the project namespace in the garden cluster.
+
+```yaml
+apiVersion: core.gardener.cloud/v1beta1
+kind: Shoot
+...
+spec:
+  kubernetes:
+    enableStaticTokenKubeconfig: true
+...
+```
+
+It is **not** the recommended method to access the shoot cluster, as the static token `kubeconfig` has some security flaws associated with it:
+- The static token in the `kubeconfig` doesn't have any expiration date. Read [this document](shoot_credentials_rotation.md#kubeconfig) to learn how to rotate the static token.
+- The static token doesn't have any user identity associated with it. The user in that token will always be `system:cluster-admin`, irrespective of the person accessing the cluster. Hence, it is impossible to audit the events in cluster.
+
+When `enableStaticTokenKubeconfig` field is not explicitly set in the Shoot spec:
+- for Shoot clusters using Kubernetes version < 1.26 the field is defaulted to `true`.
+- for Shoot clusters using Kubernetes version >= 1.26 the field is defaulted to `false`.
+
+> **Note:** Starting with Kubernetes 1.27, the `enableStaticTokenKubeconfig` field will be locked to `false`. The [`shoots/adminkubeconfig` subresource](#shootsadminkubeconfig-subresource) should be used instead.

--- a/docs/usage/shoot_access.md
+++ b/docs/usage/shoot_access.md
@@ -55,9 +55,9 @@ Shoots have to "opt-in" for such defaulting by using the `oidc=enable` label.
 
 For further information on `(Cluster)OpenIDConnectPreset`, refer to [ClusterOpenIDConnectPreset and OpenIDConnectPreset](openidconnect-presets.md).
 
-## Static Token kubeconfig (deprecated)
+## Static Token kubeconfig 
 
-> **Note:** Static token kubeconfig is deprecated for Shoot clusters using Kubernetes version >= 1.27. The [`shoots/adminkubeconfig` subresource](#shootsadminkubeconfig-subresource) should be used instead.
+> **Note:** Static token kubeconfig is not available for Shoot clusters created with Kubernetes version >= 1.27. The [`shoots/adminkubeconfig` subresource](#shootsadminkubeconfig-subresource) should be used instead.
 
 This `kubeconfig` contains a [static token](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#static-token-file) and provides `cluster-admin` privileges.
 It is created by default and persisted in the `<shoot-name>.kubeconfig` secret in the project namespace in the garden cluster.

--- a/docs/usage/shoot_access.md
+++ b/docs/usage/shoot_access.md
@@ -55,7 +55,7 @@ Shoots have to "opt-in" for such defaulting by using the `oidc=enable` label.
 
 For further information on `(Cluster)OpenIDConnectPreset`, refer to [ClusterOpenIDConnectPreset and OpenIDConnectPreset](openidconnect-presets.md).
 
-## Static Token kubeconfig
+## Static Token kubeconfig (deprecated)
 
 > **Note:** Static token kubeconfig is deprecated for Shoot clusters using Kubernetes version >= 1.27
 

--- a/docs/usage/shoot_access.md
+++ b/docs/usage/shoot_access.md
@@ -57,7 +57,7 @@ For further information on `(Cluster)OpenIDConnectPreset`, refer to [ClusterOpen
 
 ## Static Token kubeconfig (deprecated)
 
-> **Note:** Static token kubeconfig is deprecated for Shoot clusters using Kubernetes version >= 1.27
+> **Note:** Static token kubeconfig is deprecated for Shoot clusters using Kubernetes version >= 1.27. The [`shoots/adminkubeconfig` subresource](#shootsadminkubeconfig-subresource) should be used instead.
 
 This `kubeconfig` contains a [static token](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#static-token-file) and provides `cluster-admin` privileges.
 It is created by default and persisted in the `<shoot-name>.kubeconfig` secret in the project namespace in the garden cluster.
@@ -80,4 +80,4 @@ When `enableStaticTokenKubeconfig` field is not explicitly set in the Shoot spec
 - for Shoot clusters using Kubernetes version < 1.26 the field is defaulted to `true`.
 - for Shoot clusters using Kubernetes version >= 1.26 the field is defaulted to `false`.
 
-> **Note:** Starting with Kubernetes 1.27, the `enableStaticTokenKubeconfig` field will be locked to `false`. The [`shoots/adminkubeconfig` subresource](#shootsadminkubeconfig-subresource) should be used instead.
+> **Note:** Starting with Kubernetes 1.27, the `enableStaticTokenKubeconfig` field will be locked to `false`. 


### PR DESCRIPTION
Clarification on the deprecation for enableStaticTokenKubeconfig

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area documentation
/kind enhancement

**What this PR does / why we need it**:
Clarification what happens with static tokens for shoot clusters using K8S version >= 1.27
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
