### PR TITLE
Expand `ClusterRole` of `fluent-operator`

### DIFF
--- a/pkg/operation/botanist/component/logging/fluentoperator/fluent_operator.go
+++ b/pkg/operation/botanist/component/logging/fluentoperator/fluent_operator.go
@@ -114,6 +114,16 @@ func (f *fluentOperator) Deploy(ctx context.Context) error {
 				{
 					APIGroups: []string{"rbac.authorization.k8s.io"},
 					Resources: []string{"clusterrolebindings", "clusterroles"},
+					Verbs:     []string{"get", "list", "watch", "create"},
+				},
+				{
+					APIGroups: []string{""},
+					Resources: []string{"pods"},
+					Verbs:     []string{"get"},
+				},
+				{
+					APIGroups: []string{"extensions.gardener.cloud"},
+					Resources: []string{"clusters"},
 					Verbs:     []string{"get", "list", "watch"},
 				},
 			},
@@ -157,23 +167,8 @@ func (f *fluentOperator) Deploy(ctx context.Context) error {
 				},
 				{
 					APIGroups: []string{""},
-					Resources: []string{"pods"},
-					Verbs:     []string{"get"},
-				},
-				{
-					APIGroups: []string{""},
 					Resources: []string{"secrets", "configmaps", "serviceaccounts", "services", "namespaces"},
 					Verbs:     []string{"create", "delete", "get", "list", "patch", "update", "watch"},
-				},
-				{
-					APIGroups: []string{"extensions.gardener.cloud"},
-					Resources: []string{"clusters"},
-					Verbs:     []string{"get", "list", "watch"},
-				},
-				{
-					APIGroups: []string{"rbac.authorization.k8s.io"},
-					Resources: []string{"clusterrolebindings", "clusterroles"},
-					Verbs:     []string{"create"},
 				},
 			},
 		}

--- a/pkg/operation/botanist/component/logging/fluentoperator/fluent_operator_test.go
+++ b/pkg/operation/botanist/component/logging/fluentoperator/fluent_operator_test.go
@@ -122,6 +122,16 @@ var _ = Describe("Fluent Operator", func() {
 				{
 					APIGroups: []string{"rbac.authorization.k8s.io"},
 					Resources: []string{"clusterrolebindings", "clusterroles"},
+					Verbs:     []string{"get", "list", "watch", "create"},
+				},
+				{
+					APIGroups: []string{""},
+					Resources: []string{"pods"},
+					Verbs:     []string{"get"},
+				},
+				{
+					APIGroups: []string{"extensions.gardener.cloud"},
+					Resources: []string{"clusters"},
 					Verbs:     []string{"get", "list", "watch"},
 				},
 			},
@@ -169,23 +179,8 @@ var _ = Describe("Fluent Operator", func() {
 				},
 				{
 					APIGroups: []string{""},
-					Resources: []string{"pods"},
-					Verbs:     []string{"get"},
-				},
-				{
-					APIGroups: []string{""},
 					Resources: []string{"secrets", "configmaps", "serviceaccounts", "services", "namespaces"},
 					Verbs:     []string{"create", "delete", "get", "list", "patch", "update", "watch"},
-				},
-				{
-					APIGroups: []string{"extensions.gardener.cloud"},
-					Resources: []string{"clusters"},
-					Verbs:     []string{"get", "list", "watch"},
-				},
-				{
-					APIGroups: []string{"rbac.authorization.k8s.io"},
-					Resources: []string{"clusterrolebindings", "clusterroles"},
-					Verbs:     []string{"create"},
 				},
 			},
 		}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area logging
/kind bug

**What this PR does / why we need it**:
On the @istvanballok local setup (fresh setup) we saw that the fluent-operator is trying to create a ClusterRole for fluent-bit with the escalated permissions below but it fails because it has only a Role with these permissions. That's why we are moving the needed permissions from the Role to the ClusterRole.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
@istvanballok @nickytd 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
