### PR TITLE
Upgraded ETCD druid from v0.17.0 to v0.18.1

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -29,7 +29,7 @@ images:
 - name: etcd-druid
   sourceRepository: github.com/gardener/etcd-druid
   repository: eu.gcr.io/gardener-project/gardener/etcd-druid
-  tag: "v0.17.0"
+  tag: "v0.18.1"
 - name: dependency-watchdog
   sourceRepository: github.com/gardener/dependency-watchdog
   repository: eu.gcr.io/gardener-project/gardener/dependency-watchdog

--- a/pkg/component/etcd/bootstrap.go
+++ b/pkg/component/etcd/bootstrap.go
@@ -136,7 +136,7 @@ func (b *bootstrapper) Deploy(ctx context.Context) error {
 				{
 					APIGroups: []string{corev1.GroupName},
 					Resources: []string{"pods"},
-					Verbs:     []string{"get", "list", "watch", "delete"},
+					Verbs:     []string{"get", "list", "watch", "delete", "deletecollection"},
 				},
 				{
 					APIGroups: []string{corev1.GroupName},

--- a/pkg/component/etcd/bootstrap_test.go
+++ b/pkg/component/etcd/bootstrap_test.go
@@ -129,6 +129,7 @@ rules:
   - list
   - watch
   - delete
+  - deletecollection
 - apiGroups:
   - ""
   resources:


### PR DESCRIPTION
**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
``` other developer github.com/gardener/etcd-druid #579 @shreyas-s-rao
Upgrade to go 1.20.3.
```

``` feature developer github.com/gardener/etcd-druid #547 @abdasgupta
Run `make ci-e2e-kind` to run the e2e tests on local machine
```

``` improvement developer github.com/gardener/etcd-druid #581 @shreyas-s-rao
Block public access for S3 buckets created by e2e tests.
```

``` bugfix operator github.com/gardener/etcd-druid #587 @ishan16696
Added check to ensure that the scale up annotation is removed from the etcd statefulset only when scale-up succeeds
```

``` feature developer github.com/gardener/etcd-druid #538 @seshachalam-yv
Eliminated `Role` helm charts and converted into Golang component with added unit tests.
```

``` improvement operator github.com/gardener/etcd-backup-restore #612 @aaronfern
Base alpine image upgraded from `3.15.7` to `3.15.8`
```

``` improvement developer github.com/gardener/etcd-backup-restore #613 @shreyas-s-rao
Upgrade to go 1.20.3
```

``` bugfix operator github.com/gardener/etcd-backup-restore #614 @ishan16696
Fixes a bug in backup-restore which falsely detects scale-up scenario incase of rolling update of statefulset.
```

``` improvement developer github.com/gardener/etcd-backup-restore #615 @shreyas-s-rao
Block public access for S3 buckets created by integration tests.
```

``` improvement operator github.com/gardener/etcd-backup-restore #617 @ishan16696
Add a learner with backoff in case of scale-up feature is triggered.
```

``` improvement operator github.com/gardener/etcd-backup-restore #605 @ishan16696
Added a safety check before adding a learner(non-voting) member in etcd cluster.
```

``` other operator github.com/gardener/etcd-druid #598 @unmarshall
When scaling from single-node to multi-node etcd cluster, Etcd Druid will now first ensure that any change to the peer URL (e.g TLS enablement)  is seen by the existing etcd process running within the etcd member pod. Once that is confirmed then it will scale up the Etcd StatefulSet and add relevant annotations.
```

``` other operator github.com/gardener/etcd-druid #602 @abdasgupta
Backup-restore waits for its etcd to be ready before attempting to update peerUrl
```

``` other operator github.com/gardener/etcd-druid #602 @abdasgupta
When scaling from single-node to multi-node etcd cluster, Etcd Druid will now first ensure that any change to the peer URL (e.g TLS enablement)  is seen by the existing etcd process running within the etcd member pod. Once that is confirmed then it will scale up the Etcd StatefulSet and add relevant annotations.
```

``` feature developer github.com/gardener/etcd-druid #539 @seshachalam-yv
Eliminated `RoleBinding` helm charts and converted into Golang component with added unit tests.
```

``` other operator github.com/gardener/etcd-druid #575 @aaronfern
etcd-custom-image updates from `v3.4.13-bootstrap-9` to `v3.4.13-bootstrap-10`
```

``` other operator github.com/gardener/etcd-custom-image #32 @aaronfern
Base alpine image for etcd-custom-image upgraded from `3.15.7` to `3.15.8`
```
