### PR TITLE
Bump up vali version to v2.2.6

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -453,7 +453,7 @@ images:
 - name: vali
   sourceRepository: github.com/credativ/vali
   repository: ghcr.io/credativ/vali
-  tag: "v2.2.5"
+  tag: "v2.2.6"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:
@@ -493,7 +493,7 @@ images:
 - name: valitail
   sourceRepository: github.com/credativ/vali
   repository: ghcr.io/credativ/valitail
-  tag: "v2.2.5"
+  tag: "v2.2.6"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:


### PR DESCRIPTION
/area  logging
/kind enhancement

This PR brings `vali` version to [v2.2.6](https://github.com/credativ/vali/releases/tag/v2.2.6)
This version features updates in the build `golang` libraries and in the container base image.

```other operator
Vali is now updated to version v2.2.6
```
