### PR TITLE
Fix Gardenlet permission for `Machine`s

### DIFF
--- a/charts/gardener/gardenlet/templates/clusterrole-gardenlet.yaml
+++ b/charts/gardener/gardenlet/templates/clusterrole-gardenlet.yaml
@@ -440,6 +440,7 @@ rules:
   - machine.sapcloud.io
   resources:
   - machinedeployments
+  - machines
   verbs:
   - list
   - watch

--- a/pkg/gardenlet/controller/managedseed/charttest/charttest.go
+++ b/pkg/gardenlet/controller/managedseed/charttest/charttest.go
@@ -392,7 +392,7 @@ func getGardenletClusterRole(labels map[string]string) *rbacv1.ClusterRole {
 			},
 			{
 				APIGroups: []string{"machine.sapcloud.io"},
-				Resources: []string{"machinedeployments"},
+				Resources: []string{"machinedeployments", "machines"},
 				Verbs:     []string{"list", "watch", "get"},
 			},
 		},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug

**What this PR does / why we need it**:
This PR adds missing Gardenlet permissions for `Machine`s after #8056.

```
{"level":"info","ts":"2023-06-20T13:23:24.137Z","msg":"k8s.io/client-go@v11.0.1-0.20190409021438-1a26190bd76a+incompatible/tools/cache/reflector.go:169: failed to list *v1alpha1.Machine: machines.machine.sapcloud.io is forbidden: User \"system:serviceaccount:garden:gardenlet\" cannot list resource \"machines\" in API group \"machine.sapcloud.io\" at the cluster scope\n"}
{"level":"error","ts":"2023-06-20T13:23:24.137Z","msg":"k8s.io/client-go@v11.0.1-0.20190409021438-1a26190bd76a+incompatible/tools/cache/reflector.go:169: Failed to watch *v1alpha1.Machine: failed to list *v1alpha1.Machine: machines.machine.sapcloud.io is forbidden: User \"system:serviceaccount:garden:gardenlet\" cannot list resource \"machines\" in API group \"machine.sapcloud.io\" at the cluster scope\n","stacktrace":"k8s.io/client-go/tools/cache.DefaultWatchErrorHandler\n\tk8s.io/client-go@v11.0.1-0.20190409021438-1a26190bd76a+incompatible/tools/cache/reflector.go:140\nk8s.io/client-go/tools/cache.(*Reflector).Run.func1\n\tk8s.io/client-go@v11.0.1-0.20190409021438-1a26190bd76a+incompatible/tools/cache/reflector.go:224\nk8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1\n\tk8s.io/apimachinery@v0.26.3/pkg/util/wait/wait.go:157\nk8s.io/apimachinery/pkg/util/wait.BackoffUntil\n\tk8s.io/apimachinery@v0.26.3/pkg/util/wait/wait.go:158\nk8s.io/client-go/tools/cache.(*Reflector).Run\n\tk8s.io/client-go@v11.0.1-0.20190409021438-1a26190bd76a+incompatible/tools/cache/reflector.go:222\nk8s.io/apimachinery/pkg/util/wait.(*Group).StartWithChannel.func1\n\tk8s.io/apimachinery@v0.26.3/pkg/util/wait/wait.go:58\nk8s.io/apimachinery/pkg/util/wait.(*Group).Start.func1\n\tk8s.io/apimachinery@v0.26.3/pkg/util/wait/wait.go:75"}
```

**Special notes for reviewers**:
/cc @rfranzke

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Missing permissions were added for the Gardenlet service account for `Machine` objects. This fix is relevant if feature gate `MachineControllerManagerDeployment` is enabled in your landscape.
```
