### PR TITLE
Enhance validation for `worker.maximum` configuration

### DIFF
--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -1726,7 +1726,6 @@ func ValidateWorkers(workers []core.Worker, fldPath *field.Path) field.ErrorList
 		allErrs = field.ErrorList{}
 
 		workerNames                               = make(map[string]bool)
-		atLeastOneActivePool                      = false
 		atLeastOnePoolWithCompatibleTaints        = len(workers) == 0
 		atLeastOnePoolWithAllowedSystemComponents = false
 	)
@@ -1766,17 +1765,9 @@ func ValidateWorkers(workers []core.Worker, fldPath *field.Path) field.ErrorList
 			atLeastOnePoolWithAllowedSystemComponents = true
 		}
 
-		if !atLeastOneActivePool {
-			atLeastOneActivePool = poolIsActive
-		}
-
 		if !atLeastOnePoolWithCompatibleTaints {
 			atLeastOnePoolWithCompatibleTaints = poolHasCompatibleTaints
 		}
-	}
-
-	if !atLeastOneActivePool {
-		allErrs = append(allErrs, field.Forbidden(fldPath, "at least one worker pool with min>0 and max> 0 needed"))
 	}
 
 	if !atLeastOnePoolWithCompatibleTaints {

--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -5197,9 +5197,6 @@ var _ = Describe("Shoot Validation Tests", func() {
 				PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type": Equal(field.ErrorTypeForbidden),
 				})),
-				PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type": Equal(field.ErrorTypeForbidden),
-				})),
 			)),
 		)
 
@@ -5231,8 +5228,6 @@ var _ = Describe("Shoot Validation Tests", func() {
 
 			Entry("all worker pools min=max=0", zero, zero, zero, zero, true, true, nil, nil, ConsistOf(
 				PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type": Equal(field.ErrorTypeForbidden),
-				})), PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type": Equal(field.ErrorTypeForbidden),
 				})),
 			)),

--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -5216,7 +5216,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 					},
 				}
 
-				Expect(ValidateSystemComponentWorkers("", workers, field.NewPath("workers"))).To(matcher)
+				Expect(ValidateSystemComponentWorkers(workers, "", field.NewPath("workers"))).To(matcher)
 			},
 
 			Entry("at least one worker pool min>0, max>0", zero, zero, one, one, BeEmpty()),
@@ -5248,7 +5248,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 					},
 				}
 
-				Expect(ValidateSystemComponentWorkers("", workers, field.NewPath("workers"))).To(matcher)
+				Expect(ValidateSystemComponentWorkers(workers, "", field.NewPath("workers"))).To(matcher)
 			},
 
 			Entry("all worker pools min=max=0", zero, zero, zero, zero, true, true, ConsistOf(
@@ -5282,10 +5282,12 @@ var _ = Describe("Shoot Validation Tests", func() {
 					},
 				}
 
-				Expect(ValidateSystemComponentWorkers(kubernetesVersion, workers, field.NewPath("workers"))).To(matcher)
+				Expect(ValidateSystemComponentWorkers(workers, kubernetesVersion, field.NewPath("workers"))).To(matcher)
 			},
 
 			Entry("maximum == len(zones)", "v1.27", three, one, true, false, []string{"1", "2", "3"}, []string{"1"}, BeEmpty()),
+			Entry("maximum == len(zones) with multiple system component worker pools and smaller group first", "v1.27", one, three, true, true, []string{"1", "2", "3"}, []string{"1", "2", "3"}, BeEmpty()),
+			Entry("maximum == len(zones) with multiple system component worker pools and smaller group last", "v1.27", three, one, true, true, []string{"1", "2", "3"}, []string{"1", "2", "3"}, BeEmpty()),
 			Entry("maximum < len(zones)", "1.27", two, one, true, false, []string{"1", "2", "3"}, []string{"1"}, ConsistOf(
 				PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":  Equal(field.ErrorTypeForbidden),

--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -5163,7 +5163,29 @@ var _ = Describe("Shoot Validation Tests", func() {
 	})
 
 	Describe("#ValidateWorkers", func() {
+		It("should succeed checking workers", func() {
+			workers := []core.Worker{
+				{Name: "worker1"},
+				{Name: "worker2"},
+			}
 
+			Expect(ValidateWorkers(workers, nil)).To(BeEmpty())
+		})
+
+		It("should fail because worker name is duplicated", func() {
+			workers := []core.Worker{
+				{Name: "worker1"},
+				{Name: "worker2"},
+				{Name: "worker1"},
+			}
+
+			Expect(ValidateWorkers(workers, field.NewPath("workers"))).To(ConsistOf(
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeDuplicate),
+					"Field": Equal("workers[2].name"),
+				})),
+			))
+		})
 	})
 
 	Describe("#ValidateSystemComponentWorkers", func() {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area high-availability
/area usability
/kind api-change

**What this PR does / why we need it**:
This PR changes the worker validation to enforce the `worker.maximum` value is >= the number of zones configured for this pool, if it is configured for system components (see linked issue for motivation). This check is enforced as of Kubernetes `v1.27`.

In addition, some redundant validation is dropped. Please see the individual commit messages for more details.

**Which issue(s) this PR fixes**:
Fixes #7834

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking user
As of Kubernetes `v1.27`, Gardener enforces a `worker.maximum` configuration for system component worker pools. The value must be greater or equal to the number of zones configured for this pool. This ensures, that the pool has the minimum required nodes to schedule system component across nodes.
```
