### PR TITLE
Switch the coredns image to be pulled from `registry.k8s.io`

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -303,8 +303,8 @@ images:
   tag: "0.16.0"
 - name: coredns
   sourceRepository: github.com/coredns/coredns
-  repository: eu.gcr.io/gardener-project/3rd/coredns/coredns
-  tag: "1.10.0"
+  repository: registry.k8s.io/coredns/coredns
+  tag: "v1.10.0"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area cost open-source
/kind enhancement

**What this PR does / why we need it**:
Kubernetes maintains coredns images under `registry.k8s.io` - ref https://github.com/kubernetes/k8s.io/blob/1415eaa6ac734fb7d8284beee3032ad1d2f3bb14/k8s.gcr.io/images/k8s-staging-coredns/images.yaml.
Both images are the same:
```
% docker images | grep coredns
coredns/coredns                                                                                     1.10.0                                                       0ad7f9e4a77d   9 months ago    50.2MB
eu.gcr.io/gardener-project/3rd/coredns/coredns                                                      1.10.0                                                       0ad7f9e4a77d   9 months ago    50.2MB
registry.k8s.io/coredns/coredns                                                                     v1.10.0                                                      0ad7f9e4a77d   9 months ago    50.2MB
```

We can use `registry.k8s.io/coredns/coredns` to reduce networking and storage costs for the gardener GCR and to make our life easier when adopting new coredns version.

**Which issue(s) this PR fixes**:
Follow-up after https://github.com/gardener/gardener/pull/7686 :)

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
