### PR TITLE
Adapt `Worker` controller to persist state in `Migrate` phase

### DIFF
--- a/extensions/pkg/controller/worker/genericactuator/actuator_migrate.go
+++ b/extensions/pkg/controller/worker/genericactuator/actuator_migrate.go
@@ -20,8 +20,10 @@ import (
 
 	machinev1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
 	"github.com/go-logr/logr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/gardener/gardener/extensions/pkg/controller"
+	extensionsworkercontroller "github.com/gardener/gardener/extensions/pkg/controller/worker"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/managedresources"
@@ -53,6 +55,20 @@ func (a *genericActuator) Migrate(ctx context.Context, log logr.Logger, worker *
 		}
 	}
 
+	// TODO(rfranzke): Instead of checking for machine objects, we could also only persist the state when it is nil.
+	//  This is only to prevent that subsequent executions of Migrate don't overwrite/delete previously persisted state.
+	//  We cannot do it this way yet since gardenlet does not persist the ShootState after all extension resources have
+	//  been migrated. It is planned to do so after v1.79 has been released, hence we have to wait a bit longer.
+	machineObjectsExist, err := kubernetesutils.ResourcesExist(ctx, a.client, machinev1alpha1.SchemeGroupVersion.WithKind("MachineList"), client.InNamespace(worker.Namespace))
+	if err != nil {
+		return fmt.Errorf("failed checking whether machine objects exist: %w", err)
+	}
+	if machineObjectsExist {
+		if err := extensionsworkercontroller.PersistState(ctx, log, a.client, worker); err != nil {
+			return fmt.Errorf("failed persisting worker state: %w", err)
+		}
+	}
+
 	if err := a.shallowDeleteAllObjects(ctx, log, worker.Namespace, &machinev1alpha1.MachineList{}); err != nil {
 		return fmt.Errorf("shallow deletion of all machine failed: %w", err)
 	}
@@ -79,7 +95,7 @@ func (a *genericActuator) Migrate(ctx context.Context, log logr.Logger, worker *
 
 	// Wait until all machine resources have been properly deleted.
 	if err := a.waitUntilMachineResourcesDeleted(ctx, log, worker, workerDelegate); err != nil {
-		return fmt.Errorf("Failed while waiting for all machine resources to be deleted: %w", err)
+		return fmt.Errorf("failed while waiting for all machine resources to be deleted: %w", err)
 	}
 
 	return nil

--- a/extensions/pkg/controller/worker/genericactuator/actuator_restore.go
+++ b/extensions/pkg/controller/worker/genericactuator/actuator_restore.go
@@ -111,6 +111,11 @@ func (a *genericActuator) Restore(ctx context.Context, log logr.Logger, worker *
 		return err
 	}
 	return a.Reconcile(ctx, log, worker, cluster)
+	// TODO(rfranzke): Uncomment these lines after the stateReconciler has been dropped (probably after v1.79 has been
+	//  released).
+	// patch := client.MergeFromWithOptions(worker.DeepCopy(), client.MergeFromWithOptimisticLock{})
+	// worker.Status.State = nil
+	// return a.client.Status().Patch(ctx, worker, patch)
 }
 
 func addStateToMachineDeployment(worker *extensionsv1alpha1.Worker, wantedMachineDeployments extensionsworkercontroller.MachineDeployments) error {

--- a/extensions/pkg/controller/worker/state_reconciler.go
+++ b/extensions/pkg/controller/worker/state_reconciler.go
@@ -22,6 +22,7 @@ import (
 	"sort"
 
 	machinev1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
+	"github.com/go-logr/logr"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -33,7 +34,6 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
-	reconcilerutils "github.com/gardener/gardener/pkg/controllerutils/reconciler"
 )
 
 type stateReconciler struct {
@@ -75,43 +75,48 @@ func (r *stateReconciler) Reconcile(ctx context.Context, request reconcile.Reque
 		return reconcile.Result{}, nil
 	}
 
-	state, err := r.computeState(ctx, worker.Namespace)
+	return reconcile.Result{}, PersistState(ctx, log, r.client, worker)
+}
+
+// PersistState persists the worker state into the .status.state field.
+func PersistState(ctx context.Context, log logr.Logger, c client.Client, worker *extensionsv1alpha1.Worker) error {
+	state, err := computeState(ctx, c, worker.Namespace)
 	if err != nil {
-		return reconcile.Result{}, err
+		return err
 	}
 
 	rawState, err := json.Marshal(state)
 	if err != nil {
-		return reconcile.Result{}, err
+		return err
 	}
 
 	// If the state did not change, do not even try to send an empty PATCH request.
 	if worker.Status.State != nil && bytes.Equal(rawState, worker.Status.State.Raw) {
-		return reconcile.Result{}, nil
+		return nil
 	}
 
 	patch := client.MergeFromWithOptions(worker.DeepCopy(), client.MergeFromWithOptimisticLock{})
 	worker.Status.State = &runtime.RawExtension{Raw: rawState}
-	if err := r.client.Status().Patch(ctx, worker, patch); err != nil {
-		return reconcilerutils.ReconcileErr(fmt.Errorf("error updating Worker state: %w", err))
+	if err := c.Status().Patch(ctx, worker, patch); err != nil {
+		return fmt.Errorf("error updating Worker state: %w", err)
 	}
 
 	log.Info("Successfully updated Worker state")
-	return reconcile.Result{}, nil
+	return nil
 }
 
-func (r *stateReconciler) computeState(ctx context.Context, namespace string) (*State, error) {
+func computeState(ctx context.Context, c client.Client, namespace string) (*State, error) {
 	existingMachineDeployments := &machinev1alpha1.MachineDeploymentList{}
-	if err := r.client.List(ctx, existingMachineDeployments, client.InNamespace(namespace)); err != nil {
+	if err := c.List(ctx, existingMachineDeployments, client.InNamespace(namespace)); err != nil {
 		return nil, err
 	}
 
-	machineSets, err := r.getExistingMachineSetsMap(ctx, namespace)
+	machineSets, err := getExistingMachineSetsMap(ctx, c, namespace)
 	if err != nil {
 		return nil, err
 	}
 
-	machines, err := r.getExistingMachinesMap(ctx, namespace)
+	machines, err := getExistingMachinesMap(ctx, c, namespace)
 	if err != nil {
 		return nil, err
 	}
@@ -147,9 +152,9 @@ func (r *stateReconciler) computeState(ctx context.Context, namespace string) (*
 }
 
 // getExistingMachineSetsMap returns a map of existing MachineSets as values and their owners as keys
-func (r *stateReconciler) getExistingMachineSetsMap(ctx context.Context, namespace string) (map[string][]machinev1alpha1.MachineSet, error) {
+func getExistingMachineSetsMap(ctx context.Context, c client.Client, namespace string) (map[string][]machinev1alpha1.MachineSet, error) {
 	existingMachineSets := &machinev1alpha1.MachineSetList{}
-	if err := r.client.List(ctx, existingMachineSets, client.InNamespace(namespace)); err != nil {
+	if err := c.List(ctx, existingMachineSets, client.InNamespace(namespace)); err != nil {
 		return nil, err
 	}
 
@@ -163,9 +168,9 @@ func (r *stateReconciler) getExistingMachineSetsMap(ctx context.Context, namespa
 // no matter of being machineSet or MachineDeployment. If a Machine has a ownerReference the key(owner)
 // will be the MachineSet if not the key will be the name of the MachineDeployment which is stored as
 // a label. We assume that there is no MachineDeployment and MachineSet with the same names.
-func (r *stateReconciler) getExistingMachinesMap(ctx context.Context, namespace string) (map[string][]machinev1alpha1.Machine, error) {
+func getExistingMachinesMap(ctx context.Context, c client.Client, namespace string) (map[string][]machinev1alpha1.Machine, error) {
 	existingMachines := &machinev1alpha1.MachineList{}
-	if err := r.client.List(ctx, existingMachines, client.InNamespace(namespace)); err != nil {
+	if err := c.List(ctx, existingMachines, client.InNamespace(namespace)); err != nil {
 		return nil, err
 	}
 

--- a/extensions/pkg/controller/worker/state_reconciler.go
+++ b/extensions/pkg/controller/worker/state_reconciler.go
@@ -36,6 +36,9 @@ import (
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 )
 
+// TODO(rfranzke): Drop this stateReconciler after a few releases as soon as the shoot migrate flow persists the Shoot
+//  state only after all extension resources have been migrated.
+
 type stateReconciler struct {
 	client client.Client
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind enhancement

**What this PR does / why we need it**:
Similar to https://github.com/gardener/gardener/pull/8093 which adapted the `ControlPlane` controller, this PR adapts the `Worker` controller to the clarified extension contract when it comes to migration:

> The `migrate` operation [...]. This is also the last opportunity for extensions to persist their state into the `.status.state` field of the reconciled extension resource before its restored in the new destination seed cluster.

With this PR, the generic `Worker` actuator persists the machine state in the `Migrate` phase. It only does so if there are still `Machine` objects (otherwise, there is nothing relevant to persist). This check also prevents it from accidentally overwriting the state in subsequent executions of `Migrate()` with empty data (ref #8143).

[GEP-22](https://github.com/gardener/gardener/blob/master/docs/proposals/22-improved-usage-of-shootstate-api.md#eliminating-the-worker-state-reconciler) actually talks about letting `gardenlet` fetch the worker state directly from the seed API server when it persists the `ShootState`. However, after a more careful evaluation of flow, I think it's still better if the generic `Worker` actuator continues to persist the machine state and `gardenlet` only reads it from `.status.state` of the `Worker` resource. The generic `Worker` actuator needs to understand and read this state in the `Restore` phase anyways, so there is not much that can be saved with shifting it to `gardenlet`.
Still, the plan is to drop the `Worker` state reconciler in the extensions library which is the culprit of too many update calls against the seed API servers.
For now, we have to keep the `Worker` state reconciler for a bit longer until the `gardenlet` only persists the `ShootState` after all extension resources have been migrated.

So, the final target picture is:
- `Worker` state reconciler gets dropped (i.e., no continuous persisting of the machine state in `.status.state`)
- `Migrate()` of generic `Worker` actuator persists the machine state before shallow-deleting all machine resources (though, it only persists when `.status.state` is nil (this is to prevent subsequent executions from accidentally overwriting previously persisted state))
- `Restore()` of generic `Worker` actuator sets `.status.state` to `nil` after successful restoration.
- `gardenlet` continuous to fetch and restore the state from/to `.status.state` just like today (the only change will be that it fetches the state only after all extension resources have been successfully migrated)

Related to #8073 

**Special notes for your reviewer**:
/cc @timebertt 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
