### PR TITLE
Clean up DNS handling

### DIFF
--- a/charts/gardener/controlplane/charts/utils-common/templates/_secret-default-domain.yaml
+++ b/charts/gardener/controlplane/charts/utils-common/templates/_secret-default-domain.yaml
@@ -17,7 +17,6 @@ metadata:
     dns.gardener.cloud/domain: {{ ( required ".defaultDomains[].domain is required" $domain.domain ) }}
     {{- if $domain.zone }}
     dns.gardener.cloud/zone: {{ $domain.zone }}
-    dns.gardener.cloud/include-zones: {{ $domain.zone }}
     {{- end }}
 type: Opaque
 data:

--- a/docs/api-reference/core.md
+++ b/docs/api-reference/core.md
@@ -3841,7 +3841,9 @@ not a default domain is used.</p>
 <a href="#core.gardener.cloud/v1beta1.DNSProvider">DNSProvider</a>)
 </p>
 <p>
-<p>DNSIncludeExclude contains information about which domains shall be included/excluded.</p>
+<p>DNSIncludeExclude contains information about which domains shall be included/excluded.
+Note: This struct is not used by Gardener anymore. However, providers might still be synced by the DNS extension which
+is mainly why we can&rsquo;t deprecate or remove it, see <a href="https://github.com/gardener/gardener-extension-shoot-dns-service/blob/f599bec786ab6e27e6fd41d423d4e73dd4952f4f/pkg/admission/mutator/shoot_mutator.go#L110">https://github.com/gardener/gardener-extension-shoot-dns-service/blob/f599bec786ab6e27e6fd41d423d4e73dd4952f4f/pkg/admission/mutator/shoot_mutator.go#L110</a>.</p>
 </p>
 <table>
 <thead>

--- a/docs/api-reference/core.md
+++ b/docs/api-reference/core.md
@@ -3841,9 +3841,7 @@ not a default domain is used.</p>
 <a href="#core.gardener.cloud/v1beta1.DNSProvider">DNSProvider</a>)
 </p>
 <p>
-<p>DNSIncludeExclude contains information about which domains shall be included/excluded.
-Note: This struct is not used by Gardener anymore. However, providers might still be synced by the DNS extension which
-is mainly why we can&rsquo;t deprecate or remove it, see <a href="https://github.com/gardener/gardener-extension-shoot-dns-service/blob/f599bec786ab6e27e6fd41d423d4e73dd4952f4f/pkg/admission/mutator/shoot_mutator.go#L110">https://github.com/gardener/gardener-extension-shoot-dns-service/blob/f599bec786ab6e27e6fd41d423d4e73dd4952f4f/pkg/admission/mutator/shoot_mutator.go#L110</a>.</p>
+<p>DNSIncludeExclude contains information about which domains shall be included/excluded.</p>
 </p>
 <table>
 <thead>

--- a/docs/api-reference/core.md
+++ b/docs/api-reference/core.md
@@ -3905,7 +3905,8 @@ DNSIncludeExclude
 </td>
 <td>
 <em>(Optional)</em>
-<p>Domains contains information about which domains shall be included/excluded for this provider.</p>
+<p>Domains contains information about which domains shall be included/excluded for this provider.
+Deprecated: This field is deprecated and will be removed in Gardener release v1.87.</p>
 </td>
 </tr>
 <tr>
@@ -3958,7 +3959,8 @@ DNSIncludeExclude
 </td>
 <td>
 <em>(Optional)</em>
-<p>Zones contains information about which hosted zones shall be included/excluded for this provider.</p>
+<p>Zones contains information about which hosted zones shall be included/excluded for this provider.
+Deprecated: This field is deprecated and will be removed in Gardener release v1.87.</p>
 </td>
 </tr>
 </tbody>

--- a/example/10-secret-default-domain.yaml
+++ b/example/10-secret-default-domain.yaml
@@ -10,8 +10,6 @@ metadata:
     dns.gardener.cloud/provider: aws-route53
     dns.gardener.cloud/domain: example.com
   # dns.gardener.cloud/domain-default-priority: "10"
-  # dns.gardener.cloud/include-zones: "first-zone-id,second-zone-id"
-  # dns.gardener.cloud/exclude-zones: "first-zone-id,second-zone-id"
 type: Opaque
 data: {}
   # Actual values here depend on the DNS extension of your choice.

--- a/example/10-secret-internal-domain.yaml
+++ b/example/10-secret-internal-domain.yaml
@@ -9,8 +9,6 @@ metadata:
   annotations:
     dns.gardener.cloud/provider: aws-route53
     dns.gardener.cloud/domain: example.com
-  # dns.gardener.cloud/include-zones: "first-zone-id,second-zone-id"
-  # dns.gardener.cloud/exclude-zones: "first-zone-id,second-zone-id"
 type: Opaque
 data: {}
   # Actual values here depend on the DNS extension of your choice.

--- a/example/90-shoot.yaml
+++ b/example/90-shoot.yaml
@@ -304,17 +304,6 @@ spec:
   # - type: aws-route53
   #   secretName: my-custom-domain-secret
   #   primary: true # `true` indicates that this provider is also used to manage the shoot domain `.spec.dns.domain`
-  #   domains:
-  #     include:
-  #     - my-custom-domain.com
-  #     - my-other-custom-domain.com
-  #     exclude:
-  #     - yet-another-custom-domain.com
-  #   zones:
-  #     include:
-  #     - zone-id-1
-  #     exclude:
-  #     - zone-id-2
   extensions:
   - type: foobar
   # providerConfig:

--- a/pkg/admissioncontroller/webhook/admission/internaldomainsecret/handler.go
+++ b/pkg/admissioncontroller/webhook/admission/internaldomainsecret/handler.go
@@ -62,7 +62,7 @@ func (h *Handler) ValidateCreate(ctx context.Context, obj runtime.Object) error 
 		return apierrors.NewConflict(schema.GroupResource{Group: corev1.GroupName, Resource: "Secret"}, secret.Name, fmt.Errorf("cannot create internal domain secret because there can be only one secret with the 'internal-domain' secret role per namespace"))
 	}
 
-	if _, _, _, _, _, err := gardenerutils.GetDomainInfoFromAnnotations(secret.Annotations); err != nil {
+	if _, _, _, err := gardenerutils.GetDomainInfoFromAnnotations(secret.Annotations); err != nil {
 		return apierrors.NewBadRequest(err.Error())
 	}
 
@@ -102,11 +102,11 @@ func (h *Handler) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Obj
 		}
 	}
 
-	_, oldDomain, _, _, _, err := gardenerutils.GetDomainInfoFromAnnotations(oldSecret.Annotations)
+	_, oldDomain, _, err := gardenerutils.GetDomainInfoFromAnnotations(oldSecret.Annotations)
 	if err != nil {
 		return apierrors.NewInternalError(err)
 	}
-	_, newDomain, _, _, _, err := gardenerutils.GetDomainInfoFromAnnotations(secret.Annotations)
+	_, newDomain, _, err := gardenerutils.GetDomainInfoFromAnnotations(secret.Annotations)
 	if err != nil {
 		return apierrors.NewInternalError(err)
 	}

--- a/pkg/apis/core/types_shoot.go
+++ b/pkg/apis/core/types_shoot.go
@@ -347,6 +347,9 @@ type DNS struct {
 
 // DNSProvider contains information about a DNS provider.
 type DNSProvider struct {
+	// Note: This field is not used by Gardener anymore. However, providers might still be synced by the DNS extension which
+	// is mainly why we can't deprecate or remove it, see https://github.com/gardener/gardener-extension-shoot-dns-service/blob/f599bec786ab6e27e6fd41d423d4e73dd4952f4f/pkg/admission/mutator/shoot_mutator.go#L105-L106.
+
 	// Domains contains information about which domains shall be included/excluded for this provider.
 	Domains *DNSIncludeExclude
 	// Primary indicates that this DNSProvider is used for shoot related domains.
@@ -359,13 +362,14 @@ type DNSProvider struct {
 	// Type is the DNS provider type for the Shoot. Only relevant if not the default domain is used for
 	// this shoot.
 	Type *string
+	// Note: This field is not used by Gardener anymore. However, providers might still be synced by the DNS extension which
+	// is mainly why we can't deprecate or remove it, see https://github.com/gardener/gardener-extension-shoot-dns-service/blob/f599bec786ab6e27e6fd41d423d4e73dd4952f4f/pkg/admission/mutator/shoot_mutator.go#L105-L106.
+
 	// Zones contains information about which hosted zones shall be included/excluded for this provider.
 	Zones *DNSIncludeExclude
 }
 
 // DNSIncludeExclude contains information about which domains shall be included/excluded.
-// Note: This struct is not used by Gardener anymore. However, providers might still be synced by the DNS extension which
-// is mainly why we can't deprecate or remove it, see https://github.com/gardener/gardener-extension-shoot-dns-service/blob/f599bec786ab6e27e6fd41d423d4e73dd4952f4f/pkg/admission/mutator/shoot_mutator.go#L110.
 type DNSIncludeExclude struct {
 	// Include is a list of domains that shall be included.
 	Include []string

--- a/pkg/apis/core/types_shoot.go
+++ b/pkg/apis/core/types_shoot.go
@@ -347,10 +347,10 @@ type DNS struct {
 
 // DNSProvider contains information about a DNS provider.
 type DNSProvider struct {
-	// Note: This field is not used by Gardener anymore. However, providers might still be synced by the DNS extension which
-	// is mainly why we can't deprecate or remove it, see https://github.com/gardener/gardener-extension-shoot-dns-service/blob/f599bec786ab6e27e6fd41d423d4e73dd4952f4f/pkg/admission/mutator/shoot_mutator.go#L105-L106.
+	// TODO(timuthy): Remove this field with release v1.87.
 
 	// Domains contains information about which domains shall be included/excluded for this provider.
+	// Deprecated: This field is deprecated and will be removed in Gardener release v1.87.
 	Domains *DNSIncludeExclude
 	// Primary indicates that this DNSProvider is used for shoot related domains.
 	Primary *bool
@@ -362,10 +362,10 @@ type DNSProvider struct {
 	// Type is the DNS provider type for the Shoot. Only relevant if not the default domain is used for
 	// this shoot.
 	Type *string
-	// Note: This field is not used by Gardener anymore. However, providers might still be synced by the DNS extension which
-	// is mainly why we can't deprecate or remove it, see https://github.com/gardener/gardener-extension-shoot-dns-service/blob/f599bec786ab6e27e6fd41d423d4e73dd4952f4f/pkg/admission/mutator/shoot_mutator.go#L105-L106.
+	// TODO(timuthy): Remove this field with release v1.87.
 
 	// Zones contains information about which hosted zones shall be included/excluded for this provider.
+	// Deprecated: This field is deprecated and will be removed in Gardener release v1.87.
 	Zones *DNSIncludeExclude
 }
 

--- a/pkg/apis/core/types_shoot.go
+++ b/pkg/apis/core/types_shoot.go
@@ -364,6 +364,8 @@ type DNSProvider struct {
 }
 
 // DNSIncludeExclude contains information about which domains shall be included/excluded.
+// Note: This struct is not used by Gardener anymore. However, providers might still be synced by the DNS extension which
+// is mainly why we can't deprecate or remove it, see https://github.com/gardener/gardener-extension-shoot-dns-service/blob/f599bec786ab6e27e6fd41d423d4e73dd4952f4f/pkg/admission/mutator/shoot_mutator.go#L110.
 type DNSIncludeExclude struct {
 	// Include is a list of domains that shall be included.
 	Include []string

--- a/pkg/apis/core/v1beta1/generated.proto
+++ b/pkg/apis/core/v1beta1/generated.proto
@@ -642,8 +642,6 @@ message DNS {
 }
 
 // DNSIncludeExclude contains information about which domains shall be included/excluded.
-// Note: This struct is not used by Gardener anymore. However, providers might still be synced by the DNS extension which
-// is mainly why we can't deprecate or remove it, see https://github.com/gardener/gardener-extension-shoot-dns-service/blob/f599bec786ab6e27e6fd41d423d4e73dd4952f4f/pkg/admission/mutator/shoot_mutator.go#L110.
 message DNSIncludeExclude {
   // Include is a list of domains that shall be included.
   // +optional

--- a/pkg/apis/core/v1beta1/generated.proto
+++ b/pkg/apis/core/v1beta1/generated.proto
@@ -642,6 +642,8 @@ message DNS {
 }
 
 // DNSIncludeExclude contains information about which domains shall be included/excluded.
+// Note: This struct is not used by Gardener anymore. However, providers might still be synced by the DNS extension which
+// is mainly why we can't deprecate or remove it, see https://github.com/gardener/gardener-extension-shoot-dns-service/blob/f599bec786ab6e27e6fd41d423d4e73dd4952f4f/pkg/admission/mutator/shoot_mutator.go#L110.
 message DNSIncludeExclude {
   // Include is a list of domains that shall be included.
   // +optional

--- a/pkg/apis/core/v1beta1/generated.proto
+++ b/pkg/apis/core/v1beta1/generated.proto
@@ -655,6 +655,7 @@ message DNSIncludeExclude {
 // DNSProvider contains information about a DNS provider.
 message DNSProvider {
   // Domains contains information about which domains shall be included/excluded for this provider.
+  // Deprecated: This field is deprecated and will be removed in Gardener release v1.87.
   // +optional
   optional DNSIncludeExclude domains = 1;
 
@@ -674,6 +675,7 @@ message DNSProvider {
   optional string type = 4;
 
   // Zones contains information about which hosted zones shall be included/excluded for this provider.
+  // Deprecated: This field is deprecated and will be removed in Gardener release v1.87.
   // +optional
   optional DNSIncludeExclude zones = 5;
 }

--- a/pkg/apis/core/v1beta1/types_shoot.go
+++ b/pkg/apis/core/v1beta1/types_shoot.go
@@ -448,6 +448,8 @@ type DNSProvider struct {
 }
 
 // DNSIncludeExclude contains information about which domains shall be included/excluded.
+// Note: This struct is not used by Gardener anymore. However, providers might still be synced by the DNS extension which
+// is mainly why we can't deprecate or remove it, see https://github.com/gardener/gardener-extension-shoot-dns-service/blob/f599bec786ab6e27e6fd41d423d4e73dd4952f4f/pkg/admission/mutator/shoot_mutator.go#L110.
 type DNSIncludeExclude struct {
 	// Include is a list of domains that shall be included.
 	// +optional

--- a/pkg/apis/core/v1beta1/types_shoot.go
+++ b/pkg/apis/core/v1beta1/types_shoot.go
@@ -427,10 +427,10 @@ type DNS struct {
 
 // DNSProvider contains information about a DNS provider.
 type DNSProvider struct {
-	// Note: This field is not used by Gardener anymore. However, providers might still be synced by the DNS extension which
-	// is mainly why we can't deprecate or remove it, see https://github.com/gardener/gardener-extension-shoot-dns-service/blob/f599bec786ab6e27e6fd41d423d4e73dd4952f4f/pkg/admission/mutator/shoot_mutator.go#L99-L100.
+	// TODO(timuthy): Remove this field with release v1.87.
 
 	// Domains contains information about which domains shall be included/excluded for this provider.
+	// Deprecated: This field is deprecated and will be removed in Gardener release v1.87.
 	// +optional
 	Domains *DNSIncludeExclude `json:"domains,omitempty" protobuf:"bytes,1,opt,name=domains"`
 	// Primary indicates that this DNSProvider is used for shoot related domains.
@@ -445,10 +445,10 @@ type DNSProvider struct {
 	// Type is the DNS provider type.
 	// +optional
 	Type *string `json:"type,omitempty" protobuf:"bytes,4,opt,name=type"`
-	// Note: This field is not used by Gardener anymore. However, providers might still be synced by the DNS extension which
-	// is mainly why we can't deprecate or remove it, see https://github.com/gardener/gardener-extension-shoot-dns-service/blob/f599bec786ab6e27e6fd41d423d4e73dd4952f4f/pkg/admission/mutator/shoot_mutator.go#L105-L106.
+	// TODO(timuthy): Remove this field with release v1.87.
 
 	// Zones contains information about which hosted zones shall be included/excluded for this provider.
+	// Deprecated: This field is deprecated and will be removed in Gardener release v1.87.
 	// +optional
 	Zones *DNSIncludeExclude `json:"zones,omitempty" protobuf:"bytes,5,opt,name=zones"`
 }

--- a/pkg/apis/core/v1beta1/types_shoot.go
+++ b/pkg/apis/core/v1beta1/types_shoot.go
@@ -427,6 +427,9 @@ type DNS struct {
 
 // DNSProvider contains information about a DNS provider.
 type DNSProvider struct {
+	// Note: This field is not used by Gardener anymore. However, providers might still be synced by the DNS extension which
+	// is mainly why we can't deprecate or remove it, see https://github.com/gardener/gardener-extension-shoot-dns-service/blob/f599bec786ab6e27e6fd41d423d4e73dd4952f4f/pkg/admission/mutator/shoot_mutator.go#L99-L100.
+
 	// Domains contains information about which domains shall be included/excluded for this provider.
 	// +optional
 	Domains *DNSIncludeExclude `json:"domains,omitempty" protobuf:"bytes,1,opt,name=domains"`
@@ -442,14 +445,15 @@ type DNSProvider struct {
 	// Type is the DNS provider type.
 	// +optional
 	Type *string `json:"type,omitempty" protobuf:"bytes,4,opt,name=type"`
+	// Note: This field is not used by Gardener anymore. However, providers might still be synced by the DNS extension which
+	// is mainly why we can't deprecate or remove it, see https://github.com/gardener/gardener-extension-shoot-dns-service/blob/f599bec786ab6e27e6fd41d423d4e73dd4952f4f/pkg/admission/mutator/shoot_mutator.go#L105-L106.
+
 	// Zones contains information about which hosted zones shall be included/excluded for this provider.
 	// +optional
 	Zones *DNSIncludeExclude `json:"zones,omitempty" protobuf:"bytes,5,opt,name=zones"`
 }
 
 // DNSIncludeExclude contains information about which domains shall be included/excluded.
-// Note: This struct is not used by Gardener anymore. However, providers might still be synced by the DNS extension which
-// is mainly why we can't deprecate or remove it, see https://github.com/gardener/gardener-extension-shoot-dns-service/blob/f599bec786ab6e27e6fd41d423d4e73dd4952f4f/pkg/admission/mutator/shoot_mutator.go#L110.
 type DNSIncludeExclude struct {
 	// Include is a list of domains that shall be included.
 	// +optional

--- a/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
@@ -144,7 +144,7 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 		})
 		deployKubeAPIServerService = g.Add(flow.Task{
 			Name:         "Deploying Kubernetes API server service in the Seed cluster",
-			Fn:           flow.TaskFn(botanist.Shoot.Components.ControlPlane.KubeAPIServerService.Deploy).RetryUntilTimeout(defaultInterval, defaultTimeout).SkipIf(o.Shoot.HibernationEnabled && !useDNS),
+			Fn:           flow.TaskFn(botanist.Shoot.Components.ControlPlane.KubeAPIServerService.Deploy).RetryUntilTimeout(defaultInterval, defaultTimeout),
 			Dependencies: flow.NewTaskIDs(deployNamespace, ensureShootClusterIdentity),
 		})
 		_ = g.Add(flow.Task{
@@ -153,8 +153,8 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 			Dependencies: flow.NewTaskIDs(deployKubeAPIServerService),
 		})
 		waitUntilKubeAPIServerServiceIsReady = g.Add(flow.Task{
-			Name:         "Waiting until Kubernetes API LoadBalancer in the Seed cluster has reported readiness",
-			Fn:           flow.TaskFn(botanist.Shoot.Components.ControlPlane.KubeAPIServerService.Wait).SkipIf(o.Shoot.HibernationEnabled && !useDNS),
+			Name:         "Waiting until Kubernetes API server service in the Seed cluster has reported readiness",
+			Fn:           flow.TaskFn(botanist.Shoot.Components.ControlPlane.KubeAPIServerService.Wait).SkipIf(o.Shoot.HibernationEnabled),
 			Dependencies: flow.NewTaskIDs(deployKubeAPIServerService),
 		})
 		_ = g.Add(flow.Task{

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -2482,7 +2482,7 @@ func schema_pkg_apis_core_v1beta1_DNSIncludeExclude(ref common.ReferenceCallback
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "DNSIncludeExclude contains information about which domains shall be included/excluded. Note: This struct is not used by Gardener anymore. However, providers might still be synced by the DNS extension which is mainly why we can't deprecate or remove it, see https://github.com/gardener/gardener-extension-shoot-dns-service/blob/f599bec786ab6e27e6fd41d423d4e73dd4952f4f/pkg/admission/mutator/shoot_mutator.go#L110.",
+				Description: "DNSIncludeExclude contains information about which domains shall be included/excluded.",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"include": {

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -2482,7 +2482,7 @@ func schema_pkg_apis_core_v1beta1_DNSIncludeExclude(ref common.ReferenceCallback
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "DNSIncludeExclude contains information about which domains shall be included/excluded.",
+				Description: "DNSIncludeExclude contains information about which domains shall be included/excluded. Note: This struct is not used by Gardener anymore. However, providers might still be synced by the DNS extension which is mainly why we can't deprecate or remove it, see https://github.com/gardener/gardener-extension-shoot-dns-service/blob/f599bec786ab6e27e6fd41d423d4e73dd4952f4f/pkg/admission/mutator/shoot_mutator.go#L110.",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"include": {

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -2530,7 +2530,7 @@ func schema_pkg_apis_core_v1beta1_DNSProvider(ref common.ReferenceCallback) comm
 				Properties: map[string]spec.Schema{
 					"domains": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Domains contains information about which domains shall be included/excluded for this provider.",
+							Description: "Domains contains information about which domains shall be included/excluded for this provider. Deprecated: This field is deprecated and will be removed in Gardener release v1.87.",
 							Ref:         ref("github.com/gardener/gardener/pkg/apis/core/v1beta1.DNSIncludeExclude"),
 						},
 					},
@@ -2557,7 +2557,7 @@ func schema_pkg_apis_core_v1beta1_DNSProvider(ref common.ReferenceCallback) comm
 					},
 					"zones": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Zones contains information about which hosted zones shall be included/excluded for this provider.",
+							Description: "Zones contains information about which hosted zones shall be included/excluded for this provider. Deprecated: This field is deprecated and will be removed in Gardener release v1.87.",
 							Ref:         ref("github.com/gardener/gardener/pkg/apis/core/v1beta1.DNSIncludeExclude"),
 						},
 					},

--- a/pkg/operation/botanist/dns.go
+++ b/pkg/operation/botanist/dns.go
@@ -15,8 +15,6 @@
 package botanist
 
 import (
-	"strings"
-
 	extensionsv1alpha1helper "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1/helper"
 )
 
@@ -30,7 +28,6 @@ func (b *Botanist) NeedsExternalDNS() bool {
 	return b.Shoot.GetInfo().Spec.DNS != nil &&
 		b.Shoot.GetInfo().Spec.DNS.Domain != nil &&
 		b.Shoot.ExternalClusterDomain != nil &&
-		!strings.HasSuffix(*b.Shoot.ExternalClusterDomain, ".nip.io") &&
 		b.Shoot.ExternalDomain != nil &&
 		b.Shoot.ExternalDomain.Provider != "unmanaged"
 }

--- a/pkg/operation/botanist/dns_test.go
+++ b/pkg/operation/botanist/dns_test.go
@@ -116,12 +116,6 @@ var _ = Describe("dns", func() {
 			Expect(b.NeedsExternalDNS()).To(BeFalse())
 		})
 
-		It("should be false when Shoot ExternalClusterDomain is in nip.io", func() {
-			b.Shoot.GetInfo().Spec.DNS = &gardencorev1beta1.DNS{Domain: pointer.String("foo")}
-			b.Shoot.ExternalClusterDomain = pointer.String("foo.nip.io")
-			Expect(b.NeedsExternalDNS()).To(BeFalse())
-		})
-
 		It("should be false when Shoot ExternalDomain is nil", func() {
 			b.Shoot.GetInfo().Spec.DNS = &gardencorev1beta1.DNS{Domain: pointer.String("foo")}
 			b.Shoot.ExternalClusterDomain = pointer.String("baz")

--- a/pkg/utils/gardener/dns.go
+++ b/pkg/utils/gardener/dns.go
@@ -16,7 +16,6 @@ package gardener
 
 import (
 	"fmt"
-	"strings"
 )
 
 const (
@@ -58,9 +57,9 @@ const (
 )
 
 // GetDomainInfoFromAnnotations returns the provider, domain, and zones that are specified in the given annotations.
-func GetDomainInfoFromAnnotations(annotations map[string]string) (provider string, domain string, zone string, includeZones, excludeZones []string, err error) {
+func GetDomainInfoFromAnnotations(annotations map[string]string) (provider string, domain string, zone string, err error) {
 	if annotations == nil {
-		return "", "", "", nil, nil, fmt.Errorf("domain secret has no annotations")
+		return "", "", "", fmt.Errorf("domain secret has no annotations")
 	}
 
 	if providerAnnotation, ok := annotations[DNSProvider]; ok {
@@ -75,18 +74,11 @@ func GetDomainInfoFromAnnotations(annotations map[string]string) (provider strin
 		zone = zoneAnnotation
 	}
 
-	if includeZonesAnnotation, ok := annotations[DNSIncludeZones]; ok {
-		includeZones = strings.Split(includeZonesAnnotation, ",")
-	}
-	if excludeZonesAnnotation, ok := annotations[DNSExcludeZones]; ok {
-		excludeZones = strings.Split(excludeZonesAnnotation, ",")
-	}
-
 	if len(domain) == 0 {
-		return "", "", "", nil, nil, fmt.Errorf("missing dns domain annotation on domain secret")
+		return "", "", "", fmt.Errorf("missing dns domain annotation on domain secret")
 	}
 	if len(provider) == 0 {
-		return "", "", "", nil, nil, fmt.Errorf("missing dns provider annotation on domain secret")
+		return "", "", "", fmt.Errorf("missing dns provider annotation on domain secret")
 	}
 
 	return

--- a/pkg/utils/gardener/dns.go
+++ b/pkg/utils/gardener/dns.go
@@ -31,12 +31,6 @@ const (
 	// DNSZone is the key for an annotation on a Kubernetes Secret object whose value must point to a valid
 	// DNS hosted zone id.
 	DNSZone = "dns.gardener.cloud/zone"
-	// DNSIncludeZones is the key for an annotation on a Kubernetes Secret object whose value must point to a list
-	// of zones that shall be included.
-	DNSIncludeZones = "dns.gardener.cloud/include-zones"
-	// DNSExcludeZones is the key for an annotation on a Kubernetes Secret object whose value must point to a list
-	// of zones that shall be excluded.
-	DNSExcludeZones = "dns.gardener.cloud/exclude-zones"
 
 	// APIServerFQDNPrefix is the part of a FQDN which will be used to construct the domain name for the kube-apiserver of
 	// a Shoot cluster. For example, when a Shoot specifies domain 'cluster.example.com', the apiserver domain would be

--- a/pkg/utils/gardener/dns_test.go
+++ b/pkg/utils/gardener/dns_test.go
@@ -40,11 +40,9 @@ var _ = Describe("Dns", func() {
 			DNSDomain: "foo",
 		}, BeEmpty(), BeEmpty(), BeEmpty(), HaveOccurred()),
 		Entry("all present", map[string]string{
-			DNSProvider:     "bar",
-			DNSDomain:       "foo",
-			DNSZone:         "zoo",
-			DNSIncludeZones: "a,b,c",
-			DNSExcludeZones: "d,e,f",
+			DNSProvider: "bar",
+			DNSDomain:   "foo",
+			DNSZone:     "zoo",
 		}, Equal("bar"), Equal("foo"), Equal("zoo"), Not(HaveOccurred())),
 	)
 

--- a/pkg/utils/gardener/dns_test.go
+++ b/pkg/utils/gardener/dns_test.go
@@ -24,30 +24,28 @@ import (
 
 var _ = Describe("Dns", func() {
 	DescribeTable("#GetDomainInfoFromAnnotations",
-		func(annotations map[string]string, expectedProvider, expectedDomain, expectedZone, expectedIncludeZones, expectedExcludeZones, expectedErr gomegatypes.GomegaMatcher) {
-			provider, domain, zone, includeZones, excludeZones, err := GetDomainInfoFromAnnotations(annotations)
+		func(annotations map[string]string, expectedProvider, expectedDomain, expectedZone, expectedErr gomegatypes.GomegaMatcher) {
+			provider, domain, zone, err := GetDomainInfoFromAnnotations(annotations)
 			Expect(provider).To(expectedProvider)
 			Expect(domain).To(expectedDomain)
 			Expect(zone).To(expectedZone)
-			Expect(includeZones).To(expectedIncludeZones)
-			Expect(excludeZones).To(expectedExcludeZones)
 			Expect(err).To(expectedErr)
 		},
 
-		Entry("no annotations", nil, BeEmpty(), BeEmpty(), BeEmpty(), BeEmpty(), BeEmpty(), HaveOccurred()),
+		Entry("no annotations", nil, BeEmpty(), BeEmpty(), BeEmpty(), HaveOccurred()),
 		Entry("no domain", map[string]string{
 			DNSProvider: "bar",
-		}, BeEmpty(), BeEmpty(), BeEmpty(), BeEmpty(), BeEmpty(), HaveOccurred()),
+		}, BeEmpty(), BeEmpty(), BeEmpty(), HaveOccurred()),
 		Entry("no provider", map[string]string{
 			DNSDomain: "foo",
-		}, BeEmpty(), BeEmpty(), BeEmpty(), BeEmpty(), BeEmpty(), HaveOccurred()),
+		}, BeEmpty(), BeEmpty(), BeEmpty(), HaveOccurred()),
 		Entry("all present", map[string]string{
 			DNSProvider:     "bar",
 			DNSDomain:       "foo",
 			DNSZone:         "zoo",
 			DNSIncludeZones: "a,b,c",
 			DNSExcludeZones: "d,e,f",
-		}, Equal("bar"), Equal("foo"), Equal("zoo"), Equal([]string{"a", "b", "c"}), Equal([]string{"d", "e", "f"}), Not(HaveOccurred())),
+		}, Equal("bar"), Equal("foo"), Equal("zoo"), Not(HaveOccurred())),
 	)
 
 	DescribeTable("#GenerateDNSProviderName",

--- a/pkg/utils/gardener/garden.go
+++ b/pkg/utils/gardener/garden.go
@@ -37,8 +37,6 @@ type Domain struct {
 	SecretData     map[string][]byte
 	IncludeDomains []string
 	ExcludeDomains []string
-	IncludeZones   []string
-	ExcludeZones   []string
 }
 
 // GetDefaultDomains finds all the default domain secrets within the given map and returns a list of
@@ -71,18 +69,16 @@ func GetInternalDomain(secrets map[string]*corev1.Secret) (*Domain, error) {
 }
 
 func constructDomainFromSecret(secret *corev1.Secret) (*Domain, error) {
-	provider, domain, zone, includeZones, excludeZones, err := GetDomainInfoFromAnnotations(secret.Annotations)
+	provider, domain, zone, err := GetDomainInfoFromAnnotations(secret.Annotations)
 	if err != nil {
 		return nil, err
 	}
 
 	return &Domain{
-		Domain:       domain,
-		Provider:     provider,
-		Zone:         zone,
-		SecretData:   secret.Data,
-		IncludeZones: includeZones,
-		ExcludeZones: excludeZones,
+		Domain:     domain,
+		Provider:   provider,
+		Zone:       zone,
+		SecretData: secret.Data,
 	}, nil
 }
 
@@ -128,7 +124,7 @@ func ReadGardenSecrets(
 		// Retrieving default domain secrets based on all secrets in the Garden namespace which have
 		// a label indicating the Garden role default-domain.
 		if secret.Labels[v1beta1constants.GardenRole] == v1beta1constants.GardenRoleDefaultDomain {
-			_, domain, _, _, _, err := GetDomainInfoFromAnnotations(secret.Annotations)
+			_, domain, _, err := GetDomainInfoFromAnnotations(secret.Annotations)
 			if err != nil {
 				log.Error(err, "Error getting information out of default domain secret", "secret", client.ObjectKeyFromObject(&secret))
 				continue
@@ -142,7 +138,7 @@ func ReadGardenSecrets(
 		// Retrieving internal domain secrets based on all secrets in the Garden namespace which have
 		// a label indicating the Garden role internal-domain.
 		if secret.Labels[v1beta1constants.GardenRole] == v1beta1constants.GardenRoleInternalDomain {
-			_, domain, _, _, _, err := GetDomainInfoFromAnnotations(secret.Annotations)
+			_, domain, _, err := GetDomainInfoFromAnnotations(secret.Annotations)
 			if err != nil {
 				log.Error(err, "Error getting information out of internal domain secret", "secret", client.ObjectKeyFromObject(&secret))
 				continue

--- a/pkg/utils/gardener/garden.go
+++ b/pkg/utils/gardener/garden.go
@@ -31,12 +31,10 @@ import (
 
 // Domain contains information about a domain configured in the garden cluster.
 type Domain struct {
-	Domain         string
-	Provider       string
-	Zone           string
-	SecretData     map[string][]byte
-	IncludeDomains []string
-	ExcludeDomains []string
+	Domain     string
+	Provider   string
+	Zone       string
+	SecretData map[string][]byte
 }
 
 // GetDefaultDomains finds all the default domain secrets within the given map and returns a list of

--- a/pkg/utils/gardener/garden_test.go
+++ b/pkg/utils/gardener/garden_test.go
@@ -37,16 +37,12 @@ var _ = Describe("Garden", func() {
 				data     = map[string][]byte{
 					"foo": []byte("bar"),
 				}
-				includeZones = []string{"a", "b"}
-				excludeZones = []string{"c", "d"}
 
 				secret = &corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						Annotations: map[string]string{
-							DNSProvider:     provider,
-							DNSDomain:       domain,
-							DNSIncludeZones: strings.Join(includeZones, ","),
-							DNSExcludeZones: strings.Join(excludeZones, ","),
+							DNSProvider: provider,
+							DNSDomain:   domain,
 						},
 					},
 					Data: data,
@@ -61,11 +57,9 @@ var _ = Describe("Garden", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(defaultDomains).To(Equal([]*Domain{
 				{
-					Domain:       domain,
-					Provider:     provider,
-					SecretData:   data,
-					IncludeZones: includeZones,
-					ExcludeZones: excludeZones,
+					Domain:     domain,
+					Provider:   provider,
+					SecretData: data,
 				},
 			}))
 		})
@@ -118,11 +112,9 @@ var _ = Describe("Garden", func() {
 
 			Expect(err).NotTo(HaveOccurred())
 			Expect(internalDomain).To(Equal(&Domain{
-				Domain:       domain,
-				Provider:     provider,
-				SecretData:   data,
-				IncludeZones: includeZones,
-				ExcludeZones: excludeZones,
+				Domain:     domain,
+				Provider:   provider,
+				SecretData: data,
 			}))
 		})
 

--- a/pkg/utils/gardener/garden_test.go
+++ b/pkg/utils/gardener/garden_test.go
@@ -33,7 +33,7 @@ var _ = Describe("Garden", func() {
 		It("should return all default domain", func() {
 			var (
 				provider = "aws"
-				domain   = "nip.io"
+				domain   = "example.com"
 				data     = map[string][]byte{
 					"foo": []byte("bar"),
 				}
@@ -85,7 +85,7 @@ var _ = Describe("Garden", func() {
 		It("should return the internal domain", func() {
 			var (
 				provider = "aws"
-				domain   = "nip.io"
+				domain   = "example.com"
 				data     = map[string][]byte{
 					"foo": []byte("bar"),
 				}

--- a/pkg/utils/gardener/garden_test.go
+++ b/pkg/utils/gardener/garden_test.go
@@ -16,7 +16,6 @@ package gardener_test
 
 import (
 	"fmt"
-	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -89,16 +88,12 @@ var _ = Describe("Garden", func() {
 				data     = map[string][]byte{
 					"foo": []byte("bar"),
 				}
-				includeZones = []string{"a", "b"}
-				excludeZones = []string{"c", "d"}
 
 				secret = &corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						Annotations: map[string]string{
-							DNSProvider:     provider,
-							DNSDomain:       domain,
-							DNSIncludeZones: strings.Join(includeZones, ","),
-							DNSExcludeZones: strings.Join(excludeZones, ","),
+							DNSProvider: provider,
+							DNSDomain:   domain,
 						},
 					},
 					Data: data,

--- a/pkg/utils/gardener/shoot.go
+++ b/pkg/utils/gardener/shoot.go
@@ -596,8 +596,6 @@ func ConstructExternalDomain(ctx context.Context, c client.Reader, shoot *garden
 		externalDomain.SecretData = defaultDomain.SecretData
 		externalDomain.Provider = defaultDomain.Provider
 		externalDomain.Zone = defaultDomain.Zone
-		externalDomain.IncludeDomains = defaultDomain.IncludeDomains
-		externalDomain.ExcludeDomains = defaultDomain.ExcludeDomains
 
 	case primaryProvider != nil:
 		if primaryProvider.SecretName != nil {
@@ -614,10 +612,6 @@ func ConstructExternalDomain(ctx context.Context, c client.Reader, shoot *garden
 		}
 		if primaryProvider.Type != nil {
 			externalDomain.Provider = *primaryProvider.Type
-		}
-		if domains := primaryProvider.Domains; domains != nil {
-			externalDomain.IncludeDomains = domains.Include
-			externalDomain.ExcludeDomains = domains.Exclude
 		}
 		if zones := primaryProvider.Zones; zones != nil {
 			if len(zones.Include) == 1 {

--- a/pkg/utils/gardener/shoot.go
+++ b/pkg/utils/gardener/shoot.go
@@ -598,8 +598,6 @@ func ConstructExternalDomain(ctx context.Context, c client.Reader, shoot *garden
 		externalDomain.Zone = defaultDomain.Zone
 		externalDomain.IncludeDomains = defaultDomain.IncludeDomains
 		externalDomain.ExcludeDomains = defaultDomain.ExcludeDomains
-		externalDomain.IncludeZones = defaultDomain.IncludeZones
-		externalDomain.ExcludeZones = defaultDomain.ExcludeZones
 
 	case primaryProvider != nil:
 		if primaryProvider.SecretName != nil {
@@ -622,8 +620,6 @@ func ConstructExternalDomain(ctx context.Context, c client.Reader, shoot *garden
 			externalDomain.ExcludeDomains = domains.Exclude
 		}
 		if zones := primaryProvider.Zones; zones != nil {
-			externalDomain.IncludeZones = zones.Include
-			externalDomain.ExcludeZones = zones.Exclude
 			if len(zones.Include) == 1 {
 				externalDomain.Zone = zones.Include[0]
 			}

--- a/pkg/utils/gardener/shoot_test.go
+++ b/pkg/utils/gardener/shoot_test.go
@@ -911,8 +911,8 @@ var _ = Describe("Shoot", func() {
 			Expect(ConstructInternalClusterDomain(shootName, shootProject, &Domain{Domain: internalDomain})).To(Equal(expected))
 		},
 
-		Entry("with internal domain key", "foo", "bar", "internal.nip.io", "foo.bar.internal.nip.io"),
-		Entry("without internal domain key", "foo", "bar", "nip.io", "foo.bar.internal.nip.io"),
+		Entry("with internal domain key", "foo", "bar", "internal.example.com", "foo.bar.internal.example.com"),
+		Entry("without internal domain key", "foo", "bar", "example.com", "foo.bar.internal.example.com"),
 	)
 
 	Describe("#ConstructExternalClusterDomain", func() {

--- a/plugin/pkg/managedseed/validator/admission.go
+++ b/plugin/pkg/managedseed/validator/admission.go
@@ -522,7 +522,7 @@ func (v *ManagedSeed) getSeedDNSProviderForDefaultDomain(shoot *gardencore.Shoot
 
 	// Search for a default domain secret that matches the shoot domain
 	for _, secret := range defaultDomainSecrets {
-		provider, domain, _, _, _, err := gardenerutils.GetDomainInfoFromAnnotations(secret.Annotations)
+		provider, domain, _, err := gardenerutils.GetDomainInfoFromAnnotations(secret.Annotations)
 		if err != nil {
 			return nil, apierrors.NewInternalError(fmt.Errorf("could not get domain info from domain secret annotations: %v", err))
 		}

--- a/plugin/pkg/shoot/dns/admission.go
+++ b/plugin/pkg/shoot/dns/admission.go
@@ -401,7 +401,7 @@ func getDefaultDomains(secretLister kubecorev1listers.SecretLister) ([]string, e
 
 	var defaultDomains []string
 	for _, domainSecret := range domainSecrets {
-		_, domain, _, _, _, err := gardenerutils.GetDomainInfoFromAnnotations(domainSecret.GetAnnotations())
+		_, domain, _, err := gardenerutils.GetDomainInfoFromAnnotations(domainSecret.GetAnnotations())
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area open-source
/kind cleanup

**What this PR does / why we need it**:
This PR cleans up some leftovers regarding DNS handling, please see individual commits.

It mainly drops support for the `nip.io` domains - A functionality that's been broken for a long time, is untested and likely not used by the community.

**Special notes for your reviewer**:
/cc @rfranzke

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
Support for `nip.io` shoot domains is discontinued.
```
```breaking user
Shoot fields `.spec.dns.providers[].domains` and `.spec.dns.providers[].zones` are now deprecated and expected to be removed in version `v1.87`. Please use the extensions' configuration to configure providers with this ability.
```
```breaking developer
Shoot fields `.spec.dns.providers[].domains` and `.spec.dns.providers[].zones` are now deprecated and expected to be removed in version `v1.87`. Please plan ahead to drop using those fields in extensions.
```
