### PR TITLE
Fix Seed logging test

### DIFF
--- a/test/framework/dump.go
+++ b/test/framework/dump.go
@@ -182,7 +182,7 @@ func (f *CommonFramework) DumpLogsForPodsWithLabelsInNamespace(ctx context.Conte
 
 	var result error
 	for _, pod := range pods.Items {
-		if err := f.DumpLogsForPodInNamespace(ctx, k8sClient, namespace, pod.Name); err != nil {
+		if err := f.DumpLogsForPodInNamespace(ctx, k8sClient, namespace, pod.Name, ""); err != nil {
 			result = multierror.Append(result, err)
 		}
 	}
@@ -190,12 +190,12 @@ func (f *CommonFramework) DumpLogsForPodsWithLabelsInNamespace(ctx context.Conte
 }
 
 // DumpLogsForPodInNamespace prints the logs of the pod with the given namespace and name.
-func (f *CommonFramework) DumpLogsForPodInNamespace(ctx context.Context, k8sClient kubernetes.Interface, namespace, name string) error {
+func (f *CommonFramework) DumpLogsForPodInNamespace(ctx context.Context, k8sClient kubernetes.Interface, namespace, name, containerName string) error {
 	log := f.Logger.WithValues("pod", client.ObjectKey{Namespace: namespace, Name: name})
 	log.Info("Dumping logs for corev1.Pod")
 
 	podIf := k8sClient.Kubernetes().CoreV1().Pods(namespace)
-	logs, err := kubernetes.GetPodLogs(ctx, podIf, name, &corev1.PodLogOptions{})
+	logs, err := kubernetes.GetPodLogs(ctx, podIf, name, &corev1.PodLogOptions{Container: containerName})
 	if err != nil {
 		return err
 	}

--- a/test/framework/dump.go
+++ b/test/framework/dump.go
@@ -182,7 +182,7 @@ func (f *CommonFramework) DumpLogsForPodsWithLabelsInNamespace(ctx context.Conte
 
 	var result error
 	for _, pod := range pods.Items {
-		if err := f.DumpLogsForPodInNamespace(ctx, k8sClient, namespace, pod.Name, ""); err != nil {
+		if err := f.DumpLogsForPodInNamespace(ctx, k8sClient, namespace, pod.Name, &corev1.PodLogOptions{}); err != nil {
 			result = multierror.Append(result, err)
 		}
 	}
@@ -190,12 +190,12 @@ func (f *CommonFramework) DumpLogsForPodsWithLabelsInNamespace(ctx context.Conte
 }
 
 // DumpLogsForPodInNamespace prints the logs of the pod with the given namespace and name.
-func (f *CommonFramework) DumpLogsForPodInNamespace(ctx context.Context, k8sClient kubernetes.Interface, namespace, name, containerName string) error {
+func (f *CommonFramework) DumpLogsForPodInNamespace(ctx context.Context, k8sClient kubernetes.Interface, namespace, name string, options *corev1.PodLogOptions) error {
 	log := f.Logger.WithValues("pod", client.ObjectKey{Namespace: namespace, Name: name})
 	log.Info("Dumping logs for corev1.Pod")
 
 	podIf := k8sClient.Kubernetes().CoreV1().Pods(namespace)
-	logs, err := kubernetes.GetPodLogs(ctx, podIf, name, &corev1.PodLogOptions{Container: containerName})
+	logs, err := kubernetes.GetPodLogs(ctx, podIf, name, options)
 	if err != nil {
 		return err
 	}

--- a/test/testmachinery/shoots/logging/utils.go
+++ b/test/testmachinery/shoots/logging/utils.go
@@ -111,7 +111,7 @@ func WaitUntilValiReceivesLogs(ctx context.Context, interval time.Duration, f *f
 		defer dumpLogsCancel()
 
 		f.Logger.Info("Dump Vali logs")
-		if dumpError := f.DumpLogsForPodInNamespace(dumpLogsCtx, c, valiNamespace, "vali-0"); dumpError != nil {
+		if dumpError := f.DumpLogsForPodInNamespace(dumpLogsCtx, c, valiNamespace, "vali-0", "vali"); dumpError != nil {
 			f.Logger.Error(dumpError, "Error dumping logs for pod")
 		}
 

--- a/test/testmachinery/shoots/logging/utils.go
+++ b/test/testmachinery/shoots/logging/utils.go
@@ -151,6 +151,12 @@ func getCluster(number int) *extensionsv1alpha1.Cluster {
 			},
 			Purpose: (*gardencorev1beta1.ShootPurpose)(pointer.String("evaluation")),
 		},
+		Status: gardencorev1beta1.ShootStatus{
+			LastOperation: &gardencorev1beta1.LastOperation{
+				Progress: 100,
+				Type:     gardencorev1beta1.LastOperationTypeReconcile,
+			},
+		},
 	}
 
 	return &extensionsv1alpha1.Cluster{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing logging
/kind bug

**What this PR does / why we need it**:
After #7568 , the name of the fluent-bit daemonset is not constant, also the clusterrole and clusterrolebinding names have changed. 
This PR adapts the test to this change.
Also for cluster scoped resources, we should not specify the namespace.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @vlvasilev @nickytd 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
