### PR TITLE
Do not recreate VPA for `kube-proxy` when Kubernetes patch version changes

### DIFF
--- a/pkg/component/kubeproxy/kube_proxy.go
+++ b/pkg/component/kubeproxy/kube_proxy.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/Masterminds/semver"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -111,7 +112,7 @@ type WorkerPool struct {
 	// Name is the name of the worker pool.
 	Name string
 	// KubernetesVersion is the Kubernetes version of the worker pool.
-	KubernetesVersion string
+	KubernetesVersion *semver.Version
 	// Image is the container image used for kube-proxy for this worker pool.
 	Image string
 }
@@ -251,7 +252,7 @@ func runParallelFunctions(ctx context.Context, withTimeout bool, fns []flow.Task
 
 func (k *kubeProxy) isExistingManagedResourceStillDesired(labels map[string]string) bool {
 	for _, pool := range k.values.WorkerPools {
-		if pool.Name == labels[labelKeyPoolName] && pool.KubernetesVersion == labels[labelKeyKubernetesVersion] {
+		if pool.Name == labels[labelKeyPoolName] && pool.KubernetesVersion.String() == labels[labelKeyKubernetesVersion] {
 			return true
 		}
 	}
@@ -268,7 +269,7 @@ func getManagedResourceLabels(pool *WorkerPool) map[string]string {
 	if pool != nil {
 		labels[v1beta1constants.LabelRole] = labelValueRole
 		labels[labelKeyPoolName] = pool.Name
-		labels[labelKeyKubernetesVersion] = pool.KubernetesVersion
+		labels[labelKeyKubernetesVersion] = pool.KubernetesVersion.String()
 	}
 
 	return labels

--- a/pkg/component/kubeproxy/resources.go
+++ b/pkg/component/kubeproxy/resources.go
@@ -301,7 +301,7 @@ func (k *kubeProxy) computePoolResourcesData(pool WorkerPool) (map[string][]byte
 
 		daemonSet = &appsv1.DaemonSet{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      name(pool),
+				Name:      name(pool, pointer.Bool(false)),
 				Namespace: metav1.NamespaceSystem,
 				Labels: utils.MergeStringMaps(
 					getSystemComponentLabels(),
@@ -566,7 +566,7 @@ func (k *kubeProxy) computePoolResourcesData(pool WorkerPool) (map[string][]byte
 		controlledValues := vpaautoscalingv1.ContainerControlledValuesRequestsOnly
 		vpa = &vpaautoscalingv1.VerticalPodAutoscaler{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      name(pool),
+				Name:      name(pool, pointer.Bool(false)),
 				Namespace: metav1.NamespaceSystem,
 			},
 			Spec: vpaautoscalingv1.VerticalPodAutoscalerSpec{

--- a/pkg/operation/botanist/kubeproxy_test.go
+++ b/pkg/operation/botanist/kubeproxy_test.go
@@ -62,8 +62,8 @@ var _ = Describe("KubeProxy", func() {
 		poolName1                     = "pool1"
 		poolName2                     = "pool2"
 		poolName3                     = "pool3"
-		kubernetesVersionControlPlane = "1.24.3"
-		kubernetesVersionPool2        = "1.23.4"
+		kubernetesVersionControlPlane = semver.MustParse("1.24.3")
+		kubernetesVersionPool2        = semver.MustParse("1.23.4")
 		kubernetesVersionPool3        = kubernetesVersionControlPlane
 	)
 
@@ -106,7 +106,7 @@ var _ = Describe("KubeProxy", func() {
 				SecretsManager: sm,
 				Shoot: &shootpkg.Shoot{
 					InternalClusterDomain: internalClusterDomain,
-					KubernetesVersion:     semver.MustParse(kubernetesVersionControlPlane),
+					KubernetesVersion:     kubernetesVersionControlPlane,
 					SeedNamespace:         namespace,
 				},
 			},
@@ -114,7 +114,7 @@ var _ = Describe("KubeProxy", func() {
 		botanist.Shoot.SetInfo(&gardencorev1beta1.Shoot{
 			Spec: gardencorev1beta1.ShootSpec{
 				Kubernetes: gardencorev1beta1.Kubernetes{
-					Version: kubernetesVersionControlPlane,
+					Version: kubernetesVersionControlPlane.String(),
 				},
 				Provider: gardencorev1beta1.Provider{
 					Workers: []gardencorev1beta1.Worker{
@@ -124,13 +124,13 @@ var _ = Describe("KubeProxy", func() {
 						{
 							Name: poolName2,
 							Kubernetes: &gardencorev1beta1.WorkerKubernetes{
-								Version: &kubernetesVersionPool2,
+								Version: pointer.String(kubernetesVersionPool2.String()),
 							},
 						},
 						{
 							Name: poolName3,
 							Kubernetes: &gardencorev1beta1.WorkerKubernetes{
-								Version: &kubernetesVersionPool3,
+								Version: pointer.String(kubernetesVersionPool3.String()),
 							},
 						},
 					},
@@ -216,17 +216,17 @@ users:
 						{
 							Name:              poolName1,
 							KubernetesVersion: kubernetesVersionControlPlane,
-							Image:             repositoryKubeProxyImage + ":v" + kubernetesVersionControlPlane,
+							Image:             repositoryKubeProxyImage + ":v" + kubernetesVersionControlPlane.String(),
 						},
 						{
 							Name:              poolName2,
 							KubernetesVersion: kubernetesVersionPool2,
-							Image:             repositoryKubeProxyImage + ":v" + kubernetesVersionPool2,
+							Image:             repositoryKubeProxyImage + ":v" + kubernetesVersionPool2.String(),
 						},
 						{
 							Name:              poolName3,
 							KubernetesVersion: kubernetesVersionPool3,
-							Image:             repositoryKubeProxyImage + ":v" + kubernetesVersionPool3,
+							Image:             repositoryKubeProxyImage + ":v" + kubernetesVersionPool3.String(),
 						},
 					})
 				})
@@ -242,7 +242,7 @@ users:
 							Name: "node1",
 							Labels: map[string]string{
 								"worker.gardener.cloud/pool":               poolName1,
-								"worker.gardener.cloud/kubernetes-version": kubernetesVersionControlPlane,
+								"worker.gardener.cloud/kubernetes-version": kubernetesVersionControlPlane.String(),
 							},
 						},
 					},
@@ -260,7 +260,7 @@ users:
 							Name: "node3",
 							Labels: map[string]string{
 								"worker.gardener.cloud/pool":               poolName2,
-								"worker.gardener.cloud/kubernetes-version": kubernetesVersionPool2,
+								"worker.gardener.cloud/kubernetes-version": kubernetesVersionPool2.String(),
 							},
 						},
 					},
@@ -282,26 +282,26 @@ users:
 						{
 							Name:              poolName1,
 							KubernetesVersion: kubernetesVersionControlPlane,
-							Image:             repositoryKubeProxyImage + ":v" + kubernetesVersionControlPlane,
+							Image:             repositoryKubeProxyImage + ":v" + kubernetesVersionControlPlane.String(),
 						},
 						{
 							Name:              poolName2,
 							KubernetesVersion: kubernetesVersionPool2,
-							Image:             repositoryKubeProxyImage + ":v" + kubernetesVersionPool2,
+							Image:             repositoryKubeProxyImage + ":v" + kubernetesVersionPool2.String(),
 						},
 						{
 							Name:              poolName3,
 							KubernetesVersion: kubernetesVersionPool3,
-							Image:             repositoryKubeProxyImage + ":v" + kubernetesVersionPool3,
+							Image:             repositoryKubeProxyImage + ":v" + kubernetesVersionPool3.String(),
 						},
 						{
 							Name:              poolName2,
-							KubernetesVersion: "1.24.3",
+							KubernetesVersion: semver.MustParse("1.24.3"),
 							Image:             repositoryKubeProxyImage + ":v1.24.3",
 						},
 						{
 							Name:              "pool4",
-							KubernetesVersion: "1.24.3",
+							KubernetesVersion: semver.MustParse("1.24.3"),
 							Image:             repositoryKubeProxyImage + ":v1.24.3",
 						},
 					})
@@ -323,7 +323,7 @@ func verifyWorkerPools(expected, actual []kubeproxy.WorkerPool) {
 			if slice[i].Name > slice[j].Name {
 				return false
 			}
-			return slice[i].KubernetesVersion < slice[j].KubernetesVersion
+			return slice[i].KubernetesVersion.String() < slice[j].KubernetesVersion.String()
 		}
 	}
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area scalability
/kind enhancement

**What this PR does**:
This PR introduces a new `ManagedResource` specific only for the major/minor version of a worker pool for `kube-proxy` resources. This `ManagedResource` only contains the `VerticalPodAutoscaler` which is now no longer specific for the full Kubernetes version but only the major/minor parts. In order to put this change into effect, all existing `VerticalPodAutoscaler`s for `kube-proxy`s are getting recreated.

**Why we need it**:
Earlier, when the Kubernetes patch version was updated, the new `kube-proxy` pods were coming up again on the existing shoot worker nodes with the initial CPU/memory resource requirements as defined in the source code. However, in some cases, actual resource consumption was much lower such that VPA scaled down. Now it could happen that the new, "bigger" `kube-proxy`s led to user workload pod evictions (since they now consumed more resources (at least for a short time until VPA recognizes that they actual need less resources) and have the highest possible priority).

With this PR, such scenario is prevented since the VPA is now specific to the major/minor part of the Kubernetes version only, hence its recommendations will still apply for a new `kube-proxy` with bumped patch version.
When the minor Kubernetes version is increased, also the VPA is recreated, but since the worker nodes of the shoot are also rolled out and the new `kube-proxy`s only come up on newly created nodes, the issue cannot occur.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
The `VerticalPodAutoscaler` resources for `kube-proxy`s is no longer recreated when the Kubernetes patch version of the `Shoot` or the respective worker pools is updated. This ensures updated `kube-proxy`s keep the same CPU/memory resource requirements as before the patch version update. In order to put this change into effect, all existing `VerticalPodAutoscaler`s for `kube-proxy`s are getting recreated.
```
