### PR TITLE
Enhance guestbook test.

### DIFF
--- a/.test-defs/CreateShoot.yaml
+++ b/.test-defs/CreateShoot.yaml
@@ -11,7 +11,7 @@ spec:
   args:
   - >-
     go test -timeout=0 -mod=vendor ./test/testmachinery/system/shoot_creation
-    --v -ginkgo.v -ginkgo.progress -ginkgo.no-color
+    --v -ginkgo.v -ginkgo.show-node-events -ginkgo.no-color
     -verbose=debug
     -kubecfg=$TM_KUBECONFIG_PATH/gardener.config
     -seed-kubecfg-path=$TM_KUBECONFIG_PATH/seed.config

--- a/.test-defs/DeleteShoot.yaml
+++ b/.test-defs/DeleteShoot.yaml
@@ -11,7 +11,7 @@ spec:
   args:
   - >-
     go test -timeout=0 -mod=vendor ./test/testmachinery/system/shoot_deletion
-    --v -ginkgo.v -ginkgo.progress -ginkgo.no-color
+    --v -ginkgo.v -ginkgo.show-node-events -ginkgo.no-color
     --shoot-name=$SHOOT_NAME
     --project-namespace=$PROJECT_NAMESPACE
     --kubecfg="$TM_KUBECONFIG_PATH/gardener.config"

--- a/.test-defs/HibernateShoot.yaml
+++ b/.test-defs/HibernateShoot.yaml
@@ -11,7 +11,7 @@ spec:
   args:
   - >-
     go test -timeout=0 -mod=vendor ./test/testmachinery/system/shoot_hibernation
-    --v -ginkgo.v -ginkgo.progress -ginkgo.no-color
+    --v -ginkgo.v -ginkgo.show-node-events -ginkgo.no-color
     --shoot-name=$SHOOT_NAME
     --project-namespace=$PROJECT_NAMESPACE
     --kubecfg="$TM_KUBECONFIG_PATH/gardener.config"

--- a/.test-defs/MigrateShoot.yaml
+++ b/.test-defs/MigrateShoot.yaml
@@ -11,7 +11,7 @@ spec:
   args:
   - >-
     go test -timeout=0 -mod=vendor ./test/testmachinery/system/shoot_cp_migration
-    --v -ginkgo.v -ginkgo.progress -ginkgo.no-color
+    --v -ginkgo.v -ginkgo.show-node-events -ginkgo.no-color
     -target-seed-name=$SEED_NAME
     -shoot-name=$SHOOT_NAME
     -shoot-namespace=$PROJECT_NAMESPACE

--- a/.test-defs/ReconcileShoots.yaml
+++ b/.test-defs/ReconcileShoots.yaml
@@ -11,7 +11,7 @@ spec:
   args:
   - >-
     go test -timeout=0 -mod=vendor ./test/testmachinery/system/complete_reconcile
-    --v -ginkgo.v -ginkgo.progress -ginkgo.no-color --verbose=debug
+    --v -ginkgo.v -ginkgo.show-node-events -ginkgo.no-color --verbose=debug
     -kubecfg=$TM_KUBECONFIG_PATH/gardener.config
     -version=$GARDENER_VERSION
 

--- a/.test-defs/ShootKubernetesUpdateTest.yaml
+++ b/.test-defs/ShootKubernetesUpdateTest.yaml
@@ -13,7 +13,7 @@ spec:
   args:
   - >-
     go test -timeout=0 -mod=vendor ./test/testmachinery/system/shoot_update
-    --v -ginkgo.v -ginkgo.progress -ginkgo.no-color -verbose=debug
+    --v -ginkgo.v -ginkgo.show-node-events -ginkgo.no-color -verbose=debug
     -kubecfg=$TM_KUBECONFIG_PATH/gardener.config
     -shoot-name=$SHOOT_NAME
     -project-namespace=$PROJECT_NAMESPACE

--- a/.test-defs/TestSuiteGardenerBeta.yaml
+++ b/.test-defs/TestSuiteGardenerBeta.yaml
@@ -12,7 +12,7 @@ spec:
   args:
     - >-
       go test -timeout=0 -mod=vendor ./test/testmachinery/suites/gardener
-      --v -ginkgo.v -ginkgo.progress -ginkgo.no-color
+      --v -ginkgo.v -ginkgo.show-node-events -ginkgo.no-color
       --report-file=$TM_EXPORT_PATH/report.json
       -kubecfg=$TM_KUBECONFIG_PATH/gardener.config
       -project-namespace=$PROJECT_NAMESPACE

--- a/.test-defs/TestSuiteGardenerBetaSerial.yaml
+++ b/.test-defs/TestSuiteGardenerBetaSerial.yaml
@@ -14,7 +14,7 @@ spec:
   args:
     - >-
       go test -timeout=0 -mod=vendor ./test/testmachinery/suites/gardener
-      --v -ginkgo.v -ginkgo.progress -ginkgo.no-color
+      --v -ginkgo.v -ginkgo.show-node-events -ginkgo.no-color
       --report-file=$TM_EXPORT_PATH/report.json
       -kubecfg=$TM_KUBECONFIG_PATH/gardener.config
       -project-namespace=$PROJECT_NAMESPACE

--- a/.test-defs/TestSuiteGardenerDefault.yaml
+++ b/.test-defs/TestSuiteGardenerDefault.yaml
@@ -12,7 +12,7 @@ spec:
   args:
     - >-
       go test -timeout=0 -mod=vendor ./test/testmachinery/suites/gardener
-      --v -ginkgo.v -ginkgo.progress -ginkgo.no-color
+      --v -ginkgo.v -ginkgo.show-node-events -ginkgo.no-color
       --report-file=$TM_EXPORT_PATH/report.json
       -kubecfg=$TM_KUBECONFIG_PATH/gardener.config
       -project-namespace=$PROJECT_NAMESPACE

--- a/.test-defs/TestSuiteGardenerDefaultSerial.yaml
+++ b/.test-defs/TestSuiteGardenerDefaultSerial.yaml
@@ -14,7 +14,7 @@ spec:
   args:
     - >-
       go test -timeout=0 -mod=vendor ./test/testmachinery/suites/gardener
-      --v -ginkgo.v -ginkgo.progress -ginkgo.no-color
+      --v -ginkgo.v -ginkgo.show-node-events -ginkgo.no-color
       --report-file=$TM_EXPORT_PATH/report.json
       -kubecfg=$TM_KUBECONFIG_PATH/gardener.config
       -project-namespace=$PROJECT_NAMESPACE

--- a/.test-defs/TestSuiteGardenerRelease.yaml
+++ b/.test-defs/TestSuiteGardenerRelease.yaml
@@ -12,7 +12,7 @@ spec:
   args:
     - >-
       go test -timeout=0 -mod=vendor ./test/testmachinery/suites/gardener
-      --v -ginkgo.v -ginkgo.progress -ginkgo.no-color
+      --v -ginkgo.v -ginkgo.show-node-events -ginkgo.no-color
       --report-file=$TM_EXPORT_PATH/report.json
       -kubecfg=$TM_KUBECONFIG_PATH/gardener.config
       -project-namespace=$PROJECT_NAMESPACE

--- a/.test-defs/TestSuiteGardenerReleaseSerial.yaml
+++ b/.test-defs/TestSuiteGardenerReleaseSerial.yaml
@@ -14,7 +14,7 @@ spec:
   args:
     - >-
       go test -timeout=0 -mod=vendor ./test/testmachinery/suites/gardener
-      --v -ginkgo.v -ginkgo.progress -ginkgo.no-color
+      --v -ginkgo.v -ginkgo.show-node-events -ginkgo.no-color
       --report-file=$TM_EXPORT_PATH/report.json
       -kubecfg=$TM_KUBECONFIG_PATH/gardener.config
       -project-namespace=$PROJECT_NAMESPACE

--- a/.test-defs/TestSuiteShootBeta.yaml
+++ b/.test-defs/TestSuiteShootBeta.yaml
@@ -12,7 +12,7 @@ spec:
   args:
     - >-
       go test -timeout=0 -mod=vendor ./test/testmachinery/suites/shoot
-      --v -ginkgo.v -ginkgo.progress -ginkgo.no-color
+      --v -ginkgo.v -ginkgo.show-node-events -ginkgo.no-color
       --report-file=$TM_EXPORT_PATH/report.json
       -kubecfg=$TM_KUBECONFIG_PATH/gardener.config
       -shoot-name=$SHOOT_NAME

--- a/.test-defs/TestSuiteShootBetaDisruptive.yaml
+++ b/.test-defs/TestSuiteShootBetaDisruptive.yaml
@@ -14,7 +14,7 @@ spec:
   args:
     - >-
       go test -timeout=0 -mod=vendor ./test/testmachinery/suites/shoot
-      --v -ginkgo.v -ginkgo.progress -ginkgo.no-color
+      --v -ginkgo.v -ginkgo.show-node-events -ginkgo.no-color
       --report-file=$TM_EXPORT_PATH/report.json
       -kubecfg=$TM_KUBECONFIG_PATH/gardener.config
       -shoot-name=$SHOOT_NAME

--- a/.test-defs/TestSuiteShootBetaSerial.yaml
+++ b/.test-defs/TestSuiteShootBetaSerial.yaml
@@ -14,7 +14,7 @@ spec:
   args:
     - >-
       go test -timeout=0 -mod=vendor ./test/testmachinery/suites/shoot
-      --v -ginkgo.v -ginkgo.progress -ginkgo.no-color
+      --v -ginkgo.v -ginkgo.show-node-events -ginkgo.no-color
       --report-file=$TM_EXPORT_PATH/report.json
       -kubecfg=$TM_KUBECONFIG_PATH/gardener.config
       -shoot-name=$SHOOT_NAME

--- a/.test-defs/TestSuiteShootDefault.yaml
+++ b/.test-defs/TestSuiteShootDefault.yaml
@@ -12,7 +12,7 @@ spec:
   args:
     - >-
       go test -timeout=0 -mod=vendor ./test/testmachinery/suites/shoot
-      --v -ginkgo.v -ginkgo.progress -ginkgo.no-color
+      --v -ginkgo.v -ginkgo.show-node-events -ginkgo.no-color
       --report-file=$TM_EXPORT_PATH/report.json
       -kubecfg=$TM_KUBECONFIG_PATH/gardener.config
       -shoot-name=$SHOOT_NAME

--- a/.test-defs/TestSuiteShootDefaultDisruptive.yaml
+++ b/.test-defs/TestSuiteShootDefaultDisruptive.yaml
@@ -14,7 +14,7 @@ spec:
   args:
     - >-
       go test -timeout=0 -mod=vendor ./test/testmachinery/suites/shoot
-      --v -ginkgo.v -ginkgo.progress -ginkgo.no-color
+      --v -ginkgo.v -ginkgo.show-node-events -ginkgo.no-color
       --report-file=$TM_EXPORT_PATH/report.json
       -kubecfg=$TM_KUBECONFIG_PATH/gardener.config
       -shoot-name=$SHOOT_NAME

--- a/.test-defs/TestSuiteShootDefaultSerial.yaml
+++ b/.test-defs/TestSuiteShootDefaultSerial.yaml
@@ -14,7 +14,7 @@ spec:
   args:
     - >-
       go test -timeout=0 -mod=vendor ./test/testmachinery/suites/shoot
-      --v -ginkgo.v -ginkgo.progress -ginkgo.no-color
+      --v -ginkgo.v -ginkgo.show-node-events -ginkgo.no-color
       --report-file=$TM_EXPORT_PATH/report.json
       -kubecfg=$TM_KUBECONFIG_PATH/gardener.config
       -shoot-name=$SHOOT_NAME

--- a/.test-defs/TestSuiteShootRelease.yaml
+++ b/.test-defs/TestSuiteShootRelease.yaml
@@ -12,7 +12,7 @@ spec:
   args:
     - >-
       go test -timeout=0 -mod=vendor ./test/testmachinery/suites/shoot
-      --v -ginkgo.v -ginkgo.progress -ginkgo.no-color
+      --v -ginkgo.v -ginkgo.show-node-events -ginkgo.no-color
       --report-file=$TM_EXPORT_PATH/report.json
       -kubecfg=$TM_KUBECONFIG_PATH/gardener.config
       -shoot-name=$SHOOT_NAME

--- a/.test-defs/TestSuiteShootReleaseDisruptive.yaml
+++ b/.test-defs/TestSuiteShootReleaseDisruptive.yaml
@@ -14,7 +14,7 @@ spec:
   args:
     - >-
       go test -timeout=0 -mod=vendor ./test/testmachinery/suites/shoot
-      --v -ginkgo.v -ginkgo.progress -ginkgo.no-color
+      --v -ginkgo.v -ginkgo.show-node-events -ginkgo.no-color
       --report-file=$TM_EXPORT_PATH/report.json
       -kubecfg=$TM_KUBECONFIG_PATH/gardener.config
       -shoot-name=$SHOOT_NAME

--- a/.test-defs/TestSuiteShootReleaseSerial.yaml
+++ b/.test-defs/TestSuiteShootReleaseSerial.yaml
@@ -14,7 +14,7 @@ spec:
   args:
     - >-
       go test -timeout=0 -mod=vendor ./test/testmachinery/suites/shoot
-      --v -ginkgo.v -ginkgo.progress -ginkgo.no-color
+      --v -ginkgo.v -ginkgo.show-node-events -ginkgo.no-color
       --report-file=$TM_EXPORT_PATH/report.json
       -kubecfg=$TM_KUBECONFIG_PATH/gardener.config
       -shoot-name=$SHOOT_NAME

--- a/.test-defs/WakeUpShoot.yaml
+++ b/.test-defs/WakeUpShoot.yaml
@@ -11,7 +11,7 @@ spec:
   args:
   - >-
     go test -timeout=0 -mod=vendor ./test/testmachinery/system/shoot_hibernation_wakeup
-    --v -ginkgo.v -ginkgo.progress -ginkgo.no-color
+    --v -ginkgo.v -ginkgo.show-node-events -ginkgo.no-color
     --shoot-name=$SHOOT_NAME
     --project-namespace=$PROJECT_NAMESPACE
     --kubecfg="$TM_KUBECONFIG_PATH/gardener.config"

--- a/docs/development/testmachinery_tests.md
+++ b/docs/development/testmachinery_tests.md
@@ -64,7 +64,7 @@ A suite can be executed by running the suite definition with ginkgo's `focus` an
 to control the execution of specific labeled test. See the example below:
 ```console
 go test -timeout=0 -mod=vendor ./test/testmachinery/suites/shoot \
-      --v -ginkgo.v -ginkgo.progress -ginkgo.no-color \
+      --v -ginkgo.v -ginkgo.show-node-events -ginkgo.no-color \
       --report-file=/tmp/report.json \                     # write elasticsearch formatted output to a file
       --disable-dump=false \                               # disables dumping of teh current state if a test fails
       -kubecfg=/path/to/gardener/kubeconfig \
@@ -96,7 +96,7 @@ The newly created test can be tested by focusing the test with the default ginkg
 and running the shoot test suite with:
 ```
 go test -timeout=0 -mod=vendor ./test/testmachinery/suites/shoot \
-      --v -ginkgo.v -ginkgo.progress -ginkgo.no-color \
+      --v -ginkgo.v -ginkgo.show-node-events -ginkgo.no-color \
       --report-file=/tmp/report.json \                     # write elasticsearch formatted output to a file
       --disable-dump=false \                               # disables dumping of the current state if a test fails
       -kubecfg=/path/to/gardener/kubeconfig \
@@ -107,7 +107,7 @@ go test -timeout=0 -mod=vendor ./test/testmachinery/suites/shoot \
 or for the gardener suite with:
 ```
 go test -timeout=0 -mod=vendor ./test/testmachinery/suites/gardener \
-      --v -ginkgo.v -ginkgo.progress -ginkgo.no-color \
+      --v -ginkgo.v -ginkgo.show-node-events -ginkgo.no-color \
       --report-file=/tmp/report.json \                     # write elasticsearch formatted output to a file
       --disable-dump=false \                               # disables dumping of the current state if a test fails
       -kubecfg=/path/to/gardener/kubeconfig \
@@ -119,7 +119,7 @@ go test -timeout=0 -mod=vendor ./test/testmachinery/suites/gardener \
 Alternatively, a test can be triggered by specifying a ginkgo focus regex with the name of the test e.g.
 ```
 go test -timeout=0 -mod=vendor ./test/testmachinery/suites/gardener \
-      --v -ginkgo.v -ginkgo.progress -ginkgo.no-color \
+      --v -ginkgo.v -ginkgo.show-node-events -ginkgo.no-color \
       --report-file=/tmp/report.json \                     # write elasticsearch formatted output to a file
       -kubecfg=/path/to/gardener/kubeconfig \
       -project-namespace=<gardener project namespace> \
@@ -250,7 +250,7 @@ Create Shoot test is meant to test shoot creation.
 
 ```console
 go test -mod=vendor -timeout=0 ./test/testmachinery/system/shoot_creation \
-  --v -ginkgo.v -ginkgo.progress \
+  --v -ginkgo.v -ginkgo.show-node-events \
   -kubecfg=$HOME/.kube/config \
   -shoot-name=$SHOOT_NAME \
   -cloud-profile=$CLOUDPROFILE \
@@ -278,7 +278,7 @@ Delete Shoot test is meant to test the deletion of a shoot.
 **Example Run**
 
 ```console
-go test -mod=vendor -timeout=0 -ginkgo.v -ginkgo.progress \
+go test -mod=vendor -timeout=0 -ginkgo.v -ginkgo.show-node-events \
   ./test/testmachinery/system/shoot_deletion \
   -kubecfg=$HOME/.kube/config \
   -shoot-name=$SHOOT_NAME \
@@ -295,7 +295,7 @@ If there is no available newer version, this test is a noop.
 
 ```console
 go test -mod=vendor -timeout=0 ./test/testmachinery/system/shoot_update \
-  --v -ginkgo.v -ginkgo.progress \
+  --v -ginkgo.v -ginkgo.show-node-events \
   -kubecfg=$HOME/.kube/config \
   -shoot-name=$SHOOT_NAME \
   -project-namespace=$PROJECT_NAMESPACE \
@@ -310,7 +310,7 @@ The Gardener Full Reconcile test is meant to test if all shoots of a Gardener in
 
 ```console
 go test -mod=vendor -timeout=0 ./test/testmachinery/system/complete_reconcile \
-  --v -ginkgo.v -ginkgo.progress \
+  --v -ginkgo.v -ginkgo.show-node-events \
   -kubecfg=$HOME/.kube/config \
   -project-namespace=$PROJECT_NAMESPACE \
   -gardenerVersion=$GARDENER_VERSION # needed to validate the last acted gardener version of a shoot

--- a/example/provider-local/shoot-workerless.yaml
+++ b/example/provider-local/shoot-workerless.yaml
@@ -10,4 +10,4 @@ spec:
   provider:
     type: local
   kubernetes:
-    version: 1.26.0
+    version: 1.27.1

--- a/hack/kind-up.sh
+++ b/hack/kind-up.sh
@@ -140,7 +140,7 @@ fi
 
 kind create cluster \
   --name "$CLUSTER_NAME" \
-  --image "kindest/node:v1.26.3" \
+  --image "kindest/node:v1.27.1" \
   --config <(helm template $CHART --values "$PATH_CLUSTER_VALUES" $ADDITIONAL_ARGS --set "environment=$ENVIRONMENT" --set "gardener.repositoryRoot"=$(dirname "$0")/..)
 
 # adjust Kind's CRI default OCI runtime spec for new containers to include the cgroup namespace

--- a/test/e2e/gardener/common.go
+++ b/test/e2e/gardener/common.go
@@ -128,7 +128,7 @@ func DefaultWorkerlessShoot(name string) *gardencorev1beta1.Shoot {
 			Region:           "local",
 			CloudProfileName: "local",
 			Kubernetes: gardencorev1beta1.Kubernetes{
-				Version:                     "1.26.0",
+				Version:                     "1.27.1",
 				EnableStaticTokenKubeconfig: pointer.Bool(false),
 			},
 			Provider: gardencorev1beta1.Provider{

--- a/test/e2e/operator/garden/common.go
+++ b/test/e2e/operator/garden/common.go
@@ -111,7 +111,7 @@ func defaultGarden(backupSecret *corev1.Secret) *operatorv1alpha1.Garden {
 					},
 				},
 				Kubernetes: operatorv1alpha1.Kubernetes{
-					Version: "1.26.3",
+					Version: "1.27.1",
 				},
 				Maintenance: operatorv1alpha1.Maintenance{
 					TimeWindow: gardencorev1beta1.MaintenanceTimeWindow{

--- a/test/framework/applications/guestbooktest.go
+++ b/test/framework/applications/guestbooktest.go
@@ -84,6 +84,12 @@ func (t *GuestBookTest) WaitUntilGuestbookDeploymentIsReady(ctx context.Context)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 }
 
+// WaitUntilGuestbookIngressIsReady waits until the guestbook ingress is ready.
+func (t *GuestBookTest) WaitUntilGuestbookIngressIsReady(ctx context.Context) {
+	err := t.framework.WaitUntilIngressIsReady(ctx, GuestBook, t.framework.Namespace, t.framework.ShootClient)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+}
+
 // WaitUntilGuestbookURLsRespondOK waits until the deployed guestbook application can be reached via http
 func (t *GuestBookTest) WaitUntilGuestbookURLsRespondOK(ctx context.Context, guestbookAppUrls []string) error {
 	defaultPollInterval := time.Minute
@@ -181,6 +187,7 @@ func (t *GuestBookTest) DeployGuestBookApp(ctx context.Context) {
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 	t.WaitUntilGuestbookDeploymentIsReady(ctx)
+	t.WaitUntilGuestbookIngressIsReady(ctx)
 
 	ginkgo.By("Guestbook app was deployed successfully!")
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind enhancement

**What this PR does / why we need it**:
Recently `Guestbook` test is flaking a lot for OpenStack providers, In most the occurrences, The test fails with error 
```
{"level":"info","ts":"2023-06-06T09:42:44.406Z","logger":"test","msg":"Guestbook app is not available yet (call failed)","url":"http://guestbook-jvf.ingress.tm73c-i7u.it.shoot.staging.k8s-hana.ondemand.com","reason":"Get \"http://guestbook-jvf.ingress.tm73c-i7u.it.shoot.staging.k8s-hana.ondemand.com\": dial tcp 10.236.222.144:80: connect: connection timed out"}
```
And this is because ingress doesn't get load balancer IPs in the mean time.

This PR enhances the Guestbook test to wait for `guestbook` ingress to get ready before any request is sent to it.
In the future, if test flakes again, we can invest time directly into looking at why ingress fails to get the load balancer IP.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
