### PR TITLE
Fix unit tests in `pkg/utils/gardener/shootstate`

### DIFF
--- a/pkg/utils/gardener/shootstate/shootstate_test.go
+++ b/pkg/utils/gardener/shootstate/shootstate_test.go
@@ -78,7 +78,7 @@ var _ = Describe("ShootState", func() {
 			Expect(Deploy(ctx, fakeClock, fakeGardenClient, fakeSeedClient, shoot)).To(Succeed())
 			Expect(fakeGardenClient.Get(ctx, client.ObjectKeyFromObject(shootState), shootState)).To(Succeed())
 			Expect(shootState.Spec).To(Equal(gardencorev1beta1.ShootStateSpec{}))
-			Expect(shootState.Annotations).To(HaveKeyWithValue("gardener.cloud/timestamp", fakeClock.Now().Format(time.RFC3339)))
+			Expect(shootState.Annotations).To(HaveKeyWithValue("gardener.cloud/timestamp", fakeClock.Now().UTC().Format(time.RFC3339)))
 		})
 
 		It("should compute the expected spec for both gardener and extensions data", func() {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind test

**What this PR does / why we need it**:
If your system does not run with UTC time zone the tests will fail:

```
------------------------------
• [FAILED] [0.009 seconds]
ShootState #Deploy [It] should deploy a ShootState with an empty spec when there is nothing to persist /Users/rfranzke/go/src/github.com/gardener/gardener/pkg/utils/gardener/shootstate/shootstate_test.go:77

  [FAILED] Expected
      <map[string]string | len:1>: {
          "gardener.cloud/timestamp": "2023-06-21T14:41:25Z",
      }
  to have {key: value}
      <map[interface {}]interface {} | len:1>: {
          <string>"gardener.cloud/timestamp": <string>"2023-06-21T16:41:25+02:00",
      }
  In [It] at: /Users/rfranzke/go/src/github.com/gardener/gardener/pkg/utils/gardener/shootstate/shootstate_test.go:81 @ 06/21/23 16:41:25.155
```

Introduced with https://github.com/gardener/gardener/pull/8112

/cc @oliver-goetz 