### PR TITLE
[Workerless Shoots] Add upgrade tests

### DIFF
--- a/docs/deployment/content/remote-local-setup.yaml
+++ b/docs/deployment/content/remote-local-setup.yaml
@@ -33,7 +33,7 @@ spec:
           echo kubectl           && curl -sL  "https://dl.k8s.io/release/$(curl -sL https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" -o /usr/local/bin/kubectl && chmod +x /usr/local/bin/kubectl
           echo tmux-completion   && curl -sL  "https://raw.githubusercontent.com/imomaliev/tmux-bash-completion/master/completions/tmux" -o /usr/share/bash-completion/completions/tmux
           echo docker-completion && curl -sL  "https://raw.githubusercontent.com/docker/docker-ce/master/components/cli/contrib/completion/bash/docker" -o /usr/share/bash-completion/completions/docker
-          bash -c "echo api.{e2e-managedseed.garden,{local,e2e-{managedseed,hib,hib-wl,unpriv,wake-up,wake-up-wl,migrate,migrate-wl,rotate,rotate-wl,default,default-wl,update-node,update-node-wl,update-zone,update-zone-wl,upgrade}}.local}.{internal,external}.local.gardener.cloud \
+          bash -c "echo api.{e2e-managedseed.garden,{local,e2e-{managedseed,hib,hib-wl,unpriv,wake-up,wake-up-wl,migrate,migrate-wl,rotate,rotate-wl,default,default-wl,upd-node,upd-node-wl,upgrade,upgrade-wl,upg-hib,upg-hib-wl}}.local}.{internal,external}.local.gardener.cloud \
                    | sed 's/ /\n/g' | sed 's/^/127.0.0.1 /' | sort >> /etc/hosts"
           echo 'source ~/.bashrc' > ~/.bash_profile
           cat > ~/.bashrc <<"EOF"

--- a/docs/deployment/getting_started_locally.md
+++ b/docs/deployment/getting_started_locally.md
@@ -204,12 +204,12 @@ cat <<EOF | sudo tee -a /etc/hosts
 
 127.0.0.1 api.e2e-managedseed.garden.external.local.gardener.cloud
 127.0.0.1 api.e2e-managedseed.garden.internal.local.gardener.cloud
-127.0.0.1 api.e2e-hibernated.local.external.local.gardener.cloud
-127.0.0.1 api.e2e-hibernated.local.internal.local.gardener.cloud
+127.0.0.1 api.e2e-hib.local.external.local.gardener.cloud
+127.0.0.1 api.e2e-hib.local.internal.local.gardener.cloud
+127.0.0.1 api.e2e-hib-wl.local.external.local.gardener.cloud
+127.0.0.1 api.e2e-hib-wl.local.internal.local.gardener.cloud
 127.0.0.1 api.e2e-unpriv.local.external.local.gardener.cloud
 127.0.0.1 api.e2e-unpriv.local.internal.local.gardener.cloud
-127.0.0.1 api.e2e-unpriv-wl.local.external.local.gardener.cloud
-127.0.0.1 api.e2e-unpriv-wl.local.internal.local.gardener.cloud
 127.0.0.1 api.e2e-wake-up.local.external.local.gardener.cloud
 127.0.0.1 api.e2e-wake-up.local.internal.local.gardener.cloud
 127.0.0.1 api.e2e-wake-up-wl.local.external.local.gardener.cloud
@@ -226,10 +226,10 @@ cat <<EOF | sudo tee -a /etc/hosts
 127.0.0.1 api.e2e-default.local.internal.local.gardener.cloud
 127.0.0.1 api.e2e-default-wl.local.external.local.gardener.cloud
 127.0.0.1 api.e2e-default-wl.local.internal.local.gardener.cloud
-127.0.0.1 api.e2e-update-node.local.external.local.gardener.cloud
-127.0.0.1 api.e2e-update-node.local.internal.local.gardener.cloud
-127.0.0.1 api.e2e-update-node-wl.local.external.local.gardener.cloud
-127.0.0.1 api.e2e-update-node-wl.local.internal.local.gardener.cloud
+127.0.0.1 api.e2e-upd-node.local.external.local.gardener.cloud
+127.0.0.1 api.e2e-upd-node.local.internal.local.gardener.cloud
+127.0.0.1 api.e2e-upd-node-wl.local.external.local.gardener.cloud
+127.0.0.1 api.e2e-upd-node-wl.local.internal.local.gardener.cloud
 127.0.0.1 api.e2e-upgrade.local.external.local.gardener.cloud
 127.0.0.1 api.e2e-upgrade.local.internal.local.gardener.cloud
 127.0.0.1 api.e2e-upgrade-wl.local.external.local.gardener.cloud

--- a/docs/deployment/getting_started_locally.md
+++ b/docs/deployment/getting_started_locally.md
@@ -232,6 +232,12 @@ cat <<EOF | sudo tee -a /etc/hosts
 127.0.0.1 api.e2e-update-node-wl.local.internal.local.gardener.cloud
 127.0.0.1 api.e2e-upgrade.local.external.local.gardener.cloud
 127.0.0.1 api.e2e-upgrade.local.internal.local.gardener.cloud
+127.0.0.1 api.e2e-upgrade-wl.local.external.local.gardener.cloud
+127.0.0.1 api.e2e-upgrade-wl.local.internal.local.gardener.cloud
+127.0.0.1 api.e2e-upg-hib.local.external.local.gardener.cloud
+127.0.0.1 api.e2e-upg-hib.local.internal.local.gardener.cloud
+127.0.0.1 api.e2e-upg-hib-wl.local.external.local.gardener.cloud
+127.0.0.1 api.e2e-upg-hib-wl.local.internal.local.gardener.cloud
 EOF
 ```
 

--- a/hack/test-e2e-local.sh
+++ b/hack/test-e2e-local.sh
@@ -60,13 +60,16 @@ if [[ "$1" != "operator" ]]; then
     e2e-upd-zone.local
     e2e-upd-zone-wl.local
     e2e-upgrade.local
-    e2e-upgrade-ha.local
-    e2e-upgrade-hib.local
+    e2e-upgrade-wl.local
+    e2e-upg-ha.local
+    e2e-upg-ha-wl.local
+    e2e-upg-hib.local
+    e2e-upg-hib-wl.local
   )
 
   if [ -n "${CI:-}" -a -n "${ARTIFACTS:-}" ]; then
     for shoot in "${shoot_names[@]}" ; do
-      if [[ "${SHOOT_FAILURE_TOLERANCE_TYPE:-}" == "zone" && ("$shoot" == "e2e-upgrade-ha.local" || "$shoot" == "e2e-upd-zone.local" || "$shoot" == "e2e-upd-zone-wl.local") ]]; then
+      if [[ "${SHOOT_FAILURE_TOLERANCE_TYPE:-}" == "zone" && ("$shoot" == "e2e-upg-ha.local" || "$shoot" == "e2e-upg-ha-wl.local" || "$shoot" == "e2e-upd-zone.local" || "$shoot" == "e2e-upd-zone-wl.local") ]]; then
         # Do not add the entry for the e2e-upd-zone test as the target ip is dynamic.
         # The shoot cluster in e2e-upd-zone is created as single-zone control plane and afterwards updated to a multi-zone control plane.
         # This means that the external loadbalancer IP will change from a zone-specific istio ingress gateway to the default istio ingress gateway.
@@ -81,7 +84,7 @@ if [[ "$1" != "operator" ]]; then
     printf "\n127.0.0.1 api.e2e-managedseed.garden.external.local.gardener.cloud\n127.0.0.1 api.e2e-managedseed.garden.internal.local.gardener.cloud\n" >>/etc/hosts
   else
     for shoot in "${shoot_names[@]}" ; do
-      if [[ "${SHOOT_FAILURE_TOLERANCE_TYPE:-}" == "zone" && ("$shoot" == "e2e-upgrade-ha.local" || "$shoot" == "e2e-upd-zone.local" || "$shoot" == "e2e-upd-zone-wl.local") ]]; then
+      if [[ "${SHOOT_FAILURE_TOLERANCE_TYPE:-}" == "zone" && ("$shoot" == "e2e-upg-ha.local" || "$shoot" == "e2e-upg-ha-wl.local" || "$shoot" == "e2e-upd-zone.local" || "$shoot" == "e2e-upd-zone-wl.local") ]]; then
         # Do not check the entry for the e2e-upd-zone test as the target ip is dynamic.
         continue
       fi

--- a/plugin/pkg/global/extensionvalidation/admission.go
+++ b/plugin/pkg/global/extensionvalidation/admission.go
@@ -306,7 +306,7 @@ func (e *ExtensionValidator) validateShoot(kindToTypesMap map[string]sets.Set[st
 	}
 
 	for i, extension := range spec.Extensions {
-		requiredExtensions = append(requiredExtensions, requiredExtension{extensionsv1alpha1.ExtensionResource, extension.Type, fmt.Sprintf("%s extension type: %s", message, field.NewPath("spec", "extensions").Index(i).Child("type"))})
+		requiredExtensions = append(requiredExtensions, requiredExtension{extensionsv1alpha1.ExtensionResource, extension.Type, fmt.Sprintf("extension type: %s", field.NewPath("spec", "extensions").Index(i).Child("type"))})
 	}
 
 	for i, worker := range spec.Provider.Workers {
@@ -362,7 +362,7 @@ func (r requiredExtensions) areRegistered(kindToTypesMap map[string]sets.Set[str
 // kind/type combination is registered then it returns nil, otherwise it returns an error with the given message.
 func isExtensionRegistered(kindToTypesMap map[string]sets.Set[string], extensionKind, extensionType, message string) error {
 	if types, ok := kindToTypesMap[extensionKind]; !ok || !types.Has(extensionType) {
-		return fmt.Errorf("%s (%q)", message, extensionType)
+		return fmt.Errorf("given Shoot uses non-registered %s (%q)", message, extensionType)
 	}
 	return nil
 }
@@ -414,7 +414,7 @@ func (r requiredExtensions) areSupportedForWorkerlessShoots(workerlessSupportedE
 		}
 
 		if !workerlessSupportedExtensionTypes.Has(requiredExtension.extensionType) {
-			result = multierror.Append(result, fmt.Errorf("given Shoot is workerless and uses non-supported Extension type: %q", requiredExtension.extensionType))
+			result = multierror.Append(result, fmt.Errorf("given Shoot is workerless and uses non-supported %s (%q)", requiredExtension.message, requiredExtension.extensionType))
 		}
 	}
 

--- a/plugin/pkg/global/extensionvalidation/admission_test.go
+++ b/plugin/pkg/global/extensionvalidation/admission_test.go
@@ -408,7 +408,7 @@ var _ = Describe("ExtensionValidator", func() {
 				err := admissionHandler.Validate(context.TODO(), attrs, nil)
 
 				Expect(err).To(HaveOccurred())
-				Expect(err).To(MatchError(ContainSubstring("given Shoot is workerless and uses non-supported Extension type: %q", nonSupportedType)))
+				Expect(err).To(MatchError(ContainSubstring("given Shoot is workerless and uses non-supported extension type: spec.extensions[0].type (%q)", nonSupportedType)))
 			})
 
 			It("should prevent the object from being created because the extension type doesn't specify WorkerlessSupported field for workerless Shoots", func() {
@@ -433,7 +433,7 @@ var _ = Describe("ExtensionValidator", func() {
 				err := admissionHandler.Validate(context.TODO(), attrs, nil)
 
 				Expect(err).To(HaveOccurred())
-				Expect(err).To(MatchError(ContainSubstring("given Shoot is workerless and uses non-supported Extension type: %q", nonSupportedType)))
+				Expect(err).To(MatchError(ContainSubstring("given Shoot is workerless and uses non-supported extension type: spec.extensions[0].type (%q)", nonSupportedType)))
 			})
 
 			It("should allow object creation because the extension type supports workerless Shoots", func() {

--- a/test/e2e/gardener/shoot/create_and_delete_hibernated.go
+++ b/test/e2e/gardener/shoot/create_and_delete_hibernated.go
@@ -25,11 +25,13 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	e2e "github.com/gardener/gardener/test/e2e/gardener"
-	"github.com/gardener/gardener/test/framework"
 )
 
 var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
-	test := func(f *framework.ShootCreationFramework) {
+	test := func(shoot *gardencorev1beta1.Shoot) {
+		f := defaultShootCreationFramework()
+		f.Shoot = shoot
+
 		f.Shoot.Spec.Hibernation = &gardencorev1beta1.Hibernation{
 			Enabled: pointer.Bool(true),
 		}
@@ -53,16 +55,10 @@ var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
 	}
 
 	Context("Shoot with workers", func() {
-		f := defaultShootCreationFramework()
-		f.Shoot = e2e.DefaultShoot("e2e-hib")
-
-		test(f)
+		test(e2e.DefaultShoot("e2e-hib"))
 	})
 
 	Context("Workerless Shoot", Label("workerless"), func() {
-		f := defaultShootCreationFramework()
-		f.Shoot = e2e.DefaultWorkerlessShoot("e2e-hib")
-
-		test(f)
+		test(e2e.DefaultWorkerlessShoot("e2e-hib"))
 	})
 })

--- a/test/e2e/gardener/shoot/create_hibernate_wakeup_delete.go
+++ b/test/e2e/gardener/shoot/create_hibernate_wakeup_delete.go
@@ -21,14 +21,17 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	e2e "github.com/gardener/gardener/test/e2e/gardener"
 	"github.com/gardener/gardener/test/e2e/gardener/shoot/internal/node"
-	"github.com/gardener/gardener/test/framework"
 )
 
 var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
-	test := func(f *framework.ShootCreationFramework) {
+	test := func(shoot *gardencorev1beta1.Shoot) {
+		f := defaultShootCreationFramework()
+		f.Shoot = shoot
+
 		It("Create, Hibernate, Wake up and Delete Shoot", Offset(1), func() {
 			By("Create Shoot")
 			ctx, cancel := context.WithTimeout(parentCtx, 15*time.Minute)
@@ -64,18 +67,10 @@ var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
 	}
 
 	Context("Shoot with workers", func() {
-		f := defaultShootCreationFramework()
-
-		f.Shoot = e2e.DefaultShoot("e2e-wake-up")
-
-		test(f)
+		test(e2e.DefaultShoot("e2e-wake-up"))
 	})
 
 	Context("Workerless Shoot", Label("workerless"), func() {
-		f := defaultShootCreationFramework()
-
-		f.Shoot = e2e.DefaultWorkerlessShoot("e2e-wake-up")
-
-		test(f)
+		test(e2e.DefaultWorkerlessShoot("e2e-wake-up"))
 	})
 })

--- a/test/e2e/gardener/shoot/create_migrate_delete.go
+++ b/test/e2e/gardener/shoot/create_migrate_delete.go
@@ -24,13 +24,16 @@ import (
 	"k8s.io/utils/pointer"
 
 	"github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	e2e "github.com/gardener/gardener/test/e2e/gardener"
-	"github.com/gardener/gardener/test/framework"
 	. "github.com/gardener/gardener/test/framework"
 )
 
 var _ = Describe("Shoot Tests", Label("Shoot", "control-plane-migration"), func() {
-	test := func(f *framework.ShootCreationFramework) {
+	test := func(shoot *gardencorev1beta1.Shoot) {
+		f := defaultShootCreationFramework()
+		f.Shoot = shoot
+
 		// Assign seedName so that shoot does not get scheduled to the seed that will be used as target.
 		f.Shoot.Spec.SeedName = pointer.String(getSeedName(false))
 
@@ -57,17 +60,11 @@ var _ = Describe("Shoot Tests", Label("Shoot", "control-plane-migration"), func(
 	}
 
 	Context("Shoot with workers", func() {
-		f := defaultShootCreationFramework()
-		f.Shoot = e2e.DefaultShoot("e2e-migrate")
-
-		test(f)
+		test(e2e.DefaultShoot("e2e-migrate"))
 	})
 
 	Context("Workerless Shoot", Label("workerless"), func() {
-		f := defaultShootCreationFramework()
-		f.Shoot = e2e.DefaultWorkerlessShoot("e2e-migrate")
-
-		test(f)
+		test(e2e.DefaultWorkerlessShoot("e2e-migrate"))
 	})
 })
 

--- a/test/e2e/gardener/shoot/create_rotate_delete.go
+++ b/test/e2e/gardener/shoot/create_rotate_delete.go
@@ -30,16 +30,19 @@ import (
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	e2e "github.com/gardener/gardener/test/e2e/gardener"
 	"github.com/gardener/gardener/test/e2e/gardener/shoot/internal/rotation"
-	"github.com/gardener/gardener/test/framework"
 	"github.com/gardener/gardener/test/utils/access"
 	rotationutils "github.com/gardener/gardener/test/utils/rotation"
 )
 
 var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
-	test := func(f *framework.ShootCreationFramework) {
+	test := func(shoot *gardencorev1beta1.Shoot) {
+		f := defaultShootCreationFramework()
+		f.Shoot = shoot
+
 		// Setting the kubernetes versions to < 1.27 as enableStaticTokenKubeconfig cannot be enabled
 		// for Shoot clusters with k8s version >= 1.27.
 		f.Shoot.Spec.Kubernetes.Version = "1.26.0"
+
 		// Explicitly enable the static token kubeconfig to test the kubeconfig rotation.
 		f.Shoot.Spec.Kubernetes.EnableStaticTokenKubeconfig = pointer.Bool(true)
 
@@ -149,16 +152,10 @@ var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
 	}
 
 	Context("Shoot with workers", func() {
-		f := defaultShootCreationFramework()
-		f.Shoot = e2e.DefaultShoot("e2e-rotate")
-
-		test(f)
+		test(e2e.DefaultShoot("e2e-rotate"))
 	})
 
 	Context("Workerless Shoot", Label("workerless"), func() {
-		f := defaultShootCreationFramework()
-		f.Shoot = e2e.DefaultWorkerlessShoot("e2e-rotate")
-
-		test(f)
+		test(e2e.DefaultWorkerlessShoot("e2e-rotate"))
 	})
 })

--- a/test/e2e/gardener/shoot/create_update_delete.go
+++ b/test/e2e/gardener/shoot/create_update_delete.go
@@ -37,7 +37,10 @@ import (
 )
 
 var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
-	test := func(f *framework.ShootCreationFramework) {
+	test := func(shoot *gardencorev1beta1.Shoot) {
+		f := defaultShootCreationFramework()
+		f.Shoot = shoot
+
 		// explicitly use one version below the latest supported minor version so that Kubernetes version update test can be
 		// performed
 		f.Shoot.Spec.Kubernetes.Version = "1.26.0"
@@ -146,16 +149,10 @@ var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
 	}
 
 	Context("Shoot with workers", func() {
-		f := defaultShootCreationFramework()
-		f.Shoot = e2e.DefaultShoot("e2e-default")
-
-		test(f)
+		test(e2e.DefaultShoot("e2e-default"))
 	})
 
 	Context("Workerless Shoot", Label("workerless"), func() {
-		f := defaultShootCreationFramework()
-		f.Shoot = e2e.DefaultWorkerlessShoot("e2e-default")
-
-		test(f)
+		test(e2e.DefaultWorkerlessShoot("e2e-default"))
 	})
 })

--- a/test/e2e/gardener/shoot/upgrade_non-ha_to_node.go
+++ b/test/e2e/gardener/shoot/upgrade_non-ha_to_node.go
@@ -22,13 +22,16 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	e2e "github.com/gardener/gardener/test/e2e/gardener"
-	"github.com/gardener/gardener/test/framework"
 	"github.com/gardener/gardener/test/utils/shoots/update/highavailability"
 )
 
 var _ = Describe("Shoot Tests", Label("Shoot", "high-availability", "upgrade-to-node"), func() {
-	test := func(f *framework.ShootCreationFramework) {
+	test := func(shoot *gardencorev1beta1.Shoot) {
+		f := defaultShootCreationFramework()
+		f.Shoot = shoot
+
 		f.Shoot.Spec.ControlPlane = nil
 
 		It("Create, Upgrade (non-HA to HA with failure tolerance type 'node') and Delete Shoot", Offset(1), func() {
@@ -52,16 +55,10 @@ var _ = Describe("Shoot Tests", Label("Shoot", "high-availability", "upgrade-to-
 	}
 
 	Context("Shoot with workers", func() {
-		f := defaultShootCreationFramework()
-		f.Shoot = e2e.DefaultShoot("e2e-upd-node")
-
-		test(f)
+		test(e2e.DefaultShoot("e2e-upd-node"))
 	})
 
 	Context("Workerless Shoot", Label("workerless"), func() {
-		f := defaultShootCreationFramework()
-		f.Shoot = e2e.DefaultWorkerlessShoot("e2e-upd-node")
-
-		test(f)
+		test(e2e.DefaultWorkerlessShoot("e2e-upd-node"))
 	})
 })

--- a/test/e2e/gardener/shoot/upgrade_non-ha_to_zone.go
+++ b/test/e2e/gardener/shoot/upgrade_non-ha_to_zone.go
@@ -22,13 +22,16 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	e2e "github.com/gardener/gardener/test/e2e/gardener"
-	"github.com/gardener/gardener/test/framework"
 	"github.com/gardener/gardener/test/utils/shoots/update/highavailability"
 )
 
 var _ = Describe("Shoot Tests", Label("Shoot", "high-availability", "upgrade-to-zone"), func() {
-	test := func(f *framework.ShootCreationFramework) {
+	test := func(shoot *gardencorev1beta1.Shoot) {
+		f := defaultShootCreationFramework()
+		f.Shoot = shoot
+
 		f.Shoot.Spec.ControlPlane = nil
 
 		It("Create, Upgrade (non-HA to HA with failure tolerance type 'zone') and Delete Shoot", Offset(1), func() {
@@ -52,16 +55,10 @@ var _ = Describe("Shoot Tests", Label("Shoot", "high-availability", "upgrade-to-
 	}
 
 	Context("Shoot with workers", func() {
-		f := defaultShootCreationFramework()
-		f.Shoot = e2e.DefaultShoot("e2e-upd-zone")
-
-		test(f)
+		test(e2e.DefaultShoot("e2e-upd-zone"))
 	})
 
 	Context("Workerless Shoot", Label("workerless"), func() {
-		f := defaultShootCreationFramework()
-		f.Shoot = e2e.DefaultWorkerlessShoot("e2e-upd-zone")
-
-		test(f)
+		test(e2e.DefaultWorkerlessShoot("e2e-upd-zone"))
 	})
 })

--- a/test/e2e/gardener/upgrade/upgrade.go
+++ b/test/e2e/gardener/upgrade/upgrade.go
@@ -41,13 +41,15 @@ var _ = Describe("Gardener upgrade Tests for", func() {
 		projectNamespace           = "garden-local"
 	)
 
-	test_e2e_upgrade := func(f *framework.ShootCreationFramework) {
+	test_e2e_upgrade := func(shoot *gardencorev1beta1.Shoot) {
 		var (
 			parentCtx = context.Background()
 			job       *batchv1.Job
 			err       error
+			f         = framework.NewShootCreationFramework(&framework.ShootCreationConfig{GardenerConfig: e2e.DefaultGardenConfig(projectNamespace)})
 		)
 
+		f.Shoot = shoot
 		f.Shoot.Namespace = projectNamespace
 
 		When("Pre-Upgrade (Gardener version:'"+gardenerPreviousVersion+"', Git version:'"+gardenerPreviousGitVersion+"')", Ordered, Offset(1), Label("pre-upgrade"), func() {
@@ -117,27 +119,23 @@ var _ = Describe("Gardener upgrade Tests for", func() {
 	}
 
 	Context("Shoot with workers::e2e-upgrade", func() {
-		f := framework.NewShootCreationFramework(&framework.ShootCreationConfig{GardenerConfig: e2e.DefaultGardenConfig(projectNamespace)})
-		f.Shoot = e2e.DefaultShoot("e2e-upgrade")
-
-		test_e2e_upgrade(f)
+		test_e2e_upgrade(e2e.DefaultShoot("e2e-upgrade"))
 	})
 
 	Context("Workerless Shoot::e2e-upgrade", Label("workerless"), func() {
-		f := framework.NewShootCreationFramework(&framework.ShootCreationConfig{GardenerConfig: e2e.DefaultGardenConfig(projectNamespace)})
-		f.Shoot = e2e.DefaultWorkerlessShoot("e2e-upgrade")
-
-		test_e2e_upgrade(f)
+		test_e2e_upgrade(e2e.DefaultWorkerlessShoot("e2e-upgrade"))
 	})
 
 	// This test will create a non-HA control plane shoot in Gardener version vX.X.X
 	// and then upgrades shoot's control plane to HA once successfully upgraded Gardener version to vY.Y.Y.
-	test_e2e_upgrade_ha := func(f *framework.ShootCreationFramework) {
+	test_e2e_upgrade_ha := func(shoot *gardencorev1beta1.Shoot) {
 		var (
 			parentCtx = context.Background()
 			err       error
+			f         = framework.NewShootCreationFramework(&framework.ShootCreationConfig{GardenerConfig: e2e.DefaultGardenConfig(projectNamespace)})
 		)
 
+		f.Shoot = shoot
 		f.Shoot.Namespace = projectNamespace
 		f.Shoot.Spec.ControlPlane = nil
 
@@ -184,25 +182,21 @@ var _ = Describe("Gardener upgrade Tests for", func() {
 	}
 
 	Context("Shoot with workers::e2e-upg-ha", Label("high-availability"), func() {
-		f := framework.NewShootCreationFramework(&framework.ShootCreationConfig{GardenerConfig: e2e.DefaultGardenConfig(projectNamespace)})
-		f.Shoot = e2e.DefaultShoot("e2e-upg-ha")
-
-		test_e2e_upgrade_ha(f)
+		test_e2e_upgrade_ha(e2e.DefaultShoot("e2e-upg-ha"))
 	})
 
 	Context("Workerless Shoot::e2e-upg-ha", Label("high-availability", "workerless"), func() {
-		f := framework.NewShootCreationFramework(&framework.ShootCreationConfig{GardenerConfig: e2e.DefaultGardenConfig(projectNamespace)})
-		f.Shoot = e2e.DefaultWorkerlessShoot("e2e-upg-ha")
-
-		test_e2e_upgrade_ha(f)
+		test_e2e_upgrade_ha(e2e.DefaultWorkerlessShoot("e2e-upg-ha"))
 	})
 
-	test_e2e_upgrade_hib := func(f *framework.ShootCreationFramework) {
+	test_e2e_upgrade_hib := func(shoot *gardencorev1beta1.Shoot) {
 		var (
 			parentCtx = context.Background()
 			err       error
+			f         = framework.NewShootCreationFramework(&framework.ShootCreationConfig{GardenerConfig: e2e.DefaultGardenConfig(projectNamespace)})
 		)
 
+		f.Shoot = shoot
 		f.Shoot.Namespace = projectNamespace
 
 		When("Pre-upgrade (Gardener version:'"+gardenerCurrentVersion+"', Git version:'"+gardenerCurrentGitVersion+"')", Ordered, Offset(1), Label("pre-upgrade"), func() {
@@ -254,17 +248,11 @@ var _ = Describe("Gardener upgrade Tests for", func() {
 	}
 
 	Context("Shoot with workers::e2e-upg-hib", func() {
-		f := framework.NewShootCreationFramework(&framework.ShootCreationConfig{GardenerConfig: e2e.DefaultGardenConfig(projectNamespace)})
-		f.Shoot = e2e.DefaultShoot("e2e-upg-hib")
-
-		test_e2e_upgrade_hib(f)
+		test_e2e_upgrade_hib(e2e.DefaultShoot("e2e-upg-hib"))
 	})
 
 	Context("Workerless Shoot::e2e-upg-hib", Label("workerless"), func() {
-		f := framework.NewShootCreationFramework(&framework.ShootCreationConfig{GardenerConfig: e2e.DefaultGardenConfig(projectNamespace)})
-		f.Shoot = e2e.DefaultWorkerlessShoot("e2e-upg-hib")
-
-		test_e2e_upgrade_hib(f)
+		test_e2e_upgrade_hib(e2e.DefaultWorkerlessShoot("e2e-upg-hib"))
 	})
 })
 

--- a/test/e2e/gardener/upgrade/upgrade.go
+++ b/test/e2e/gardener/upgrade/upgrade.go
@@ -183,16 +183,16 @@ var _ = Describe("Gardener upgrade Tests for", func() {
 		})
 	}
 
-	Context("Shoot with workers::e2e-upgrade-ha", Label("high-availability"), func() {
+	Context("Shoot with workers::e2e-upg-ha", Label("high-availability"), func() {
 		f := framework.NewShootCreationFramework(&framework.ShootCreationConfig{GardenerConfig: e2e.DefaultGardenConfig(projectNamespace)})
-		f.Shoot = e2e.DefaultShoot("e2e-upgrade-ha")
+		f.Shoot = e2e.DefaultShoot("e2e-upg-ha")
 
 		test_e2e_upgrade_ha(f)
 	})
 
-	Context("Workerless Shoot::e2e-upgrade-ha", Label("high-availability", "workerless"), func() {
+	Context("Workerless Shoot::e2e-upg-ha", Label("high-availability", "workerless"), func() {
 		f := framework.NewShootCreationFramework(&framework.ShootCreationConfig{GardenerConfig: e2e.DefaultGardenConfig(projectNamespace)})
-		f.Shoot = e2e.DefaultWorkerlessShoot("e2e-upgrade-ha")
+		f.Shoot = e2e.DefaultWorkerlessShoot("e2e-upg-ha")
 
 		test_e2e_upgrade_ha(f)
 	})
@@ -253,16 +253,16 @@ var _ = Describe("Gardener upgrade Tests for", func() {
 		})
 	}
 
-	Context("Shoot with workers::e2e-upgrade-hib", func() {
+	Context("Shoot with workers::e2e-upg-hib", func() {
 		f := framework.NewShootCreationFramework(&framework.ShootCreationConfig{GardenerConfig: e2e.DefaultGardenConfig(projectNamespace)})
-		f.Shoot = e2e.DefaultShoot("e2e-upgrade-hib")
+		f.Shoot = e2e.DefaultShoot("e2e-upg-hib")
 
 		test_e2e_upgrade_hib(f)
 	})
 
-	Context("Workerless Shoot::e2e-upgrade-hib", Label("workerless"), func() {
+	Context("Workerless Shoot::e2e-upg-hib", Label("workerless"), func() {
 		f := framework.NewShootCreationFramework(&framework.ShootCreationConfig{GardenerConfig: e2e.DefaultGardenConfig(projectNamespace)})
-		f.Shoot = e2e.DefaultWorkerlessShoot("e2e-upgrade-hib")
+		f.Shoot = e2e.DefaultWorkerlessShoot("e2e-upg-hib")
 
 		test_e2e_upgrade_hib(f)
 	})


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind enhancement

**What this PR does / why we need it**:
This PR extends the existing shoot upgrade tests to workerless shoots as well.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/7635

**Special notes for your reviewer**:
/cc @seshachalam-yv 
/hold until gardener v1.71 is released.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
