### PR TITLE
Bump `nginx-ingress-controller` addon image to v1.3.0 for 1.22+ shoots

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -353,7 +353,7 @@ images:
 - name: nginx-ingress-controller
   sourceRepository: github.com/kubernetes/ingress-nginx
   repository: registry.k8s.io/ingress-nginx/controller-chroot
-  tag: "v1.2.1"
+  tag: "v1.3.0"
   targetVersion: ">= 1.22"
   labels: *optionalAddonLabels
 

--- a/pkg/operation/botanist/component/nginxingressshoot/nginxingress.go
+++ b/pkg/operation/botanist/component/nginxingressshoot/nginxingress.go
@@ -494,7 +494,7 @@ func (n *nginxIngress) computeResourcesData() (map[string][]byte, error) {
 				{
 					APIGroups:     []string{"coordination.k8s.io"},
 					Resources:     []string{"leases"},
-					ResourceNames: []string{"ingress-controller-leader-nginx"},
+					ResourceNames: []string{"ingress-controller-leader"},
 					Verbs:         []string{"get", "update"},
 				},
 				{
@@ -505,7 +505,7 @@ func (n *nginxIngress) computeResourcesData() (map[string][]byte, error) {
 				{
 					APIGroups:     []string{""},
 					Resources:     []string{"configmaps"},
-					ResourceNames: []string{"ingress-controller-leader-nginx"},
+					ResourceNames: []string{"ingress-controller-leader"},
 					Verbs:         []string{"get", "update"},
 				},
 			},

--- a/pkg/operation/botanist/component/nginxingressshoot/nginxingress.go
+++ b/pkg/operation/botanist/component/nginxingressshoot/nginxingress.go
@@ -228,6 +228,11 @@ func (n *nginxIngress) computeResourcesData() (map[string][]byte, error) {
 					Resources: []string{"ingressclasses"},
 					Verbs:     []string{"get", "list", "watch"},
 				},
+				{
+					APIGroups: []string{"coordination.k8s.io"},
+					Resources: []string{"leases"},
+					Verbs:     []string{"list", "watch"},
+				},
 			},
 		}
 
@@ -480,6 +485,17 @@ func (n *nginxIngress) computeResourcesData() (map[string][]byte, error) {
 					APIGroups: []string{""},
 					Resources: []string{"endpoints"},
 					Verbs:     []string{"create", "get", "update"},
+				},
+				{
+					APIGroups: []string{"coordination.k8s.io"},
+					Resources: []string{"leases"},
+					Verbs:     []string{"create"},
+				},
+				{
+					APIGroups:     []string{"coordination.k8s.io"},
+					Resources:     []string{"leases"},
+					ResourceNames: []string{"ingress-controller-leader-nginx"},
+					Verbs:         []string{"get", "update"},
 				},
 				{
 					APIGroups: []string{""},

--- a/pkg/operation/botanist/component/nginxingressshoot/nginxingress_test.go
+++ b/pkg/operation/botanist/component/nginxingressshoot/nginxingress_test.go
@@ -229,6 +229,13 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - list
+  - watch
 `
 
 		clusterRoleBindingYAML = `apiVersion: rbac.authorization.k8s.io/v1
@@ -504,6 +511,21 @@ rules:
   - get
   - update
 - apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+- apiGroups:
+  - coordination.k8s.io
+  resourceNames:
+  - ingress-controller-leader
+  resources:
+  - leases
+  verbs:
+  - get
+  - update
+- apiGroups:
   - ""
   resources:
   - configmaps
@@ -512,7 +534,7 @@ rules:
 - apiGroups:
   - ""
   resourceNames:
-  - ingress-controller-leader-nginx
+  - ingress-controller-leader
   resources:
   - configmaps
   verbs:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area open-source
/kind enhancement

**What this PR does / why we need it**:
For shoot addons, we're using a pretty old nginx version which has lot of CVEs.
We can't directly update to the latest version because of "migration to leases".
We need to use `v1.3.0` for one release and then we can go for the latest image.
The required RBAC for leases are updated. Similar to https://github.com/gardener/gardener/pull/6356
See compatibility matrix: https://github.com/kubernetes/ingress-nginx#supported-versions-table

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other dependency
Shoot addon `nginx-ingress-controller` image is updated to `v1.3.0` for `v1.22+` shoots.
```
