### PR TITLE
Update kube-rbac-proxy image to v0.14.2

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -434,7 +434,7 @@ images:
 - name: kube-rbac-proxy
   sourceRepository: github.com/brancz/kube-rbac-proxy
   repository: quay.io/brancz/kube-rbac-proxy
-  tag: v0.14.0
+  tag: v0.14.2
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:


### PR DESCRIPTION
/area logging
/kind enhancement

This PR bumps up the kuber-rbac-proxy from[ 0.14.0 to 0.14.2](https://github.com/brancz/kube-rbac-proxy/compare/v0.14.0...v0.14.2). It brings fixes to few CVEs among other small improvements. 
[PR 236](https://github.com/brancz/kube-rbac-proxy/pull/236)

```other operator
The following image is updated:
- quay.io/brancz/kube-rbac-proxy: v0.14.0 -> v0.14.2
```
