### PR TITLE
Extension resource health check enhancement

### DIFF
--- a/extensions/pkg/predicate/default.go
+++ b/extensions/pkg/predicate/default.go
@@ -83,11 +83,6 @@ var defaultControllerPredicate = predicate.Funcs{
 			return true
 		}
 
-		// If the last operation does not indicate success and the object's timestamp changes then we admit reconciliation.
-		if lastOperationNotSuccessful(e.ObjectNew) && e.ObjectOld.GetAnnotations()[v1beta1constants.GardenerTimestamp] != e.ObjectNew.GetAnnotations()[v1beta1constants.GardenerTimestamp] {
-			return true
-		}
-
 		// If none of the above conditions applies then reconciliation is not allowed.
 		return false
 	},

--- a/extensions/pkg/predicate/default_test.go
+++ b/extensions/pkg/predicate/default_test.go
@@ -15,8 +15,6 @@
 package predicate_test
 
 import (
-	"time"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -34,7 +32,6 @@ var _ = Describe("Default", func() {
 			pred      predicate.Predicate
 			obj       *extensionsv1alpha1.Infrastructure
 			namespace = "shoot--foo--bar"
-			now       = time.Now()
 		)
 
 		BeforeEach(func() {
@@ -112,20 +109,6 @@ var _ = Describe("Default", func() {
 					obj.SetDeletionTimestamp(&metav1.Time{})
 					oldObj := obj.DeepCopy()
 					obj.Status.ObservedGeneration = 3
-					Expect(pred.Update(event.UpdateEvent{ObjectNew: obj, ObjectOld: oldObj})).To(BeFalse())
-				})
-
-				It("should return true when last operation has not succeeded and the timestamp changed", func() {
-					obj.Status.LastOperation = &gardencorev1beta1.LastOperation{State: gardencorev1beta1.LastOperationStateError}
-					oldObj := obj.DeepCopy()
-					obj.SetAnnotations(map[string]string{"gardener.cloud/timestamp": now.UTC().Add(time.Second).Format(time.RFC3339Nano)})
-					Expect(pred.Update(event.UpdateEvent{ObjectNew: obj, ObjectOld: oldObj})).To(BeTrue())
-				})
-
-				It("should return false when last operation has succeeded and the timestamp changed", func() {
-					obj.Status.LastOperation = &gardencorev1beta1.LastOperation{State: gardencorev1beta1.LastOperationStateSucceeded}
-					oldObj := obj.DeepCopy()
-					obj.SetAnnotations(map[string]string{"gardener.cloud/timestamp": now.UTC().Add(time.Second).Format(time.RFC3339Nano)})
 					Expect(pred.Update(event.UpdateEvent{ObjectNew: obj, ObjectOld: oldObj})).To(BeFalse())
 				})
 			})

--- a/pkg/operation/botanist/component/extensions/backupentry/backupentry_test.go
+++ b/pkg/operation/botanist/component/extensions/backupentry/backupentry_test.go
@@ -198,7 +198,8 @@ var _ = Describe("#BackupEntry", func() {
 				v1beta1constants.GardenerTimestamp: fakeClock.Now().UTC().Format(time.RFC3339Nano),
 			}
 			expected.Status.LastOperation = &gardencorev1beta1.LastOperation{
-				State: gardencorev1beta1.LastOperationStateSucceeded,
+				State:          gardencorev1beta1.LastOperationStateSucceeded,
+				LastUpdateTime: metav1.Time{Time: fakeClock.Now().UTC().Add(time.Second)},
 			}
 			Expect(c.Patch(ctx, expected, patch)).To(Succeed(), "patching backupentry succeeds")
 

--- a/pkg/operation/botanist/component/extensions/containerruntime/containerruntime_test.go
+++ b/pkg/operation/botanist/component/extensions/containerruntime/containerruntime_test.go
@@ -230,7 +230,8 @@ var _ = Describe("#ContainerRuntime", func() {
 				}
 				// set last operation
 				expected[i].Status.LastOperation = &gardencorev1beta1.LastOperation{
-					State: gardencorev1beta1.LastOperationStateSucceeded,
+					State:          gardencorev1beta1.LastOperationStateSucceeded,
+					LastUpdateTime: metav1.Time{Time: now.UTC().Add(time.Second)},
 				}
 				Expect(c.Patch(ctx, expected[i], patch)).ToNot(HaveOccurred(), "patching containerruntime succeeds")
 			}

--- a/pkg/operation/botanist/component/extensions/controlplane/controlplane_test.go
+++ b/pkg/operation/botanist/component/extensions/controlplane/controlplane_test.go
@@ -236,7 +236,8 @@ var _ = Describe("ControlPlane", func() {
 				v1beta1constants.GardenerTimestamp: now.UTC().Format(time.RFC3339Nano),
 			}
 			cp.Status.LastOperation = &gardencorev1beta1.LastOperation{
-				State: gardencorev1beta1.LastOperationStateSucceeded,
+				State:          gardencorev1beta1.LastOperationStateSucceeded,
+				LastUpdateTime: metav1.Time{Time: now.UTC().Add(time.Second)},
 			}
 			Expect(c.Patch(ctx, cp, patch)).To(Succeed(), "patching controlplane succeeds")
 
@@ -290,7 +291,8 @@ var _ = Describe("ControlPlane", func() {
 				v1beta1constants.GardenerTimestamp: now.UTC().Format(time.RFC3339Nano),
 			}
 			cp.Status.LastOperation = &gardencorev1beta1.LastOperation{
-				State: gardencorev1beta1.LastOperationStateSucceeded,
+				State:          gardencorev1beta1.LastOperationStateSucceeded,
+				LastUpdateTime: metav1.Time{Time: now.UTC().Add(time.Second)},
 			}
 			Expect(c.Patch(ctx, cp, patch)).To(Succeed(), "patching controlplane succeeds")
 

--- a/pkg/operation/botanist/component/extensions/dnsrecord/dnsrecord.go
+++ b/pkg/operation/botanist/component/extensions/dnsrecord/dnsrecord.go
@@ -132,109 +132,109 @@ type dnsRecord struct {
 }
 
 // Deploy uses the seed client to create or update the DNSRecord resource.
-func (c *dnsRecord) Deploy(ctx context.Context) error {
-	_, err := c.deploy(ctx, v1beta1constants.GardenerOperationReconcile)
+func (d *dnsRecord) Deploy(ctx context.Context) error {
+	_, err := d.deploy(ctx, v1beta1constants.GardenerOperationReconcile)
 	return err
 }
 
-func (c *dnsRecord) deploy(ctx context.Context, operation string) (extensionsv1alpha1.Object, error) {
-	if err := c.deploySecret(ctx); err != nil {
+func (d *dnsRecord) deploy(ctx context.Context, operation string) (extensionsv1alpha1.Object, error) {
+	if err := d.deploySecret(ctx); err != nil {
 		return nil, err
 	}
 
 	mutateFn := func() error {
-		if c.values.AnnotateOperation || c.valuesDontMatchDNSRecord() || c.lastOperationNotSuccessful() {
-			metav1.SetMetaDataAnnotation(&c.dnsRecord.ObjectMeta, v1beta1constants.GardenerOperation, operation)
-			metav1.SetMetaDataAnnotation(&c.dnsRecord.ObjectMeta, v1beta1constants.GardenerTimestamp, TimeNow().UTC().Format(time.RFC3339Nano))
+		if d.values.AnnotateOperation || d.valuesDontMatchDNSRecord() || d.lastOperationNotSuccessful() {
+			metav1.SetMetaDataAnnotation(&d.dnsRecord.ObjectMeta, v1beta1constants.GardenerOperation, operation)
+			metav1.SetMetaDataAnnotation(&d.dnsRecord.ObjectMeta, v1beta1constants.GardenerTimestamp, TimeNow().UTC().Format(time.RFC3339Nano))
 		}
 
-		c.dnsRecord.Spec = extensionsv1alpha1.DNSRecordSpec{
+		d.dnsRecord.Spec = extensionsv1alpha1.DNSRecordSpec{
 			DefaultSpec: extensionsv1alpha1.DefaultSpec{
-				Type: c.values.Type,
+				Type: d.values.Type,
 			},
 			SecretRef: corev1.SecretReference{
-				Name:      c.secret.Name,
-				Namespace: c.secret.Namespace,
+				Name:      d.secret.Name,
+				Namespace: d.secret.Namespace,
 			},
-			Zone:       c.values.Zone,
-			Name:       c.values.DNSName,
-			RecordType: c.values.RecordType,
-			Values:     c.values.Values,
-			TTL:        c.values.TTL,
+			Zone:       d.values.Zone,
+			Name:       d.values.DNSName,
+			RecordType: d.values.RecordType,
+			Values:     d.values.Values,
+			TTL:        d.values.TTL,
 		}
 
 		return nil
 	}
 
-	if c.values.ReconcileOnlyOnChangeOrError {
-		if err := c.client.Get(ctx, client.ObjectKeyFromObject(c.dnsRecord), c.dnsRecord); err != nil {
+	if d.values.ReconcileOnlyOnChangeOrError {
+		if err := d.client.Get(ctx, client.ObjectKeyFromObject(d.dnsRecord), d.dnsRecord); err != nil {
 			if !apierrors.IsNotFound(err) {
 				return nil, err
 			}
 
 			// DNSRecord doesn't exist yet, create it.
 			_ = mutateFn()
-			if err := c.client.Create(ctx, c.dnsRecord); err != nil {
+			if err := d.client.Create(ctx, d.dnsRecord); err != nil {
 				return nil, err
 			}
 		} else {
-			patch := client.MergeFrom(c.dnsRecord.DeepCopy())
-			if c.valuesDontMatchDNSRecord() || c.lastOperationNotSuccessful() {
+			patch := client.MergeFrom(d.dnsRecord.DeepCopy())
+			if d.valuesDontMatchDNSRecord() || d.lastOperationNotSuccessful() {
 				// If the DNSRecord is not yet Succeeded or values have changed, reconcile it again.
 				_ = mutateFn()
 			}
-			if err := c.client.Patch(ctx, c.dnsRecord, patch); err != nil {
+			if err := d.client.Patch(ctx, d.dnsRecord, patch); err != nil {
 				return nil, err
 			}
 		}
 	} else {
-		if _, err := controllerutils.GetAndCreateOrMergePatch(ctx, c.client, c.dnsRecord, mutateFn); err != nil {
+		if _, err := controllerutils.GetAndCreateOrMergePatch(ctx, d.client, d.dnsRecord, mutateFn); err != nil {
 			return nil, err
 		}
 	}
 
-	return c.dnsRecord, nil
+	return d.dnsRecord, nil
 }
 
-func (c *dnsRecord) deploySecret(ctx context.Context) error {
-	_, err := controllerutils.GetAndCreateOrMergePatch(ctx, c.client, c.secret, func() error {
-		c.secret.Type = corev1.SecretTypeOpaque
-		c.secret.Data = c.values.SecretData
+func (d *dnsRecord) deploySecret(ctx context.Context) error {
+	_, err := controllerutils.GetAndCreateOrMergePatch(ctx, d.client, d.secret, func() error {
+		d.secret.Type = corev1.SecretTypeOpaque
+		d.secret.Data = d.values.SecretData
 		return nil
 	})
 	return err
 }
 
 // Restore uses the seed client and the ShootState to create the DNSRecord resource and restore its state.
-func (c *dnsRecord) Restore(ctx context.Context, shootState *gardencorev1beta1.ShootState) error {
+func (d *dnsRecord) Restore(ctx context.Context, shootState *gardencorev1beta1.ShootState) error {
 	return extensions.RestoreExtensionWithDeployFunction(
 		ctx,
-		c.client,
+		d.client,
 		shootState,
 		extensionsv1alpha1.DNSRecordResource,
-		c.deploy,
+		d.deploy,
 	)
 }
 
 // Migrate migrates the DNSRecord resource.
-func (c *dnsRecord) Migrate(ctx context.Context) error {
+func (d *dnsRecord) Migrate(ctx context.Context) error {
 	return extensions.MigrateExtensionObject(
 		ctx,
-		c.client,
-		c.dnsRecord,
+		d.client,
+		d.dnsRecord,
 	)
 }
 
 // Destroy deletes the DNSRecord resource.
-func (c *dnsRecord) Destroy(ctx context.Context) error {
-	if err := c.deploySecret(ctx); err != nil {
+func (d *dnsRecord) Destroy(ctx context.Context) error {
+	if err := d.deploySecret(ctx); err != nil {
 		return err
 	}
 
 	return extensions.DeleteExtensionObject(
 		ctx,
-		c.client,
-		c.dnsRecord,
+		d.client,
+		d.dnsRecord,
 	)
 }
 
@@ -242,67 +242,67 @@ func (c *dnsRecord) Destroy(ctx context.Context) error {
 var WaitUntilExtensionObjectReady = extensions.WaitUntilExtensionObjectReady
 
 // Wait waits until the DNSRecord resource is ready.
-func (c *dnsRecord) Wait(ctx context.Context) error {
+func (d *dnsRecord) Wait(ctx context.Context) error {
 	return WaitUntilExtensionObjectReady(
 		ctx,
-		c.client,
-		c.log,
-		c.dnsRecord,
+		d.client,
+		d.log,
+		d.dnsRecord,
 		extensionsv1alpha1.DNSRecordResource,
-		c.waitInterval,
-		c.waitSevereThreshold,
-		c.waitTimeout,
+		d.waitInterval,
+		d.waitSevereThreshold,
+		d.waitTimeout,
 		nil,
 	)
 }
 
 // WaitMigrate waits until the DNSRecord resource is migrated successfully.
-func (c *dnsRecord) WaitMigrate(ctx context.Context) error {
+func (d *dnsRecord) WaitMigrate(ctx context.Context) error {
 	return extensions.WaitUntilExtensionObjectMigrated(
 		ctx,
-		c.client,
-		c.dnsRecord,
+		d.client,
+		d.dnsRecord,
 		extensionsv1alpha1.DNSRecordResource,
-		c.waitInterval,
-		c.waitTimeout,
+		d.waitInterval,
+		d.waitTimeout,
 	)
 }
 
 // WaitCleanup waits until the DNSRecord resource is deleted.
-func (c *dnsRecord) WaitCleanup(ctx context.Context) error {
+func (d *dnsRecord) WaitCleanup(ctx context.Context) error {
 	return extensions.WaitUntilExtensionObjectDeleted(
 		ctx,
-		c.client,
-		c.log,
-		c.dnsRecord,
+		d.client,
+		d.log,
+		d.dnsRecord,
 		extensionsv1alpha1.DNSRecordResource,
-		c.waitInterval,
-		c.waitTimeout,
+		d.waitInterval,
+		d.waitTimeout,
 	)
 }
 
 // GetValues returns the current configuration values of the deployer.
-func (c *dnsRecord) GetValues() *Values {
-	return c.values
+func (d *dnsRecord) GetValues() *Values {
+	return d.values
 }
 
 // SetRecordType sets the record type in the values.
-func (c *dnsRecord) SetRecordType(recordType extensionsv1alpha1.DNSRecordType) {
-	c.values.RecordType = recordType
+func (d *dnsRecord) SetRecordType(recordType extensionsv1alpha1.DNSRecordType) {
+	d.values.RecordType = recordType
 }
 
 // SetValues sets the values in the values.
-func (c *dnsRecord) SetValues(values []string) {
-	c.values.Values = values
+func (d *dnsRecord) SetValues(values []string) {
+	d.values.Values = values
 }
 
-func (c *dnsRecord) valuesDontMatchDNSRecord() bool {
-	return c.values.SecretName != c.dnsRecord.Spec.SecretRef.Name ||
-		!pointer.StringEqual(c.values.Zone, c.dnsRecord.Spec.Zone) ||
-		!reflect.DeepEqual(c.values.Values, c.dnsRecord.Spec.Values) ||
-		!pointer.Int64Equal(c.values.TTL, c.dnsRecord.Spec.TTL)
+func (d *dnsRecord) valuesDontMatchDNSRecord() bool {
+	return d.values.SecretName != d.dnsRecord.Spec.SecretRef.Name ||
+		!pointer.StringEqual(d.values.Zone, d.dnsRecord.Spec.Zone) ||
+		!reflect.DeepEqual(d.values.Values, d.dnsRecord.Spec.Values) ||
+		!pointer.Int64Equal(d.values.TTL, d.dnsRecord.Spec.TTL)
 }
 
-func (c *dnsRecord) lastOperationNotSuccessful() bool {
-	return c.dnsRecord.Status.LastOperation != nil && c.dnsRecord.Status.LastOperation.State != gardencorev1beta1.LastOperationStateSucceeded
+func (d *dnsRecord) lastOperationNotSuccessful() bool {
+	return d.dnsRecord.Status.LastOperation != nil && d.dnsRecord.Status.LastOperation.State != gardencorev1beta1.LastOperationStateSucceeded
 }

--- a/pkg/operation/botanist/component/extensions/dnsrecord/dnsrecord_test.go
+++ b/pkg/operation/botanist/component/extensions/dnsrecord/dnsrecord_test.go
@@ -282,7 +282,7 @@ var _ = Describe("DNSRecord", func() {
 			By("Create existing DNSRecord")
 			existingDNS := dns.DeepCopy()
 			delete(existingDNS.Annotations, v1beta1constants.GardenerOperation)
-			metav1.SetMetaDataAnnotation(&existingDNS.ObjectMeta, v1beta1constants.GardenerTimestamp, now.UTC().Add(-time.Second).Format(time.RFC3339Nano))
+			metav1.SetMetaDataAnnotation(&existingDNS.ObjectMeta, v1beta1constants.GardenerTimestamp, now.UTC().Format(time.RFC3339Nano))
 			Expect(c.Create(ctx, existingDNS)).To(Succeed())
 
 			By("Deploy DNSRecord again")
@@ -430,13 +430,13 @@ var _ = Describe("DNSRecord", func() {
 				Expect(deployedDNS).To(DeepEqual(expectedDNSRecord))
 			})
 
-			It("should only update the timestamp annotation if the DNSRecord exists with the same values", func() {
+			It("should not update the timestamp annotation if the DNSRecord exists with the same values", func() {
 				delete(dns.Annotations, v1beta1constants.GardenerOperation)
 				// set old timestamp (e.g. added on creation / earlier Deploy call)
 				metav1.SetMetaDataAnnotation(&dns.ObjectMeta, v1beta1constants.GardenerTimestamp, now.UTC().Add(-time.Second).Format(time.RFC3339Nano))
 
 				expectedDNSRecord.Annotations = map[string]string{
-					v1beta1constants.GardenerTimestamp: now.UTC().Format(time.RFC3339Nano),
+					v1beta1constants.GardenerTimestamp: now.UTC().Add(-time.Second).Format(time.RFC3339Nano),
 				}
 
 				Expect(c.Create(ctx, dns)).To(Succeed())
@@ -514,7 +514,8 @@ var _ = Describe("DNSRecord", func() {
 				v1beta1constants.GardenerTimestamp: now.UTC().Format(time.RFC3339Nano),
 			}
 			dns.Status.LastOperation = &gardencorev1beta1.LastOperation{
-				State: gardencorev1beta1.LastOperationStateSucceeded,
+				State:          gardencorev1beta1.LastOperationStateSucceeded,
+				LastUpdateTime: metav1.Time{Time: now.UTC().Add(time.Second)},
 			}
 			Expect(c.Patch(ctx, dns, patch)).To(Succeed(), "patching dnsrecord succeeds")
 

--- a/pkg/operation/botanist/component/extensions/infrastructure/infrastructure_test.go
+++ b/pkg/operation/botanist/component/extensions/infrastructure/infrastructure_test.go
@@ -168,10 +168,8 @@ var _ = Describe("#Interface", func() {
 
 			actual := &extensionsv1alpha1.Infrastructure{}
 			expected.Spec.SSHPublicKey = []byte("")
+			expected.Annotations = map[string]string{}
 			Expect(c.Get(ctx, client.ObjectKeyFromObject(expected), actual)).To(Succeed())
-			expected.SetAnnotations(map[string]string{
-				v1beta1constants.GardenerTimestamp: now.UTC().Format(time.RFC3339Nano),
-			})
 			Expect(actual).To(DeepEqual(expected))
 		})
 
@@ -253,7 +251,8 @@ var _ = Describe("#Interface", func() {
 				v1beta1constants.GardenerTimestamp: now.UTC().Format(time.RFC3339Nano),
 			}
 			expected.Status.LastOperation = &gardencorev1beta1.LastOperation{
-				State: gardencorev1beta1.LastOperationStateSucceeded,
+				State:          gardencorev1beta1.LastOperationStateSucceeded,
+				LastUpdateTime: metav1.Time{Time: now.UTC().Add(time.Second)},
 			}
 			expected.Status.NodesCIDR = nodesCIDR
 			expected.Status.ProviderStatus = providerStatus

--- a/pkg/operation/botanist/component/extensions/infrastructure/infrastructure_test.go
+++ b/pkg/operation/botanist/component/extensions/infrastructure/infrastructure_test.go
@@ -187,6 +187,43 @@ var _ = Describe("#Interface", func() {
 			Expect(c.Get(ctx, client.ObjectKeyFromObject(expected), actual)).To(Succeed())
 			Expect(actual).To(DeepEqual(expected))
 		})
+
+		It("should deploy the Infrastructure with operation annotation if it is in error state", func() {
+			defer test.WithVars(
+				&infrastructure.TimeNow, mockNow.Do,
+			)()
+			mockNow.EXPECT().Do().Return(now.UTC()).AnyTimes()
+			existingInfra := expected.DeepCopy()
+			existingInfra.ResourceVersion = ""
+			delete(existingInfra.Annotations, v1beta1constants.GardenerOperation)
+			metav1.SetMetaDataAnnotation(&existingInfra.ObjectMeta, v1beta1constants.GardenerTimestamp, now.UTC().Add(-time.Second).Format(time.RFC3339Nano))
+			existingInfra.Status.LastOperation = &gardencorev1beta1.LastOperation{
+				State: gardencorev1beta1.LastOperationStateError,
+			}
+
+			expected.ResourceVersion = "2"
+			expected.Status = extensionsv1alpha1.InfrastructureStatus{
+				DefaultStatus: extensionsv1alpha1.DefaultStatus{
+					LastOperation: &gardencorev1beta1.LastOperation{
+						State: gardencorev1beta1.LastOperationStateError,
+					},
+				},
+			}
+
+			Expect(c.Create(ctx, existingInfra)).To(Succeed())
+			values.AnnotateOperation = false
+			deployWaiter = infrastructure.New(log, c, values, time.Millisecond, 250*time.Millisecond, 500*time.Millisecond)
+			deployWaiter.SetSSHPublicKey(sshPublicKey)
+			Expect(deployWaiter.Deploy(ctx)).To(Succeed())
+
+			deployedInfra := &extensionsv1alpha1.Infrastructure{ObjectMeta: metav1.ObjectMeta{
+				Name:      existingInfra.Name,
+				Namespace: existingInfra.Namespace,
+			}}
+			err := c.Get(ctx, client.ObjectKeyFromObject(deployedInfra), deployedInfra)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(deployedInfra).To(DeepEqual(expected))
+		})
 	})
 
 	Describe("#Wait", func() {

--- a/pkg/operation/botanist/component/extensions/network/network_test.go
+++ b/pkg/operation/botanist/component/extensions/network/network_test.go
@@ -211,7 +211,8 @@ var _ = Describe("#Network", func() {
 				v1beta1constants.GardenerTimestamp: now.UTC().Format(time.RFC3339Nano),
 			}
 			expected.Status.LastOperation = &gardencorev1beta1.LastOperation{
-				State: gardencorev1beta1.LastOperationStateSucceeded,
+				State:          gardencorev1beta1.LastOperationStateSucceeded,
+				LastUpdateTime: metav1.Time{Time: now.UTC().Add(time.Second)},
 			}
 			Expect(c.Patch(ctx, expected, patch)).To(Succeed(), "patching network succeeds")
 

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/operatingsystemconfig_test.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/operatingsystemconfig_test.go
@@ -614,7 +614,8 @@ var _ = Describe("OperatingSystemConfig", func() {
 					}
 					// set last operation
 					expected[i].Status.LastOperation = &gardencorev1beta1.LastOperation{
-						State: gardencorev1beta1.LastOperationStateSucceeded,
+						State:          gardencorev1beta1.LastOperationStateSucceeded,
+						LastUpdateTime: metav1.Time{Time: now.UTC().Add(time.Second)},
 					}
 					// set cloud-config secret information
 					expected[i].Status.CloudConfig = &extensionsv1alpha1.CloudConfig{

--- a/pkg/operation/botanist/component/extensions/worker/worker_test.go
+++ b/pkg/operation/botanist/component/extensions/worker/worker_test.go
@@ -531,7 +531,8 @@ var _ = Describe("Worker", func() {
 				v1beta1constants.GardenerTimestamp: now.UTC().Format(time.RFC3339Nano),
 			}
 			w.Status.LastOperation = &gardencorev1beta1.LastOperation{
-				State: gardencorev1beta1.LastOperationStateSucceeded,
+				State:          gardencorev1beta1.LastOperationStateSucceeded,
+				LastUpdateTime: metav1.Time{Time: now.UTC().Add(time.Second)},
 			}
 			Expect(c.Patch(ctx, w, patch)).To(Succeed(), "patching worker succeeds")
 
@@ -635,7 +636,8 @@ var _ = Describe("Worker", func() {
 				v1beta1constants.GardenerTimestamp: now.UTC().Format(time.RFC3339Nano),
 			}
 			w.Status.LastOperation = &gardencorev1beta1.LastOperation{
-				State: gardencorev1beta1.LastOperationStateSucceeded,
+				State:          gardencorev1beta1.LastOperationStateSucceeded,
+				LastUpdateTime: metav1.Time{Time: now.UTC().Add(time.Second)},
 			}
 			Expect(c.Patch(ctx, w, patch)).To(Succeed(), "patching worker succeeds")
 

--- a/pkg/utils/kubernetes/health/extensions_test.go
+++ b/pkg/utils/kubernetes/health/extensions_test.go
@@ -115,6 +115,60 @@ var _ = Describe("Extensions", func() {
 				},
 				HaveOccurred(),
 			),
+			Entry("timestamp is before last update time",
+				&extensionsv1alpha1.Infrastructure{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							"gardener.cloud/timestamp": time.Now().UTC().Add(-5 * time.Second).Format(time.RFC3339Nano),
+						},
+					},
+					Status: extensionsv1alpha1.InfrastructureStatus{
+						DefaultStatus: extensionsv1alpha1.DefaultStatus{
+							LastOperation: &gardencorev1beta1.LastOperation{
+								State:          gardencorev1beta1.LastOperationStateSucceeded,
+								LastUpdateTime: metav1.Time{Time: time.Now().UTC()},
+							},
+						},
+					},
+				},
+				Succeed(),
+			),
+			Entry("timestamp is after last update time",
+				&extensionsv1alpha1.Infrastructure{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							"gardener.cloud/timestamp": time.Now().UTC().Add(5 * time.Second).Format(time.RFC3339Nano),
+						},
+					},
+					Status: extensionsv1alpha1.InfrastructureStatus{
+						DefaultStatus: extensionsv1alpha1.DefaultStatus{
+							LastOperation: &gardencorev1beta1.LastOperation{
+								State:          gardencorev1beta1.LastOperationStateSucceeded,
+								LastUpdateTime: metav1.Time{Time: time.Now().UTC()},
+							},
+						},
+					},
+				},
+				HaveOccurred(),
+			),
+			Entry("invalid timestamp",
+				&extensionsv1alpha1.Infrastructure{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							"gardener.cloud/timestamp": "not a valid value",
+						},
+					},
+					Status: extensionsv1alpha1.InfrastructureStatus{
+						DefaultStatus: extensionsv1alpha1.DefaultStatus{
+							LastOperation: &gardencorev1beta1.LastOperation{
+								State:          gardencorev1beta1.LastOperationStateSucceeded,
+								LastUpdateTime: metav1.Now(),
+							},
+						},
+					},
+				},
+				HaveOccurred(),
+			),
 		)
 	})
 

--- a/pkg/utils/kubernetes/health/extensions_test.go
+++ b/pkg/utils/kubernetes/health/extensions_test.go
@@ -133,6 +133,24 @@ var _ = Describe("Extensions", func() {
 				},
 				Succeed(),
 			),
+			Entry("truncated timestamp equals last update time",
+				&extensionsv1alpha1.Infrastructure{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							"gardener.cloud/timestamp": time.Date(2023, 05, 10, 10, 58, 28, 770312000, time.UTC).Format(time.RFC3339Nano), // 2023-05-10T10:58:28.770312Z
+						},
+					},
+					Status: extensionsv1alpha1.InfrastructureStatus{
+						DefaultStatus: extensionsv1alpha1.DefaultStatus{
+							LastOperation: &gardencorev1beta1.LastOperation{
+								State:          gardencorev1beta1.LastOperationStateSucceeded,
+								LastUpdateTime: metav1.Time{Time: time.Date(2023, 05, 10, 10, 58, 28, 0, time.UTC)}, // 2023-05-10T10:58:28Z
+							},
+						},
+					},
+				},
+				Succeed(),
+			),
 			Entry("timestamp is after last update time",
 				&extensionsv1alpha1.Infrastructure{
 					ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness quality
/kind enhancement

**What this PR does / why we need it**:
This PR adds an additional check which purpose is to ensure that when waiting for an extension to become healthy we are actually evaluating the state that has been reported after a reconciliation was requested (and not the previous state). Previously the `gardenlet` could have observed "ready/healthy" state before the extension controller even picks up the reconciliation. In order to prevent this we now compare the `gardener.cloud/timestamp` annotation against the reported last update time. `dnsrecord` and `infrastructure` are no longer always annotated with the `gardener.cloud/timestamp`. Instead the reconciliation decision is taken by the `gardenlet` and not the extension library. Basically https://github.com/gardener/gardener/pull/5943 was partly reverted (cc @ary1992 @acumino @shafeeqes )

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
I have doubts about how the `lastOperationNotSuccessful()` should look like
```golang
return i.infrastructure.Status.LastOperation != nil && i.infrastructure.Status.LastOperation.State != gardencorev1beta1.LastOperationStateSucceeded
```
or
```golang
return i.infrastructure.Status.LastOperation == nil || i.infrastructure.Status.LastOperation.State != gardencorev1beta1.LastOperationStateSucceeded
```

I am not sure that it matters much since we previously had it both ways (in the default predicate and in the `dnsrecord` implementation). Any input on this will be helpful.

cc @timuthy @rfranzke 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
A bug which was causing race conditions to occur during reconciliation of extension resources was fixed. 
```
