### PR TITLE
Adapt Shoot maintenance controller to disable `EnableStaticTokenKubeconfig` when upgrading Shoot cluster to k8s version >= 1.27

### DIFF
--- a/pkg/controllermanager/controller/shoot/maintenance/reconciler.go
+++ b/pkg/controllermanager/controller/shoot/maintenance/reconciler.go
@@ -144,8 +144,11 @@ func (r *Reconciler) reconcile(ctx context.Context, log logr.Logger, shoot *gard
 	}
 
 	// Reset the `EnableStaticTokenKubeconfig` value to false, when shoot cluster is updated to  k8s version >= 1.27.
-	if versionutils.ConstraintK8sLess127.Check(oldShootKubernetesVersion) && versionutils.ConstraintK8sGreaterEqual127.Check(shootKubernetesVersion) {
+	if versionutils.ConstraintK8sLess127.Check(oldShootKubernetesVersion) && pointer.BoolDeref(maintainedShoot.Spec.Kubernetes.EnableStaticTokenKubeconfig, false) && versionutils.ConstraintK8sGreaterEqual127.Check(shootKubernetesVersion) {
 		maintainedShoot.Spec.Kubernetes.EnableStaticTokenKubeconfig = pointer.Bool(false)
+
+		reason := "EnableStaticTokenKubeconfig is set to false. Reason: The static token kubeconfig can no longer be enabled for Shoot clusters using Kubernetes version 1.27 and higher"
+		operations = append(operations, reason)
 	}
 
 	// Now it's time to update worker pool kubernetes version if specified

--- a/pkg/controllermanager/controller/shoot/maintenance/reconciler.go
+++ b/pkg/controllermanager/controller/shoot/maintenance/reconciler.go
@@ -41,6 +41,7 @@ import (
 	"github.com/gardener/gardener/pkg/controllerutils"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
+	versionutils "github.com/gardener/gardener/pkg/utils/version"
 )
 
 // Reconciler reconciles Shoots and maintains them by updating versions or triggering operations.
@@ -132,9 +133,19 @@ func (r *Reconciler) reconcile(ctx context.Context, log logr.Logger, shoot *gard
 		log.Error(err, "Failed to maintain Shoot kubernetes version")
 	}
 
+	oldShootKubernetesVersion, err := semver.NewVersion(shoot.Spec.Kubernetes.Version)
+	if err != nil {
+		return err
+	}
+
 	shootKubernetesVersion, err := semver.NewVersion(maintainedShoot.Spec.Kubernetes.Version)
 	if err != nil {
 		return err
+	}
+
+	// Reset the `EnableStaticTokenKubeconfig` value to false, when shoot cluster is updated to  k8s version >= 1.27.
+	if versionutils.ConstraintK8sLess127.Check(oldShootKubernetesVersion) && versionutils.ConstraintK8sGreaterEqual127.Check(shootKubernetesVersion) {
+		maintainedShoot.Spec.Kubernetes.EnableStaticTokenKubeconfig = pointer.Bool(false)
 	}
 
 	// Now it's time to update worker pool kubernetes version if specified

--- a/test/integration/controllermanager/shoot/maintenance/maintenance_test.go
+++ b/test/integration/controllermanager/shoot/maintenance/maintenance_test.go
@@ -452,7 +452,7 @@ var _ = Describe("Shoot Maintenance controller tests", func() {
 				}).Should(Equal(testKubernetesVersionHighestPatchLowMinor.Version))
 			})
 
-			It("Kubernetes version should be updated: force update patch version(>= v1.27) and set EnableStaticTokenKubeconfig value to false", func() {
+			It("Kubernetes version should be updated: force update minor version(>= v1.27) and set EnableStaticTokenKubeconfig value to false", func() {
 				By("Expire Shoot's kubernetes version in the CloudProfile")
 				Expect(patchCloudProfileForKubernetesVersionMaintenance(ctx, testClient, shoot126.Spec.CloudProfileName, "1.26.0", &expirationDateInThePast, &deprecatedClassification)).To(Succeed())
 
@@ -465,7 +465,8 @@ var _ = Describe("Shoot Maintenance controller tests", func() {
 					g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(shoot126), shoot126)).To(Succeed())
 					g.Expect(shoot126.Status.LastMaintenance).NotTo(BeNil())
 					g.Expect(*shoot126.Status.LastMaintenance).To(Equal(gardencorev1beta1.LastMaintenance{
-						Description:   "For \"Control Plane\": Kubernetes version upgraded \"1.26.0\" to version \"1.27.0\". Reason: Kubernetes version expired - force update required",
+						Description: "EnableStaticTokenKubeconfig is set to false. Reason: The static token kubeconfig can no longer be enabled for Shoot clusters using Kubernetes version 1.27 and higher" + ", " +
+							"For \"Control Plane\": Kubernetes version upgraded \"1.26.0\" to version \"1.27.0\". Reason: Kubernetes version expired - force update required",
 						TriggeredTime: metav1.Time{Time: fakeClock.Now()},
 						State:         gardencorev1beta1.LastOperationStateSucceeded,
 					}))
@@ -708,7 +709,7 @@ var _ = Describe("Shoot Maintenance controller tests", func() {
 				}).Should(Equal(testKubernetesVersionHighestPatchConsecutiveMinor.Version))
 			})
 
-			It("Kubernetes version should be updated: force update patch version(>= v1.27) and set EnableStaticTokenKubeconfig value to false", func() {
+			It("Kubernetes version should be updated: force update minor version(>= v1.27) and set EnableStaticTokenKubeconfig value to false", func() {
 				By("Expire Shoot's kubernetes version in the CloudProfile")
 				Expect(patchCloudProfileForKubernetesVersionMaintenance(ctx, testClient, shoot126.Spec.CloudProfileName, "1.26.0", &expirationDateInThePast, &deprecatedClassification)).To(Succeed())
 
@@ -721,7 +722,8 @@ var _ = Describe("Shoot Maintenance controller tests", func() {
 					g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(shoot126), shoot126)).To(Succeed())
 					g.Expect(shoot126.Status.LastMaintenance).NotTo(BeNil())
 					g.Expect(*shoot126.Status.LastMaintenance).To(Equal(gardencorev1beta1.LastMaintenance{
-						Description:   "For \"Control Plane\": Kubernetes version upgraded \"1.26.0\" to version \"1.27.0\". Reason: Kubernetes version expired - force update required",
+						Description: "EnableStaticTokenKubeconfig is set to false. Reason: The static token kubeconfig can no longer be enabled for Shoot clusters using Kubernetes version 1.27 and higher" + ", " +
+							"For \"Control Plane\": Kubernetes version upgraded \"1.26.0\" to version \"1.27.0\". Reason: Kubernetes version expired - force update required",
 						TriggeredTime: metav1.Time{Time: fakeClock.Now()},
 						State:         gardencorev1beta1.LastOperationStateSucceeded,
 					}))

--- a/test/integration/controllermanager/shoot/maintenance/maintenance_test.go
+++ b/test/integration/controllermanager/shoot/maintenance/maintenance_test.go
@@ -35,7 +35,7 @@ var _ = Describe("Shoot Maintenance controller tests", func() {
 	var (
 		cloudProfile *gardencorev1beta1.CloudProfile
 		shoot        *gardencorev1beta1.Shoot
-		shoot_126    *gardencorev1beta1.Shoot
+		shoot126     *gardencorev1beta1.Shoot
 
 		// Test Machine Image
 		machineImageName                = "foo-image"
@@ -194,7 +194,7 @@ var _ = Describe("Shoot Maintenance controller tests", func() {
 			},
 		}
 
-		shoot_126 = shoot.DeepCopy()
+		shoot126 = shoot.DeepCopy()
 		// set dummy kubernetes version to shoot
 		shoot.Spec.Kubernetes.Version = testKubernetesVersionLowPatchLowMinor.Version
 
@@ -388,18 +388,19 @@ var _ = Describe("Shoot Maintenance controller tests", func() {
 
 	Describe("Kubernetes version maintenance tests", func() {
 		BeforeEach(func() {
-			shoot_126.Spec.Kubernetes.Version = "1.26.0"
-			shoot_126.Spec.Kubernetes.EnableStaticTokenKubeconfig = pointer.BoolPtr(true)
+			shoot126.Spec.Kubernetes.Version = "1.26.0"
+			shoot126.Spec.Kubernetes.EnableStaticTokenKubeconfig = pointer.BoolPtr(true)
 
 			By("Create k8s v1.26 Shoot")
-			Expect(testClient.Create(ctx, shoot_126)).To(Succeed())
+			Expect(testClient.Create(ctx, shoot126)).To(Succeed())
 			log.Info("Created shoot with k8s v1.26 for test", "shoot", client.ObjectKeyFromObject(shoot))
 
 			DeferCleanup(func() {
 				By("Delete Shoot with k8s v1.26")
-				Expect(client.IgnoreNotFound(testClient.Delete(ctx, shoot_126))).To(Succeed())
+				Expect(client.IgnoreNotFound(testClient.Delete(ctx, shoot126))).To(Succeed())
 			})
 		})
+
 		Context("Shoot with worker", func() {
 			It("Kubernetes version should not be updated: auto update not enabled", func() {
 				Expect(kubernetesutils.SetAnnotationAndUpdate(ctx, testClient, shoot, v1beta1constants.GardenerOperation, v1beta1constants.ShootOperationMaintain)).To(Succeed())
@@ -453,23 +454,23 @@ var _ = Describe("Shoot Maintenance controller tests", func() {
 
 			It("Kubernetes version should be updated: force update patch version(>= v1.27) and set EnableStaticTokenKubeconfig value to false", func() {
 				By("Expire Shoot's kubernetes version in the CloudProfile")
-				Expect(patchCloudProfileForKubernetesVersionMaintenance(ctx, testClient, shoot_126.Spec.CloudProfileName, "1.26.0", &expirationDateInThePast, &deprecatedClassification)).To(Succeed())
+				Expect(patchCloudProfileForKubernetesVersionMaintenance(ctx, testClient, shoot126.Spec.CloudProfileName, "1.26.0", &expirationDateInThePast, &deprecatedClassification)).To(Succeed())
 
 				By("Wait until manager has observed the CloudProfile update")
-				waitKubernetesVersionToBeExpiredInCloudProfile(shoot_126.Spec.CloudProfileName, "1.26.0", &expirationDateInThePast)
+				waitKubernetesVersionToBeExpiredInCloudProfile(shoot126.Spec.CloudProfileName, "1.26.0", &expirationDateInThePast)
 
-				Expect(kubernetesutils.SetAnnotationAndUpdate(ctx, testClient, shoot_126, v1beta1constants.GardenerOperation, v1beta1constants.ShootOperationMaintain)).To(Succeed())
+				Expect(kubernetesutils.SetAnnotationAndUpdate(ctx, testClient, shoot126, v1beta1constants.GardenerOperation, v1beta1constants.ShootOperationMaintain)).To(Succeed())
 
 				Eventually(func(g Gomega) string {
-					g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(shoot_126), shoot_126)).To(Succeed())
-					g.Expect(shoot_126.Status.LastMaintenance).NotTo(BeNil())
-					g.Expect(*shoot_126.Status.LastMaintenance).To(Equal(gardencorev1beta1.LastMaintenance{
+					g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(shoot126), shoot126)).To(Succeed())
+					g.Expect(shoot126.Status.LastMaintenance).NotTo(BeNil())
+					g.Expect(*shoot126.Status.LastMaintenance).To(Equal(gardencorev1beta1.LastMaintenance{
 						Description:   "For \"Control Plane\": Kubernetes version upgraded \"1.26.0\" to version \"1.27.0\". Reason: Kubernetes version expired - force update required",
 						TriggeredTime: metav1.Time{Time: fakeClock.Now()},
 						State:         gardencorev1beta1.LastOperationStateSucceeded,
 					}))
-					g.Expect(shoot_126.Spec.Kubernetes.EnableStaticTokenKubeconfig).To(Equal(pointer.BoolPtr(false)))
-					return shoot_126.Spec.Kubernetes.Version
+					g.Expect(shoot126.Spec.Kubernetes.EnableStaticTokenKubeconfig).To(Equal(pointer.BoolPtr(false)))
+					return shoot126.Spec.Kubernetes.Version
 				}).Should(Equal("1.27.0"))
 			})
 
@@ -709,23 +710,23 @@ var _ = Describe("Shoot Maintenance controller tests", func() {
 
 			It("Kubernetes version should be updated: force update patch version(>= v1.27) and set EnableStaticTokenKubeconfig value to false", func() {
 				By("Expire Shoot's kubernetes version in the CloudProfile")
-				Expect(patchCloudProfileForKubernetesVersionMaintenance(ctx, testClient, shoot_126.Spec.CloudProfileName, "1.26.0", &expirationDateInThePast, &deprecatedClassification)).To(Succeed())
+				Expect(patchCloudProfileForKubernetesVersionMaintenance(ctx, testClient, shoot126.Spec.CloudProfileName, "1.26.0", &expirationDateInThePast, &deprecatedClassification)).To(Succeed())
 
 				By("Wait until manager has observed the CloudProfile update")
-				waitKubernetesVersionToBeExpiredInCloudProfile(shoot_126.Spec.CloudProfileName, "1.26.0", &expirationDateInThePast)
+				waitKubernetesVersionToBeExpiredInCloudProfile(shoot126.Spec.CloudProfileName, "1.26.0", &expirationDateInThePast)
 
-				Expect(kubernetesutils.SetAnnotationAndUpdate(ctx, testClient, shoot_126, v1beta1constants.GardenerOperation, v1beta1constants.ShootOperationMaintain)).To(Succeed())
+				Expect(kubernetesutils.SetAnnotationAndUpdate(ctx, testClient, shoot126, v1beta1constants.GardenerOperation, v1beta1constants.ShootOperationMaintain)).To(Succeed())
 
 				Eventually(func(g Gomega) string {
-					g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(shoot_126), shoot_126)).To(Succeed())
-					g.Expect(shoot_126.Status.LastMaintenance).NotTo(BeNil())
-					g.Expect(*shoot_126.Status.LastMaintenance).To(Equal(gardencorev1beta1.LastMaintenance{
+					g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(shoot126), shoot126)).To(Succeed())
+					g.Expect(shoot126.Status.LastMaintenance).NotTo(BeNil())
+					g.Expect(*shoot126.Status.LastMaintenance).To(Equal(gardencorev1beta1.LastMaintenance{
 						Description:   "For \"Control Plane\": Kubernetes version upgraded \"1.26.0\" to version \"1.27.0\". Reason: Kubernetes version expired - force update required",
 						TriggeredTime: metav1.Time{Time: fakeClock.Now()},
 						State:         gardencorev1beta1.LastOperationStateSucceeded,
 					}))
-					g.Expect(shoot_126.Spec.Kubernetes.EnableStaticTokenKubeconfig).To(Equal(pointer.BoolPtr(false)))
-					return shoot_126.Spec.Kubernetes.Version
+					g.Expect(shoot126.Spec.Kubernetes.EnableStaticTokenKubeconfig).To(Equal(pointer.BoolPtr(false)))
+					return shoot126.Spec.Kubernetes.Version
 				}).Should(Equal("1.27.0"))
 			})
 		})

--- a/test/integration/controllermanager/shoot/maintenance/maintenance_test.go
+++ b/test/integration/controllermanager/shoot/maintenance/maintenance_test.go
@@ -35,6 +35,7 @@ var _ = Describe("Shoot Maintenance controller tests", func() {
 	var (
 		cloudProfile *gardencorev1beta1.CloudProfile
 		shoot        *gardencorev1beta1.Shoot
+		shoot_126    *gardencorev1beta1.Shoot
 
 		// Test Machine Image
 		machineImageName                = "foo-image"
@@ -78,6 +79,12 @@ var _ = Describe("Shoot Maintenance controller tests", func() {
 					Versions: []gardencorev1beta1.ExpirableVersion{
 						{
 							Version: "1.21.1",
+						},
+						{
+							Version: "1.26.0",
+						},
+						{
+							Version: "1.27.0",
 						},
 						testKubernetesVersionLowPatchLowMinor,
 						testKubernetesVersionHighestPatchLowMinor,
@@ -187,6 +194,7 @@ var _ = Describe("Shoot Maintenance controller tests", func() {
 			},
 		}
 
+		shoot_126 = shoot.DeepCopy()
 		// set dummy kubernetes version to shoot
 		shoot.Spec.Kubernetes.Version = testKubernetesVersionLowPatchLowMinor.Version
 
@@ -379,6 +387,19 @@ var _ = Describe("Shoot Maintenance controller tests", func() {
 	})
 
 	Describe("Kubernetes version maintenance tests", func() {
+		BeforeEach(func() {
+			shoot_126.Spec.Kubernetes.Version = "1.26.0"
+			shoot_126.Spec.Kubernetes.EnableStaticTokenKubeconfig = pointer.BoolPtr(true)
+
+			By("Create k8s v1.26 Shoot")
+			Expect(testClient.Create(ctx, shoot_126)).To(Succeed())
+			log.Info("Created shoot with k8s v1.26 for test", "shoot", client.ObjectKeyFromObject(shoot))
+
+			DeferCleanup(func() {
+				By("Delete Shoot with k8s v1.26")
+				Expect(client.IgnoreNotFound(testClient.Delete(ctx, shoot_126))).To(Succeed())
+			})
+		})
 		Context("Shoot with worker", func() {
 			It("Kubernetes version should not be updated: auto update not enabled", func() {
 				Expect(kubernetesutils.SetAnnotationAndUpdate(ctx, testClient, shoot, v1beta1constants.GardenerOperation, v1beta1constants.ShootOperationMaintain)).To(Succeed())
@@ -428,6 +449,28 @@ var _ = Describe("Shoot Maintenance controller tests", func() {
 					}))
 					return shoot.Spec.Kubernetes.Version
 				}).Should(Equal(testKubernetesVersionHighestPatchLowMinor.Version))
+			})
+
+			It("Kubernetes version should be updated: force update patch version(>= v1.27) and set EnableStaticTokenKubeconfig value to false", func() {
+				By("Expire Shoot's kubernetes version in the CloudProfile")
+				Expect(patchCloudProfileForKubernetesVersionMaintenance(ctx, testClient, shoot_126.Spec.CloudProfileName, "1.26.0", &expirationDateInThePast, &deprecatedClassification)).To(Succeed())
+
+				By("Wait until manager has observed the CloudProfile update")
+				waitKubernetesVersionToBeExpiredInCloudProfile(shoot_126.Spec.CloudProfileName, "1.26.0", &expirationDateInThePast)
+
+				Expect(kubernetesutils.SetAnnotationAndUpdate(ctx, testClient, shoot_126, v1beta1constants.GardenerOperation, v1beta1constants.ShootOperationMaintain)).To(Succeed())
+
+				Eventually(func(g Gomega) string {
+					g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(shoot_126), shoot_126)).To(Succeed())
+					g.Expect(shoot_126.Status.LastMaintenance).NotTo(BeNil())
+					g.Expect(*shoot_126.Status.LastMaintenance).To(Equal(gardencorev1beta1.LastMaintenance{
+						Description:   "For \"Control Plane\": Kubernetes version upgraded \"1.26.0\" to version \"1.27.0\". Reason: Kubernetes version expired - force update required",
+						TriggeredTime: metav1.Time{Time: fakeClock.Now()},
+						State:         gardencorev1beta1.LastOperationStateSucceeded,
+					}))
+					g.Expect(shoot_126.Spec.Kubernetes.EnableStaticTokenKubeconfig).To(Equal(pointer.BoolPtr(false)))
+					return shoot_126.Spec.Kubernetes.Version
+				}).Should(Equal("1.27.0"))
 			})
 
 			It("Kubernetes version should be updated: force update minor version", func() {
@@ -662,6 +705,28 @@ var _ = Describe("Shoot Maintenance controller tests", func() {
 					}))
 					return shoot.Spec.Kubernetes.Version
 				}).Should(Equal(testKubernetesVersionHighestPatchConsecutiveMinor.Version))
+			})
+
+			It("Kubernetes version should be updated: force update patch version(>= v1.27) and set EnableStaticTokenKubeconfig value to false", func() {
+				By("Expire Shoot's kubernetes version in the CloudProfile")
+				Expect(patchCloudProfileForKubernetesVersionMaintenance(ctx, testClient, shoot_126.Spec.CloudProfileName, "1.26.0", &expirationDateInThePast, &deprecatedClassification)).To(Succeed())
+
+				By("Wait until manager has observed the CloudProfile update")
+				waitKubernetesVersionToBeExpiredInCloudProfile(shoot_126.Spec.CloudProfileName, "1.26.0", &expirationDateInThePast)
+
+				Expect(kubernetesutils.SetAnnotationAndUpdate(ctx, testClient, shoot_126, v1beta1constants.GardenerOperation, v1beta1constants.ShootOperationMaintain)).To(Succeed())
+
+				Eventually(func(g Gomega) string {
+					g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(shoot_126), shoot_126)).To(Succeed())
+					g.Expect(shoot_126.Status.LastMaintenance).NotTo(BeNil())
+					g.Expect(*shoot_126.Status.LastMaintenance).To(Equal(gardencorev1beta1.LastMaintenance{
+						Description:   "For \"Control Plane\": Kubernetes version upgraded \"1.26.0\" to version \"1.27.0\". Reason: Kubernetes version expired - force update required",
+						TriggeredTime: metav1.Time{Time: fakeClock.Now()},
+						State:         gardencorev1beta1.LastOperationStateSucceeded,
+					}))
+					g.Expect(shoot_126.Spec.Kubernetes.EnableStaticTokenKubeconfig).To(Equal(pointer.BoolPtr(false)))
+					return shoot_126.Spec.Kubernetes.Version
+				}).Should(Equal("1.27.0"))
 			})
 		})
 	})


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area open-source
/kind enhancement

**What this PR does / why we need it**:
During maintenance while upgrading the Shoot cluster to k8s version >= 1.27, shoot validation will fail if the `EnableStaticTokenKubeconfig` was set to `true` because setting `EnableStaticTokenKubeconfig` to true is not allowed for Shoot clusters with k8s version >= 1.27.

This PR adapts the `maintenance` controller of shoot to set the `EnableStaticTokenKubeconfig` to `false`, when shoot cluster is updated to k8s version >= 1.27
**Which issue(s) this PR fixes**:
part of #7783 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
