### PR TITLE
Improve admissionplugin validation

### DIFF
--- a/pkg/registry/core/shoot/strategy.go
+++ b/pkg/registry/core/shoot/strategy.go
@@ -34,7 +34,6 @@ import (
 	"github.com/gardener/gardener/pkg/api"
 	"github.com/gardener/gardener/pkg/api/core/shoot"
 	"github.com/gardener/gardener/pkg/apis/core"
-	"github.com/gardener/gardener/pkg/apis/core/helper"
 	gardencorehelper "github.com/gardener/gardener/pkg/apis/core/helper"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/apis/core/validation"
@@ -123,7 +122,7 @@ func mustIncreaseGeneration(oldShoot, newShoot *core.Shoot) bool {
 				mustIncrease, mustRemoveOperationAnnotation = true, false
 
 			case v1beta1constants.ShootOperationRotateSSHKeypair:
-				if !helper.ShootEnablesSSHAccess(newShoot) {
+				if !gardencorehelper.ShootEnablesSSHAccess(newShoot) {
 					// If SSH is not enabled for the Shoot, don't increase generation, just remove the annotation
 					mustIncrease, mustRemoveOperationAnnotation = false, true
 				} else {

--- a/pkg/registry/core/shoot/strategy.go
+++ b/pkg/registry/core/shoot/strategy.go
@@ -176,12 +176,14 @@ func cleanupAdmissionPlugins(shoot *core.Shoot) {
 		shootAdmissionPlugins = shoot.Spec.Kubernetes.KubeAPIServer.AdmissionPlugins
 	)
 
+	kubernetesVersion, err := semver.NewVersion(shoot.Spec.Kubernetes.Version)
+	if err != nil {
+		return
+	}
+
 	for _, plugin := range shootAdmissionPlugins {
-		if constraint, ok := admissionpluginsvalidation.PluginsInMigration[plugin.Name]; ok {
-			// It should be safe to use MustParse here since Canonicalize runs after validation.
-			if constraint.Check(semver.MustParse(shoot.Spec.Kubernetes.Version)) {
-				continue
-			}
+		if constraint, ok := admissionpluginsvalidation.PluginsInMigration[plugin.Name]; ok && constraint.Check(kubernetesVersion) {
+			continue
 		}
 
 		admissionPlugins = append(admissionPlugins, plugin)

--- a/pkg/registry/core/shoot/strategy.go
+++ b/pkg/registry/core/shoot/strategy.go
@@ -17,12 +17,10 @@ package shoot
 import (
 	"context"
 	"fmt"
-	"reflect"
 	"time"
 
 	"github.com/Masterminds/semver"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -79,18 +77,6 @@ func (shootStrategy) PrepareForUpdate(_ context.Context, obj, old runtime.Object
 
 	if mustIncreaseGeneration(oldShoot, newShoot) {
 		newShoot.Generation = oldShoot.Generation + 1
-	}
-}
-
-// defaultNodeMonitorGracePeriod will set the kube controller manager's nodeMonitorGracePeriod to 40s when upgrading the shoot to k8s version 1.27
-// and the old shoot was having default value for nodeMonitorGracePeriod of 2m0s.
-func defaultNodeMonitorGracePeriod(newShoot, oldShoot *core.Shoot) {
-	oldShootK8sLess127, _ := versionutils.CheckVersionMeetsConstraint(oldShoot.Spec.Kubernetes.Version, "< 1.27")
-	newShootK8sGreaterEqual127, _ := versionutils.CheckVersionMeetsConstraint(newShoot.Spec.Kubernetes.Version, ">= 1.27")
-	defaultNodeMonitorGracePeriod := &metav1.Duration{Duration: 2 * time.Minute}
-
-	if oldShootK8sLess127 && newShootK8sGreaterEqual127 && newShoot.Spec.Kubernetes.KubeControllerManager != nil && reflect.DeepEqual(newShoot.Spec.Kubernetes.KubeControllerManager.NodeMonitorGracePeriod, defaultNodeMonitorGracePeriod) {
-		newShoot.Spec.Kubernetes.KubeControllerManager.NodeMonitorGracePeriod = &metav1.Duration{Duration: 40 * time.Second}
 	}
 }
 

--- a/pkg/registry/core/shoot/strategy_test.go
+++ b/pkg/registry/core/shoot/strategy_test.go
@@ -461,53 +461,52 @@ var _ = Describe("Strategy", func() {
 			}
 		})
 
-		Context("k8s version >=1.25", func() {
-			BeforeEach(func() {
-				shoot.Spec.Kubernetes.Version = "1.25.0"
-			})
-			It("should cleanup PodSecurityPolicy from the admission plugins list", func() {
-				shootregistry.NewStrategy(0).Canonicalize(shoot)
+		Context("PluginsInMigration", func() {
 
-				Expect(shoot.Spec.Kubernetes.KubeAPIServer.AdmissionPlugins).To(ContainElements(
-					core.AdmissionPlugin{
-						Name:   "NodeRestriction",
-						Config: &runtime.RawExtension{Raw: []byte("bar")},
-					},
-					core.AdmissionPlugin{
-						Name:   "PodSecurity",
-						Config: &runtime.RawExtension{Raw: []byte("foo")},
-					},
-				))
-				Expect(shoot.Spec.Kubernetes.KubeAPIServer.AdmissionPlugins).NotTo(ContainElement(
-					core.AdmissionPlugin{
-						Name:     "PodSecurityPolicy",
-						Disabled: pointer.Bool(true),
-					},
-				))
-			})
-		})
+			Context("k8s version >=1.25", func() {
+				BeforeEach(func() {
+					shoot.Spec.Kubernetes.Version = "1.25.0"
+				})
 
-		Context("k8s version < 1.25", func() {
-			BeforeEach(func() {
-				shoot.Spec.Kubernetes.Version = "1.24.0"
-			})
-			It("should not cleanup PodSecurityPolicy from the admission plugins list", func() {
-				shootregistry.NewStrategy(0).Canonicalize(shoot)
+				It("should cleanup PodSecurityPolicy from the admission plugins list", func() {
+					shootregistry.NewStrategy(0).Canonicalize(shoot)
 
-				Expect(shoot.Spec.Kubernetes.KubeAPIServer.AdmissionPlugins).To(ContainElements(
-					core.AdmissionPlugin{
-						Name:   "NodeRestriction",
-						Config: &runtime.RawExtension{Raw: []byte("bar")},
-					},
-					core.AdmissionPlugin{
-						Name:   "PodSecurity",
-						Config: &runtime.RawExtension{Raw: []byte("foo")},
-					},
-					core.AdmissionPlugin{
-						Name:     "PodSecurityPolicy",
-						Disabled: pointer.Bool(true),
-					},
-				))
+					Expect(shoot.Spec.Kubernetes.KubeAPIServer.AdmissionPlugins).To(ConsistOf(
+						core.AdmissionPlugin{
+							Name:   "NodeRestriction",
+							Config: &runtime.RawExtension{Raw: []byte("bar")},
+						},
+						core.AdmissionPlugin{
+							Name:   "PodSecurity",
+							Config: &runtime.RawExtension{Raw: []byte("foo")},
+						},
+					))
+				})
+			})
+
+			Context("k8s version < 1.25", func() {
+				BeforeEach(func() {
+					shoot.Spec.Kubernetes.Version = "1.24.0"
+				})
+
+				It("should not cleanup PodSecurityPolicy from the admission plugins list", func() {
+					shootregistry.NewStrategy(0).Canonicalize(shoot)
+
+					Expect(shoot.Spec.Kubernetes.KubeAPIServer.AdmissionPlugins).To(ConsistOf(
+						core.AdmissionPlugin{
+							Name:   "NodeRestriction",
+							Config: &runtime.RawExtension{Raw: []byte("bar")},
+						},
+						core.AdmissionPlugin{
+							Name:   "PodSecurity",
+							Config: &runtime.RawExtension{Raw: []byte("foo")},
+						},
+						core.AdmissionPlugin{
+							Name:     "PodSecurityPolicy",
+							Disabled: pointer.Bool(true),
+						},
+					))
+				})
 			})
 		})
 	})

--- a/pkg/utils/validation/admissionplugins/admissionplugins.go
+++ b/pkg/utils/validation/admissionplugins/admissionplugins.go
@@ -85,11 +85,12 @@ var (
 
 	admissionPluginsSupportingExternalKubeconfig = sets.New("ValidatingAdmissionWebhook", "MutatingAdmissionWebhook", "ImagePolicyWebhook")
 
-	// These plugins can be specified in the Shoot spec even if the version doesn't support it. This is required to facilitate migration of these plugins in some cases.
-	// For example, the "PodSecurityPolicy" plugin should be disabled in the Shoot spec for an upgrade from Kubernetes v1.24 to v1.25, but in v1.25 this plugin is not
-	// supported. gardener-apiserver will/should take care to clean this plugin from the spec, because otherwise this will be passed to the kube-apiserver as a flag and
-	// kube-apiserver will panic. See https://github.com/gardener/gardener/pull/8212 for more details.
-	pluginsInMigration = sets.New("PodSecurityPolicy")
+	// PluginsInMigration is the list of plugins which can be specified in the Shoot spec if the constraints are satisfied. This is required to facilitate migration of
+	// these plugins in some cases. For example, the "PodSecurityPolicy" plugin should be disabled in the Shoot spec for an upgrade from Kubernetes v1.24 to v1.25, but in v1.25
+	// this plugin is not supported. gardener-apiserver will take care to clean this plugin from the spec. See https://github.com/gardener/gardener/pull/8212 for more details.
+	PluginsInMigration = map[string]*semver.Constraints{
+		"PodSecurityPolicy": versionutils.ConstraintK8sGreaterEqual125,
+	}
 
 	runtimeScheme *runtime.Scheme
 	codec         runtime.Codec
@@ -179,9 +180,11 @@ func ValidateAdmissionPlugins(admissionPlugins []core.AdmissionPlugin, version s
 		if err != nil {
 			allErrs = append(allErrs, field.Invalid(idxPath.Child("name"), plugin.Name, err.Error()))
 		} else if !supported {
-			// If the plugin is not supported, but it's disabled and is a plugin in migration, then skip it.
-			if pointer.BoolDeref(plugin.Disabled, false) && pluginsInMigration.Has(plugin.Name) {
-				continue
+			// If the plugin is not supported, but it's disabled and it's a plugin in migration, then skip it.
+			if constraint, ok := PluginsInMigration[plugin.Name]; ok {
+				if constraint.Check(semver.MustParse(version)) && pointer.BoolDeref(plugin.Disabled, false) {
+					continue
+				}
 			}
 			allErrs = append(allErrs, field.Forbidden(idxPath.Child("name"), fmt.Sprintf("admission plugin %q is not supported in Kubernetes version %s", plugin.Name, version)))
 		} else {

--- a/pkg/utils/validation/admissionplugins/admissionplugins_test.go
+++ b/pkg/utils/validation/admissionplugins/admissionplugins_test.go
@@ -96,6 +96,12 @@ var _ = Describe("admissionplugins", func() {
 				"Field":  Equal(field.NewPath("admissionPlugins[0].name").String()),
 				"Detail": Equal("admission plugin \"PodSecurityPolicy\" is not supported in Kubernetes version 1.26.6"),
 			})))),
+			Entry("unsupported admission plugin but is disabled", []core.AdmissionPlugin{{Name: "ClusterTrustBundleAttest", Disabled: pointer.Bool(true)}}, "1.26.6", ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+				"Type":   Equal(field.ErrorTypeForbidden),
+				"Field":  Equal(field.NewPath("admissionPlugins[0].name").String()),
+				"Detail": Equal("admission plugin \"ClusterTrustBundleAttest\" is not supported in Kubernetes version 1.26.6"),
+			})))),
+			Entry("unsupported admission plugin and is disabled but plugin in migration", []core.AdmissionPlugin{{Name: "PodSecurityPolicy", Disabled: pointer.Bool(true)}}, "1.25.6", BeEmpty()),
 			Entry("admission plugin without name", []core.AdmissionPlugin{{}}, "1.18.14", ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 				"Type":   Equal(field.ErrorTypeRequired),
 				"Field":  Equal(field.NewPath("admissionPlugins[0].name").String()),


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality usability
/kind enhancement

**What this PR does / why we need it**:
Previously if the plugin was disabled, then even if it's not supported, it is allowed to be mentioned in the Spec.
This is wrong since the disabled admission plugins are also passed as a flag to the `kube-apiserver` and it can panic with an unknown admission plugin error.
But this was needed because the "PodSecurityPolicy" plugin should be disabled in the Shoot spec for an upgrade from Kubernetes `v1.24` to `v1.25`, but in `v1.25` this plugin is not supported. But without it in the spec, we cannot allow the upgrade. Also, it cannot be done in the same patch call because the Shoot needs to be reconciled at least once successfully to clean up gardener-deployed PSPs.

This PR improves this validation to allow specifying disabled plugins even if it's not supported and if the plugin is in migration and it satisfies the version constraints.
For these special cases, `gardener-apiserver` should take care to clean up the plugin from the Shoot spec once the migration is completed. See https://github.com/gardener/gardener/blob/ade4da2edf1a5f8603bf5e45cf9a88d2b1ac656a/pkg/registry/core/shoot/strategy.go#L174-L187

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
https://github.com/gardener/gardener/commit/91bbf6e0cc1b9e5082caeae5f0127285ea51458e cleanups a function which was missed in https://github.com/gardener/gardener/pull/8198/

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
