### PR TITLE
Adapt vpa-updater QPS limits such that it doesn't get throttled on large clusters

### DIFF
--- a/pkg/component/vpa/updater.go
+++ b/pkg/component/vpa/updater.go
@@ -159,6 +159,8 @@ func (v *vpa) reconcileUpdaterDeployment(deployment *appsv1.Deployment, serviceA
 						fmt.Sprintf("--updater-interval=%s", durationDeref(v.values.Updater.Interval, gardencorev1beta1.DefaultUpdaterInterval).Duration),
 						"--stderrthreshold=info",
 						"--v=2",
+						"--kube-api-qps=100",
+						"--kube-api-burst=120",
 					},
 					LivenessProbe: newDefaultLivenessProbe(),
 					Ports: []corev1.ContainerPort{

--- a/pkg/component/vpa/vpa_test.go
+++ b/pkg/component/vpa/vpa_test.go
@@ -330,6 +330,8 @@ var _ = Describe("VPA", func() {
 									fmt.Sprintf("--updater-interval=%s", flagUpdaterIntervalValue),
 									"--stderrthreshold=info",
 									"--v=2",
+									"--kube-api-qps=100",
+									"--kube-api-burst=120",
 								},
 								LivenessProbe: livenessProbeVpa,
 								Ports: []corev1.ContainerPort{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area auto-scaling
/kind enhancement

**What this PR does / why we need it**:
Set the QPS limits that vpa-updater uses to communicate with the kube-apiserver to the same values as for the vpa-recommender. On large clusters we were seeing things like this regularly in the updater logs:
```
2023-06-14 04:14:36 | {"log":"Waited for 5.595273229s due to client-side throttling, not priority and fairness, request: GET:https://kube-apiserver/apis/crd.projectcalico.org/v1?timeout=32s","pid":"1","severity":"INFO","source":"request.go:601"}
2023-06-14 04:24:32 | {"log":"Waited for 2.196752866s due to client-side throttling, not priority and fairness, request: GET:https://kube-apiserver/apis/crd.projectcalico.org/v1?timeout=32s","pid":"1","severity":"INFO","source":"request.go:601"}
```


**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Adapt vpa-updater QPS limits such that it doesn't get throttled on large clusters
```
