### PR TITLE
Deploy `Etcd` CRDs independent of Etcd bootstrap

### DIFF
--- a/charts/gardener/gardenlet/templates/clusterrole-gardenlet.yaml
+++ b/charts/gardener/gardenlet/templates/clusterrole-gardenlet.yaml
@@ -148,6 +148,8 @@ rules:
   resources:
   - customresourcedefinitions
   resourceNames:
+  - etcds.druid.gardener.cloud
+  - etcdcopybackupstasks.druid.gardener.cloud
   - hvpas.autoscaling.k8s.io
   - destinationrules.networking.istio.io
   - envoyfilters.networking.istio.io

--- a/pkg/component/etcd/bootstrap.go
+++ b/pkg/component/etcd/bootstrap.go
@@ -370,6 +370,8 @@ func (b *bootstrapper) Deploy(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+
+	// TODO(acumino): Drop CRDs deployment from here in release v1.73.
 	resources["crd.yaml"] = []byte(etcdCRD)
 	resources["crdEtcdCopyBackupsTask.yaml"] = []byte(etcdCopyBackupsTaskCRD1)
 

--- a/pkg/component/etcd/bootstrap.go
+++ b/pkg/component/etcd/bootstrap.go
@@ -16,6 +16,7 @@ package etcd
 
 import (
 	"context"
+	_ "embed"
 	"fmt"
 	"strconv"
 	"time"
@@ -67,6 +68,13 @@ const (
 	druidConfigMapImageVectorOverwriteDataKey          = "images_overwrite.yaml"
 	druidDeploymentVolumeMountPathImageVectorOverwrite = "/charts_overwrite"
 	druidDeploymentVolumeNameImageVectorOverwrite      = "imagevector-overwrite"
+)
+
+var (
+	//go:embed crds/templates/crd-druid.gardener.cloud_etcds-copy.yaml
+	etcdCRD string
+	//go:embed crds/templates/crd-druid.gardener.cloud_etcdcopybackupstasks-copy.yaml
+	etcdCopyBackupsTaskCRD1 string
 )
 
 // NewBootstrapper creates a new instance of DeployWaiter for the etcd bootstrapper.
@@ -362,6 +370,8 @@ func (b *bootstrapper) Deploy(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	resources["crd.yaml"] = []byte(etcdCRD)
+	resources["crdEtcdCopyBackupsTask.yaml"] = []byte(etcdCopyBackupsTaskCRD1)
 
 	return managedresources.CreateForSeed(ctx, b.client, b.namespace, managedResourceControlName, false, resources)
 }

--- a/pkg/component/etcd/bootstrap.go
+++ b/pkg/component/etcd/bootstrap.go
@@ -16,8 +16,6 @@ package etcd
 
 import (
 	"context"
-	_ "embed"
-	"fmt"
 	"strconv"
 	"time"
 
@@ -31,9 +29,6 @@ import (
 	policyv1 "k8s.io/api/policy/v1"
 	policyv1beta1 "k8s.io/api/policy/v1beta1"
 	rbacv1 "k8s.io/api/rbac/v1"
-	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -49,7 +44,6 @@ import (
 	"github.com/gardener/gardener/pkg/gardenlet/apis/config"
 	"github.com/gardener/gardener/pkg/resourcemanager/controller/garbagecollector/references"
 	"github.com/gardener/gardener/pkg/utils"
-	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 	"github.com/gardener/gardener/pkg/utils/imagevector"
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/managedresources"
@@ -60,8 +54,6 @@ const (
 	// Druid is a constant for the name of the etcd-druid.
 	Druid = "etcd-druid"
 
-	etcdCRDName                                  = "etcds.druid.gardener.cloud"
-	etcdCopyBackupsTaskCRDName                   = "etcdcopybackupstasks.druid.gardener.cloud"
 	druidRBACName                                = "gardener.cloud:system:" + Druid
 	druidServiceAccountName                      = Druid
 	druidVPAName                                 = Druid + "-vpa"
@@ -72,14 +64,6 @@ const (
 	druidConfigMapImageVectorOverwriteDataKey          = "images_overwrite.yaml"
 	druidDeploymentVolumeMountPathImageVectorOverwrite = "/charts_overwrite"
 	druidDeploymentVolumeNameImageVectorOverwrite      = "imagevector-overwrite"
-)
-
-var (
-	//go:embed crds/templates/crd-druid.gardener.cloud_etcds.yaml
-	// CRD holds the etcd custom resource definition template
-	CRD string
-	//go:embed crds/templates/crd-druid.gardener.cloud_etcdcopybackupstasks.yaml
-	etcdCopyBackupsTaskCRD string
 )
 
 // NewBootstrapper creates a new instance of DeployWaiter for the etcd bootstrapper.
@@ -375,8 +359,6 @@ func (b *bootstrapper) Deploy(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	resources["crd.yaml"] = []byte(CRD)
-	resources["crdEtcdCopyBackupsTask.yaml"] = []byte(etcdCopyBackupsTaskCRD)
 
 	return managedresources.CreateForSeed(ctx, b.client, b.namespace, managedResourceControlName, false, resources)
 }
@@ -402,33 +384,6 @@ func getDruidDeployCommands(etcdConfig *config.ETCDConfig) []string {
 }
 
 func (b *bootstrapper) Destroy(ctx context.Context) error {
-	etcdList := &druidv1alpha1.EtcdList{}
-	// Need to check for both error types. The DynamicRestMapper can hold a stale cache returning a path to a non-existing api-resource leading to a NotFound error.
-	if err := b.client.List(ctx, etcdList); err != nil && !meta.IsNoMatchError(err) && !apierrors.IsNotFound(err) {
-		return err
-	}
-
-	if len(etcdList.Items) > 0 {
-		return fmt.Errorf("cannot debootstrap etcd-druid because there are still druidv1alpha1.Etcd resources left in the cluster")
-	}
-
-	if err := gardenerutils.ConfirmDeletion(ctx, b.client, &apiextensionsv1.CustomResourceDefinition{ObjectMeta: metav1.ObjectMeta{Name: etcdCRDName}}); client.IgnoreNotFound(err) != nil {
-		return err
-	}
-
-	etcdCopyBackupsTaskList := &druidv1alpha1.EtcdCopyBackupsTaskList{}
-	if err := b.client.List(ctx, etcdCopyBackupsTaskList); err != nil && !meta.IsNoMatchError(err) && !apierrors.IsNotFound(err) {
-		return err
-	}
-
-	if len(etcdCopyBackupsTaskList.Items) > 0 {
-		return fmt.Errorf("cannot debootstrap etcd-druid because there are still druidv1alpha1.EtcdCopyBackupsTask resources left in the cluster")
-	}
-
-	if err := gardenerutils.ConfirmDeletion(ctx, b.client, &apiextensionsv1.CustomResourceDefinition{ObjectMeta: metav1.ObjectMeta{Name: etcdCopyBackupsTaskCRDName}}); client.IgnoreNotFound(err) != nil {
-		return err
-	}
-
 	return managedresources.DeleteForSeed(ctx, b.client, b.namespace, managedResourceControlName)
 }
 

--- a/pkg/component/etcd/bootstrap.go
+++ b/pkg/component/etcd/bootstrap.go
@@ -16,6 +16,7 @@ package etcd
 
 import (
 	"context"
+	"fmt"
 	"strconv"
 	"time"
 
@@ -29,6 +30,8 @@ import (
 	policyv1 "k8s.io/api/policy/v1"
 	policyv1beta1 "k8s.io/api/policy/v1beta1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -384,6 +387,25 @@ func getDruidDeployCommands(etcdConfig *config.ETCDConfig) []string {
 }
 
 func (b *bootstrapper) Destroy(ctx context.Context) error {
+	etcdList := &druidv1alpha1.EtcdList{}
+	// Need to check for both error types. The DynamicRestMapper can hold a stale cache returning a path to a non-existing api-resource leading to a NotFound error.
+	if err := b.client.List(ctx, etcdList); err != nil && !meta.IsNoMatchError(err) && !apierrors.IsNotFound(err) {
+		return err
+	}
+
+	if len(etcdList.Items) > 0 {
+		return fmt.Errorf("cannot debootstrap etcd-druid because there are still druidv1alpha1.Etcd resources left in the cluster")
+	}
+
+	etcdCopyBackupsTaskList := &druidv1alpha1.EtcdCopyBackupsTaskList{}
+	if err := b.client.List(ctx, etcdCopyBackupsTaskList); err != nil && !meta.IsNoMatchError(err) && !apierrors.IsNotFound(err) {
+		return err
+	}
+
+	if len(etcdCopyBackupsTaskList.Items) > 0 {
+		return fmt.Errorf("cannot debootstrap etcd-druid because there are still druidv1alpha1.EtcdCopyBackupsTask resources left in the cluster")
+	}
+
 	return managedresources.DeleteForSeed(ctx, b.client, b.namespace, managedResourceControlName)
 }
 

--- a/pkg/component/etcd/bootstrap_test.go
+++ b/pkg/component/etcd/bootstrap_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/Masterminds/semver"
+	druidv1alpha1 "github.com/gardener/etcd-druid/api/v1alpha1"
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -32,7 +33,6 @@ import (
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	druidv1alpha1 "github.com/gardener/etcd-druid/api/v1alpha1"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	"github.com/gardener/gardener/pkg/component"
@@ -43,6 +43,13 @@ import (
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
+)
+
+var (
+	//go:embed crds/templates/crd-druid.gardener.cloud_etcds-copy.yaml
+	etcdCRD string
+	//go:embed crds/templates/crd-druid.gardener.cloud_etcdcopybackupstasks-copy.yaml
+	etcdCopyBackupsTaskCRD1 string
 )
 
 var _ = Describe("Etcd", func() {
@@ -472,6 +479,8 @@ status:
 					"verticalpodautoscaler__" + namespace + "__etcd-druid-vpa.yaml": []byte(vpaYAML),
 					"deployment__" + namespace + "__etcd-druid.yaml":                []byte(deploymentWithoutImageVectorOverwriteYAML),
 					"poddisruptionbudget__" + namespace + "__etcd-druid.yaml":       []byte(podDisruptionYAML),
+					"crd.yaml":                    []byte(etcdCRD),
+					"crdEtcdCopyBackupsTask.yaml": []byte(etcdCopyBackupsTaskCRD1),
 				},
 			}
 			managedResource = &resourcesv1alpha1.ManagedResource{

--- a/pkg/component/etcd/bootstrap_test.go
+++ b/pkg/component/etcd/bootstrap_test.go
@@ -26,11 +26,13 @@ import (
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	druidv1alpha1 "github.com/gardener/etcd-druid/api/v1alpha1"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	"github.com/gardener/gardener/pkg/component"
@@ -633,8 +635,67 @@ status:
 		)
 
 		Describe("#Destroy", func() {
+			It("should fail when the etcd listing fails", func() {
+				c.EXPECT().List(ctx, gomock.AssignableToTypeOf(&druidv1alpha1.EtcdList{})).Return(fakeErr)
+
+				Expect(bootstrapper.Destroy(ctx)).To(MatchError(fakeErr))
+			})
+
+			It("should succeed when isNoMatch error is returned", func() {
+				noMatchError := &meta.NoKindMatchError{}
+				c.EXPECT().List(ctx, gomock.AssignableToTypeOf(&druidv1alpha1.EtcdList{})).Return(noMatchError)
+
+				c.EXPECT().List(ctx, gomock.AssignableToTypeOf(&druidv1alpha1.EtcdCopyBackupsTaskList{})).Return(noMatchError)
+
+				c.EXPECT().Delete(gomock.Any(), gomock.Any())
+				c.EXPECT().Delete(gomock.Any(), gomock.Any())
+
+				Expect(bootstrapper.Destroy(ctx)).To(Succeed())
+			})
+
+			It("should suceed when NotFoundError is returned", func() {
+				notFoundError := apierrors.NewNotFound(schema.GroupResource{}, "etcd")
+				c.EXPECT().List(ctx, gomock.AssignableToTypeOf(&druidv1alpha1.EtcdList{})).Return(notFoundError)
+
+				c.EXPECT().List(ctx, gomock.AssignableToTypeOf(&druidv1alpha1.EtcdCopyBackupsTaskList{})).Return(notFoundError)
+
+				c.EXPECT().Delete(gomock.Any(), gomock.Any())
+				c.EXPECT().Delete(gomock.Any(), gomock.Any())
+
+				Expect(bootstrapper.Destroy(ctx)).To(Succeed())
+			})
+
+			It("should fail when there are etcd resources left", func() {
+				c.EXPECT().List(ctx, gomock.AssignableToTypeOf(&druidv1alpha1.EtcdList{})).DoAndReturn(
+					func(ctx context.Context, list client.ObjectList, _ ...client.ListOptions) error {
+						(&druidv1alpha1.EtcdList{
+							Items: []druidv1alpha1.Etcd{{}},
+						}).DeepCopyInto(list.(*druidv1alpha1.EtcdList))
+						return nil
+					},
+				)
+
+				Expect(bootstrapper.Destroy(ctx)).To(MatchError(ContainSubstring("because there are still druidv1alpha1.Etcd resources left in the cluster")))
+			})
+
+			It("should fail when there are EtcdCopyBackupsTask resources left", func() {
+				notFoundError := apierrors.NewNotFound(schema.GroupResource{}, "etcd")
+				c.EXPECT().List(ctx, gomock.AssignableToTypeOf(&druidv1alpha1.EtcdList{})).Return(notFoundError)
+				c.EXPECT().List(ctx, gomock.AssignableToTypeOf(&druidv1alpha1.EtcdCopyBackupsTaskList{})).DoAndReturn(
+					func(ctx context.Context, list client.ObjectList, _ ...client.ListOptions) error {
+						(&druidv1alpha1.EtcdCopyBackupsTaskList{
+							Items: []druidv1alpha1.EtcdCopyBackupsTask{{}},
+						}).DeepCopyInto(list.(*druidv1alpha1.EtcdCopyBackupsTaskList))
+						return nil
+					},
+				)
+				Expect(bootstrapper.Destroy(ctx)).To(MatchError(ContainSubstring("because there are still druidv1alpha1.EtcdCopyBackupsTask resources left in the cluster")))
+			})
+
 			It("should fail when the managed resource deletion fails", func() {
 				gomock.InOrder(
+					c.EXPECT().List(ctx, gomock.AssignableToTypeOf(&druidv1alpha1.EtcdList{})),
+					c.EXPECT().List(ctx, gomock.AssignableToTypeOf(&druidv1alpha1.EtcdCopyBackupsTaskList{})),
 					c.EXPECT().Delete(ctx, managedResource).Return(fakeErr),
 				)
 
@@ -643,6 +704,8 @@ status:
 
 			It("should fail when the secret deletion fails", func() {
 				gomock.InOrder(
+					c.EXPECT().List(ctx, gomock.AssignableToTypeOf(&druidv1alpha1.EtcdList{})),
+					c.EXPECT().List(ctx, gomock.AssignableToTypeOf(&druidv1alpha1.EtcdCopyBackupsTaskList{})),
 					c.EXPECT().Delete(ctx, managedResource),
 					c.EXPECT().Delete(ctx, secret).Return(fakeErr),
 				)
@@ -652,6 +715,8 @@ status:
 
 			It("should successfully delete all resources", func() {
 				gomock.InOrder(
+					c.EXPECT().List(ctx, gomock.AssignableToTypeOf(&druidv1alpha1.EtcdList{})),
+					c.EXPECT().List(ctx, gomock.AssignableToTypeOf(&druidv1alpha1.EtcdCopyBackupsTaskList{})),
 					c.EXPECT().Delete(ctx, managedResource),
 					c.EXPECT().Delete(ctx, secret),
 				)

--- a/pkg/component/etcd/crd.go
+++ b/pkg/component/etcd/crd.go
@@ -1,0 +1,116 @@
+// Copyright 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package etcd
+
+import (
+	"context"
+	_ "embed"
+	"fmt"
+
+	druidv1alpha1 "github.com/gardener/etcd-druid/api/v1alpha1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	"github.com/gardener/gardener/pkg/component"
+	"github.com/gardener/gardener/pkg/utils/flow"
+	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
+)
+
+var (
+	//go:embed crds/templates/crd-druid.gardener.cloud_etcds.yaml
+	// CRD holds the etcd custom resource definition template
+	CRD string
+	//go:embed crds/templates/crd-druid.gardener.cloud_etcdcopybackupstasks.yaml
+	etcdCopyBackupsTaskCRD string
+
+	etcdCRDName                = "etcds.druid.gardener.cloud"
+	etcdCopyBackupsTaskCRDName = "etcdcopybackupstasks.druid.gardener.cloud"
+	crdResources               []string
+)
+
+type etcdCRD struct {
+	client  client.Client
+	applier kubernetes.Applier
+}
+
+func init() {
+	crdResources = append(crdResources, CRD, etcdCopyBackupsTaskCRD)
+}
+
+// NewCRD can be used to deploy the CRD definitions for Etcd and EtcdCopyBackupsTask.
+func NewCRD(c client.Client, applier kubernetes.Applier) component.Deployer {
+	return &etcdCRD{
+		client:  c,
+		applier: applier,
+	}
+}
+
+// Deploy creates and updates the CRD definitions for Etcd and EtcdCopyBackupsTask.
+func (e *etcdCRD) Deploy(ctx context.Context) error {
+	var fns []flow.TaskFn
+
+	for _, resource := range crdResources {
+		r := resource
+		fns = append(fns, func(ctx context.Context) error {
+			return e.applier.ApplyManifest(ctx, kubernetes.NewManifestReader([]byte(r)), kubernetes.DefaultMergeFuncs)
+		})
+	}
+
+	return flow.Parallel(fns...)(ctx)
+}
+
+func (e *etcdCRD) Destroy(ctx context.Context) error {
+	etcdList := &druidv1alpha1.EtcdList{}
+	// Need to check for both error types. The DynamicRestMapper can hold a stale cache returning a path to a non-existing api-resource leading to a NotFound error.
+	if err := e.client.List(ctx, etcdList); err != nil && !meta.IsNoMatchError(err) && !apierrors.IsNotFound(err) {
+		return err
+	}
+
+	if len(etcdList.Items) > 0 {
+		return fmt.Errorf("cannot delete etcd CRDs because there are still druidv1alpha1.Etcd resources left in the cluster")
+	}
+
+	if err := gardenerutils.ConfirmDeletion(ctx, e.client, &apiextensionsv1.CustomResourceDefinition{ObjectMeta: metav1.ObjectMeta{Name: etcdCRDName}}); client.IgnoreNotFound(err) != nil {
+		return err
+	}
+
+	etcdCopyBackupsTaskList := &druidv1alpha1.EtcdCopyBackupsTaskList{}
+	if err := e.client.List(ctx, etcdCopyBackupsTaskList); err != nil && !meta.IsNoMatchError(err) && !apierrors.IsNotFound(err) {
+		return err
+	}
+
+	if len(etcdCopyBackupsTaskList.Items) > 0 {
+		return fmt.Errorf("cannot delete etcd CRDs because there are still druidv1alpha1.EtcdCopyBackupsTask resources left in the cluster")
+	}
+
+	if err := gardenerutils.ConfirmDeletion(ctx, e.client, &apiextensionsv1.CustomResourceDefinition{ObjectMeta: metav1.ObjectMeta{Name: etcdCopyBackupsTaskCRDName}}); client.IgnoreNotFound(err) != nil {
+		return err
+	}
+
+	var fns []flow.TaskFn
+
+	for _, resource := range crdResources {
+		r := resource
+		fns = append(fns, func(ctx context.Context) error {
+			return client.IgnoreNotFound(e.applier.DeleteManifest(ctx, kubernetes.NewManifestReader([]byte(r))))
+		})
+	}
+
+	return flow.Parallel(fns...)(ctx)
+}

--- a/pkg/component/etcd/crd_test.go
+++ b/pkg/component/etcd/crd_test.go
@@ -1,0 +1,76 @@
+// Copyright 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package etcd_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	"github.com/gardener/gardener/pkg/component"
+	. "github.com/gardener/gardener/pkg/component/etcd"
+	. "github.com/gardener/gardener/pkg/utils/test/matchers"
+)
+
+var _ = Describe("CRD", func() {
+	var (
+		c           client.Client
+		ctx         = context.TODO()
+		crdDeployer component.Deployer
+	)
+
+	BeforeEach(func() {
+		c = fake.NewClientBuilder().WithScheme(kubernetes.SeedScheme).Build()
+
+		mapper := meta.NewDefaultRESTMapper([]schema.GroupVersion{apiextensionsv1.SchemeGroupVersion})
+		mapper.Add(apiextensionsv1.SchemeGroupVersion.WithKind("CustomResourceDefinition"), meta.RESTScopeRoot)
+		applier := kubernetes.NewApplier(c, mapper)
+
+		crdDeployer = NewCRD(c, applier)
+	})
+
+	JustBeforeEach(func() {
+		Expect(crdDeployer.Deploy(ctx)).To(Succeed(), "Etcd/EtcdCopyBackupsTask CRD deployment succeeds")
+	})
+
+	DescribeTable("CRD is deployed",
+		func(crdName string) {
+			Expect(c.Get(ctx, client.ObjectKey{Name: crdName}, &apiextensionsv1.CustomResourceDefinition{})).To(Succeed())
+		},
+
+		Entry("Etcd", "etcds.druid.gardener.cloud"),
+		Entry("EtcdCopyBackupsTask", "etcdcopybackupstasks.druid.gardener.cloud"),
+	)
+
+	DescribeTable("should re-create CRD if it is deleted",
+		func(crdName string) {
+			Expect(c.Delete(ctx, &apiextensionsv1.CustomResourceDefinition{ObjectMeta: metav1.ObjectMeta{Name: crdName}}, &client.DeleteOptions{})).To(Succeed())
+			Expect(c.Get(ctx, client.ObjectKey{Name: crdName}, &apiextensionsv1.CustomResourceDefinition{})).To(BeNotFoundError())
+			Expect(crdDeployer.Deploy(ctx)).To(Succeed())
+			Expect(c.Get(ctx, client.ObjectKey{Name: crdName}, &apiextensionsv1.CustomResourceDefinition{})).To(Succeed())
+		},
+
+		Entry("Etcd", "etcds.druid.gardener.cloud"),
+		Entry("EtcdCopyBackupsTask", "etcdcopybackupstasks.druid.gardener.cloud"),
+	)
+})

--- a/pkg/component/etcd/crds/templates/crd-druid.gardener.cloud_etcdcopybackupstasks-copy.yaml
+++ b/pkg/component/etcd/crds/templates/crd-druid.gardener.cloud_etcdcopybackupstasks-copy.yaml
@@ -1,0 +1,6 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: etcdcopybackupstasks.druid.gardener.cloud
+  annotations:
+    resources.gardener.cloud/mode: Ignore

--- a/pkg/component/etcd/crds/templates/crd-druid.gardener.cloud_etcds-copy.yaml
+++ b/pkg/component/etcd/crds/templates/crd-druid.gardener.cloud_etcds-copy.yaml
@@ -1,0 +1,6 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: etcds.druid.gardener.cloud
+  annotations:
+    resources.gardener.cloud/mode: Ignore

--- a/pkg/gardenlet/controller/managedseed/charttest/charttest.go
+++ b/pkg/gardenlet/controller/managedseed/charttest/charttest.go
@@ -252,6 +252,8 @@ func getGardenletClusterRole(labels map[string]string) *rbacv1.ClusterRole {
 				APIGroups: []string{"apiextensions.k8s.io"},
 				Resources: []string{"customresourcedefinitions"},
 				ResourceNames: []string{
+					"etcds.druid.gardener.cloud",
+					"etcdcopybackupstasks.druid.gardener.cloud",
 					"hvpas.autoscaling.k8s.io",
 					"destinationrules.networking.istio.io",
 					"envoyfilters.networking.istio.io",

--- a/pkg/gardenlet/controller/seed/seed/reconciler_delete.go
+++ b/pkg/gardenlet/controller/seed/seed/reconciler_delete.go
@@ -303,6 +303,7 @@ func (r *Reconciler) runDeleteSeedFlow(
 	if !seedIsGarden {
 		var (
 			kubeStateMetrics              = kubestatemetrics.New(seedClient, r.GardenNamespace, nil, kubestatemetrics.Values{ClusterType: component.ClusterTypeSeed})
+			etcdCRD                       = etcd.NewCRD(seedClient, r.SeedClientSet.Applier())
 			etcdDruid                     = etcd.NewBootstrapper(seedClient, r.GardenNamespace, nil, r.Config.ETCDConfig, "", nil, "")
 			hvpa                          = hvpa.New(seedClient, r.GardenNamespace, hvpa.Values{})
 			verticalPodAutoscaler         = vpa.New(seedClient, r.GardenNamespace, nil, vpa.Values{ClusterType: component.ClusterTypeSeed, RuntimeKubernetesVersion: kubernetesVersion})
@@ -339,6 +340,11 @@ func (r *Reconciler) runDeleteSeedFlow(
 				Fn:           component.OpDestroyAndWait(fluentOperator).Destroy,
 				Dependencies: flow.NewTaskIDs(destroyFluentOperatorResources),
 			})
+			destroyEtcdCRD = g.Add(flow.Task{
+				Name:         "Destroy custom resource definition for ETCD/EtcdCopyBackupsTask",
+				Fn:           component.OpDestroyAndWait(etcdCRD).Destroy,
+				Dependencies: flow.NewTaskIDs(destroyEtcdDruid),
+			})
 		)
 
 		syncPointCleanedUp.Insert(
@@ -348,6 +354,7 @@ func (r *Reconciler) runDeleteSeedFlow(
 			destroyVPA,
 			destroyFluentOperatorResources,
 			destroyFluentOperator,
+			destroyEtcdCRD,
 		)
 
 		var (

--- a/pkg/gardenlet/controller/seed/seed/reconciler_delete.go
+++ b/pkg/gardenlet/controller/seed/seed/reconciler_delete.go
@@ -341,7 +341,7 @@ func (r *Reconciler) runDeleteSeedFlow(
 				Dependencies: flow.NewTaskIDs(destroyFluentOperatorResources),
 			})
 			destroyEtcdCRD = g.Add(flow.Task{
-				Name:         "Destroy custom resource definition for ETCD/EtcdCopyBackupsTask",
+				Name:         "Destroy ETCD-related custom resource definitions",
 				Fn:           component.OpDestroyAndWait(etcdCRD).Destroy,
 				Dependencies: flow.NewTaskIDs(destroyEtcdDruid),
 			})

--- a/pkg/operator/controller/garden/components.go
+++ b/pkg/operator/controller/garden/components.go
@@ -58,6 +58,7 @@ import (
 )
 
 type components struct {
+	etcdCRD  component.Deployer
 	vpaCRD   component.Deployer
 	hvpaCRD  component.Deployer
 	istioCRD component.DeployWaiter
@@ -93,6 +94,7 @@ func (r *Reconciler) instantiateComponents(
 	err error,
 ) {
 	// crds
+	c.etcdCRD = etcd.NewCRD(r.RuntimeClientSet.Client(), applier)
 	c.vpaCRD = vpa.NewCRD(applier, nil)
 	c.hvpaCRD = hvpa.NewCRD(applier)
 	if !hvpaEnabled() {

--- a/pkg/operator/controller/garden/reconciler_delete.go
+++ b/pkg/operator/controller/garden/reconciler_delete.go
@@ -171,6 +171,11 @@ func (r *Reconciler) delete(
 			Dependencies: flow.NewTaskIDs(destroyGardenerResourceManager),
 		})
 		_ = g.Add(flow.Task{
+			Name:         "Destroying custom resource definition for ETCD/EtcdCopyBackupsTask",
+			Fn:           c.etcdCRD.Destroy,
+			Dependencies: flow.NewTaskIDs(destroyGardenerResourceManager),
+		})
+		_ = g.Add(flow.Task{
 			Name:         "Cleaning up secrets",
 			Fn:           secretsManager.Cleanup,
 			Dependencies: flow.NewTaskIDs(destroyGardenerResourceManager),

--- a/pkg/operator/controller/garden/reconciler_delete.go
+++ b/pkg/operator/controller/garden/reconciler_delete.go
@@ -171,7 +171,7 @@ func (r *Reconciler) delete(
 			Dependencies: flow.NewTaskIDs(destroyGardenerResourceManager),
 		})
 		_ = g.Add(flow.Task{
-			Name:         "Destroying custom resource definition for ETCD/EtcdCopyBackupsTask",
+			Name:         "Destroying ETCD-related custom resource definitions",
 			Fn:           c.etcdCRD.Destroy,
 			Dependencies: flow.NewTaskIDs(destroyGardenerResourceManager),
 		})

--- a/pkg/operator/controller/garden/reconciler_reconcile.go
+++ b/pkg/operator/controller/garden/reconciler_reconcile.go
@@ -114,7 +114,7 @@ func (r *Reconciler) reconcile(
 			},
 		})
 		deployEtcdCRD = g.Add(flow.Task{
-			Name: "Deploying custom resource definition for ETCD/EtcdCopyBackupsTask",
+			Name: "Deploying ETCD-related custom resource definitions",
 			Fn:   c.etcdCRD.Deploy,
 		})
 		deployVPACRD = g.Add(flow.Task{

--- a/pkg/operator/controller/garden/reconciler_reconcile.go
+++ b/pkg/operator/controller/garden/reconciler_reconcile.go
@@ -113,6 +113,10 @@ func (r *Reconciler) reconcile(
 				return r.generateGenericTokenKubeconfig(ctx, secretsManager)
 			},
 		})
+		deployEtcdCRD = g.Add(flow.Task{
+			Name: "Deploying custom resource definition for ETCD/EtcdCopyBackupsTask",
+			Fn:   c.etcdCRD.Deploy,
+		})
 		deployVPACRD = g.Add(flow.Task{
 			Name: "Deploying custom resource definition for VPA",
 			Fn:   flow.TaskFn(c.vpaCRD.Deploy).DoIf(vpaEnabled(garden.Spec.RuntimeCluster.Settings)),
@@ -128,7 +132,7 @@ func (r *Reconciler) reconcile(
 		deployGardenerResourceManager = g.Add(flow.Task{
 			Name:         "Deploying and waiting for gardener-resource-manager to be healthy",
 			Fn:           component.OpWait(c.gardenerResourceManager).Deploy,
-			Dependencies: flow.NewTaskIDs(deployVPACRD, reconcileHVPACRD, deployIstioCRD),
+			Dependencies: flow.NewTaskIDs(deployEtcdCRD, deployVPACRD, reconcileHVPACRD, deployIstioCRD),
 		})
 		deploySystemResources = g.Add(flow.Task{
 			Name:         "Deploying system resources",

--- a/test/integration/operator/garden/garden_suite_test.go
+++ b/test/integration/operator/garden/garden_suite_test.go
@@ -61,9 +61,6 @@ var _ = BeforeSuite(func() {
 		CRDInstallOptions: envtest.CRDInstallOptions{
 			Paths: []string{
 				filepath.Join("..", "..", "..", "..", "example", "operator", "10-crd-operator.gardener.cloud_gardens.yaml"),
-				// This CRD would be installed by gardener-resource-manager (GRM) in a real system, however in this
-				// integration test GRM is not running. Hence, we have to create it manually to satisfy the test setup.
-				filepath.Join("..", "..", "..", "..", "example", "seed-crds", "10-crd-druid.gardener.cloud_etcds.yaml"),
 			},
 		},
 		ErrorIfCRDPathMissing: true,

--- a/test/integration/operator/garden/garden_test.go
+++ b/test/integration/operator/garden/garden_test.go
@@ -264,6 +264,8 @@ var _ = Describe("Garden controller tests", func() {
 			return crdList.Items
 		}).Should(ContainElements(
 			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("hvpas.autoscaling.k8s.io")})}),
+			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("etcds.druid.gardener.cloud")})}),
+			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("etcdcopybackupstasks.druid.gardener.cloud")})}),
 			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("managedresources.resources.gardener.cloud")})}),
 			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("verticalpodautoscalers.autoscaling.k8s.io")})}),
 			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("verticalpodautoscalercheckpoints.autoscaling.k8s.io")})}),
@@ -644,6 +646,7 @@ var _ = Describe("Garden controller tests", func() {
 		}).ShouldNot(ContainElements(
 			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("hvpas.autoscaling.k8s.io")})}),
 			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("etcds.druid.gardener.cloud")})}),
+			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("etcdcopybackupstasks.druid.gardener.cloud")})}),
 			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("managedresources.resources.gardener.cloud")})}),
 			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("verticalpodautoscalers.autoscaling.k8s.io")})}),
 			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("verticalpodautoscalercheckpoints.autoscaling.k8s.io")})}),


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug

**What this PR does / why we need it**:
This PR separates the Etcd CRD deployment from Etcd Bootstrap step. Check the motivation for this PR in https://github.com/gardener/gardener/issues/7997

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener/issues/7997

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
