### PR TITLE
Allow deletion for `Shoot`s with invalid spec

### DIFF
--- a/pkg/gardenlet/controller/shoot/shoot/reconciler.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler.go
@@ -197,8 +197,8 @@ func (r *Reconciler) deleteShoot(ctx context.Context, log logr.Logger, shoot *ga
 	log = log.WithValues("operation", "delete")
 
 	// If the .status.uid field is empty, then we assume that there has never been any operation running for this shoot.
-	// Gardenlet can directly finalize the shoot deletion since not resources need to be cleaned up.
-	// This shortcut also allows users to delete shoot clusters that were wrongly configured in the first place, e.g. https://github.com/gardener/gardener/issues/1926.
+	// Gardenlet can directly finalize the shoot deletion since no resources need to be cleaned up.
+	// This shortcut also allows users to delete shoot clusters that were wrongly configured in the first place, e.g. see https://github.com/gardener/gardener/issues/1926.
 	if len(shoot.Status.UID) == 0 {
 		log.Info("The `.status.uid` is empty, assuming Shoot cluster did never exist, deletion accepted")
 		return r.finalizeShootDeletion(ctx, log, shoot)

--- a/test/e2e/gardener/shoot/create_and_delete_failed.go
+++ b/test/e2e/gardener/shoot/create_and_delete_failed.go
@@ -1,0 +1,67 @@
+// Copyright 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package shoot
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/utils/pointer"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	e2e "github.com/gardener/gardener/test/e2e/gardener"
+)
+
+var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
+	test := func(shoot *gardencorev1beta1.Shoot) {
+		f := defaultShootCreationFramework()
+		f.Shoot = shoot
+
+		It("Create and Delete Failed Shoot", Offset(1), func() {
+			By("Create Shoot")
+			if shoot.Namespace == "" {
+				shoot.SetNamespace(f.ProjectNamespace)
+			}
+			f.Shoot = shoot
+
+			ctx, cancel := context.WithTimeout(parentCtx, 15*time.Minute)
+			defer cancel()
+
+			Expect(f.GardenClient.Client().Create(ctx, shoot)).To(Succeed())
+
+			By("Wait until Shoot is set to Failed")
+			Eventually(func(g Gomega) {
+				f.GetShoot(ctx, shoot)
+				g.Expect(shoot.Status.LastOperation).ToNot(BeNil())
+				g.Expect(shoot.Status.LastOperation.State).To(Equal(gardencorev1beta1.LastOperationStateFailed))
+			}).WithTimeout(1 * time.Minute).Should(Succeed())
+
+			By("Delete Shoot")
+			ctx, cancel = context.WithTimeout(parentCtx, 2*time.Minute)
+			defer cancel()
+			Expect(f.DeleteShootAndWaitForDeletion(ctx, f.Shoot)).To(Succeed())
+		})
+	}
+
+	Context("Shoot with invalid DNS configuration", func() {
+		shoot := e2e.DefaultShoot("e2e-invalid-dns")
+		shoot.Spec.DNS = &gardencorev1beta1.DNS{
+			Domain: pointer.String("shoot.non-existing-domain"),
+		}
+		test(shoot)
+	})
+})

--- a/test/e2e/gardener/shoot/create_and_delete_failed.go
+++ b/test/e2e/gardener/shoot/create_and_delete_failed.go
@@ -38,14 +38,14 @@ var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
 			}
 			f.Shoot = shoot
 
-			ctx, cancel := context.WithTimeout(parentCtx, 15*time.Minute)
+			ctx, cancel := context.WithTimeout(parentCtx, 2*time.Minute)
 			defer cancel()
 
 			Expect(f.GardenClient.Client().Create(ctx, shoot)).To(Succeed())
 
-			By("Wait until Shoot is set to Failed")
+			By("Wait until last operation in Shoot is set to Failed")
 			Eventually(func(g Gomega) {
-				f.GetShoot(ctx, shoot)
+				g.Expect(f.GetShoot(ctx, shoot)).To(Succeed())
 				g.Expect(shoot.Status.LastOperation).ToNot(BeNil())
 				g.Expect(shoot.Status.LastOperation.State).To(Equal(gardencorev1beta1.LastOperationStateFailed))
 			}).WithTimeout(1 * time.Minute).Should(Succeed())


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/area ops-productivity
/kind regression

**What this PR does / why we need it**:
This PR reverts the behavior added with https://github.com/gardener/gardener/pull/2118 but reverted again in the scope of the controller-runtime refactoring in https://github.com/gardener/gardener/pull/7082/commits/3c88461ba4702125dd712574d41938f1e1fb4597.

The `shoot.status.uid` was intentionally only set when the operation could be initialized once. It serves as a marker in order to determine if Gardenlet has ever created resources that must be cleaned up during deletion. Thus, we can immediately finalize shoot clusters that were created with a wrong configuration at the outset (see #1926) and don't initialize an `operation`.

**Which issue(s) this PR fixes**:
Fixes #1926

**Special notes for your reviewer**:
/cc @rfranzke

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
A regression was fixed that prevented deletions for shoot clusters which were created with a wrong configuration (e.g. with an unavailable domain name).
```
