### PR TITLE
Partially Revert "Drop `identity` value from Helm chart values"

### DIFF
--- a/pkg/admissioncontroller/webhook/auth/seed/authorizer.go
+++ b/pkg/admissioncontroller/webhook/auth/seed/authorizer.go
@@ -154,7 +154,7 @@ func (a *authorizer) Authorize(_ context.Context, attrs auth.Attributes) (auth.D
 				[]string{"status"},
 			)
 		case namespaceResource:
-			return a.authorizeRead(requestLog, seedName, graph.VertexTypeNamespace, attrs)
+			return a.authorizeNamespace(requestLog, seedName, attrs)
 		case projectResource:
 			return a.authorizeRead(requestLog, seedName, graph.VertexTypeProject, attrs)
 		case secretBindingResource:
@@ -242,6 +242,16 @@ func (a *authorizer) authorizeLease(log logr.Logger, seedName string, attrs auth
 		[]string{"create"},
 		nil,
 	)
+}
+
+func (a *authorizer) authorizeNamespace(log logr.Logger, seedName string, attrs auth.Attributes) (auth.Decision, string, error) {
+	if attrs.GetName() == v1beta1constants.GardenNamespace &&
+		utils.ValueExists(attrs.GetVerb(), []string{"get", "list", "watch"}) {
+
+		return auth.DecisionAllow, "", nil
+	}
+
+	return a.authorizeRead(log, seedName, graph.VertexTypeNamespace, attrs)
 }
 
 func (a *authorizer) authorizeSecret(log logr.Logger, seedName string, attrs auth.Attributes) (auth.Decision, string, error) {

--- a/pkg/admissioncontroller/webhook/auth/seed/authorizer_test.go
+++ b/pkg/admissioncontroller/webhook/auth/seed/authorizer_test.go
@@ -506,6 +506,17 @@ var _ = Describe("Seed", func() {
 				}
 			})
 
+			It("should allow without consulting graph because name is 'garden'", func() {
+				name = "garden"
+				attrs.Name = name
+
+				decision, reason, err := authorizer.Authorize(ctx, attrs)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(decision).To(Equal(auth.DecisionAllow))
+				Expect(reason).To(BeEmpty())
+			})
+
 			DescribeTable("should return correct result if path exists",
 				func(verb string) {
 					attrs.Verb = verb


### PR DESCRIPTION
This partially reverts commit e23e054d6b8286f6f94390359a9bbbe80872ff09.

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug

**What this PR does / why we need it**:
In `v1.71 `of gardener-admission-controller , we removed the permission for gardenlet to get  the garden namespace, https://github.com/gardener/gardener/pull/7868/commits/e23e054d6b8286f6f94390359a9bbbe80872ff09
Since gardenlet was still not updated and was in v1.70 , It tries to get the garden namespace during startup and panics, https://github.com/gardener/gardener/blob/5abed1bfedd6f2188e5dcec9af161d1b5c286236/pkg/gardenlet/controller/add.go#L85-L88

gardenlet panic:-
```
panic: failed adding controllers to manager: failed getting garden namespace in garden cluster: namespaces "garden" is forbidden: User "gardener.cloud:system:seed:test" cannot get resource "namespaces" in API group "" in the namespace "garden": no relationship found between seed 'test' and this object
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
A bug causing `gardenlet` to panic when `admission-controller` is upgraded to `v1.71` but gardenlet is still on `v1.70`.
```
