### PR TITLE
Extend configurability of `kubecontrollermanager` component

### DIFF
--- a/pkg/operation/botanist/component/kubecontrollermanager/kube_controller_manager.go
+++ b/pkg/operation/botanist/component/kubecontrollermanager/kube_controller_manager.go
@@ -109,23 +109,21 @@ func New(
 	values Values,
 ) Interface {
 	return &kubeControllerManager{
-		log:                           log,
-		seedClient:                    seedClient,
-		namespace:                     namespace,
-		secretsManager:                secretsManager,
-		values:                        values,
-		runtimeVersionGreaterEqual123: versionutils.ConstraintK8sGreaterEqual123.Check(values.RuntimeVersion),
+		log:            log,
+		seedClient:     seedClient,
+		namespace:      namespace,
+		secretsManager: secretsManager,
+		values:         values,
 	}
 }
 
 type kubeControllerManager struct {
-	log                           logr.Logger
-	seedClient                    kubernetes.Interface
-	shootClient                   client.Client
-	namespace                     string
-	secretsManager                secretsmanager.Interface
-	values                        Values
-	runtimeVersionGreaterEqual123 bool
+	log            logr.Logger
+	seedClient     kubernetes.Interface
+	shootClient    client.Client
+	namespace      string
+	secretsManager secretsmanager.Interface
+	values         Values
 }
 
 // Values are the values for the kube-controller-manager deployment.
@@ -584,7 +582,7 @@ func (k *kubeControllerManager) emptyDeployment() *appsv1.Deployment {
 func (k *kubeControllerManager) emptyPodDisruptionBudget() client.Object {
 	objectMeta := metav1.ObjectMeta{Name: v1beta1constants.DeploymentNameKubeControllerManager, Namespace: k.namespace}
 
-	if k.runtimeVersionGreaterEqual123 {
+	if versionutils.ConstraintK8sGreaterEqual121.Check(k.values.RuntimeVersion) {
 		return &policyv1.PodDisruptionBudget{ObjectMeta: objectMeta}
 	}
 	return &policyv1beta1.PodDisruptionBudget{ObjectMeta: objectMeta}

--- a/pkg/operation/botanist/component/kubecontrollermanager/kube_controller_manager.go
+++ b/pkg/operation/botanist/component/kubecontrollermanager/kube_controller_manager.go
@@ -148,6 +148,8 @@ type Values struct {
 	PodNetwork *net.IPNet
 	// ServiceNetwork is the service CIDR of the target cluster.
 	ServiceNetwork *net.IPNet
+	// ClusterSigningDuration is the value for the `--cluster-signing-duration` flag.
+	ClusterSigningDuration *time.Duration
 }
 
 func (k *kubeControllerManager) Deploy(ctx context.Context) error {
@@ -625,7 +627,7 @@ func (k *kubeControllerManager) computeCommand(port int32) []string {
 	)
 
 	command = append(command,
-		"--cluster-signing-duration=720h",
+		"--cluster-signing-duration="+pointer.DurationDeref(k.values.ClusterSigningDuration, 720*time.Hour).String(),
 		"--concurrent-endpoint-syncs=15",
 		"--concurrent-gc-syncs=30",
 		"--concurrent-namespace-syncs=50",

--- a/pkg/operation/botanist/component/kubecontrollermanager/kube_controller_manager.go
+++ b/pkg/operation/botanist/component/kubecontrollermanager/kube_controller_manager.go
@@ -152,6 +152,8 @@ type Values struct {
 	ClusterSigningDuration *time.Duration
 	// ControllerWorkers is used for configuring the workers for controllers.
 	ControllerWorkers ControllerWorkers
+	// ControllerSyncPeriods is used for configuring the sync periods for controllers.
+	ControllerSyncPeriods ControllerSyncPeriods
 }
 
 // ControllerWorkers is used for configuring the workers for controllers.
@@ -174,6 +176,12 @@ type ControllerWorkers struct {
 	ServiceEndpoint *int
 	// ServiceAccountToken is the number of workers for the ServiceAccountToken controller.
 	ServiceAccountToken *int
+}
+
+// ControllerSyncPeriods is used for configuring the sync periods for controllers.
+type ControllerSyncPeriods struct {
+	// ResourceQuota is the sync period for the ResourceQuota controller.
+	ResourceQuota *time.Duration
 }
 
 func (k *kubeControllerManager) Deploy(ctx context.Context) error {
@@ -651,6 +659,10 @@ func (k *kubeControllerManager) computeCommand(port int32) []string {
 		fmt.Sprintf("--concurrent-service-endpoint-syncs=%d", pointer.IntDeref(k.values.ControllerWorkers.ServiceEndpoint, 15)),
 		fmt.Sprintf("--concurrent-serviceaccount-token-syncs=%d", pointer.IntDeref(k.values.ControllerWorkers.ServiceAccountToken, 15)),
 	)
+
+	if k.values.ControllerSyncPeriods.ResourceQuota != nil {
+		command = append(command, "--resource-quota-sync-period="+k.values.ControllerSyncPeriods.ResourceQuota.String())
+	}
 
 	if len(k.values.Config.FeatureGates) > 0 {
 		command = append(command, kubernetesutils.FeatureGatesToCommandLineParameter(k.values.Config.FeatureGates))

--- a/pkg/operation/botanist/component/kubecontrollermanager/kube_controller_manager_test.go
+++ b/pkg/operation/botanist/component/kubecontrollermanager/kube_controller_manager_test.go
@@ -68,6 +68,7 @@ var _ = Describe("KubeControllerManager", func() {
 		fakeInterface         kubernetes.Interface
 		sm                    secretsmanager.Interface
 		kubeControllerManager Interface
+		values                Values
 
 		_, podCIDR, _                 = net.ParseCIDR("100.96.0.0/11")
 		_, serviceCIDR, _             = net.ParseCIDR("100.64.0.0/13")
@@ -133,19 +134,22 @@ var _ = Describe("KubeControllerManager", func() {
 	Describe("#Deploy", func() {
 		Context("Tests expecting a failure", func() {
 			BeforeEach(func() {
+				values = Values{
+					RuntimeVersion: runtimeKubernetesVersion,
+					TargetVersion:  semverVersion,
+					Image:          image,
+					Config:         &kcmConfig,
+					HVPAConfig:     hvpaConfigDisabled,
+					IsWorkerless:   isWorkerless,
+					PodNetwork:     podCIDR,
+					ServiceNetwork: serviceCIDR,
+				}
 				kubeControllerManager = New(
 					testLogger,
 					fakeInterface,
 					namespace,
 					sm,
-					semverVersion,
-					image,
-					&kcmConfig,
-					isWorkerless,
-					podCIDR,
-					serviceCIDR,
-					hvpaConfigDisabled,
-					runtimeKubernetesVersion,
+					values,
 				)
 			})
 
@@ -678,21 +682,17 @@ subjects:
 					semverVersion, err := semver.NewVersion(version)
 					Expect(err).NotTo(HaveOccurred())
 
-					kubeControllerManager = New(
-						testLogger,
-						fakeInterface,
-						namespace,
-						sm,
-						semverVersion,
-						image,
-						config,
-						isWorkerless,
-						podCIDR,
-						serviceCIDR,
-						hvpaConfig,
-						runtimeKubernetesVersion,
-					)
-
+					values = Values{
+						RuntimeVersion: runtimeKubernetesVersion,
+						TargetVersion:  semverVersion,
+						Image:          image,
+						Config:         config,
+						HVPAConfig:     hvpaConfig,
+						IsWorkerless:   isWorkerless,
+						PodNetwork:     podCIDR,
+						ServiceNetwork: serviceCIDR,
+					}
+					kubeControllerManager = New(testLogger, fakeInterface, namespace, sm, values)
 					kubeControllerManager.SetReplicaCount(replicas)
 
 					if hvpaConfig.Enabled {
@@ -792,21 +792,17 @@ subjects:
 					semverVersion, err := semver.NewVersion(version)
 					Expect(err).NotTo(HaveOccurred())
 
-					kubeControllerManager = New(
-						testLogger,
-						fakeInterface,
-						namespace,
-						sm,
-						semverVersion,
-						image,
-						config,
-						isWorkerless,
-						podCIDR,
-						serviceCIDR,
-						hvpaConfig,
-						runtimeKubernetesVersion,
-					)
-
+					values = Values{
+						RuntimeVersion: runtimeKubernetesVersion,
+						TargetVersion:  semverVersion,
+						Image:          image,
+						Config:         config,
+						HVPAConfig:     hvpaConfig,
+						IsWorkerless:   isWorkerless,
+						PodNetwork:     podCIDR,
+						ServiceNetwork: serviceCIDR,
+					}
+					kubeControllerManager = New(testLogger, fakeInterface, namespace, sm, values)
 					kubeControllerManager.SetReplicaCount(replicas)
 
 					if hvpaConfig.Enabled {
@@ -931,20 +927,11 @@ subjects:
 			fakeClient := fakeclient.NewClientBuilder().WithScheme(kubernetes.SeedScheme).Build()
 			fakeKubernetesInterface := kubernetesfake.NewClientSetBuilder().WithAPIReader(fakeClient).WithClient(fakeClient).Build()
 
-			kubeControllerManager = New(
-				testLogger,
-				fakeKubernetesInterface,
-				namespace,
-				nil,
-				nil,
-				"",
-				nil,
-				isWorkerless,
-				nil,
-				nil,
-				nil,
-				semver.MustParse("1.25.0"),
-			)
+			values = Values{
+				RuntimeVersion: semver.MustParse("1.25.0"),
+				IsWorkerless:   isWorkerless,
+			}
+			kubeControllerManager = New(testLogger, fakeKubernetesInterface, namespace, nil, values)
 
 			deploy := deployment.DeepCopy()
 

--- a/pkg/operation/botanist/component/kubecontrollermanager/monitoring_test.go
+++ b/pkg/operation/botanist/component/kubecontrollermanager/monitoring_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/Masterminds/semver"
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 
 	. "github.com/gardener/gardener/pkg/operation/botanist/component/kubecontrollermanager"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/test"
@@ -29,9 +28,7 @@ import (
 var _ = Describe("Monitoring", func() {
 	DescribeTable("success tests for scrape config various kubernetes versions",
 		func(version, expectedScrapeConfig string) {
-			semverVersion, err := semver.NewVersion(version)
-			Expect(err).NotTo(HaveOccurred())
-			kubeControllerManager := New(logr.Discard(), nil, "", nil, semverVersion, "", nil, false, nil, nil, nil, semver.MustParse("1.25.0"))
+			kubeControllerManager := New(logr.Discard(), nil, "", nil, Values{RuntimeVersion: semver.MustParse("1.25.0"), TargetVersion: semver.MustParse(version)})
 			test.ScrapeConfigs(kubeControllerManager, expectedScrapeConfig)
 		},
 
@@ -41,9 +38,7 @@ var _ = Describe("Monitoring", func() {
 	)
 
 	It("should successfully test the alerting rules", func() {
-		semverVersion, err := semver.NewVersion("1.21.4")
-		Expect(err).NotTo(HaveOccurred())
-		kubeControllerManager := New(logr.Discard(), nil, "", nil, semverVersion, "", nil, false, nil, nil, nil, semver.MustParse("1.25.0"))
+		kubeControllerManager := New(logr.Discard(), nil, "", nil, Values{RuntimeVersion: semver.MustParse("1.25.0"), TargetVersion: semver.MustParse("1.21.4")})
 
 		test.AlertingRulesWithPromtool(
 			kubeControllerManager,

--- a/pkg/operation/botanist/component/kubecontrollermanager/waiter_test.go
+++ b/pkg/operation/botanist/component/kubecontrollermanager/waiter_test.go
@@ -83,21 +83,11 @@ var _ = Describe("WaiterTest", func() {
 
 	Describe("#WaitForControllerToBeActive", func() {
 		BeforeEach(func() {
-			kubeControllerManager = New(
-				testLogger,
-				fakeSeedInterface,
-				namespace,
-				nil,
-				version,
-				"",
-				nil,
-				isWorkerless,
-				nil,
-				nil,
-				nil,
-				semver.MustParse("1.25.0"),
-			)
-
+			kubeControllerManager = New(testLogger, fakeSeedInterface, namespace, nil, Values{
+				RuntimeVersion: semver.MustParse("1.25.0"),
+				TargetVersion:  version,
+				IsWorkerless:   isWorkerless,
+			})
 			kubeControllerManager.SetShootClient(shootClient)
 
 			waiter = &retryfake.Ops{MaxAttempts: 1}

--- a/pkg/operation/botanist/kubecontrollermanager.go
+++ b/pkg/operation/botanist/kubecontrollermanager.go
@@ -58,17 +58,19 @@ func (b *Botanist) DefaultKubeControllerManager() (kubecontrollermanager.Interfa
 		b.SeedClientSet,
 		b.Shoot.SeedNamespace,
 		b.SecretsManager,
-		b.Shoot.KubernetesVersion,
-		image.String(),
-		b.Shoot.GetInfo().Spec.Kubernetes.KubeControllerManager,
-		b.Shoot.IsWorkerless,
-		pods,
-		services,
-		&kubecontrollermanager.HVPAConfig{
-			Enabled:             hvpaEnabled,
-			ScaleDownUpdateMode: &scaleDownUpdateMode,
+		kubecontrollermanager.Values{
+			RuntimeVersion: b.Seed.KubernetesVersion,
+			TargetVersion:  b.Shoot.KubernetesVersion,
+			Image:          image.String(),
+			Config:         b.Shoot.GetInfo().Spec.Kubernetes.KubeControllerManager,
+			HVPAConfig: &kubecontrollermanager.HVPAConfig{
+				Enabled:             hvpaEnabled,
+				ScaleDownUpdateMode: &scaleDownUpdateMode,
+			},
+			IsWorkerless:   b.Shoot.IsWorkerless,
+			PodNetwork:     pods,
+			ServiceNetwork: services,
 		},
-		b.Seed.KubernetesVersion,
 	), nil
 }
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind enhancement

**What this PR does / why we need it**:
This PR extends the configurability for `kube-controller-manager` by

- introducing a `Values` struct (prefactoring to make configuration easier extensible)
- allowing configuration of `--cluster-signing-duration`
- allowing configuration of concurrent syncs (workers) for controllers
- allowing configuration of sync period for `ResourceQuota` controller
- allowing disablement of certain controllers for workerless clusters

Note that not all possible flags for concurrent syncs or sync periods are exposed as of today. I only focused on the minimal set of configuration needed for the `gardener-operator` use case. When needed, we can easily also add the respective values for other controllers in the future.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/7016

**Special notes for your reviewer**:
/cc @shafeeqes @acumino @ary1992

This PR builds on top of https://github.com/gardener/gardener/pull/7858, thanks for all the preliminary work!

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
