### PR TITLE
adjust default fluent-bit log level

### DIFF
--- a/pkg/operation/botanist/component/logging/fluentoperator/customresources/cluster_fluent_bit_config.go
+++ b/pkg/operation/botanist/component/logging/fluentoperator/customresources/cluster_fluent_bit_config.go
@@ -37,7 +37,7 @@ func GetClusterFluentBitConfig(fluentBitName string, matchLabels map[string]stri
 			Service: &fluentbitv1alpha2.Service{
 				FlushSeconds: pointer.Int64(30),
 				Daemon:       pointer.Bool(false),
-				LogLevel:     "info",
+				LogLevel:     "error",
 				ParsersFile:  "parsers.conf",
 				HttpServer:   pointer.Bool(true),
 				HttpListen:   "0.0.0.0",

--- a/pkg/operation/botanist/component/logging/fluentoperator/customresources/cluster_fluent_bit_config_test.go
+++ b/pkg/operation/botanist/component/logging/fluentoperator/customresources/cluster_fluent_bit_config_test.go
@@ -47,7 +47,7 @@ var _ = Describe("Logging", func() {
 						Service: &fluentbitv1alpha2.Service{
 							FlushSeconds: pointer.Int64(30),
 							Daemon:       pointer.Bool(false),
-							LogLevel:     "info",
+							LogLevel:     "error",
 							ParsersFile:  "parsers.conf",
 							HttpServer:   pointer.Bool(true),
 							HttpListen:   "0.0.0.0",


### PR DESCRIPTION
/area logging
/kind improvement
This PR switches the default fluent-bit log level to `error`. With the operator the individual plugins can adjust if needed, allowing much more precise log output. 

```other operator
Default log level in fluent-bit is changed from `info` to `error`
```
