### PR TITLE
update tunnel-probe-apiserver-proxy for HA mode

### DIFF
--- a/charts/seed-monitoring/charts/core/charts/prometheus/templates/config.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/templates/config.yaml
@@ -366,10 +366,13 @@ data:
       - source_labels: [ __meta_kubernetes_pod_name ]
         action: keep
         regex: vpn-shoot-(.+)
-      - source_labels: [ __meta_kubernetes_pod_name ]
+      - source_labels: [ __meta_kubernetes_pod_container_name ]
+        action: keep
+        regex: .*?\bvpn-seed\b
+      - source_labels: [__meta_kubernetes_pod_name,__meta_kubernetes_pod_container_name]
         target_label: __param_target
-        regex: (.+)
-        replacement: https://kube-apiserver:443/api/v1/namespaces/kube-system/pods/${1}/log?tailLines=1
+        regex: (.+);(.+)
+        replacement: https://kube-apiserver:443/api/v1/namespaces/kube-system/pods/${1}/log?container=${2}&tailLines=1
         action: replace
       - source_labels: [ __param_target ]
         target_label: instance

--- a/charts/seed-monitoring/charts/core/charts/prometheus/templates/config.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/templates/config.yaml
@@ -367,8 +367,9 @@ data:
         action: keep
         regex: vpn-shoot-(.+)
       - source_labels: [ __meta_kubernetes_pod_container_name ]
-        action: keep
-        regex: .*?\bvpn-seed\b
+        regex: ^(vpn-seed)\b(?!.*\bvpn-seed\b).*$
+        replacement: $1
+        action: replace
       - source_labels: [__meta_kubernetes_pod_name,__meta_kubernetes_pod_container_name]
         target_label: __param_target
         regex: (.+);(.+)

--- a/charts/seed-monitoring/charts/core/charts/prometheus/templates/config.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/templates/config.yaml
@@ -367,7 +367,7 @@ data:
         action: keep
         regex: vpn-shoot-(.+)
       - source_labels: [ __meta_kubernetes_pod_container_name ]
-        regex: ^(vpn-seed)\b(?!.*\bvpn-seed\b).*$
+        regex: (vpn-seed-.*|vpn-seed)
         replacement: $1
         action: replace
       - source_labels: [__meta_kubernetes_pod_name,__meta_kubernetes_pod_container_name]

--- a/charts/seed-monitoring/charts/core/charts/prometheus/templates/config.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/templates/config.yaml
@@ -367,7 +367,7 @@ data:
         action: keep
         regex: vpn-shoot-(.+)
       - source_labels: [ __meta_kubernetes_pod_container_name ]
-        regex: (vpn-seed-.*|vpn-seed)
+        regex: (vpn-shoot-.*|vpn-shoot)
         replacement: $1
         action: replace
       - source_labels: [__meta_kubernetes_pod_name,__meta_kubernetes_pod_container_name]

--- a/charts/seed-monitoring/charts/core/charts/prometheus/templates/config.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/templates/config.yaml
@@ -363,13 +363,9 @@ data:
       relabel_configs:
       - target_label: type
         replacement: seed
-      - source_labels: [ __meta_kubernetes_pod_name ]
+      - source_labels: [ __meta_kubernetes_pod_name,__meta_kubernetes_pod_container_name ]
         action: keep
-        regex: vpn-shoot-(.+)
-      - source_labels: [ __meta_kubernetes_pod_container_name ]
-        regex: (vpn-shoot-.*|vpn-shoot)
-        replacement: $1
-        action: replace
+        regex: vpn-shoot-(0|.+-.+);vpn-shoot-init
       - source_labels: [__meta_kubernetes_pod_name,__meta_kubernetes_pod_container_name]
         target_label: __param_target
         regex: (.+);(.+)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind bug

**What this PR does / why we need it**:
Prometheus job `tunnel-probe-apiserver-proxy` doesn't work for HA VPN and the grafana dashboard VPN will always show vpn connection failure of HA Shoot. 
<img width="1414" alt="Screenshot 2023-05-16 at 16 54 43" src="https://github.com/gardener/gardener/assets/50126000/44f4225e-db75-4b1e-b6dd-0832db5a7e7f">

The probe target `https://kube-apiserver:443/api/v1/namespaces/kube-system/pods/${1}/log?tailLines=1` works well for non-HA cluster as pod has one container. But for HA mode, `vpn-shoot` pod has two containers. 

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener/issues/7941

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Update Prometheus job `tunnel-probe-apiserver-proxy` to fix for HA VPN mode
```
