### PR TITLE
Improve the formatting of grafana.dashboards.data

### DIFF
--- a/charts/seed-monitoring/charts/grafana/templates/_helpers.tpl
+++ b/charts/seed-monitoring/charts/grafana/templates/_helpers.tpl
@@ -56,38 +56,38 @@ grafana-datasources-{{ include "grafana.datasources.data" . | sha256sum | trunc 
 {{- end }}
 
 {{- define "grafana.dashboards.data" -}}
-{{- if eq $.Values.workerless false }}
-{{- if .Values.sni.enabled }}
-{{ range $name, $bytes := .Files.Glob "dashboards/owners/istio/**.json" }}
-{{ base $name }}: |-
-{{ toString $bytes | include "grafana.toCompactedJson" | indent 2 }}
-{{- end }}
-{{- end }}
-{{- if .Values.nodeLocalDNS.enabled }}
-{{ range $name, $bytes := .Files.Glob "dashboards/dns/**.json" }}
-{{ base $name }}: |-
-{{ toString $bytes | include "grafana.toCompactedJson" | indent 2 }}
-{{- end }}
-{{- end }}
-{{ range $name, $bytes := .Files.Glob "dashboards/owners/worker/**.json" }}
-{{ base $name }}: |-
-{{ toString $bytes | include "grafana.toCompactedJson" | indent 2 }}
-{{- end }}
-{{ else }}
-{{ range $name, $bytes := .Files.Glob "dashboards/owners/workerless/**.json" }}
-{{ base $name }}: |-
-{{ toString $bytes | include "grafana.toCompactedJson" | indent 2 }}
-{{- end }}
-{{- end }}
-{{ range $name, $bytes := .Files.Glob "dashboards/owners/*.json" }}
-{{ if not (and (eq $name "dashboards/owners/vpa-dashboard.json") (eq $.Values.vpaEnabled false)) }}
-{{ base $name }}: |-
-{{ toString $bytes | include "grafana.toCompactedJson" | indent 2 }}
-{{- end }}
-{{- end }}
-{{- if .Values.extensions.dashboards }}
-{{- toString .Values.extensions.dashboards }}
-{{ end }}
+{{-   if eq $.Values.workerless false }}
+{{-     if .Values.sni.enabled }}
+{{        range $name, $bytes := .Files.Glob "dashboards/owners/istio/**.json" }}
+{{          base $name }}: |-
+{{          toString $bytes | include "grafana.toCompactedJson" | indent 2 }}
+{{-       end }}
+{{-     end }}
+{{-     if .Values.nodeLocalDNS.enabled }}
+{{        range $name, $bytes := .Files.Glob "dashboards/dns/**.json" }}
+{{          base $name }}: |-
+{{          toString $bytes | include "grafana.toCompactedJson" | indent 2 }}
+{{-       end }}
+{{-     end }}
+{{      range $name, $bytes := .Files.Glob "dashboards/owners/worker/**.json" }}
+{{        base $name }}: |-
+{{        toString $bytes | include "grafana.toCompactedJson" | indent 2 }}
+{{-     end }}
+{{    else }}
+{{      range $name, $bytes := .Files.Glob "dashboards/owners/workerless/**.json" }}
+{{        base $name }}: |-
+{{        toString $bytes | include "grafana.toCompactedJson" | indent 2 }}
+{{-     end }}
+{{-   end }}
+{{    range $name, $bytes := .Files.Glob "dashboards/owners/*.json" }}
+{{      if not (and (eq $name "dashboards/owners/vpa-dashboard.json") (eq $.Values.vpaEnabled false)) }}
+{{        base $name }}: |-
+{{        toString $bytes | include "grafana.toCompactedJson" | indent 2 }}
+{{-     end }}
+{{-   end }}
+{{-   if .Values.extensions.dashboards }}
+{{-     toString .Values.extensions.dashboards }}
+{{    end }}
 {{- end -}}
 
 {{- define "grafana.dashboards.name" -}}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind enhancement

**What this PR does / why we need it**:

When reviewing #7889, I noticed that it is challenging to follow the nested control structures in this golang text templating helm function.

A bit of indentation inside the curly braces does not change the generated output and improves the readability a bit.

Verify it with
  `helm template . 2>/dev/null`
in `charts/seed-monitoring/charts/grafana`

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

/cc @rickardsjp 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
