### PR TITLE
Added service for metrics endpoint of `etcd-druid`

### DIFF
--- a/pkg/component/etcd/bootstrap.go
+++ b/pkg/component/etcd/bootstrap.go
@@ -256,9 +256,8 @@ func (b *bootstrapper) Deploy(ctx context.Context) error {
 				}, labels()),
 			},
 			Spec: corev1.ServiceSpec{
-				Type:            corev1.ServiceTypeClusterIP,
-				SessionAffinity: corev1.ServiceAffinityNone,
-				Selector:        labels(),
+				Type:     corev1.ServiceTypeClusterIP,
+				Selector: labels(),
 				Ports: []corev1.ServicePort{
 					{
 						Name:       "metrics",

--- a/pkg/component/etcd/bootstrap_test.go
+++ b/pkg/component/etcd/bootstrap_test.go
@@ -356,7 +356,7 @@ spec:
         imagePullPolicy: IfNotPresent
         name: etcd-druid
         ports:
-        - containerPort: 9569
+        - containerPort: 8080
         resources:
           limits:
             memory: 512Mi
@@ -414,7 +414,7 @@ spec:
         imagePullPolicy: IfNotPresent
         name: etcd-druid
         ports:
-        - containerPort: 9569
+        - containerPort: 8080
         resources:
           limits:
             memory: 512Mi
@@ -432,6 +432,30 @@ spec:
           name: ` + configMapName + `
         name: imagevector-overwrite
 status: {}
+`
+			serviceYAML = `apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    networking.resources.gardener.cloud/from-all-seed-scrape-targets-allowed-ports: '[{"protocol":"TCP","port":8080}]'
+  creationTimestamp: null
+  labels:
+    gardener.cloud/role: etcd-druid
+    high-availability-config.resources.gardener.cloud/type: controller
+  name: etcd-druid
+  namespace: ` + namespace + `
+spec:
+  ports:
+  - name: metrics
+    port: 8080
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    gardener.cloud/role: etcd-druid
+  sessionAffinity: None
+  type: ClusterIP
+status:
+  loadBalancer: {}
 `
 			podDisruptionYAML = `apiVersion: policy/v1
 kind: PodDisruptionBudget
@@ -469,6 +493,7 @@ status:
 					"clusterrole____gardener.cloud_system_etcd-druid.yaml":          []byte(clusterRoleYAML),
 					"clusterrolebinding____gardener.cloud_system_etcd-druid.yaml":   []byte(clusterRoleBindingYAML),
 					"verticalpodautoscaler__" + namespace + "__etcd-druid-vpa.yaml": []byte(vpaYAML),
+					"service__" + namespace + "__etcd-druid.yaml":                   []byte(serviceYAML),
 					"deployment__" + namespace + "__etcd-druid.yaml":                []byte(deploymentWithoutImageVectorOverwriteYAML),
 					"poddisruptionbudget__" + namespace + "__etcd-druid.yaml":       []byte(podDisruptionYAML),
 				},

--- a/pkg/component/etcd/bootstrap_test.go
+++ b/pkg/component/etcd/bootstrap_test.go
@@ -452,7 +452,6 @@ spec:
     targetPort: 8080
   selector:
     gardener.cloud/role: etcd-druid
-  sessionAffinity: None
   type: ClusterIP
 status:
   loadBalancer: {}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement

**What this PR does / why we need it**:
We exposed compaction metrics through https://github.com/gardener/etcd-druid/pull/569. The metrics were exposed in k8s controller's metrics endpoint. But the endpoint was not exposed through service yet. This PR brings the change in etcd-druid deployment to open the port 8080 for k8s controller's metrics endpoint.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
