### PR TITLE
Wait for `etcds` to get ready for hibernation to succeed

### DIFF
--- a/pkg/operation/botanist/controlplane.go
+++ b/pkg/operation/botanist/controlplane.go
@@ -148,7 +148,11 @@ func (b *Botanist) HibernateControlPlane(ctx context.Context) error {
 		return err
 	}
 
-	return client.IgnoreNotFound(b.ScaleETCDToZero(ctx))
+	if err := client.IgnoreNotFound(b.ScaleETCDToZero(ctx)); err != nil {
+		return err
+	}
+
+	return b.WaitUntilEtcdsReady(ctx)
 }
 
 // DefaultControlPlane creates the default deployer for the ControlPlane custom resource with the given purpose.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement

**What this PR does / why we need it**:
Recently, there have been failures of the e2e test fails during verifying that no pods are running in control plane after the hibernation of the shoot. 

One such example - https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/8151/pull-gardener-e2e-kind-ha-multi-zone-upgrade/1672253552870821888#

In the test STS was successfully patched to replicas `0`, so my assumption is there can be case that after patching STS it can take some time for all replicas to get deleted.

This PR enhances shoot hibernation to also wait till there are no etcd pods present in the control plane.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
