### PR TITLE
Bump `nginx-ingress-controller-seed` to `v1.7.1` for `1.24.x+` seeds

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -79,7 +79,7 @@ images:
 - name: nginx-ingress-controller-seed
   sourceRepository: github.com/kubernetes/ingress-nginx
   repository: registry.k8s.io/ingress-nginx/controller-chroot
-  tag: "v1.7.0"
+  tag: "v1.7.1"
   targetVersion: ">= 1.24"
   labels:
   - name: 'gardener.cloud/cve-categorisation'


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane open-source
/kind enhancement

**What this PR does / why we need it**:
Bump `nginx-ingress-controller-seed` to `v1.7.1` for `1.24.x+` seeds
See compatibility matrix: https://github.com/kubernetes/ingress-nginx#supported-versions-table

https://github.com/kubernetes/ingress-nginx/releases/tag/controller-v1.7.1


**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
`nginx-ingress-controller-seed` image is updated to `v1.7.1` for `1.24.x+` seeds.
```
