### PR TITLE
Update images.yaml - set logging responsibles

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -421,6 +421,10 @@ images:
       confidentiality_requirement: 'low'
       integrity_requirement: 'low'
       availability_requirement: 'low'
+  - name: 'cloud.gardener.cnudie/responsibles'
+    value:
+    - type: 'githubTeam'
+      teamname: 'gardener/logging-maintainers'
 - name: fluent-bit
   sourceRepository: github.com/fluent/fluent-operator
   repository: eu.gcr.io/gardener-project/3rd/kubesphere/fluent-bit
@@ -434,6 +438,10 @@ images:
       confidentiality_requirement: 'high'
       integrity_requirement: 'low'
       availability_requirement: 'low'
+  - name: 'cloud.gardener.cnudie/responsibles'
+    value:
+    - type: 'githubTeam'
+      teamname: 'gardener/logging-maintainers'
 - name: fluent-bit-plugin-installer
   resourceId:
     name: fluent-bit-to-vali
@@ -450,6 +458,10 @@ images:
       integrity_requirement: 'none'
       availability_requirement: 'none'
       comment: no data is stored or processed by the installer
+  - name: 'cloud.gardener.cnudie/responsibles'
+    value:
+    - type: 'githubTeam'
+      teamname: 'gardener/logging-maintainers'
 - name: vali
   sourceRepository: github.com/credativ/vali
   repository: ghcr.io/credativ/vali
@@ -463,6 +475,10 @@ images:
       confidentiality_requirement: 'high'
       integrity_requirement: 'high'
       availability_requirement: 'low'
+  - name: 'cloud.gardener.cnudie/responsibles'
+    value:
+    - type: 'githubTeam'
+      teamname: 'gardener/logging-maintainers'
 - name: vali-curator
   sourceRepository: github.com/gardener/logging
   repository: eu.gcr.io/gardener-project/gardener/vali-curator
@@ -476,6 +492,10 @@ images:
       confidentiality_requirement: 'none'
       integrity_requirement: 'high'
       availability_requirement: 'low'
+  - name: 'cloud.gardener.cnudie/responsibles'
+    value:
+    - type: 'githubTeam'
+      teamname: 'gardener/logging-maintainers'
 - name: kube-rbac-proxy
   sourceRepository: github.com/brancz/kube-rbac-proxy
   repository: quay.io/brancz/kube-rbac-proxy
@@ -490,6 +510,10 @@ images:
       integrity_requirement: 'high'
       availability_requirement: 'low'
       comment: kube-rbac-proxy is an authentication proxy working with credentials
+  - name: 'cloud.gardener.cnudie/responsibles'
+    value:
+    - type: 'githubTeam'
+      teamname: 'gardener/logging-maintainers'
 - name: valitail
   sourceRepository: github.com/credativ/vali
   repository: ghcr.io/credativ/valitail
@@ -504,6 +528,10 @@ images:
       integrity_requirement: 'high'
       availability_requirement: 'low'
       comment: network exposure is public due to the outbound connectivity, there is no exposed endpoint requiring auth.
+  - name: 'cloud.gardener.cnudie/responsibles'
+    value:
+    - type: 'githubTeam'
+      teamname: 'gardener/logging-maintainers'
 - name: telegraf
   resourceId:
     name: telegraf-iptables
@@ -522,6 +550,10 @@ images:
       comment: >
         telegraf is not accessible from outside the seed cluster and does not
         interact with confidential data
+  - name: 'cloud.gardener.cnudie/responsibles'
+    value:
+    - type: 'githubTeam'
+      teamname: 'gardener/logging-maintainers'
 - name: event-logger
   sourceRepository: github.com/gardener/logging
   repository: eu.gcr.io/gardener-project/gardener/event-logger
@@ -535,6 +567,10 @@ images:
       confidentiality_requirement: 'high'
       integrity_requirement: 'high'
       availability_requirement: 'low'
+  - name: 'cloud.gardener.cnudie/responsibles'
+    value:
+    - type: 'githubTeam'
+      teamname: 'gardener/logging-maintainers'
 - name: tune2fs
   sourceRepository: github.com/gardener/logging
   repository: eu.gcr.io/gardener-project/gardener/tune2fs
@@ -548,6 +584,10 @@ images:
       confidentiality_requirement: 'none'
       integrity_requirement: 'none'
       availability_requirement: 'low'
+  - name: 'cloud.gardener.cnudie/responsibles'
+    value:
+    - type: 'githubTeam'
+      teamname: 'gardener/logging-maintainers'
 
 # VPA
 - name: vpa-admission-controller


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area logging
/kind enhancement

**What this PR does / why we need it**:
Sets 'cloud.gardener.cnudie/responsibles' labels for logging component

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
