### PR TITLE
deploy Controlplane config chart on deletion

### DIFF
--- a/extensions/pkg/controller/controlplane/genericactuator/actuator_test.go
+++ b/extensions/pkg/controller/controlplane/genericactuator/actuator_test.go
@@ -470,6 +470,12 @@ webhooks:
 				atomicWebhookConfig.Store(webhookConfig)
 			}
 
+			// Create mock values provider
+			vp := extensionsmockgenericactuator.NewMockValuesProvider(ctrl)
+
+			// Create mock chart applier
+			chartApplier := kubernetesmock.NewMockChartApplier(ctrl)
+
 			// Create mock clients
 			client := mockclient.NewMockClient(ctrl)
 
@@ -494,6 +500,8 @@ webhooks:
 			var configChart chart.Interface
 			if configName != "" {
 				configChartMock := mockchartutil.NewMockInterface(ctrl)
+				vp.EXPECT().GetConfigChartValues(ctx, cp, cluster).Return(configChartValues, nil)
+				configChartMock.EXPECT().Apply(ctx, chartApplier, namespace, nil, "", "", configChartValues).Return(nil)
 				configChartMock.EXPECT().Delete(ctx, client, namespace).Return(nil)
 				configChart = configChartMock
 			}
@@ -511,9 +519,10 @@ webhooks:
 			client.EXPECT().Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: shootAccessSecretsFunc(namespace)[0].Secret.Name, Namespace: namespace}})
 
 			// Create actuator
-			a := NewActuator(providerName, getSecretsConfigs, shootAccessSecretsFunc, nil, nil, configChart, ccmChart, nil, cpShootCRDsChart, nil, nil, nil, nil, nil, configName, atomicWebhookConfig, webhookServerNamespace, webhookServerPort)
+			a := NewActuator(providerName, getSecretsConfigs, shootAccessSecretsFunc, nil, nil, configChart, ccmChart, nil, cpShootCRDsChart, nil, nil, vp, nil, nil, configName, atomicWebhookConfig, webhookServerNamespace, webhookServerPort)
 			Expect(a.(inject.Client).InjectClient(client)).To(Succeed())
 			a.(*actuator).newSecretsManager = newSecretsManager
+			a.(*actuator).chartApplier = chartApplier
 
 			// Call Delete method and check the result
 			Expect(a.Delete(ctx, logger, cp, cluster)).To(Succeed())


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug

**What this PR does / why we need it**:
While preferable, it is not the case that we can always configure the credentials for components (e.g. CCM and CSI) using the cloudprovider secret. Some of these components require specialised config files. To update these we need to redeploy the config chart after the cloudprovider secret has been updated. 

During deletion Gardener does in fact  update the configuration chart but under certain conditions this does not happen. One of these is the when the controlplane resource already has a deletion timestamp, in which case, the actuator will skip the chart update.

This can lead to deadlock in certain cases, one described by https://github.com/gardener/gardener-extension-provider-azure/issues/601. For the issue mentioned, the root cause is the need to deploy managed resources inside the shoot as part of the control plane deployment. The deletion cannot proceed if the credentials have not been updated, but by the time the user realizes that (during CP deletion), the CP resource will not try to redeploy the config chart and thus breaking the deadlock.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener-extension-provider-azure/issues/601

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix developer
On deletion, the generic `ControlPlane` actuator will now redeploy the cloud config chart to allow provider extensions update the content with the most up-to-date information.
```
