### PR TITLE
Improve `make check-apidiff`

### DIFF
--- a/hack/check-apidiff.sh
+++ b/hack/check-apidiff.sh
@@ -28,8 +28,8 @@ retval=0
 temp=0
 
 # PULL_BASE_SHA env variable is set by default in prow presubmit jobs
-echo "invoking: go-apidiff ${PULL_BASE_SHA:-master} --print-compatible --repo-path=."
-go-apidiff ${PULL_BASE_SHA:-master} --print-compatible --repo-path=. >${tmpDir}/output.txt || true
+echo "invoking: go-apidiff ${PULL_BASE_SHA:-master} --repo-path=."
+go-apidiff ${PULL_BASE_SHA:-master} --repo-path=. >${tmpDir}/output.txt || true
 
 exported_pkg=(
   "gardener/gardener/extensions/"

--- a/hack/check-apidiff.sh
+++ b/hack/check-apidiff.sh
@@ -43,6 +43,7 @@ exported_pkg=(
   "gardener/gardener/pkg/logger/"
   "gardener/gardener/pkg/mock/controller-runtime/client/"
   "gardener/gardener/pkg/operation/botanist/component/extensions/operatingsystemconfig/"
+  "gardener/gardener/pkg/operator/apis/config/"
   "gardener/gardener/pkg/resourcemanager/controller/garbagecollector/references/"
   "gardener/gardener/pkg/scheduler/"
   "gardener/gardener/pkg/utils/"

--- a/hack/check-apidiff.sh
+++ b/hack/check-apidiff.sh
@@ -32,22 +32,24 @@ echo "invoking: go-apidiff ${PULL_BASE_SHA:-master} --repo-path=."
 go-apidiff ${PULL_BASE_SHA:-master} --repo-path=. >${tmpDir}/output.txt || true
 
 exported_pkg=(
-  "gardener/gardener/extensions/"
-  "gardener/gardener/pkg/api/"
-  "gardener/gardener/pkg/apis/"
-  "gardener/gardener/pkg/chartrenderer/"
-  "gardener/gardener/pkg/client/"
-  "gardener/gardener/pkg/controllerutils/"
-  "gardener/gardener/pkg/extensions/"
-  "gardener/gardener/pkg/gardenlet/apis/config/"
-  "gardener/gardener/pkg/logger/"
-  "gardener/gardener/pkg/mock/controller-runtime/client/"
-  "gardener/gardener/pkg/operation/botanist/component/extensions/operatingsystemconfig/"
-  "gardener/gardener/pkg/operator/apis/config/"
-  "gardener/gardener/pkg/resourcemanager/controller/garbagecollector/references/"
-  "gardener/gardener/pkg/scheduler/"
-  "gardener/gardener/pkg/utils/"
-  "gardener/gardener/test/framework/"
+  gardener/gardener/extensions/
+  gardener/gardener/pkg/api/
+  gardener/gardener/pkg/apis/.*/v1alpha1
+  gardener/gardener/pkg/apis/.*/v1beta1
+  gardener/gardener/pkg/apis/extensions/validation
+  gardener/gardener/pkg/chartrenderer/
+  gardener/gardener/pkg/client/
+  gardener/gardener/pkg/controllerutils/
+  gardener/gardener/pkg/extensions/
+  gardener/gardener/pkg/gardenlet/apis/config/v1alpha1
+  gardener/gardener/pkg/logger/
+  gardener/gardener/pkg/mock/controller-runtime/client/
+  gardener/gardener/pkg/operation/botanist/component/extensions/operatingsystemconfig/
+  gardener/gardener/pkg/operator/apis/config/v1alpha1
+  gardener/gardener/pkg/resourcemanager/controller/garbagecollector/references/
+  gardener/gardener/pkg/scheduler/
+  gardener/gardener/pkg/utils/
+  gardener/gardener/test/framework/
 )
 
 # check the changes only for the package that is in the exported_pkg list


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
This PR improves the `check-apidiff` check (also see commit messages):

- To only report incompatible changes
- Adds missing Operator config API
- Refines some paths taken into consideration for the check

The [pull-gardener-apidiff](https://github.com/gardener/ci-infra/blob/master/config/jobs/gardener/gardener-apidiff.yaml) check used to fail often in the past for non-critical and compatible changes. This rather leads to disregarding the job results in the long run.
With the changes above we want to report "more relevant" changes that indeed need attention.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
The `check-apidiff` check was changed to only report incompatible and critical changes which need inspection from the developer's side.
```
