### PR TITLE
Move fluent-bit persistent folder from /opt/fluent-bit to /var/fluent…

### DIFF
--- a/pkg/operation/botanist/component/logging/fluentoperator/customresources/cluster_inputs.go
+++ b/pkg/operation/botanist/component/logging/fluentoperator/customresources/cluster_inputs.go
@@ -37,7 +37,7 @@ func GetClusterInputs(labels map[string]string) []*fluentbitv1alpha2.ClusterInpu
 					RefreshIntervalSeconds: pointer.Int64(10),
 					MemBufLimit:            "30MB",
 					SkipLongLines:          pointer.Bool(true),
-					DB:                     "/opt/fluentbit/flb_kube.db",
+					DB:                     "/var/fluentbit/flb_kube.db",
 					IgnoreOlder:            "30m",
 				},
 			},

--- a/pkg/operation/botanist/component/logging/fluentoperator/customresources/cluster_inputs_test.go
+++ b/pkg/operation/botanist/component/logging/fluentoperator/customresources/cluster_inputs_test.go
@@ -49,7 +49,7 @@ var _ = Describe("Logging", func() {
 								RefreshIntervalSeconds: pointer.Int64(10),
 								MemBufLimit:            "30MB",
 								SkipLongLines:          pointer.Bool(true),
-								DB:                     "/opt/fluentbit/flb_kube.db",
+								DB:                     "/var/fluentbit/flb_kube.db",
 								IgnoreOlder:            "30m",
 							},
 						},

--- a/pkg/operation/botanist/component/logging/fluentoperator/customresources/fluent_bit.go
+++ b/pkg/operation/botanist/component/logging/fluentoperator/customresources/fluent_bit.go
@@ -99,10 +99,10 @@ func GetFluentBit(labels map[string]string, fluentBitName, namespace, image, ini
 					},
 				},
 				{
-					Name: "optfluent",
+					Name: "varfluent",
 					VolumeSource: corev1.VolumeSource{
 						HostPath: &corev1.HostPathVolumeSource{
-							Path: "/opt/fluentbit",
+							Path: "/var/fluentbit",
 						},
 					},
 				},
@@ -119,8 +119,8 @@ func GetFluentBit(labels map[string]string, fluentBitName, namespace, image, ini
 					MountPath: "/run/log/journal",
 				},
 				{
-					Name:      "optfluent",
-					MountPath: "/opt/fluentbit",
+					Name:      "varfluent",
+					MountPath: "/var/fluentbit",
 				},
 				{
 					Name:      "plugins",

--- a/pkg/operation/botanist/component/logging/fluentoperator/customresources/fluent_bit_test.go
+++ b/pkg/operation/botanist/component/logging/fluentoperator/customresources/fluent_bit_test.go
@@ -114,10 +114,10 @@ var _ = Describe("Logging", func() {
 								},
 							},
 							{
-								Name: "optfluent",
+								Name: "varfluent",
 								VolumeSource: corev1.VolumeSource{
 									HostPath: &corev1.HostPathVolumeSource{
-										Path: "/opt/fluentbit",
+										Path: "/var/fluentbit",
 									},
 								},
 							},
@@ -134,8 +134,8 @@ var _ = Describe("Logging", func() {
 								MountPath: "/run/log/journal",
 							},
 							{
-								Name:      "optfluent",
-								MountPath: "/opt/fluentbit",
+								Name:      "varfluent",
+								MountPath: "/var/fluentbit",
 							},
 							{
 								Name:      "plugins",


### PR DESCRIPTION
/area logging
/kind bug

This PR moves the fluent-bit persistent storage from `/opt/fluentbit` to `/var/fluentbit`. This is required to fix the case where we have a read-only root file system on the node, usually due to security hardening of the nodes. In those cases where the /opt is in readonly mode the fluent-bits will not be able to start.

```other operator
NONE
```
