### PR TITLE
Improve documentation about worker pool configuration with multiple zones

### DIFF
--- a/docs/api-reference/core.md
+++ b/docs/api-reference/core.md
@@ -12113,7 +12113,8 @@ int32
 </em>
 </td>
 <td>
-<p>Maximum is the maximum number of VMs to create.</p>
+<p>Maximum is the maximum number of machines to create.
+This value is divided by the number of configured zones for a fair distribution.</p>
 </td>
 </tr>
 <tr>
@@ -12124,7 +12125,8 @@ int32
 </em>
 </td>
 <td>
-<p>Minimum is the minimum number of VMs to create.</p>
+<p>Minimum is the minimum number of machines to create.
+This value is divided by the number of configured zones for a fair distribution.</p>
 </td>
 </tr>
 <tr>
@@ -12138,7 +12140,8 @@ k8s.io/apimachinery/pkg/util/intstr.IntOrString
 </td>
 <td>
 <em>(Optional)</em>
-<p>MaxSurge is maximum number of VMs that are created during an update.</p>
+<p>MaxSurge is maximum number of machines that are created during an update.
+This value is divided by the number of configured zones for a fair distribution.</p>
 </td>
 </tr>
 <tr>
@@ -12152,7 +12155,8 @@ k8s.io/apimachinery/pkg/util/intstr.IntOrString
 </td>
 <td>
 <em>(Optional)</em>
-<p>MaxUnavailable is the maximum number of VMs that can be unavailable during an update.</p>
+<p>MaxUnavailable is the maximum number of machines that can be unavailable during an update.
+This value is divided by the number of configured zones for a fair distribution.</p>
 </td>
 </tr>
 <tr>
@@ -12273,7 +12277,7 @@ map[string]string
 </td>
 <td>
 <em>(Optional)</em>
-<p>Sysctls is a map of kernel settings to apply on all VMs in this worker pool.</p>
+<p>Sysctls is a map of kernel settings to apply on all machines in this worker pool.</p>
 </td>
 </tr>
 </tbody>

--- a/pkg/apis/core/types_shoot.go
+++ b/pkg/apis/core/types_shoot.go
@@ -1050,13 +1050,17 @@ type Worker struct {
 	Name string
 	// Machine contains information about the machine type and image.
 	Machine Machine
-	// Maximum is the maximum number of VMs to create.
+	// Maximum is the maximum number of machines to create.
+	// This value is divided by the number of configured zones for a fair distribution.
 	Maximum int32
-	// Minimum is the minimum number of VMs to create.
+	// Minimum is the minimum number of machines to create.
+	// This value is divided by the number of configured zones for a fair distribution.
 	Minimum int32
-	// MaxSurge is maximum number of VMs that are created during an update.
+	// MaxSurge is maximum number of machines that are created during an update.
+	// This value is divided by the number of configured zones for a fair distribution.
 	MaxSurge *intstr.IntOrString
-	// MaxUnavailable is the maximum number of VMs that can be unavailable during an update.
+	// MaxUnavailable is the maximum number of machines that can be unavailable during an update.
+	// This value is divided by the number of configured zones for a fair distribution.
 	MaxUnavailable *intstr.IntOrString
 	// ProviderConfig is the provider-specific configuration for this worker pool.
 	ProviderConfig *runtime.RawExtension
@@ -1075,7 +1079,7 @@ type Worker struct {
 	Zones []string
 	// MachineControllerManagerSettings contains configurations for different worker-pools. Eg. MachineDrainTimeout, MachineHealthTimeout.
 	MachineControllerManagerSettings *MachineControllerManagerSettings
-	// Sysctls is a map of kernel settings to apply on all VMs in this worker pool.
+	// Sysctls is a map of kernel settings to apply on all machines in this worker pool.
 	Sysctls map[string]string
 }
 

--- a/pkg/apis/core/v1beta1/generated.proto
+++ b/pkg/apis/core/v1beta1/generated.proto
@@ -3017,17 +3017,21 @@ message Worker {
   // Machine contains information about the machine type and image.
   optional Machine machine = 7;
 
-  // Maximum is the maximum number of VMs to create.
+  // Maximum is the maximum number of machines to create.
+  // This value is divided by the number of configured zones for a fair distribution.
   optional int32 maximum = 8;
 
-  // Minimum is the minimum number of VMs to create.
+  // Minimum is the minimum number of machines to create.
+  // This value is divided by the number of configured zones for a fair distribution.
   optional int32 minimum = 9;
 
-  // MaxSurge is maximum number of VMs that are created during an update.
+  // MaxSurge is maximum number of machines that are created during an update.
+  // This value is divided by the number of configured zones for a fair distribution.
   // +optional
   optional k8s.io.apimachinery.pkg.util.intstr.IntOrString maxSurge = 10;
 
-  // MaxUnavailable is the maximum number of VMs that can be unavailable during an update.
+  // MaxUnavailable is the maximum number of machines that can be unavailable during an update.
+  // This value is divided by the number of configured zones for a fair distribution.
   // +optional
   optional k8s.io.apimachinery.pkg.util.intstr.IntOrString maxUnavailable = 11;
 
@@ -3064,7 +3068,7 @@ message Worker {
   // +optional
   optional MachineControllerManagerSettings machineControllerManager = 19;
 
-  // Sysctls is a map of kernel settings to apply on all VMs in this worker pool.
+  // Sysctls is a map of kernel settings to apply on all machines in this worker pool.
   // +optional
   map<string, string> sysctls = 20;
 }

--- a/pkg/apis/core/v1beta1/types_shoot.go
+++ b/pkg/apis/core/v1beta1/types_shoot.go
@@ -1348,14 +1348,18 @@ type Worker struct {
 	Name string `json:"name" protobuf:"bytes,6,opt,name=name"`
 	// Machine contains information about the machine type and image.
 	Machine Machine `json:"machine" protobuf:"bytes,7,opt,name=machine"`
-	// Maximum is the maximum number of VMs to create.
+	// Maximum is the maximum number of machines to create.
+	// This value is divided by the number of configured zones for a fair distribution.
 	Maximum int32 `json:"maximum" protobuf:"varint,8,opt,name=maximum"`
-	// Minimum is the minimum number of VMs to create.
+	// Minimum is the minimum number of machines to create.
+	// This value is divided by the number of configured zones for a fair distribution.
 	Minimum int32 `json:"minimum" protobuf:"varint,9,opt,name=minimum"`
-	// MaxSurge is maximum number of VMs that are created during an update.
+	// MaxSurge is maximum number of machines that are created during an update.
+	// This value is divided by the number of configured zones for a fair distribution.
 	// +optional
 	MaxSurge *intstr.IntOrString `json:"maxSurge,omitempty" protobuf:"bytes,10,opt,name=maxSurge"`
-	// MaxUnavailable is the maximum number of VMs that can be unavailable during an update.
+	// MaxUnavailable is the maximum number of machines that can be unavailable during an update.
+	// This value is divided by the number of configured zones for a fair distribution.
 	// +optional
 	MaxUnavailable *intstr.IntOrString `json:"maxUnavailable,omitempty" protobuf:"bytes,11,opt,name=maxUnavailable"`
 	// ProviderConfig is the provider-specific configuration for this worker pool.
@@ -1383,7 +1387,7 @@ type Worker struct {
 	// MachineControllerManagerSettings contains configurations for different worker-pools. Eg. MachineDrainTimeout, MachineHealthTimeout.
 	// +optional
 	MachineControllerManagerSettings *MachineControllerManagerSettings `json:"machineControllerManager,omitempty" protobuf:"bytes,19,opt,name=machineControllerManager"`
-	// Sysctls is a map of kernel settings to apply on all VMs in this worker pool.
+	// Sysctls is a map of kernel settings to apply on all machines in this worker pool.
 	// +optional
 	Sysctls map[string]string `json:"sysctls,omitempty" protobuf:"bytes,20,rep,name=sysctls"`
 }

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -8467,7 +8467,7 @@ func schema_pkg_apis_core_v1beta1_Worker(ref common.ReferenceCallback) common.Op
 					},
 					"maximum": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Maximum is the maximum number of VMs to create.",
+							Description: "Maximum is the maximum number of machines to create. This value is divided by the number of configured zones for a fair distribution.",
 							Default:     0,
 							Type:        []string{"integer"},
 							Format:      "int32",
@@ -8475,7 +8475,7 @@ func schema_pkg_apis_core_v1beta1_Worker(ref common.ReferenceCallback) common.Op
 					},
 					"minimum": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Minimum is the minimum number of VMs to create.",
+							Description: "Minimum is the minimum number of machines to create. This value is divided by the number of configured zones for a fair distribution.",
 							Default:     0,
 							Type:        []string{"integer"},
 							Format:      "int32",
@@ -8483,13 +8483,13 @@ func schema_pkg_apis_core_v1beta1_Worker(ref common.ReferenceCallback) common.Op
 					},
 					"maxSurge": {
 						SchemaProps: spec.SchemaProps{
-							Description: "MaxSurge is maximum number of VMs that are created during an update.",
+							Description: "MaxSurge is maximum number of machines that are created during an update. This value is divided by the number of configured zones for a fair distribution.",
 							Ref:         ref("k8s.io/apimachinery/pkg/util/intstr.IntOrString"),
 						},
 					},
 					"maxUnavailable": {
 						SchemaProps: spec.SchemaProps{
-							Description: "MaxUnavailable is the maximum number of VMs that can be unavailable during an update.",
+							Description: "MaxUnavailable is the maximum number of machines that can be unavailable during an update. This value is divided by the number of configured zones for a fair distribution.",
 							Ref:         ref("k8s.io/apimachinery/pkg/util/intstr.IntOrString"),
 						},
 					},
@@ -8569,7 +8569,7 @@ func schema_pkg_apis_core_v1beta1_Worker(ref common.ReferenceCallback) common.Op
 					},
 					"sysctls": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Sysctls is a map of kernel settings to apply on all VMs in this worker pool.",
+							Description: "Sysctls is a map of kernel settings to apply on all machines in this worker pool.",
 							Type:        []string{"object"},
 							AdditionalProperties: &spec.SchemaOrBool{
 								Allows: true,


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/area documentation
/kind enhancement

**What this PR does / why we need it**:
This PR clarifies and emphasizes the meaning of the worker pool configuration options `minimum`, `maximum`, `maxSurge` and `maxUnavailable` and how it impacts the cluster if multiple availability zones are configured:

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/machine-controller-manager/issues/798

**Special notes for your reviewer**:
We didn't reach a consensus in https://github.com/gardener/machine-controller-manager/issues/798, so I decided to at least document it properly.

/cc @vlerenc @BeckerMax 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
