### PR TITLE
Fix: Grafana dashboard of VPN

### DIFF
--- a/charts/seed-monitoring/charts/plutono/dashboards/owners/worker/vpn-dashboard.json
+++ b/charts/seed-monitoring/charts/plutono/dashboards/owners/worker/vpn-dashboard.json
@@ -518,7 +518,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(container_cpu_usage_seconds_total{pod=~\"vpn-seed-.*\", container=\"vpn-seed-server\"}[$__rate_interval])",
+          "expr": "rate(container_cpu_usage_seconds_total{pod=~\"kube-apiserver-.*|vpn-seed-.*\", container=\"vpn-.*\"}[$__rate_interval])",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -528,14 +528,14 @@
           "step": 20
         },
         {
-          "expr": "kube_pod_container_resource_requests{resource=\"cpu\", unit=\"core\", pod=~\"vpn-seed-.*\", container=\"vpn-seed-server\"}",
+          "expr": "kube_pod_container_resource_requests{resource=\"cpu\", unit=\"core\", pod=~\"kube-apiserver-.*|vpn-seed-.*\", container=\"vpn-.*\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Requests ({{pod}}/{{container}})",
           "refId": "B"
         },
         {
-          "expr": "kube_pod_container_resource_limits{resource=\"cpu\", unit=\"core\", pod=~\"vpn-seed-.*\", container=\"vpn-seed-server\"}",
+          "expr": "kube_pod_container_resource_limits{resource=\"cpu\", unit=\"core\", pod=~\"kube-apiserver-.*|vpn-seed-.*\", container=\"vpn-.*\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Limits ({{pod}}/{{container}})",
@@ -642,14 +642,14 @@
           "step": 10
         },
         {
-          "expr": "kube_pod_container_resource_requests{resource=\"memory\", unit=\"byte\", pod=~\"vpn-seed-.*\", container=\"vpn-seed-server\"}",
+          "expr": "kube_pod_container_resource_requests{resource=\"memory\", unit=\"byte\", pod=~\"kube-apiserver-.*|vpn-seed-.*\", container=\"vpn-.*\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Request ({{pod}}/{{container}})",
           "refId": "B"
         },
         {
-          "expr": "kube_pod_container_resource_limits{resource=\"memory\", unit=\"byte\", pod=~\"vpn-seed-.*\", container=\"vpn-seed-server\"}",
+          "expr": "kube_pod_container_resource_limits{resource=\"memory\", unit=\"byte\", pod=~\"kube-apiserver-.*|vpn-seed-.*\", container=\"vpn-.*\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Limits ({{pod}}/{{container}})",

--- a/charts/seed-monitoring/charts/plutono/dashboards/owners/worker/vpn-dashboard.json
+++ b/charts/seed-monitoring/charts/plutono/dashboards/owners/worker/vpn-dashboard.json
@@ -518,7 +518,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(container_cpu_usage_seconds_total{pod=~\"kube-apiserver-.*|prometheus-.*\", container=\"vpn-seed\"}[$__rate_interval])",
+          "expr": "rate(container_cpu_usage_seconds_total{pod=~\"vpn-seed-.*\", container=\"vpn-seed-server\"}[$__rate_interval])",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -528,14 +528,14 @@
           "step": 20
         },
         {
-          "expr": "kube_pod_container_resource_requests{resource=\"cpu\", unit=\"core\", pod=~\"kube-apiserver-.*|prometheus-.*\", container=\"vpn-seed\"}",
+          "expr": "kube_pod_container_resource_requests{resource=\"cpu\", unit=\"core\", pod=~\"vpn-seed-.*\", container=\"vpn-seed-server\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Requests ({{pod}}/{{container}})",
           "refId": "B"
         },
         {
-          "expr": "kube_pod_container_resource_limits{resource=\"cpu\", unit=\"core\", pod=~\"kube-apiserver-.*|prometheus-.*\", container=\"vpn-seed\"}",
+          "expr": "kube_pod_container_resource_limits{resource=\"cpu\", unit=\"core\", pod=~\"vpn-seed-.*\", container=\"vpn-seed-server\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Limits ({{pod}}/{{container}})",
@@ -632,7 +632,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "container_memory_working_set_bytes{pod=~\"kube-apiserver-.*|prometheus-.*\", container=\"vpn-seed\"}",
+          "expr": "container_memory_working_set_bytes{pod=~\"vpn-seed-.*\", container=\"vpn-seed-server\"}",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -642,14 +642,14 @@
           "step": 10
         },
         {
-          "expr": "kube_pod_container_resource_requests{resource=\"memory\", unit=\"byte\", pod=~\"kube-apiserver-.*|prometheus-.*\", container=\"vpn-seed\"}",
+          "expr": "kube_pod_container_resource_requests{resource=\"memory\", unit=\"byte\", pod=~\"vpn-seed-.*\", container=\"vpn-seed-server\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Request ({{pod}}/{{container}})",
           "refId": "B"
         },
         {
-          "expr": "kube_pod_container_resource_limits{resource=\"memory\", unit=\"byte\", pod=~\"kube-apiserver-.*|prometheus-.*\", container=\"vpn-seed\"}",
+          "expr": "kube_pod_container_resource_limits{resource=\"memory\", unit=\"byte\", pod=~\"vpn-seed-.*\", container=\"vpn-seed-server\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Limits ({{pod}}/{{container}})",

--- a/charts/seed-monitoring/charts/plutono/dashboards/owners/worker/vpn-dashboard.json
+++ b/charts/seed-monitoring/charts/plutono/dashboards/owners/worker/vpn-dashboard.json
@@ -276,7 +276,7 @@
         {
           "expr": "sum(rate(container_cpu_usage_seconds_total{pod=~\"vpn-shoot-.*\"}[$__rate_interval]))",
           "format": "time_series",
-          "interval": "10s",
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "Actual",
           "refId": "A",
@@ -286,7 +286,7 @@
           "expr": "sum(kube_pod_container_resource_requests{resource=\"cpu\", unit=\"core\", pod=~\"vpn-shoot-.*\"})",
           "format": "time_series",
           "hide": false,
-          "interval": "10s",
+          "interval": "",
           "intervalFactor": 2,
           "legendFormat": "Requests",
           "refId": "B"
@@ -294,7 +294,7 @@
         {
           "expr": "sum(kube_pod_container_resource_limits{resource=\"cpu\", unit=\"core\", pod=~\"vpn-shoot-.*\"})",
           "format": "time_series",
-          "interval": "10s",
+          "interval": "",
           "intervalFactor": 2,
           "legendFormat": "Limits",
           "refId": "C"
@@ -391,7 +391,7 @@
         {
           "expr": "sum (container_memory_working_set_bytes{pod=~\"vpn-shoot-.*\"})",
           "format": "time_series",
-          "interval": "10s",
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "Actual",
           "metric": "container_memory_working_set_bytes",
@@ -402,7 +402,7 @@
           "expr": "sum(kube_pod_container_resource_requests{resource=\"memory\", unit=\"byte\", pod=~\"vpn-shoot-.*\"})",
           "format": "time_series",
           "hide": false,
-          "interval": "10s",
+          "interval": "",
           "intervalFactor": 2,
           "legendFormat": "Requests",
           "refId": "C"
@@ -410,7 +410,7 @@
         {
           "expr": "sum(kube_pod_container_resource_limits{resource=\"memory\", unit=\"byte\", pod=~\"vpn-shoot-.*\"})",
           "format": "time_series",
-          "interval": "10s",
+          "interval": "",
           "intervalFactor": 2,
           "legendFormat": "Limits",
           "refId": "B"
@@ -521,7 +521,7 @@
           "expr": "rate(container_cpu_usage_seconds_total{pod=~\"kube-apiserver-.*|prometheus-.*\", container=\"vpn-seed\"}[$__rate_interval])",
           "format": "time_series",
           "hide": false,
-          "interval": "10s",
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "Actual ({{pod}}/{{container}})",
           "refId": "A",
@@ -634,7 +634,7 @@
         {
           "expr": "container_memory_working_set_bytes{pod=~\"kube-apiserver-.*|prometheus-.*\", container=\"vpn-seed\"}",
           "format": "time_series",
-          "interval": "10s",
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "Actual ({{pod}}/{{container}})",
           "metric": "container_memory_working_set_bytes",


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind bug

**What this PR does / why we need it**:
In grafana dashboard `VPN`, panel `VPN Shoot CPU Usage` only shows the CPU Request, not show the data of `Actual` and `Limits`
For `VPN Seed (CPU| Memory) Usage` panels don't show data
<img width="1494" alt="Screenshot 2023-05-03 at 11 14 12" src="https://user-images.githubusercontent.com/50126000/235870439-d48a8ee3-27fd-4208-a796-632d7dad86d0.png">


**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener/issues/7402

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
An issue causing `VPN Seed (CPU| Memory) Usage` dashboards not showing data is now fixed.
```
