### PR TITLE
Introduce constraints for CRDs with multiple stored versions and a conversion webhook

### DIFF
--- a/docs/usage/shoot_status.md
+++ b/docs/usage/shoot_status.md
@@ -101,9 +101,15 @@ It is meant to make the user aware of potential problems that might occur due to
 
 **`CACertificateValiditiesAcceptable`**:
 
-This constraints indicates that there is at least one CA certificate which expires in less than `1y`.
+This constraint indicates that there is at least one CA certificate which expires in less than `1y`.
 It will not be added to the `.status.constraints` if there is no such CA certificate.
 However, if it's visible, then a [credentials rotation operation](shoot_credentials_rotation.md#certificate-authorities) should be considered.
+
+**`CRDsWithConversionWebhooksPresent`**:
+
+This constraint indicates that there is at least one CustomResourceDefinition in the cluster which has multiple stored versions and a conversion webhook configured. This could break the reconciliation flow of a `Shoot` cluster in some cases. See https://github.com/gardener/gardener/issues/7471 for more details.
+It will not be added to the `.status.constraints` if there is no such CRD.
+However, if it's visible, then you should consider upgrading the existing objects to the current stored version. See [Upgrade existing objects to a new stored version ](https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definition-versioning/#upgrade-existing-objects-to-a-new-stored-version) for detailed steps.
 
 ### Last Operation
 

--- a/docs/usage/shoot_status.md
+++ b/docs/usage/shoot_status.md
@@ -105,9 +105,9 @@ This constraint indicates that there is at least one CA certificate which expire
 It will not be added to the `.status.constraints` if there is no such CA certificate.
 However, if it's visible, then a [credentials rotation operation](shoot_credentials_rotation.md#certificate-authorities) should be considered.
 
-**`CRDsWithConversionWebhooksPresent`**:
+**`CRDsWithProblematicConversionWebhooks`**:
 
-This constraint indicates that there is at least one CustomResourceDefinition in the cluster which has multiple stored versions and a conversion webhook configured. This could break the reconciliation flow of a `Shoot` cluster in some cases. See https://github.com/gardener/gardener/issues/7471 for more details.
+This constraint indicates that there is at least one `CustomResourceDefinition` in the cluster which has multiple stored versions and a conversion webhook configured. This could break the reconciliation flow of a `Shoot` cluster in some cases. See https://github.com/gardener/gardener/issues/7471 for more details.
 It will not be added to the `.status.constraints` if there is no such CRD.
 However, if it's visible, then you should consider upgrading the existing objects to the current stored version. See [Upgrade existing objects to a new stored version ](https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definition-versioning/#upgrade-existing-objects-to-a-new-stored-version) for detailed steps.
 

--- a/docs/usage/shoot_status.md
+++ b/docs/usage/shoot_status.md
@@ -109,7 +109,7 @@ However, if it's visible, then a [credentials rotation operation](shoot_credenti
 
 This constraint indicates that there is at least one `CustomResourceDefinition` in the cluster which has multiple stored versions and a conversion webhook configured. This could break the reconciliation flow of a `Shoot` cluster in some cases. See https://github.com/gardener/gardener/issues/7471 for more details.
 It will not be added to the `.status.constraints` if there is no such CRD.
-However, if it's visible, then you should consider upgrading the existing objects to the current stored version. See [Upgrade existing objects to a new stored version ](https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definition-versioning/#upgrade-existing-objects-to-a-new-stored-version) for detailed steps.
+However, if it's visible, then you should consider upgrading the existing objects to the current stored version. See [Upgrade existing objects to a new stored version](https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definition-versioning/#upgrade-existing-objects-to-a-new-stored-version) for detailed steps.
 
 ### Last Operation
 

--- a/pkg/apis/core/v1beta1/types_shoot.go
+++ b/pkg/apis/core/v1beta1/types_shoot.go
@@ -1637,9 +1637,9 @@ const (
 	// ShootCACertificateValiditiesAcceptable is a constant for a condition type indicating that the validities of all
 	// CA certificates is long enough.
 	ShootCACertificateValiditiesAcceptable ConditionType = "CACertificateValiditiesAcceptable"
-	// ShootCRDsWithConversionWebhooksPresent is a constant for a condition type indicating that the Shoot cluster has
+	// ShootCRDsWithProblematicConversionWebhooks is a constant for a condition type indicating that the Shoot cluster has
 	// CRDs with conversion webhooks and multiple stored versions which can break the reconciliation flow of the cluster.
-	ShootCRDsWithConversionWebhooksPresent ConditionType = "CRDsWithConversionWebhooksPresent"
+	ShootCRDsWithProblematicConversionWebhooks ConditionType = "CRDsWithProblematicConversionWebhooks"
 )
 
 // ShootPurpose is a type alias for string.

--- a/pkg/apis/core/v1beta1/types_shoot.go
+++ b/pkg/apis/core/v1beta1/types_shoot.go
@@ -1637,6 +1637,9 @@ const (
 	// ShootCACertificateValiditiesAcceptable is a constant for a condition type indicating that the validities of all
 	// CA certificates is long enough.
 	ShootCACertificateValiditiesAcceptable ConditionType = "CACertificateValiditiesAcceptable"
+	// ShootCRDsWithConversionWebhooksPresent is a constant for a condition type indicating that the Shoot cluster has
+	// CRDs with conversion webhooks and multiple stored versions which can break the reconciliation flow of the cluster.
+	ShootCRDsWithConversionWebhooksPresent ConditionType = "CRDsWithConversionWebhooksPresent"
 )
 
 // ShootPurpose is a type alias for string.

--- a/pkg/gardenlet/controller/shoot/care/reconciler.go
+++ b/pkg/gardenlet/controller/shoot/care/reconciler.go
@@ -126,7 +126,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		gardencorev1beta1.ShootHibernationPossible,
 		gardencorev1beta1.ShootMaintenancePreconditionsSatisfied,
 		gardencorev1beta1.ShootCACertificateValiditiesAcceptable,
-		gardencorev1beta1.ShootCRDsWithConversionWebhooksPresent,
+		gardencorev1beta1.ShootCRDsWithProblematicConversionWebhooks,
 	}
 	var constraints []gardencorev1beta1.Condition
 	for _, constr := range constraintTypes {

--- a/pkg/gardenlet/controller/shoot/care/reconciler.go
+++ b/pkg/gardenlet/controller/shoot/care/reconciler.go
@@ -126,6 +126,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		gardencorev1beta1.ShootHibernationPossible,
 		gardencorev1beta1.ShootMaintenancePreconditionsSatisfied,
 		gardencorev1beta1.ShootCACertificateValiditiesAcceptable,
+		gardencorev1beta1.ShootCRDsWithConversionWebhooksPresent,
 	}
 	var constraints []gardencorev1beta1.Condition
 	for _, constr := range constraintTypes {

--- a/pkg/gardenlet/controller/shoot/care/reconciler_test.go
+++ b/pkg/gardenlet/controller/shoot/care/reconciler_test.go
@@ -619,5 +619,10 @@ func consistOfConstraintsInUnknownStatus(message string) types.GomegaMatcher {
 			"Status":  Equal(gardencorev1beta1.ConditionUnknown),
 			"Message": Equal(message),
 		}),
+		MatchFields(IgnoreExtras, Fields{
+			"Type":    Equal(gardencorev1beta1.ShootCRDsWithConversionWebhooksPresent),
+			"Status":  Equal(gardencorev1beta1.ConditionUnknown),
+			"Message": Equal(message),
+		}),
 	)
 }

--- a/pkg/gardenlet/controller/shoot/care/reconciler_test.go
+++ b/pkg/gardenlet/controller/shoot/care/reconciler_test.go
@@ -620,7 +620,7 @@ func consistOfConstraintsInUnknownStatus(message string) types.GomegaMatcher {
 			"Message": Equal(message),
 		}),
 		MatchFields(IgnoreExtras, Fields{
-			"Type":    Equal(gardencorev1beta1.ShootCRDsWithConversionWebhooksPresent),
+			"Type":    Equal(gardencorev1beta1.ShootCRDsWithProblematicConversionWebhooks),
 			"Status":  Equal(gardencorev1beta1.ConditionUnknown),
 			"Message": Equal(message),
 		}),

--- a/pkg/operation/care/constraints.go
+++ b/pkg/operation/care/constraints.go
@@ -273,7 +273,7 @@ func (c *Constraint) checkIfCRDsWithProblematicConversionWebhooksPresent(ctx con
 	)
 
 	if err := c.shootClient.List(ctx, crdList); err != nil {
-		return "", "", "", fmt.Errorf("could not list all CRDs in the shoot: %w", err)
+		return "", "", "", fmt.Errorf("could not list CRDs in the shoot: %w", err)
 	}
 
 	for _, crd := range crdList.Items {

--- a/pkg/operation/care/constraints.go
+++ b/pkg/operation/care/constraints.go
@@ -24,9 +24,11 @@ import (
 	"github.com/go-logr/logr"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/utils/clock"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -118,6 +120,7 @@ func (c *Constraint) constraintsChecks(
 		hibernationPossibleConstraint, maintenancePreconditionsSatisfiedConstraint gardencorev1beta1.Condition
 		// optional constraints (not always present in .status.constraints)
 		caCertificateValiditiesAcceptableConstraint = gardencorev1beta1.Condition{Type: gardencorev1beta1.ShootCACertificateValiditiesAcceptable}
+		crdsWithConversionWebhooksPresent           = gardencorev1beta1.Condition{Type: gardencorev1beta1.ShootCRDsWithConversionWebhooksPresent}
 	)
 
 	for _, cons := range constraints {
@@ -128,6 +131,8 @@ func (c *Constraint) constraintsChecks(
 			maintenancePreconditionsSatisfiedConstraint = cons
 		case gardencorev1beta1.ShootCACertificateValiditiesAcceptable:
 			caCertificateValiditiesAcceptableConstraint = cons
+		case gardencorev1beta1.ShootCRDsWithConversionWebhooksPresent:
+			crdsWithConversionWebhooksPresent = cons
 		}
 	}
 
@@ -171,9 +176,16 @@ func (c *Constraint) constraintsChecks(
 		maintenancePreconditionsSatisfiedConstraint = v1beta1helper.UpdatedConditionWithClock(c.clock, maintenancePreconditionsSatisfiedConstraint, status, reason, message, errorCodes...)
 	}
 
+	status, reason, message, err = c.checkIfCRDsWithConversionWebhooksPresent(ctx)
+	if err != nil {
+		crdsWithConversionWebhooksPresent = v1beta1helper.UpdatedConditionUnknownErrorWithClock(c.clock, crdsWithConversionWebhooksPresent, err)
+	} else {
+		crdsWithConversionWebhooksPresent = v1beta1helper.UpdatedConditionWithClock(c.clock, crdsWithConversionWebhooksPresent, status, reason, message)
+	}
+
 	return filterOptionalConstraints(
 		[]gardencorev1beta1.Condition{hibernationPossibleConstraint, maintenancePreconditionsSatisfiedConstraint},
-		[]gardencorev1beta1.Condition{caCertificateValiditiesAcceptableConstraint},
+		[]gardencorev1beta1.Condition{caCertificateValiditiesAcceptableConstraint, crdsWithConversionWebhooksPresent},
 	)
 }
 
@@ -249,6 +261,38 @@ func (c *Constraint) CheckIfCACertificateValiditiesAcceptable(ctx context.Contex
 		"NoExpiringCACertificates",
 		fmt.Sprintf("All CA certificates are still valid for at least %s.", minimumValidity),
 		nil,
+		nil
+}
+
+// checkIfCRDsWithConversionWebhooksPresent checks whether there are CRDs with multiple stored versions and
+// conversion webhooks are present in the cluster.
+func (c *Constraint) checkIfCRDsWithConversionWebhooksPresent(ctx context.Context) (gardencorev1beta1.ConditionStatus, string, string, error) {
+	var (
+		crdList                   = &apiextensionsv1.CustomResourceDefinitionList{}
+		crdsWithConversionWebhook = sets.New[string]()
+	)
+
+	if err := c.shootClient.List(ctx, crdList); err != nil {
+		return "", "", "", fmt.Errorf("could not list all CRDs in the shoot: %w", err)
+	}
+
+	for _, crd := range crdList.Items {
+		if len(crd.Status.StoredVersions) > 1 && crd.Spec.Conversion != nil && crd.Spec.Conversion.Strategy == apiextensionsv1.WebhookConverter {
+			crdsWithConversionWebhook.Insert(crd.Name)
+		}
+	}
+
+	if crdsWithConversionWebhook.Len() > 0 {
+		return gardencorev1beta1.ConditionFalse,
+			"CRDsWithConversionWebhooksPresent",
+			fmt.Sprintf("Some CRDs in your cluster have multiple stored versions present and have a conversion webhook configured: %s. Please see https://github.com/gardener/gardener/blob/master/docs/usage/shoot_status.md#constraints for more details.",
+				strings.Join(sets.List(crdsWithConversionWebhook), ", ")),
+			nil
+	}
+
+	return gardencorev1beta1.ConditionTrue,
+		"NoCRDsWithConversionWebhooksPresent",
+		"No CRDs have multiple stored versions present and a conversion webhook configured",
 		nil
 }
 

--- a/pkg/operation/care/constraints_test.go
+++ b/pkg/operation/care/constraints_test.go
@@ -497,7 +497,7 @@ var _ = Describe("Constraints", func() {
 				constraints = []gardencorev1beta1.Condition{
 					{Type: gardencorev1beta1.ShootHibernationPossible},
 					{Type: gardencorev1beta1.ShootMaintenancePreconditionsSatisfied},
-					{Type: gardencorev1beta1.ShootCRDsWithConversionWebhooksPresent},
+					{Type: gardencorev1beta1.ShootCRDsWithProblematicConversionWebhooks},
 				}
 			)
 
@@ -517,13 +517,13 @@ var _ = Describe("Constraints", func() {
 				))
 			})
 
-			It("should not keep the `CRDsWithConversionWebhooksPresent` condition when it's true", func() {
+			It("should not keep the `CRDsWithProblematicConversionWebhooks` condition when it's true", func() {
 				Expect(constraint.Check(ctx, constraints)).NotTo(ContainCondition(
-					OfType(gardencorev1beta1.ShootCRDsWithConversionWebhooksPresent),
+					OfType(gardencorev1beta1.ShootCRDsWithProblematicConversionWebhooks),
 				))
 			})
 
-			It("should keep the `CRDsWithConversionWebhooksPresent` condition when it's false", func() {
+			It("should keep the `CRDsWithProblematicConversionWebhooks` condition when it's false", func() {
 				crd1 := &apiextensionsv1.CustomResourceDefinition{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "sample1.example.com",
@@ -554,9 +554,9 @@ var _ = Describe("Constraints", func() {
 				Expect(shootClient.Create(ctx, crd2)).To(Succeed())
 
 				Expect(constraint.Check(ctx, constraints)).To(ContainCondition(
-					OfType(gardencorev1beta1.ShootCRDsWithConversionWebhooksPresent),
+					OfType(gardencorev1beta1.ShootCRDsWithProblematicConversionWebhooks),
 					WithStatus(gardencorev1beta1.ConditionProgressing),
-					WithReason("CRDsWithConversionWebhooksPresent"),
+					WithReason("CRDsWithProblematicConversionWebhooks"),
 					WithMessage(fmt.Sprintf("Some CRDs in your cluster have multiple stored versions present and have a conversion webhook configured: %s.", crd1.Name)),
 				))
 			})

--- a/pkg/operation/care/constraints_test.go
+++ b/pkg/operation/care/constraints_test.go
@@ -22,7 +22,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	. "github.com/onsi/gomega/gstruct"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	appsv1beta1 "k8s.io/api/apps/v1beta1"
@@ -58,6 +57,7 @@ import (
 	"github.com/gardener/gardener/pkg/operation"
 	. "github.com/gardener/gardener/pkg/operation/care"
 	shootpkg "github.com/gardener/gardener/pkg/operation/shoot"
+	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 )
 
 type webhookTestCase struct {
@@ -450,6 +450,7 @@ var _ = Describe("Constraints", func() {
 			ctx           = context.TODO()
 			seedNamespace = "shoot--foo--bar"
 			seedClient    client.Client
+			shootClient   client.Client
 
 			now   = time.Date(2022, 2, 22, 22, 22, 22, 0, time.UTC)
 			clock clock.Clock
@@ -476,6 +477,7 @@ var _ = Describe("Constraints", func() {
 
 		BeforeEach(func() {
 			seedClient = fakeclient.NewClientBuilder().WithScheme(kubernetes.SeedScheme).Build()
+			shootClient = fakeclient.NewClientBuilder().WithScheme(kubernetes.ShootScheme).Build()
 
 			clock = testing.NewFakeClock(now)
 			op = &operation.Operation{
@@ -486,7 +488,7 @@ var _ = Describe("Constraints", func() {
 			}
 			op.Shoot.SetInfo(&gardencorev1beta1.Shoot{})
 			constraint = NewConstraint(clock, op, func() (kubernetes.Interface, bool, error) {
-				return nil, false, nil
+				return kubernetesfake.NewClientSetBuilder().WithClient(shootClient).Build(), true, nil
 			})
 		})
 
@@ -495,45 +497,67 @@ var _ = Describe("Constraints", func() {
 				constraints = []gardencorev1beta1.Condition{
 					{Type: gardencorev1beta1.ShootHibernationPossible},
 					{Type: gardencorev1beta1.ShootMaintenancePreconditionsSatisfied},
+					{Type: gardencorev1beta1.ShootCRDsWithConversionWebhooksPresent},
 				}
 			)
 
 			It("should remove the 'CACertificateValiditiesAcceptable' constraint because it's true", func() {
-				Expect(constraint.Check(ctx, constraints)).To(ConsistOf(
-					MatchFields(IgnoreExtras, Fields{
-						"Type":    Equal(gardencorev1beta1.ShootHibernationPossible),
-						"Reason":  Equal("ConstraintNotChecked"),
-						"Message": Equal("Shoot control plane is not running at the moment."),
-					}),
-					MatchFields(IgnoreExtras, Fields{
-						"Type":    Equal(gardencorev1beta1.ShootMaintenancePreconditionsSatisfied),
-						"Reason":  Equal("ConstraintNotChecked"),
-						"Message": Equal("Shoot control plane is not running at the moment."),
-					}),
+				Expect(constraint.Check(ctx, constraints)).NotTo(ContainCondition(
+					OfType(gardencorev1beta1.ShootCACertificateValiditiesAcceptable),
 				))
 			})
 
 			It("should keep the 'CACertificateValiditiesAcceptable' constraint because it's false (before pardoned)", func() {
 				Expect(seedClient.Create(ctx, newCASecret(now))).To(Succeed())
 
-				Expect(constraint.Check(ctx, constraints)).To(ConsistOf(
-					MatchFields(IgnoreExtras, Fields{
-						"Type":    Equal(gardencorev1beta1.ShootHibernationPossible),
-						"Status":  Equal(gardencorev1beta1.ConditionProgressing),
-						"Reason":  Equal("ConstraintNotChecked"),
-						"Message": Equal("Shoot control plane is not running at the moment."),
-					}),
-					MatchFields(IgnoreExtras, Fields{
-						"Type":    Equal(gardencorev1beta1.ShootMaintenancePreconditionsSatisfied),
-						"Status":  Equal(gardencorev1beta1.ConditionProgressing),
-						"Reason":  Equal("ConstraintNotChecked"),
-						"Message": Equal("Shoot control plane is not running at the moment."),
-					}),
-					MatchFields(IgnoreExtras, Fields{
-						"Type":   Equal(gardencorev1beta1.ShootCACertificateValiditiesAcceptable),
-						"Status": Equal(gardencorev1beta1.ConditionProgressing),
-						"Reason": Equal("ExpiringCACertificates"),
-					}),
+				Expect(constraint.Check(ctx, constraints)).To(ContainCondition(
+					OfType(gardencorev1beta1.ShootCACertificateValiditiesAcceptable),
+					WithStatus(gardencorev1beta1.ConditionProgressing),
+					WithReason("ExpiringCACertificates"),
+				))
+			})
+
+			It("should not keep the `CRDsWithConversionWebhooksPresent` condition when it's true", func() {
+				Expect(constraint.Check(ctx, constraints)).NotTo(ContainCondition(
+					OfType(gardencorev1beta1.ShootCRDsWithConversionWebhooksPresent),
+				))
+			})
+
+			It("should keep the `CRDsWithConversionWebhooksPresent` condition when it's false", func() {
+				crd1 := &apiextensionsv1.CustomResourceDefinition{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "sample1.example.com",
+					},
+					Spec: apiextensionsv1.CustomResourceDefinitionSpec{
+						Conversion: &apiextensionsv1.CustomResourceConversion{
+							Strategy: "Webhook",
+						},
+					},
+					Status: apiextensionsv1.CustomResourceDefinitionStatus{
+						StoredVersions: []string{"v1", "v1beta1"},
+					},
+				}
+				crd2 := &apiextensionsv1.CustomResourceDefinition{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "sample2.example.com",
+					},
+					Spec: apiextensionsv1.CustomResourceDefinitionSpec{
+						Conversion: &apiextensionsv1.CustomResourceConversion{
+							Strategy: "None",
+						},
+					},
+					Status: apiextensionsv1.CustomResourceDefinitionStatus{
+						StoredVersions: []string{"v1"},
+					},
+				}
+				Expect(shootClient.Create(ctx, crd1)).To(Succeed())
+				Expect(shootClient.Create(ctx, crd2)).To(Succeed())
+
+				Expect(constraint.Check(ctx, constraints)).To(ContainCondition(
+					OfType(gardencorev1beta1.ShootCRDsWithConversionWebhooksPresent),
+					WithStatus(gardencorev1beta1.ConditionProgressing),
+					WithReason("CRDsWithConversionWebhooksPresent"),
+					WithMessage(fmt.Sprintf("Some CRDs in your cluster have multiple stored versions present and have a conversion webhook configured: %s.", crd1.Name)),
 				))
 			})
 		})


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind enhancement

**What this PR does / why we need it**:
A new optional constraint `CRDsWithProblematicConversionWebhooks` is introduced in the Shoot status.
This constraint indicates that there is at least one CustomResourceDefinition in the cluster which has multiple stored versions and a conversion webhook configured which could break the reconciliation flow of a Shoot in some cases. See https://github.com/gardener/gardener/issues/7471 for more details.
It will not be added to the `.status.constraints` if there is no such CRD.

**Which issue(s) this PR fixes**:
Fixes #7471

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
A new optional constraint `CRDsWithProblematicConversionWebhooks` is introduced in the `Shoot` status. This constraint indicates that there is at least one CRD in the cluster which has multiple stored versions and a conversion webhook configured, which could break the reconciliation flow of a `Shoot` in some cases.
```
