### PR TITLE
gardener-apiserver: Do not validate Shoot networks for a DELETE request

### DIFF
--- a/plugin/pkg/shoot/validator/admission.go
+++ b/plugin/pkg/shoot/validator/admission.go
@@ -274,7 +274,7 @@ func (v *ValidateShoot) Admit(ctx context.Context, a admission.Attributes, o adm
 	validationContext.addMetadataAnnotations(a)
 
 	allErrs = append(allErrs, validationContext.validateAPIVersionForRawExtensions()...)
-	allErrs = append(allErrs, validationContext.validateShootNetworks(helper.IsWorkerless(shoot))...)
+	allErrs = append(allErrs, validationContext.validateShootNetworks(a, helper.IsWorkerless(shoot))...)
 	allErrs = append(allErrs, validationContext.validateKubernetes(a)...)
 	allErrs = append(allErrs, validationContext.validateRegion()...)
 	allErrs = append(allErrs, validationContext.validateProvider(a)...)
@@ -623,11 +623,15 @@ func (c *validationContext) addMetadataAnnotations(a admission.Attributes) {
 	}
 }
 
-func (c *validationContext) validateShootNetworks(workerless bool) field.ErrorList {
+func (c *validationContext) validateShootNetworks(a admission.Attributes, workerless bool) field.ErrorList {
 	var (
 		allErrs field.ErrorList
 		path    = field.NewPath("spec", "networking")
 	)
+
+	if a.GetOperation() == admission.Delete {
+		return nil
+	}
 
 	if c.seed != nil {
 		if c.shoot.Spec.Networking.Pods == nil && !workerless {
@@ -646,29 +650,27 @@ func (c *validationContext) validateShootNetworks(workerless bool) field.ErrorLi
 			}
 		}
 
-		if c.shoot.DeletionTimestamp == nil {
-			// validate network disjointedness within shoot network
-			allErrs = append(allErrs, cidrvalidation.ValidateShootNetworkDisjointedness(
+		// validate network disjointedness within shoot network
+		allErrs = append(allErrs, cidrvalidation.ValidateShootNetworkDisjointedness(
+			path,
+			c.shoot.Spec.Networking.Nodes,
+			c.shoot.Spec.Networking.Pods,
+			c.shoot.Spec.Networking.Services,
+			workerless,
+		)...)
+
+		// validate network disjointedness with seed networks if shoot is being (re)scheduled
+		if !apiequality.Semantic.DeepEqual(c.oldShoot.Spec.SeedName, c.shoot.Spec.SeedName) {
+			allErrs = append(allErrs, cidrvalidation.ValidateNetworkDisjointedness(
 				path,
 				c.shoot.Spec.Networking.Nodes,
 				c.shoot.Spec.Networking.Pods,
 				c.shoot.Spec.Networking.Services,
+				c.seed.Spec.Networks.Nodes,
+				c.seed.Spec.Networks.Pods,
+				c.seed.Spec.Networks.Services,
 				workerless,
 			)...)
-
-			// validate network disjointedness with seed networks if shoot is being (re)scheduled
-			if !apiequality.Semantic.DeepEqual(c.oldShoot.Spec.SeedName, c.shoot.Spec.SeedName) {
-				allErrs = append(allErrs, cidrvalidation.ValidateNetworkDisjointedness(
-					path,
-					c.shoot.Spec.Networking.Nodes,
-					c.shoot.Spec.Networking.Pods,
-					c.shoot.Spec.Networking.Services,
-					c.seed.Spec.Networks.Nodes,
-					c.seed.Spec.Networks.Pods,
-					c.seed.Spec.Networks.Services,
-					workerless,
-				)...)
-			}
 		}
 	}
 

--- a/plugin/pkg/shoot/validator/admission_test.go
+++ b/plugin/pkg/shoot/validator/admission_test.go
@@ -1557,9 +1557,6 @@ var _ = Describe("validator", func() {
 				It("delete should pass because validation of network disjointedness should not be executed", func() {
 					// set shoot pod cidr to overlap with vpn pod cidr
 					shoot.Spec.Networking.Pods = pointer.String(v1beta1constants.DefaultVPNRange)
-					deletionTimestamp := metav1.NewTime(time.Now())
-					shoot.DeletionTimestamp = &deletionTimestamp
-					oldShoot = &core.Shoot{}
 
 					Expect(coreInformerFactory.Core().InternalVersion().Projects().Informer().GetStore().Add(&project)).To(Succeed())
 					Expect(coreInformerFactory.Core().InternalVersion().CloudProfiles().Informer().GetStore().Add(&cloudProfile)).To(Succeed())


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind bug

**What this PR does / why we need it**:
According to my testing https://github.com/gardener/gardener/pull/8126 does not help much due to the reasons explained in https://github.com/gardener/gardener/pull/8126#discussion_r1236783939.

**Which issue(s) this PR fixes**:
See the motivation in https://github.com/gardener/gardener/pull/8126

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
An issue causing deletion of a legacy (wrongly configured) Shoot cluster to be denied because of network ranges overlapping with the default VPN network is now fixed.
```
