### PR TITLE
Add label to fluent-bit to allow ingress and egress to shoot Vali

### DIFF
--- a/pkg/component/logging/fluentoperator/custom_resources_test.go
+++ b/pkg/component/logging/fluentoperator/custom_resources_test.go
@@ -109,12 +109,11 @@ var _ = Describe("Fluent Operator Custom Resources", func() {
 					KeepObjects: pointer.Bool(false),
 				},
 			}))
-
 			Expect(c.Get(ctx, client.ObjectKeyFromObject(customResourcesManagedResourceSecret), customResourcesManagedResourceSecret)).To(Succeed())
 			Expect(customResourcesManagedResourceSecret.Type).To(Equal(corev1.SecretTypeOpaque))
 			Expect(customResourcesManagedResourceSecret.Data).To(HaveLen(12))
 			Expect(customResourcesManagedResourceSecret.Data).To(HaveKey(MatchRegexp("configmap__" + namespace + "__fluent-bit-lua-config-.*" + ".yaml")))
-			Expect(customResourcesManagedResourceSecret.Data).To(HaveKey("fluentbit__" + namespace + "__fluent-bit-093d91.yaml"))
+			Expect(customResourcesManagedResourceSecret.Data).To(HaveKey("fluentbit__" + namespace + "__fluent-bit-8259c5.yaml"))
 			Expect(customResourcesManagedResourceSecret.Data).To(HaveKey("clusterfluentbitconfig____fluent-bit-config.yaml"))
 			Expect(customResourcesManagedResourceSecret.Data).To(HaveKey("clusterinput____tail-kubernetes.yaml"))
 			Expect(customResourcesManagedResourceSecret.Data).To(HaveKey("clusterfilter____01-docker.yaml"))

--- a/pkg/component/logging/fluentoperator/fluent_operator.go
+++ b/pkg/component/logging/fluentoperator/fluent_operator.go
@@ -340,13 +340,12 @@ func getLabels() map[string]string {
 
 func getFluentBitLabels() map[string]string {
 	return map[string]string{
-		v1beta1constants.LabelApp:                                         v1beta1constants.DaemonSetNameFluentBit,
-		v1beta1constants.LabelRole:                                        v1beta1constants.LabelLogging,
-		v1beta1constants.GardenRole:                                       v1beta1constants.GardenRoleLogging,
-		v1beta1constants.LabelNetworkPolicyToDNS:                          v1beta1constants.LabelNetworkPolicyAllowed,
-		v1beta1constants.LabelNetworkPolicyToRuntimeAPIServer:             v1beta1constants.LabelNetworkPolicyAllowed,
-		"networking.resources.gardener.cloud/to-logging-tcp-3100":         v1beta1constants.LabelNetworkPolicyAllowed,
-		"networking.resources.gardener.cloud/to-all-shoots-vali-tcp-3100": v1beta1constants.LabelNetworkPolicyAllowed,
-		"networking.resources.gardener.cloud/to-all-shoots-loki-tcp-3100": v1beta1constants.LabelNetworkPolicyAllowed,
+		v1beta1constants.LabelApp:                                            v1beta1constants.DaemonSetNameFluentBit,
+		v1beta1constants.LabelRole:                                           v1beta1constants.LabelLogging,
+		v1beta1constants.GardenRole:                                          v1beta1constants.GardenRoleLogging,
+		v1beta1constants.LabelNetworkPolicyToDNS:                             v1beta1constants.LabelNetworkPolicyAllowed,
+		v1beta1constants.LabelNetworkPolicyToRuntimeAPIServer:                v1beta1constants.LabelNetworkPolicyAllowed,
+		"networking.resources.gardener.cloud/to-logging-tcp-3100":            v1beta1constants.LabelNetworkPolicyAllowed,
+		"networking.resources.gardener.cloud/to-all-shoots-logging-tcp-3100": v1beta1constants.LabelNetworkPolicyAllowed,
 	}
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area logging
/kind bug

**What this PR does / why we need it**:
This PR adds `networking.resources.gardener.cloud/to-all-shoots-logging-tcp-3100: allowed` to the fluent-bit pods to make them able to connect to the shoot Valis.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer*
This PT must be cherry-picked.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fix network annotations to allow fluent-bit connecting to shoot Valis.
```
