### PR TITLE
Adapt `from-world` network policies to work with all CNIs.

### DIFF
--- a/pkg/resourcemanager/controller/networkpolicy/reconciler.go
+++ b/pkg/resourcemanager/controller/networkpolicy/reconciler.go
@@ -342,14 +342,7 @@ func (r *Reconciler) reconcileIngressFromWorldPolicy(ctx context.Context, servic
 			"ingress traffic from everywhere to ports %v for pods selected by the %s service selector.", portAndProtocolOf(ports),
 			client.ObjectKeyFromObject(service)))
 
-		networkPolicy.Spec.Ingress = []networkingv1.NetworkPolicyIngressRule{{
-			From: []networkingv1.NetworkPolicyPeer{
-				{PodSelector: &metav1.LabelSelector{}, NamespaceSelector: &metav1.LabelSelector{}},
-				{IPBlock: &networkingv1.IPBlock{CIDR: "0.0.0.0/0"}},
-				{IPBlock: &networkingv1.IPBlock{CIDR: "::/0"}},
-			},
-			Ports: ports,
-		}}
+		networkPolicy.Spec.Ingress = []networkingv1.NetworkPolicyIngressRule{{Ports: ports}}
 		networkPolicy.Spec.Egress = nil
 		networkPolicy.Spec.PodSelector = metav1.LabelSelector{MatchLabels: service.Spec.Selector}
 		networkPolicy.Spec.PolicyTypes = []networkingv1.PolicyType{networkingv1.PolicyTypeIngress}

--- a/test/integration/resourcemanager/networkpolicy/networkpolicy_test.go
+++ b/test/integration/resourcemanager/networkpolicy/networkpolicy_test.go
@@ -849,11 +849,6 @@ var _ = Describe("NetworkPolicy Controller tests", func() {
 				PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
 				PodSelector: metav1.LabelSelector{MatchLabels: serviceSelector},
 				Ingress: []networkingv1.NetworkPolicyIngressRule{{
-					From: []networkingv1.NetworkPolicyPeer{
-						{PodSelector: &metav1.LabelSelector{}, NamespaceSelector: &metav1.LabelSelector{}},
-						{IPBlock: &networkingv1.IPBlock{CIDR: "0.0.0.0/0"}},
-						{IPBlock: &networkingv1.IPBlock{CIDR: "::/0"}},
-					},
 					Ports: []networkingv1.NetworkPolicyPort{
 						{Protocol: &port1Protocol, Port: &port1TargetPort},
 						{Protocol: &port2Protocol, Port: &port2TargetPort},
@@ -879,13 +874,7 @@ var _ = Describe("NetworkPolicy Controller tests", func() {
 			}).Should(Equal(networkingv1.NetworkPolicySpec{
 				PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
 				PodSelector: metav1.LabelSelector{MatchLabels: serviceSelector},
-				Ingress: []networkingv1.NetworkPolicyIngressRule{{
-					From: []networkingv1.NetworkPolicyPeer{
-						{PodSelector: &metav1.LabelSelector{}, NamespaceSelector: &metav1.LabelSelector{}},
-						{IPBlock: &networkingv1.IPBlock{CIDR: "0.0.0.0/0"}},
-						{IPBlock: &networkingv1.IPBlock{CIDR: "::/0"}},
-					},
-				}},
+				Ingress:     []networkingv1.NetworkPolicyIngressRule{{}},
 			}))
 		})
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind bug

**What this PR does / why we need it**:
Adapt `from-world` network policies to work with all CNIs.

Different CNIs interpret kubernetes network policies quite differently. While one might think that allowing all pods from all namespaces and all IP addresses to talk to a given target might be sufficient as an allow all rule there are CNIs out there, which beg to differ. It seems to work more reliably across CNIs to not specify a from block at all when all sources are allowed.

**Which issue(s) this PR fixes**:
None.

**Special notes for your reviewer**:
This allows to have a seed with cilium running on AWS with network load balancers using internal IP addresses for health check. Previously, the health checks were (mostly!) dropped by the `from-world` network policy.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
A bug has been fixed which prevented components using the `networking.resources.gardener.cloud/from-world-to-ports` annotation from being reached from internal IP addresses when the cluster was using Cilium as CNI.
```
