### PR TITLE
Use release branch of previous minor version as backup for upgrade tests

### DIFF
--- a/hack/ci-e2e-kind-upgrade.sh
+++ b/hack/ci-e2e-kind-upgrade.sh
@@ -125,16 +125,18 @@ function upgrade_to_next_release() {
 
 function set_gardener_upgrade_version_env_variables() {
   if [[ -z "$GARDENER_PREVIOUS_RELEASE" ]]; then
-    previous_minor_version=$(echo "$VERSION" | awk -F. '{printf("%s.%d.*\n", $1, $2-1)}')
+    previous_minor_version=$(echo "$VERSION" | awk -F. '{printf("%s.%d", $1, $2-1)}')
     # List all the tags that match the previous minor version pattern
-    tag_list=$(git tag -l "$previous_minor_version")
+    tag_list=$(git tag -l "${previous_minor_version}.*")
 
     if [ -z "$tag_list" ]; then
-      echo "No tags found for the previous minor version ($VERSION) to upgrade Gardener." >&2
-      exit 1
+      # Use release branch of previous version as backup
+      export GARDENER_PREVIOUS_RELEASE="release-${previous_minor_version}"
+      echo "No tags found for the previous minor version ($VERSION) to upgrade Gardener. Using branch $GARDENER_PREVIOUS_RELEASE instead." >&2
+    else
+      # Find the most recent tag for the previous minor version
+      export GARDENER_PREVIOUS_RELEASE=$(echo "$tag_list" | tail -n 1)
     fi
-    # Find the most recent tag for the previous minor version
-    export GARDENER_PREVIOUS_RELEASE=$(echo "$tag_list" | tail -n 1)
   fi
 
   if [[ -z "$GARDENER_NEXT_RELEASE" ]]; then


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind bug

**What this PR does / why we need it**:
This PR changes the determination of previous minor versions for the upgrade tests. If there are no tags found, it uses the release branch of the previous minor version instead.
This is required to make upgrade tests work when creating release branches earlier in the process.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
