### PR TITLE
Set references.InjectAnnotations to consider also image pull secrets

### DIFF
--- a/pkg/resourcemanager/controller/garbagecollector/references/references.go
+++ b/pkg/resourcemanager/controller/garbagecollector/references/references.go
@@ -81,7 +81,7 @@ func KindFromAnnotationKey(key string) string {
 }
 
 // InjectAnnotations injects annotations into the annotation maps based on the referenced ConfigMaps/Secrets appearing
-// in the pod template spec's `.volumes[]` or `.containers[].envFrom[]` or `.containers[].env[].valueFrom[]` lists.
+// in the pod template spec's `.volumes[]` or `.containers[].envFrom[]` or `.containers[].env[].valueFrom[]` or `.imagePullSecrets[]` lists.
 // Additional reference annotations can be specified via the variadic parameter (expected format is that returned by
 // `AnnotationKey`).
 func InjectAnnotations(obj runtime.Object, additional ...string) error {

--- a/pkg/resourcemanager/controller/garbagecollector/references/references.go
+++ b/pkg/resourcemanager/controller/garbagecollector/references/references.go
@@ -201,6 +201,10 @@ func computeAnnotations(spec corev1.PodSpec, additional ...string) map[string]st
 		}
 	}
 
+	for _, imagePullSecret := range spec.ImagePullSecrets {
+		out[AnnotationKey(KindSecret, imagePullSecret.Name)] = imagePullSecret.Name
+	}
+
 	for _, v := range additional {
 		out[v] = ""
 	}

--- a/pkg/resourcemanager/controller/garbagecollector/references/references_test.go
+++ b/pkg/resourcemanager/controller/garbagecollector/references/references_test.go
@@ -72,6 +72,7 @@ var _ = Describe("References", func() {
 			secret4               = "secret4"
 			secret5               = "secret5"
 			secret6               = "secret6"
+			secret7               = "secret7"
 			additionalAnnotation1 = "foo"
 			additionalAnnotation2 = "bar"
 
@@ -141,6 +142,9 @@ var _ = Describe("References", func() {
 						},
 					},
 				},
+				ImagePullSecrets: []corev1.LocalObjectReference{
+					{Name: secret7},
+				},
 				Volumes: []corev1.Volume{
 					{
 						VolumeSource: corev1.VolumeSource{
@@ -208,6 +212,7 @@ var _ = Describe("References", func() {
 				AnnotationKey(KindSecret, secret4):       secret4,
 				AnnotationKey(KindSecret, secret5):       secret5,
 				AnnotationKey(KindSecret, secret6):       secret6,
+				AnnotationKey(KindSecret, secret7):       secret7,
 				additionalAnnotation1:                    "",
 				additionalAnnotation2:                    "",
 			}
@@ -224,6 +229,7 @@ var _ = Describe("References", func() {
 				AnnotationKey(KindSecret, secret4):       secret4,
 				AnnotationKey(KindSecret, secret5):       secret5,
 				AnnotationKey(KindSecret, secret6):       secret6,
+				AnnotationKey(KindSecret, secret7):       secret7,
 				additionalAnnotation1:                    "",
 				additionalAnnotation2:                    "",
 			}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity usability
/kind bug

**What this PR does / why we need it**:
Set references.InjectAnnotations to consider also image pull secrets

**Which issue(s) this PR fixes**:
Fixes #8027

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix developer
`pkg/resourcemanager/controller/garbagecollector/references.InjectAnnotations` now also handles `pods.spec.imagePullSecrets`. 
```
