### PR TITLE
Fix `fluent-bit` service

### DIFF
--- a/pkg/component/logging/fluentoperator/custom_resources_test.go
+++ b/pkg/component/logging/fluentoperator/custom_resources_test.go
@@ -114,7 +114,7 @@ var _ = Describe("Fluent Operator Custom Resources", func() {
 			Expect(customResourcesManagedResourceSecret.Type).To(Equal(corev1.SecretTypeOpaque))
 			Expect(customResourcesManagedResourceSecret.Data).To(HaveLen(12))
 			Expect(customResourcesManagedResourceSecret.Data).To(HaveKey(MatchRegexp("configmap__" + namespace + "__fluent-bit-lua-config-.*" + ".yaml")))
-			Expect(customResourcesManagedResourceSecret.Data).To(HaveKey("fluentbit__" + namespace + "__fluent-bit-7efa8b.yaml"))
+			Expect(customResourcesManagedResourceSecret.Data).To(HaveKey("fluentbit__" + namespace + "__fluent-bit-093d91.yaml"))
 			Expect(customResourcesManagedResourceSecret.Data).To(HaveKey("clusterfluentbitconfig____fluent-bit-config.yaml"))
 			Expect(customResourcesManagedResourceSecret.Data).To(HaveKey("clusterinput____tail-kubernetes.yaml"))
 			Expect(customResourcesManagedResourceSecret.Data).To(HaveKey("clusterfilter____01-docker.yaml"))

--- a/pkg/component/logging/fluentoperator/customresources/fluent_bit.go
+++ b/pkg/component/logging/fluentoperator/customresources/fluent_bit.go
@@ -31,9 +31,13 @@ import (
 
 // GetFluentBit returns instance of FluentBit custom resource.
 func GetFluentBit(labels map[string]string, fluentBitName, namespace, image, initImage, priorityClass string) *fluentbitv1alpha2.FluentBit {
+	annotations := map[string]string{
+		resourcesv1alpha1.NetworkPolicyFromPolicyAnnotationPrefix + v1beta1constants.LabelNetworkPolicySeedScrapeTargets + resourcesv1alpha1.NetworkPolicyFromPolicyAnnotationSuffix: `[{"port":2020,"protocol":"TCP"},{"port":2021,"protocol":"TCP"}]`,
+	}
+
 	return &fluentbitv1alpha2.FluentBit{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("%v-%v", fluentBitName, utils.ComputeSHA256Hex([]byte(fmt.Sprintf("%v", labels)))[:6]),
+			Name:      fmt.Sprintf("%v-%v", fluentBitName, utils.ComputeSHA256Hex([]byte(fmt.Sprintf("%v%v", labels, annotations)))[:6]),
 			Namespace: namespace,
 			Labels:    labels,
 		},
@@ -156,11 +160,9 @@ func GetFluentBit(labels map[string]string, fluentBitName, namespace, image, ini
 				},
 			},
 			Service: fluentbitv1alpha2.FluentBitService{
-				Name: fluentBitName,
-				Annotations: map[string]string{
-					resourcesv1alpha1.NetworkPolicyFromPolicyAnnotationPrefix + v1beta1constants.LabelNetworkPolicySeedScrapeTargets + resourcesv1alpha1.NetworkPolicyFromPolicyAnnotationSuffix: `[{"port":"2020","protocol":"TCP"},{"port":"2021","protocol":"TCP"}]`,
-				},
-				Labels: labels,
+				Name:        fluentBitName,
+				Annotations: annotations,
+				Labels:      labels,
 			},
 		},
 	}

--- a/pkg/component/logging/fluentoperator/customresources/fluent_bit_test.go
+++ b/pkg/component/logging/fluentoperator/customresources/fluent_bit_test.go
@@ -41,12 +41,15 @@ var _ = Describe("Logging", func() {
 		)
 
 		It("should return the expected FluentBit custom resource", func() {
-			fluentBitCustomResource := GetFluentBit(labels, name, namespace, image, image, priorityClass)
+			var (
+				fluentBitCustomResource = GetFluentBit(labels, name, namespace, image, image, priorityClass)
+				annotations             = map[string]string{"networking.resources.gardener.cloud/from-all-seed-scrape-targets-allowed-ports": `[{"port":2020,"protocol":"TCP"},{"port":2021,"protocol":"TCP"}]`}
+			)
 
 			Expect(fluentBitCustomResource).To(Equal(
 				&fluentbitv1alpha2.FluentBit{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      fmt.Sprintf("%v-%v", name, utils.ComputeSHA256Hex([]byte(fmt.Sprintf("%v", labels)))[:6]),
+						Name:      fmt.Sprintf("%v-%v", name, utils.ComputeSHA256Hex([]byte(fmt.Sprintf("%v%v", labels, annotations)))[:6]),
 						Namespace: namespace,
 						Labels:    labels,
 					},
@@ -170,7 +173,7 @@ var _ = Describe("Logging", func() {
 						},
 						Service: fluentbitv1alpha2.FluentBitService{
 							Name:        name,
-							Annotations: map[string]string{"networking.resources.gardener.cloud/from-all-seed-scrape-targets-allowed-ports": `[{"port":"2020","protocol":"TCP"},{"port":"2021","protocol":"TCP"}]`},
+							Annotations: annotations,
 							Labels:      labels,
 						},
 					},

--- a/pkg/component/logging/fluentoperator/fluent_operator.go
+++ b/pkg/component/logging/fluentoperator/fluent_operator.go
@@ -43,7 +43,6 @@ const (
 	OperatorManagedResourceName = "fluent-operator"
 	name                        = "fluent-operator"
 	roleName                    = "gardener.cloud:logging:fluent-operator"
-	vpaName                     = "fluent-operator-vpa"
 )
 
 var (

--- a/pkg/component/shared/fluent_operator_custom_resources.go
+++ b/pkg/component/shared/fluent_operator_custom_resources.go
@@ -15,7 +15,6 @@
 package shared
 
 import (
-	"github.com/Masterminds/semver"
 	fluentbitv1alpha2 "github.com/fluent/fluent-operator/v2/apis/fluentbit/v1alpha2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -29,7 +28,6 @@ import (
 func NewFluentOperatorCustomResources(
 	c client.Client,
 	gardenNamespaceName string,
-	runtimeVersion *semver.Version,
 	imageVector imagevector.ImageVector,
 	enabled bool,
 	priorityClassName string,

--- a/pkg/gardenlet/controller/seed/seed/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/seed/seed/reconciler_reconcile.go
@@ -980,7 +980,6 @@ func (r *Reconciler) runReconcileSeedFlow(
 		fluentOperatorCustomResources, err := sharedcomponent.NewFluentOperatorCustomResources(
 			seedClient,
 			r.GardenNamespace,
-			kubernetesVersion,
 			r.ImageVector,
 			loggingEnabled,
 			v1beta1constants.PriorityClassNameSeedSystem600,


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/area monitoring
/kind bug

**What this PR does / why we need it**:
This PR fixes the `garden/fluent-bit` service. Earlier, `gardener-resource-manager` failed creating the scraping network config:

```
4 errors occurred:\n\t* NetworkPolicy.extensions \"ingress-to-fluent-bit-tcp-2021-via-all-seed-scrape-targets\" is invalid: spec.ingress[0].ports[0].port: Invalid value: \"2021\": must contain at least one letter (a-z)\n\t* NetworkPolicy.extensions \"egress-to-fluent-bit-tcp-2021-via-all-seed-scrape-targets\" is invalid: spec.egress[0].ports[0].port: Invalid value: \"2021\": must contain at least one letter (a-z)\n\t* NetworkPolicy.extensions \"ingress-to-fluent-bit-tcp-2020-via-all-seed-scrape-targets\" is invalid: spec.ingress[0].ports[0].port: Invalid value: \"2020\": must contain at least one letter (a-z)\n\t* NetworkPolicy.extensions \"egress-to-fluent-bit-tcp-2020-via-all-seed-scrape-targets\" is invalid: spec.egress[0].ports[0].port: Invalid value: \"2020\": must contain at least one letter (a-z)\n\n",
```

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
A bug has been fixed in the `garden/fluent-bit` that caused a failure in creating `networkpolicies` for scraping metrics.
```
