### PR TITLE
Remove deprecated prometheus relabel config

### DIFF
--- a/charts/seed-bootstrap/charts/monitoring/templates/config.yaml
+++ b/charts/seed-bootstrap/charts/monitoring/templates/config.yaml
@@ -30,9 +30,6 @@ data:
         target_label: __address__
       - action: labelmap
         regex: __meta_kubernetes_pod_label_(.+)
-        # TODO(shafeeqes) : remove this relabel config in favor of one below once all extensions have added the prometheus.io/name annotation  
-      - source_labels: [ __meta_kubernetes_pod_label_app_kubernetes_io_instance ] # deprecated, use the prometheus.io/name annotation instead
-        target_label: job
       - source_labels: [ __meta_kubernetes_pod_annotation_prometheus_io_name ]
         regex: (.+)
         action: replace


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind cleanup

**What this PR does / why we need it**:
With https://github.com/gardener/gardener/pull/7180, we were using the `kubernetes.io/instance` label value to replace the job label for extensions.
The extensions are adapted now to use `prometheus.io/name` annotation, hence this relabel config can be cleaned up.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking dependency
Extensions that wish to be scraped by the `seed-prometheus` must annotate their pods with `prometheus.io/scrape=true` along with `prometheus.io/name=<name>`. See https://github.com/gardener/gardener/blob/master/docs/monitoring/README.md#seed-prometheus for more details.
```
