### PR TITLE
Allow deletion of shoot clusters with incorrect networking settings.

### DIFF
--- a/plugin/pkg/shoot/validator/admission.go
+++ b/plugin/pkg/shoot/validator/admission.go
@@ -655,20 +655,20 @@ func (c *validationContext) validateShootNetworks(workerless bool) field.ErrorLi
 				c.shoot.Spec.Networking.Services,
 				workerless,
 			)...)
-		}
 
-		// validate network disjointedness with seed networks if shoot is being (re)scheduled
-		if !apiequality.Semantic.DeepEqual(c.oldShoot.Spec.SeedName, c.shoot.Spec.SeedName) {
-			allErrs = append(allErrs, cidrvalidation.ValidateNetworkDisjointedness(
-				path,
-				c.shoot.Spec.Networking.Nodes,
-				c.shoot.Spec.Networking.Pods,
-				c.shoot.Spec.Networking.Services,
-				c.seed.Spec.Networks.Nodes,
-				c.seed.Spec.Networks.Pods,
-				c.seed.Spec.Networks.Services,
-				workerless,
-			)...)
+			// validate network disjointedness with seed networks if shoot is being (re)scheduled
+			if !apiequality.Semantic.DeepEqual(c.oldShoot.Spec.SeedName, c.shoot.Spec.SeedName) {
+				allErrs = append(allErrs, cidrvalidation.ValidateNetworkDisjointedness(
+					path,
+					c.shoot.Spec.Networking.Nodes,
+					c.shoot.Spec.Networking.Pods,
+					c.shoot.Spec.Networking.Services,
+					c.seed.Spec.Networks.Nodes,
+					c.seed.Spec.Networks.Pods,
+					c.seed.Spec.Networks.Services,
+					workerless,
+				)...)
+			}
 		}
 	}
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind bug

**What this PR does / why we need it**:
Allow deletion of shoot clusters with incorrect networking settings.

Previously, gardener allowed overlap of shoot network ranges and the vpn. This was rather a bug than a feature, but led to shoot clusters in the wild, which have such an overlap. Those clusters cannot be deleted at the moment as the admission validation will reject them.
This change is to allow deletion of those clusters without weakening the general validation for create/update.

**Which issue(s) this PR fixes**:
None.

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
NONE
```
