### PR TITLE
Unify the registry hostname configured in containerd for the kind cluster

### DIFF
--- a/docs/concepts/operator.md
+++ b/docs/concepts/operator.md
@@ -100,7 +100,7 @@ make kind-operator-up
 This command sets up a new KinD cluster named `gardener-local` and stores the kubeconfig in the `./example/gardener-local/kind/operator/kubeconfig` file.
 
 > It might be helpful to copy this file to `$HOME/.kube/config`, since you will need to target this KinD cluster multiple times.
-Alternatively, make sure to set your `KUBECONFIG` environment variable to `./example/gardener-local/kind/operator/kubeconfig` for all future steps via `export KUBECONFIG=example/gardener-local/kind/operator/kubeconfig`.
+Alternatively, make sure to set your `KUBECONFIG` environment variable to `./example/gardener-local/kind/operator/kubeconfig` for all future steps via `export KUBECONFIG=$PWD/example/gardener-local/kind/operator/kubeconfig`.
  
 All the following steps assume that you are using this kubeconfig.
 

--- a/docs/deployment/getting_started_locally.md
+++ b/docs/deployment/getting_started_locally.md
@@ -44,7 +44,7 @@ make kind-up
 This command sets up a new KinD cluster named `gardener-local` and stores the kubeconfig in the `./example/gardener-local/kind/local/kubeconfig` file.
 
 > It might be helpful to copy this file to `$HOME/.kube/config`, since you will need to target this KinD cluster multiple times.
-Alternatively, make sure to set your `KUBECONFIG` environment variable to `./example/gardener-local/kind/local/kubeconfig` for all future steps via `export KUBECONFIG=example/gardener-local/kind/local/kubeconfig`.
+Alternatively, make sure to set your `KUBECONFIG` environment variable to `./example/gardener-local/kind/local/kubeconfig` for all future steps via `export KUBECONFIG=$PWD/example/gardener-local/kind/local/kubeconfig`.
 
 All of the following steps assume that you are using this kubeconfig.
 
@@ -267,7 +267,7 @@ In order to deploy required resources in the KinD cluster that you just created,
 make gardenlet-kind2-up
 ```
 
-The following steps assume that you are using the kubeconfig that points to the `gardener-local` cluster (first KinD cluster): `export KUBECONFIG=example/gardener-local/kind/local/kubeconfig`.
+The following steps assume that you are using the kubeconfig that points to the `gardener-local` cluster (first KinD cluster): `export KUBECONFIG=$PWD/example/gardener-local/kind/local/kubeconfig`.
 
 You can wait for the `local2` `Seed` to be ready by running:
 

--- a/docs/development/getting_started_locally.md
+++ b/docs/development/getting_started_locally.md
@@ -53,7 +53,7 @@ make kind-up KIND_ENV=local
 This command sets up a new KinD cluster named `gardener-local` and stores the kubeconfig in the `./example/gardener-local/kind/local/kubeconfig` file.
 
 > It might be helpful to copy this file to `$HOME/.kube/config` since you will need to target this KinD cluster multiple times.
-Alternatively, make sure to set your `KUBECONFIG` environment variable to `./example/gardener-local/kind/local/kubeconfig` for all future steps via `export KUBECONFIG=example/gardener-local/kind/local/kubeconfig`.
+Alternatively, make sure to set your `KUBECONFIG` environment variable to `./example/gardener-local/kind/local/kubeconfig` for all future steps via `export KUBECONFIG=$PWD/example/gardener-local/kind/local/kubeconfig`.
 
 All following steps assume that you are using this kubeconfig.
 

--- a/example/gardener-local/kind/cluster/templates/_containerd_config_patches.tpl
+++ b/example/gardener-local/kind/cluster/templates/_containerd_config_patches.tpl
@@ -2,16 +2,16 @@
 - |-
   {{- if eq .Values.environment "skaffold" }}
   [plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:5001"]
-    endpoint = ["http://{{ .Values.registry.hostname }}:5001"]
+    endpoint = ["http://garden.local.gardener.cloud:5001"]
   {{- end }}
   [plugins."io.containerd.grpc.v1.cri".registry.mirrors."gcr.io"]
-    endpoint = ["http://{{ .Values.registry.hostname }}:5003"]
+    endpoint = ["http://garden.local.gardener.cloud:5003"]
   [plugins."io.containerd.grpc.v1.cri".registry.mirrors."eu.gcr.io"]
-    endpoint = ["http://{{ .Values.registry.hostname }}:5004"]
+    endpoint = ["http://garden.local.gardener.cloud:5004"]
   [plugins."io.containerd.grpc.v1.cri".registry.mirrors."ghcr.io"]
-    endpoint = ["http://{{ .Values.registry.hostname }}:5005"]
+    endpoint = ["http://garden.local.gardener.cloud:5005"]
   [plugins."io.containerd.grpc.v1.cri".registry.mirrors."registry.k8s.io"]
-    endpoint = ["http://{{ .Values.registry.hostname }}:5006"]
+    endpoint = ["http://garden.local.gardener.cloud:5006"]
   [plugins."io.containerd.grpc.v1.cri".registry.mirrors."quay.io"]
-    endpoint = ["http://{{ .Values.registry.hostname }}:5007"]
+    endpoint = ["http://garden.local.gardener.cloud:5007"]
 {{- end -}}

--- a/example/gardener-local/kind/cluster/values.yaml
+++ b/example/gardener-local/kind/cluster/values.yaml
@@ -20,7 +20,6 @@ backupBucket:
 
 registry:
   deployed: true
-  hostname: garden.local.gardener.cloud
 
 networking:
   ipFamily: ipv4

--- a/example/gardener-local/kind/extensions/values.yaml
+++ b/example/gardener-local/kind/extensions/values.yaml
@@ -1,6 +1,3 @@
-registry:
-  hostname: gardener-extensions-control-plane
-
 gardener:
   apiserverRelay:
     deployed: true

--- a/example/gardener-local/kind/ha-single-zone2/values.yaml
+++ b/example/gardener-local/kind/ha-single-zone2/values.yaml
@@ -8,7 +8,6 @@ gardener:
 
 registry:
   deployed: false
-  hostname: gardener-local-ha-single-zone-control-plane
 
 workers:
 - zone: "0"

--- a/example/gardener-local/kind/operator/values.yaml
+++ b/example/gardener-local/kind/operator/values.yaml
@@ -6,9 +6,6 @@ gardener:
   garden:
     deployed: true
 
-registry:
-  hostname: gardener-operator-local-control-plane
-
 workers:
   - zone: "1"
   - zone: "2"


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
This PR is a follow-up result after the discussion in https://github.com/gardener/gardener/pull/8047#discussion_r1223957978.

https://github.com/gardener/gardener/pull/7561 introduced `garden.local.gardener.cloud` - a DNS name pointing to the kind control plane Node. It also made `garden.local.gardener.cloud` accessible from the kind cluster Nodes and all Pods running in the kind cluster (via coredns config). 
https://github.com/gardener/gardener/blob/50a5a60b85bd908d28caabfa5ca3fa504057ee21/hack/kind-up.sh#L247-L266
It also adapted containerd config for the registry mirror in `make kind-up` and `make kind-ha-single-zone-up` to access the registry mirror via `garden.local.gardener.cloud` not by the kind control plane Node name. But the above-mentioned PR didn't adapt this for the kind clusters created by `make kind2-ha-single-zone-up`, `make kind-operator-up` and `make kind-extensions-up`.
The current PR tackles this by using `garden.local.gardener.cloud` everywhere in the containerd config for all kind clusters. The Node name of the control plane Node is no longer used.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener-extension-registry-cache/issues/3
Prerequisite for https://github.com/gardener/gardener/pull/8047

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
The kind clusters are now unified to use `garden.local.gardener.cloud` DNS name in the containerd config when configuring registry mirror hostnames. Previously, to access the pull through registry cache some kind clusters were configured to use `garden.local.gardener.cloud`, others - the Node name of the control plane Node.
```
