### PR TITLE
Renew all garden access secrets on seed when triggered by annotation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -170,9 +170,10 @@
   * [Extension Admission](extensions/admission.md)
   * [Heartbeat controller](extensions/heartbeat.md)
 * [Provider Local](extensions/provider-local.md)
+* [Access to the Garden Cluster](extensions/garden-api-access.md)
+* [Control plane migration](extensions/migration.md)
 * [Extending project roles](extensions/project-roles.md)
 * [Referenced resources](extensions/referenced-resources.md)
-* [Control plane migration](extensions/migration.md)
 
 ## Deployment
 

--- a/docs/concepts/gardenlet.md
+++ b/docs/concepts/gardenlet.md
@@ -446,8 +446,6 @@ The mechanism works the same way as for shoot control plane components running i
 However, `gardenlet`'s instance of the `TokenRequestor` controller is restricted to `Secret`s labeled with `resources.gardener.cloud/class=garden`.
 Furthermore, it doesn't respect the `serviceaccount.resources.gardener.cloud/namespace` annotation. Instead, it always uses the seed's namespace in the garden cluster for managing `ServiceAccounts` and their tokens.
 
-> ⚠️ This feature is under development. The managed `ServiceAccounts` in the garden cluster don't have any API permissions as of now. They will be handled by the `SeedAuthorizer` in the future and equipped with permissions similar to the gardenlets' credentials.
-
 ## Managed Seeds
 
 Gardener users can use shoot clusters as seed clusters, so-called "managed seeds" (aka "shooted seeds"),

--- a/docs/concepts/gardenlet.md
+++ b/docs/concepts/gardenlet.md
@@ -416,17 +416,6 @@ If at least one check fails and there is threshold configuration for the conditi
 The condition thresholds can be used to prevent reporting issues too early just because there is a rollout or a short disruption.
 Only if the unhealthiness persists for at least the configured threshold duration, then the issues will be reported (by setting the status to `False`).
 
-### [`TokenRequestor` Controller](../../pkg/controller/tokenrequestor)
-
-The `gardenlet` uses an instance of the `TokenRequestor` controller which initially was developed in the context of the `gardener-resource-manager`, please read [this document](resource-manager.md#tokenrequestor-controller) for further information.
-
-`gardenlet` uses it for requesting tokens for components running in the seed cluster that need to communicate with the garden cluster.
-The mechanism works the same way as for shoot control plane components running in the seed which need to communicate with the shoot cluster.
-However, `gardenlet`'s instance of the `TokenRequestor` controller is restricted to `Secret`s labeled with `resources.gardener.cloud/class=garden`.
-Furthermore, it doesn't respect the `serviceaccount.resources.gardener.cloud/namespace` annotation. Instead, it always uses the seed's namespace in the garden cluster for managing `ServiceAccounts` and their tokens.
-
-> ⚠️ This feature is under development. The managed `ServiceAccounts` in the garden cluster don't have any API permissions as of now. They will be handled by the `SeedAuthorizer` in the future and equipped with permissions similar to the gardenlets' credentials.
-
 ##### Constraints And Automatic Webhook Remediation
 
 Please see [Shoot Status](../usage/shoot_status.md#constraints) for more details.
@@ -447,6 +436,17 @@ It is only started in case the `gardenlet` is responsible for an unmanaged `Seed
 Alternatively, it can be disabled by setting the `concurrentSyncs=0` for the controller in the `gardenlet`'s component configuration.
 
 Please refer to [GEP-22: Improved Usage of the `ShootState` API](../proposals/22-improved-usage-of-shootstate-api.md) for all information.
+
+### [`TokenRequestor` Controller](../../pkg/controller/tokenrequestor)
+
+The `gardenlet` uses an instance of the `TokenRequestor` controller which initially was developed in the context of the `gardener-resource-manager`, please read [this document](resource-manager.md#tokenrequestor-controller) for further information.
+
+`gardenlet` uses it for requesting tokens for components running in the seed cluster that need to communicate with the garden cluster.
+The mechanism works the same way as for shoot control plane components running in the seed which need to communicate with the shoot cluster.
+However, `gardenlet`'s instance of the `TokenRequestor` controller is restricted to `Secret`s labeled with `resources.gardener.cloud/class=garden`.
+Furthermore, it doesn't respect the `serviceaccount.resources.gardener.cloud/namespace` annotation. Instead, it always uses the seed's namespace in the garden cluster for managing `ServiceAccounts` and their tokens.
+
+> ⚠️ This feature is under development. The managed `ServiceAccounts` in the garden cluster don't have any API permissions as of now. They will be handled by the `SeedAuthorizer` in the future and equipped with permissions similar to the gardenlets' credentials.
 
 ## Managed Seeds
 

--- a/docs/extensions/garden-api-access.md
+++ b/docs/extensions/garden-api-access.md
@@ -7,14 +7,14 @@ title: Access to the Garden Cluster for Extensions
 ## Background
 
 Historically, `gardenlet` has been the only component running in the seed cluster that has access to both the seed cluster and the garden cluster.
-Accordingly, gardener extensions running on the seed cluster didn't have access to the garden cluster.
+Accordingly, extensions running on the seed cluster didn't have access to the garden cluster.
 
-Starting from gardener [v1.74.0](https://github.com/gardener/gardener/releases/v1.74.0), there is a new mechanism for components running on seed clusters to get access to the garden cluster.
+Starting from Gardener [`v1.74.0`](https://github.com/gardener/gardener/releases/v1.74.0), there is a new mechanism for components running on seed clusters to get access to the garden cluster.
 For this, `gardenlet` runs an instance of the [`TokenRequestor`](../concepts/gardenlet.md#tokenrequestor-controller) for requesting tokens that can be used to communicate with the garden cluster.
 
 ## Manually Requesting a Token for the Garden Cluster
 
-Seed components that need to communicate with the garden cluster, can request a token in the garden cluster by creating a garden access secret.
+Seed components that need to communicate with the garden cluster can request a token in the garden cluster by creating a garden access secret.
 This secret has to be labelled with `resources.gardener.cloud/purpose=token-requestor` and `resources.gardener.cloud/class=garden`, e.g.:
 
 ```yaml
@@ -37,6 +37,5 @@ This will instruct gardenlet to create a new `ServiceAccount` named `example` in
 
 ## Renewing All Garden Access Secrets
 
-Operators can trigger an automatic renewal of all gardener access secrets in a given Seed and their requested `ServiceAccount` tokens, e.g., when rotating the garden cluster's `ServiceAccount` signing key.
+Operators can trigger an automatic renewal of all garden access secrets in a given `Seed` and their requested `ServiceAccount` tokens, e.g., when rotating the garden cluster's `ServiceAccount` signing key.
 For this, the `Seed` has to be annotated with `gardener.cloud/operation=renew-garden-access-secrets`.
-

--- a/docs/extensions/garden-api-access.md
+++ b/docs/extensions/garden-api-access.md
@@ -1,0 +1,42 @@
+---
+title: Access to the Garden Cluster for Extensions
+---
+
+# Access to the Garden Cluster for Extensions
+
+## Background
+
+Historically, `gardenlet` has been the only component running in the seed cluster that has access to both the seed cluster and the garden cluster.
+Accordingly, gardener extensions running on the seed cluster didn't have access to the garden cluster.
+
+Starting from gardener [v1.74.0](https://github.com/gardener/gardener/releases/v1.74.0), there is a new mechanism for components running on seed clusters to get access to the garden cluster.
+For this, `gardenlet` runs an instance of the [`TokenRequestor`](../concepts/gardenlet.md#tokenrequestor-controller) for requesting tokens that can be used to communicate with the garden cluster.
+
+## Manually Requesting a Token for the Garden Cluster
+
+Seed components that need to communicate with the garden cluster, can request a token in the garden cluster by creating a garden access secret.
+This secret has to be labelled with `resources.gardener.cloud/purpose=token-requestor` and `resources.gardener.cloud/class=garden`, e.g.:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: garden-access-example
+  namespace: example
+  labels:
+    resources.gardener.cloud/purpose: token-requestor
+    resources.gardener.cloud/class: garden
+  annotations:
+    serviceaccount.resources.gardener.cloud/name: example
+type: Opaque
+```
+
+This will instruct gardenlet to create a new `ServiceAccount` named `example` in its own `seed-<seed-name>` namespace in the garden cluster, request a token for it, and populate the token in the secret's data under the `token` key.
+
+> ⚠️ This feature is under development. The managed `ServiceAccounts` in the garden cluster don't have any API permissions as of now. They will be handled by the `SeedAuthorizer` in the future and equipped with permissions similar to the gardenlets' credentials. See [gardener/gardener#8001](https://github.com/gardener/gardener/issues/8001) for more information.
+
+## Renewing All Garden Access Secrets
+
+Operators can trigger an automatic renewal of all gardener access secrets in a given Seed and their requested `ServiceAccount` tokens, e.g., when rotating the garden cluster's `ServiceAccount` signing key.
+For this, the `Seed` has to be annotated with `gardener.cloud/operation=renew-garden-access-secrets`.
+

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -383,6 +383,9 @@ const (
 	// OperationRotateETCDEncryptionKeyComplete is a constant for an annotation on a Shoot indicating that the
 	// rotation of the ETCD encryption key shall be completed.
 	OperationRotateETCDEncryptionKeyComplete = "rotate-etcd-encryption-key-complete"
+	// SeedOperationRenewGardenAccessSecrets is a constant for an annotation on a Seed indicating that the
+	// all garden access secrets on the seed shall be renewed.
+	SeedOperationRenewGardenAccessSecrets = "renew-garden-access-secrets"
 
 	// SeedResourceManagerClass is the resource-class managed by the Gardener-Resource-Manager
 	// instance in the garden namespace on the seeds.

--- a/pkg/apis/core/validation/seed_test.go
+++ b/pkg/apis/core/validation/seed_test.go
@@ -153,6 +153,27 @@ var _ = Describe("Seed Validation Tests", func() {
 			),
 		)
 
+		Context("operation annotation", func() {
+			It("should do nothing if the operation annotation is not set", func() {
+				Expect(ValidateSeed(seed)).To(BeEmpty())
+			})
+
+			It("should return an error if the operation annotation is invalid", func() {
+				metav1.SetMetaDataAnnotation(&seed.ObjectMeta, "gardener.cloud/operation", "foo-bar")
+				Expect(ValidateSeed(seed)).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeNotSupported),
+					"Field": Equal("metadata.annotations[gardener.cloud/operation]"),
+				}))))
+			})
+
+			DescribeTable("should return nothing if the operation annotations is valid", func(operation string) {
+				metav1.SetMetaDataAnnotation(&seed.ObjectMeta, "gardener.cloud/operation", operation)
+				Expect(ValidateSeed(seed)).To(BeEmpty())
+			},
+				Entry("renew-garden-access-secrets", "renew-garden-access-secrets"),
+			)
+		})
+
 		It("should forbid Seed specification with empty or invalid keys", func() {
 			invalidCIDR := "invalid-cidr"
 			seed.Spec.Provider = core.SeedProvider{

--- a/pkg/operator/controller/garden/reconciler_reconcile.go
+++ b/pkg/operator/controller/garden/reconciler_reconcile.go
@@ -224,7 +224,12 @@ func (r *Reconciler) reconcile(
 		renewVirtualClusterAccess = g.Add(flow.Task{
 			Name: "Renewing virtual garden access secrets after creation of new ServiceAccount signing key",
 			Fn: flow.TaskFn(func(ctx context.Context) error {
-				return tokenrequest.RenewAccessSecrets(ctx, r.RuntimeClientSet.Client(), r.GardenNamespace)
+				return tokenrequest.RenewAccessSecrets(ctx, r.RuntimeClientSet.Client(),
+					client.InNamespace(r.GardenNamespace),
+					// TODO(rfranzke): Uncomment the next line after v1.85 has been released
+					//  (together with restricting the garden's/shoot's tokenrequestor to the shoot class).
+					// client.MatchingLabels{resourcesv1alpha1.ResourceManagerClass: resourcesv1alpha1.ResourceManagerClassShoot},
+				)
 			}).
 				RetryUntilTimeout(5*time.Second, 30*time.Second).
 				DoIf(helper.GetServiceAccountKeyRotationPhase(garden.Status.Credentials) == gardencorev1beta1.RotationPreparing),

--- a/pkg/registry/core/seed/strategy_test.go
+++ b/pkg/registry/core/seed/strategy_test.go
@@ -19,6 +19,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
 
 	"github.com/gardener/gardener/pkg/apis/core"
@@ -45,10 +46,56 @@ var _ = Describe("Strategy", func() {
 			Expect(newSeed.Status).To(Equal(oldSeed.Status))
 		})
 
-		It("should bump the generation if the spec changes", func() {
-			newSeed.Spec.Provider.Type = "foo"
-			strategy.PrepareForUpdate(ctx, newSeed, oldSeed)
-			Expect(newSeed.Generation).To(Equal(oldSeed.Generation + 1))
+		Context("generation increment", func() {
+			It("should not bump the generation if nothing changed", func() {
+				strategy.PrepareForUpdate(ctx, newSeed, oldSeed)
+
+				Expect(newSeed.Generation).To(Equal(oldSeed.Generation))
+			})
+
+			It("should bump the generation if the spec changed", func() {
+				newSeed.Spec.Provider.Type = "foo"
+
+				strategy.PrepareForUpdate(ctx, newSeed, oldSeed)
+
+				Expect(newSeed.Generation).To(Equal(oldSeed.Generation + 1))
+			})
+
+			It("should bump the generation if the deletionTimestamp was set", func() {
+				now := metav1.Now()
+				newSeed.DeletionTimestamp = &now
+
+				strategy.PrepareForUpdate(ctx, newSeed, oldSeed)
+
+				Expect(newSeed.Generation).To(Equal(oldSeed.Generation + 1))
+			})
+
+			It("should not bump the generation if the deletionTimestamp was already set", func() {
+				now := metav1.Now()
+				oldSeed.DeletionTimestamp = &now
+				newSeed.DeletionTimestamp = &now
+
+				strategy.PrepareForUpdate(ctx, newSeed, oldSeed)
+
+				Expect(newSeed.Generation).To(Equal(oldSeed.Generation))
+			})
+
+			It("should bump the generation if the operation annotation was set to renew-garden-access-secrets", func() {
+				metav1.SetMetaDataAnnotation(&newSeed.ObjectMeta, "gardener.cloud/operation", "renew-garden-access-secrets")
+
+				strategy.PrepareForUpdate(ctx, newSeed, oldSeed)
+
+				Expect(newSeed.Generation).To(Equal(oldSeed.Generation + 1))
+			})
+
+			It("should not bump the generation if the operation annotation didn't change", func() {
+				metav1.SetMetaDataAnnotation(&oldSeed.ObjectMeta, "gardener.cloud/operation", "renew-garden-access-secrets")
+				metav1.SetMetaDataAnnotation(&newSeed.ObjectMeta, "gardener.cloud/operation", "renew-garden-access-secrets")
+
+				strategy.PrepareForUpdate(ctx, newSeed, oldSeed)
+
+				Expect(newSeed.Generation).To(Equal(oldSeed.Generation))
+			})
 		})
 
 		Context("syncDependencyWatchdogSettings", func() {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security usability
/kind enhancement

**What this PR does / why we need it**:

This PR adds a mechanism for renewing all garden access secrets on a given seed by annotating it with `gardener.cloud/operation=renew-garden-access-secrets`.
ref https://github.com/gardener/gardener/pull/8032#discussion_r1224445056

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/8001

**Special notes for your reviewer**:

/cc @oliver-goetz @rfranzke 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
`gardener.cloud/operation` annotation was introduced to `seeds`. This includes a verification of its value. Please check your `seeds` for this annotation and remove it if necessary prior to the update.
```
