### PR TITLE
Fix Istio-Ingress `service` annotation issue

### DIFF
--- a/pkg/operation/seed/seed.go
+++ b/pkg/operation/seed/seed.go
@@ -23,6 +23,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	"github.com/gardener/gardener/pkg/utils"
 )
 
 // NewBuilder returns a new Builder.
@@ -168,7 +169,8 @@ func (s *Seed) GetValidVolumeSize(size string) string {
 func (s *Seed) GetLoadBalancerServiceAnnotations() map[string]string {
 	seed := s.GetInfo()
 	if seed.Spec.Settings != nil && seed.Spec.Settings.LoadBalancerServices != nil {
-		return seed.Spec.Settings.LoadBalancerServices.Annotations
+		// return copy of annotations to prevent any accidental mutation by components
+		return utils.MergeStringMaps(seed.Spec.Settings.LoadBalancerServices.Annotations)
 	}
 	return nil
 }
@@ -188,7 +190,8 @@ func (s *Seed) GetZonalLoadBalancerServiceAnnotations(zone string) map[string]st
 	if seed.Spec.Settings != nil && seed.Spec.Settings.LoadBalancerServices != nil {
 		for _, zoneSettings := range seed.Spec.Settings.LoadBalancerServices.Zones {
 			if zoneSettings.Name == zone {
-				return zoneSettings.Annotations
+				// return copy of annotations to prevent any accidental mutation by components
+				return utils.MergeStringMaps(zoneSettings.Annotations)
 			}
 		}
 	}

--- a/pkg/operation/seed/seed_test.go
+++ b/pkg/operation/seed/seed_test.go
@@ -22,6 +22,7 @@ import (
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	. "github.com/gardener/gardener/pkg/operation/seed"
+	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 )
 
 var _ = Describe("seed", func() {
@@ -99,6 +100,7 @@ var _ = Describe("seed", func() {
 				},
 			})
 
+			Expect(seed.GetLoadBalancerServiceAnnotations()).ToNot(ShareSameReferenceAs(seed.GetInfo().Annotations))
 			Expect(seed.GetLoadBalancerServiceAnnotations()).To(Equal(map[string]string{annotationKey1: annotationValue1, annotationKey2: annotationValue2}))
 		})
 
@@ -116,6 +118,7 @@ var _ = Describe("seed", func() {
 				},
 			})
 
+			Expect(seed.GetLoadBalancerServiceAnnotations()).ToNot(ShareSameReferenceAs(seed.GetInfo().Annotations))
 			Expect(seed.GetLoadBalancerServiceAnnotations()).To(Equal(map[string]string{}))
 		})
 
@@ -180,9 +183,17 @@ var _ = Describe("seed", func() {
 				annotationValue1 = "my-value"
 				annotationKey2   = "second-annotation"
 				annotationValue2 = "second-value"
-				zone1            = "a"
-				zone2            = "b"
-				seed             = &Seed{}
+				annotationsZone1 = map[string]string{
+					annotationKey1: annotationValue1,
+					annotationKey2: annotationValue2,
+				}
+				annotationsZone2 = map[string]string{
+					annotationKey1: annotationValue1,
+				}
+
+				zone1 = "a"
+				zone2 = "b"
+				seed  = &Seed{}
 			)
 			seed.SetInfo(&gardencorev1beta1.Seed{
 				Spec: gardencorev1beta1.SeedSpec{
@@ -190,17 +201,12 @@ var _ = Describe("seed", func() {
 						LoadBalancerServices: &gardencorev1beta1.SeedSettingLoadBalancerServices{
 							Zones: []gardencorev1beta1.SeedSettingLoadBalancerServicesZones{
 								{
-									Name: zone1,
-									Annotations: map[string]string{
-										annotationKey1: annotationValue1,
-										annotationKey2: annotationValue2,
-									},
+									Name:        zone1,
+									Annotations: annotationsZone1,
 								},
 								{
-									Name: zone2,
-									Annotations: map[string]string{
-										annotationKey1: annotationValue1,
-									},
+									Name:        zone2,
+									Annotations: annotationsZone2,
 								},
 							},
 						},
@@ -208,7 +214,9 @@ var _ = Describe("seed", func() {
 				},
 			})
 
+			Expect(seed.GetZonalLoadBalancerServiceAnnotations(zone1)).ToNot(ShareSameReferenceAs(annotationsZone1))
 			Expect(seed.GetZonalLoadBalancerServiceAnnotations(zone1)).To(Equal(map[string]string{annotationKey1: annotationValue1, annotationKey2: annotationValue2}))
+			Expect(seed.GetZonalLoadBalancerServiceAnnotations(zone2)).ToNot(ShareSameReferenceAs(annotationsZone2))
 			Expect(seed.GetZonalLoadBalancerServiceAnnotations(zone2)).To(Equal(map[string]string{annotationKey1: annotationValue1}))
 		})
 

--- a/pkg/utils/test/matchers/matchers.go
+++ b/pkg/utils/test/matchers/matchers.go
@@ -131,3 +131,12 @@ func BeCacheError() types.GomegaMatcher {
 		message: "",
 	}
 }
+
+// ShareSameReferenceAs checks if objects shares the same underlying reference as the passed object.
+// This can be used to check if maps or slices have the same underlying data store.
+// Only objects that work for 'reflect.ValueOf(x).Pointer' can be compared.
+func ShareSameReferenceAs(expected interface{}) types.GomegaMatcher {
+	return &referenceMatcher{
+		expected: expected,
+	}
+}

--- a/pkg/utils/test/matchers/reference.go
+++ b/pkg/utils/test/matchers/reference.go
@@ -1,0 +1,43 @@
+// Copyright 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package matchers
+
+import (
+	"reflect"
+
+	"github.com/onsi/gomega/format"
+)
+
+type referenceMatcher struct {
+	expected interface{}
+}
+
+func (r *referenceMatcher) Match(actual interface{}) (success bool, err error) {
+	return func(expected, actual interface{}) bool {
+		return reflect.ValueOf(expected).Pointer() == reflect.ValueOf(actual).Pointer()
+	}(r.expected, actual), nil
+}
+
+func (r *referenceMatcher) FailureMessage(actual interface{}) (message string) {
+	return r.failureMessage(actual, "")
+}
+
+func (r *referenceMatcher) NegatedFailureMessage(actual interface{}) (message string) {
+	return r.failureMessage(actual, " not")
+}
+
+func (r *referenceMatcher) failureMessage(actual interface{}, messagePrefix string) (message string) {
+	return format.Message(actual, "to"+messagePrefix+" share reference with the compared object")
+}

--- a/pkg/utils/test/matchers/reference_test.go
+++ b/pkg/utils/test/matchers/reference_test.go
@@ -1,0 +1,49 @@
+// Copyright 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package matchers_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/utils/pointer"
+
+	. "github.com/gardener/gardener/pkg/utils/test/matchers"
+)
+
+var _ = Describe("Reference Matcher", func() {
+	test := func(actual, expected interface{}) {
+		It("should be true if objects share the same reference", func() {
+			sameRef := actual
+
+			Expect(actual).To(ShareSameReferenceAs(sameRef))
+		})
+
+		It("should be false if objects don't share the same reference", func() {
+			Expect(actual).NotTo(ShareSameReferenceAs(expected))
+		})
+	}
+
+	Context("when values are maps", func() {
+		test(map[string]string{"foo": "bar"}, map[string]string{"foo": "bar"})
+	})
+
+	Context("when values are slices", func() {
+		test([]string{"foo", "bar"}, []string{"foo", "bar"})
+	})
+
+	Context("when values are pointers", func() {
+		test(pointer.String("foo"), pointer.String("foo"))
+	})
+})


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug

**What this PR does / why we need it**:
This PR fixes an issue with the Istio-Ingress `service` object introduced with https://github.com/gardener/gardener/pull/7835.

The `Nginx-Ingress` component adds the `from-world-to-ports` entry to the service annotations (see [here](https://github.com/gardener/gardener/blob/13d5158c55cc6b21ff1a24bb068c00dd223e8563/pkg/operation/botanist/component/nginxingress/nginxingress.go#L604)) but unfortunately mutation happens on a shared annotation map that is also read by the `Istio` component.

As a result, the Istio-Ingress `service` had a wrongly assigned annotation value that prevent the intended network policies from being created and blocked access to Istio-Ingress gateway from outside. This only happened if [load balancer annotations](https://github.com/gardener/gardener/blob/13d5158c55cc6b21ff1a24bb068c00dd223e8563/example/50-seed.yaml#LL67C3-L67C3) were specified in the seed resource.

```
k get secrets -n istio-system managedresource-istio -ojson | jq -r '.data."istio-ingress_templates_service_istio-ingress.yaml"' | base64 -d
apiVersion: v1
kind: Service
metadata:
  name: istio-ingressgateway
  namespace: istio-ingress
  annotations:
    service.alpha.kubernetes.io/aws-load-balancer-type: "nlb"
    service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
    networking.resources.gardener.cloud/from-world-to-ports: '[{"port":8132,"protocol":"TCP"},{"port":8443,"protocol":"TCP"},{"port":9443,"protocol":"TCP"}]'
    networking.resources.gardener.cloud/namespace-selectors: '[{"matchLabels":{"gardener.cloud/role":"shoot"}},{"matchLabels":{"kubernetes.io/metadata.name":"garden"}}]'
    networking.resources.gardener.cloud/pod-label-selector-namespace-alias: all-istio-ingresses
    networking.resources.gardener.cloud/from-policy-allowed-ports: '[{"port":15020,"protocol":"TCP"}]'
    networking.resources.gardener.cloud/from-policy-pod-label-selector: all-seed-scrape-targets
    foo: bar
    networking.resources.gardener.cloud/from-world-to-ports: '[{"protocol":"TCP","port":80},{"protocol":"TCP","port":443}]' # <-- this value is not supposed to be there and overwrites the `from-world-to-ports` key above.
```

**Special notes for your reviewer**:
/cc @ScheererJ @rfranzke @shaoyongfeng  

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
An issue has been fixed that caused traffic from outside of the cluster to `Istio-Ingress` being blocked. This is only relevant if seed(s) specify additional load balancer annotations via `seed.spec.settings.loadBalancerServices.annotations`.
```
