### PR TITLE
Extend the SeedPredicate of `controllerregistration` controller

### DIFF
--- a/pkg/controllermanager/controller/controllerregistration/seed/add.go
+++ b/pkg/controllermanager/controller/controllerregistration/seed/add.go
@@ -124,7 +124,8 @@ func (r *Reconciler) SeedPredicate() predicate.Predicate {
 			}
 
 			return !apiequality.Semantic.DeepEqual(oldSeed.Spec.DNS.Provider, seed.Spec.DNS.Provider) ||
-				seed.DeletionTimestamp != nil
+				seed.DeletionTimestamp != nil ||
+				topologyAwareRoutingSettingsHasChanged(oldSeed.Spec.Settings, seed.Spec.Settings)
 		},
 	}
 }
@@ -374,4 +375,13 @@ func shootNetworkingTypeHasChanged(old, new *gardencorev1beta1.Networking) bool 
 		return old.Type != nil
 	}
 	return !pointer.StringEqual(old.Type, new.Type)
+}
+
+func topologyAwareRoutingSettingsHasChanged(old, new *gardencorev1beta1.SeedSettings) bool {
+	var (
+		oldHasTopologyAwareRoutingEnabled = old != nil && old.TopologyAwareRouting != nil && old.TopologyAwareRouting.Enabled
+		newHasTopologyAwareRoutingEnabled = new != nil && new.TopologyAwareRouting != nil && new.TopologyAwareRouting.Enabled
+	)
+
+	return oldHasTopologyAwareRoutingEnabled != newHasTopologyAwareRoutingEnabled
 }

--- a/pkg/controllermanager/controller/controllerregistration/seed/add.go
+++ b/pkg/controllermanager/controller/controllerregistration/seed/add.go
@@ -123,9 +123,10 @@ func (r *Reconciler) SeedPredicate() predicate.Predicate {
 				return false
 			}
 
-			return !apiequality.Semantic.DeepEqual(oldSeed.Spec.DNS.Provider, seed.Spec.DNS.Provider) ||
-				seed.DeletionTimestamp != nil ||
-				topologyAwareRoutingSettingsHasChanged(oldSeed.Spec.Settings, seed.Spec.Settings)
+			return !apiequality.Semantic.DeepEqual(oldSeed.Spec, seed.Spec) ||
+				!apiequality.Semantic.DeepEqual(oldSeed.Annotations, seed.Annotations) ||
+				!apiequality.Semantic.DeepEqual(oldSeed.Labels, seed.Labels) ||
+				seed.DeletionTimestamp != nil
 		},
 	}
 }
@@ -375,13 +376,4 @@ func shootNetworkingTypeHasChanged(old, new *gardencorev1beta1.Networking) bool 
 		return old.Type != nil
 	}
 	return !pointer.StringEqual(old.Type, new.Type)
-}
-
-func topologyAwareRoutingSettingsHasChanged(old, new *gardencorev1beta1.SeedSettings) bool {
-	var (
-		oldHasTopologyAwareRoutingEnabled = old != nil && old.TopologyAwareRouting != nil && old.TopologyAwareRouting.Enabled
-		newHasTopologyAwareRoutingEnabled = new != nil && new.TopologyAwareRouting != nil && new.TopologyAwareRouting.Enabled
-	)
-
-	return oldHasTopologyAwareRoutingEnabled != newHasTopologyAwareRoutingEnabled
 }

--- a/pkg/controllermanager/controller/controllerregistration/seed/add_test.go
+++ b/pkg/controllermanager/controller/controllerregistration/seed/add_test.go
@@ -85,6 +85,31 @@ var _ = Describe("Add", func() {
 				seed.DeletionTimestamp = &metav1.Time{}
 				Expect(p.Update(event.UpdateEvent{ObjectNew: seed, ObjectOld: oldSeed})).To(BeTrue())
 			})
+
+			It("should return true if the TopologyAwareRouting setting has been changed (disabled to enabled)", func() {
+				oldSeed := seed.DeepCopy()
+				seed.Spec.Settings = &gardencorev1beta1.SeedSettings{
+					TopologyAwareRouting: &gardencorev1beta1.SeedSettingTopologyAwareRouting{
+						Enabled: true,
+					},
+				}
+				Expect(p.Update(event.UpdateEvent{ObjectNew: seed, ObjectOld: oldSeed})).To(BeTrue())
+			})
+
+			It("should return true if the TopologyAwareRouting setting has been changed (enabled to disabled)", func() {
+				oldSeed := seed.DeepCopy()
+				oldSeed.Spec.Settings = &gardencorev1beta1.SeedSettings{
+					TopologyAwareRouting: &gardencorev1beta1.SeedSettingTopologyAwareRouting{
+						Enabled: true,
+					},
+				}
+				seed.Spec.Settings = &gardencorev1beta1.SeedSettings{
+					TopologyAwareRouting: &gardencorev1beta1.SeedSettingTopologyAwareRouting{
+						Enabled: false,
+					},
+				}
+				Expect(p.Update(event.UpdateEvent{ObjectNew: seed, ObjectOld: oldSeed})).To(BeTrue())
+			})
 		})
 
 		Describe("#Delete", func() {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind enhancement

**What this PR does / why we need it**:
This PR enhances the SeedPredicate of the `controllerregistration` controller to return true if there is a change in spec, labels or annotations.

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener/issues/7732

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
