### PR TITLE
[release-v1.70] Fix zone affinity merge

### DIFF
--- a/pkg/resourcemanager/webhook/highavailabilityconfig/handler.go
+++ b/pkg/resourcemanager/webhook/highavailabilityconfig/handler.go
@@ -408,24 +408,23 @@ func (h *Handler) mutateNodeAffinity(
 			podTemplateSpec.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution = &corev1.NodeSelector{}
 		}
 
-		// Filter existing terms with the same expression key to prevent that we are trying to add an expression with
-		// the same key multiple times.
-		var filteredNodeSelectorTerms []corev1.NodeSelectorTerm
-		for _, term := range podTemplateSpec.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms {
-			for _, expr := range term.MatchExpressions {
-				if expr.Key != corev1.LabelTopologyZone {
-					filteredNodeSelectorTerms = append(filteredNodeSelectorTerms, term)
-				}
-			}
-		}
-		podTemplateSpec.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms = filteredNodeSelectorTerms
-
 		if len(podTemplateSpec.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms) == 0 {
 			podTemplateSpec.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms = []corev1.NodeSelectorTerm{{}}
 		}
 
-		for i := range podTemplateSpec.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms {
-			podTemplateSpec.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[i].MatchExpressions = append(podTemplateSpec.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[i].MatchExpressions, *nodeSelectorRequirement)
+		for i, term := range podTemplateSpec.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms {
+			filteredExpressions := make([]corev1.NodeSelectorRequirement, 0, len(term.MatchExpressions))
+			// Remove existing expressions for `topology.kubernetes.io/zone` to
+			// - avoid duplicates for the same key
+			// - remove expressions that prevent zone pinning
+			for _, expr := range term.MatchExpressions {
+				if expr.Key != corev1.LabelTopologyZone {
+					filteredExpressions = append(filteredExpressions, expr)
+				}
+			}
+
+			// Add remaining expressions with intended zone expression.
+			podTemplateSpec.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[i].MatchExpressions = append(filteredExpressions, *nodeSelectorRequirement)
 		}
 	}
 }

--- a/test/integration/resourcemanager/highavailabilityconfig/highavailabilityconfig_test.go
+++ b/test/integration/resourcemanager/highavailabilityconfig/highavailabilityconfig_test.go
@@ -433,42 +433,124 @@ var _ = Describe("HighAvailabilityConfig tests", func() {
 								})
 							})
 
-							It("should add a node affinity", func() {
-								Expect(getPodSpec().Affinity).To(Equal(&corev1.Affinity{
-									NodeAffinity: &corev1.NodeAffinity{
-										RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
-											NodeSelectorTerms: []corev1.NodeSelectorTerm{
-												{
-													MatchExpressions: []corev1.NodeSelectorRequirement{
+							Context("when correct affinity is already defined", func() {
+								BeforeEach(func() {
+									setPodSpec(func(spec *corev1.PodSpec) {
+										spec.Affinity = &corev1.Affinity{
+											NodeAffinity: &corev1.NodeAffinity{
+												RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+													NodeSelectorTerms: []corev1.NodeSelectorTerm{
 														{
-															Key:      corev1.LabelHostname,
-															Operator: corev1.NodeSelectorOpExists,
-														},
-														{
-															Key:      corev1.LabelTopologyZone,
-															Operator: corev1.NodeSelectorOpIn,
-															Values:   zones,
+															MatchExpressions: []corev1.NodeSelectorRequirement{
+																{
+																	Key:      corev1.LabelHostname,
+																	Operator: corev1.NodeSelectorOpExists,
+																},
+																{
+																	Key:      corev1.LabelTopologyZone,
+																	Operator: corev1.NodeSelectorOpIn,
+																	Values:   zones,
+																},
+															},
 														},
 													},
 												},
-												{
-													MatchExpressions: []corev1.NodeSelectorRequirement{
-														{
-															Key:      "foo",
-															Operator: corev1.NodeSelectorOpNotIn,
-															Values:   []string{"bar"},
-														},
-														{
-															Key:      corev1.LabelTopologyZone,
-															Operator: corev1.NodeSelectorOpIn,
-															Values:   zones,
+											},
+										}
+									})
+								})
+
+								It("should not re-add the same expressions", func() {
+									Expect(getPodSpec().Affinity).To(Equal(&corev1.Affinity{
+										NodeAffinity: &corev1.NodeAffinity{
+											RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+												NodeSelectorTerms: []corev1.NodeSelectorTerm{
+													{
+														MatchExpressions: []corev1.NodeSelectorRequirement{
+															{
+																Key:      corev1.LabelHostname,
+																Operator: corev1.NodeSelectorOpExists,
+															},
+															{
+																Key:      corev1.LabelTopologyZone,
+																Operator: corev1.NodeSelectorOpIn,
+																Values:   zones,
+															},
 														},
 													},
 												},
 											},
 										},
-									},
-								}))
+									}))
+								})
+							})
+
+							Context("when correct affinities are already defined", func() {
+								BeforeEach(func() {
+									setPodSpec(func(spec *corev1.PodSpec) {
+										spec.Affinity = &corev1.Affinity{
+											NodeAffinity: &corev1.NodeAffinity{
+												RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+													NodeSelectorTerms: []corev1.NodeSelectorTerm{
+														{
+															MatchExpressions: []corev1.NodeSelectorRequirement{
+																{
+																	Key:      corev1.LabelHostname,
+																	Operator: corev1.NodeSelectorOpExists,
+																},
+																{
+																	Key:      corev1.LabelTopologyZone,
+																	Operator: corev1.NodeSelectorOpIn,
+																	Values:   zones,
+																},
+															},
+														},
+														{
+															MatchExpressions: []corev1.NodeSelectorRequirement{{
+																Key:      corev1.LabelTopologyZone,
+																Operator: corev1.NodeSelectorOpIn,
+																Values:   zones,
+															}},
+														},
+													},
+												},
+											},
+										}
+									})
+								})
+
+								It("should not re-add the same expressions", func() {
+									Expect(getPodSpec().Affinity).To(Equal(&corev1.Affinity{
+										NodeAffinity: &corev1.NodeAffinity{
+											RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+												NodeSelectorTerms: []corev1.NodeSelectorTerm{
+													{
+														MatchExpressions: []corev1.NodeSelectorRequirement{
+															{
+																Key:      corev1.LabelHostname,
+																Operator: corev1.NodeSelectorOpExists,
+															},
+															{
+																Key:      corev1.LabelTopologyZone,
+																Operator: corev1.NodeSelectorOpIn,
+																Values:   zones,
+															},
+														},
+													},
+													{
+														MatchExpressions: []corev1.NodeSelectorRequirement{
+															{
+																Key:      corev1.LabelTopologyZone,
+																Operator: corev1.NodeSelectorOpIn,
+																Values:   zones,
+															},
+														},
+													},
+												},
+											},
+										},
+									}))
+								})
 							})
 						})
 					})


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area high-availability
/kind bug

**What this PR does / why we need it**:
This is a cherry-pick of https://github.com/gardener/gardener/pull/8042.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
A bug has been fixed in the [HighAvailabilityConfig-Webhook](https://github.com/gardener/gardener/blob/master/docs/concepts/resource-manager.md#high-availability-config) which caused duplicated entries for zone affinities.
```
