### PR TITLE
Cleanup TODO

### DIFF
--- a/pkg/component/etcd/bootstrap.go
+++ b/pkg/component/etcd/bootstrap.go
@@ -16,7 +16,6 @@ package etcd
 
 import (
 	"context"
-	_ "embed"
 	"fmt"
 	"strconv"
 	"time"
@@ -68,13 +67,6 @@ const (
 	druidConfigMapImageVectorOverwriteDataKey          = "images_overwrite.yaml"
 	druidDeploymentVolumeMountPathImageVectorOverwrite = "/charts_overwrite"
 	druidDeploymentVolumeNameImageVectorOverwrite      = "imagevector-overwrite"
-)
-
-var (
-	//go:embed crds/templates/crd-druid.gardener.cloud_etcds-copy.yaml
-	etcdCRD string
-	//go:embed crds/templates/crd-druid.gardener.cloud_etcdcopybackupstasks-copy.yaml
-	etcdCopyBackupsTaskCRD1 string
 )
 
 // NewBootstrapper creates a new instance of DeployWaiter for the etcd bootstrapper.
@@ -370,10 +362,6 @@ func (b *bootstrapper) Deploy(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-
-	// TODO(acumino): Drop CRDs deployment from here in release v1.73.
-	resources["crd.yaml"] = []byte(etcdCRD)
-	resources["crdEtcdCopyBackupsTask.yaml"] = []byte(etcdCopyBackupsTaskCRD1)
 
 	return managedresources.CreateForSeed(ctx, b.client, b.namespace, managedResourceControlName, false, resources)
 }

--- a/pkg/component/etcd/bootstrap_test.go
+++ b/pkg/component/etcd/bootstrap_test.go
@@ -16,7 +16,6 @@ package etcd_test
 
 import (
 	"context"
-	_ "embed"
 	"fmt"
 	"time"
 
@@ -43,13 +42,6 @@ import (
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
-)
-
-var (
-	//go:embed crds/templates/crd-druid.gardener.cloud_etcds-copy.yaml
-	etcdCRD string
-	//go:embed crds/templates/crd-druid.gardener.cloud_etcdcopybackupstasks-copy.yaml
-	etcdCopyBackupsTaskCRD1 string
 )
 
 var _ = Describe("Etcd", func() {
@@ -479,8 +471,6 @@ status:
 					"verticalpodautoscaler__" + namespace + "__etcd-druid-vpa.yaml": []byte(vpaYAML),
 					"deployment__" + namespace + "__etcd-druid.yaml":                []byte(deploymentWithoutImageVectorOverwriteYAML),
 					"poddisruptionbudget__" + namespace + "__etcd-druid.yaml":       []byte(podDisruptionYAML),
-					"crd.yaml":                    []byte(etcdCRD),
-					"crdEtcdCopyBackupsTask.yaml": []byte(etcdCopyBackupsTaskCRD1),
 				},
 			}
 			managedResource = &resourcesv1alpha1.ManagedResource{

--- a/pkg/component/etcd/crds/templates/crd-druid.gardener.cloud_etcdcopybackupstasks-copy.yaml
+++ b/pkg/component/etcd/crds/templates/crd-druid.gardener.cloud_etcdcopybackupstasks-copy.yaml
@@ -1,6 +1,0 @@
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  name: etcdcopybackupstasks.druid.gardener.cloud
-  annotations:
-    resources.gardener.cloud/mode: Ignore

--- a/pkg/component/etcd/crds/templates/crd-druid.gardener.cloud_etcds-copy.yaml
+++ b/pkg/component/etcd/crds/templates/crd-druid.gardener.cloud_etcds-copy.yaml
@@ -1,6 +1,0 @@
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  name: etcds.druid.gardener.cloud
-  annotations:
-    resources.gardener.cloud/mode: Ignore


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind cleanup

**What this PR does / why we need it**:
This PR cleans up TODO introduced with https://github.com/gardener/gardener/pull/8002.
commit d8698d1170ff9bca640ba57c62a85340de339284

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
