### PR TITLE
Increase workers for `NetworkPolicy` controller

### DIFF
--- a/pkg/component/resourcemanager/resource_manager.go
+++ b/pkg/component/resourcemanager/resource_manager.go
@@ -270,14 +270,16 @@ type Values struct {
 	LogLevel string
 	// LogFormat is the output format for the logs. Must be one of [text,json].
 	LogFormat string
-	// MaxConcurrentHealthWorkers configures the number of worker threads for concurrent health reconciliation of resources
+	// MaxConcurrentHealthWorkers configures the number of worker threads for concurrent health reconciliation of resources.
 	MaxConcurrentHealthWorkers *int
-	// MaxConcurrentTokenInvalidatorWorkers configures the number of worker threads for concurrent token invalidator reconciliations
+	// MaxConcurrentTokenInvalidatorWorkers configures the number of worker threads for concurrent token invalidator reconciliations.
 	MaxConcurrentTokenInvalidatorWorkers *int
-	// MaxConcurrentTokenRequestorWorkers configures the number of worker threads for concurrent token requestor reconciliations
+	// MaxConcurrentTokenRequestorWorkers configures the number of worker threads for concurrent token requestor reconciliations.
 	MaxConcurrentTokenRequestorWorkers *int
-	// MaxConcurrentCSRApproverWorkers configures the number of worker threads for concurrent kubelet CSR approver reconciliations
+	// MaxConcurrentCSRApproverWorkers configures the number of worker threads for concurrent kubelet CSR approver reconciliations.
 	MaxConcurrentCSRApproverWorkers *int
+	// MaxConcurrentCSRApproverWorkers configures the number of worker threads for the network policy controller.
+	MaxConcurrentNetworkPolicyWorkers *int
 	// NamePrefix is the prefix for the resource names.
 	NamePrefix string
 	// PriorityClassName is the name of the priority class.
@@ -584,7 +586,8 @@ func (r *resourceManager) ensureConfigMap(ctx context.Context, configMap *corev1
 		}
 	} else {
 		config.Controllers.NetworkPolicy = resourcemanagerv1alpha1.NetworkPolicyControllerConfig{
-			Enabled: true,
+			Enabled:         true,
+			ConcurrentSyncs: r.values.MaxConcurrentNetworkPolicyWorkers,
 			NamespaceSelectors: append([]metav1.LabelSelector{
 				{MatchLabels: map[string]string{v1beta1constants.GardenRole: v1beta1constants.GardenRoleShoot}},
 				{MatchLabels: map[string]string{v1beta1constants.GardenRole: v1beta1constants.GardenRoleExtension}},

--- a/pkg/component/resourcemanager/resource_manager_test.go
+++ b/pkg/component/resourcemanager/resource_manager_test.go
@@ -101,6 +101,7 @@ var _ = Describe("ResourceManager", func() {
 		maxConcurrentTokenInvalidatorWorkers = 23
 		maxConcurrentTokenRequestorWorkers   = 21
 		maxConcurrentCSRApproverWorkers      = 24
+		maxConcurrentNetworkPolicyWorkers    = 25
 		resourceClass                        = "fake-ResourceClass"
 		syncPeriod                           = metav1.Duration{Duration: time.Second * 80}
 		watchedNamespace                     = "fake-ns"
@@ -324,6 +325,7 @@ var _ = Describe("ResourceManager", func() {
 			MaxConcurrentTokenInvalidatorWorkers:             &maxConcurrentTokenInvalidatorWorkers,
 			MaxConcurrentTokenRequestorWorkers:               &maxConcurrentTokenRequestorWorkers,
 			MaxConcurrentCSRApproverWorkers:                  &maxConcurrentCSRApproverWorkers,
+			MaxConcurrentNetworkPolicyWorkers:                &maxConcurrentNetworkPolicyWorkers,
 			PriorityClassName:                                priorityClassName,
 			Replicas:                                         &replicas,
 			ResourceClass:                                    &resourceClass,
@@ -476,7 +478,8 @@ var _ = Describe("ResourceManager", func() {
 				}
 			} else {
 				config.Controllers.NetworkPolicy = resourcemanagerv1alpha1.NetworkPolicyControllerConfig{
-					Enabled: true,
+					Enabled:         true,
+					ConcurrentSyncs: &maxConcurrentNetworkPolicyWorkers,
 					NamespaceSelectors: []metav1.LabelSelector{
 						{MatchLabels: map[string]string{"gardener.cloud/role": "shoot"}},
 						{MatchLabels: map[string]string{"gardener.cloud/role": "extension"}},

--- a/pkg/component/shared/resourcemanager.go
+++ b/pkg/component/shared/resourcemanager.go
@@ -85,6 +85,7 @@ func NewRuntimeGardenerResourceManager(
 		DefaultNotReadyToleration:                 defaultNotReadyToleration,
 		DefaultUnreachableToleration:              defaultUnreachableToleration,
 		EndpointSliceHintsEnabled:                 endpointSliceHintsEnabled,
+		MaxConcurrentNetworkPolicyWorkers:         pointer.Int(20),
 		NetworkPolicyAdditionalNamespaceSelectors: additionalNetworkPolicyNamespaceSelectors,
 		NetworkPolicyControllerIngressControllerSelector: &resourcemanagerv1alpha1.IngressControllerSelector{
 			Namespace: v1beta1constants.GardenNamespace,

--- a/pkg/resourcemanager/apis/config/v1alpha1/defaults.go
+++ b/pkg/resourcemanager/apis/config/v1alpha1/defaults.go
@@ -137,6 +137,13 @@ func SetDefaults_GarbageCollectorControllerConfig(obj *GarbageCollectorControlle
 	}
 }
 
+// SetDefaults_NetworkPolicyControllerConfig sets defaults for the NetworkPolicyControllerConfig object.
+func SetDefaults_NetworkPolicyControllerConfig(obj *NetworkPolicyControllerConfig) {
+	if obj.Enabled && obj.ConcurrentSyncs == nil {
+		obj.ConcurrentSyncs = pointer.Int(5)
+	}
+}
+
 // SetDefaults_HealthControllerConfig sets defaults for the HealthControllerConfig object.
 func SetDefaults_HealthControllerConfig(obj *HealthControllerConfig) {
 	if obj.ConcurrentSyncs == nil {

--- a/pkg/resourcemanager/apis/config/v1alpha1/defaults_test.go
+++ b/pkg/resourcemanager/apis/config/v1alpha1/defaults_test.go
@@ -276,6 +276,26 @@ var _ = Describe("Defaults", func() {
 		})
 	})
 
+	Describe("#SetDefaults_NetworkPolicyConfig", func() {
+		It("should not default the object", func() {
+			obj := &NetworkPolicyControllerConfig{}
+
+			SetDefaults_NetworkPolicyControllerConfig(obj)
+
+			Expect(obj.ConcurrentSyncs).To(BeNil())
+		})
+
+		It("should not overwrite existing values", func() {
+			obj := &NetworkPolicyControllerConfig{
+				Enabled: true,
+			}
+
+			SetDefaults_NetworkPolicyControllerConfig(obj)
+
+			Expect(obj.ConcurrentSyncs).To(PointTo(Equal(5)))
+		})
+	})
+
 	Describe("#SetDefaults_HealthControllerConfig", func() {
 		It("should not default the object", func() {
 			obj := &HealthControllerConfig{}

--- a/pkg/resourcemanager/apis/config/v1alpha1/defaults_test.go
+++ b/pkg/resourcemanager/apis/config/v1alpha1/defaults_test.go
@@ -285,7 +285,7 @@ var _ = Describe("Defaults", func() {
 			Expect(obj.ConcurrentSyncs).To(BeNil())
 		})
 
-		It("should not overwrite existing values", func() {
+		It("should default the object", func() {
 			obj := &NetworkPolicyControllerConfig{
 				Enabled: true,
 			}
@@ -293,6 +293,17 @@ var _ = Describe("Defaults", func() {
 			SetDefaults_NetworkPolicyControllerConfig(obj)
 
 			Expect(obj.ConcurrentSyncs).To(PointTo(Equal(5)))
+		})
+
+		It("should not overwrite existing values", func() {
+			obj := &NetworkPolicyControllerConfig{
+				Enabled:         true,
+				ConcurrentSyncs: pointer.Int(6),
+			}
+
+			SetDefaults_NetworkPolicyControllerConfig(obj)
+
+			Expect(obj.ConcurrentSyncs).To(PointTo(Equal(6)))
 		})
 	})
 

--- a/pkg/resourcemanager/apis/config/v1alpha1/zz_generated.defaults.go
+++ b/pkg/resourcemanager/apis/config/v1alpha1/zz_generated.defaults.go
@@ -50,6 +50,7 @@ func SetObjectDefaults_ResourceManagerConfiguration(in *ResourceManagerConfigura
 	SetDefaults_HealthControllerConfig(&in.Controllers.Health)
 	SetDefaults_KubeletCSRApproverControllerConfig(&in.Controllers.KubeletCSRApprover)
 	SetDefaults_ManagedResourceControllerConfig(&in.Controllers.ManagedResource)
+	SetDefaults_NetworkPolicyControllerConfig(&in.Controllers.NetworkPolicy)
 	SetDefaults_NodeControllerConfig(&in.Controllers.Node)
 	SetDefaults_SecretControllerConfig(&in.Controllers.Secret)
 	SetDefaults_TokenInvalidatorControllerConfig(&in.Controllers.TokenInvalidator)

--- a/pkg/utils/kubernetes/managedseed.go
+++ b/pkg/utils/kubernetes/managedseed.go
@@ -43,7 +43,7 @@ func GetManagedSeedWithReader(ctx context.Context, r client.Reader, shootNamespa
 	return &managedSeedList.Items[0], nil
 }
 
-// GetManagedSeedByName tries to reads a ManagedSeed in the garden namespace. If it's not found then `nil` is returned.
+// GetManagedSeedByName tries to read a ManagedSeed in the garden namespace. If it's not found then `nil` is returned.
 func GetManagedSeedByName(ctx context.Context, client client.Client, name string) (*seedmanagementv1alpha1.ManagedSeed, error) {
 	managedSeed := &seedmanagementv1alpha1.ManagedSeed{}
 	if err := client.Get(ctx, Key(constants.GardenNamespace, name), managedSeed); err != nil {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area performance
/kind enhancement

**What this PR does / why we need it**:
This PR changes the concurrent sync count for the `NetworkPolicy` controller in GRM from `1` to `20`. Having only one worker is insufficient, esp. in lager seed clusters where many `Service`s exists.

The default count was increased to `5` along the way.

**Special notes for your reviewer**:
I followed the handling of the `ManagedResource` controller for which we use `20` workers as well.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The worker count for the [NetworkPolicy controller](https://github.com/gardener/gardener/blob/master/docs/concepts/resource-manager.md#networkpolicy-controller) in GRM was increased to `20`. This is necessary to create and update `NetworkPolicies` in time, esp. on larger seed clusters.
```
