### PR TITLE
Deprecate `spec.secretRef` field in Seed API

### DIFF
--- a/docs/api-reference/core.md
+++ b/docs/api-reference/core.md
@@ -1431,6 +1431,8 @@ Kubernetes core/v1.SecretReference
 <em>(Optional)</em>
 <p>SecretRef is a reference to a Secret object containing the Kubeconfig of the Kubernetes
 cluster to be registered as Seed.</p>
+<p>Deprecated: This field is deprecated, gardenlet must run in the Seed cluster,
+hence it should use the in-cluster rest config via ServiceAccount to communicate with the Seed cluster.</p>
 </td>
 </tr>
 <tr>
@@ -9569,6 +9571,8 @@ Kubernetes core/v1.SecretReference
 <em>(Optional)</em>
 <p>SecretRef is a reference to a Secret object containing the Kubeconfig of the Kubernetes
 cluster to be registered as Seed.</p>
+<p>Deprecated: This field is deprecated, gardenlet must run in the Seed cluster,
+hence it should use the in-cluster rest config via ServiceAccount to communicate with the Seed cluster.</p>
 </td>
 </tr>
 <tr>
@@ -9911,6 +9915,8 @@ Kubernetes core/v1.SecretReference
 <em>(Optional)</em>
 <p>SecretRef is a reference to a Secret object containing the Kubeconfig of the Kubernetes
 cluster to be registered as Seed.</p>
+<p>Deprecated: This field is deprecated, gardenlet must run in the Seed cluster,
+hence it should use the in-cluster rest config via ServiceAccount to communicate with the Seed cluster.</p>
 </td>
 </tr>
 <tr>

--- a/pkg/apis/core/types_seed.go
+++ b/pkg/apis/core/types_seed.go
@@ -70,6 +70,9 @@ type SeedSpec struct {
 	Provider SeedProvider
 	// SecretRef is a reference to a Secret object containing the Kubeconfig of the Kubernetes
 	// cluster to be registered as Seed.
+	//
+	// Deprecated: This field is deprecated, gardenlet must run in the Seed cluster,
+	// hence it should use the in-cluster rest config via ServiceAccount to communicate with the Seed cluster.
 	SecretRef *corev1.SecretReference
 	// Settings contains certain settings for this seed cluster.
 	Settings *SeedSettings

--- a/pkg/apis/core/v1beta1/generated.proto
+++ b/pkg/apis/core/v1beta1/generated.proto
@@ -2379,6 +2379,9 @@ message SeedSpec {
 
   // SecretRef is a reference to a Secret object containing the Kubeconfig of the Kubernetes
   // cluster to be registered as Seed.
+  //
+  // Deprecated: This field is deprecated, gardenlet must run in the Seed cluster,
+  // hence it should use the in-cluster rest config via ServiceAccount to communicate with the Seed cluster.
   // +optional
   optional k8s.io.api.core.v1.SecretReference secretRef = 5;
 

--- a/pkg/apis/core/v1beta1/types_seed.go
+++ b/pkg/apis/core/v1beta1/types_seed.go
@@ -74,6 +74,9 @@ type SeedSpec struct {
 	Provider SeedProvider `json:"provider" protobuf:"bytes,4,opt,name=provider"`
 	// SecretRef is a reference to a Secret object containing the Kubeconfig of the Kubernetes
 	// cluster to be registered as Seed.
+	//
+	// Deprecated: This field is deprecated, gardenlet must run in the Seed cluster,
+	// hence it should use the in-cluster rest config via ServiceAccount to communicate with the Seed cluster.
 	// +optional
 	SecretRef *corev1.SecretReference `json:"secretRef,omitempty" protobuf:"bytes,5,opt,name=secretRef"`
 	// Taints describes taints on the seed.

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -6884,7 +6884,7 @@ func schema_pkg_apis_core_v1beta1_SeedSpec(ref common.ReferenceCallback) common.
 					},
 					"secretRef": {
 						SchemaProps: spec.SchemaProps{
-							Description: "SecretRef is a reference to a Secret object containing the Kubeconfig of the Kubernetes cluster to be registered as Seed.",
+							Description: "SecretRef is a reference to a Secret object containing the Kubeconfig of the Kubernetes cluster to be registered as Seed.\n\nDeprecated: This field is deprecated, gardenlet must run in the Seed cluster, hence it should use the in-cluster rest config via ServiceAccount to communicate with the Seed cluster.",
 							Ref:         ref("k8s.io/api/core/v1.SecretReference"),
 						},
 					},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement



**What this PR does / why we need it**:
This PR deprecate `spec.secretRef` field in Seed API.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/7597

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
The field `.spec.secretRef` in the `Seed` API has been deprecated and will be removed in a future release of Gardener.
```
