### PR TITLE
Include signing CA certificate in `kube-apiserver`'s certificate chain

### DIFF
--- a/pkg/component/kubeapiserver/secrets.go
+++ b/pkg/component/kubeapiserver/secrets.go
@@ -273,12 +273,13 @@ func (k *kubeAPIServer) reconcileSecretServer(ctx context.Context) (*corev1.Secr
 	}
 
 	return k.secretsManager.Generate(ctx, &secretsutils.CertificateSecretConfig{
-		Name:                        secretNameServer,
-		CommonName:                  deploymentName,
-		IPAddresses:                 append(ipAddresses, k.values.ServerCertificate.ExtraIPAddresses...),
-		DNSNames:                    append(dnsNames, k.values.ServerCertificate.ExtraDNSNames...),
-		CertType:                    secretsutils.ServerCert,
-		SkipPublishingCACertificate: true,
+		Name:                              secretNameServer,
+		CommonName:                        deploymentName,
+		IPAddresses:                       append(ipAddresses, k.values.ServerCertificate.ExtraIPAddresses...),
+		DNSNames:                          append(dnsNames, k.values.ServerCertificate.ExtraDNSNames...),
+		CertType:                          secretsutils.ServerCert,
+		SkipPublishingCACertificate:       true,
+		IncludeCACertificateInServerChain: true,
 	}, secretsmanager.SignedByCA(v1beta1constants.SecretNameCACluster), secretsmanager.Rotate(secretsmanager.InPlace))
 }
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind enhancement

**What this PR does / why we need it**:
With this PR, the certificate chain of `kube-apiserver` not only includes its server certificate but also the CA certificate used to sign it.

**Which issue(s) this PR fixes**:
Fixes #7905

**Special notes for your reviewer**:
/cc @dimityrmirchev 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
The certificate chains served by `kube-apiserver`s does now include the CA certificates used to sign their server certificates.
```
