### PR TITLE
Fix `NetworkPolicy` for scraping machine-controller-manager

### DIFF
--- a/charts/gardener/provider-local/internal/machine-controller-manager/seed/templates/service.yaml
+++ b/charts/gardener/provider-local/internal/machine-controller-manager/seed/templates/service.yaml
@@ -7,7 +7,7 @@ metadata:
     app: kubernetes
     role: machine-controller-manager
   annotations:
-    networking.resources.gardener.cloud/from-all-seed-scrape-targets-allowed-ports: '[{"port":{{ .Values.metricsPort }},"protocol":"TCP"}]'
+    networking.resources.gardener.cloud/from-all-scrape-targets-allowed-ports: '[{"port":{{ .Values.metricsPort }},"protocol":"TCP"}]'
 spec:
   type: ClusterIP
   clusterIP: None


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking security
/kind bug

**What this PR does / why we need it**:

With https://github.com/gardener/gardener/pull/7907, prometheus in the shoot namespace is not able to scrape machine-controller-manager managed by provider-local anymore because of a wrong `NetworkPolicy` configuration.

**Special notes for your reviewer**:

cc @rfranzke 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
