### PR TITLE
Prevent concurrent updates on in-memory Garden object of operator during parallel task flow.

### DIFF
--- a/pkg/operator/controller/garden/components.go
+++ b/pkg/operator/controller/garden/components.go
@@ -643,9 +643,6 @@ func (r *Reconciler) newSNI(garden *operatorv1alpha1.Garden, ingressGatewayValue
 		return nil, fmt.Errorf("exactly one Istio Ingress Gateway is required for the SNI config")
 	}
 
-	// Explicitly render server domain at initialization time as garden object may be changed by kubernetes clients later on
-	serverDomain := gardenerutils.GetAPIServerDomain(garden.Spec.VirtualCluster.DNS.Domain)
-
 	return kubeapiserverexposure.NewSNI(
 		r.RuntimeClientSet.Client(),
 		r.RuntimeClientSet.Applier(),
@@ -653,7 +650,7 @@ func (r *Reconciler) newSNI(garden *operatorv1alpha1.Garden, ingressGatewayValue
 		r.GardenNamespace,
 		func() *kubeapiserverexposure.SNIValues {
 			return &kubeapiserverexposure.SNIValues{
-				Hosts: []string{serverDomain},
+				Hosts: []string{gardenerutils.GetAPIServerDomain(garden.Spec.VirtualCluster.DNS.Domain)},
 				IstioIngressGateway: kubeapiserverexposure.IstioIngressGateway{
 					Namespace: ingressGatewayValues[0].Namespace,
 					Labels:    ingressGatewayValues[0].Labels,

--- a/pkg/operator/controller/garden/reconciler_delete.go
+++ b/pkg/operator/controller/garden/reconciler_delete.go
@@ -178,12 +178,14 @@ func (r *Reconciler) delete(
 		})
 	)
 
+	gardenCopy := garden.DeepCopy()
 	if err := g.Compile().Run(ctx, flow.Opts{
 		Log:              log,
-		ProgressReporter: r.reportProgress(log, garden),
+		ProgressReporter: r.reportProgress(log, gardenCopy),
 	}); err != nil {
 		return reconcilerutils.ReconcileErr(flow.Errors(err))
 	}
+	*garden = *gardenCopy
 
 	if controllerutil.ContainsFinalizer(garden, finalizerName) {
 		log.Info("Removing finalizer")

--- a/pkg/operator/controller/garden/reconciler_reconcile.go
+++ b/pkg/operator/controller/garden/reconciler_reconcile.go
@@ -274,12 +274,14 @@ func (r *Reconciler) reconcile(
 		})
 	)
 
+	gardenCopy := garden.DeepCopy()
 	if err := g.Compile().Run(ctx, flow.Opts{
 		Log:              log,
-		ProgressReporter: r.reportProgress(log, garden),
+		ProgressReporter: r.reportProgress(log, gardenCopy),
 	}); err != nil {
 		return reconcile.Result{}, flow.Errors(err)
 	}
+	*garden = *gardenCopy
 
 	return reconcile.Result{}, secretsManager.Cleanup(ctx)
 }


### PR DESCRIPTION
Co-authored-by: Rafael Franzke <rafael.franzke@sap.com>

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind enhancement

**What this PR does / why we need it**:
Prevent concurrent updates on in-memory Garden object of operator during parallel task flow.

Patching/updating object via controller runtime kubernetes clients can have negative consequences for parallel readers of the in-memory golang object (see https://github.com/gardener/gardener/blob/master/docs/development/kubernetes-clients.md for details). For example, parts of the structure can be temporarily (and unexpectedly) empty.
In PR #8103, the immediate issue was addressed while the overarching problem remained. This change reverts the hotfix and replaces it with a proper solution, i.e. it decouples the continuous status patch updates of the progress reporter from the golang in-memory object used during the parallel task flow. Therefore, reading the in-memory object should now be safe again while the in-memory object is updated after the flow so that execution can continue as usual.

**Which issue(s) this PR fixes**:
None.

**Special notes for your reviewer**:
This change reverts #8103 as it is no longer necessary.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Decouple progess update of gardener operator from task flow logic and thereby prevent concurrency bugs.
```
