### PR TITLE
Forbid hibernating the `Shoot` during credential rotation and triggering rotation when the `Shoot` is waking up

### DIFF
--- a/pkg/apis/core/helper/helpers.go
+++ b/pkg/apis/core/helper/helpers.go
@@ -337,7 +337,16 @@ func GetShootAuditPolicyConfigMapRef(apiServerConfig *core.KubeAPIServerConfig) 
 
 // HibernationIsEnabled checks if the given shoot's desired state is hibernated.
 func HibernationIsEnabled(shoot *core.Shoot) bool {
-	return shoot.Spec.Hibernation != nil && shoot.Spec.Hibernation.Enabled != nil && *shoot.Spec.Hibernation.Enabled
+	return shoot.Spec.Hibernation != nil && pointer.BoolDeref(shoot.Spec.Hibernation.Enabled, false)
+}
+
+// HibernationIsEnabled checks if the given shoot is in hibernation or is waking up.
+func IsShootInHibernation(shoot *core.Shoot) bool {
+	if shoot.Spec.Hibernation != nil && shoot.Spec.Hibernation.Enabled != nil {
+		return *shoot.Spec.Hibernation.Enabled || shoot.Status.IsHibernated
+	}
+
+	return shoot.Status.IsHibernated
 }
 
 // SystemComponentsAllowed checks if the given worker allows system components to be scheduled onto it

--- a/pkg/apis/core/helper/helpers.go
+++ b/pkg/apis/core/helper/helpers.go
@@ -340,7 +340,7 @@ func HibernationIsEnabled(shoot *core.Shoot) bool {
 	return shoot.Spec.Hibernation != nil && pointer.BoolDeref(shoot.Spec.Hibernation.Enabled, false)
 }
 
-// HibernationIsEnabled checks if the given shoot is in hibernation or is waking up.
+// IsShootInHibernation checks if the given shoot is in hibernation or is waking up.
 func IsShootInHibernation(shoot *core.Shoot) bool {
 	if shoot.Spec.Hibernation != nil && shoot.Spec.Hibernation.Enabled != nil {
 		return *shoot.Spec.Hibernation.Enabled || shoot.Status.IsHibernated

--- a/pkg/apis/core/helper/helpers_test.go
+++ b/pkg/apis/core/helper/helpers_test.go
@@ -488,6 +488,34 @@ var _ = Describe("helper", func() {
 		}, true),
 	)
 
+	DescribeTable("#IsShootInHibernation",
+		func(shoot *core.Shoot, hibernated bool) {
+			Expect(IsShootInHibernation(shoot)).To(Equal(hibernated))
+		},
+		Entry("no hibernation section and status.isHibernated is false", &core.Shoot{}, false),
+		Entry("no hibernation section and status.isHibernated is true", &core.Shoot{
+			Status: core.ShootStatus{IsHibernated: true},
+		}, true),
+		Entry("hibernation.enabled = false and status.isHibernated is false", &core.Shoot{
+			Spec: core.ShootSpec{
+				Hibernation: &core.Hibernation{Enabled: &falseVar},
+			},
+		}, false),
+		Entry("hibernation.enabled = false and status.isHibernated is true", &core.Shoot{
+			Spec: core.ShootSpec{
+				Hibernation: &core.Hibernation{Enabled: &falseVar},
+			},
+			Status: core.ShootStatus{
+				IsHibernated: true,
+			},
+		}, true),
+		Entry("hibernation.enabled = true", &core.Shoot{
+			Spec: core.ShootSpec{
+				Hibernation: &core.Hibernation{Enabled: &trueVar},
+			},
+		}, true),
+	)
+
 	DescribeTable("#SeedSettingExcessCapacityReservationEnabled",
 		func(settings *core.SeedSettings, expectation bool) {
 			Expect(SeedSettingExcessCapacityReservationEnabled(settings)).To(Equal(expectation))

--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -1035,14 +1035,12 @@ func validateHibernationUpdate(new, old *core.Shoot) field.ErrorList {
 
 	if !hibernationEnabledInOld && hibernationEnabledInNew {
 		if new.Status.Credentials != nil && new.Status.Credentials.Rotation != nil && new.Status.Credentials.Rotation.ETCDEncryptionKey != nil {
-			etcdEncryptionKeyRotation := new.Status.Credentials.Rotation.ETCDEncryptionKey
-			if etcdEncryptionKeyRotation.Phase == core.RotationPreparing || etcdEncryptionKeyRotation.Phase == core.RotationCompleting {
+			if etcdEncryptionKeyRotation := new.Status.Credentials.Rotation.ETCDEncryptionKey; etcdEncryptionKeyRotation.Phase == core.RotationPreparing || etcdEncryptionKeyRotation.Phase == core.RotationCompleting {
 				allErrs = append(allErrs, field.Forbidden(fldPath, fmt.Sprintf("shoot cannot be hibernated when .status.credentials.rotation.etcdEncryptionKey.phase is %q", string(etcdEncryptionKeyRotation.Phase))))
 			}
 		}
 		if new.Status.Credentials != nil && new.Status.Credentials.Rotation != nil && new.Status.Credentials.Rotation.ServiceAccountKey != nil {
-			serviceAccountKeyRotation := new.Status.Credentials.Rotation.ServiceAccountKey
-			if serviceAccountKeyRotation.Phase == core.RotationPreparing || serviceAccountKeyRotation.Phase == core.RotationCompleting {
+			if serviceAccountKeyRotation := new.Status.Credentials.Rotation.ServiceAccountKey; serviceAccountKeyRotation.Phase == core.RotationPreparing || serviceAccountKeyRotation.Phase == core.RotationCompleting {
 				allErrs = append(allErrs, field.Forbidden(fldPath, fmt.Sprintf("shoot cannot be hibernated when .status.credentials.rotation.serviceAccountKey.phase is %q", string(serviceAccountKeyRotation.Phase))))
 			}
 		}

--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -2087,8 +2087,8 @@ func validateShootOperation(operation, maintenanceOperation string, shoot *core.
 		if !availableShootOperations.Has(operation) {
 			allErrs = append(allErrs, field.NotSupported(fldPathOp, operation, sets.List(availableShootOperations)))
 		}
-		if helper.HibernationIsEnabled(shoot) && forbiddenShootOperationsWhenHibernated.Has(operation) {
-			allErrs = append(allErrs, field.Forbidden(fldPathOp, "operation is not permitted when shoot is hibernated"))
+		if helper.IsShootInHibernation(shoot) && forbiddenShootOperationsWhenHibernated.Has(operation) {
+			allErrs = append(allErrs, field.Forbidden(fldPathOp, "operation is not permitted when shoot is hibernated or is waking up"))
 		}
 	}
 
@@ -2096,8 +2096,8 @@ func validateShootOperation(operation, maintenanceOperation string, shoot *core.
 		if !availableShootMaintenanceOperations.Has(maintenanceOperation) {
 			allErrs = append(allErrs, field.NotSupported(fldPathMaintOp, maintenanceOperation, sets.List(availableShootMaintenanceOperations)))
 		}
-		if helper.HibernationIsEnabled(shoot) && forbiddenShootOperationsWhenHibernated.Has(maintenanceOperation) {
-			allErrs = append(allErrs, field.Forbidden(fldPathMaintOp, "operation is not permitted when shoot is hibernated"))
+		if helper.IsShootInHibernation(shoot) && forbiddenShootOperationsWhenHibernated.Has(maintenanceOperation) {
+			allErrs = append(allErrs, field.Forbidden(fldPathMaintOp, "operation is not permitted when shoot is hibernated or is waking up"))
 		}
 	}
 
@@ -2213,7 +2213,7 @@ func validateShootHAControlPlaneSpecUpdate(newShoot, oldShoot *core.Shoot, fldPa
 	if newShoot.Spec.ControlPlane != nil && newShoot.Spec.ControlPlane.HighAvailability != nil {
 		newVal = newShoot.Spec.ControlPlane.HighAvailability.FailureTolerance.Type
 		// TODO(@aaronfern): remove this validation of not allowing scale-up to HA while hibernated when https://github.com/gardener/etcd-druid/issues/589 is resolved
-		if !oldValExists && isShootInHibernation(newShoot) {
+		if !oldValExists && helper.IsShootInHibernation(newShoot) {
 			allErrs = append(allErrs, field.Forbidden(fldPath.Child("highAvailability", "failureTolerance", "type"), "Shoot is currently hibernated and cannot be scaled up to HA. Please make sure your cluster has woken up before scaling it up to HA"))
 		}
 	}
@@ -2237,12 +2237,4 @@ func isShootReadyForRotationStart(lastOperation *core.LastOperation) bool {
 		return true
 	}
 	return lastOperation.Type == core.LastOperationTypeReconcile
-}
-
-func isShootInHibernation(shoot *core.Shoot) bool {
-	if shoot.Spec.Hibernation != nil && shoot.Spec.Hibernation.Enabled != nil {
-		return *shoot.Spec.Hibernation.Enabled || shoot.Status.IsHibernated
-	}
-
-	return shoot.Status.IsHibernated
 }

--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -4396,7 +4396,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 					Expect(ValidateShoot(shoot)).To(ContainElement(PointTo(MatchFields(IgnoreExtras, Fields{
 						"Type":   Equal(field.ErrorTypeForbidden),
 						"Field":  Equal("metadata.annotations[gardener.cloud/operation]"),
-						"Detail": ContainSubstring("operation is not permitted when shoot is hibernated"),
+						"Detail": ContainSubstring("operation is not permitted when shoot is hibernated or is waking up"),
 					}))))
 					delete(shoot.Annotations, "gardener.cloud/operation")
 
@@ -4404,7 +4404,39 @@ var _ = Describe("Shoot Validation Tests", func() {
 					Expect(ValidateShoot(shoot)).To(ContainElement(PointTo(MatchFields(IgnoreExtras, Fields{
 						"Type":   Equal(field.ErrorTypeForbidden),
 						"Field":  Equal("metadata.annotations[maintenance.gardener.cloud/operation]"),
-						"Detail": ContainSubstring("operation is not permitted when shoot is hibernated"),
+						"Detail": ContainSubstring("operation is not permitted when shoot is hibernated or is waking up"),
+					}))))
+					delete(shoot.Annotations, "maintenance.gardener.cloud/operation")
+				},
+
+				Entry("rotate-credentials-start", "rotate-credentials-start"),
+				Entry("rotate-credentials-complete", "rotate-credentials-complete"),
+				Entry("rotate-etcd-encryption-key-start", "rotate-etcd-encryption-key-start"),
+				Entry("rotate-etcd-encryption-key-complete", "rotate-etcd-encryption-key-complete"),
+				Entry("rotate-serviceaccount-key-start", "rotate-serviceaccount-key-start"),
+				Entry("rotate-serviceaccount-key-complete", "rotate-serviceaccount-key-complete"),
+			)
+
+			DescribeTable("forbid certain rotation operations when shoot is waking up",
+				func(operation string) {
+					shoot.Spec.Hibernation = &core.Hibernation{Enabled: pointer.Bool(false)}
+					shoot.Status = core.ShootStatus{
+						IsHibernated: true,
+					}
+
+					metav1.SetMetaDataAnnotation(&shoot.ObjectMeta, "gardener.cloud/operation", operation)
+					Expect(ValidateShoot(shoot)).To(ContainElement(PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":   Equal(field.ErrorTypeForbidden),
+						"Field":  Equal("metadata.annotations[gardener.cloud/operation]"),
+						"Detail": ContainSubstring("operation is not permitted when shoot is hibernated or is waking up"),
+					}))))
+					delete(shoot.Annotations, "gardener.cloud/operation")
+
+					metav1.SetMetaDataAnnotation(&shoot.ObjectMeta, "maintenance.gardener.cloud/operation", operation)
+					Expect(ValidateShoot(shoot)).To(ContainElement(PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":   Equal(field.ErrorTypeForbidden),
+						"Field":  Equal("metadata.annotations[maintenance.gardener.cloud/operation]"),
+						"Detail": ContainSubstring("operation is not permitted when shoot is hibernated or is waking up"),
 					}))))
 					delete(shoot.Annotations, "maintenance.gardener.cloud/operation")
 				},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality ops-productivity
/kind bug

**What this PR does / why we need it**:
It is not possible to support etcd-encryption key rotation and ServiceAccount signing key rotation for hibernated/hibernating Shoots as shared in https://github.com/gardener/gardener/issues/8155#issuecomment-1607066937.
If the shoot is in waking up and the rotation is triggered, and if the reconciliation is retried, this is also a problem.

This PR adds validation to:
- Forbid hibernating a shoot if ETCD encryption key rotation or ServiceAccount signing key rotation is in progress, ie; in `Preparing` or `Completing` phase.
- Forbid triggering a rotation operation on Shoots which are waking up, ie; `status.IsHibernated=true`.

**Which issue(s) this PR fixes**:
Fixes #8155

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
A bug causing the gardenlet to panic when a ETCD encryption key rotation operation is triggered for a hibernated Shoot is now fixed. Now, triggering ETCD encryption key rotation or ServiceAccount signing key rotation is forbidden when the Shoot is in waking up phase.
```
