### PR TITLE
Nit: Annotate the garden resources with confirmation annotation during `make operator-down`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -485,6 +485,7 @@ operator-dev: $(SKAFFOLD) $(HELM) $(KUBECTL)
 operator-debug: $(SKAFFOLD) $(HELM) $(KUBECTL)
 	$(SKAFFOLD) debug
 operator-down: $(SKAFFOLD) $(HELM) $(KUBECTL)
+	$(KUBECTL) annotate garden --all confirmation.gardener.cloud/deletion=true
 	$(KUBECTL) delete garden --all --ignore-not-found --wait --timeout 5m
 	$(SKAFFOLD) delete
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
Currently, if there is a existing `garden` resource, then `make operator-down` would fail with:
```
% make operator-down
hack/tools/bin/kubectl delete garden --all --ignore-not-found --wait --timeout 5m
Error from server (must have a "confirmation.gardener.cloud/deletion" annotation to delete): admission webhook "validation.operator.gardener.cloud" denied the request: must have a "confirmation.gardener.cloud/deletion" annotation to delete
make: *** [operator-down] Error 1
```

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
