### PR TITLE
Deflake `KubernetesServiceHost` integration test

### DIFF
--- a/test/integration/resourcemanager/kubernetesservicehost/kubernetesservicehost_suite_test.go
+++ b/test/integration/resourcemanager/kubernetesservicehost/kubernetesservicehost_suite_test.go
@@ -55,6 +55,7 @@ var (
 	testEnv    *envtest.Environment
 	restConfig *rest.Config
 	testClient client.Client
+	mgrClient  client.Client
 
 	testNamespace *corev1.Namespace
 
@@ -119,6 +120,7 @@ var _ = BeforeSuite(func() {
 		Logger: log,
 		Host:   host,
 	}).AddToManager(mgr)).To(Succeed())
+	mgrClient = mgr.GetClient()
 
 	By("Start manager")
 	mgrContext, mgrCancel := context.WithCancel(ctx)

--- a/test/integration/resourcemanager/kubernetesservicehost/kubernetesservicehost_test.go
+++ b/test/integration/resourcemanager/kubernetesservicehost/kubernetesservicehost_test.go
@@ -90,6 +90,11 @@ var _ = Describe("KubernetesServiceHost tests", func() {
 			Expect(testClient.Update(ctx, testNamespace)).To(Succeed())
 		})
 
+		Eventually(func(g Gomega) string {
+			g.Expect(mgrClient.Get(ctx, client.ObjectKeyFromObject(testNamespace), testNamespace)).To(Succeed())
+			return testNamespace.Labels["apiserver-proxy.networking.gardener.cloud/inject"]
+		}).Should((Equal("disable")))
+
 		Expect(testClient.Create(ctx, pod)).To(Succeed())
 
 		Expect(testClient.Get(ctx, client.ObjectKeyFromObject(pod), pod)).To(Succeed())


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind flake

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener/issues/8004

**Special notes for your reviewer**:
Stress test results.
Before -
```
stress -ignore "unable to grab random port" -p 32 ./test/integration/resourcemanager/kubernetesservicehost/kubernetesservicehost.test -ginkgo.v -ginkgo.show-node-events
5s: 0 runs so far, 0 failures
10s: 9 runs so far, 0 failures
15s: 32 runs so far, 1 failures (3.12%)
20s: 60 runs so far, 1 failures (1.67%)
.
.
2m20s: 571 runs so far, 7 failures (1.23%)
2m25s: 593 runs so far, 7 failures (1.18%)
```
After -
```
stress -ignore "unable to grab random port" -p 32 ./test/integration/resourcemanager/kubernetesservicehost/kubernetesservicehost.test -ginkgo.v -ginkgo.show-node-events
5s: 0 runs so far, 0 failures
.
1m5s: 260 runs so far, 0 failures
.
2m20s: 580 runs so far, 0 failures
.
3m45s: 944 runs so far, 0 failures
.
6m0s: 1544 runs so far, 0 failures
```


**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
