### PR TITLE
Add note about encrypting `internalsecrets.core.gardener.cloud` in etcd

### DIFF
--- a/charts/gardener/controlplane/values.yaml
+++ b/charts/gardener/controlplane/values.yaml
@@ -50,6 +50,7 @@ global:
           - resources:
             - controllerdeployments.core.gardener.cloud
             - controllerregistrations.core.gardener.cloud
+            - internalsecrets.core.gardener.cloud
             - shootstates.core.gardener.cloud
             providers:
             - identity: {}

--- a/docs/concepts/apiserver.md
+++ b/docs/concepts/apiserver.md
@@ -29,6 +29,8 @@ End-users can read and/or write `Secret`s in their project namespaces in the gar
 `InternalSecret`s are defined like plain Kubernetes `Secret`s, behave exactly like them, and can be used in the same manners. The only difference is, that the `InternalSecret` resource is a dedicated API resource (exposed by gardener-apiserver).
 This allows separating access to "normal" secrets and internal secrets by the usual RBAC means.
 
+Operators should configure `gardener-apiserver` to encrypt the `internalsecrets.core.gardener.cloud` resource in etcd.
+
 Please see [this](../../example/11-internal-secret.yaml) example manifest.
 
 ## `Seed`s


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind enhancement

**What this PR does / why we need it**:

Before upgrading to g/g@v1.73, operators should configure `gardener-apiserver` to encrypt the `internalsecrets.core.gardener.cloud` resource in etcd.
Otherwise, configuring encryption afterwards will become more painful.
We can't really do this by default from within g/g (only once we have gardener-operator). Hence, let's add it to the docs and values to encourage encryption, but also push a breaking release note to make this prominent enough.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/7999

**Special notes for your reviewer**:

This should go into the v1.73.0 release.
/milestone v1.73
/cc @timuthy

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
Before upgrading to this gardener version, operators should configure `gardener-apiserver` to encrypt the `internalsecrets.core.gardener.cloud` resource in etcd.
```
