### PR TITLE
Fix flaky gardener operator tests caused by concurrent writes to garden object.

### DIFF
--- a/pkg/operator/controller/garden/components.go
+++ b/pkg/operator/controller/garden/components.go
@@ -643,6 +643,9 @@ func (r *Reconciler) newSNI(garden *operatorv1alpha1.Garden, ingressGatewayValue
 		return nil, fmt.Errorf("exactly one Istio Ingress Gateway is required for the SNI config")
 	}
 
+	// Explicitly render server domain at initialization time as garden object may be changed by kubernetes clients later on
+	serverDomain := gardenerutils.GetAPIServerDomain(garden.Spec.VirtualCluster.DNS.Domain)
+
 	return kubeapiserverexposure.NewSNI(
 		r.RuntimeClientSet.Client(),
 		r.RuntimeClientSet.Applier(),
@@ -650,7 +653,7 @@ func (r *Reconciler) newSNI(garden *operatorv1alpha1.Garden, ingressGatewayValue
 		r.GardenNamespace,
 		func() *kubeapiserverexposure.SNIValues {
 			return &kubeapiserverexposure.SNIValues{
-				Hosts: []string{gardenerutils.GetAPIServerDomain(garden.Spec.VirtualCluster.DNS.Domain)},
+				Hosts: []string{serverDomain},
 				IstioIngressGateway: kubeapiserverexposure.IstioIngressGateway{
 					Namespace: ingressGatewayValues[0].Namespace,
 					Labels:    ingressGatewayValues[0].Labels,


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind flake

**What this PR does / why we need it**:
Fix flaky gardener operator tests caused by concurrent writes to garden object.

Gardener operator tests sometimes failed when accessing the virtual kube-apiserver. The result was usually a connection reset. This was due to the fact that istio closed the corresponding port as it was reconfigured to use a different host name for the gateway resource and hence had no matching virtual service/destination rule. The original reason for the different host name with a missing suffix was probably the concurrent update of the garden resource due to a parallel write (see https://github.com/gardener/gardener/blob/master/docs/development/kubernetes-clients.md). Therefore, the domain name is now calculated ahead of use during initialization when the garden object is not changed concurrently.

**Which issue(s) this PR fixes**:
Fixes #8036 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Fixed flaky operator behaviour with regards to istio deployment caused by concurrent update of garden object
```
