### PR TITLE
Remove `service.beta.kubernetes.io/aws-load-balancer-type: nlb` from service `istio-ingress/istio-ingressgateway`.

### DIFF
--- a/pkg/component/istio/charts/istio/istio-ingress/templates/service.yaml
+++ b/pkg/component/istio/charts/istio/istio-ingress/templates/service.yaml
@@ -4,8 +4,6 @@ metadata:
   name: {{ .Values.serviceName }}
   namespace: {{ .Release.Namespace }}
   annotations:
-    service.alpha.kubernetes.io/aws-load-balancer-type: "nlb"
-    service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
     networking.resources.gardener.cloud/from-world-to-ports: '[{"port":8132,"protocol":"TCP"},{"port":8443,"protocol":"TCP"},{"port":9443,"protocol":"TCP"}]'
     networking.resources.gardener.cloud/namespace-selectors: '[{"matchLabels":{"gardener.cloud/role":"shoot"}},{"matchLabels":{"kubernetes.io/metadata.name":"garden"}}]'
     networking.resources.gardener.cloud/pod-label-selector-namespace-alias: all-istio-ingresses

--- a/pkg/component/istio/istio_test.go
+++ b/pkg/component/istio/istio_test.go
@@ -1667,8 +1667,6 @@ metadata:
   name: istio-ingressgateway
   namespace: ` + deployNSIngress + `
   annotations:
-    service.alpha.kubernetes.io/aws-load-balancer-type: "nlb"
-    service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
     networking.resources.gardener.cloud/from-world-to-ports: '[{"port":8132,"protocol":"TCP"},{"port":8443,"protocol":"TCP"},{"port":9443,"protocol":"TCP"}]'
     networking.resources.gardener.cloud/namespace-selectors: '[{"matchLabels":{"gardener.cloud/role":"shoot"}},{"matchLabels":{"kubernetes.io/metadata.name":"garden"}}]'
     networking.resources.gardener.cloud/pod-label-selector-namespace-alias: all-istio-ingresses


### PR DESCRIPTION

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind cleanup

**What this PR does / why we need it**:
We want to remove an AWS specific annotation from the load balancer service `istio-ingress/istio-ingressgateway` in the Istio templates.
The annotation should be set only for AWS seeds in the [seed configuration](https://github.com/gardener/gardener/blob/d30150fc0bdc5702aa316de265d0a576577fb9f4/example/50-seed.yaml#L66-L68).
In the event that the annotation is not set within the seed, a classic load balancer will be created. Please note that any pre-existing network load balancer will not be automatically deleted. As such, manual clean-up will be required to remove it.
 
Additionally, this change in seed configuration will impact the service `garden/nginx-ingress-controller`. A new network load balancer will be created in this case. Similar to the above, the existing classic load balancer will not be automatically removed, necessitating manual clean-up.
This change is part of ongoing efforts to enhance the flexibility and control over load balancer service configurations.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
Removed `service.beta.kubernetes.io/aws-load-balancer-type: nlb` annotation from istio-ingressgateway service template. Set this annotation in seed configuration. Note: Changing load balancer type creates a new one, old one requires manual clean-up.
```
