### PR TITLE
Improvements for Workerless Shoot

### DIFF
--- a/pkg/api/core/shoot/warnings.go
+++ b/pkg/api/core/shoot/warnings.go
@@ -118,7 +118,7 @@ func getWarningsForDueCredentialsRotations(shoot *core.Shoot, credentialsRotatio
 		warnings = append(warnings, "you should consider rotating the ServiceAccount token signing key, see https://github.com/gardener/gardener/blob/master/docs/usage/shoot_credentials_rotation.md#serviceaccount-token-signing-key for details")
 	}
 
-	if shootEnablesSSHAccess(shoot) && (rotation.SSHKeypair == nil || initiationDue(rotation.SSHKeypair.LastInitiationTime, credentialsRotationInterval)) {
+	if helper.ShootEnablesSSHAccess(shoot) && (rotation.SSHKeypair == nil || initiationDue(rotation.SSHKeypair.LastInitiationTime, credentialsRotationInterval)) {
 		warnings = append(warnings, "you should consider rotating the SSH keypair, see https://github.com/gardener/gardener/blob/master/docs/usage/shoot_credentials_rotation.md#ssh-key-pair-for-worker-nodes for details")
 	}
 
@@ -183,9 +183,4 @@ func getWarningsForPSPAdmissionPlugin(shoot *core.Shoot) string {
 	}
 
 	return "you should consider migrating to PodSecurity, see https://github.com/gardener/gardener/blob/master/docs/usage/pod-security.md#migrating-from-podsecuritypolicys-to-podsecurity-admission-controller for details"
-}
-
-func shootEnablesSSHAccess(shoot *core.Shoot) bool {
-	return !helper.IsWorkerless(shoot) &&
-		(shoot.Spec.Provider.WorkersSettings == nil || shoot.Spec.Provider.WorkersSettings.SSHAccess == nil || shoot.Spec.Provider.WorkersSettings.SSHAccess.Enabled)
 }

--- a/pkg/apis/core/helper/helpers.go
+++ b/pkg/apis/core/helper/helpers.go
@@ -494,6 +494,12 @@ func IsWorkerless(shoot *core.Shoot) bool {
 	return len(shoot.Spec.Provider.Workers) == 0
 }
 
+// ShootEnablesSSHAccess returns true if ssh access to worker nodes should be allowed for the given shoot.
+func ShootEnablesSSHAccess(shoot *core.Shoot) bool {
+	return !IsWorkerless(shoot) &&
+		(shoot.Spec.Provider.WorkersSettings == nil || shoot.Spec.Provider.WorkersSettings.SSHAccess == nil || shoot.Spec.Provider.WorkersSettings.SSHAccess.Enabled)
+}
+
 // DeterminePrimaryIPFamily determines the primary IP family out of a specified list of IP families.
 func DeterminePrimaryIPFamily(ipFamilies []core.IPFamily) core.IPFamily {
 	if len(ipFamilies) == 0 {

--- a/pkg/apis/core/helper/helpers_test.go
+++ b/pkg/apis/core/helper/helpers_test.go
@@ -880,6 +880,26 @@ var _ = Describe("helper", func() {
 		})
 	})
 
+	DescribeTable("#ShootEnablesSSHAccess",
+		func(workers []core.Worker, workersSettings *core.WorkersSettings, expectedResult bool) {
+			shoot := &core.Shoot{
+				Spec: core.ShootSpec{
+					Provider: core.Provider{
+						Workers:         workers,
+						WorkersSettings: workersSettings,
+					},
+				},
+			}
+			Expect(ShootEnablesSSHAccess(shoot)).To(Equal(expectedResult))
+		},
+
+		Entry("should return false when shoot provider has zero workers", nil, nil, false),
+		Entry("should return true when shoot provider has no WorkersSettings", []core.Worker{core.Worker{}}, nil, true),
+		Entry("should return true when shoot worker settings has no SSHAccess", []core.Worker{core.Worker{}}, &core.WorkersSettings{}, true),
+		Entry("should return true when shoot worker settings has SSHAccess set to true", []core.Worker{core.Worker{}}, &core.WorkersSettings{SSHAccess: &core.SSHAccess{Enabled: true}}, true),
+		Entry("should return false when shoot worker settings has SSHAccess set to false", []core.Worker{core.Worker{}}, &core.WorkersSettings{SSHAccess: &core.SSHAccess{Enabled: false}}, false),
+	)
+
 	Describe("#DeterminePrimaryIPFamily", func() {
 		It("should return IPv4 for empty ipFamilies", func() {
 			Expect(DeterminePrimaryIPFamily(nil)).To(Equal(core.IPFamilyIPv4))

--- a/pkg/registry/core/shoot/strategy.go
+++ b/pkg/registry/core/shoot/strategy.go
@@ -36,6 +36,7 @@ import (
 	"github.com/gardener/gardener/pkg/api"
 	"github.com/gardener/gardener/pkg/api/core/shoot"
 	"github.com/gardener/gardener/pkg/apis/core"
+	"github.com/gardener/gardener/pkg/apis/core/helper"
 	gardencorehelper "github.com/gardener/gardener/pkg/apis/core/helper"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/apis/core/validation"
@@ -132,11 +133,18 @@ func mustIncreaseGeneration(oldShoot, newShoot *core.Shoot) bool {
 				v1beta1constants.OperationRotateETCDEncryptionKeyStart,
 				v1beta1constants.OperationRotateETCDEncryptionKeyComplete,
 				v1beta1constants.ShootOperationRotateKubeconfigCredentials,
-				v1beta1constants.ShootOperationRotateSSHKeypair,
 				v1beta1constants.ShootOperationRotateObservabilityCredentials:
 				// We don't want to remove the annotation so that the gardenlet can pick it up and perform
 				// the rotation. It has to remove the annotation after it is done.
 				mustIncrease, mustRemoveOperationAnnotation = true, false
+
+			case v1beta1constants.ShootOperationRotateSSHKeypair:
+				if !helper.ShootEnablesSSHAccess(newShoot) {
+					// If SSH is not enabled for the Shoot, don't increase generation, just remove the annotation
+					mustIncrease, mustRemoveOperationAnnotation = false, true
+				} else {
+					mustIncrease, mustRemoveOperationAnnotation = true, false
+				}
 			}
 		}
 

--- a/pkg/registry/core/shoot/strategy_test.go
+++ b/pkg/registry/core/shoot/strategy_test.go
@@ -328,6 +328,15 @@ var _ = Describe("Strategy", func() {
 			DescribeTable("operation annotations",
 				func(operationAnnotation string, mutateOldShoot func(*core.Shoot), shouldIncreaseGeneration, shouldKeepAnnotation bool) {
 					oldShoot := &core.Shoot{
+						Spec: core.ShootSpec{
+							Provider: core.Provider{
+								Workers: []core.Worker{
+									{
+										Name: "worker",
+									},
+								},
+							},
+						},
 						Status: core.ShootStatus{
 							LastOperation: &core.LastOperation{},
 						},
@@ -399,11 +408,17 @@ var _ = Describe("Strategy", func() {
 					true,
 					true,
 				),
-				Entry("rotate-ssh-keypair",
+				Entry("rotate-ssh-keypair (ssh enabled)",
 					v1beta1constants.ShootOperationRotateSSHKeypair,
 					nil,
 					true,
 					true,
+				),
+				Entry("rotate-ssh-keypair (ssh is not enabled)",
+					v1beta1constants.ShootOperationRotateSSHKeypair,
+					func(s *core.Shoot) { s.Spec.Provider.Workers = nil },
+					false,
+					false,
 				),
 				Entry("rotate-observability-credentials",
 					v1beta1constants.ShootOperationRotateObservabilityCredentials,

--- a/plugin/pkg/global/extensionlabels/admission.go
+++ b/plugin/pkg/global/extensionlabels/admission.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/utils/pointer"
 
 	"github.com/gardener/gardener/pkg/apis/core"
+	"github.com/gardener/gardener/pkg/apis/core/helper"
 	gardencorehelper "github.com/gardener/gardener/pkg/apis/core/helper"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
@@ -253,6 +254,9 @@ func getEnabledExtensionsForShoot(shoot *core.Shoot, controllerRegistrations []*
 	for _, reg := range controllerRegistrations {
 		for _, resource := range reg.Spec.Resources {
 			if resource.Kind == extensionsv1alpha1.ExtensionResource && pointer.BoolDeref(resource.GloballyEnabled, false) {
+				if helper.IsWorkerless(shoot) && !pointer.BoolDeref(resource.WorkerlessSupported, false) {
+					continue
+				}
 				enabledExtensions.Insert(resource.Type)
 			}
 		}


### PR DESCRIPTION
Co-Authored-By: Ashish Ranjan Yadav <ashish.ranjan.yadav@sap.com>
Co-Authored-By: Sonu Kumar Singh <sonu.kumar.singh02@sap.com>

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality usability
/kind enhancement

**What this PR does / why we need it**:
This PR improves two things:
- The `rotate-ssh-keypair` annotation is no-op now if the ssh is not enabled for the Shoot.
- The extension labels are not added to workerless shoots for globally enabled extensions if they are not supported.

**Which issue(s) this PR fixes**:
Part of #7635

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
