### PR TITLE
bump up plutono to v7.5.22

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -192,7 +192,7 @@ images:
   - name: 'cloud.gardener.cnudie/responsibles'
     value:
     - type: 'githubTeam'
-      teamname: 'gardener/monitoring-maintainers'  
+      teamname: 'gardener/monitoring-maintainers'
 - name: prometheus
   sourceRepository: github.com/prometheus/prometheus
   repository: quay.io/prometheus/prometheus
@@ -265,7 +265,7 @@ images:
 - name: plutono
   sourceRepository: github.com/credativ/plutono
   repository: ghcr.io/credativ/plutono
-  tag: "v7.5.21"
+  tag: "v7.5.22"
   labels:
   - name: gardener.cloud/cve-categorisation
     value:


### PR DESCRIPTION
/area logging
/area monitoring

This PR updates `plutono` to [v7.5.22](https://github.com/credativ/plutono/releases/tag/v7.5.22), bringing a number of improvements among which is fixing the query field on Chromium based browsers.

```other operator
Plutono is now updated to v7.5.22
```
