### PR TITLE
Skip reading zone for non-existing PVs

### DIFF
--- a/pkg/apis/core/v1beta1/helper/helper.go
+++ b/pkg/apis/core/v1beta1/helper/helper.go
@@ -660,7 +660,7 @@ func IsAPIServerExposureManaged(obj metav1.Object) bool {
 }
 
 // FindPrimaryDNSProvider finds the primary provider among the given `providers`.
-// It returns the first provider in case no primary provider is available or the first one if multiple candidates are found.
+// It returns the first provider if multiple candidates are found.
 func FindPrimaryDNSProvider(providers []gardencorev1beta1.DNSProvider) *gardencorev1beta1.DNSProvider {
 	for _, provider := range providers {
 		if provider.Primary != nil && *provider.Primary {

--- a/pkg/operation/botanist/namespaces.go
+++ b/pkg/operation/botanist/namespaces.go
@@ -112,6 +112,11 @@ func (b *Botanist) DeploySeedNamespace(ctx context.Context) error {
 			}
 
 			for _, pvc := range pvcList.Items {
+				// Skip handling if PV has not been created yet.
+				if pvc.Spec.VolumeName == "" {
+					continue
+				}
+
 				pv := &corev1.PersistentVolume{}
 				if err := b.SeedClientSet.Client().Get(ctx, client.ObjectKey{Name: pvc.Spec.VolumeName}, pv); err != nil {
 					return fmt.Errorf("failed getting PV %s: %w", pvc.Spec.VolumeName, err)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement

**What this PR does / why we need it**:
This PR fixes a transient error that occasionally occurred during shoot creation:

The shoot reconciliation may exit at any time because of any errors or timeouts. During the next reconciliation run, the `Deploying Shoot namespace in Seed` step reads zones from all `PersistentVolume`s but might not succeed because there are `PersistentVolumeClaim`s for which a volume has not been created, i.e. `pvc.Spec.VolumeName` is empty.

```
task "Deploying Shoot namespace in Seed" failed: retry failed with context deadline exceeded, last error: failed getting PV : PersistentVolume "" not found
```

**Special notes for your reviewer**:
/cc @vpnachev thanks for reporting.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The `Deploying Shoot namespace in Seed` step was slightly improved. Earlier it failed at some occasions when it tried to read zone information for volumes that have not been created yet. This was a transient error that dissolved in subsequent reconcile runs.
```
