### PR TITLE
Change `log` mount path of `node-problem-detector` from `/var/log` to `/var/log/journal`.

### DIFF
--- a/pkg/operation/botanist/component/nodeproblemdetector/node_problem_detector.go
+++ b/pkg/operation/botanist/component/nodeproblemdetector/node_problem_detector.go
@@ -244,7 +244,8 @@ func (c *nodeProblemDetector) computeResourcesData() (map[string][]byte, error) 
 								VolumeMounts: []corev1.VolumeMount{
 									{
 										Name:      "log",
-										MountPath: "/var/log",
+										MountPath: "/var/log/journal",
+										ReadOnly:  true,
 									},
 									{
 										Name:      "localtime",
@@ -287,7 +288,7 @@ func (c *nodeProblemDetector) computeResourcesData() (map[string][]byte, error) 
 								Name: "log",
 								VolumeSource: corev1.VolumeSource{
 									HostPath: &corev1.HostPathVolumeSource{
-										Path: "/var/log/",
+										Path: "/var/log/journal",
 									},
 								},
 							},

--- a/pkg/operation/botanist/component/nodeproblemdetector/node_problem_detector_test.go
+++ b/pkg/operation/botanist/component/nodeproblemdetector/node_problem_detector_test.go
@@ -291,8 +291,9 @@ spec:
         securityContext:
           privileged: true
         volumeMounts:
-        - mountPath: /var/log
+        - mountPath: /var/log/journal
           name: log
+          readOnly: true
         - mountPath: /etc/localtime
           name: localtime
           readOnly: true
@@ -313,7 +314,7 @@ spec:
         operator: Exists
       volumes:
       - hostPath:
-          path: /var/log/
+          path: /var/log/journal
         name: log
       - hostPath:
           path: /etc/localtime


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/area compliance
/kind enhancement

**What this PR does / why we need it**:
This PR changes the `log` mount path of `node-problem-detector` from `/var/log` to `/var/log/journal`. `node-problem-detector` is configured to use only the `journal` directory from `/var/log` and does not need to mount the whole `/var/log` directory. Moreover, DISA STIG requires our pods to not mount paths with files that have permissions higher than `644`, while `/var/log` contains 3 files that break that rule: `lastlog 664`, `wtmp 664` and `btmp 660`.
This PR also sets `readOnly: true` for the `log` volume as it is set in the example `node-problem-detector.yaml` in [kubernetes](https://github.com/kubernetes/node-problem-detector/blob/6e57ca6e6c0135ff4a73788e28563476ed9c9334/deployment/node-problem-detector.yaml#L49-L51).
This PR is in sync with Kubernetes' STIG.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
List of config files we use for `node-problem-detector`: [/config/kernel-monitor.json](https://github.com/kubernetes/node-problem-detector/blob/master/config/kernel-monitor.json), [/config/docker-monitor.json](https://github.com/kubernetes/node-problem-detector/blob/master/config/docker-monitor.json), [/config/systemd-monitor.json](https://github.com/kubernetes/node-problem-detector/blob/master/config/systemd-monitor.json), [/config/kernel-monitor-counter.json](https://github.com/kubernetes/node-problem-detector/blob/master/config/kernel-monitor-counter.json), [/config/systemd-monitor-counter.json](https://github.com/kubernetes/node-problem-detector/blob/master/config/systemd-monitor-counter.json) and [system-stats-monitor.json](https://github.com/kubernetes/node-problem-detector/blob/master/config/system-stats-monitor.json).

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Change `log` mount path of `node-problem-detector` from `/var/log` to `/var/log/journal`.
```
