### PR TITLE
 Deploy `ControlPlane` extension after `kube-apiserver` in the reconciliation flow

### DIFF
--- a/pkg/gardenlet/controller/shoot/shoot/reconciler.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler.go
@@ -845,6 +845,47 @@ func lastErrorsOperationInitializationFailure(lastErrors []gardencorev1beta1.Las
 	return lastErrors
 }
 
+func needsControlPlaneDeployment(ctx context.Context, o *operation.Operation, kubeAPIServerDeploymentFound bool, infrastructure *extensionsv1alpha1.Infrastructure) (bool, error) {
+	var (
+		namespace = o.Shoot.SeedNamespace
+		name      = o.Shoot.GetInfo().Name
+	)
+
+	// If the `ControlPlane` resource and the kube-apiserver deployment do no longer exist then we don't want to re-deploy it.
+	// The reason for the second condition is that some providers inject a cloud-provider-config into the kube-apiserver deployment
+	// which is needed for it to run.
+	exists, markedForDeletion, err := extensionResourceStillExists(ctx, o.SeedClientSet.APIReader(), &extensionsv1alpha1.ControlPlane{}, namespace, name)
+	if err != nil {
+		return false, err
+	}
+
+	switch {
+	// treat `ControlPlane` in deletion as if it is already gone. If it is marked for deletion, we also shouldn't wait
+	// for it to be reconciled, as it can potentially block the whole deletion flow (deletion depends on other control
+	// plane components like kcm and grm) which are scaled up later in the flow
+	case !exists && !kubeAPIServerDeploymentFound || markedForDeletion:
+		return false, nil
+	// The infrastructure resource has not been found, no need to redeploy the control plane
+	case infrastructure == nil:
+		return false, nil
+	// The infrastructure resource has been found with a non-nil provider status, so redeploy the control plane
+	case infrastructure.Status.ProviderStatus != nil:
+		return true, nil
+	default:
+		return false, nil
+	}
+}
+
+func extensionResourceStillExists(ctx context.Context, reader client.Reader, obj client.Object, namespace, name string) (bool, bool, error) {
+	if err := reader.Get(ctx, kubernetesutils.Key(namespace, name), obj); err != nil {
+		if apierrors.IsNotFound(err) {
+			return false, false, nil
+		}
+		return false, false, err
+	}
+	return true, obj.GetDeletionTimestamp() != nil, nil
+}
+
 func checkIfSeedNamespaceExists(ctx context.Context, o *operation.Operation, botanist *botanistpkg.Botanist) error {
 	botanist.SeedNamespaceObject = &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: o.Shoot.SeedNamespace}}
 	if err := botanist.SeedClientSet.APIReader().Get(ctx, client.ObjectKeyFromObject(botanist.SeedNamespaceObject), botanist.SeedNamespaceObject); err != nil {

--- a/pkg/gardenlet/controller/shoot/shoot/reconciler_delete.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler_delete.go
@@ -283,7 +283,7 @@ func (r *Reconciler) runDeleteShootFlow(ctx context.Context, o *operation.Operat
 			Dependencies: flow.NewTaskIDs(deployCloudProviderSecret, waitUntilKubeAPIServerIsReady, deployInternalDomainDNSRecord, waitUntilControlPlaneExposureReady, deployGardenerAccess),
 		})
 
-		// Redeploy the worker extensions, and kube-controller-manager to make sure all components that depend on the
+		// Redeploy kube-controller-manager to make sure all components that depend on the
 		// cloud provider secret are restarted in case it has changed.
 		deployKubeControllerManager = g.Add(flow.Task{
 			Name:         "Deploying Kubernetes controller manager",


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind cleanup

**What this PR does / why we need it**:
The `ControlPlane` extension resource is now deployed after `kube-apiserver` in the reconciliation flow.
Previously some issues like https://github.com/gardener/gardener/issues/4484 were caused because the extensions used to mutate the `kube-apiserver` deployment based on the `cloud-provider-config` secret, and if the extension is already migrated and the operation is retried, then it fails.
This is not the case anymore after #8087, because the extensions no longer need the secret to be present.

**Which issue(s) this PR fixes**:
Part of #7405 
Fixes https://github.com/gardener/gardener/issues/6565 ([ref](https://github.com/gardener/gardener/issues/6565#issuecomment-1290433357))

**Special notes for your reviewer**:
/cc @plkokanov 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
`extensions.gardener.cloud/v1alpha1.ControlPlane` is now deployed after `kube-apiserver` in the Shoot reconciliation flow.
```
