### PR TITLE
Deprecate `node-local-dns` annotations

### DIFF
--- a/pkg/api/core/shoot/warnings.go
+++ b/pkg/api/core/shoot/warnings.go
@@ -40,6 +40,7 @@ func GetWarnings(_ context.Context, shoot, oldShoot *core.Shoot, credentialsRota
 		warnings = append(warnings, "you should consider disabling the static token kubeconfig, see https://github.com/gardener/gardener/blob/master/docs/usage/shoot_access.md for details")
 	}
 
+	// TODO(acumino): Drop this warning in v1.77, with droping of annotaion to enable node-local-dns.
 	warnings = append(warnings, getWarningsForDeprecatedNodeLocalDNSLabels(shoot)...)
 
 	if oldShoot != nil {

--- a/pkg/api/core/shoot/warnings.go
+++ b/pkg/api/core/shoot/warnings.go
@@ -68,7 +68,7 @@ func getWarningsForDeprecatedNodeLocalDNSLabels(shoot *core.Shoot) []string {
 	var warnings []string
 
 	if _, ok := shoot.Annotations[v1beta1constants.AnnotationNodeLocalDNS]; ok {
-		warnings = append(warnings, fmt.Sprintf("annotation %v is deprecated. Use field `.spec.systemComponents.nodeLocalDNS.enabled` in Shoot instead.", v1beta1constants.AnnotationNodeLocalDNS))
+		warnings = append(warnings, fmt.Sprintf("annotation %v is deprecated. Use field `.spec.systemComponents.nodeLocalDNS.enabled` in Shoot instead. Switching on node-local-dns via shoot specification will roll the nodes even if node-local-dns was enabled beforehand via annotation.", v1beta1constants.AnnotationNodeLocalDNS))
 	}
 
 	if _, ok := shoot.Annotations[v1beta1constants.AnnotationNodeLocalDNSForceTcpToClusterDns]; ok {

--- a/pkg/api/core/shoot/warnings.go
+++ b/pkg/api/core/shoot/warnings.go
@@ -40,7 +40,7 @@ func GetWarnings(_ context.Context, shoot, oldShoot *core.Shoot, credentialsRota
 		warnings = append(warnings, "you should consider disabling the static token kubeconfig, see https://github.com/gardener/gardener/blob/master/docs/usage/shoot_access.md for details")
 	}
 
-	// TODO(acumino): Drop this warning in v1.77, with droping of annotaion to enable node-local-dns.
+	// TODO(acumino): Drop this warning in v1.78, with dropping of annotation to enable node-local-dns.
 	warnings = append(warnings, getWarningsForDeprecatedNodeLocalDNSLabels(shoot)...)
 
 	if oldShoot != nil {
@@ -65,20 +65,18 @@ func GetWarnings(_ context.Context, shoot, oldShoot *core.Shoot, credentialsRota
 }
 
 func getWarningsForDeprecatedNodeLocalDNSLabels(shoot *core.Shoot) []string {
-	var (
-		warnings []string
-	)
+	var warnings []string
 
 	if _, ok := shoot.Annotations[v1beta1constants.AnnotationNodeLocalDNS]; ok {
 		warnings = append(warnings, fmt.Sprintf("annotation %v is deprecated. Use field `.spec.systemComponents.nodeLocalDNS.enabled` in Shoot instead.", v1beta1constants.AnnotationNodeLocalDNS))
 	}
 
 	if _, ok := shoot.Annotations[v1beta1constants.AnnotationNodeLocalDNSForceTcpToClusterDns]; ok {
-		warnings = append(warnings, fmt.Sprintf("annotation %v is deprecated. Use field `.spec.systemComponents.nodeLocalDNSforceTCPToClusterDNS` in Shoot instead.", v1beta1constants.AnnotationNodeLocalDNSForceTcpToClusterDns))
+		warnings = append(warnings, fmt.Sprintf("annotation %v is deprecated. Use field `.spec.systemComponents.nodeLocalDNS.forceTCPToClusterDNS` in Shoot instead.", v1beta1constants.AnnotationNodeLocalDNSForceTcpToClusterDns))
 	}
 
 	if _, ok := shoot.Annotations[v1beta1constants.AnnotationNodeLocalDNSForceTcpToUpstreamDns]; ok {
-		warnings = append(warnings, fmt.Sprintf("annotation %v is deprecated. Use field `.spec.systemComponents.nodeLocalDNSforceTCPToUpstreamDNS` in Shoot instead.", v1beta1constants.AnnotationNodeLocalDNSForceTcpToUpstreamDns))
+		warnings = append(warnings, fmt.Sprintf("annotation %v is deprecated. Use field `.spec.systemComponents.nodeLocalDNS.forceTCPToUpstreamDNS` in Shoot instead.", v1beta1constants.AnnotationNodeLocalDNSForceTcpToUpstreamDns))
 	}
 
 	return warnings

--- a/pkg/api/core/shoot/warnings_test.go
+++ b/pkg/api/core/shoot/warnings_test.go
@@ -350,14 +350,14 @@ var _ = Describe("Warnings", func() {
 				shoot.Annotations = map[string]string{
 					v1beta1constants.AnnotationNodeLocalDNSForceTcpToClusterDns: "true",
 				}
-				Expect(GetWarnings(ctx, shoot, nil, credentialsRotationInterval)).To(ContainElement(Equal("annotation alpha.featuregates.shoot.gardener.cloud/node-local-dns-force-tcp-to-cluster-dns is deprecated. Use field `.spec.systemComponents.nodeLocalDNSforceTCPToClusterDNS` in Shoot instead.")))
+				Expect(GetWarnings(ctx, shoot, nil, credentialsRotationInterval)).To(ContainElement(Equal("annotation alpha.featuregates.shoot.gardener.cloud/node-local-dns-force-tcp-to-cluster-dns is deprecated. Use field `.spec.systemComponents.nodeLocalDNS.forceTCPToClusterDNS` in Shoot instead.")))
 			})
 
 			It("should return a warning when annotation `alpha.featuregates.shoot.gardener.cloud/node-local-dns-force-tcp-to-upstream-dns` is present", func() {
 				shoot.Annotations = map[string]string{
 					v1beta1constants.AnnotationNodeLocalDNSForceTcpToUpstreamDns: "true",
 				}
-				Expect(GetWarnings(ctx, shoot, nil, credentialsRotationInterval)).To(ContainElement(Equal("annotation alpha.featuregates.shoot.gardener.cloud/node-local-dns-force-tcp-to-upstream-dns is deprecated. Use field `.spec.systemComponents.nodeLocalDNSforceTCPToUpstreamDNS` in Shoot instead.")))
+				Expect(GetWarnings(ctx, shoot, nil, credentialsRotationInterval)).To(ContainElement(Equal("annotation alpha.featuregates.shoot.gardener.cloud/node-local-dns-force-tcp-to-upstream-dns is deprecated. Use field `.spec.systemComponents.nodeLocalDNS.forceTCPToUpstreamDNS` in Shoot instead.")))
 			})
 
 			It("should not return a warning when the node-local-dns related annotation is not present", func() {

--- a/pkg/api/core/shoot/warnings_test.go
+++ b/pkg/api/core/shoot/warnings_test.go
@@ -343,7 +343,7 @@ var _ = Describe("Warnings", func() {
 				shoot.Annotations = map[string]string{
 					v1beta1constants.AnnotationNodeLocalDNS: "true",
 				}
-				Expect(GetWarnings(ctx, shoot, nil, credentialsRotationInterval)).To(ContainElement(Equal("annotation alpha.featuregates.shoot.gardener.cloud/node-local-dns is deprecated. Use field `.spec.systemComponents.nodeLocalDNS.enabled` in Shoot instead.")))
+				Expect(GetWarnings(ctx, shoot, nil, credentialsRotationInterval)).To(ContainElement(Equal("annotation alpha.featuregates.shoot.gardener.cloud/node-local-dns is deprecated. Use field `.spec.systemComponents.nodeLocalDNS.enabled` in Shoot instead. Switching on node-local-dns via shoot specification will roll the nodes even if node-local-dns was enabled beforehand via annotation.")))
 			})
 
 			It("should return a warning when annotation `alpha.featuregates.shoot.gardener.cloud/node-local-dns-force-tcp-to-cluster-dns` is present", func() {

--- a/pkg/api/core/shoot/warnings_test.go
+++ b/pkg/api/core/shoot/warnings_test.go
@@ -26,6 +26,7 @@ import (
 
 	. "github.com/gardener/gardener/pkg/api/core/shoot"
 	"github.com/gardener/gardener/pkg/apis/core"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 )
 
 var _ = Describe("Warnings", func() {
@@ -334,6 +335,33 @@ var _ = Describe("Warnings", func() {
 
 				warnings := GetWarnings(ctx, shoot, shoot, credentialsRotationInterval)
 				Expect(warnings).To(BeEmpty())
+			})
+		})
+
+		Context("node-local-dns annotations", func() {
+			It("should return a warning when annotation `alpha.featuregates.shoot.gardener.cloud/node-local-dns` is present", func() {
+				shoot.Annotations = map[string]string{
+					v1beta1constants.AnnotationNodeLocalDNS: "true",
+				}
+				Expect(GetWarnings(ctx, shoot, nil, credentialsRotationInterval)).To(ContainElement(Equal("annotation alpha.featuregates.shoot.gardener.cloud/node-local-dns is deprecated. Use field `.spec.systemComponents.nodeLocalDNS.enabled` in Shoot instead.")))
+			})
+
+			It("should return a warning when annotation `alpha.featuregates.shoot.gardener.cloud/node-local-dns-force-tcp-to-cluster-dns` is present", func() {
+				shoot.Annotations = map[string]string{
+					v1beta1constants.AnnotationNodeLocalDNSForceTcpToClusterDns: "true",
+				}
+				Expect(GetWarnings(ctx, shoot, nil, credentialsRotationInterval)).To(ContainElement(Equal("annotation alpha.featuregates.shoot.gardener.cloud/node-local-dns-force-tcp-to-cluster-dns is deprecated. Use field `.spec.systemComponents.nodeLocalDNSforceTCPToClusterDNS` in Shoot instead.")))
+			})
+
+			It("should return a warning when annotation `alpha.featuregates.shoot.gardener.cloud/node-local-dns-force-tcp-to-upstream-dns` is present", func() {
+				shoot.Annotations = map[string]string{
+					v1beta1constants.AnnotationNodeLocalDNSForceTcpToUpstreamDns: "true",
+				}
+				Expect(GetWarnings(ctx, shoot, nil, credentialsRotationInterval)).To(ContainElement(Equal("annotation alpha.featuregates.shoot.gardener.cloud/node-local-dns-force-tcp-to-upstream-dns is deprecated. Use field `.spec.systemComponents.nodeLocalDNSforceTCPToUpstreamDNS` in Shoot instead.")))
+			})
+
+			It("should not return a warning when the node-local-dns related annotation is not present", func() {
+				Expect(GetWarnings(ctx, shoot, nil, credentialsRotationInterval)).To(BeEmpty())
 			})
 		})
 

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -574,10 +574,16 @@ const (
 	// delays will not recompute it.
 	AnnotationShootCloudConfigExecutionMaxDelaySeconds = "shoot.gardener.cloud/cloud-config-execution-max-delay-seconds"
 	// AnnotationNodeLocalDNS enables a per node dns cache on the shoot cluster.
+	// Deprecated: This annotation is deprecated and will be removed in a future version.
+	// Use field `.spec.systemComponents.nodeLocalDNS.enabled` in Shoot instead.
 	AnnotationNodeLocalDNS = "alpha.featuregates.shoot.gardener.cloud/node-local-dns"
 	// AnnotationNodeLocalDNSForceTcpToClusterDns enforces upgrade to tcp connections for communication between node local and cluster dns.
+	// Deprecated: This annotation is deprecated and will be removed in a future version.
+	// Use field `.spec.systemComponents.nodeLocalDNSforceTCPToClusterDNS` in Shoot instead.
 	AnnotationNodeLocalDNSForceTcpToClusterDns = "alpha.featuregates.shoot.gardener.cloud/node-local-dns-force-tcp-to-cluster-dns"
 	// AnnotationNodeLocalDNSForceTcpToUpstreamDns enforces upgrade to tcp connections for communication between node local and upstream dns.
+	// Deprecated: This annotation is deprecated and will be removed in a future version.
+	// Use field `.spec.systemComponents.nodeLocalDNSforceTCPToUpstreamDNS` in Shoot instead.
 	AnnotationNodeLocalDNSForceTcpToUpstreamDns = "alpha.featuregates.shoot.gardener.cloud/node-local-dns-force-tcp-to-upstream-dns"
 	// AnnotationCoreDNSRewritingDisabled disables core dns query rewriting even if the corresponding feature gate is enabled.
 	AnnotationCoreDNSRewritingDisabled = "alpha.featuregates.shoot.gardener.cloud/core-dns-rewriting-disabled"

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -579,11 +579,11 @@ const (
 	AnnotationNodeLocalDNS = "alpha.featuregates.shoot.gardener.cloud/node-local-dns"
 	// AnnotationNodeLocalDNSForceTcpToClusterDns enforces upgrade to tcp connections for communication between node local and cluster dns.
 	// Deprecated: This annotation is deprecated and will be removed in a future version.
-	// Use field `.spec.systemComponents.nodeLocalDNSforceTCPToClusterDNS` in Shoot instead.
+	// Use field `.spec.systemComponents.nodeLocalDNS.forceTCPToClusterDNS` in Shoot instead.
 	AnnotationNodeLocalDNSForceTcpToClusterDns = "alpha.featuregates.shoot.gardener.cloud/node-local-dns-force-tcp-to-cluster-dns"
 	// AnnotationNodeLocalDNSForceTcpToUpstreamDns enforces upgrade to tcp connections for communication between node local and upstream dns.
 	// Deprecated: This annotation is deprecated and will be removed in a future version.
-	// Use field `.spec.systemComponents.nodeLocalDNSforceTCPToUpstreamDNS` in Shoot instead.
+	// Use field `.spec.systemComponents.nodeLocalDNS.forceTCPToUpstreamDNS` in Shoot instead.
 	AnnotationNodeLocalDNSForceTcpToUpstreamDns = "alpha.featuregates.shoot.gardener.cloud/node-local-dns-force-tcp-to-upstream-dns"
 	// AnnotationCoreDNSRewritingDisabled disables core dns query rewriting even if the corresponding feature gate is enabled.
 	AnnotationCoreDNSRewritingDisabled = "alpha.featuregates.shoot.gardener.cloud/core-dns-rewriting-disabled"


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind cleanup

**What this PR does / why we need it**:
This PR deprecates annotations related to enabling `node-local-dns`, in favor to use fields in `Shoot` API.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/7581

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking user
Annotation `alpha.featuregates.shoot.gardener.cloud/node-local-dns` is deprecated and will be removed in future releases. Use field `.spec.systemComponents.nodeLocalDNS.enabled` in `Shoot` instead. Switching on node-local-dns via shoot specification will roll the nodes even if node-local-dns was enabled beforehand via annotation.
```
```breaking user
Annotation `alpha.featuregates.shoot.gardener.cloud/node-local-dns-force-tcp-to-{cluster-dns, upstream-dns}` is deprecated and will be removed in future releases. Use field `.spec.systemComponents.nodeLocalDNS.{forceTCPToClusterDNS, forceTCPToUpstreamDNS}` in `Shoot` instead.
```
