### PR TITLE
resource-manager: Ignore the `ToBeDeletedByClusterAutoscaler` taint in the system-components-config webhook

### DIFF
--- a/test/integration/resourcemanager/systemcomponentsconfig/systemcomponentsconfig_test.go
+++ b/test/integration/resourcemanager/systemcomponentsconfig/systemcomponentsconfig_test.go
@@ -118,6 +118,37 @@ var _ = Describe("SystemComponentsConfig tests", func() {
 						Effect: corev1.TaintEffectNoSchedule,
 					},
 				}
+				ignoredTaints := []corev1.Taint{
+					{
+						Key:    "node.kubernetes.io/memory-pressure",
+						Effect: corev1.TaintEffectNoSchedule,
+					},
+					{
+						Key:    "node.kubernetes.io/disk-pressure",
+						Effect: corev1.TaintEffectNoSchedule,
+					},
+					{
+						Key:    "node.kubernetes.io/pid-pressure",
+						Effect: corev1.TaintEffectNoSchedule,
+					},
+					{
+						Key:    "node.kubernetes.io/network-unavailable",
+						Effect: corev1.TaintEffectNoSchedule,
+					},
+					{
+						Key:    "node.kubernetes.io/unschedulable",
+						Effect: corev1.TaintEffectNoSchedule,
+					},
+					{
+						Key:    "node.cloudprovider.kubernetes.io/uninitialized",
+						Effect: corev1.TaintEffectNoSchedule,
+					},
+					{
+						Key:    "ToBeDeletedByClusterAutoscaler",
+						Effect: corev1.TaintEffectNoSchedule,
+						Value:  "1687448388",
+					},
+				}
 
 				nodes = append(nodes,
 					corev1.Node{
@@ -133,6 +164,11 @@ var _ = Describe("SystemComponentsConfig tests", func() {
 					corev1.Node{
 						Spec: corev1.NodeSpec{
 							Taints: additionalTaintsPool1,
+						},
+					},
+					corev1.Node{
+						Spec: corev1.NodeSpec{
+							Taints: ignoredTaints,
 						},
 					},
 				)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality ops-productivity
/kind bug

**What this PR does / why we need it**:
See https://github.com/gardener/gardener/issues/8154

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener/issues/8154

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
`gardener-resource-manager`'s `system-components-config` webhook no longer adds the toleration for the `ToBeDeletedByClusterAutoscaler` taint to system components in shoot clusters. The `ToBeDeletedByClusterAutoscaler` taint is maintained by the `cluster-autoscaler`. This was breaking `cluster-autoscaler`'s drain mechanism when scaling down an under-utilized node. It was causing just evicted system components from to be deleted node to be scheduled again on the to be deleted node.
```
