### PR TITLE
Lock the Seed's `.spec.settings.ownerChecks.enabled` field to `false`

### DIFF
--- a/docs/api-reference/core.md
+++ b/docs/api-reference/core.md
@@ -9100,8 +9100,7 @@ bool
 </em>
 </td>
 <td>
-<p>Enabled controls whether owner checks are enabled for shoots scheduled on this seed. It
-is enabled by default because it is a prerequisite for control plane migration.</p>
+<p>Enabled controls whether owner checks are enabled for shoots scheduled on this seed.</p>
 </td>
 </tr>
 </tbody>

--- a/docs/api-reference/core.md
+++ b/docs/api-reference/core.md
@@ -9081,8 +9081,8 @@ Defaults to &ldquo;Cluster&rdquo;.</p>
 <p>
 <p>SeedSettingOwnerChecks controls certain owner checks settings for shoots scheduled on this seed.</p>
 <p>Deprecated: This field is deprecated. The &ldquo;bad-case&rdquo; control plane migration is being removed in favor of the HA Shoot control planes (see <a href="https://github.com/gardener/gardener/issues/6302">https://github.com/gardener/gardener/issues/6302</a>).
-The field will be locked to false in a future version of Gardener. In this way gardenlet will clean up all owner DNSRecords. Finally, the field will be removed from the API.
-Set this field to false to be prepared for the above-mentioned locking.</p>
+The field is locked to false (i.e. if the field value is true a validation error will be returned). In this way gardenlet will clean up all owner DNSRecords.
+Finally, the field will be removed from the API in a future version of Gardener.</p>
 </p>
 <table>
 <thead>
@@ -9288,8 +9288,8 @@ SeedSettingOwnerChecks
 <em>(Optional)</em>
 <p>SeedSettingOwnerChecks controls certain owner checks settings for shoots scheduled on this seed.</p>
 <p>Deprecated: This field is deprecated. The &ldquo;bad-case&rdquo; control plane migration is being removed in favor of the HA Shoot control planes (see <a href="https://github.com/gardener/gardener/issues/6302">https://github.com/gardener/gardener/issues/6302</a>).
-The field will be locked to false in a future version of Gardener. In this way gardenlet will clean up all owner DNSRecords. Finally, the field will be removed from the API.
-Set this field to false to be prepared for the above-mentioned locking.</p>
+The field is locked to false (i.e. if the field value is true a validation error will be returned). In this way gardenlet will clean up all owner DNSRecords.
+Finally, the field will be removed from the API in a future version of Gardener.</p>
 </td>
 </tr>
 <tr>

--- a/example/50-seed.yaml
+++ b/example/50-seed.yaml
@@ -75,7 +75,7 @@ spec:
     verticalPodAutoscaler:
       enabled: true # a Gardener-managed VPA deployment is enabled
     ownerChecks:
-      enabled: true # owner checks are enabled for shoots scheduled on this seed
+      enabled: false # owner checks are disabled for shoots scheduled on this seed
     topologyAwareRouting:
       enabled: true # certain Services deployed in the seed will be topology-aware
 # taints:

--- a/example/provider-extensions/gardenlet/values.yaml.tmpl
+++ b/example/provider-extensions/gardenlet/values.yaml.tmpl
@@ -49,7 +49,7 @@ config:
         excessCapacityReservation:
           enabled: false
         ownerChecks:
-          enabled: true
+          enabled: false
         scheduling:
           visible: true
         verticalPodAutoscaler:

--- a/pkg/apis/core/helper/helpers.go
+++ b/pkg/apis/core/helper/helpers.go
@@ -205,7 +205,7 @@ func SeedSettingSchedulingVisible(settings *core.SeedSettings) bool {
 
 // SeedSettingOwnerChecksEnabled returns true if the 'ownerChecks' setting is enabled.
 func SeedSettingOwnerChecksEnabled(settings *core.SeedSettings) bool {
-	return settings == nil || settings.OwnerChecks == nil || settings.OwnerChecks.Enabled
+	return settings != nil && settings.OwnerChecks != nil && settings.OwnerChecks.Enabled
 }
 
 // SeedSettingTopologyAwareRoutingEnabled returns true if the topology-aware routing is enabled.

--- a/pkg/apis/core/helper/helpers_test.go
+++ b/pkg/apis/core/helper/helpers_test.go
@@ -515,8 +515,8 @@ var _ = Describe("helper", func() {
 			Expect(SeedSettingOwnerChecksEnabled(settings)).To(Equal(expected))
 		},
 
-		Entry("no settings", nil, true),
-		Entry("no owner checks setting", &core.SeedSettings{}, true),
+		Entry("no settings", nil, false),
+		Entry("no owner checks setting", &core.SeedSettings{}, false),
 		Entry("owner checks enabled", &core.SeedSettings{OwnerChecks: &core.SeedSettingOwnerChecks{Enabled: true}}, true),
 		Entry("owner checks disabled", &core.SeedSettings{OwnerChecks: &core.SeedSettingOwnerChecks{Enabled: false}}, false),
 	)

--- a/pkg/apis/core/types_seed.go
+++ b/pkg/apis/core/types_seed.go
@@ -205,8 +205,8 @@ type SeedSettings struct {
 	// SeedSettingOwnerChecks controls certain owner checks settings for shoots scheduled on this seed.
 	//
 	// Deprecated: This field is deprecated. The "bad-case" control plane migration is being removed in favor of the HA Shoot control planes (see https://github.com/gardener/gardener/issues/6302).
-	// The field will be locked to false in a future version of Gardener. In this way gardenlet will clean up all owner DNSRecords. Finally, the field will be removed from the API.
-	// Set this field to false to be prepared for the above-mentioned locking.
+	// The field is locked to false (i.e. if the field value is true a validation error will be returned). In this way gardenlet will clean up all owner DNSRecords.
+	// Finally, the field will be removed from the API in a future version of Gardener.
 	OwnerChecks *SeedSettingOwnerChecks
 	// DependencyWatchdog controls certain settings for the dependency-watchdog components deployed in the seed.
 	DependencyWatchdog *SeedSettingDependencyWatchdog
@@ -268,8 +268,8 @@ type SeedSettingVerticalPodAutoscaler struct {
 // SeedSettingOwnerChecks controls certain owner checks settings for shoots scheduled on this seed.
 //
 // Deprecated: This field is deprecated. The "bad-case" control plane migration is being removed in favor of the HA Shoot control planes (see https://github.com/gardener/gardener/issues/6302).
-// The field will be locked to false in a future version of Gardener. In this way gardenlet will clean up all owner DNSRecords. Finally, the field will be removed from the API.
-// Set this field to false to be prepared for the above-mentioned locking.
+// The field is locked to false (i.e. if the field value is true a validation error will be returned). In this way gardenlet will clean up all owner DNSRecords.
+// Finally, the field will be removed from the API in a future version of Gardener.
 type SeedSettingOwnerChecks struct {
 	// Enabled controls whether owner checks are enabled for shoots scheduled on this seed. It
 	// is enabled by default because it is a prerequisite for control plane migration.

--- a/pkg/apis/core/types_seed.go
+++ b/pkg/apis/core/types_seed.go
@@ -271,8 +271,7 @@ type SeedSettingVerticalPodAutoscaler struct {
 // The field is locked to false (i.e. if the field value is true a validation error will be returned). In this way gardenlet will clean up all owner DNSRecords.
 // Finally, the field will be removed from the API in a future version of Gardener.
 type SeedSettingOwnerChecks struct {
-	// Enabled controls whether owner checks are enabled for shoots scheduled on this seed. It
-	// is enabled by default because it is a prerequisite for control plane migration.
+	// Enabled controls whether owner checks are enabled for shoots scheduled on this seed.
 	Enabled bool
 }
 

--- a/pkg/apis/core/v1alpha1/defaults.go
+++ b/pkg/apis/core/v1alpha1/defaults.go
@@ -65,7 +65,7 @@ func SetDefaults_Seed(obj *Seed) {
 	}
 
 	if obj.Spec.Settings.OwnerChecks == nil {
-		obj.Spec.Settings.OwnerChecks = &SeedSettingOwnerChecks{Enabled: true}
+		obj.Spec.Settings.OwnerChecks = &SeedSettingOwnerChecks{Enabled: false}
 	}
 
 	if obj.Spec.Settings.DependencyWatchdog == nil {

--- a/pkg/apis/core/v1alpha1/defaults_test.go
+++ b/pkg/apis/core/v1alpha1/defaults_test.go
@@ -43,7 +43,7 @@ var _ = Describe("Defaults", func() {
 			Expect(obj.Spec.Settings.ExcessCapacityReservation.Enabled).To(BeTrue())
 			Expect(obj.Spec.Settings.Scheduling.Visible).To(BeTrue())
 			Expect(obj.Spec.Settings.VerticalPodAutoscaler.Enabled).To(BeTrue())
-			Expect(obj.Spec.Settings.OwnerChecks.Enabled).To(BeTrue())
+			Expect(obj.Spec.Settings.OwnerChecks.Enabled).To(BeFalse())
 			Expect(obj.Spec.Settings.TopologyAwareRouting.Enabled).To(BeFalse())
 		})
 
@@ -61,7 +61,7 @@ var _ = Describe("Defaults", func() {
 			Expect(obj.Spec.Settings.ExcessCapacityReservation.Enabled).To(BeTrue())
 			Expect(obj.Spec.Settings.Scheduling.Visible).To(BeTrue())
 			Expect(obj.Spec.Settings.VerticalPodAutoscaler.Enabled).To(BeTrue())
-			Expect(obj.Spec.Settings.OwnerChecks.Enabled).To(BeTrue())
+			Expect(obj.Spec.Settings.OwnerChecks.Enabled).To(BeFalse())
 			Expect(obj.Spec.Settings.TopologyAwareRouting.Enabled).To(BeFalse())
 			Expect(obj.Spec.Taints).To(HaveLen(3))
 			Expect(obj.Spec.Taints).To(Equal(taints))
@@ -75,7 +75,7 @@ var _ = Describe("Defaults", func() {
 				excessCapacityReservation = false
 				scheduling                = true
 				vpaEnabled                = false
-				ownerChecks               = false
+				ownerChecks               = true
 			)
 
 			obj.Spec.Settings = &SeedSettings{

--- a/pkg/apis/core/v1alpha1/generated.proto
+++ b/pkg/apis/core/v1alpha1/generated.proto
@@ -2227,8 +2227,7 @@ message SeedSettingLoadBalancerServicesZones {
 // The field is locked to false (i.e. if the field value is true a validation error will be returned). In this way gardenlet will clean up all owner DNSRecords.
 // Finally, the field will be removed from the API in a future version of Gardener.
 message SeedSettingOwnerChecks {
-  // Enabled controls whether owner checks are enabled for shoots scheduled on this seed. It
-  // is enabled by default because it is a prerequisite for control plane migration.
+  // Enabled controls whether owner checks are enabled for shoots scheduled on this seed.
   optional bool enabled = 1;
 }
 

--- a/pkg/apis/core/v1alpha1/generated.proto
+++ b/pkg/apis/core/v1alpha1/generated.proto
@@ -2224,8 +2224,8 @@ message SeedSettingLoadBalancerServicesZones {
 // SeedSettingOwnerChecks controls certain owner checks settings for shoots scheduled on this seed.
 //
 // Deprecated: This field is deprecated. The "bad-case" control plane migration is being removed in favor of the HA Shoot control planes (see https://github.com/gardener/gardener/issues/6302).
-// The field will be locked to false in a future version of Gardener. In this way gardenlet will clean up all owner DNSRecords. Finally, the field will be removed from the API.
-// Set this field to false to be prepared for the above-mentioned locking.
+// The field is locked to false (i.e. if the field value is true a validation error will be returned). In this way gardenlet will clean up all owner DNSRecords.
+// Finally, the field will be removed from the API in a future version of Gardener.
 message SeedSettingOwnerChecks {
   // Enabled controls whether owner checks are enabled for shoots scheduled on this seed. It
   // is enabled by default because it is a prerequisite for control plane migration.
@@ -2277,8 +2277,8 @@ message SeedSettings {
   // SeedSettingOwnerChecks controls certain owner checks settings for shoots scheduled on this seed.
   //
   // Deprecated: This field is deprecated. The "bad-case" control plane migration is being removed in favor of the HA Shoot control planes (see https://github.com/gardener/gardener/issues/6302).
-  // The field will be locked to false in a future version of Gardener. In this way gardenlet will clean up all owner DNSRecords. Finally, the field will be removed from the API.
-  // Set this field to false to be prepared for the above-mentioned locking.
+  // The field is locked to false (i.e. if the field value is true a validation error will be returned). In this way gardenlet will clean up all owner DNSRecords.
+  // Finally, the field will be removed from the API in a future version of Gardener.
   // +optional
   optional SeedSettingOwnerChecks ownerChecks = 6;
 

--- a/pkg/apis/core/v1alpha1/types_seed.go
+++ b/pkg/apis/core/v1alpha1/types_seed.go
@@ -231,8 +231,8 @@ type SeedSettings struct {
 	// SeedSettingOwnerChecks controls certain owner checks settings for shoots scheduled on this seed.
 	//
 	// Deprecated: This field is deprecated. The "bad-case" control plane migration is being removed in favor of the HA Shoot control planes (see https://github.com/gardener/gardener/issues/6302).
-	// The field will be locked to false in a future version of Gardener. In this way gardenlet will clean up all owner DNSRecords. Finally, the field will be removed from the API.
-	// Set this field to false to be prepared for the above-mentioned locking.
+	// The field is locked to false (i.e. if the field value is true a validation error will be returned). In this way gardenlet will clean up all owner DNSRecords.
+	// Finally, the field will be removed from the API in a future version of Gardener.
 	// +optional
 	OwnerChecks *SeedSettingOwnerChecks `json:"ownerChecks,omitempty" protobuf:"bytes,6,opt,name=ownerChecks"`
 	// DependencyWatchdog controls certain settings for the dependency-watchdog components deployed in the seed.
@@ -301,8 +301,8 @@ type SeedSettingVerticalPodAutoscaler struct {
 // SeedSettingOwnerChecks controls certain owner checks settings for shoots scheduled on this seed.
 //
 // Deprecated: This field is deprecated. The "bad-case" control plane migration is being removed in favor of the HA Shoot control planes (see https://github.com/gardener/gardener/issues/6302).
-// The field will be locked to false in a future version of Gardener. In this way gardenlet will clean up all owner DNSRecords. Finally, the field will be removed from the API.
-// Set this field to false to be prepared for the above-mentioned locking.
+// The field is locked to false (i.e. if the field value is true a validation error will be returned). In this way gardenlet will clean up all owner DNSRecords.
+// Finally, the field will be removed from the API in a future version of Gardener.
 type SeedSettingOwnerChecks struct {
 	// Enabled controls whether owner checks are enabled for shoots scheduled on this seed. It
 	// is enabled by default because it is a prerequisite for control plane migration.

--- a/pkg/apis/core/v1alpha1/types_seed.go
+++ b/pkg/apis/core/v1alpha1/types_seed.go
@@ -304,8 +304,7 @@ type SeedSettingVerticalPodAutoscaler struct {
 // The field is locked to false (i.e. if the field value is true a validation error will be returned). In this way gardenlet will clean up all owner DNSRecords.
 // Finally, the field will be removed from the API in a future version of Gardener.
 type SeedSettingOwnerChecks struct {
-	// Enabled controls whether owner checks are enabled for shoots scheduled on this seed. It
-	// is enabled by default because it is a prerequisite for control plane migration.
+	// Enabled controls whether owner checks are enabled for shoots scheduled on this seed.
 	Enabled bool `json:"enabled" protobuf:"bytes,1,opt,name=enabled"`
 }
 

--- a/pkg/apis/core/v1beta1/defaults.go
+++ b/pkg/apis/core/v1beta1/defaults.go
@@ -65,7 +65,7 @@ func SetDefaults_Seed(obj *Seed) {
 	}
 
 	if obj.Spec.Settings.OwnerChecks == nil {
-		obj.Spec.Settings.OwnerChecks = &SeedSettingOwnerChecks{Enabled: true}
+		obj.Spec.Settings.OwnerChecks = &SeedSettingOwnerChecks{Enabled: false}
 	}
 
 	if obj.Spec.Settings.DependencyWatchdog == nil {

--- a/pkg/apis/core/v1beta1/defaults_test.go
+++ b/pkg/apis/core/v1beta1/defaults_test.go
@@ -43,7 +43,7 @@ var _ = Describe("Defaults", func() {
 			Expect(obj.Spec.Settings.ExcessCapacityReservation.Enabled).To(BeTrue())
 			Expect(obj.Spec.Settings.Scheduling.Visible).To(BeTrue())
 			Expect(obj.Spec.Settings.VerticalPodAutoscaler.Enabled).To(BeTrue())
-			Expect(obj.Spec.Settings.OwnerChecks.Enabled).To(BeTrue())
+			Expect(obj.Spec.Settings.OwnerChecks.Enabled).To(BeFalse())
 			Expect(obj.Spec.Settings.TopologyAwareRouting.Enabled).To(BeFalse())
 		})
 
@@ -61,7 +61,7 @@ var _ = Describe("Defaults", func() {
 			Expect(obj.Spec.Settings.ExcessCapacityReservation.Enabled).To(BeTrue())
 			Expect(obj.Spec.Settings.Scheduling.Visible).To(BeTrue())
 			Expect(obj.Spec.Settings.VerticalPodAutoscaler.Enabled).To(BeTrue())
-			Expect(obj.Spec.Settings.OwnerChecks.Enabled).To(BeTrue())
+			Expect(obj.Spec.Settings.OwnerChecks.Enabled).To(BeFalse())
 			Expect(obj.Spec.Settings.TopologyAwareRouting.Enabled).To(BeFalse())
 			Expect(obj.Spec.Taints).To(HaveLen(3))
 			Expect(obj.Spec.Taints).To(Equal(taints))
@@ -75,7 +75,7 @@ var _ = Describe("Defaults", func() {
 				excessCapacityReservation = false
 				scheduling                = true
 				vpaEnabled                = false
-				ownerChecks               = false
+				ownerChecks               = true
 			)
 
 			obj.Spec.Settings = &SeedSettings{

--- a/pkg/apis/core/v1beta1/generated.proto
+++ b/pkg/apis/core/v1beta1/generated.proto
@@ -2232,8 +2232,8 @@ message SeedSettingLoadBalancerServicesZones {
 // SeedSettingOwnerChecks controls certain owner checks settings for shoots scheduled on this seed.
 //
 // Deprecated: This field is deprecated. The "bad-case" control plane migration is being removed in favor of the HA Shoot control planes (see https://github.com/gardener/gardener/issues/6302).
-// The field will be locked to false in a future version of Gardener. In this way gardenlet will clean up all owner DNSRecords. Finally, the field will be removed from the API.
-// Set this field to false to be prepared for the above-mentioned locking.
+// The field is locked to false (i.e. if the field value is true a validation error will be returned). In this way gardenlet will clean up all owner DNSRecords.
+// Finally, the field will be removed from the API in a future version of Gardener.
 message SeedSettingOwnerChecks {
   // Enabled controls whether owner checks are enabled for shoots scheduled on this seed. It
   // is enabled by default because it is a prerequisite for control plane migration.
@@ -2285,8 +2285,8 @@ message SeedSettings {
   // SeedSettingOwnerChecks controls certain owner checks settings for shoots scheduled on this seed.
   //
   // Deprecated: This field is deprecated. The "bad-case" control plane migration is being removed in favor of the HA Shoot control planes (see https://github.com/gardener/gardener/issues/6302).
-  // The field will be locked to false in a future version of Gardener. In this way gardenlet will clean up all owner DNSRecords. Finally, the field will be removed from the API.
-  // Set this field to false to be prepared for the above-mentioned locking.
+  // The field is locked to false (i.e. if the field value is true a validation error will be returned). In this way gardenlet will clean up all owner DNSRecords.
+  // Finally, the field will be removed from the API in a future version of Gardener.
   // +optional
   optional SeedSettingOwnerChecks ownerChecks = 6;
 

--- a/pkg/apis/core/v1beta1/generated.proto
+++ b/pkg/apis/core/v1beta1/generated.proto
@@ -2235,8 +2235,7 @@ message SeedSettingLoadBalancerServicesZones {
 // The field is locked to false (i.e. if the field value is true a validation error will be returned). In this way gardenlet will clean up all owner DNSRecords.
 // Finally, the field will be removed from the API in a future version of Gardener.
 message SeedSettingOwnerChecks {
-  // Enabled controls whether owner checks are enabled for shoots scheduled on this seed. It
-  // is enabled by default because it is a prerequisite for control plane migration.
+  // Enabled controls whether owner checks are enabled for shoots scheduled on this seed.
   optional bool enabled = 1;
 }
 

--- a/pkg/apis/core/v1beta1/helper/helper.go
+++ b/pkg/apis/core/v1beta1/helper/helper.go
@@ -495,7 +495,7 @@ func SeedSettingVerticalPodAutoscalerEnabled(settings *gardencorev1beta1.SeedSet
 
 // SeedSettingOwnerChecksEnabled returns true if the 'ownerChecks' setting is enabled.
 func SeedSettingOwnerChecksEnabled(settings *gardencorev1beta1.SeedSettings) bool {
-	return settings == nil || settings.OwnerChecks == nil || settings.OwnerChecks.Enabled
+	return settings != nil && settings.OwnerChecks != nil && settings.OwnerChecks.Enabled
 }
 
 // SeedSettingDependencyWatchdogWeederEnabled returns true if the dependency-watchdog-weeder is enabled.

--- a/pkg/apis/core/v1beta1/helper/helper_test.go
+++ b/pkg/apis/core/v1beta1/helper/helper_test.go
@@ -858,8 +858,8 @@ var _ = Describe("helper", func() {
 			Expect(SeedSettingOwnerChecksEnabled(settings)).To(Equal(expected))
 		},
 
-		Entry("no settings", nil, true),
-		Entry("no owner checks setting", &gardencorev1beta1.SeedSettings{}, true),
+		Entry("no settings", nil, false),
+		Entry("no owner checks setting", &gardencorev1beta1.SeedSettings{}, false),
 		Entry("owner checks enabled", &gardencorev1beta1.SeedSettings{OwnerChecks: &gardencorev1beta1.SeedSettingOwnerChecks{Enabled: true}}, true),
 		Entry("owner checks disabled", &gardencorev1beta1.SeedSettings{OwnerChecks: &gardencorev1beta1.SeedSettingOwnerChecks{Enabled: false}}, false),
 	)

--- a/pkg/apis/core/v1beta1/types_seed.go
+++ b/pkg/apis/core/v1beta1/types_seed.go
@@ -248,8 +248,8 @@ type SeedSettings struct {
 	// SeedSettingOwnerChecks controls certain owner checks settings for shoots scheduled on this seed.
 	//
 	// Deprecated: This field is deprecated. The "bad-case" control plane migration is being removed in favor of the HA Shoot control planes (see https://github.com/gardener/gardener/issues/6302).
-	// The field will be locked to false in a future version of Gardener. In this way gardenlet will clean up all owner DNSRecords. Finally, the field will be removed from the API.
-	// Set this field to false to be prepared for the above-mentioned locking.
+	// The field is locked to false (i.e. if the field value is true a validation error will be returned). In this way gardenlet will clean up all owner DNSRecords.
+	// Finally, the field will be removed from the API in a future version of Gardener.
 	// +optional
 	OwnerChecks *SeedSettingOwnerChecks `json:"ownerChecks,omitempty" protobuf:"bytes,6,opt,name=ownerChecks"`
 	// DependencyWatchdog controls certain settings for the dependency-watchdog components deployed in the seed.
@@ -318,8 +318,8 @@ type SeedSettingVerticalPodAutoscaler struct {
 // SeedSettingOwnerChecks controls certain owner checks settings for shoots scheduled on this seed.
 //
 // Deprecated: This field is deprecated. The "bad-case" control plane migration is being removed in favor of the HA Shoot control planes (see https://github.com/gardener/gardener/issues/6302).
-// The field will be locked to false in a future version of Gardener. In this way gardenlet will clean up all owner DNSRecords. Finally, the field will be removed from the API.
-// Set this field to false to be prepared for the above-mentioned locking.
+// The field is locked to false (i.e. if the field value is true a validation error will be returned). In this way gardenlet will clean up all owner DNSRecords.
+// Finally, the field will be removed from the API in a future version of Gardener.
 type SeedSettingOwnerChecks struct {
 	// Enabled controls whether owner checks are enabled for shoots scheduled on this seed. It
 	// is enabled by default because it is a prerequisite for control plane migration.

--- a/pkg/apis/core/v1beta1/types_seed.go
+++ b/pkg/apis/core/v1beta1/types_seed.go
@@ -321,8 +321,7 @@ type SeedSettingVerticalPodAutoscaler struct {
 // The field is locked to false (i.e. if the field value is true a validation error will be returned). In this way gardenlet will clean up all owner DNSRecords.
 // Finally, the field will be removed from the API in a future version of Gardener.
 type SeedSettingOwnerChecks struct {
-	// Enabled controls whether owner checks are enabled for shoots scheduled on this seed. It
-	// is enabled by default because it is a prerequisite for control plane migration.
+	// Enabled controls whether owner checks are enabled for shoots scheduled on this seed.
 	Enabled bool `json:"enabled" protobuf:"bytes,1,opt,name=enabled"`
 }
 

--- a/pkg/apis/core/validation/seed.go
+++ b/pkg/apis/core/validation/seed.go
@@ -191,7 +191,7 @@ func ValidateSeedSpec(seedSpec *core.SeedSpec, fldPath *field.Path, inTemplate b
 			allErrs = append(allErrs, field.Forbidden(fldPath.Child("settings", "topologyAwareRouting", "enabled"), "topology-aware routing can only be enabled on multi-zone Seed clusters (with at least two zones in spec.provider.zones)"))
 		}
 		if helper.SeedSettingOwnerChecksEnabled(seedSpec.Settings) {
-			allErrs = append(allErrs, field.Forbidden(fldPath.Child("settings", "ownerChecks", "enabled"), "owner checks is locked to false in Gardener v1.71.0"))
+			allErrs = append(allErrs, field.Forbidden(fldPath.Child("settings", "ownerChecks", "enabled"), "owner checks is locked to false in Gardener v1.72+"))
 		}
 	}
 

--- a/pkg/apis/core/validation/seed.go
+++ b/pkg/apis/core/validation/seed.go
@@ -190,6 +190,9 @@ func ValidateSeedSpec(seedSpec *core.SeedSpec, fldPath *field.Path, inTemplate b
 		if helper.SeedSettingTopologyAwareRoutingEnabled(seedSpec.Settings) && len(seedSpec.Provider.Zones) <= 1 {
 			allErrs = append(allErrs, field.Forbidden(fldPath.Child("settings", "topologyAwareRouting", "enabled"), "topology-aware routing can only be enabled on multi-zone Seed clusters (with at least two zones in spec.provider.zones)"))
 		}
+		if helper.SeedSettingOwnerChecksEnabled(seedSpec.Settings) {
+			allErrs = append(allErrs, field.Forbidden(fldPath.Child("settings", "ownerChecks", "enabled"), "owner checks is locked to false in Gardener v1.71.0"))
+		}
 	}
 
 	if !inTemplate && seedSpec.Ingress == nil {

--- a/pkg/apis/core/validation/seed_test.go
+++ b/pkg/apis/core/validation/seed_test.go
@@ -889,6 +889,45 @@ var _ = Describe("Seed Validation Tests", func() {
 
 				Expect(errorList).To(BeEmpty())
 			})
+
+			Context("ownerChecks", func() {
+				It("should allow unspecified owner checks", func() {
+					seed.Spec.Settings = &core.SeedSettings{}
+
+					errorList := ValidateSeed(seed)
+
+					Expect(errorList).To(BeEmpty())
+				})
+
+				It("should allow owner checks disablement", func() {
+					seed.Spec.Settings = &core.SeedSettings{
+						OwnerChecks: &core.SeedSettingOwnerChecks{
+							Enabled: false,
+						},
+					}
+
+					errorList := ValidateSeed(seed)
+
+					Expect(errorList).To(BeEmpty())
+				})
+
+				It("should prevent owner checks enablement", func() {
+					seed.Spec.Settings = &core.SeedSettings{
+						OwnerChecks: &core.SeedSettingOwnerChecks{
+							Enabled: true,
+						},
+					}
+
+					errorList := ValidateSeed(seed)
+
+					Expect(errorList).To(ConsistOf(
+						PointTo(MatchFields(IgnoreExtras, Fields{
+							"Type":  Equal(field.ErrorTypeForbidden),
+							"Field": Equal("spec.settings.ownerChecks.enabled"),
+						})),
+					))
+				})
+			})
 		})
 
 		It("should fail updating immutable fields", func() {

--- a/pkg/apis/core/validation/seed_test.go
+++ b/pkg/apis/core/validation/seed_test.go
@@ -922,8 +922,9 @@ var _ = Describe("Seed Validation Tests", func() {
 
 					Expect(errorList).To(ConsistOf(
 						PointTo(MatchFields(IgnoreExtras, Fields{
-							"Type":  Equal(field.ErrorTypeForbidden),
-							"Field": Equal("spec.settings.ownerChecks.enabled"),
+							"Type":   Equal(field.ErrorTypeForbidden),
+							"Field":  Equal("spec.settings.ownerChecks.enabled"),
+							"Detail": Equal("owner checks is locked to false in Gardener v1.72+"),
 						})),
 					))
 				})

--- a/pkg/controllerutils/predicate/predicate.go
+++ b/pkg/controllerutils/predicate/predicate.go
@@ -15,7 +15,6 @@
 package predicate
 
 import (
-	"context"
 	"reflect"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -27,7 +26,6 @@ import (
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
-	contextutils "github.com/gardener/gardener/pkg/utils/context"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 )
 
@@ -220,47 +218,6 @@ func lastOperationStateChanged(oldObj, newObj client.Object) bool {
 	}
 
 	return false
-}
-
-// IsBeingMigratedPredicate returns a predicate which returns true for objects that are being migrated to a different
-// seed cluster.
-func IsBeingMigratedPredicate(reader client.Reader, seedName string, getSeedNamesFromObject func(client.Object) (*string, *string)) predicate.Predicate {
-	return &isBeingMigratedPredicate{
-		reader:                 reader,
-		seedName:               seedName,
-		getSeedNamesFromObject: getSeedNamesFromObject,
-	}
-}
-
-type isBeingMigratedPredicate struct {
-	ctx                    context.Context
-	reader                 client.Reader
-	seedName               string
-	getSeedNamesFromObject func(client.Object) (*string, *string)
-}
-
-func (p *isBeingMigratedPredicate) InjectStopChannel(stopChan <-chan struct{}) error {
-	p.ctx = contextutils.FromStopChannel(stopChan)
-	return nil
-}
-
-// IsObjectBeingMigrated is an alias for gardenerutils.IsObjectBeingMigrated.
-var IsObjectBeingMigrated = gardenerutils.IsObjectBeingMigrated
-
-func (p *isBeingMigratedPredicate) Create(e event.CreateEvent) bool {
-	return IsObjectBeingMigrated(p.ctx, p.reader, e.Object, p.seedName, p.getSeedNamesFromObject)
-}
-
-func (p *isBeingMigratedPredicate) Update(e event.UpdateEvent) bool {
-	return IsObjectBeingMigrated(p.ctx, p.reader, e.ObjectNew, p.seedName, p.getSeedNamesFromObject)
-}
-
-func (p *isBeingMigratedPredicate) Delete(e event.DeleteEvent) bool {
-	return IsObjectBeingMigrated(p.ctx, p.reader, e.Object, p.seedName, p.getSeedNamesFromObject)
-}
-
-func (p *isBeingMigratedPredicate) Generic(e event.GenericEvent) bool {
-	return IsObjectBeingMigrated(p.ctx, p.reader, e.Object, p.seedName, p.getSeedNamesFromObject)
 }
 
 // SeedNamePredicate returns a predicate which returns true for objects that are being migrated to a different

--- a/pkg/controllerutils/predicate/predicate_test.go
+++ b/pkg/controllerutils/predicate/predicate_test.go
@@ -15,25 +15,19 @@
 package predicate_test
 
 import (
-	"context"
-
 	. "github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	gomegatypes "github.com/onsi/gomega/types"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
-	"sigs.k8s.io/controller-runtime/pkg/runtime/inject"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
-	"github.com/gardener/gardener/pkg/client/kubernetes"
 	. "github.com/gardener/gardener/pkg/controllerutils/predicate"
-	"github.com/gardener/gardener/pkg/utils/test"
 )
 
 var _ = Describe("Predicate", func() {
@@ -476,37 +470,6 @@ var _ = Describe("Predicate", func() {
 			newExtensionBackupBucket := extensionBackupBucket.DeepCopy()
 
 			gomega.Expect(p.Update(event.UpdateEvent{ObjectNew: newExtensionBackupBucket, ObjectOld: extensionBackupBucket})).To(gomega.BeFalse())
-		})
-	})
-
-	Describe("#IsBeingMigratedPredicate", func() {
-		var (
-			ctx        = context.TODO()
-			fakeClient client.Client
-			p          predicate.Predicate
-
-			obj      *gardencorev1beta1.BackupEntry
-			seedName = "seed"
-		)
-
-		BeforeEach(func() {
-			fakeClient = fakeclient.NewClientBuilder().WithScheme(kubernetes.GardenScheme).Build()
-
-			p = IsBeingMigratedPredicate(fakeClient, seedName, nil)
-			gomega.Expect(inject.StopChannelInto(ctx.Done(), p)).To(gomega.BeTrue())
-
-			DeferCleanup(test.WithVar(&IsObjectBeingMigrated, func(_ context.Context, _ client.Reader, obj client.Object, _ string, _ func(client.Object) (*string, *string)) bool {
-				return false
-			}))
-
-			obj = &gardencorev1beta1.BackupEntry{}
-		})
-
-		It("should call the IsObjectBeingMigrated helper functions", func() {
-			gomega.Expect(p.Create(event.CreateEvent{Object: obj})).To(gomega.BeFalse())
-			gomega.Expect(p.Update(event.UpdateEvent{ObjectNew: obj})).To(gomega.BeFalse())
-			gomega.Expect(p.Delete(event.DeleteEvent{Object: obj})).To(gomega.BeFalse())
-			gomega.Expect(p.Generic(event.GenericEvent{Object: obj})).To(gomega.BeFalse())
 		})
 	})
 

--- a/pkg/gardenlet/apis/config/helper/helpers.go
+++ b/pkg/gardenlet/apis/config/helper/helpers.go
@@ -37,10 +37,10 @@ func SeedNameFromSeedConfig(seedConfig *config.SeedConfig) string {
 	return seedConfig.SeedTemplate.Name
 }
 
-// OwnerChecksEnabledInSeedConfig returns true if the given seed config is nil or the 'ownerChecks' setting is enabled.
+// OwnerChecksEnabledInSeedConfig returns false if the given seed config is nil or the 'ownerChecks' setting is enabled.
 func OwnerChecksEnabledInSeedConfig(seedConfig *config.SeedConfig) bool {
 	if seedConfig == nil {
-		return true
+		return false
 	}
 	return gardencorehelper.SeedSettingOwnerChecksEnabled(seedConfig.Spec.Settings)
 }

--- a/pkg/gardenlet/apis/config/helper/helpers_test.go
+++ b/pkg/gardenlet/apis/config/helper/helpers_test.go
@@ -49,23 +49,23 @@ var _ = Describe("helper", func() {
 	})
 
 	Describe("#OwnerChecksEnabledInSeedConfig", func() {
-		It("should return true with nil config", func() {
-			Expect(OwnerChecksEnabledInSeedConfig(nil)).To(BeTrue())
+		It("should return false with nil config", func() {
+			Expect(OwnerChecksEnabledInSeedConfig(nil)).To(BeFalse())
 		})
 
-		It("should return false if owner checks are disabled", func() {
+		It("should return true if owner checks are enabled", func() {
 			config := &config.SeedConfig{
 				SeedTemplate: gardencore.SeedTemplate{
 					Spec: gardencore.SeedSpec{
 						Settings: &gardencore.SeedSettings{
 							OwnerChecks: &gardencore.SeedSettingOwnerChecks{
-								Enabled: false,
+								Enabled: true,
 							},
 						},
 					},
 				},
 			}
-			Expect(OwnerChecksEnabledInSeedConfig(config)).To(BeFalse())
+			Expect(OwnerChecksEnabledInSeedConfig(config)).To(BeTrue())
 		})
 	})
 

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -6696,7 +6696,7 @@ func schema_pkg_apis_core_v1alpha1_SeedSettingOwnerChecks(ref common.ReferenceCa
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "SeedSettingOwnerChecks controls certain owner checks settings for shoots scheduled on this seed.\n\nDeprecated: This field is deprecated. The \"bad-case\" control plane migration is being removed in favor of the HA Shoot control planes (see https://github.com/gardener/gardener/issues/6302). The field will be locked to false in a future version of Gardener. In this way gardenlet will clean up all owner DNSRecords. Finally, the field will be removed from the API. Set this field to false to be prepared for the above-mentioned locking.",
+				Description: "SeedSettingOwnerChecks controls certain owner checks settings for shoots scheduled on this seed.\n\nDeprecated: This field is deprecated. The \"bad-case\" control plane migration is being removed in favor of the HA Shoot control planes (see https://github.com/gardener/gardener/issues/6302). The field is locked to false (i.e. if the field value is true a validation error will be returned). In this way gardenlet will clean up all owner DNSRecords. Finally, the field will be removed from the API in a future version of Gardener.",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"enabled": {
@@ -6813,7 +6813,7 @@ func schema_pkg_apis_core_v1alpha1_SeedSettings(ref common.ReferenceCallback) co
 					},
 					"ownerChecks": {
 						SchemaProps: spec.SchemaProps{
-							Description: "SeedSettingOwnerChecks controls certain owner checks settings for shoots scheduled on this seed.\n\nDeprecated: This field is deprecated. The \"bad-case\" control plane migration is being removed in favor of the HA Shoot control planes (see https://github.com/gardener/gardener/issues/6302). The field will be locked to false in a future version of Gardener. In this way gardenlet will clean up all owner DNSRecords. Finally, the field will be removed from the API. Set this field to false to be prepared for the above-mentioned locking.",
+							Description: "SeedSettingOwnerChecks controls certain owner checks settings for shoots scheduled on this seed.\n\nDeprecated: This field is deprecated. The \"bad-case\" control plane migration is being removed in favor of the HA Shoot control planes (see https://github.com/gardener/gardener/issues/6302). The field is locked to false (i.e. if the field value is true a validation error will be returned). In this way gardenlet will clean up all owner DNSRecords. Finally, the field will be removed from the API in a future version of Gardener.",
 							Ref:         ref("github.com/gardener/gardener/pkg/apis/core/v1alpha1.SeedSettingOwnerChecks"),
 						},
 					},
@@ -14465,7 +14465,7 @@ func schema_pkg_apis_core_v1beta1_SeedSettingOwnerChecks(ref common.ReferenceCal
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "SeedSettingOwnerChecks controls certain owner checks settings for shoots scheduled on this seed.\n\nDeprecated: This field is deprecated. The \"bad-case\" control plane migration is being removed in favor of the HA Shoot control planes (see https://github.com/gardener/gardener/issues/6302). The field will be locked to false in a future version of Gardener. In this way gardenlet will clean up all owner DNSRecords. Finally, the field will be removed from the API. Set this field to false to be prepared for the above-mentioned locking.",
+				Description: "SeedSettingOwnerChecks controls certain owner checks settings for shoots scheduled on this seed.\n\nDeprecated: This field is deprecated. The \"bad-case\" control plane migration is being removed in favor of the HA Shoot control planes (see https://github.com/gardener/gardener/issues/6302). The field is locked to false (i.e. if the field value is true a validation error will be returned). In this way gardenlet will clean up all owner DNSRecords. Finally, the field will be removed from the API in a future version of Gardener.",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"enabled": {
@@ -14582,7 +14582,7 @@ func schema_pkg_apis_core_v1beta1_SeedSettings(ref common.ReferenceCallback) com
 					},
 					"ownerChecks": {
 						SchemaProps: spec.SchemaProps{
-							Description: "SeedSettingOwnerChecks controls certain owner checks settings for shoots scheduled on this seed.\n\nDeprecated: This field is deprecated. The \"bad-case\" control plane migration is being removed in favor of the HA Shoot control planes (see https://github.com/gardener/gardener/issues/6302). The field will be locked to false in a future version of Gardener. In this way gardenlet will clean up all owner DNSRecords. Finally, the field will be removed from the API. Set this field to false to be prepared for the above-mentioned locking.",
+							Description: "SeedSettingOwnerChecks controls certain owner checks settings for shoots scheduled on this seed.\n\nDeprecated: This field is deprecated. The \"bad-case\" control plane migration is being removed in favor of the HA Shoot control planes (see https://github.com/gardener/gardener/issues/6302). The field is locked to false (i.e. if the field value is true a validation error will be returned). In this way gardenlet will clean up all owner DNSRecords. Finally, the field will be removed from the API in a future version of Gardener.",
 							Ref:         ref("github.com/gardener/gardener/pkg/apis/core/v1beta1.SeedSettingOwnerChecks"),
 						},
 					},

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -6701,7 +6701,7 @@ func schema_pkg_apis_core_v1alpha1_SeedSettingOwnerChecks(ref common.ReferenceCa
 				Properties: map[string]spec.Schema{
 					"enabled": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Enabled controls whether owner checks are enabled for shoots scheduled on this seed. It is enabled by default because it is a prerequisite for control plane migration.",
+							Description: "Enabled controls whether owner checks are enabled for shoots scheduled on this seed.",
 							Default:     false,
 							Type:        []string{"boolean"},
 							Format:      "",
@@ -14470,7 +14470,7 @@ func schema_pkg_apis_core_v1beta1_SeedSettingOwnerChecks(ref common.ReferenceCal
 				Properties: map[string]spec.Schema{
 					"enabled": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Enabled controls whether owner checks are enabled for shoots scheduled on this seed. It is enabled by default because it is a prerequisite for control plane migration.",
+							Description: "Enabled controls whether owner checks are enabled for shoots scheduled on this seed.",
 							Default:     false,
 							Type:        []string{"boolean"},
 							Format:      "",

--- a/pkg/operation/botanist/dnsresources_test.go
+++ b/pkg/operation/botanist/dnsresources_test.go
@@ -124,6 +124,11 @@ var _ = Describe("dnsrecord", func() {
 
 	Describe("#DeployOwnerDNSResources", func() {
 		It("should deploy the owner DNSRecord resource", func() {
+			b.Seed.GetInfo().Spec.Settings = &gardencorev1beta1.SeedSettings{
+				OwnerChecks: &gardencorev1beta1.SeedSettingOwnerChecks{
+					Enabled: true,
+				},
+			}
 			gomock.InOrder(
 				ownerDNSRecord.EXPECT().Deploy(ctx),
 				ownerDNSRecord.EXPECT().Wait(ctx),
@@ -132,11 +137,6 @@ var _ = Describe("dnsrecord", func() {
 		})
 
 		It("should delete the owner DNSRecord resource if owner checks are disabled", func() {
-			b.Seed.GetInfo().Spec.Settings = &gardencorev1beta1.SeedSettings{
-				OwnerChecks: &gardencorev1beta1.SeedSettingOwnerChecks{
-					Enabled: false,
-				},
-			}
 			gomock.InOrder(
 				ownerDNSRecord.EXPECT().Destroy(ctx),
 				ownerDNSRecord.EXPECT().WaitCleanup(ctx),
@@ -217,6 +217,11 @@ var _ = Describe("dnsrecord", func() {
 
 	Describe("#MigrateOwnerDNSResources", func() {
 		It("should migrate the owner DNSRecord resource", func() {
+			b.Seed.GetInfo().Spec.Settings = &gardencorev1beta1.SeedSettings{
+				OwnerChecks: &gardencorev1beta1.SeedSettingOwnerChecks{
+					Enabled: true,
+				},
+			}
 			gomock.InOrder(
 				ownerDNSRecord.EXPECT().Migrate(ctx),
 				ownerDNSRecord.EXPECT().WaitMigrate(ctx),
@@ -225,11 +230,6 @@ var _ = Describe("dnsrecord", func() {
 		})
 
 		It("should delete the owner DNSRecord resource if owner checks are disabled", func() {
-			b.Seed.GetInfo().Spec.Settings = &gardencorev1beta1.SeedSettings{
-				OwnerChecks: &gardencorev1beta1.SeedSettingOwnerChecks{
-					Enabled: false,
-				},
-			}
 			gomock.InOrder(
 				ownerDNSRecord.EXPECT().Destroy(ctx),
 				ownerDNSRecord.EXPECT().WaitCleanup(ctx),

--- a/pkg/utils/gardener/migration.go
+++ b/pkg/utils/gardener/migration.go
@@ -14,37 +14,6 @@
 
 package gardener
 
-import (
-	"context"
-
-	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
-	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
-	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
-)
-
-// IsObjectBeingMigrated checks whether the object is being migrated.
-func IsObjectBeingMigrated(
-	ctx context.Context,
-	reader client.Reader,
-	obj client.Object,
-	seedName string,
-	getSeedNamesFromObject func(client.Object) (*string, *string),
-) bool {
-	specSeedName, statusSeedName := getSeedNamesFromObject(obj)
-
-	if specSeedName != nil && statusSeedName != nil && *specSeedName != *statusSeedName && *specSeedName == seedName {
-		seed := &gardencorev1beta1.Seed{}
-		if err := reader.Get(ctx, kubernetesutils.Key(*statusSeedName), seed); err != nil {
-			return false
-		}
-		return v1beta1helper.SeedSettingOwnerChecksEnabled(seed.Spec.Settings)
-	}
-
-	return false
-}
-
 // GetResponsibleSeedName returns the seed name which is responsible for the next reconciliation.
 func GetResponsibleSeedName(specSeedName, statusSeedName *string) string {
 	switch {

--- a/pkg/utils/gardener/migration_test.go
+++ b/pkg/utils/gardener/migration_test.go
@@ -15,101 +15,14 @@
 package gardener_test
 
 import (
-	"context"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
-	"github.com/gardener/gardener/pkg/client/kubernetes"
 	. "github.com/gardener/gardener/pkg/utils/gardener"
 )
 
 var _ = Describe("Migration", func() {
-	Describe("#IsObjectBeingMigrated", func() {
-		var (
-			ctx        = context.TODO()
-			fakeClient client.Client
-
-			obj        *gardencorev1beta1.BackupEntry
-			sourceSeed *gardencorev1beta1.Seed
-			seedName   = "seed"
-
-			getSeedNamesFromObject = func(obj client.Object) (*string, *string) {
-				backupEntry := obj.(*gardencorev1beta1.BackupEntry)
-				return backupEntry.Spec.SeedName, backupEntry.Status.SeedName
-			}
-		)
-
-		BeforeEach(func() {
-			fakeClient = fakeclient.NewClientBuilder().WithScheme(kubernetes.GardenScheme).Build()
-
-			sourceSeed = &gardencorev1beta1.Seed{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "source-seed",
-				},
-				Spec: gardencorev1beta1.SeedSpec{
-					Settings: &gardencorev1beta1.SeedSettings{
-						OwnerChecks: &gardencorev1beta1.SeedSettingOwnerChecks{
-							Enabled: true,
-						},
-					},
-				},
-			}
-
-			obj = &gardencorev1beta1.BackupEntry{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "entry",
-				},
-				Spec: gardencorev1beta1.BackupEntrySpec{
-					SeedName: &seedName,
-				},
-				Status: gardencorev1beta1.BackupEntryStatus{
-					SeedName: &sourceSeed.Name,
-				},
-			}
-		})
-
-		It("should return false if status.seedName is nil", func() {
-			obj.Status.SeedName = nil
-
-			Expect(IsObjectBeingMigrated(ctx, fakeClient, obj, seedName, getSeedNamesFromObject)).To(BeFalse())
-		})
-
-		It("should return false if spec.seedName and status.seedName are equal", func() {
-			obj.Status.SeedName = pointer.String("seed")
-
-			Expect(IsObjectBeingMigrated(ctx, fakeClient, obj, seedName, getSeedNamesFromObject)).To(BeFalse())
-		})
-
-		It("should return false if the obj does not belong to this seed", func() {
-			obj.Spec.SeedName = pointer.String("another-seed")
-
-			Expect(IsObjectBeingMigrated(ctx, fakeClient, obj, seedName, getSeedNamesFromObject)).To(BeFalse())
-		})
-
-		It("should return false if the get call on source seed fails", func() {
-			Expect(IsObjectBeingMigrated(ctx, fakeClient, obj, seedName, getSeedNamesFromObject)).To(BeFalse())
-		})
-
-		It("should return true if the source seed has owner checks enabled", func() {
-			Expect(fakeClient.Create(ctx, sourceSeed)).To(Succeed())
-
-			Expect(IsObjectBeingMigrated(ctx, fakeClient, obj, seedName, getSeedNamesFromObject)).To(BeTrue())
-		})
-
-		It("should return false if the source seed has owner checks disabled", func() {
-			sourceSeed.Spec.Settings.OwnerChecks.Enabled = false
-			Expect(fakeClient.Create(ctx, sourceSeed)).To(Succeed())
-
-			Expect(IsObjectBeingMigrated(ctx, fakeClient, obj, seedName, getSeedNamesFromObject)).To(BeFalse())
-		})
-	})
-
 	Describe("#GetResponsibleSeedName", func() {
 		It("returns nothing if spec.seedName is not set", func() {
 			Expect(GetResponsibleSeedName(nil, nil)).To(BeEmpty())

--- a/test/integration/gardenlet/controllerinstallation/controllerinstallation/controllerinstallation_test.go
+++ b/test/integration/gardenlet/controllerinstallation/controllerinstallation/controllerinstallation_test.go
@@ -250,7 +250,7 @@ var _ = Describe("ControllerInstallation controller tests", func() {
         excessCapacityReservation:
           enabled: true
         ownerChecks:
-          enabled: true
+          enabled: false
         scheduling:
           visible: true
         topologyAwareRouting:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane-migration
/kind cleanup

**What this PR does / why we need it**:
Prevents owner checks enablement. Seeds' `.spec.settings.ownerChecks.enabled` field is locked to `false` (i.e. if the field value is true a validation error will be returned).

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/6302

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
⚠️ Seeds' `.spec.settings.ownerChecks.enabled` field is locked to `false` (i.e. if the field value is true a validation error will be returned). Before updating to this version of Gardener, set `.spec.settings.ownerChecks.enabled` field to `false` for you Seeds and ManagedSeeds.
```

```breaking dependency
The `{github.com/gardener/gardener/pkg/apis/core/helper,github.com/gardener/gardener/pkg/apis/core/v1beta1/helper}.SeedSettingOwnerChecksEnabled` will now return `false` if the corresponding Seed setting is `nil`. Previously, the func was returning `true` when the Seed setting is `nil`.
```

```breaking dependency
The unused `github.com/gardener/gardener/pkg/controllerutils/predicate.IsBeingMigratedPredicate`, `github.com/gardener/gardener/pkg/controllerutils/predicate.IsObjectBeingMigrated` and `github.com/gardener/gardener/pkg/utils/gardener.IsObjectBeingMigrated` funcs are now removed.
```
