### PR TITLE
Minor nits in the `provider-extensions` setup

### DIFF
--- a/example/provider-extensions/seed/configure-seed.sh
+++ b/example/provider-extensions/seed/configure-seed.sh
@@ -106,7 +106,7 @@ ensure-config-file "$REPO_ROOT_DIR"/example/provider-extensions/garden/project/c
 ensure-config-file "$REPO_ROOT_DIR"/example/provider-extensions/"$gardenlet_values" "$REPO_ROOT_DIR"/example/provider-extensions/gardenlet/values.yaml.tmpl
 
 echo "Check if essential config options are initialized"
-check-not-initial "$SCRIPT_DIR"/kubeconfig ""
+check-not-initial $seed_kubeconfig ""
 check-not-initial "$REPO_ROOT_DIR"/example/provider-extensions/garden/controlplane/values.yaml ".global.internalDomain.domain"
 check-not-initial "$REPO_ROOT_DIR"/example/provider-extensions/garden/controlplane/values.yaml ".global.internalDomain.provider"
 

--- a/example/provider-extensions/seed/create-seed.sh
+++ b/example/provider-extensions/seed/create-seed.sh
@@ -22,7 +22,7 @@ usage() {
   echo "Usage:"
   echo "> create-seed.sh [ -h | <garden-kubeconfig> <seed-kubeconfig> <seed-name> ]"
   echo
-  echo ">> For example: create-seed.sh ~/.kube/garden-kubeconfig.yaml ~/.kube/kubeconfig.yaml"
+  echo ">> For example: create-seed.sh ~/.kube/garden-kubeconfig.yaml ~/.kube/kubeconfig.yaml seed-local"
 
   exit 0
 }

--- a/pkg/operator/controller/garden/garden_suite_test.go
+++ b/pkg/operator/controller/garden/garden_suite_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package garden
+package garden_test
 
 import (
 	"testing"


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability dev-productivity
/kind bug

**What this PR does / why we need it**:
The check for the initial configuration was looking for the kubeconfig in `"$SCRIPT_DIR"/kubeconfig`, but in the case where we mention a custom seed name, it will be `kubeconfig-<seed-name>`.
 Example for calling `create-seed.sh` script is updated with an example seed name.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
