### PR TITLE
Promote `FullNetworkPoliciesInRuntimeCluster` feature gate to beta

### DIFF
--- a/docs/deployment/feature_gates.md
+++ b/docs/deployment/feature_gates.md
@@ -31,7 +31,8 @@ The following tables are a summary of the feature gates that you can set on diff
 | CoreDNSQueryRewriting                      | `false` | `Alpha` | `1.55` |        |
 | IPv6SingleStack                            | `false` | `Alpha` | `1.63` |        |
 | MutableShootSpecNetworkingNodes            | `false` | `Alpha` | `1.64` |        |
-| FullNetworkPoliciesInRuntimeCluster        | `false` | `Alpha` | `1.66` |        |
+| FullNetworkPoliciesInRuntimeCluster        | `false` | `Alpha` | `1.66` | `1.70` |
+| FullNetworkPoliciesInRuntimeCluster        | `true`  | `Beta`  | `1.71` |        |
 | WorkerlessShoots                           | `false` | `Alpha` | `1.70` |        |
 
 ## Feature Gates for Graduated or Deprecated Features

--- a/example/gardener-local/gardenlet/values.yaml
+++ b/example/gardener-local/gardenlet/values.yaml
@@ -42,7 +42,6 @@ config:
     # This feature gate doesn't change gardenlet's default behavior, it only allows setting `ipFamilies=[IPv6]` in the
     # Seed config. Only when this is set, gardenlet's behavior changes.
     IPv6SingleStack: true
-    FullNetworkPoliciesInRuntimeCluster: true
   logging:
     enabled: true
     loki:

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -93,6 +93,7 @@ const (
 	// all relevant namespaces in the seed cluster.
 	// owner: @rfranzke
 	// alpha: v1.66.0
+	// beta: v1.71.0
 	FullNetworkPoliciesInRuntimeCluster featuregate.Feature = "FullNetworkPoliciesInRuntimeCluster"
 
 	// WorkerlessShoots allows creation of Shoot clusters with no worker pools.
@@ -135,7 +136,7 @@ var allFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	CoreDNSQueryRewriting:               {Default: false, PreRelease: featuregate.Alpha},
 	IPv6SingleStack:                     {Default: false, PreRelease: featuregate.Alpha},
 	MutableShootSpecNetworkingNodes:     {Default: false, PreRelease: featuregate.Alpha},
-	FullNetworkPoliciesInRuntimeCluster: {Default: false, PreRelease: featuregate.Alpha},
+	FullNetworkPoliciesInRuntimeCluster: {Default: true, PreRelease: featuregate.Beta},
 	WorkerlessShoots:                    {Default: false, PreRelease: featuregate.Alpha},
 }
 

--- a/pkg/gardenlet/controller/networkpolicy/add_test.go
+++ b/pkg/gardenlet/controller/networkpolicy/add_test.go
@@ -37,9 +37,7 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
-	"github.com/gardener/gardener/pkg/features"
 	. "github.com/gardener/gardener/pkg/gardenlet/controller/networkpolicy"
-	"github.com/gardener/gardener/pkg/utils/test"
 )
 
 var _ = Describe("Add", func() {
@@ -225,8 +223,6 @@ var _ = Describe("Add", func() {
 		)
 
 		BeforeEach(func() {
-			DeferCleanup(test.WithFeatureGate(features.DefaultFeatureGate, features.FullNetworkPoliciesInRuntimeCluster, true))
-
 			fakeClient = fakeclient.NewClientBuilder().WithScheme(scheme.Scheme).Build()
 			reconciler.RuntimeClient = fakeClient
 

--- a/test/integration/gardenlet/networkpolicy/networkpolicy_suite_test.go
+++ b/test/integration/gardenlet/networkpolicy/networkpolicy_suite_test.go
@@ -40,14 +40,12 @@ import (
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	gardenerenvtest "github.com/gardener/gardener/pkg/envtest"
-	"github.com/gardener/gardener/pkg/features"
 	"github.com/gardener/gardener/pkg/gardenlet/apis/config"
 	"github.com/gardener/gardener/pkg/gardenlet/controller/networkpolicy"
 	"github.com/gardener/gardener/pkg/gardenlet/controller/networkpolicy/hostnameresolver"
 	gardenletfeatures "github.com/gardener/gardener/pkg/gardenlet/features"
 	"github.com/gardener/gardener/pkg/logger"
 	"github.com/gardener/gardener/pkg/utils"
-	"github.com/gardener/gardener/pkg/utils/test"
 )
 
 func TestNetworkPolicy(t *testing.T) {
@@ -75,8 +73,6 @@ var (
 var _ = BeforeSuite(func() {
 	logf.SetLogger(logger.MustNewZapLogger(logger.DebugLevel, logger.FormatJSON, zap.WriteTo(GinkgoWriter)))
 	log = logf.Log.WithName(testID)
-
-	DeferCleanup(test.WithFeatureGate(features.DefaultFeatureGate, features.FullNetworkPoliciesInRuntimeCluster, true))
 
 	By("Start test environment")
 	testEnv = &gardenerenvtest.GardenerTestEnvironment{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement

**What this PR does / why we need it**:
Promote `FullNetworkPoliciesInRuntimeCluster` feature gate to beta and turn it on by default.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/7352

/hold until gardener/gardener@v1.70 got released

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
The `FullNetworkPoliciesInRuntimeCluster` feature gate has been promoted to beta and is now turned on by default. Before deploying this Gardener version, make sure that all your registered extensions support this feature gate.
```
