### PR TITLE
Fix zone affinity merge

### DIFF
--- a/pkg/resourcemanager/webhook/highavailabilityconfig/handler.go
+++ b/pkg/resourcemanager/webhook/highavailabilityconfig/handler.go
@@ -424,8 +424,7 @@ func (h *Handler) mutateNodeAffinity(
 			podTemplateSpec.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms = []corev1.NodeSelectorTerm{{}}
 		}
 
-		nodeSelectorTerms := podTemplateSpec.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms
-		for i, term := range nodeSelectorTerms {
+		for i, term := range podTemplateSpec.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms {
 			filteredExpressions := make([]corev1.NodeSelectorRequirement, 0, len(term.MatchExpressions))
 			// Remove existing expressions for `topology.kubernetes.io/zone` to
 			// - avoid duplicates for the same key
@@ -437,7 +436,7 @@ func (h *Handler) mutateNodeAffinity(
 			}
 
 			// Add remaining expressions with intended zone expression.
-			nodeSelectorTerms[i].MatchExpressions = append(filteredExpressions, *nodeSelectorRequirement)
+			podTemplateSpec.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[i].MatchExpressions = append(filteredExpressions, *nodeSelectorRequirement)
 		}
 	}
 }

--- a/pkg/resourcemanager/webhook/highavailabilityconfig/handler.go
+++ b/pkg/resourcemanager/webhook/highavailabilityconfig/handler.go
@@ -427,7 +427,7 @@ func (h *Handler) mutateNodeAffinity(
 		nodeSelectorTerms := podTemplateSpec.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms
 		for i, term := range nodeSelectorTerms {
 			filteredExpressions := make([]corev1.NodeSelectorRequirement, 0, len(term.MatchExpressions))
-			// Remove exiting expressions for `topology.kubernetes.io/zone` to
+			// Remove existing expressions for `topology.kubernetes.io/zone` to
 			// - avoid duplicates for the same key
 			// - remove expressions that prevent zone pinning
 			for _, expr := range term.MatchExpressions {

--- a/test/integration/resourcemanager/highavailabilityconfig/highavailabilityconfig_test.go
+++ b/test/integration/resourcemanager/highavailabilityconfig/highavailabilityconfig_test.go
@@ -434,42 +434,124 @@ var _ = Describe("HighAvailabilityConfig tests", func() {
 								})
 							})
 
-							It("should add a node affinity", func() {
-								Expect(getPodSpec().Affinity).To(Equal(&corev1.Affinity{
-									NodeAffinity: &corev1.NodeAffinity{
-										RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
-											NodeSelectorTerms: []corev1.NodeSelectorTerm{
-												{
-													MatchExpressions: []corev1.NodeSelectorRequirement{
+							Context("when correct affinity is already defined", func() {
+								BeforeEach(func() {
+									setPodSpec(func(spec *corev1.PodSpec) {
+										spec.Affinity = &corev1.Affinity{
+											NodeAffinity: &corev1.NodeAffinity{
+												RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+													NodeSelectorTerms: []corev1.NodeSelectorTerm{
 														{
-															Key:      corev1.LabelHostname,
-															Operator: corev1.NodeSelectorOpExists,
-														},
-														{
-															Key:      corev1.LabelTopologyZone,
-															Operator: corev1.NodeSelectorOpIn,
-															Values:   zones,
+															MatchExpressions: []corev1.NodeSelectorRequirement{
+																{
+																	Key:      corev1.LabelHostname,
+																	Operator: corev1.NodeSelectorOpExists,
+																},
+																{
+																	Key:      corev1.LabelTopologyZone,
+																	Operator: corev1.NodeSelectorOpIn,
+																	Values:   zones,
+																},
+															},
 														},
 													},
 												},
-												{
-													MatchExpressions: []corev1.NodeSelectorRequirement{
-														{
-															Key:      "foo",
-															Operator: corev1.NodeSelectorOpNotIn,
-															Values:   []string{"bar"},
-														},
-														{
-															Key:      corev1.LabelTopologyZone,
-															Operator: corev1.NodeSelectorOpIn,
-															Values:   zones,
+											},
+										}
+									})
+								})
+
+								It("should not re-add the same expressions", func() {
+									Expect(getPodSpec().Affinity).To(Equal(&corev1.Affinity{
+										NodeAffinity: &corev1.NodeAffinity{
+											RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+												NodeSelectorTerms: []corev1.NodeSelectorTerm{
+													{
+														MatchExpressions: []corev1.NodeSelectorRequirement{
+															{
+																Key:      corev1.LabelHostname,
+																Operator: corev1.NodeSelectorOpExists,
+															},
+															{
+																Key:      corev1.LabelTopologyZone,
+																Operator: corev1.NodeSelectorOpIn,
+																Values:   zones,
+															},
 														},
 													},
 												},
 											},
 										},
-									},
-								}))
+									}))
+								})
+							})
+
+							Context("when correct affinities are already defined", func() {
+								BeforeEach(func() {
+									setPodSpec(func(spec *corev1.PodSpec) {
+										spec.Affinity = &corev1.Affinity{
+											NodeAffinity: &corev1.NodeAffinity{
+												RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+													NodeSelectorTerms: []corev1.NodeSelectorTerm{
+														{
+															MatchExpressions: []corev1.NodeSelectorRequirement{
+																{
+																	Key:      corev1.LabelHostname,
+																	Operator: corev1.NodeSelectorOpExists,
+																},
+																{
+																	Key:      corev1.LabelTopologyZone,
+																	Operator: corev1.NodeSelectorOpIn,
+																	Values:   zones,
+																},
+															},
+														},
+														{
+															MatchExpressions: []corev1.NodeSelectorRequirement{{
+																Key:      corev1.LabelTopologyZone,
+																Operator: corev1.NodeSelectorOpIn,
+																Values:   zones,
+															}},
+														},
+													},
+												},
+											},
+										}
+									})
+								})
+
+								It("should not re-add the same expressions", func() {
+									Expect(getPodSpec().Affinity).To(Equal(&corev1.Affinity{
+										NodeAffinity: &corev1.NodeAffinity{
+											RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+												NodeSelectorTerms: []corev1.NodeSelectorTerm{
+													{
+														MatchExpressions: []corev1.NodeSelectorRequirement{
+															{
+																Key:      corev1.LabelHostname,
+																Operator: corev1.NodeSelectorOpExists,
+															},
+															{
+																Key:      corev1.LabelTopologyZone,
+																Operator: corev1.NodeSelectorOpIn,
+																Values:   zones,
+															},
+														},
+													},
+													{
+														MatchExpressions: []corev1.NodeSelectorRequirement{
+															{
+																Key:      corev1.LabelTopologyZone,
+																Operator: corev1.NodeSelectorOpIn,
+																Values:   zones,
+															},
+														},
+													},
+												},
+											},
+										},
+									}))
+								})
 							})
 						})
 					})
@@ -743,14 +825,12 @@ var _ = Describe("HighAvailabilityConfig tests", func() {
 					})
 
 					Context("when 'not-ready' toleration exists", func() {
-						existingTolerations := []corev1.Toleration{
-							corev1.Toleration{
-								Key:               "node.kubernetes.io/not-ready",
-								Operator:          "Exists",
-								Effect:            "NoExecute",
-								TolerationSeconds: pointer.Int64(300),
-							},
-						}
+						existingTolerations := []corev1.Toleration{{
+							Key:               "node.kubernetes.io/not-ready",
+							Operator:          "Exists",
+							Effect:            "NoExecute",
+							TolerationSeconds: pointer.Int64(300),
+						}}
 
 						BeforeEach(func() {
 							setPodSpec(func(spec *corev1.PodSpec) {
@@ -777,14 +857,12 @@ var _ = Describe("HighAvailabilityConfig tests", func() {
 					})
 
 					Context("when 'unreachable' toleration exists", func() {
-						existingTolerations := []corev1.Toleration{
-							corev1.Toleration{
-								Key:               "node.kubernetes.io/unreachable",
-								Operator:          "Exists",
-								Effect:            "NoExecute",
-								TolerationSeconds: pointer.Int64(300),
-							},
-						}
+						existingTolerations := []corev1.Toleration{{
+							Key:               "node.kubernetes.io/unreachable",
+							Operator:          "Exists",
+							Effect:            "NoExecute",
+							TolerationSeconds: pointer.Int64(300),
+						}}
 
 						BeforeEach(func() {
 							setPodSpec(func(spec *corev1.PodSpec) {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area high-availability
/kind bug

**What this PR does / why we need it**:
This PR fixes an issue in the [HighAvailabilityConfig-Webhook](https://github.com/gardener/gardener/blob/master/docs/concepts/resource-manager.md#high-availability-config) which caused node affinities being duplicated on every `statefulset` or `deployment` update.

**Special notes for your reviewer**:
This only happened when the resource defined multiple `nodeSelectorTerms`:

_Before Update_:

```
 spec:
      affinity:
        nodeAffinity:
          requiredDuringSchedulingIgnoredDuringExecution:
            nodeSelectorTerms:
            - matchExpressions:
              - key: foo
                operator: In
                values:
                - bar
              - key: topology.kubernetes.io/zone
                operator: In
                values:
                - eu-west-1a
                - eu-west-1b
                - eu-west-1c
```

_After Update_:

```
spec:
      affinity:
        nodeAffinity:
          requiredDuringSchedulingIgnoredDuringExecution:
            nodeSelectorTerms:
            - matchExpressions:
              - key: foo
                operator: In
                values:
                - bar
              - key: topology.kubernetes.io/zone
                operator: In
                values:
                - eu-west-1a
                - eu-west-1b
                - eu-west-1c
              - key: topology.kubernetes.io/zone
                operator: In
                values:
                - eu-west-1a
                - eu-west-1b
                - eu-west-1c
```

Thanks for reporting @shreyas-s-rao and @unmarshall.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
A bug has been fixed in the [HighAvailabilityConfig-Webhook](https://github.com/gardener/gardener/blob/master/docs/concepts/resource-manager.md#high-availability-config) which caused duplicated entries for zone affinities.
```
