### PR TITLE
Don't kill terraform pod on context cancelation

### DIFF
--- a/extensions/pkg/terraformer/terraformer.go
+++ b/extensions/pkg/terraformer/terraformer.go
@@ -266,8 +266,8 @@ func (t *terraformer) execute(ctx context.Context, command string) error {
 		switch {
 		case errors.Is(ctx.Err(), context.Canceled):
 			// If the context error is Canceled, the parent context has been canceled. Because the Terraform is fairly unstable
-			// and interruptions may cause it to not properly store the state, we will allow it to continue. The next reconciliation will
-			// adopt the running pod.
+			// and interruptions may cause it to not properly store the state (ref https://github.com/hashicorp/terraform/issues/33358),
+			// we will allow it to continue. The next reconciliation will adopt the running pod.
 			podLogger.Info("Skipping Terraformer pod deletion because context was cancelled")
 		case errors.Is(ctx.Err(), context.DeadlineExceeded):
 			// If the context error is deadline exceeded, create a new context for deleting the pod since attempting to use the

--- a/extensions/pkg/terraformer/terraformer.go
+++ b/extensions/pkg/terraformer/terraformer.go
@@ -271,8 +271,7 @@ func (t *terraformer) execute(ctx context.Context, command string) error {
 			podLogger.Info("Skipping Terraformer pod deletion because context was cancelled")
 		case errors.Is(ctx.Err(), context.DeadlineExceeded):
 			// If the context error is deadline exceeded, create a new context for deleting the pod since attempting to use the
-			// original context will fail. The context might get cancelled for example by the owner check watchdog and the pod
-			// should be deleted to prevent the terraform script from running after the context was cancelled.
+			// original context will fail.
 			var cancel context.CancelFunc
 			ctx, cancel = context.WithTimeout(context.Background(), 1*time.Minute)
 			defer cancel()

--- a/extensions/pkg/terraformer/terraformer.go
+++ b/extensions/pkg/terraformer/terraformer.go
@@ -263,18 +263,25 @@ func (t *terraformer) execute(ctx context.Context, command string) error {
 			}
 		}
 
-		podLogger.Info("Cleaning up Terraformer pod")
-		// If the context error is non-nil (cancelled or deadline exceeded),
-		// create a new context for deleting the pod since attempting to use the original context will fail.
-		// The context might get cancelled for example by the owner check watchdog and the pod should be
-		// deleted to prevent the terraform script from running after the context was cancelled.
-		if ctx.Err() != nil {
+		switch {
+		case errors.Is(ctx.Err(), context.Canceled):
+			// If the context error is Canceled, the parent context has been canceled. Because the Terraform is fairly unstable
+			// and interruptions may cause it to not properly store the state, we will allow it to continue. The next reconciliation will
+			// adopt the running pod.
+			podLogger.Info("Skipping Terraformer pod deletion because context was cancelled")
+		case errors.Is(ctx.Err(), context.DeadlineExceeded):
+			// If the context error is deadline exceeded, create a new context for deleting the pod since attempting to use the
+			// original context will fail. The context might get cancelled for example by the owner check watchdog and the pod
+			// should be deleted to prevent the terraform script from running after the context was cancelled.
 			var cancel context.CancelFunc
 			ctx, cancel = context.WithTimeout(context.Background(), 1*time.Minute)
 			defer cancel()
-		}
-		if err := t.client.Delete(ctx, pod); client.IgnoreNotFound(err) != nil {
-			return err
+			fallthrough
+		default:
+			podLogger.Info("Cleaning up Terraformer pod")
+			if err := t.client.Delete(ctx, pod); client.IgnoreNotFound(err) != nil {
+				return err
+			}
 		}
 
 		if status != podStatusSucceeded {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug

**What this PR does / why we need it**:
Revert partially the behavior introduced with https://github.com/gardener/gardener/pull/4720 and only delete the TF pod when the context was in deadline exceeded. If the current context is cancelled this indicates likely that the parent context was deleted but still we should allow the Terraformer pod to continue its execution uninterrupted. 

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener/issues/8058

**Special notes for your reviewer**:
The terraformer library will now skip deletion of the Terraformer pod when the request context has been canceled. 
Previously, if the parent context of a reconciliation was cancelled (e.g. a provider-extension pod restart) during a command execution via Gardener's Terraformer interface, the library would attempt to delete the active Terraformer pod. However, not all Terraform providers handle abrupt terminations gracefully. This change aims to prevent inconsistencies in Terraform state by attempting to allow uninterrupted execution of healthy Terraformer pods. Subsequent calls to the Terraform interface should be able to proceed either via adopting currently running pods or by cleaning up already finished pods.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
The `terraformer` library will now skip deletion of the Terraformer pod when the request context has been canceled. This change aims to prevent inconsistencies in Terraform state by attempting to allow uninterrupted execution of healthy Terraformer pods.
```
