### PR TITLE
Enhance managed resource health check

### DIFF
--- a/pkg/component/apiserverproxy/apiserver_proxy_test.go
+++ b/pkg/component/apiserverproxy/apiserver_proxy_test.go
@@ -717,11 +717,25 @@ subjects:
 			It("should successfully wait for the managed resource to become healthy", func() {
 				fakeOps.MaxAttempts = 2
 
+				expectedChecksum := "fcde2b2edba56bf408601fb721fe9b5c338d10ee429ea04fae5511b68fbf8fb9"
+				secret := &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "secret1",
+						Namespace: namespace,
+					},
+					Data: map[string][]byte{
+						"foo": []byte("bar"),
+					},
+				}
+				Expect(c.Create(ctx, secret)).To(Succeed())
 				Expect(c.Create(ctx, &resourcesv1alpha1.ManagedResource{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:       managedResourceName,
 						Namespace:  namespace,
 						Generation: 1,
+					},
+					Spec: resourcesv1alpha1.ManagedResourceSpec{
+						SecretRefs: []corev1.LocalObjectReference{{Name: secret.Name}},
 					},
 					Status: resourcesv1alpha1.ManagedResourceStatus{
 						ObservedGeneration: 1,
@@ -735,6 +749,7 @@ subjects:
 								Status: gardencorev1beta1.ConditionTrue,
 							},
 						},
+						SecretsDataChecksum: &expectedChecksum,
 					},
 				})).To(Succeed())
 

--- a/pkg/component/clusterautoscaler/bootstrap_test.go
+++ b/pkg/component/clusterautoscaler/bootstrap_test.go
@@ -190,28 +190,51 @@ rules:
 		})
 
 		It("should successfully wait for all resources to be ready", func() {
-			c.EXPECT().Get(gomock.Any(), kubernetesutils.Key(namespace, managedResourceName), gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})).DoAndReturn(
-				func(ctx context.Context, _ client.ObjectKey, obj client.Object, _ ...client.GetOption) error {
-					(&resourcesv1alpha1.ManagedResource{
-						ObjectMeta: metav1.ObjectMeta{
-							Generation: 1,
-						},
-						Status: resourcesv1alpha1.ManagedResourceStatus{
-							ObservedGeneration: 1,
-							Conditions: []gardencorev1beta1.Condition{
-								{
-									Type:   resourcesv1alpha1.ResourcesApplied,
-									Status: gardencorev1beta1.ConditionTrue,
-								},
-								{
-									Type:   resourcesv1alpha1.ResourcesHealthy,
-									Status: gardencorev1beta1.ConditionTrue,
-								},
-							},
-						},
-					}).DeepCopyInto(obj.(*resourcesv1alpha1.ManagedResource))
-					return nil
+			expectedChecksum := "fcde2b2edba56bf408601fb721fe9b5c338d10ee429ea04fae5511b68fbf8fb9"
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "secret1",
+					Namespace: namespace,
 				},
+				Data: map[string][]byte{
+					"foo": []byte("bar"),
+				},
+			}
+			gomock.InOrder(
+				c.EXPECT().Get(gomock.Any(), kubernetesutils.Key(namespace, managedResourceName), gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})).DoAndReturn(
+					func(ctx context.Context, _ client.ObjectKey, obj client.Object, _ ...client.GetOption) error {
+						(&resourcesv1alpha1.ManagedResource{
+							ObjectMeta: metav1.ObjectMeta{
+								Namespace:  namespace,
+								Generation: 1,
+							},
+							Spec: resourcesv1alpha1.ManagedResourceSpec{
+								SecretRefs: []corev1.LocalObjectReference{{Name: secret.Name}},
+							},
+							Status: resourcesv1alpha1.ManagedResourceStatus{
+								ObservedGeneration: 1,
+								Conditions: []gardencorev1beta1.Condition{
+									{
+										Type:   resourcesv1alpha1.ResourcesApplied,
+										Status: gardencorev1beta1.ConditionTrue,
+									},
+									{
+										Type:   resourcesv1alpha1.ResourcesHealthy,
+										Status: gardencorev1beta1.ConditionTrue,
+									},
+								},
+								SecretsDataChecksum: &expectedChecksum,
+							},
+						}).DeepCopyInto(obj.(*resourcesv1alpha1.ManagedResource))
+						return nil
+					},
+				),
+				c.EXPECT().Get(gomock.Any(), kubernetesutils.Key(namespace, secret.Name), gomock.AssignableToTypeOf(&corev1.Secret{})).DoAndReturn(
+					func(ctx context.Context, _ client.ObjectKey, obj client.Object, _ ...client.GetOption) error {
+						(secret).DeepCopyInto(obj.(*corev1.Secret))
+						return nil
+					},
+				),
 			)
 
 			Expect(bootstrapper.Wait(ctx)).To(Succeed())

--- a/pkg/component/clusteridentity/clusteridentity_test.go
+++ b/pkg/component/clusteridentity/clusteridentity_test.go
@@ -224,28 +224,51 @@ metadata:
 			defer func() { TimeoutWaitForManagedResource = oldTimeout }()
 			TimeoutWaitForManagedResource = time.Millisecond
 
-			c.EXPECT().Get(gomock.Any(), kubernetesutils.Key(namespace, managedResourceName), gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})).DoAndReturn(
-				func(ctx context.Context, _ client.ObjectKey, obj client.Object, _ ...client.GetOption) error {
-					(&resourcesv1alpha1.ManagedResource{
-						ObjectMeta: metav1.ObjectMeta{
-							Generation: 1,
-						},
-						Status: resourcesv1alpha1.ManagedResourceStatus{
-							ObservedGeneration: 1,
-							Conditions: []gardencorev1beta1.Condition{
-								{
-									Type:   resourcesv1alpha1.ResourcesApplied,
-									Status: gardencorev1beta1.ConditionTrue,
-								},
-								{
-									Type:   resourcesv1alpha1.ResourcesHealthy,
-									Status: gardencorev1beta1.ConditionTrue,
-								},
-							},
-						},
-					}).DeepCopyInto(obj.(*resourcesv1alpha1.ManagedResource))
-					return nil
+			expectedChecksum := "fcde2b2edba56bf408601fb721fe9b5c338d10ee429ea04fae5511b68fbf8fb9"
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "secret1",
+					Namespace: namespace,
 				},
+				Data: map[string][]byte{
+					"foo": []byte("bar"),
+				},
+			}
+			gomock.InOrder(
+				c.EXPECT().Get(gomock.Any(), kubernetesutils.Key(namespace, managedResourceName), gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})).DoAndReturn(
+					func(ctx context.Context, _ client.ObjectKey, obj client.Object, _ ...client.GetOption) error {
+						(&resourcesv1alpha1.ManagedResource{
+							ObjectMeta: metav1.ObjectMeta{
+								Namespace:  namespace,
+								Generation: 1,
+							},
+							Spec: resourcesv1alpha1.ManagedResourceSpec{
+								SecretRefs: []corev1.LocalObjectReference{{Name: secret.Name}},
+							},
+							Status: resourcesv1alpha1.ManagedResourceStatus{
+								ObservedGeneration: 1,
+								Conditions: []gardencorev1beta1.Condition{
+									{
+										Type:   resourcesv1alpha1.ResourcesApplied,
+										Status: gardencorev1beta1.ConditionTrue,
+									},
+									{
+										Type:   resourcesv1alpha1.ResourcesHealthy,
+										Status: gardencorev1beta1.ConditionTrue,
+									},
+								},
+								SecretsDataChecksum: &expectedChecksum,
+							},
+						}).DeepCopyInto(obj.(*resourcesv1alpha1.ManagedResource))
+						return nil
+					},
+				),
+				c.EXPECT().Get(gomock.Any(), kubernetesutils.Key(namespace, secret.Name), gomock.AssignableToTypeOf(&corev1.Secret{})).DoAndReturn(
+					func(ctx context.Context, _ client.ObjectKey, obj client.Object, _ ...client.GetOption) error {
+						(secret).DeepCopyInto(obj.(*corev1.Secret))
+						return nil
+					},
+				),
 			)
 
 			Expect(clusterIdentity.Wait(ctx)).To(Succeed())

--- a/pkg/component/coredns/coredns_test.go
+++ b/pkg/component/coredns/coredns_test.go
@@ -897,11 +897,25 @@ status: {}
 			It("should successfully wait for the managed resource to become healthy", func() {
 				fakeOps.MaxAttempts = 2
 
+				expectedChecksum := "fcde2b2edba56bf408601fb721fe9b5c338d10ee429ea04fae5511b68fbf8fb9"
+				secret := &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "secret1",
+						Namespace: namespace,
+					},
+					Data: map[string][]byte{
+						"foo": []byte("bar"),
+					},
+				}
+				Expect(c.Create(ctx, secret)).To(Succeed())
 				Expect(c.Create(ctx, &resourcesv1alpha1.ManagedResource{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:       managedResourceName,
 						Namespace:  namespace,
 						Generation: 1,
+					},
+					Spec: resourcesv1alpha1.ManagedResourceSpec{
+						SecretRefs: []corev1.LocalObjectReference{{Name: secret.Name}},
 					},
 					Status: resourcesv1alpha1.ManagedResourceStatus{
 						ObservedGeneration: 1,
@@ -915,6 +929,7 @@ status: {}
 								Status: gardencorev1beta1.ConditionTrue,
 							},
 						},
+						SecretsDataChecksum: &expectedChecksum,
 					},
 				})).To(Succeed())
 

--- a/pkg/component/dependencywatchdog/bootstrap_test.go
+++ b/pkg/component/dependencywatchdog/bootstrap_test.go
@@ -640,11 +640,25 @@ status:
 			It("should successfully wait for the managed resource to become healthy", func() {
 				fakeOps.MaxAttempts = 2
 
+				expectedChecksum := "fcde2b2edba56bf408601fb721fe9b5c338d10ee429ea04fae5511b68fbf8fb9"
+				secret := &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "secret1",
+						Namespace: namespace,
+					},
+					Data: map[string][]byte{
+						"foo": []byte("bar"),
+					},
+				}
+				Expect(c.Create(ctx, secret)).To(Succeed())
 				Expect(c.Create(ctx, &resourcesv1alpha1.ManagedResource{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:       managedResourceName,
 						Namespace:  namespace,
 						Generation: 1,
+					},
+					Spec: resourcesv1alpha1.ManagedResourceSpec{
+						SecretRefs: []corev1.LocalObjectReference{{Name: secret.Name}},
 					},
 					Status: resourcesv1alpha1.ManagedResourceStatus{
 						ObservedGeneration: 1,
@@ -658,6 +672,7 @@ status:
 								Status: gardencorev1beta1.ConditionTrue,
 							},
 						},
+						SecretsDataChecksum: &expectedChecksum,
 					},
 				})).To(Succeed())
 

--- a/pkg/component/gardensystem/gardensystem_test.go
+++ b/pkg/component/gardensystem/gardensystem_test.go
@@ -168,11 +168,25 @@ var _ = Describe("GardenSystem", func() {
 			It("should successfully wait for the managed resource to become healthy", func() {
 				fakeOps.MaxAttempts = 2
 
+				expectedChecksum := "fcde2b2edba56bf408601fb721fe9b5c338d10ee429ea04fae5511b68fbf8fb9"
+				secret := &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "secret1",
+						Namespace: namespace,
+					},
+					Data: map[string][]byte{
+						"foo": []byte("bar"),
+					},
+				}
+				Expect(c.Create(ctx, secret)).To(Succeed())
 				Expect(c.Create(ctx, &resourcesv1alpha1.ManagedResource{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:       managedResourceName,
 						Namespace:  namespace,
 						Generation: 1,
+					},
+					Spec: resourcesv1alpha1.ManagedResourceSpec{
+						SecretRefs: []corev1.LocalObjectReference{{Name: secret.Name}},
 					},
 					Status: resourcesv1alpha1.ManagedResourceStatus{
 						ObservedGeneration: 1,
@@ -186,6 +200,7 @@ var _ = Describe("GardenSystem", func() {
 								Status: gardencorev1beta1.ConditionTrue,
 							},
 						},
+						SecretsDataChecksum: &expectedChecksum,
 					},
 				})).To(Succeed())
 

--- a/pkg/component/hvpa/hvpa_test.go
+++ b/pkg/component/hvpa/hvpa_test.go
@@ -442,11 +442,25 @@ var _ = Describe("HVPA", func() {
 			It("should successfully wait for the managed resource to become healthy", func() {
 				fakeOps.MaxAttempts = 2
 
+				expectedChecksum := "fcde2b2edba56bf408601fb721fe9b5c338d10ee429ea04fae5511b68fbf8fb9"
+				secret := &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "secret1",
+						Namespace: namespace,
+					},
+					Data: map[string][]byte{
+						"foo": []byte("bar"),
+					},
+				}
+				Expect(c.Create(ctx, secret)).To(Succeed())
 				Expect(c.Create(ctx, &resourcesv1alpha1.ManagedResource{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:       managedResourceName,
 						Namespace:  namespace,
 						Generation: 1,
+					},
+					Spec: resourcesv1alpha1.ManagedResourceSpec{
+						SecretRefs: []corev1.LocalObjectReference{{Name: secret.Name}},
 					},
 					Status: resourcesv1alpha1.ManagedResourceStatus{
 						ObservedGeneration: 1,
@@ -460,6 +474,7 @@ var _ = Describe("HVPA", func() {
 								Status: gardencorev1beta1.ConditionTrue,
 							},
 						},
+						SecretsDataChecksum: &expectedChecksum,
 					},
 				})).To(Succeed())
 

--- a/pkg/component/istio/istio_test.go
+++ b/pkg/component/istio/istio_test.go
@@ -2693,11 +2693,25 @@ spec:
 				fakeOps.MaxAttempts = 2
 
 				for _, mr := range []string{managedResourceIstioName, managedResourceIstioSystemName} {
+					expectedChecksum := "fcde2b2edba56bf408601fb721fe9b5c338d10ee429ea04fae5511b68fbf8fb9"
+					secret := &corev1.Secret{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      mr + "secret",
+							Namespace: deployNS,
+						},
+						Data: map[string][]byte{
+							"foo": []byte("bar"),
+						},
+					}
+					Expect(c.Create(ctx, secret)).To(Succeed())
 					Expect(c.Create(ctx, &resourcesv1alpha1.ManagedResource{
 						ObjectMeta: metav1.ObjectMeta{
 							Name:       mr,
 							Namespace:  deployNS,
 							Generation: 1,
+						},
+						Spec: resourcesv1alpha1.ManagedResourceSpec{
+							SecretRefs: []corev1.LocalObjectReference{{Name: secret.Name}},
 						},
 						Status: resourcesv1alpha1.ManagedResourceStatus{
 							ObservedGeneration: 1,
@@ -2711,6 +2725,7 @@ spec:
 									Status: gardencorev1beta1.ConditionTrue,
 								},
 							},
+							SecretsDataChecksum: &expectedChecksum,
 						},
 					})).To(Succeed())
 				}

--- a/pkg/component/kubeproxy/kube_proxy_test.go
+++ b/pkg/component/kubeproxy/kube_proxy_test.go
@@ -996,8 +996,9 @@ status: {}
 
 	Context("waiting functions", func() {
 		var (
-			fakeOps   *retryfake.Ops
-			resetVars func()
+			fakeOps          *retryfake.Ops
+			resetVars        func()
+			expectedChecksum = "fcde2b2edba56bf408601fb721fe9b5c338d10ee429ea04fae5511b68fbf8fb9"
 		)
 
 		BeforeEach(func() {
@@ -1124,11 +1125,24 @@ status: {}
 			It("should successfully wait for the managed resource to become healthy", func() {
 				fakeOps.MaxAttempts = 2
 
+				secret := &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      managedResourceCentral.Name + "secret",
+						Namespace: namespace,
+					},
+					Data: map[string][]byte{
+						"foo": []byte("bar"),
+					},
+				}
+				Expect(c.Create(ctx, secret)).To(Succeed())
 				Expect(c.Create(ctx, &resourcesv1alpha1.ManagedResource{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:       managedResourceCentral.Name,
 						Namespace:  namespace,
 						Generation: 1,
+					},
+					Spec: resourcesv1alpha1.ManagedResourceSpec{
+						SecretRefs: []corev1.LocalObjectReference{{Name: secret.Name}},
 					},
 					Status: resourcesv1alpha1.ManagedResourceStatus{
 						ObservedGeneration: 1,
@@ -1142,17 +1156,31 @@ status: {}
 								Status: gardencorev1beta1.ConditionTrue,
 							},
 						},
+						SecretsDataChecksum: &expectedChecksum,
 					},
 				})).To(Succeed())
 
 				for _, pool := range values.WorkerPools {
 					By(pool.Name)
 
+					secret := &corev1.Secret{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      managedResourceForPool(pool).Name + "secret",
+							Namespace: namespace,
+						},
+						Data: map[string][]byte{
+							"foo": []byte("bar"),
+						},
+					}
+					Expect(c.Create(ctx, secret)).To(Succeed())
 					Expect(c.Create(ctx, &resourcesv1alpha1.ManagedResource{
 						ObjectMeta: metav1.ObjectMeta{
 							Name:       managedResourceForPool(pool).Name,
 							Namespace:  namespace,
 							Generation: 1,
+						},
+						Spec: resourcesv1alpha1.ManagedResourceSpec{
+							SecretRefs: []corev1.LocalObjectReference{{Name: secret.Name}},
 						},
 						Status: resourcesv1alpha1.ManagedResourceStatus{
 							ObservedGeneration: 1,
@@ -1166,6 +1194,7 @@ status: {}
 									Status: gardencorev1beta1.ConditionTrue,
 								},
 							},
+							SecretsDataChecksum: &expectedChecksum,
 						},
 					})).To(Succeed())
 				}
@@ -1175,12 +1204,24 @@ status: {}
 
 			It("should successfully wait for the managed resource to become healthy despite undesired managed resource unhealthy", func() {
 				fakeOps.MaxAttempts = 2
-
+				secret := &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      managedResourceCentral.Name + "secret",
+						Namespace: namespace,
+					},
+					Data: map[string][]byte{
+						"foo": []byte("bar"),
+					},
+				}
+				Expect(c.Create(ctx, secret)).To(Succeed())
 				Expect(c.Create(ctx, &resourcesv1alpha1.ManagedResource{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:       managedResourceCentral.Name,
 						Namespace:  namespace,
 						Generation: 1,
+					},
+					Spec: resourcesv1alpha1.ManagedResourceSpec{
+						SecretRefs: []corev1.LocalObjectReference{{Name: secret.Name}},
 					},
 					Status: resourcesv1alpha1.ManagedResourceStatus{
 						ObservedGeneration: 1,
@@ -1194,6 +1235,7 @@ status: {}
 								Status: gardencorev1beta1.ConditionTrue,
 							},
 						},
+						SecretsDataChecksum: &expectedChecksum,
 					},
 				})).To(Succeed())
 
@@ -1222,11 +1264,24 @@ status: {}
 				for _, pool := range values.WorkerPools {
 					By(pool.Name)
 
+					secret := &corev1.Secret{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      managedResourceForPool(pool).Name + "secret",
+							Namespace: namespace,
+						},
+						Data: map[string][]byte{
+							"foo": []byte("bar"),
+						},
+					}
+					Expect(c.Create(ctx, secret)).To(Succeed())
 					Expect(c.Create(ctx, &resourcesv1alpha1.ManagedResource{
 						ObjectMeta: metav1.ObjectMeta{
 							Name:       managedResourceForPool(pool).Name,
 							Namespace:  namespace,
 							Generation: 1,
+						},
+						Spec: resourcesv1alpha1.ManagedResourceSpec{
+							SecretRefs: []corev1.LocalObjectReference{{Name: secret.Name}},
 						},
 						Status: resourcesv1alpha1.ManagedResourceStatus{
 							ObservedGeneration: 1,
@@ -1240,6 +1295,7 @@ status: {}
 									Status: gardencorev1beta1.ConditionTrue,
 								},
 							},
+							SecretsDataChecksum: &expectedChecksum,
 						},
 					})).To(Succeed())
 				}

--- a/pkg/component/kubernetesdashboard/kubernetes_dashboard_test.go
+++ b/pkg/component/kubernetesdashboard/kubernetes_dashboard_test.go
@@ -665,11 +665,25 @@ status: {}
 			It("should successfully wait for the managed resource to become healthy", func() {
 				fakeOps.MaxAttempts = 2
 
+				expectedChecksum := "fcde2b2edba56bf408601fb721fe9b5c338d10ee429ea04fae5511b68fbf8fb9"
+				secret := &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "secret1",
+						Namespace: namespace,
+					},
+					Data: map[string][]byte{
+						"foo": []byte("bar"),
+					},
+				}
+				Expect(c.Create(ctx, secret)).To(Succeed())
 				Expect(c.Create(ctx, &resourcesv1alpha1.ManagedResource{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:       managedResourceName,
 						Namespace:  namespace,
 						Generation: 1,
+					},
+					Spec: resourcesv1alpha1.ManagedResourceSpec{
+						SecretRefs: []corev1.LocalObjectReference{{Name: secret.Name}},
 					},
 					Status: resourcesv1alpha1.ManagedResourceStatus{
 						ObservedGeneration: 1,
@@ -683,6 +697,7 @@ status: {}
 								Status: gardencorev1beta1.ConditionTrue,
 							},
 						},
+						SecretsDataChecksum: &expectedChecksum,
 					},
 				})).To(Succeed())
 

--- a/pkg/component/kubestatemetrics/kube_state_metrics_test.go
+++ b/pkg/component/kubestatemetrics/kube_state_metrics_test.go
@@ -691,11 +691,25 @@ var _ = Describe("KubeStateMetrics", func() {
 				It("should successfully wait for the managed resource to become healthy", func() {
 					fakeOps.MaxAttempts = 2
 
+					expectedChecksum := "fcde2b2edba56bf408601fb721fe9b5c338d10ee429ea04fae5511b68fbf8fb9"
+					secret := &corev1.Secret{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "secret1",
+							Namespace: namespace,
+						},
+						Data: map[string][]byte{
+							"foo": []byte("bar"),
+						},
+					}
+					Expect(c.Create(ctx, secret)).To(Succeed())
 					Expect(c.Create(ctx, &resourcesv1alpha1.ManagedResource{
 						ObjectMeta: metav1.ObjectMeta{
 							Name:       managedResourceName,
 							Namespace:  namespace,
 							Generation: 1,
+						},
+						Spec: resourcesv1alpha1.ManagedResourceSpec{
+							SecretRefs: []corev1.LocalObjectReference{{Name: secret.Name}},
 						},
 						Status: resourcesv1alpha1.ManagedResourceStatus{
 							ObservedGeneration: 1,
@@ -709,6 +723,7 @@ var _ = Describe("KubeStateMetrics", func() {
 									Status: gardencorev1beta1.ConditionTrue,
 								},
 							},
+							SecretsDataChecksum: &expectedChecksum,
 						},
 					})).To(Succeed())
 

--- a/pkg/component/logging/fluentoperator/custom_resources_test.go
+++ b/pkg/component/logging/fluentoperator/custom_resources_test.go
@@ -186,11 +186,25 @@ var _ = Describe("Fluent Operator Custom Resources", func() {
 			It("should successfully wait for the managed resources to become healthy", func() {
 				fakeOps.MaxAttempts = 2
 
+				expectedChecksum := "fcde2b2edba56bf408601fb721fe9b5c338d10ee429ea04fae5511b68fbf8fb9"
+				secret := &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "secret1",
+						Namespace: namespace,
+					},
+					Data: map[string][]byte{
+						"foo": []byte("bar"),
+					},
+				}
+				Expect(c.Create(ctx, secret)).To(Succeed())
 				Expect(c.Create(ctx, &resourcesv1alpha1.ManagedResource{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:       customResourcesManagedResourceName,
 						Namespace:  namespace,
 						Generation: 1,
+					},
+					Spec: resourcesv1alpha1.ManagedResourceSpec{
+						SecretRefs: []corev1.LocalObjectReference{{Name: secret.Name}},
 					},
 					Status: resourcesv1alpha1.ManagedResourceStatus{
 						ObservedGeneration: 1,
@@ -204,6 +218,7 @@ var _ = Describe("Fluent Operator Custom Resources", func() {
 								Status: gardencorev1beta1.ConditionTrue,
 							},
 						},
+						SecretsDataChecksum: &expectedChecksum,
 					},
 				})).To(Succeed())
 

--- a/pkg/component/logging/fluentoperator/fluent_operator_test.go
+++ b/pkg/component/logging/fluentoperator/fluent_operator_test.go
@@ -425,11 +425,25 @@ var _ = Describe("Fluent Operator", func() {
 			It("should successfully wait for the managed resources to become healthy", func() {
 				fakeOps.MaxAttempts = 2
 
+				expectedChecksum := "fcde2b2edba56bf408601fb721fe9b5c338d10ee429ea04fae5511b68fbf8fb9"
+				secret := &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "secret1",
+						Namespace: namespace,
+					},
+					Data: map[string][]byte{
+						"foo": []byte("bar"),
+					},
+				}
+				Expect(c.Create(ctx, secret)).To(Succeed())
 				Expect(c.Create(ctx, &resourcesv1alpha1.ManagedResource{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:       operatorManagedResourceName,
 						Namespace:  namespace,
 						Generation: 1,
+					},
+					Spec: resourcesv1alpha1.ManagedResourceSpec{
+						SecretRefs: []corev1.LocalObjectReference{{Name: secret.Name}},
 					},
 					Status: resourcesv1alpha1.ManagedResourceStatus{
 						ObservedGeneration: 1,
@@ -443,6 +457,7 @@ var _ = Describe("Fluent Operator", func() {
 								Status: gardencorev1beta1.ConditionTrue,
 							},
 						},
+						SecretsDataChecksum: &expectedChecksum,
 					},
 				})).To(Succeed())
 

--- a/pkg/component/machinecontrollermanager/bootstrap_test.go
+++ b/pkg/component/machinecontrollermanager/bootstrap_test.go
@@ -203,11 +203,25 @@ rules:
 			It("should successfully wait for the managed resource to become healthy", func() {
 				fakeOps.MaxAttempts = 2
 
+				expectedChecksum := "fcde2b2edba56bf408601fb721fe9b5c338d10ee429ea04fae5511b68fbf8fb9"
+				secret := &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "secret1",
+						Namespace: namespace,
+					},
+					Data: map[string][]byte{
+						"foo": []byte("bar"),
+					},
+				}
+				Expect(fakeClient.Create(ctx, secret)).To(Succeed())
 				Expect(fakeClient.Create(ctx, &resourcesv1alpha1.ManagedResource{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:       managedResourceName,
 						Namespace:  namespace,
 						Generation: 1,
+					},
+					Spec: resourcesv1alpha1.ManagedResourceSpec{
+						SecretRefs: []corev1.LocalObjectReference{{Name: secret.Name}},
 					},
 					Status: resourcesv1alpha1.ManagedResourceStatus{
 						ObservedGeneration: 1,
@@ -221,6 +235,7 @@ rules:
 								Status: gardencorev1beta1.ConditionTrue,
 							},
 						},
+						SecretsDataChecksum: &expectedChecksum,
 					},
 				})).To(Succeed())
 

--- a/pkg/component/namespaces/namespaces_test.go
+++ b/pkg/component/namespaces/namespaces_test.go
@@ -247,11 +247,25 @@ status: {}
 			It("should successfully wait for the managed resource to become healthy", func() {
 				fakeOps.MaxAttempts = 2
 
+				expectedChecksum := "fcde2b2edba56bf408601fb721fe9b5c338d10ee429ea04fae5511b68fbf8fb9"
+				secret := &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "secret1",
+						Namespace: namespace,
+					},
+					Data: map[string][]byte{
+						"foo": []byte("bar"),
+					},
+				}
+				Expect(fakeClient.Create(ctx, secret)).To(Succeed())
 				Expect(fakeClient.Create(ctx, &resourcesv1alpha1.ManagedResource{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:       managedResourceName,
 						Namespace:  namespace,
 						Generation: 1,
+					},
+					Spec: resourcesv1alpha1.ManagedResourceSpec{
+						SecretRefs: []corev1.LocalObjectReference{{Name: secret.Name}},
 					},
 					Status: resourcesv1alpha1.ManagedResourceStatus{
 						ObservedGeneration: 1,
@@ -265,6 +279,7 @@ status: {}
 								Status: gardencorev1beta1.ConditionTrue,
 							},
 						},
+						SecretsDataChecksum: &expectedChecksum,
 					},
 				})).To(Succeed())
 

--- a/pkg/component/nginxingress/nginxingress_test.go
+++ b/pkg/component/nginxingress/nginxingress_test.go
@@ -716,11 +716,25 @@ status: {}
 			It("should successfully wait for the managed resource to become healthy", func() {
 				fakeOps.MaxAttempts = 2
 
+				expectedChecksum := "fcde2b2edba56bf408601fb721fe9b5c338d10ee429ea04fae5511b68fbf8fb9"
+				secret := &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "secret1",
+						Namespace: namespace,
+					},
+					Data: map[string][]byte{
+						"foo": []byte("bar"),
+					},
+				}
+				Expect(c.Create(ctx, secret)).To(Succeed())
 				Expect(c.Create(ctx, &resourcesv1alpha1.ManagedResource{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:       managedResourceName,
 						Namespace:  namespace,
 						Generation: 1,
+					},
+					Spec: resourcesv1alpha1.ManagedResourceSpec{
+						SecretRefs: []corev1.LocalObjectReference{{Name: secret.Name}},
 					},
 					Status: resourcesv1alpha1.ManagedResourceStatus{
 						ObservedGeneration: 1,
@@ -734,6 +748,7 @@ status: {}
 								Status: gardencorev1beta1.ConditionTrue,
 							},
 						},
+						SecretsDataChecksum: &expectedChecksum,
 					},
 				})).To(Succeed())
 				Expect(nginxIngress.Wait(ctx)).To(Succeed())

--- a/pkg/component/nginxingressshoot/nginxingress_test.go
+++ b/pkg/component/nginxingressshoot/nginxingress_test.go
@@ -809,11 +809,25 @@ status: {}
 			It("should successfully wait for the managed resource to become healthy", func() {
 				fakeOps.MaxAttempts = 2
 
+				expectedChecksum := "fcde2b2edba56bf408601fb721fe9b5c338d10ee429ea04fae5511b68fbf8fb9"
+				secret := &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "secret1",
+						Namespace: namespace,
+					},
+					Data: map[string][]byte{
+						"foo": []byte("bar"),
+					},
+				}
+				Expect(c.Create(ctx, secret)).To(Succeed())
 				Expect(c.Create(ctx, &resourcesv1alpha1.ManagedResource{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:       managedResourceName,
 						Namespace:  namespace,
 						Generation: 1,
+					},
+					Spec: resourcesv1alpha1.ManagedResourceSpec{
+						SecretRefs: []corev1.LocalObjectReference{{Name: secret.Name}},
 					},
 					Status: resourcesv1alpha1.ManagedResourceStatus{
 						ObservedGeneration: 1,
@@ -827,6 +841,7 @@ status: {}
 								Status: gardencorev1beta1.ConditionTrue,
 							},
 						},
+						SecretsDataChecksum: &expectedChecksum,
 					},
 				})).To(Succeed())
 

--- a/pkg/component/nodelocaldns/nodelocaldns_test.go
+++ b/pkg/component/nodelocaldns/nodelocaldns_test.go
@@ -1240,11 +1240,25 @@ ip6.arpa:53 {
 			It("should successfully wait for the managed resource to become healthy", func() {
 				fakeOps.MaxAttempts = 2
 
+				expectedChecksum := "fcde2b2edba56bf408601fb721fe9b5c338d10ee429ea04fae5511b68fbf8fb9"
+				secret := &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "secret1",
+						Namespace: namespace,
+					},
+					Data: map[string][]byte{
+						"foo": []byte("bar"),
+					},
+				}
+				Expect(c.Create(ctx, secret)).To(Succeed())
 				Expect(c.Create(ctx, &resourcesv1alpha1.ManagedResource{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:       managedResourceName,
 						Namespace:  namespace,
 						Generation: 1,
+					},
+					Spec: resourcesv1alpha1.ManagedResourceSpec{
+						SecretRefs: []corev1.LocalObjectReference{{Name: secret.Name}},
 					},
 					Status: resourcesv1alpha1.ManagedResourceStatus{
 						ObservedGeneration: 1,
@@ -1258,6 +1272,7 @@ ip6.arpa:53 {
 								Status: gardencorev1beta1.ConditionTrue,
 							},
 						},
+						SecretsDataChecksum: &expectedChecksum,
 					},
 				})).To(Succeed())
 

--- a/pkg/component/nodeproblemdetector/node_problem_detector_test.go
+++ b/pkg/component/nodeproblemdetector/node_problem_detector_test.go
@@ -506,11 +506,25 @@ status: {}
 			It("should successfully wait for the managed resource to become healthy", func() {
 				fakeOps.MaxAttempts = 2
 
+				expectedChecksum := "fcde2b2edba56bf408601fb721fe9b5c338d10ee429ea04fae5511b68fbf8fb9"
+				secret := &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "secret1",
+						Namespace: namespace,
+					},
+					Data: map[string][]byte{
+						"foo": []byte("bar"),
+					},
+				}
+				Expect(c.Create(ctx, secret)).To(Succeed())
 				Expect(c.Create(ctx, &resourcesv1alpha1.ManagedResource{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:       managedResourceName,
 						Namespace:  namespace,
 						Generation: 1,
+					},
+					Spec: resourcesv1alpha1.ManagedResourceSpec{
+						SecretRefs: []corev1.LocalObjectReference{{Name: secret.Name}},
 					},
 					Status: resourcesv1alpha1.ManagedResourceStatus{
 						ObservedGeneration: 1,
@@ -524,6 +538,7 @@ status: {}
 								Status: gardencorev1beta1.ConditionTrue,
 							},
 						},
+						SecretsDataChecksum: &expectedChecksum,
 					},
 				})).To(Succeed())
 

--- a/pkg/component/seedsystem/seedsystem_test.go
+++ b/pkg/component/seedsystem/seedsystem_test.go
@@ -220,11 +220,25 @@ status: {}
 			It("should successfully wait for the managed resource to become healthy", func() {
 				fakeOps.MaxAttempts = 2
 
+				expectedChecksum := "fcde2b2edba56bf408601fb721fe9b5c338d10ee429ea04fae5511b68fbf8fb9"
+				secret := &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "secret1",
+						Namespace: namespace,
+					},
+					Data: map[string][]byte{
+						"foo": []byte("bar"),
+					},
+				}
+				Expect(c.Create(ctx, secret)).To(Succeed())
 				Expect(c.Create(ctx, &resourcesv1alpha1.ManagedResource{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:       managedResourceName,
 						Namespace:  namespace,
 						Generation: 1,
+					},
+					Spec: resourcesv1alpha1.ManagedResourceSpec{
+						SecretRefs: []corev1.LocalObjectReference{{Name: secret.Name}},
 					},
 					Status: resourcesv1alpha1.ManagedResourceStatus{
 						ObservedGeneration: 1,
@@ -238,6 +252,7 @@ status: {}
 								Status: gardencorev1beta1.ConditionTrue,
 							},
 						},
+						SecretsDataChecksum: &expectedChecksum,
 					},
 				})).To(Succeed())
 

--- a/pkg/component/shootsystem/shootsystem_test.go
+++ b/pkg/component/shootsystem/shootsystem_test.go
@@ -491,11 +491,25 @@ status: {}
 			It("should successfully wait for the managed resource to become healthy", func() {
 				fakeOps.MaxAttempts = 2
 
+				expectedChecksum := "fcde2b2edba56bf408601fb721fe9b5c338d10ee429ea04fae5511b68fbf8fb9"
+				secret := &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "secret1",
+						Namespace: namespace,
+					},
+					Data: map[string][]byte{
+						"foo": []byte("bar"),
+					},
+				}
+				Expect(c.Create(ctx, secret)).To(Succeed())
 				Expect(c.Create(ctx, &resourcesv1alpha1.ManagedResource{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:       managedResourceName,
 						Namespace:  namespace,
 						Generation: 1,
+					},
+					Spec: resourcesv1alpha1.ManagedResourceSpec{
+						SecretRefs: []corev1.LocalObjectReference{{Name: secret.Name}},
 					},
 					Status: resourcesv1alpha1.ManagedResourceStatus{
 						ObservedGeneration: 1,
@@ -509,6 +523,7 @@ status: {}
 								Status: gardencorev1beta1.ConditionTrue,
 							},
 						},
+						SecretsDataChecksum: &expectedChecksum,
 					},
 				})).To(Succeed())
 

--- a/pkg/component/vpa/vpa_test.go
+++ b/pkg/component/vpa/vpa_test.go
@@ -1762,11 +1762,25 @@ var _ = Describe("VPA", func() {
 				It("should successfully wait for the managed resource to become healthy", func() {
 					fakeOps.MaxAttempts = 2
 
+					expectedChecksum := "fcde2b2edba56bf408601fb721fe9b5c338d10ee429ea04fae5511b68fbf8fb9"
+					secret := &corev1.Secret{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "secret1",
+							Namespace: namespace,
+						},
+						Data: map[string][]byte{
+							"foo": []byte("bar"),
+						},
+					}
+					Expect(c.Create(ctx, secret)).To(Succeed())
 					Expect(c.Create(ctx, &resourcesv1alpha1.ManagedResource{
 						ObjectMeta: metav1.ObjectMeta{
 							Name:       managedResourceName,
 							Namespace:  namespace,
 							Generation: 1,
+						},
+						Spec: resourcesv1alpha1.ManagedResourceSpec{
+							SecretRefs: []corev1.LocalObjectReference{{Name: secret.Name}},
 						},
 						Status: resourcesv1alpha1.ManagedResourceStatus{
 							ObservedGeneration: 1,
@@ -1780,6 +1794,7 @@ var _ = Describe("VPA", func() {
 									Status: gardencorev1beta1.ConditionTrue,
 								},
 							},
+							SecretsDataChecksum: &expectedChecksum,
 						},
 					})).To(Succeed())
 

--- a/pkg/component/vpnshoot/vpnshoot_test.go
+++ b/pkg/component/vpnshoot/vpnshoot_test.go
@@ -890,11 +890,25 @@ status: {}
 			It("should successfully wait for the managed resource to become healthy", func() {
 				fakeOps.MaxAttempts = 2
 
+				expectedChecksum := "fcde2b2edba56bf408601fb721fe9b5c338d10ee429ea04fae5511b68fbf8fb9"
+				secret := &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "secret1",
+						Namespace: namespace,
+					},
+					Data: map[string][]byte{
+						"foo": []byte("bar"),
+					},
+				}
+				Expect(c.Create(ctx, secret)).To(Succeed())
 				Expect(c.Create(ctx, &resourcesv1alpha1.ManagedResource{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:       managedResourceName,
 						Namespace:  namespace,
 						Generation: 1,
+					},
+					Spec: resourcesv1alpha1.ManagedResourceSpec{
+						SecretRefs: []corev1.LocalObjectReference{{Name: secret.Name}},
 					},
 					Status: resourcesv1alpha1.ManagedResourceStatus{
 						ObservedGeneration: 1,
@@ -908,6 +922,7 @@ status: {}
 								Status: gardencorev1beta1.ConditionTrue,
 							},
 						},
+						SecretsDataChecksum: &expectedChecksum,
 					},
 				})).To(Succeed())
 				Expect(vpnShoot.Wait(ctx)).To(Succeed())

--- a/pkg/utils/kubernetes/health/managedresource.go
+++ b/pkg/utils/kubernetes/health/managedresource.go
@@ -49,10 +49,10 @@ func CheckManagedResourceApplied(mr *resourcesv1alpha1.ManagedResource, expected
 	if *status.SecretsDataChecksum != expectedSecretsDataChecksum {
 		return fmt.Errorf(
 			"observed secrets data checksum for managed resource %s/%s is outdated - expected: %s actual: %s",
-			expectedSecretsDataChecksum,
-			*status.SecretsDataChecksum,
 			mr.GetNamespace(),
 			mr.GetName(),
+			expectedSecretsDataChecksum,
+			*status.SecretsDataChecksum,
 		)
 	}
 

--- a/skaffold-operator.yaml
+++ b/skaffold-operator.yaml
@@ -223,12 +223,16 @@ build:
         - pkg/resourcemanager/webhook/systemcomponentsconfig
         - pkg/resourcemanager/webhook/tokeninvalidator
         - pkg/utils
+        - pkg/utils/chart
         - pkg/utils/context
         - pkg/utils/errors
         - pkg/utils/flow
         - pkg/utils/gardener
+        - pkg/utils/imagevector
         - pkg/utils/kubernetes
         - pkg/utils/kubernetes/health
+        - pkg/utils/managedresources
+        - pkg/utils/managedresources/builder
         - pkg/utils/retry
         - pkg/utils/secrets
         - pkg/utils/timewindow

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -1043,12 +1043,16 @@ build:
         - pkg/resourcemanager/webhook/systemcomponentsconfig
         - pkg/resourcemanager/webhook/tokeninvalidator
         - pkg/utils
+        - pkg/utils/chart
         - pkg/utils/context
         - pkg/utils/errors
         - pkg/utils/flow
         - pkg/utils/gardener
+        - pkg/utils/imagevector
         - pkg/utils/kubernetes
         - pkg/utils/kubernetes/health
+        - pkg/utils/managedresources
+        - pkg/utils/managedresources/builder
         - pkg/utils/retry
         - pkg/utils/secrets
         - pkg/utils/timewindow


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality robustness
/kind enhancement

**What this PR does / why we need it**:
Similar to #7906. This PR aims to improve the health check condition for the managed resources. Right now if we change the underlying secret of a `managedresource` and we call `WaitUntilHealthy` the function might immediately return since all conditions are met even though the later function calls `CheckManagedResourceApplied`. `CheckManagedResourceApplied` checks the generation of the `managedresource` which does not change when an underlying secret is updated. This PR adds an additional check in the form of a checksum which has to be passed when waiting for a `managedresource` to become healthy. This checksum is also reported in the status of the `managedresource` by the MR controller.

cc @timuthy 
 
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking developer
Functions `pkg/utils/kubernetes/health.CheckManagedResource{Applied}` now require an additional argument `expectedSecretsDataChecksum` in order to ensure that the managed resource has its latest version applied. This checksum can be computed by calling `pkg/utils/managedresources.ComputeExpectedSecretsDataChecksum`.
```

```feature operator
The health check for `managedresources` was enhanced in order to guarantee that the latest version of the managed resource is observed.
```