### PR TITLE
Populate `gardenlet` feature gates to extensions when installing

### DIFF
--- a/test/integration/gardenlet/controllerinstallation/controllerinstallation/controllerinstallation_test.go
+++ b/test/integration/gardenlet/controllerinstallation/controllerinstallation/controllerinstallation_test.go
@@ -170,6 +170,10 @@ var _ = Describe("ControllerInstallation controller tests", func() {
 			}).Should(Succeed())
 
 			By("Ensure chart was deployed correctly")
+			// Note that the list of feature gates is unexpectedly longer than in reality since the envtest starts
+			// gardener-apiserver which adds its own as well as the default Kubernetes features gates to the same
+			// map that is reused in gardenlet:
+			// `features.DefaultFeatureGate` is the same as `utilfeature.DefaultMutableFeatureGate`
 			Eventually(func(g Gomega) string {
 				managedResource := &resourcesv1alpha1.ManagedResource{}
 				g.Expect(testClient.Get(ctx, client.ObjectKey{Namespace: "garden", Name: controllerInstallation.Name}, managedResource)).To(Succeed())
@@ -184,6 +188,42 @@ var _ = Describe("ControllerInstallation controller tests", func() {
 			}).Should(Equal(`gardener:
   garden:
     clusterIdentity: ` + gardenClusterIdentity + `
+  gardenlet:
+    featureGates:
+      APIListChunking: true
+      APIPriorityAndFairness: true
+      APIResponseCompression: true
+      APIServerIdentity: true
+      APIServerSNI: true
+      APIServerTracing: false
+      AdvancedAuditing: true
+      AggregatedDiscoveryEndpoint: false
+      AllAlpha: false
+      AllBeta: false
+      ComponentSLIs: false
+      CoreDNSQueryRewriting: false
+      CustomResourceValidationExpressions: true
+      DefaultSeccompProfile: false
+      DryRun: true
+      EfficientWatchResumption: true
+      FullNetworkPoliciesInRuntimeCluster: true
+      HAControlPlanes: true
+      HVPA: false
+      HVPAForShootedSeed: false
+      IPv6SingleStack: false
+      KMSv2: false
+      MutableShootSpecNetworkingNodes: false
+      OpenAPIEnums: true
+      OpenAPIV3: true
+      RemainingItemCount: true
+      RemoveSelfLink: true
+      ServerSideApply: true
+      ServerSideFieldValidation: true
+      StorageVersionAPI: false
+      StorageVersionHash: true
+      ValidatingAdmissionPolicy: false
+      WatchBookmark: true
+      WorkerlessShoots: false
   seed:
     annotations: null
     blockCIDRs: null


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
With this PR, `gardenlet` populates its feature gates to extensions when they are getting installed. This information can be used by extensions to enable/disable certain behaviour based on whether a feature gate on `gardenlet` is enabled or disabled.

**Which issue(s) this PR fixes**:
Related to https://github.com/gardener/gardener/issues/7594

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature developer
`gardenlet`'s `ControllerInstallation` controller now populates the feature gate of `gardenlet` via the Helm values to extensions when they are getting installed. The information is populated via the `.gardener.gardenlet.featureGates` key. It contains a map whose keys are feature gates names and whose values are booleans (depicting the enablement status).
```
