### PR TITLE
Reconcile `networkpolicy`s on `Update` events of `Garden`

### DIFF
--- a/pkg/operator/controller/networkpolicyregistrar/add.go
+++ b/pkg/operator/controller/networkpolicyregistrar/add.go
@@ -35,7 +35,7 @@ func (r *Reconciler) AddToManager(mgr manager.Manager) error {
 	return builder.
 		ControllerManagedBy(mgr).
 		Named(ControllerName).
-		For(&operatorv1alpha1.Garden{}, builder.WithPredicates(predicateutils.ForEventTypes(predicateutils.Create))).
+		For(&operatorv1alpha1.Garden{}, builder.WithPredicates(predicateutils.ForEventTypes(predicateutils.Create, predicateutils.Update))).
 		WithOptions(controller.Options{
 			MaxConcurrentReconciles: 1,
 		}).


### PR DESCRIPTION
Co-Authored-By: Sonu Kumar Singh [sonu.kumar.singh02@sap.com](mailto:sonu.kumar.singh02@sap.com)

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug

**What this PR does / why we need it**:
The reconciler was getting added to the controller only on `Create` events of `Garden`. The networking values from the Garden resource is also passed here, https://github.com/gardener/gardener/blob/4a9a3ee4e48655ffe674dd5907d5d55ebfd37c72/pkg/operator/controller/networkpolicyregistrar/reconciler.go#L56-L67
But when the networking spec is updated, this is not passed down to the reconciler. This PR calls the reconciler adding logic also on `Update` events of `Garden` so that the values of networking are populated properly.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
NONE
```
