### PR TITLE
Fixed broken links - 2023.05 (Part 2 - rebased)

### DIFF
--- a/docs/concepts/gardenlet.md
+++ b/docs/concepts/gardenlet.md
@@ -1,5 +1,5 @@
 ---
-title: gardenelet
+title: gardenlet
 ---
 
 # gardenlet
@@ -302,7 +302,7 @@ The `NetworkPolicy` controller reconciles `NetworkPolicy`s in all relevant names
 
 The controller resolves the IP address of the Kubernetes service in the `default` namespace and creates an egress `NetworkPolicy`s for it.
 
-For more details about `NetworkPolicy`s in Gardener, please see [Network Policies in Gardener](../usage/network_policies.md).
+For more details about `NetworkPolicy`s in Gardener, please see [`NetworkPolicy`s In Garden, Seed, Shoot Clusters](../usage/network_policies.md).
 
 ### [`Seed` Controller](../../pkg/gardenlet/controller/seed)
 

--- a/docs/development/component-checklist.md
+++ b/docs/development/component-checklist.md
@@ -85,7 +85,7 @@ This document provides a checklist for them that you can walk through.
 4. **Use [`NetworkPolicy`s](https://kubernetes.io/docs/concepts/services-networking/network-policies/) to restrict network traffic** ([example](https://github.com/gardener/gardener/blob/6a0fea86850ffec8937d1956bdf1a8ca6d074f3b/pkg/component/etcd/etcd.go#L293-L339))
 
    You should restrict both ingress and egress traffic to/from your component as much as possible to ensure that it only gets access to/from other components if really needed.
-   Gardener provides a few default policies for typical usage scenarios. For more information, see [`NetworkPolicy`s In Garden, Seed, Shoot Clusters](network_policies.md) and [Shoot Network Policies](../usage/shoot_network_policies.md).
+   Gardener provides a few default policies for typical usage scenarios. For more information, see [`NetworkPolicy`s In Garden, Seed, Shoot Clusters](../usage/network_policies.md).
 
 5. **Do not run components in privileged mode** ([example 1](https://github.com/gardener/gardener/blob/6a0fea86850ffec8937d1956bdf1a8ca6d074f3b/pkg/component/nodelocaldns/nodelocaldns.go#L329-L333), [example 2](https://github.com/gardener/gardener/blob/6a0fea86850ffec8937d1956bdf1a8ca6d074f3b/pkg/component/nodelocaldns/nodelocaldns.go#L507))
 

--- a/docs/extensions/controlplane.md
+++ b/docs/extensions/controlplane.md
@@ -64,7 +64,7 @@ The control plane controller as part of the `ControlPlane` reconciliation often 
 Because the namespace contains [network policies](https://kubernetes.io/docs/concepts/services-networking/network-policies/) that per default [deny all ingress and egress traffic](https://kubernetes.io/docs/concepts/services-networking/network-policies/#default-deny-all-ingress-and-all-egress-traffic), 
 the pods may need to have proper labels matching to the selectors of the network policies in order to allow the required network traffic. 
 Otherwise, they won't be allowed to talk to certain other components (e.g., the kube-apiserver of the shoot).
-For more information, see [`NetworkPolicy`s In Garden, Seed, Shoot Clusters](../development/network_policies.md).
+For more information, see [`NetworkPolicy`s In Garden, Seed, Shoot Clusters](../usage/network_policies.md).
 
 ## Non-Provider Specific Information Required for Infrastructure Creation
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area documentation
/kind enhancement

**What this PR does / why we need it**:
This PR fixes additional broken links in the documentation; opening new PR due to merge issues in the [previous PR](https://github.com/gardener/gardener/pull/7944).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```doc developer
NONE
```
