### PR TITLE
Drop temporary cleanup code for old `fluent-bit`

### DIFF
--- a/charts/gardener/gardenlet/templates/clusterrole-gardenlet.yaml
+++ b/charts/gardener/gardenlet/templates/clusterrole-gardenlet.yaml
@@ -184,8 +184,6 @@ rules:
   resources:
   - deployments
   - deployments/scale
-  # TODO(Kristian-ZH): remove this when the old fluent-bit deletion logic is removed
-  - daemonsets
   - statefulsets
   - statefulsets/scale
   - replicasets

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -407,7 +407,7 @@ const (
 	// LabelMonitoring is a constant for a label for monitoring stack configurations
 	LabelMonitoring = "monitoring"
 	// LabelKeyCustomLoggingResource is the key of the label which is used from the operator to select the CustomResources which will be imported in the FluentBit configuration.
-	// TODO(Kristian-ZH): the label key has to be migrated to "fluentbit.gardener.cloud/type".
+	// TODO(nickytd): the label key has to be migrated to "fluentbit.gardener.cloud/type".
 	LabelKeyCustomLoggingResource = "fluentbit.gardener/type"
 	// LabelValueCustomLoggingResource is the value of the label which is used from the operator to select the CustomResources which will be imported in the FluentBit configuration.
 	LabelValueCustomLoggingResource = "seed"

--- a/pkg/gardenlet/controller/managedseed/charttest/charttest.go
+++ b/pkg/gardenlet/controller/managedseed/charttest/charttest.go
@@ -284,7 +284,7 @@ func getGardenletClusterRole(labels map[string]string) *rbacv1.ClusterRole {
 			},
 			{
 				APIGroups: []string{"apps"},
-				Resources: []string{"deployments", "deployments/scale", "daemonsets", "statefulsets", "statefulsets/scale", "replicasets"},
+				Resources: []string{"deployments", "deployments/scale", "statefulsets", "statefulsets/scale", "replicasets"},
 				Verbs:     []string{"create", "delete", "deletecollection", "get", "list", "watch", "patch", "update"},
 			},
 			{

--- a/pkg/gardenlet/controller/seed/seed/reconciler_reconcile_test.go
+++ b/pkg/gardenlet/controller/seed/seed/reconciler_reconcile_test.go
@@ -24,7 +24,6 @@ import (
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -229,124 +228,6 @@ var _ = Describe("Reconcile", func() {
 			runtimeClient.EXPECT().Delete(ctx, valiPVC)
 			runtimeClient.EXPECT().Delete(ctx, statefulset).Return(errForbidden)
 			Expect(ResizeOrDeleteValiDataVolumeIfStorageNotTheSame(ctx, log, runtimeClient, new80GiStorageQuantity)).ToNot(Succeed())
-		})
-	})
-
-	Describe("#CleanupOldFluentBit", func() {
-		const (
-			fluentBitName   = "fluent-bit"
-			gardenNamespace = "garden"
-		)
-
-		var (
-			ctrl          *gomock.Controller
-			runtimeClient *mockclient.MockClient
-			ctx           = context.TODO()
-
-			fluentBitClusterRole        = &rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: fluentBitName + "-read"}}
-			fluentBitClusterRoleBinding = &rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: fluentBitName + "-read"}}
-			fluentBitDaemonSet          = &appsv1.DaemonSet{ObjectMeta: metav1.ObjectMeta{Name: fluentBitName, Namespace: gardenNamespace}}
-			fluentBitService            = &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: fluentBitName, Namespace: gardenNamespace}}
-			fluentBitServiceAccount     = &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: fluentBitName, Namespace: gardenNamespace}}
-
-			fluentOperatorOwnerReferenceKind       = "FluentBit"
-			fluentOperatorOwnerReferenceAPIVersion = "fluentbit.fluent.io/v1alpha2"
-
-			managedByOperatorDaemonSet = &appsv1.DaemonSet{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      fluentBitName,
-					Namespace: gardenNamespace,
-					OwnerReferences: []metav1.OwnerReference{
-						{Kind: fluentOperatorOwnerReferenceKind, APIVersion: fluentOperatorOwnerReferenceAPIVersion},
-					},
-				},
-			}
-
-			managedByOperatorService = &corev1.Service{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      fluentBitName,
-					Namespace: gardenNamespace,
-					OwnerReferences: []metav1.OwnerReference{
-						{Kind: fluentOperatorOwnerReferenceKind, APIVersion: fluentOperatorOwnerReferenceAPIVersion},
-					},
-				},
-			}
-
-			managedByOperatorServiceAccount = &corev1.ServiceAccount{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      fluentBitName,
-					Namespace: gardenNamespace,
-					OwnerReferences: []metav1.OwnerReference{
-						{Kind: fluentOperatorOwnerReferenceKind, APIVersion: fluentOperatorOwnerReferenceAPIVersion},
-					},
-				},
-			}
-
-			funcGetManagedByOperatorFluentBitDaemonSet = func(_ context.Context, _ types.NamespacedName, ds *appsv1.DaemonSet, _ ...client.GetOption) error {
-				*ds = *managedByOperatorDaemonSet
-				return nil
-			}
-
-			funcGetNotManagedByOperatorFluentBitDaemonSet = func(_ context.Context, _ types.NamespacedName, ds *appsv1.DaemonSet, _ ...client.GetOption) error {
-				*ds = *fluentBitDaemonSet
-				return nil
-			}
-
-			funcGetManagedByOperatorFluentBitService = func(_ context.Context, _ types.NamespacedName, svc *corev1.Service, _ ...client.GetOption) error {
-				*svc = *managedByOperatorService
-				return nil
-			}
-
-			funcGetNotManagedByOperatorFluentBitService = func(_ context.Context, _ types.NamespacedName, svc *corev1.Service, _ ...client.GetOption) error {
-				*svc = *fluentBitService
-				return nil
-			}
-
-			funcGetManagedByOperatorFluentBitServiceAccount = func(_ context.Context, _ types.NamespacedName, sa *corev1.ServiceAccount, _ ...client.GetOption) error {
-				*sa = *managedByOperatorServiceAccount
-				return nil
-			}
-
-			funcGetNotManagedByOperatorFluentBitServiceAccount = func(_ context.Context, _ types.NamespacedName, sa *corev1.ServiceAccount, _ ...client.GetOption) error {
-				*sa = *fluentBitServiceAccount
-				return nil
-			}
-		)
-
-		BeforeEach(func() {
-			ctrl = gomock.NewController(GinkgoT())
-			runtimeClient = mockclient.NewMockClient(ctrl)
-		})
-
-		AfterEach(func() {
-			ctrl.Finish()
-		})
-
-		It("should delete all fluent bit resources if they are not managed by the fluent operator", func() {
-			gomock.InOrder(
-				runtimeClient.EXPECT().Get(ctx, kubernetesutils.Key(fluentBitDaemonSet.GetNamespace(), fluentBitDaemonSet.GetName()), fluentBitDaemonSet).DoAndReturn(funcGetNotManagedByOperatorFluentBitDaemonSet),
-				runtimeClient.EXPECT().Get(ctx, kubernetesutils.Key(fluentBitService.GetNamespace(), fluentBitService.GetName()), fluentBitService).DoAndReturn(funcGetNotManagedByOperatorFluentBitService),
-				runtimeClient.EXPECT().Get(ctx, kubernetesutils.Key(fluentBitServiceAccount.GetNamespace(), fluentBitServiceAccount.GetName()), fluentBitServiceAccount).DoAndReturn(funcGetNotManagedByOperatorFluentBitServiceAccount),
-				runtimeClient.EXPECT().Delete(ctx, fluentBitDaemonSet),
-				runtimeClient.EXPECT().Delete(ctx, fluentBitService),
-				runtimeClient.EXPECT().Delete(ctx, fluentBitServiceAccount),
-				runtimeClient.EXPECT().Delete(ctx, fluentBitClusterRole),
-				runtimeClient.EXPECT().Delete(ctx, fluentBitClusterRoleBinding),
-			)
-
-			Expect(CleanupOldFluentBit(ctx, runtimeClient)).To(Succeed())
-		})
-
-		It("should not delete resources if they are managed by the fluent operator", func() {
-			gomock.InOrder(
-				runtimeClient.EXPECT().Get(ctx, kubernetesutils.Key(fluentBitDaemonSet.GetNamespace(), fluentBitDaemonSet.GetName()), fluentBitDaemonSet).DoAndReturn(funcGetManagedByOperatorFluentBitDaemonSet),
-				runtimeClient.EXPECT().Get(ctx, kubernetesutils.Key(fluentBitService.GetNamespace(), fluentBitService.GetName()), fluentBitService).DoAndReturn(funcGetManagedByOperatorFluentBitService),
-				runtimeClient.EXPECT().Get(ctx, kubernetesutils.Key(fluentBitServiceAccount.GetNamespace(), fluentBitServiceAccount.GetName()), fluentBitServiceAccount).DoAndReturn(funcGetManagedByOperatorFluentBitServiceAccount),
-				runtimeClient.EXPECT().Delete(ctx, fluentBitClusterRole),
-				runtimeClient.EXPECT().Delete(ctx, fluentBitClusterRoleBinding),
-			)
-
-			Expect(CleanupOldFluentBit(ctx, runtimeClient)).To(Succeed())
 		})
 	})
 })


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind cleanup

**What this PR does / why we need it**:
Drop temporary cleanup code for old `fluent-bit`.

**Which issue(s) this PR fixes**:
Follow-up of https://github.com/gardener/gardener/pull/7568

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
