### PR TITLE
Forbid adding well-known gardener finalizers on `Shoot` creation

### DIFF
--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -102,6 +102,9 @@ const (
 	// ControllerInstallation.
 	ExtensionGardenServiceAccountPrefix = "extension-"
 
+	// ReferenceProtectionFinalizerName is the name of the finalizer used for the reference protection.
+	ReferenceProtectionFinalizerName = "gardener.cloud/reference-protection"
+
 	// DeploymentNameClusterAutoscaler is a constant for the name of a Kubernetes deployment object that contains
 	// the cluster-autoscaler pod.
 	DeploymentNameClusterAutoscaler = "cluster-autoscaler"

--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -2081,9 +2081,8 @@ func ValidateFinalizersOnCreation(finalizers []string, fldPath *field.Path) fiel
 	allErrs := field.ErrorList{}
 
 	for i, finalizer := range finalizers {
-		idxPath := fldPath.Index(i)
 		if ForbiddenShootFinalizersOnCreation.Has(finalizer) {
-			allErrs = append(allErrs, field.Forbidden(idxPath, fmt.Sprintf("finalizer %q cannot be added on creation", finalizer)))
+			allErrs = append(allErrs, field.Forbidden(fldPath.Index(i), fmt.Sprintf("finalizer %q cannot be added on creation", finalizer)))
 		}
 	}
 

--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -42,6 +42,7 @@ import (
 
 	"github.com/gardener/gardener/pkg/apis/core"
 	"github.com/gardener/gardener/pkg/apis/core/helper"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/features"
 	"github.com/gardener/gardener/pkg/utils"
@@ -108,6 +109,9 @@ var (
 	availableSchedulingProfiles = sets.New(
 		string(core.SchedulingProfileBalanced),
 		string(core.SchedulingProfileBinPacking),
+	)
+	forbiddenShootFinalizersOnCreation = sets.New(
+		gardencorev1beta1.GardenerName,
 	)
 
 	// asymmetric algorithms from https://datatracker.ietf.org/doc/html/rfc7518#section-3.1
@@ -2065,6 +2069,20 @@ func validateCoreDNS(coreDNS *core.CoreDNS, fldPath *field.Path) field.ErrorList
 	}
 	if coreDNS.Rewriting != nil {
 		allErrs = append(allErrs, ValidateCoreDNSRewritingCommonSuffixes(coreDNS.Rewriting.CommonSuffixes, fldPath.Child("rewriting"))...)
+	}
+
+	return allErrs
+}
+
+// ValidateFinalizersOnCreation validates the finalizers of a Shoot object.
+func ValidateFinalizersOnCreation(finalizers []string, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	for i, finalizer := range finalizers {
+		idxPath := fldPath.Index(i)
+		if forbiddenShootFinalizersOnCreation.Has(finalizer) {
+			allErrs = append(allErrs, field.Forbidden(idxPath, fmt.Sprintf("finalizer %q cannot be added on creation", finalizer)))
+		}
 	}
 
 	return allErrs

--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -110,7 +110,7 @@ var (
 		string(core.SchedulingProfileBalanced),
 		string(core.SchedulingProfileBinPacking),
 	)
-	forbiddenShootFinalizersOnCreation = sets.New(
+	ForbiddenShootFinalizersOnCreation = sets.New(
 		gardencorev1beta1.GardenerName,
 	)
 
@@ -2080,7 +2080,7 @@ func ValidateFinalizersOnCreation(finalizers []string, fldPath *field.Path) fiel
 
 	for i, finalizer := range finalizers {
 		idxPath := fldPath.Index(i)
-		if forbiddenShootFinalizersOnCreation.Has(finalizer) {
+		if ForbiddenShootFinalizersOnCreation.Has(finalizer) {
 			allErrs = append(allErrs, field.Forbidden(idxPath, fmt.Sprintf("finalizer %q cannot be added on creation", finalizer)))
 		}
 	}

--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -112,6 +112,7 @@ var (
 	)
 	ForbiddenShootFinalizersOnCreation = sets.New(
 		gardencorev1beta1.GardenerName,
+		v1beta1constants.ReferenceProtectionFinalizerName,
 	)
 
 	// asymmetric algorithms from https://datatracker.ietf.org/doc/html/rfc7518#section-3.1

--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -110,6 +110,7 @@ var (
 		string(core.SchedulingProfileBalanced),
 		string(core.SchedulingProfileBinPacking),
 	)
+	// ForbiddenShootFinalizersOnCreation is a list of finalizers which are forbidden to be specified on Shoot creation.
 	ForbiddenShootFinalizersOnCreation = sets.New(
 		gardencorev1beta1.GardenerName,
 		v1beta1constants.ReferenceProtectionFinalizerName,

--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -6168,19 +6168,24 @@ var _ = Describe("Shoot Validation Tests", func() {
 	Describe("#ValidateFinalizersOnCreation", func() {
 		It("should return error if the finalizers contain forbidden finalizers", func() {
 			finalizers := []string{
+				"some-finalizer",
 				"gardener.cloud/reference-protection",
 				"gardener",
 				"random",
-				"finalizer",
 			}
 
-			Expect(ValidateFinalizersOnCreation(finalizers, field.NewPath("metadata", "finalizers"))).To(
-				ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+			Expect(ValidateFinalizersOnCreation(finalizers, field.NewPath("metadata", "finalizers"))).To(ConsistOf(
+				PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":   Equal(field.ErrorTypeForbidden),
 					"Field":  Equal("metadata.finalizers[1]"),
+					"Detail": ContainSubstring("finalizer %q cannot be added on creation", "gardener.cloud/reference-protection"),
+				})),
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":   Equal(field.ErrorTypeForbidden),
+					"Field":  Equal("metadata.finalizers[2]"),
 					"Detail": ContainSubstring("finalizer %q cannot be added on creation", "gardener"),
-				}))),
-			)
+				})),
+			))
 		})
 	})
 })

--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -6164,6 +6164,25 @@ var _ = Describe("Shoot Validation Tests", func() {
 				)),
 		)
 	})
+
+	Describe("#ValidateFinalizersOnCreation", func() {
+		It("should return error if the finalizers contain forbidden finalizers", func() {
+			finalizers := []string{
+				"gardener.cloud/reference-protection",
+				"gardener",
+				"random",
+				"finalizer",
+			}
+
+			Expect(ValidateFinalizersOnCreation(finalizers, field.NewPath("metadata", "finalizers"))).To(
+				ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":   Equal(field.ErrorTypeForbidden),
+					"Field":  Equal("metadata.finalizers[1]"),
+					"Detail": ContainSubstring("finalizer %q cannot be added on creation", "gardener"),
+				}))),
+			)
+		})
+	})
 })
 
 func prepareShootForUpdate(shoot *core.Shoot) *core.Shoot {

--- a/pkg/controllermanager/controller/shoot/reference/reconciler.go
+++ b/pkg/controllermanager/controller/shoot/reference/reconciler.go
@@ -40,7 +40,7 @@ import (
 )
 
 // FinalizerName is the name of the finalizer used for the reference protection.
-const FinalizerName = "gardener.cloud/reference-protection"
+const FinalizerName = v1beta1constants.ReferenceProtectionFinalizerName
 
 // Reconciler checks the shoot in the given request for references to further objects in order to protect them from
 // deletions as long as they are still referenced.

--- a/pkg/controllermanager/controller/shoot/reference/reconciler_test.go
+++ b/pkg/controllermanager/controller/shoot/reference/reconciler_test.go
@@ -33,6 +33,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	. "github.com/gardener/gardener/pkg/controllermanager/controller/shoot/reference"
 	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
@@ -256,17 +257,17 @@ var _ = Describe("Shoot References", func() {
 
 			Expect(err).To(Not(HaveOccurred()))
 			Expect(result).To(Equal(emptyResult()))
-			Expect(updatedShoot.ObjectMeta.Finalizers).To(ConsistOf(Equal(FinalizerName)))
+			Expect(updatedShoot.ObjectMeta.Finalizers).To(ConsistOf(Equal(v1beta1constants.ReferenceProtectionFinalizerName)))
 			Expect(updatedSecrets).To(ConsistOf(
 				PointTo(MatchFields(IgnoreExtras, Fields{
 					"ObjectMeta": MatchFields(IgnoreExtras, Fields{
-						"Finalizers": ConsistOf(FinalizerName),
+						"Finalizers": ConsistOf(v1beta1constants.ReferenceProtectionFinalizerName),
 						"Name":       Equal(secretName),
 					}),
 				})),
 				PointTo(MatchFields(IgnoreExtras, Fields{
 					"ObjectMeta": MatchFields(IgnoreExtras, Fields{
-						"Finalizers": ConsistOf(FinalizerName),
+						"Finalizers": ConsistOf(v1beta1constants.ReferenceProtectionFinalizerName),
 						"Name":       Equal(secretName2),
 					}),
 				})),
@@ -275,11 +276,11 @@ var _ = Describe("Shoot References", func() {
 
 		It("should remove finalizer from shoot and secret because shoot is in deletion", func() {
 			secretName := secrets[0].Name
-			secrets[0].Finalizers = []string{FinalizerName}
+			secrets[0].Finalizers = []string{v1beta1constants.ReferenceProtectionFinalizerName}
 
 			now := metav1.Now()
 			shoot.ObjectMeta.DeletionTimestamp = &now
-			shoot.Finalizers = []string{FinalizerName}
+			shoot.Finalizers = []string{v1beta1constants.ReferenceProtectionFinalizerName}
 
 			shoot.Spec.DNS = &gardencorev1beta1.DNS{
 				Domain: pointer.String("shoot.example.com"),
@@ -332,11 +333,11 @@ var _ = Describe("Shoot References", func() {
 
 		It("should remove finalizer only from shoot because secret is still referenced by another shoot", func() {
 			secretName := secrets[0].Name
-			secrets[0].Finalizers = []string{FinalizerName}
+			secrets[0].Finalizers = []string{v1beta1constants.ReferenceProtectionFinalizerName}
 
 			now := metav1.Now()
 			shoot.ObjectMeta.DeletionTimestamp = &now
-			shoot.Finalizers = []string{FinalizerName}
+			shoot.Finalizers = []string{v1beta1constants.ReferenceProtectionFinalizerName}
 
 			dnsProvider := gardencorev1beta1.DNSProvider{Type: pointer.String("managed-dns"), SecretName: pointer.String(secretName)}
 
@@ -393,10 +394,10 @@ var _ = Describe("Shoot References", func() {
 
 		It("should remove finalizer from secret because it is not referenced any more", func() {
 			secretName := secrets[1].Name
-			secrets[0].Finalizers = []string{FinalizerName}
-			secrets[1].Finalizers = []string{FinalizerName}
+			secrets[0].Finalizers = []string{v1beta1constants.ReferenceProtectionFinalizerName}
+			secrets[1].Finalizers = []string{v1beta1constants.ReferenceProtectionFinalizerName}
 
-			shoot.Finalizers = []string{FinalizerName}
+			shoot.Finalizers = []string{v1beta1constants.ReferenceProtectionFinalizerName}
 
 			shoot.Spec.DNS = &gardencorev1beta1.DNS{
 				Domain: pointer.String("shoot.example.com"),
@@ -556,11 +557,11 @@ var _ = Describe("Shoot References", func() {
 
 			Expect(err).To(Not(HaveOccurred()))
 			Expect(result).To(Equal(emptyResult()))
-			Expect(updatedShoot.ObjectMeta.Finalizers).To(ConsistOf(Equal(FinalizerName)))
+			Expect(updatedShoot.ObjectMeta.Finalizers).To(ConsistOf(Equal(v1beta1constants.ReferenceProtectionFinalizerName)))
 			Expect(updatedConfigMap).To(PointTo(
 				MatchFields(IgnoreExtras, Fields{
 					"ObjectMeta": MatchFields(IgnoreExtras, Fields{
-						"Finalizers": ConsistOf(FinalizerName),
+						"Finalizers": ConsistOf(v1beta1constants.ReferenceProtectionFinalizerName),
 						"Name":       Equal(configMapName),
 					}),
 				})),
@@ -569,11 +570,11 @@ var _ = Describe("Shoot References", func() {
 
 		It("should remove finalizer from shoot and configmap because shoot is in deletion", func() {
 			configMapName := configMaps[0].Name
-			configMaps[0].Finalizers = []string{FinalizerName}
+			configMaps[0].Finalizers = []string{v1beta1constants.ReferenceProtectionFinalizerName}
 
 			now := metav1.Now()
 			shoot.ObjectMeta.DeletionTimestamp = &now
-			shoot.Finalizers = []string{FinalizerName}
+			shoot.Finalizers = []string{v1beta1constants.ReferenceProtectionFinalizerName}
 
 			shoot.Spec.Kubernetes.KubeAPIServer = &gardencorev1beta1.KubeAPIServerConfig{
 				AuditConfig: &gardencorev1beta1.AuditConfig{
@@ -629,11 +630,11 @@ var _ = Describe("Shoot References", func() {
 
 		It("should remove finalizer only from shoot because configmap is still referenced by another shoot", func() {
 			configMapName := configMaps[0].Name
-			configMaps[0].Finalizers = []string{FinalizerName}
+			configMaps[0].Finalizers = []string{v1beta1constants.ReferenceProtectionFinalizerName}
 
 			now := metav1.Now()
 			shoot.ObjectMeta.DeletionTimestamp = &now
-			shoot.Finalizers = []string{FinalizerName}
+			shoot.Finalizers = []string{v1beta1constants.ReferenceProtectionFinalizerName}
 
 			apiServerConfig := &gardencorev1beta1.KubeAPIServerConfig{
 				AuditConfig: &gardencorev1beta1.AuditConfig{
@@ -695,10 +696,10 @@ var _ = Describe("Shoot References", func() {
 
 		It("should remove finalizer from configmap because it is not referenced any more", func() {
 			configMapName := configMaps[1].Name
-			configMaps[0].Finalizers = []string{FinalizerName}
-			configMaps[1].Finalizers = []string{FinalizerName}
+			configMaps[0].Finalizers = []string{v1beta1constants.ReferenceProtectionFinalizerName}
+			configMaps[1].Finalizers = []string{v1beta1constants.ReferenceProtectionFinalizerName}
 
-			shoot.Finalizers = []string{FinalizerName}
+			shoot.Finalizers = []string{v1beta1constants.ReferenceProtectionFinalizerName}
 
 			shoot.Spec.Kubernetes.KubeAPIServer = &gardencorev1beta1.KubeAPIServerConfig{
 				AuditConfig: &gardencorev1beta1.AuditConfig{
@@ -885,17 +886,17 @@ var _ = Describe("Shoot References", func() {
 
 			Expect(err).To(Not(HaveOccurred()))
 			Expect(result).To(Equal(emptyResult()))
-			Expect(updatedShoot.ObjectMeta.Finalizers).To(ConsistOf(Equal(FinalizerName)))
+			Expect(updatedShoot.ObjectMeta.Finalizers).To(ConsistOf(Equal(v1beta1constants.ReferenceProtectionFinalizerName)))
 			Expect(updatedSecrets).To(ConsistOf(
 				PointTo(MatchFields(IgnoreExtras, Fields{
 					"ObjectMeta": MatchFields(IgnoreExtras, Fields{
-						"Finalizers": ConsistOf(FinalizerName),
+						"Finalizers": ConsistOf(v1beta1constants.ReferenceProtectionFinalizerName),
 						"Name":       Equal(secretName),
 					}),
 				})),
 				PointTo(MatchFields(IgnoreExtras, Fields{
 					"ObjectMeta": MatchFields(IgnoreExtras, Fields{
-						"Finalizers": ConsistOf(FinalizerName),
+						"Finalizers": ConsistOf(v1beta1constants.ReferenceProtectionFinalizerName),
 						"Name":       Equal(secretName2),
 					}),
 				})),
@@ -904,11 +905,11 @@ var _ = Describe("Shoot References", func() {
 
 		It("should remove finalizer from secret because shoot is in deletion", func() {
 			secretName := secrets[0].Name
-			secrets[0].Finalizers = []string{FinalizerName}
+			secrets[0].Finalizers = []string{v1beta1constants.ReferenceProtectionFinalizerName}
 
 			now := metav1.Now()
 			shoot.ObjectMeta.DeletionTimestamp = &now
-			shoot.Finalizers = []string{FinalizerName}
+			shoot.Finalizers = []string{v1beta1constants.ReferenceProtectionFinalizerName}
 
 			shoot.Spec.Resources = []gardencorev1beta1.NamedResourceReference{
 				{
@@ -965,10 +966,10 @@ var _ = Describe("Shoot References", func() {
 
 		It("should remove finalizer from secret because it is not referenced any more", func() {
 			secretName := secrets[1].Name
-			secrets[0].Finalizers = []string{FinalizerName}
-			secrets[1].Finalizers = []string{FinalizerName}
+			secrets[0].Finalizers = []string{v1beta1constants.ReferenceProtectionFinalizerName}
+			secrets[1].Finalizers = []string{v1beta1constants.ReferenceProtectionFinalizerName}
 
-			shoot.Finalizers = []string{FinalizerName}
+			shoot.Finalizers = []string{v1beta1constants.ReferenceProtectionFinalizerName}
 
 			shoot.Spec.Resources = []gardencorev1beta1.NamedResourceReference{
 				{

--- a/pkg/gardenlet/controller/bastion/reconciler.go
+++ b/pkg/gardenlet/controller/bastion/reconciler.go
@@ -43,12 +43,6 @@ import (
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 )
 
-const (
-	// finalizerName is the Kubernetes finalizerName that is used to control the cleanup of
-	// Bastion resources in the seed cluster.
-	finalizerName = gardencorev1beta1.GardenerName
-)
-
 // RequeueDurationWhenResourceDeletionStillPresent is the duration used for requeueing when owned resources are still in
 // the process of being deleted when deleting a Bastion.
 var RequeueDurationWhenResourceDeletionStillPresent = 5 * time.Second
@@ -109,9 +103,9 @@ func (r *Reconciler) reconcileBastion(
 	bastion *operationsv1alpha1.Bastion,
 	shoot *gardencorev1beta1.Shoot,
 ) error {
-	if !controllerutil.ContainsFinalizer(bastion, finalizerName) {
+	if !controllerutil.ContainsFinalizer(bastion, gardencorev1beta1.GardenerName) {
 		log.Info("Adding finalizer")
-		if err := controllerutils.AddFinalizers(gardenCtx, r.GardenClient, bastion, finalizerName); err != nil {
+		if err := controllerutils.AddFinalizers(gardenCtx, r.GardenClient, bastion, gardencorev1beta1.GardenerName); err != nil {
 			return fmt.Errorf("failed to add finalizer: %w", err)
 		}
 	}
@@ -211,7 +205,7 @@ func (r *Reconciler) cleanupBastion(
 	bastion *operationsv1alpha1.Bastion,
 	shoot *gardencorev1beta1.Shoot,
 ) error {
-	if !sets.New(bastion.Finalizers...).Has(finalizerName) {
+	if !sets.New(bastion.Finalizers...).Has(gardencorev1beta1.GardenerName) {
 		return nil
 	}
 
@@ -225,9 +219,9 @@ func (r *Reconciler) cleanupBastion(
 		if apierrors.IsNotFound(err) {
 			log.Info("Successfully deleted")
 
-			if controllerutil.ContainsFinalizer(bastion, finalizerName) {
+			if controllerutil.ContainsFinalizer(bastion, gardencorev1beta1.GardenerName) {
 				log.Info("Removing finalizer")
-				if err := controllerutils.RemoveFinalizers(gardenCtx, r.GardenClient, bastion, finalizerName); err != nil {
+				if err := controllerutils.RemoveFinalizers(gardenCtx, r.GardenClient, bastion, gardencorev1beta1.GardenerName); err != nil {
 					return fmt.Errorf("failed to remove finalizer: %w", err)
 				}
 			}

--- a/pkg/registry/core/shoot/strategy.go
+++ b/pkg/registry/core/shoot/strategy.go
@@ -169,6 +169,7 @@ func (shootStrategy) Validate(_ context.Context, obj runtime.Object) field.Error
 	shoot := obj.(*core.Shoot)
 	allErrs := field.ErrorList{}
 	allErrs = append(allErrs, validation.ValidateShoot(shoot)...)
+	allErrs = append(allErrs, validation.ValidateFinalizersOnCreation(shoot.Finalizers, field.NewPath("metadata", "finalizers"))...)
 	if gardencorehelper.IsWorkerless(shoot) {
 		if !utilfeature.DefaultFeatureGate.Enabled(features.WorkerlessShoots) {
 			allErrs = append(allErrs, field.Forbidden(field.NewPath("spec", "provider", "workers"), "must provide at least one worker pool when WorkerlessShoots feature gate is disabled"))

--- a/pkg/registry/core/shoot/strategy.go
+++ b/pkg/registry/core/shoot/strategy.go
@@ -68,7 +68,7 @@ func (shootStrategy) PrepareForCreate(_ context.Context, obj runtime.Object) {
 	shoot.Generation = 1
 	shoot.Status = core.ShootStatus{}
 
-	// TODO(shafeeqes): Drop this after gardener v1.78 has been released.
+	// TODO(shafeeqes): Drop this after gardener v1.80 has been released.
 	removeForbiddenFinalizers(shoot)
 }
 

--- a/pkg/registry/core/shoot/strategy_test.go
+++ b/pkg/registry/core/shoot/strategy_test.go
@@ -88,6 +88,7 @@ var _ = Describe("Strategy", func() {
 					Finalizers: []string{
 						"random",
 						gardencorev1beta1.GardenerName,
+						v1beta1constants.ReferenceProtectionFinalizerName,
 						"some-finalizer",
 					},
 				},

--- a/pkg/registry/core/shoot/strategy_test.go
+++ b/pkg/registry/core/shoot/strategy_test.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/utils/pointer"
 
 	"github.com/gardener/gardener/pkg/apis/core"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/features"
 	shootregistry "github.com/gardener/gardener/pkg/registry/core/shoot"
@@ -77,6 +78,24 @@ var _ = Describe("Strategy", func() {
 			errorList := shootregistry.NewStrategy(0).Validate(context.TODO(), shoot)
 
 			Expect(errorList).To(BeEmpty())
+		})
+	})
+
+	Describe("#PrepareForCreate", func() {
+		It("should remove forbidden finalizers from the Shoot", func() {
+			shoot := &core.Shoot{
+				ObjectMeta: metav1.ObjectMeta{
+					Finalizers: []string{
+						"random",
+						gardencorev1beta1.GardenerName,
+						"some-finalizer",
+					},
+				},
+			}
+
+			shootregistry.NewStrategy(0).PrepareForCreate(context.TODO(), shoot)
+
+			Expect(shoot.Finalizers).To(ConsistOf("random", "some-finalizer"))
 		})
 	})
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind enhancement

**What this PR does / why we need it**:
This PR adds validation to forbid users from creating Shoots with well-known gardener finalizers added.

**Which issue(s) this PR fixes**:
Fixes #8208

**Special notes for your reviewer**:
/cc @dguendisch 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking user
Adding Gardener-managed finalizers (e.g., `gardener` or `gardener.cloud/reference-protection`) to the `Shoot` on creation is now forbidden. 
```
