### PR TITLE
Improve accuracy of local control plane migration e2e tests

### DIFF
--- a/extensions/pkg/controller/worker/genericactuator/actuator_restore.go
+++ b/extensions/pkg/controller/worker/genericactuator/actuator_restore.go
@@ -58,15 +58,15 @@ func (a *genericActuator) Restore(ctx context.Context, log logr.Logger, worker *
 	// Parse the worker state to a separate machineDeployment states and attach them to
 	// the corresponding machineDeployments which are to be deployed later
 	log.Info("Extracting state from worker status")
-	if err := a.addStateToMachineDeployment(worker, wantedMachineDeployments); err != nil {
+	if err := addStateToMachineDeployment(worker, wantedMachineDeployments); err != nil {
 		return err
 	}
 
 	wantedMachineDeployments = removeWantedDeploymentWithoutState(wantedMachineDeployments)
 
 	// Scale the machine-controller-manager to 0. During restoration MCM must not be working
-	if err := a.scaleMachineControllerManager(ctx, log, worker, 0); err != nil {
-		return fmt.Errorf("failed scale down machine-controller-manager: %w", err)
+	if err := scaleMachineControllerManager(ctx, log, cl, worker, 0); err != nil {
+		return fmt.Errorf("failed to scale down machine-controller-manager: %w", err)
 	}
 
 	// Deploy generated machine classes.
@@ -74,17 +74,17 @@ func (a *genericActuator) Restore(ctx context.Context, log logr.Logger, worker *
 		return fmt.Errorf("failed to deploy the machine classes: %w", err)
 	}
 
-	if err := kubernetes.WaitUntilDeploymentScaledToDesiredReplicas(ctx, a.client, kubernetesutils.Key(worker.Namespace, McmDeploymentName), 0); err != nil && !apierrors.IsNotFound(err) {
+	if err := kubernetes.WaitUntilDeploymentScaledToDesiredReplicas(ctx, cl, kubernetesutils.Key(worker.Namespace, McmDeploymentName), 0); err != nil && !apierrors.IsNotFound(err) {
 		return fmt.Errorf("deadline exceeded while scaling down machine-controller-manager: %w", err)
 	}
 
 	// Do the actual restoration
-	if err := a.restoreMachineSetsAndMachines(ctx, log, wantedMachineDeployments); err != nil {
+	if err := restoreMachineSetsAndMachines(ctx, log, cl, wantedMachineDeployments); err != nil {
 		return fmt.Errorf("failed restoration of the machineSet and the machines: %w", err)
 	}
 
 	// Generate machine deployment configuration based on previously computed list of deployments and deploy them.
-	if err := a.deployMachineDeployments(ctx, log, cluster, worker, existingMachineDeployments, wantedMachineDeployments, workerDelegate.MachineClassKind(), true); err != nil {
+	if err := deployMachineDeployments(ctx, log, cl, cluster, worker, existingMachineDeployments, wantedMachineDeployments, workerDelegate.MachineClassKind(), true); err != nil {
 		return fmt.Errorf("failed to restore the machine deployment config: %w", err)
 	}
 
@@ -93,7 +93,7 @@ func (a *genericActuator) Restore(ctx context.Context, log logr.Logger, worker *
 	return a.Reconcile(ctx, log, worker, cluster)
 }
 
-func (a *genericActuator) addStateToMachineDeployment(worker *extensionsv1alpha1.Worker, wantedMachineDeployments extensionsworkercontroller.MachineDeployments) error {
+func addStateToMachineDeployment(worker *extensionsv1alpha1.Worker, wantedMachineDeployments extensionsworkercontroller.MachineDeployments) error {
 	if worker.Status.State == nil || len(worker.Status.State.Raw) <= 0 {
 		return nil
 	}
@@ -115,17 +115,17 @@ func (a *genericActuator) addStateToMachineDeployment(worker *extensionsv1alpha1
 	return nil
 }
 
-func (a *genericActuator) restoreMachineSetsAndMachines(ctx context.Context, log logr.Logger, wantedMachineDeployments extensionsworkercontroller.MachineDeployments) error {
+func restoreMachineSetsAndMachines(ctx context.Context, log logr.Logger, cl client.Client, wantedMachineDeployments extensionsworkercontroller.MachineDeployments) error {
 	log.Info("Deploying Machines and MachineSets")
 	for _, wantedMachineDeployment := range wantedMachineDeployments {
 		for _, machineSet := range wantedMachineDeployment.State.MachineSets {
-			if err := a.client.Create(ctx, &machineSet); client.IgnoreAlreadyExists(err) != nil {
+			if err := cl.Create(ctx, &machineSet); client.IgnoreAlreadyExists(err) != nil {
 				return err
 			}
 		}
 
 		for _, machine := range wantedMachineDeployment.State.Machines {
-			if err := a.client.Create(ctx, &machine); err != nil {
+			if err := cl.Create(ctx, &machine); err != nil {
 				if !apierrors.IsAlreadyExists(err) {
 					return err
 				}

--- a/extensions/pkg/controller/worker/genericactuator/actuator_test.go
+++ b/extensions/pkg/controller/worker/genericactuator/actuator_test.go
@@ -299,7 +299,7 @@ var _ = Describe("Actuator", func() {
 			mockClient.EXPECT().Create(ctx, &expectedMachine1)
 			mockClient.EXPECT().Create(ctx, &expectedMachine2)
 
-			Expect(a.restoreMachineSetsAndMachines(ctx, logger, machineDeployments)).To(Succeed())
+			Expect(restoreMachineSetsAndMachines(ctx, logger, a.client, machineDeployments)).To(Succeed())
 		})
 
 		It("should not return error if machineset and machines already exist", func() {
@@ -307,7 +307,7 @@ var _ = Describe("Actuator", func() {
 			mockClient.EXPECT().Create(ctx, &expectedMachine1).Return(alreadyExistsError)
 			mockClient.EXPECT().Create(ctx, &expectedMachine2).Return(alreadyExistsError)
 
-			Expect(a.restoreMachineSetsAndMachines(ctx, logger, machineDeployments)).To(Succeed())
+			Expect(restoreMachineSetsAndMachines(ctx, logger, a.client, machineDeployments)).To(Succeed())
 		})
 	})
 })

--- a/extensions/pkg/controller/worker/genericactuator/machine_controller_manager.go
+++ b/extensions/pkg/controller/worker/genericactuator/machine_controller_manager.go
@@ -118,9 +118,9 @@ func (a *genericActuator) waitUntilMachineControllerManagerIsDeleted(ctx context
 	}, ctx.Done())
 }
 
-func (a *genericActuator) scaleMachineControllerManager(ctx context.Context, logger logr.Logger, worker *extensionsv1alpha1.Worker, replicas int32) error {
+func scaleMachineControllerManager(ctx context.Context, logger logr.Logger, cl client.Client, worker *extensionsv1alpha1.Worker, replicas int32) error {
 	logger.Info("Scaling machine-controller-manager", "replicas", replicas)
-	return client.IgnoreNotFound(kubernetes.ScaleDeployment(ctx, a.client, kubernetesutils.Key(worker.Namespace, McmDeploymentName), replicas))
+	return client.IgnoreNotFound(kubernetes.ScaleDeployment(ctx, cl, kubernetesutils.Key(worker.Namespace, McmDeploymentName), replicas))
 }
 
 func (a *genericActuator) applyMachineControllerManagerShootChart(ctx context.Context, workerDelegate WorkerDelegate, workerObj *extensionsv1alpha1.Worker, cluster *controller.Cluster) error {

--- a/pkg/provider-local/controller/worker/actuator.go
+++ b/pkg/provider-local/controller/worker/actuator.go
@@ -86,14 +86,14 @@ func (a *actuator) Restore(ctx context.Context, log logr.Logger, worker *extensi
 	// automatically recreate new Machines now, which in fact will result in new pods and nodes.
 	// In summary, we are still not simulating the very same CPM scenario as for real clouds (here, the nodes/VMs are
 	// external and remain during the migration), but this is as good as we can get for the local scenario.
-	if err := a.deleteNoLongerMachines(ctx, log, worker.Namespace); err != nil {
+	if err := a.deleteNoLongerNeededMachines(ctx, log, worker.Namespace); err != nil {
 		return fmt.Errorf("failed deleting no longer existing machines after restoration: %w", err)
 	}
 
 	return a.Actuator.Reconcile(ctx, log, worker, cluster)
 }
 
-func (a *actuator) deleteNoLongerMachines(ctx context.Context, log logr.Logger, namespace string) error {
+func (a *actuator) deleteNoLongerNeededMachines(ctx context.Context, log logr.Logger, namespace string) error {
 	_, shootClient, err := util.NewClientForShoot(ctx, a.workerDelegate.Client(), namespace, client.Options{}, extensionsconfig.RESTOptions{})
 	if err != nil {
 		return fmt.Errorf("failed creating client for shoot cluster: %w", err)

--- a/pkg/provider-local/controller/worker/actuator.go
+++ b/pkg/provider-local/controller/worker/actuator.go
@@ -17,11 +17,17 @@ package worker
 import (
 	"context"
 	"fmt"
+	"strings"
 
+	machinev1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
 	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/runtime/inject"
 
+	extensionsconfig "github.com/gardener/gardener/extensions/pkg/apis/config"
 	extensionscontroller "github.com/gardener/gardener/extensions/pkg/controller"
 	"github.com/gardener/gardener/extensions/pkg/controller/common"
 	"github.com/gardener/gardener/extensions/pkg/controller/worker"
@@ -41,21 +47,23 @@ type delegateFactory struct {
 
 type actuator struct {
 	worker.Actuator
+	workerDelegate *delegateFactory
 }
 
 // NewActuator creates a new Actuator that updates the status of the handled WorkerPoolConfigs.
 func NewActuator() worker.Actuator {
-	delegateFactory := &delegateFactory{}
+	workerDelegate := &delegateFactory{}
 
 	return &actuator{
-		genericactuator.NewActuator(
-			delegateFactory,
+		Actuator: genericactuator.NewActuator(
+			workerDelegate,
 			local.MachineControllerManagerName,
 			mcmChart,
 			mcmShootChart,
 			imagevector.ImageVector(),
 			extensionscontroller.ChartRendererFactoryFunc(util.NewChartRendererForShoot),
 		),
+		workerDelegate: workerDelegate,
 	}
 }
 
@@ -68,7 +76,62 @@ func (a *actuator) Restore(ctx context.Context, log logr.Logger, worker *extensi
 		return fmt.Errorf("failed restoring the worker state: %w", err)
 	}
 
+	// At this point, the generic actuator has restored all Machine objects into the shoot namespace of the new
+	// destination seed. However, in the local scenario, the shoot worker nodes are not really external machines but
+	// "internal" pods running next to the control plane in the seed.
+	// Since the pods cannot be migrated from the source seed to the destination seed, the shoot worker node pods cannot
+	// be restored. Instead, they have to be recreated.
+	// In order to trigger this recreation, we are deleting all (restored) machines which are no longer backed by any
+	// pods now. We also delete the corresponding Node objects in the shoot. The MCM's MachineSet controller will
+	// automatically recreate new Machines now, which in fact will result in new pods and nodes.
+	// In summary, we are still not simulating the very same CPM scenario as for real clouds (here, the nodes/VMs are
+	// external and remain during the migration), but this is as good as we can get for the local scenario.
+	if err := a.deleteNoLongerMachines(ctx, log, worker.Namespace); err != nil {
+		return fmt.Errorf("failed deleting no longer existing machines after restoration: %w", err)
+	}
+
 	return a.Actuator.Reconcile(ctx, log, worker, cluster)
+}
+
+func (a *actuator) deleteNoLongerMachines(ctx context.Context, log logr.Logger, namespace string) error {
+	_, shootClient, err := util.NewClientForShoot(ctx, a.workerDelegate.Client(), namespace, client.Options{}, extensionsconfig.RESTOptions{})
+	if err != nil {
+		return fmt.Errorf("failed creating client for shoot cluster: %w", err)
+	}
+
+	machineList := &machinev1alpha1.MachineList{}
+	if err := a.workerDelegate.Client().List(ctx, machineList, client.InNamespace(namespace)); err != nil {
+		return fmt.Errorf("failed listing machines: %w", err)
+	}
+
+	podList := &corev1.PodList{}
+	if err := a.workerDelegate.Client().List(ctx, podList, client.InNamespace(namespace), client.MatchingLabels{"app": "machine"}); err != nil {
+		return fmt.Errorf("failed listing pods: %w", err)
+	}
+
+	machineNameToPodName := make(map[string]string)
+	for _, pod := range podList.Items {
+		machineNameToPodName[strings.TrimPrefix(pod.Name, "machine-")] = pod.Name
+	}
+
+	for _, machine := range machineList.Items {
+		if _, ok := machineNameToPodName[machine.Name]; ok {
+			continue
+		}
+
+		log.Info("Deleting machine since it is not backed by any pod", "machine", client.ObjectKeyFromObject(machine.DeepCopy()))
+
+		nodeName := "machine-" + machine.Name
+		if err := shootClient.Delete(ctx, &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: nodeName}}); client.IgnoreNotFound(err) != nil {
+			return fmt.Errorf("failed deleting node %q for machine %q: %w", nodeName, machine.Name, err)
+		}
+
+		if err := a.workerDelegate.Client().Delete(ctx, machine.DeepCopy()); err != nil {
+			return fmt.Errorf("failed deleting machine %q: %w", machine.Name, err)
+		}
+	}
+
+	return nil
 }
 
 func (d *delegateFactory) WorkerDelegate(_ context.Context, worker *extensionsv1alpha1.Worker, cluster *extensionscontroller.Cluster) (genericactuator.WorkerDelegate, error) {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
When performing control plane migration with `provider-local`, the full migration and restoration logic implemented in the extensions library (generic `Worker` actuator) is now executed (previously, it was skipped). This improves the accuracy of the e2e tests for control plane migration.

**Which issue(s) this PR fixes**:
Introduced with https://github.com/gardener/gardener/pull/6059

**Special notes for your reviewer**:
/cc @plkokanov 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature developer
When performing control plane migration with `provider-local`, the full migration and restoration logic implemented in the extensions library (generic `Worker` actuator) is now executed (previously, it was skipped). This improves the accuracy of the e2e tests for control plane migration.
```
