### PR TITLE
Introduce the `ContainerdRegistryHostsDir` feature gate

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -27,6 +27,7 @@
 * [Audit a Kubernetes cluster](usage/shoot_auditpolicy.md)
 * [Auto-Scaling for shoot clusters](usage/shoot_autoscaling.md)
 * [Cleanup of Shoot clusters in deletion](usage/shoot_cleanup.md)
+* [`containerd` registry configuration](usage/containerd-registry-configuration.md)
 * [Custom `containerd` configuration](usage/custom-containerd-config.md)
 * [Custom `CoreDNS` configuration](usage/custom-dns-config.md)
 * [(Custom) CSI components](usage/csi_components.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,7 +27,7 @@
 * [Audit a Kubernetes cluster](usage/shoot_auditpolicy.md)
 * [Auto-Scaling for shoot clusters](usage/shoot_autoscaling.md)
 * [Cleanup of Shoot clusters in deletion](usage/shoot_cleanup.md)
-* [`containerd` registry configuration](usage/containerd-registry-configuration.md)
+* [`containerd` Registry Configuration](usage/containerd-registry-configuration.md)
 * [Custom `containerd` configuration](usage/custom-containerd-config.md)
 * [Custom `CoreDNS` configuration](usage/custom-dns-config.md)
 * [(Custom) CSI components](usage/csi_components.md)

--- a/docs/deployment/feature_gates.md
+++ b/docs/deployment/feature_gates.md
@@ -29,6 +29,7 @@ The following tables are a summary of the feature gates that you can set on diff
 | WorkerlessShoots                    | `false` | `Alpha` | `1.70` |        |
 | MachineControllerManagerDeployment  | `false` | `Alpha` | `1.73` |        |
 | DisableScalingClassesForShoots      | `false` | `Alpha` | `1.73` |        |
+| ContainerdRegistryHostsDir          | `false` | `Alpha` | `1.76` |        |
 
 ## Feature Gates for Graduated or Deprecated Features
 
@@ -177,3 +178,4 @@ A *General Availability* (GA) feature is also referred to as a *stable* feature.
 | WorkerlessShoots                           | `gardener-apiserver`              | WorkerlessShoots allows creation of Shoot clusters with no worker pools.                                                                                                                                                                                                                                                                                                           |
 | MachineControllerManagerDeployment         | `gardenlet`                       | Enables Gardener to take over the deployment of the machine-controller-manager. If enabled, all registered provider extensions must support injecting the provider-specific MCM sidecar container into the deployment via the `controlplane` webhook.                                                                                                                              |
 | DisableScalingClassesForShoots             | `gardenlet`                       | Disables assigning a ScalingClass to Shoots based on their maximum Node count. All Shoot kube-apiservers will get the same initial resource requests for CPU and memory instead of making this depend on the ScalingClass.                                                                                                                                                         |
+| ContainerdRegistryHostsDir                 | `gardenlet`                       | Enables registry configuration in containerd based on the hosts directory pattern. The hosts directory pattern is the new way of configuring registries/mirrors in containerd. Ref https://github.com/containerd/containerd/blob/main/docs/hosts.md.                                                                                                                               |

--- a/docs/deployment/feature_gates.md
+++ b/docs/deployment/feature_gates.md
@@ -29,7 +29,7 @@ The following tables are a summary of the feature gates that you can set on diff
 | WorkerlessShoots                    | `false` | `Alpha` | `1.70` |        |
 | MachineControllerManagerDeployment  | `false` | `Alpha` | `1.73` |        |
 | DisableScalingClassesForShoots      | `false` | `Alpha` | `1.73` |        |
-| ContainerdRegistryHostsDir          | `false` | `Alpha` | `1.76` |        |
+| ContainerdRegistryHostsDir          | `false` | `Alpha` | `1.77` |        |
 
 ## Feature Gates for Graduated or Deprecated Features
 

--- a/docs/usage/containerd-registry-configuration.md
+++ b/docs/usage/containerd-registry-configuration.md
@@ -4,7 +4,7 @@ title: containerd Registry Configuration
 
 # `containerd` Registry Configuration
 
-containerd supports configuring registries and mirrors. Using this native containerd feature end users can configure containerd to use public or private mirrors for a given upstream registry. More details about the registry configuration can be found in the [corresponding upstream documentation](https://github.com/containerd/containerd/blob/main/docs/hosts.md).
+containerd supports configuring registries and mirrors. Using this native containerd feature Shoot owners can configure containerd to use public or private mirrors for a given upstream registry. More details about the registry configuration can be found in the [corresponding upstream documentation](https://github.com/containerd/containerd/blob/main/docs/hosts.md).
 
 ### `containerd` Registry Configuration Patterns
 
@@ -67,7 +67,7 @@ Gardener supports configuring `containerd` registries on a Shoot using the new [
    config_path = "/etc/containerd/certs.d"
 ```
 
-In this way, end users can use the [hosts directory pattern](https://github.com/containerd/containerd/blob/main/docs/hosts.md) to configure registries for containerd.
+This allows Shoot owners to use the [hosts directory pattern](https://github.com/containerd/containerd/blob/main/docs/hosts.md) to configure registries for containerd. To do this, the Shoot owners need to create a directory under `/etc/containerd/certs.d` that is named with the upstream registry host name. In the newly created directory, a `hosts.toml` file needs to be created. For more details, see the [hosts directory pattern section](#hosts-directory-pattern) and the [upstream documentation](https://github.com/containerd/containerd/blob/main/docs/hosts.md).
 
 ### The registry-cache Extension
 

--- a/docs/usage/containerd-registry-configuration.md
+++ b/docs/usage/containerd-registry-configuration.md
@@ -1,0 +1,105 @@
+---
+title: containerd Registry Configuration
+---
+
+# `containerd` Registry Configuration
+
+containerd supports configuring registries and mirrors. Using this native containerd feature end users can configure containerd to use public or private mirrors for a given upstream registry. More details about the registry configuration can be found in the [corresponding upstream documentation](https://github.com/containerd/containerd/blob/main/docs/hosts.md).
+
+### `containerd` Registry Configuration Patterns
+
+At the time of writing this document, containerd support two patterns for configuring registries/mirrors.
+
+> Note: Trying to use both of the patterns at the same time is not supported by containerd. Only one of the configuration patterns has to be followed strictly.
+
+##### Old and Deprecated Pattern
+
+The old and deprecated pattern is for specifying `registry.mirrors` and `registry.configs` in the containerd's config.toml file. See the [upstream documentation](https://github.com/containerd/containerd/blob/main/docs/cri/registry.md).
+Example of the old and deprecated pattern:
+```toml
+version = 2
+
+[plugins."io.containerd.grpc.v1.cri".registry]
+  [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
+    [plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]
+      endpoint = ["https://public-mirror.example.com"]
+```
+
+In the above example, containerd is configured to first try to pull `docker.io` images from a configured endpoint (`https://public-mirror.example.com`). If the image is not available in `https://public-mirror.example.com`, then containerd will fall back to the upstream registry (`docker.io`) and will pull the image from there.
+
+##### Hosts Directory Pattern
+
+The hosts directory pattern is the new and recommended pattern for configuring registries. It is available starting `containerd@v1.5.0`. See the [upstream documentation](https://github.com/containerd/containerd/blob/main/docs/hosts.md).
+The above example in the hosts directory pattern looks as follows.
+The `/etc/containerd/config.toml` file has the following section:
+```toml
+version = 2
+
+[plugins."io.containerd.grpc.v1.cri".registry]
+   config_path = "/etc/containerd/certs.d"
+```
+
+The following hosts directory structure has to be created:
+```
+$ tree /etc/containerd/certs.d
+/etc/containerd/certs.d
+└── docker.io
+    └── hosts.toml
+```
+
+Finally, for the `docker.io` upstream registry, we configure a `hosts.toml` file as follows:
+```toml
+server = "https://registry-1.docker.io"
+
+[host."http://public-mirror.example.com"]
+  capabilities = ["pull", "resolve"]
+```
+
+> Note: The hosts directory pattern is available in `containerd` 1.5+.
+
+### Configuring `containerd` Registries for a Shoot
+
+> Note: The below-described functionality is provided by the `ContainerdRegistryHostsDir` feature gate in gardenlet.
+
+Gardener supports configuring `containerd` registries on a Shoot using the new [hosts directory pattern](https://github.com/containerd/containerd/blob/main/docs/hosts.md). For each Shoot Node, Gardener creates the `/etc/containerd/certs.d` directory and adds the following section to the containerd's `/etc/containerd/config.toml` file:
+```toml
+[plugins."io.containerd.grpc.v1.cri".registry] # gardener-managed
+   config_path = "/etc/containerd/certs.d"
+```
+
+In this way, end users can use the [hosts directory pattern](https://github.com/containerd/containerd/blob/main/docs/hosts.md) to configure registries for containerd.
+
+### The registry-cache Extension
+
+[Configuring `containerd` registries for a Shoot](#configuring-containerd-registries-for-a-shoot) is not the recommended approach for configuring a pull through cache for a Shoot. There is a Gardener-native extension named [registry-cache](https://github.com/gardener/gardener-extension-registry-cache) that manages a pull through cache for a Shoot using the upstream [distribution/distribution](https://github.com/distribution/distribution) project.
+
+> Note: The [registry-cache](https://github.com/gardener/gardener-extension-registry-cache) extension is currently under active development and not recommended for productive usage.
+
+### Migration
+
+This section describe the migration process from the old and deprecated pattern to the hosts directory pattern for a Shoot cluster.
+
+Let's assume that the following `containerd` registries configuration using the old and deprecated pattern is being configured (for example via DaemonSet) for a Shoot:
+```toml
+version = 2
+
+[plugins."io.containerd.grpc.v1.cri".registry]
+  [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
+    [plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]
+      endpoint = ["https://public-mirror.example.com"]
+```
+
+The migration steps are as follows:
+1. The `containerd` registries configuration has to be adapted to the hosts directory pattern.
+
+1.1 The `/etc/containerd/config.toml` file needs to be adapted as follows:
+```toml
+version = 2
+
+[plugins."io.containerd.grpc.v1.cri".registry]
+   config_path = "/etc/containerd/certs.d"
+```
+
+1.2 The appropriate directory structure and `hosts.toml` file has to be created as described in the [hosts directory pattern section](#hosts-directory-pattern).
+
+2. When the `ContainerdRegistryHostsDir` feature gate is GA, then the machinery that performs step 1.1 can be removed. A Shoot cluster can rely that the `config_path` will be always set by gardenlet.

--- a/docs/usage/containerd-registry-configuration.md
+++ b/docs/usage/containerd-registry-configuration.md
@@ -4,7 +4,7 @@ title: containerd Registry Configuration
 
 # `containerd` Registry Configuration
 
-containerd supports configuring registries and mirrors. Using this native containerd feature Shoot owners can configure containerd to use public or private mirrors for a given upstream registry. More details about the registry configuration can be found in the [corresponding upstream documentation](https://github.com/containerd/containerd/blob/main/docs/hosts.md).
+containerd supports configuring registries and mirrors. Using this native containerd feature, Shoot owners can configure containerd to use public or private mirrors for a given upstream registry. More details about the registry configuration can be found in the [corresponding upstream documentation](https://github.com/containerd/containerd/blob/main/docs/hosts.md).
 
 ### `containerd` Registry Configuration Patterns
 
@@ -14,8 +14,9 @@ At the time of writing this document, containerd support two patterns for config
 
 ##### Old and Deprecated Pattern
 
-The old and deprecated pattern is for specifying `registry.mirrors` and `registry.configs` in the containerd's config.toml file. See the [upstream documentation](https://github.com/containerd/containerd/blob/main/docs/cri/registry.md).
+The old and deprecated pattern is specifying `registry.mirrors` and `registry.configs` in the containerd's config.toml file. See the [upstream documentation](https://github.com/containerd/containerd/blob/main/docs/cri/registry.md).
 Example of the old and deprecated pattern:
+
 ```toml
 version = 2
 
@@ -32,6 +33,7 @@ In the above example, containerd is configured to first try to pull `docker.io` 
 The hosts directory pattern is the new and recommended pattern for configuring registries. It is available starting `containerd@v1.5.0`. See the [upstream documentation](https://github.com/containerd/containerd/blob/main/docs/hosts.md).
 The above example in the hosts directory pattern looks as follows.
 The `/etc/containerd/config.toml` file has the following section:
+
 ```toml
 version = 2
 
@@ -48,6 +50,7 @@ $ tree /etc/containerd/certs.d
 ```
 
 Finally, for the `docker.io` upstream registry, we configure a `hosts.toml` file as follows:
+
 ```toml
 server = "https://registry-1.docker.io"
 
@@ -55,13 +58,12 @@ server = "https://registry-1.docker.io"
   capabilities = ["pull", "resolve"]
 ```
 
-> Note: The hosts directory pattern is available in `containerd` 1.5+.
-
 ### Configuring `containerd` Registries for a Shoot
 
 > Note: The below-described functionality is provided by the `ContainerdRegistryHostsDir` feature gate in gardenlet.
 
 Gardener supports configuring `containerd` registries on a Shoot using the new [hosts directory pattern](https://github.com/containerd/containerd/blob/main/docs/hosts.md). For each Shoot Node, Gardener creates the `/etc/containerd/certs.d` directory and adds the following section to the containerd's `/etc/containerd/config.toml` file:
+
 ```toml
 [plugins."io.containerd.grpc.v1.cri".registry] # gardener-managed
    config_path = "/etc/containerd/certs.d"
@@ -71,7 +73,7 @@ This allows Shoot owners to use the [hosts directory pattern](https://github.com
 
 ### The registry-cache Extension
 
-[Configuring `containerd` registries for a Shoot](#configuring-containerd-registries-for-a-shoot) is not the recommended approach for configuring a pull through cache for a Shoot. There is a Gardener-native extension named [registry-cache](https://github.com/gardener/gardener-extension-registry-cache) that manages a pull through cache for a Shoot using the upstream [distribution/distribution](https://github.com/distribution/distribution) project.
+[Configuring `containerd` registries for a Shoot](#configuring-containerd-registries-for-a-shoot) won't be the recommended approach for configuring a pull through cache for a Shoot in near future. There is a Gardener-native extension named [registry-cache](https://github.com/gardener/gardener-extension-registry-cache) that manages a pull through cache for a Shoot using the upstream [distribution/distribution](https://github.com/distribution/distribution) project.
 
 > Note: The [registry-cache](https://github.com/gardener/gardener-extension-registry-cache) extension is currently under active development and not recommended for productive usage.
 
@@ -80,6 +82,7 @@ This allows Shoot owners to use the [hosts directory pattern](https://github.com
 This section describe the migration process from the old and deprecated pattern to the hosts directory pattern for a Shoot cluster.
 
 Let's assume that the following `containerd` registries configuration using the old and deprecated pattern is being configured (for example via DaemonSet) for a Shoot:
+
 ```toml
 version = 2
 
@@ -91,15 +94,12 @@ version = 2
 
 The migration steps are as follows:
 1. The `containerd` registries configuration has to be adapted to the hosts directory pattern.
-
 1.1 The `/etc/containerd/config.toml` file needs to be adapted as follows:
-```toml
-version = 2
-
-[plugins."io.containerd.grpc.v1.cri".registry]
-   config_path = "/etc/containerd/certs.d"
-```
-
+   ```toml
+   version = 2
+   
+   [plugins."io.containerd.grpc.v1.cri".registry]
+      config_path = "/etc/containerd/certs.d"
+   ```
 1.2 The appropriate directory structure and `hosts.toml` file has to be created as described in the [hosts directory pattern section](#hosts-directory-pattern).
-
 2. When the `ContainerdRegistryHostsDir` feature gate is GA, then the machinery that performs step 1.1 can be removed. A Shoot cluster can rely that the `config_path` will be always set by gardenlet.

--- a/example/gardener-local/gardenlet/values.yaml
+++ b/example/gardener-local/gardenlet/values.yaml
@@ -44,6 +44,11 @@ config:
     # This feature gate doesn't change gardenlet's default behavior, it only allows setting `ipFamilies=[IPv6]` in the
     # Seed config. Only when this is set, gardenlet's behavior changes.
     IPv6SingleStack: true
+    # Enable ContainerdRegistryHostsDir as provider-local requires the feature gate to be enabled 
+    # in order to have the registry cache working for a Shoot cluster in local setup.
+    # If disabled, a Shoot cluster in local setup won't be able to use the registry cache
+    # (it will be still able to pull images but registry cache won't be used).
+    ContainerdRegistryHostsDir: true
   logging:
     enabled: true
     vali:

--- a/extensions/pkg/webhook/controlplane/genericmutator/.import-restrictions
+++ b/extensions/pkg/webhook/controlplane/genericmutator/.import-restrictions
@@ -10,7 +10,13 @@ rules:
   - github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/original/components/docker
   - github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/original/components/logrotate
   - github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/utils
-# allow the transitive import of  github.com/gardener/gardener/pkg/component
+# allow the transitive import of github.com/gardener/gardener/pkg/component
+# which is imported by github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/original/components/{containerd,kubelet,docker}
 - selectorRegexp: github[.]com/gardener/gardener/pkg/component
   allowedPrefixes:
   - github.com/gardener/gardener/pkg/component
+# allow the transitive import of github.com/gardener/gardener/pkg/features
+# which is imported by github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/original/components/containerd
+- selectorRegexp: github[.]com/gardener/gardener/pkg/features
+  allowedPrefixes:
+  - github.com/gardener/gardener/pkg/features

--- a/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig_test.go
@@ -322,6 +322,11 @@ var _ = Describe("OperatingSystemConfig", func() {
 
 		Describe("#Deploy", func() {
 			It("should successfully deploy the shoot access secret for the cloud config downloader", func() {
+				defer test.WithVars(
+					&DownloaderConfigFn, downloaderConfigFn,
+					&OriginalConfigFn, originalConfigFn,
+				)()
+
 				Expect(defaultDepWaiter.Deploy(ctx)).To(Succeed())
 
 				secret := &corev1.Secret{}

--- a/pkg/component/extensions/operatingsystemconfig/original/components/containerd/containerd_suite_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/containerd/containerd_suite_test.go
@@ -19,9 +19,12 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	"github.com/gardener/gardener/pkg/gardenlet/features"
 )
 
 func TestContainerD(t *testing.T) {
+	features.RegisterFeatureGates()
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Component Extensions OperatingSystemConfig Original Components ContainerD Suite")
 }

--- a/pkg/component/extensions/operatingsystemconfig/original/components/containerd/initializer.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/containerd/initializer.go
@@ -25,6 +25,7 @@ import (
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/original/components"
+	"github.com/gardener/gardener/pkg/features"
 	"github.com/gardener/gardener/pkg/utils"
 	"github.com/gardener/gardener/pkg/utils/images"
 )
@@ -66,8 +67,9 @@ func (initializer) Config(ctx components.Context) ([]extensionsv1alpha1.Unit, []
 
 	var script bytes.Buffer
 	if err := tplInitializer.Execute(&script, map[string]interface{}{
-		"binaryPath":          extensionsv1alpha1.ContainerDRuntimeContainersBinFolder,
-		"pauseContainerImage": ctx.Images[images.ImageNamePauseContainer],
+		"binaryPath":                        extensionsv1alpha1.ContainerDRuntimeContainersBinFolder,
+		"pauseContainerImage":               ctx.Images[images.ImageNamePauseContainer],
+		"containerdRegistryHostsDirEnabled": features.DefaultFeatureGate.Enabled(features.ContainerdRegistryHostsDir),
 	}); err != nil {
 		return nil, nil, err
 	}

--- a/pkg/component/extensions/operatingsystemconfig/original/components/containerd/initializer_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/containerd/initializer_test.go
@@ -125,7 +125,7 @@ else
     echo "CRI registry section is already gardener managed. Nothing to do."
   else
     echo "CRI registry section is not gardener managed. Setting config_path = \"$CONFIG_PATH\" in $FILE."
-    sed --null-data --in-place 's/\(\[plugins\."io\.containerd\.grpc\.v1\.cri"\.registry\]\)\n\(\s*config_path = \)""\n/\1 \# gardener-managed\n\2"\/etc\/containerd\/certs.d"\n/' "$FILE"
+    sed --null-data --in-place 's/\(\[plugins\."io\.containerd\.grpc\.v1\.cri"\.registry\]\)\n\(\s*config_path\s*=\s*\)""\n/\1 \# gardener-managed\n\2"\/etc\/containerd\/certs.d"\n/' "$FILE"
   fi
 fi`
 	} else {

--- a/pkg/component/extensions/operatingsystemconfig/original/components/containerd/templates/scripts/init.tpl.sh
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/containerd/templates/scripts/init.tpl.sh
@@ -11,6 +11,37 @@ sandbox_image_line="$(grep sandbox_image $FILE | sed -e 's/^[ ]*//')"
 pause_image={{ .pauseContainerImage }}
 sed -i  "s|$sandbox_image_line|sandbox_image = \"$pause_image\"|g" $FILE
 
+# create and configure registry hosts directory
+# or remove registry hosts directory configuration
+{{- if .containerdRegistryHostsDirEnabled }}
+CONFIG_PATH=/etc/containerd/certs.d
+mkdir -p "$CONFIG_PATH"
+if ! grep --quiet --fixed-strings '[plugins."io.containerd.grpc.v1.cri".registry]' "$FILE"; then
+  echo "CRI registry section not found. Adding CRI registry section with config_path = \"$CONFIG_PATH\" in $FILE."
+  # TODO(ialidzhikov): Drop the "# gardener-managed" comment when removing the ContainerdRegistryHostsDir feature gate.
+  # Currently we need such comment to distinguish whether the config is added by this script or externally by the Shoot owner.
+  # When the feature gate is disabled, the config section is being removed only when it was added by this script.
+  cat <<EOF >> $FILE
+[plugins."io.containerd.grpc.v1.cri".registry] # gardener-managed
+  config_path = "/etc/containerd/certs.d"
+EOF
+else
+  if grep --quiet --fixed-strings '[plugins."io.containerd.grpc.v1.cri".registry] # gardener-managed' "$FILE"; then
+    echo "CRI registry section is already gardener managed. Nothing to do."
+  else
+    echo "CRI registry section is not gardener managed. Setting config_path = \"$CONFIG_PATH\" in $FILE."
+    sed --null-data --in-place 's/\(\[plugins\."io\.containerd\.grpc\.v1\.cri"\.registry\]\)\n\(\s*config_path = \)""\n/\1 \# gardener-managed\n\2"\/etc\/containerd\/certs.d"\n/' "$FILE"
+  fi
+fi
+{{- else }}
+if grep --quiet --fixed-strings '[plugins."io.containerd.grpc.v1.cri".registry] # gardener-managed' "$FILE"; then
+  echo "CRI registry section is gardener managed. Removing CRI registry section from $FILE."
+  sed --null-data --in-place 's/\[plugins\."io\.containerd\.grpc\.v1\.cri"\.registry\]\ #\ gardener-managed\n\s*config_path.*\n//' "$FILE"
+else
+  echo "A gardener managed CRI section is not found. Nothing to do."
+fi
+{{- end }}
+
 # allow to import custom configuration files
 CUSTOM_CONFIG_DIR=/etc/containerd/conf.d
 CUSTOM_CONFIG_FILES="$CUSTOM_CONFIG_DIR/*.toml"

--- a/pkg/component/extensions/operatingsystemconfig/original/components/containerd/templates/scripts/init.tpl.sh
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/containerd/templates/scripts/init.tpl.sh
@@ -30,7 +30,7 @@ else
     echo "CRI registry section is already gardener managed. Nothing to do."
   else
     echo "CRI registry section is not gardener managed. Setting config_path = \"$CONFIG_PATH\" in $FILE."
-    sed --null-data --in-place 's/\(\[plugins\."io\.containerd\.grpc\.v1\.cri"\.registry\]\)\n\(\s*config_path = \)""\n/\1 \# gardener-managed\n\2"\/etc\/containerd\/certs.d"\n/' "$FILE"
+    sed --null-data --in-place 's/\(\[plugins\."io\.containerd\.grpc\.v1\.cri"\.registry\]\)\n\(\s*config_path\s*=\s*\)""\n/\1 \# gardener-managed\n\2"\/etc\/containerd\/certs.d"\n/' "$FILE"
   fi
 fi
 {{- else }}

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -76,6 +76,21 @@ const (
 	// owner: @voelzmo, @andrerun
 	// alpha: v1.73.0
 	DisableScalingClassesForShoots featuregate.Feature = "DisableScalingClassesForShoots"
+
+	// ContainerdRegistryHostsDir enables registry configuration in containerd based on the hosts directory pattern.
+	// The hosts directory pattern is the new way of configuring registries/mirrors in containerd.
+	// Ref https://github.com/containerd/containerd/blob/main/docs/hosts.md.
+	// When this feature gate is enabled, gardenlet adds the following config to containerd's config.toml:
+	//
+	// [plugins."io.containerd.grpc.v1.cri".registry] # gardener-managed
+	//   config_path = "/etc/containerd/certs.d"
+	//
+	// This config allows registries to be configured by creating new hosts.toml files under the predefined
+	// /etc/containerd/certs.d directory.
+	//
+	// owner: @ialidzhikov, @dimitar-kostadinov
+	// alpha: v1.76.0
+	ContainerdRegistryHostsDir featuregate.Feature = "ContainerdRegistryHostsDir"
 )
 
 // DefaultFeatureGate is the central feature gate map used by all gardener components.
@@ -112,6 +127,7 @@ var AllFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	WorkerlessShoots:                   {Default: false, PreRelease: featuregate.Alpha},
 	MachineControllerManagerDeployment: {Default: false, PreRelease: featuregate.Alpha},
 	DisableScalingClassesForShoots:     {Default: false, PreRelease: featuregate.Alpha},
+	ContainerdRegistryHostsDir:         {Default: false, PreRelease: featuregate.Alpha},
 }
 
 // GetFeatures returns a feature gate map with the respective specifications. Non-existing feature gates are ignored.

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -89,7 +89,7 @@ const (
 	// /etc/containerd/certs.d directory.
 	//
 	// owner: @ialidzhikov, @dimitar-kostadinov
-	// alpha: v1.76.0
+	// alpha: v1.77.0
 	ContainerdRegistryHostsDir featuregate.Feature = "ContainerdRegistryHostsDir"
 )
 

--- a/pkg/gardenlet/features/features.go
+++ b/pkg/gardenlet/features/features.go
@@ -36,5 +36,6 @@ func GetFeatures() []featuregate.Feature {
 		features.IPv6SingleStack,
 		features.MachineControllerManagerDeployment,
 		features.DisableScalingClassesForShoots,
+		features.ContainerdRegistryHostsDir,
 	}
 }

--- a/pkg/provider-local/webhook/controlplane/controlplane_suite_test.go
+++ b/pkg/provider-local/webhook/controlplane/controlplane_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controlplane_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestControlPlaneWebhook(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "ControlPlane Webhook Suite")
+}

--- a/pkg/provider-local/webhook/controlplane/controlplane_suite_test.go
+++ b/pkg/provider-local/webhook/controlplane/controlplane_suite_test.go
@@ -23,5 +23,5 @@ import (
 
 func TestControlPlaneWebhook(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "ControlPlane Webhook Suite")
+	RunSpecs(t, "Provider-Local Webhook ControlPlane Suite")
 }

--- a/pkg/provider-local/webhook/controlplane/ensurer.go
+++ b/pkg/provider-local/webhook/controlplane/ensurer.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"context"
 	_ "embed"
+	"path/filepath"
 	"text/template"
 
 	"github.com/Masterminds/semver"
@@ -163,6 +164,32 @@ Requires=` + unitNameInitializer,
 		},
 	})
 
+	mirrors := []RegistryMirror{
+		{UpstreamHost: "localhost:5001", UpstreamServer: "http://localhost:5001", MirrorHost: "http://garden.local.gardener.cloud:5001"},
+		{UpstreamHost: "gcr.io", UpstreamServer: "https://gcr.io", MirrorHost: "http://garden.local.gardener.cloud:5003"},
+		{UpstreamHost: "eu.gcr.io", UpstreamServer: "https://eu.gcr.io", MirrorHost: "http://garden.local.gardener.cloud:5004"},
+		{UpstreamHost: "ghcr.io", UpstreamServer: "https://ghcr.io", MirrorHost: "http://garden.local.gardener.cloud:5005"},
+		{UpstreamHost: "registry.k8s.io", UpstreamServer: "https://registry.k8s.io", MirrorHost: "http://garden.local.gardener.cloud:5006"},
+		{UpstreamHost: "quay.io", UpstreamServer: "https://quay.io", MirrorHost: "http://garden.local.gardener.cloud:5007"},
+	}
+
+	for _, mirror := range mirrors {
+		// appendFileIfNotPresent in used instead of appendUniqueFile intentionally to allow enabling and testing the registry-cache extension in local setup.
+		// A file appended by the registry-cache extension is always picked up because:
+		// - if a file is already appended by the registry-cache extension, provider-local won't overwrite it (appendFileIfNotPresent)
+		// - if a file is already appended by provider-local, the registry-cache extension will overwrite it (appendUniqueFile)
+		appendFileIfNotPresent(new, extensionsv1alpha1.File{
+			Path:        filepath.Join("/etc/containerd/certs.d", mirror.UpstreamHost, "hosts.toml"),
+			Permissions: pointer.Int32(0644),
+			Content: extensionsv1alpha1.FileContent{
+				Inline: &extensionsv1alpha1.FileContentInline{
+					Encoding: "",
+					Data:     mirror.HostsTOML(),
+				},
+			},
+		})
+	}
+
 	return nil
 }
 
@@ -204,6 +231,12 @@ func appendUniqueFile(files *[]extensionsv1alpha1.File, file extensionsv1alpha1.
 	*files = append(resFiles, file)
 }
 
+func appendFileIfNotPresent(files *[]extensionsv1alpha1.File, file extensionsv1alpha1.File) {
+	if !containsFilePath(files, file.Path) {
+		*files = append(*files, file)
+	}
+}
+
 // appendUniqueUnit appends a unit only if it does not exist, otherwise overwrite content of previous unit
 func appendUniqueUnit(units *[]extensionsv1alpha1.Unit, unit extensionsv1alpha1.Unit) {
 	resFiles := make([]extensionsv1alpha1.Unit, 0, len(*units))
@@ -215,4 +248,14 @@ func appendUniqueUnit(units *[]extensionsv1alpha1.Unit, unit extensionsv1alpha1.
 	}
 
 	*units = append(resFiles, unit)
+}
+
+func containsFilePath(files *[]extensionsv1alpha1.File, filePath string) bool {
+	for _, f := range *files {
+		if f.Path == filePath {
+			return true
+		}
+	}
+
+	return false
 }

--- a/pkg/provider-local/webhook/controlplane/ensurer.go
+++ b/pkg/provider-local/webhook/controlplane/ensurer.go
@@ -183,8 +183,7 @@ Requires=` + unitNameInitializer,
 			Permissions: pointer.Int32(0644),
 			Content: extensionsv1alpha1.FileContent{
 				Inline: &extensionsv1alpha1.FileContentInline{
-					Encoding: "",
-					Data:     mirror.HostsTOML(),
+					Data: mirror.HostsTOML(),
 				},
 			},
 		})

--- a/pkg/provider-local/webhook/controlplane/registry_mirror.go
+++ b/pkg/provider-local/webhook/controlplane/registry_mirror.go
@@ -1,0 +1,36 @@
+// Copyright 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controlplane
+
+import (
+	"fmt"
+)
+
+// RegistryMirror represents a registry mirror for containerd.
+type RegistryMirror struct {
+	UpstreamHost   string
+	UpstreamServer string
+	MirrorHost     string
+}
+
+// HostsTOML returns hosts.toml configuration.
+func (r *RegistryMirror) HostsTOML() string {
+	const hostsTOMLYAMLTemplate = `server = "%s"
+
+[host."%s"]
+  capabilities = ["pull", "resolve"]
+`
+	return fmt.Sprintf(hostsTOMLYAMLTemplate, r.UpstreamServer, r.MirrorHost)
+}

--- a/pkg/provider-local/webhook/controlplane/registry_mirror_test.go
+++ b/pkg/provider-local/webhook/controlplane/registry_mirror_test.go
@@ -1,0 +1,36 @@
+// Copyright 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controlplane_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/gardener/gardener/pkg/provider-local/webhook/controlplane"
+)
+
+var _ = Describe("RegistryMirror", func() {
+	Describe("HostsTOML", func() {
+		It("should return the expected hosts.toml", func() {
+			mirror := controlplane.RegistryMirror{UpstreamServer: "http://localhost:5001", MirrorHost: "http://garden.local.gardener.cloud:5001"}
+
+			Expect(mirror.HostsTOML()).To(Equal(`server = "http://localhost:5001"
+
+[host."http://garden.local.gardener.cloud:5001"]
+  capabilities = ["pull", "resolve"]
+`))
+		})
+	})
+})

--- a/pkg/provider-local/webhook/controlplane/templates/scripts/configure-containerd.tpl.sh
+++ b/pkg/provider-local/webhook/controlplane/templates/scripts/configure-containerd.tpl.sh
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 # TODO(alidzhikov): The following code is migration code to ensure graceful enablement of the ContainerdRegistryHostsDir feature 
-# for existing Shoots with provider-local. Remove this script and the related units/files in v1.78.
+# for existing Shoots with provider-local. Remove this script and the related units/files in v1.79.
 FILENAME=/etc/containerd/config.toml
 if grep --quiet --fixed-strings '[plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:5001"]' "$FILENAME"; then
   sed -i -E '/\[plugins\."io\.containerd\.grpc\.v1\.cri"\.registry\.mirrors\."localhost:5001"\]/,+11d' $FILENAME

--- a/pkg/provider-local/webhook/controlplane/templates/scripts/configure-containerd.tpl.sh
+++ b/pkg/provider-local/webhook/controlplane/templates/scripts/configure-containerd.tpl.sh
@@ -13,26 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
-hostname=garden.local.gardener.cloud
-
+# TODO(alidzhikov): The following code is migration code to ensure graceful enablement of the ContainerdRegistryHostsDir feature 
+# for existing Shoots with provider-local. Remove this script and the related units/files in v1.78.
 FILENAME=/etc/containerd/config.toml
-if ! grep -q plugins.\"io.containerd.grpc.v1.cri\".registry.mirrors.\"localhost:5001\" "$FILENAME"; then
-  cat <<EOF >> $FILENAME
-[plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:5001"]
-  endpoint = ["http://$hostname:5001"]
-[plugins."io.containerd.grpc.v1.cri".registry.mirrors."gcr.io"]
-  endpoint = ["http://$hostname:5003"]
-[plugins."io.containerd.grpc.v1.cri".registry.mirrors."eu.gcr.io"]
-  endpoint = ["http://$hostname:5004"]
-[plugins."io.containerd.grpc.v1.cri".registry.mirrors."ghcr.io"]
-  endpoint = ["http://$hostname:5005"]
-[plugins."io.containerd.grpc.v1.cri".registry.mirrors."registry.k8s.io"]
-  endpoint = ["http://$hostname:5006"]
-[plugins."io.containerd.grpc.v1.cri".registry.mirrors."quay.io"]
-  endpoint = ["http://$hostname:5007"]
-EOF
-  echo "Configured containerd with registry mirrors for local-setup."
-else
-  echo "Containerd already configured with registry mirrors."
+if grep --quiet --fixed-strings '[plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:5001"]' "$FILENAME"; then
+  sed -i -E '/\[plugins\."io\.containerd\.grpc\.v1\.cri"\.registry\.mirrors\."localhost:5001"\]/,+11d' $FILENAME
+  echo "Cleaned up old registry mirrors configuration for local-setup."
 fi

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -606,6 +606,7 @@ build:
         - pkg/controllerutils/predicate
         - pkg/controllerutils/reconciler
         - pkg/extensions
+        - pkg/features
         - pkg/gardenlet/apis/config
         - pkg/gardenlet/apis/config/v1alpha1
         - pkg/healthz


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area cost
/kind enhancement

**What this PR does / why we need it**:
Currently there are two configuration patterns for configuring containerd registries. As part of https://github.com/gardener/gardener-extension-registry-cache/issues/3, for the registry-cache extension we decided to use the new and recommended configuration pattern - [hosts directory pattern](https://github.com/containerd/containerd/blob/main/docs/hosts.md).
Only one of the configuration patterns has to be followed strictly. In order to realise the hosts directory pattern in the registry-cache, we have to adapt registry config contributed by provider-local to be in hosts directory pattern.
We decided gardenlet (containerd-initializer unit's script) to take over to create the `/etc/containerd/certs.d` dir and to add the following config to containerd's config.toml:
```toml
[plugins."io.containerd.grpc.v1.cri".registry]
   config_path = "/etc/containerd/certs.d"
```

Providing such config should be okay for Shoots that don't want to configure containerd registries and should not have any side effects.
The motivation to introduce this handling in gardenlet (containerd-initializer unit's script):
- Expose the containerd registry configuration as feature (similar to the containerd's import feature). End users need to created only dir and hosts.toml file under `/etc/containerd/certs.d` to configure containerd registries.
- Make it easier for extensions (provider-local and gardener-extension-registry-cache) to contribute registry config. With this feature, such extensions only have to mutate the OperatingSystemConfig resource and add the corresponding config files there. And they don't need to add systemd units that append/remove containerd config.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener-extension-registry-cache/issues/3

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
A new feature gate named `ContainerdRegistryHostsDir` is introduced to gardenlet. When enabled, the `/etc/containerd/certs.d` directory is created on the Node and containerd is configured to look up for registries/mirrors configuration in this directory (if there is any configuration applied). In future, the [registry-cache extension](https://github.com/gardener/gardener-extension-registry-cache/) will add such registries/mirrors configuration under this directory (via OperatingSystemConfig mutation).
```
