### PR TITLE
[GEP-22] Prevent losing `ShootState` data

### DIFF
--- a/pkg/gardenlet/controller/shoot/shoot/reconciler_migrate.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler_migrate.go
@@ -217,7 +217,7 @@ func (r *Reconciler) runMigrateShootFlow(ctx context.Context, o *operation.Opera
 		persistShootState = g.Add(flow.Task{
 			Name: "Persisting ShootState in garden cluster",
 			Fn: func(ctx context.Context) error {
-				return shootstate.Deploy(ctx, r.Clock, botanist.GardenClient, botanist.SeedClientSet.Client(), botanist.Shoot.GetInfo())
+				return shootstate.Deploy(ctx, r.Clock, botanist.GardenClient, botanist.SeedClientSet.Client(), botanist.Shoot.GetInfo(), false)
 			},
 			Dependencies: flow.NewTaskIDs(waitUntilMachineControllerManagerDeleted),
 		})

--- a/pkg/gardenlet/controller/shoot/state/reconciler.go
+++ b/pkg/gardenlet/controller/shoot/state/reconciler.go
@@ -93,7 +93,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 
 	if nextBackupDue := lastBackup.Add(r.Config.SyncPeriod.Duration); nextBackupDue.Before(r.Clock.Now().UTC()) {
 		log.Info("Performing periodic ShootState backup", "lastBackup", lastBackup.Round(time.Minute), "nextBackupDue", nextBackupDue.Round(time.Minute))
-		if err := shootstate.Deploy(ctx, r.Clock, r.GardenClient, r.SeedClient, shoot); err != nil {
+		if err := shootstate.Deploy(ctx, r.Clock, r.GardenClient, r.SeedClient, shoot, true); err != nil {
 			return reconcile.Result{}, fmt.Errorf("failed performing periodic ShootState backup: %w", err)
 		}
 		lastBackup = r.Clock.Now()

--- a/test/integration/gardenlet/shoot/state/state_test.go
+++ b/test/integration/gardenlet/shoot/state/state_test.go
@@ -215,7 +215,7 @@ var _ = Describe("Shoot State controller tests", func() {
 				return testClient.Get(ctx, client.ObjectKeyFromObject(shoot), &gardencorev1beta1.ShootState{})
 			}).Should(BeNotFoundError())
 
-			By("Mark shoot as 'restore procession'")
+			By("Mark shoot as 'restore processing'")
 			patch := client.MergeFrom(shoot.DeepCopy())
 			shoot.Status.LastOperation.Type = gardencorev1beta1.LastOperationTypeRestore
 			Expect(testClient.Status().Patch(ctx, shoot, patch)).To(Succeed())


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area scalability
/kind bug

**What this PR does / why we need it**:
- After https://github.com/gardener/gardener/pull/8082, the shoot migration flow could fail after persisting the state and deleting the extension resources, and any subsequent reconciliation will overwrite the `ShootState` with empty data (effectively rendering it useless for restoration).
- After https://github.com/gardener/gardener/pull/8112, the new `ShootState` controller could trigger at a similar unfortunate moment and overwrite the `ShootState` with empty data.

This PR fixes both concerns by
- using "upsert" when persisting data in the shoot migration flow (this way, subsequent invocations do not delete existing data)
- changing the `ShootState` controller to requeue the `Shoot` when it is currently in migration

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/8073

**Special notes for your reviewer**:
In the future, we can consider changing the shoot migration flow as follows:

- only migrate all extension resources without deleting them
- persist shoot state just before deleting the shoot namespace (and only if shoot namespace has no deletion timestamp yet)
- this automatically deletes all extension resources

This way, we can drop the `overwriteSpec` argument again.

/cc @timebertt 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
