### PR TITLE
Don't allow shoot to scale up to HA if it is hibernated

### DIFF
--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -2223,7 +2223,7 @@ func isShootReadyForRotationStart(lastOperation *core.LastOperation) bool {
 }
 
 func isShootInHibernation(shoot *core.Shoot) bool {
-	if shoot.Spec.Hibernation != nil  && shoot.Spec.Hibernation.Enabled != nil {
+	if shoot.Spec.Hibernation != nil && shoot.Spec.Hibernation.Enabled != nil {
 		return *shoot.Spec.Hibernation.Enabled || shoot.Status.IsHibernated
 	}
 

--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -2166,9 +2166,9 @@ func ValidateShootHAConfig(shoot *core.Shoot) field.ErrorList {
 }
 
 // ValidateShootHAConfigUpdate validates the HA shoot control plane configuration.
-func ValidateShootHAConfigUpdate(newShoot, oldSnoot *core.Shoot) field.ErrorList {
+func ValidateShootHAConfigUpdate(newShoot, oldShoot *core.Shoot) field.ErrorList {
 	allErrs := field.ErrorList{}
-	allErrs = append(allErrs, validateShootHAControlPlaneSpecUpdate(newShoot, oldSnoot, field.NewPath("spec.controlPlane"))...)
+	allErrs = append(allErrs, validateShootHAControlPlaneSpecUpdate(newShoot, oldShoot, field.NewPath("spec.controlPlane"))...)
 	return allErrs
 }
 
@@ -2197,7 +2197,7 @@ func validateShootHAControlPlaneSpecUpdate(newShoot, oldShoot *core.Shoot, fldPa
 	if newShoot.Spec.ControlPlane != nil && newShoot.Spec.ControlPlane.HighAvailability != nil {
 		newVal = newShoot.Spec.ControlPlane.HighAvailability.FailureTolerance.Type
 		if !oldValExists && isShootInHibernation(newShoot) {
-			allErrs = append(allErrs, field.Forbidden(field.NewPath("spec", "controlPlane", "highAvailability", "failureTolerance", "type"), "Shoot is currently hibernated and cannot be scaled up to HA. Please make sure your cluster has woken up before scaling it up to HA"))
+			allErrs = append(allErrs, field.Forbidden(fldPath.Child("highAvailability", "failureTolerance", "type"), "Shoot is currently hibernated and cannot be scaled up to HA. Please make sure your cluster has woken up before scaling it up to HA"))
 		}
 	}
 

--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -2223,7 +2223,7 @@ func isShootReadyForRotationStart(lastOperation *core.LastOperation) bool {
 }
 
 func isShootInHibernation(shoot *core.Shoot) bool {
-	if shoot.Spec.Hibernation != nil {
+	if shoot.Spec.Hibernation != nil  && shoot.Spec.Hibernation.Enabled != nil {
 		return *shoot.Spec.Hibernation.Enabled || shoot.Status.IsHibernated
 	}
 

--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -2168,7 +2168,7 @@ func ValidateShootHAConfig(shoot *core.Shoot) field.ErrorList {
 // ValidateShootHAConfigUpdate validates the HA shoot control plane configuration.
 func ValidateShootHAConfigUpdate(newShoot, oldSnoot *core.Shoot) field.ErrorList {
 	allErrs := field.ErrorList{}
-	allErrs = append(allErrs, validateShootHAControlPlaneSpecUpdate(&newShoot.Spec, &oldSnoot.Spec, field.NewPath("spec.controlPlane"))...)
+	allErrs = append(allErrs, validateShootHAControlPlaneSpecUpdate(newShoot, oldSnoot, field.NewPath("spec.controlPlane"))...)
 	return allErrs
 }
 
@@ -2180,22 +2180,25 @@ func validateHAShootControlPlaneConfigurationValue(shoot *core.Shoot) field.Erro
 	return allErrs
 }
 
-func validateShootHAControlPlaneSpecUpdate(newSpec, oldSpec *core.ShootSpec, fldPath *field.Path) field.ErrorList {
+func validateShootHAControlPlaneSpecUpdate(newShoot, oldShoot *core.Shoot, fldPath *field.Path) field.ErrorList {
 	var (
 		allErrs          = field.ErrorList{}
-		shootIsScheduled = newSpec.SeedName != nil
+		shootIsScheduled = newShoot.Spec.SeedName != nil
 
 		oldVal, newVal core.FailureToleranceType
 		oldValExists   bool
 	)
 
-	if oldSpec.ControlPlane != nil && oldSpec.ControlPlane.HighAvailability != nil {
-		oldVal = oldSpec.ControlPlane.HighAvailability.FailureTolerance.Type
+	if oldShoot.Spec.ControlPlane != nil && oldShoot.Spec.ControlPlane.HighAvailability != nil {
+		oldVal = oldShoot.Spec.ControlPlane.HighAvailability.FailureTolerance.Type
 		oldValExists = true
 	}
 
-	if newSpec.ControlPlane != nil && newSpec.ControlPlane.HighAvailability != nil {
-		newVal = newSpec.ControlPlane.HighAvailability.FailureTolerance.Type
+	if newShoot.Spec.ControlPlane != nil && newShoot.Spec.ControlPlane.HighAvailability != nil {
+		newVal = newShoot.Spec.ControlPlane.HighAvailability.FailureTolerance.Type
+		if !oldValExists && isShootInHibernation(newShoot) {
+			allErrs = append(allErrs, field.Forbidden(field.NewPath("spec", "controlPlane", "highAvailability", "failureTolerance", "type"), "Shoot is currently hibernated and cannot be scaled up to HA. Please make sure your cluster has woken up before scaling it up to HA"))
+		}
 	}
 
 	if oldValExists && shootIsScheduled {
@@ -2217,4 +2220,12 @@ func isShootReadyForRotationStart(lastOperation *core.LastOperation) bool {
 		return true
 	}
 	return lastOperation.Type == core.LastOperationTypeReconcile
+}
+
+func isShootInHibernation(shoot *core.Shoot) bool {
+	if shoot.Spec.Hibernation != nil {
+		return *shoot.Spec.Hibernation.Enabled
+	}
+
+	return shoot.Status.IsHibernated
 }

--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -2224,7 +2224,7 @@ func isShootReadyForRotationStart(lastOperation *core.LastOperation) bool {
 
 func isShootInHibernation(shoot *core.Shoot) bool {
 	if shoot.Spec.Hibernation != nil {
-		return *shoot.Spec.Hibernation.Enabled
+		return *shoot.Spec.Hibernation.Enabled || shoot.Status.IsHibernated
 	}
 
 	return shoot.Status.IsHibernated

--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -2196,6 +2196,7 @@ func validateShootHAControlPlaneSpecUpdate(newShoot, oldShoot *core.Shoot, fldPa
 
 	if newShoot.Spec.ControlPlane != nil && newShoot.Spec.ControlPlane.HighAvailability != nil {
 		newVal = newShoot.Spec.ControlPlane.HighAvailability.FailureTolerance.Type
+		// TODO(@aaronfern): remove this validation of not allowing scale-up to HA while hibernated when https://github.com/gardener/etcd-druid/issues/589 is resolved
 		if !oldValExists && isShootInHibernation(newShoot) {
 			allErrs = append(allErrs, field.Forbidden(fldPath.Child("highAvailability", "failureTolerance", "type"), "Shoot is currently hibernated and cannot be scaled up to HA. Please make sure your cluster has woken up before scaling it up to HA"))
 		}

--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -420,13 +420,12 @@ var _ = Describe("Shoot Validation Tests", func() {
 				})
 			})
 
-			Context("Shoot is hibernated", func() {
-				It("Should not allow upgrading from non-HA to HA when Spec.Hibernation.Enabled is set to `true`", func() {
+			Context("shoot is hibernated", func() {
+				It("should not allow upgrading from non-HA to HA when Spec.Hibernation.Enabled is set to `true`", func() {
 					shoot.Spec.ControlPlane = &core.ControlPlane{}
-					ValueTrue := true
 					newShoot := prepareShootForUpdate(shoot)
 					newShoot.Spec.ControlPlane = &core.ControlPlane{HighAvailability: &core.HighAvailability{FailureTolerance: core.FailureTolerance{Type: core.FailureToleranceTypeZone}}}
-					newShoot.Spec.Hibernation = &core.Hibernation{Enabled: &ValueTrue}
+					newShoot.Spec.Hibernation = &core.Hibernation{Enabled: pointer.Bool(true)}
 					errorList := ValidateShootHAConfigUpdate(newShoot, shoot)
 					Expect(errorList).To(ConsistOf(
 						PointTo(MatchFields(IgnoreExtras, Fields{
@@ -437,7 +436,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 					))
 				})
 
-				It("Should not allow upgrading from non-HA to HA when Status.IsHibernation is set to `true`", func() {
+				It("should not allow upgrading from non-HA to HA when Status.IsHibernation is set to `true`", func() {
 					shoot.Spec.ControlPlane = &core.ControlPlane{}
 					newShoot := prepareShootForUpdate(shoot)
 					newShoot.Spec.ControlPlane = &core.ControlPlane{HighAvailability: &core.HighAvailability{FailureTolerance: core.FailureTolerance{Type: core.FailureToleranceTypeNode}}}

--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -420,7 +420,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 				})
 			})
 
-			Context("Shoot is hibarnated", func() {
+			Context("Shoot is hibernated", func() {
 				It("Should not allow upgrading from non-HA to HA when Spec.Hibernation.Enabled is set to `true`", func() {
 					shoot.Spec.ControlPlane = &core.ControlPlane{}
 					ValueTrue := true
@@ -428,16 +428,28 @@ var _ = Describe("Shoot Validation Tests", func() {
 					newShoot.Spec.ControlPlane = &core.ControlPlane{HighAvailability: &core.HighAvailability{FailureTolerance: core.FailureTolerance{Type: core.FailureToleranceTypeZone}}}
 					newShoot.Spec.Hibernation = &core.Hibernation{Enabled: &ValueTrue}
 					errorList := ValidateShootHAConfigUpdate(newShoot, shoot)
-					Expect(errorList).NotTo(BeEmpty())
+					Expect(errorList).To(ConsistOf(
+						PointTo(MatchFields(IgnoreExtras, Fields{
+							"Type":   Equal(field.ErrorTypeForbidden),
+							"Field":  Equal("spec.controlPlane.highAvailability.failureTolerance.type"),
+							"Detail": Equal("Shoot is currently hibernated and cannot be scaled up to HA. Please make sure your cluster has woken up before scaling it up to HA"),
+						})),
+					))
 				})
 
 				It("Should not allow upgrading from non-HA to HA when Status.IsHibernation is set to `true`", func() {
 					shoot.Spec.ControlPlane = &core.ControlPlane{}
 					newShoot := prepareShootForUpdate(shoot)
-					newShoot.Spec.ControlPlane = &core.ControlPlane{HighAvailability: &core.HighAvailability{FailureTolerance: core.FailureTolerance{Type: core.FailureToleranceTypeZone}}}
+					newShoot.Spec.ControlPlane = &core.ControlPlane{HighAvailability: &core.HighAvailability{FailureTolerance: core.FailureTolerance{Type: core.FailureToleranceTypeNode}}}
 					newShoot.Status.IsHibernated = true
 					errorList := ValidateShootHAConfigUpdate(newShoot, shoot)
-					Expect(errorList).NotTo(BeEmpty())
+					Expect(errorList).To(ConsistOf(
+						PointTo(MatchFields(IgnoreExtras, Fields{
+							"Type":   Equal(field.ErrorTypeForbidden),
+							"Field":  Equal("spec.controlPlane.highAvailability.failureTolerance.type"),
+							"Detail": Equal("Shoot is currently hibernated and cannot be scaled up to HA. Please make sure your cluster has woken up before scaling it up to HA"),
+						})),
+					))
 				})
 			})
 		})

--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -419,6 +419,27 @@ var _ = Describe("Shoot Validation Tests", func() {
 					Expect(ValidateShootHAConfigUpdate(newShoot, shoot)).To(BeEmpty())
 				})
 			})
+
+			Context("Shoot is hibarnated", func() {
+				It("Should not allow upgrading from non-HA to HA when Spec.Hibernation.Enabled is set to `true`", func() {
+					shoot.Spec.ControlPlane = &core.ControlPlane{}
+					ValueTrue := true
+					newShoot := prepareShootForUpdate(shoot)
+					newShoot.Spec.ControlPlane = &core.ControlPlane{HighAvailability: &core.HighAvailability{FailureTolerance: core.FailureTolerance{Type: core.FailureToleranceTypeZone}}}
+					newShoot.Spec.Hibernation = &core.Hibernation{Enabled: &ValueTrue}
+					errorList := ValidateShootHAConfigUpdate(newShoot, shoot)
+					Expect(errorList).NotTo(BeEmpty())
+				})
+
+				It("Should not allow upgrading from non-HA to HA when Status.IsHibernation is set to `true`", func() {
+					shoot.Spec.ControlPlane = &core.ControlPlane{}
+					newShoot := prepareShootForUpdate(shoot)
+					newShoot.Spec.ControlPlane = &core.ControlPlane{HighAvailability: &core.HighAvailability{FailureTolerance: core.FailureTolerance{Type: core.FailureToleranceTypeZone}}}
+					newShoot.Status.IsHibernated = true
+					errorList := ValidateShootHAConfigUpdate(newShoot, shoot)
+					Expect(errorList).NotTo(BeEmpty())
+				})
+			})
 		})
 
 		Context("#ValidateShootHAConfig", func() {

--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -450,6 +450,32 @@ var _ = Describe("Shoot Validation Tests", func() {
 						})),
 					))
 				})
+
+				It("should not allow upgrading from non-HA to HA when Spec.Hibernation.Enabled is set to `false` and Status.IsHibernation is set to `true`", func() {
+					shoot.Spec.ControlPlane = &core.ControlPlane{}
+					newShoot := prepareShootForUpdate(shoot)
+					newShoot.Spec.ControlPlane = &core.ControlPlane{HighAvailability: &core.HighAvailability{FailureTolerance: core.FailureTolerance{Type: core.FailureToleranceTypeNode}}}
+					newShoot.Spec.Hibernation = &core.Hibernation{Enabled: pointer.Bool(false)}
+					newShoot.Status.IsHibernated = true
+					errorList := ValidateShootHAConfigUpdate(newShoot, shoot)
+					Expect(errorList).To(ConsistOf(
+						PointTo(MatchFields(IgnoreExtras, Fields{
+							"Type":   Equal(field.ErrorTypeForbidden),
+							"Field":  Equal("spec.controlPlane.highAvailability.failureTolerance.type"),
+							"Detail": Equal("Shoot is currently hibernated and cannot be scaled up to HA. Please make sure your cluster has woken up before scaling it up to HA"),
+						})),
+					))
+				})
+
+				It("should allow upgrading from non-HA to HA when Spec.Hibernation.Enabled is set to `false` and Status.IsHibernation is set to `false`", func() {
+					shoot.Spec.ControlPlane = &core.ControlPlane{}
+					newShoot := prepareShootForUpdate(shoot)
+					newShoot.Spec.ControlPlane = &core.ControlPlane{HighAvailability: &core.HighAvailability{FailureTolerance: core.FailureTolerance{Type: core.FailureToleranceTypeNode}}}
+					newShoot.Spec.Hibernation = &core.Hibernation{Enabled: pointer.Bool(false)}
+					newShoot.Status.IsHibernated = false
+					errorList := ValidateShootHAConfigUpdate(newShoot, shoot)
+					Expect(errorList).To(BeEmpty())
+				})
 			})
 		})
 

--- a/plugin/pkg/shoot/validator/admission.go
+++ b/plugin/pkg/shoot/validator/admission.go
@@ -279,9 +279,6 @@ func (v *ValidateShoot) Admit(ctx context.Context, a admission.Attributes, o adm
 	if err := validationContext.ensureMachineImages(); err != nil {
 		return err
 	}
-	if err := validationContext.validateShootScaleupToHA(); err != nil {
-		return err
-	}
 
 	validationContext.addMetadataAnnotations(a)
 
@@ -1534,28 +1531,4 @@ func isShootInMigrationOrRestorePhase(shoot *core.Shoot) bool {
 		(shoot.Status.LastOperation.Type == core.LastOperationTypeRestore &&
 			shoot.Status.LastOperation.State != core.LastOperationStateSucceeded ||
 			shoot.Status.LastOperation.Type == core.LastOperationTypeMigrate)
-}
-
-func (c *validationContext) validateShootScaleupToHA() error {
-	if !isShootHA(c.oldShoot) && isShootHA(c.shoot) {
-		if isShootInHibernation(c.shoot) {
-			return fmt.Errorf("Shoot is currently hibernated and cannot be scaled up to HA. Please make sure your cluster has woken up before scaling it up to HA")
-		}
-	}
-	return nil
-}
-
-func isShootHA(shoot *core.Shoot) bool {
-	if shoot.Spec.ControlPlane != nil {
-		return shoot.Spec.ControlPlane.HighAvailability.FailureTolerance.Type == core.FailureToleranceTypeNode || shoot.Spec.ControlPlane.HighAvailability.FailureTolerance.Type == core.FailureToleranceTypeZone
-	}
-	return false
-}
-
-func isShootInHibernation(shoot *core.Shoot) bool {
-	if shoot.Spec.Hibernation != nil {
-		return *shoot.Spec.Hibernation.Enabled
-	}
-
-	return shoot.Status.IsHibernated
 }

--- a/plugin/pkg/shoot/validator/admission.go
+++ b/plugin/pkg/shoot/validator/admission.go
@@ -279,6 +279,9 @@ func (v *ValidateShoot) Admit(ctx context.Context, a admission.Attributes, o adm
 	if err := validationContext.ensureMachineImages(); err != nil {
 		return err
 	}
+	if err := validationContext.validateShootScaleupToHA(); err != nil {
+		return err
+	}
 
 	validationContext.addMetadataAnnotations(a)
 
@@ -1531,4 +1534,28 @@ func isShootInMigrationOrRestorePhase(shoot *core.Shoot) bool {
 		(shoot.Status.LastOperation.Type == core.LastOperationTypeRestore &&
 			shoot.Status.LastOperation.State != core.LastOperationStateSucceeded ||
 			shoot.Status.LastOperation.Type == core.LastOperationTypeMigrate)
+}
+
+func (c *validationContext) validateShootScaleupToHA() error {
+	if !isShootHA(c.oldShoot) && isShootHA(c.shoot) {
+		if isShootInHibernation(c.shoot) {
+			return fmt.Errorf("Shoot is currently hibernated and cannot be scaled up to HA. Please make sure your cluster has woken up before scaling it up to HA")
+		}
+	}
+	return nil
+}
+
+func isShootHA(shoot *core.Shoot) bool {
+	if shoot.Spec.ControlPlane != nil {
+		return shoot.Spec.ControlPlane.HighAvailability.FailureTolerance.Type == core.FailureToleranceTypeNode || shoot.Spec.ControlPlane.HighAvailability.FailureTolerance.Type == core.FailureToleranceTypeZone
+	}
+	return false
+}
+
+func isShootInHibernation(shoot *core.Shoot) bool {
+	if shoot.Spec.Hibernation != nil {
+		return *shoot.Spec.Hibernation.Enabled
+	}
+
+	return shoot.Status.IsHibernated
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/area high-availability
/kind enhancement

**What this PR does / why we need it**:
There have been instances where shoots go into an error state when a user scales it to HA while they are hibernated. 
In such a scenario, the etcd resource is updated and when woken up later on, `etcd-druid` starts up a multi node cluster. Since the shoot was hibernated before and there are no etcd pods already up, `etcd-druid` cannot properly differentiate between it's bootstrap and scale up flow resulting in incorrect etcd clusters.

A simple remedy is not to allow a shoot to be scaled up unless it has woken up.
This PR updated the shoot static validations to not allow the `Shoot.Spec.ControlPlane.HighAvailability.FailureTolerance.Type` field to be set if a shoot is hibernated.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking user
Gardener denies setting `Shoot.Spec.ControlPlane.HighAvailability.FailureTolerance.Type` if shoot is hibernated.
```
