### PR TITLE
Cleanup `core/v1alpha1` API version from local-setup

### DIFF
--- a/docs/development/local_setup.md
+++ b/docs/development/local_setup.md
@@ -280,7 +280,6 @@ service/gardener-apiserver created
 service/gardener-admission-controller created
 endpoints/gardener-apiserver created
 endpoints/gardener-admission-controller created
-apiservice.apiregistration.k8s.io/v1alpha1.core.gardener.cloud created
 apiservice.apiregistration.k8s.io/v1beta1.core.gardener.cloud created
 apiservice.apiregistration.k8s.io/v1alpha1.seedmanagement.gardener.cloud created
 apiservice.apiregistration.k8s.io/v1alpha1.settings.gardener.cloud created

--- a/hack/local-development/dev-setup-register-gardener
+++ b/hack/local-development/dev-setup-register-gardener
@@ -40,7 +40,6 @@ if [[ "$(uname -s)" == *"Darwin"* ]] || [[ "$(uname -s)" == "Linux" && "$(uname 
   APISERVER_EXTERNAL_NAME=host.docker.internal
 fi
 
-CORE_V1ALPHA1_APISERVICE_NAME="v1alpha1.core.gardener.cloud"
 CORE_V1BETA1_APISERVICE_NAME="v1beta1.core.gardener.cloud"
 SEEDMANAGEMENT_APISERVICE_NAME="v1alpha1.seedmanagement.gardener.cloud"
 SETTINGS_APISERVICE_NAME="v1alpha1.settings.gardener.cloud"
@@ -63,10 +62,6 @@ if [[ $(k8s_env) == "$NODELESS" ]]; then
 fi
 ADMISSION_CONTROLLER_PORT_STRING="      port: $ADMISSION_CONTROLLER_SERVICE_PORT"
 
-if kubectl get apiservice "$CORE_V1ALPHA1_APISERVICE_NAME" &> /dev/null; then
-  kubectl delete apiservice $CORE_V1ALPHA1_APISERVICE_NAME --wait=false
-  kubectl patch  apiservice $CORE_V1ALPHA1_APISERVICE_NAME -p '{"metadata":{"finalizers":null}}' 2> /dev/null || true
-fi
 if kubectl get apiservice "$CORE_V1BETA1_APISERVICE_NAME" &> /dev/null; then
   kubectl delete apiservice $CORE_V1BETA1_APISERVICE_NAME --wait=false
   kubectl patch  apiservice $CORE_V1BETA1_APISERVICE_NAME -p '{"metadata":{"finalizers":null}}' 2> /dev/null || true
@@ -173,21 +168,6 @@ EOF
 fi
 
 cat <<EOF | kubectl apply -f -
-apiVersion: apiregistration.k8s.io/v1
-kind: APIService
-metadata:
-  name: $CORE_V1ALPHA1_APISERVICE_NAME
-spec:
-  insecureSkipTLSVerify: true
-  group: core.gardener.cloud
-  version: v1alpha1
-  groupPriorityMinimum: 9999
-  versionPriority: 19
-  service:
-    name: gardener-apiserver
-    namespace: garden
-$APISERVICE_PORT_STRING
----
 apiVersion: apiregistration.k8s.io/v1
 kind: APIService
 metadata:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind cleanup

**What this PR does / why we need it**:
This PR cleans up `core/v1alpha1` API version from local-setup left out in https://github.com/gardener/gardener/pull/7965.
/cc @ary1992 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
