### PR TITLE
Update `calico` manifests to `v3.26.1`

### DIFF
--- a/example/gardener-local/calico/base/kustomization.yaml
+++ b/example/gardener-local/calico/base/kustomization.yaml
@@ -6,8 +6,8 @@ resources:
 
 images:
 - name: docker.io/calico/cni
-  newName: eu.gcr.io/gardener-project/3rd/calico/cni
+  newName: quay.io/calico/cni
 - name: docker.io/calico/node
-  newName: eu.gcr.io/gardener-project/3rd/calico/node
+  newName: quay.io/calico/node
 - name: docker.io/calico/kube-controllers
-  newName: eu.gcr.io/gardener-project/3rd/calico/kube-controllers
+  newName: quay.io/calico/kube-controllers

--- a/example/gardener-local/calico/base/kustomization.yaml
+++ b/example/gardener-local/calico/base/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-- https://raw.githubusercontent.com/projectcalico/calico/v3.25.0/manifests/calico.yaml
+- https://raw.githubusercontent.com/projectcalico/calico/v3.26.1/manifests/calico.yaml
 
 images:
 - name: docker.io/calico/cni

--- a/example/provider-local/garden/base/kustomization.yaml
+++ b/example/provider-local/garden/base/kustomization.yaml
@@ -8,7 +8,7 @@ resources:
 - secret-backup.yaml
 - secretbinding.yaml
 - https://raw.githubusercontent.com/gardener/gardener-extension-networking-cilium/v1.24.0/example/controller-registration.yaml
-- https://raw.githubusercontent.com/gardener/gardener-extension-networking-calico/v1.33.0/example/controller-registration.yaml
+- https://raw.githubusercontent.com/gardener/gardener-extension-networking-calico/v1.34.1/example/controller-registration.yaml
 
 patchesStrategicMerge:
 - patch-controller-registrations.yaml

--- a/example/provider-local/garden/base/kustomization.yaml
+++ b/example/provider-local/garden/base/kustomization.yaml
@@ -7,7 +7,7 @@ resources:
 - project.yaml
 - secret-backup.yaml
 - secretbinding.yaml
-- https://raw.githubusercontent.com/gardener/gardener-extension-networking-cilium/v1.24.0/example/controller-registration.yaml
+- https://raw.githubusercontent.com/gardener/gardener-extension-networking-cilium/v1.25.0/example/controller-registration.yaml
 - https://raw.githubusercontent.com/gardener/gardener-extension-networking-calico/v1.34.1/example/controller-registration.yaml
 
 patchesStrategicMerge:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind enhancement

**What this PR does / why we need it**:
This PR does following task - 
 - Updates the `calico` manifests used in local-kind setup to `v3.26.1`
  Calico release notes:
    - https://github.com/projectcalico/calico/blob/v3.26.0/release-notes/v3.26.0-release-notes.md
    - https://github.com/projectcalico/calico/blob/v3.26.1/release-notes/v3.26.1-release-notes.md
  - Switch calico images from `quay.io` instead of `gcr`.  [ref1](https://github.com/gardener/gardener-extension-networking-calico/pull/275), [ref2](https://github.com/gardener/gardener-extension-networking-calico/pull/275#issuecomment-1582021232)
  - Update `networking-calico` v1.33.0 -> v1.34.1
  - Update `networking-cilium ` v1.24.0 -> v1.25.0

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @ialidzhikov for - https://github.com/gardener/gardener/pull/8150/commits/e6df2c3bc7429403f3062b90a269daef509d0380

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
