### PR TITLE
Update kyverno to `v1.9.5`

### DIFF
--- a/example/provider-extensions/kyverno/kustomization.yaml
+++ b/example/provider-extensions/kyverno/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-- https://raw.githubusercontent.com/kyverno/kyverno/release-1.7/config/release/install.yaml
+- https://github.com/kyverno/kyverno/releases/download/v1.8.0/install.yaml
 - kyverno-poddisruptionbudget.yaml
 
 patchesStrategicMerge:

--- a/example/provider-extensions/kyverno/kustomization.yaml
+++ b/example/provider-extensions/kyverno/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-- https://github.com/kyverno/kyverno/releases/download/v1.8.0/install.yaml
+- https://github.com/kyverno/kyverno/releases/download/v1.9.5/install.yaml
 - kyverno-poddisruptionbudget.yaml
 
 patchesStrategicMerge:

--- a/example/provider-extensions/seed/configure-seed.sh
+++ b/example/provider-extensions/seed/configure-seed.sh
@@ -199,7 +199,7 @@ echo "Create host and client keys for SSH reverse tunnel"
 "$SCRIPT_DIR"/../ssh-reverse-tunnel/create-client-keys.sh "$seed_name" "$relay_domain"
 
 echo "Deploying kyverno, SSH reverse tunnel and container registry"
-kubectl --server-side=true --kubeconfig "$seed_kubeconfig" apply -k "$SCRIPT_DIR"/../kyverno
+kubectl --server-side=true --force-conflicts=true --kubeconfig "$seed_kubeconfig" apply -k "$SCRIPT_DIR"/../kyverno
 until kubectl --kubeconfig "$seed_kubeconfig" get clusterpolicies.kyverno.io ; do date; sleep 1; echo ""; done
 kubectl --server-side=true --force-conflicts=true --kubeconfig "$seed_kubeconfig" apply -k "$SCRIPT_DIR"/../kyverno-policies
 kubectl --server-side=true --kubeconfig "$seed_kubeconfig" apply -k "$seed_base_dir"/sshd


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
With https://github.com/gardener/gardener/pull/7902 `kyverno-verify-mutating-webhook-cfg` webhook timeoutSeconds get modified to `3` seconds, because of this cluster used for `provider-extension` setup gets following error - 
```
MutatingWebhookConfiguration "kyverno-verify-mutating-webhook-cfg" is problematic and was remediated by Gardener (please check its annotations for details).
``` 
In follow-up PR https://github.com/gardener/gardener/pull/8034, adaption was made so webhook with config similar to this `kyverno-verify-mutating-webhook-cfg` doesn't get considered problematic.

But this will only work if kyverno version is >=v1.8.0

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @oliver-goetz 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
