### PR TITLE
[operator] Introduce `gardenerapiserver` Golang component

### DIFF
--- a/docs/development/priority-classes.md
+++ b/docs/development/priority-classes.md
@@ -19,14 +19,14 @@ When using the `gardener-operator` for managing the garden runtime and virtual c
 
 ### `PriorityClass`es for Garden Control Plane Components
 
-| Name                              | Priority  | Associated Components (Examples)                                                          |
-|---------------------------------- |-----------|-------------------------------------------------------------------------------------------|
-| `gardener-garden-system-critical` | 999999550 | `gardener-operator`, `gardener-resource-manager`, `istio`                                 |
-| `gardener-garden-system-500`      | 999999500 | `virtual-garden-etcd-events`, `virtual-garden-etcd-main`, `virtual-garden-kube-apiserver` |
-| `gardener-garden-system-400`      | 999999400 | `virtual-garden-gardener-resource-manager`                                                |
-| `gardener-garden-system-300`      | 999999300 | `virtual-garden-kube-controller-manager`, `vpa-admission-controller`, `etcd-druid`, `nginx-ingress-controller`        |
-| `gardener-garden-system-200`      | 999999200 | `vpa-recommender`, `vpa-updater`, `hvpa-controller`                                       |
-| `gardener-garden-system-100`      | 999999100 | `kube-state-metrics`                                                                      |
+| Name                              | Priority  | Associated Components (Examples)                                                                                |
+|---------------------------------- |-----------|-----------------------------------------------------------------------------------------------------------------|
+| `gardener-garden-system-critical` | 999999550 | `gardener-operator`, `gardener-resource-manager`, `istio`                                                       |
+| `gardener-garden-system-500`      | 999999500 | `virtual-garden-etcd-events`, `virtual-garden-etcd-main`, `virtual-garden-kube-apiserver`, `gardener-apiserver` |
+| `gardener-garden-system-400`      | 999999400 | `virtual-garden-gardener-resource-manager`                                                                      |
+| `gardener-garden-system-300`      | 999999300 | `virtual-garden-kube-controller-manager`, `vpa-admission-controller`, `etcd-druid`, `nginx-ingress-controller`  |
+| `gardener-garden-system-200`      | 999999200 | `vpa-recommender`, `vpa-updater`, `hvpa-controller`                                                             |
+| `gardener-garden-system-100`      | 999999100 | `kube-state-metrics`                                                                                            |
 
 ## Seed Clusters
 

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -47,6 +47,9 @@ const (
 	// SecretNameCASeed is a constant for the name of a Kubernetes secret object that contains the CA
 	// certificate generated for a seed cluster.
 	SecretNameCASeed = "ca-seed"
+	// SecretNameCAGardener is a constant for the name of a Kubernetes secret object that contains the CA
+	// certificate of the Gardener control plane.
+	SecretNameCAGardener = "ca-gardener"
 
 	// SecretNameCloudProvider is a constant for the name of a Kubernetes secret object that contains the provider
 	// specific credentials that shall be used to create/delete the shoot.

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -72,6 +72,12 @@ const (
 	// SecretNamePrefixETCDEncryptionConfiguration is a constant for the name prefix of a Kubernetes secret object that
 	// contains the configuration for encryption data in ETCD.
 	SecretNamePrefixETCDEncryptionConfiguration = "kube-apiserver-etcd-encryption-configuration"
+	// SecretNameGardenerETCDEncryptionKey is a constant for the name of a Kubernetes secret object that contains the
+	// key for encryption data in ETCD for gardener-apiserver.
+	SecretNameGardenerETCDEncryptionKey = "gardener-apiserver-etcd-encryption-key"
+	// SecretNamePrefixGardenerETCDEncryptionConfiguration is a constant for the name prefix of a Kubernetes secret
+	// object that contains the configuration for encryption data in ETCD for gardener-apiserver.
+	SecretNamePrefixGardenerETCDEncryptionConfiguration = "gardener-apiserver-etcd-encryption-configuration"
 
 	// SecretNameGardener is a constant for the name of a Kubernetes secret object that contains the client
 	// certificate and a kubeconfig for a shoot cluster. It is used by Gardener and can be used by extension

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -511,6 +511,8 @@ const (
 	LabelRole = "role"
 	// LabelKubernetes is a constant for a label for Kubernetes workload.
 	LabelKubernetes = "kubernetes"
+	// LabelGardener is a constant for a label for Gardener workload.
+	LabelGardener = "gardener"
 	// LabelAPIServer is a constant for a label for the kube-apiserver.
 	LabelAPIServer = "apiserver"
 	// LabelControllerManager is a constant for a label for the kube-controller-manager.

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -47,9 +47,6 @@ const (
 	// SecretNameCASeed is a constant for the name of a Kubernetes secret object that contains the CA
 	// certificate generated for a seed cluster.
 	SecretNameCASeed = "ca-seed"
-	// SecretNameCAGardener is a constant for the name of a Kubernetes secret object that contains the CA
-	// certificate of the Gardener control plane.
-	SecretNameCAGardener = "ca-gardener"
 
 	// SecretNameCloudProvider is a constant for the name of a Kubernetes secret object that contains the provider
 	// specific credentials that shall be used to create/delete the shoot.

--- a/pkg/apis/operator/v1alpha1/constants.go
+++ b/pkg/apis/operator/v1alpha1/constants.go
@@ -20,4 +20,7 @@ const (
 
 	// SecretNameCARuntime is a constant for the name of a secret containing the CA for the garden runtime cluster.
 	SecretNameCARuntime = "ca-garden-runtime"
+	// SecretNameCAGardener is a constant for the name of a Kubernetes secret object that contains the CA
+	// certificate of the Gardener control plane.
+	SecretNameCAGardener = "ca-gardener"
 )

--- a/pkg/component/apiserver/admission.go
+++ b/pkg/component/apiserver/admission.go
@@ -1,0 +1,44 @@
+// Copyright 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package apiserver
+
+import (
+	"context"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
+)
+
+// ReconcileSecretAdmissionKubeconfigs reconciles the secret containing the kubeconfig for admission plugins.
+func ReconcileSecretAdmissionKubeconfigs(ctx context.Context, c client.Client, secret *corev1.Secret, values Values) error {
+	secret.Data = make(map[string][]byte)
+
+	for _, plugin := range values.EnabledAdmissionPlugins {
+		if len(plugin.Kubeconfig) != 0 {
+			secret.Data[admissionPluginsKubeconfigFilename(plugin.Name)] = plugin.Kubeconfig
+		}
+	}
+
+	utilruntime.Must(kubernetesutils.MakeUnique(secret))
+	return client.IgnoreAlreadyExists(c.Create(ctx, secret))
+}
+
+func admissionPluginsKubeconfigFilename(name string) string {
+	return strings.ToLower(name) + "-kubeconfig.yaml"
+}

--- a/pkg/component/apiserver/admission.go
+++ b/pkg/component/apiserver/admission.go
@@ -205,7 +205,7 @@ func admissionPluginsKubeconfigFilename(name string) string {
 	return strings.ToLower(name) + "-kubeconfig.yaml"
 }
 
-// InjectAdmissionSettings injects the admission settings into the deployment.
+// InjectAdmissionSettings injects the admission settings into `gardener-apiserver` and `kube-apiserver` deployments.
 func InjectAdmissionSettings(deployment *appsv1.Deployment, configMapAdmissionConfigs *corev1.ConfigMap, secretAdmissionKubeconfigs *corev1.Secret, values Values) {
 	if len(values.EnabledAdmissionPlugins) > 0 {
 		deployment.Spec.Template.Spec.Containers[0].Args = append(deployment.Spec.Template.Spec.Containers[0].Args, "--enable-admission-plugins="+strings.Join(admissionPluginNames(values), ","))

--- a/pkg/component/apiserver/admission.go
+++ b/pkg/component/apiserver/admission.go
@@ -16,13 +16,58 @@ package apiserver
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/apimachinery/pkg/runtime/serializer/json"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	webhookadmissionv1 "k8s.io/apiserver/pkg/admission/plugin/webhook/config/apis/webhookadmission/v1"
+	webhookadmissionv1alpha1 "k8s.io/apiserver/pkg/admission/plugin/webhook/config/apis/webhookadmission/v1alpha1"
+	apiserverv1alpha1 "k8s.io/apiserver/pkg/apis/apiserver/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/yaml"
 
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
+)
+
+var admissionCodec runtime.Codec
+
+func init() {
+	admissionScheme := runtime.NewScheme()
+	utilruntime.Must(apiserverv1alpha1.AddToScheme(admissionScheme))
+	utilruntime.Must(webhookadmissionv1.AddToScheme(admissionScheme))
+	utilruntime.Must(webhookadmissionv1alpha1.AddToScheme(admissionScheme))
+
+	var (
+		ser = json.NewSerializerWithOptions(json.DefaultMetaFactory, admissionScheme, admissionScheme, json.SerializerOptions{
+			Yaml:   true,
+			Pretty: false,
+			Strict: false,
+		})
+		versions = schema.GroupVersions([]schema.GroupVersion{
+			apiserverv1alpha1.SchemeGroupVersion,
+			webhookadmissionv1.SchemeGroupVersion,
+			webhookadmissionv1alpha1.SchemeGroupVersion,
+		})
+	)
+
+	admissionCodec = serializer.NewCodecFactory(admissionScheme).CodecForVersions(ser, ser, versions, versions)
+}
+
+const (
+	// ConfigMapAdmissionDataKey is a constant for a key in the data of the ConfigMap containing the configuration of
+	// admission plugins.
+	ConfigMapAdmissionDataKey = "admission-configuration.yaml"
+	// VolumeMountPathAdmissionConfiguration is a constant for the volume mount path of the admission configuration
+	// files.
+	VolumeMountPathAdmissionConfiguration = "/etc/kubernetes/admission"
+	// VolumeMountPathAdmissionKubeconfigSecrets is a constant for the volume mount path of the admission kubeconfig
+	// files.
+	VolumeMountPathAdmissionKubeconfigSecrets = "/etc/kubernetes/admission-kubeconfigs"
 )
 
 // ReconcileSecretAdmissionKubeconfigs reconciles the secret containing the kubeconfig for admission plugins.
@@ -37,6 +82,125 @@ func ReconcileSecretAdmissionKubeconfigs(ctx context.Context, c client.Client, s
 
 	utilruntime.Must(kubernetesutils.MakeUnique(secret))
 	return client.IgnoreAlreadyExists(c.Create(ctx, secret))
+}
+
+// ReconcileConfigMapAdmission reconciles the ConfigMap containing the configs for the admission plugins.
+func ReconcileConfigMapAdmission(ctx context.Context, c client.Client, configMap *corev1.ConfigMap, values Values) error {
+	configMap.Data = map[string]string{}
+
+	admissionConfig := &apiserverv1alpha1.AdmissionConfiguration{}
+	for _, plugin := range values.EnabledAdmissionPlugins {
+		rawConfig, err := computeRelevantAdmissionPluginRawConfig(plugin)
+		if err != nil {
+			return err
+		}
+
+		if rawConfig != nil {
+			admissionConfig.Plugins = append(admissionConfig.Plugins, apiserverv1alpha1.AdmissionPluginConfiguration{
+				Name: plugin.Name,
+				Path: VolumeMountPathAdmissionConfiguration + "/" + admissionPluginsConfigFilename(plugin.Name),
+			})
+
+			configMap.Data[admissionPluginsConfigFilename(plugin.Name)] = string(rawConfig)
+		}
+	}
+
+	data, err := runtime.Encode(admissionCodec, admissionConfig)
+	if err != nil {
+		return err
+	}
+
+	configMap.Data[ConfigMapAdmissionDataKey] = string(data)
+	utilruntime.Must(kubernetesutils.MakeUnique(configMap))
+
+	return client.IgnoreAlreadyExists(c.Create(ctx, configMap))
+}
+
+func computeRelevantAdmissionPluginRawConfig(plugin AdmissionPluginConfig) ([]byte, error) {
+	var (
+		nothingToMutate    = (plugin.Config == nil || plugin.Config.Raw == nil) && len(plugin.Kubeconfig) == 0
+		mustDefaultConfig  = (plugin.Config == nil || plugin.Config.Raw == nil) && len(plugin.Kubeconfig) > 0
+		kubeconfigFilePath = VolumeMountPathAdmissionKubeconfigSecrets + "/" + admissionPluginsKubeconfigFilename(plugin.Name)
+	)
+
+	if len(plugin.Kubeconfig) == 0 {
+		// This makes sure that the path to the kubeconfig is overwritten if specified in case no kubeconfig was
+		// provided. It prevents that users can access arbitrary files in the kube-apiserver pods and disguise them as
+		// kubeconfigs for their admission plugin configs.
+		kubeconfigFilePath = ""
+	}
+
+	switch plugin.Name {
+	case "ValidatingAdmissionWebhook", "MutatingAdmissionWebhook":
+		if nothingToMutate {
+			return nil, nil
+		}
+
+		if mustDefaultConfig {
+			if plugin.Config == nil {
+				plugin.Config = &runtime.RawExtension{}
+			}
+			if len(plugin.Config.Raw) == 0 {
+				plugin.Config.Raw = []byte(fmt.Sprintf(`apiVersion: %s
+kind: WebhookAdmissionConfiguration`, webhookadmissionv1.SchemeGroupVersion.String()))
+			}
+		}
+
+		configObj, err := runtime.Decode(admissionCodec, plugin.Config.Raw)
+		if err != nil {
+			return nil, fmt.Errorf("cannot decode config for admission plugin %s: %w", plugin.Name, err)
+		}
+
+		switch config := configObj.(type) {
+		case *webhookadmissionv1.WebhookAdmission:
+			config.KubeConfigFile = kubeconfigFilePath
+			return runtime.Encode(admissionCodec, config)
+		case *webhookadmissionv1alpha1.WebhookAdmission:
+			config.KubeConfigFile = kubeconfigFilePath
+			return runtime.Encode(admissionCodec, config)
+		default:
+			return nil, fmt.Errorf("expected apiserver.config.k8s.io/{v1alpha1.WebhookAdmission,v1.WebhookAdmissionConfiguration} in %s plugin configuration but got %T", plugin.Name, config)
+		}
+
+	case "ImagePolicyWebhook":
+		// The configuration for this admission plugin is not backed by the API machinery, hence we have to use
+		// regular marshalling.
+		if nothingToMutate {
+			return nil, nil
+		}
+
+		if mustDefaultConfig {
+			if plugin.Config == nil {
+				plugin.Config = &runtime.RawExtension{}
+			}
+			if len(plugin.Config.Raw) == 0 {
+				plugin.Config.Raw = []byte("imagePolicy: {}")
+			}
+		}
+
+		config := map[string]interface{}{}
+		if err := yaml.Unmarshal(plugin.Config.Raw, &config); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal plugin configuration for %s: %w", plugin.Name, err)
+		}
+		if config["imagePolicy"] == nil {
+			return nil, fmt.Errorf(`expected "imagePolicy" key in configuration but it does not exist`)
+		}
+
+		config["imagePolicy"].(map[string]interface{})["kubeConfigFile"] = kubeconfigFilePath
+		return yaml.Marshal(config)
+
+	default:
+		// For all other plugins, we do not need to mutate anything, hence we only return the provided config if set.
+		if plugin.Config != nil && plugin.Config.Raw != nil {
+			return plugin.Config.Raw, nil
+		}
+	}
+
+	return nil, nil
+}
+
+func admissionPluginsConfigFilename(name string) string {
+	return strings.ToLower(name) + ".yaml"
 }
 
 func admissionPluginsKubeconfigFilename(name string) string {

--- a/pkg/component/apiserver/admission_test.go
+++ b/pkg/component/apiserver/admission_test.go
@@ -21,6 +21,7 @@ import (
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -100,6 +101,270 @@ var _ = Describe("Admission", func() {
 				Immutable: pointer.Bool(true),
 				Data: map[string][]byte{
 					"baz-kubeconfig.yaml": []byte("foo"),
+				},
+			}))
+		})
+	})
+
+	Describe("#ReconcileConfigMapAdmission", func() {
+		It("should successfully deploy the configmap resource w/o admission plugins", func() {
+			configMap := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "apiserver-admission-config", Namespace: namespace}}
+			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(configMap), configMap)).To(BeNotFoundError())
+
+			Expect(ReconcileConfigMapAdmission(ctx, fakeClient, configMap, Values{})).To(Succeed())
+
+			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(configMap), configMap)).To(Succeed())
+			Expect(configMap).To(DeepEqual(&corev1.ConfigMap{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: corev1.SchemeGroupVersion.String(),
+					Kind:       "ConfigMap",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            configMap.Name,
+					Namespace:       configMap.Namespace,
+					Labels:          map[string]string{"resources.gardener.cloud/garbage-collectable-reference": "true"},
+					ResourceVersion: "1",
+				},
+				Immutable: pointer.Bool(true),
+				Data: map[string]string{"admission-configuration.yaml": `apiVersion: apiserver.k8s.io/v1alpha1
+kind: AdmissionConfiguration
+plugins: null
+`},
+			}))
+		})
+
+		It("should successfully deploy the configmap resource w/ admission plugins", func() {
+			admissionPlugins := []AdmissionPluginConfig{
+				{AdmissionPlugin: gardencorev1beta1.AdmissionPlugin{Name: "Foo"}},
+				{AdmissionPlugin: gardencorev1beta1.AdmissionPlugin{Name: "Baz", Config: &runtime.RawExtension{Raw: []byte("some-config-for-baz")}}},
+				{
+					AdmissionPlugin: gardencorev1beta1.AdmissionPlugin{
+						Name: "MutatingAdmissionWebhook",
+						Config: &runtime.RawExtension{Raw: []byte(`apiVersion: apiserver.config.k8s.io/v1
+kind: WebhookAdmissionConfiguration
+kubeConfigFile: /etc/kubernetes/foobar.yaml
+`)},
+					},
+					Kubeconfig: []byte("foo"),
+				},
+				{
+					AdmissionPlugin: gardencorev1beta1.AdmissionPlugin{
+						Name: "ValidatingAdmissionWebhook",
+						Config: &runtime.RawExtension{Raw: []byte(`apiVersion: apiserver.config.k8s.io/v1alpha1
+kind: WebhookAdmission
+kubeConfigFile: /etc/kubernetes/foobar.yaml
+`)},
+					},
+					Kubeconfig: []byte("foo"),
+				},
+				{
+					AdmissionPlugin: gardencorev1beta1.AdmissionPlugin{
+						Name: "ImagePolicyWebhook",
+						Config: &runtime.RawExtension{Raw: []byte(`imagePolicy:
+  foo: bar
+  kubeConfigFile: /etc/kubernetes/foobar.yaml
+`)},
+					},
+					Kubeconfig: []byte("foo"),
+				},
+			}
+
+			configMap := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "apiserver-admission-config", Namespace: namespace}}
+			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(configMap), configMap)).To(BeNotFoundError())
+
+			Expect(ReconcileConfigMapAdmission(ctx, fakeClient, configMap, Values{EnabledAdmissionPlugins: admissionPlugins})).To(Succeed())
+
+			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(configMap), configMap)).To(Succeed())
+			Expect(configMap).To(DeepEqual(&corev1.ConfigMap{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: corev1.SchemeGroupVersion.String(),
+					Kind:       "ConfigMap",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            configMap.Name,
+					Namespace:       configMap.Namespace,
+					Labels:          map[string]string{"resources.gardener.cloud/garbage-collectable-reference": "true"},
+					ResourceVersion: "1",
+				},
+				Immutable: pointer.Bool(true),
+				Data: map[string]string{
+					"admission-configuration.yaml": `apiVersion: apiserver.k8s.io/v1alpha1
+kind: AdmissionConfiguration
+plugins:
+- configuration: null
+  name: Baz
+  path: /etc/kubernetes/admission/baz.yaml
+- configuration: null
+  name: MutatingAdmissionWebhook
+  path: /etc/kubernetes/admission/mutatingadmissionwebhook.yaml
+- configuration: null
+  name: ValidatingAdmissionWebhook
+  path: /etc/kubernetes/admission/validatingadmissionwebhook.yaml
+- configuration: null
+  name: ImagePolicyWebhook
+  path: /etc/kubernetes/admission/imagepolicywebhook.yaml
+`,
+					"baz.yaml": "some-config-for-baz",
+					"mutatingadmissionwebhook.yaml": `apiVersion: apiserver.config.k8s.io/v1
+kind: WebhookAdmissionConfiguration
+kubeConfigFile: /etc/kubernetes/admission-kubeconfigs/mutatingadmissionwebhook-kubeconfig.yaml
+`,
+					"validatingadmissionwebhook.yaml": `apiVersion: apiserver.config.k8s.io/v1alpha1
+kind: WebhookAdmission
+kubeConfigFile: /etc/kubernetes/admission-kubeconfigs/validatingadmissionwebhook-kubeconfig.yaml
+`,
+					"imagepolicywebhook.yaml": `imagePolicy:
+  foo: bar
+  kubeConfigFile: /etc/kubernetes/admission-kubeconfigs/imagepolicywebhook-kubeconfig.yaml
+`,
+				},
+			}))
+		})
+
+		It("should successfully deploy the configmap resource w/ admission plugins w/ config but w/o kubeconfigs", func() {
+			admissionPlugins := []AdmissionPluginConfig{
+				{
+					AdmissionPlugin: gardencorev1beta1.AdmissionPlugin{
+						Name: "MutatingAdmissionWebhook",
+						Config: &runtime.RawExtension{Raw: []byte(`apiVersion: apiserver.config.k8s.io/v1
+kind: WebhookAdmissionConfiguration
+kubeConfigFile: /etc/kubernetes/foobar.yaml
+`)},
+					},
+				},
+				{
+					AdmissionPlugin: gardencorev1beta1.AdmissionPlugin{
+						Name: "ValidatingAdmissionWebhook",
+						Config: &runtime.RawExtension{Raw: []byte(`apiVersion: apiserver.config.k8s.io/v1alpha1
+kind: WebhookAdmission
+kubeConfigFile: /etc/kubernetes/foobar.yaml
+`)},
+					},
+				},
+				{
+					AdmissionPlugin: gardencorev1beta1.AdmissionPlugin{
+						Name: "ImagePolicyWebhook",
+						Config: &runtime.RawExtension{Raw: []byte(`imagePolicy:
+  foo: bar
+  kubeConfigFile: /etc/kubernetes/foobar.yaml
+`)},
+					},
+				},
+			}
+
+			configMap := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "apiserver-admission-config", Namespace: namespace}}
+			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(configMap), configMap)).To(BeNotFoundError())
+
+			Expect(ReconcileConfigMapAdmission(ctx, fakeClient, configMap, Values{EnabledAdmissionPlugins: admissionPlugins})).To(Succeed())
+
+			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(configMap), configMap)).To(Succeed())
+			Expect(configMap).To(DeepEqual(&corev1.ConfigMap{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: corev1.SchemeGroupVersion.String(),
+					Kind:       "ConfigMap",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            configMap.Name,
+					Namespace:       configMap.Namespace,
+					Labels:          map[string]string{"resources.gardener.cloud/garbage-collectable-reference": "true"},
+					ResourceVersion: "1",
+				},
+				Immutable: pointer.Bool(true),
+				Data: map[string]string{
+					"admission-configuration.yaml": `apiVersion: apiserver.k8s.io/v1alpha1
+kind: AdmissionConfiguration
+plugins:
+- configuration: null
+  name: MutatingAdmissionWebhook
+  path: /etc/kubernetes/admission/mutatingadmissionwebhook.yaml
+- configuration: null
+  name: ValidatingAdmissionWebhook
+  path: /etc/kubernetes/admission/validatingadmissionwebhook.yaml
+- configuration: null
+  name: ImagePolicyWebhook
+  path: /etc/kubernetes/admission/imagepolicywebhook.yaml
+`,
+					"mutatingadmissionwebhook.yaml": `apiVersion: apiserver.config.k8s.io/v1
+kind: WebhookAdmissionConfiguration
+kubeConfigFile: ""
+`,
+					"validatingadmissionwebhook.yaml": `apiVersion: apiserver.config.k8s.io/v1alpha1
+kind: WebhookAdmission
+kubeConfigFile: ""
+`,
+					"imagepolicywebhook.yaml": `imagePolicy:
+  foo: bar
+  kubeConfigFile: ""
+`,
+				},
+			}))
+		})
+
+		It("should successfully deploy the configmap resource w/ admission plugins w/o configs but w/ kubeconfig", func() {
+			admissionPlugins := []AdmissionPluginConfig{
+				{
+					AdmissionPlugin: gardencorev1beta1.AdmissionPlugin{
+						Name: "MutatingAdmissionWebhook",
+					},
+					Kubeconfig: []byte("foo"),
+				},
+				{
+					AdmissionPlugin: gardencorev1beta1.AdmissionPlugin{
+						Name: "ValidatingAdmissionWebhook",
+					},
+					Kubeconfig: []byte("foo"),
+				},
+				{
+					AdmissionPlugin: gardencorev1beta1.AdmissionPlugin{
+						Name: "ImagePolicyWebhook",
+					},
+					Kubeconfig: []byte("foo"),
+				},
+			}
+
+			configMap := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "apiserver-admission-config", Namespace: namespace}}
+			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(configMap), configMap)).To(BeNotFoundError())
+
+			Expect(ReconcileConfigMapAdmission(ctx, fakeClient, configMap, Values{EnabledAdmissionPlugins: admissionPlugins})).To(Succeed())
+
+			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(configMap), configMap)).To(Succeed())
+			Expect(configMap).To(DeepEqual(&corev1.ConfigMap{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: corev1.SchemeGroupVersion.String(),
+					Kind:       "ConfigMap",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            configMap.Name,
+					Namespace:       configMap.Namespace,
+					Labels:          map[string]string{"resources.gardener.cloud/garbage-collectable-reference": "true"},
+					ResourceVersion: "1",
+				},
+				Immutable: pointer.Bool(true),
+				Data: map[string]string{
+					"admission-configuration.yaml": `apiVersion: apiserver.k8s.io/v1alpha1
+kind: AdmissionConfiguration
+plugins:
+- configuration: null
+  name: MutatingAdmissionWebhook
+  path: /etc/kubernetes/admission/mutatingadmissionwebhook.yaml
+- configuration: null
+  name: ValidatingAdmissionWebhook
+  path: /etc/kubernetes/admission/validatingadmissionwebhook.yaml
+- configuration: null
+  name: ImagePolicyWebhook
+  path: /etc/kubernetes/admission/imagepolicywebhook.yaml
+`,
+					"mutatingadmissionwebhook.yaml": `apiVersion: apiserver.config.k8s.io/v1
+kind: WebhookAdmissionConfiguration
+kubeConfigFile: /etc/kubernetes/admission-kubeconfigs/mutatingadmissionwebhook-kubeconfig.yaml
+`,
+					"validatingadmissionwebhook.yaml": `apiVersion: apiserver.config.k8s.io/v1
+kind: WebhookAdmissionConfiguration
+kubeConfigFile: /etc/kubernetes/admission-kubeconfigs/validatingadmissionwebhook-kubeconfig.yaml
+`,
+					"imagepolicywebhook.yaml": `imagePolicy:
+  kubeConfigFile: /etc/kubernetes/admission-kubeconfigs/imagepolicywebhook-kubeconfig.yaml
+`,
 				},
 			}))
 		})

--- a/pkg/component/apiserver/admission_test.go
+++ b/pkg/component/apiserver/admission_test.go
@@ -1,0 +1,107 @@
+// Copyright 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package apiserver_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	. "github.com/gardener/gardener/pkg/component/apiserver"
+	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
+	. "github.com/gardener/gardener/pkg/utils/test/matchers"
+)
+
+var _ = Describe("Admission", func() {
+	var (
+		ctx       = context.TODO()
+		namespace = "some-namespace"
+
+		fakeClient client.Client
+	)
+
+	BeforeEach(func() {
+		fakeClient = fakeclient.NewClientBuilder().WithScheme(kubernetes.SeedScheme).Build()
+	})
+
+	Describe("#ReconcileSecretAdmissionKubeconfigs", func() {
+		It("should successfully deploy the secret resource w/o admission plugin kubeconfigs", func() {
+			secret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "apiserver-admission-kubeconfigs", Namespace: namespace}}
+			Expect(kubernetesutils.MakeUnique(secret)).To(Succeed())
+
+			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(secret), secret)).To(BeNotFoundError())
+
+			Expect(ReconcileSecretAdmissionKubeconfigs(ctx, fakeClient, secret, Values{})).To(Succeed())
+
+			actualSecret := &corev1.Secret{ObjectMeta: secret.ObjectMeta}
+			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(actualSecret), actualSecret)).To(Succeed())
+			Expect(actualSecret).To(DeepEqual(&corev1.Secret{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: corev1.SchemeGroupVersion.String(),
+					Kind:       "Secret",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            secret.Name,
+					Namespace:       secret.Namespace,
+					Labels:          map[string]string{"resources.gardener.cloud/garbage-collectable-reference": "true"},
+					ResourceVersion: "1",
+				},
+				Immutable: pointer.Bool(true),
+				Data:      map[string][]byte{},
+			}))
+		})
+
+		It("should successfully deploy the configmap resource w/ admission plugins", func() {
+			admissionPlugins := []AdmissionPluginConfig{
+				{AdmissionPlugin: gardencorev1beta1.AdmissionPlugin{Name: "Foo"}},
+				{AdmissionPlugin: gardencorev1beta1.AdmissionPlugin{Name: "Baz"}, Kubeconfig: []byte("foo")},
+			}
+
+			secret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "apiserver-admission-kubeconfigs", Namespace: namespace}}
+			Expect(kubernetesutils.MakeUnique(secret)).To(Succeed())
+
+			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(secret), secret)).To(BeNotFoundError())
+
+			Expect(ReconcileSecretAdmissionKubeconfigs(ctx, fakeClient, secret, Values{EnabledAdmissionPlugins: admissionPlugins})).To(Succeed())
+
+			actualSecret := &corev1.Secret{ObjectMeta: secret.ObjectMeta}
+			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(actualSecret), actualSecret)).To(Succeed())
+			Expect(actualSecret).To(DeepEqual(&corev1.Secret{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: corev1.SchemeGroupVersion.String(),
+					Kind:       "Secret",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            secret.Name,
+					Namespace:       secret.Namespace,
+					Labels:          map[string]string{"resources.gardener.cloud/garbage-collectable-reference": "true"},
+					ResourceVersion: "1",
+				},
+				Immutable: pointer.Bool(true),
+				Data: map[string][]byte{
+					"baz-kubeconfig.yaml": []byte("foo"),
+				},
+			}))
+		})
+	})
+})

--- a/pkg/component/apiserver/apiserver_suite_test.go
+++ b/pkg/component/apiserver/apiserver_suite_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package gardenerapiserver_test
+package apiserver_test
 
 import (
 	"testing"
@@ -26,9 +26,9 @@ import (
 	"github.com/gardener/gardener/pkg/utils/test"
 )
 
-func TestGardenerAPIServer(t *testing.T) {
+func TestAPIServer(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Component GardenerAPIServer Suite")
+	RunSpecs(t, "Component APIServer Suite")
 }
 
 var _ = BeforeSuite(func() {

--- a/pkg/component/apiserver/audit.go
+++ b/pkg/component/apiserver/audit.go
@@ -104,7 +104,7 @@ func ReconcileConfigMapAuditPolicy(ctx context.Context, c client.Client, configM
 	return client.IgnoreAlreadyExists(c.Create(ctx, configMap))
 }
 
-// InjectAuditSettings injects the audit settings into the deployment.
+// InjectAuditSettings injects the audit settings into `gardener-apiserver` and `kube-apiserver` deployments.
 func InjectAuditSettings(deployment *appsv1.Deployment, configMapAuditPolicy *corev1.ConfigMap, secretWebhookKubeconfig *corev1.Secret, auditConfig *AuditConfig) {
 	deployment.Spec.Template.Spec.Containers[0].Args = append(deployment.Spec.Template.Spec.Containers[0].Args, fmt.Sprintf("--audit-policy-file=%s/%s", volumeMountPathAuditPolicy, configMapAuditPolicyDataKey))
 

--- a/pkg/component/apiserver/auditwebhook.go
+++ b/pkg/component/apiserver/auditwebhook.go
@@ -1,0 +1,48 @@
+// Copyright 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package apiserver
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
+)
+
+const (
+	// SecretWebhookKubeconfigDataKey is a constant for a key in the data of the secret containing a kubeconfig.
+	SecretWebhookKubeconfigDataKey = "kubeconfig.yaml"
+)
+
+// ReconcileSecretAuditWebhookKubeconfig reconciles the secret containing the kubeconfig for audit webhooks.
+func ReconcileSecretAuditWebhookKubeconfig(ctx context.Context, c client.Client, secret *corev1.Secret, auditConfig *AuditConfig) error {
+	if auditConfig == nil || auditConfig.Webhook == nil || len(auditConfig.Webhook.Kubeconfig) == 0 {
+		// We don't delete the secret here as we don't know its name (as it's unique). Instead, we rely on the usual
+		// garbage collection for unique secrets/configmaps.
+		return nil
+	}
+
+	return ReconcileSecretWebhookKubeconfig(ctx, c, secret, auditConfig.Webhook.Kubeconfig)
+}
+
+// ReconcileSecretWebhookKubeconfig reconciles the secret containing a kubeconfig for webhooks.
+func ReconcileSecretWebhookKubeconfig(ctx context.Context, c client.Client, secret *corev1.Secret, kubeconfig []byte) error {
+	secret.Data = map[string][]byte{SecretWebhookKubeconfigDataKey: kubeconfig}
+	utilruntime.Must(kubernetesutils.MakeUnique(secret))
+	return client.IgnoreAlreadyExists(c.Create(ctx, secret))
+}

--- a/pkg/component/apiserver/auditwebhook_test.go
+++ b/pkg/component/apiserver/auditwebhook_test.go
@@ -1,0 +1,122 @@
+// Copyright 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package apiserver_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	. "github.com/gardener/gardener/pkg/component/apiserver"
+	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
+	. "github.com/gardener/gardener/pkg/utils/test/matchers"
+)
+
+var _ = Describe("AuditWebhook", func() {
+	var (
+		ctx        = context.TODO()
+		namespace  = "some-namespace"
+		kubeconfig = []byte("some-kubeconfig")
+
+		fakeClient client.Client
+	)
+
+	BeforeEach(func() {
+		fakeClient = fakeclient.NewClientBuilder().WithScheme(kubernetes.SeedScheme).Build()
+	})
+
+	Describe("#ReconcileSecretAuditWebhookKubeconfig", func() {
+		It("should do nothing because config is nil", func() {
+			Expect(ReconcileSecretAuditWebhookKubeconfig(ctx, fakeClient, nil, nil)).To(Succeed())
+
+			secretList := &corev1.SecretList{}
+			Expect(fakeClient.List(ctx, secretList)).To(Succeed())
+			Expect(secretList.Items).To(BeEmpty())
+		})
+
+		It("should do nothing because webhook config is nil", func() {
+			Expect(ReconcileSecretAuditWebhookKubeconfig(ctx, fakeClient, nil, &AuditConfig{})).To(Succeed())
+
+			secretList := &corev1.SecretList{}
+			Expect(fakeClient.List(ctx, secretList)).To(Succeed())
+			Expect(secretList.Items).To(BeEmpty())
+		})
+
+		It("should do nothing because webhook kubeconfig is nil", func() {
+			Expect(ReconcileSecretAuditWebhookKubeconfig(ctx, fakeClient, nil, &AuditConfig{Webhook: &AuditWebhook{}})).To(Succeed())
+
+			secretList := &corev1.SecretList{}
+			Expect(fakeClient.List(ctx, secretList)).To(Succeed())
+			Expect(secretList.Items).To(BeEmpty())
+		})
+
+		It("should successfully deploy the audit webhook kubeconfig secret resource", func() {
+			expectedSecret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: "apiserver-audit-webhook-kubeconfig", Namespace: namespace},
+				Data:       map[string][]byte{"kubeconfig.yaml": kubeconfig},
+			}
+			Expect(kubernetesutils.MakeUnique(expectedSecret)).To(Succeed())
+
+			actualSecret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "apiserver-audit-webhook-kubeconfig", Namespace: namespace}}
+			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(expectedSecret), actualSecret)).To(BeNotFoundError())
+
+			Expect(ReconcileSecretAuditWebhookKubeconfig(ctx, fakeClient, actualSecret, &AuditConfig{Webhook: &AuditWebhook{Kubeconfig: kubeconfig}})).To(Succeed())
+
+			Expect(actualSecret).To(DeepEqual(&corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            expectedSecret.Name,
+					Namespace:       expectedSecret.Namespace,
+					Labels:          map[string]string{"resources.gardener.cloud/garbage-collectable-reference": "true"},
+					ResourceVersion: "1",
+				},
+				Immutable: pointer.Bool(true),
+				Data:      expectedSecret.Data,
+			}))
+		})
+	})
+
+	Describe("#ReconcileSecretWebhookKubeconfig", func() {
+		It("should successully delpoy the kubeconfig secret and make it unique", func() {
+			expectedSecret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: "apiserver-kubeconfig", Namespace: namespace},
+				Data:       map[string][]byte{"kubeconfig.yaml": kubeconfig},
+			}
+			Expect(kubernetesutils.MakeUnique(expectedSecret)).To(Succeed())
+
+			actualSecret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "apiserver-kubeconfig", Namespace: namespace}}
+			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(expectedSecret), actualSecret)).To(BeNotFoundError())
+
+			Expect(ReconcileSecretAuditWebhookKubeconfig(ctx, fakeClient, actualSecret, &AuditConfig{Webhook: &AuditWebhook{Kubeconfig: kubeconfig}})).To(Succeed())
+
+			Expect(actualSecret).To(DeepEqual(&corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            expectedSecret.Name,
+					Namespace:       expectedSecret.Namespace,
+					Labels:          map[string]string{"resources.gardener.cloud/garbage-collectable-reference": "true"},
+					ResourceVersion: "1",
+				},
+				Immutable: pointer.Bool(true),
+				Data:      expectedSecret.Data,
+			}))
+		})
+	})
+})

--- a/pkg/component/apiserver/deployment.go
+++ b/pkg/component/apiserver/deployment.go
@@ -1,0 +1,146 @@
+// Copyright 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package apiserver
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/Masterminds/semver"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	etcdconstants "github.com/gardener/gardener/pkg/component/etcd/constants"
+	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
+	"github.com/gardener/gardener/pkg/utils/secrets"
+)
+
+const (
+	volumeNameCAEtcd          = "ca-etcd"
+	volumeNameEtcdClient      = "etcd-client"
+	volumeNameServer          = "server"
+	volumeMountPathCAEtcd     = "/srv/kubernetes/etcd/ca"
+	volumeMountPathEtcdClient = "/srv/kubernetes/etcd/client"
+	volumeMountPathServer     = "/srv/kubernetes/apiserver"
+)
+
+// InjectDefaultSettings injects default settings into the deployment.
+func InjectDefaultSettings(
+	deployment *appsv1.Deployment,
+	namePrefix string,
+	values Values,
+	k8sVersion *semver.Version,
+	secretCAETCD *corev1.Secret,
+	secretETCDClient *corev1.Secret,
+	secretServer *corev1.Secret,
+) {
+	deployment.Spec.Template.Spec.Containers[0].Args = append(deployment.Spec.Template.Spec.Containers[0].Args,
+		"--http2-max-streams-per-connection=1000",
+		fmt.Sprintf("--etcd-cafile=%s/%s", volumeMountPathCAEtcd, secrets.DataKeyCertificateBundle),
+		fmt.Sprintf("--etcd-certfile=%s/%s", volumeMountPathEtcdClient, secrets.DataKeyCertificate),
+		fmt.Sprintf("--etcd-keyfile=%s/%s", volumeMountPathEtcdClient, secrets.DataKeyPrivateKey),
+		fmt.Sprintf("--etcd-servers=https://%s%s:%d", namePrefix, etcdconstants.ServiceName(v1beta1constants.ETCDRoleMain), etcdconstants.PortEtcdClient),
+		"--livez-grace-period=1m",
+		"--profiling=false",
+		"--shutdown-delay-duration=15s",
+		fmt.Sprintf("--tls-cert-file=%s/%s", volumeMountPathServer, secrets.DataKeyCertificate),
+		fmt.Sprintf("--tls-private-key-file=%s/%s", volumeMountPathServer, secrets.DataKeyPrivateKey),
+		"--tls-cipher-suites="+strings.Join(kubernetesutils.TLSCipherSuites(k8sVersion), ","),
+	)
+
+	if values.FeatureGates != nil {
+		deployment.Spec.Template.Spec.Containers[0].Args = append(deployment.Spec.Template.Spec.Containers[0].Args, kubernetesutils.FeatureGatesToCommandLineParameter(values.FeatureGates))
+	}
+
+	if values.Requests != nil {
+		if values.Requests.MaxNonMutatingInflight != nil {
+			deployment.Spec.Template.Spec.Containers[0].Args = append(deployment.Spec.Template.Spec.Containers[0].Args, fmt.Sprintf("--max-requests-inflight=%d", *values.Requests.MaxNonMutatingInflight))
+		}
+		if values.Requests.MaxMutatingInflight != nil {
+			deployment.Spec.Template.Spec.Containers[0].Args = append(deployment.Spec.Template.Spec.Containers[0].Args, fmt.Sprintf("--max-mutating-requests-inflight=%d", *values.Requests.MaxMutatingInflight))
+		}
+	}
+
+	if values.Logging != nil {
+		if values.Logging.HTTPAccessVerbosity != nil {
+			deployment.Spec.Template.Spec.Containers[0].Args = append(deployment.Spec.Template.Spec.Containers[0].Args, fmt.Sprintf("--vmodule=httplog=%d", *values.Logging.HTTPAccessVerbosity))
+		}
+		if values.Logging.Verbosity != nil {
+			deployment.Spec.Template.Spec.Containers[0].Args = append(deployment.Spec.Template.Spec.Containers[0].Args, fmt.Sprintf("--v=%d", *values.Logging.Verbosity))
+		}
+	}
+
+	if values.WatchCacheSizes != nil && len(values.WatchCacheSizes.Resources) > 0 {
+		if values.WatchCacheSizes != nil && values.WatchCacheSizes.Default != nil {
+			deployment.Spec.Template.Spec.Containers[0].Args = append(deployment.Spec.Template.Spec.Containers[0].Args, fmt.Sprintf("--default-watch-cache-size=%d", *values.WatchCacheSizes.Default))
+		}
+
+		var sizes []string
+		for _, resource := range values.WatchCacheSizes.Resources {
+			size := resource.Resource
+			if resource.APIGroup != nil {
+				size += "." + *resource.APIGroup
+			}
+			size += fmt.Sprintf("#%d", resource.CacheSize)
+
+			sizes = append(sizes, size)
+		}
+
+		deployment.Spec.Template.Spec.Containers[0].Args = append(deployment.Spec.Template.Spec.Containers[0].Args, "--watch-cache-sizes="+strings.Join(sizes, ","))
+	}
+
+	deployment.Spec.Template.Spec.Containers[0].VolumeMounts = append(deployment.Spec.Template.Spec.Containers[0].VolumeMounts,
+		corev1.VolumeMount{
+			Name:      volumeNameCAEtcd,
+			MountPath: volumeMountPathCAEtcd,
+		},
+		corev1.VolumeMount{
+			Name:      volumeNameEtcdClient,
+			MountPath: volumeMountPathEtcdClient,
+		},
+		corev1.VolumeMount{
+			Name:      volumeNameServer,
+			MountPath: volumeMountPathServer,
+		},
+	)
+
+	deployment.Spec.Template.Spec.Volumes = append(deployment.Spec.Template.Spec.Volumes,
+		corev1.Volume{
+			Name: volumeNameCAEtcd,
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName: secretCAETCD.Name,
+				},
+			},
+		},
+		corev1.Volume{
+			Name: volumeNameEtcdClient,
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName: secretETCDClient.Name,
+				},
+			},
+		},
+		corev1.Volume{
+			Name: volumeNameServer,
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName: secretServer.Name,
+				},
+			},
+		},
+	)
+}

--- a/pkg/component/apiserver/deployment.go
+++ b/pkg/component/apiserver/deployment.go
@@ -37,7 +37,7 @@ const (
 	volumeMountPathServer     = "/srv/kubernetes/apiserver"
 )
 
-// InjectDefaultSettings injects default settings into the deployment.
+// InjectDefaultSettings injects default settings into `gardener-apiserver` and `kube-apiserver` deployments.
 func InjectDefaultSettings(
 	deployment *appsv1.Deployment,
 	namePrefix string,

--- a/pkg/component/apiserver/deployment_test.go
+++ b/pkg/component/apiserver/deployment_test.go
@@ -1,0 +1,136 @@
+// Copyright 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package apiserver_test
+
+import (
+	"github.com/Masterminds/semver"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	. "github.com/gardener/gardener/pkg/component/apiserver"
+)
+
+var _ = Describe("Deployment", func() {
+	Describe("#InjectDefaultSettings", func() {
+		It("should inject the correct settings", func() {
+			deployment := &appsv1.Deployment{}
+			deployment.Spec.Template.Spec.Containers = append(deployment.Spec.Template.Spec.Containers, corev1.Container{})
+
+			var (
+				namePrefix       = "foo"
+				k8sVersion       = semver.MustParse("1.24.5")
+				secretCAETCD     = &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "ca-etcd"}}
+				secretETCDClient = &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "etcd-client"}}
+				secretServer     = &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "server"}}
+				values           = Values{
+					FeatureGates: map[string]bool{"Foo": true, "Bar": false},
+					Requests: &gardencorev1beta1.KubeAPIServerRequests{
+						MaxMutatingInflight:    pointer.Int32(1),
+						MaxNonMutatingInflight: pointer.Int32(2),
+					},
+					Logging: &gardencorev1beta1.KubeAPIServerLogging{
+						Verbosity:           pointer.Int32(3),
+						HTTPAccessVerbosity: pointer.Int32(4),
+					},
+					WatchCacheSizes: &gardencorev1beta1.WatchCacheSizes{
+						Default: pointer.Int32(6),
+						Resources: []gardencorev1beta1.ResourceWatchCacheSize{
+							{APIGroup: pointer.String("foo"), Resource: "bar"},
+							{APIGroup: pointer.String("baz"), Resource: "foo", CacheSize: 7},
+						},
+					},
+				}
+			)
+
+			InjectDefaultSettings(deployment, namePrefix, values, k8sVersion, secretCAETCD, secretETCDClient, secretServer)
+
+			Expect(deployment).To(Equal(&appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{{
+								Args: []string{
+									"--http2-max-streams-per-connection=1000",
+									"--etcd-cafile=/srv/kubernetes/etcd/ca/bundle.crt",
+									"--etcd-certfile=/srv/kubernetes/etcd/client/tls.crt",
+									"--etcd-keyfile=/srv/kubernetes/etcd/client/tls.key",
+									"--etcd-servers=https://" + namePrefix + "etcd-main-client:2379",
+									"--livez-grace-period=1m",
+									"--profiling=false",
+									"--shutdown-delay-duration=15s",
+									"--tls-cert-file=/srv/kubernetes/apiserver/tls.crt",
+									"--tls-private-key-file=/srv/kubernetes/apiserver/tls.key",
+									"--tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_CHACHA20_POLY1305_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305",
+									"--feature-gates=Bar=false,Foo=true",
+									"--max-requests-inflight=2",
+									"--max-mutating-requests-inflight=1",
+									"--vmodule=httplog=4",
+									"--v=3",
+									"--default-watch-cache-size=6",
+									"--watch-cache-sizes=bar.foo#0,foo.baz#7",
+								},
+								VolumeMounts: []corev1.VolumeMount{
+									{
+										Name:      "ca-etcd",
+										MountPath: "/srv/kubernetes/etcd/ca",
+									},
+									{
+										Name:      "etcd-client",
+										MountPath: "/srv/kubernetes/etcd/client",
+									},
+									{
+										Name:      "server",
+										MountPath: "/srv/kubernetes/apiserver",
+									},
+								},
+							}},
+							Volumes: []corev1.Volume{
+								{
+									Name: "ca-etcd",
+									VolumeSource: corev1.VolumeSource{
+										Secret: &corev1.SecretVolumeSource{
+											SecretName: secretCAETCD.Name,
+										},
+									},
+								},
+								{
+									Name: "etcd-client",
+									VolumeSource: corev1.VolumeSource{
+										Secret: &corev1.SecretVolumeSource{
+											SecretName: secretETCDClient.Name,
+										},
+									},
+								},
+								{
+									Name: "server",
+									VolumeSource: corev1.VolumeSource{
+										Secret: &corev1.SecretVolumeSource{
+											SecretName: secretServer.Name,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}))
+		})
+	})
+})

--- a/pkg/component/apiserver/encryptionconfiguration.go
+++ b/pkg/component/apiserver/encryptionconfiguration.go
@@ -157,7 +157,7 @@ func aesKeyFromSecretData(data map[string][]byte) apiserverconfigv1.Key {
 	}
 }
 
-// InjectEncryptionSettings injects the encryption settings into the deployment.
+// InjectEncryptionSettings injects the encryption settings into `gardener-apiserver` and `kube-apiserver` deployments.
 func InjectEncryptionSettings(deployment *appsv1.Deployment, secretETCDEncryptionConfiguration *corev1.Secret) {
 	deployment.Spec.Template.Spec.Containers[0].Args = append(deployment.Spec.Template.Spec.Containers[0].Args, fmt.Sprintf("--encryption-provider-config=%s/%s", volumeMountPathEtcdEncryptionConfig, secretETCDEncryptionConfigurationDataKey))
 	deployment.Spec.Template.Spec.Containers[0].VolumeMounts = append(deployment.Spec.Template.Spec.Containers[0].VolumeMounts, corev1.VolumeMount{

--- a/pkg/component/apiserver/encryptionconfiguration.go
+++ b/pkg/component/apiserver/encryptionconfiguration.go
@@ -123,7 +123,7 @@ func ReconcileSecretETCDEncryptionConfiguration(
 		return err
 	}
 
-	// reconcile labels of existing secret
+	// creation of secret failed as it already exists => reconcile labels of existing secret
 	if err := c.Get(ctx, client.ObjectKeyFromObject(secretETCDEncryptionConfiguration), secretETCDEncryptionConfiguration); err != nil {
 		return err
 	}

--- a/pkg/component/apiserver/encryptionconfiguration.go
+++ b/pkg/component/apiserver/encryptionconfiguration.go
@@ -1,0 +1,151 @@
+// Copyright 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package apiserver
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/apimachinery/pkg/runtime/serializer/json"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	apiserverconfigv1 "k8s.io/apiserver/pkg/apis/config/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	"github.com/gardener/gardener/pkg/utils"
+	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
+	secretsutils "github.com/gardener/gardener/pkg/utils/secrets"
+	secretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager"
+)
+
+var encryptionCodec runtime.Codec
+
+func init() {
+	encryptionScheme := runtime.NewScheme()
+	utilruntime.Must(apiserverconfigv1.AddToScheme(encryptionScheme))
+
+	var (
+		ser = json.NewSerializerWithOptions(json.DefaultMetaFactory, encryptionScheme, encryptionScheme, json.SerializerOptions{
+			Yaml:   true,
+			Pretty: false,
+			Strict: false,
+		})
+		versions = schema.GroupVersions([]schema.GroupVersion{
+			apiserverconfigv1.SchemeGroupVersion,
+		})
+	)
+
+	encryptionCodec = serializer.NewCodecFactory(encryptionScheme).CodecForVersions(ser, ser, versions, versions)
+}
+
+const secretETCDEncryptionConfigurationDataKey = "encryption-configuration.yaml"
+
+// ReconcileSecretETCDEncryptionConfiguration reconciles the ETCD encryption secret configuration.
+func ReconcileSecretETCDEncryptionConfiguration(
+	ctx context.Context,
+	c client.Client,
+	secretsManager secretsmanager.Interface,
+	config ETCDEncryptionConfig,
+	secretETCDEncryptionConfiguration *corev1.Secret,
+	secretNameETCDEncryptionKey string,
+	roleLabel string,
+) error {
+	options := []secretsmanager.GenerateOption{
+		secretsmanager.Persist(),
+		secretsmanager.Rotate(secretsmanager.KeepOld),
+	}
+
+	if config.RotationPhase == gardencorev1beta1.RotationCompleting {
+		options = append(options, secretsmanager.IgnoreOldSecrets())
+	}
+
+	keySecret, err := secretsManager.Generate(ctx, &secretsutils.ETCDEncryptionKeySecretConfig{
+		Name:         secretNameETCDEncryptionKey,
+		SecretLength: 32,
+	}, options...)
+	if err != nil {
+		return err
+	}
+
+	keySecretOld, _ := secretsManager.Get(secretNameETCDEncryptionKey, secretsmanager.Old)
+
+	encryptionConfiguration := &apiserverconfigv1.EncryptionConfiguration{
+		Resources: []apiserverconfigv1.ResourceConfiguration{{
+			Resources: config.Resources,
+			Providers: []apiserverconfigv1.ProviderConfiguration{
+				{
+					AESCBC: &apiserverconfigv1.AESConfiguration{
+						Keys: etcdEncryptionAESKeys(keySecret, keySecretOld, config.EncryptWithCurrentKey),
+					},
+				},
+				{
+					Identity: &apiserverconfigv1.IdentityConfiguration{},
+				},
+			},
+		}},
+	}
+
+	data, err := runtime.Encode(encryptionCodec, encryptionConfiguration)
+	if err != nil {
+		return err
+	}
+
+	secretETCDEncryptionConfiguration.Labels = map[string]string{v1beta1constants.LabelRole: roleLabel}
+	secretETCDEncryptionConfiguration.Data = map[string][]byte{secretETCDEncryptionConfigurationDataKey: data}
+	utilruntime.Must(kubernetesutils.MakeUnique(secretETCDEncryptionConfiguration))
+	desiredLabels := utils.MergeStringMaps(secretETCDEncryptionConfiguration.Labels) // copy
+
+	if err := c.Create(ctx, secretETCDEncryptionConfiguration); err == nil || !apierrors.IsAlreadyExists(err) {
+		return err
+	}
+
+	// reconcile labels of existing secret
+	if err := c.Get(ctx, client.ObjectKeyFromObject(secretETCDEncryptionConfiguration), secretETCDEncryptionConfiguration); err != nil {
+		return err
+	}
+	patch := client.MergeFrom(secretETCDEncryptionConfiguration.DeepCopy())
+	secretETCDEncryptionConfiguration.Labels = desiredLabels
+	return c.Patch(ctx, secretETCDEncryptionConfiguration, patch)
+}
+
+func etcdEncryptionAESKeys(keySecretCurrent, keySecretOld *corev1.Secret, encryptWithCurrentKey bool) []apiserverconfigv1.Key {
+	if keySecretOld == nil {
+		return []apiserverconfigv1.Key{
+			aesKeyFromSecretData(keySecretCurrent.Data),
+		}
+	}
+
+	keyForEncryption, keyForDecryption := keySecretCurrent, keySecretOld
+	if !encryptWithCurrentKey {
+		keyForEncryption, keyForDecryption = keySecretOld, keySecretCurrent
+	}
+
+	return []apiserverconfigv1.Key{
+		aesKeyFromSecretData(keyForEncryption.Data),
+		aesKeyFromSecretData(keyForDecryption.Data),
+	}
+}
+
+func aesKeyFromSecretData(data map[string][]byte) apiserverconfigv1.Key {
+	return apiserverconfigv1.Key{
+		Name:   string(data[secretsutils.DataKeyEncryptionKeyName]),
+		Secret: string(data[secretsutils.DataKeyEncryptionSecret]),
+	}
+}

--- a/pkg/component/apiserver/encryptionconfiguration_test.go
+++ b/pkg/component/apiserver/encryptionconfiguration_test.go
@@ -1,0 +1,202 @@
+// Copyright 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package apiserver_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	. "github.com/gardener/gardener/pkg/component/apiserver"
+	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
+	secretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager"
+	fakesecretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager/fake"
+	. "github.com/gardener/gardener/pkg/utils/test/matchers"
+)
+
+var _ = Describe("EncryptionConfiguration", func() {
+	var (
+		ctx                         = context.TODO()
+		secretNameETCDEncryptionKey = "etcd-encryption-key"
+		encryptionRoleLabel         = "etcd-encryption"
+		namespace                   = "some-namespace"
+
+		config ETCDEncryptionConfig
+
+		fakeClient        client.Client
+		fakeSecretManager secretsmanager.Interface
+	)
+
+	BeforeEach(func() {
+		config = ETCDEncryptionConfig{Resources: []string{"foo"}}
+
+		fakeClient = fakeclient.NewClientBuilder().WithScheme(kubernetes.SeedScheme).Build()
+		fakeSecretManager = fakesecretsmanager.New(fakeClient, namespace)
+	})
+
+	Describe("#ReconcileSecretETCDEncryptionConfiguration", func() {
+		It("should successfully deploy the ETCD encryption configuration secret resource", func() {
+			etcdEncryptionConfiguration := `apiVersion: apiserver.config.k8s.io/v1
+kind: EncryptionConfiguration
+resources:
+- providers:
+  - aescbc:
+      keys:
+      - name: key-62135596800
+        secret: ________________________________
+  - identity: {}
+  resources:
+  - foo
+`
+
+			By("Verify encryption config secret")
+			expectedSecretETCDEncryptionConfiguration := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: "apiserver-encryption-config", Namespace: namespace},
+				Data:       map[string][]byte{"encryption-configuration.yaml": []byte(etcdEncryptionConfiguration)},
+			}
+			Expect(kubernetesutils.MakeUnique(expectedSecretETCDEncryptionConfiguration)).To(Succeed())
+
+			actualSecretETCDEncryptionConfiguration := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "apiserver-encryption-config", Namespace: namespace}}
+			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(actualSecretETCDEncryptionConfiguration), actualSecretETCDEncryptionConfiguration)).To(BeNotFoundError())
+
+			Expect(ReconcileSecretETCDEncryptionConfiguration(ctx, fakeClient, fakeSecretManager, config, actualSecretETCDEncryptionConfiguration, secretNameETCDEncryptionKey, encryptionRoleLabel)).To(Succeed())
+
+			Expect(actualSecretETCDEncryptionConfiguration).To(Equal(&corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      expectedSecretETCDEncryptionConfiguration.Name,
+					Namespace: expectedSecretETCDEncryptionConfiguration.Namespace,
+					Labels: map[string]string{
+						"resources.gardener.cloud/garbage-collectable-reference": "true",
+						"role": encryptionRoleLabel,
+					},
+					ResourceVersion: "1",
+				},
+				Immutable: pointer.Bool(true),
+				Data:      expectedSecretETCDEncryptionConfiguration.Data,
+			}))
+
+			By("Deploy again and ensure that labels are still present")
+			actualSecretETCDEncryptionConfiguration.ResourceVersion = ""
+			Expect(ReconcileSecretETCDEncryptionConfiguration(ctx, fakeClient, fakeSecretManager, config, actualSecretETCDEncryptionConfiguration, secretNameETCDEncryptionKey, encryptionRoleLabel)).To(Succeed())
+			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(expectedSecretETCDEncryptionConfiguration), actualSecretETCDEncryptionConfiguration)).To(Succeed())
+			Expect(actualSecretETCDEncryptionConfiguration.Labels).To(Equal(map[string]string{
+				"resources.gardener.cloud/garbage-collectable-reference": "true",
+				"role": encryptionRoleLabel,
+			}))
+
+			By("Verify encryption key secret")
+			secretList := &corev1.SecretList{}
+			Expect(fakeClient.List(ctx, secretList, client.InNamespace(namespace), client.MatchingLabels{
+				"name":       secretNameETCDEncryptionKey,
+				"managed-by": "secrets-manager",
+			})).To(Succeed())
+			Expect(secretList.Items).To(HaveLen(1))
+			Expect(secretList.Items[0].Labels).To(HaveKeyWithValue("persist", "true"))
+		})
+
+		DescribeTable("successfully deploy the ETCD encryption configuration secret resource w/ old key",
+			func(encryptWithCurrentKey bool) {
+				config.EncryptWithCurrentKey = encryptWithCurrentKey
+
+				oldKeyName, oldKeySecret := "key-old", "old-secret"
+				Expect(fakeClient.Create(ctx, &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      secretNameETCDEncryptionKey + "-old",
+						Namespace: namespace,
+					},
+					Data: map[string][]byte{
+						"key":    []byte(oldKeyName),
+						"secret": []byte(oldKeySecret),
+					},
+				})).To(Succeed())
+
+				etcdEncryptionConfiguration := `apiVersion: apiserver.config.k8s.io/v1
+kind: EncryptionConfiguration
+resources:
+- providers:
+  - aescbc:
+      keys:`
+
+				if encryptWithCurrentKey {
+					etcdEncryptionConfiguration += `
+      - name: key-62135596800
+        secret: ________________________________
+      - name: ` + oldKeyName + `
+        secret: ` + oldKeySecret
+				} else {
+					etcdEncryptionConfiguration += `
+      - name: ` + oldKeyName + `
+        secret: ` + oldKeySecret + `
+      - name: key-62135596800
+        secret: ________________________________`
+				}
+
+				etcdEncryptionConfiguration += `
+  - identity: {}
+  resources:
+  - foo
+`
+
+				expectedSecretETCDEncryptionConfiguration := &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{Name: "apiserver-encryption-config", Namespace: namespace},
+					Data:       map[string][]byte{"encryption-configuration.yaml": []byte(etcdEncryptionConfiguration)},
+				}
+				Expect(kubernetesutils.MakeUnique(expectedSecretETCDEncryptionConfiguration)).To(Succeed())
+
+				actualSecretETCDEncryptionConfiguration := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "apiserver-encryption-config", Namespace: namespace}}
+				Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(expectedSecretETCDEncryptionConfiguration), actualSecretETCDEncryptionConfiguration)).To(BeNotFoundError())
+
+				Expect(ReconcileSecretETCDEncryptionConfiguration(ctx, fakeClient, fakeSecretManager, config, actualSecretETCDEncryptionConfiguration, secretNameETCDEncryptionKey, encryptionRoleLabel)).To(Succeed())
+
+				Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(expectedSecretETCDEncryptionConfiguration), actualSecretETCDEncryptionConfiguration)).To(Succeed())
+				Expect(actualSecretETCDEncryptionConfiguration).To(Equal(&corev1.Secret{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: corev1.SchemeGroupVersion.String(),
+						Kind:       "Secret",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      expectedSecretETCDEncryptionConfiguration.Name,
+						Namespace: expectedSecretETCDEncryptionConfiguration.Namespace,
+						Labels: map[string]string{
+							"resources.gardener.cloud/garbage-collectable-reference": "true",
+							"role": encryptionRoleLabel,
+						},
+						ResourceVersion: "1",
+					},
+					Immutable: pointer.Bool(true),
+					Data:      expectedSecretETCDEncryptionConfiguration.Data,
+				}))
+
+				secretList := &corev1.SecretList{}
+				Expect(fakeClient.List(ctx, secretList, client.InNamespace(namespace), client.MatchingLabels{
+					"name":       secretNameETCDEncryptionKey,
+					"managed-by": "secrets-manager",
+				})).To(Succeed())
+				Expect(secretList.Items).To(HaveLen(1))
+				Expect(secretList.Items[0].Labels).To(HaveKeyWithValue("persist", "true"))
+			},
+
+			Entry("encrypting with current", true),
+			Entry("encrypting with old", false),
+		)
+	})
+})

--- a/pkg/component/apiserver/types.go
+++ b/pkg/component/apiserver/types.go
@@ -1,0 +1,119 @@
+// Copyright 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package apiserver
+
+import (
+	"github.com/Masterminds/semver"
+	corev1 "k8s.io/api/core/v1"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	"github.com/gardener/gardener/pkg/component"
+)
+
+// Interface contains functions for a deployer for an API server built with k8s.io/apiserver.
+type Interface interface {
+	component.DeployWaiter
+	// GetAutoscalingReplicas gets the Replicas field in the AutoscalingConfig of the Values of the deployer.
+	GetAutoscalingReplicas() *int32
+	// SetAutoscalingAPIServerResources sets the APIServerResources field in the AutoscalingConfig of the Values of the
+	// deployer.
+	SetAutoscalingAPIServerResources(corev1.ResourceRequirements)
+	// SetAutoscalingReplicas sets the Replicas field in the AutoscalingConfig of the Values of the deployer.
+	SetAutoscalingReplicas(*int32)
+	// SetETCDEncryptionConfig sets the ETCDEncryptionConfig field in the Values of the deployer.
+	SetETCDEncryptionConfig(ETCDEncryptionConfig)
+}
+
+// Values contains configuration values for the API server resources.
+type Values struct {
+	// EnabledAdmissionPlugins is the list of admission plugins that should be enabled with configuration for the API server.
+	EnabledAdmissionPlugins []AdmissionPluginConfig
+	// DisabledAdmissionPlugins is the list of admission plugins that should be disabled for the API server.
+	DisabledAdmissionPlugins []gardencorev1beta1.AdmissionPlugin
+	// Audit contains information for configuring audit settings for the API server.
+	Audit *AuditConfig
+	// Autoscaling contains information for configuring autoscaling settings for the API server.
+	Autoscaling AutoscalingConfig
+	// ETCDEncryption contains configuration for the encryption of resources in etcd.
+	ETCDEncryption ETCDEncryptionConfig
+	// FeatureGates is the set of feature gates.
+	FeatureGates map[string]bool
+	// Logging contains configuration settings for the log and access logging verbosity
+	Logging *gardencorev1beta1.KubeAPIServerLogging
+	// Requests contains configuration for the API server requests.
+	Requests *gardencorev1beta1.KubeAPIServerRequests
+	// RuntimeVersion is the Kubernetes version of the runtime cluster.
+	RuntimeVersion *semver.Version
+	// WatchCacheSizes are the configured sizes for the watch caches.
+	WatchCacheSizes *gardencorev1beta1.WatchCacheSizes
+}
+
+// AdmissionPluginConfig contains information about a specific admission plugin and its corresponding configuration.
+type AdmissionPluginConfig struct {
+	gardencorev1beta1.AdmissionPlugin
+	// Kubeconfig is an optional API server the configuration of this admission plugins. The configs for some
+	// admission plugins like `ImagePolicyWebhook` or `ValidatingAdmissionWebhook` can take a reference to a API server
+	Kubeconfig []byte
+}
+
+// AuditConfig contains information for configuring audit settings for the API server.
+type AuditConfig struct {
+	// Policy is the audit policy document in YAML format.
+	Policy *string
+	// Webhook contains configuration for the audit webhook.
+	Webhook *AuditWebhook
+}
+
+// AuditWebhook contains configuration for the audit webhook.
+type AuditWebhook struct {
+	// Kubeconfig contains the API server file that defines the audit webhook configuration.
+	Kubeconfig []byte
+	// BatchMaxSize is the maximum size of a batch.
+	BatchMaxSize *int32
+	// Version is the API group and version used for serializing audit events written to webhook.
+	Version *string
+}
+
+// AutoscalingConfig contains information for configuring autoscaling settings for the API server.
+type AutoscalingConfig struct {
+	// APIServerResources are the resource requirements for the API server container.
+	APIServerResources corev1.ResourceRequirements
+	// HVPAEnabled states whether an HVPA object shall be deployed. If false, HPA and VPA will be used.
+	HVPAEnabled bool
+	// Replicas is the number of pod replicas for the API server.
+	Replicas *int32
+	// MinReplicas are the minimum Replicas for horizontal autoscaling.
+	MinReplicas int32
+	// MaxReplicas are the maximum Replicas for horizontal autoscaling.
+	MaxReplicas int32
+	// UseMemoryMetricForHvpaHPA states whether the memory metric shall be used when the HPA is configured in an HVPA
+	// resource.
+	UseMemoryMetricForHvpaHPA bool
+	// ScaleDownDisabledForHvpa states whether scale-down shall be disabled when HPA or VPA are configured in an HVPA
+	// resource.
+	ScaleDownDisabledForHvpa bool
+}
+
+// ETCDEncryptionConfig contains configuration for the encryption of resources in etcd.
+type ETCDEncryptionConfig struct {
+	// RotationPhase specifies the credentials rotation phase of the encryption key.
+	RotationPhase gardencorev1beta1.CredentialsRotationPhase
+	// EncryptWithCurrentKey specifies whether the current encryption key should be used for encryption. If this is
+	// false and if there are two keys then the old key will be used for encryption while the current/new key will only
+	// be used for decryption.
+	EncryptWithCurrentKey bool
+	// Resources are the resources which should be encrypted.
+	Resources []string
+}

--- a/pkg/component/apiserver/types.go
+++ b/pkg/component/apiserver/types.go
@@ -63,8 +63,8 @@ type Values struct {
 // AdmissionPluginConfig contains information about a specific admission plugin and its corresponding configuration.
 type AdmissionPluginConfig struct {
 	gardencorev1beta1.AdmissionPlugin
-	// Kubeconfig is an optional API server the configuration of this admission plugins. The configs for some
-	// admission plugins like `ImagePolicyWebhook` or `ValidatingAdmissionWebhook` can take a reference to a API server
+	// Kubeconfig is an optional API server connection configuration of this admission plugin. The configs for some
+	// admission plugins like `ImagePolicyWebhook` or `ValidatingAdmissionWebhook` can take a reference to an API server
 	Kubeconfig []byte
 }
 

--- a/pkg/component/gardenerapiserver/apiservice.go
+++ b/pkg/component/gardenerapiserver/apiservice.go
@@ -1,0 +1,45 @@
+// Copyright 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gardenerapiserver
+
+import (
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	apiregistrationv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
+
+	"github.com/gardener/gardener/pkg/utils/secrets"
+)
+
+func (g *gardenerAPIServer) apiService(secretCAGardener *corev1.Secret, group, version string) *apiregistrationv1.APIService {
+	return &apiregistrationv1.APIService{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   fmt.Sprintf("%s.%s", version, group),
+			Labels: GetLabels(),
+		},
+		Spec: apiregistrationv1.APIServiceSpec{
+			CABundle: secretCAGardener.Data[secrets.DataKeyCertificateBundle],
+			Service: &apiregistrationv1.ServiceReference{
+				Name:      serviceName,
+				Namespace: metav1.NamespaceSystem,
+			},
+			Group:                group,
+			Version:              version,
+			GroupPriorityMinimum: 10000,
+			VersionPriority:      20,
+		},
+	}
+}

--- a/pkg/component/gardenerapiserver/configmaps.go
+++ b/pkg/component/gardenerapiserver/configmaps.go
@@ -1,0 +1,19 @@
+// Copyright 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gardenerapiserver
+
+const (
+	configMapAuditPolicyNamePrefix = "gardener-apiserver-audit-policy-config"
+)

--- a/pkg/component/gardenerapiserver/configmaps.go
+++ b/pkg/component/gardenerapiserver/configmaps.go
@@ -14,6 +14,16 @@
 
 package gardenerapiserver
 
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
 const (
 	configMapAuditPolicyNamePrefix = "gardener-apiserver-audit-policy-config"
+	configMapAdmissionNamePrefix   = "gardener-apiserver-admission-config"
 )
+
+func (g *gardenerAPIServer) emptyConfigMap(name string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: g.namespace}}
+}

--- a/pkg/component/gardenerapiserver/deployment.go
+++ b/pkg/component/gardenerapiserver/deployment.go
@@ -16,4 +16,6 @@ package gardenerapiserver
 
 const (
 	secretNameServer = "gardener-apiserver"
+
+	port = 8443
 )

--- a/pkg/component/gardenerapiserver/deployment.go
+++ b/pkg/component/gardenerapiserver/deployment.go
@@ -14,9 +14,139 @@
 
 package gardenerapiserver
 
+import (
+	"fmt"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/utils/pointer"
+
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
+	"github.com/gardener/gardener/pkg/component/apiserver"
+	etcdconstants "github.com/gardener/gardener/pkg/component/etcd/constants"
+	kubeapiserverconstants "github.com/gardener/gardener/pkg/component/kubeapiserver/constants"
+	"github.com/gardener/gardener/pkg/resourcemanager/controller/garbagecollector/references"
+	"github.com/gardener/gardener/pkg/utils"
+	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
+)
+
 const (
 	secretNameServer = "gardener-apiserver"
 	containerName    = "gardener-apiserver"
 
 	port = 8443
 )
+
+func (g *gardenerAPIServer) deployment(
+	secretCAETCD *corev1.Secret,
+	secretETCDClient *corev1.Secret,
+	secretGenericTokenKubeconfig *corev1.Secret,
+	secretServer *corev1.Secret,
+	secretAdmissionKubeconfigs *corev1.Secret,
+	secretETCDEncryptionConfiguration *corev1.Secret,
+	secretAuditWebhookKubeconfig *corev1.Secret,
+	secretVirtualGardenAccess *gardenerutils.AccessSecret,
+	configMapAuditPolicy *corev1.ConfigMap,
+	configMapAdmissionConfigs *corev1.ConfigMap,
+) *appsv1.Deployment {
+	deployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      DeploymentName,
+			Namespace: g.namespace,
+			Labels: utils.MergeStringMaps(GetLabels(), map[string]string{
+				resourcesv1alpha1.HighAvailabilityConfigType: resourcesv1alpha1.HighAvailabilityConfigTypeServer,
+			}),
+		},
+		Spec: appsv1.DeploymentSpec{
+			MinReadySeconds:      30,
+			RevisionHistoryLimit: pointer.Int32(2),
+			Replicas:             g.values.Autoscaling.Replicas,
+			Selector:             &metav1.LabelSelector{MatchLabels: GetLabels()},
+			Strategy: appsv1.DeploymentStrategy{
+				Type: appsv1.RollingUpdateDeploymentStrategyType,
+				RollingUpdate: &appsv1.RollingUpdateDeployment{
+					MaxSurge:       utils.IntStrPtrFromInt(1),
+					MaxUnavailable: utils.IntStrPtrFromInt(0),
+				},
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: utils.MergeStringMaps(GetLabels(), map[string]string{
+						v1beta1constants.LabelNetworkPolicyToDNS:                                                                                                   v1beta1constants.LabelNetworkPolicyAllowed,
+						v1beta1constants.LabelNetworkPolicyToPublicNetworks:                                                                                        v1beta1constants.LabelNetworkPolicyAllowed,
+						v1beta1constants.LabelNetworkPolicyToPrivateNetworks:                                                                                       v1beta1constants.LabelNetworkPolicyAllowed,
+						"networking.resources.gardener.cloud/to-" + v1beta1constants.LabelNetworkPolicyWebhookTargets:                                              v1beta1constants.LabelNetworkPolicyAllowed,
+						gardenerutils.NetworkPolicyLabel("virtual-garden-"+etcdconstants.ServiceName(v1beta1constants.ETCDRoleMain), etcdconstants.PortEtcdClient): v1beta1constants.LabelNetworkPolicyAllowed,
+						gardenerutils.NetworkPolicyLabel("virtual-garden-"+v1beta1constants.DeploymentNameKubeAPIServer, kubeapiserverconstants.Port):              v1beta1constants.LabelNetworkPolicyAllowed,
+					}),
+				},
+				Spec: corev1.PodSpec{
+					AutomountServiceAccountToken: pointer.Bool(false),
+					PriorityClassName:            v1beta1constants.PriorityClassNameGardenSystem500,
+					Containers: []corev1.Container{{
+						Name:            containerName,
+						Image:           g.values.Image,
+						ImagePullPolicy: corev1.PullIfNotPresent,
+						Args: []string{
+							"--authorization-always-allow-paths=/healthz",
+							"--cluster-identity=" + g.values.ClusterIdentity,
+							"--authentication-kubeconfig=" + gardenerutils.PathGenericKubeconfig,
+							"--authorization-kubeconfig=" + gardenerutils.PathGenericKubeconfig,
+							"--kubeconfig=" + gardenerutils.PathGenericKubeconfig,
+							"--log-level=" + g.values.LogLevel,
+							"--log-format=" + g.values.LogFormat,
+							fmt.Sprintf("--secure-port=%d", port),
+						},
+						Ports: []corev1.ContainerPort{{
+							Name:          "https",
+							ContainerPort: port,
+							Protocol:      corev1.ProtocolTCP,
+						}},
+						Resources: g.values.Autoscaling.APIServerResources,
+						LivenessProbe: &corev1.Probe{
+							ProbeHandler: corev1.ProbeHandler{
+								HTTPGet: &corev1.HTTPGetAction{
+									Path:   "/livez",
+									Scheme: corev1.URISchemeHTTPS,
+									Port:   intstr.FromInt(port),
+								},
+							},
+							SuccessThreshold:    1,
+							FailureThreshold:    3,
+							InitialDelaySeconds: 15,
+							PeriodSeconds:       10,
+							TimeoutSeconds:      15,
+						},
+						ReadinessProbe: &corev1.Probe{
+							ProbeHandler: corev1.ProbeHandler{
+								HTTPGet: &corev1.HTTPGetAction{
+									Path:   "/readyz",
+									Scheme: corev1.URISchemeHTTPS,
+									Port:   intstr.FromInt(port),
+								},
+							},
+							SuccessThreshold:    1,
+							FailureThreshold:    3,
+							InitialDelaySeconds: 15,
+							PeriodSeconds:       10,
+							TimeoutSeconds:      15,
+						},
+					}},
+				},
+			},
+		},
+	}
+
+	apiserver.InjectDefaultSettings(deployment, "virtual-garden-", g.values.Values, nil, secretCAETCD, secretETCDClient, secretServer)
+	apiserver.InjectAuditSettings(deployment, configMapAuditPolicy, secretAuditWebhookKubeconfig, g.values.Audit)
+	apiserver.InjectAdmissionSettings(deployment, configMapAdmissionConfigs, secretAdmissionKubeconfigs, g.values.Values)
+	apiserver.InjectEncryptionSettings(deployment, secretETCDEncryptionConfiguration)
+
+	utilruntime.Must(gardenerutils.InjectGenericKubeconfig(deployment, secretGenericTokenKubeconfig.Name, secretVirtualGardenAccess.Secret.Name))
+	utilruntime.Must(references.InjectAnnotations(deployment))
+	return deployment
+}

--- a/pkg/component/gardenerapiserver/deployment.go
+++ b/pkg/component/gardenerapiserver/deployment.go
@@ -1,0 +1,19 @@
+// Copyright 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gardenerapiserver
+
+const (
+	secretNameServer = "gardener-apiserver"
+)

--- a/pkg/component/gardenerapiserver/deployment.go
+++ b/pkg/component/gardenerapiserver/deployment.go
@@ -16,6 +16,7 @@ package gardenerapiserver
 
 const (
 	secretNameServer = "gardener-apiserver"
+	containerName    = "gardener-apiserver"
 
 	port = 8443
 )

--- a/pkg/component/gardenerapiserver/deployment.go
+++ b/pkg/component/gardenerapiserver/deployment.go
@@ -35,8 +35,8 @@ import (
 )
 
 const (
-	secretNameServer = "gardener-apiserver"
-	containerName    = "gardener-apiserver"
+	secretNameServerCert = "gardener-apiserver"
+	containerName        = "gardener-apiserver"
 
 	port = 8443
 )

--- a/pkg/component/gardenerapiserver/endpoints.go
+++ b/pkg/component/gardenerapiserver/endpoints.go
@@ -1,0 +1,39 @@
+// Copyright 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gardenerapiserver
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func (g *gardenerAPIServer) endpoints(clusterIP string) *corev1.Endpoints {
+	return &corev1.Endpoints{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      serviceName,
+			Namespace: metav1.NamespaceSystem,
+			Labels:    GetLabels(),
+		},
+		Subsets: []corev1.EndpointSubset{{
+			Ports: []corev1.EndpointPort{{
+				Port:     servicePort,
+				Protocol: corev1.ProtocolTCP,
+			}},
+			Addresses: []corev1.EndpointAddress{{
+				IP: clusterIP,
+			}},
+		}},
+	}
+}

--- a/pkg/component/gardenerapiserver/gardener_apiserver.go
+++ b/pkg/component/gardenerapiserver/gardener_apiserver.go
@@ -82,6 +82,7 @@ func (g *gardenerAPIServer) Deploy(ctx context.Context) error {
 		runtimeRegistry = managedresources.NewRegistry(operatorclient.RuntimeScheme, operatorclient.RuntimeCodec, operatorclient.RuntimeSerializer)
 
 		secretETCDEncryptionConfiguration = g.emptySecret(v1beta1constants.SecretNamePrefixGardenerETCDEncryptionConfiguration)
+		secretAuditWebhookKubeconfig      = g.emptySecret(secretAuditWebhookKubeconfigNamePrefix)
 		virtualGardenAccessSecret         = g.newVirtualGardenAccessSecret()
 	)
 
@@ -95,6 +96,10 @@ func (g *gardenerAPIServer) Deploy(ctx context.Context) error {
 	}
 
 	if err := g.reconcileSecretETCDEncryptionConfiguration(ctx, secretETCDEncryptionConfiguration); err != nil {
+		return err
+	}
+
+	if err := apiserver.ReconcileSecretAuditWebhookKubeconfig(ctx, g.client, secretAuditWebhookKubeconfig, g.values.Audit); err != nil {
 		return err
 	}
 

--- a/pkg/component/gardenerapiserver/gardener_apiserver.go
+++ b/pkg/component/gardenerapiserver/gardener_apiserver.go
@@ -121,6 +121,7 @@ func (g *gardenerAPIServer) Deploy(ctx context.Context) error {
 	runtimeResources, err := runtimeRegistry.AddAllAndSerialize(
 		g.podDisruptionBudget(),
 		g.service(),
+		g.verticalPodAutoscaler(),
 	)
 	if err != nil {
 		return err

--- a/pkg/component/gardenerapiserver/gardener_apiserver.go
+++ b/pkg/component/gardenerapiserver/gardener_apiserver.go
@@ -183,6 +183,10 @@ func (g *gardenerAPIServer) Deploy(ctx context.Context) error {
 		g.apiService(secretCAGardener, settingsv1alpha1.SchemeGroupVersion.Group, settingsv1alpha1.SchemeGroupVersion.Version),
 		g.service(),
 		g.endpoints(serviceRuntime.Spec.ClusterIP),
+		g.clusterRole(),
+		g.clusterRoleBinding(secretVirtualGardenAccess.ServiceAccountName),
+		g.clusterRoleBindingAuthDelegation(secretVirtualGardenAccess.ServiceAccountName),
+		g.roleBindingAuthReader(secretVirtualGardenAccess.ServiceAccountName),
 	)
 	if err != nil {
 		return err

--- a/pkg/component/gardenerapiserver/gardener_apiserver.go
+++ b/pkg/component/gardenerapiserver/gardener_apiserver.go
@@ -81,6 +81,7 @@ func (g *gardenerAPIServer) Deploy(ctx context.Context) error {
 	var (
 		runtimeRegistry = managedresources.NewRegistry(operatorclient.RuntimeScheme, operatorclient.RuntimeCodec, operatorclient.RuntimeSerializer)
 
+		secretAdmissionKubeconfigs        = g.emptySecret(secretAdmissionKubeconfigsNamePrefix)
 		secretETCDEncryptionConfiguration = g.emptySecret(v1beta1constants.SecretNamePrefixGardenerETCDEncryptionConfiguration)
 		secretAuditWebhookKubeconfig      = g.emptySecret(secretAuditWebhookKubeconfigNamePrefix)
 		virtualGardenAccessSecret         = g.newVirtualGardenAccessSecret()
@@ -96,6 +97,10 @@ func (g *gardenerAPIServer) Deploy(ctx context.Context) error {
 	}
 
 	if err := g.reconcileSecretETCDEncryptionConfiguration(ctx, secretETCDEncryptionConfiguration); err != nil {
+		return err
+	}
+
+	if err := apiserver.ReconcileSecretAdmissionKubeconfigs(ctx, g.client, secretAdmissionKubeconfigs, g.values.Values); err != nil {
 		return err
 	}
 

--- a/pkg/component/gardenerapiserver/gardener_apiserver.go
+++ b/pkg/component/gardenerapiserver/gardener_apiserver.go
@@ -34,6 +34,9 @@ import (
 )
 
 const (
+	// DeploymentName is the name of the deployment.
+	DeploymentName = "gardener-apiserver"
+
 	managedResourceNameRuntime = "gardener-apiserver-runtime"
 	managedResourceNameVirtual = "gardener-apiserver-virtual"
 )
@@ -77,6 +80,11 @@ func (g *gardenerAPIServer) Deploy(ctx context.Context) error {
 	var (
 		runtimeRegistry = managedresources.NewRegistry(operatorclient.RuntimeScheme, operatorclient.RuntimeCodec, operatorclient.RuntimeSerializer)
 	)
+
+	secretServer, err := g.reconcileSecretServer(ctx)
+	if err != nil {
+		return err
+	}
 
 	runtimeResources, err := runtimeRegistry.AddAllAndSerialize()
 	if err != nil {

--- a/pkg/component/gardenerapiserver/gardener_apiserver.go
+++ b/pkg/component/gardenerapiserver/gardener_apiserver.go
@@ -116,7 +116,9 @@ func (g *gardenerAPIServer) Deploy(ctx context.Context) error {
 		return err
 	}
 
-	runtimeResources, err := runtimeRegistry.AddAllAndSerialize()
+	runtimeResources, err := runtimeRegistry.AddAllAndSerialize(
+		g.podDisruptionBudget(),
+	)
 	if err != nil {
 		return err
 	}

--- a/pkg/component/gardenerapiserver/gardener_apiserver.go
+++ b/pkg/component/gardenerapiserver/gardener_apiserver.go
@@ -58,6 +58,8 @@ type Values struct {
 	apiserver.Values
 	// Image is the container images used for the gardener-apiserver pods.
 	Image string
+	// TopologyAwareRoutingEnabled specifies where the topology-aware feature is enabled.
+	TopologyAwareRoutingEnabled bool
 }
 
 // New creates a new instance of DeployWaiter for the gardener-apiserver.
@@ -118,6 +120,7 @@ func (g *gardenerAPIServer) Deploy(ctx context.Context) error {
 
 	runtimeResources, err := runtimeRegistry.AddAllAndSerialize(
 		g.podDisruptionBudget(),
+		g.service(),
 	)
 	if err != nil {
 		return err

--- a/pkg/component/gardenerapiserver/gardener_apiserver.go
+++ b/pkg/component/gardenerapiserver/gardener_apiserver.go
@@ -79,10 +79,16 @@ type gardenerAPIServer struct {
 func (g *gardenerAPIServer) Deploy(ctx context.Context) error {
 	var (
 		runtimeRegistry = managedresources.NewRegistry(operatorclient.RuntimeScheme, operatorclient.RuntimeCodec, operatorclient.RuntimeSerializer)
+
+		secretETCDEncryptionConfiguration = g.emptySecret(v1beta1constants.SecretNamePrefixGardenerETCDEncryptionConfiguration)
 	)
 
 	secretServer, err := g.reconcileSecretServer(ctx)
 	if err != nil {
+		return err
+	}
+
+	if err := g.reconcileSecretETCDEncryptionConfiguration(ctx, secretETCDEncryptionConfiguration); err != nil {
 		return err
 	}
 
@@ -182,6 +188,10 @@ func (g *gardenerAPIServer) waitUntilRuntimeManagedResourceHealthyAndNotProgress
 
 		return retry.Ok()
 	})
+}
+
+func (g *gardenerAPIServer) emptySecret(name string) *corev1.Secret {
+	return &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: g.namespace}}
 }
 
 func (g *gardenerAPIServer) GetValues() Values {

--- a/pkg/component/gardenerapiserver/gardener_apiserver.go
+++ b/pkg/component/gardenerapiserver/gardener_apiserver.go
@@ -1,0 +1,205 @@
+// Copyright 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gardenerapiserver
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
+	"github.com/gardener/gardener/pkg/component/apiserver"
+	operatorclient "github.com/gardener/gardener/pkg/operator/client"
+	"github.com/gardener/gardener/pkg/utils/kubernetes/health"
+	"github.com/gardener/gardener/pkg/utils/managedresources"
+	"github.com/gardener/gardener/pkg/utils/retry"
+	secretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager"
+)
+
+const (
+	managedResourceNameRuntime = "gardener-apiserver-runtime"
+	managedResourceNameVirtual = "gardener-apiserver-virtual"
+)
+
+// TimeoutWaitForManagedResource is the timeout used while waiting for the ManagedResources to become healthy or
+// deleted.
+var TimeoutWaitForManagedResource = 5 * time.Minute
+
+// Interface contains functions for a gardener-apiserver deployer.
+type Interface interface {
+	apiserver.Interface
+	// GetValues returns the current configuration values of the deployer.
+	GetValues() Values
+}
+
+// Values contains configuration values for the gardener-apiserver resources.
+type Values struct {
+	apiserver.Values
+	// Image is the container images used for the gardener-apiserver pods.
+	Image string
+}
+
+// New creates a new instance of DeployWaiter for the gardener-apiserver.
+func New(client client.Client, namespace string, secretsManager secretsmanager.Interface, values Values) Interface {
+	return &gardenerAPIServer{
+		client:         client,
+		namespace:      namespace,
+		secretsManager: secretsManager,
+		values:         values,
+	}
+}
+
+type gardenerAPIServer struct {
+	client         client.Client
+	namespace      string
+	secretsManager secretsmanager.Interface
+	values         Values
+}
+
+func (g *gardenerAPIServer) Deploy(ctx context.Context) error {
+	var (
+		runtimeRegistry = managedresources.NewRegistry(operatorclient.RuntimeScheme, operatorclient.RuntimeCodec, operatorclient.RuntimeSerializer)
+	)
+
+	runtimeResources, err := runtimeRegistry.AddAllAndSerialize()
+	if err != nil {
+		return err
+	}
+
+	timeoutCtx, cancel := context.WithTimeout(ctx, TimeoutWaitForManagedResource)
+	defer cancel()
+
+	if err := managedresources.CreateForSeed(ctx, g.client, g.namespace, managedResourceNameRuntime, false, runtimeResources); err != nil {
+		return err
+	}
+	if err := managedresources.WaitUntilHealthy(timeoutCtx, g.client, g.namespace, managedResourceNameRuntime); err != nil {
+		return err
+	}
+
+	var (
+		virtualRegistry = managedresources.NewRegistry(operatorclient.VirtualScheme, operatorclient.VirtualCodec, operatorclient.VirtualSerializer)
+	)
+
+	virtualResources, err := virtualRegistry.AddAllAndSerialize()
+	if err != nil {
+		return err
+	}
+
+	timeoutCtx, cancel = context.WithTimeout(ctx, TimeoutWaitForManagedResource)
+	defer cancel()
+
+	if err := managedresources.CreateForShoot(ctx, g.client, g.namespace, managedResourceNameVirtual, managedresources.LabelValueGardener, false, virtualResources); err != nil {
+		return err
+	}
+	return managedresources.WaitUntilHealthy(timeoutCtx, g.client, g.namespace, managedResourceNameVirtual)
+}
+
+func (g *gardenerAPIServer) Destroy(ctx context.Context) error {
+	timeoutCtx, cancel := context.WithTimeout(ctx, TimeoutWaitForManagedResource)
+	defer cancel()
+
+	if err := managedresources.DeleteForShoot(ctx, g.client, g.namespace, managedResourceNameVirtual); err != nil {
+		return err
+	}
+	if err := managedresources.WaitUntilDeleted(timeoutCtx, g.client, g.namespace, managedResourceNameVirtual); err != nil {
+		return err
+	}
+
+	timeoutCtx, cancel = context.WithTimeout(ctx, TimeoutWaitForManagedResource)
+	defer cancel()
+
+	if err := managedresources.DeleteForSeed(ctx, g.client, g.namespace, managedResourceNameRuntime); err != nil {
+		return err
+	}
+	return managedresources.WaitUntilDeleted(timeoutCtx, g.client, g.namespace, managedResourceNameRuntime)
+}
+
+func (g *gardenerAPIServer) Wait(ctx context.Context) error {
+	timeoutCtx, cancel := context.WithTimeout(ctx, TimeoutWaitForManagedResource)
+	defer cancel()
+
+	if err := g.waitUntilRuntimeManagedResourceHealthyAndNotProgressing(ctx); err != nil {
+		return err
+	}
+	return managedresources.WaitUntilHealthy(timeoutCtx, g.client, g.namespace, managedResourceNameVirtual)
+}
+
+func (g *gardenerAPIServer) WaitCleanup(ctx context.Context) error {
+	timeoutCtx, cancel := context.WithTimeout(ctx, TimeoutWaitForManagedResource)
+	defer cancel()
+
+	if err := managedresources.WaitUntilDeleted(timeoutCtx, g.client, g.namespace, managedResourceNameVirtual); err != nil {
+		return err
+	}
+	return managedresources.WaitUntilDeleted(timeoutCtx, g.client, g.namespace, managedResourceNameRuntime)
+}
+
+func (g *gardenerAPIServer) waitUntilRuntimeManagedResourceHealthyAndNotProgressing(ctx context.Context) error {
+	obj := &resourcesv1alpha1.ManagedResource{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      managedResourceNameRuntime,
+			Namespace: g.namespace,
+		},
+	}
+
+	return retry.Until(ctx, managedresources.IntervalWait, func(ctx context.Context) (done bool, err error) {
+		if err := g.client.Get(ctx, client.ObjectKeyFromObject(obj), obj); err != nil {
+			return retry.SevereError(err)
+		}
+
+		if err := health.CheckManagedResource(obj); err != nil {
+			return retry.MinorError(fmt.Errorf("managed resource %s is unhealthy", client.ObjectKeyFromObject(obj)))
+		}
+
+		if err := health.CheckManagedResourceProgressing(obj); err != nil {
+			return retry.MinorError(fmt.Errorf("managed resource %s is still progressing", client.ObjectKeyFromObject(obj)))
+		}
+
+		return retry.Ok()
+	})
+}
+
+func (g *gardenerAPIServer) GetValues() Values {
+	return g.values
+}
+
+func (g *gardenerAPIServer) GetAutoscalingReplicas() *int32 {
+	return g.values.Autoscaling.Replicas
+}
+
+func (g *gardenerAPIServer) SetAutoscalingAPIServerResources(resources corev1.ResourceRequirements) {
+	g.values.Autoscaling.APIServerResources = resources
+}
+
+func (g *gardenerAPIServer) SetAutoscalingReplicas(replicas *int32) {
+	g.values.Autoscaling.Replicas = replicas
+}
+
+func (g *gardenerAPIServer) SetETCDEncryptionConfig(config apiserver.ETCDEncryptionConfig) {
+	g.values.ETCDEncryption = config
+}
+
+// GetLabels returns the labels for the gardener-apiserver.
+func GetLabels() map[string]string {
+	return map[string]string{
+		v1beta1constants.LabelApp:  v1beta1constants.LabelGardener,
+		v1beta1constants.LabelRole: v1beta1constants.LabelAPIServer,
+	}
+}

--- a/pkg/component/gardenerapiserver/gardener_apiserver.go
+++ b/pkg/component/gardenerapiserver/gardener_apiserver.go
@@ -229,9 +229,13 @@ func (g *gardenerAPIServer) Wait(ctx context.Context) error {
 	timeoutCtx, cancel := context.WithTimeout(ctx, TimeoutWaitForManagedResource)
 	defer cancel()
 
-	if err := g.waitUntilRuntimeManagedResourceHealthyAndNotProgressing(ctx); err != nil {
+	if err := g.waitUntilRuntimeManagedResourceHealthyAndNotProgressing(timeoutCtx); err != nil {
 		return err
 	}
+
+	timeoutCtx, cancel = context.WithTimeout(ctx, TimeoutWaitForManagedResource)
+	defer cancel()
+
 	return managedresources.WaitUntilHealthy(timeoutCtx, g.client, g.namespace, managedResourceNameVirtual)
 }
 
@@ -242,6 +246,10 @@ func (g *gardenerAPIServer) WaitCleanup(ctx context.Context) error {
 	if err := managedresources.WaitUntilDeleted(timeoutCtx, g.client, g.namespace, managedResourceNameVirtual); err != nil {
 		return err
 	}
+
+	timeoutCtx, cancel = context.WithTimeout(ctx, TimeoutWaitForManagedResource)
+	defer cancel()
+
 	return managedresources.WaitUntilDeleted(timeoutCtx, g.client, g.namespace, managedResourceNameRuntime)
 }
 

--- a/pkg/component/gardenerapiserver/gardener_apiserver.go
+++ b/pkg/component/gardenerapiserver/gardener_apiserver.go
@@ -82,6 +82,7 @@ func (g *gardenerAPIServer) Deploy(ctx context.Context) error {
 		runtimeRegistry = managedresources.NewRegistry(operatorclient.RuntimeScheme, operatorclient.RuntimeCodec, operatorclient.RuntimeSerializer)
 
 		configMapAuditPolicy              = g.emptyConfigMap(configMapAuditPolicyNamePrefix)
+		configMapAdmissionConfigs         = g.emptyConfigMap(configMapAdmissionNamePrefix)
 		secretAdmissionKubeconfigs        = g.emptySecret(secretAdmissionKubeconfigsNamePrefix)
 		secretETCDEncryptionConfiguration = g.emptySecret(v1beta1constants.SecretNamePrefixGardenerETCDEncryptionConfiguration)
 		secretAuditWebhookKubeconfig      = g.emptySecret(secretAuditWebhookKubeconfigNamePrefix)
@@ -101,6 +102,9 @@ func (g *gardenerAPIServer) Deploy(ctx context.Context) error {
 		return err
 	}
 
+	if err := apiserver.ReconcileConfigMapAdmission(ctx, g.client, configMapAdmissionConfigs, g.values.Values); err != nil {
+		return err
+	}
 	if err := apiserver.ReconcileSecretAdmissionKubeconfigs(ctx, g.client, secretAdmissionKubeconfigs, g.values.Values); err != nil {
 		return err
 	}
@@ -212,14 +216,6 @@ func (g *gardenerAPIServer) waitUntilRuntimeManagedResourceHealthyAndNotProgress
 
 		return retry.Ok()
 	})
-}
-
-func (g *gardenerAPIServer) emptyConfigMap(name string) *corev1.ConfigMap {
-	return &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: g.namespace}}
-}
-
-func (g *gardenerAPIServer) emptySecret(name string) *corev1.Secret {
-	return &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: g.namespace}}
 }
 
 func (g *gardenerAPIServer) GetValues() Values {

--- a/pkg/component/gardenerapiserver/gardener_apiserver.go
+++ b/pkg/component/gardenerapiserver/gardener_apiserver.go
@@ -122,6 +122,7 @@ func (g *gardenerAPIServer) Deploy(ctx context.Context) error {
 		g.podDisruptionBudget(),
 		g.service(),
 		g.verticalPodAutoscaler(),
+		g.hvpa(),
 	)
 	if err != nil {
 		return err

--- a/pkg/component/gardenerapiserver/gardener_apiserver_suite_test.go
+++ b/pkg/component/gardenerapiserver/gardener_apiserver_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gardenerapiserver_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestGardenerAPIServer(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Component GardenerAPIServer Suite")
+}

--- a/pkg/component/gardenerapiserver/gardener_apiserver_test.go
+++ b/pkg/component/gardenerapiserver/gardener_apiserver_test.go
@@ -1491,7 +1491,7 @@ kubeConfigFile: /etc/kubernetes/admission-kubeconfigs/validatingadmissionwebhook
 				Expect(deployer.Deploy(ctx)).To(MatchError(ContainSubstring("is unhealthy")))
 			})
 
-			It("should fail because the virtual ManagedResource doesn't become healthy", func() {
+			It("should not fail when the virtual ManagedResource doesn't become healthy", func() {
 				fakeOps.MaxAttempts = 2
 
 				Expect(fakeClient.Create(ctx, &resourcesv1alpha1.ManagedResource{
@@ -1512,7 +1512,7 @@ kubeConfigFile: /etc/kubernetes/admission-kubeconfigs/validatingadmissionwebhook
 					Status: unhealthyManagedResourceStatus,
 				})).To(Succeed())
 
-				Expect(deployer.Deploy(ctx)).To(MatchError(ContainSubstring("is not healthy")))
+				Expect(deployer.Deploy(ctx)).To(Succeed())
 			})
 		})
 	})

--- a/pkg/component/gardenerapiserver/gardener_apiserver_test.go
+++ b/pkg/component/gardenerapiserver/gardener_apiserver_test.go
@@ -1,0 +1,416 @@
+// Copyright 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gardenerapiserver_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	. "github.com/gardener/gardener/pkg/component/gardenerapiserver"
+	"github.com/gardener/gardener/pkg/utils/retry"
+	retryfake "github.com/gardener/gardener/pkg/utils/retry/fake"
+	secretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager"
+	fakesecretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager/fake"
+	"github.com/gardener/gardener/pkg/utils/test"
+	. "github.com/gardener/gardener/pkg/utils/test/matchers"
+)
+
+var _ = Describe("GardenerAPIServer", func() {
+	var (
+		ctx = context.TODO()
+
+		managedResourceNameRuntime = "gardener-apiserver-runtime"
+		managedResourceNameVirtual = "gardener-apiserver-virtual"
+		namespace                  = "some-namespace"
+
+		fakeClient        client.Client
+		fakeSecretManager secretsmanager.Interface
+		deployer          Interface
+
+		fakeOps *retryfake.Ops
+
+		managedResourceRuntime       *resourcesv1alpha1.ManagedResource
+		managedResourceVirtual       *resourcesv1alpha1.ManagedResource
+		managedResourceSecretRuntime *corev1.Secret
+		managedResourceSecretVirtual *corev1.Secret
+	)
+
+	BeforeEach(func() {
+		fakeClient = fakeclient.NewClientBuilder().WithScheme(kubernetes.SeedScheme).Build()
+		fakeSecretManager = fakesecretsmanager.New(fakeClient, namespace)
+		deployer = New(fakeClient, namespace, fakeSecretManager, Values{})
+
+		fakeOps = &retryfake.Ops{MaxAttempts: 2}
+		DeferCleanup(test.WithVars(
+			&retry.Until, fakeOps.Until,
+			&retry.UntilTimeout, fakeOps.UntilTimeout,
+		))
+
+		managedResourceRuntime = &resourcesv1alpha1.ManagedResource{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      managedResourceNameRuntime,
+				Namespace: namespace,
+			},
+		}
+		managedResourceVirtual = &resourcesv1alpha1.ManagedResource{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      managedResourceNameVirtual,
+				Namespace: namespace,
+			},
+		}
+		managedResourceSecretRuntime = &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "managedresource-" + managedResourceRuntime.Name,
+				Namespace: namespace,
+			},
+		}
+		managedResourceSecretVirtual = &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "managedresource-" + managedResourceVirtual.Name,
+				Namespace: namespace,
+			},
+		}
+	})
+
+	Describe("#Deploy", func() {
+		Context("resources generation", func() {
+			BeforeEach(func() {
+				Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(managedResourceRuntime), managedResourceRuntime)).To(BeNotFoundError())
+				Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(managedResourceVirtual), managedResourceVirtual)).To(BeNotFoundError())
+				Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(managedResourceSecretRuntime), managedResourceSecretRuntime)).To(BeNotFoundError())
+				Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(managedResourceSecretVirtual), managedResourceSecretVirtual)).To(BeNotFoundError())
+
+				Expect(fakeClient.Create(ctx, &resourcesv1alpha1.ManagedResource{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       managedResourceNameRuntime,
+						Namespace:  namespace,
+						Generation: 1,
+					},
+					Status: healthyManagedResourceStatus,
+				})).To(Succeed())
+
+				Expect(fakeClient.Create(ctx, &resourcesv1alpha1.ManagedResource{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       managedResourceNameVirtual,
+						Namespace:  namespace,
+						Generation: 1,
+					},
+					Status: healthyManagedResourceStatus,
+				})).To(Succeed())
+
+				Expect(deployer.Deploy(ctx)).To(Succeed())
+
+				Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(managedResourceRuntime), managedResourceRuntime)).To(Succeed())
+				Expect(managedResourceRuntime).To(Equal(&resourcesv1alpha1.ManagedResource{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: resourcesv1alpha1.SchemeGroupVersion.String(),
+						Kind:       "ManagedResource",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            managedResourceRuntime.Name,
+						Namespace:       managedResourceRuntime.Namespace,
+						ResourceVersion: "2",
+						Generation:      1,
+						Labels:          map[string]string{"gardener.cloud/role": "seed-system-component"},
+					},
+					Spec: resourcesv1alpha1.ManagedResourceSpec{
+						Class:       pointer.String("seed"),
+						SecretRefs:  []corev1.LocalObjectReference{{Name: managedResourceSecretRuntime.Name}},
+						KeepObjects: pointer.Bool(false),
+					},
+					Status: healthyManagedResourceStatus,
+				}))
+
+				Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(managedResourceSecretRuntime), managedResourceSecretRuntime)).To(Succeed())
+
+				Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(managedResourceVirtual), managedResourceVirtual)).To(Succeed())
+				Expect(managedResourceVirtual).To(Equal(&resourcesv1alpha1.ManagedResource{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: resourcesv1alpha1.SchemeGroupVersion.String(),
+						Kind:       "ManagedResource",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            managedResourceVirtual.Name,
+						Namespace:       managedResourceVirtual.Namespace,
+						ResourceVersion: "2",
+						Generation:      1,
+						Labels:          map[string]string{"origin": "gardener"},
+					},
+					Spec: resourcesv1alpha1.ManagedResourceSpec{
+						InjectLabels: map[string]string{"shoot.gardener.cloud/no-cleanup": "true"},
+						SecretRefs:   []corev1.LocalObjectReference{{Name: managedResourceSecretVirtual.Name}},
+						KeepObjects:  pointer.Bool(false),
+					},
+					Status: healthyManagedResourceStatus,
+				}))
+
+				Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(managedResourceSecretVirtual), managedResourceSecretVirtual)).To(Succeed())
+			})
+
+			It("should successfully deploy all resources", func() {
+				Expect(managedResourceSecretRuntime.Type).To(Equal(corev1.SecretTypeOpaque))
+				Expect(managedResourceSecretRuntime.Data).To(HaveLen(0))
+
+				Expect(managedResourceSecretVirtual.Type).To(Equal(corev1.SecretTypeOpaque))
+				Expect(managedResourceSecretVirtual.Data).To(HaveLen(0))
+			})
+		})
+
+		Context("waiting logic", func() {
+			It("should fail because the runtime ManagedResource doesn't become healthy", func() {
+				fakeOps.MaxAttempts = 2
+
+				Expect(fakeClient.Create(ctx, &resourcesv1alpha1.ManagedResource{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       managedResourceNameRuntime,
+						Namespace:  namespace,
+						Generation: 1,
+					},
+					Status: unhealthyManagedResourceStatus,
+				})).To(Succeed())
+
+				Expect(deployer.Deploy(ctx)).To(MatchError(ContainSubstring("is not healthy")))
+			})
+
+			It("should fail because the virtual ManagedResource doesn't become healthy", func() {
+				fakeOps.MaxAttempts = 2
+
+				Expect(fakeClient.Create(ctx, &resourcesv1alpha1.ManagedResource{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       managedResourceNameRuntime,
+						Namespace:  namespace,
+						Generation: 1,
+					},
+					Status: healthyManagedResourceStatus,
+				})).To(Succeed())
+
+				Expect(fakeClient.Create(ctx, &resourcesv1alpha1.ManagedResource{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       managedResourceNameVirtual,
+						Namespace:  namespace,
+						Generation: 1,
+					},
+					Status: unhealthyManagedResourceStatus,
+				})).To(Succeed())
+
+				Expect(deployer.Deploy(ctx)).To(MatchError(ContainSubstring("is not healthy")))
+			})
+		})
+	})
+
+	Describe("#Destroy", func() {
+		It("should successfully destroy all resources", func() {
+			Expect(fakeClient.Create(ctx, managedResourceRuntime)).To(Succeed())
+			Expect(fakeClient.Create(ctx, managedResourceVirtual)).To(Succeed())
+			Expect(fakeClient.Create(ctx, managedResourceSecretRuntime)).To(Succeed())
+			Expect(fakeClient.Create(ctx, managedResourceSecretVirtual)).To(Succeed())
+
+			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(managedResourceRuntime), managedResourceRuntime)).To(Succeed())
+			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(managedResourceVirtual), managedResourceVirtual)).To(Succeed())
+			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(managedResourceSecretRuntime), managedResourceSecretRuntime)).To(Succeed())
+			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(managedResourceSecretVirtual), managedResourceSecretVirtual)).To(Succeed())
+
+			Expect(deployer.Destroy(ctx)).To(Succeed())
+
+			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(managedResourceRuntime), managedResourceRuntime)).To(BeNotFoundError())
+			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(managedResourceVirtual), managedResourceVirtual)).To(BeNotFoundError())
+			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(managedResourceSecretRuntime), managedResourceSecretRuntime)).To(BeNotFoundError())
+			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(managedResourceSecretVirtual), managedResourceSecretVirtual)).To(BeNotFoundError())
+		})
+	})
+
+	Context("waiting functions", func() {
+		Describe("#Wait", func() {
+			It("should fail because reading the runtime ManagedResource fails", func() {
+				Expect(deployer.Wait(ctx)).To(MatchError(ContainSubstring("not found")))
+			})
+
+			It("should fail because the runtime ManagedResource is unhealthy", func() {
+				Expect(fakeClient.Create(ctx, &resourcesv1alpha1.ManagedResource{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       managedResourceNameRuntime,
+						Namespace:  namespace,
+						Generation: 1,
+					},
+					Status: unhealthyManagedResourceStatus,
+				})).To(Succeed())
+
+				Expect(deployer.Wait(ctx)).To(MatchError(ContainSubstring("is unhealthy")))
+			})
+
+			It("should fail because the runtime ManagedResource is still progressing", func() {
+				Expect(fakeClient.Create(ctx, &resourcesv1alpha1.ManagedResource{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       managedResourceNameRuntime,
+						Namespace:  namespace,
+						Generation: 1,
+					},
+					Status: resourcesv1alpha1.ManagedResourceStatus{
+						ObservedGeneration: 1,
+						Conditions: []gardencorev1beta1.Condition{
+							{
+								Type:   resourcesv1alpha1.ResourcesApplied,
+								Status: gardencorev1beta1.ConditionTrue,
+							},
+							{
+								Type:   resourcesv1alpha1.ResourcesHealthy,
+								Status: gardencorev1beta1.ConditionTrue,
+							},
+							{
+								Type:   resourcesv1alpha1.ResourcesProgressing,
+								Status: gardencorev1beta1.ConditionTrue,
+							},
+						},
+					},
+				})).To(Succeed())
+
+				Expect(deployer.Wait(ctx)).To(MatchError(ContainSubstring("still progressing")))
+			})
+
+			It("should fail because the virtual ManagedResource is unhealthy", func() {
+				Expect(fakeClient.Create(ctx, &resourcesv1alpha1.ManagedResource{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       managedResourceNameRuntime,
+						Namespace:  namespace,
+						Generation: 1,
+					},
+					Status: resourcesv1alpha1.ManagedResourceStatus{
+						ObservedGeneration: 1,
+						Conditions: []gardencorev1beta1.Condition{
+							{
+								Type:   resourcesv1alpha1.ResourcesApplied,
+								Status: gardencorev1beta1.ConditionTrue,
+							},
+							{
+								Type:   resourcesv1alpha1.ResourcesHealthy,
+								Status: gardencorev1beta1.ConditionTrue,
+							},
+							{
+								Type:   resourcesv1alpha1.ResourcesProgressing,
+								Status: gardencorev1beta1.ConditionFalse,
+							},
+						},
+					},
+				})).To(Succeed())
+
+				Expect(fakeClient.Create(ctx, &resourcesv1alpha1.ManagedResource{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       managedResourceNameVirtual,
+						Namespace:  namespace,
+						Generation: 1,
+					},
+					Status: unhealthyManagedResourceStatus,
+				})).To(Succeed())
+
+				Expect(deployer.Wait(ctx)).To(MatchError(ContainSubstring("is not healthy")))
+			})
+
+			It("should succeed because the both ManagedResource are healthy and progressed", func() {
+				Expect(fakeClient.Create(ctx, &resourcesv1alpha1.ManagedResource{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       managedResourceNameRuntime,
+						Namespace:  namespace,
+						Generation: 1,
+					},
+					Status: resourcesv1alpha1.ManagedResourceStatus{
+						ObservedGeneration: 1,
+						Conditions: []gardencorev1beta1.Condition{
+							{
+								Type:   resourcesv1alpha1.ResourcesApplied,
+								Status: gardencorev1beta1.ConditionTrue,
+							},
+							{
+								Type:   resourcesv1alpha1.ResourcesHealthy,
+								Status: gardencorev1beta1.ConditionTrue,
+							},
+							{
+								Type:   resourcesv1alpha1.ResourcesProgressing,
+								Status: gardencorev1beta1.ConditionFalse,
+							},
+						},
+					},
+				})).To(Succeed())
+
+				Expect(fakeClient.Create(ctx, &resourcesv1alpha1.ManagedResource{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       managedResourceNameVirtual,
+						Namespace:  namespace,
+						Generation: 1,
+					},
+					Status: healthyManagedResourceStatus,
+				})).To(Succeed())
+
+				Expect(deployer.Wait(ctx)).To(Succeed())
+			})
+		})
+
+		Describe("#WaitCleanup", func() {
+			It("should fail when the wait for the runtime managed resource deletion times out", func() {
+				Expect(fakeClient.Create(ctx, managedResourceRuntime)).To(Succeed())
+
+				Expect(deployer.WaitCleanup(ctx)).To(MatchError(ContainSubstring("still exists")))
+			})
+
+			It("should fail when the wait for the virtual managed resource deletion times out", func() {
+				Expect(fakeClient.Create(ctx, managedResourceVirtual)).To(Succeed())
+
+				Expect(deployer.WaitCleanup(ctx)).To(MatchError(ContainSubstring("still exists")))
+			})
+
+			It("should not return an error when they are already removed", func() {
+				Expect(deployer.WaitCleanup(ctx)).To(Succeed())
+			})
+		})
+	})
+})
+
+var (
+	healthyManagedResourceStatus = resourcesv1alpha1.ManagedResourceStatus{
+		ObservedGeneration: 1,
+		Conditions: []gardencorev1beta1.Condition{
+			{
+				Type:   resourcesv1alpha1.ResourcesApplied,
+				Status: gardencorev1beta1.ConditionTrue,
+			},
+			{
+				Type:   resourcesv1alpha1.ResourcesHealthy,
+				Status: gardencorev1beta1.ConditionTrue,
+			},
+		},
+	}
+	unhealthyManagedResourceStatus = resourcesv1alpha1.ManagedResourceStatus{
+		ObservedGeneration: 1,
+		Conditions: []gardencorev1beta1.Condition{
+			{
+				Type:   resourcesv1alpha1.ResourcesApplied,
+				Status: gardencorev1beta1.ConditionFalse,
+			},
+			{
+				Type:   resourcesv1alpha1.ResourcesHealthy,
+				Status: gardencorev1beta1.ConditionFalse,
+			},
+		},
+	}
+)

--- a/pkg/component/gardenerapiserver/gardener_apiserver_test.go
+++ b/pkg/component/gardenerapiserver/gardener_apiserver_test.go
@@ -282,6 +282,35 @@ resources:
 					Entry("encrypting with current", true),
 					Entry("encrypting with old", false),
 				)
+
+				It("should successfully deploy the access secret for the virtual garden", func() {
+					accessSecret := &corev1.Secret{
+						TypeMeta: metav1.TypeMeta{
+							APIVersion: "v1",
+							Kind:       "Secret",
+						},
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "shoot-access-gardener-apiserver",
+							Namespace: namespace,
+							Labels: map[string]string{
+								"resources.gardener.cloud/purpose": "token-requestor",
+								"resources.gardener.cloud/class":   "shoot",
+							},
+							Annotations: map[string]string{
+								"serviceaccount.resources.gardener.cloud/name":      "gardener-apiserver",
+								"serviceaccount.resources.gardener.cloud/namespace": "kube-system",
+							},
+						},
+						Type: corev1.SecretTypeOpaque,
+					}
+
+					Expect(deployer.Deploy(ctx)).To(Succeed())
+
+					actualShootAccessSecret := &corev1.Secret{}
+					Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(accessSecret), actualShootAccessSecret)).To(Succeed())
+					accessSecret.ResourceVersion = "1"
+					Expect(actualShootAccessSecret).To(Equal(accessSecret))
+				})
 			})
 
 			Context("resources generation", func() {

--- a/pkg/component/gardenerapiserver/gardener_apiserver_test.go
+++ b/pkg/component/gardenerapiserver/gardener_apiserver_test.go
@@ -1488,7 +1488,7 @@ kubeConfigFile: /etc/kubernetes/admission-kubeconfigs/validatingadmissionwebhook
 					Status: unhealthyManagedResourceStatus,
 				})).To(Succeed())
 
-				Expect(deployer.Deploy(ctx)).To(MatchError(ContainSubstring("is not healthy")))
+				Expect(deployer.Deploy(ctx)).To(MatchError(ContainSubstring("is unhealthy")))
 			})
 
 			It("should fail because the virtual ManagedResource doesn't become healthy", func() {
@@ -1695,6 +1695,10 @@ var (
 				Type:   resourcesv1alpha1.ResourcesHealthy,
 				Status: gardencorev1beta1.ConditionTrue,
 			},
+			{
+				Type:   resourcesv1alpha1.ResourcesProgressing,
+				Status: gardencorev1beta1.ConditionFalse,
+			},
 		},
 	}
 	unhealthyManagedResourceStatus = resourcesv1alpha1.ManagedResourceStatus{
@@ -1707,6 +1711,10 @@ var (
 			{
 				Type:   resourcesv1alpha1.ResourcesHealthy,
 				Status: gardencorev1beta1.ConditionFalse,
+			},
+			{
+				Type:   resourcesv1alpha1.ResourcesProgressing,
+				Status: gardencorev1beta1.ConditionTrue,
 			},
 		},
 	}

--- a/pkg/component/gardenerapiserver/hvpa.go
+++ b/pkg/component/gardenerapiserver/hvpa.go
@@ -1,0 +1,167 @@
+// Copyright 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gardenerapiserver
+
+import (
+	hvpav1alpha1 "github.com/gardener/hvpa-controller/api/v1alpha1"
+	appsv1 "k8s.io/api/apps/v1"
+	autoscalingv2beta1 "k8s.io/api/autoscaling/v2beta1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	vpaautoscalingv1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
+	"k8s.io/utils/pointer"
+
+	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
+	"github.com/gardener/gardener/pkg/utils"
+)
+
+func (g *gardenerAPIServer) hvpa() *hvpav1alpha1.Hvpa {
+	if !g.values.Autoscaling.HVPAEnabled {
+		return nil
+	}
+
+	var (
+		replicas    int32 = 1
+		maxReplicas int32 = 4
+		hpaLabels         = map[string]string{"role": "gardener-apiserver-hpa"}
+		vpaLabels         = map[string]string{"role": "gardener-apiserver-vpa"}
+	)
+
+	return &hvpav1alpha1.Hvpa{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      DeploymentName + "-hvpa",
+			Namespace: g.namespace,
+			Labels:    utils.MergeStringMaps(GetLabels(), map[string]string{resourcesv1alpha1.HighAvailabilityConfigType: resourcesv1alpha1.HighAvailabilityConfigTypeServer}),
+		},
+		Spec: hvpav1alpha1.HvpaSpec{
+			Replicas: pointer.Int32(1),
+			Hpa: hvpav1alpha1.HpaSpec{
+				Selector: &metav1.LabelSelector{MatchLabels: hpaLabels},
+				Deploy:   true,
+				ScaleUp: hvpav1alpha1.ScaleType{
+					UpdatePolicy: hvpav1alpha1.UpdatePolicy{
+						UpdateMode: pointer.String(hvpav1alpha1.UpdateModeAuto),
+					},
+				},
+				ScaleDown: hvpav1alpha1.ScaleType{
+					UpdatePolicy: hvpav1alpha1.UpdatePolicy{
+						UpdateMode: pointer.String(hvpav1alpha1.UpdateModeAuto),
+					},
+				},
+				Template: hvpav1alpha1.HpaTemplate{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: hpaLabels,
+					},
+					Spec: hvpav1alpha1.HpaTemplateSpec{
+						MinReplicas: pointer.Int32(replicas),
+						MaxReplicas: maxReplicas,
+						Metrics: []autoscalingv2beta1.MetricSpec{
+							{
+								Type: autoscalingv2beta1.ResourceMetricSourceType,
+								Resource: &autoscalingv2beta1.ResourceMetricSource{
+									Name:                     corev1.ResourceCPU,
+									TargetAverageUtilization: pointer.Int32(80),
+								},
+							},
+							{
+								Type: autoscalingv2beta1.ResourceMetricSourceType,
+								Resource: &autoscalingv2beta1.ResourceMetricSource{
+									Name:                     corev1.ResourceMemory,
+									TargetAverageUtilization: pointer.Int32(80),
+								},
+							},
+						},
+					},
+				},
+			},
+			Vpa: hvpav1alpha1.VpaSpec{
+				Selector: &metav1.LabelSelector{MatchLabels: vpaLabels},
+				Deploy:   true,
+				ScaleUp: hvpav1alpha1.ScaleType{
+					UpdatePolicy: hvpav1alpha1.UpdatePolicy{
+						UpdateMode: pointer.String(hvpav1alpha1.UpdateModeAuto),
+					},
+					StabilizationDuration: pointer.String("3m"),
+					MinChange: hvpav1alpha1.ScaleParams{
+						CPU: hvpav1alpha1.ChangeParams{
+							Value:      pointer.String("300m"),
+							Percentage: pointer.Int32(80),
+						},
+						Memory: hvpav1alpha1.ChangeParams{
+							Value:      pointer.String("200M"),
+							Percentage: pointer.Int32(80),
+						},
+					},
+				},
+				ScaleDown: hvpav1alpha1.ScaleType{
+					UpdatePolicy: hvpav1alpha1.UpdatePolicy{
+						UpdateMode: pointer.String(hvpav1alpha1.UpdateModeAuto),
+					},
+					StabilizationDuration: pointer.String("15m"),
+					MinChange: hvpav1alpha1.ScaleParams{
+						CPU: hvpav1alpha1.ChangeParams{
+							Value:      pointer.String("600m"),
+							Percentage: pointer.Int32(80),
+						},
+						Memory: hvpav1alpha1.ChangeParams{
+							Value:      pointer.String("600M"),
+							Percentage: pointer.Int32(80),
+						},
+					},
+				},
+				LimitsRequestsGapScaleParams: hvpav1alpha1.ScaleParams{
+					CPU: hvpav1alpha1.ChangeParams{
+						Value:      pointer.String("1"),
+						Percentage: pointer.Int32(70),
+					},
+					Memory: hvpav1alpha1.ChangeParams{
+						Value:      pointer.String("1G"),
+						Percentage: pointer.Int32(70),
+					},
+				},
+				Template: hvpav1alpha1.VpaTemplate{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: vpaLabels,
+					},
+					Spec: hvpav1alpha1.VpaTemplateSpec{
+						ResourcePolicy: &vpaautoscalingv1.PodResourcePolicy{
+							ContainerPolicies: []vpaautoscalingv1.ContainerResourcePolicy{{
+								ContainerName: containerName,
+								MinAllowed: corev1.ResourceList{
+									corev1.ResourceMemory: resource.MustParse("400M"),
+								},
+								MaxAllowed: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("4"),
+									corev1.ResourceMemory: resource.MustParse("25G"),
+								},
+							}},
+						},
+					},
+				},
+			},
+			WeightBasedScalingIntervals: []hvpav1alpha1.WeightBasedScalingInterval{{
+				VpaWeight:         hvpav1alpha1.HpaOnly,
+				StartReplicaCount: replicas,
+				LastReplicaCount:  maxReplicas - 1,
+			}},
+			TargetRef: &autoscalingv2beta1.CrossVersionObjectReference{
+				APIVersion: appsv1.SchemeGroupVersion.String(),
+				Kind:       "Deployment",
+				Name:       DeploymentName,
+			},
+		},
+	}
+}

--- a/pkg/component/gardenerapiserver/poddisruptionbudget.go
+++ b/pkg/component/gardenerapiserver/poddisruptionbudget.go
@@ -1,0 +1,36 @@
+// Copyright 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gardenerapiserver
+
+import (
+	policyv1 "k8s.io/api/policy/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	gardenerutils "github.com/gardener/gardener/pkg/utils"
+)
+
+func (g *gardenerAPIServer) podDisruptionBudget() *policyv1.PodDisruptionBudget {
+	return &policyv1.PodDisruptionBudget{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      DeploymentName,
+			Namespace: g.namespace,
+			Labels:    GetLabels(),
+		},
+		Spec: policyv1.PodDisruptionBudgetSpec{
+			MaxUnavailable: gardenerutils.IntStrPtrFromInt(1),
+			Selector:       &metav1.LabelSelector{MatchLabels: GetLabels()},
+		},
+	}
+}

--- a/pkg/component/gardenerapiserver/rbac.go
+++ b/pkg/component/gardenerapiserver/rbac.go
@@ -1,0 +1,96 @@
+// Copyright 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gardenerapiserver
+
+import (
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	clusterRoleName = "gardener.cloud:system:apiserver"
+)
+
+func (g *gardenerAPIServer) clusterRole() *rbacv1.ClusterRole {
+	return &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   clusterRoleName,
+			Labels: GetLabels(),
+		},
+		Rules: []rbacv1.PolicyRule{{
+			APIGroups: []string{"*"},
+			Resources: []string{"*"},
+			Verbs:     []string{"*"},
+		}},
+	}
+}
+
+func (g *gardenerAPIServer) clusterRoleBinding(serviceAccountName string) *rbacv1.ClusterRoleBinding {
+	return &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   clusterRoleName,
+			Labels: GetLabels(),
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: rbacv1.GroupName,
+			Kind:     "ClusterRole",
+			Name:     clusterRoleName,
+		},
+		Subjects: []rbacv1.Subject{{
+			Kind:      "ServiceAccount",
+			Name:      serviceAccountName,
+			Namespace: metav1.NamespaceSystem,
+		}},
+	}
+}
+
+func (g *gardenerAPIServer) clusterRoleBindingAuthDelegation(serviceAccountName string) *rbacv1.ClusterRoleBinding {
+	return &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "gardener.cloud:apiserver:auth-delegator",
+			Labels: GetLabels(),
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: rbacv1.GroupName,
+			Kind:     "ClusterRole",
+			Name:     "system:auth-delegator",
+		},
+		Subjects: []rbacv1.Subject{{
+			Kind:      "ServiceAccount",
+			Name:      serviceAccountName,
+			Namespace: metav1.NamespaceSystem,
+		}},
+	}
+}
+
+func (g *gardenerAPIServer) roleBindingAuthReader(serviceAccountName string) *rbacv1.RoleBinding {
+	return &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "gardener.cloud:apiserver:auth-reader",
+			Namespace: metav1.NamespaceSystem,
+			Labels:    GetLabels(),
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: rbacv1.GroupName,
+			Kind:     "ClusterRole",
+			Name:     "extension-apiserver-authentication-reader",
+		},
+		Subjects: []rbacv1.Subject{{
+			Kind:      "ServiceAccount",
+			Name:      serviceAccountName,
+			Namespace: metav1.NamespaceSystem,
+		}},
+	}
+}

--- a/pkg/component/gardenerapiserver/secrets.go
+++ b/pkg/component/gardenerapiserver/secrets.go
@@ -28,6 +28,10 @@ import (
 	secretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager"
 )
 
+const (
+	secretAuditWebhookKubeconfigNamePrefix = "gardener-apiserver-audit-webhook-kubeconfig"
+)
+
 func (g *gardenerAPIServer) newVirtualGardenAccessSecret() *gardenerutils.AccessSecret {
 	return gardenerutils.NewShootAccessSecret(DeploymentName, g.namespace)
 }

--- a/pkg/component/gardenerapiserver/secrets.go
+++ b/pkg/component/gardenerapiserver/secrets.go
@@ -21,10 +21,23 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	"github.com/gardener/gardener/pkg/component/apiserver"
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	secretsutils "github.com/gardener/gardener/pkg/utils/secrets"
 	secretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager"
 )
+
+func (g *gardenerAPIServer) reconcileSecretETCDEncryptionConfiguration(ctx context.Context, secret *corev1.Secret) error {
+	return apiserver.ReconcileSecretETCDEncryptionConfiguration(
+		ctx,
+		g.client,
+		g.secretsManager,
+		g.values.ETCDEncryption,
+		secret,
+		v1beta1constants.SecretNameGardenerETCDEncryptionKey,
+		v1beta1constants.SecretNamePrefixGardenerETCDEncryptionConfiguration,
+	)
+}
 
 func (g *gardenerAPIServer) reconcileSecretServer(ctx context.Context) (*corev1.Secret, error) {
 	return g.secretsManager.Generate(ctx, &secretsutils.CertificateSecretConfig{

--- a/pkg/component/gardenerapiserver/secrets.go
+++ b/pkg/component/gardenerapiserver/secrets.go
@@ -30,6 +30,7 @@ import (
 
 const (
 	secretAuditWebhookKubeconfigNamePrefix = "gardener-apiserver-audit-webhook-kubeconfig"
+	secretAdmissionKubeconfigsNamePrefix   = "gardener-apiserver-admission-kubeconfigs"
 )
 
 func (g *gardenerAPIServer) newVirtualGardenAccessSecret() *gardenerutils.AccessSecret {

--- a/pkg/component/gardenerapiserver/secrets.go
+++ b/pkg/component/gardenerapiserver/secrets.go
@@ -21,6 +21,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	operatorv1alpha1 "github.com/gardener/gardener/pkg/apis/operator/v1alpha1"
 	"github.com/gardener/gardener/pkg/component/apiserver"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
@@ -55,10 +56,10 @@ func (g *gardenerAPIServer) reconcileSecretETCDEncryptionConfiguration(ctx conte
 
 func (g *gardenerAPIServer) reconcileSecretServer(ctx context.Context) (*corev1.Secret, error) {
 	return g.secretsManager.Generate(ctx, &secretsutils.CertificateSecretConfig{
-		Name:                        secretNameServer,
-		CommonName:                  DeploymentName,
+		Name:                        secretNameServerCert,
+		CommonName:                  serviceName,
 		DNSNames:                    append(kubernetesutils.DNSNamesForService(DeploymentName, g.namespace), kubernetesutils.DNSNamesForService(DeploymentName, metav1.NamespaceSystem)...),
 		CertType:                    secretsutils.ServerCert,
 		SkipPublishingCACertificate: true,
-	}, secretsmanager.SignedByCA(v1beta1constants.SecretNameCAGardener), secretsmanager.Rotate(secretsmanager.InPlace))
+	}, secretsmanager.SignedByCA(operatorv1alpha1.SecretNameCAGardener), secretsmanager.Rotate(secretsmanager.InPlace))
 }

--- a/pkg/component/gardenerapiserver/secrets.go
+++ b/pkg/component/gardenerapiserver/secrets.go
@@ -22,10 +22,15 @@ import (
 
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/component/apiserver"
+	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	secretsutils "github.com/gardener/gardener/pkg/utils/secrets"
 	secretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager"
 )
+
+func (g *gardenerAPIServer) newVirtualGardenAccessSecret() *gardenerutils.AccessSecret {
+	return gardenerutils.NewShootAccessSecret(DeploymentName, g.namespace)
+}
 
 func (g *gardenerAPIServer) reconcileSecretETCDEncryptionConfiguration(ctx context.Context, secret *corev1.Secret) error {
 	return apiserver.ReconcileSecretETCDEncryptionConfiguration(

--- a/pkg/component/gardenerapiserver/secrets.go
+++ b/pkg/component/gardenerapiserver/secrets.go
@@ -1,0 +1,37 @@
+// Copyright 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gardenerapiserver
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
+	secretsutils "github.com/gardener/gardener/pkg/utils/secrets"
+	secretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager"
+)
+
+func (g *gardenerAPIServer) reconcileSecretServer(ctx context.Context) (*corev1.Secret, error) {
+	return g.secretsManager.Generate(ctx, &secretsutils.CertificateSecretConfig{
+		Name:                        secretNameServer,
+		CommonName:                  DeploymentName,
+		DNSNames:                    append(kubernetesutils.DNSNamesForService(DeploymentName, g.namespace), kubernetesutils.DNSNamesForService(DeploymentName, metav1.NamespaceSystem)...),
+		CertType:                    secretsutils.ServerCert,
+		SkipPublishingCACertificate: true,
+	}, secretsmanager.SignedByCA(v1beta1constants.SecretNameCAGardener), secretsmanager.Rotate(secretsmanager.InPlace))
+}

--- a/pkg/component/gardenerapiserver/secrets.go
+++ b/pkg/component/gardenerapiserver/secrets.go
@@ -33,6 +33,10 @@ const (
 	secretAdmissionKubeconfigsNamePrefix   = "gardener-apiserver-admission-kubeconfigs"
 )
 
+func (g *gardenerAPIServer) emptySecret(name string) *corev1.Secret {
+	return &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: g.namespace}}
+}
+
 func (g *gardenerAPIServer) newVirtualGardenAccessSecret() *gardenerutils.AccessSecret {
 	return gardenerutils.NewShootAccessSecret(DeploymentName, g.namespace)
 }

--- a/pkg/component/gardenerapiserver/service.go
+++ b/pkg/component/gardenerapiserver/service.go
@@ -26,7 +26,7 @@ import (
 )
 
 const (
-	serviceName = "gardener-apiserver"
+	serviceName = DeploymentName
 	servicePort = 443
 )
 

--- a/pkg/component/gardenerapiserver/service.go
+++ b/pkg/component/gardenerapiserver/service.go
@@ -25,10 +25,14 @@ import (
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 )
 
-func (g *gardenerAPIServer) service() *corev1.Service {
+const (
+	serviceName = "gardener-apiserver"
+)
+
+func (g *gardenerAPIServer) serviceRuntime() *corev1.Service {
 	service := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      DeploymentName,
+			Name:      serviceName,
 			Namespace: g.namespace,
 			Labels:    GetLabels(),
 		},

--- a/pkg/component/gardenerapiserver/service.go
+++ b/pkg/component/gardenerapiserver/service.go
@@ -1,0 +1,55 @@
+// Copyright 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gardenerapiserver
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+
+	"github.com/gardener/gardener/pkg/utils"
+	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
+)
+
+func (g *gardenerAPIServer) service() *corev1.Service {
+	service := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      DeploymentName,
+			Namespace: g.namespace,
+			Labels:    GetLabels(),
+		},
+		Spec: corev1.ServiceSpec{
+			Type:     corev1.ServiceTypeClusterIP,
+			Selector: GetLabels(),
+			Ports: []corev1.ServicePort{{
+				Port:       443,
+				Protocol:   corev1.ProtocolTCP,
+				TargetPort: intstr.FromInt(port),
+			}},
+		},
+	}
+
+	gardenerutils.ReconcileTopologyAwareRoutingMetadata(service, g.values.TopologyAwareRoutingEnabled, g.values.RuntimeVersion)
+
+	// allow gardener-apiserver being reached from kube-apiserver
+	utilruntime.Must(gardenerutils.InjectNetworkPolicyAnnotationsForWebhookTargets(service, networkingv1.NetworkPolicyPort{
+		Port:     utils.IntStrPtrFromInt(port),
+		Protocol: utils.ProtocolPtr(corev1.ProtocolTCP),
+	}))
+
+	return service
+}

--- a/pkg/component/gardenerapiserver/vpa.go
+++ b/pkg/component/gardenerapiserver/vpa.go
@@ -1,0 +1,59 @@
+// Copyright 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gardenerapiserver
+
+import (
+	appsv1 "k8s.io/api/apps/v1"
+	autoscalingv1 "k8s.io/api/autoscaling/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	vpaautoscalingv1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
+)
+
+func (g *gardenerAPIServer) verticalPodAutoscaler() *vpaautoscalingv1.VerticalPodAutoscaler {
+	if g.values.Autoscaling.HVPAEnabled {
+		return nil
+	}
+
+	vpaUpdateMode := vpaautoscalingv1.UpdateModeAuto
+	return &vpaautoscalingv1.VerticalPodAutoscaler{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      DeploymentName + "-vpa",
+			Namespace: g.namespace,
+			Labels:    GetLabels(),
+		},
+		Spec: vpaautoscalingv1.VerticalPodAutoscalerSpec{
+			TargetRef: &autoscalingv1.CrossVersionObjectReference{
+				APIVersion: appsv1.SchemeGroupVersion.String(),
+				Kind:       "Deployment",
+				Name:       DeploymentName,
+			},
+			UpdatePolicy: &vpaautoscalingv1.PodUpdatePolicy{
+				UpdateMode: &vpaUpdateMode,
+			},
+			ResourcePolicy: &vpaautoscalingv1.PodResourcePolicy{
+				ContainerPolicies: []vpaautoscalingv1.ContainerResourcePolicy{
+					{
+						ContainerName: vpaautoscalingv1.DefaultContainerResourcePolicy,
+						MinAllowed: corev1.ResourceList{
+							corev1.ResourceMemory: resource.MustParse("256Mi"),
+						},
+					},
+				},
+			},
+		},
+	}
+}

--- a/pkg/component/kubeapiserver/configmaps.go
+++ b/pkg/component/kubeapiserver/configmaps.go
@@ -33,13 +33,10 @@ import (
 	secretsutils "github.com/gardener/gardener/pkg/utils/secrets"
 )
 
-var (
-	apiServerScheme *runtime.Scheme
-	apiServerCodec  runtime.Codec
-)
+var apiServerCodec runtime.Codec
 
 func init() {
-	apiServerScheme = runtime.NewScheme()
+	apiServerScheme := runtime.NewScheme()
 	utilruntime.Must(apiserverv1alpha1.AddToScheme(apiServerScheme))
 
 	var (
@@ -48,9 +45,7 @@ func init() {
 			Pretty: false,
 			Strict: false,
 		})
-		versions = schema.GroupVersions([]schema.GroupVersion{
-			apiserverv1alpha1.SchemeGroupVersion,
-		})
+		versions = schema.GroupVersions([]schema.GroupVersion{apiserverv1alpha1.SchemeGroupVersion})
 	)
 
 	apiServerCodec = serializer.NewCodecFactory(apiServerScheme).CodecForVersions(ser, ser, versions, versions)

--- a/pkg/component/kubeapiserver/configmaps.go
+++ b/pkg/component/kubeapiserver/configmaps.go
@@ -17,154 +17,54 @@ package kubeapiserver
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/apimachinery/pkg/runtime/serializer/json"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	webhookadmissionv1 "k8s.io/apiserver/pkg/admission/plugin/webhook/config/apis/webhookadmission/v1"
-	webhookadmissionv1alpha1 "k8s.io/apiserver/pkg/admission/plugin/webhook/config/apis/webhookadmission/v1alpha1"
 	apiserverv1alpha1 "k8s.io/apiserver/pkg/apis/apiserver/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/yaml"
 
-	"github.com/gardener/gardener/pkg/component/apiserver"
 	"github.com/gardener/gardener/pkg/component/vpnseedserver"
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	secretsutils "github.com/gardener/gardener/pkg/utils/secrets"
 )
 
+var (
+	apiServerScheme *runtime.Scheme
+	apiServerCodec  runtime.Codec
+)
+
+func init() {
+	apiServerScheme = runtime.NewScheme()
+	utilruntime.Must(apiserverv1alpha1.AddToScheme(apiServerScheme))
+
+	var (
+		ser = json.NewSerializerWithOptions(json.DefaultMetaFactory, apiServerScheme, apiServerScheme, json.SerializerOptions{
+			Yaml:   true,
+			Pretty: false,
+			Strict: false,
+		})
+		versions = schema.GroupVersions([]schema.GroupVersion{
+			apiserverv1alpha1.SchemeGroupVersion,
+		})
+	)
+
+	apiServerCodec = serializer.NewCodecFactory(apiServerScheme).CodecForVersions(ser, ser, versions, versions)
+}
+
 const (
-	configMapAdmissionNamePrefix = "kube-apiserver-admission-config"
-	configMapAdmissionDataKey    = "admission-configuration.yaml"
-
-	configMapAuditPolicyNamePrefix = "audit-policy-config"
-
+	configMapAdmissionNamePrefix      = "kube-apiserver-admission-config"
+	configMapAuditPolicyNamePrefix    = "audit-policy-config"
 	configMapEgressSelectorNamePrefix = "kube-apiserver-egress-selector-config"
 	configMapEgressSelectorDataKey    = "egress-selector-configuration.yaml"
 )
 
 func (k *kubeAPIServer) emptyConfigMap(name string) *corev1.ConfigMap {
 	return &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: k.namespace}}
-}
-
-func (k *kubeAPIServer) reconcileConfigMapAdmission(ctx context.Context, configMap *corev1.ConfigMap) error {
-	configMap.Data = map[string]string{}
-
-	admissionConfig := &apiserverv1alpha1.AdmissionConfiguration{}
-	for _, plugin := range k.values.EnabledAdmissionPlugins {
-		rawConfig, err := computeRelevantAdmissionPluginRawConfig(plugin)
-		if err != nil {
-			return err
-		}
-
-		if rawConfig != nil {
-			admissionConfig.Plugins = append(admissionConfig.Plugins, apiserverv1alpha1.AdmissionPluginConfiguration{
-				Name: plugin.Name,
-				Path: volumeMountPathAdmissionConfiguration + "/" + admissionPluginsConfigFilename(plugin.Name),
-			})
-
-			configMap.Data[admissionPluginsConfigFilename(plugin.Name)] = string(rawConfig)
-		}
-	}
-
-	data, err := runtime.Encode(codec, admissionConfig)
-	if err != nil {
-		return err
-	}
-
-	configMap.Data[configMapAdmissionDataKey] = string(data)
-	utilruntime.Must(kubernetesutils.MakeUnique(configMap))
-
-	return client.IgnoreAlreadyExists(k.client.Client().Create(ctx, configMap))
-}
-
-func admissionPluginsConfigFilename(name string) string {
-	return strings.ToLower(name) + ".yaml"
-}
-
-func computeRelevantAdmissionPluginRawConfig(plugin apiserver.AdmissionPluginConfig) ([]byte, error) {
-	var (
-		nothingToMutate    = (plugin.Config == nil || plugin.Config.Raw == nil) && len(plugin.Kubeconfig) == 0
-		mustDefaultConfig  = (plugin.Config == nil || plugin.Config.Raw == nil) && len(plugin.Kubeconfig) > 0
-		kubeconfigFilePath = volumeMountPathAdmissionKubeconfigSecrets + "/" + admissionPluginsKubeconfigFilename(plugin.Name)
-	)
-
-	if len(plugin.Kubeconfig) == 0 {
-		// This makes sure that the path to the kubeconfig is overwritten if specified in case no kubeconfig was
-		// provided. It prevents that users can access arbitrary files in the kube-apiserver pods and disguise them as
-		// kubeconfigs for their admission plugin configs.
-		kubeconfigFilePath = ""
-	}
-
-	switch plugin.Name {
-	case "ValidatingAdmissionWebhook", "MutatingAdmissionWebhook":
-		if nothingToMutate {
-			return nil, nil
-		}
-
-		if mustDefaultConfig {
-			if plugin.Config == nil {
-				plugin.Config = &runtime.RawExtension{}
-			}
-			if len(plugin.Config.Raw) == 0 {
-				plugin.Config.Raw = []byte(fmt.Sprintf(`apiVersion: %s
-kind: WebhookAdmissionConfiguration`, webhookadmissionv1.SchemeGroupVersion.String()))
-			}
-		}
-
-		configObj, err := runtime.Decode(codec, plugin.Config.Raw)
-		if err != nil {
-			return nil, fmt.Errorf("cannot decode config for admission plugin %s: %w", plugin.Name, err)
-		}
-
-		switch config := configObj.(type) {
-		case *webhookadmissionv1.WebhookAdmission:
-			config.KubeConfigFile = kubeconfigFilePath
-			return runtime.Encode(codec, config)
-		case *webhookadmissionv1alpha1.WebhookAdmission:
-			config.KubeConfigFile = kubeconfigFilePath
-			return runtime.Encode(codec, config)
-		default:
-			return nil, fmt.Errorf("expected apiserver.config.k8s.io/{v1alpha1.WebhookAdmission,v1.WebhookAdmissionConfiguration} in %s plugin configuration but got %T", plugin.Name, config)
-		}
-
-	case "ImagePolicyWebhook":
-		// The configuration for this admission plugin is not backed by the API machinery, hence we have to use
-		// regular marshalling.
-		if nothingToMutate {
-			return nil, nil
-		}
-
-		if mustDefaultConfig {
-			if plugin.Config == nil {
-				plugin.Config = &runtime.RawExtension{}
-			}
-			if len(plugin.Config.Raw) == 0 {
-				plugin.Config.Raw = []byte("imagePolicy: {}")
-			}
-		}
-
-		config := map[string]interface{}{}
-		if err := yaml.Unmarshal(plugin.Config.Raw, &config); err != nil {
-			return nil, fmt.Errorf("failed to unmarshal plugin configuration for %s: %w", plugin.Name, err)
-		}
-		if config["imagePolicy"] == nil {
-			return nil, fmt.Errorf(`expected "imagePolicy" key in configuration but it does not exist`)
-		}
-
-		config["imagePolicy"].(map[string]interface{})["kubeConfigFile"] = kubeconfigFilePath
-		return yaml.Marshal(config)
-
-	default:
-		// For all other plugins, we do not need to mutate anything, hence we only return the provided config if set.
-		if plugin.Config != nil && plugin.Config.Raw != nil {
-			return plugin.Config.Raw, nil
-		}
-	}
-
-	return nil, nil
 }
 
 func (k *kubeAPIServer) reconcileConfigMapEgressSelector(ctx context.Context, configMap *corev1.ConfigMap) error {
@@ -203,7 +103,7 @@ func (k *kubeAPIServer) reconcileConfigMapEgressSelector(ctx context.Context, co
 		},
 	}
 
-	data, err := runtime.Encode(codec, egressSelectorConfig)
+	data, err := runtime.Encode(apiServerCodec, egressSelectorConfig)
 	if err != nil {
 		return err
 	}

--- a/pkg/component/kubeapiserver/configmaps.go
+++ b/pkg/component/kubeapiserver/configmaps.go
@@ -30,6 +30,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
 
+	"github.com/gardener/gardener/pkg/component/apiserver"
 	"github.com/gardener/gardener/pkg/component/vpnseedserver"
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	secretsutils "github.com/gardener/gardener/pkg/utils/secrets"
@@ -85,7 +86,7 @@ func admissionPluginsConfigFilename(name string) string {
 	return strings.ToLower(name) + ".yaml"
 }
 
-func computeRelevantAdmissionPluginRawConfig(plugin AdmissionPluginConfig) ([]byte, error) {
+func computeRelevantAdmissionPluginRawConfig(plugin apiserver.AdmissionPluginConfig) ([]byte, error) {
 	var (
 		nothingToMutate    = (plugin.Config == nil || plugin.Config.Raw == nil) && len(plugin.Kubeconfig) == 0
 		mustDefaultConfig  = (plugin.Config == nil || plugin.Config.Raw == nil) && len(plugin.Kubeconfig) > 0

--- a/pkg/component/kubeapiserver/deployment.go
+++ b/pkg/component/kubeapiserver/deployment.go
@@ -94,8 +94,6 @@ const (
 	volumeNameUsrShareCaCerts                 = "usr-share-cacerts"
 	volumeNameWatchdog                        = "watchdog"
 
-	volumeMountPathAdmissionConfiguration          = "/etc/kubernetes/admission"
-	volumeMountPathAdmissionKubeconfigSecrets      = "/etc/kubernetes/admission-kubeconfigs"
 	volumeMountPathAuditPolicy                     = "/etc/kubernetes/audit"
 	volumeMountPathAuditWebhookKubeconfig          = "/etc/kubernetes/webhook/audit"
 	volumeMountPathAuthenticationWebhookKubeconfig = "/etc/kubernetes/webhook/authentication"
@@ -297,11 +295,11 @@ func (k *kubeAPIServer) reconcileDeployment(
 						VolumeMounts: []corev1.VolumeMount{
 							{
 								Name:      volumeNameAdmissionConfiguration,
-								MountPath: volumeMountPathAdmissionConfiguration,
+								MountPath: apiserver.VolumeMountPathAdmissionConfiguration,
 							},
 							{
 								Name:      volumeNameAdmissionKubeconfigSecrets,
-								MountPath: volumeMountPathAdmissionKubeconfigSecrets,
+								MountPath: apiserver.VolumeMountPathAdmissionKubeconfigSecrets,
 							},
 							{
 								Name:      volumeNameCA,
@@ -504,7 +502,7 @@ func (k *kubeAPIServer) computeKubeAPIServerCommand() []string {
 		out = append(out, "--disable-admission-plugins="+strings.Join(k.disabledAdmissionPluginNames(), ","))
 	}
 
-	out = append(out, fmt.Sprintf("--admission-control-config-file=%s/%s", volumeMountPathAdmissionConfiguration, configMapAdmissionDataKey))
+	out = append(out, fmt.Sprintf("--admission-control-config-file=%s/%s", apiserver.VolumeMountPathAdmissionConfiguration, apiserver.ConfigMapAdmissionDataKey))
 	out = append(out, "--anonymous-auth="+strconv.FormatBool(k.values.AnonymousAuthenticationEnabled))
 
 	if len(k.values.APIAudiences) > 0 {

--- a/pkg/component/kubeapiserver/deployment.go
+++ b/pkg/component/kubeapiserver/deployment.go
@@ -31,6 +31,7 @@ import (
 
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
+	"github.com/gardener/gardener/pkg/component/apiserver"
 	"github.com/gardener/gardener/pkg/component/etcd"
 	etcdconstants "github.com/gardener/gardener/pkg/component/etcd/constants"
 	kubeapiserverconstants "github.com/gardener/gardener/pkg/component/kubeapiserver/constants"
@@ -1322,7 +1323,7 @@ func (k *kubeAPIServer) handleAuditSettings(deployment *appsv1.Deployment, confi
 	}
 
 	if len(k.values.Audit.Webhook.Kubeconfig) > 0 {
-		deployment.Spec.Template.Spec.Containers[0].Command = append(deployment.Spec.Template.Spec.Containers[0].Command, fmt.Sprintf("--audit-webhook-config-file=%s/%s", volumeMountPathAuditWebhookKubeconfig, secretWebhookKubeconfigDataKey))
+		deployment.Spec.Template.Spec.Containers[0].Command = append(deployment.Spec.Template.Spec.Containers[0].Command, fmt.Sprintf("--audit-webhook-config-file=%s/%s", volumeMountPathAuditWebhookKubeconfig, apiserver.SecretWebhookKubeconfigDataKey))
 		deployment.Spec.Template.Spec.Containers[0].VolumeMounts = append(deployment.Spec.Template.Spec.Containers[0].VolumeMounts, corev1.VolumeMount{
 			Name:      volumeNameAuditWebhookKubeconfig,
 			MountPath: volumeMountPathAuditWebhookKubeconfig,
@@ -1353,7 +1354,7 @@ func (k *kubeAPIServer) handleAuthenticationSettings(deployment *appsv1.Deployme
 	}
 
 	if len(k.values.AuthenticationWebhook.Kubeconfig) > 0 {
-		deployment.Spec.Template.Spec.Containers[0].Command = append(deployment.Spec.Template.Spec.Containers[0].Command, fmt.Sprintf("--authentication-token-webhook-config-file=%s/%s", volumeMountPathAuthenticationWebhookKubeconfig, secretWebhookKubeconfigDataKey))
+		deployment.Spec.Template.Spec.Containers[0].Command = append(deployment.Spec.Template.Spec.Containers[0].Command, fmt.Sprintf("--authentication-token-webhook-config-file=%s/%s", volumeMountPathAuthenticationWebhookKubeconfig, apiserver.SecretWebhookKubeconfigDataKey))
 		deployment.Spec.Template.Spec.Containers[0].VolumeMounts = append(deployment.Spec.Template.Spec.Containers[0].VolumeMounts, corev1.VolumeMount{
 			Name:      volumeNameAuthenticationWebhookKubeconfig,
 			MountPath: volumeMountPathAuthenticationWebhookKubeconfig,
@@ -1389,7 +1390,7 @@ func (k *kubeAPIServer) handleAuthorizationSettings(deployment *appsv1.Deploymen
 		authModes = append(authModes, "Webhook")
 
 		if len(k.values.AuthorizationWebhook.Kubeconfig) > 0 {
-			deployment.Spec.Template.Spec.Containers[0].Command = append(deployment.Spec.Template.Spec.Containers[0].Command, fmt.Sprintf("--authorization-webhook-config-file=%s/%s", volumeMountPathAuthorizationWebhookKubeconfig, secretWebhookKubeconfigDataKey))
+			deployment.Spec.Template.Spec.Containers[0].Command = append(deployment.Spec.Template.Spec.Containers[0].Command, fmt.Sprintf("--authorization-webhook-config-file=%s/%s", volumeMountPathAuthorizationWebhookKubeconfig, apiserver.SecretWebhookKubeconfigDataKey))
 			deployment.Spec.Template.Spec.Containers[0].VolumeMounts = append(deployment.Spec.Template.Spec.Containers[0].VolumeMounts, corev1.VolumeMount{
 				Name:      volumeNameAuthorizationWebhookKubeconfig,
 				MountPath: volumeMountPathAuthorizationWebhookKubeconfig,

--- a/pkg/component/kubeapiserver/deployment.go
+++ b/pkg/component/kubeapiserver/deployment.go
@@ -60,26 +60,18 @@ const (
 	containerNameVPNSeedClient = "vpn-client"
 	containerNameWatchdog      = "watchdog"
 
-	volumeNameAdmissionConfiguration          = "admission-config"
-	volumeNameAdmissionKubeconfigSecrets      = "admission-kubeconfigs"
-	volumeNameAuditPolicy                     = "audit-policy-config"
-	volumeNameAuditWebhookKubeconfig          = "audit-webhook-kubeconfig"
 	volumeNameAuthenticationWebhookKubeconfig = "authentication-webhook-kubeconfig"
 	volumeNameAuthorizationWebhookKubeconfig  = "authorization-webhook-kubeconfig"
 	volumeNameCA                              = "ca"
 	volumeNameCAClient                        = "ca-client"
-	volumeNameCAEtcd                          = "ca-etcd"
 	volumeNameCAFrontProxy                    = "ca-front-proxy"
 	volumeNameCAKubelet                       = "ca-kubelet"
 	volumeNameCAVPN                           = "ca-vpn"
 	volumeNameEgressSelector                  = "egress-selection-config"
-	volumeNameEtcdClient                      = "etcd-client"
-	volumeNameEtcdEncryptionConfig            = "etcd-encryption-secret"
 	volumeNameHTTPProxy                       = "http-proxy"
 	volumeNameKubeAPIServerToKubelet          = "kubelet-client"
 	volumeNameKubeAggregator                  = "kube-aggregator"
 	volumeNameOIDCCABundle                    = "oidc-cabundle"
-	volumeNameServer                          = "kube-apiserver-server"
 	volumeNameServiceAccountKey               = "service-account-key"
 	volumeNameServiceAccountKeyBundle         = "service-account-key-bundle"
 	volumeNameStaticToken                     = "static-token"
@@ -94,24 +86,18 @@ const (
 	volumeNameUsrShareCaCerts                 = "usr-share-cacerts"
 	volumeNameWatchdog                        = "watchdog"
 
-	volumeMountPathAuditPolicy                     = "/etc/kubernetes/audit"
-	volumeMountPathAuditWebhookKubeconfig          = "/etc/kubernetes/webhook/audit"
 	volumeMountPathAuthenticationWebhookKubeconfig = "/etc/kubernetes/webhook/authentication"
 	volumeMountPathAuthorizationWebhookKubeconfig  = "/etc/kubernetes/webhook/authorization"
 	volumeMountPathCA                              = "/srv/kubernetes/ca"
 	volumeMountPathCAClient                        = "/srv/kubernetes/ca-client"
-	volumeMountPathCAEtcd                          = "/srv/kubernetes/etcd/ca"
 	volumeMountPathCAFrontProxy                    = "/srv/kubernetes/ca-front-proxy"
 	volumeMountPathCAKubelet                       = "/srv/kubernetes/ca-kubelet"
 	volumeMountPathCAVPN                           = "/srv/kubernetes/ca-vpn"
 	volumeMountPathEgressSelector                  = "/etc/kubernetes/egress"
-	volumeMountPathEtcdEncryptionConfig            = "/etc/kubernetes/etcd-encryption-secret"
-	volumeMountPathEtcdClient                      = "/srv/kubernetes/etcd/client"
 	volumeMountPathHTTPProxy                       = "/etc/srv/kubernetes/envoy"
 	volumeMountPathKubeAPIServerToKubelet          = "/srv/kubernetes/apiserver-kubelet"
 	volumeMountPathKubeAggregator                  = "/srv/kubernetes/aggregator"
 	volumeMountPathOIDCCABundle                    = "/srv/kubernetes/oidc"
-	volumeMountPathServer                          = "/srv/kubernetes/apiserver"
 	volumeMountPathServiceAccountKey               = "/srv/kubernetes/service-account-key"
 	volumeMountPathServiceAccountKeyBundle         = "/srv/kubernetes/service-account-key-bundle"
 	volumeMountPathStaticToken                     = "/srv/kubernetes/token"
@@ -247,7 +233,8 @@ func (k *kubeAPIServer) reconcileDeployment(
 						Name:                     ContainerNameKubeAPIServer,
 						Image:                    k.values.Images.KubeAPIServer,
 						ImagePullPolicy:          corev1.PullIfNotPresent,
-						Command:                  k.computeKubeAPIServerCommand(),
+						Command:                  []string{"/usr/local/bin/kube-apiserver"},
+						Args:                     k.computeKubeAPIServerArgs(),
 						TerminationMessagePath:   corev1.TerminationMessagePathDefault,
 						TerminationMessagePolicy: corev1.TerminationMessageReadFile,
 						Ports: []corev1.ContainerPort{{
@@ -294,14 +281,6 @@ func (k *kubeAPIServer) reconcileDeployment(
 						},
 						VolumeMounts: []corev1.VolumeMount{
 							{
-								Name:      volumeNameAdmissionConfiguration,
-								MountPath: apiserver.VolumeMountPathAdmissionConfiguration,
-							},
-							{
-								Name:      volumeNameAdmissionKubeconfigSecrets,
-								MountPath: apiserver.VolumeMountPathAdmissionKubeconfigSecrets,
-							},
-							{
 								Name:      volumeNameCA,
 								MountPath: volumeMountPathCA,
 							},
@@ -310,20 +289,8 @@ func (k *kubeAPIServer) reconcileDeployment(
 								MountPath: volumeMountPathCAClient,
 							},
 							{
-								Name:      volumeNameCAEtcd,
-								MountPath: volumeMountPathCAEtcd,
-							},
-							{
 								Name:      volumeNameCAFrontProxy,
 								MountPath: volumeMountPathCAFrontProxy,
-							},
-							{
-								Name:      volumeNameEtcdClient,
-								MountPath: volumeMountPathEtcdClient,
-							},
-							{
-								Name:      volumeNameServer,
-								MountPath: volumeMountPathServer,
 							},
 							{
 								Name:      volumeNameServiceAccountKey,
@@ -341,32 +308,9 @@ func (k *kubeAPIServer) reconcileDeployment(
 								Name:      volumeNameKubeAggregator,
 								MountPath: volumeMountPathKubeAggregator,
 							},
-							{
-								Name:      volumeNameEtcdEncryptionConfig,
-								MountPath: volumeMountPathEtcdEncryptionConfig,
-								ReadOnly:  true,
-							},
 						},
 					}},
 					Volumes: []corev1.Volume{
-						{
-							Name: volumeNameAdmissionConfiguration,
-							VolumeSource: corev1.VolumeSource{
-								ConfigMap: &corev1.ConfigMapVolumeSource{
-									LocalObjectReference: corev1.LocalObjectReference{
-										Name: configMapAdmissionConfigs.Name,
-									},
-								},
-							},
-						},
-						{
-							Name: volumeNameAdmissionKubeconfigSecrets,
-							VolumeSource: corev1.VolumeSource{
-								Secret: &corev1.SecretVolumeSource{
-									SecretName: secretAdmissionKubeconfigs.Name,
-								},
-							},
-						},
 						{
 							Name: volumeNameCA,
 							VolumeSource: corev1.VolumeSource{
@@ -384,26 +328,10 @@ func (k *kubeAPIServer) reconcileDeployment(
 							},
 						},
 						{
-							Name: volumeNameCAEtcd,
-							VolumeSource: corev1.VolumeSource{
-								Secret: &corev1.SecretVolumeSource{
-									SecretName: secretCAETCD.Name,
-								},
-							},
-						},
-						{
 							Name: volumeNameCAFrontProxy,
 							VolumeSource: corev1.VolumeSource{
 								Secret: &corev1.SecretVolumeSource{
 									SecretName: secretCAFrontProxy.Name,
-								},
-							},
-						},
-						{
-							Name: volumeNameEtcdClient,
-							VolumeSource: corev1.VolumeSource{
-								Secret: &corev1.SecretVolumeSource{
-									SecretName: secretETCDClient.Name,
 								},
 							},
 						},
@@ -439,34 +367,21 @@ func (k *kubeAPIServer) reconcileDeployment(
 								},
 							},
 						},
-						{
-							Name: volumeNameEtcdEncryptionConfig,
-							VolumeSource: corev1.VolumeSource{
-								Secret: &corev1.SecretVolumeSource{
-									SecretName: secretETCDEncryptionConfiguration.Name,
-								},
-							},
-						},
-						{
-							Name: volumeNameServer,
-							VolumeSource: corev1.VolumeSource{
-								Secret: &corev1.SecretVolumeSource{
-									SecretName: secretServer.Name,
-								},
-							},
-						},
 					},
 				},
 			},
 		}
 
+		apiserver.InjectDefaultSettings(deployment, k.values.NamePrefix, k.values.Values, k.values.Version, secretCAETCD, secretETCDClient, secretServer)
+		apiserver.InjectAuditSettings(deployment, configMapAuditPolicy, secretAuditWebhookKubeconfig, k.values.Audit)
+		apiserver.InjectAdmissionSettings(deployment, configMapAdmissionConfigs, secretAdmissionKubeconfigs, k.values.Values)
+		apiserver.InjectEncryptionSettings(deployment, secretETCDEncryptionConfiguration)
 		k.handleLifecycleSettings(deployment)
 		k.handleHostCertVolumes(deployment)
 		k.handleSNISettings(deployment)
 		k.handleTLSSNISettings(deployment, tlsSNISecrets)
 		k.handleOIDCSettings(deployment, secretOIDCCABundle)
 		k.handleServiceAccountSigningKeySettings(deployment)
-		k.handleAuditSettings(deployment, configMapAuditPolicy, secretAuditWebhookKubeconfig)
 		k.handleAuthenticationSettings(deployment, secretAuthenticationWebhookKubeconfig)
 		k.handleAuthorizationSettings(deployment, secretAuthorizationWebhookKubeconfig)
 		if err := k.handleVPNSettings(deployment, serviceAccount, configMapEgressSelector, secretHTTPProxy, secretHAVPNSeedClient, secretHAVPNSeedClientSeedTLSAuth); err != nil {
@@ -490,19 +405,9 @@ func (k *kubeAPIServer) reconcileDeployment(
 	return err
 }
 
-func (k *kubeAPIServer) computeKubeAPIServerCommand() []string {
+func (k *kubeAPIServer) computeKubeAPIServerArgs() []string {
 	var out []string
 
-	out = append(out, "/usr/local/bin/kube-apiserver")
-
-	if len(k.values.EnabledAdmissionPlugins) > 0 {
-		out = append(out, "--enable-admission-plugins="+strings.Join(k.admissionPluginNames(), ","))
-	}
-	if len(k.values.DisabledAdmissionPlugins) > 0 {
-		out = append(out, "--disable-admission-plugins="+strings.Join(k.disabledAdmissionPluginNames(), ","))
-	}
-
-	out = append(out, fmt.Sprintf("--admission-control-config-file=%s/%s", apiserver.VolumeMountPathAdmissionConfiguration, apiserver.ConfigMapAdmissionDataKey))
 	out = append(out, "--anonymous-auth="+strconv.FormatBool(k.values.AnonymousAuthenticationEnabled))
 
 	if len(k.values.APIAudiences) > 0 {
@@ -512,13 +417,7 @@ func (k *kubeAPIServer) computeKubeAPIServerCommand() []string {
 	out = append(out, fmt.Sprintf("--client-ca-file=%s/%s", volumeMountPathCAClient, secrets.DataKeyCertificateBundle))
 	out = append(out, "--enable-aggregator-routing=true")
 	out = append(out, "--enable-bootstrap-token-auth=true")
-	out = append(out, "--http2-max-streams-per-connection=1000")
-	out = append(out, fmt.Sprintf("--etcd-cafile=%s/%s", volumeMountPathCAEtcd, secrets.DataKeyCertificateBundle))
-	out = append(out, fmt.Sprintf("--etcd-certfile=%s/%s", volumeMountPathEtcdClient, secrets.DataKeyCertificate))
-	out = append(out, fmt.Sprintf("--etcd-keyfile=%s/%s", volumeMountPathEtcdClient, secrets.DataKeyPrivateKey))
-	out = append(out, fmt.Sprintf("--etcd-servers=https://%s%s:%d", k.values.NamePrefix, etcdconstants.ServiceName(v1beta1constants.ETCDRoleMain), etcdconstants.PortEtcdClient))
 	out = append(out, "--etcd-servers-overrides="+k.etcdServersOverrides())
-	out = append(out, fmt.Sprintf("--encryption-provider-config=%s/%s", volumeMountPathEtcdEncryptionConfig, secretETCDEncryptionConfigurationDataKey))
 	out = append(out, "--external-hostname="+k.values.ExternalHostname)
 
 	if k.values.DefaultNotReadyTolerationSeconds != nil {
@@ -532,25 +431,10 @@ func (k *kubeAPIServer) computeKubeAPIServerCommand() []string {
 		out = append(out, fmt.Sprintf("--event-ttl=%s", k.values.EventTTL.Duration))
 	}
 
-	if k.values.FeatureGates != nil {
-		out = append(out, kubernetesutils.FeatureGatesToCommandLineParameter(k.values.FeatureGates))
-	}
-
 	if version.ConstraintK8sLess124.Check(k.values.Version) {
 		out = append(out, "--insecure-port=0")
 	}
 
-	if k.values.Requests != nil {
-		if k.values.Requests.MaxNonMutatingInflight != nil {
-			out = append(out, fmt.Sprintf("--max-requests-inflight=%d", *k.values.Requests.MaxNonMutatingInflight))
-		}
-
-		if k.values.Requests.MaxMutatingInflight != nil {
-			out = append(out, fmt.Sprintf("--max-mutating-requests-inflight=%d", *k.values.Requests.MaxMutatingInflight))
-		}
-	}
-
-	out = append(out, "--profiling=false")
 	out = append(out, fmt.Sprintf("--proxy-client-cert-file=%s/%s", volumeMountPathKubeAggregator, secrets.DataKeyCertificate))
 	out = append(out, fmt.Sprintf("--proxy-client-key-file=%s/%s", volumeMountPathKubeAggregator, secrets.DataKeyPrivateKey))
 	out = append(out, fmt.Sprintf("--requestheader-client-ca-file=%s/%s", volumeMountPathCAFrontProxy, secrets.DataKeyCertificateBundle))
@@ -593,40 +477,6 @@ func (k *kubeAPIServer) computeKubeAPIServerCommand() []string {
 	out = append(out, fmt.Sprintf("--service-cluster-ip-range=%s", k.values.ServiceNetworkCIDR))
 	out = append(out, fmt.Sprintf("--secure-port=%d", kubeapiserverconstants.Port))
 	out = append(out, fmt.Sprintf("--token-auth-file=%s/%s", volumeMountPathStaticToken, secrets.DataKeyStaticTokenCSV))
-	out = append(out, fmt.Sprintf("--tls-cert-file=%s/%s", volumeMountPathServer, secrets.DataKeyCertificate))
-	out = append(out, fmt.Sprintf("--tls-private-key-file=%s/%s", volumeMountPathServer, secrets.DataKeyPrivateKey))
-	out = append(out, "--tls-cipher-suites="+strings.Join(kubernetesutils.TLSCipherSuites(k.values.Version), ","))
-
-	if k.values.Logging != nil {
-		if k.values.Logging.HTTPAccessVerbosity != nil {
-			out = append(out, fmt.Sprintf("--vmodule=httplog=%d", *k.values.Logging.HTTPAccessVerbosity))
-		}
-		if k.values.Logging.Verbosity != nil {
-			out = append(out, fmt.Sprintf("--v=%d", *k.values.Logging.Verbosity))
-		}
-	}
-
-	if k.values.WatchCacheSizes != nil {
-		if k.values.WatchCacheSizes.Default != nil {
-			out = append(out, fmt.Sprintf("--default-watch-cache-size=%d", *k.values.WatchCacheSizes.Default))
-		}
-
-		if len(k.values.WatchCacheSizes.Resources) > 0 {
-			var sizes []string
-
-			for _, resource := range k.values.WatchCacheSizes.Resources {
-				size := resource.Resource
-				if resource.APIGroup != nil {
-					size += "." + *resource.APIGroup
-				}
-				size += fmt.Sprintf("#%d", resource.CacheSize)
-
-				sizes = append(sizes, size)
-			}
-
-			out = append(out, "--watch-cache-sizes="+strings.Join(sizes, ","))
-		}
-	}
 
 	return out
 }
@@ -646,26 +496,6 @@ func (k *kubeAPIServer) etcdServersOverrides() string {
 		overrides = append(overrides, fmt.Sprintf("%s/%s#https://%s%s:%d", resource.Group, resource.Resource, k.values.NamePrefix, etcdconstants.ServiceName(v1beta1constants.ETCDRoleEvents), etcdconstants.PortEtcdClient))
 	}
 	return strings.Join(overrides, ",")
-}
-
-func (k *kubeAPIServer) admissionPluginNames() []string {
-	var out []string
-
-	for _, plugin := range k.values.EnabledAdmissionPlugins {
-		out = append(out, plugin.Name)
-	}
-
-	return out
-}
-
-func (k *kubeAPIServer) disabledAdmissionPluginNames() []string {
-	var out []string
-
-	for _, plugin := range k.values.DisabledAdmissionPlugins {
-		out = append(out, plugin.Name)
-	}
-
-	return out
 }
 
 func (k *kubeAPIServer) handleHostCertVolumes(deployment *appsv1.Deployment) {
@@ -742,7 +572,7 @@ func (k *kubeAPIServer) handleSNISettings(deployment *appsv1.Deployment) {
 	}
 
 	deployment.Labels[v1beta1constants.LabelAPIServerExposure] = v1beta1constants.LabelAPIServerExposureGardenerManaged
-	deployment.Spec.Template.Spec.Containers[0].Command = append(deployment.Spec.Template.Spec.Containers[0].Command, fmt.Sprintf("--advertise-address=%s", k.values.SNI.AdvertiseAddress))
+	deployment.Spec.Template.Spec.Containers[0].Args = append(deployment.Spec.Template.Spec.Containers[0].Args, fmt.Sprintf("--advertise-address=%s", k.values.SNI.AdvertiseAddress))
 }
 
 func (k *kubeAPIServer) handleTLSSNISettings(deployment *appsv1.Deployment, tlsSNISecrets []tlsSNISecret) {
@@ -757,7 +587,7 @@ func (k *kubeAPIServer) handleTLSSNISettings(deployment *appsv1.Deployment, tlsS
 			flag += ":" + strings.Join(sni.domainPatterns, ",")
 		}
 
-		deployment.Spec.Template.Spec.Containers[0].Command = append(deployment.Spec.Template.Spec.Containers[0].Command, flag)
+		deployment.Spec.Template.Spec.Containers[0].Args = append(deployment.Spec.Template.Spec.Containers[0].Args, flag)
 		deployment.Spec.Template.Spec.Containers[0].VolumeMounts = append(deployment.Spec.Template.Spec.Containers[0].VolumeMounts, corev1.VolumeMount{
 			Name:      volumeName,
 			MountPath: volumeMountPath,
@@ -775,8 +605,6 @@ func (k *kubeAPIServer) handleTLSSNISettings(deployment *appsv1.Deployment, tlsS
 }
 
 func (k *kubeAPIServer) handleLifecycleSettings(deployment *appsv1.Deployment) {
-	deployment.Spec.Template.Spec.Containers[0].Command = append(deployment.Spec.Template.Spec.Containers[0].Command, "--livez-grace-period=1m")
-	deployment.Spec.Template.Spec.Containers[0].Command = append(deployment.Spec.Template.Spec.Containers[0].Command, "--shutdown-delay-duration=15s")
 	// For kube-apiserver version 1.24 there is a deadlock that can occur during shutdown that prevents the graceful termination
 	// of the kube-apiserver container to complete when the --audit-log-mode setting is set to batch. Open TCP connections to that
 	// kube-apiserver are not terminated and clients will keep receiving an error that the kube-apiserver is shutting down which leads
@@ -785,7 +613,7 @@ func (k *kubeAPIServer) handleLifecycleSettings(deployment *appsv1.Deployment) {
 	// requests will have their connections closed and eventually be reopened to healthy kube-apiservers.
 	// TODO: Once https://github.com/kubernetes/kubernetes/pull/113741 is merged this setting can be removed.
 	if version.ConstraintK8sEqual124.Check(k.values.Version) {
-		deployment.Spec.Template.Spec.Containers[0].Command = append(deployment.Spec.Template.Spec.Containers[0].Command, "--shutdown-send-retry-after=true")
+		deployment.Spec.Template.Spec.Containers[0].Args = append(deployment.Spec.Template.Spec.Containers[0].Args, "--shutdown-send-retry-after=true")
 	}
 }
 
@@ -824,7 +652,7 @@ func (k *kubeAPIServer) handleVPNSettingsNonHA(
 	deployment.Spec.Template.Labels = utils.MergeStringMaps(deployment.Spec.Template.Labels, map[string]string{
 		gardenerutils.NetworkPolicyLabel(vpnseedserver.ServiceName, vpnseedserver.EnvoyPort): v1beta1constants.LabelNetworkPolicyAllowed,
 	})
-	deployment.Spec.Template.Spec.Containers[0].Command = append(deployment.Spec.Template.Spec.Containers[0].Command, fmt.Sprintf("--egress-selector-config-file=%s/%s", volumeMountPathEgressSelector, configMapEgressSelectorDataKey))
+	deployment.Spec.Template.Spec.Containers[0].Args = append(deployment.Spec.Template.Spec.Containers[0].Args, fmt.Sprintf("--egress-selector-config-file=%s/%s", volumeMountPathEgressSelector, configMapEgressSelectorDataKey))
 	deployment.Spec.Template.Spec.Containers[0].VolumeMounts = append(deployment.Spec.Template.Spec.Containers[0].VolumeMounts, []corev1.VolumeMount{
 		{
 			Name:      volumeNameCAVPN,
@@ -1151,7 +979,7 @@ func (k *kubeAPIServer) handleOIDCSettings(deployment *appsv1.Deployment, secret
 	}
 
 	if k.values.OIDC.CABundle != nil {
-		deployment.Spec.Template.Spec.Containers[0].Command = append(deployment.Spec.Template.Spec.Containers[0].Command, fmt.Sprintf("--oidc-ca-file=%s/%s", volumeMountPathOIDCCABundle, secretOIDCCABundleDataKeyCaCrt))
+		deployment.Spec.Template.Spec.Containers[0].Args = append(deployment.Spec.Template.Spec.Containers[0].Args, fmt.Sprintf("--oidc-ca-file=%s/%s", volumeMountPathOIDCCABundle, secretOIDCCABundleDataKeyCaCrt))
 		deployment.Spec.Template.Spec.Containers[0].VolumeMounts = append(deployment.Spec.Template.Spec.Containers[0].VolumeMounts, []corev1.VolumeMount{
 			{
 				Name:      volumeNameOIDCCABundle,
@@ -1171,41 +999,41 @@ func (k *kubeAPIServer) handleOIDCSettings(deployment *appsv1.Deployment, secret
 	}
 
 	if v := k.values.OIDC.IssuerURL; v != nil {
-		deployment.Spec.Template.Spec.Containers[0].Command = append(deployment.Spec.Template.Spec.Containers[0].Command, "--oidc-issuer-url="+*v)
+		deployment.Spec.Template.Spec.Containers[0].Args = append(deployment.Spec.Template.Spec.Containers[0].Args, "--oidc-issuer-url="+*v)
 	}
 
 	if v := k.values.OIDC.ClientID; v != nil {
-		deployment.Spec.Template.Spec.Containers[0].Command = append(deployment.Spec.Template.Spec.Containers[0].Command, "--oidc-client-id="+*v)
+		deployment.Spec.Template.Spec.Containers[0].Args = append(deployment.Spec.Template.Spec.Containers[0].Args, "--oidc-client-id="+*v)
 	}
 
 	if v := k.values.OIDC.UsernameClaim; v != nil {
-		deployment.Spec.Template.Spec.Containers[0].Command = append(deployment.Spec.Template.Spec.Containers[0].Command, "--oidc-username-claim="+*v)
+		deployment.Spec.Template.Spec.Containers[0].Args = append(deployment.Spec.Template.Spec.Containers[0].Args, "--oidc-username-claim="+*v)
 	}
 
 	if v := k.values.OIDC.GroupsClaim; v != nil {
-		deployment.Spec.Template.Spec.Containers[0].Command = append(deployment.Spec.Template.Spec.Containers[0].Command, "--oidc-groups-claim="+*v)
+		deployment.Spec.Template.Spec.Containers[0].Args = append(deployment.Spec.Template.Spec.Containers[0].Args, "--oidc-groups-claim="+*v)
 	}
 
 	if v := k.values.OIDC.UsernamePrefix; v != nil {
-		deployment.Spec.Template.Spec.Containers[0].Command = append(deployment.Spec.Template.Spec.Containers[0].Command, "--oidc-username-prefix="+*v)
+		deployment.Spec.Template.Spec.Containers[0].Args = append(deployment.Spec.Template.Spec.Containers[0].Args, "--oidc-username-prefix="+*v)
 	}
 
 	if v := k.values.OIDC.GroupsPrefix; v != nil {
-		deployment.Spec.Template.Spec.Containers[0].Command = append(deployment.Spec.Template.Spec.Containers[0].Command, "--oidc-groups-prefix="+*v)
+		deployment.Spec.Template.Spec.Containers[0].Args = append(deployment.Spec.Template.Spec.Containers[0].Args, "--oidc-groups-prefix="+*v)
 	}
 
 	if k.values.OIDC.SigningAlgs != nil {
-		deployment.Spec.Template.Spec.Containers[0].Command = append(deployment.Spec.Template.Spec.Containers[0].Command, "--oidc-signing-algs="+strings.Join(k.values.OIDC.SigningAlgs, ","))
+		deployment.Spec.Template.Spec.Containers[0].Args = append(deployment.Spec.Template.Spec.Containers[0].Args, "--oidc-signing-algs="+strings.Join(k.values.OIDC.SigningAlgs, ","))
 	}
 
 	for key, value := range k.values.OIDC.RequiredClaims {
-		deployment.Spec.Template.Spec.Containers[0].Command = append(deployment.Spec.Template.Spec.Containers[0].Command, "--oidc-required-claim="+fmt.Sprintf("%s=%s", key, value))
+		deployment.Spec.Template.Spec.Containers[0].Args = append(deployment.Spec.Template.Spec.Containers[0].Args, "--oidc-required-claim="+fmt.Sprintf("%s=%s", key, value))
 	}
 }
 
 func (k *kubeAPIServer) handleServiceAccountSigningKeySettings(deployment *appsv1.Deployment) {
-	deployment.Spec.Template.Spec.Containers[0].Command = append(deployment.Spec.Template.Spec.Containers[0].Command, fmt.Sprintf("--service-account-signing-key-file=%s/%s", volumeMountPathServiceAccountKey, secrets.DataKeyRSAPrivateKey))
-	deployment.Spec.Template.Spec.Containers[0].Command = append(deployment.Spec.Template.Spec.Containers[0].Command, fmt.Sprintf("--service-account-key-file=%s/%s", volumeMountPathServiceAccountKeyBundle, secrets.DataKeyPrivateKeyBundle))
+	deployment.Spec.Template.Spec.Containers[0].Args = append(deployment.Spec.Template.Spec.Containers[0].Args, fmt.Sprintf("--service-account-signing-key-file=%s/%s", volumeMountPathServiceAccountKey, secrets.DataKeyRSAPrivateKey))
+	deployment.Spec.Template.Spec.Containers[0].Args = append(deployment.Spec.Template.Spec.Containers[0].Args, fmt.Sprintf("--service-account-key-file=%s/%s", volumeMountPathServiceAccountKeyBundle, secrets.DataKeyPrivateKeyBundle))
 }
 
 func (k *kubeAPIServer) handleKubeletSettings(deployment *appsv1.Deployment, secretKubeletClient *corev1.Secret) error {
@@ -1218,7 +1046,7 @@ func (k *kubeAPIServer) handleKubeletSettings(deployment *appsv1.Deployment, sec
 		return fmt.Errorf("secret %q not found", v1beta1constants.SecretNameCAKubelet)
 	}
 
-	deployment.Spec.Template.Spec.Containers[0].Command = append(deployment.Spec.Template.Spec.Containers[0].Command,
+	deployment.Spec.Template.Spec.Containers[0].Args = append(deployment.Spec.Template.Spec.Containers[0].Args,
 		"--allow-privileged=true",
 		"--kubelet-preferred-address-types=InternalIP,Hostname,ExternalIP",
 		fmt.Sprintf("--kubelet-certificate-authority=%s/%s", volumeMountPathCAKubelet, secrets.DataKeyCertificateBundle),
@@ -1293,66 +1121,13 @@ func (k *kubeAPIServer) handleWatchdogSidecar(deployment *appsv1.Deployment, con
 	})
 }
 
-func (k *kubeAPIServer) handleAuditSettings(deployment *appsv1.Deployment, configMapAuditPolicy *corev1.ConfigMap, secretWebhookKubeconfig *corev1.Secret) {
-	deployment.Spec.Template.Spec.Containers[0].Command = append(deployment.Spec.Template.Spec.Containers[0].Command, fmt.Sprintf("--audit-policy-file=%s/%s", volumeMountPathAuditPolicy, apiserver.ConfigMapAuditPolicyDataKey))
-
-	deployment.Spec.Template.Spec.Containers[0].VolumeMounts = append(deployment.Spec.Template.Spec.Containers[0].VolumeMounts, corev1.VolumeMount{
-		Name:      volumeNameAuditPolicy,
-		MountPath: volumeMountPathAuditPolicy,
-	})
-	deployment.Spec.Template.Spec.Volumes = append(deployment.Spec.Template.Spec.Volumes, corev1.Volume{
-		Name: volumeNameAuditPolicy,
-		VolumeSource: corev1.VolumeSource{
-			ConfigMap: &corev1.ConfigMapVolumeSource{
-				LocalObjectReference: corev1.LocalObjectReference{
-					Name: configMapAuditPolicy.Name,
-				},
-			},
-		},
-	})
-
-	if k.values.Audit == nil || k.values.Audit.Webhook == nil {
-		deployment.Spec.Template.Spec.Containers[0].Command = append(deployment.Spec.Template.Spec.Containers[0].Command,
-			"--audit-log-path=/var/lib/audit.log",
-			"--audit-log-maxsize=100",
-			"--audit-log-maxbackup=5",
-		)
-		return
-	}
-
-	if len(k.values.Audit.Webhook.Kubeconfig) > 0 {
-		deployment.Spec.Template.Spec.Containers[0].Command = append(deployment.Spec.Template.Spec.Containers[0].Command, fmt.Sprintf("--audit-webhook-config-file=%s/%s", volumeMountPathAuditWebhookKubeconfig, apiserver.SecretWebhookKubeconfigDataKey))
-		deployment.Spec.Template.Spec.Containers[0].VolumeMounts = append(deployment.Spec.Template.Spec.Containers[0].VolumeMounts, corev1.VolumeMount{
-			Name:      volumeNameAuditWebhookKubeconfig,
-			MountPath: volumeMountPathAuditWebhookKubeconfig,
-			ReadOnly:  true,
-		})
-		deployment.Spec.Template.Spec.Volumes = append(deployment.Spec.Template.Spec.Volumes, corev1.Volume{
-			Name: volumeNameAuditWebhookKubeconfig,
-			VolumeSource: corev1.VolumeSource{
-				Secret: &corev1.SecretVolumeSource{
-					SecretName: secretWebhookKubeconfig.Name,
-				},
-			},
-		})
-	}
-
-	if v := k.values.Audit.Webhook.BatchMaxSize; v != nil {
-		deployment.Spec.Template.Spec.Containers[0].Command = append(deployment.Spec.Template.Spec.Containers[0].Command, fmt.Sprintf("--audit-webhook-batch-max-size=%d", *v))
-	}
-
-	if v := k.values.Audit.Webhook.Version; v != nil {
-		deployment.Spec.Template.Spec.Containers[0].Command = append(deployment.Spec.Template.Spec.Containers[0].Command, fmt.Sprintf("--audit-webhook-version=%s", *v))
-	}
-}
-
 func (k *kubeAPIServer) handleAuthenticationSettings(deployment *appsv1.Deployment, secretWebhookKubeconfig *corev1.Secret) {
 	if k.values.AuthenticationWebhook == nil {
 		return
 	}
 
 	if len(k.values.AuthenticationWebhook.Kubeconfig) > 0 {
-		deployment.Spec.Template.Spec.Containers[0].Command = append(deployment.Spec.Template.Spec.Containers[0].Command, fmt.Sprintf("--authentication-token-webhook-config-file=%s/%s", volumeMountPathAuthenticationWebhookKubeconfig, apiserver.SecretWebhookKubeconfigDataKey))
+		deployment.Spec.Template.Spec.Containers[0].Args = append(deployment.Spec.Template.Spec.Containers[0].Args, fmt.Sprintf("--authentication-token-webhook-config-file=%s/%s", volumeMountPathAuthenticationWebhookKubeconfig, apiserver.SecretWebhookKubeconfigDataKey))
 		deployment.Spec.Template.Spec.Containers[0].VolumeMounts = append(deployment.Spec.Template.Spec.Containers[0].VolumeMounts, corev1.VolumeMount{
 			Name:      volumeNameAuthenticationWebhookKubeconfig,
 			MountPath: volumeMountPathAuthenticationWebhookKubeconfig,
@@ -1369,11 +1144,11 @@ func (k *kubeAPIServer) handleAuthenticationSettings(deployment *appsv1.Deployme
 	}
 
 	if v := k.values.AuthenticationWebhook.CacheTTL; v != nil {
-		deployment.Spec.Template.Spec.Containers[0].Command = append(deployment.Spec.Template.Spec.Containers[0].Command, fmt.Sprintf("--authentication-token-webhook-cache-ttl=%s", v.String()))
+		deployment.Spec.Template.Spec.Containers[0].Args = append(deployment.Spec.Template.Spec.Containers[0].Args, fmt.Sprintf("--authentication-token-webhook-cache-ttl=%s", v.String()))
 	}
 
 	if v := k.values.AuthenticationWebhook.Version; v != nil {
-		deployment.Spec.Template.Spec.Containers[0].Command = append(deployment.Spec.Template.Spec.Containers[0].Command, fmt.Sprintf("--authentication-token-webhook-version=%s", *v))
+		deployment.Spec.Template.Spec.Containers[0].Args = append(deployment.Spec.Template.Spec.Containers[0].Args, fmt.Sprintf("--authentication-token-webhook-version=%s", *v))
 	}
 }
 
@@ -1388,7 +1163,7 @@ func (k *kubeAPIServer) handleAuthorizationSettings(deployment *appsv1.Deploymen
 		authModes = append(authModes, "Webhook")
 
 		if len(k.values.AuthorizationWebhook.Kubeconfig) > 0 {
-			deployment.Spec.Template.Spec.Containers[0].Command = append(deployment.Spec.Template.Spec.Containers[0].Command, fmt.Sprintf("--authorization-webhook-config-file=%s/%s", volumeMountPathAuthorizationWebhookKubeconfig, apiserver.SecretWebhookKubeconfigDataKey))
+			deployment.Spec.Template.Spec.Containers[0].Args = append(deployment.Spec.Template.Spec.Containers[0].Args, fmt.Sprintf("--authorization-webhook-config-file=%s/%s", volumeMountPathAuthorizationWebhookKubeconfig, apiserver.SecretWebhookKubeconfigDataKey))
 			deployment.Spec.Template.Spec.Containers[0].VolumeMounts = append(deployment.Spec.Template.Spec.Containers[0].VolumeMounts, corev1.VolumeMount{
 				Name:      volumeNameAuthorizationWebhookKubeconfig,
 				MountPath: volumeMountPathAuthorizationWebhookKubeconfig,
@@ -1405,16 +1180,16 @@ func (k *kubeAPIServer) handleAuthorizationSettings(deployment *appsv1.Deploymen
 		}
 
 		if v := k.values.AuthorizationWebhook.CacheAuthorizedTTL; v != nil {
-			deployment.Spec.Template.Spec.Containers[0].Command = append(deployment.Spec.Template.Spec.Containers[0].Command, fmt.Sprintf("--authorization-webhook-cache-authorized-ttl=%s", v.String()))
+			deployment.Spec.Template.Spec.Containers[0].Args = append(deployment.Spec.Template.Spec.Containers[0].Args, fmt.Sprintf("--authorization-webhook-cache-authorized-ttl=%s", v.String()))
 		}
 		if v := k.values.AuthorizationWebhook.CacheUnauthorizedTTL; v != nil {
-			deployment.Spec.Template.Spec.Containers[0].Command = append(deployment.Spec.Template.Spec.Containers[0].Command, fmt.Sprintf("--authorization-webhook-cache-unauthorized-ttl=%s", v.String()))
+			deployment.Spec.Template.Spec.Containers[0].Args = append(deployment.Spec.Template.Spec.Containers[0].Args, fmt.Sprintf("--authorization-webhook-cache-unauthorized-ttl=%s", v.String()))
 		}
 
 		if v := k.values.AuthorizationWebhook.Version; v != nil {
-			deployment.Spec.Template.Spec.Containers[0].Command = append(deployment.Spec.Template.Spec.Containers[0].Command, fmt.Sprintf("--authorization-webhook-version=%s", *v))
+			deployment.Spec.Template.Spec.Containers[0].Args = append(deployment.Spec.Template.Spec.Containers[0].Args, fmt.Sprintf("--authorization-webhook-version=%s", *v))
 		}
 	}
 
-	deployment.Spec.Template.Spec.Containers[0].Command = append(deployment.Spec.Template.Spec.Containers[0].Command, "--authorization-mode="+strings.Join(authModes, ","))
+	deployment.Spec.Template.Spec.Containers[0].Args = append(deployment.Spec.Template.Spec.Containers[0].Args, "--authorization-mode="+strings.Join(authModes, ","))
 }

--- a/pkg/component/kubeapiserver/deployment.go
+++ b/pkg/component/kubeapiserver/deployment.go
@@ -49,7 +49,7 @@ import (
 )
 
 const (
-	secretNameServer                 = "kube-apiserver"
+	secretNameServerCert             = "kube-apiserver"
 	secretNameKubeAPIServerToKubelet = "kube-apiserver-kubelet"
 	secretNameKubeAggregator         = "kube-aggregator"
 	secretNameHTTPProxy              = "kube-apiserver-http-proxy"

--- a/pkg/component/kubeapiserver/deployment.go
+++ b/pkg/component/kubeapiserver/deployment.go
@@ -1296,7 +1296,7 @@ func (k *kubeAPIServer) handleWatchdogSidecar(deployment *appsv1.Deployment, con
 }
 
 func (k *kubeAPIServer) handleAuditSettings(deployment *appsv1.Deployment, configMapAuditPolicy *corev1.ConfigMap, secretWebhookKubeconfig *corev1.Secret) {
-	deployment.Spec.Template.Spec.Containers[0].Command = append(deployment.Spec.Template.Spec.Containers[0].Command, fmt.Sprintf("--audit-policy-file=%s/%s", volumeMountPathAuditPolicy, configMapAuditPolicyDataKey))
+	deployment.Spec.Template.Spec.Containers[0].Command = append(deployment.Spec.Template.Spec.Containers[0].Command, fmt.Sprintf("--audit-policy-file=%s/%s", volumeMountPathAuditPolicy, apiserver.ConfigMapAuditPolicyDataKey))
 
 	deployment.Spec.Template.Spec.Containers[0].VolumeMounts = append(deployment.Spec.Template.Spec.Containers[0].VolumeMounts, corev1.VolumeMount{
 		Name:      volumeNameAuditPolicy,

--- a/pkg/component/kubeapiserver/kube_apiserver.go
+++ b/pkg/component/kubeapiserver/kube_apiserver.go
@@ -329,10 +329,6 @@ func (k *kubeAPIServer) Deploy(ctx context.Context) error {
 		return err
 	}
 
-	if err := apiserver.ReconcileSecretAuditWebhookKubeconfig(ctx, k.client.Client(), secretAuditWebhookKubeconfig, k.values.Audit); err != nil {
-		return err
-	}
-
 	if err := k.reconcileSecretAuthenticationWebhookKubeconfig(ctx, secretAuthenticationWebhookKubeconfig); err != nil {
 		return err
 	}
@@ -378,7 +374,10 @@ func (k *kubeAPIServer) Deploy(ctx context.Context) error {
 		return err
 	}
 
-	if err := k.reconcileConfigMapAuditPolicy(ctx, configMapAuditPolicy); err != nil {
+	if err := apiserver.ReconcileConfigMapAuditPolicy(ctx, k.client.Client(), configMapAuditPolicy, k.values.Audit); err != nil {
+		return err
+	}
+	if err := apiserver.ReconcileSecretAuditWebhookKubeconfig(ctx, k.client.Client(), secretAuditWebhookKubeconfig, k.values.Audit); err != nil {
 		return err
 	}
 

--- a/pkg/component/kubeapiserver/kube_apiserver.go
+++ b/pkg/component/kubeapiserver/kube_apiserver.go
@@ -35,7 +35,6 @@ import (
 	webhookadmissionv1alpha1 "k8s.io/apiserver/pkg/admission/plugin/webhook/config/apis/webhookadmission/v1alpha1"
 	apiserverv1alpha1 "k8s.io/apiserver/pkg/apis/apiserver/v1alpha1"
 	auditv1 "k8s.io/apiserver/pkg/apis/audit/v1"
-	apiserverconfigv1 "k8s.io/apiserver/pkg/apis/config/v1"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -61,7 +60,6 @@ var (
 func init() {
 	scheme = runtime.NewScheme()
 	utilruntime.Must(apiserverv1alpha1.AddToScheme(scheme))
-	utilruntime.Must(apiserverconfigv1.AddToScheme(scheme))
 	utilruntime.Must(auditv1.AddToScheme(scheme))
 	utilruntime.Must(webhookadmissionv1.AddToScheme(scheme))
 	utilruntime.Must(webhookadmissionv1alpha1.AddToScheme(scheme))
@@ -74,7 +72,6 @@ func init() {
 		})
 		versions = schema.GroupVersions([]schema.GroupVersion{
 			apiserverv1alpha1.SchemeGroupVersion,
-			apiserverconfigv1.SchemeGroupVersion,
 			auditv1.SchemeGroupVersion,
 			webhookadmissionv1.SchemeGroupVersion,
 			webhookadmissionv1alpha1.SchemeGroupVersion,

--- a/pkg/component/kubeapiserver/kube_apiserver.go
+++ b/pkg/component/kubeapiserver/kube_apiserver.go
@@ -329,7 +329,7 @@ func (k *kubeAPIServer) Deploy(ctx context.Context) error {
 		return err
 	}
 
-	if err := k.reconcileSecretAuditWebhookKubeconfig(ctx, secretAuditWebhookKubeconfig); err != nil {
+	if err := apiserver.ReconcileSecretAuditWebhookKubeconfig(ctx, k.client.Client(), secretAuditWebhookKubeconfig, k.values.Audit); err != nil {
 		return err
 	}
 

--- a/pkg/component/kubeapiserver/kube_apiserver.go
+++ b/pkg/component/kubeapiserver/kube_apiserver.go
@@ -374,7 +374,7 @@ func (k *kubeAPIServer) Deploy(ctx context.Context) error {
 	if err := k.reconcileConfigMapAdmission(ctx, configMapAdmissionConfigs); err != nil {
 		return err
 	}
-	if err := k.reconcileSecretAdmissionKubeconfigs(ctx, secretAdmissionKubeconfigs); err != nil {
+	if err := apiserver.ReconcileSecretAdmissionKubeconfigs(ctx, k.client.Client(), secretAdmissionKubeconfigs, k.values.Values); err != nil {
 		return err
 	}
 

--- a/pkg/component/kubeapiserver/kube_apiserver_test.go
+++ b/pkg/component/kubeapiserver/kube_apiserver_test.go
@@ -108,7 +108,7 @@ var _ = Describe("KubeAPIServer", func() {
 
 		configMapNameAdmissionConfigs   = "kube-apiserver-admission-config-e38ff146"
 		secretNameAdmissionKubeconfigs  = "kube-apiserver-admission-kubeconfigs-e3b0c442"
-		secretNameETCDEncryptionConfig  = "kube-apiserver-etcd-encryption-configuration-235f7353"
+		secretNameETCDEncryptionConfig  = "kube-apiserver-etcd-encryption-configuration-97e14df3"
 		configMapNameAuditPolicy        = "audit-policy-config-f5b578b4"
 		configMapNameEgressPolicy       = "kube-apiserver-egress-selector-config-53d92abc"
 		configMapNameTerminationHandler = "kube-apiserver-watchdog-f4f4b3d5"
@@ -1748,7 +1748,7 @@ rules:
 						"reference.resources.gardener.cloud/secret-998b2966":    secretNameKubeAggregator,
 						"reference.resources.gardener.cloud/secret-3ddd1800":    secretNameServer,
 						"reference.resources.gardener.cloud/secret-430944e0":    secretNameStaticToken,
-						"reference.resources.gardener.cloud/secret-b1b53288":    secretNameETCDEncryptionConfig,
+						"reference.resources.gardener.cloud/secret-a61a895c":    secretNameETCDEncryptionConfig,
 						"reference.resources.gardener.cloud/configmap-130aa219": configMapNameAdmissionConfigs,
 						"reference.resources.gardener.cloud/secret-5613e39f":    secretNameAdmissionKubeconfigs,
 						"reference.resources.gardener.cloud/configmap-d4419cd4": configMapNameAuditPolicy,
@@ -1947,7 +1947,7 @@ rules:
 						"reference.resources.gardener.cloud/secret-998b2966":    secretNameKubeAggregator,
 						"reference.resources.gardener.cloud/secret-3ddd1800":    secretNameServer,
 						"reference.resources.gardener.cloud/secret-430944e0":    secretNameStaticToken,
-						"reference.resources.gardener.cloud/secret-b1b53288":    secretNameETCDEncryptionConfig,
+						"reference.resources.gardener.cloud/secret-a61a895c":    secretNameETCDEncryptionConfig,
 						"reference.resources.gardener.cloud/configmap-130aa219": configMapNameAdmissionConfigs,
 						"reference.resources.gardener.cloud/secret-5613e39f":    secretNameAdmissionKubeconfigs,
 						"reference.resources.gardener.cloud/configmap-d4419cd4": configMapNameAuditPolicy,

--- a/pkg/component/kubeapiserver/kube_apiserver_test.go
+++ b/pkg/component/kubeapiserver/kube_apiserver_test.go
@@ -52,6 +52,7 @@ import (
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	kubernetesfake "github.com/gardener/gardener/pkg/client/kubernetes/fake"
+	"github.com/gardener/gardener/pkg/component/apiserver"
 	. "github.com/gardener/gardener/pkg/component/kubeapiserver"
 	"github.com/gardener/gardener/pkg/component/vpnseedserver"
 	"github.com/gardener/gardener/pkg/utils"
@@ -86,7 +87,7 @@ var _ = Describe("KubeAPIServer", func() {
 		kapi                Interface
 		version             *semver.Version
 		runtimeVersion      *semver.Version
-		autoscalingConfig   AutoscalingConfig
+		autoscalingConfig   apiserver.AutoscalingConfig
 
 		secretNameStaticToken             = "kube-apiserver-static-token-c069a0e6"
 		secretNameCA                      = "ca"
@@ -140,12 +141,13 @@ var _ = Describe("KubeAPIServer", func() {
 
 	JustBeforeEach(func() {
 		values = Values{
-			Autoscaling:       autoscalingConfig,
+			Values: apiserver.Values{
+				Autoscaling:    autoscalingConfig,
+				ETCDEncryption: apiserver.ETCDEncryptionConfig{Resources: []string{"secrets"}},
+				RuntimeVersion: runtimeVersion},
 			PriorityClassName: priorityClassName,
-			RuntimeVersion:    runtimeVersion,
 			Version:           version,
 			VPN:               VPNConfig{Enabled: true},
-			ETCDEncryption:    ETCDEncryptionConfig{Resources: []string{"secrets"}},
 		}
 		kubernetesInterface = kubernetesfake.NewClientSetBuilder().WithAPIReader(c).WithClient(c).Build()
 		kapi = New(kubernetesInterface, namespace, sm, values)
@@ -226,8 +228,14 @@ var _ = Describe("KubeAPIServer", func() {
 	Describe("#Deploy", func() {
 		Describe("HorizontalPodAutoscaler", func() {
 			DescribeTable("should delete the HPA resource",
-				func(autoscalingConfig AutoscalingConfig) {
-					kapi = New(kubernetesInterface, namespace, sm, Values{Autoscaling: autoscalingConfig, RuntimeVersion: runtimeVersion, Version: version})
+				func(autoscalingConfig apiserver.AutoscalingConfig) {
+					kapi = New(kubernetesInterface, namespace, sm, Values{
+						Values: apiserver.Values{
+							Autoscaling:    autoscalingConfig,
+							RuntimeVersion: runtimeVersion,
+						},
+						Version: version},
+					)
 
 					Expect(c.Create(ctx, horizontalPodAutoscalerV2beta1)).To(Succeed())
 					Expect(c.Get(ctx, client.ObjectKeyFromObject(horizontalPodAutoscalerV2beta1), horizontalPodAutoscalerV2beta1)).To(Succeed())
@@ -235,14 +243,14 @@ var _ = Describe("KubeAPIServer", func() {
 					Expect(c.Get(ctx, client.ObjectKeyFromObject(horizontalPodAutoscalerV2beta1), horizontalPodAutoscalerV2beta1)).To(MatchError(apierrors.NewNotFound(schema.GroupResource{Group: autoscalingv2beta1.SchemeGroupVersion.Group, Resource: "horizontalpodautoscalers"}, horizontalPodAutoscalerV2beta1.Name)))
 				},
 
-				Entry("HVPA is enabled", AutoscalingConfig{HVPAEnabled: true}),
-				Entry("replicas is nil", AutoscalingConfig{HVPAEnabled: false, Replicas: nil}),
-				Entry("replicas is 0", AutoscalingConfig{HVPAEnabled: false, Replicas: pointer.Int32(0)}),
+				Entry("HVPA is enabled", apiserver.AutoscalingConfig{HVPAEnabled: true}),
+				Entry("replicas is nil", apiserver.AutoscalingConfig{HVPAEnabled: false, Replicas: nil}),
+				Entry("replicas is 0", apiserver.AutoscalingConfig{HVPAEnabled: false, Replicas: pointer.Int32(0)}),
 			)
 
 			Context("Kubernetes version < 1.23", func() {
 				BeforeEach(func() {
-					autoscalingConfig = AutoscalingConfig{
+					autoscalingConfig = apiserver.AutoscalingConfig{
 						HVPAEnabled: false,
 						Replicas:    pointer.Int32(2),
 						MinReplicas: 4,
@@ -297,7 +305,7 @@ var _ = Describe("KubeAPIServer", func() {
 
 			Context("Kubernetes version >=1.23", func() {
 				BeforeEach(func() {
-					autoscalingConfig = AutoscalingConfig{
+					autoscalingConfig = apiserver.AutoscalingConfig{
 						HVPAEnabled: false,
 						Replicas:    pointer.Int32(2),
 						MinReplicas: 4,
@@ -360,7 +368,7 @@ var _ = Describe("KubeAPIServer", func() {
 		Describe("VerticalPodAutoscaler", func() {
 			Context("HVPAEnabled = true", func() {
 				BeforeEach(func() {
-					autoscalingConfig = AutoscalingConfig{HVPAEnabled: true}
+					autoscalingConfig = apiserver.AutoscalingConfig{HVPAEnabled: true}
 				})
 
 				It("should delete the VPA resource", func() {
@@ -373,7 +381,7 @@ var _ = Describe("KubeAPIServer", func() {
 
 			Context("HVPAEnabled = false", func() {
 				BeforeEach(func() {
-					autoscalingConfig = AutoscalingConfig{HVPAEnabled: false}
+					autoscalingConfig = apiserver.AutoscalingConfig{HVPAEnabled: false}
 				})
 
 				It("should successfully deploy the VPA resource", func() {
@@ -413,8 +421,14 @@ var _ = Describe("KubeAPIServer", func() {
 
 		Describe("HVPA", func() {
 			DescribeTable("should delete the HVPA resource",
-				func(autoscalingConfig AutoscalingConfig) {
-					kapi = New(kubernetesInterface, namespace, sm, Values{Autoscaling: autoscalingConfig, RuntimeVersion: runtimeVersion, Version: version})
+				func(autoscalingConfig apiserver.AutoscalingConfig) {
+					kapi = New(kubernetesInterface, namespace, sm, Values{
+						Values: apiserver.Values{
+							Autoscaling:    autoscalingConfig,
+							RuntimeVersion: runtimeVersion,
+						},
+						Version: version,
+					})
 
 					Expect(c.Create(ctx, hvpa)).To(Succeed())
 					Expect(c.Get(ctx, client.ObjectKeyFromObject(hvpa), hvpa)).To(Succeed())
@@ -422,9 +436,9 @@ var _ = Describe("KubeAPIServer", func() {
 					Expect(c.Get(ctx, client.ObjectKeyFromObject(hvpa), hvpa)).To(MatchError(apierrors.NewNotFound(schema.GroupResource{Group: hvpav1alpha1.SchemeGroupVersionHvpa.Group, Resource: "hvpas"}, hvpa.Name)))
 				},
 
-				Entry("HVPA disabled", AutoscalingConfig{HVPAEnabled: false}),
-				Entry("HVPA enabled but replicas nil", AutoscalingConfig{HVPAEnabled: true}),
-				Entry("HVPA enabled but replicas zero", AutoscalingConfig{HVPAEnabled: true, Replicas: pointer.Int32(0)}),
+				Entry("HVPA disabled", apiserver.AutoscalingConfig{HVPAEnabled: false}),
+				Entry("HVPA enabled but replicas nil", apiserver.AutoscalingConfig{HVPAEnabled: true}),
+				Entry("HVPA enabled but replicas zero", apiserver.AutoscalingConfig{HVPAEnabled: true, Replicas: pointer.Int32(0)}),
 			)
 
 			var (
@@ -462,7 +476,7 @@ var _ = Describe("KubeAPIServer", func() {
 
 			DescribeTable("should successfully deploy the HVPA resource",
 				func(
-					autoscalingConfig AutoscalingConfig,
+					autoscalingConfig apiserver.AutoscalingConfig,
 					sniConfig SNIConfig,
 					expectedScaleDownUpdateMode string,
 					expectedHPAMetrics []autoscalingv2beta1.MetricSpec,
@@ -470,10 +484,12 @@ var _ = Describe("KubeAPIServer", func() {
 					expectedWeightBasedScalingIntervals []hvpav1alpha1.WeightBasedScalingInterval,
 				) {
 					kapi = New(kubernetesInterface, namespace, sm, Values{
-						Autoscaling:    autoscalingConfig,
-						SNI:            sniConfig,
-						RuntimeVersion: runtimeVersion,
-						Version:        version,
+						Values: apiserver.Values{
+							Autoscaling:    autoscalingConfig,
+							RuntimeVersion: runtimeVersion,
+						},
+						SNI:     sniConfig,
+						Version: version,
 					})
 
 					Expect(c.Get(ctx, client.ObjectKeyFromObject(hvpa), hvpa)).To(MatchError(apierrors.NewNotFound(schema.GroupResource{Group: hvpav1alpha1.SchemeGroupVersionHvpa.Group, Resource: "hvpas"}, hvpa.Name)))
@@ -589,7 +605,7 @@ var _ = Describe("KubeAPIServer", func() {
 				},
 
 				Entry("default behaviour",
-					AutoscalingConfig{
+					apiserver.AutoscalingConfig{
 						HVPAEnabled: true,
 						Replicas:    pointer.Int32(2),
 						MinReplicas: 5,
@@ -602,7 +618,7 @@ var _ = Describe("KubeAPIServer", func() {
 					defaultExpectedWeightBasedScalingIntervals,
 				),
 				Entry("UseMemoryMetricForHvpaHPA is true",
-					AutoscalingConfig{
+					apiserver.AutoscalingConfig{
 						HVPAEnabled:               true,
 						Replicas:                  pointer.Int32(2),
 						UseMemoryMetricForHvpaHPA: true,
@@ -631,7 +647,7 @@ var _ = Describe("KubeAPIServer", func() {
 					defaultExpectedWeightBasedScalingIntervals,
 				),
 				Entry("scale down is disabled",
-					AutoscalingConfig{
+					apiserver.AutoscalingConfig{
 						HVPAEnabled:              true,
 						Replicas:                 pointer.Int32(2),
 						MinReplicas:              5,
@@ -645,7 +661,7 @@ var _ = Describe("KubeAPIServer", func() {
 					defaultExpectedWeightBasedScalingIntervals,
 				),
 				Entry("max replicas > min replicas",
-					AutoscalingConfig{
+					apiserver.AutoscalingConfig{
 						HVPAEnabled: true,
 						Replicas:    pointer.Int32(2),
 						MinReplicas: 3,
@@ -824,12 +840,18 @@ subjects:
 				})
 
 				It("should successfully deploy the configmap resource w/ admission plugins", func() {
-					admissionPlugins := []AdmissionPluginConfig{
+					admissionPlugins := []apiserver.AdmissionPluginConfig{
 						{AdmissionPlugin: gardencorev1beta1.AdmissionPlugin{Name: "Foo"}},
 						{AdmissionPlugin: gardencorev1beta1.AdmissionPlugin{Name: "Baz"}, Kubeconfig: []byte("foo")},
 					}
 
-					kapi = New(kubernetesInterface, namespace, sm, Values{EnabledAdmissionPlugins: admissionPlugins, RuntimeVersion: runtimeVersion, Version: version})
+					kapi = New(kubernetesInterface, namespace, sm, Values{
+						Values: apiserver.Values{
+							EnabledAdmissionPlugins: admissionPlugins,
+							RuntimeVersion:          runtimeVersion,
+						},
+						Version: version,
+					})
 
 					secretAdmissionKubeconfigs = &corev1.Secret{
 						ObjectMeta: metav1.ObjectMeta{Name: "kube-apiserver-admission-kubeconfigs", Namespace: namespace},
@@ -865,7 +887,13 @@ subjects:
 					oidcConfig = &gardencorev1beta1.OIDCConfig{CABundle: &caBundle}
 				)
 
-				kapi = New(kubernetesInterface, namespace, sm, Values{OIDC: oidcConfig, RuntimeVersion: runtimeVersion, Version: version})
+				kapi = New(kubernetesInterface, namespace, sm, Values{
+					Values: apiserver.Values{
+						RuntimeVersion: runtimeVersion,
+					},
+					OIDC:    oidcConfig,
+					Version: version,
+				})
 
 				expectedSecretOIDCCABundle := &corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{Name: "kube-apiserver-oidc-cabundle", Namespace: namespace},
@@ -960,7 +988,13 @@ resources:
 
 			DescribeTable("successfully deploy the ETCD encryption configuration secret resource w/ old key",
 				func(encryptWithCurrentKey bool) {
-					kapi = New(kubernetesInterface, namespace, sm, Values{ETCDEncryption: ETCDEncryptionConfig{EncryptWithCurrentKey: encryptWithCurrentKey, Resources: []string{"secrets"}}, RuntimeVersion: runtimeVersion, Version: version})
+					kapi = New(kubernetesInterface, namespace, sm, Values{
+						Values: apiserver.Values{
+							ETCDEncryption: apiserver.ETCDEncryptionConfig{EncryptWithCurrentKey: encryptWithCurrentKey, Resources: []string{"secrets"}},
+							RuntimeVersion: runtimeVersion,
+						},
+						Version: version,
+					})
 
 					oldKeyName, oldKeySecret := "key-old", "old-secret"
 					Expect(c.Create(ctx, &corev1.Secret{
@@ -1046,11 +1080,17 @@ resources:
 
 			Context("TLS SNI", func() {
 				It("should successfully deploy the needed secret resources", func() {
-					kapi = New(kubernetesInterface, namespace, sm, Values{RuntimeVersion: runtimeVersion, Version: version, SNI: SNIConfig{TLS: []TLSSNIConfig{
-						{SecretName: pointer.String("foo")},
-						{Certificate: []byte("foo"), PrivateKey: []byte("bar")},
-						{SecretName: pointer.String("baz"), Certificate: []byte("foo"), PrivateKey: []byte("bar")},
-					}}})
+					kapi = New(kubernetesInterface, namespace, sm, Values{
+						Values: apiserver.Values{
+							RuntimeVersion: runtimeVersion,
+						},
+						Version: version,
+						SNI: SNIConfig{TLS: []TLSSNIConfig{
+							{SecretName: pointer.String("foo")},
+							{Certificate: []byte("foo"), PrivateKey: []byte("bar")},
+							{SecretName: pointer.String("baz"), Certificate: []byte("foo"), PrivateKey: []byte("bar")},
+						}},
+					})
 
 					expectedSecret := &corev1.Secret{
 						ObjectMeta: metav1.ObjectMeta{Name: "kube-apiserver-tls-sni-1", Namespace: namespace},
@@ -1081,7 +1121,13 @@ resources:
 				})
 
 				It("should return an error for invalid configuration", func() {
-					kapi = New(kubernetesInterface, namespace, sm, Values{RuntimeVersion: runtimeVersion, Version: version, SNI: SNIConfig{TLS: []TLSSNIConfig{{}}}})
+					kapi = New(kubernetesInterface, namespace, sm, Values{
+						Values: apiserver.Values{
+							RuntimeVersion: runtimeVersion,
+						},
+						Version: version,
+						SNI:     SNIConfig{TLS: []TLSSNIConfig{{}}},
+					})
 
 					Expect(kapi.Deploy(ctx)).To(MatchError(ContainSubstring("either the name of an existing secret or both certificate and private key must be provided for TLS SNI config")))
 				})
@@ -1090,10 +1136,16 @@ resources:
 			It("should successfully deploy the audit webhook kubeconfig secret resource", func() {
 				var (
 					kubeconfig  = []byte("some-kubeconfig")
-					auditConfig = &AuditConfig{Webhook: &AuditWebhook{Kubeconfig: kubeconfig}}
+					auditConfig = &apiserver.AuditConfig{Webhook: &apiserver.AuditWebhook{Kubeconfig: kubeconfig}}
 				)
 
-				kapi = New(kubernetesInterface, namespace, sm, Values{Audit: auditConfig, RuntimeVersion: runtimeVersion, Version: version})
+				kapi = New(kubernetesInterface, namespace, sm, Values{
+					Values: apiserver.Values{
+						Audit:          auditConfig,
+						RuntimeVersion: runtimeVersion,
+					},
+					Version: version,
+				})
 
 				expectedSecret := &corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{Name: "kube-apiserver-audit-webhook-kubeconfig", Namespace: namespace},
@@ -1129,7 +1181,13 @@ resources:
 					authWebhookConfig = &AuthenticationWebhook{Kubeconfig: kubeconfig}
 				)
 
-				kapi = New(kubernetesInterface, namespace, sm, Values{AuthenticationWebhook: authWebhookConfig, RuntimeVersion: runtimeVersion, Version: version})
+				kapi = New(kubernetesInterface, namespace, sm, Values{
+					Values: apiserver.Values{
+						RuntimeVersion: runtimeVersion,
+					},
+					AuthenticationWebhook: authWebhookConfig,
+					Version:               version,
+				})
 
 				expectedSecret := &corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{Name: "kube-apiserver-authentication-webhook-kubeconfig", Namespace: namespace},
@@ -1165,7 +1223,13 @@ resources:
 					authWebhookConfig = &AuthorizationWebhook{Kubeconfig: kubeconfig}
 				)
 
-				kapi = New(kubernetesInterface, namespace, sm, Values{AuthorizationWebhook: authWebhookConfig, RuntimeVersion: runtimeVersion, Version: version})
+				kapi = New(kubernetesInterface, namespace, sm, Values{
+					Values: apiserver.Values{
+						RuntimeVersion: runtimeVersion,
+					},
+					AuthorizationWebhook: authWebhookConfig,
+					Version:              version,
+				})
 
 				expectedSecret := &corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{Name: "kube-apiserver-authorization-webhook-kubeconfig", Namespace: namespace},
@@ -1228,7 +1292,7 @@ plugins: null
 				})
 
 				It("should successfully deploy the configmap resource w/ admission plugins", func() {
-					admissionPlugins := []AdmissionPluginConfig{
+					admissionPlugins := []apiserver.AdmissionPluginConfig{
 						{AdmissionPlugin: gardencorev1beta1.AdmissionPlugin{Name: "Foo"}},
 						{AdmissionPlugin: gardencorev1beta1.AdmissionPlugin{Name: "Baz", Config: &runtime.RawExtension{Raw: []byte("some-config-for-baz")}}},
 						{
@@ -1263,7 +1327,13 @@ kubeConfigFile: /etc/kubernetes/foobar.yaml
 						},
 					}
 
-					kapi = New(kubernetesInterface, namespace, sm, Values{EnabledAdmissionPlugins: admissionPlugins, RuntimeVersion: runtimeVersion, Version: version})
+					kapi = New(kubernetesInterface, namespace, sm, Values{
+						Values: apiserver.Values{
+							EnabledAdmissionPlugins: admissionPlugins,
+							RuntimeVersion:          runtimeVersion,
+						},
+						Version: version,
+					})
 
 					configMapAdmission = &corev1.ConfigMap{
 						ObjectMeta: metav1.ObjectMeta{Name: "kube-apiserver-admission-config", Namespace: namespace},
@@ -1321,7 +1391,7 @@ kubeConfigFile: /etc/kubernetes/admission-kubeconfigs/validatingadmissionwebhook
 				})
 
 				It("should successfully deploy the configmap resource w/ admission plugins w/ config but w/o kubeconfigs", func() {
-					admissionPlugins := []AdmissionPluginConfig{
+					admissionPlugins := []apiserver.AdmissionPluginConfig{
 						{
 							AdmissionPlugin: gardencorev1beta1.AdmissionPlugin{
 								Name: "MutatingAdmissionWebhook",
@@ -1351,7 +1421,13 @@ kubeConfigFile: /etc/kubernetes/foobar.yaml
 						},
 					}
 
-					kapi = New(kubernetesInterface, namespace, sm, Values{EnabledAdmissionPlugins: admissionPlugins, RuntimeVersion: runtimeVersion, Version: version})
+					kapi = New(kubernetesInterface, namespace, sm, Values{
+						Values: apiserver.Values{
+							EnabledAdmissionPlugins: admissionPlugins,
+							RuntimeVersion:          runtimeVersion,
+						},
+						Version: version,
+					})
 
 					configMapAdmission = &corev1.ConfigMap{
 						ObjectMeta: metav1.ObjectMeta{Name: "kube-apiserver-admission-config", Namespace: namespace},
@@ -1405,7 +1481,7 @@ kubeConfigFile: ""
 				})
 
 				It("should successfully deploy the configmap resource w/ admission plugins w/o configs but w/ kubeconfig", func() {
-					admissionPlugins := []AdmissionPluginConfig{
+					admissionPlugins := []apiserver.AdmissionPluginConfig{
 						{
 							AdmissionPlugin: gardencorev1beta1.AdmissionPlugin{
 								Name: "MutatingAdmissionWebhook",
@@ -1426,7 +1502,13 @@ kubeConfigFile: ""
 						},
 					}
 
-					kapi = New(kubernetesInterface, namespace, sm, Values{EnabledAdmissionPlugins: admissionPlugins, RuntimeVersion: runtimeVersion, Version: version})
+					kapi = New(kubernetesInterface, namespace, sm, Values{
+						Values: apiserver.Values{
+							EnabledAdmissionPlugins: admissionPlugins,
+							RuntimeVersion:          runtimeVersion,
+						},
+						Version: version,
+					})
 
 					configMapAdmission = &corev1.ConfigMap{
 						ObjectMeta: metav1.ObjectMeta{Name: "kube-apiserver-admission-config", Namespace: namespace},
@@ -1515,10 +1597,16 @@ rules:
 				It("should successfully deploy the configmap resource w/o default policy", func() {
 					var (
 						policy      = "some-audit-policy"
-						auditConfig = &AuditConfig{Policy: &policy}
+						auditConfig = &apiserver.AuditConfig{Policy: &policy}
 					)
 
-					kapi = New(kubernetesInterface, namespace, sm, Values{Audit: auditConfig, RuntimeVersion: runtimeVersion, Version: version})
+					kapi = New(kubernetesInterface, namespace, sm, Values{
+						Values: apiserver.Values{
+							Audit:          auditConfig,
+							RuntimeVersion: runtimeVersion,
+						},
+						Version: version,
+					})
 
 					configMapAuditPolicy = &corev1.ConfigMap{
 						ObjectMeta: metav1.ObjectMeta{Name: "audit-policy-config", Namespace: namespace},
@@ -1549,9 +1637,11 @@ rules:
 			Context("egress selector", func() {
 				It("should successfully deploy the configmap resource", func() {
 					kapi = New(kubernetesInterface, namespace, sm, Values{
-						RuntimeVersion: runtimeVersion,
-						Version:        version,
-						VPN:            VPNConfig{Enabled: true},
+						Values: apiserver.Values{
+							RuntimeVersion: runtimeVersion,
+						},
+						Version: version,
+						VPN:     VPNConfig{Enabled: true},
 					})
 
 					configMapEgressSelector = &corev1.ConfigMap{
@@ -1626,9 +1716,11 @@ rules:
 
 			It("should have the expected labels w/ SNI", func() {
 				kapi = New(kubernetesInterface, namespace, sm, Values{
-					SNI:            SNIConfig{Enabled: true},
-					RuntimeVersion: runtimeVersion,
-					Version:        version,
+					Values: apiserver.Values{
+						RuntimeVersion: runtimeVersion,
+					},
+					SNI:     SNIConfig{Enabled: true},
+					Version: version,
 				})
 				deployAndRead()
 
@@ -1665,9 +1757,11 @@ rules:
 
 				It("should have the expected annotations when there are no nodes", func() {
 					kapi = New(kubernetesInterface, namespace, sm, Values{
-						IsWorkerless:   true,
-						RuntimeVersion: runtimeVersion,
-						Version:        version,
+						Values: apiserver.Values{
+							RuntimeVersion: runtimeVersion,
+						},
+						IsWorkerless: true,
+						Version:      version,
 					})
 					deployAndRead()
 
@@ -1676,9 +1770,11 @@ rules:
 
 				It("should have the expected annotations when there are nodes", func() {
 					kapi = New(kubernetesInterface, namespace, sm, Values{
-						IsWorkerless:   false,
-						RuntimeVersion: runtimeVersion,
-						Version:        version,
+						Values: apiserver.Values{
+							RuntimeVersion: runtimeVersion,
+						},
+						IsWorkerless: false,
+						Version:      version,
 					})
 					deployAndRead()
 
@@ -1690,10 +1786,12 @@ rules:
 
 				It("should have the expected annotations when VPN is disabled", func() {
 					kapi = New(kubernetesInterface, namespace, sm, Values{
-						IsWorkerless:   true,
-						RuntimeVersion: runtimeVersion,
-						Version:        version,
-						VPN:            VPNConfig{Enabled: false},
+						Values: apiserver.Values{
+							RuntimeVersion: runtimeVersion,
+						},
+						IsWorkerless: true,
+						Version:      version,
+						VPN:          VPNConfig{Enabled: false},
 					})
 					deployAndRead()
 
@@ -1702,10 +1800,12 @@ rules:
 
 				It("should have the expected annotations when VPN is enabled but HA is disabled", func() {
 					kapi = New(kubernetesInterface, namespace, sm, Values{
-						IsWorkerless:   true,
-						RuntimeVersion: runtimeVersion,
-						Version:        version,
-						VPN:            VPNConfig{Enabled: true, HighAvailabilityEnabled: false},
+						Values: apiserver.Values{
+							RuntimeVersion: runtimeVersion,
+						},
+						IsWorkerless: true,
+						Version:      version,
+						VPN:          VPNConfig{Enabled: true, HighAvailabilityEnabled: false},
 					})
 					deployAndRead()
 
@@ -1718,10 +1818,12 @@ rules:
 
 				It("should have the expected annotations when VPN and HA is enabled", func() {
 					kapi = New(kubernetesInterface, namespace, sm, Values{
-						IsWorkerless:   true,
-						RuntimeVersion: runtimeVersion,
-						Version:        version,
-						VPN:            VPNConfig{Enabled: true, HighAvailabilityEnabled: true},
+						Values: apiserver.Values{
+							RuntimeVersion: runtimeVersion,
+						},
+						IsWorkerless: true,
+						Version:      version,
+						VPN:          VPNConfig{Enabled: true, HighAvailabilityEnabled: true},
 					})
 					deployAndRead()
 
@@ -1742,9 +1844,11 @@ rules:
 				)
 
 				kapi = New(kubernetesInterface, namespace, sm, Values{
-					Autoscaling:    AutoscalingConfig{Replicas: &replicas},
-					RuntimeVersion: runtimeVersion,
-					Version:        version,
+					Values: apiserver.Values{
+						Autoscaling:    apiserver.AutoscalingConfig{Replicas: &replicas},
+						RuntimeVersion: runtimeVersion,
+					},
+					Version: version,
 				})
 				deployAndRead()
 
@@ -1794,10 +1898,12 @@ rules:
 
 				It("should have the expected pod template labels with vpn enabled", func() {
 					kapi = New(kubernetesInterface, namespace, sm, Values{
-						IsWorkerless:   true,
-						RuntimeVersion: runtimeVersion,
-						Version:        version,
-						VPN:            VPNConfig{Enabled: true},
+						Values: apiserver.Values{
+							RuntimeVersion: runtimeVersion,
+						},
+						IsWorkerless: true,
+						Version:      version,
+						VPN:          VPNConfig{Enabled: true},
 					})
 					deployAndRead()
 
@@ -1808,10 +1914,12 @@ rules:
 
 				It("should have the expected pod template labels with ha vpn enabled", func() {
 					kapi = New(kubernetesInterface, namespace, sm, Values{
-						IsWorkerless:   true,
-						RuntimeVersion: runtimeVersion,
-						Version:        version,
-						VPN:            VPNConfig{Enabled: true, HighAvailabilityEnabled: true, HighAvailabilityNumberOfSeedServers: 2},
+						Values: apiserver.Values{
+							RuntimeVersion: runtimeVersion,
+						},
+						IsWorkerless: true,
+						Version:      version,
+						VPN:          VPNConfig{Enabled: true, HighAvailabilityEnabled: true, HighAvailabilityNumberOfSeedServers: 2},
 					})
 					deployAndRead()
 
@@ -1848,9 +1956,11 @@ rules:
 
 				It("should have the expected annotations when there are no nodes", func() {
 					kapi = New(kubernetesInterface, namespace, sm, Values{
-						IsWorkerless:   true,
-						RuntimeVersion: runtimeVersion,
-						Version:        version,
+						Values: apiserver.Values{
+							RuntimeVersion: runtimeVersion,
+						},
+						IsWorkerless: true,
+						Version:      version,
 					})
 					deployAndRead()
 
@@ -1859,9 +1969,11 @@ rules:
 
 				It("should have the expected annotations when there are nodes", func() {
 					kapi = New(kubernetesInterface, namespace, sm, Values{
-						IsWorkerless:   false,
-						RuntimeVersion: runtimeVersion,
-						Version:        version,
+						Values: apiserver.Values{
+							RuntimeVersion: runtimeVersion,
+						},
+						IsWorkerless: false,
+						Version:      version,
 					})
 					deployAndRead()
 
@@ -1873,10 +1985,12 @@ rules:
 
 				It("should have the expected annotations when VPN is disabled", func() {
 					kapi = New(kubernetesInterface, namespace, sm, Values{
-						IsWorkerless:   true,
-						RuntimeVersion: runtimeVersion,
-						Version:        version,
-						VPN:            VPNConfig{Enabled: false},
+						Values: apiserver.Values{
+							RuntimeVersion: runtimeVersion,
+						},
+						IsWorkerless: true,
+						Version:      version,
+						VPN:          VPNConfig{Enabled: false},
 					})
 					deployAndRead()
 
@@ -1885,10 +1999,12 @@ rules:
 
 				It("should have the expected annotations when VPN is enabled but HA is disabled", func() {
 					kapi = New(kubernetesInterface, namespace, sm, Values{
-						IsWorkerless:   true,
-						RuntimeVersion: runtimeVersion,
-						Version:        version,
-						VPN:            VPNConfig{Enabled: true, HighAvailabilityEnabled: false},
+						Values: apiserver.Values{
+							RuntimeVersion: runtimeVersion,
+						},
+						IsWorkerless: true,
+						Version:      version,
+						VPN:          VPNConfig{Enabled: true, HighAvailabilityEnabled: false},
 					})
 					deployAndRead()
 
@@ -1901,10 +2017,12 @@ rules:
 
 				It("should have the expected annotations when VPN and HA is enabled", func() {
 					kapi = New(kubernetesInterface, namespace, sm, Values{
-						IsWorkerless:   true,
-						RuntimeVersion: runtimeVersion,
-						Version:        version,
-						VPN:            VPNConfig{Enabled: true, HighAvailabilityEnabled: true},
+						Values: apiserver.Values{
+							RuntimeVersion: runtimeVersion,
+						},
+						IsWorkerless: true,
+						Version:      version,
+						VPN:          VPNConfig{Enabled: true, HighAvailabilityEnabled: true},
 					})
 					deployAndRead()
 
@@ -1929,7 +2047,12 @@ rules:
 			})
 
 			It("should have no init containers", func() {
-				kapi = New(kubernetesInterface, namespace, sm, Values{RuntimeVersion: runtimeVersion, Version: version})
+				kapi = New(kubernetesInterface, namespace, sm, Values{
+					Values: apiserver.Values{
+						RuntimeVersion: runtimeVersion,
+					},
+					Version: version,
+				})
 
 				deployAndRead()
 
@@ -1938,6 +2061,9 @@ rules:
 
 			It("should have one init container and three vpn-seed-client sidecar containers when VPN high availability are enabled", func() {
 				values := Values{
+					Values: apiserver.Values{
+						RuntimeVersion: runtimeVersion,
+					},
 					Images:             Images{VPNClient: "vpn-client-image:really-latest"},
 					ServiceNetworkCIDR: "4.5.6.0/24",
 					VPN: VPNConfig{
@@ -1948,8 +2074,7 @@ rules:
 						PodNetworkCIDR:                       "1.2.3.0/24",
 						NodeNetworkCIDR:                      pointer.String("7.8.9.0/24"),
 					},
-					RuntimeVersion: runtimeVersion,
-					Version:        version,
+					Version: version,
 				}
 				kapi = New(kubernetesInterface, namespace, sm, values)
 				deployAndRead()
@@ -2180,7 +2305,13 @@ rules:
 					images  = Images{Watchdog: "some-image:latest"}
 				)
 
-				kapi = New(kubernetesInterface, namespace, sm, Values{Images: images, RuntimeVersion: runtimeVersion, Version: version})
+				kapi = New(kubernetesInterface, namespace, sm, Values{
+					Values: apiserver.Values{
+						RuntimeVersion: runtimeVersion,
+					},
+					Images:  images,
+					Version: version,
+				})
 				deployAndRead()
 
 				expectedHealthCheckToken, err := secretsutils.FakeGenerateRandomString(128)
@@ -2232,7 +2363,13 @@ rules:
 						}
 					)
 
-					kapi = New(kubernetesInterface, namespace, sm, Values{Images: images, RuntimeVersion: runtimeVersion, Version: version})
+					kapi = New(kubernetesInterface, namespace, sm, Values{
+						Values: apiserver.Values{
+							RuntimeVersion: runtimeVersion,
+						},
+						Images:  images,
+						Version: version,
+					})
 					deployAndRead()
 
 					Expect(c.Get(ctx, client.ObjectKeyFromObject(expectedConfigMap), expectedConfigMap)).To(Succeed())
@@ -2244,7 +2381,7 @@ rules:
 					acceptedIssuers  = []string{"issuer1", "issuer2"}
 					admissionPlugin1 = "foo"
 					admissionPlugin2 = "foo"
-					admissionPlugins = []AdmissionPluginConfig{
+					admissionPlugins = []apiserver.AdmissionPluginConfig{
 						{AdmissionPlugin: gardencorev1beta1.AdmissionPlugin{Name: admissionPlugin1}},
 						{AdmissionPlugin: gardencorev1beta1.AdmissionPlugin{Name: admissionPlugin2}},
 					}
@@ -2268,23 +2405,25 @@ rules:
 
 				JustBeforeEach(func() {
 					values = Values{
-						EnabledAdmissionPlugins: admissionPlugins,
-						Autoscaling:             AutoscalingConfig{APIServerResources: apiServerResources},
-						EventTTL:                &metav1.Duration{Duration: eventTTL},
-						ExternalHostname:        externalHostname,
-						Images:                  images,
-						IsWorkerless:            true,
-						Logging: &gardencorev1beta1.KubeAPIServerLogging{
-							Verbosity:           pointer.Int32(3),
-							HTTPAccessVerbosity: pointer.Int32(3),
+						Values: apiserver.Values{
+							EnabledAdmissionPlugins: admissionPlugins,
+							Autoscaling:             apiserver.AutoscalingConfig{APIServerResources: apiServerResources},
+							Logging: &gardencorev1beta1.KubeAPIServerLogging{
+								Verbosity:           pointer.Int32(3),
+								HTTPAccessVerbosity: pointer.Int32(3),
+							},
+							RuntimeVersion: runtimeVersion,
 						},
+						EventTTL:         &metav1.Duration{Duration: eventTTL},
+						ExternalHostname: externalHostname,
+						Images:           images,
+						IsWorkerless:     true,
 						ServiceAccount: ServiceAccountConfig{
 							Issuer:                serviceAccountIssuer,
 							AcceptedIssuers:       acceptedIssuers,
 							MaxTokenExpiration:    &metav1.Duration{Duration: serviceAccountMaxTokenExpiration},
 							ExtendTokenExpiration: &serviceAccountExtendTokenExpiration,
 						},
-						RuntimeVersion:     runtimeVersion,
 						ServiceNetworkCIDR: serviceNetworkCIDR,
 						Version:            version,
 						VPN:                VPNConfig{},
@@ -2719,7 +2858,13 @@ rules:
 						"name": "user-kubeconfig",
 					})).To(Succeed())
 
-					kapi = New(kubernetesInterface, namespace, sm, Values{RuntimeVersion: runtimeVersion, Version: version, StaticTokenKubeconfigEnabled: pointer.Bool(false)})
+					kapi = New(kubernetesInterface, namespace, sm, Values{
+						Values: apiserver.Values{
+							RuntimeVersion: runtimeVersion,
+						},
+						Version:                      version,
+						StaticTokenKubeconfigEnabled: pointer.Bool(false),
+					})
 					Expect(kapi.Deploy(ctx)).To(Succeed())
 					Expect(c.Get(ctx, client.ObjectKeyFromObject(deployment), deployment)).To(Succeed())
 
@@ -2747,7 +2892,13 @@ rules:
 
 					newSecretNameStaticToken := "kube-apiserver-static-token-53d619b2"
 
-					kapi = New(kubernetesInterface, namespace, sm, Values{RuntimeVersion: runtimeVersion, Version: version, StaticTokenKubeconfigEnabled: pointer.Bool(false)})
+					kapi = New(kubernetesInterface, namespace, sm, Values{
+						Values: apiserver.Values{
+							RuntimeVersion: runtimeVersion,
+						},
+						Version:                      version,
+						StaticTokenKubeconfigEnabled: pointer.Bool(false),
+					})
 					Expect(kapi.Deploy(ctx)).To(Succeed())
 					Expect(c.Get(ctx, client.ObjectKeyFromObject(deployment), deployment)).To(Succeed())
 
@@ -2779,7 +2930,14 @@ rules:
 				})
 
 				It("should properly set the anonymous auth flag if enabled", func() {
-					kapi = New(kubernetesInterface, namespace, sm, Values{AnonymousAuthenticationEnabled: true, Images: images, RuntimeVersion: runtimeVersion, Version: version})
+					kapi = New(kubernetesInterface, namespace, sm, Values{
+						Values: apiserver.Values{
+							RuntimeVersion: runtimeVersion,
+						},
+						AnonymousAuthenticationEnabled: true,
+						Images:                         images,
+						Version:                        version,
+					})
 					deployAndRead()
 
 					Expect(deployment.Spec.Template.Spec.Containers[0].Command).To(ContainElement(ContainSubstring(
@@ -2790,7 +2948,14 @@ rules:
 				It("should configure the advertise address if SNI is enabled", func() {
 					advertiseAddress := "1.2.3.4"
 
-					kapi = New(kubernetesInterface, namespace, sm, Values{SNI: SNIConfig{Enabled: true, AdvertiseAddress: advertiseAddress}, Images: images, RuntimeVersion: runtimeVersion, Version: version})
+					kapi = New(kubernetesInterface, namespace, sm, Values{
+						Values: apiserver.Values{
+							RuntimeVersion: runtimeVersion,
+						},
+						SNI:     SNIConfig{Enabled: true, AdvertiseAddress: advertiseAddress},
+						Images:  images,
+						Version: version,
+					})
 					deployAndRead()
 
 					Expect(deployment.Spec.Template.Spec.Containers[0].Command).To(ContainElement(
@@ -2799,7 +2964,14 @@ rules:
 				})
 
 				It("should not configure the advertise address if SNI is enabled", func() {
-					kapi = New(kubernetesInterface, namespace, sm, Values{SNI: SNIConfig{Enabled: false, AdvertiseAddress: "foo"}, Images: images, RuntimeVersion: runtimeVersion, Version: version})
+					kapi = New(kubernetesInterface, namespace, sm, Values{
+						Values: apiserver.Values{
+							RuntimeVersion: runtimeVersion,
+						},
+						SNI:     SNIConfig{Enabled: false, AdvertiseAddress: "foo"},
+						Images:  images,
+						Version: version,
+					})
 					deployAndRead()
 
 					Expect(deployment.Spec.Template.Spec.Containers[0].Command).NotTo(ContainElement(ContainSubstring("--advertise-address=")))
@@ -2814,7 +2986,14 @@ rules:
 						}
 					)
 
-					kapi = New(kubernetesInterface, namespace, sm, Values{ResourcesToStoreInETCDEvents: resourcesToStoreInETCDEvents, Images: images, RuntimeVersion: runtimeVersion, Version: version})
+					kapi = New(kubernetesInterface, namespace, sm, Values{
+						Values: apiserver.Values{
+							RuntimeVersion: runtimeVersion,
+						},
+						ResourcesToStoreInETCDEvents: resourcesToStoreInETCDEvents,
+						Images:                       images,
+						Version:                      version,
+					})
 					deployAndRead()
 
 					Expect(deployment.Spec.Template.Spec.Containers[0].Command).To(ContainElement(
@@ -2829,7 +3008,14 @@ rules:
 						apiAudiences = []string{apiAudience1, apiAudience2}
 					)
 
-					kapi = New(kubernetesInterface, namespace, sm, Values{APIAudiences: apiAudiences, Images: images, RuntimeVersion: runtimeVersion, Version: version})
+					kapi = New(kubernetesInterface, namespace, sm, Values{
+						Values: apiserver.Values{
+							RuntimeVersion: runtimeVersion,
+						},
+						APIAudiences: apiAudiences,
+						Images:       images,
+						Version:      version,
+					})
 					deployAndRead()
 
 					Expect(deployment.Spec.Template.Spec.Containers[0].Command).To(ContainElement(
@@ -2846,7 +3032,14 @@ rules:
 				It("should configure the feature gates if provided", func() {
 					featureGates := map[string]bool{"Foo": true, "Bar": false}
 
-					kapi = New(kubernetesInterface, namespace, sm, Values{FeatureGates: featureGates, Images: images, RuntimeVersion: runtimeVersion, Version: version})
+					kapi = New(kubernetesInterface, namespace, sm, Values{
+						Values: apiserver.Values{
+							FeatureGates:   featureGates,
+							RuntimeVersion: runtimeVersion,
+						},
+						Images:  images,
+						Version: version,
+					})
 					deployAndRead()
 
 					Expect(deployment.Spec.Template.Spec.Containers[0].Command).To(ContainElement(
@@ -2866,7 +3059,14 @@ rules:
 						MaxMutatingInflight:    pointer.Int32(456),
 					}
 
-					kapi = New(kubernetesInterface, namespace, sm, Values{Requests: requests, Images: images, RuntimeVersion: runtimeVersion, Version: version})
+					kapi = New(kubernetesInterface, namespace, sm, Values{
+						Values: apiserver.Values{
+							Requests:       requests,
+							RuntimeVersion: runtimeVersion,
+						},
+						Images:  images,
+						Version: version,
+					})
 					deployAndRead()
 
 					Expect(deployment.Spec.Template.Spec.Containers[0].Command).To(ContainElements(
@@ -2887,7 +3087,15 @@ rules:
 				It("should configure the runtime config if provided", func() {
 					runtimeConfig := map[string]bool{"foo": true, "bar": false}
 
-					kapi = New(kubernetesInterface, namespace, sm, Values{RuntimeConfig: runtimeConfig, Images: images, RuntimeVersion: runtimeVersion, Version: version, IsWorkerless: false})
+					kapi = New(kubernetesInterface, namespace, sm, Values{
+						Values: apiserver.Values{
+							RuntimeVersion: runtimeVersion,
+						},
+						RuntimeConfig: runtimeConfig,
+						Images:        images,
+						Version:       version,
+						IsWorkerless:  false,
+					})
 					deployAndRead()
 
 					Expect(deployment.Spec.Template.Spec.Containers[0].Command).To(ContainElement(
@@ -2896,7 +3104,14 @@ rules:
 				})
 
 				It("should not configure the runtime config if not provided when shoot has workers", func() {
-					kapi = New(kubernetesInterface, namespace, sm, Values{Images: images, RuntimeVersion: runtimeVersion, Version: version, IsWorkerless: false})
+					kapi = New(kubernetesInterface, namespace, sm, Values{
+						Values: apiserver.Values{
+							RuntimeVersion: runtimeVersion,
+						},
+						Images:       images,
+						Version:      version,
+						IsWorkerless: false,
+					})
 					deployAndRead()
 
 					Expect(deployment.Spec.Template.Spec.Containers[0].Command).NotTo(ContainElement(ContainSubstring("--runtime-config=")))
@@ -2905,7 +3120,15 @@ rules:
 				It("should disable apis in case of workerless shoot with k8s version < 1.25", func() {
 					runtimeConfig := map[string]bool{"apps/v1": true, "bar": false}
 
-					kapi = New(kubernetesInterface, namespace, sm, Values{RuntimeConfig: runtimeConfig, Images: images, RuntimeVersion: runtimeVersion, Version: version, IsWorkerless: true})
+					kapi = New(kubernetesInterface, namespace, sm, Values{
+						Values: apiserver.Values{
+							RuntimeVersion: runtimeVersion,
+						},
+						RuntimeConfig: runtimeConfig,
+						Images:        images,
+						Version:       version,
+						IsWorkerless:  true,
+					})
 					deployAndRead()
 
 					Expect(deployment.Spec.Template.Spec.Containers[0].Command).To(ContainElement(
@@ -2917,7 +3140,15 @@ rules:
 					runtimeConfig := map[string]bool{"apps/v1": true, "bar": false}
 					version = semver.MustParse("v1.26.0")
 
-					kapi = New(kubernetesInterface, namespace, sm, Values{RuntimeConfig: runtimeConfig, Images: images, RuntimeVersion: runtimeVersion, Version: version, IsWorkerless: true})
+					kapi = New(kubernetesInterface, namespace, sm, Values{
+						Values: apiserver.Values{
+							RuntimeVersion: runtimeVersion,
+						},
+						RuntimeConfig: runtimeConfig,
+						Images:        images,
+						Version:       version,
+						IsWorkerless:  true,
+					})
 					deployAndRead()
 
 					Expect(deployment.Spec.Template.Spec.Containers[0].Command).To(ContainElement(
@@ -2934,7 +3165,14 @@ rules:
 						},
 					}
 
-					kapi = New(kubernetesInterface, namespace, sm, Values{WatchCacheSizes: watchCacheSizes, Images: images, RuntimeVersion: runtimeVersion, Version: version})
+					kapi = New(kubernetesInterface, namespace, sm, Values{
+						Values: apiserver.Values{
+							RuntimeVersion:  runtimeVersion,
+							WatchCacheSizes: watchCacheSizes,
+						},
+						Images:  images,
+						Version: version,
+					})
 					deployAndRead()
 
 					Expect(deployment.Spec.Template.Spec.Containers[0].Command).To(ContainElements(
@@ -2953,7 +3191,15 @@ rules:
 				})
 
 				It("should configure the defaultNotReadyTolerationSeconds and defaultUnreachableTolerationSeconds settings if provided", func() {
-					kapi = New(kubernetesInterface, namespace, sm, Values{DefaultNotReadyTolerationSeconds: pointer.Int64(120), DefaultUnreachableTolerationSeconds: pointer.Int64(130), Images: images, RuntimeVersion: runtimeVersion, Version: version})
+					kapi = New(kubernetesInterface, namespace, sm, Values{
+						Values: apiserver.Values{
+							RuntimeVersion: runtimeVersion,
+						},
+						DefaultNotReadyTolerationSeconds:    pointer.Int64(120),
+						DefaultUnreachableTolerationSeconds: pointer.Int64(130),
+						Images:                              images,
+						Version:                             version,
+					})
 
 					deployAndRead()
 
@@ -2969,7 +3215,13 @@ rules:
 						HTTPAccessVerbosity: pointer.Int32(3),
 					}
 
-					kapi = New(kubernetesInterface, namespace, sm, Values{Logging: logging, RuntimeVersion: runtimeVersion, Version: version})
+					kapi = New(kubernetesInterface, namespace, sm, Values{
+						Values: apiserver.Values{
+							Logging:        logging,
+							RuntimeVersion: runtimeVersion,
+						},
+						Version: version,
+					})
 					deployAndRead()
 
 					Expect(deployment.Spec.Template.Spec.Containers[0].Command).To(ContainElements(
@@ -2979,7 +3231,12 @@ rules:
 				})
 
 				It("should not configure the KubeAPISeverLogging settings if not provided", func() {
-					kapi = New(kubernetesInterface, namespace, sm, Values{RuntimeVersion: runtimeVersion, Version: version})
+					kapi = New(kubernetesInterface, namespace, sm, Values{
+						Values: apiserver.Values{
+							RuntimeVersion: runtimeVersion,
+						},
+						Version: version,
+					})
 					deployAndRead()
 
 					Expect(deployment.Spec.Template.Spec.Containers[0].Command).NotTo(ContainElements(
@@ -2991,7 +3248,13 @@ rules:
 				It("should mount the host pki directories", func() {
 					directoryOrCreate := corev1.HostPathDirectoryOrCreate
 
-					kapi = New(kubernetesInterface, namespace, sm, Values{Images: images, RuntimeVersion: runtimeVersion, Version: version})
+					kapi = New(kubernetesInterface, namespace, sm, Values{
+						Values: apiserver.Values{
+							RuntimeVersion: runtimeVersion,
+						},
+						Images:  images,
+						Version: version,
+					})
 					deployAndRead()
 
 					Expect(deployment.Spec.Template.Spec.Containers[0].VolumeMounts).To(ContainElements(
@@ -3059,10 +3322,12 @@ rules:
 
 				It("should properly configure the settings related to reversed vpn if enabled", func() {
 					kapi = New(kubernetesInterface, namespace, sm, Values{
-						Images:         images,
-						RuntimeVersion: runtimeVersion,
-						Version:        version,
-						VPN:            VPNConfig{Enabled: true},
+						Values: apiserver.Values{
+							RuntimeVersion: runtimeVersion,
+						},
+						Images:  images,
+						Version: version,
+						VPN:     VPNConfig{Enabled: true},
 					})
 					deployAndRead()
 
@@ -3130,7 +3395,14 @@ rules:
 				})
 
 				It("should have the proper probes", func() {
-					kapi = New(kubernetesInterface, namespace, sm, Values{Images: images, RuntimeVersion: runtimeVersion, Version: semver.MustParse("1.24.9"), StaticTokenKubeconfigEnabled: pointer.Bool(true)})
+					kapi = New(kubernetesInterface, namespace, sm, Values{
+						Values: apiserver.Values{
+							RuntimeVersion: runtimeVersion,
+						},
+						Images:                       images,
+						Version:                      semver.MustParse("1.24.9"),
+						StaticTokenKubeconfigEnabled: pointer.Bool(true),
+					})
 					deployAndRead()
 
 					validateProbe := func(probe *corev1.Probe, path string, initialDelaySeconds int32) {
@@ -3160,7 +3432,13 @@ rules:
 
 				It("should set the --shutdown-send-retry-after=true flag if the kubernetes version is 1.24", func() {
 					version = semver.MustParse("1.24.7")
-					kapi = New(kubernetesInterface, namespace, sm, Values{Images: images, RuntimeVersion: runtimeVersion, Version: version})
+					kapi = New(kubernetesInterface, namespace, sm, Values{
+						Values: apiserver.Values{
+							RuntimeVersion: runtimeVersion,
+						},
+						Images:  images,
+						Version: version,
+					})
 					deployAndRead()
 
 					Expect(deployment.Spec.Template.Spec.Containers[0].Command).To(ContainElements(
@@ -3213,8 +3491,8 @@ rules:
 				})
 
 				It("should properly configure the audit settings with webhook", func() {
-					values.Audit = &AuditConfig{
-						Webhook: &AuditWebhook{
+					values.Audit = &apiserver.AuditConfig{
+						Webhook: &apiserver.AuditWebhook{
 							Kubeconfig:   []byte("foo"),
 							BatchMaxSize: pointer.Int32(30),
 							Version:      pointer.String("audit.k8s.io/v1beta1"),
@@ -3354,6 +3632,9 @@ rules:
 			Context("HA VPN role", func() {
 				It("should not deploy role, rolebinding and service account w/o HA VPN", func() {
 					values := Values{
+						Values: apiserver.Values{
+							RuntimeVersion: runtimeVersion,
+						},
 						Images:             Images{VPNClient: "vpn-client-image:really-latest"},
 						ServiceNetworkCIDR: "4.5.6.0/24",
 						VPN: VPNConfig{
@@ -3364,8 +3645,7 @@ rules:
 							PodNetworkCIDR:                       "1.2.3.0/24",
 							NodeNetworkCIDR:                      pointer.String("7.8.9.0/24"),
 						},
-						RuntimeVersion: runtimeVersion,
-						Version:        version,
+						Version: version,
 					}
 					kapi = New(kubernetesInterface, namespace, sm, values)
 					deployAndRead()
@@ -3378,6 +3658,9 @@ rules:
 
 				It("should successfully deploy and destroy the role, rolebinding and service account w/ HA VPN", func() {
 					values := Values{
+						Values: apiserver.Values{
+							RuntimeVersion: runtimeVersion,
+						},
 						Images:             Images{VPNClient: "vpn-client-image:really-latest"},
 						ServiceNetworkCIDR: "4.5.6.0/24",
 						VPN: VPNConfig{
@@ -3388,8 +3671,7 @@ rules:
 							PodNetworkCIDR:                       "1.2.3.0/24",
 							NodeNetworkCIDR:                      pointer.String("7.8.9.0/24"),
 						},
-						RuntimeVersion: runtimeVersion,
-						Version:        version,
+						Version: version,
 					}
 					kapi = New(kubernetesInterface, namespace, sm, values)
 					deployAndRead()
@@ -3497,7 +3779,12 @@ rules:
 		It("should successfully wait for the deployment to be updated", func() {
 			fakeClient := fakeclient.NewClientBuilder().WithScheme(kubernetes.SeedScheme).Build()
 			fakeKubernetesInterface := kubernetesfake.NewClientSetBuilder().WithAPIReader(fakeClient).WithClient(fakeClient).Build()
-			kapi = New(fakeKubernetesInterface, namespace, nil, Values{RuntimeVersion: runtimeVersion, Version: version})
+			kapi = New(fakeKubernetesInterface, namespace, nil, Values{
+				Values: apiserver.Values{
+					RuntimeVersion: runtimeVersion,
+				},
+				Version: version,
+			})
 			deploy := deployment.DeepCopy()
 
 			defer test.WithVars(&IntervalWaitForDeployment, time.Millisecond)()

--- a/pkg/component/kubeapiserver/kube_apiserver_test.go
+++ b/pkg/component/kubeapiserver/kube_apiserver_test.go
@@ -2237,7 +2237,7 @@ rules:
 					TerminationMessagePolicy: corev1.TerminationMessageReadFile,
 				}))
 
-				Expect(deployment.Spec.Template.Spec.Containers[0].Command).NotTo(ContainElement(ContainSubstring("--egress-selector-config-file=")))
+				Expect(deployment.Spec.Template.Spec.Containers[0].Args).NotTo(ContainElement(ContainSubstring("--egress-selector-config-file=")))
 				Expect(deployment.Spec.Template.Spec.Containers[0].VolumeMounts).NotTo(ContainElement(MatchFields(IgnoreExtras, Fields{"Name": Equal("http-proxy")})))
 				Expect(deployment.Spec.Template.Spec.Volumes).NotTo(ContainElement(MatchFields(IgnoreExtras, Fields{"Name": Equal("http-proxy")})))
 
@@ -2436,20 +2436,20 @@ rules:
 					kapi = New(kubernetesInterface, namespace, sm, values)
 					deployAndRead()
 
-					issuerIdx := indexOfElement(deployment.Spec.Template.Spec.Containers[0].Command, "--service-account-issuer="+serviceAccountIssuer)
-					issuerIdx1 := indexOfElement(deployment.Spec.Template.Spec.Containers[0].Command, "--service-account-issuer="+acceptedIssuers[0])
-					issuerIdx2 := indexOfElement(deployment.Spec.Template.Spec.Containers[0].Command, "--service-account-issuer="+acceptedIssuers[1])
+					issuerIdx := indexOfElement(deployment.Spec.Template.Spec.Containers[0].Args, "--service-account-issuer="+serviceAccountIssuer)
+					issuerIdx1 := indexOfElement(deployment.Spec.Template.Spec.Containers[0].Args, "--service-account-issuer="+acceptedIssuers[0])
+					issuerIdx2 := indexOfElement(deployment.Spec.Template.Spec.Containers[0].Args, "--service-account-issuer="+acceptedIssuers[1])
 					tlscipherSuites := kubernetesutils.TLSCipherSuites(version)
 
 					Expect(deployment.Spec.Template.Spec.Containers[0].Name).To(Equal("kube-apiserver"))
 					Expect(deployment.Spec.Template.Spec.Containers[0].Image).To(Equal(images.KubeAPIServer))
 					Expect(deployment.Spec.Template.Spec.Containers[0].ImagePullPolicy).To(Equal(corev1.PullIfNotPresent))
-					Expect(deployment.Spec.Template.Spec.Containers[0].Command).To(ConsistOf(
-						"/usr/local/bin/kube-apiserver",
+					Expect(deployment.Spec.Template.Spec.Containers[0].Command).To(ConsistOf("/usr/local/bin/kube-apiserver"))
+					Expect(deployment.Spec.Template.Spec.Containers[0].Args).To(ConsistOf(
 						"--enable-admission-plugins="+admissionPlugin1+","+admissionPlugin2,
 						"--admission-control-config-file=/etc/kubernetes/admission/admission-configuration.yaml",
 						"--anonymous-auth=false",
-						"--audit-log-path=/var/lib/audit.log",
+						"--audit-log-path=/tmp/audit/audit.log",
 						"--audit-policy-file=/etc/kubernetes/audit/audit-policy.yaml",
 						"--audit-log-maxsize=100",
 						"--audit-log-maxbackup=5",
@@ -2538,7 +2538,7 @@ rules:
 							MountPath: "/srv/kubernetes/etcd/client",
 						},
 						corev1.VolumeMount{
-							Name:      "kube-apiserver-server",
+							Name:      "server",
 							MountPath: "/srv/kubernetes/apiserver",
 						},
 						corev1.VolumeMount{
@@ -2693,7 +2693,7 @@ rules:
 							},
 						},
 						corev1.Volume{
-							Name: "kube-apiserver-server",
+							Name: "server",
 							VolumeSource: corev1.VolumeSource{
 								Secret: &corev1.SecretVolumeSource{
 									SecretName: secretNameServer,
@@ -2748,7 +2748,7 @@ rules:
 					kapi = New(kubernetesInterface, namespace, sm, values)
 					deployAndRead()
 
-					Expect(deployment.Spec.Template.Spec.Containers[0].Command).To(ContainElements(
+					Expect(deployment.Spec.Template.Spec.Containers[0].Args).To(ContainElements(
 						"--allow-privileged=true",
 						"--kubelet-preferred-address-types=InternalIP,Hostname,ExternalIP",
 						"--kubelet-certificate-authority=/srv/kubernetes/ca-kubelet/bundle.crt",
@@ -2790,7 +2790,7 @@ rules:
 					kapi = New(kubernetesInterface, namespace, sm, values)
 					deployAndRead()
 
-					Expect(deployment.Spec.Template.Spec.Containers[0].Command).To(ContainElement(
+					Expect(deployment.Spec.Template.Spec.Containers[0].Args).To(ContainElement(
 						"--egress-selector-config-file=/etc/kubernetes/egress/egress-selector-configuration.yaml",
 					))
 					Expect(deployment.Spec.Template.Spec.Containers[0].VolumeMounts).To(ContainElements(
@@ -2940,7 +2940,7 @@ rules:
 					})
 					deployAndRead()
 
-					Expect(deployment.Spec.Template.Spec.Containers[0].Command).To(ContainElement(ContainSubstring(
+					Expect(deployment.Spec.Template.Spec.Containers[0].Args).To(ContainElement(ContainSubstring(
 						"--anonymous-auth=true",
 					)))
 				})
@@ -2958,7 +2958,7 @@ rules:
 					})
 					deployAndRead()
 
-					Expect(deployment.Spec.Template.Spec.Containers[0].Command).To(ContainElement(
+					Expect(deployment.Spec.Template.Spec.Containers[0].Args).To(ContainElement(
 						"--advertise-address=" + advertiseAddress,
 					))
 				})
@@ -2974,7 +2974,7 @@ rules:
 					})
 					deployAndRead()
 
-					Expect(deployment.Spec.Template.Spec.Containers[0].Command).NotTo(ContainElement(ContainSubstring("--advertise-address=")))
+					Expect(deployment.Spec.Template.Spec.Containers[0].Args).NotTo(ContainElement(ContainSubstring("--advertise-address=")))
 				})
 
 				It("should configure the correct etcd overrides for etcd-events", func() {
@@ -2996,7 +2996,7 @@ rules:
 					})
 					deployAndRead()
 
-					Expect(deployment.Spec.Template.Spec.Containers[0].Command).To(ContainElement(
+					Expect(deployment.Spec.Template.Spec.Containers[0].Args).To(ContainElement(
 						"--etcd-servers-overrides=networking.k8s.io/networkpolicies#https://etcd-events-client:2379,/events#https://etcd-events-client:2379,apps/daemonsets#https://etcd-events-client:2379",
 					))
 				})
@@ -3018,7 +3018,7 @@ rules:
 					})
 					deployAndRead()
 
-					Expect(deployment.Spec.Template.Spec.Containers[0].Command).To(ContainElement(
+					Expect(deployment.Spec.Template.Spec.Containers[0].Args).To(ContainElement(
 						"--api-audiences=" + apiAudience1 + "," + apiAudience2,
 					))
 				})
@@ -3026,7 +3026,7 @@ rules:
 				It("should not configure the api audiences if not provided", func() {
 					deployAndRead()
 
-					Expect(deployment.Spec.Template.Spec.Containers[0].Command).NotTo(ContainElement(ContainSubstring("--api-audiences=")))
+					Expect(deployment.Spec.Template.Spec.Containers[0].Args).NotTo(ContainElement(ContainSubstring("--api-audiences=")))
 				})
 
 				It("should configure the feature gates if provided", func() {
@@ -3042,7 +3042,7 @@ rules:
 					})
 					deployAndRead()
 
-					Expect(deployment.Spec.Template.Spec.Containers[0].Command).To(ContainElement(
+					Expect(deployment.Spec.Template.Spec.Containers[0].Args).To(ContainElement(
 						"--feature-gates=Bar=false,Foo=true",
 					))
 				})
@@ -3050,7 +3050,7 @@ rules:
 				It("should not configure the feature gates if not provided", func() {
 					deployAndRead()
 
-					Expect(deployment.Spec.Template.Spec.Containers[0].Command).NotTo(ContainElement(ContainSubstring("--feature-gates=")))
+					Expect(deployment.Spec.Template.Spec.Containers[0].Args).NotTo(ContainElement(ContainSubstring("--feature-gates=")))
 				})
 
 				It("should configure the request settings if provided", func() {
@@ -3069,7 +3069,7 @@ rules:
 					})
 					deployAndRead()
 
-					Expect(deployment.Spec.Template.Spec.Containers[0].Command).To(ContainElements(
+					Expect(deployment.Spec.Template.Spec.Containers[0].Args).To(ContainElements(
 						"--max-requests-inflight=123",
 						"--max-mutating-requests-inflight=456",
 					))
@@ -3078,7 +3078,7 @@ rules:
 				It("should not configure the request settings if not provided", func() {
 					deployAndRead()
 
-					Expect(deployment.Spec.Template.Spec.Containers[0].Command).NotTo(ContainElements(
+					Expect(deployment.Spec.Template.Spec.Containers[0].Args).NotTo(ContainElements(
 						ContainSubstring("--max-requests-inflight="),
 						ContainSubstring("--max-mutating-requests-inflight="),
 					))
@@ -3098,7 +3098,7 @@ rules:
 					})
 					deployAndRead()
 
-					Expect(deployment.Spec.Template.Spec.Containers[0].Command).To(ContainElement(
+					Expect(deployment.Spec.Template.Spec.Containers[0].Args).To(ContainElement(
 						"--runtime-config=bar=false,foo=true",
 					))
 				})
@@ -3114,7 +3114,7 @@ rules:
 					})
 					deployAndRead()
 
-					Expect(deployment.Spec.Template.Spec.Containers[0].Command).NotTo(ContainElement(ContainSubstring("--runtime-config=")))
+					Expect(deployment.Spec.Template.Spec.Containers[0].Args).NotTo(ContainElement(ContainSubstring("--runtime-config=")))
 				})
 
 				It("should disable apis in case of workerless shoot with k8s version < 1.25", func() {
@@ -3131,7 +3131,7 @@ rules:
 					})
 					deployAndRead()
 
-					Expect(deployment.Spec.Template.Spec.Containers[0].Command).To(ContainElement(
+					Expect(deployment.Spec.Template.Spec.Containers[0].Args).To(ContainElement(
 						"--runtime-config=apps/v1=false,autoscaling/v2=false,bar=false,batch/v1=false,policy/v1/poddisruptionbudgets=false,policy/v1beta1/podsecuritypolicies=false,storage.k8s.io/v1/csidrivers=false,storage.k8s.io/v1/csinodes=false",
 					))
 				})
@@ -3151,7 +3151,7 @@ rules:
 					})
 					deployAndRead()
 
-					Expect(deployment.Spec.Template.Spec.Containers[0].Command).To(ContainElement(
+					Expect(deployment.Spec.Template.Spec.Containers[0].Args).To(ContainElement(
 						"--runtime-config=apps/v1=false,autoscaling/v2=false,bar=false,batch/v1=false,policy/v1/poddisruptionbudgets=false,storage.k8s.io/v1/csidrivers=false,storage.k8s.io/v1/csinodes=false",
 					))
 				})
@@ -3175,7 +3175,7 @@ rules:
 					})
 					deployAndRead()
 
-					Expect(deployment.Spec.Template.Spec.Containers[0].Command).To(ContainElements(
+					Expect(deployment.Spec.Template.Spec.Containers[0].Args).To(ContainElements(
 						"--default-watch-cache-size=123",
 						"--watch-cache-sizes=foo#456,bar.baz#789",
 					))
@@ -3184,7 +3184,7 @@ rules:
 				It("should not configure the watch cache settings if not provided", func() {
 					deployAndRead()
 
-					Expect(deployment.Spec.Template.Spec.Containers[0].Command).NotTo(ContainElements(
+					Expect(deployment.Spec.Template.Spec.Containers[0].Args).NotTo(ContainElements(
 						ContainSubstring("--default-watch-cache-size="),
 						ContainSubstring("--watch-cache-sizes="),
 					))
@@ -3203,7 +3203,7 @@ rules:
 
 					deployAndRead()
 
-					Expect(deployment.Spec.Template.Spec.Containers[0].Command).To(ContainElements(
+					Expect(deployment.Spec.Template.Spec.Containers[0].Args).To(ContainElements(
 						"--default-not-ready-toleration-seconds=120",
 						"--default-unreachable-toleration-seconds=130",
 					))
@@ -3224,7 +3224,7 @@ rules:
 					})
 					deployAndRead()
 
-					Expect(deployment.Spec.Template.Spec.Containers[0].Command).To(ContainElements(
+					Expect(deployment.Spec.Template.Spec.Containers[0].Args).To(ContainElements(
 						"--vmodule=httplog=3",
 						"--v=3",
 					))
@@ -3239,7 +3239,7 @@ rules:
 					})
 					deployAndRead()
 
-					Expect(deployment.Spec.Template.Spec.Containers[0].Command).NotTo(ContainElements(
+					Expect(deployment.Spec.Template.Spec.Containers[0].Args).NotTo(ContainElements(
 						ContainSubstring("--vmodule=httplog"),
 						ContainSubstring("--v="),
 					))
@@ -3331,7 +3331,7 @@ rules:
 					})
 					deployAndRead()
 
-					Expect(deployment.Spec.Template.Spec.Containers[0].Command).To(ContainElement(
+					Expect(deployment.Spec.Template.Spec.Containers[0].Args).To(ContainElement(
 						"--egress-selector-config-file=/etc/kubernetes/egress/egress-selector-configuration.yaml",
 					))
 
@@ -3441,7 +3441,7 @@ rules:
 					})
 					deployAndRead()
 
-					Expect(deployment.Spec.Template.Spec.Containers[0].Command).To(ContainElements(
+					Expect(deployment.Spec.Template.Spec.Containers[0].Args).To(ContainElements(
 						"--shutdown-send-retry-after=true",
 					))
 				})
@@ -3454,7 +3454,7 @@ rules:
 					kapi = New(kubernetesInterface, namespace, sm, values)
 					deployAndRead()
 
-					Expect(deployment.Spec.Template.Spec.Containers[0].Command).To(ContainElements(
+					Expect(deployment.Spec.Template.Spec.Containers[0].Args).To(ContainElements(
 						"--tls-sni-cert-key=/srv/kubernetes/tls-sni/0/tls.crt,/srv/kubernetes/tls-sni/0/tls.key",
 						"--tls-sni-cert-key=/srv/kubernetes/tls-sni/1/tls.crt,/srv/kubernetes/tls-sni/1/tls.key:foo1.com,*.foo2.com",
 					))
@@ -3501,7 +3501,7 @@ rules:
 					kapi = New(kubernetesInterface, namespace, sm, values)
 					deployAndRead()
 
-					Expect(deployment.Spec.Template.Spec.Containers[0].Command).To(ContainElements(
+					Expect(deployment.Spec.Template.Spec.Containers[0].Args).To(ContainElements(
 						"--audit-webhook-config-file=/etc/kubernetes/webhook/audit/kubeconfig.yaml",
 						"--audit-webhook-batch-max-size=30",
 						"--audit-webhook-version=audit.k8s.io/v1beta1",
@@ -3534,7 +3534,7 @@ rules:
 					kapi = New(kubernetesInterface, namespace, sm, values)
 					deployAndRead()
 
-					Expect(deployment.Spec.Template.Spec.Containers[0].Command).To(ContainElements(
+					Expect(deployment.Spec.Template.Spec.Containers[0].Args).To(ContainElements(
 						"--authentication-token-webhook-config-file=/etc/kubernetes/webhook/authentication/kubeconfig.yaml",
 						"--authentication-token-webhook-cache-ttl=30s",
 						"--authentication-token-webhook-version=v1beta1",
@@ -3568,7 +3568,7 @@ rules:
 					kapi = New(kubernetesInterface, namespace, sm, values)
 					deployAndRead()
 
-					Expect(deployment.Spec.Template.Spec.Containers[0].Command).To(ContainElements(
+					Expect(deployment.Spec.Template.Spec.Containers[0].Args).To(ContainElements(
 						"--authorization-webhook-config-file=/etc/kubernetes/webhook/authorization/kubeconfig.yaml",
 						"--authorization-webhook-cache-authorized-ttl=13s",
 						"--authorization-webhook-cache-unauthorized-ttl=37s",

--- a/pkg/component/kubeapiserver/mock/mocks.go
+++ b/pkg/component/kubeapiserver/mock/mocks.go
@@ -8,6 +8,7 @@ import (
 	context "context"
 	reflect "reflect"
 
+	apiserver "github.com/gardener/gardener/pkg/component/apiserver"
 	kubeapiserver "github.com/gardener/gardener/pkg/component/kubeapiserver"
 	gomock "github.com/golang/mock/gomock"
 	v1 "k8s.io/api/core/v1"
@@ -147,7 +148,7 @@ func (mr *MockInterfaceMockRecorder) SetAutoscalingReplicas(arg0 interface{}) *g
 }
 
 // SetETCDEncryptionConfig mocks base method.
-func (m *MockInterface) SetETCDEncryptionConfig(arg0 kubeapiserver.ETCDEncryptionConfig) {
+func (m *MockInterface) SetETCDEncryptionConfig(arg0 apiserver.ETCDEncryptionConfig) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "SetETCDEncryptionConfig", arg0)
 }

--- a/pkg/component/kubeapiserver/secrets.go
+++ b/pkg/component/kubeapiserver/secrets.go
@@ -21,12 +21,8 @@ import (
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	"k8s.io/apimachinery/pkg/util/sets"
-	apiserverconfigv1 "k8s.io/apiserver/pkg/apis/config/v1"
 	"k8s.io/apiserver/pkg/authentication/user"
 	clientcmdv1 "k8s.io/client-go/tools/clientcmd/api/v1"
 	"k8s.io/utils/pointer"
@@ -34,8 +30,8 @@ import (
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	"github.com/gardener/gardener/pkg/component/apiserver"
 	"github.com/gardener/gardener/pkg/component/vpnseedserver"
-	"github.com/gardener/gardener/pkg/utils"
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	secretsutils "github.com/gardener/gardener/pkg/utils/secrets"
 	secretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager"
@@ -167,87 +163,15 @@ func (k *kubeAPIServer) reconcileSecretUserKubeconfig(ctx context.Context, secre
 }
 
 func (k *kubeAPIServer) reconcileSecretETCDEncryptionConfiguration(ctx context.Context, secret *corev1.Secret) error {
-	options := []secretsmanager.GenerateOption{
-		secretsmanager.Persist(),
-		secretsmanager.Rotate(secretsmanager.KeepOld),
-	}
-
-	if k.values.ETCDEncryption.RotationPhase == gardencorev1beta1.RotationCompleting {
-		options = append(options, secretsmanager.IgnoreOldSecrets())
-	}
-
-	keySecret, err := k.secretsManager.Generate(ctx, &secretsutils.ETCDEncryptionKeySecretConfig{
-		Name:         v1beta1constants.SecretNameETCDEncryptionKey,
-		SecretLength: 32,
-	}, options...)
-	if err != nil {
-		return err
-	}
-
-	keySecretOld, _ := k.secretsManager.Get(v1beta1constants.SecretNameETCDEncryptionKey, secretsmanager.Old)
-
-	encryptionConfiguration := &apiserverconfigv1.EncryptionConfiguration{
-		Resources: []apiserverconfigv1.ResourceConfiguration{{
-			Resources: sets.List(sets.New(k.values.ETCDEncryption.Resources...).Insert("secrets")),
-			Providers: []apiserverconfigv1.ProviderConfiguration{
-				{
-					AESCBC: &apiserverconfigv1.AESConfiguration{
-						Keys: k.etcdEncryptionAESKeys(keySecret, keySecretOld),
-					},
-				},
-				{
-					Identity: &apiserverconfigv1.IdentityConfiguration{},
-				},
-			},
-		}},
-	}
-
-	data, err := runtime.Encode(codec, encryptionConfiguration)
-	if err != nil {
-		return err
-	}
-
-	secret.Labels = map[string]string{v1beta1constants.LabelRole: v1beta1constants.SecretNamePrefixETCDEncryptionConfiguration}
-	secret.Data = map[string][]byte{secretETCDEncryptionConfigurationDataKey: data}
-	utilruntime.Must(kubernetesutils.MakeUnique(secret))
-	desiredLabels := utils.MergeStringMaps(secret.Labels) // copy
-
-	if err := k.client.Client().Create(ctx, secret); err == nil || !apierrors.IsAlreadyExists(err) {
-		return err
-	}
-
-	// reconcile labels of existing secret
-	if err := k.client.Client().Get(ctx, client.ObjectKeyFromObject(secret), secret); err != nil {
-		return err
-	}
-	patch := client.MergeFrom(secret.DeepCopy())
-	secret.Labels = desiredLabels
-	return k.client.Client().Patch(ctx, secret, patch)
-}
-
-func (k *kubeAPIServer) etcdEncryptionAESKeys(keySecretCurrent, keySecretOld *corev1.Secret) []apiserverconfigv1.Key {
-	if keySecretOld == nil {
-		return []apiserverconfigv1.Key{
-			aesKeyFromSecretData(keySecretCurrent.Data),
-		}
-	}
-
-	keyForEncryption, keyForDecryption := keySecretCurrent, keySecretOld
-	if !k.values.ETCDEncryption.EncryptWithCurrentKey {
-		keyForEncryption, keyForDecryption = keySecretOld, keySecretCurrent
-	}
-
-	return []apiserverconfigv1.Key{
-		aesKeyFromSecretData(keyForEncryption.Data),
-		aesKeyFromSecretData(keyForDecryption.Data),
-	}
-}
-
-func aesKeyFromSecretData(data map[string][]byte) apiserverconfigv1.Key {
-	return apiserverconfigv1.Key{
-		Name:   string(data[secretsutils.DataKeyEncryptionKeyName]),
-		Secret: string(data[secretsutils.DataKeyEncryptionSecret]),
-	}
+	return apiserver.ReconcileSecretETCDEncryptionConfiguration(
+		ctx,
+		k.client.Client(),
+		k.secretsManager,
+		k.values.ETCDEncryption,
+		secret,
+		v1beta1constants.SecretNameETCDEncryptionKey,
+		v1beta1constants.SecretNamePrefixETCDEncryptionConfiguration,
+	)
 }
 
 func (k *kubeAPIServer) reconcileSecretServer(ctx context.Context) (*corev1.Secret, error) {

--- a/pkg/component/kubeapiserver/secrets.go
+++ b/pkg/component/kubeapiserver/secrets.go
@@ -171,7 +171,7 @@ func (k *kubeAPIServer) reconcileSecretServer(ctx context.Context) (*corev1.Secr
 	}
 
 	return k.secretsManager.Generate(ctx, &secretsutils.CertificateSecretConfig{
-		Name:                              secretNameServer,
+		Name:                              secretNameServerCert,
 		CommonName:                        deploymentName,
 		IPAddresses:                       append(ipAddresses, k.values.ServerCertificate.ExtraIPAddresses...),
 		DNSNames:                          append(dnsNames, k.values.ServerCertificate.ExtraDNSNames...),

--- a/pkg/component/kubeapiserver/secrets.go
+++ b/pkg/component/kubeapiserver/secrets.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 	"net"
-	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -57,23 +56,6 @@ const (
 
 func (k *kubeAPIServer) emptySecret(name string) *corev1.Secret {
 	return &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: k.namespace}}
-}
-
-func (k *kubeAPIServer) reconcileSecretAdmissionKubeconfigs(ctx context.Context, secret *corev1.Secret) error {
-	secret.Data = make(map[string][]byte)
-
-	for _, plugin := range k.values.EnabledAdmissionPlugins {
-		if len(plugin.Kubeconfig) != 0 {
-			secret.Data[admissionPluginsKubeconfigFilename(plugin.Name)] = plugin.Kubeconfig
-		}
-	}
-
-	utilruntime.Must(kubernetesutils.MakeUnique(secret))
-	return client.IgnoreAlreadyExists(k.client.Client().Create(ctx, secret))
-}
-
-func admissionPluginsKubeconfigFilename(name string) string {
-	return strings.ToLower(name) + "-kubeconfig.yaml"
 }
 
 func (k *kubeAPIServer) reconcileSecretOIDCCABundle(ctx context.Context, secret *corev1.Secret) error {

--- a/pkg/operation/botanist/kubeapiserver.go
+++ b/pkg/operation/botanist/kubeapiserver.go
@@ -29,6 +29,7 @@ import (
 	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap/keys"
+	"github.com/gardener/gardener/pkg/component/apiserver"
 	"github.com/gardener/gardener/pkg/component/kubeapiserver"
 	"github.com/gardener/gardener/pkg/component/shared"
 	"github.com/gardener/gardener/pkg/features"
@@ -94,7 +95,7 @@ func (b *Botanist) DefaultKubeAPIServer(ctx context.Context) (kubeapiserver.Inte
 	)
 }
 
-func (b *Botanist) computeKubeAPIServerAutoscalingConfig() kubeapiserver.AutoscalingConfig {
+func (b *Botanist) computeKubeAPIServerAutoscalingConfig() apiserver.AutoscalingConfig {
 	var (
 		hvpaEnabled               = features.DefaultFeatureGate.Enabled(features.HVPA)
 		useMemoryMetricForHvpaHPA = false
@@ -157,7 +158,7 @@ func (b *Botanist) computeKubeAPIServerAutoscalingConfig() kubeapiserver.Autosca
 		}
 	}
 
-	return kubeapiserver.AutoscalingConfig{
+	return apiserver.AutoscalingConfig{
 		APIServerResources:        apiServerResources,
 		HVPAEnabled:               hvpaEnabled,
 		Replicas:                  defaultReplicas,

--- a/pkg/operation/botanist/kubeapiserver_test.go
+++ b/pkg/operation/botanist/kubeapiserver_test.go
@@ -38,6 +38,7 @@ import (
 	fakeclientmap "github.com/gardener/gardener/pkg/client/kubernetes/clientmap/fake"
 	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap/keys"
 	"github.com/gardener/gardener/pkg/client/kubernetes/fake"
+	"github.com/gardener/gardener/pkg/component/apiserver"
 	"github.com/gardener/gardener/pkg/component/kubeapiserver"
 	mockkubeapiserver "github.com/gardener/gardener/pkg/component/kubeapiserver/mock"
 	"github.com/gardener/gardener/pkg/features"
@@ -182,7 +183,7 @@ var _ = Describe("KubeAPIServer", func() {
 	Describe("#DefaultKubeAPIServer", func() {
 		Describe("AutoscalingConfig", func() {
 			DescribeTable("should have the expected autoscaling config",
-				func(prepTest func(), featureGates map[featuregate.Feature]bool, expectedConfig kubeapiserver.AutoscalingConfig) {
+				func(prepTest func(), featureGates map[featuregate.Feature]bool, expectedConfig apiserver.AutoscalingConfig) {
 					if prepTest != nil {
 						prepTest()
 					}
@@ -199,7 +200,7 @@ var _ = Describe("KubeAPIServer", func() {
 				Entry("default behaviour, HVPA is disabled",
 					nil,
 					map[featuregate.Feature]bool{features.HVPA: false},
-					kubeapiserver.AutoscalingConfig{
+					apiserver.AutoscalingConfig{
 						APIServerResources:        resourcesRequirementsForKubeAPIServer(4, ""),
 						HVPAEnabled:               false,
 						MinReplicas:               1,
@@ -211,7 +212,7 @@ var _ = Describe("KubeAPIServer", func() {
 				Entry("default behaviour, HVPA is enabled",
 					nil,
 					map[featuregate.Feature]bool{features.HVPA: true},
-					kubeapiserver.AutoscalingConfig{
+					apiserver.AutoscalingConfig{
 						APIServerResources:        resourcesRequirementsForKubeAPIServer(40, ""),
 						HVPAEnabled:               true,
 						MinReplicas:               1,
@@ -226,7 +227,7 @@ var _ = Describe("KubeAPIServer", func() {
 						features.HVPA:                           true,
 						features.DisableScalingClassesForShoots: true,
 					},
-					kubeapiserver.AutoscalingConfig{
+					apiserver.AutoscalingConfig{
 						APIServerResources: corev1.ResourceRequirements{
 							Requests: corev1.ResourceList{
 								corev1.ResourceCPU:    resource.MustParse("500m"),
@@ -246,7 +247,7 @@ var _ = Describe("KubeAPIServer", func() {
 						features.HVPA:                           false,
 						features.DisableScalingClassesForShoots: true,
 					},
-					kubeapiserver.AutoscalingConfig{
+					apiserver.AutoscalingConfig{
 						APIServerResources:        resourcesRequirementsForKubeAPIServer(4, ""),
 						HVPAEnabled:               false,
 						MinReplicas:               1,
@@ -260,7 +261,7 @@ var _ = Describe("KubeAPIServer", func() {
 						botanist.Shoot.Purpose = gardencorev1beta1.ShootPurposeProduction
 					},
 					nil,
-					kubeapiserver.AutoscalingConfig{
+					apiserver.AutoscalingConfig{
 						APIServerResources:        resourcesRequirementsForKubeAPIServer(4, ""),
 						HVPAEnabled:               false,
 						MinReplicas:               2,
@@ -274,7 +275,7 @@ var _ = Describe("KubeAPIServer", func() {
 						botanist.Shoot.GetInfo().Annotations = map[string]string{"alpha.control-plane.scaling.shoot.gardener.cloud/scale-down-disabled": "true"}
 					},
 					nil,
-					kubeapiserver.AutoscalingConfig{
+					apiserver.AutoscalingConfig{
 						APIServerResources:        resourcesRequirementsForKubeAPIServer(4, ""),
 						HVPAEnabled:               false,
 						MinReplicas:               4,
@@ -288,7 +289,7 @@ var _ = Describe("KubeAPIServer", func() {
 						botanist.ManagedSeed = &seedmanagementv1alpha1.ManagedSeed{}
 					},
 					map[featuregate.Feature]bool{features.HVPAForShootedSeed: false},
-					kubeapiserver.AutoscalingConfig{
+					apiserver.AutoscalingConfig{
 						APIServerResources:        resourcesRequirementsForKubeAPIServer(4, ""),
 						HVPAEnabled:               false,
 						MinReplicas:               1,
@@ -302,7 +303,7 @@ var _ = Describe("KubeAPIServer", func() {
 						botanist.ManagedSeed = &seedmanagementv1alpha1.ManagedSeed{}
 					},
 					map[featuregate.Feature]bool{features.HVPAForShootedSeed: true},
-					kubeapiserver.AutoscalingConfig{
+					apiserver.AutoscalingConfig{
 						APIServerResources:        resourcesRequirementsForKubeAPIServer(40, ""),
 						HVPAEnabled:               true,
 						MinReplicas:               1,
@@ -323,7 +324,7 @@ var _ = Describe("KubeAPIServer", func() {
 						}
 					},
 					map[featuregate.Feature]bool{features.HVPAForShootedSeed: true},
-					kubeapiserver.AutoscalingConfig{
+					apiserver.AutoscalingConfig{
 						APIServerResources:        resourcesRequirementsForKubeAPIServer(40, ""),
 						HVPAEnabled:               true,
 						MinReplicas:               16,
@@ -347,7 +348,7 @@ var _ = Describe("KubeAPIServer", func() {
 						features.HVPAForShootedSeed:             true,
 						features.DisableScalingClassesForShoots: true,
 					},
-					kubeapiserver.AutoscalingConfig{
+					apiserver.AutoscalingConfig{
 						APIServerResources: corev1.ResourceRequirements{
 							Requests: corev1.ResourceList{
 								corev1.ResourceCPU:    resource.MustParse("500m"),
@@ -373,7 +374,7 @@ var _ = Describe("KubeAPIServer", func() {
 						}
 					},
 					map[featuregate.Feature]bool{features.HVPAForShootedSeed: false},
-					kubeapiserver.AutoscalingConfig{
+					apiserver.AutoscalingConfig{
 						APIServerResources: corev1.ResourceRequirements{
 							Requests: corev1.ResourceList{
 								corev1.ResourceCPU:    resource.MustParse("1750m"),
@@ -403,7 +404,7 @@ var _ = Describe("KubeAPIServer", func() {
 						features.HVPAForShootedSeed:             false,
 						features.DisableScalingClassesForShoots: true,
 					},
-					kubeapiserver.AutoscalingConfig{
+					apiserver.AutoscalingConfig{
 						APIServerResources: corev1.ResourceRequirements{
 							Requests: corev1.ResourceList{
 								corev1.ResourceCPU:    resource.MustParse("1750m"),
@@ -427,7 +428,7 @@ var _ = Describe("KubeAPIServer", func() {
 						}
 					},
 					nil,
-					kubeapiserver.AutoscalingConfig{
+					apiserver.AutoscalingConfig{
 						APIServerResources:        resourcesRequirementsForKubeAPIServer(4, ""),
 						HVPAEnabled:               false,
 						MinReplicas:               3,

--- a/pkg/operator/client/scheme.go
+++ b/pkg/operator/client/scheme.go
@@ -21,6 +21,8 @@ import (
 	istionetworkingv1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
 	apiextensionsinstall "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/install"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/apimachinery/pkg/runtime/serializer/json"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	vpaautoscalingv1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
 	kubernetesscheme "k8s.io/client-go/kubernetes/scheme"
@@ -34,6 +36,16 @@ var (
 	RuntimeScheme = runtime.NewScheme()
 	// VirtualScheme is the scheme used in the virtual cluster.
 	VirtualScheme = runtime.NewScheme()
+
+	// RuntimeSerializer is a YAML serializer using the Runtime scheme.
+	RuntimeSerializer = json.NewSerializerWithOptions(json.DefaultMetaFactory, RuntimeScheme, RuntimeScheme, json.SerializerOptions{Yaml: true, Pretty: false, Strict: false})
+	// RuntimeCodec is a codec factory using the Runtime scheme.
+	RuntimeCodec = serializer.NewCodecFactory(RuntimeScheme)
+
+	// VirtualSerializer is a YAML serializer using the Virtual scheme.
+	VirtualSerializer = json.NewSerializerWithOptions(json.DefaultMetaFactory, VirtualScheme, VirtualScheme, json.SerializerOptions{Yaml: true, Pretty: false, Strict: false})
+	// VirtualCodec is a codec factory using the Virtual scheme.
+	VirtualCodec = serializer.NewCodecFactory(VirtualScheme)
 )
 
 func init() {

--- a/pkg/operator/controller/garden/garden/components.go
+++ b/pkg/operator/controller/garden/garden/components.go
@@ -39,6 +39,7 @@ import (
 	"github.com/gardener/gardener/pkg/apis/operator/v1alpha1/helper"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/component"
+	"github.com/gardener/gardener/pkg/component/apiserver"
 	"github.com/gardener/gardener/pkg/component/etcd"
 	"github.com/gardener/gardener/pkg/component/gardeneraccess"
 	"github.com/gardener/gardener/pkg/component/gardensystem"
@@ -408,7 +409,7 @@ func (r *Reconciler) newKubeAPIServer(
 	var (
 		err                          error
 		apiServerConfig              *gardencorev1beta1.KubeAPIServerConfig
-		auditWebhookConfig           *kubeapiserver.AuditWebhook
+		auditWebhookConfig           *apiserver.AuditWebhook
 		authenticationWebhookConfig  *kubeapiserver.AuthenticationWebhook
 		authorizationWebhookConfig   *kubeapiserver.AuthorizationWebhook
 		resourcesToStoreInETCDEvents []schema.GroupResource
@@ -454,7 +455,7 @@ func (r *Reconciler) newKubeAPIServer(
 		secretsManager,
 		namePrefix,
 		apiServerConfig,
-		kubeapiserver.AutoscalingConfig{
+		apiserver.AutoscalingConfig{
 			APIServerResources: corev1.ResourceRequirements{
 				Requests: corev1.ResourceList{
 					corev1.ResourceCPU:    resource.MustParse("600m"),
@@ -479,7 +480,7 @@ func (r *Reconciler) newKubeAPIServer(
 	)
 }
 
-func (r *Reconciler) computeKubeAPIServerAuditWebhookConfig(ctx context.Context, config *operatorv1alpha1.AuditWebhook) (*kubeapiserver.AuditWebhook, error) {
+func (r *Reconciler) computeKubeAPIServerAuditWebhookConfig(ctx context.Context, config *operatorv1alpha1.AuditWebhook) (*apiserver.AuditWebhook, error) {
 	if config == nil {
 		return nil, nil
 	}
@@ -490,7 +491,7 @@ func (r *Reconciler) computeKubeAPIServerAuditWebhookConfig(ctx context.Context,
 		return nil, fmt.Errorf("failed reading kubeconfig for audit webhook from referenced secret %s: %w", key, err)
 	}
 
-	return &kubeapiserver.AuditWebhook{
+	return &apiserver.AuditWebhook{
 		Kubeconfig:   kubeconfig,
 		BatchMaxSize: config.BatchMaxSize,
 		Version:      config.Version,

--- a/pkg/operator/controller/garden/garden/reconciler.go
+++ b/pkg/operator/controller/garden/garden/reconciler.go
@@ -359,7 +359,7 @@ func nonAutoRotatedCACertConfigurations() []secretsutils.ConfigInterface {
 		&secretsutils.CertificateSecretConfig{Name: v1beta1constants.SecretNameCACluster, CommonName: "kubernetes", CertType: secretsutils.CACert},
 		&secretsutils.CertificateSecretConfig{Name: v1beta1constants.SecretNameCAClient, CommonName: "kubernetes-client", CertType: secretsutils.CACert},
 		&secretsutils.CertificateSecretConfig{Name: v1beta1constants.SecretNameCAFrontProxy, CommonName: "front-proxy", CertType: secretsutils.CACert},
-		&secretsutils.CertificateSecretConfig{Name: v1beta1constants.SecretNameCAGardener, CommonName: "gardener", CertType: secretsutils.CACert},
+		&secretsutils.CertificateSecretConfig{Name: operatorv1alpha1.SecretNameCAGardener, CommonName: "gardener", CertType: secretsutils.CACert},
 	}
 }
 

--- a/pkg/operator/controller/garden/garden/reconciler.go
+++ b/pkg/operator/controller/garden/garden/reconciler.go
@@ -359,6 +359,7 @@ func nonAutoRotatedCACertConfigurations() []secretsutils.ConfigInterface {
 		&secretsutils.CertificateSecretConfig{Name: v1beta1constants.SecretNameCACluster, CommonName: "kubernetes", CertType: secretsutils.CACert},
 		&secretsutils.CertificateSecretConfig{Name: v1beta1constants.SecretNameCAClient, CommonName: "kubernetes-client", CertType: secretsutils.CACert},
 		&secretsutils.CertificateSecretConfig{Name: v1beta1constants.SecretNameCAFrontProxy, CommonName: "front-proxy", CertType: secretsutils.CACert},
+		&secretsutils.CertificateSecretConfig{Name: v1beta1constants.SecretNameCAGardener, CommonName: "gardener", CertType: secretsutils.CACert},
 	}
 }
 

--- a/pkg/utils/kubernetes/tls_cipher_suites.go
+++ b/pkg/utils/kubernetes/tls_cipher_suites.go
@@ -35,17 +35,17 @@ func TLSCipherSuites(k8sVersion *semver.Version) []string {
 		)
 	)
 
-	// For Kubernetes 1.22 Gardener only allows suites permissible for TLS 1.3
-	// see https://github.com/gardener/gardener/issues/4300#issuecomment-885498872
-	if version.ConstraintK8sEqual122.Check(k8sVersion) {
-		return tlsV13Suites
+	if k8sVersion == nil || !version.ConstraintK8sEqual122.Check(k8sVersion) {
+		// For Kubernetes >= 1.23 the Cipher list was again adapted as described in
+		// https://github.com/gardener/gardener/issues/4823#issue-1022865330
+		return append(tlsV13Suites,
+			"TLS_CHACHA20_POLY1305_SHA256",
+			"TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305",
+			"TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305",
+		)
 	}
 
-	// For Kubernetes >= 1.23 the Cipher list was again adapted as described in
-	// https://github.com/gardener/gardener/issues/4823#issue-1022865330
-	return append(tlsV13Suites,
-		"TLS_CHACHA20_POLY1305_SHA256",
-		"TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305",
-		"TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305",
-	)
+	// For Kubernetes 1.22 Gardener only allows suites permissible for TLS 1.3
+	// see https://github.com/gardener/gardener/issues/4300#issuecomment-885498872
+	return tlsV13Suites
 }

--- a/skaffold-operator.yaml
+++ b/skaffold-operator.yaml
@@ -53,6 +53,7 @@ build:
         - pkg/client/kubernetes/clientmap/internal
         - pkg/client/kubernetes/clientmap/keys
         - pkg/component
+        - pkg/component/apiserver
         - pkg/component/apiserverproxy
         - pkg/component/backupentry
         - pkg/component/blackboxexporter

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -834,8 +834,9 @@ build:
         - pkg/operation
         - pkg/operation/botanist
         - pkg/operator/client
-        - pkg/component/apiserverproxy
         - pkg/component
+        - pkg/component/apiserver
+        - pkg/component/apiserverproxy
         - pkg/component/backupentry
         - pkg/component/blackboxexporter
         - pkg/component/clusterautoscaler

--- a/test/e2e/operator/garden/create_delete.go
+++ b/test/e2e/operator/garden/create_delete.go
@@ -64,6 +64,7 @@ var _ = Describe("Garden Tests", Label("Garden", "default"), func() {
 			waitForGardenToBeDeleted(ctx, garden)
 			cleanupVolumes(ctx)
 			Expect(runtimeClient.DeleteAllOf(ctx, &corev1.Secret{}, client.InNamespace(namespace), client.MatchingLabels{"role": "kube-apiserver-etcd-encryption-configuration"})).To(Succeed())
+			Expect(runtimeClient.DeleteAllOf(ctx, &corev1.Secret{}, client.InNamespace(namespace), client.MatchingLabels{"role": "gardener-apiserver-etcd-encryption-configuration"})).To(Succeed())
 
 			By("Verify deletion")
 			secretList := &corev1.SecretList{}

--- a/test/e2e/operator/garden/create_rotate_delete.go
+++ b/test/e2e/operator/garden/create_rotate_delete.go
@@ -58,6 +58,7 @@ var _ = Describe("Garden Tests", Label("Garden", "default"), func() {
 			waitForGardenToBeDeleted(ctx, garden)
 			cleanupVolumes(ctx)
 			Expect(runtimeClient.DeleteAllOf(ctx, &corev1.Secret{}, client.InNamespace(namespace), client.MatchingLabels{"role": "kube-apiserver-etcd-encryption-configuration"})).To(Succeed())
+			Expect(runtimeClient.DeleteAllOf(ctx, &corev1.Secret{}, client.InNamespace(namespace), client.MatchingLabels{"role": "gardener-apiserver-etcd-encryption-configuration"})).To(Succeed())
 		})
 
 		v := rotationutils.Verifiers{

--- a/test/e2e/operator/garden/internal/rotation/certificate_authorities.go
+++ b/test/e2e/operator/garden/internal/rotation/certificate_authorities.go
@@ -50,6 +50,7 @@ var allCAs = []string{
 	caETCD,
 	caETCDPeer,
 	caFrontProxy,
+	caGardener,
 }
 
 const (
@@ -58,6 +59,7 @@ const (
 	caETCD       = "ca-etcd"
 	caETCDPeer   = "ca-etcd-peer"
 	caFrontProxy = "ca-front-proxy"
+	caGardener   = "ca-gardener"
 )
 
 // Before is called before the rotation is started.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind enhancement

**What this PR does / why we need it**:
This PR introduces a new `gardenerapiserver` Golang component. It is not yet instantiated anywhere, but the plan is to let `gardener-operator` deploy it eventually.
Lots of code is similar to the `kubeapiserver` component and was made reusable so that it can be shared amongst both components.
Note that the vast majority of configuration options in the current Helm chart are not needed in the `gardener-operator deploys gardener-apiserver` scenario, at least as of now. If we get aware of the necessity of more configuration options (e.g., more options for audit configurations) then we can support them in the future (similar to how we extend configurability for Kubernetes components on a per-need basis).

There is also a dedicated CA, `ca-gardener`, which is now already generated by `gardener-operator`. It is used to sign the server certificate of `gardener-apiserver` and is present in the CA bundle in the respective `APIService`s created in the virtual cluster.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/7016

**Special notes for your reviewer**:
We will keep the respective manifests in the `gardener/controlplane` Helm chart and don't plan to remove them until `gardener-operator` has been promoted to "stable" and has become the standard for deploying/managing the garden cluster. This means that we have to double-maintain both places in case there are changes to the Gardener control plane components. However, from our practical experience of the past years, this rather occurs rarely and should not be a problem for the foreseeable time.

/cc @oliver-goetz @ScheererJ @timuthy 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
