### PR TITLE
Promote `HAControlPlanes` feature gate to beta

### DIFF
--- a/docs/deployment/feature_gates.md
+++ b/docs/deployment/feature_gates.md
@@ -25,7 +25,8 @@ The following tables are a summary of the feature gates that you can set on diff
 | APIServerSNI                               | `false` | `Alpha` | `1.7`  | `1.18` |
 | APIServerSNI                               | `true`  | `Beta`  | `1.19` |        |
 | APIServerSNI (deprecated)                  | `true`  | `Beta`  | `1.48` |        |
-| HAControlPlanes                            | `false` | `Alpha` | `1.49` |        |
+| HAControlPlanes                            | `false` | `Alpha` | `1.49` | `1.70` |
+| HAControlPlanes                            | `true`  | `Beta`  | `1.71` |        |
 | DefaultSeccompProfile                      | `false` | `Alpha` | `1.54` |        |
 | CoreDNSQueryRewriting                      | `false` | `Alpha` | `1.55` |        |
 | IPv6SingleStack                            | `false` | `Alpha` | `1.63` |        |

--- a/example/gardener-local/controlplane/values.yaml
+++ b/example/gardener-local/controlplane/values.yaml
@@ -158,7 +158,6 @@ global:
         maxSize: 0
         policy: ""
     featureGates:
-      HAControlPlanes: true
       IPv6SingleStack: true
       MutableShootSpecNetworkingNodes: true
     resources: {}

--- a/hack/local-development/start-apiserver
+++ b/hack/local-development/start-apiserver
@@ -57,7 +57,7 @@ apiserver_flags="
   --secure-port=8443 \
   --tls-cert-file $TLS_CERT_FILE \
   --tls-private-key-file $TLS_KEY_FILE \
-  --feature-gates HAControlPlanes=true,IPv6SingleStack=true,MutableShootSpecNetworkingNodes=true \
+  --feature-gates IPv6SingleStack=true,MutableShootSpecNetworkingNodes=true \
   --shoot-admin-kubeconfig-max-expiration=24h \
   --enable-admission-plugins=ShootVPAEnabledByDefault \
   --v 2"

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -65,6 +65,7 @@ const (
 	// HAControlPlanes allows shoot control planes to be run in high availability mode.
 	// owner: @shreyas-s-rao @timuthy
 	// alpha: v1.49.0
+	// beta: v1.71.0
 	HAControlPlanes featuregate.Feature = "HAControlPlanes"
 
 	// DefaultSeccompProfile defaults the seccomp profile for Gardener managed workload in the seed to RuntimeDefault.
@@ -129,7 +130,7 @@ var allFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	APIServerSNI:       {Default: true, PreRelease: featuregate.Deprecated, LockToDefault: true},
 	SeedChange:         {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
 	CopyEtcdBackupsDuringControlPlaneMigration: {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
-	HAControlPlanes:                     {Default: false, PreRelease: featuregate.Alpha},
+	HAControlPlanes:                     {Default: true, PreRelease: featuregate.Beta},
 	DefaultSeccompProfile:               {Default: false, PreRelease: featuregate.Alpha},
 	CoreDNSQueryRewriting:               {Default: false, PreRelease: featuregate.Alpha},
 	IPv6SingleStack:                     {Default: false, PreRelease: featuregate.Alpha},

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -478,18 +478,6 @@ deploy:
       createNamespace: true
       wait: true
 profiles:
-- name: ha-single-zone
-  patches:
-  - op: add
-    path: /deploy/helm/releases/0/setValues
-    value:
-      global.apiserver.featureGates.HAControlPlanes: true
-- name: ha-multi-zone
-  patches:
-  - op: add
-    path: /deploy/helm/releases/0/setValues
-    value:
-      global.apiserver.featureGates.HAControlPlanes: true
 - name: extensions
   patches:
   - op: add

--- a/test/integration/scheduler/shoot/shoot_suite_test.go
+++ b/test/integration/scheduler/shoot/shoot_suite_test.go
@@ -69,8 +69,7 @@ var _ = BeforeSuite(func() {
 	testEnv = &gardenerenvtest.GardenerTestEnvironment{
 		GardenerAPIServer: &gardenerenvtest.GardenerAPIServer{
 			Args: []string{
-				"--disable-admission-plugins=DeletionConfirmation,ResourceReferenceManager,ExtensionValidator,ShootQuotaValidator,SeedValidator",
-				"--feature-gates=HAControlPlanes=true"},
+				"--disable-admission-plugins=DeletionConfirmation,ResourceReferenceManager,ExtensionValidator,ShootQuotaValidator,SeedValidator"},
 		},
 	}
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area high-availability
/kind enhancement

**What this PR does / why we need it**:
Promote `HAControlPlanes` feature gate to beta and turn it on by default.

**Which issue(s) this PR fixes**:
Part of #6529

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
The `HAControlPlanes` feature gate has been promoted to beta and is now turned on by default.
```

