### PR TITLE
Drop Kubernetes version support timeline docs

### DIFF
--- a/docs/usage/supported_k8s_versions.md
+++ b/docs/usage/supported_k8s_versions.md
@@ -17,30 +17,3 @@ However, the concrete versions that can be used for shoot clusters depend on the
 Consequently, please consult the documentation of your provider extension to see which Kubernetes versions are supported for shoot clusters.
 
 > 👨🏼‍💻 Developers note: The [Adding Support For a New Kubernetes Version](../development/new-kubernetes-version.md) topic explains what needs to be done in order to add support for a new Kubernetes version.
-
-## Support Timeline
-
-The Kubernetes project maintains the most recent three minor releases and releases a new minor version every 4 months.
-This means that a release has patch support for approximately 1 year.
-See the official [Releases](https://kubernetes.io/releases/) topic for the official upstream information.
-
-In the past, the Gardener project did not have a policy regarding the number of supported Kubernetes versions at the same time.
-Beginning with 2023, a new policy has been introduced:
-
-> The Gardener project supports the last four Kubernetes minor versions and drops support for the oldest minor version as soon as support for a new minor version has been introduced.
-
-| Kubernetes Version | End of Life | Supported Since | Support Dropped After         |
-|--------------------|-------------|-----------------|-------------------------------|
-| 1.20               | 2022-02-28  | v1.15.0         | 2023-01-31                    |
-| 1.21               | 2022-06-28  | v1.21.0         | 2023-02-28                    |
-| 1.22               | 2022-10-28  | v1.31.0         | 2023-04-30                    |
-| 1.23               | 2023-02-28  | v1.39.0         | 1.27 is supported (> 2023-04) |
-| 1.24               | 2023-07-28  | v1.48.0         | 1.28 is supported (> 2023-08) |
-| 1.25               | 2023-10-28  | v1.56.0         | 1.29 is supported (> 2023-12) |
-| 1.26               | 2024-02-28  | v1.63.0         | 1.30 is supported (> 2024-04) |
-
-The three versions 1.20, 1.21, 1.22 (which all are officially out of maintenance already) are handled specially to allow users to adapt to this new policy.
-Beginning with 1.23, the support of the oldest version is dropped after the support of a new version was introduced.
-
-> ⚠️ Note that this guideline only concerns the code of `gardener/gardener` and is not related to the versions offered in `CloudProfile`s.
-> It is recommended to always only offer the last three minor versions with `supported` classification in `CloudProfile`s and deprecate the oldest version with an expiration date before a new minor Kubernetes version is released.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area documentation
/kind cleanup

**What this PR does / why we need it**:
Due to too many boundary conditions, the support timeline docs for Kubernetes versions have been dropped.

**Special notes for your reviewer**:
/cc @dguendisch @ialidzhikov 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
