### PR TITLE
Increased default reconciliation timeout to 3 minutes.

### DIFF
--- a/pkg/controllerutils/miscellaneous.go
+++ b/pkg/controllerutils/miscellaneous.go
@@ -29,7 +29,7 @@ import (
 )
 
 // DefaultReconciliationTimeout is the default timeout for the context of reconciliation functions.
-const DefaultReconciliationTimeout = 1 * time.Minute
+const DefaultReconciliationTimeout = 3 * time.Minute
 
 const separator = ","
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind enhancement

**What this PR does / why we need it**:
Increased default reconciliation timeout to 3 minutes.

The default reconciliation timeout is used as a safety net to prevent reconciliation operations to hang forever. Therefore, it should be long enough that all usual operations succeed, but short enough so that the waiting time is not endless in case of issues/hanging operations.
With larger amount of resources being applied for example as managed resources the default reconciliation timeout needs to be increased. An example for such a resource is the istio ingress gateway in case the seed uses multiple availability zones as the managed resource will then include all entities for all availability zones. Another contributing factor may be if the control plane of a seed is latency-wise fairly distant to its data plane causing operations such as applying resources to be rather slow.

**Which issue(s) this PR fixes**:
None.

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The reconciliation time limit for the controller resource reconciliation, e.g. for `ManagedResource`, has been increased from `1m` to `3m`.
```
