### PR TITLE
Remediate webhooks affecting lease resource in kube-system namespace with timeoutSeconds more than 4

### DIFF
--- a/docs/usage/shoot_status.md
+++ b/docs/usage/shoot_status.md
@@ -88,6 +88,8 @@ However, some other resources (some of them cluster-scoped) might still trigger 
 
 If one of the above resources triggers the remediator, the preferred solution is to remove that particular resource from your webhook's `rules`. You can also use the `objectSelector` to reduce the scope of webhook's `rules`. However, in special cases where a webhook is absolutely needed for the workload, it is possible to add the `remediation.webhook.shoot.gardener.cloud/exclude=true` label to your webhook so that the remediator ignores it. This label **should not be used to silence an alert**, but rather to confirm that a webhook won't cause problems. Note that all of this is no perfect solution and just done on a best effort basis, and only the owner of the webhook can know whether it indeed is problematic and configured correctly.
 
+In a special case, if a webhook has a rule for `CREATE/UPDATE` lease resources in `kube-system` namespace, its `timeoutSeconds` is updated to 3 seconds. This is required to ensure the proper functioning of the leader election of essential control plane controllers.
+
 You can also find more help from the [Kubernetes documentation](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#best-practices-and-warnings)
 
 **`MaintenancePreconditionsSatisfied`**:

--- a/pkg/operation/botanist/matchers/matcher.go
+++ b/pkg/operation/botanist/matchers/matcher.go
@@ -61,8 +61,8 @@ var (
 		managedresources.LabelKeyOrigin: managedresources.LabelValueGardener,
 	}
 
-	// WebhookConstraintMatchersForLeases contains a list of lease api resources which can break
-	// the waking up of a cluster.
+	// WebhookConstraintMatchersForLeases contains a list of lease API resources that can break
+	// leader election of essential control plane controllers.
 	WebhookConstraintMatchersForLeases = []WebhookConstraintMatcher{
 		{GVR: coordinationv1.SchemeGroupVersion.WithResource("leases"), NamespaceLabels: kubeSystemNamespaceLabels},
 		{GVR: coordinationv1beta1.SchemeGroupVersion.WithResource("leases"), NamespaceLabels: kubeSystemNamespaceLabels},

--- a/pkg/operation/botanist/matchers/matcher.go
+++ b/pkg/operation/botanist/matchers/matcher.go
@@ -60,6 +60,14 @@ var (
 		v1beta1constants.ShootNoCleanup: "true",
 		managedresources.LabelKeyOrigin: managedresources.LabelValueGardener,
 	}
+
+	// WebhookConstraintMatchersForLeases contains a list of lease api resources which can break
+	// the waking up of a cluster.
+	WebhookConstraintMatchersForLeases = []WebhookConstraintMatcher{
+		{GVR: coordinationv1.SchemeGroupVersion.WithResource("leases"), NamespaceLabels: kubeSystemNamespaceLabels},
+		{GVR: coordinationv1beta1.SchemeGroupVersion.WithResource("leases"), NamespaceLabels: kubeSystemNamespaceLabels},
+	}
+
 	// WebhookConstraintMatchers contains a list of all api resources which can break
 	// the waking up of a cluster.
 	WebhookConstraintMatchers = []WebhookConstraintMatcher{

--- a/pkg/operation/care/constraints_test.go
+++ b/pkg/operation/care/constraints_test.go
@@ -153,6 +153,14 @@ var _ = Describe("Constraints", func() {
 			}
 
 			commonTests = func(gvr schema.GroupVersionResource, problematic, notProblematic []TableEntry) {
+				if gvr.Resource == "leases" || (gvr.Group == "*" && gvr.Resource == "*") {
+					problematic = append(problematic,
+						Entry("failurePolicy 'Ignore' and timeoutSeconds ok", webhookTestCase{failurePolicy: &failurePolicyIgnore, timeoutSeconds: &timeoutSecondsNotProblematic}))
+				} else {
+					notProblematic = append(notProblematic,
+						Entry("failurePolicy 'Ignore' and timeoutSeconds ok", webhookTestCase{failurePolicy: &failurePolicyIgnore, timeoutSeconds: &timeoutSecondsNotProblematic}))
+				}
+
 				DescribeTable(fmt.Sprintf("problematic webhook for %s", gvr.String()),
 					func(testCase webhookTestCase) {
 						testCase.gvr = gvr
@@ -184,7 +192,6 @@ var _ = Describe("Constraints", func() {
 						testCase.gvr = gvr
 						Expect(IsProblematicWebhook(testCase.build())).To(BeFalse(), "expected webhook not to be problematic")
 					},
-					Entry("failurePolicy 'Ignore' and timeoutSeconds ok", webhookTestCase{failurePolicy: &failurePolicyIgnore, timeoutSeconds: &timeoutSecondsNotProblematic}),
 					Entry("operationType 'DELETE'", webhookTestCase{operationType: &operationDelete}),
 					notProblematic,
 				)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity
/kind enhancement

**What this PR does / why we need it**:
This PR enhances the webhooks remediator to set the timeoutSeonds to 3 seconds for webhook affecting lease resources in `kube-system` namespace.

For more details ref - #7625

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener/issues/7625

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking user
Webhooks remediator now sets the timeoutSeonds to 3 seconds for webhook affecting lease resources in `kube-system` namespace.
```
