### PR TITLE
Enhance Decoder to cope with plaintext

### DIFF
--- a/extensions/pkg/controller/operatingsystemconfig/oscommon/actuator/actuator_util.go
+++ b/extensions/pkg/controller/operatingsystemconfig/oscommon/actuator/actuator_util.go
@@ -77,9 +77,6 @@ func CloudConfigFromOperatingSystemConfig(
 // DataForFileContent returns the content for a FileContent, retrieving from a Secret if necessary.
 func DataForFileContent(ctx context.Context, c client.Client, namespace string, content *extensionsv1alpha1.FileContent) ([]byte, error) {
 	if inline := content.Inline; inline != nil {
-		if len(inline.Encoding) == 0 {
-			return []byte(inline.Data), nil
-		}
 		return extensionsv1alpha1helper.Decode(inline.Encoding, []byte(inline.Data))
 	}
 

--- a/pkg/apis/extensions/v1alpha1/helper/filecodec.go
+++ b/pkg/apis/extensions/v1alpha1/helper/filecodec.go
@@ -25,6 +25,7 @@ import (
 )
 
 var validFileCodecIDs = map[extensionsv1alpha1.FileCodecID]struct{}{
+	extensionsv1alpha1.PlainFileCodecID:   {},
 	extensionsv1alpha1.B64FileCodecID:     {},
 	extensionsv1alpha1.GZIPFileCodecID:    {},
 	extensionsv1alpha1.GZIPB64FileCodecID: {},
@@ -37,11 +38,21 @@ type FileCodec interface {
 }
 
 var (
+	PlainFileCodec FileCodec = plainFileCodec{}
 	// B64FileCodec is the base64 FileCodec.
 	B64FileCodec FileCodec = b64FileCodec{}
 	// GZIPFileCodec is the gzip FileCodec.
 	GZIPFileCodec FileCodec = gzipFileCodec{}
 )
+
+type plainFileCodec struct{}
+
+func (plainFileCodec) Encode(data []byte) ([]byte, error) {
+	return data, nil
+}
+func (plainFileCodec) Decode(data []byte) ([]byte, error) {
+	return data, nil
+}
 
 type b64FileCodec struct{}
 
@@ -92,8 +103,9 @@ func ParseFileCodecID(s string) (extensionsv1alpha1.FileCodecID, error) {
 }
 
 var fileCodecIDToFileCodec = map[extensionsv1alpha1.FileCodecID]FileCodec{
-	extensionsv1alpha1.B64FileCodecID:  B64FileCodec,
-	extensionsv1alpha1.GZIPFileCodecID: GZIPFileCodec,
+	extensionsv1alpha1.PlainFileCodecID: PlainFileCodec,
+	extensionsv1alpha1.B64FileCodecID:   B64FileCodec,
+	extensionsv1alpha1.GZIPFileCodecID:  GZIPFileCodec,
 }
 
 // FileCodecForID retrieves the FileCodec for the given FileCodecID.

--- a/pkg/apis/extensions/v1alpha1/helper/filecodec.go
+++ b/pkg/apis/extensions/v1alpha1/helper/filecodec.go
@@ -38,6 +38,7 @@ type FileCodec interface {
 }
 
 var (
+	// PlainFileCodec is a noop FileCodec.
 	PlainFileCodec FileCodec = plainFileCodec{}
 	// B64FileCodec is the base64 FileCodec.
 	B64FileCodec FileCodec = b64FileCodec{}

--- a/pkg/apis/extensions/v1alpha1/helper/helper_test.go
+++ b/pkg/apis/extensions/v1alpha1/helper/helper_test.go
@@ -76,3 +76,22 @@ var _ = Describe("helper", func() {
 		})
 	})
 })
+
+var _ = Describe("filecodec", func() {
+	DescribeTable("#EncodeDecode",
+		func(input extensionsv1alpha1.FileContentInline) {
+			codeID, err := ParseFileCodecID(input.Encoding)
+			Expect(err).To(BeNil())
+			encoded, err := FileCodecForID(codeID).Encode([]byte(input.Data))
+			Expect(err).To(BeNil())
+
+			decoded, err := Decode(input.Encoding, encoded)
+			Expect(err).To(BeNil())
+			Expect(input.Data).To(Equal(string(decoded)))
+		},
+
+		Entry("plain", extensionsv1alpha1.FileContentInline{Encoding: "", Data: "plain data input"}),
+		Entry("base64", extensionsv1alpha1.FileContentInline{Encoding: "b64", Data: "base64 data input"}),
+		Entry("gzip", extensionsv1alpha1.FileContentInline{Encoding: "gzip", Data: "gzip data input"}),
+	)
+})

--- a/pkg/apis/extensions/v1alpha1/types_operatingsystemconfig.go
+++ b/pkg/apis/extensions/v1alpha1/types_operatingsystemconfig.go
@@ -241,6 +241,8 @@ const ContainerDRuntimeContainersBinFolder = "/var/bin/containerruntimes"
 type FileCodecID string
 
 const (
+	// PlainFileCodecID is the plain file codec id.
+	PlainFileCodecID FileCodecID = ""
 	// B64FileCodecID is the base64 file codec id.
 	B64FileCodecID FileCodecID = "b64"
 	// GZIPFileCodecID is the gzip file codec id.


### PR DESCRIPTION
**How to categorize this PR?**
  /area quality
  /kind enhancement

**What this PR does / why we need it**:
When creating an OSC with a FileContent without encoding, e.g. `encoding: ""` the decoding must be guarded with a check for this type of encoding to prevent a runtime error.

Now `helper.Decode` is able to handle this case as well.

This was identified during the 5/2023 Gardener Hackathon when implementing the `gardener-node-agent`

@Gerrit91 @vknabel @rfranzke @timebertt
