### PR TITLE
[release-v1.72] Prevent sending empty patches in `NetworkPolicy` controller

### DIFF
--- a/pkg/resourcemanager/controller/networkpolicy/reconciler.go
+++ b/pkg/resourcemanager/controller/networkpolicy/reconciler.go
@@ -23,6 +23,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -287,6 +288,21 @@ func (r *Reconciler) deleteStalePolicies(networkPolicyList *metav1.PartialObject
 	return taskFns
 }
 
+// This is used as a compatible alternative of https://github.com/gardener/gardener/pull/8043
+// and is only included by minor releases of >= v1.72.1, v1.71.4, v1.70.3
+type objectUnchangedError struct{}
+
+func (o *objectUnchangedError) Error() string {
+	return "object unchanged"
+}
+
+func ignoreObjectUnchangedError(err error) error {
+	if _, ok := err.(*objectUnchangedError); ok {
+		return nil
+	}
+	return err
+}
+
 func (r *Reconciler) reconcileIngressPolicy(
 	ctx context.Context,
 	service *corev1.Service,
@@ -298,6 +314,8 @@ func (r *Reconciler) reconcileIngressPolicy(
 	networkPolicy := &networkingv1.NetworkPolicy{ObjectMeta: networkPolicyObjectMeta}
 
 	_, err := controllerutils.GetAndCreateOrMergePatch(ctx, r.TargetClient, networkPolicy, func() error {
+		networkPolicyBefore := networkPolicy.DeepCopy()
+
 		metav1.SetMetaDataLabel(&networkPolicy.ObjectMeta, resourcesv1alpha1.NetworkingServiceName, service.Name)
 		metav1.SetMetaDataLabel(&networkPolicy.ObjectMeta, resourcesv1alpha1.NetworkingServiceNamespace, service.Namespace)
 
@@ -316,10 +334,16 @@ func (r *Reconciler) reconcileIngressPolicy(
 		networkPolicy.Spec.PodSelector = metav1.LabelSelector{MatchLabels: service.Spec.Selector}
 		networkPolicy.Spec.PolicyTypes = []networkingv1.PolicyType{networkingv1.PolicyTypeIngress}
 
+		// This block is used as a compatible alternative of https://github.com/gardener/gardener/pull/8043
+		// and is only included by minor releases of >= v1.72.1, v1.71.4, v1.70.3
+		if apiequality.Semantic.DeepEqual(networkPolicyBefore, networkPolicy) {
+			logf.Log.V(1).Info("Object unchanged", "objectKey", client.ObjectKeyFromObject(networkPolicy))
+			return &objectUnchangedError{}
+		}
 		return nil
 	})
 
-	return err
+	return ignoreObjectUnchangedError(err)
 }
 
 func (r *Reconciler) reconcileEgressPolicy(
@@ -333,6 +357,8 @@ func (r *Reconciler) reconcileEgressPolicy(
 	networkPolicy := &networkingv1.NetworkPolicy{ObjectMeta: networkPolicyObjectMeta}
 
 	_, err := controllerutils.GetAndCreateOrMergePatch(ctx, r.TargetClient, networkPolicy, func() error {
+		networkPolicyBefore := networkPolicy.DeepCopy()
+
 		metav1.SetMetaDataLabel(&networkPolicy.ObjectMeta, resourcesv1alpha1.NetworkingServiceName, service.Name)
 		metav1.SetMetaDataLabel(&networkPolicy.ObjectMeta, resourcesv1alpha1.NetworkingServiceNamespace, service.Namespace)
 
@@ -351,10 +377,16 @@ func (r *Reconciler) reconcileEgressPolicy(
 		networkPolicy.Spec.PodSelector = podLabelSelector
 		networkPolicy.Spec.PolicyTypes = []networkingv1.PolicyType{networkingv1.PolicyTypeEgress}
 
+		// This is used as a compatible alternative of https://github.com/gardener/gardener/pull/8043
+		// and is only included by minor releases of >= v1.72.1, v1.71.4, v1.70.3
+		if apiequality.Semantic.DeepEqual(networkPolicyBefore, networkPolicy) {
+			logf.Log.V(1).Info("Object unchanged", "objectKey", client.ObjectKeyFromObject(networkPolicy))
+			return &objectUnchangedError{}
+		}
 		return nil
 	})
 
-	return err
+	return ignoreObjectUnchangedError(err)
 }
 
 func (r *Reconciler) reconcileIngressFromWorldPolicy(ctx context.Context, service *corev1.Service, networkPolicyObjectMeta metav1.ObjectMeta) error {
@@ -365,6 +397,8 @@ func (r *Reconciler) reconcileIngressFromWorldPolicy(ctx context.Context, servic
 
 	networkPolicy := &networkingv1.NetworkPolicy{ObjectMeta: networkPolicyObjectMeta}
 	_, err := controllerutils.GetAndCreateOrMergePatch(ctx, r.TargetClient, networkPolicy, func() error {
+		networkPolicyBefore := networkPolicy.DeepCopy()
+
 		metav1.SetMetaDataLabel(&networkPolicy.ObjectMeta, resourcesv1alpha1.NetworkingServiceName, service.Name)
 		metav1.SetMetaDataLabel(&networkPolicy.ObjectMeta, resourcesv1alpha1.NetworkingServiceNamespace, service.Namespace)
 
@@ -377,9 +411,15 @@ func (r *Reconciler) reconcileIngressFromWorldPolicy(ctx context.Context, servic
 		networkPolicy.Spec.PodSelector = metav1.LabelSelector{MatchLabels: service.Spec.Selector}
 		networkPolicy.Spec.PolicyTypes = []networkingv1.PolicyType{networkingv1.PolicyTypeIngress}
 
+		// This is used as a compatible alternative of https://github.com/gardener/gardener/pull/8043
+		// and is only included by minor releases of >= v1.72.1, v1.71.4, v1.70.3
+		if apiequality.Semantic.DeepEqual(networkPolicyBefore, networkPolicy) {
+			logf.Log.V(1).Info("Object unchanged", "objectKey", client.ObjectKeyFromObject(networkPolicy))
+			return &objectUnchangedError{}
+		}
 		return nil
 	})
-	return err
+	return ignoreObjectUnchangedError(err)
 }
 
 func portAndProtocolOf(ports []networkingv1.NetworkPolicyPort) []string {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area performance
/area cost
/kind enhancement

**What this PR does / why we need it**:
This PR implements a compatible alternative of https://github.com/gardener/gardener/pull/8043 which can be used for release branches `v1.72`, `v1.71` and `v1.70`.

**Special notes for your reviewer**:
/cc @rfranzke @ScheererJ

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
