### PR TITLE
Change trigger for static token secret rotation

### DIFF
--- a/pkg/operation/botanist/secrets.go
+++ b/pkg/operation/botanist/secrets.go
@@ -84,7 +84,7 @@ func (b *Botanist) lastSecretRotationStartTimes() map[string]time.Time {
 
 		// When the static token kubeconfig is disabled, there will not be any kubeconfig rotation anymore. However, the
 		// static token secret does not only contain the token for the user kubeconfig but also a token for the health
-		// check of the kube-apiserver. This token must still be rotated even when the userk ubeconfig is disabled.
+		// check of the kube-apiserver. This token must still be rotated even when the user kubeconfig is disabled.
 		// Hence, let's use the last rotation initiation time of the CA rotation also to rotate the static token secret.
 		if !pointer.BoolDeref(b.Shoot.GetInfo().Spec.Kubernetes.EnableStaticTokenKubeconfig, false) {
 			if shootStatus.Credentials.Rotation.CertificateAuthorities != nil && shootStatus.Credentials.Rotation.CertificateAuthorities.LastInitiationTime != nil {

--- a/pkg/operator/controller/garden/reconciler.go
+++ b/pkg/operator/controller/garden/reconciler.go
@@ -38,6 +38,7 @@ import (
 	"github.com/gardener/gardener/pkg/apis/operator/v1alpha1/helper"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/features"
+	"github.com/gardener/gardener/pkg/operation/botanist/component/kubeapiserver"
 	"github.com/gardener/gardener/pkg/operator/apis/config"
 	"github.com/gardener/gardener/pkg/utils/flow"
 	"github.com/gardener/gardener/pkg/utils/imagevector"
@@ -356,6 +357,10 @@ func lastSecretRotationStartTimes(garden *operatorv1alpha1.Garden) map[string]ti
 			for _, config := range nonAutoRotatedCACertConfigurations() {
 				rotation[config.GetName()] = gardenStatus.Credentials.Rotation.CertificateAuthorities.LastInitiationTime.Time
 			}
+		}
+
+		if gardenStatus.Credentials.Rotation.CertificateAuthorities != nil && gardenStatus.Credentials.Rotation.CertificateAuthorities.LastInitiationTime != nil {
+			rotation[kubeapiserver.SecretStaticTokenName] = gardenStatus.Credentials.Rotation.CertificateAuthorities.LastInitiationTime.Time
 		}
 
 		if gardenStatus.Credentials.Rotation.ServiceAccountKey != nil && gardenStatus.Credentials.Rotation.ServiceAccountKey.LastInitiationTime != nil {

--- a/pkg/operator/controller/garden/reconciler.go
+++ b/pkg/operator/controller/garden/reconciler.go
@@ -357,9 +357,6 @@ func lastSecretRotationStartTimes(garden *operatorv1alpha1.Garden) map[string]ti
 			for _, config := range nonAutoRotatedCACertConfigurations() {
 				rotation[config.GetName()] = gardenStatus.Credentials.Rotation.CertificateAuthorities.LastInitiationTime.Time
 			}
-		}
-
-		if gardenStatus.Credentials.Rotation.CertificateAuthorities != nil && gardenStatus.Credentials.Rotation.CertificateAuthorities.LastInitiationTime != nil {
 			rotation[kubeapiserver.SecretStaticTokenName] = gardenStatus.Credentials.Rotation.CertificateAuthorities.LastInitiationTime.Time
 		}
 

--- a/pkg/utils/version/version.go
+++ b/pkg/utils/version/version.go
@@ -55,6 +55,8 @@ var (
 	ConstraintK8sLess125 *semver.Constraints
 	// ConstraintK8sGreaterEqual126 is a version constraint for versions >= 1.26.
 	ConstraintK8sGreaterEqual126 *semver.Constraints
+	// ConstraintK8sGreaterEqual127 is a version constraint for versions >= 1.27.
+	ConstraintK8sGreaterEqual127 *semver.Constraints
 	// ConstraintK8sLess126 is a version constraint for versions < 1.26.
 	ConstraintK8sLess126 *semver.Constraints
 )
@@ -94,6 +96,8 @@ func init() {
 	ConstraintK8sGreaterEqual126, err = semver.NewConstraint(">= 1.26-0")
 	utilruntime.Must(err)
 	ConstraintK8sLess126, err = semver.NewConstraint("< 1.26-0")
+	utilruntime.Must(err)
+	ConstraintK8sGreaterEqual127, err = semver.NewConstraint(">= 1.27-0")
 	utilruntime.Must(err)
 }
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind enhancement

**What this PR does / why we need it**:
For `Shoot`s with Kubernetes `1.27` and higher, Gardener will no longer allow the static token kubeconfig to be enabled. However, the static toke kubeconfig could also already be disabled for shoots < `1.27`. In such cases, there will also be no rotation of said kubeconfig anymore (i.e., `gardener.cloud/operation=rotate-kubeconfig` will not be used anymore). However, there is still one static token left for the health check of the `kube-apiserver` pods.

With this PR, we'll change the trigger for the rotation of said token to be the last initiation time of the CA rotation. This way, its rotation is not forgotten/skipped.
For `Garden`s, kubeconfig rotation was never implemented since the static token kuebconfig will soon be unconditionally disabled. Hence, we use the same trigger here as well.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/7016

**Special notes for your reviewer**:
/cc @timuthy 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
