### PR TITLE
Fix race in `gardener-operator` integration test suite

### DIFF
--- a/pkg/operation/botanist/component/shared/resourcemanager.go
+++ b/pkg/operation/botanist/component/shared/resourcemanager.go
@@ -191,10 +191,16 @@ func NewTargetGardenerResourceManager(
 	), nil
 }
 
-// TimeoutWaitForGardenerResourceManagerBootstrapping is the maximum time the bootstrap process for the
-// gardener-resource-manager may take.
-// Exposed for testing.
-var TimeoutWaitForGardenerResourceManagerBootstrapping = 2 * time.Minute
+var (
+	// TimeoutWaitForGardenerResourceManagerBootstrapping is the maximum time the bootstrap process for the
+	// gardener-resource-manager may take.
+	// Exposed for testing.
+	TimeoutWaitForGardenerResourceManagerBootstrapping = 2 * time.Minute
+	// IntervalWaitForGardenerResourceManagerBootstrapping is the interval how often it's checked whether the bootstrap
+	// process for the gardener-resource-manager has completed.
+	// Exposed for testing.
+	IntervalWaitForGardenerResourceManagerBootstrapping = 5 * time.Second
+)
 
 // DeployGardenerResourceManager deploys the gardener-resource-manager
 func DeployGardenerResourceManager(
@@ -333,7 +339,7 @@ func reconcileGardenerResourceManagerBootstrapKubeconfigSecret(ctx context.Conte
 func waitUntilGardenerResourceManagerBootstrapped(ctx context.Context, c client.Client, namespace string) error {
 	shootAccessSecret := gardenerutils.NewShootAccessSecret(resourcemanager.SecretNameShootAccess, namespace)
 
-	if err := retryutils.Until(ctx, 5*time.Second, func(ctx context.Context) (bool, error) {
+	if err := retryutils.Until(ctx, IntervalWaitForGardenerResourceManagerBootstrapping, func(ctx context.Context) (bool, error) {
 		if err2 := c.Get(ctx, client.ObjectKeyFromObject(shootAccessSecret.Secret), shootAccessSecret.Secret); err2 != nil {
 			if apierrors.IsNotFound(err2) {
 				return retryutils.MinorError(err2)

--- a/test/integration/operator/garden/garden_test.go
+++ b/test/integration/operator/garden/garden_test.go
@@ -524,7 +524,7 @@ var _ = Describe("Garden controller tests", func() {
 			g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(secret), secret)).To(Succeed())
 
 			patch := client.MergeFrom(secret.DeepCopy())
-			kubeconfig := `apiVersion: v1
+			secret.Data = map[string][]byte{"kubeconfig": []byte(`apiVersion: v1
 clusters:
 - cluster:
     certificate-authority-data: AAAA
@@ -542,8 +542,7 @@ users:
 - name: garden
   user:
     token: foobar
-`
-			secret.Data = map[string][]byte{"kubeconfig": []byte(kubeconfig)}
+`)}
 			g.Expect(testClient.Patch(ctx, secret, patch)).To(Succeed())
 		}).Should(Succeed())
 

--- a/test/integration/operator/garden/garden_test.go
+++ b/test/integration/operator/garden/garden_test.go
@@ -48,6 +48,7 @@ import (
 	"github.com/gardener/gardener/pkg/operation/botanist/component/kubeapiserver"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/kubeapiserverexposure"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/resourcemanager"
+	"github.com/gardener/gardener/pkg/operation/botanist/component/shared"
 	"github.com/gardener/gardener/pkg/operator/apis/config"
 	operatorclient "github.com/gardener/gardener/pkg/operator/client"
 	gardencontroller "github.com/gardener/gardener/pkg/operator/controller/garden"
@@ -80,6 +81,7 @@ var _ = Describe("Garden controller tests", func() {
 			&resourcemanager.SkipWebhookDeployment, true,
 			&resourcemanager.IntervalWaitForDeployment, 100*time.Millisecond,
 			&resourcemanager.TimeoutWaitForDeployment, 500*time.Millisecond,
+			&shared.IntervalWaitForGardenerResourceManagerBootstrapping, 500*time.Millisecond,
 		))
 
 		By("Create test Namespace")


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind flake

**What this PR does / why we need it**:
Fix race in `gardener-operator` integration test suite, examples:

- https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/7929/pull-gardener-integration/1656925671609339904
- https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/7929/pull-gardener-integration/1656930607399178240
- https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/7907/pull-gardener-integration/1656931429801529344

**Which issue(s) this PR fixes**:
Introduced with #7881 

**Special notes for your reviewer**:
/cc @ScheererJ 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
