### PR TITLE
Adapt `gardenlet` to take over management of `machine-controller-manager` deployment

### DIFF
--- a/charts/gardener/gardenlet/templates/clusterrole-gardenlet.yaml
+++ b/charts/gardener/gardenlet/templates/clusterrole-gardenlet.yaml
@@ -435,3 +435,11 @@ rules:
   - envoyfilters
   verbs:
   - delete
+- apiGroups:
+  - machine.sapcloud.io
+  resources:
+  - machinedeployments
+  verbs:
+  - list
+  - watch
+  - get

--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -122,6 +122,19 @@ images:
 - name: kube-proxy
   sourceRepository: github.com/kubernetes/kubernetes
   repository: registry.k8s.io/kube-proxy
+- name: machine-controller-manager
+  sourceRepository: github.com/gardener/machine-controller-manager
+  repository: eu.gcr.io/gardener-project/gardener/machine-controller-manager
+  tag: "v0.49.1"
+  labels:
+  - name: gardener.cloud/cve-categorisation
+    value:
+      network_exposure: protected
+      authentication_enforced: false
+      user_interaction: gardener-operator
+      confidentiality_requirement: high
+      integrity_requirement: high
+      availability_requirement: low
 - name: cluster-autoscaler
   sourceRepository: github.com/gardener/autoscaler
   repository: eu.gcr.io/gardener-project/gardener/autoscaler/cluster-autoscaler

--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -125,7 +125,7 @@ images:
 - name: machine-controller-manager
   sourceRepository: github.com/gardener/machine-controller-manager
   repository: eu.gcr.io/gardener-project/gardener/machine-controller-manager
-  tag: "v0.49.1"
+  tag: "v0.49.2"
   labels:
   - name: gardener.cloud/cve-categorisation
     value:

--- a/charts/seed-monitoring/charts/plutono/dashboards/owners/machine-controller-manager/mcm-dashboard.json
+++ b/charts/seed-monitoring/charts/plutono/dashboards/owners/machine-controller-manager/mcm-dashboard.json
@@ -1,0 +1,1175 @@
+{
+  "description": "Information about the operations of the Machine Controller Manager",
+  "editable": false,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": 16,
+  "iteration": 1564731005347,
+  "links": [
+    {
+      "icon": "external link",
+      "tags": [],
+      "targetBlank": true,
+      "title": "Machine Controller Manager",
+      "tooltip": "",
+      "type": "link",
+      "url": "https://github.com/gardener/machine-controller-manager"
+    }
+  ],
+  "panels": [
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "decimals": null,
+      "description": "State of the managed machines.\n\n| Code | Machine State |\n|---|---|\n| 0 | Running |\n| 1 | Terminating |\n| 2 | Unknown |\n| 3 | Failed |\n| -1 | Available |\n| -2 | Pending |",
+      "fill": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 5,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "mcm_machine_current_status_phase",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{name}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Managed Machines States",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": null,
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": "3.2",
+          "min": "-2.2",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "description": "Shows the CPU usage of the Machine Controller Manager and shows the requests and limits.",
+      "fill": 0,
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 7
+      },
+      "id": 13,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(rate(container_cpu_usage_seconds_total{pod=~\"machine-controller-manager-(.+)\"}[5m])) by (pod)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "Current ({{pod}})",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(kube_pod_container_resource_limits{resource=\"cpu\", unit=\"core\", pod=~\"machine-controller-manager-(.+)\"}) by (pod)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "Limits ({{pod}})",
+          "refId": "C"
+        },
+        {
+          "expr": "sum(kube_pod_container_resource_requests{resource=\"cpu\", unit=\"core\", pod=~\"machine-controller-manager-(.+)\"}) by (pod)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "Requests ({{pod}})",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "MCM CPU usage",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": null,
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "description": "Shows the memory usage of the Machine Controller Manager.",
+      "fill": 0,
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 12,
+        "y": 7
+      },
+      "id": 11,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(container_memory_working_set_bytes{pod=~\"machine-controller-manager-(.+)\"}) by (pod)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "Current ({{pod}})",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(kube_pod_container_resource_limits{resource=\"memory\", unit=\"byte\", pod=~\"machine-controller-manager-(.+)\"}) by (pod)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "Limits ({{pod}})",
+          "refId": "B"
+        },
+        {
+          "expr": "sum(kube_pod_container_resource_requests{resource=\"memory\", unit=\"byte\", pod=~\"machine-controller-manager-(.+)\"}) by (pod)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "Requests ({{pod}})",
+          "refId": "C"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "MCM Memory Usage",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "bytes",
+          "label": null,
+          "logBase": 2,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "none",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "description": "Indicates if the Machine Controller Manager is frozen due to unreachable API server.\n\n0 = ok; 1= frozen",
+      "fill": 0,
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 13
+      },
+      "id": 2,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 2,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "mcm_machine_controller_frozen",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{pod}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [
+        {
+          "colorMode": "critical",
+          "fill": true,
+          "line": true,
+          "op": "gt",
+          "value": 0.5,
+          "yaxis": "left"
+        },
+        {
+          "colorMode": "ok",
+          "fill": true,
+          "line": true,
+          "op": "lt",
+          "value": 0.5,
+          "yaxis": "left"
+        }
+      ],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "MCM Frozen Status (API Server reachable)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": 0,
+          "format": "short",
+          "label": "",
+          "logBase": 1,
+          "max": "1.2",
+          "min": "-0.2",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "decimals": null,
+      "description": "Average per Second rate over 1m of IaaS provider api calls split by services. \n\nShows also the rate of failed iaas calls if at least one failed.",
+      "fill": 0,
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 12,
+        "y": 13
+      },
+      "id": 4,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "rate(mcm_cloud_api_requests_total[1m])",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{provider}} / {{service}} ({{pod}})",
+          "refId": "A"
+        },
+        {
+          "expr": "rate(mcm_cloud_api_requests_failed_total[1m])",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "Error: {{provider}} / {{service}} ({{pod}})",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "IaaS API Calls",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": null,
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "decimals": 0,
+      "description": "The count of kubernetes resources managed by the Machine Controller Manager.",
+      "fill": 0,
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 19
+      },
+      "id": 3,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "mcm_machine_items_total",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "machine(s)",
+          "refId": "A"
+        },
+        {
+          "expr": "mcm_machine_set_items_total",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "machine set(s)",
+          "refId": "B"
+        },
+        {
+          "expr": "mcm_machine_deployment_items_total",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "machine deployment(s)",
+          "refId": "C"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Count of Managed Resouces",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": 0,
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 25
+      },
+      "id": 9,
+      "panels": [],
+      "title": "Control Loops",
+      "type": "row"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "description": "Average processing time of items in the workqueue.",
+      "fill": 1,
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 26
+      },
+      "id": 19,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "${controlloop}_work_duration{quantile=\"0.5\"}",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "p50 ({{pod}})",
+          "refId": "A"
+        },
+        {
+          "expr": "${controlloop}_work_duration{quantile=\"0.9\"}",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "p90 ({{pod}})",
+          "refId": "B"
+        },
+        {
+          "expr": "${controlloop}_work_duration{quantile=\"0.99\"}",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "p99 ({{pod}})",
+          "refId": "C"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Workqueue item processing time: ${controlloop}",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "ms",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "description": "How long items stay in the workqueue before they get processed.",
+      "fill": 1,
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 26
+      },
+      "id": 18,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "${controlloop}_queue_latency{quantile=\"0.5\"}",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "p50 ({{pod}})",
+          "refId": "A"
+        },
+        {
+          "expr": "${controlloop}_queue_latency{quantile=\"0.9\"}",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "p90 ({{pod}})",
+          "refId": "B"
+        },
+        {
+          "expr": "${controlloop}_queue_latency{quantile=\"0.99\"}",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "p99 ({{pod}})",
+          "refId": "C"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Workqueue item latency: ${controlloop}",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "ms",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "description": "Current amount of items in the workqueue.",
+      "fill": 1,
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 0,
+        "y": 33
+      },
+      "id": 16,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": false,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "${controlloop}_depth",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "${controlloop} ({{pod}})",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Items in Workqueue: ${controlloop}",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "description": "Average per second rate over 5m of workqueue item adds.",
+      "fill": 1,
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 8,
+        "y": 33
+      },
+      "id": 7,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": false,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "rate(${controlloop}_adds[5m])",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "${controlloop} ({{pod}})",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Adds to Workqueue: ${controlloop}",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "description": "Average per second rate over 5m of workqueue item retries.",
+      "fill": 1,
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 16,
+        "y": 33
+      },
+      "id": 17,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": false,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "rate(${controlloop}_retries[5m])",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "${controlloop} ({{pod}})",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Workqueue item retries: ${controlloop}",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 18,
+  "style": "dark",
+  "tags": [
+    "controlplane",
+    "seed"
+  ],
+  "templating": {
+    "list": [
+      {
+        "allValue": null,
+        "current": {
+          "tags": [],
+          "text": "machine",
+          "value": "machine"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Control Loop",
+        "multi": false,
+        "name": "controlloop",
+        "options": [
+          {
+            "selected": true,
+            "text": "machine",
+            "value": "machine"
+          },
+          {
+            "selected": false,
+            "text": "machineset",
+            "value": "machineset"
+          },
+          {
+            "selected": false,
+            "text": "machinedeployment",
+            "value": "machinedeployment"
+          },
+          {
+            "selected": false,
+            "text": "node",
+            "value": "node"
+          },
+          {
+            "selected": false,
+            "text": "secret",
+            "value": "secret"
+          },
+          {
+            "selected": false,
+            "text": "machinesafetyapiserver",
+            "value": "machinesafetyapiserver"
+          },
+          {
+            "selected": false,
+            "text": "machinesafetyorphanvms",
+            "value": "machinesafetyorphanvms"
+          },
+          {
+            "selected": false,
+            "text": "machinesafetyovershooting",
+            "value": "machinesafetyovershooting"
+          }
+        ],
+        "query": "machine, machineset, machinedeployment, node, secret, machinesafetyapiserver, machinesafetyorphanvms, machinesafetyovershooting",
+        "skipUrlSync": false,
+        "type": "custom"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-3h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "14d"
+    ]
+  },
+  "timezone": "",
+  "title": "Machine Controller Manager",
+  "uid": "machine-controller-manager",
+  "version": 1
+}

--- a/charts/seed-monitoring/charts/plutono/templates/_helpers.tpl
+++ b/charts/seed-monitoring/charts/plutono/templates/_helpers.tpl
@@ -69,6 +69,12 @@ plutono-datasources-{{ include "plutono.datasources.data" . | sha256sum | trunc 
 {{          toString $bytes | include "plutono.toCompactedJson" | indent 2 }}
 {{-       end }}
 {{-     end }}
+{{-     if .Values.gardenletManagesMCM }}
+{{        range $name, $bytes := .Files.Glob "dashboards/machine-controller-manager/**.json" }}
+{{          base $name }}: |-
+{{          toString $bytes | include "plutono.toCompactedJson" | indent 2 }}
+{{-       end }}
+{{-     end }}
 {{      range $name, $bytes := .Files.Glob "dashboards/owners/worker/**.json" }}
 {{        base $name }}: |-
 {{        toString $bytes | include "plutono.toCompactedJson" | indent 2 }}

--- a/charts/seed-monitoring/charts/plutono/values.yaml
+++ b/charts/seed-monitoring/charts/plutono/values.yaml
@@ -23,6 +23,8 @@ sni:
 nodeLocalDNS:
   enabled: false
 
+gardenletManagesMCM: false
+
 reversedVPN:
   highAvailabilityEnabled: false
 

--- a/docs/deployment/feature_gates.md
+++ b/docs/deployment/feature_gates.md
@@ -36,6 +36,7 @@ The following tables are a summary of the feature gates that you can set on diff
 | FullNetworkPoliciesInRuntimeCluster        | `true`  | `Beta`  | `1.71` | `1.72` |
 | FullNetworkPoliciesInRuntimeCluster        | `true`  | `GA`    | `1.73` |        |
 | WorkerlessShoots                           | `false` | `Alpha` | `1.70` |        |
+| MachineControllerManagerDeployment         | `false` | `Alpha` | `1.73` |        |
 
 ## Feature Gates for Graduated or Deprecated Features
 
@@ -173,3 +174,4 @@ A *General Availability* (GA) feature is also referred to as a *stable* feature.
 | MutableShootSpecNetworkingNodes            | `gardener-apiserver`              | Allows updating the field `spec.networking.nodes`. The validity of the values has to be checked in the provider extensions. Only enable this feature gate when your system runs provider extensions which have implemented the validation.                                                                                                                                         |
 | FullNetworkPoliciesInRuntimeCluster        | `gardenlet`, `gardener-operator`  | Enables the `NetworkPolicy` controller to place 'deny-all' network policies in all relevant namespaces in the runtime cluster.                                                                                                                                                                                                                                                     |
 | WorkerlessShoots                           | `gardener-apiserver`              | WorkerlessShoots allows creation of Shoot clusters with no worker pools.                                                                                                                                                                                                                                                                                                           |
+| MachineControllerManagerDeployment         | `gardenlet`                       | Enables Gardener to take over the deployment of the machine-controller-manager. If enabled, all registered provider extensions must support injecting the provider-specific MCM sidecar container into the deployment via the `controlplane` webhook.                                                                                                                              |

--- a/docs/extensions/conventions.md
+++ b/docs/extensions/conventions.md
@@ -29,7 +29,7 @@ As there is no formal process to validate non-existence of conflicts between two
 
 *The resource name should be prefixed with `extensions.gardener.cloud:<extension-type>-<extension-name>:<resource-name>`*, for example:
 
-* `extensions.gardener.cloud:provider-aws:machine-controller-manager`
+* `extensions.gardener.cloud:provider-aws:some-controller-manager`
 * `extensions.gardener.cloud:extension-certificate-service:cert-broker`
 
 ## How to create resources in the shoot cluster?

--- a/docs/extensions/logging-and-monitoring.md
+++ b/docs/extensions/logging-and-monitoring.md
@@ -110,7 +110,7 @@ To contribute its own configuration to the fluent-bit agents data pipelines, an 
 
 > **Note:** Take care to provide the correct data pipeline elements in the corresponding fields and not to mix them.
 
-**Example:** Logging configuration for provider-specific (OpenStack) worker controller deploying a `machine-controller-manager` component into a shoot namespace that reuses the `kube-apiserver-parser` defined in [logging.go](../../pkg/component/kubeapiserver/logging.go) to parse the component logs:
+**Example:** Logging configuration for provider-specific `cloud-controller-manager` deployed into shoot namespaces that reuses the `kube-apiserver-parser` defined in [logging.go](../../pkg/component/kubeapiserver/logging.go) to parse the component logs:
 
 ```yaml
 apiVersion: fluentbit.fluent.io/v1alpha2
@@ -118,14 +118,14 @@ kind: ClusterFilter
 metadata:
   labels:
     fluentbit.gardener/type: "seed"
-  name: machine-controller-manager-openstack
+  name: cloud-controller-manager-aws-cloud-controller-manager
 spec:
   filters:
   - parser:
       keyName: log
       parser: kube-apiserver-parser
       reserveData: true
-  match: kubernetes.*machine-controller-manager*openstack*
+  match: kubernetes.*cloud-controller-manager*aws-cloud-controller-manager*
 ```
 
 Further details how to define parsers and use them with examples can be found in the following [guide](../development/log_parsers.md).

--- a/extensions/pkg/controller/cmd/options.go
+++ b/extensions/pkg/controller/cmd/options.go
@@ -73,6 +73,9 @@ const (
 
 	// GardenerVersionFlag is the name of the command line flag containing the Gardener version.
 	GardenerVersionFlag = "gardener-version"
+	// GardenletManagesMCMFlag is the name of the command line flag containing the Gardener version.
+	// TODO(rfranzke): Remove this flag when all provider extensions support the feature, see https://github.com/gardener/gardener/issues/7594.
+	GardenletManagesMCMFlag = "gardenlet-manages-mcm"
 
 	// LogLevelFlag is the name of the command line flag containing the log level.
 	LogLevelFlag = "log-level"
@@ -491,21 +494,25 @@ type SwitchConfig struct {
 
 // GeneralOptions are command line options that can be set for general configuration.
 type GeneralOptions struct {
-	// GardenerVersion string
+	// GardenerVersion is the version of the Gardener.
 	GardenerVersion string
+	// GardenletManagesMCM specifies whether gardenlet manages the machine-controller-manager.
+	GardenletManagesMCM bool
 
 	config *GeneralConfig
 }
 
 // GeneralConfig is a completed general configuration.
 type GeneralConfig struct {
-	// GardenerVersion string
+	// GardenerVersion is the version of the Gardener.
 	GardenerVersion string
+	// GardenletManagesMCM specifies whether gardenlet manages the machine-controller-manager.
+	GardenletManagesMCM bool
 }
 
 // Complete implements Complete.
 func (r *GeneralOptions) Complete() error {
-	r.config = &GeneralConfig{r.GardenerVersion}
+	r.config = &GeneralConfig{r.GardenerVersion, r.GardenletManagesMCM}
 	return nil
 }
 
@@ -517,4 +524,5 @@ func (r *GeneralOptions) Completed() *GeneralConfig {
 // AddFlags implements Flagger.AddFlags.
 func (r *GeneralOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&r.GardenerVersion, GardenerVersionFlag, "", "Version of the gardenlet.")
+	fs.BoolVar(&r.GardenletManagesMCM, GardenletManagesMCMFlag, false, "Specifies whether gardenlet manages the machine-controller-manager.")
 }

--- a/extensions/pkg/controller/worker/genericactuator/actuator.go
+++ b/extensions/pkg/controller/worker/genericactuator/actuator.go
@@ -51,6 +51,7 @@ const GardenPurposeMachineClass = "machineclass"
 
 type genericActuator struct {
 	delegateFactory DelegateFactory
+	mcmManaged      bool
 	mcmName         string
 	mcmSeedChart    chart.Interface
 	mcmShootChart   chart.Interface
@@ -68,6 +69,7 @@ type genericActuator struct {
 // NewActuator creates a new Actuator that reconciles
 // Worker resources of Gardener's `extensions.gardener.cloud` API group.
 // It provides a default implementation that allows easier integration of providers.
+// If machine-controller-manager should not be managed then only the delegateFactory must be provided.
 func NewActuator(
 	delegateFactory DelegateFactory,
 	mcmName string,
@@ -78,6 +80,7 @@ func NewActuator(
 ) worker.Actuator {
 	return &genericActuator{
 		delegateFactory:      delegateFactory,
+		mcmManaged:           mcmName != "" && mcmSeedChart != nil && mcmShootChart != nil && imageVector != nil && chartRendererFactory != nil,
 		mcmName:              mcmName,
 		mcmSeedChart:         mcmSeedChart,
 		mcmShootChart:        mcmShootChart,

--- a/extensions/pkg/controller/worker/genericactuator/actuator_migrate.go
+++ b/extensions/pkg/controller/worker/genericactuator/actuator_migrate.go
@@ -42,13 +42,15 @@ func (a *genericActuator) Migrate(ctx context.Context, log logr.Logger, worker *
 		return fmt.Errorf("could not keep objects of managed resource containing mcm chart for worker '%s': %w", kubernetesutils.ObjectName(worker), err)
 	}
 
-	// Make sure machine-controller-manager is deleted before deleting the machines.
-	if err := a.deleteMachineControllerManager(ctx, log, worker); err != nil {
-		return fmt.Errorf("failed deleting machine-controller-manager: %w", err)
-	}
+	if a.mcmManaged {
+		// Make sure machine-controller-manager is deleted before deleting the machines.
+		if err := a.deleteMachineControllerManager(ctx, log, worker); err != nil {
+			return fmt.Errorf("failed deleting machine-controller-manager: %w", err)
+		}
 
-	if err := a.waitUntilMachineControllerManagerIsDeleted(ctx, log, worker.Namespace); err != nil {
-		return fmt.Errorf("failed deleting machine-controller-manager: %w", err)
+		if err := a.waitUntilMachineControllerManagerIsDeleted(ctx, log, worker.Namespace); err != nil {
+			return fmt.Errorf("failed deleting machine-controller-manager: %w", err)
+		}
 	}
 
 	if err := a.shallowDeleteAllObjects(ctx, log, worker.Namespace, &machinev1alpha1.MachineList{}); err != nil {

--- a/extensions/pkg/controller/worker/genericactuator/actuator_restore.go
+++ b/extensions/pkg/controller/worker/genericactuator/actuator_restore.go
@@ -93,6 +93,13 @@ func RestoreWithoutReconcile(
 		return fmt.Errorf("failed to restore the machine deployment config: %w", err)
 	}
 
+	// Scale the machine-controller-manager to 1 now that all resources have been restored.
+	if !extensionscontroller.IsHibernated(cluster) {
+		if err := scaleMachineControllerManager(ctx, log, cl, worker, 1); err != nil {
+			return fmt.Errorf("failed to scale up machine-controller-manager: %w", err)
+		}
+	}
+
 	return nil
 }
 

--- a/extensions/pkg/controller/worker/genericactuator/machine_controller_manager.go
+++ b/extensions/pkg/controller/worker/genericactuator/machine_controller_manager.go
@@ -48,6 +48,11 @@ const (
 type ReplicaCount func() int32
 
 func (a *genericActuator) deployMachineControllerManager(ctx context.Context, logger logr.Logger, workerObj *extensionsv1alpha1.Worker, cluster *extensionscontroller.Cluster, workerDelegate WorkerDelegate, replicas ReplicaCount) error {
+	if !a.mcmManaged {
+		logger.Info("Skip machine-controller-manager deployment since gardenlet manages it")
+		return managedresources.Delete(ctx, a.client, workerObj.Namespace, McmShootResourceName, false)
+	}
+
 	logger.Info("Deploying the machine-controller-manager")
 
 	mcmValues, err := workerDelegate.GetMachineControllerManagerChartValues(ctx)
@@ -71,7 +76,7 @@ func (a *genericActuator) deployMachineControllerManager(ctx context.Context, lo
 		return fmt.Errorf("could not apply MCM chart in seed for worker '%s': %w", kubernetesutils.ObjectName(workerObj), err)
 	}
 
-	if err := a.applyMachineControllerManagerShootChart(ctx, workerDelegate, workerObj, cluster); err != nil {
+	if err := a.applyMachineControllerManagerShootChart(ctx, logger, workerDelegate, workerObj, cluster); err != nil {
 		return fmt.Errorf("could not apply machine-controller-manager shoot chart: %w", err)
 	}
 
@@ -84,6 +89,11 @@ func (a *genericActuator) deployMachineControllerManager(ctx context.Context, lo
 }
 
 func (a *genericActuator) deleteMachineControllerManager(ctx context.Context, logger logr.Logger, workerObj *extensionsv1alpha1.Worker) error {
+	if !a.mcmManaged {
+		logger.Info("Skip machine-controller-manager deletion since gardenlet manages it")
+		return managedresources.Delete(ctx, a.client, workerObj.Namespace, McmShootResourceName, false)
+	}
+
 	logger.Info("Deleting the machine-controller-manager")
 	if err := managedresources.Delete(ctx, a.client, workerObj.Namespace, McmShootResourceName, false); err != nil {
 		return fmt.Errorf("could not delete managed resource containing mcm chart for worker '%s': %w", kubernetesutils.ObjectName(workerObj), err)
@@ -123,7 +133,12 @@ func scaleMachineControllerManager(ctx context.Context, logger logr.Logger, cl c
 	return client.IgnoreNotFound(kubernetes.ScaleDeployment(ctx, cl, kubernetesutils.Key(worker.Namespace, McmDeploymentName), replicas))
 }
 
-func (a *genericActuator) applyMachineControllerManagerShootChart(ctx context.Context, workerDelegate WorkerDelegate, workerObj *extensionsv1alpha1.Worker, cluster *controller.Cluster) error {
+func (a *genericActuator) applyMachineControllerManagerShootChart(ctx context.Context, logger logr.Logger, workerDelegate WorkerDelegate, workerObj *extensionsv1alpha1.Worker, cluster *controller.Cluster) error {
+	if !a.mcmManaged {
+		logger.Info("Skip machine-controller-manager shoot chart application since gardenlet manages it")
+		return nil
+	}
+
 	// Create shoot chart renderer
 	chartRenderer, err := a.chartRendererFactory.NewChartRendererForShoot(cluster.Shoot.Spec.Kubernetes.Version)
 	if err != nil {

--- a/extensions/pkg/controller/worker/genericactuator/machine_controller_manager.go
+++ b/extensions/pkg/controller/worker/genericactuator/machine_controller_manager.go
@@ -49,7 +49,10 @@ type ReplicaCount func() int32
 
 func (a *genericActuator) deployMachineControllerManager(ctx context.Context, logger logr.Logger, workerObj *extensionsv1alpha1.Worker, cluster *extensionscontroller.Cluster, workerDelegate WorkerDelegate, replicas ReplicaCount) error {
 	if !a.mcmManaged {
-		logger.Info("Skip machine-controller-manager deployment since gardenlet manages it")
+		logger.Info("Skip machine-controller-manager deployment since gardenlet manages it - deleting monitoring ConfigMap and extension-worker-mcm-shoot ManagedResource")
+		if err := a.client.Delete(ctx, &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "machine-controller-manager-monitoring-config", Namespace: workerObj.Namespace}}); client.IgnoreNotFound(err) != nil {
+			return err
+		}
 		return managedresources.Delete(ctx, a.client, workerObj.Namespace, McmShootResourceName, false)
 	}
 
@@ -90,7 +93,10 @@ func (a *genericActuator) deployMachineControllerManager(ctx context.Context, lo
 
 func (a *genericActuator) deleteMachineControllerManager(ctx context.Context, logger logr.Logger, workerObj *extensionsv1alpha1.Worker) error {
 	if !a.mcmManaged {
-		logger.Info("Skip machine-controller-manager deletion since gardenlet manages it")
+		logger.Info("Skip machine-controller-manager deployment since gardenlet manages it - deleting monitoring ConfigMap and extension-worker-mcm-shoot ManagedResource")
+		if err := a.client.Delete(ctx, &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "machine-controller-manager-monitoring-config", Namespace: workerObj.Namespace}}); client.IgnoreNotFound(err) != nil {
+			return err
+		}
 		return managedresources.Delete(ctx, a.client, workerObj.Namespace, McmShootResourceName, false)
 	}
 

--- a/extensions/pkg/webhook/controlplane/genericmutator/mock/mocks.go
+++ b/extensions/pkg/webhook/controlplane/genericmutator/mock/mocks.go
@@ -16,6 +16,7 @@ import (
 	gomock "github.com/golang/mock/gomock"
 	v1 "k8s.io/api/apps/v1"
 	v10 "k8s.io/api/core/v1"
+	v11 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
 	v1beta1 "k8s.io/kubelet/config/v1beta1"
 )
 
@@ -209,6 +210,34 @@ func (m *MockEnsurer) EnsureKubernetesGeneralConfiguration(arg0 context.Context,
 func (mr *MockEnsurerMockRecorder) EnsureKubernetesGeneralConfiguration(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureKubernetesGeneralConfiguration", reflect.TypeOf((*MockEnsurer)(nil).EnsureKubernetesGeneralConfiguration), arg0, arg1, arg2, arg3)
+}
+
+// EnsureMachineControllerManagerDeployment mocks base method.
+func (m *MockEnsurer) EnsureMachineControllerManagerDeployment(arg0 context.Context, arg1 context0.GardenContext, arg2, arg3 *v1.Deployment) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "EnsureMachineControllerManagerDeployment", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// EnsureMachineControllerManagerDeployment indicates an expected call of EnsureMachineControllerManagerDeployment.
+func (mr *MockEnsurerMockRecorder) EnsureMachineControllerManagerDeployment(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureMachineControllerManagerDeployment", reflect.TypeOf((*MockEnsurer)(nil).EnsureMachineControllerManagerDeployment), arg0, arg1, arg2, arg3)
+}
+
+// EnsureMachineControllerManagerVPA mocks base method.
+func (m *MockEnsurer) EnsureMachineControllerManagerVPA(arg0 context.Context, arg1 context0.GardenContext, arg2, arg3 *v11.VerticalPodAutoscaler) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "EnsureMachineControllerManagerVPA", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// EnsureMachineControllerManagerVPA indicates an expected call of EnsureMachineControllerManagerVPA.
+func (mr *MockEnsurerMockRecorder) EnsureMachineControllerManagerVPA(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureMachineControllerManagerVPA", reflect.TypeOf((*MockEnsurer)(nil).EnsureMachineControllerManagerVPA), arg0, arg1, arg2, arg3)
 }
 
 // EnsureVPNSeedServerDeployment mocks base method.

--- a/extensions/pkg/webhook/controlplane/genericmutator/noopensurer.go
+++ b/extensions/pkg/webhook/controlplane/genericmutator/noopensurer.go
@@ -22,6 +22,7 @@ import (
 	druidv1alpha1 "github.com/gardener/etcd-druid/api/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	vpaautoscalingv1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
 	kubeletconfigv1beta1 "k8s.io/kubelet/config/v1beta1"
 
 	extensionscontextwebhook "github.com/gardener/gardener/extensions/pkg/webhook/context"
@@ -50,6 +51,16 @@ func (e *NoopEnsurer) EnsureKubeControllerManagerDeployment(ctx context.Context,
 
 // EnsureKubeSchedulerDeployment ensures that the kube-scheduler deployment conforms to the provider requirements.
 func (e *NoopEnsurer) EnsureKubeSchedulerDeployment(ctx context.Context, gctx extensionscontextwebhook.GardenContext, new, old *appsv1.Deployment) error {
+	return nil
+}
+
+// EnsureMachineControllerManagerDeployment ensures that the machine-controller-manager deployment conforms to the provider requirements.
+func (e *NoopEnsurer) EnsureMachineControllerManagerDeployment(ctx context.Context, gctx extensionscontextwebhook.GardenContext, new, old *appsv1.Deployment) error {
+	return nil
+}
+
+// EnsureMachineControllerManagerVPA ensures that the machine-controller-manager deployment conforms to the provider requirements.
+func (e *NoopEnsurer) EnsureMachineControllerManagerVPA(ctx context.Context, gctx extensionscontextwebhook.GardenContext, new, old *vpaautoscalingv1.VerticalPodAutoscaler) error {
 	return nil
 }
 

--- a/extensions/pkg/webhook/utils.go
+++ b/extensions/pkg/webhook/utils.go
@@ -229,7 +229,7 @@ func EnsureNoContainerWithName(items []corev1.Container, name string) []corev1.C
 }
 
 // EnsureVPAContainerResourcePolicyWithName ensures that a container policy with a name equal to the name of the given
-// container policy exists in the given slice and is equal to the given contailer policy.
+// container policy exists in the given slice and is equal to the given container policy.
 func EnsureVPAContainerResourcePolicyWithName(items []vpaautoscalingv1.ContainerResourcePolicy, item vpaautoscalingv1.ContainerResourcePolicy) []vpaautoscalingv1.ContainerResourcePolicy {
 	if i := vpaContainerResourcePolicyWithNameIndex(items, item.ContainerName); i < 0 {
 		items = append(items, item)

--- a/extensions/pkg/webhook/utils.go
+++ b/extensions/pkg/webhook/utils.go
@@ -22,6 +22,7 @@ import (
 	"github.com/coreos/go-systemd/v22/unit"
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
+	vpaautoscalingv1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
 
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 )
@@ -227,6 +228,17 @@ func EnsureNoContainerWithName(items []corev1.Container, name string) []corev1.C
 	return items
 }
 
+// EnsureVPAContainerResourcePolicyWithName ensures that a container policy with a name equal to the name of the given
+// container policy exists in the given slice and is equal to the given contailer policy.
+func EnsureVPAContainerResourcePolicyWithName(items []vpaautoscalingv1.ContainerResourcePolicy, item vpaautoscalingv1.ContainerResourcePolicy) []vpaautoscalingv1.ContainerResourcePolicy {
+	if i := vpaContainerResourcePolicyWithNameIndex(items, item.ContainerName); i < 0 {
+		items = append(items, item)
+	} else if !reflect.DeepEqual(items[i], item) {
+		items = append(append(items[:i], item), items[i+1:]...)
+	}
+	return items
+}
+
 // EnsurePVCWithName ensures that a PVC with a name equal to the name of the given PVC exists
 // in the given slice and is equal to the given PVC.
 func EnsurePVCWithName(items []corev1.PersistentVolumeClaim, item corev1.PersistentVolumeClaim) []corev1.PersistentVolumeClaim {
@@ -297,6 +309,15 @@ func StringWithPrefixIndex(items []string, prefix string) int {
 func containerWithNameIndex(items []corev1.Container, name string) int {
 	for i, item := range items {
 		if item.Name == name {
+			return i
+		}
+	}
+	return -1
+}
+
+func vpaContainerResourcePolicyWithNameIndex(items []vpaautoscalingv1.ContainerResourcePolicy, name string) int {
+	for i, item := range items {
+		if item.ContainerName == name {
 			return i
 		}
 	}

--- a/pkg/component/machinecontrollermanager/machine_controller_manager.go
+++ b/pkg/component/machinecontrollermanager/machine_controller_manager.go
@@ -59,6 +59,8 @@ const (
 	containerName             = "machine-controller-manager"
 	serviceName               = "machine-controller-manager"
 	managedResourceTargetName = "shoot-core-machine-controller-manager"
+	// VPAName is the name of the vertical pod autoscaler for the machine-controller-manager.
+	VPAName = "machine-controller-manager-vpa"
 )
 
 // Interface contains functions for a machine-controller-manager deployer.
@@ -489,7 +491,7 @@ func (m *machineControllerManager) emptyPodDisruptionBudget() client.Object {
 }
 
 func (m *machineControllerManager) emptyVPA() *vpaautoscalingv1.VerticalPodAutoscaler {
-	return &vpaautoscalingv1.VerticalPodAutoscaler{ObjectMeta: metav1.ObjectMeta{Name: "machine-controller-manager-vpa", Namespace: m.namespace}}
+	return &vpaautoscalingv1.VerticalPodAutoscaler{ObjectMeta: metav1.ObjectMeta{Name: VPAName, Namespace: m.namespace}}
 }
 
 func (m *machineControllerManager) emptyManagedResource() *resourcesv1alpha1.ManagedResource {

--- a/pkg/component/machinecontrollermanager/provider.go
+++ b/pkg/component/machinecontrollermanager/provider.go
@@ -1,0 +1,87 @@
+// Copyright 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package machinecontrollermanager
+
+import (
+	"strconv"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	vpaautoscalingv1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
+
+	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
+)
+
+// ProviderSidecarContainer returns a corev1.Container object which can be injected into the machine-controller-manager
+// deployment managed by the gardenlet. This function can be used in provider-specific control plane webhook
+// implementations when the standard sidecar container is required.
+func ProviderSidecarContainer(namespace, providerName, image string) corev1.Container {
+	const metricsPort = 10259
+	return corev1.Container{
+		Name:            providerSidecarContainerName(providerName),
+		Image:           image,
+		ImagePullPolicy: corev1.PullIfNotPresent,
+		Command: []string{
+			"./machine-controller",
+			"--control-kubeconfig=inClusterConfig",
+			"--machine-creation-timeout=20m",
+			"--machine-drain-timeout=2h",
+			"--machine-health-timeout=10m",
+			"--machine-safety-apiserver-statuscheck-timeout=30s",
+			"--machine-safety-apiserver-statuscheck-period=1m",
+			"--machine-safety-orphan-vms-period=30m",
+			"--namespace=" + namespace,
+			"--port=" + strconv.Itoa(metricsPort),
+			"--target-kubeconfig=" + gardenerutils.PathGenericKubeconfig,
+			"--v=3",
+		},
+		LivenessProbe: &corev1.Probe{
+			ProbeHandler: corev1.ProbeHandler{
+				HTTPGet: &corev1.HTTPGetAction{
+					Path:   "/healthz",
+					Port:   intstr.FromInt(metricsPort),
+					Scheme: corev1.URISchemeHTTP,
+				},
+			},
+			InitialDelaySeconds: 30,
+			TimeoutSeconds:      5,
+			PeriodSeconds:       10,
+			SuccessThreshold:    1,
+			FailureThreshold:    3,
+		},
+		VolumeMounts: []corev1.VolumeMount{{
+			Name:      "kubeconfig",
+			MountPath: gardenerutils.VolumeMountPathGenericKubeconfig,
+			ReadOnly:  true,
+		}},
+	}
+}
+
+// ProviderSidecarVPAContainerPolicy returns a vpaautoscalingv1.ContainerResourcePolicy object which can be injected
+// into the machine-controller-manager-vpa VPA managed by the gardenlet. This function can be used in provider-specific
+// control plane webhook implementations when the standard container policy for the sidecar is required.
+func ProviderSidecarVPAContainerPolicy(providerName string, minAllowed, maxAllowed corev1.ResourceList) vpaautoscalingv1.ContainerResourcePolicy {
+	ccv := vpaautoscalingv1.ContainerControlledValuesRequestsOnly
+	return vpaautoscalingv1.ContainerResourcePolicy{
+		ContainerName:    providerSidecarContainerName(providerName),
+		ControlledValues: &ccv,
+		MinAllowed:       minAllowed,
+		MaxAllowed:       maxAllowed,
+	}
+}
+
+func providerSidecarContainerName(providerName string) string {
+	return "machine-controller-manager-" + providerName
+}

--- a/pkg/component/machinecontrollermanager/provider_test.go
+++ b/pkg/component/machinecontrollermanager/provider_test.go
@@ -1,0 +1,91 @@
+// Copyright 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package machinecontrollermanager_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	vpaautoscalingv1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
+
+	. "github.com/gardener/gardener/pkg/component/machinecontrollermanager"
+)
+
+var _ = Describe("Provider", func() {
+	var provider = "provider-test"
+
+	It("should return a default provider-specific sidecar container object", func() {
+		var (
+			namespace = "test-namespace"
+			image     = "provider-test:latest"
+		)
+
+		Expect(ProviderSidecarContainer(namespace, provider, image)).To(Equal(corev1.Container{
+			Name:            "machine-controller-manager-" + provider,
+			Image:           image,
+			ImagePullPolicy: "IfNotPresent",
+			Command: []string{
+				"./machine-controller",
+				"--control-kubeconfig=inClusterConfig",
+				"--machine-creation-timeout=20m",
+				"--machine-drain-timeout=2h",
+				"--machine-health-timeout=10m",
+				"--machine-safety-apiserver-statuscheck-timeout=30s",
+				"--machine-safety-apiserver-statuscheck-period=1m",
+				"--machine-safety-orphan-vms-period=30m",
+				"--namespace=" + namespace,
+				"--port=10259",
+				"--target-kubeconfig=/var/run/secrets/gardener.cloud/shoot/generic-kubeconfig/kubeconfig",
+				"--v=3",
+			},
+			LivenessProbe: &corev1.Probe{
+				ProbeHandler: corev1.ProbeHandler{
+					HTTPGet: &corev1.HTTPGetAction{
+						Path:   "/healthz",
+						Port:   intstr.FromInt(10259),
+						Scheme: "HTTP",
+					},
+				},
+				InitialDelaySeconds: 30,
+				TimeoutSeconds:      5,
+				PeriodSeconds:       10,
+				SuccessThreshold:    1,
+				FailureThreshold:    3,
+			},
+			VolumeMounts: []corev1.VolumeMount{{
+				Name:      "kubeconfig",
+				MountPath: "/var/run/secrets/gardener.cloud/shoot/generic-kubeconfig",
+				ReadOnly:  true,
+			}},
+		}))
+	})
+
+	It("should return a default VPA container policy object for the provider-specific sidecar container", func() {
+		var (
+			ccv        = vpaautoscalingv1.ContainerControlledValuesRequestsOnly
+			minAllowed = corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("1M")}
+			maxAllowed = corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("5M")}
+		)
+
+		Expect(ProviderSidecarVPAContainerPolicy(provider, minAllowed, maxAllowed)).To(Equal(vpaautoscalingv1.ContainerResourcePolicy{
+			ContainerName:    "machine-controller-manager-" + provider,
+			ControlledValues: &ccv,
+			MinAllowed:       minAllowed,
+			MaxAllowed:       maxAllowed,
+		}))
+	})
+})

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -86,6 +86,13 @@ const (
 	// owner: @acumino @ary1992 @shafeeqes
 	// alpha: v1.70.0
 	WorkerlessShoots featuregate.Feature = "WorkerlessShoots"
+
+	// MachineControllerManagerDeployment enables Gardener to take over the deployment of the
+	// machine-controller-manager. If enabled, all registered provider extensions must support injecting the
+	// provider-specific MCM provider sidecar container into the deployment via the `controlplane` webhook.
+	// owner: @rfranzke @JensAc @mreiger
+	// alpha: v1.73.0
+	MachineControllerManagerDeployment featuregate.Feature = "MachineControllerManagerDeployment"
 )
 
 // DefaultFeatureGate is the central feature gate map used by all gardener components.
@@ -122,6 +129,7 @@ var allFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	MutableShootSpecNetworkingNodes:     {Default: false, PreRelease: featuregate.Alpha},
 	FullNetworkPoliciesInRuntimeCluster: {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
 	WorkerlessShoots:                    {Default: false, PreRelease: featuregate.Alpha},
+	MachineControllerManagerDeployment:  {Default: false, PreRelease: featuregate.Alpha},
 }
 
 // GetFeatures returns a feature gate map with the respective specifications. Non-existing feature gates are ignored.

--- a/pkg/gardenlet/controller/managedseed/charttest/charttest.go
+++ b/pkg/gardenlet/controller/managedseed/charttest/charttest.go
@@ -392,6 +392,11 @@ func getGardenletClusterRole(labels map[string]string) *rbacv1.ClusterRole {
 				Resources: []string{"destinationrules", "gateways", "virtualservices", "envoyfilters"},
 				Verbs:     []string{"delete"},
 			},
+			{
+				APIGroups: []string{"machine.sapcloud.io"},
+				Resources: []string{"machinedeployments"},
+				Verbs:     []string{"list", "watch", "get"},
+			},
 		},
 	}
 }

--- a/pkg/gardenlet/features/features.go
+++ b/pkg/gardenlet/features/features.go
@@ -30,5 +30,6 @@ func RegisterFeatureGates() {
 		features.CoreDNSQueryRewriting,
 		features.IPv6SingleStack,
 		features.FullNetworkPoliciesInRuntimeCluster,
+		features.MachineControllerManagerDeployment,
 	)))
 }

--- a/pkg/operation/botanist/botanist.go
+++ b/pkg/operation/botanist/botanist.go
@@ -29,6 +29,7 @@ import (
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/component/etcd"
 	"github.com/gardener/gardener/pkg/component/logging/kuberbacproxy"
+	"github.com/gardener/gardener/pkg/features"
 	"github.com/gardener/gardener/pkg/operation"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 	secretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager"
@@ -165,6 +166,12 @@ func New(ctx context.Context, o *operation.Operation) (*Botanist, error) {
 		o.Shoot.Components.ControlPlane.VPNSeedServer, err = b.DefaultVPNSeedServer()
 		if err != nil {
 			return nil, err
+		}
+		if features.DefaultFeatureGate.Enabled(features.MachineControllerManagerDeployment) {
+			o.Shoot.Components.ControlPlane.MachineControllerManager, err = b.DefaultMachineControllerManager(ctx)
+			if err != nil {
+				return nil, err
+			}
 		}
 	}
 

--- a/pkg/operation/botanist/machinecontrollermanager.go
+++ b/pkg/operation/botanist/machinecontrollermanager.go
@@ -1,0 +1,90 @@
+// Copyright 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package botanist
+
+import (
+	"context"
+
+	machinev1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	"github.com/gardener/gardener/pkg/component/machinecontrollermanager"
+	"github.com/gardener/gardener/pkg/utils/images"
+	"github.com/gardener/gardener/pkg/utils/imagevector"
+	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
+)
+
+// DefaultMachineControllerManager returns a deployer for the machine-controller-manager.
+func (b *Botanist) DefaultMachineControllerManager(ctx context.Context) (machinecontrollermanager.Interface, error) {
+	image, err := b.ImageVector.FindImage(images.ImageNameMachineControllerManager, imagevector.RuntimeVersion(b.SeedVersion()), imagevector.TargetVersion(b.ShootVersion()))
+	if err != nil {
+		return nil, err
+	}
+
+	machineDeploymentList := &machinev1alpha1.MachineDeploymentList{}
+	if err := b.SeedClientSet.Client().List(ctx, machineDeploymentList, client.InNamespace(b.Shoot.SeedNamespace)); err != nil {
+		return nil, err
+	}
+
+	var replicas int32 = 1
+	switch {
+	// if there are any existing machine deployments present with a positive replica count then MCM is needed.
+	case machineDeploymentWithPositiveReplicaCountExist(machineDeploymentList):
+		replicas = 1
+	// If the cluster is hibernated then there is no further need of MCM and therefore its desired replicas is 0
+	case b.Shoot.HibernationEnabled && b.Shoot.GetInfo().Status.IsHibernated:
+		replicas = 0
+	// If the cluster is created with hibernation enabled, then desired replicas for MCM is 0
+	case b.Shoot.HibernationEnabled && (b.Shoot.GetInfo().Status.LastOperation == nil || b.Shoot.GetInfo().Status.LastOperation.Type == gardencorev1beta1.LastOperationTypeCreate):
+		replicas = 0
+	// If shoot is either waking up or in the process of hibernation then, MCM is required and therefore its desired replicas is 1
+	case b.Shoot.HibernationEnabled != b.Shoot.GetInfo().Status.IsHibernated:
+		replicas = 1
+	}
+
+	return machinecontrollermanager.New(
+		b.SeedClientSet.Client(),
+		b.Shoot.SeedNamespace,
+		b.SecretsManager,
+		machinecontrollermanager.Values{
+			Image:                    image.String(),
+			Replicas:                 replicas,
+			RuntimeKubernetesVersion: b.Seed.KubernetesVersion,
+		},
+	), nil
+}
+
+// DeployMachineControllerManager deploys the machine-controller-manager.
+func (b *Botanist) DeployMachineControllerManager(ctx context.Context) error {
+	b.Shoot.Components.ControlPlane.MachineControllerManager.SetNamespaceUID(b.SeedNamespaceObject.UID)
+	return b.Shoot.Components.ControlPlane.MachineControllerManager.Deploy(ctx)
+}
+
+// ScaleMachineControllerManagerToZero scales machine-controller-manager replicas to zero.
+func (b *Botanist) ScaleMachineControllerManagerToZero(ctx context.Context) error {
+	return kubernetes.ScaleDeployment(ctx, b.SeedClientSet.Client(), kubernetesutils.Key(b.Shoot.SeedNamespace, v1beta1constants.DeploymentNameMachineControllerManager), 0)
+}
+
+func machineDeploymentWithPositiveReplicaCountExist(existingMachineDeployments *machinev1alpha1.MachineDeploymentList) bool {
+	for _, machineDeployment := range existingMachineDeployments.Items {
+		if machineDeployment.Status.Replicas > 0 {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/operation/botanist/machinecontrollermanager_test.go
+++ b/pkg/operation/botanist/machinecontrollermanager_test.go
@@ -1,0 +1,226 @@
+// Copyright 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package botanist_test
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/Masterminds/semver"
+	machinev1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
+	"github.com/golang/mock/gomock"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	kubernetesmock "github.com/gardener/gardener/pkg/client/kubernetes/mock"
+	mockmachinecontrollermanager "github.com/gardener/gardener/pkg/component/machinecontrollermanager/mock"
+	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
+	"github.com/gardener/gardener/pkg/operation"
+	. "github.com/gardener/gardener/pkg/operation/botanist"
+	seedpkg "github.com/gardener/gardener/pkg/operation/seed"
+	shootpkg "github.com/gardener/gardener/pkg/operation/shoot"
+	"github.com/gardener/gardener/pkg/utils/imagevector"
+	secretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager"
+	fakesecretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager/fake"
+)
+
+var _ = Describe("MachineControllerManager", func() {
+	var (
+		ctx     = context.TODO()
+		fakeErr = fmt.Errorf("fake err")
+
+		ctrl               *gomock.Controller
+		kubernetesClient   *kubernetesmock.MockInterface
+		fakeClient         client.Client
+		fakeSecretsManager secretsmanager.Interface
+
+		shoot      *gardencorev1beta1.Shoot
+		deployment *appsv1.Deployment
+
+		botanist  *Botanist
+		namespace = "shoot--foo--bar"
+	)
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+
+		kubernetesClient = kubernetesmock.NewMockInterface(ctrl)
+		fakeClient = fakeclient.NewClientBuilder().WithScheme(kubernetes.SeedScheme).Build()
+		fakeSecretsManager = fakesecretsmanager.New(fakeClient, namespace)
+
+		shoot = &gardencorev1beta1.Shoot{Spec: gardencorev1beta1.ShootSpec{Kubernetes: gardencorev1beta1.Kubernetes{Version: "1.25.0"}}}
+		deployment = &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "machine-controller-manager", Namespace: namespace}}
+
+		botanist = &Botanist{Operation: &operation.Operation{}}
+		botanist.SeedClientSet = kubernetesClient
+		botanist.SecretsManager = fakeSecretsManager
+		botanist.Seed = &seedpkg.Seed{KubernetesVersion: semver.MustParse("1.25.0")}
+		botanist.Shoot = &shootpkg.Shoot{SeedNamespace: namespace}
+		botanist.Shoot.SetInfo(shoot)
+
+		DeferCleanup(func() {
+			ctrl.Finish()
+		})
+	})
+
+	Describe("#DefaultMachineControllerManager", func() {
+		BeforeEach(func() {
+			kubernetesClient.EXPECT().Version()
+
+			By("Create secrets managed outside of this package for whose secretsmanager.Get() will be called")
+			Expect(fakeClient.Create(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "generic-token-kubeconfig", Namespace: namespace}})).To(Succeed())
+		})
+
+		It("should return an error because the image cannot be found", func() {
+			botanist.ImageVector = imagevector.ImageVector{}
+
+			machineControllerManager, err := botanist.DefaultMachineControllerManager(ctx)
+			Expect(machineControllerManager).To(BeNil())
+			Expect(err).To(HaveOccurred())
+		})
+
+		DescribeTable("it should successfully create a machine-controller-manager interface",
+			func(expectedReplicas int, prepTest func()) {
+				kubernetesClient.EXPECT().Client().Return(fakeClient).Times(2)
+				botanist.ImageVector = imagevector.ImageVector{{Name: "machine-controller-manager"}}
+
+				if prepTest != nil {
+					prepTest()
+				}
+
+				machineControllerManager, err := botanist.DefaultMachineControllerManager(ctx)
+				Expect(machineControllerManager).NotTo(BeNil())
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(machineControllerManager.Deploy(ctx)).To(Succeed())
+				Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(deployment), deployment)).To(Succeed())
+				Expect(deployment.Spec.Replicas).To(PointTo(Equal(int32(expectedReplicas))))
+			},
+
+			Entry("with default replicas", 1, nil),
+			Entry("when machine deployments with positive replica count exist", 1, func() {
+				machineDeployment := &machinev1alpha1.MachineDeployment{
+					ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: namespace},
+					Spec:       machinev1alpha1.MachineDeploymentSpec{Replicas: 5},
+				}
+				Expect(fakeClient.Create(ctx, machineDeployment)).To(Succeed())
+			}),
+			Entry("when shoot is fully hibernated", 0, func() {
+				botanist.Shoot.HibernationEnabled = true
+				shoot.Status.IsHibernated = true
+				botanist.Shoot.SetInfo(shoot)
+			}),
+			Entry("when shoot shall be hibernated but last operation is nil", 0, func() {
+				botanist.Shoot.HibernationEnabled = true
+				shoot.Status.LastOperation = nil
+				botanist.Shoot.SetInfo(shoot)
+			}),
+			Entry("when shoot shall be hibernated but last operation is create", 0, func() {
+				botanist.Shoot.HibernationEnabled = true
+				shoot.Status.LastOperation = &gardencorev1beta1.LastOperation{Type: gardencorev1beta1.LastOperationTypeCreate}
+				botanist.Shoot.SetInfo(shoot)
+			}),
+			Entry("when shoot shall be hibernated but last operation is not create", 1, func() {
+				botanist.Shoot.HibernationEnabled = true
+				shoot.Status.LastOperation = &gardencorev1beta1.LastOperation{Type: gardencorev1beta1.LastOperationTypeReconcile}
+				botanist.Shoot.SetInfo(shoot)
+			}),
+			Entry("when shoot shall be hibernated but process is not finished yet", 1, func() {
+				botanist.Shoot.HibernationEnabled = true
+				shoot.Status.LastOperation = &gardencorev1beta1.LastOperation{Type: gardencorev1beta1.LastOperationTypeReconcile}
+				shoot.Status.IsHibernated = false
+				botanist.Shoot.SetInfo(shoot)
+			}),
+			Entry("when shoot shall be woken up but process is not finished yet", 1, func() {
+				botanist.Shoot.HibernationEnabled = false
+				shoot.Status.LastOperation = &gardencorev1beta1.LastOperation{Type: gardencorev1beta1.LastOperationTypeReconcile}
+				shoot.Status.IsHibernated = true
+				botanist.Shoot.SetInfo(shoot)
+			}),
+		)
+	})
+
+	Describe("#DeployMachineControllerManager", func() {
+		var (
+			machineControllerManager *mockmachinecontrollermanager.MockInterface
+			namespaceUID             = types.UID("5678")
+		)
+
+		BeforeEach(func() {
+			machineControllerManager = mockmachinecontrollermanager.NewMockInterface(ctrl)
+			machineControllerManager.EXPECT().SetNamespaceUID(namespaceUID)
+
+			botanist.SeedNamespaceObject = &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					UID: namespaceUID,
+				},
+			}
+			botanist.Shoot = &shootpkg.Shoot{
+				Components: &shootpkg.Components{
+					ControlPlane: &shootpkg.ControlPlane{
+						MachineControllerManager: machineControllerManager,
+					},
+				},
+			}
+		})
+
+		It("should set the namespace uid and deploy", func() {
+			machineControllerManager.EXPECT().Deploy(ctx)
+			Expect(botanist.DeployMachineControllerManager(ctx)).To(Succeed())
+		})
+
+		It("should fail when the deploy function fails", func() {
+			machineControllerManager.EXPECT().Deploy(ctx).Return(fakeErr)
+			Expect(botanist.DeployMachineControllerManager(ctx)).To(Equal(fakeErr))
+		})
+	})
+
+	Describe("#ScaleMachineControllerManagerToZero", func() {
+		var (
+			mockClient            *mockclient.MockClient
+			mockSubresourceClient *mockclient.MockSubResourceClient
+			patch                 = client.RawPatch(types.MergePatchType, []byte(`{"spec":{"replicas":0}}`))
+		)
+
+		BeforeEach(func() {
+			mockClient = mockclient.NewMockClient(ctrl)
+			mockSubresourceClient = mockclient.NewMockSubResourceClient(ctrl)
+
+			kubernetesClient.EXPECT().Client().Return(mockClient)
+			mockClient.EXPECT().SubResource("scale").Return(mockSubresourceClient)
+
+			botanist.SeedClientSet = kubernetesClient
+		})
+
+		It("should scale the CA deployment", func() {
+			mockSubresourceClient.EXPECT().Patch(ctx, deployment, patch)
+			Expect(botanist.ScaleMachineControllerManagerToZero(ctx)).To(Succeed())
+		})
+
+		It("should fail when the scale call fails", func() {
+			mockSubresourceClient.EXPECT().Patch(ctx, deployment, patch).Return(fakeErr)
+			Expect(botanist.ScaleMachineControllerManagerToZero(ctx)).To(MatchError(fakeErr))
+		})
+	})
+})

--- a/pkg/operation/botanist/monitoring.go
+++ b/pkg/operation/botanist/monitoring.go
@@ -99,6 +99,10 @@ func (b *Botanist) DeploySeedMonitoring(ctx context.Context) error {
 		if b.Shoot.WantsClusterAutoscaler {
 			monitoringComponents = append(monitoringComponents, b.Shoot.Components.ControlPlane.ClusterAutoscaler)
 		}
+
+		if features.DefaultFeatureGate.Enabled(features.MachineControllerManagerDeployment) {
+			monitoringComponents = append(monitoringComponents, b.Shoot.Components.ControlPlane.MachineControllerManager)
+		}
 	}
 
 	for _, component := range monitoringComponents {

--- a/pkg/operation/botanist/monitoring.go
+++ b/pkg/operation/botanist/monitoring.go
@@ -33,6 +33,7 @@ import (
 	"github.com/gardener/gardener/pkg/component"
 	"github.com/gardener/gardener/pkg/component/etcd"
 	"github.com/gardener/gardener/pkg/controllerutils"
+	"github.com/gardener/gardener/pkg/features"
 	gardenlethelper "github.com/gardener/gardener/pkg/gardenlet/apis/config/helper"
 	"github.com/gardener/gardener/pkg/operation/common"
 	"github.com/gardener/gardener/pkg/utils"
@@ -199,6 +200,7 @@ func (b *Botanist) DeploySeedMonitoring(ctx context.Context) error {
 			"nodeLocalDNS": map[string]interface{}{
 				"enabled": b.Shoot.NodeLocalDNSEnabled,
 			},
+			"gardenletManagesMCM": features.DefaultFeatureGate.Enabled(features.MachineControllerManagerDeployment),
 			"ingress": map[string]interface{}{
 				"class":          ingressClass,
 				"authSecretName": credentialsSecret.Name,
@@ -406,7 +408,7 @@ func (b *Botanist) DeploySeedPlutono(ctx context.Context) error {
 		return kubernetesutils.DeleteObject(ctx, b.GardenClient, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: secretName, Namespace: b.Shoot.GetInfo().Namespace}})
 	}
 
-	//TODO(rickardsjp, istvanballok): Remove in release v1.77 once the Grafana to Plutono migration is complete.
+	// TODO(rickardsjp, istvanballok): Remove in release v1.77 once the Grafana to Plutono migration is complete.
 	if err := b.DeleteGrafana(ctx); err != nil {
 		return err
 	}

--- a/pkg/operation/shoot/types.go
+++ b/pkg/operation/shoot/types.go
@@ -46,6 +46,7 @@ import (
 	"github.com/gardener/gardener/pkg/component/kubernetesdashboard"
 	"github.com/gardener/gardener/pkg/component/kubescheduler"
 	"github.com/gardener/gardener/pkg/component/kubestatemetrics"
+	"github.com/gardener/gardener/pkg/component/machinecontrollermanager"
 	"github.com/gardener/gardener/pkg/component/nodelocaldns"
 	"github.com/gardener/gardener/pkg/component/resourcemanager"
 	"github.com/gardener/gardener/pkg/component/vpa"
@@ -116,21 +117,22 @@ type Components struct {
 
 // ControlPlane contains references to K8S control plane components.
 type ControlPlane struct {
-	ClusterAutoscaler     clusterautoscaler.Interface
-	EtcdMain              etcd.Interface
-	EtcdEvents            etcd.Interface
-	EtcdCopyBackupsTask   etcdcopybackupstask.Interface
-	KubeAPIServerIngress  component.Deployer
-	KubeAPIServerService  component.DeployWaiter
-	KubeAPIServerSNI      component.DeployWaiter
-	KubeAPIServerSNIPhase component.Phase
-	KubeAPIServer         kubeapiserver.Interface
-	KubeScheduler         kubescheduler.Interface
-	KubeControllerManager kubecontrollermanager.Interface
-	KubeStateMetrics      kubestatemetrics.Interface
-	ResourceManager       resourcemanager.Interface
-	VerticalPodAutoscaler vpa.Interface
-	VPNSeedServer         vpnseedserver.Interface
+	ClusterAutoscaler        clusterautoscaler.Interface
+	EtcdMain                 etcd.Interface
+	EtcdEvents               etcd.Interface
+	EtcdCopyBackupsTask      etcdcopybackupstask.Interface
+	KubeAPIServerIngress     component.Deployer
+	KubeAPIServerService     component.DeployWaiter
+	KubeAPIServerSNI         component.DeployWaiter
+	KubeAPIServerSNIPhase    component.Phase
+	KubeAPIServer            kubeapiserver.Interface
+	KubeScheduler            kubescheduler.Interface
+	KubeControllerManager    kubecontrollermanager.Interface
+	KubeStateMetrics         kubestatemetrics.Interface
+	MachineControllerManager machinecontrollermanager.Interface
+	ResourceManager          resourcemanager.Interface
+	VerticalPodAutoscaler    vpa.Interface
+	VPNSeedServer            vpnseedserver.Interface
 }
 
 // Extensions contains references to extension resources.

--- a/pkg/utils/images/images.go
+++ b/pkg/utils/images/images.go
@@ -81,6 +81,8 @@ const (
 	ImageNameKubernetesDashboard = "kubernetes-dashboard"
 	// ImageNameKubernetesDashboardMetricsScraper is a constant for an image in the image vector with name 'kubernetes-dashboard-metrics-scraper'.
 	ImageNameKubernetesDashboardMetricsScraper = "kubernetes-dashboard-metrics-scraper"
+	// ImageNameMachineControllerManager is a constant for an image in the image vector with name 'machine-controller-manager'.
+	ImageNameMachineControllerManager = "machine-controller-manager"
 	// ImageNameMetricsServer is a constant for an image in the image vector with name 'metrics-server'.
 	ImageNameMetricsServer = "metrics-server"
 	// ImageNameNginxIngressController is a constant for an image in the image vector with name 'nginx-ingress-controller'.

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -597,6 +597,7 @@ build:
         - pkg/component/extensions/operatingsystemconfig/utils
         - pkg/component/kubeapiserver/constants
         - pkg/component/kubeproxy
+        - pkg/component/machinecontrollermanager
         - pkg/controller/service
         - pkg/controllerutils
         - pkg/controllerutils/mapper

--- a/test/integration/gardenlet/controllerinstallation/controllerinstallation/controllerinstallation_test.go
+++ b/test/integration/gardenlet/controllerinstallation/controllerinstallation/controllerinstallation_test.go
@@ -212,6 +212,7 @@ var _ = Describe("ControllerInstallation controller tests", func() {
       HVPAForShootedSeed: false
       IPv6SingleStack: false
       KMSv2: false
+      MachineControllerManagerDeployment: false
       MutableShootSpecNetworkingNodes: false
       OpenAPIEnums: true
       OpenAPIV3: true


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
This PR introduces a new `MachineControllerManagerDeployment` feature gate in `gardenlet`. When enabled, `gardenlet` takes over the deployment of `machine-controller-manager`. In this case, provider extensions have to inject their provider-specific `machine-controller-manager` sidecar container via the control plane webhook (see https://github.com/gardener/gardener/pull/8019 for an example how `provider-local` was adapted).

The feature gate is disabled by default and should not be enabled on landscapes unless all registered provider extensions have been adapted to support it.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/7594

**Special notes for your reviewer**:
/cc @himanshu-kun @rishabh-11 
FYI @JensAc @mreiger 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
A new alpha feature gate named `MachineControllerManagerDeployment` has been introduced in `gardenlet`. Only enable it when all registered provider extensions in your landscape support this feature.
```
```feature developer
Provider extensions should be adapted such that they only inject their provider-specific `machine-controller-manager` sidecar container into the `machine-controller-manager` deployment instead of managing the full deployment themselves. In the future, `gardenlet` will take over managing it. Please see https://github.com/gardener/gardener/pull/8019 for an example how `provider-local` was adapted and replicate it for your provider extensions.
```