### PR TITLE
gardenlet: Deploy/destroy the owner DNSRecord when the Shoot namespace exists and is not terminating

### DIFF
--- a/pkg/gardenlet/controller/shoot/shoot/reconciler_delete.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler_delete.go
@@ -201,7 +201,7 @@ func (r *Reconciler) runDeleteShootFlow(ctx context.Context, o *operation.Operat
 		})
 		deployOwnerDomainDNSRecord = g.Add(flow.Task{
 			Name:         "Deploying owner domain DNS record",
-			Fn:           flow.TaskFn(botanist.DeployOwnerDNSResources),
+			Fn:           flow.TaskFn(botanist.DeployOwnerDNSResources).DoIf(nonTerminatingNamespace),
 			Dependencies: flow.NewTaskIDs(ensureShootStateExists, deployReferencedResources),
 		})
 		deployInternalDomainDNSRecord = g.Add(flow.Task{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind bug
/kind regression

**What this PR does / why we need it**:
With https://github.com/gardener/gardener/pull/7842 I introduced the following issue. As the PR deploys/destroys the owner DNSRecord unconditionally, this will fail for a Shoot deletion when the Shoot namespace in the Seed does not exist.
In the Destroy func of the dnsrecord component, it first tries to create or update the DNSRecord Secret. This will fail when the Shoot namespace in the Seed does not exist:
```yaml
  lastErrors:
    - description: >-
        task "Deploying owner domain DNS record" failed: namespaces
        "shoot--it--tmond-ye4" not found
      taskID: Deploying owner domain DNS record
      lastUpdateTime: '2023-05-04T07:07:04Z'
```

The solution would be to Deploy/destroy the owner DNSRecord only when the Shoot namespace exists and is not terminating.

**Which issue(s) this PR fixes**:
See above

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
