### PR TITLE
Create script for creating release branches

### DIFF
--- a/.ci/create_releasebranch
+++ b/.ci/create_releasebranch
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -e
+git fetch upstream master
+git checkout master
+VERSION=$(cat VERSION)
+MAJOR_MINOR=$(echo "${VERSION}" | cut -d '.' -f -2)
+NEXT_MINOR=$(echo "${MAJOR_MINOR}" | awk -F. -v OFS=. '{$NF += 1 ; print}')
+NEXT_DEV_VERSION=${NEXT_MINOR}.0-dev
+git checkout -b release-"${MAJOR_MINOR}"
+git push upstream release-"${MAJOR_MINOR}"
+git checkout master
+echo -n "${NEXT_DEV_VERSION}" >VERSION
+git add VERSION
+git commit -m "Prepare next Dev Cycle ${NEXT_DEV_VERSION}"
+git push upstream master


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
This script could be used to create a new release branch for `gardener/gardener` and prepare the next dev cycle on `master` branch.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
