### PR TITLE
Cleanup Shoot provider label from the secret if there are no secretbindings referring it

### DIFF
--- a/pkg/controllermanager/controller/secretbinding/reconciler_test.go
+++ b/pkg/controllermanager/controller/secretbinding/reconciler_test.go
@@ -16,39 +16,33 @@ package secretbinding
 
 import (
 	"context"
-	"fmt"
-	"reflect"
 	"time"
 
-	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
-	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
+	"github.com/gardener/gardener/pkg/client/kubernetes"
 )
 
 var _ = Describe("SecretBindingControl", func() {
 	var (
-		ctrl *gomock.Controller
-		c    *mockclient.MockClient
-
-		ctx     = context.TODO()
-		fakeErr = fmt.Errorf("fake err")
+		fakeClient client.Client
+		ctx        = context.TODO()
 	)
 
 	BeforeEach(func() {
-		ctrl = gomock.NewController(GinkgoT())
-		c = mockclient.NewMockClient(ctrl)
-	})
+		testScheme := runtime.NewScheme()
+		Expect(kubernetes.AddGardenSchemeToScheme(testScheme)).To(Succeed())
 
-	AfterEach(func() {
-		ctrl.Finish()
+		fakeClient = fakeclient.NewClientBuilder().WithScheme(testScheme).Build()
 	})
 
 	Describe("#mayReleaseSecret", func() {
@@ -64,12 +58,10 @@ var _ = Describe("SecretBindingControl", func() {
 		)
 
 		BeforeEach(func() {
-			reconciler = &Reconciler{Client: c}
+			reconciler = &Reconciler{Client: fakeClient}
 		})
 
 		It("should return true as no other secretbinding exists", func() {
-			c.EXPECT().List(ctx, gomock.AssignableToTypeOf(&gardencorev1beta1.SecretBindingList{}))
-
 			allowed, err := reconciler.mayReleaseSecret(ctx, secretBinding1Namespace, secretBinding1Name, secretNamespace, secretName)
 
 			Expect(allowed).To(BeTrue())
@@ -88,10 +80,7 @@ var _ = Describe("SecretBindingControl", func() {
 				},
 			}
 
-			c.EXPECT().List(ctx, gomock.AssignableToTypeOf(&gardencorev1beta1.SecretBindingList{})).DoAndReturn(func(_ context.Context, list *gardencorev1beta1.SecretBindingList, _ ...client.ListOption) error {
-				(&gardencorev1beta1.SecretBindingList{Items: []gardencorev1beta1.SecretBinding{*secretBinding}}).DeepCopyInto(list)
-				return nil
-			})
+			Expect(fakeClient.Create(ctx, secretBinding)).To(Succeed())
 
 			allowed, err := reconciler.mayReleaseSecret(ctx, secretBinding1Namespace, secretBinding1Name, secretNamespace, secretName)
 
@@ -111,24 +100,12 @@ var _ = Describe("SecretBindingControl", func() {
 				},
 			}
 
-			c.EXPECT().List(ctx, gomock.AssignableToTypeOf(&gardencorev1beta1.SecretBindingList{})).DoAndReturn(func(_ context.Context, list *gardencorev1beta1.SecretBindingList, _ ...client.ListOption) error {
-				(&gardencorev1beta1.SecretBindingList{Items: []gardencorev1beta1.SecretBinding{*secretBinding}}).DeepCopyInto(list)
-				return nil
-			})
+			Expect(fakeClient.Create(ctx, secretBinding)).To(Succeed())
 
 			allowed, err := reconciler.mayReleaseSecret(ctx, secretBinding1Namespace, secretBinding1Name, secretNamespace, secretName)
 
 			Expect(allowed).To(BeFalse())
 			Expect(err).NotTo(HaveOccurred())
-		})
-
-		It("should return an error as the list failed", func() {
-			c.EXPECT().List(ctx, gomock.AssignableToTypeOf(&gardencorev1beta1.SecretBindingList{})).Return(fakeErr)
-
-			allowed, err := reconciler.mayReleaseSecret(ctx, secretBinding1Namespace, secretBinding1Name, secretNamespace, secretName)
-
-			Expect(allowed).To(BeFalse())
-			Expect(err).To(MatchError(fakeErr))
 		})
 	})
 
@@ -139,8 +116,18 @@ var _ = Describe("SecretBindingControl", func() {
 
 			secretBindingNamespace = "foo"
 			secretBindingName      = "bar"
-			secretNamespace        = "foo"
-			secretName             = "bar"
+
+			secret        *corev1.Secret
+			secretBinding *gardencorev1beta1.SecretBinding
+		)
+
+		BeforeEach(func() {
+			secret = &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "secret",
+					Namespace: "namespace",
+				},
+			}
 
 			secretBinding = &gardencorev1beta1.SecretBinding{
 				ObjectMeta: metav1.ObjectMeta{
@@ -148,76 +135,43 @@ var _ = Describe("SecretBindingControl", func() {
 					Namespace: secretBindingNamespace,
 				},
 				SecretRef: corev1.SecretReference{
-					Namespace: secretNamespace,
-					Name:      secretName,
+					Namespace: secret.Namespace,
+					Name:      secret.Name,
 				},
 			}
 
-			secret = &corev1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      secretName,
-					Namespace: secretNamespace,
-				},
-			}
-		)
+			Expect(fakeClient.Create(ctx, secret)).To(Succeed())
+			Expect(fakeClient.Create(ctx, secretBinding)).To(Succeed())
 
-		BeforeEach(func() {
-			reconciler = &Reconciler{Client: c}
+			reconciler = &Reconciler{Client: fakeClient}
 			request = reconcile.Request{NamespacedName: types.NamespacedName{Namespace: secretBindingNamespace, Name: secretBindingName}}
-
-			c.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.AssignableToTypeOf(&gardencorev1beta1.SecretBinding{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.SecretBinding, _ ...client.GetOption) error {
-				secretBinding.DeepCopyInto(obj)
-				return nil
-			})
-
-			c.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.AssignableToTypeOf(&corev1.Secret{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *corev1.Secret, _ ...client.GetOption) error {
-				secret.DeepCopyInto(obj)
-				return nil
-			})
-
-			c.EXPECT().Patch(gomock.Any(), gomock.AssignableToTypeOf(&gardencorev1beta1.SecretBinding{}), gomock.Any()).DoAndReturn(
-				func(_ context.Context, sb *gardencorev1beta1.SecretBinding, _ client.Patch, _ ...client.PatchOption) error {
-					*secretBinding = *sb
-					return nil
-				},
-			).AnyTimes()
-
-			c.EXPECT().Patch(gomock.Any(), gomock.AssignableToTypeOf(&corev1.Secret{}), gomock.Any()).DoAndReturn(
-				func(_ context.Context, s *corev1.Secret, _ client.Patch, _ ...client.PatchOption) error {
-					*secret = *s
-					return nil
-				},
-			).AnyTimes()
 		})
 
 		It("should add the label to the secret referred by the secretbinding", func() {
 			_, err := reconciler.Reconcile(ctx, request)
 			Expect(err).NotTo(HaveOccurred())
 
-			expectedLabels := map[string]string{
-				"reference.gardener.cloud/secretbinding": "true",
-			}
-
-			Expect(secret.ObjectMeta.Labels).To(Equal(expectedLabels))
+			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(secret), secret)).To(Succeed())
+			Expect(secret.ObjectMeta.Labels).To(HaveKeyWithValue(
+				"reference.gardener.cloud/secretbinding", "true",
+			))
 		})
 
 		It("should remove the label from the secret when there are no secretbindings referring it", func() {
-			secretBinding.DeletionTimestamp = &metav1.Time{Time: time.Date(1, 1, 1, 1, 1, 1, 1, time.UTC)}
-
-			c.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&gardencorev1beta1.SecretBindingList{})).DoAndReturn(func(_ context.Context, list *gardencorev1beta1.SecretBindingList, _ ...client.ListOption) error {
-				(&gardencorev1beta1.SecretBindingList{Items: []gardencorev1beta1.SecretBinding{*secretBinding}}).DeepCopyInto(list)
-				return nil
-			}).AnyTimes()
-
-			c.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&gardencorev1beta1.ShootList{})).DoAndReturn(func(_ context.Context, list *gardencorev1beta1.ShootList, _ ...client.ListOption) error {
-				(&gardencorev1beta1.ShootList{}).DeepCopyInto(list)
-				return nil
-			})
-
 			_, err := reconciler.Reconcile(ctx, request)
 			Expect(err).NotTo(HaveOccurred())
 
-			Expect(len(secret.ObjectMeta.Labels)).To(Equal(0))
+			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(secretBinding), secretBinding)).To(Succeed())
+			secretBinding.DeletionTimestamp = &metav1.Time{Time: time.Date(1, 1, 1, 1, 1, 1, 1, time.UTC)}
+			// Add dummy finalizer to prevent deletion
+			secretBinding.Finalizers = append(secretBinding.Finalizers, "finalizer")
+			Expect(fakeClient.Update(ctx, secretBinding)).To(Succeed())
+
+			_, err = reconciler.Reconcile(ctx, request)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(secret), secret)).To(Succeed())
+			Expect(secret.ObjectMeta.Labels).To(BeEmpty())
 		})
 	})
 
@@ -235,32 +189,16 @@ var _ = Describe("SecretBindingControl", func() {
 			quotaNamespace2         = "quota-ns-2"
 			quotaName2              = "quota-2"
 
-			secretBinding1 = &gardencorev1beta1.SecretBinding{
+			secret                         *corev1.Secret
+			secretBinding1, secretBinding2 *gardencorev1beta1.SecretBinding
+			quota1, quota2                 *gardencorev1beta1.Quota
+		)
+
+		BeforeEach(func() {
+			secret = &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      secretBindingName1,
-					Namespace: secretBindingNamespace1,
-				},
-				Quotas: []corev1.ObjectReference{
-					{
-						Name:      quotaName1,
-						Namespace: quotaNamespace1,
-					},
-					{
-						Name:      quotaName2,
-						Namespace: quotaNamespace2,
-					},
-				},
-			}
-			secretBinding2 = &gardencorev1beta1.SecretBinding{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      secretBindingName2,
-					Namespace: secretBindingNamespace2,
-				},
-				Quotas: []corev1.ObjectReference{
-					{
-						Name:      quotaName2,
-						Namespace: quotaNamespace2,
-					},
+					Name:      "secret",
+					Namespace: "namespace",
 				},
 			}
 
@@ -276,102 +214,108 @@ var _ = Describe("SecretBindingControl", func() {
 					Namespace: quotaNamespace2,
 				},
 			}
-		)
 
-		BeforeEach(func() {
-			reconciler = &Reconciler{Client: c}
-
-			c.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&gardencorev1beta1.SecretBindingList{}), gomock.Any()).DoAndReturn(func(_ context.Context, list *gardencorev1beta1.SecretBindingList, _ ...client.ListOption) error {
-				(&gardencorev1beta1.SecretBindingList{Items: []gardencorev1beta1.SecretBinding{*secretBinding1, *secretBinding2}}).DeepCopyInto(list)
-				return nil
-			}).AnyTimes()
-
-			c.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.AssignableToTypeOf(&gardencorev1beta1.SecretBinding{})).DoAndReturn(func(_ context.Context, namespacedName client.ObjectKey, obj *gardencorev1beta1.SecretBinding, _ ...client.GetOption) error {
-				for _, sb := range []gardencorev1beta1.SecretBinding{*secretBinding1, *secretBinding2} {
-					if reflect.DeepEqual(namespacedName.Name, sb.Name) && reflect.DeepEqual(namespacedName.Namespace, sb.Namespace) {
-						sb.DeepCopyInto(obj)
-						return nil
-					}
-				}
-				return nil
-			}).AnyTimes()
-
-			c.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.AssignableToTypeOf(&gardencorev1beta1.Quota{})).DoAndReturn(func(_ context.Context, namespacedName client.ObjectKey, obj *gardencorev1beta1.Quota, _ ...client.GetOption) error {
-				for _, q := range []gardencorev1beta1.Quota{*quota1, *quota2} {
-					if reflect.DeepEqual(namespacedName.Name, q.Name) && reflect.DeepEqual(namespacedName.Namespace, q.Namespace) {
-						q.DeepCopyInto(obj)
-						return nil
-					}
-				}
-				return nil
-			}).AnyTimes()
-
-			c.EXPECT().Patch(gomock.Any(), gomock.AssignableToTypeOf(&gardencorev1beta1.SecretBinding{}), gomock.Any()).DoAndReturn(
-				func(_ context.Context, sb *gardencorev1beta1.SecretBinding, _ client.Patch, _ ...client.PatchOption) error {
-					if sb.Name == secretBindingName1 {
-						*secretBinding1 = *sb
-					} else if sb.Name == secretBindingName2 {
-						*secretBinding2 = *sb
-					}
-					return nil
+			secretBinding1 = &gardencorev1beta1.SecretBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      secretBindingName1,
+					Namespace: secretBindingNamespace1,
 				},
-			).AnyTimes()
-
-			c.EXPECT().Patch(gomock.Any(), gomock.AssignableToTypeOf(&gardencorev1beta1.Quota{}), gomock.Any()).DoAndReturn(
-				func(_ context.Context, q *gardencorev1beta1.Quota, _ client.Patch, _ ...client.PatchOption) error {
-					if q.Name == quotaName1 {
-						*quota1 = *q
-					} else if q.Name == quotaName2 {
-						*quota2 = *q
-					}
-					return nil
+				Quotas: []corev1.ObjectReference{
+					{
+						Name:      quotaName1,
+						Namespace: quotaNamespace1,
+					},
+					{
+						Name:      quotaName2,
+						Namespace: quotaNamespace2,
+					},
 				},
-			).AnyTimes()
-
-			c.EXPECT().Patch(gomock.Any(), gomock.AssignableToTypeOf(&corev1.Secret{}), gomock.Any()).DoAndReturn(
-				func(_ context.Context, s *corev1.Secret, _ client.Patch, _ ...client.PatchOption) error {
-					return nil
+				SecretRef: corev1.SecretReference{
+					Name:      secret.Name,
+					Namespace: secret.Namespace,
 				},
-			).AnyTimes()
+			}
+
+			secretBinding2 = &gardencorev1beta1.SecretBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       secretBindingName2,
+					Namespace:  secretBindingNamespace2,
+					Finalizers: []string{"gardener"},
+				},
+				Quotas: []corev1.ObjectReference{
+					{
+						Name:      quotaName2,
+						Namespace: quotaNamespace2,
+					},
+				},
+				SecretRef: corev1.SecretReference{
+					Name:      secret.Name,
+					Namespace: secret.Namespace,
+				},
+			}
+
+			reconciler = &Reconciler{Client: fakeClient}
+			request = reconcile.Request{NamespacedName: types.NamespacedName{Namespace: secretBindingNamespace1, Name: secretBindingName1}}
+
+			Expect(fakeClient.Create(ctx, secret)).To(Succeed())
+			Expect(fakeClient.Create(ctx, quota1)).To(Succeed())
+			Expect(fakeClient.Create(ctx, quota2)).To(Succeed())
+			Expect(fakeClient.Create(ctx, secretBinding1)).To(Succeed())
+			Expect(fakeClient.Create(ctx, secretBinding2)).To(Succeed())
 		})
 
 		It("should add the label to the quota referred by the secretbinding", func() {
-			c.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.AssignableToTypeOf(&corev1.Secret{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *corev1.Secret, _ ...client.GetOption) error {
-				(&corev1.Secret{}).DeepCopyInto(obj)
-				return nil
-			})
-
-			request = reconcile.Request{NamespacedName: types.NamespacedName{Namespace: secretBindingNamespace1, Name: secretBindingName1}}
-
 			_, err := reconciler.Reconcile(ctx, request)
 			Expect(err).NotTo(HaveOccurred())
 
-			expectedLabels := map[string]string{
-				"reference.gardener.cloud/secretbinding": "true",
-			}
-
-			Expect(quota1.ObjectMeta.Labels).To(Equal(expectedLabels))
-			Expect(quota2.ObjectMeta.Labels).To(Equal(expectedLabels))
+			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(quota1), quota1)).To(Succeed())
+			Expect(quota1.ObjectMeta.Labels).To(HaveKeyWithValue(
+				"reference.gardener.cloud/secretbinding", "true",
+			))
+			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(quota2), quota2)).To(Succeed())
+			Expect(quota2.ObjectMeta.Labels).To(HaveKeyWithValue(
+				"reference.gardener.cloud/secretbinding", "true",
+			))
 		})
 
-		It("should remove the label from the quota when there are no secretbindings referring it", func() {
-			secretBinding1.DeletionTimestamp = &metav1.Time{Time: time.Date(1, 1, 1, 1, 1, 1, 1, time.UTC)}
-
-			c.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&gardencorev1beta1.ShootList{})).DoAndReturn(func(_ context.Context, list *gardencorev1beta1.ShootList, _ ...client.ListOption) error {
-				(&gardencorev1beta1.ShootList{}).DeepCopyInto(list)
-				return nil
-			})
-
+		It("should remove the label from the quotas when there are no secretbindings referring it", func() {
 			_, err := reconciler.Reconcile(ctx, request)
 			Expect(err).NotTo(HaveOccurred())
 
-			Expect(len(quota1.ObjectMeta.Labels)).To(Equal(0))
+			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(secretBinding1), secretBinding1)).To(Succeed())
+			secretBinding1.DeletionTimestamp = &metav1.Time{Time: time.Date(1, 1, 1, 1, 1, 1, 1, time.UTC)}
+			// Add dummy finalizer to prevent deletion
+			secretBinding1.Finalizers = append(secretBinding1.Finalizers, "finalizer")
+			Expect(fakeClient.Update(ctx, secretBinding1)).To(Succeed())
 
-			expectedLabels := map[string]string{
-				"reference.gardener.cloud/secretbinding": "true",
-			}
+			_, err = reconciler.Reconcile(ctx, request)
+			Expect(err).NotTo(HaveOccurred())
 
-			Expect(quota2.ObjectMeta.Labels).To(Equal(expectedLabels))
+			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(quota1), quota1)).To(Succeed())
+			Expect(quota1.ObjectMeta.Labels).To(BeEmpty())
+
+			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(quota2), quota2)).To(Succeed())
+			Expect(quota2.ObjectMeta.Labels).To(HaveKeyWithValue(
+				"reference.gardener.cloud/secretbinding", "true",
+			))
+
+			// Remove the finalizer from secretBinding1 so that the deletion can proceed
+			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(secretBinding1), secretBinding1)).To(Succeed())
+			secretBinding1.Finalizers = nil
+			Expect(fakeClient.Update(ctx, secretBinding1)).To(Succeed())
+
+			// Now delete the other secretbinding referencing the quota
+			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(secretBinding2), secretBinding2)).To(Succeed())
+			secretBinding2.DeletionTimestamp = &metav1.Time{Time: time.Date(1, 1, 1, 1, 1, 1, 1, time.UTC)}
+			secretBinding2.Finalizers = append(secretBinding2.Finalizers, "finalizer")
+			Expect(fakeClient.Update(ctx, secretBinding2)).To(Succeed())
+
+			request = reconcile.Request{NamespacedName: types.NamespacedName{Namespace: secretBindingNamespace2, Name: secretBindingName2}}
+			_, err = reconciler.Reconcile(ctx, request)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(quota2), quota2)).To(Succeed())
+			Expect(quota2.ObjectMeta.Labels).To(BeEmpty())
 		})
 	})
 })

--- a/pkg/controllermanager/controller/secretbinding/reconciler_test.go
+++ b/pkg/controllermanager/controller/secretbinding/reconciler_test.go
@@ -16,7 +16,6 @@ package secretbinding
 
 import (
 	"context"
-	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -165,11 +164,7 @@ var _ = Describe("SecretBindingControl", func() {
 			_, err := reconciler.Reconcile(ctx, request)
 			Expect(err).NotTo(HaveOccurred())
 
-			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(secretBinding), secretBinding)).To(Succeed())
-			secretBinding.DeletionTimestamp = &metav1.Time{Time: time.Date(1, 1, 1, 1, 1, 1, 1, time.UTC)}
-			// Add dummy finalizer to prevent deletion
-			secretBinding.Finalizers = append(secretBinding.Finalizers, "finalizer")
-			Expect(fakeClient.Update(ctx, secretBinding)).To(Succeed())
+			Expect(fakeClient.Delete(ctx, secretBinding)).To(Succeed())
 
 			_, err = reconciler.Reconcile(ctx, request)
 			Expect(err).NotTo(HaveOccurred())
@@ -194,11 +189,7 @@ var _ = Describe("SecretBindingControl", func() {
 			_, err := reconciler.Reconcile(ctx, request)
 			Expect(err).NotTo(HaveOccurred())
 
-			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(secretBinding), secretBinding)).To(Succeed())
-			secretBinding.DeletionTimestamp = &metav1.Time{Time: time.Date(1, 1, 1, 1, 1, 1, 1, time.UTC)}
-			// Add dummy finalizer to prevent deletion
-			secretBinding.Finalizers = append(secretBinding.Finalizers, "finalizer")
-			Expect(fakeClient.Update(ctx, secretBinding)).To(Succeed())
+			Expect(fakeClient.Delete(ctx, secretBinding)).To(Succeed())
 
 			_, err = reconciler.Reconcile(ctx, request)
 			Expect(err).NotTo(HaveOccurred())
@@ -319,10 +310,7 @@ var _ = Describe("SecretBindingControl", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(secretBinding1), secretBinding1)).To(Succeed())
-			secretBinding1.DeletionTimestamp = &metav1.Time{Time: time.Date(1, 1, 1, 1, 1, 1, 1, time.UTC)}
-			// Add dummy finalizer to prevent deletion
-			secretBinding1.Finalizers = append(secretBinding1.Finalizers, "finalizer")
-			Expect(fakeClient.Update(ctx, secretBinding1)).To(Succeed())
+			Expect(fakeClient.Delete(ctx, secretBinding1)).To(Succeed())
 
 			_, err = reconciler.Reconcile(ctx, request)
 			Expect(err).NotTo(HaveOccurred())
@@ -335,18 +323,12 @@ var _ = Describe("SecretBindingControl", func() {
 				"reference.gardener.cloud/secretbinding", "true",
 			))
 
-			// Remove the finalizer from secretBinding1 so that the deletion can proceed
-			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(secretBinding1), secretBinding1)).To(Succeed())
-			secretBinding1.Finalizers = nil
-			Expect(fakeClient.Update(ctx, secretBinding1)).To(Succeed())
-
-			// Now delete the other secretbinding referencing the quota
-			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(secretBinding2), secretBinding2)).To(Succeed())
-			secretBinding2.DeletionTimestamp = &metav1.Time{Time: time.Date(1, 1, 1, 1, 1, 1, 1, time.UTC)}
-			secretBinding2.Finalizers = append(secretBinding2.Finalizers, "finalizer")
-			Expect(fakeClient.Update(ctx, secretBinding2)).To(Succeed())
-
 			request = reconcile.Request{NamespacedName: types.NamespacedName{Namespace: secretBindingNamespace2, Name: secretBindingName2}}
+			_, err = reconciler.Reconcile(ctx, request)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(fakeClient.Delete(ctx, secretBinding2)).To(Succeed())
+
 			_, err = reconciler.Reconcile(ctx, request)
 			Expect(err).NotTo(HaveOccurred())
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug

**What this PR does / why we need it**:
See https://github.com/gardener/gardener/issues/7977 for detailed issue description.
Now, if no other secretbinding is referring the secret, we also cleanup the shoot provider label.

**Which issue(s) this PR fixes**:
Fixes #7977

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
A bug causing the shoot provider label in the infrastructure secret to not get cleaned up is now fixed.
```
