### PR TITLE
Reconcile dnsrecord when status is outdated

### DIFF
--- a/pkg/component/extensions/dnsrecord/dnsrecord_test.go
+++ b/pkg/component/extensions/dnsrecord/dnsrecord_test.go
@@ -350,6 +350,53 @@ var _ = Describe("DNSRecord", func() {
 			}))
 		})
 
+		It("should deploy the DNSRecord with operation annotation if status is outdated", func() {
+			expectedDNSRecord := &extensionsv1alpha1.DNSRecord{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: extensionsv1alpha1.SchemeGroupVersion.String(),
+					Kind:       extensionsv1alpha1.DNSRecordResource},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					Namespace: namespace,
+					Annotations: map[string]string{
+						v1beta1constants.GardenerOperation: v1beta1constants.GardenerOperationReconcile,
+						v1beta1constants.GardenerTimestamp: now.UTC().Format(time.RFC3339Nano),
+					},
+					ResourceVersion: "2",
+				},
+				Spec: dns.Spec,
+				Status: extensionsv1alpha1.DNSRecordStatus{
+					DefaultStatus: extensionsv1alpha1.DefaultStatus{
+						LastOperation: &gardencorev1beta1.LastOperation{
+							State:          gardencorev1beta1.LastOperationStateSucceeded,
+							LastUpdateTime: metav1.NewTime(now.Truncate(time.Second)), // this is also truncated when read from the client later on in the test
+						},
+					},
+				},
+			}
+
+			existingDNS := dns.DeepCopy()
+			delete(existingDNS.Annotations, v1beta1constants.GardenerOperation)
+			metav1.SetMetaDataAnnotation(&existingDNS.ObjectMeta, v1beta1constants.GardenerTimestamp, now.UTC().Add(time.Second*10).Format(time.RFC3339Nano))
+			existingDNS.Status.LastOperation = &gardencorev1beta1.LastOperation{
+				State:          gardencorev1beta1.LastOperationStateSucceeded,
+				LastUpdateTime: metav1.NewTime(now.UTC()),
+			}
+
+			Expect(c.Create(ctx, existingDNS)).To(Succeed())
+			values.AnnotateOperation = false
+			dnsRecord = dnsrecord.New(log, c, values, dnsrecord.DefaultInterval, dnsrecord.DefaultSevereThreshold, dnsrecord.DefaultTimeout)
+			Expect(dnsRecord.Deploy(ctx)).To(Succeed())
+
+			deployedDNS := &extensionsv1alpha1.DNSRecord{ObjectMeta: metav1.ObjectMeta{
+				Name:      existingDNS.Name,
+				Namespace: existingDNS.Namespace,
+			}}
+			err := c.Get(ctx, client.ObjectKeyFromObject(deployedDNS), deployedDNS)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(deployedDNS).To(DeepEqual(expectedDNSRecord))
+		})
+
 		It("should deploy the DNSRecord with operation annotation if it is in error state", func() {
 			expectedDNSRecord := &extensionsv1alpha1.DNSRecord{
 				TypeMeta: metav1.TypeMeta{

--- a/pkg/component/extensions/dnsrecord/dnsrecord_test.go
+++ b/pkg/component/extensions/dnsrecord/dnsrecord_test.go
@@ -350,7 +350,7 @@ var _ = Describe("DNSRecord", func() {
 			}))
 		})
 
-		It("should deploy the DNSRecord with operation annotation if status is outdated", func() {
+		It("should deploy the DNSRecord with operation annotation if gardener timestamp is after status.lastOperation.lastUpdateTime", func() {
 			expectedDNSRecord := &extensionsv1alpha1.DNSRecord{
 				TypeMeta: metav1.TypeMeta{
 					APIVersion: extensionsv1alpha1.SchemeGroupVersion.String(),


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness quality
/kind bug

**What this PR does / why we need it**:
Fixes a regression introduced with #7906. Previously `dnsrecords` were always annotated with the gardener timestamp. As a result there may be records for which the timestamp is after the `lastOperation.lastUpdateTime` and the healthcheck introduced with #7906 will not pass until reconciliation is requested. If that is the case then we request a reconciliation of the `dnsrecord`.

Thanks for reporting @shafeeqes !
cc @timuthy 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
NONE
```
