### PR TITLE
Bump up fluent-operator to 2.3.0, fluent-bit to 2.1.4 and g/logging to 0.55.3

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -367,7 +367,7 @@ images:
 - name: fluent-operator
   sourceRepository: github.com/fluent/fluent-operator
   repository: eu.gcr.io/gardener-project/3rd/kubesphere/fluent-operator
-  tag: "v2.2.0"
+  tag: "v2.3.0"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:
@@ -384,7 +384,7 @@ images:
 - name: fluent-bit
   sourceRepository: github.com/fluent/fluent-operator
   repository: eu.gcr.io/gardener-project/3rd/kubesphere/fluent-bit
-  tag: "v2.0.9"
+  tag: "v2.1.4"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:
@@ -403,7 +403,7 @@ images:
     name: fluent-bit-to-vali
   sourceRepository: github.com/gardener/logging
   repository: eu.gcr.io/gardener-project/gardener/fluent-bit-to-vali
-  tag: "v0.55.2"
+  tag: "v0.55.3"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:
@@ -438,7 +438,7 @@ images:
 - name: vali-curator
   sourceRepository: github.com/gardener/logging
   repository: eu.gcr.io/gardener-project/gardener/vali-curator
-  tag: "v0.55.2"
+  tag: "v0.55.3"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:
@@ -493,7 +493,7 @@ images:
     name: telegraf-iptables
   sourceRepository: github.com/gardener/logging
   repository: eu.gcr.io/gardener-project/gardener/telegraf-iptables
-  tag: "v0.55.2"
+  tag: "v0.55.3"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:
@@ -513,7 +513,7 @@ images:
 - name: event-logger
   sourceRepository: github.com/gardener/logging
   repository: eu.gcr.io/gardener-project/gardener/event-logger
-  tag: "v0.55.2"
+  tag: "v0.55.3"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:
@@ -530,7 +530,7 @@ images:
 - name: tune2fs
   sourceRepository: github.com/gardener/logging
   repository: eu.gcr.io/gardener-project/gardener/tune2fs
-  tag: "v0.55.2"
+  tag: "v0.55.3"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:


### PR DESCRIPTION
/area logging
/kind enhancement

This PR brings following logging stack updates:
- fluent-bit is now updated from 2.0.9 to 2.1.4 - [release notes](https://github.com/fluent/fluent-bit/releases/tag/v2.1.4)
- fluent-operator is now updated from 2.2.0 to 2.3.0 - [release notes](https://github.com/fluent/fluent-operator/releases/tag/v2.3.0)
- gardener/logging is now updated from 0.55.2 to 0.55.3 - [release notes](https://github.com/gardener/logging/releases/tag/v0.55.3)


```other operator
All components in the gardener logging stack are now updated to the following respective versions. Fluent-bit to 2.1.4, Fluent-operator to 2.3.0 and logging to 0.55.3
```
``` other operator github.com/gardener/logging #199 @nickytd
The logging e2e event logger test is now adapted to vali logging stack.
```

``` other operator github.com/gardener/logging #200 @nickytd
Now git revision and commit ids are properly propagated through build variables. These are showed in the fluent-bit plugin logs during start.
```

``` other operator github.com/gardener/logging #201 @nickytd
Base image on `telegraf` and `tune2fs` is upgraded from 3.17.2 to 3.18.0
```

``` other developer github.com/gardener/logging #202 @nickytd
Introduces a skaffold local development pipeline to fluent-bit-vali-plugin
```

``` other developer github.com/gardener/logging #204 @nickytd
The project vendors the latest released gardener version - v1.73.0
```

``` other developer github.com/gardener/logging #205 @nickytd
The `fluent-bit-vali-plugin` now supports fluent-bit v2.1.0 and above.
```

``` other operator github.com/gardener/logging #191 @vlvasilev
Gardener-based e2e test for the event-logger.
```