### PR TITLE
Move remaining `gardener-local` images from docker.io to registry mirror

### DIFF
--- a/example/gardener-local/calico/base/kustomization.yaml
+++ b/example/gardener-local/calico/base/kustomization.yaml
@@ -3,3 +3,11 @@ kind: Kustomization
 
 resources:
 - https://raw.githubusercontent.com/projectcalico/calico/v3.25.0/manifests/calico.yaml
+
+images:
+- name: docker.io/calico/cni
+  newName: eu.gcr.io/gardener-project/3rd/calico/cni
+- name: docker.io/calico/node
+  newName: eu.gcr.io/gardener-project/3rd/calico/node
+- name: docker.io/calico/kube-controllers
+  newName: eu.gcr.io/gardener-project/3rd/calico/kube-controllers

--- a/example/gardener-local/registry/base/registry.yaml
+++ b/example/gardener-local/registry/base/registry.yaml
@@ -12,7 +12,7 @@ spec:
       automountServiceAccountToken: false
       containers:
       - name: registry
-        image: registry:2
+        image: eu.gcr.io/gardener-project/3rd/registry:2.8.1
         imagePullPolicy: IfNotPresent
         ports:
         - name: registry


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind bug

**What this PR does / why we need it**:
This PR moves `calico` and `registry` images to our registry mirror.
https://github.com/gardener/gardener/pull/7698 removed the pull through cache registry for docker.io, so the calico images are not cached anymore.

**Which issue(s) this PR fixes**:
Part of #7051 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
