### PR TITLE
Cleanup the seed secret when `.spec.secretRef` is unset in the seed template in the `ManagedSeed`

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -144,6 +144,8 @@ linters-settings:
         alias: ${1}helper
       - pkg: github.com/gardener/gardener/pkg/apis/([^c]\w+)/([\w\d]+)
         alias: $1$2
+      - pkg: github.com/gardener/gardener/pkg/apis/([^c]\w+)/([\w\d]+)/([\w\d]+)
+        alias: $1$2$3
       - pkg: github.com/gardener/gardener/pkg/(\w+)/apis/config
         alias: ${1}config
       - pkg: github.com/gardener/gardener/pkg/(\w+)/apis/config/([\w\d]+)

--- a/pkg/admissioncontroller/webhook/auth/seed/graph/eventhandler_managedseed.go
+++ b/pkg/admissioncontroller/webhook/auth/seed/graph/eventhandler_managedseed.go
@@ -27,6 +27,7 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
+	seedmanagementv1alpha1constants "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1/constants"
 	seedmanagementv1alpha1helper "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1/helper"
 	gardenletbootstraputil "github.com/gardener/gardener/pkg/gardenlet/bootstrap/util"
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
@@ -99,6 +100,12 @@ func (g *graph) handleManagedSeedCreateOrUpdate(ctx context.Context, managedSeed
 			secretVertex := g.getOrCreateVertex(VertexTypeSecret, seedTemplate.Spec.SecretRef.Namespace, seedTemplate.Spec.SecretRef.Name)
 			g.addEdge(secretVertex, managedSeedVertex)
 		}
+	}
+
+	if metav1.HasAnnotation(managedSeed.ObjectMeta, seedmanagementv1alpha1constants.AnnotationSeedSecretName) &&
+		metav1.HasAnnotation(managedSeed.ObjectMeta, seedmanagementv1alpha1constants.AnnotationSeedSecretNamespace) {
+		secretVertex := g.getOrCreateVertex(VertexTypeSecret, managedSeed.GetAnnotations()[seedmanagementv1alpha1constants.AnnotationSeedSecretNamespace], managedSeed.GetAnnotations()[seedmanagementv1alpha1constants.AnnotationSeedSecretName])
+		g.addEdge(secretVertex, managedSeedVertex)
 	}
 
 	if gardenletConfig == nil || managedSeed.Spec.Gardenlet.Bootstrap == nil {

--- a/pkg/apis/seedmanagement/v1alpha1/constants/types_constants.go
+++ b/pkg/apis/seedmanagement/v1alpha1/constants/types_constants.go
@@ -19,8 +19,8 @@ const (
 	//(either ManagedSeed or Shoot) to protect it from deletion..
 	AnnotationProtectFromDeletion = "seedmanagement.gardener.cloud/protect-from-deletion"
 
-	// AnnotationSeedSecretName is the name of the secret which are referred in the Seed spec of a ManagedSeed.
+	// AnnotationSeedSecretName is the name of the secret which is referred in the Seed spec of a ManagedSeed.
 	AnnotationSeedSecretName = "seedmanagement.gardener.cloud/seed-secret-name"
-	// AnnotationSeedSecretNamespace is the namespace of the secret which are referred in the Seed spec of a ManagedSeed.
+	// AnnotationSeedSecretNamespace is the namespace of the secret which is referred in the Seed spec of a ManagedSeed.
 	AnnotationSeedSecretNamespace = "seedmanagement.gardener.cloud/seed-secret-namespace"
 )

--- a/pkg/apis/seedmanagement/v1alpha1/constants/types_constants.go
+++ b/pkg/apis/seedmanagement/v1alpha1/constants/types_constants.go
@@ -18,4 +18,9 @@ const (
 	// AnnotationProtectFromDeletion is a constant for an annotation on a replica of a ManagedSeedSet
 	//(either ManagedSeed or Shoot) to protect it from deletion..
 	AnnotationProtectFromDeletion = "seedmanagement.gardener.cloud/protect-from-deletion"
+
+	// AnnotationSeedSecretName is the name of the secret which are referred in the Seed spec of a ManagedSeed.
+	AnnotationSeedSecretName = "seedmanagement.gardener.cloud/seed-secret-name"
+	// AnnotationSeedSecretNamespace is the namespace of the secret which are referred in the Seed spec of a ManagedSeed.
+	AnnotationSeedSecretNamespace = "seedmanagement.gardener.cloud/seed-secret-namespace"
 )

--- a/pkg/gardenlet/controller/managedseed/actuator.go
+++ b/pkg/gardenlet/controller/managedseed/actuator.go
@@ -37,7 +37,6 @@ import (
 	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
 	"github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1/helper"
-	v1alpha1helper "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1/helper"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap"
 	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap/keys"
@@ -400,7 +399,7 @@ func (a *actuator) deployGardenlet(
 		managedSeed,
 		seed,
 		gardenletConfig,
-		v1alpha1helper.GetBootstrap(managedSeed.Spec.Gardenlet.Bootstrap),
+		helper.GetBootstrap(managedSeed.Spec.Gardenlet.Bootstrap),
 		pointer.BoolDeref(managedSeed.Spec.Gardenlet.MergeWithParent, false),
 		shoot,
 	)
@@ -442,7 +441,7 @@ func (a *actuator) deleteGardenlet(
 		managedSeed,
 		seed,
 		gardenletConfig,
-		v1alpha1helper.GetBootstrap(managedSeed.Spec.Gardenlet.Bootstrap),
+		helper.GetBootstrap(managedSeed.Spec.Gardenlet.Bootstrap),
 		pointer.BoolDeref(managedSeed.Spec.Gardenlet.MergeWithParent, false),
 		shoot,
 	)

--- a/pkg/gardenlet/controller/managedseed/add.go
+++ b/pkg/gardenlet/controller/managedseed/add.go
@@ -294,7 +294,7 @@ func (r *Reconciler) EnqueueWithJitterDelay() handler.EventHandler {
 				return
 			}
 
-			if *r.Config.Controllers.ManagedSeed.JitterUpdates {
+			if pointer.BoolDeref(r.Config.Controllers.ManagedSeed.JitterUpdates, false) {
 				q.AddAfter(reconcileRequest(evt.ObjectNew), RandomDurationWithMetaDuration(r.Config.Controllers.ManagedSeed.SyncJitterPeriod))
 			} else {
 				q.Add(reconcileRequest(evt.ObjectNew))

--- a/pkg/resourcemanager/controller/health/utils/controller.go
+++ b/pkg/resourcemanager/controller/health/utils/controller.go
@@ -24,7 +24,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
-	resourceshelper "github.com/gardener/gardener/pkg/apis/resources/v1alpha1/helper"
+	resourcesv1alpha1helper "github.com/gardener/gardener/pkg/apis/resources/v1alpha1/helper"
 	"github.com/gardener/gardener/pkg/controllerutils/mapper"
 )
 
@@ -78,7 +78,7 @@ func MapToOriginManagedResource(clusterID string) mapper.MapFunc {
 			return nil
 		}
 
-		originClusterID, key, err := resourceshelper.SplitOrigin(origin)
+		originClusterID, key, err := resourcesv1alpha1helper.SplitOrigin(origin)
 		if err != nil {
 			log.Error(err, "Failed to parse origin of object", "object", obj, "origin", origin)
 			return nil

--- a/pkg/resourcemanager/controller/managedresource/reconciler.go
+++ b/pkg/resourcemanager/controller/managedresource/reconciler.go
@@ -56,7 +56,7 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
-	resourceshelper "github.com/gardener/gardener/pkg/apis/resources/v1alpha1/helper"
+	resourcesv1alpha1helper "github.com/gardener/gardener/pkg/apis/resources/v1alpha1/helper"
 	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/resourcemanager/apis/config"
 	"github.com/gardener/gardener/pkg/resourcemanager/controller/garbagecollector/references"
@@ -141,7 +141,7 @@ func (r *Reconciler) reconcile(ctx context.Context, log logr.Logger, mr *resourc
 
 		equivalences           = NewEquivalences(mr.Spec.Equivalences...)
 		existingResourcesIndex = NewObjectIndex(mr.Status.Resources, equivalences)
-		origin                 = resourceshelper.OriginForManagedResource(r.ClusterID, mr)
+		origin                 = resourcesv1alpha1helper.OriginForManagedResource(r.ClusterID, mr)
 
 		forceOverwriteLabels      bool
 		forceOverwriteAnnotations bool

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -54,6 +54,7 @@ build:
         - pkg/apis/seedmanagement/helper
         - pkg/apis/seedmanagement/install
         - pkg/apis/seedmanagement/v1alpha1
+        - pkg/apis/seedmanagement/v1alpha1/constants
         - pkg/apis/seedmanagement/v1alpha1/helper
         - pkg/apis/seedmanagement/validation
         - pkg/apis/settings
@@ -411,6 +412,7 @@ build:
         - pkg/apis/seedmanagement/encoding
         - pkg/apis/seedmanagement/install
         - pkg/apis/seedmanagement/v1alpha1
+        - pkg/apis/seedmanagement/v1alpha1/constants
         - pkg/apis/seedmanagement/v1alpha1/helper
         - pkg/apis/settings
         - pkg/apis/settings/install
@@ -776,6 +778,7 @@ build:
         - pkg/apis/seedmanagement/encoding
         - pkg/apis/seedmanagement/install
         - pkg/apis/seedmanagement/v1alpha1
+        - pkg/apis/seedmanagement/v1alpha1/constants
         - pkg/apis/seedmanagement/v1alpha1/helper
         - pkg/apis/settings
         - pkg/apis/settings/install

--- a/test/integration/gardenlet/managedseed/managedseed_test.go
+++ b/test/integration/gardenlet/managedseed/managedseed_test.go
@@ -336,6 +336,40 @@ var _ = Describe("ManagedSeed controller test", func() {
 			checkIfSeedSecretsCreated()
 			checkIfGardenletWasDeployed()
 		})
+
+		It("should delete the seed secret when .spec.secretRef is unset", func() {
+			Eventually(func(g Gomega) {
+				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(managedSeed), managedSeed)).To(Succeed())
+				condition := v1beta1helper.GetCondition(managedSeed.Status.Conditions, seedmanagementv1alpha1.ManagedSeedShootReconciled)
+				g.Expect(condition).NotTo(BeNil())
+				g.Expect(condition.Status).To(Equal(gardencorev1beta1.ConditionTrue))
+				g.Expect(condition.Reason).To(Equal(gardencorev1beta1.EventReconciled))
+			}).Should(Succeed())
+
+			checkIfSeedSecretsCreated()
+			checkIfGardenletWasDeployed()
+
+			patch := client.MergeFrom(managedSeed.DeepCopy())
+			gardenletConfig, err := encoding.DecodeGardenletConfiguration(&managedSeed.Spec.Gardenlet.Config, false)
+			Expect(err).NotTo(HaveOccurred())
+			gardenletConfig.SeedConfig.Spec.SecretRef = nil
+			gardenletConfigRaw, err := encoding.EncodeGardenletConfiguration(gardenletConfig)
+			Expect(err).NotTo(HaveOccurred())
+			managedSeed.Spec.Gardenlet.Config = *gardenletConfigRaw
+			// This should be ideally done by the ManagedSeed admission plugin, but it's disabled in the test
+			metav1.SetMetaDataAnnotation(&managedSeed.ObjectMeta, "seedmanagement.gardener.cloud/seed-secret-name", seedSecretName)
+			metav1.SetMetaDataAnnotation(&managedSeed.ObjectMeta, "seedmanagement.gardener.cloud/seed-secret-namespace", gardenNamespaceGarden.Name)
+			Expect(testClient.Patch(ctx, managedSeed, patch)).To(Succeed())
+
+			Eventually(func(g Gomega) {
+				g.Expect(testClient.Get(ctx, client.ObjectKey{Name: seedSecretName, Namespace: gardenNamespaceGarden.Name}, &corev1.Secret{})).Should(BeNotFoundError())
+				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(managedSeed), managedSeed)).To(Succeed())
+				g.Expect(managedSeed.Annotations).NotTo(And(
+					HaveKey("seedmanagement.gardener.cloud/seed-secret-name"),
+					HaveKey("seedmanagement.gardener.cloud/seed-secret-namespace"),
+				))
+			}).Should(Succeed())
+		})
 	})
 
 	Context("deletion", func() {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind enhancement

**What this PR does / why we need it**:
See https://github.com/gardener/gardener/issues/7586 for the motivation and detailed description.
Now the managedseed controller cleans up the secret created by it when `spec.secretRef` is unset in its seed template.
The ManagedSeed admission plugin annotates the managedseed with reference to the secret name and namespace.
The seedauthorizer is enhanced to add the vertex to the secret even if secretRef is nil, by checking the newly added reference annotations. This is needed for the gardenlet to have permission to cleanup the secret when secretRef is unset.

**Which issue(s) this PR fixes**:
Fixes #7586

**Special notes for your reviewer**:
/cc @ialidzhikov 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
The `gardenlet`'s `ManagedSeed` controller now cleans up the referred seed secret when `.spec.secretRef` is unset in the seed template.
```
