### PR TITLE
Clean up unused field from the `pkg/registry/core/seed.Strategy`

### DIFF
--- a/pkg/registry/core/rest/storage_core.go
+++ b/pkg/registry/core/rest/storage_core.go
@@ -97,7 +97,7 @@ func (p StorageProvider) v1alpha1Storage(restOptionsGetter generic.RESTOptionsGe
 	secretBindingStorage := secretbindingstore.NewStorage(restOptionsGetter)
 	storage["secretbindings"] = secretBindingStorage.SecretBinding
 
-	seedStorage := seedstore.NewStorage(restOptionsGetter, cloudprofileStorage.CloudProfile)
+	seedStorage := seedstore.NewStorage(restOptionsGetter)
 	storage["seeds"] = seedStorage.Seed
 	storage["seeds/status"] = seedStorage.Status
 
@@ -154,7 +154,7 @@ func (p StorageProvider) v1beta1Storage(restOptionsGetter generic.RESTOptionsGet
 	secretBindingStorage := secretbindingstore.NewStorage(restOptionsGetter)
 	storage["secretbindings"] = secretBindingStorage.SecretBinding
 
-	seedStorage := seedstore.NewStorage(restOptionsGetter, cloudprofileStorage.CloudProfile)
+	seedStorage := seedstore.NewStorage(restOptionsGetter)
 	storage["seeds"] = seedStorage.Seed
 	storage["seeds/status"] = seedStorage.Status
 

--- a/pkg/registry/core/seed/storage/storage.go
+++ b/pkg/registry/core/seed/storage/storage.go
@@ -39,8 +39,8 @@ type SeedStorage struct {
 }
 
 // NewStorage creates a new SeedStorage object.
-func NewStorage(optsGetter generic.RESTOptionsGetter, cloudProfiles rest.StandardStorage) SeedStorage {
-	seedRest, seedStatusRest := NewREST(optsGetter, cloudProfiles)
+func NewStorage(optsGetter generic.RESTOptionsGetter) SeedStorage {
+	seedRest, seedStatusRest := NewREST(optsGetter)
 
 	return SeedStorage{
 		Seed:   seedRest,
@@ -49,9 +49,9 @@ func NewStorage(optsGetter generic.RESTOptionsGetter, cloudProfiles rest.Standar
 }
 
 // NewREST returns a RESTStorage object that will work with Seed objects.
-func NewREST(optsGetter generic.RESTOptionsGetter, cloudProfiles rest.StandardStorage) (*REST, *StatusREST) {
-	strategy := seed.NewStrategy(cloudProfiles)
-	statusStrategy := seed.NewStatusStrategy(cloudProfiles)
+func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, *StatusREST) {
+	strategy := seed.NewStrategy()
+	statusStrategy := seed.NewStatusStrategy()
 
 	store := &genericregistry.Store{
 		NewFunc:                  func() runtime.Object { return &core.Seed{} },

--- a/pkg/registry/core/seed/strategy.go
+++ b/pkg/registry/core/seed/strategy.go
@@ -20,7 +20,6 @@ import (
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	"k8s.io/apiserver/pkg/registry/rest"
 	"k8s.io/apiserver/pkg/storage/names"
 
 	"github.com/gardener/gardener/pkg/api"
@@ -32,13 +31,11 @@ import (
 type Strategy struct {
 	runtime.ObjectTyper
 	names.NameGenerator
-
-	CloudProfiles rest.StandardStorage
 }
 
 // NewStrategy defines the storage strategy for Seeds.
-func NewStrategy(cloudProfiles rest.StandardStorage) Strategy {
-	return Strategy{api.Scheme, names.SimpleNameGenerator, cloudProfiles}
+func NewStrategy() Strategy {
+	return Strategy{api.Scheme, names.SimpleNameGenerator}
 }
 
 // NamespaceScoped returns true if the object must be within a namespace.
@@ -150,8 +147,8 @@ type StatusStrategy struct {
 }
 
 // NewStatusStrategy defines the storage strategy for the status subresource of Seeds.
-func NewStatusStrategy(cloudProfiles rest.StandardStorage) StatusStrategy {
-	return StatusStrategy{NewStrategy(cloudProfiles)}
+func NewStatusStrategy() StatusStrategy {
+	return StatusStrategy{NewStrategy()}
 }
 
 // PrepareForUpdate is invoked on update before validation to normalize


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind cleanup

**What this PR does / why we need it**:
The `CloudProfiles` field in `pkg/registry/core/seed.Strategy` seems to be unused. It is introduced with https://github.com/gardener/gardener/commit/568eb02bf99d4622f61ebd270882da184910d8aa for a migration code in strategy. In https://github.com/gardener/gardener/commit/7fea07bc8a851fdad009a20b5b3d52aec1c48726 this migration code is dropped but the `CloudProfiles` field is not removed.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
