### PR TITLE
Deflake integration tests

### DIFF
--- a/pkg/component/kubeapiserver/kube_apiserver.go
+++ b/pkg/component/kubeapiserver/kube_apiserver.go
@@ -600,6 +600,8 @@ var (
 	// TimeoutWaitForDeployment is the timeout used while waiting for the Deployments to become healthy
 	// or deleted.
 	TimeoutWaitForDeployment = 5 * time.Minute
+	// Until is an alias for retry.Until. Exposed for tests.
+	Until = retry.Until
 )
 
 func (k *kubeAPIServer) Wait(ctx context.Context) error {
@@ -608,7 +610,7 @@ func (k *kubeAPIServer) Wait(ctx context.Context) error {
 
 	deployment := k.emptyDeployment()
 
-	if err := retry.Until(timeoutCtx, IntervalWaitForDeployment, health.IsDeploymentUpdated(k.client.APIReader(), deployment)); err != nil {
+	if err := Until(timeoutCtx, IntervalWaitForDeployment, health.IsDeploymentUpdated(k.client.APIReader(), deployment)); err != nil {
 		var (
 			retryError *retry.Error
 			headBytes  *int64

--- a/pkg/component/kubecontrollermanager/waiter.go
+++ b/pkg/component/kubecontrollermanager/waiter.go
@@ -37,13 +37,15 @@ var (
 	IntervalWaitForDeployment = 5 * time.Second
 	// TimeoutWaitForDeployment is the timeout used while waiting for the Deployments to become healthy or deleted.
 	TimeoutWaitForDeployment = 3 * time.Minute
+	// Until is an alias for retry.Until. Exposed for tests.
+	Until = retry.Until
 )
 
 func (k *kubeControllerManager) Wait(ctx context.Context) error {
 	timeoutCtx, cancel := context.WithTimeout(ctx, TimeoutWaitForDeployment)
 	defer cancel()
 
-	return retry.Until(timeoutCtx, IntervalWaitForDeployment, health.IsDeploymentUpdated(k.seedClient.APIReader(), k.emptyDeployment()))
+	return Until(timeoutCtx, IntervalWaitForDeployment, health.IsDeploymentUpdated(k.seedClient.APIReader(), k.emptyDeployment()))
 }
 
 func (k *kubeControllerManager) WaitCleanup(_ context.Context) error { return nil }

--- a/test/integration/gardenlet/shoot/care/care_suite_test.go
+++ b/test/integration/gardenlet/shoot/care/care_suite_test.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/client-go/rest"
 	testclock "k8s.io/utils/clock/testing"
+	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
@@ -77,8 +78,10 @@ var (
 	shootClientMap clientmap.ClientMap
 	mgrClient      client.Client
 
-	testRunID     string
+	project       *gardencorev1beta1.Project
+	seed          *gardencorev1beta1.Seed
 	testNamespace *corev1.Namespace
+	testRunID     string
 	projectName   string
 	seedName      string
 	shootName     string
@@ -160,6 +163,68 @@ var _ = BeforeSuite(func() {
 	DeferCleanup(func() {
 		By("Delete test Namespace")
 		Expect(testClient.Delete(ctx, testNamespace)).To(Or(Succeed(), BeNotFoundError()))
+	})
+
+	project = &gardencorev1beta1.Project{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   projectName,
+			Labels: map[string]string{testID: testRunID},
+		},
+		Spec: gardencorev1beta1.ProjectSpec{
+			Namespace: &testNamespace.Name,
+		},
+	}
+
+	By("Create Project")
+	Expect(testClient.Create(ctx, project)).To(Succeed())
+	log.Info("Created Project for test", "project", project.Name)
+
+	DeferCleanup(func() {
+		By("Delete Project")
+		Expect(client.IgnoreNotFound(testClient.Delete(ctx, project))).To(Succeed())
+	})
+
+	seed = &gardencorev1beta1.Seed{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   seedName,
+			Labels: map[string]string{testID: testRunID},
+		},
+		Spec: gardencorev1beta1.SeedSpec{
+			Provider: gardencorev1beta1.SeedProvider{
+				Region: "region",
+				Type:   "providerType",
+				Zones:  []string{"a", "b", "c"},
+			},
+			Ingress: &gardencorev1beta1.Ingress{
+				Domain: "seed.example.com",
+				Controller: gardencorev1beta1.IngressController{
+					Kind: "nginx",
+				},
+			},
+			DNS: gardencorev1beta1.SeedDNS{
+				Provider: &gardencorev1beta1.SeedDNSProvider{
+					Type: "providerType",
+					SecretRef: corev1.SecretReference{
+						Name:      "some-secret",
+						Namespace: "some-namespace",
+					},
+				},
+			},
+			Networks: gardencorev1beta1.SeedNetworks{
+				Pods:     "10.0.0.0/16",
+				Services: "10.1.0.0/16",
+				Nodes:    pointer.String("10.2.0.0/16"),
+			},
+		},
+	}
+
+	By("Create Seed")
+	Expect(testClient.Create(ctx, seed)).To(Succeed())
+	log.Info("Created Seed for test", "seed", seed.Name)
+
+	DeferCleanup(func() {
+		By("Delete Project")
+		Expect(client.IgnoreNotFound(testClient.Delete(ctx, seed))).To(Succeed())
 	})
 
 	By("Setup manager")

--- a/test/integration/operator/garden/garden_test.go
+++ b/test/integration/operator/garden/garden_test.go
@@ -264,7 +264,9 @@ var _ = Describe("Garden controller tests", func() {
 			return crdList.Items
 		}).Should(ContainElements(
 			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("hvpas.autoscaling.k8s.io")})}),
+			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("managedresources.resources.gardener.cloud")})}),
 			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("verticalpodautoscalers.autoscaling.k8s.io")})}),
+			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("verticalpodautoscalercheckpoints.autoscaling.k8s.io")})}),
 			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("authorizationpolicies.security.istio.io")})}),
 			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("destinationrules.networking.istio.io")})}),
 			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("envoyfilters.networking.istio.io")})}),
@@ -625,8 +627,6 @@ var _ = Describe("Garden controller tests", func() {
 		}).Should(BeNotFoundError())
 
 		By("Verify that the custom resource definitions have been deleted")
-		// When the controller succeeds then it deletes the `ManagedResource` CRD, so we only need to ensure here that
-		// the `ManagedResource` API is no longer available.
 		Eventually(func(g Gomega) []apiextensionsv1.CustomResourceDefinition {
 			crdList := &apiextensionsv1.CustomResourceDefinitionList{}
 			g.Expect(testClient.List(ctx, crdList)).To(Succeed())
@@ -634,6 +634,9 @@ var _ = Describe("Garden controller tests", func() {
 		}).ShouldNot(ContainElements(
 			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("hvpas.autoscaling.k8s.io")})}),
 			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("etcds.druid.gardener.cloud")})}),
+			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("managedresources.resources.gardener.cloud")})}),
+			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("verticalpodautoscalers.autoscaling.k8s.io")})}),
+			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("verticalpodautoscalercheckpoints.autoscaling.k8s.io")})}),
 			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("authorizationpolicies.security.istio.io")})}),
 			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("destinationrules.networking.istio.io")})}),
 			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("envoyfilters.networking.istio.io")})}),


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind flake

**What this PR does / why we need it**:
- Gardenlet Shoot Care Suite.
We need to create the seed and project only once. This PR moves the seed and project creation from BeforeEach to BeforeSuite.

  - https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/7989/pull-gardener-integration/1662050474792062976
  - https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/7981/pull-gardener-integration/1661805577690419200
  - https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/7973/pull-gardener-integration/1661259252641042432

Before:
```
$ stress -p 32 ./test/integration/gardenlet/shoot/care/care.test
...
10m55s: 622 runs so far, 2 failures (0.32%)
11m0s: 628 runs so far, 2 failures (0.32%)
11m5s: 628 runs so far, 2 failures (0.32%)
11m10s: 638 runs so far, 2 failures (0.31%)
```
After:
```
$ stress -p 32 ./test/integration/gardenlet/shoot/care/care.test
...
17m50s: 1016 runs so far, 0 failures
17m55s: 1016 runs so far, 0 failures
18m0s: 1025 runs so far, 0 failures
18m5s: 1026 runs so far, 0 failures
```

- Garden controller tests:
Fake waiting for components to be healthy by faking the `until` function in tests.

Before:
```
❯ stress -p 16 ./test/integration/operator/garden/garden.test
...
13m25s: 565 runs so far, 6 failures (1.06%)
13m30s: 565 runs so far, 6 failures (1.06%)
13m35s: 575 runs so far, 6 failures (1.04%)
13m40s: 580 runs so far, 6 failures (1.03%)
```
After
```
❯ stress -p 16 ./test/integration/operator/garden/garden.test
...
11m25s: 563 runs so far, 0 failures
11m30s: 568 runs so far, 0 failures
11m35s: 577 runs so far, 0 failures
11m40s: 577 runs so far, 0 failures
11m45s: 578 runs so far, 0 failures
```

**Which issue(s) this PR fixes**:
Fixes #7990 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
