### PR TITLE
Use the same `nginx-ingress-controller` image for `Shoot`s and `Seed`s

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -65,7 +65,7 @@ images:
 - name: nginx-ingress-controller-seed
   sourceRepository: github.com/kubernetes/ingress-nginx
   repository: registry.k8s.io/ingress-nginx/controller-chroot
-  tag: "v1.8.0"
+  tag: "v1.8.1"
   targetVersion: ">= 1.24"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
@@ -372,7 +372,7 @@ images:
 - name: nginx-ingress-controller
   sourceRepository: github.com/kubernetes/ingress-nginx
   repository: registry.k8s.io/ingress-nginx/controller-chroot
-  tag: "v1.8.0"
+  tag: "v1.8.1"
   targetVersion: ">= 1.24"
   labels: *optionalAddonLabels
 

--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -34,7 +34,7 @@ images:
   sourceRepository: github.com/gardener/dependency-watchdog
   repository: eu.gcr.io/gardener-project/gardener/dependency-watchdog
   tag: "v1.1.0"
-- name: nginx-ingress-controller-seed
+- name: nginx-ingress-controller
   sourceRepository: github.com/kubernetes/ingress-nginx
   repository: registry.k8s.io/ingress-nginx/controller-chroot
   tag: "v1.4.0"
@@ -48,7 +48,7 @@ images:
       confidentiality_requirement: 'low'
       integrity_requirement: 'low'
       availability_requirement: 'low'
-- name: nginx-ingress-controller-seed
+- name: nginx-ingress-controller
   sourceRepository: github.com/kubernetes/ingress-nginx
   repository: registry.k8s.io/ingress-nginx/controller-chroot
   tag: "v1.6.4"
@@ -62,7 +62,7 @@ images:
       confidentiality_requirement: 'low'
       integrity_requirement: 'low'
       availability_requirement: 'low'
-- name: nginx-ingress-controller-seed
+- name: nginx-ingress-controller
   sourceRepository: github.com/kubernetes/ingress-nginx
   repository: registry.k8s.io/ingress-nginx/controller-chroot
   tag: "v1.8.1"
@@ -356,24 +356,6 @@ images:
   sourceRepository: github.com/kubernetes/dashboard
   repository: eu.gcr.io/gardener-project/3rd/kubernetesui/metrics-scraper
   tag: v1.0.7
-  labels: *optionalAddonLabels
-- name: nginx-ingress-controller
-  sourceRepository: github.com/kubernetes/ingress-nginx
-  repository: registry.k8s.io/ingress-nginx/controller-chroot
-  tag: "v1.4.0"
-  targetVersion: "1.22.x"
-  labels: *optionalAddonLabels
-- name: nginx-ingress-controller
-  sourceRepository: github.com/kubernetes/ingress-nginx
-  repository: registry.k8s.io/ingress-nginx/controller-chroot
-  tag: "v1.6.4"
-  targetVersion: "1.23.x"
-  labels: *optionalAddonLabels
-- name: nginx-ingress-controller
-  sourceRepository: github.com/kubernetes/ingress-nginx
-  repository: registry.k8s.io/ingress-nginx/controller-chroot
-  tag: "v1.8.1"
-  targetVersion: ">= 1.24"
   labels: *optionalAddonLabels
 
 # Miscellaenous

--- a/pkg/component/shared/nginx_ingress.go
+++ b/pkg/component/shared/nginx_ingress.go
@@ -45,7 +45,7 @@ func NewNginxIngress(
 	component.DeployWaiter,
 	error,
 ) {
-	imageController, err := imageVector.FindImage(images.ImageNameNginxIngressControllerSeed, imagevector.TargetVersion(kubernetesVersion.String()))
+	imageController, err := imageVector.FindImage(images.ImageNameNginxIngressController, imagevector.TargetVersion(kubernetesVersion.String()))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/operation/botanist/nginxingress_test.go
+++ b/pkg/operation/botanist/nginxingress_test.go
@@ -100,7 +100,7 @@ var _ = Describe("NginxIngress", func() {
 
 		It("should successfully create a nginxingress interface", func() {
 			kubernetesClient.EXPECT().Client()
-			botanist.ImageVector = imagevector.ImageVector{{Name: "nginx-ingress-controller-seed"}, {Name: "ingress-default-backend"}}
+			botanist.ImageVector = imagevector.ImageVector{{Name: "nginx-ingress-controller"}, {Name: "ingress-default-backend"}}
 
 			nginxIngress, err := botanist.DefaultNginxIngress()
 			Expect(nginxIngress).NotTo(BeNil())

--- a/pkg/utils/images/images.go
+++ b/pkg/utils/images/images.go
@@ -87,8 +87,6 @@ const (
 	ImageNameMetricsServer = "metrics-server"
 	// ImageNameNginxIngressController is a constant for an image in the image vector with name 'nginx-ingress-controller'.
 	ImageNameNginxIngressController = "nginx-ingress-controller"
-	// ImageNameNginxIngressControllerSeed is a constant for an image in the image vector with name 'nginx-ingress-controller-seed'.
-	ImageNameNginxIngressControllerSeed = "nginx-ingress-controller-seed"
 	// ImageNameNodeExporter is a constant for an image in the image vector with name 'node-exporter'.
 	ImageNameNodeExporter = "node-exporter"
 	// ImageNameNodeLocalDns is a constant for an image in the image vector with name 'node-local-dns'.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane open-source
/kind enhancement

**What this PR does / why we need it**:
- Bump `nginx-ingress-controller` image to `v1.8.1` for `1.24.x+` clusters.
- Uses the same nginx-ingress image for Seeds, Shoots and Garden.

https://github.com/kubernetes/ingress-nginx/releases/tag/controller-v1.8.1

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
/cc @StenlyTU 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
`nginx-ingress-controller` image is updated to `v1.8.1` for Kubernetes`v1.24+` clusters.
```
