### PR TITLE
Add the `networkpolicy` reconciler only if the `.spec.runtimeCluster.networking.{pods,services}` fields are set

### DIFF
--- a/pkg/operator/controller/networkpolicyregistrar/add.go
+++ b/pkg/operator/controller/networkpolicyregistrar/add.go
@@ -46,6 +46,7 @@ func (r *Reconciler) AddToManager(mgr manager.Manager) error {
 
 // NetworkingPredicate returns true for Create and Update events if the
 // garden.Spec.RuntimeCluster.Networking.{Pods,Services} fields are not empty
+// TODO(shafeeqes): Remove this predicate in v1.75
 func NetworkingPredicate() predicate.Predicate {
 	return predicate.Funcs{
 		CreateFunc: func(e event.CreateEvent) bool {

--- a/pkg/operator/controller/networkpolicyregistrar/add.go
+++ b/pkg/operator/controller/networkpolicyregistrar/add.go
@@ -44,6 +44,8 @@ func (r *Reconciler) AddToManager(mgr manager.Manager) error {
 		Complete(r)
 }
 
+// NetworkingPredicate returns true for Create and Update events if the
+// garden.Spec.RuntimeCluster.Networking.{Pods,Services} fields are not empty
 func NetworkingPredicate() predicate.Predicate {
 	return predicate.Funcs{
 		CreateFunc: func(e event.CreateEvent) bool {

--- a/pkg/operator/controller/networkpolicyregistrar/add_test.go
+++ b/pkg/operator/controller/networkpolicyregistrar/add_test.go
@@ -1,0 +1,119 @@
+// Copyright 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package networkpolicyregistrar_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	operatorv1alpha1 "github.com/gardener/gardener/pkg/apis/operator/v1alpha1"
+	. "github.com/gardener/gardener/pkg/operator/controller/networkpolicyregistrar"
+)
+
+var _ = Describe("Add", func() {
+	Describe("#Garden Predicate", func() {
+		var (
+			p      predicate.Predicate
+			garden *operatorv1alpha1.Garden
+		)
+
+		BeforeEach(func() {
+			p = NetworkingPredicate()
+			garden = &operatorv1alpha1.Garden{
+				Spec: operatorv1alpha1.GardenSpec{
+					RuntimeCluster: operatorv1alpha1.RuntimeCluster{
+						Networking: operatorv1alpha1.RuntimeNetworking{
+							Pods:     "10.1.0.0/16",
+							Services: "10.2.0.0/16"},
+					},
+				},
+			}
+		})
+
+		Describe("#Create", func() {
+			It("should return false because spec.runtimeCluster.networking.pods is empty", func() {
+				garden.Spec.RuntimeCluster.Networking.Pods = ""
+
+				Expect(p.Create(event.CreateEvent{Object: garden})).To(BeFalse())
+			})
+
+			It("should return false because spec.runtimeCluster.networking.services is empty", func() {
+				garden.Spec.RuntimeCluster.Networking.Services = ""
+
+				Expect(p.Create(event.CreateEvent{Object: garden})).To(BeFalse())
+			})
+
+			It("should return true because both spec.runtimeCluster.networking.{pods, services} are present", func() {
+				Expect(p.Create(event.CreateEvent{Object: garden})).To(BeTrue())
+			})
+		})
+
+		Describe("#Update", func() {
+			It("should return false because spec.runtimeCluster.networking.pods is empty", func() {
+				garden.Spec.RuntimeCluster.Networking.Pods = ""
+
+				Expect(p.Update(event.UpdateEvent{ObjectNew: garden})).To(BeFalse())
+			})
+
+			It("should return false because spec.runtimeCluster.networking.services is empty", func() {
+				garden.Spec.RuntimeCluster.Networking.Services = ""
+
+				Expect(p.Update(event.UpdateEvent{ObjectNew: garden})).To(BeFalse())
+			})
+
+			It("should return true because both spec.runtimeCluster.networking.{pods, services} are present", func() {
+				Expect(p.Update(event.UpdateEvent{ObjectNew: garden})).To(BeTrue())
+			})
+		})
+
+		Describe("#Delete", func() {
+			It("should return false because spec.runtimeCluster.networking.pods is empty", func() {
+				garden.Spec.RuntimeCluster.Networking.Pods = ""
+
+				Expect(p.Delete(event.DeleteEvent{Object: garden})).To(BeFalse())
+			})
+
+			It("should return false because spec.runtimeCluster.networking.services is empty", func() {
+				garden.Spec.RuntimeCluster.Networking.Services = ""
+
+				Expect(p.Delete(event.DeleteEvent{Object: garden})).To(BeFalse())
+			})
+
+			It("should return true because both spec.runtimeCluster.networking.{pods, services} are present", func() {
+				Expect(p.Delete(event.DeleteEvent{Object: garden})).To(BeTrue())
+			})
+		})
+
+		Describe("#Generic", func() {
+			It("should return false because spec.runtimeCluster.networking.pods is empty", func() {
+				garden.Spec.RuntimeCluster.Networking.Pods = ""
+
+				Expect(p.Generic(event.GenericEvent{Object: garden})).To(BeFalse())
+			})
+
+			It("should return false because spec.runtimeCluster.networking.services is empty", func() {
+				garden.Spec.RuntimeCluster.Networking.Services = ""
+
+				Expect(p.Generic(event.GenericEvent{Object: garden})).To(BeFalse())
+			})
+
+			It("should return true because both spec.runtimeCluster.networking.{pods, services} are present", func() {
+				Expect(p.Generic(event.GenericEvent{Object: garden})).To(BeTrue())
+			})
+		})
+	})
+})

--- a/pkg/operator/controller/networkpolicyregistrar/add_test.go
+++ b/pkg/operator/controller/networkpolicyregistrar/add_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 var _ = Describe("Add", func() {
-	Describe("#NetworkingPredicate Predicate", func() {
+	Describe("#NetworkingPredicate", func() {
 		var (
 			p      predicate.Predicate
 			garden *operatorv1alpha1.Garden

--- a/pkg/operator/controller/networkpolicyregistrar/add_test.go
+++ b/pkg/operator/controller/networkpolicyregistrar/add_test.go
@@ -93,8 +93,8 @@ var _ = Describe("Add", func() {
 				Expect(p.Delete(event.DeleteEvent{Object: garden})).To(BeFalse())
 			})
 
-			It("should return true because both spec.runtimeCluster.networking.{pods, services} are present", func() {
-				Expect(p.Delete(event.DeleteEvent{Object: garden})).To(BeTrue())
+			It("should return false even if both spec.runtimeCluster.networking.{pods, services} are present", func() {
+				Expect(p.Delete(event.DeleteEvent{Object: garden})).To(BeFalse())
 			})
 		})
 
@@ -111,8 +111,8 @@ var _ = Describe("Add", func() {
 				Expect(p.Generic(event.GenericEvent{Object: garden})).To(BeFalse())
 			})
 
-			It("should return true because both spec.runtimeCluster.networking.{pods, services} are present", func() {
-				Expect(p.Generic(event.GenericEvent{Object: garden})).To(BeTrue())
+			It("should return false even if both spec.runtimeCluster.networking.{pods, services} are present", func() {
+				Expect(p.Generic(event.GenericEvent{Object: garden})).To(BeFalse())
 			})
 		})
 	})

--- a/pkg/operator/controller/networkpolicyregistrar/add_test.go
+++ b/pkg/operator/controller/networkpolicyregistrar/add_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 var _ = Describe("Add", func() {
-	Describe("#Garden Predicate", func() {
+	Describe("#NetworkingPredicate Predicate", func() {
 		var (
 			p      predicate.Predicate
 			garden *operatorv1alpha1.Garden
@@ -38,7 +38,8 @@ var _ = Describe("Add", func() {
 					RuntimeCluster: operatorv1alpha1.RuntimeCluster{
 						Networking: operatorv1alpha1.RuntimeNetworking{
 							Pods:     "10.1.0.0/16",
-							Services: "10.2.0.0/16"},
+							Services: "10.2.0.0/16",
+						},
 					},
 				},
 			}

--- a/pkg/operator/controller/networkpolicyregistrar/garden_suite_test.go
+++ b/pkg/operator/controller/networkpolicyregistrar/garden_suite_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package networkpolicyregistrar
+package networkpolicyregistrar_test
 
 import (
 	"testing"

--- a/pkg/operator/controller/networkpolicyregistrar/garden_suite_test.go
+++ b/pkg/operator/controller/networkpolicyregistrar/garden_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package networkpolicyregistrar
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestGarden(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Network Policy Registrar Controller Suite")
+}

--- a/pkg/operator/controller/networkpolicyregistrar/garden_suite_test.go
+++ b/pkg/operator/controller/networkpolicyregistrar/garden_suite_test.go
@@ -21,7 +21,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestGarden(t *testing.T) {
+func TestNetworkPolicyRegistrar(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Network Policy Registrar Controller Suite")
+	RunSpecs(t, "Operator Controller NetworkPolicyRegistrar Suite")
 }


### PR DESCRIPTION
Co-Authored-By: Sonu Kumar Singh [sonu.kumar.singh02@sap.com](mailto:sonu.kumar.singh02@sap.com)

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug

**What this PR does / why we need it**:
https://github.com/gardener/gardener/pull/7975 added the predicate to add the reconciler on `Update` events, but it doesn't work since we set `r.added` true in the `Create` event, and we return here,https://github.com/gardener/gardener/blob/4a9a3ee4e48655ffe674dd5907d5d55ebfd37c72/pkg/operator/controller/networkpolicyregistrar/reconciler.go#L43-L45

With the current approach, when the controller restarts, It's a `Create` event , but the predicate is false since the networking fields are empty, so `r.added`  is still false, and on the next `Update` the fields are set and the reconciler is added and `r.added` is true. On any later `Update`  events, we exit early without adding the reconciler.

Steps to reproduce the issue:
1. Start the operator in gardener v1.70.2, apply the garden resource in `example/operator/20-garden.yaml`
2. Checkout to gardener v1.71.1, Do `make operator-up` again, and see the controller panics with, 
```
{"level":"error","ts":"2023-05-24T09:37:45.590Z","msg":"Reconciler error","controller":"networkpolicy","namespace":"","name":"virtual-garden-istio-ingress","reconcileID":"cd0604ba-a2e8-4208-a56a-b90dbfaf71cf","error":"failed to reconcile NetworkPolicy virtual-garden-istio-ingress/allow-to-dns: invalid CIDR address: ","stacktrace":"sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\t/go/src/github.com/gardener/gardener/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:329\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/go/src/github.com/gardener/gardener/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:274\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2\n\t/go/src/github.com/gardener/gardener/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:235"}
```
3. Apply the garden resource again (the example now contains networking fields), still the reconciler doesn't have these fields.
#7975 was adding the reconciler on every update call, which is also not optimal.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
3. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
The `NetworkPolicy` reconciler is only added to `gardener-operator` if the `.spec.runtimeCluster.networking.{pods,services}` fields of the `Garden` are set.
```