### PR TITLE
Enhance Webhook remediator

### DIFF
--- a/pkg/operation/botanist/matchers/matcher.go
+++ b/pkg/operation/botanist/matchers/matcher.go
@@ -64,8 +64,8 @@ var (
 	// WebhookConstraintMatchersForLeases contains a list of lease API resources that can break
 	// leader election of essential control plane controllers.
 	WebhookConstraintMatchersForLeases = []WebhookConstraintMatcher{
-		{GVR: coordinationv1.SchemeGroupVersion.WithResource("leases"), NamespaceLabels: kubeSystemNamespaceLabels},
-		{GVR: coordinationv1beta1.SchemeGroupVersion.WithResource("leases"), NamespaceLabels: kubeSystemNamespaceLabels},
+		{GVR: coordinationv1.SchemeGroupVersion.WithResource("leases"), NamespaceLabels: kubeSystemNamespaceLabels, ObjectLabels: labels.Set{}},
+		{GVR: coordinationv1beta1.SchemeGroupVersion.WithResource("leases"), NamespaceLabels: kubeSystemNamespaceLabels, ObjectLabels: labels.Set{}},
 	}
 
 	// WebhookConstraintMatchers contains a list of all api resources which can break

--- a/pkg/operation/botanist/matchers/matcher.go
+++ b/pkg/operation/botanist/matchers/matcher.go
@@ -64,6 +64,7 @@ var (
 	// WebhookConstraintMatchersForLeases contains a list of lease API resources that can break
 	// leader election of essential control plane controllers.
 	WebhookConstraintMatchersForLeases = []WebhookConstraintMatcher{
+		// object selector here is added to support the use case described in - https://github.com/gardener/gardener/pull/8034
 		{GVR: coordinationv1.SchemeGroupVersion.WithResource("leases"), NamespaceLabels: kubeSystemNamespaceLabels, ObjectLabels: labels.Set{}},
 		{GVR: coordinationv1beta1.SchemeGroupVersion.WithResource("leases"), NamespaceLabels: kubeSystemNamespaceLabels, ObjectLabels: labels.Set{}},
 	}

--- a/pkg/operation/care/constraints_test.go
+++ b/pkg/operation/care/constraints_test.go
@@ -158,6 +158,10 @@ var _ = Describe("Constraints", func() {
 						Entry("failurePolicy 'Ignore' and timeoutSeconds ok", webhookTestCase{failurePolicy: &failurePolicyIgnore, timeoutSeconds: &timeoutSecondsNotProblematic}))
 				} else {
 					notProblematic = append(notProblematic,
+						Entry("failurePolicy 'Ignore' and timeoutSeconds ok", webhookTestCase{failurePolicy: &failurePolicyIgnore, timeoutSeconds: &timeoutSecondsNotProblematic, objectSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								"app.kubernetes.io/name": "test",
+							}}}),
 						Entry("failurePolicy 'Ignore' and timeoutSeconds ok", webhookTestCase{failurePolicy: &failurePolicyIgnore, timeoutSeconds: &timeoutSecondsNotProblematic}))
 				}
 

--- a/pkg/operation/care/webhook_remediation_test.go
+++ b/pkg/operation/care/webhook_remediation_test.go
@@ -339,6 +339,11 @@ var _ = Describe("WebhookRemediation", func() {
 							Name:           "some-webhook2.example.com",
 							TimeoutSeconds: pointer.Int32(10),
 							FailurePolicy:  &ignore,
+							ObjectSelector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{
+									"app.kubernetes.io/name": "test",
+								},
+							},
 							Rules: []admissionregistrationv1.RuleWithOperations{
 								{
 									Rule: admissionregistrationv1.Rule{
@@ -354,6 +359,23 @@ var _ = Describe("WebhookRemediation", func() {
 						},
 						{
 							Name:           "some-webhook3.example.com",
+							TimeoutSeconds: pointer.Int32(10),
+							FailurePolicy:  &ignore,
+							Rules: []admissionregistrationv1.RuleWithOperations{
+								{
+									Rule: admissionregistrationv1.Rule{
+										APIGroups:   []string{"coordination.k8s.io"},
+										APIVersions: []string{"v1", "v1beta1"},
+										Resources:   []string{"leases"},
+									},
+									Operations: []admissionregistrationv1.OperationType{
+										"UPDATE",
+									},
+								},
+							},
+						},
+						{
+							Name:           "some-webhook4.example.com",
 							TimeoutSeconds: pointer.Int32(1),
 							FailurePolicy:  &ignore,
 							Rules: []admissionregistrationv1.RuleWithOperations{
@@ -377,8 +399,9 @@ var _ = Describe("WebhookRemediation", func() {
 					Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(mutatingWebhookConfiguration), mutatingWebhookConfiguration)).To(Succeed())
 					Expect(mutatingWebhookConfiguration.Annotations).To(HaveKey("gardener.cloud/warning"))
 					Expect(mutatingWebhookConfiguration.Webhooks[0].TimeoutSeconds).To(Equal(pointer.Int32(15)))
-					Expect(mutatingWebhookConfiguration.Webhooks[1].TimeoutSeconds).To(Equal(pointer.Int32(3)))
-					Expect(mutatingWebhookConfiguration.Webhooks[2].TimeoutSeconds).To(Equal(pointer.Int32(1)))
+					Expect(mutatingWebhookConfiguration.Webhooks[1].TimeoutSeconds).To(Equal(pointer.Int32(10)))
+					Expect(mutatingWebhookConfiguration.Webhooks[2].TimeoutSeconds).To(Equal(pointer.Int32(3)))
+					Expect(mutatingWebhookConfiguration.Webhooks[3].TimeoutSeconds).To(Equal(pointer.Int32(1)))
 				})
 
 				It("failurePolicy", func() {

--- a/pkg/operation/care/webhook_remediation_test.go
+++ b/pkg/operation/care/webhook_remediation_test.go
@@ -335,8 +335,20 @@ var _ = Describe("WebhookRemediation", func() {
 							TimeoutSeconds: pointer.Int32(30),
 							FailurePolicy:  &ignore,
 						},
+					}
+					Expect(fakeClient.Create(ctx, mutatingWebhookConfiguration)).To(Succeed())
+
+					Expect(remediator.Remediate(ctx)).To(Succeed())
+
+					Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(mutatingWebhookConfiguration), mutatingWebhookConfiguration)).To(Succeed())
+					Expect(mutatingWebhookConfiguration.Annotations).To(HaveKey("gardener.cloud/warning"))
+					Expect(mutatingWebhookConfiguration.Webhooks[0].TimeoutSeconds).To(Equal(pointer.Int32(15)))
+				})
+
+				It("timeoutSeconds when failurePolicy=Ignore for lease resource", func() {
+					mutatingWebhookConfiguration.Webhooks = []admissionregistrationv1.MutatingWebhook{
 						{
-							Name:           "some-webhook2.example.com",
+							Name:           "some-webhook1.example.com",
 							TimeoutSeconds: pointer.Int32(10),
 							FailurePolicy:  &ignore,
 							ObjectSelector: &metav1.LabelSelector{
@@ -358,7 +370,7 @@ var _ = Describe("WebhookRemediation", func() {
 							},
 						},
 						{
-							Name:           "some-webhook3.example.com",
+							Name:           "some-webhook2.example.com",
 							TimeoutSeconds: pointer.Int32(10),
 							FailurePolicy:  &ignore,
 							Rules: []admissionregistrationv1.RuleWithOperations{
@@ -375,7 +387,7 @@ var _ = Describe("WebhookRemediation", func() {
 							},
 						},
 						{
-							Name:           "some-webhook4.example.com",
+							Name:           "some-webhook3.example.com",
 							TimeoutSeconds: pointer.Int32(1),
 							FailurePolicy:  &ignore,
 							Rules: []admissionregistrationv1.RuleWithOperations{
@@ -398,10 +410,9 @@ var _ = Describe("WebhookRemediation", func() {
 
 					Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(mutatingWebhookConfiguration), mutatingWebhookConfiguration)).To(Succeed())
 					Expect(mutatingWebhookConfiguration.Annotations).To(HaveKey("gardener.cloud/warning"))
-					Expect(mutatingWebhookConfiguration.Webhooks[0].TimeoutSeconds).To(Equal(pointer.Int32(15)))
-					Expect(mutatingWebhookConfiguration.Webhooks[1].TimeoutSeconds).To(Equal(pointer.Int32(10)))
-					Expect(mutatingWebhookConfiguration.Webhooks[2].TimeoutSeconds).To(Equal(pointer.Int32(3)))
-					Expect(mutatingWebhookConfiguration.Webhooks[3].TimeoutSeconds).To(Equal(pointer.Int32(1)))
+					Expect(mutatingWebhookConfiguration.Webhooks[0].TimeoutSeconds).To(Equal(pointer.Int32(10)))
+					Expect(mutatingWebhookConfiguration.Webhooks[1].TimeoutSeconds).To(Equal(pointer.Int32(3)))
+					Expect(mutatingWebhookConfiguration.Webhooks[2].TimeoutSeconds).To(Equal(pointer.Int32(1)))
 				})
 
 				It("failurePolicy", func() {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind enhancement

**What this PR does / why we need it**:
This https://github.com/gardener/gardener/pull/7902 PR introduced a special case in webhook remediator to set the `timeoutSeonds` to 3 seconds for webhook affecting lease resources in kube-system namespace.
Above PR only considered `namespaceSelector` and didn't check `objectSelector` of webhook. 
In some special cases user can't modify namespaceSelector and has to rely only on the label selector for ex - `kyverno-verify-mutating-webhook-cfg` webhook, which only affects lease object with label  `app.kubernetes.io/name: kyverno` and not the lease which is required to ensure the proper functioning of the leader election of essential control plane controllers.

```
apiVersion: admissionregistration.k8s.io/v1
kind: MutatingWebhookConfiguration
metadata:
  labels:
    webhook.kyverno.io/managed-by: kyverno
  name: kyverno-verify-mutating-webhook-cfg
webhooks:
- admissionReviewVersions:
  - v1
  failurePolicy: Ignore
  matchPolicy: Equivalent
  name: monitor-webhooks.kyverno.svc
  namespaceSelector: {}
  objectSelector:
    matchLabels:
      app.kubernetes.io/name: kyverno
  reinvocationPolicy: IfNeeded
  rules:
  - apiGroups:
    - coordination.k8s.io
    apiVersions:
    - v1
    operations:
    - UPDATE
    resources:
    - leases
    scope: '*'
  sideEffects: NoneOnDryRun
  timeoutSeconds: 10
```

But the webhook remediator considers the above webhook as a problematic webhook. Since the user can't modify the `namespaceSelector` and `timeoutSeconds` cluster hibernation/maintenance will be blocked.

This PR adapts the webhook remediator so it checks if the webhook is working on `kube-system` namespace but has `objectSelector` then it is not considered problematic. (Only for the case introduced in #7902)

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Webhooks remediator sets the timeoutSeonds to 3 seconds for webhook affecting lease resources in `kube-system` namespace only if there is no objectSelector provided in webhook.
```
