### PR TITLE
Allow deletion of old shoot clusters with network ranges overlapping with vpn.

### DIFF
--- a/plugin/pkg/shoot/validator/admission_test.go
+++ b/plugin/pkg/shoot/validator/admission_test.go
@@ -1557,9 +1557,6 @@ var _ = Describe("validator", func() {
 				It("delete should pass because validation of network disjointedness should not be executed", func() {
 					// set shoot pod cidr to overlap with vpn pod cidr
 					shoot.Spec.Networking.Pods = pointer.String(v1beta1constants.DefaultVPNRange)
-					deletionTimestamp := metav1.NewTime(time.Now())
-					shoot.DeletionTimestamp = &deletionTimestamp
-					oldShoot = &core.Shoot{}
 
 					Expect(coreInformerFactory.Core().InternalVersion().Projects().Informer().GetStore().Add(&project)).To(Succeed())
 					Expect(coreInformerFactory.Core().InternalVersion().CloudProfiles().Informer().GetStore().Add(&cloudProfile)).To(Succeed())


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind bug

**What this PR does / why we need it**:
Allow deletion of old shoot clusters with network ranges overlapping with vpn.

Use operation instead of deletion timestamp as the deletion timestamp is not set, yet, in the admission plugin.

**Which issue(s) this PR fixes**:
Nonw.

**Special notes for your reviewer**:
Unfortunately, the previous attempt to fix this (#8126) was incorrect as the deletion timestamp is not available during admission, yet, but it is set only at a later point in time (as pointed out [here](https://github.com/gardener/gardener/pull/8126#discussion_r1236783939)). Therefore, this change uses the operation instead.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Allow deletion of shoot clusters with network ranges overlapping with the shoot vpn.
```
