### PR TITLE
Fix `plutono` dashboard

### DIFF
--- a/charts/seed-bootstrap/dashboards/seed-deployments-replicas.json
+++ b/charts/seed-bootstrap/dashboards/seed-deployments-replicas.json
@@ -59,7 +59,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "max(kube_deployment_spec_replicas{instance=\"kube-state-metrics\",deployment=\"$deployment_name\"}) without (instance, pod)",
+          "expr": "max(kube_deployment_spec_replicas{deployment=\"$deployment_name\"}) without (instance, pod)",
           "interval": "",
           "legendFormat": "{{namespace}}",
           "refId": "A"
@@ -118,7 +118,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "min(kube_deployment_status_replicas_available{instance=\"kube-state-metrics\",deployment=\"$deployment_name\"}) without (instance, pod)",
+          "expr": "min(kube_deployment_status_replicas_available{deployment=\"$deployment_name\"}) without (instance, pod)",
           "interval": "",
           "legendFormat": "{{namespace}}",
           "refId": "A"
@@ -173,7 +173,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "max(kube_deployment_status_observed_generation{instance=\"kube-state-metrics\",deployment=\"$deployment_name\"}) without (instance, pod)",
+          "expr": "max(kube_deployment_status_observed_generation{deployment=\"$deployment_name\"}) without (instance, pod)",
           "interval": "",
           "legendFormat": "{{namespace}}",
           "refId": "A"
@@ -228,7 +228,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "max(kube_deployment_metadata_generation{instance=\"kube-state-metrics\",deployment=\"$deployment_name\"}) without (instance, pod)",
+          "expr": "max(kube_deployment_metadata_generation{deployment=\"$deployment_name\"}) without (instance, pod)",
           "interval": "",
           "legendFormat": "{{namespace}}",
           "refId": "A"

--- a/charts/seed-monitoring/charts/plutono/dashboards/owners/kubernetes-deployments-dashboard.json
+++ b/charts/seed-monitoring/charts/plutono/dashboards/owners/kubernetes-deployments-dashboard.json
@@ -341,7 +341,7 @@
       },
       "targets": [
         {
-          "expr": "max(kube_deployment_spec_replicas{instance=\"kube-state-metrics\",deployment=\"$deployment_name\"}) without (instance, pod)",
+          "expr": "max(kube_deployment_spec_replicas{deployment=\"$deployment_name\"}) without (instance, pod)",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "",
@@ -431,7 +431,7 @@
       },
       "targets": [
         {
-          "expr": "min(kube_deployment_status_replicas_available{instance=\"kube-state-metrics\",deployment=\"$deployment_name\"}) without (instance, pod)",
+          "expr": "min(kube_deployment_status_replicas_available{deployment=\"$deployment_name\"}) without (instance, pod)",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "",
@@ -521,7 +521,7 @@
       "tableColumn": "{deployment=\"aws-lb-readvertiser\", job=\"kube-state-metrics\", namespace=\"kube-system\", type=\"seed\"}",
       "targets": [
         {
-          "expr": "max(kube_deployment_status_observed_generation{instance=\"kube-state-metrics\",deployment=\"$deployment_name\"}) without (instance, pod)",
+          "expr": "max(kube_deployment_status_observed_generation{deployment=\"$deployment_name\"}) without (instance, pod)",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "",
@@ -611,7 +611,7 @@
       "tableColumn": "{deployment=\"aws-lb-readvertiser\", job=\"kube-state-metrics-seed\", namespace=\"kube-system\", type=\"seed\"}",
       "targets": [
         {
-          "expr": "max(kube_deployment_metadata_generation{instance=\"kube-state-metrics\",deployment=\"$deployment_name\"}) without (instance, pod)",
+          "expr": "max(kube_deployment_metadata_generation{deployment=\"$deployment_name\"}) without (instance, pod)",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "",

--- a/charts/seed-monitoring/charts/plutono/dashboards/owners/kubernetes-statefulsets-dashboard.json
+++ b/charts/seed-monitoring/charts/plutono/dashboards/owners/kubernetes-statefulsets-dashboard.json
@@ -341,7 +341,7 @@
       },
       "targets": [
         {
-          "expr": "max(kube_statefulset_replicas{instance=\"kube-state-metrics\", statefulset=\"$statefulset_name\"}) without (instance, pod)",
+          "expr": "max(kube_statefulset_replicas{statefulset=\"$statefulset_name\"}) without (instance, pod)",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -433,7 +433,7 @@
       "tableColumn": "{job=\"kube-state-metrics-seed\", namespace=\"kube-system\", statefulset=\"etcd-events\", type=\"seed\"}",
       "targets": [
         {
-          "expr": "min(kube_statefulset_status_replicas_ready{instance=\"kube-state-metrics\",statefulset=\"$statefulset_name\"}) without (instance, pod)",
+          "expr": "min(kube_statefulset_status_replicas_ready{statefulset=\"$statefulset_name\"}) without (instance, pod)",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -523,7 +523,7 @@
       },
       "targets": [
         {
-          "expr": "max(kube_statefulset_status_observed_generation{instance=\"kube-state-metrics\",statefulset=\"$statefulset_name\"}) without (instance, pod)",
+          "expr": "max(kube_statefulset_status_observed_generation{statefulset=\"$statefulset_name\"}) without (instance, pod)",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "",
@@ -612,7 +612,7 @@
       },
       "targets": [
         {
-          "expr": "max(kube_statefulset_metadata_generation{instance=\"kube-state-metrics\",statefulset=\"$statefulset_name\"}) without (instance, pod)",
+          "expr": "max(kube_statefulset_metadata_generation{statefulset=\"$statefulset_name\"}) without (instance, pod)",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "",


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind bug

**What this PR does / why we need it**:
This PR fixes `Kubernetes StatefulSets` and `Kubernetes Deployments` to show `Desired Replicas`, `Available Replicas`, `Observed Generation` and `Metadata Generation` correctly for resources in Seed. 

Before -
<img width="1728" alt="Screenshot 2023-06-22 at 8 46 17 PM" src="https://github.com/gardener/gardener/assets/28653770/96251004-81e2-450e-82cb-d3becad5e59e">

After - 
<img width="1727" alt="Screenshot 2023-06-22 at 8 40 16 PM" src="https://github.com/gardener/gardener/assets/28653770/548c37f7-0fb9-4b57-97f0-2c0f78f41571">


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @istvanballok @rickardsjp 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
