### PR TITLE
Address TODOs related to calico's providerConfig in provider-local Shoot manifests

### DIFF
--- a/example/provider-local/managedseeds/shoot-managedseed.yaml
+++ b/example/provider-local/managedseeds/shoot-managedseed.yaml
@@ -13,10 +13,6 @@ spec:
   region: local
   networking:
     type: calico
-    # TODO(scheererj): Drop this emtpy provider config after v1.71 has been released (otherwise, e2e upgrade tests break)
-    providerConfig:
-      apiVersion: calico.networking.extensions.gardener.cloud/v1alpha1
-      kind: NetworkConfig
   provider:
     type: local
     workers:

--- a/example/provider-local/shoot.yaml
+++ b/example/provider-local/shoot.yaml
@@ -13,10 +13,6 @@ spec:
   region: local
   networking:
     type: calico
-    # TODO(scheererj): Drop this emtpy provider config after v1.71 has been released (otherwise, e2e upgrade tests break)
-    providerConfig:
-      apiVersion: calico.networking.extensions.gardener.cloud/v1alpha1
-      kind: NetworkConfig
   provider:
     type: local
     workers:

--- a/test/e2e/gardener/common.go
+++ b/test/e2e/gardener/common.go
@@ -21,7 +21,6 @@ import (
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/utils/pointer"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
@@ -88,8 +87,6 @@ func DefaultShoot(name string) *gardencorev1beta1.Shoot {
 			},
 			Networking: &gardencorev1beta1.Networking{
 				Type: pointer.String("calico"),
-				// TODO(scheererj): Drop this emtpy provider config after v1.71 has been released (otherwise, e2e upgrade tests break)
-				ProviderConfig: &runtime.RawExtension{Raw: []byte(`{"apiVersion":"calico.networking.extensions.gardener.cloud/v1alpha1","kind":"NetworkConfig"}`)},
 			},
 			Provider: gardencorev1beta1.Provider{
 				Type: "local",


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind cleanup

**What this PR does / why we need it**:
Address TODOs related to calico's providerConfig in provider-local Shoot manifests: TODOs introduced with https://github.com/gardener/gardener/pull/7684.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
