### PR TITLE
Drop migration code for `istio` `ManagedResource` split

### DIFF
--- a/pkg/component/istio/charts/istio/istio-istiod/templates/autoscale.yaml
+++ b/pkg/component/istio/charts/istio/istio-istiod/templates/autoscale.yaml
@@ -3,10 +3,6 @@ kind: VerticalPodAutoscaler
 metadata:
   name: istiod
   namespace: {{ .Release.Namespace }}
-{{- if .Values.ignoreMode }}
-  annotations:
-    resources.gardener.cloud/mode: Ignore
-{{- end }}
   labels:
 {{ .Values.labels | toYaml | indent 4 }}
 spec:

--- a/pkg/component/istio/charts/istio/istio-istiod/templates/clusterrole.yaml
+++ b/pkg/component/istio/charts/istio/istio-istiod/templates/clusterrole.yaml
@@ -2,10 +2,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: istiod
-{{- if .Values.ignoreMode }}
-  annotations:
-    resources.gardener.cloud/mode: Ignore
-{{- end }}
   labels:
 {{ .Values.labels | toYaml | indent 4 }}
 rules:

--- a/pkg/component/istio/charts/istio/istio-istiod/templates/clusterrolebinding.yaml
+++ b/pkg/component/istio/charts/istio/istio-istiod/templates/clusterrolebinding.yaml
@@ -2,10 +2,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: istiod
-{{- if .Values.ignoreMode }}
-  annotations:
-    resources.gardener.cloud/mode: Ignore
-{{- end }}
   labels:
 {{ .Values.labels | toYaml | indent 4 }}
 roleRef:

--- a/pkg/component/istio/charts/istio/istio-istiod/templates/configmap.yaml
+++ b/pkg/component/istio/charts/istio/istio-istiod/templates/configmap.yaml
@@ -3,10 +3,6 @@ kind: ConfigMap
 metadata:
   name: istio
   namespace: {{ .Release.Namespace }}
-{{- if .Values.ignoreMode }}
-  annotations:
-    resources.gardener.cloud/mode: Ignore
-{{- end }}
   labels:
 {{ .Values.labels | toYaml | indent 4 }}
 data:

--- a/pkg/component/istio/charts/istio/istio-istiod/templates/deployment.yaml
+++ b/pkg/component/istio/charts/istio/istio-istiod/templates/deployment.yaml
@@ -3,10 +3,6 @@ kind: Deployment
 metadata:
   name: istiod
   namespace: {{ .Release.Namespace }}
-{{- if .Values.ignoreMode }}
-  annotations:
-    resources.gardener.cloud/mode: Ignore
-{{- end }}
   labels:
 {{ .Values.labels | toYaml | indent 4 }}
 spec:

--- a/pkg/component/istio/charts/istio/istio-istiod/templates/destinationrule.yaml
+++ b/pkg/component/istio/charts/istio/istio-istiod/templates/destinationrule.yaml
@@ -3,10 +3,6 @@ kind: DestinationRule
 metadata:
   name: default
   namespace: {{ .Release.Namespace }}
-{{- if .Values.ignoreMode }}
-  annotations:
-    resources.gardener.cloud/mode: Ignore
-{{- end }}
 spec:
   host: "*"
   exportTo:

--- a/pkg/component/istio/charts/istio/istio-istiod/templates/namespace.yaml
+++ b/pkg/component/istio/charts/istio/istio-istiod/templates/namespace.yaml
@@ -3,10 +3,6 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: {{ .Release.Namespace }}
-{{- if .Values.ignoreMode }}
-  annotations:
-    resources.gardener.cloud/mode: Ignore
-{{- end }}
   labels:
     istio-operator-managed: Reconcile
     istio-injection: disabled

--- a/pkg/component/istio/charts/istio/istio-istiod/templates/peerauthentication.yaml
+++ b/pkg/component/istio/charts/istio/istio-istiod/templates/peerauthentication.yaml
@@ -3,10 +3,6 @@ kind: PeerAuthentication
 metadata:
   name: default
   namespace: {{ .Release.Namespace }}
-{{- if .Values.ignoreMode }}
-  annotations:
-    resources.gardener.cloud/mode: Ignore
-{{- end }}
 spec:
   mtls:
     mode: STRICT

--- a/pkg/component/istio/charts/istio/istio-istiod/templates/poddisruptionbudget.yaml
+++ b/pkg/component/istio/charts/istio/istio-istiod/templates/poddisruptionbudget.yaml
@@ -7,10 +7,6 @@ kind: PodDisruptionBudget
 metadata:
   name: istiod
   namespace: {{ .Release.Namespace }}
-{{- if .Values.ignoreMode }}
-  annotations:
-    resources.gardener.cloud/mode: Ignore
-{{- end }}
   labels:
 {{ .Values.labels | toYaml | trim | indent 4 }}
 spec:

--- a/pkg/component/istio/charts/istio/istio-istiod/templates/role.yaml
+++ b/pkg/component/istio/charts/istio/istio-istiod/templates/role.yaml
@@ -3,10 +3,6 @@ kind: Role
 metadata:
   name: istiod
   namespace: {{ .Release.Namespace }}
-{{- if .Values.ignoreMode }}
-  annotations:
-    resources.gardener.cloud/mode: Ignore
-{{- end }}
   labels:
 {{ .Values.labels | toYaml | indent 4 }}
 rules:

--- a/pkg/component/istio/charts/istio/istio-istiod/templates/rolebinding.yaml
+++ b/pkg/component/istio/charts/istio/istio-istiod/templates/rolebinding.yaml
@@ -3,10 +3,6 @@ kind: RoleBinding
 metadata:
   name: istiod
   namespace: {{ .Release.Namespace }}
-{{- if .Values.ignoreMode }}
-  annotations:
-    resources.gardener.cloud/mode: Ignore
-{{- end }}
   labels:
 {{ .Values.labels | toYaml | indent 4 }}
 roleRef:

--- a/pkg/component/istio/charts/istio/istio-istiod/templates/service.yaml
+++ b/pkg/component/istio/charts/istio/istio-istiod/templates/service.yaml
@@ -7,9 +7,6 @@ metadata:
     networking.resources.gardener.cloud/from-all-seed-scrape-targets-allowed-ports: '[{"port":15014,"protocol":"TCP"}]'
     networking.resources.gardener.cloud/from-world-to-ports: '[{"port":{{ .Values.ports.https }},"protocol":"TCP"}]'
     networking.resources.gardener.cloud/namespace-selectors: '[{"matchLabels":{"gardener.cloud/role":"istio-ingress"}},{"matchExpressions":[{"key":"handler.exposureclass.gardener.cloud/name","operator":"Exists"}]},{"matchLabels":{"kubernetes.io/metadata.name":"garden"}}]'
-{{- if .Values.ignoreMode }}
-    resources.gardener.cloud/mode: Ignore
-{{- end }}
   labels:
 {{ .Values.labels | toYaml | indent 4 }}
 spec:

--- a/pkg/component/istio/charts/istio/istio-istiod/templates/serviceaccount.yaml
+++ b/pkg/component/istio/charts/istio/istio-istiod/templates/serviceaccount.yaml
@@ -3,10 +3,6 @@ kind: ServiceAccount
 metadata:
   name: istiod
   namespace: {{ .Release.Namespace }}
-{{- if .Values.ignoreMode }}
-  annotations:
-    resources.gardener.cloud/mode: Ignore
-{{- end }}
   labels:
 {{ .Values.labels | toYaml | indent 4 }}
 automountServiceAccountToken: false

--- a/pkg/component/istio/charts/istio/istio-istiod/templates/sidecar.yaml
+++ b/pkg/component/istio/charts/istio/istio-istiod/templates/sidecar.yaml
@@ -3,10 +3,6 @@ kind: Sidecar
 metadata:
   name: default
   namespace: {{ .Release.Namespace }}
-{{- if .Values.ignoreMode }}
-  annotations:
-    resources.gardener.cloud/mode: Ignore
-{{- end }}
   labels:
 {{ .Values.labels | toYaml | indent 4 }}
 spec:

--- a/pkg/component/istio/charts/istio/istio-istiod/templates/validatingwebhookconfiguration.yaml
+++ b/pkg/component/istio/charts/istio/istio-istiod/templates/validatingwebhookconfiguration.yaml
@@ -2,10 +2,6 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: istiod
-{{- if .Values.ignoreMode }}
-  annotations:
-    resources.gardener.cloud/mode: Ignore
-{{- end }}
   labels:
     # The istio revision is required so that the web hook is found at runtime for the caBundle update
     # Currently, we do not set the istio revision. Hence, it is just empty.

--- a/pkg/component/istio/charts/istio/istio-istiod/values.yaml
+++ b/pkg/component/istio/charts/istio/istio-istiod/values.yaml
@@ -10,6 +10,3 @@ ports:
 portsNames:
   metrics: metrics
 serviceName: istiod
-
-# TODO(rfranzke): To be removed after v1.71 got released. Only required to move istiod assets to separate ManagedResource.
-ignoreMode: false

--- a/pkg/component/istio/istio_test.go
+++ b/pkg/component/istio/istio_test.go
@@ -73,14 +73,8 @@ var _ = Describe("istiod", func() {
 
 		externalTrafficPolicy corev1.ServiceExternalTrafficPolicyType
 
-		ignoreAnnotation = `
-    resources.gardener.cloud/mode: Ignore`
-
-		istiodService = func(ignore bool) string {
+		istiodService = func() string {
 			var additionalAnnotation string
-			if ignore {
-				additionalAnnotation += ignoreAnnotation
-			}
 
 			return `apiVersion: v1
 kind: Service
@@ -115,17 +109,11 @@ spec:
     
 `
 		}
-		istioClusterRole = func(ignore bool) string {
-			var annotations string
-			if ignore {
-				annotations = `
-  annotations:` + ignoreAnnotation
-			}
-
+		istioClusterRole = func() string {
 			return `apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: istiod` + annotations + `
+  name: istiod
   labels:
     app: istiod
     istio: pilot
@@ -356,7 +344,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: istiod-gateway-controller` + annotations + `
+  name: istiod-gateway-controller
   labels:
     app: istiod
     istio: pilot
@@ -374,17 +362,11 @@ rules:
 `
 		}
 
-		istiodClusterRoleBinding = func(ignore bool) string {
-			var annotations string
-			if ignore {
-				annotations = `
-  annotations:` + ignoreAnnotation
-			}
-
+		istiodClusterRoleBinding = func() string {
 			return `apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: istiod` + annotations + `
+  name: istiod
   labels:
     app: istiod
     istio: pilot
@@ -402,7 +384,7 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: istiod-gateway-controller` + annotations + `
+  name: istiod-gateway-controller
   labels:
     app: istiod
     istio: pilot
@@ -418,18 +400,12 @@ subjects:
 `
 		}
 
-		istiodDestinationRule = func(ignore bool) string {
-			var annotations string
-			if ignore {
-				annotations = `
-  annotations:` + ignoreAnnotation
-			}
-
+		istiodDestinationRule = func() string {
 			return `apiVersion: networking.istio.io/v1beta1
 kind: DestinationRule
 metadata:
   name: default
-  namespace: ` + deployNS + annotations + `
+  namespace: ` + deployNS + `
 spec:
   host: "*"
   exportTo:
@@ -440,31 +416,19 @@ spec:
 `
 		}
 
-		istiodPeerAuthentication = func(ignore bool) string {
-			var annotations string
-			if ignore {
-				annotations = `
-  annotations:` + ignoreAnnotation
-			}
-
+		istiodPeerAuthentication = func() string {
 			return `apiVersion: security.istio.io/v1beta1
 kind: PeerAuthentication
 metadata:
   name: default
-  namespace: ` + deployNS + annotations + `
+  namespace: ` + deployNS + `
 spec:
   mtls:
     mode: STRICT
 `
 		}
 
-		istiodPodDisruptionBudgetFor = func(k8sGreaterEqual121 bool, ignore bool) string {
-			var annotations string
-			if ignore {
-				annotations = `
-  annotations:` + ignoreAnnotation
-			}
-
+		istiodPodDisruptionBudgetFor = func(k8sGreaterEqual121 bool) string {
 			apiVersion := "policy/v1beta1"
 			if k8sGreaterEqual121 {
 				apiVersion = "policy/v1"
@@ -474,7 +438,7 @@ apiVersion: ` + apiVersion + `
 kind: PodDisruptionBudget
 metadata:
   name: istiod
-  namespace: ` + deployNS + annotations + `
+  namespace: ` + deployNS + `
   labels:
     app: istiod
     istio: pilot
@@ -488,17 +452,12 @@ spec:
 			return out
 		}
 
-		istiodRole = func(ignore bool) string {
-			var annotations string
-			if ignore {
-				annotations = `
-  annotations:` + ignoreAnnotation
-			}
+		istiodRole = func() string {
 			return `apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: istiod
-  namespace: ` + deployNS + annotations + `
+  namespace: ` + deployNS + `
   labels:
     app: istiod
     istio: pilot
@@ -543,17 +502,12 @@ rules:
 `
 		}
 
-		istiodRoleBinding = func(ignore bool) string {
-			var annotations string
-			if ignore {
-				annotations = `
-  annotations:` + ignoreAnnotation
-			}
+		istiodRoleBinding = func() string {
 			return `apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: istiod
-  namespace: ` + deployNS + annotations + `
+  namespace: ` + deployNS + `
   labels:
     app: istiod
     istio: pilot
@@ -568,18 +522,12 @@ subjects:
 `
 		}
 
-		istiodServiceAccount = func(ignore bool) string {
-			var annotations string
-			if ignore {
-				annotations = `
-  annotations:` + ignoreAnnotation
-			}
-
+		istiodServiceAccount = func() string {
 			return `apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: istiod
-  namespace: ` + deployNS + annotations + `
+  namespace: ` + deployNS + `
   labels:
     app: istiod
     istio: pilot
@@ -588,17 +536,12 @@ automountServiceAccountToken: false
 `
 		}
 
-		istiodSidecar = func(ignore bool) string {
-			var annotations string
-			if ignore {
-				annotations = `
-  annotations:` + ignoreAnnotation
-			}
+		istiodSidecar = func() string {
 			return `apiVersion: networking.istio.io/v1alpha3
 kind: Sidecar
 metadata:
   name: default
-  namespace: ` + deployNS + annotations + `
+  namespace: ` + deployNS + `
   labels:
     app: istiod
     istio: pilot
@@ -612,17 +555,12 @@ spec:
 `
 		}
 
-		istiodAutoscale = func(ignore bool) string {
-			var annotations string
-			if ignore {
-				annotations = `
-  annotations:` + ignoreAnnotation
-			}
+		istiodAutoscale = func() string {
 			return `apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
 metadata:
   name: istiod
-  namespace: ` + deployNS + annotations + `
+  namespace: ` + deployNS + `
   labels:
     app: istiod
     istio: pilot
@@ -642,17 +580,11 @@ spec:
 `
 		}
 
-		istiodValidationWebhook = func(ignore bool) string {
-			var annotations string
-			if ignore {
-				annotations = `
-  annotations:` + ignoreAnnotation
-			}
-
+		istiodValidationWebhook = func() string {
 			return `apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
-  name: istiod` + annotations + `
+  name: istiod
   labels:
     # The istio revision is required so that the web hook is found at runtime for the caBundle update
     # Currently, we do not set the istio revision. Hence, it is just empty.
@@ -693,19 +625,12 @@ webhooks:
 `
 		}
 
-		istiodConfigMap = func(ignore bool) string {
-			var annotations string
-			if ignore {
-				annotations = `
-  annotations:` + ignoreAnnotation
-			}
-
+		istiodConfigMap = func() string {
 			return `apiVersion: v1
 kind: ConfigMap
 metadata:
   name: istio
-  namespace: ` + deployNS +
-				annotations + `
+  namespace: ` + deployNS + `
   labels:
     app: istiod
     istio: pilot
@@ -809,19 +734,12 @@ data:
 `
 		}
 
-		istiodDeployment = func(ignore bool, checksum string) string {
-			var annotations string
-			if ignore {
-				annotations = `
-  annotations:` + ignoreAnnotation
-			}
-
+		istiodDeployment = func(checksum string) string {
 			return `apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: istiod
-  namespace: ` + deployNS +
-				annotations + `
+  namespace: ` + deployNS + `
   labels:
     app: istiod
     istio: pilot
@@ -2243,24 +2161,7 @@ spec:
 
 			Expect(c.Get(ctx, client.ObjectKeyFromObject(managedResourceIstioSecret), managedResourceIstioSecret)).To(Succeed())
 			Expect(managedResourceIstioSecret.Type).To(Equal(corev1.SecretTypeOpaque))
-			Expect(managedResourceIstioSecret.Data).To(HaveLen(30))
-
-			By("Verify istio-system resources in `Ignore` mode")
-			Expect(string(managedResourceIstioSecret.Data["istio-istiod_templates_configmap.yaml"])).To(Equal(istiodConfigMap(true)))
-			Expect(string(managedResourceIstioSecret.Data["istio-istiod_templates_deployment.yaml"])).To(Equal(istiodDeployment(true, "b1493f472a93df6b9764ee8530150faad2fb61b22b68acded9fdf4cf2a815c15")))
-			Expect(string(managedResourceIstioSecret.Data["istio-istiod_templates_service.yaml"])).To(Equal(istiodService(true)))
-			Expect(string(managedResourceIstioSecret.Data["istio-istiod_templates_clusterrole.yaml"])).To(Equal(istioClusterRole(true)))
-			Expect(string(managedResourceIstioSecret.Data["istio-istiod_templates_clusterrolebinding.yaml"])).To(Equal(istiodClusterRoleBinding(true)))
-			Expect(string(managedResourceIstioSecret.Data["istio-istiod_templates_destinationrule.yaml"])).To(Equal(istiodDestinationRule(true)))
-			Expect(string(managedResourceIstioSecret.Data["istio-istiod_templates_namespace.yaml"])).To(BeEmpty())
-			Expect(string(managedResourceIstioSecret.Data["istio-istiod_templates_peerauthentication.yaml"])).To(Equal(istiodPeerAuthentication(true)))
-			Expect(string(managedResourceIstioSecret.Data["istio-istiod_templates_poddisruptionbudget.yaml"])).To(Equal(istiodPodDisruptionBudgetFor(true, true)))
-			Expect(string(managedResourceIstioSecret.Data["istio-istiod_templates_role.yaml"])).To(Equal(istiodRole(true)))
-			Expect(string(managedResourceIstioSecret.Data["istio-istiod_templates_rolebinding.yaml"])).To(Equal(istiodRoleBinding(true)))
-			Expect(string(managedResourceIstioSecret.Data["istio-istiod_templates_serviceaccount.yaml"])).To(Equal(istiodServiceAccount(true)))
-			Expect(string(managedResourceIstioSecret.Data["istio-istiod_templates_sidecar.yaml"])).To(Equal(istiodSidecar(true)))
-			Expect(string(managedResourceIstioSecret.Data["istio-istiod_templates_autoscale.yaml"])).To(Equal(istiodAutoscale(true)))
-			Expect(string(managedResourceIstioSecret.Data["istio-istiod_templates_validatingwebhookconfiguration.yaml"])).To(Equal(istiodValidationWebhook(true)))
+			Expect(managedResourceIstioSecret.Data).To(HaveLen(15))
 
 			By("Verify istio-ingress resources")
 			Expect(string(managedResourceIstioSecret.Data["istio-ingress_templates_autoscale_test-ingress.yaml"])).To(Equal(istioIngressAutoscaler(nil, nil)))
@@ -2287,21 +2188,21 @@ spec:
 			Expect(managedResourceIstioSystemSecret.Type).To(Equal(corev1.SecretTypeOpaque))
 			Expect(managedResourceIstioSystemSecret.Data).To(HaveLen(15))
 
-			Expect(string(managedResourceIstioSystemSecret.Data["istio-istiod_templates_configmap.yaml"])).To(Equal(istiodConfigMap(false)))
-			Expect(string(managedResourceIstioSystemSecret.Data["istio-istiod_templates_deployment.yaml"])).To(Equal(istiodDeployment(false, "d34796e6fc25a26d4a8a4cb3276e34961b18f867d70f5a1984255d57bfefb4c6")))
-			Expect(string(managedResourceIstioSystemSecret.Data["istio-istiod_templates_service.yaml"])).To(Equal(istiodService(false)))
-			Expect(string(managedResourceIstioSystemSecret.Data["istio-istiod_templates_clusterrole.yaml"])).To(Equal(istioClusterRole(false)))
-			Expect(string(managedResourceIstioSystemSecret.Data["istio-istiod_templates_clusterrolebinding.yaml"])).To(Equal(istiodClusterRoleBinding(false)))
-			Expect(string(managedResourceIstioSystemSecret.Data["istio-istiod_templates_destinationrule.yaml"])).To(Equal(istiodDestinationRule(false)))
+			Expect(string(managedResourceIstioSystemSecret.Data["istio-istiod_templates_configmap.yaml"])).To(Equal(istiodConfigMap()))
+			Expect(string(managedResourceIstioSystemSecret.Data["istio-istiod_templates_deployment.yaml"])).To(Equal(istiodDeployment("d34796e6fc25a26d4a8a4cb3276e34961b18f867d70f5a1984255d57bfefb4c6")))
+			Expect(string(managedResourceIstioSystemSecret.Data["istio-istiod_templates_service.yaml"])).To(Equal(istiodService()))
+			Expect(string(managedResourceIstioSystemSecret.Data["istio-istiod_templates_clusterrole.yaml"])).To(Equal(istioClusterRole()))
+			Expect(string(managedResourceIstioSystemSecret.Data["istio-istiod_templates_clusterrolebinding.yaml"])).To(Equal(istiodClusterRoleBinding()))
+			Expect(string(managedResourceIstioSystemSecret.Data["istio-istiod_templates_destinationrule.yaml"])).To(Equal(istiodDestinationRule()))
 			Expect(string(managedResourceIstioSystemSecret.Data["istio-istiod_templates_namespace.yaml"])).To(BeEmpty())
-			Expect(string(managedResourceIstioSystemSecret.Data["istio-istiod_templates_peerauthentication.yaml"])).To(Equal(istiodPeerAuthentication(false)))
-			Expect(string(managedResourceIstioSystemSecret.Data["istio-istiod_templates_poddisruptionbudget.yaml"])).To(Equal(istiodPodDisruptionBudgetFor(true, false)))
-			Expect(string(managedResourceIstioSystemSecret.Data["istio-istiod_templates_role.yaml"])).To(Equal(istiodRole(false)))
-			Expect(string(managedResourceIstioSystemSecret.Data["istio-istiod_templates_rolebinding.yaml"])).To(Equal(istiodRoleBinding(false)))
-			Expect(string(managedResourceIstioSystemSecret.Data["istio-istiod_templates_serviceaccount.yaml"])).To(Equal(istiodServiceAccount(false)))
-			Expect(string(managedResourceIstioSystemSecret.Data["istio-istiod_templates_sidecar.yaml"])).To(Equal(istiodSidecar(false)))
-			Expect(string(managedResourceIstioSystemSecret.Data["istio-istiod_templates_autoscale.yaml"])).To(Equal(istiodAutoscale(false)))
-			Expect(string(managedResourceIstioSystemSecret.Data["istio-istiod_templates_validatingwebhookconfiguration.yaml"])).To(Equal(istiodValidationWebhook(false)))
+			Expect(string(managedResourceIstioSystemSecret.Data["istio-istiod_templates_peerauthentication.yaml"])).To(Equal(istiodPeerAuthentication()))
+			Expect(string(managedResourceIstioSystemSecret.Data["istio-istiod_templates_poddisruptionbudget.yaml"])).To(Equal(istiodPodDisruptionBudgetFor(true)))
+			Expect(string(managedResourceIstioSystemSecret.Data["istio-istiod_templates_role.yaml"])).To(Equal(istiodRole()))
+			Expect(string(managedResourceIstioSystemSecret.Data["istio-istiod_templates_rolebinding.yaml"])).To(Equal(istiodRoleBinding()))
+			Expect(string(managedResourceIstioSystemSecret.Data["istio-istiod_templates_serviceaccount.yaml"])).To(Equal(istiodServiceAccount()))
+			Expect(string(managedResourceIstioSystemSecret.Data["istio-istiod_templates_sidecar.yaml"])).To(Equal(istiodSidecar()))
+			Expect(string(managedResourceIstioSystemSecret.Data["istio-istiod_templates_autoscale.yaml"])).To(Equal(istiodAutoscale()))
+			Expect(string(managedResourceIstioSystemSecret.Data["istio-istiod_templates_validatingwebhookconfiguration.yaml"])).To(Equal(istiodValidationWebhook()))
 		})
 
 		Context("with outdated stats filters", func() {
@@ -2358,12 +2259,11 @@ spec:
 				)
 			})
 
-			It("should succesfully deploy pdb with correct apiVersion ", func() {
+			It("should succesfully deploy pdb with correct apiVersion", func() {
 				Expect(c.Get(ctx, client.ObjectKeyFromObject(managedResourceIstioSecret), managedResourceIstioSecret)).To(Succeed())
 				Expect(managedResourceIstioSecret.Type).To(Equal(corev1.SecretTypeOpaque))
-				Expect(managedResourceIstioSecret.Data).To(HaveLen(30))
+				Expect(managedResourceIstioSecret.Data).To(HaveLen(15))
 
-				Expect(string(managedResourceIstioSecret.Data["istio-istiod_templates_poddisruptionbudget.yaml"])).To(Equal(istiodPodDisruptionBudgetFor(false, true)))
 				Expect(string(managedResourceIstioSecret.Data["istio-ingress_templates_poddisruptionbudget_test-ingress.yaml"])).To(Equal(istioIngressPodDisruptionBudgetFor(false)))
 			})
 		})
@@ -2474,7 +2374,7 @@ spec:
 			It("should successfully deploy all resources", func() {
 				Expect(c.Get(ctx, client.ObjectKeyFromObject(managedResourceIstioSecret), managedResourceIstioSecret)).To(Succeed())
 				Expect(managedResourceIstioSecret.Type).To(Equal(corev1.SecretTypeOpaque))
-				Expect(managedResourceIstioSecret.Data).To(HaveLen(30))
+				Expect(managedResourceIstioSecret.Data).To(HaveLen(15))
 
 				Expect(string(managedResourceIstioSecret.Data["istio-ingress_templates_vpn-gateway_test-ingress.yaml"])).To(BeEmpty())
 				Expect(string(managedResourceIstioSecret.Data["istio-ingress_templates_vpn-envoy-filter_test-ingress.yaml"])).To(BeEmpty())
@@ -2507,7 +2407,7 @@ spec:
 			It("should successfully deploy all resources", func() {
 				Expect(c.Get(ctx, client.ObjectKeyFromObject(managedResourceIstioSecret), managedResourceIstioSecret)).To(Succeed())
 				Expect(managedResourceIstioSecret.Type).To(Equal(corev1.SecretTypeOpaque))
-				Expect(managedResourceIstioSecret.Data).To(HaveLen(30))
+				Expect(managedResourceIstioSecret.Data).To(HaveLen(15))
 
 				Expect(string(managedResourceIstioSecret.Data["istio-ingress_templates_proxy-protocol-envoyfilter_test-ingress.yaml"])).To(BeEmpty())
 				Expect(string(managedResourceIstioSecret.Data["istio-ingress_templates_proxy-protocol-gateway_test-ingress.yaml"])).To(BeEmpty())


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind cleanup

**What this PR does / why we need it**:
Drop migration code for `istio` `ManagedResource` split. 

**Which issue(s) this PR fixes**:
Follow-up of https://github.com/gardener/gardener/pull/7868

**Special notes for your reviewer**:
/cc @timuthy 
/hold until v1.71 is released

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
