### PR TITLE
Fix Exposure Class annotation handling

### DIFF
--- a/pkg/gardenlet/controller/seed/seed/components.go
+++ b/pkg/gardenlet/controller/seed/seed/components.go
@@ -115,6 +115,7 @@ func defaultIstio(
 		if err := shared.AddIstioIngressGateway(
 			istioDeployer,
 			*handler.SNI.Ingress.Namespace,
+			// handler.LoadBalancerService.Annotations must put last to override non-exposure class related keys.
 			utils.MergeStringMaps(seed.GetLoadBalancerServiceAnnotations(), handler.LoadBalancerService.Annotations),
 			shared.GetIstioZoneLabels(gardenerutils.GetMandatoryExposureClassHandlerSNILabels(handler.SNI.Ingress.Labels, handler.Name), nil),
 			seed.GetLoadBalancerServiceExternalTrafficPolicy(),
@@ -130,7 +131,8 @@ func defaultIstio(
 				if err := shared.AddIstioIngressGateway(
 					istioDeployer,
 					shared.GetIstioNamespaceForZone(*handler.SNI.Ingress.Namespace, zone),
-					utils.MergeStringMaps(handler.LoadBalancerService.Annotations, seed.GetZonalLoadBalancerServiceAnnotations(zone)),
+					// handler.LoadBalancerService.Annotations must put last to override non-exposure class related keys.
+					utils.MergeStringMaps(seed.GetZonalLoadBalancerServiceAnnotations(zone), handler.LoadBalancerService.Annotations),
 					shared.GetIstioZoneLabels(gardenerutils.GetMandatoryExposureClassHandlerSNILabels(handler.SNI.Ingress.Labels, handler.Name), &zone),
 					seed.GetZonalLoadBalancerServiceExternalTrafficPolicy(zone),
 					nil,


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area high-availability
/area control-plane
/kind bug

**What this PR does / why we need it**:
This PR fixes an issue for zonal Istio-Ingress gateways if configured with Exposure Classes: While annotations of Exposure Class Handlers override the ones specified in `seed.spec.settings.loadBalancerServices` for the 'global' Istio-Ingress, the same was not the case of 'zonal' Istio-Ingresses. There it was the other way around. This has been the case since the introduction in #6997.

**Special notes for your reviewer**:
/cc @ScheererJ @RaphaelVogel 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
A bug has been fixed for Istio-Ingress Gateways for seeds that use `ExposureClassHandler`s. Earlier, annotations in `seed.spec.settings.loadBalancerServices` caused an override of the ones specified in `gardenletConfiguration.exposureClassHandler[].loadBalancerService` for zonal Istios. Now, annotations in `gardenletConfiguration.exposureClassHandler[].loadBalancerService` are given priority, like it was already the case of the global Istio.
```
