### PR TITLE
`shoots/adminkubeconfig`: drop fallback to `ShootState`

### DIFF
--- a/pkg/registry/core/rest/storage_core.go
+++ b/pkg/registry/core/rest/storage_core.go
@@ -111,7 +111,6 @@ func (p StorageProvider) v1beta1Storage(restOptionsGetter generic.RESTOptionsGet
 
 	shootStorage := shootstore.NewStorage(
 		restOptionsGetter,
-		shootstatestore.NewStorage(restOptionsGetter).ShootState.Store,
 		p.CoreInformerFactory.Core().InternalVersion().InternalSecrets().Lister(),
 		p.KubeInformerFactory.Core().V1().Secrets().Lister(),
 		p.AdminKubeconfigMaxExpiration,

--- a/pkg/registry/core/shoot/storage/admin_kubeconfig.go
+++ b/pkg/registry/core/shoot/storage/admin_kubeconfig.go
@@ -18,19 +18,14 @@ package storage
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/url"
-	"sort"
-	"strconv"
 	"time"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/apiserver/pkg/authentication/user"
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
@@ -41,22 +36,15 @@ import (
 	authenticationv1alpha1 "github.com/gardener/gardener/pkg/apis/authentication/v1alpha1"
 	authenticationvalidation "github.com/gardener/gardener/pkg/apis/authentication/validation"
 	"github.com/gardener/gardener/pkg/apis/core"
-	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
-	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
-	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	gardencorelisters "github.com/gardener/gardener/pkg/client/core/listers/core/internalversion"
-	"github.com/gardener/gardener/pkg/client/kubernetes"
-	"github.com/gardener/gardener/pkg/utils"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 	"github.com/gardener/gardener/pkg/utils/secrets"
-	secretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager"
 )
 
 // AdminKubeconfigREST implements a RESTStorage for shoots/adminkubeconfig.
 type AdminKubeconfigREST struct {
 	secretLister         kubecorev1listers.SecretLister
 	internalSecretLister gardencorelisters.InternalSecretLister
-	shootStateStorage    getter
 	shootStorage         getter
 	maxExpirationSeconds int64
 }
@@ -104,6 +92,7 @@ func (r *AdminKubeconfigREST) Create(ctx context.Context, name string, obj runti
 		return nil, apierrors.NewBadRequest("no user in context")
 	}
 
+	// prepare: get shoot object
 	shootObj, err := r.shootStorage.Get(ctx, name, &metav1.GetOptions{})
 	if err != nil {
 		return nil, err
@@ -119,60 +108,28 @@ func (r *AdminKubeconfigREST) Create(ctx context.Context, name string, obj runti
 		return nil, apierrors.NewInvalid(gvk.GroupKind(), shoot.Name, field.ErrorList{fieldErr})
 	}
 
-	var (
-		clusterCABundle      []byte
-		clientCACertificate  *secrets.Certificate
-		fallbackToShootState = false
-	)
-
+	// prepare: get cluster and client CA
 	caClientSecret, err := r.internalSecretLister.InternalSecrets(shoot.Namespace).Get(gardenerutils.ComputeShootProjectSecretName(shoot.Name, gardenerutils.ShootProjectSecretSuffixCAClient))
 	if err != nil {
-		if !apierrors.IsNotFound(err) {
-			return nil, apierrors.NewInternalError(fmt.Errorf("could not find client CA secret: %w", err))
-		}
-		fallbackToShootState = true
-	} else {
-		clientCACertificate, err = secrets.LoadCertificate("", caClientSecret.Data[secrets.DataKeyPrivateKeyCA], caClientSecret.Data[secrets.DataKeyCertificateCA])
-		if err != nil {
-			return nil, apierrors.NewInternalError(fmt.Errorf("could not load client CA certificate from secret: %w", err))
-		}
-
-		caClusterSecret, err := r.secretLister.Secrets(shoot.Namespace).Get(gardenerutils.ComputeShootProjectSecretName(shoot.Name, gardenerutils.ShootProjectSecretSuffixCACluster))
-		if err != nil {
-			return nil, apierrors.NewInternalError(fmt.Errorf("could not find cluster CA bundle: %w", err))
-		}
-		clusterCABundle = caClusterSecret.Data[secrets.DataKeyCertificateCA]
-
-		if len(clusterCABundle) == 0 {
-			return nil, apierrors.NewInternalError(fmt.Errorf("could not load cluster CA bundle from secret"))
-		}
+		return nil, apierrors.NewInternalError(fmt.Errorf("could not get client CA secret: %w", err))
 	}
 
-	// TODO(timebertt): drop this fallback after v1.74 has been released.
-	if fallbackToShootState {
-		shootStateObj, err := r.shootStateStorage.Get(ctx, name, &metav1.GetOptions{})
-		if err != nil {
-			return nil, err
-		}
-
-		shootState := &gardencorev1beta1.ShootState{}
-		if err := kubernetes.GardenScheme.Convert(shootStateObj, shootState, nil); err != nil {
-			return nil, err
-		}
-
-		resourceDataList := v1beta1helper.GardenerResourceDataList(shootState.Spec.Gardener)
-
-		clusterCABundle, err = getClusterCABundle(resourceDataList)
-		if err != nil {
-			return nil, apierrors.NewInternalError(fmt.Errorf("could not find cluster CA bundle: %w", err))
-		}
-
-		clientCACertificate, err = getClientCACertificate(resourceDataList)
-		if err != nil {
-			return nil, apierrors.NewInternalError(fmt.Errorf("could not find client CA certificate: %w", err))
-		}
+	clientCACertificate, err := secrets.LoadCertificate("", caClientSecret.Data[secrets.DataKeyPrivateKeyCA], caClientSecret.Data[secrets.DataKeyCertificateCA])
+	if err != nil {
+		return nil, apierrors.NewInternalError(fmt.Errorf("could not load client CA certificate from secret: %w", err))
 	}
 
+	caClusterSecret, err := r.secretLister.Secrets(shoot.Namespace).Get(gardenerutils.ComputeShootProjectSecretName(shoot.Name, gardenerutils.ShootProjectSecretSuffixCACluster))
+	if err != nil {
+		return nil, apierrors.NewInternalError(fmt.Errorf("could not get cluster CA secret: %w", err))
+	}
+	clusterCABundle := caClusterSecret.Data[secrets.DataKeyCertificateCA]
+
+	if len(clusterCABundle) == 0 {
+		return nil, apierrors.NewInternalError(fmt.Errorf("could not load cluster CA bundle from secret"))
+	}
+
+	// generate kubeconfig with client certificate
 	if r.maxExpirationSeconds > 0 && out.Spec.ExpirationSeconds > r.maxExpirationSeconds {
 		out.Spec.ExpirationSeconds = r.maxExpirationSeconds
 	}
@@ -211,6 +168,7 @@ func (r *AdminKubeconfigREST) Create(ctx context.Context, name string, obj runti
 	}
 	controlPlaneSecret := cp.(*secrets.ControlPlane)
 
+	// return generated kubeconfig in status
 	out.Status.Kubeconfig = controlPlaneSecret.Kubeconfig
 	out.Status.ExpirationTimestamp = metav1.Time{Time: controlPlaneSecret.Certificate.Certificate.NotAfter}
 
@@ -224,132 +182,4 @@ func (r *AdminKubeconfigREST) GroupVersionKind(schema.GroupVersion) schema.Group
 
 type getter interface {
 	Get(ctx context.Context, name string, options *metav1.GetOptions) (runtime.Object, error)
-}
-
-var (
-	managedBySecretsManagerReq = utils.MustNewRequirement(secretsmanager.LabelKeyManagedBy, selection.Equals, secretsmanager.LabelValueSecretsManager)
-	identityGardenletReq       = utils.MustNewRequirement(secretsmanager.LabelKeyManagerIdentity, selection.Equals, v1beta1constants.SecretManagerIdentityGardenlet)
-	nameCAClientReq            = utils.MustNewRequirement(secretsmanager.LabelKeyName, selection.Equals, v1beta1constants.SecretNameCAClient)
-	nameCAClusterReq           = utils.MustNewRequirement(secretsmanager.LabelKeyName, selection.Equals, v1beta1constants.SecretNameCACluster)
-	caCertificateSelector      = labels.NewSelector().Add(managedBySecretsManagerReq).Add(identityGardenletReq)
-)
-
-func findNewestCACertificate(results []*gardencorev1beta1.GardenerResourceData) (*gardencorev1beta1.GardenerResourceData, error) {
-	if len(results) == 1 {
-		return results[0], nil
-	}
-
-	var (
-		newestIssuedAtTime int64
-		result             *gardencorev1beta1.GardenerResourceData
-	)
-
-	for _, data := range results {
-		issuedAtTime, ok := data.Labels[secretsmanager.LabelKeyIssuedAtTime]
-		if !ok {
-			continue
-		}
-
-		issuedAtUnix, err := strconv.ParseInt(issuedAtTime, 10, 64)
-		if err != nil {
-			return nil, err
-		}
-
-		if issuedAtUnix > newestIssuedAtTime {
-			newestIssuedAtTime = issuedAtUnix
-			result = data.DeepCopy()
-		}
-	}
-
-	return result, nil
-}
-
-func getClusterCABundle(resourceDataList v1beta1helper.GardenerResourceDataList) ([]byte, error) {
-	var (
-		allCAs   = resourceDataList.Select(caCertificateSelector.Add(nameCAClusterReq))
-		caBundle []byte
-		err      error
-	)
-
-	// Sort CAs descending based on their issued-at-time label. This ensures that the current CA is always the first so
-	// that the order in the bundle is the same as in the <shoot-name>.ca-cluster secret.
-	sort.Slice(allCAs, func(i, j int) bool {
-		issuedAtUnix1, err1 := parseIssuedAtUnix(allCAs[i])
-		if err1 != nil {
-			err = err1
-		}
-
-		issuedAtUnix2, err2 := parseIssuedAtUnix(allCAs[j])
-		if err2 != nil {
-			err = err2
-		}
-
-		return issuedAtUnix1 > issuedAtUnix2
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	for _, data := range allCAs {
-		cert, _, err := getCADataRaw(data)
-		if err != nil {
-			return nil, fmt.Errorf("could not fetch raw CA data for %q", data.Name)
-		}
-		caBundle = append(caBundle, cert...)
-	}
-
-	if len(caBundle) == 0 {
-		return nil, fmt.Errorf("cluster certificate authority not yet provisioned")
-	}
-
-	return caBundle, nil
-}
-
-func getClientCACertificate(resourceDataList v1beta1helper.GardenerResourceDataList) (*secrets.Certificate, error) {
-	var (
-		ca  *gardencorev1beta1.GardenerResourceData
-		err error
-	)
-
-	if caCerts := resourceDataList.Select(caCertificateSelector.Add(nameCAClientReq)); len(caCerts) > 0 {
-		ca, err = findNewestCACertificate(caCerts)
-		if err != nil {
-			return nil, fmt.Errorf("could not find newest CA certificate for %s: %w", nameCAClientReq, err)
-		}
-	}
-
-	if ca == nil {
-		return nil, fmt.Errorf("client certificate authority not yet provisioned")
-	}
-
-	cert, key, err := getCADataRaw(ca)
-	if err != nil {
-		return nil, fmt.Errorf("could not fetch raw client CA data for %q", ca.Name)
-	}
-
-	return secrets.LoadCertificate("", key, cert)
-}
-
-func getCADataRaw(resourceData *gardencorev1beta1.GardenerResourceData) (certificate []byte, privateKey []byte, err error) {
-	data := make(map[string][]byte)
-	if err = json.Unmarshal(resourceData.Data.Raw, &data); err != nil {
-		return nil, nil, err
-	}
-
-	certificate, privateKey = data[secrets.DataKeyCertificateCA], data[secrets.DataKeyPrivateKeyCA]
-	return
-}
-
-func parseIssuedAtUnix(caSecret *gardencorev1beta1.GardenerResourceData) (int64, error) {
-	issuedAtTime, ok1 := caSecret.Labels[secretsmanager.LabelKeyIssuedAtTime]
-	if !ok1 {
-		return -1, fmt.Errorf("ca %q does not have %s label", caSecret.Name, secretsmanager.LabelKeyIssuedAtTime)
-	}
-
-	issuedAtUnix, err := strconv.ParseInt(issuedAtTime, 10, 64)
-	if err != nil {
-		return -1, fmt.Errorf("could not parse %s label for ca %q: %w", secretsmanager.LabelKeyIssuedAtTime, caSecret.Name, err)
-	}
-
-	return issuedAtUnix, nil
 }

--- a/pkg/registry/core/shoot/storage/admin_kubeconfig_test.go
+++ b/pkg/registry/core/shoot/storage/admin_kubeconfig_test.go
@@ -40,7 +40,6 @@ import (
 	authenticationapi "github.com/gardener/gardener/pkg/apis/authentication"
 	gardencore "github.com/gardener/gardener/pkg/apis/core"
 	gardencorelisters "github.com/gardener/gardener/pkg/client/core/listers/core/internalversion"
-	"github.com/gardener/gardener/pkg/utils"
 	secretsutils "github.com/gardener/gardener/pkg/utils/secrets"
 	"github.com/gardener/gardener/pkg/utils/test"
 )
@@ -51,23 +50,20 @@ var _ = Describe("Admin Kubeconfig", func() {
 		obj *authenticationapi.AdminKubeconfigRequest
 
 		shoot           *gardencore.Shoot
-		shootState      *gardencore.ShootState
 		caClusterSecret *corev1.Secret
 		caClientSecret  *gardencore.InternalSecret
 
 		akcREST          *AdminKubeconfigREST
 		createValidation registryrest.ValidateObjectFunc
 
-		shootStateGetter     *fakeGetter
 		shootGetter          *fakeGetter
 		secretLister         *fakeSecretLister
 		internalSecretLister *fakeInternalSecretLister
 
-		clusterCACert1 = []byte("cluster-ca-cert1")
-		clusterCACert2 = []byte("cluster-ca-cert2")
+		clusterCACert = []byte("cluster-ca-cert1")
 
-		clientCACert1Name = "minikubeCA"
-		clientCACert1     = []byte(`-----BEGIN CERTIFICATE-----
+		clientCACertName = "minikubeCA"
+		clientCACert     = []byte(`-----BEGIN CERTIFICATE-----
 MIIDBjCCAe6gAwIBAgIBATANBgkqhkiG9w0BAQsFADAVMRMwEQYDVQQDEwptaW5p
 a3ViZUNBMB4XDTIxMDMyNTE0MjczN1oXDTMxMDMyNDE0MjczN1owFTETMBEGA1UE
 AxMKbWluaWt1YmVDQTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALsW
@@ -86,7 +82,7 @@ OnM7+5534rkP8/eIX58QFcVibjM34BfqNQgHW5vFXobYoIX2wfMysLZVESYQdU9P
 C3KRaS8COePkaiH/NUjuIjyTXzhvJqmFbH730vABpcKi01eQMMjtRkPlWIEqUHoG
 QbU6uberp2QAQA==
 -----END CERTIFICATE-----`)
-		clientCAKey1 = []byte(`-----BEGIN RSA PRIVATE KEY-----
+		clientCAKey = []byte(`-----BEGIN RSA PRIVATE KEY-----
 MIIEowIBAAKCAQEAuxbyNToBQ/W31anrE5MBiGOsQ8aLE/6IKP1xJfleRKGlU1g1
 6bAKqkM0560oAC0VAySlyjWKx+4Hzvps1j79sLlgKtimvOWNL4RgBv794P9qFRGd
 dfLT3J8GsZMy+vq2LwEvkOqUOqEe7ex6QgxJ52twKzXR0NySCXiWCGhFKgJp3f8s
@@ -113,54 +109,6 @@ MR1b/wKBgHyhTEIz3YDAG7O/y3U6JWGnxqlr8i8+FobZWMbVSGDtgRZpDcDGyhFb
 AIOz/jD6sCJ6KPr1L6mJ5w4mDX1UmjCKy3Kz4xfqxPEbMvPDTL+9TWFSlAuNtHGC
 lIwEl8tStnO9u1JUK4w1e+lC37zI2v5k4WMQmJcolUEMwmZjnCR/
 -----END RSA PRIVATE KEY-----`)
-
-		clientCACert2Name = "new-minikube-ca"
-		clientCACert2     = []byte(`-----BEGIN CERTIFICATE-----
-MIIDBDCCAeygAwIBAgIUXutuW//tcCBAR2BKjz1N9xNosNwwDQYJKoZIhvcNAQEL
-BQAwGjEYMBYGA1UEAxMPbmV3LW1pbmlrdWJlLWNhMB4XDTIyMDQxMjA3MDcwMFoX
-DTI3MDQxMTA3MDcwMFowGjEYMBYGA1UEAxMPbmV3LW1pbmlrdWJlLWNhMIIBIjAN
-BgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAsiOi5NGvtPtJLD4FfMUne1KcgtKs
-o91WdriOJWF6mfWiB2fnbMS8EaKaU4AMXyrQpn6neZTDXeH5DOXhiQqvczRr5B4u
-/SD+OXLhdrzNaIpYc7DNhbT41DdG0F+ZiNQao0rQJrvw7pcR6D+CzqMmLk34Q4VU
-h0e2nXSqNS4S/0coKUomL1eMSHpMqJVGTQhlWHDU7xMyOZ2t5TleHBI+OhfXAMyV
-iEcaZUeengV73RoX+ycAYb5tjZOwk0GlolQxYl4rnjro2c2i5ezK8F+xdfkbCL/D
-NfUGg01JBfCc1Yb3DtOpTaQcnnwFyJjQX8aPMTtDbT/4JZsHujZdRKU9yQIDAQAB
-o0IwQDAOBgNVHQ8BAf8EBAMCAQYwDwYDVR0TAQH/BAUwAwEB/zAdBgNVHQ4EFgQU
-+8T3UU5pFUA8jFwy4pLioRxg1IgwDQYJKoZIhvcNAQELBQADggEBAELa5wEx7CAX
-y98v2iDAQ4uXNIrVZFp3zAgL1Rvtivf85Vz6+aQMSflJG8Ftk205PbUPhcvMrdFi
-NdC9mGZ1K+QoyAIP+cU6zDVhzH73Vjlg/JyMa8kRFaqJMAnExGKNuzu4Ox742XKH
-ej+WbykRbnB3t/Fvw4WrA0ZhQip/314SOyF71xDHGfBQrJYItGEB7kIriTOUL0Or
-Eh1pkuxLBmO/iz4iAMaaG5JuVlPtDEYLX1kBx/aPh9sjgw28AWvlA1L/HawmXLsR
-Yg+zBuGRGSu1IfIIwjshOGmsz+jaTM0SEZ5AtbmOl1gvGSgj8Ylod+Qb7gXBxBO8
-yUsW6+ksN+o=
------END CERTIFICATE-----`)
-		clientCAKey2 = []byte(`-----BEGIN RSA PRIVATE KEY-----
-MIIEpAIBAAKCAQEAsiOi5NGvtPtJLD4FfMUne1KcgtKso91WdriOJWF6mfWiB2fn
-bMS8EaKaU4AMXyrQpn6neZTDXeH5DOXhiQqvczRr5B4u/SD+OXLhdrzNaIpYc7DN
-hbT41DdG0F+ZiNQao0rQJrvw7pcR6D+CzqMmLk34Q4VUh0e2nXSqNS4S/0coKUom
-L1eMSHpMqJVGTQhlWHDU7xMyOZ2t5TleHBI+OhfXAMyViEcaZUeengV73RoX+ycA
-Yb5tjZOwk0GlolQxYl4rnjro2c2i5ezK8F+xdfkbCL/DNfUGg01JBfCc1Yb3DtOp
-TaQcnnwFyJjQX8aPMTtDbT/4JZsHujZdRKU9yQIDAQABAoIBAQCacqVHyLmTq478
-qeVuES2zEaQbFPeTt1LA6jBsHoECvWI3E5IlzsjUbWtqXAnd9SwkPomLszxTyJl6
-4lDR1Y7azqeAh97rntBsFLuAjB93tQMNg0wd0hMvQ6HFBi4C4QsbasDf5HD3G8nt
-2CrcZ72xxe4q9I2eIMIm8ECmjQTxiFiVf89TRz5Y+63IniId9Gh7WKmDR59sS31I
-aEVRVRS9934tdkKx3TJd4Hmb1SNusvnx8wiTfi12nVjgVtYLLzPkd18I58wNvyj/
-BE4iyiM4AqzQBqgEjc8Hw6YeR3Mwu6zyA0u7g3pXHhO4JL/eOpxWY6DAVlOt+WWC
-ZkhGxs0lAoGBAN8GgPKVOX9x75CPv44ATfbZ5g7qmT5wrhHIlcF/1B1Q0xvZsrmn
-2Hax96EINk93osWaiKAWoVIt0mHuoE2k5TK1cazI+DatyuXgU+3ngxoI7SPK95w2
-EcXTKkFGgz5/WU2XWgYRdDy2gzb3XTlygPael+pjWYb5bRQjw6hALwQHAoGBAMx6
-MWcX9FmeHvjBjXRyxz4xehqv8iXnMKIghAfCTD0zQ4OTGher5mVVCcWncKB8s/c7
-5mIaKfTaoGgfVeGlrBeGLSeDWoHQMdWP1ZBMchNKpzZ9OXU2QmYrkUzFPJGTUSJe
-sKLLYD2R+vwWGra508rJBKQKMnmIf7MLacB6lVuvAoGAJ/HoQoqLo9HqUIAOlQZk
-8GOSmvVVwSM5aiH9AI0+lomVZhWVtz7ivE+fxI3N/Gm3E6Fb+yBSgH+IgNXWjFGO
-Y4iv9XyBSHnUL1wAbEnc51rV7mU5+BaPFFl/5fUVKKpyej0zeIbDxOQDmGKxpcpm
-YsWA/BATRuOBr+u/7XChex0CgYBdGG0RsPhRLQqQ2x6aG//WsxQSvnSTCTU9O2yh
-U7b+Ti644uqISH13OUZftSI0D1Koh58Wny7nCfrqLQoe2B0IANDiIo28eJuXzgq/
-ze5KFj0XM+BLG08T0VYwC8TNyrKv4UiudcX1glcxGqdC9kwVEXyJaxMb/ieVzuZw
-+d6yhQKBgQCyR66MFetyEffnbxHng3WIG4MzJj7Bn5IewQiKe6yWgrS4xMxoUywx
-xdiQxdLMPqh48D9u+bwt+roq66lt1kcF0mvIUgEYXhaPj/9moG8cfgmbmF9tsm08
-bW4nbZLxXHQ4e+OOPeBUXUP9V0QcE4XixdvQuslfVxjn0Ja82gdzeA==
------END RSA PRIVATE KEY-----`)
 	)
 
 	const (
@@ -170,51 +118,17 @@ bW4nbZLxXHQ4e+OOPeBUXUP9V0QcE4XixdvQuslfVxjn0Ja82gdzeA==
 	)
 
 	BeforeEach(func() {
-		shootState = &gardencore.ShootState{
-			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
-			Spec: gardencore.ShootStateSpec{
-				Gardener: []gardencore.GardenerResourceData{
-					{
-						Name: "ca-hugo",
-						Type: "secret",
-						Labels: map[string]string{
-							"name":             "ca",
-							"managed-by":       "secrets-manager",
-							"manager-identity": "gardenlet",
-							"issued-at-time":   "0",
-						},
-						Data: runtime.RawExtension{
-							Raw: []byte(`{"ca.crt":"` + utils.EncodeBase64(clusterCACert1) + `"}`),
-						},
-					},
-					{
-						Name: "ca-client-foo",
-						Type: "secret",
-						Labels: map[string]string{
-							"name":             "ca-client",
-							"managed-by":       "secrets-manager",
-							"manager-identity": "gardenlet",
-							"issued-at-time":   "0",
-						},
-						Data: runtime.RawExtension{
-							Raw: []byte(`{"ca.crt":"` + utils.EncodeBase64(clientCACert1) + `","ca.key":"` + utils.EncodeBase64(clientCAKey1) + `"}`),
-						},
-					},
-				},
-			},
-		}
-
 		caClusterSecret = &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{Name: name + ".ca-cluster", Namespace: namespace},
 			Data: map[string][]byte{
-				"ca.crt": clusterCACert1,
+				"ca.crt": clusterCACert,
 			},
 		}
 		caClientSecret = &gardencore.InternalSecret{
 			ObjectMeta: metav1.ObjectMeta{Name: name + ".ca-client", Namespace: namespace},
 			Data: map[string][]byte{
-				"ca.crt": clientCACert1,
-				"ca.key": clientCAKey1,
+				"ca.crt": clientCACert,
+				"ca.key": clientCAKey,
 			},
 		}
 
@@ -236,7 +150,6 @@ bW4nbZLxXHQ4e+OOPeBUXUP9V0QcE4XixdvQuslfVxjn0Ja82gdzeA==
 		}
 
 		shootGetter = &fakeGetter{obj: shoot}
-		shootStateGetter = &fakeGetter{obj: shootState}
 
 		secretLister = &fakeSecretLister{obj: caClusterSecret}
 		internalSecretLister = &fakeInternalSecretLister{obj: caClientSecret}
@@ -251,7 +164,6 @@ bW4nbZLxXHQ4e+OOPeBUXUP9V0QcE4XixdvQuslfVxjn0Ja82gdzeA==
 			secretLister:         secretLister,
 			internalSecretLister: internalSecretLister,
 			shootStorage:         shootGetter,
-			shootStateStorage:    shootStateGetter,
 		}
 
 		ctx = request.WithUser(context.Background(), &user.DefaultInfo{
@@ -274,313 +186,125 @@ bW4nbZLxXHQ4e+OOPeBUXUP9V0QcE4XixdvQuslfVxjn0Ja82gdzeA==
 			Expect(actual).To(BeNil())
 		})
 
-		Context("retrieving CAs from secrets", func() {
-			It("returns an error if create validation fails", func() {
-				createValidation = func(ctx context.Context, obj runtime.Object) error {
-					return errors.New("some error")
-				}
-			})
-
-			It("returns an error if validation fails", func() {
-				obj.Spec.ExpirationSeconds = -1
-			})
-
-			It("returns an error if there is no user in the context", func() {
-				ctx = context.TODO()
-			})
-
-			It("returns an error if it cannot get the ca-client secret", func() {
-				internalSecretLister.err = errors.New("fake")
-			})
-
-			It("returns an error if the ca-client secret is missing the public key", func() {
-				delete(caClientSecret.Data, "ca.crt")
-			})
-
-			It("returns an error if the ca-client secret is missing the private key", func() {
-				delete(caClientSecret.Data, "ca.key")
-			})
-
-			It("returns an error if it cannot get the ca-cluster secret", func() {
-				secretLister.err = errors.New("fake")
-			})
-
-			It("returns an error if the ca-cluster secret is missing the public key", func() {
-				delete(caClusterSecret.Data, "ca.crt")
-			})
-
-			It("returns an error if the ca-cluster secret doesn't exist", func() {
-				secretLister.err = apierrors.NewNotFound(gardencore.Resource("internalsecrets"), caClusterSecret.Name)
-			})
-
-			It("returns an error if it cannot get the shoot", func() {
-				shootGetter.err = errors.New("can't get shoot")
-			})
-
-			It("returns an error if it cannot convert the object to a shoot", func() {
-				shootGetter.obj = &corev1.Pod{}
-			})
-
-			It("returns an error if there are no advertised addresses in shoot status", func() {
-				shoot.Status.AdvertisedAddresses = nil
-			})
+		It("returns an error if create validation fails", func() {
+			createValidation = func(ctx context.Context, obj runtime.Object) error {
+				return errors.New("some error")
+			}
 		})
 
-		Context("falling back to the shoot state", func() {
-			BeforeEach(func() {
-				internalSecretLister.err = apierrors.NewNotFound(gardencore.Resource("internalsecrets"), caClientSecret.Name)
-			})
+		It("returns an error if validation fails", func() {
+			obj.Spec.ExpirationSeconds = -1
+		})
 
-			It("returns an error if it cannot get the shoot state", func() {
-				shootStateGetter.err = errors.New("can't get shoot state")
-			})
+		It("returns an error if there is no user in the context", func() {
+			ctx = context.TODO()
+		})
 
-			It("returns an error if it cannot convert the object to a shoot state", func() {
-				shootStateGetter.obj = &corev1.Pod{}
-			})
+		It("returns an error if it cannot get the ca-client secret", func() {
+			internalSecretLister.err = errors.New("fake")
+		})
 
-			It("returns an error if the cluster certificate authority is not yet provisioned", func() {
-				shootState.Spec.Gardener = append(shootState.Spec.Gardener[:0], shootState.Spec.Gardener[1:]...)
-			})
+		It("returns an error if the ca-client secret doesn't exist", func() {
+			internalSecretLister.err = apierrors.NewNotFound(gardencore.Resource("internalsecrets"), caClientSecret.Name)
+		})
 
-			It("returns an error if the cluster certificate authority contains no certificate", func() {
-				shootState.Spec.Gardener[0].Data.Raw = []byte("{}")
-			})
+		It("returns an error if the ca-client secret is missing the public key", func() {
+			delete(caClientSecret.Data, "ca.crt")
+		})
 
-			It("returns an error if the client certificate authority is not yet provisioned", func() {
-				shootState.Spec.Gardener = append(shootState.Spec.Gardener[:1], shootState.Spec.Gardener[2:]...)
-			})
+		It("returns an error if the ca-client secret is missing the private key", func() {
+			delete(caClientSecret.Data, "ca.key")
+		})
 
-			It("returns an error if the client certificate authority contains no certificate", func() {
-				shootState.Spec.Gardener[1].Data.Raw = []byte("{}")
-			})
+		It("returns an error if it cannot get the ca-cluster secret", func() {
+			secretLister.err = errors.New("fake")
+		})
 
-			It("returns an error if the issued-at-time label on a CA cert secret is missing", func() {
-				shootState.Spec.Gardener = append(shootState.Spec.Gardener, gardencore.GardenerResourceData{
-					Name: "ca-2",
-					Type: "secret",
-					Labels: map[string]string{
-						"name":             "ca",
-						"managed-by":       "secrets-manager",
-						"manager-identity": "gardenlet",
-					},
-				})
-			})
+		It("returns an error if the ca-cluster secret doesn't exist", func() {
+			secretLister.err = apierrors.NewNotFound(gardencore.Resource("secrets"), caClusterSecret.Name)
+		})
+
+		It("returns an error if the ca-cluster secret is missing the public key", func() {
+			delete(caClusterSecret.Data, "ca.crt")
+		})
+
+		It("returns an error if it cannot get the shoot", func() {
+			shootGetter.err = errors.New("can't get shoot")
+		})
+
+		It("returns an error if it cannot convert the object to a shoot", func() {
+			shootGetter.obj = &corev1.Pod{}
+		})
+
+		It("returns an error if there are no advertised addresses in shoot status", func() {
+			shoot.Status.AdvertisedAddresses = nil
 		})
 	})
 
 	Context("request succeeds", func() {
-		Context("retrieving CAs from secrets", func() {
-			It("should successfully issue admin kubeconfig", func() {
-				actual, err := akcREST.Create(ctx, name, obj, nil, nil)
+		It("should successfully issue admin kubeconfig", func() {
+			actual, err := akcREST.Create(ctx, name, obj, nil, nil)
 
-				Expect(err).ToNot(HaveOccurred())
-				Expect(actual).ToNot(BeNil())
-				Expect(actual).To(BeAssignableToTypeOf(&authenticationapi.AdminKubeconfigRequest{}))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(actual).ToNot(BeNil())
+			Expect(actual).To(BeAssignableToTypeOf(&authenticationapi.AdminKubeconfigRequest{}))
 
-				akcr := actual.(*authenticationapi.AdminKubeconfigRequest)
+			akcr := actual.(*authenticationapi.AdminKubeconfigRequest)
 
-				Expect(akcr.Status.ExpirationTimestamp.Time).To(Equal(time.Unix(10, 0).Add(time.Minute * 11)))
+			Expect(akcr.Status.ExpirationTimestamp.Time).To(Equal(time.Unix(10, 0).Add(time.Minute * 11)))
 
-				config := &clientcmdv1.Config{}
-				Expect(runtime.DecodeInto(clientcmdlatest.Codec, akcr.Status.Kubeconfig, config)).To(Succeed())
+			config := &clientcmdv1.Config{}
+			Expect(runtime.DecodeInto(clientcmdlatest.Codec, akcr.Status.Kubeconfig, config)).To(Succeed())
 
-				Expect(config.Clusters).To(ConsistOf(
-					clientcmdv1.NamedCluster{
-						Name: "baz--test-external",
-						Cluster: clientcmdv1.Cluster{
-							Server:                   "https://foo.bar.external:9443",
-							CertificateAuthorityData: clusterCACert1,
-						},
+			Expect(config.Clusters).To(ConsistOf(
+				clientcmdv1.NamedCluster{
+					Name: "baz--test-external",
+					Cluster: clientcmdv1.Cluster{
+						Server:                   "https://foo.bar.external:9443",
+						CertificateAuthorityData: clusterCACert,
 					},
-					clientcmdv1.NamedCluster{
-						Name: "baz--test-internal",
-						Cluster: clientcmdv1.Cluster{
-							Server:                   "https://foo.bar.internal:9443",
-							CertificateAuthorityData: clusterCACert1,
-						},
-					},
-				))
-
-				Expect(config.Contexts).To(ConsistOf(
-					clientcmdv1.NamedContext{
-						Name: "baz--test-external",
-						Context: clientcmdv1.Context{
-							Cluster:  "baz--test-external",
-							AuthInfo: "baz--test-external",
-						},
-					},
-					clientcmdv1.NamedContext{
-						Name: "baz--test-internal",
-						Context: clientcmdv1.Context{
-							Cluster:  "baz--test-internal",
-							AuthInfo: "baz--test-external",
-						},
-					},
-				))
-				Expect(config.CurrentContext).To(Equal("baz--test-external"))
-
-				Expect(config.AuthInfos).To(HaveLen(1))
-				Expect(config.AuthInfos[0].Name).To(Equal("baz--test-external"))
-				Expect(config.AuthInfos[0].AuthInfo.ClientCertificateData).ToNot(BeEmpty())
-				Expect(config.AuthInfos[0].AuthInfo.ClientKeyData).ToNot(BeEmpty())
-
-				certPem, _ := pem.Decode(config.AuthInfos[0].AuthInfo.ClientCertificateData)
-				cert, err := x509.ParseCertificate(certPem.Bytes)
-				Expect(err).ToNot(HaveOccurred())
-
-				Expect(cert.Subject.CommonName).To(Equal(userName))
-				Expect(cert.Subject.Organization).To(ConsistOf("system:masters"))
-				Expect(cert.NotAfter.Unix()).To(Equal(akcr.Status.ExpirationTimestamp.Time.Unix())) // certificates do not have nano seconds in them
-				Expect(cert.NotBefore.UTC()).To(Equal(time.Unix(10, 0).UTC()))
-				Expect(cert.Issuer.CommonName).To(Equal(clientCACert1Name))
-			})
-		})
-
-		Context("falling back to the shoot state", func() {
-			BeforeEach(func() {
-				internalSecretLister.err = apierrors.NewNotFound(gardencore.Resource("internalsecrets"), caClientSecret.Name)
-			})
-
-			DescribeTable("request succeeds",
-				func(expectedIssuerName string, expectedClusterCABundle []byte, prepEnv func()) {
-					if prepEnv != nil {
-						prepEnv()
-					}
-
-					actual, err := akcREST.Create(ctx, name, obj, nil, nil)
-
-					Expect(err).ToNot(HaveOccurred())
-					Expect(actual).ToNot(BeNil())
-					Expect(actual).To(BeAssignableToTypeOf(&authenticationapi.AdminKubeconfigRequest{}))
-
-					akcr := actual.(*authenticationapi.AdminKubeconfigRequest)
-
-					Expect(akcr.Status.ExpirationTimestamp.Time).To(Equal(time.Unix(10, 0).Add(time.Minute * 11)))
-
-					config := &clientcmdv1.Config{}
-					Expect(runtime.DecodeInto(clientcmdlatest.Codec, akcr.Status.Kubeconfig, config)).To(Succeed())
-
-					Expect(config.Clusters).To(ConsistOf(
-						clientcmdv1.NamedCluster{
-							Name: "baz--test-external",
-							Cluster: clientcmdv1.Cluster{
-								Server:                   "https://foo.bar.external:9443",
-								CertificateAuthorityData: expectedClusterCABundle,
-							},
-						},
-						clientcmdv1.NamedCluster{
-							Name: "baz--test-internal",
-							Cluster: clientcmdv1.Cluster{
-								Server:                   "https://foo.bar.internal:9443",
-								CertificateAuthorityData: expectedClusterCABundle,
-							},
-						},
-					))
-
-					Expect(config.Contexts).To(ConsistOf(
-						clientcmdv1.NamedContext{
-							Name: "baz--test-external",
-							Context: clientcmdv1.Context{
-								Cluster:  "baz--test-external",
-								AuthInfo: "baz--test-external",
-							},
-						},
-						clientcmdv1.NamedContext{
-							Name: "baz--test-internal",
-							Context: clientcmdv1.Context{
-								Cluster:  "baz--test-internal",
-								AuthInfo: "baz--test-external",
-							},
-						},
-					))
-					Expect(config.CurrentContext).To(Equal("baz--test-external"))
-
-					Expect(config.AuthInfos).To(HaveLen(1))
-					Expect(config.AuthInfos[0].Name).To(Equal("baz--test-external"))
-					Expect(config.AuthInfos[0].AuthInfo.ClientCertificateData).ToNot(BeEmpty())
-					Expect(config.AuthInfos[0].AuthInfo.ClientKeyData).ToNot(BeEmpty())
-
-					certPem, _ := pem.Decode(config.AuthInfos[0].AuthInfo.ClientCertificateData)
-					cert, err := x509.ParseCertificate(certPem.Bytes)
-					Expect(err).ToNot(HaveOccurred())
-
-					Expect(cert.Subject.CommonName).To(Equal(userName))
-					Expect(cert.Subject.Organization).To(ConsistOf("system:masters"))
-					Expect(cert.NotAfter.Unix()).To(Equal(akcr.Status.ExpirationTimestamp.Time.Unix())) // certificates do not have nano seconds in them
-					Expect(cert.NotBefore.UTC()).To(Equal(time.Unix(10, 0).UTC()))
-					Expect(cert.Issuer.CommonName).To(Equal(expectedIssuerName))
 				},
+				clientcmdv1.NamedCluster{
+					Name: "baz--test-internal",
+					Cluster: clientcmdv1.Cluster{
+						Server:                   "https://foo.bar.internal:9443",
+						CertificateAuthorityData: clusterCACert,
+					},
+				},
+			))
 
-				Entry("one client CA, one cluster CA", clientCACert1Name, clusterCACert1, nil),
+			Expect(config.Contexts).To(ConsistOf(
+				clientcmdv1.NamedContext{
+					Name: "baz--test-external",
+					Context: clientcmdv1.Context{
+						Cluster:  "baz--test-external",
+						AuthInfo: "baz--test-external",
+					},
+				},
+				clientcmdv1.NamedContext{
+					Name: "baz--test-internal",
+					Context: clientcmdv1.Context{
+						Cluster:  "baz--test-internal",
+						AuthInfo: "baz--test-external",
+					},
+				},
+			))
+			Expect(config.CurrentContext).To(Equal("baz--test-external"))
 
-				Entry("one client CA, multiple cluster CA", clientCACert1Name, append(clusterCACert2, clusterCACert1...), func() {
-					shootState.Spec.Gardener = append(shootState.Spec.Gardener, gardencore.GardenerResourceData{
-						Name: "ca-cluster-2",
-						Type: "secret",
-						Labels: map[string]string{
-							"name":             "ca",
-							"managed-by":       "secrets-manager",
-							"manager-identity": "gardenlet",
-							"issued-at-time":   "1",
-						},
-						Data: runtime.RawExtension{
-							Raw: []byte(`{"ca.crt":"` + utils.EncodeBase64(clusterCACert2) + `"}`),
-						},
-					})
-				}),
+			Expect(config.AuthInfos).To(HaveLen(1))
+			Expect(config.AuthInfos[0].Name).To(Equal("baz--test-external"))
+			Expect(config.AuthInfos[0].AuthInfo.ClientCertificateData).ToNot(BeEmpty())
+			Expect(config.AuthInfos[0].AuthInfo.ClientKeyData).ToNot(BeEmpty())
 
-				Entry("multiple client CA (in case of rotation), one cluster CA", clientCACert2Name, clusterCACert1, func() {
-					shootState.Spec.Gardener = append(shootState.Spec.Gardener, gardencore.GardenerResourceData{
-						Name: "ca-client-bar",
-						Type: "secret",
-						Labels: map[string]string{
-							"name":             "ca-client",
-							"managed-by":       "secrets-manager",
-							"manager-identity": "gardenlet",
-							"issued-at-time":   "1",
-						},
-						Data: runtime.RawExtension{
-							Raw: []byte(`{"ca.crt":"` + utils.EncodeBase64(clientCACert2) + `","ca.key":"` + utils.EncodeBase64(clientCAKey2) + `"}`),
-						},
-					})
-				}),
+			certPem, _ := pem.Decode(config.AuthInfos[0].AuthInfo.ClientCertificateData)
+			cert, err := x509.ParseCertificate(certPem.Bytes)
+			Expect(err).ToNot(HaveOccurred())
 
-				Entry("multiple client CA (in case of rotation), multiple cluster CA", clientCACert2Name, append(clusterCACert2, clusterCACert1...), func() {
-					shootState.Spec.Gardener = append(shootState.Spec.Gardener,
-						gardencore.GardenerResourceData{
-							Name: "ca-client-bar",
-							Type: "secret",
-							Labels: map[string]string{
-								"name":             "ca-client",
-								"managed-by":       "secrets-manager",
-								"manager-identity": "gardenlet",
-								"issued-at-time":   "1",
-							},
-							Data: runtime.RawExtension{
-								Raw: []byte(`{"ca.crt":"` + utils.EncodeBase64(clientCACert2) + `","ca.key":"` + utils.EncodeBase64(clientCAKey2) + `"}`),
-							},
-						},
-						gardencore.GardenerResourceData{
-							Name: "ca-cluster-2",
-							Type: "secret",
-							Labels: map[string]string{
-								"name":             "ca",
-								"managed-by":       "secrets-manager",
-								"manager-identity": "gardenlet",
-								"issued-at-time":   "1",
-							},
-							Data: runtime.RawExtension{
-								Raw: []byte(`{"ca.crt":"` + utils.EncodeBase64(clusterCACert2) + `"}`),
-							},
-						},
-					)
-				}),
-
-				Entry("no client CA, one cluster CA", clientCACert1Name, clusterCACert1, func() {
-					shootState.Spec.Gardener[0].Labels["name"] = "ca"
-				}),
-			)
+			Expect(cert.Subject.CommonName).To(Equal(userName))
+			Expect(cert.Subject.Organization).To(ConsistOf("system:masters"))
+			Expect(cert.NotAfter.Unix()).To(Equal(akcr.Status.ExpirationTimestamp.Time.Unix())) // certificates do not have nano seconds in them
+			Expect(cert.NotBefore.UTC()).To(Equal(time.Unix(10, 0).UTC()))
+			Expect(cert.Issuer.CommonName).To(Equal(clientCACertName))
 		})
 	})
 })

--- a/pkg/registry/core/shoot/storage/storage.go
+++ b/pkg/registry/core/shoot/storage/storage.go
@@ -47,7 +47,6 @@ type ShootStorage struct {
 // NewStorage creates a new ShootStorage object.
 func NewStorage(
 	optsGetter generic.RESTOptionsGetter,
-	shootStateStore *genericregistry.Store,
 	internalSecretLister gardencorelisters.InternalSecretLister,
 	secretLister kubecorev1listers.SecretLister,
 	adminKubeconfigMaxExpiration time.Duration,
@@ -64,7 +63,6 @@ func NewStorage(
 	s.AdminKubeconfig = &AdminKubeconfigREST{
 		secretLister:         secretLister,
 		internalSecretLister: internalSecretLister,
-		shootStateStorage:    shootStateStore,
 		shootStorage:         shootRest,
 		maxExpirationSeconds: int64(adminKubeconfigMaxExpiration.Seconds()),
 	}

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -159,7 +159,6 @@ build:
         - pkg/utils/kubernetes
         - pkg/utils/retry
         - pkg/utils/secrets
-        - pkg/utils/secrets/manager
         - pkg/utils/time
         - pkg/utils/timewindow
         - pkg/utils/validation/admissionplugins


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity usability
/kind cleanup

**What this PR does / why we need it**:

Drops the fallback to the `ShootState` object in the `shoots/adminkubeconfig` subresource.

**Which issue(s) this PR fixes**:
Related to https://github.com/gardener/gardener/issues/7999
Follow-up after https://github.com/gardener/gardener/pull/8088

**Special notes for your reviewer**:

With https://github.com/gardener/gardener/pull/8144 (starting with v1.75.0), the `ShootState` objects will be deleted for `Shoots` running on non-managed `Seeds`.

/cc @rfranzke 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The `shoots/adminkubeconfig` relies on the `ca-client` `InternalSecret` only and does not use the `ShootState` object anymore.
```
