### PR TITLE
Drop GA-ed `HAControlPlanes` and `FullNetworkPoliciesInRuntimeCluster` feature gates

### DIFF
--- a/cmd/gardenlet/app/app.go
+++ b/cmd/gardenlet/app/app.go
@@ -21,7 +21,6 @@ import (
 	"os"
 	goruntime "runtime"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -31,12 +30,9 @@ import (
 	coordinationv1 "k8s.io/api/coordination/v1"
 	corev1 "k8s.io/api/core/v1"
 	eventsv1 "k8s.io/api/events/v1"
-	networkingv1 "k8s.io/api/networking/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
-	"k8s.io/apimachinery/pkg/util/intstr"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/rest"
 	"k8s.io/component-base/version"
@@ -59,11 +55,8 @@ import (
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/apis/operations"
 	operationsv1alpha1 "github.com/gardener/gardener/pkg/apis/operations/v1alpha1"
-	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	clientmapbuilder "github.com/gardener/gardener/pkg/client/kubernetes/clientmap/builder"
-	kubeapiserverconstants "github.com/gardener/gardener/pkg/component/kubeapiserver/constants"
-	"github.com/gardener/gardener/pkg/component/vpnseedserver"
 	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/controllerutils/routes"
 	"github.com/gardener/gardener/pkg/features"
@@ -354,14 +347,6 @@ func (g *garden) Start(ctx context.Context) error {
 		return err
 	}
 
-	// Migrate all relevant services in shoot control planes once, so that we don't have to wait for their reconciliation
-	// and can ensure the required policies are created.
-	// TODO(timuthy, rfranzke): To be removed in a future release.
-	log.Info("Migrating all relevant shoot control plane services to create required network policies")
-	if err := g.migrateAllShootServicesForNetworkPolicies(ctx); err != nil {
-		return err
-	}
-
 	log.Info("Setting up shoot client map")
 	shootClientMap, err := clientmapbuilder.
 		NewShootClientMapBuilder().
@@ -451,173 +436,6 @@ func (g *garden) registerSeed(ctx context.Context, gardenClient client.Client) e
 		}
 		return true, nil
 	})
-}
-
-func (g *garden) migrateAllShootServicesForNetworkPolicies(ctx context.Context) error {
-	var taskFns []flow.TaskFn
-
-	// kube-apiserver services
-	kubeAPIServerServiceList := &corev1.ServiceList{}
-	if err := g.mgr.GetClient().List(ctx, kubeAPIServerServiceList, client.MatchingLabels{v1beta1constants.LabelApp: v1beta1constants.LabelKubernetes, v1beta1constants.LabelRole: v1beta1constants.LabelAPIServer}); err != nil {
-		return err
-	}
-
-	taskFns = append(taskFns, migrationTasksForServices(g.mgr.GetClient(), kubeAPIServerServiceList.Items, kubeapiserverconstants.Port, true)...)
-
-	// vpn-seed-server services
-	for _, serviceName := range []string{vpnseedserver.ServiceName, vpnseedserver.ServiceName + "-0", vpnseedserver.ServiceName + "-1"} {
-		serviceList := &corev1.ServiceList{}
-		// Use APIReader here because an index on `metadata.name` is not available in the runtime client.
-		if err := g.mgr.GetAPIReader().List(ctx, serviceList, client.MatchingFieldsSelector{
-			Selector: fields.OneTermEqualSelector(metav1.ObjectNameField, serviceName),
-		}); err != nil {
-			return err
-		}
-
-		taskFns = append(taskFns, migrationTasksForServices(g.mgr.GetClient(), serviceList.Items, vpnseedserver.MetricsPort, false)...)
-	}
-
-	// vali services
-	serviceList := &corev1.ServiceList{}
-	if err := g.mgr.GetClient().List(ctx, serviceList, client.MatchingLabels{"app": "vali", "role": "logging"}); err != nil {
-		return err
-	}
-
-	// drop vali services of non-shoot namespaces since they should not be mutated
-	for i := len(serviceList.Items) - 1; i >= 0; i-- {
-		if !strings.HasPrefix(serviceList.Items[i].Namespace, v1beta1constants.TechnicalIDPrefix) {
-			serviceList.Items = append(serviceList.Items[:i], serviceList.Items[i+1:]...)
-		}
-	}
-
-	taskFns = append(taskFns, migrationTasksForValiServices(g.mgr.GetClient(), serviceList.Items)...)
-
-	// prometheus namespaces
-	serviceList = &corev1.ServiceList{}
-	if err := g.mgr.GetClient().List(ctx, serviceList, client.MatchingLabels{"app": "prometheus", "role": "monitoring"}); err != nil {
-		return err
-	}
-
-	// drop prometheus services of non-shoot namespaces since they one should not be mutated
-	for i := len(serviceList.Items) - 1; i >= 0; i-- {
-		if !strings.HasPrefix(serviceList.Items[i].Namespace, v1beta1constants.TechnicalIDPrefix) {
-			serviceList.Items = append(serviceList.Items[:i], serviceList.Items[i+1:]...)
-		}
-	}
-
-	taskFns = append(taskFns, migrationTasksForPrometheusServices(g.mgr.GetClient(), serviceList.Items)...)
-
-	// vpa-recommender services for shoot namespaces
-	namespaceList := &corev1.NamespaceList{}
-	if err := g.mgr.GetClient().List(ctx, namespaceList, client.MatchingLabels{v1beta1constants.GardenRole: v1beta1constants.GardenRoleShoot}); err != nil {
-		return err
-	}
-
-	taskFns = append(taskFns, migrationTasksForShootVPARecommenders(g.mgr.GetClient(), namespaceList.Items)...)
-
-	return flow.Parallel(taskFns...)(ctx)
-}
-
-func migrationTasksForServices(cl client.Client, services []corev1.Service, port int, withGardenNamespaceSelector bool) []flow.TaskFn {
-	var taskFns []flow.TaskFn
-
-	for _, svc := range services {
-		service := svc
-
-		taskFns = append(taskFns, func(ctx context.Context) error {
-			selectors := []metav1.LabelSelector{}
-			if withGardenNamespaceSelector {
-				selectors = append(selectors, metav1.LabelSelector{MatchLabels: map[string]string{corev1.LabelMetadataName: v1beta1constants.GardenNamespace}})
-			}
-
-			selectors = append(selectors,
-				metav1.LabelSelector{MatchLabels: map[string]string{v1beta1constants.GardenRole: v1beta1constants.GardenRoleIstioIngress}},
-				metav1.LabelSelector{MatchExpressions: []metav1.LabelSelectorRequirement{{Key: v1beta1constants.LabelExposureClassHandlerName, Operator: metav1.LabelSelectorOpExists}}},
-			)
-
-			if withGardenNamespaceSelector {
-				selectors = append(selectors, metav1.LabelSelector{MatchLabels: map[string]string{v1beta1constants.GardenRole: v1beta1constants.GardenRoleExtension}})
-			}
-
-			patch := client.MergeFrom(service.DeepCopy())
-			metav1.SetMetaDataAnnotation(&service.ObjectMeta, resourcesv1alpha1.NetworkingPodLabelSelectorNamespaceAlias, v1beta1constants.LabelNetworkPolicyShootNamespaceAlias)
-			utilruntime.Must(gardenerutils.InjectNetworkPolicyNamespaceSelectors(&service, selectors...))
-			utilruntime.Must(gardenerutils.InjectNetworkPolicyAnnotationsForScrapeTargets(&service, networkingv1.NetworkPolicyPort{Port: utils.IntStrPtrFromInt(port), Protocol: utils.ProtocolPtr(corev1.ProtocolTCP)}))
-			return cl.Patch(ctx, &service, patch)
-		})
-	}
-
-	return taskFns
-}
-
-func migrationTasksForValiServices(cl client.Client, services []corev1.Service) []flow.TaskFn {
-	var taskFns []flow.TaskFn
-
-	for _, svc := range services {
-		service := svc
-
-		taskFns = append(taskFns, func(ctx context.Context) error {
-			patch := client.MergeFrom(service.DeepCopy())
-			metav1.SetMetaDataAnnotation(&service.ObjectMeta, resourcesv1alpha1.NetworkingPodLabelSelectorNamespaceAlias, v1beta1constants.LabelNetworkPolicyShootNamespaceAlias)
-			utilruntime.Must(gardenerutils.InjectNetworkPolicyNamespaceSelectors(&service, metav1.LabelSelector{MatchLabels: map[string]string{corev1.LabelMetadataName: v1beta1constants.GardenNamespace}}))
-			return cl.Patch(ctx, &service, patch)
-		})
-	}
-
-	return taskFns
-}
-
-func migrationTasksForPrometheusServices(cl client.Client, services []corev1.Service) []flow.TaskFn {
-	var taskFns []flow.TaskFn
-
-	for _, svc := range services {
-		service := svc
-
-		taskFns = append(taskFns, func(ctx context.Context) error {
-			patch := client.MergeFrom(service.DeepCopy())
-			metav1.SetMetaDataAnnotation(&service.ObjectMeta, resourcesv1alpha1.NetworkingPodLabelSelectorNamespaceAlias, v1beta1constants.LabelNetworkPolicyShootNamespaceAlias)
-			utilruntime.Must(gardenerutils.InjectNetworkPolicyNamespaceSelectors(&service, metav1.LabelSelector{MatchLabels: map[string]string{corev1.LabelMetadataName: v1beta1constants.GardenNamespace}}))
-			return cl.Patch(ctx, &service, patch)
-		})
-	}
-
-	return taskFns
-}
-
-func migrationTasksForShootVPARecommenders(cl client.Client, shootNamespaces []corev1.Namespace) []flow.TaskFn {
-	var taskFns []flow.TaskFn
-
-	for _, ns := range shootNamespaces {
-		namespace := ns
-
-		// It is forbidden to create a new resource in already terminating Namespace.
-		if namespace.DeletionTimestamp != nil {
-			continue
-		}
-
-		taskFns = append(taskFns, func(ctx context.Context) error {
-			service := &corev1.Service{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "vpa-recommender",
-					Namespace: namespace.Name,
-				},
-				Spec: corev1.ServiceSpec{
-					Selector: map[string]string{v1beta1constants.LabelApp: "vpa-recommender"},
-					Ports: []corev1.ServicePort{{
-						Port:       8942,
-						TargetPort: intstr.FromInt(8942),
-					}},
-				},
-			}
-
-			metav1.SetMetaDataAnnotation(&service.ObjectMeta, resourcesv1alpha1.NetworkingPodLabelSelectorNamespaceAlias, v1beta1constants.LabelNetworkPolicyShootNamespaceAlias)
-			utilruntime.Must(gardenerutils.InjectNetworkPolicyNamespaceSelectors(service, metav1.LabelSelector{MatchLabels: map[string]string{corev1.LabelMetadataName: v1beta1constants.GardenNamespace}}))
-
-			return client.IgnoreAlreadyExists(cl.Create(ctx, service))
-		})
-	}
-
-	return taskFns
 }
 
 func (g *garden) updateProcessingShootStatusToAborted(ctx context.Context, gardenClient client.Client) error {

--- a/docs/deployment/feature_gates.md
+++ b/docs/deployment/feature_gates.md
@@ -22,9 +22,6 @@ The following tables are a summary of the feature gates that you can set on diff
 |-------------------------------------|---------|---------|--------|--------|
 | HVPA                                | `false` | `Alpha` | `0.31` |        |
 | HVPAForShootedSeed                  | `false` | `Alpha` | `0.32` |        |
-| HAControlPlanes                     | `false` | `Alpha` | `1.49` | `1.70` |
-| HAControlPlanes                     | `true`  | `Beta`  | `1.71` | `1.72` |
-| HAControlPlanes                     | `true`  | `GA`    | `1.73` |        |
 | DefaultSeccompProfile               | `false` | `Alpha` | `1.54` |        |
 | CoreDNSQueryRewriting               | `false` | `Alpha` | `1.55` |        |
 | IPv6SingleStack                     | `false` | `Alpha` | `1.63` |        |
@@ -126,6 +123,10 @@ The following tables are a summary of the feature gates that you can set on diff
 | APIServerSNI                                 | `true`  | `Beta`       | `1.19` |        |
 | APIServerSNI                                 | `true`  | `Deprecated` | `1.48` | `1.72` |
 | APIServerSNI                                 | `true`  | `Removed`    | `1.73` |        |
+| HAControlPlanes                              | `false` | `Alpha`      | `1.49` | `1.70` |
+| HAControlPlanes                              | `true`  | `Beta`       | `1.71` | `1.72` |
+| HAControlPlanes                              | `true`  | `GA`         | `1.73` | `1.74` |
+| HAControlPlanes                              | `true`  | `Removed`    | `1.74` |        |
 
 ## Using a Feature
 
@@ -168,7 +169,6 @@ A *General Availability* (GA) feature is also referred to as a *stable* feature.
 | HVPA                                       | `gardenlet`, `gardener-operator`  | Enables simultaneous horizontal and vertical scaling in garden or seed clusters.                                                                                                                                                                                                                                                                                                   |
 | HVPAForShootedSeed                         | `gardenlet`                       | Enables simultaneous horizontal and vertical scaling in managed seed (aka "shooted seed") clusters.                                                                                                                                                                                                                                                                                |
 | SecretBindingProviderValidation            | `gardener-apiserver`              | Enables validations on Gardener API server that:<br>- requires the provider type of a SecretBinding to be set (on SecretBinding creation)<br>- requires the SecretBinding provider type to match the Shoot provider type (on Shoot creation)<br>- enforces immutability on the provider type of a SecretBinding                                                                    |
-| HAControlPlanes                            | `gardener-apiserver`              | HAControlPlanes allows shoot control planes to be run in high availability mode.                                                                                                                                                                                                                                                                                                   |
 | DefaultSeccompProfile                      | `gardenlet`, `gardener-operator`  | Enables the defaulting of the seccomp profile for Gardener managed workload in the garden or seed to `RuntimeDefault`.                                                                                                                                                                                                                                                             |
 | CoreDNSQueryRewriting                      | `gardenlet`                       | Enables automatic DNS query rewriting in shoot cluster's CoreDNS to shortcut name resolution of fully qualified in-cluster and out-of-cluster names, which follow a user-defined pattern. Details can be found in [DNS Search Path Optimization](../usage/dns-search-path-optimization.md).                                                                                        |
 | IPv6SingleStack                            | `gardener-apiserver`, `gardenlet` | Allows creating seed and shoot clusters with [IPv6 single-stack networking](../usage/ipv6.md) enabled in their spec ([GEP-21](../proposals/21-ipv6-singlestack-local.md)). If enabled in gardenlet, the default behavior is unchanged, but setting `ipFamilies=[IPv6]` in the `seedConfig` is allowed. Only if the `ipFamilies` setting is changed, gardenlet behaves differently. |

--- a/docs/deployment/feature_gates.md
+++ b/docs/deployment/feature_gates.md
@@ -26,9 +26,6 @@ The following tables are a summary of the feature gates that you can set on diff
 | CoreDNSQueryRewriting               | `false` | `Alpha` | `1.55` |        |
 | IPv6SingleStack                     | `false` | `Alpha` | `1.63` |        |
 | MutableShootSpecNetworkingNodes     | `false` | `Alpha` | `1.64` |        |
-| FullNetworkPoliciesInRuntimeCluster | `false` | `Alpha` | `1.66` | `1.70` |
-| FullNetworkPoliciesInRuntimeCluster | `true`  | `Beta`  | `1.71` | `1.72` |
-| FullNetworkPoliciesInRuntimeCluster | `true`  | `GA`    | `1.73` |        |
 | WorkerlessShoots                    | `false` | `Alpha` | `1.70` |        |
 | MachineControllerManagerDeployment  | `false` | `Alpha` | `1.73` |        |
 | DisableScalingClassesForShoots      | `false` | `Alpha` | `1.73` |        |
@@ -127,6 +124,10 @@ The following tables are a summary of the feature gates that you can set on diff
 | HAControlPlanes                              | `true`  | `Beta`       | `1.71` | `1.72` |
 | HAControlPlanes                              | `true`  | `GA`         | `1.73` | `1.74` |
 | HAControlPlanes                              | `true`  | `Removed`    | `1.74` |        |
+| FullNetworkPoliciesInRuntimeCluster          | `false` | `Alpha`      | `1.66` | `1.70` |
+| FullNetworkPoliciesInRuntimeCluster          | `true`  | `Beta`       | `1.71` | `1.72` |
+| FullNetworkPoliciesInRuntimeCluster          | `true`  | `GA`         | `1.73` | `1.74` |
+| FullNetworkPoliciesInRuntimeCluster          | `true`  | `Removed`    | `1.74` |        |
 
 ## Using a Feature
 
@@ -173,7 +174,6 @@ A *General Availability* (GA) feature is also referred to as a *stable* feature.
 | CoreDNSQueryRewriting                      | `gardenlet`                       | Enables automatic DNS query rewriting in shoot cluster's CoreDNS to shortcut name resolution of fully qualified in-cluster and out-of-cluster names, which follow a user-defined pattern. Details can be found in [DNS Search Path Optimization](../usage/dns-search-path-optimization.md).                                                                                        |
 | IPv6SingleStack                            | `gardener-apiserver`, `gardenlet` | Allows creating seed and shoot clusters with [IPv6 single-stack networking](../usage/ipv6.md) enabled in their spec ([GEP-21](../proposals/21-ipv6-singlestack-local.md)). If enabled in gardenlet, the default behavior is unchanged, but setting `ipFamilies=[IPv6]` in the `seedConfig` is allowed. Only if the `ipFamilies` setting is changed, gardenlet behaves differently. |
 | MutableShootSpecNetworkingNodes            | `gardener-apiserver`              | Allows updating the field `spec.networking.nodes`. The validity of the values has to be checked in the provider extensions. Only enable this feature gate when your system runs provider extensions which have implemented the validation.                                                                                                                                         |
-| FullNetworkPoliciesInRuntimeCluster        | `gardenlet`, `gardener-operator`  | Enables the `NetworkPolicy` controller to place 'deny-all' network policies in all relevant namespaces in the runtime cluster.                                                                                                                                                                                                                                                     |
 | WorkerlessShoots                           | `gardener-apiserver`              | WorkerlessShoots allows creation of Shoot clusters with no worker pools.                                                                                                                                                                                                                                                                                                           |
 | MachineControllerManagerDeployment         | `gardenlet`                       | Enables Gardener to take over the deployment of the machine-controller-manager. If enabled, all registered provider extensions must support injecting the provider-specific MCM sidecar container into the deployment via the `controlplane` webhook.                                                                                                                              |
 | DisableScalingClassesForShoots             | `gardenlet`                       | Disables assigning a ScalingClass to Shoots based on their maximum Node count. All Shoot kube-apiservers will get the same initial resource requests for CPU and memory instead of making this depend on the ScalingClass.                                                                                                                                                         |

--- a/docs/deployment/feature_gates.md
+++ b/docs/deployment/feature_gates.md
@@ -122,11 +122,11 @@ The following tables are a summary of the feature gates that you can set on diff
 | APIServerSNI                                 | `true`  | `Removed`    | `1.73` |        |
 | HAControlPlanes                              | `false` | `Alpha`      | `1.49` | `1.70` |
 | HAControlPlanes                              | `true`  | `Beta`       | `1.71` | `1.72` |
-| HAControlPlanes                              | `true`  | `GA`         | `1.73` | `1.74` |
+| HAControlPlanes                              | `true`  | `GA`         | `1.73` | `1.73` |
 | HAControlPlanes                              | `true`  | `Removed`    | `1.74` |        |
 | FullNetworkPoliciesInRuntimeCluster          | `false` | `Alpha`      | `1.66` | `1.70` |
 | FullNetworkPoliciesInRuntimeCluster          | `true`  | `Beta`       | `1.71` | `1.72` |
-| FullNetworkPoliciesInRuntimeCluster          | `true`  | `GA`         | `1.73` | `1.74` |
+| FullNetworkPoliciesInRuntimeCluster          | `true`  | `GA`         | `1.73` | `1.73` |
 | FullNetworkPoliciesInRuntimeCluster          | `true`  | `Removed`    | `1.74` |        |
 
 ## Using a Feature

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -302,7 +302,6 @@ const (
 	// automatic scale-down shall be disabled for the etcd, kube-apiserver, kube-controller-manager.
 	// Note that this annotation is alpha and can be removed anytime without further notice. Only use it if you know
 	// what you do.
-	// TODO(shreyas-s-rao): Deprecate HA annotation with the stable release of zonal clusters feature.
 	ShootAlphaControlPlaneScaleDownDisabled = "alpha.control-plane.scaling.shoot.gardener.cloud/scale-down-disabled"
 
 	// ShootAlphaControlPlaneHAVPN is a constant for an annotation on the Shoot resource to enforce

--- a/pkg/apiserver/features/features.go
+++ b/pkg/apiserver/features/features.go
@@ -23,7 +23,6 @@ import (
 // RegisterFeatureGates registers the feature gates of gardener-apiserver.
 func RegisterFeatureGates() {
 	utilruntime.Must(features.DefaultFeatureGate.Add(features.GetFeatures(
-		features.HAControlPlanes,
 		features.IPv6SingleStack,
 		features.MutableShootSpecNetworkingNodes,
 		features.WorkerlessShoots,

--- a/pkg/controller/networkpolicy/add_test.go
+++ b/pkg/controller/networkpolicy/add_test.go
@@ -53,14 +53,6 @@ var _ = Describe("Add", func() {
 			networkPolicy = &networkingv1.NetworkPolicy{ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "kubernetes"}}
 		})
 
-		It("should return true because the NetworkPolicy has name 'allow-to-seed-apiserver'", func() {
-			networkPolicy.Name = "allow-to-seed-apiserver"
-			Expect(p.Create(event.CreateEvent{Object: networkPolicy})).To(BeTrue())
-			Expect(p.Update(event.UpdateEvent{ObjectNew: networkPolicy})).To(BeTrue())
-			Expect(p.Delete(event.DeleteEvent{Object: networkPolicy})).To(BeTrue())
-			Expect(p.Generic(event.GenericEvent{Object: networkPolicy})).To(BeTrue())
-		})
-
 		It("should return true because the NetworkPolicy has name 'allow-to-runtime-apiserver'", func() {
 			networkPolicy.Name = "allow-to-runtime-apiserver"
 			Expect(p.Create(event.CreateEvent{Object: networkPolicy})).To(BeTrue())

--- a/pkg/controller/networkpolicy/reconciler.go
+++ b/pkg/controller/networkpolicy/reconciler.go
@@ -166,19 +166,6 @@ func (r *Reconciler) networkPolicyConfigs() []networkPolicyConfig {
 				labels.NewSelector().Add(utils.MustNewRequirement(v1beta1constants.LabelExposureClassHandlerName, selection.Exists)),
 			}, r.additionalNamespaceLabelSelectors...),
 		},
-		// TODO(rfranzke): This network policy is deprecated and will be removed soon in favor of
-		//  `allow-to-runtime-apiserver`.
-		{
-			name: "allow-to-seed-apiserver",
-			reconcileFunc: func(ctx context.Context, log logr.Logger, networkPolicy *networkingv1.NetworkPolicy) error {
-				return r.reconcileNetworkPolicyAllowToAPIServer(ctx, log, networkPolicy, v1beta1constants.LabelNetworkPolicyToSeedAPIServer)
-			},
-			namespaceSelectors: append([]labels.Selector{
-				labels.SelectorFromSet(labels.Set{corev1.LabelMetadataName: v1beta1constants.GardenNamespace}),
-				labels.SelectorFromSet(labels.Set{v1beta1constants.GardenRole: v1beta1constants.GardenRoleIstioSystem}),
-				labels.SelectorFromSet(labels.Set{v1beta1constants.GardenRole: v1beta1constants.GardenRoleShoot}),
-			}, r.additionalNamespaceLabelSelectors...),
-		},
 		{
 			name: "allow-to-runtime-apiserver",
 			reconcileFunc: func(ctx context.Context, log logr.Logger, networkPolicy *networkingv1.NetworkPolicy) error {

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -37,13 +37,6 @@ const (
 	// alpha: v0.32.0
 	HVPAForShootedSeed featuregate.Feature = "HVPAForShootedSeed"
 
-	// HAControlPlanes allows shoot control planes to be run in high availability mode.
-	// owner: @shreyas-s-rao @timuthy
-	// alpha: v1.49.0
-	// beta: v1.71.0
-	// GA: v1.73.0
-	HAControlPlanes featuregate.Feature = "HAControlPlanes"
-
 	// DefaultSeccompProfile defaults the seccomp profile for Gardener managed workload in the seed to RuntimeDefault.
 	// owner: @dimityrmirchev
 	// alpha: v1.54.0
@@ -97,7 +90,7 @@ const (
 // On startup, the component needs to register all feature gates that are available for this component via `Add`, e.g.:
 //
 //	 utilruntime.Must(features.DefaultFeatureGate.Add(features.GetFeatures(
-//			features.HAControlPlanes,
+//			features.MyFeatureGateName,
 //		)))
 //
 // With this, every component has its individual set of available feature gates (different to Kubernetes, where all
@@ -119,7 +112,6 @@ var DefaultFeatureGate = utilfeature.DefaultMutableFeatureGate
 var allFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	HVPA:                                {Default: false, PreRelease: featuregate.Alpha},
 	HVPAForShootedSeed:                  {Default: false, PreRelease: featuregate.Alpha},
-	HAControlPlanes:                     {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
 	DefaultSeccompProfile:               {Default: false, PreRelease: featuregate.Alpha},
 	CoreDNSQueryRewriting:               {Default: false, PreRelease: featuregate.Alpha},
 	IPv6SingleStack:                     {Default: false, PreRelease: featuregate.Alpha},

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -58,14 +58,6 @@ const (
 	// alpha: v1.64.0
 	MutableShootSpecNetworkingNodes featuregate.Feature = "MutableShootSpecNetworkingNodes"
 
-	// FullNetworkPoliciesInRuntimeCluster enables gardenlet's NetworkPolicy controller to place 'deny-all' network policies in
-	// all relevant namespaces in the seed cluster.
-	// owner: @rfranzke
-	// alpha: v1.66.0
-	// beta: v1.71.0
-	// GA: v1.73.0
-	FullNetworkPoliciesInRuntimeCluster featuregate.Feature = "FullNetworkPoliciesInRuntimeCluster"
-
 	// WorkerlessShoots allows creation of Shoot clusters with no worker pools.
 	// owner: @acumino @ary1992 @shafeeqes
 	// alpha: v1.70.0
@@ -110,16 +102,15 @@ const (
 var DefaultFeatureGate = utilfeature.DefaultMutableFeatureGate
 
 var allFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
-	HVPA:                                {Default: false, PreRelease: featuregate.Alpha},
-	HVPAForShootedSeed:                  {Default: false, PreRelease: featuregate.Alpha},
-	DefaultSeccompProfile:               {Default: false, PreRelease: featuregate.Alpha},
-	CoreDNSQueryRewriting:               {Default: false, PreRelease: featuregate.Alpha},
-	IPv6SingleStack:                     {Default: false, PreRelease: featuregate.Alpha},
-	MutableShootSpecNetworkingNodes:     {Default: false, PreRelease: featuregate.Alpha},
-	FullNetworkPoliciesInRuntimeCluster: {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
-	WorkerlessShoots:                    {Default: false, PreRelease: featuregate.Alpha},
-	MachineControllerManagerDeployment:  {Default: false, PreRelease: featuregate.Alpha},
-	DisableScalingClassesForShoots:      {Default: false, PreRelease: featuregate.Alpha},
+	HVPA:                               {Default: false, PreRelease: featuregate.Alpha},
+	HVPAForShootedSeed:                 {Default: false, PreRelease: featuregate.Alpha},
+	DefaultSeccompProfile:              {Default: false, PreRelease: featuregate.Alpha},
+	CoreDNSQueryRewriting:              {Default: false, PreRelease: featuregate.Alpha},
+	IPv6SingleStack:                    {Default: false, PreRelease: featuregate.Alpha},
+	MutableShootSpecNetworkingNodes:    {Default: false, PreRelease: featuregate.Alpha},
+	WorkerlessShoots:                   {Default: false, PreRelease: featuregate.Alpha},
+	MachineControllerManagerDeployment: {Default: false, PreRelease: featuregate.Alpha},
+	DisableScalingClassesForShoots:     {Default: false, PreRelease: featuregate.Alpha},
 }
 
 // GetFeatures returns a feature gate map with the respective specifications. Non-existing feature gates are ignored.

--- a/pkg/gardenlet/controller/controllerinstallation/controllerinstallation/reconciler.go
+++ b/pkg/gardenlet/controller/controllerinstallation/controllerinstallation/reconciler.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
-	networkingv1 "k8s.io/api/networking/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -165,11 +164,6 @@ func (r *Reconciler) reconcile(
 		metav1.SetMetaDataAnnotation(&namespace.ObjectMeta, resourcesv1alpha1.HighAvailabilityConfigZones, strings.Join(seed.Spec.Provider.Zones, ","))
 		return nil
 	}); err != nil {
-		return reconcile.Result{}, err
-	}
-
-	// TODO(rfranzke): Drop this code when the FullNetworkPoliciesInRuntimeCluster feature gate gets removed.
-	if err := r.SeedClientSet.Client().Delete(seedCtx, &networkingv1.NetworkPolicy{ObjectMeta: metav1.ObjectMeta{Name: "gardenlet-allow-all-traffic", Namespace: namespace.Name}}); client.IgnoreNotFound(err) != nil {
 		return reconcile.Result{}, err
 	}
 

--- a/pkg/gardenlet/controller/seed/seed/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/seed/seed/reconciler_reconcile.go
@@ -870,11 +870,6 @@ func (r *Reconciler) runReconcileSeedFlow(
 		return err
 	}
 
-	// TODO(rfranzke): Drop this code when the FullNetworkPoliciesInRuntimeCluster feature gate gets removed.
-	if err := kubernetesutils.DeleteObject(ctx, seedClient, &networkingv1.NetworkPolicy{ObjectMeta: metav1.ObjectMeta{Name: "allow-seed-prometheus", Namespace: r.GardenNamespace}}); err != nil {
-		return err
-	}
-
 	var (
 		g = flow.NewGraph("Seed cluster creation")
 		_ = g.Add(flow.Task{

--- a/pkg/gardenlet/features/features.go
+++ b/pkg/gardenlet/features/features.go
@@ -28,7 +28,6 @@ func RegisterFeatureGates() {
 		features.DefaultSeccompProfile,
 		features.CoreDNSQueryRewriting,
 		features.IPv6SingleStack,
-		features.FullNetworkPoliciesInRuntimeCluster,
 		features.MachineControllerManagerDeployment,
 		features.DisableScalingClassesForShoots,
 	)))

--- a/pkg/operator/features/features.go
+++ b/pkg/operator/features/features.go
@@ -25,6 +25,5 @@ func RegisterFeatureGates() {
 	utilruntime.Must(features.DefaultFeatureGate.Add(features.GetFeatures(
 		features.DefaultSeccompProfile,
 		features.HVPA,
-		features.FullNetworkPoliciesInRuntimeCluster,
 	)))
 }

--- a/test/integration/gardenlet/controllerinstallation/controllerinstallation/controllerinstallation_test.go
+++ b/test/integration/gardenlet/controllerinstallation/controllerinstallation/controllerinstallation_test.go
@@ -207,7 +207,6 @@ var _ = Describe("ControllerInstallation controller tests", func() {
       DryRun: true
       EfficientWatchResumption: true
       FullNetworkPoliciesInRuntimeCluster: true
-      HAControlPlanes: true
       HVPA: false
       HVPAForShootedSeed: false
       IPv6SingleStack: false

--- a/test/integration/gardenlet/networkpolicy/networkpolicy_test.go
+++ b/test/integration/gardenlet/networkpolicy/networkpolicy_test.go
@@ -212,7 +212,6 @@ var _ = Describe("NetworkPolicy controller tests", func() {
 				g.Expect(testClient.List(ctx, networkPolicyList, client.InNamespace(gardenNamespace.Name))).To(Succeed())
 				return networkPolicyList.Items
 			}).Should(ConsistOf(
-				MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("allow-to-seed-apiserver")})}),
 				MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("allow-to-runtime-apiserver")})}),
 				MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("allow-to-public-networks")})}),
 				MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("allow-to-private-networks")})}),
@@ -365,30 +364,6 @@ var _ = Describe("NetworkPolicy controller tests", func() {
 			inShootNamespaces:             true,
 			inExtensionNamespaces:         true,
 			inCustomNamespace:             true,
-		})
-	})
-
-	Describe("allow-to-seed-apiserver", func() {
-		var expectedNetworkPolicySpec networkingv1.NetworkPolicySpec
-
-		JustBeforeEach(func() {
-			kubernetesEndpoint := &corev1.Endpoints{ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "kubernetes"}}
-			Expect(testClient.Get(ctx, client.ObjectKeyFromObject(kubernetesEndpoint), kubernetesEndpoint)).To(Succeed())
-
-			expectedNetworkPolicySpec = networkingv1.NetworkPolicySpec{
-				Egress:      networkpolicyhelper.GetEgressRules(kubernetesEndpoint.Subsets...),
-				PodSelector: metav1.LabelSelector{MatchLabels: map[string]string{"networking.gardener.cloud/to-seed-apiserver": "allowed"}},
-				PolicyTypes: []networkingv1.PolicyType{"Egress"},
-			}
-		})
-
-		defaultTests(testAttributes{
-			networkPolicyName:         "allow-to-seed-apiserver",
-			expectedNetworkPolicySpec: func(string) networkingv1.NetworkPolicySpec { return expectedNetworkPolicySpec },
-			inGardenNamespace:         true,
-			inIstioSystemNamespace:    true,
-			inShootNamespaces:         true,
-			inCustomNamespace:         true,
 		})
 	})
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity open-source
/kind enhancement

**What this PR does / why we need it**:
- Drop GA-ed `HAControlPlanes` feature gate
- Drop GA-ed `FullNetworkPoliciesInRuntimeCluster` feature gate

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/7352
Part of https://github.com/gardener/gardener/issues/6529

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
The GA-ed feature gates `HAControlPlanes` and `FullNetworkPoliciesInRuntimeCluster` have been removed.
```
```breaking developer
The deprecated `allow-to-seed-apiserver` `NetworkPolicy` is no longer available in garden or seed clusters. Use `allow-to-runtime-apiserver` instead.
```