### PR TITLE
Move content of `kuberbacproxy` into `vali` component

### DIFF
--- a/pkg/component/extensions/operatingsystemconfig/downloader/downloader.go
+++ b/pkg/component/extensions/operatingsystemconfig/downloader/downloader.go
@@ -31,7 +31,7 @@ import (
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/original/components/docker"
-	"github.com/gardener/gardener/pkg/component/logging/kuberbacproxy"
+	"github.com/gardener/gardener/pkg/component/logging/vali"
 	"github.com/gardener/gardener/pkg/utils"
 	"github.com/gardener/gardener/pkg/utils/managedresources"
 	"github.com/gardener/gardener/pkg/utils/secrets"
@@ -223,7 +223,7 @@ func GenerateRBACResourcesData(secretNames []string) (map[string][]byte, error) 
 				{
 					APIGroups:     []string{""},
 					Resources:     []string{"secrets"},
-					ResourceNames: append(secretNames, Name, kuberbacproxy.ValitailTokenSecretName),
+					ResourceNames: append(secretNames, Name, vali.ValitailTokenSecretName),
 					Verbs:         []string{"get"},
 				},
 			},

--- a/pkg/component/extensions/operatingsystemconfig/original/components/valitail/config.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/valitail/config.go
@@ -28,7 +28,7 @@ import (
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	"github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/downloader"
 	"github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/original/components"
-	"github.com/gardener/gardener/pkg/component/logging/kuberbacproxy"
+	"github.com/gardener/gardener/pkg/component/logging/vali"
 	"github.com/gardener/gardener/pkg/utils"
 )
 
@@ -153,7 +153,7 @@ func getFetchTokenScriptFile() (extensionsv1alpha1.File, error) {
 		"pathCredentialsCACert": downloader.PathCredentialsCACert,
 		"pathAuthToken":         PathAuthToken,
 		"dataKeyToken":          resourcesv1alpha1.DataKeyToken,
-		"secretName":            kuberbacproxy.ValitailTokenSecretName,
+		"secretName":            vali.ValitailTokenSecretName,
 	}); err != nil {
 		return extensionsv1alpha1.File{}, err
 	}

--- a/pkg/component/logging/kuberbacproxy/kube_rbac_proxy.go
+++ b/pkg/component/logging/kuberbacproxy/kube_rbac_proxy.go
@@ -67,41 +67,14 @@ func (k *kubeRBACProxy) Deploy(ctx context.Context) error {
 
 		valitailClusterRole = &rbacv1.ClusterRole{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:   valitailRBACName,
-				Labels: getValitailLabels(),
-			},
-			Rules: []rbacv1.PolicyRule{
-				{
-					APIGroups: []string{
-						"",
-					},
-					Resources: []string{
-						"nodes",
-						"nodes/proxy",
-						"services",
-						"endpoints",
-						"pods",
-					},
-					Verbs: []string{
-						"get",
-						"list",
-						"watch",
-					},
-				},
-				{
-					NonResourceURLs: []string{
-						"/vali/api/v1/push",
-					},
-					Verbs: []string{
-						"create",
-					},
-				},
+				Name:        valitailRBACName,
+				Annotations: map[string]string{resourcesv1alpha1.Mode: resourcesv1alpha1.ModeIgnore},
 			},
 		}
 
 		valitailClusterRoleBinding = &rbacv1.ClusterRoleBinding{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:   valitailRBACName,
+				Name:   "gardener.cloud:logging:valitail",
 				Labels: getValitailLabels(),
 			},
 			RoleRef: rbacv1.RoleRef{

--- a/pkg/component/logging/kuberbacproxy/kube_rbac_proxy.go
+++ b/pkg/component/logging/kuberbacproxy/kube_rbac_proxy.go
@@ -30,8 +30,6 @@ import (
 
 const (
 	managedResourceName = "shoot-node-logging"
-
-	valitailRBACName = "gardener.cloud:logging:valitail"
 )
 
 // New creates a new instance of kubeRBACProxy for the kube-rbac-proxy.
@@ -67,26 +65,16 @@ func (k *kubeRBACProxy) Deploy(ctx context.Context) error {
 
 		valitailClusterRole = &rbacv1.ClusterRole{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:        valitailRBACName,
+				Name:        "gardener.cloud:logging:valitail",
 				Annotations: map[string]string{resourcesv1alpha1.Mode: resourcesv1alpha1.ModeIgnore},
 			},
 		}
 
 		valitailClusterRoleBinding = &rbacv1.ClusterRoleBinding{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:   "gardener.cloud:logging:valitail",
-				Labels: getValitailLabels(),
+				Name:        "gardener.cloud:logging:valitail",
+				Annotations: map[string]string{resourcesv1alpha1.Mode: resourcesv1alpha1.ModeIgnore},
 			},
-			RoleRef: rbacv1.RoleRef{
-				APIGroup: rbacv1.GroupName,
-				Kind:     "ClusterRole",
-				Name:     valitailClusterRole.Name,
-			},
-			Subjects: []rbacv1.Subject{{
-				Kind:      rbacv1.ServiceAccountKind,
-				Name:      "gardener-valitail",
-				Namespace: metav1.NamespaceSystem,
-			}},
 		}
 
 		registry = managedresources.NewRegistry(kubernetes.ShootScheme, kubernetes.ShootCodec, kubernetes.ShootSerializer)
@@ -106,10 +94,4 @@ func (k *kubeRBACProxy) Deploy(ctx context.Context) error {
 
 func (k *kubeRBACProxy) Destroy(ctx context.Context) error {
 	return managedresources.DeleteForShoot(ctx, k.client, k.namespace, managedResourceName)
-}
-
-func getValitailLabels() map[string]string {
-	return map[string]string{
-		"app": "gardener-valitail",
-	}
 }

--- a/pkg/component/logging/kuberbacproxy/kube_rbac_proxy_test.go
+++ b/pkg/component/logging/kuberbacproxy/kube_rbac_proxy_test.go
@@ -182,22 +182,9 @@ var _ = Describe("KubeRBACProxy", func() {
 			})))
 			Expect(string(managedResourceSecret.Data["clusterrolebinding____gardener.cloud_logging_kube-rbac-proxy.yaml"])).To(Equal(test.Serialize(&rbacv1.ClusterRoleBinding{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "gardener.cloud:logging:kube-rbac-proxy",
-					Labels: map[string]string{
-						"app": kubeRBACProxyName,
-					},
-				},
-				RoleRef: rbacv1.RoleRef{
-					APIGroup: rbacv1.GroupName,
-					Kind:     "ClusterRole",
-					Name:     "system:auth-delegator",
-				},
-				Subjects: []rbacv1.Subject{{
-					Kind:      rbacv1.ServiceAccountKind,
-					Name:      kubeRBACProxyName,
-					Namespace: metav1.NamespaceSystem,
-				}},
-			})))
+					Name:        "gardener.cloud:logging:kube-rbac-proxy",
+					Annotations: map[string]string{"resources.gardener.cloud/mode": "Ignore"},
+				}})))
 			Expect(string(managedResourceSecret.Data["clusterrolebinding____gardener.cloud_logging_valitail.yaml"])).To(Equal(test.Serialize(&rbacv1.ClusterRoleBinding{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "gardener.cloud:logging:valitail",

--- a/pkg/component/logging/kuberbacproxy/kube_rbac_proxy_test.go
+++ b/pkg/component/logging/kuberbacproxy/kube_rbac_proxy_test.go
@@ -147,37 +147,8 @@ var _ = Describe("KubeRBACProxy", func() {
 					Kind:       "ClusterRole",
 				},
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "gardener.cloud:logging:valitail",
-					Labels: map[string]string{
-						"app": valitailName,
-					},
-				},
-				Rules: []rbacv1.PolicyRule{
-					{
-						APIGroups: []string{
-							"",
-						},
-						Resources: []string{
-							"nodes",
-							"nodes/proxy",
-							"services",
-							"endpoints",
-							"pods",
-						},
-						Verbs: []string{
-							"get",
-							"list",
-							"watch",
-						},
-					},
-					{
-						NonResourceURLs: []string{
-							"/vali/api/v1/push",
-						},
-						Verbs: []string{
-							"create",
-						},
-					},
+					Name:        "gardener.cloud:logging:valitail",
+					Annotations: map[string]string{"resources.gardener.cloud/mode": "Ignore"},
 				},
 			})))
 			Expect(string(managedResourceSecret.Data["clusterrolebinding____gardener.cloud_logging_kube-rbac-proxy.yaml"])).To(Equal(test.Serialize(&rbacv1.ClusterRoleBinding{

--- a/pkg/component/logging/kuberbacproxy/kube_rbac_proxy_test.go
+++ b/pkg/component/logging/kuberbacproxy/kube_rbac_proxy_test.go
@@ -39,8 +39,6 @@ var _ = Describe("KubeRBACProxy", func() {
 	const (
 		namespace           = "shoot--foo--bar"
 		managedResourceName = "shoot-node-logging"
-		kubeRBACProxyName   = "kube-rbac-proxy"
-		valitailName        = "gardener-valitail"
 	)
 
 	var (
@@ -158,21 +156,9 @@ var _ = Describe("KubeRBACProxy", func() {
 				}})))
 			Expect(string(managedResourceSecret.Data["clusterrolebinding____gardener.cloud_logging_valitail.yaml"])).To(Equal(test.Serialize(&rbacv1.ClusterRoleBinding{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "gardener.cloud:logging:valitail",
-					Labels: map[string]string{
-						"app": valitailName,
-					},
+					Name:        "gardener.cloud:logging:valitail",
+					Annotations: map[string]string{"resources.gardener.cloud/mode": "Ignore"},
 				},
-				RoleRef: rbacv1.RoleRef{
-					APIGroup: rbacv1.GroupName,
-					Kind:     "ClusterRole",
-					Name:     "gardener.cloud:logging:valitail",
-				},
-				Subjects: []rbacv1.Subject{{
-					Kind:      rbacv1.ServiceAccountKind,
-					Name:      valitailName,
-					Namespace: metav1.NamespaceSystem,
-				}},
 			})))
 		})
 	})

--- a/pkg/component/logging/vali/monitoring.go
+++ b/pkg/component/logging/vali/monitoring.go
@@ -167,7 +167,7 @@ func (v *vali) ScrapeConfigs() ([]string, error) {
 		return nil, err
 	}
 
-	if !v.values.KubeRBACProxyEnabled {
+	if !v.values.ShootNodeLoggingEnabled {
 		return []string{scrapeConfigVali.String()}, nil
 	}
 

--- a/pkg/component/logging/vali/monitoring_test.go
+++ b/pkg/component/logging/vali/monitoring_test.go
@@ -37,7 +37,7 @@ var _ = Describe("Monitoring", func() {
 
 	It("should successfully test the scrape config when node logging is enabled", func() {
 		component = New(nil, "test-namespace", nil, Values{
-			KubeRBACProxyEnabled: true,
+			ShootNodeLoggingEnabled: true,
 		})
 		test.ScrapeConfigs(component, expectedScrapeConfigVali, expectedScrapeConfigValiTelegraf)
 	})

--- a/pkg/component/logging/vali/vali.go
+++ b/pkg/component/logging/vali/vali.go
@@ -233,6 +233,7 @@ func (v *vali) Deploy(ctx context.Context) error {
 			AddAllAndSerialize(
 				v.getKubeRBACProxyClusterRoleBinding(kubeRBACProxyShootAccessSecret.ServiceAccountName),
 				v.getValitailClusterRole(),
+				v.getValitailClusterRoleBinding(valitailShootAccessSecret.ServiceAccountName),
 			)
 		if err != nil {
 			return err
@@ -972,6 +973,25 @@ func (v *vali) getValitailClusterRole() *rbacv1.ClusterRole {
 				Verbs:           []string{"create"},
 			},
 		},
+	}
+}
+
+func (v *vali) getValitailClusterRoleBinding(serviceAccountName string) *rbacv1.ClusterRoleBinding {
+	return &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "gardener.cloud:logging:valitail",
+			Labels: map[string]string{v1beta1constants.LabelApp: valitailName},
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: rbacv1.GroupName,
+			Kind:     "ClusterRole",
+			Name:     valitailClusterRoleName,
+		},
+		Subjects: []rbacv1.Subject{{
+			Kind:      rbacv1.ServiceAccountKind,
+			Name:      serviceAccountName,
+			Namespace: metav1.NamespaceSystem,
+		}},
 	}
 }
 

--- a/pkg/component/logging/vali/vali_test.go
+++ b/pkg/component/logging/vali/vali_test.go
@@ -50,23 +50,24 @@ import (
 )
 
 const (
-	namespace                     = "shoot--foo--bar"
-	managedResourceName           = "vali"
-	managedResourceSecretName     = "managedresource-vali"
-	valiName                      = "vali"
-	valiConfigMapName             = "vali-config-7d883cf0"
-	telegrafConfigMapName         = "telegraf-config-b4c38756"
-	maintenanceBegin              = "210000-0000"
-	maintenanceEnd                = "223000-0000"
-	valiImage                     = "vali:0.0.1"
-	curatorImage                  = "curator:0.0.1"
-	alpineImage                   = "alpine:0.0.1"
-	initLargeDirImage             = "tune2fs:0.0.1"
-	telegrafImage                 = "telegraf-iptables:0.0.1"
-	kubeRBACProxyImage            = "kube-rbac-proxy:0.0.1"
-	priorityClassName             = "foo-bar"
-	valiHost                      = "vali.foo.bar"
-	valitailShootAccessSecretName = "shoot-access-valitail"
+	namespace                          = "shoot--foo--bar"
+	managedResourceName                = "vali"
+	managedResourceSecretName          = "managedresource-vali"
+	valiName                           = "vali"
+	valiConfigMapName                  = "vali-config-7d883cf0"
+	telegrafConfigMapName              = "telegraf-config-b4c38756"
+	maintenanceBegin                   = "210000-0000"
+	maintenanceEnd                     = "223000-0000"
+	valiImage                          = "vali:0.0.1"
+	curatorImage                       = "curator:0.0.1"
+	alpineImage                        = "alpine:0.0.1"
+	initLargeDirImage                  = "tune2fs:0.0.1"
+	telegrafImage                      = "telegraf-iptables:0.0.1"
+	kubeRBACProxyImage                 = "kube-rbac-proxy:0.0.1"
+	priorityClassName                  = "foo-bar"
+	valiHost                           = "vali.foo.bar"
+	valitailShootAccessSecretName      = "shoot-access-valitail"
+	kubeRBacProxyShootAccessSecretName = "shoot-access-kube-rbac-proxy"
 )
 
 var _ = Describe("Vali", func() {
@@ -143,6 +144,7 @@ var _ = Describe("Vali", func() {
 			Expect(valiDeployer.Deploy(ctx)).To(Succeed())
 
 			Expect(c.Get(ctx, client.ObjectKey{Name: valitailShootAccessSecretName, Namespace: namespace}, &corev1.Secret{})).To(Succeed())
+			Expect(c.Get(ctx, client.ObjectKey{Name: kubeRBacProxyShootAccessSecretName, Namespace: namespace}, &corev1.Secret{})).To(Succeed())
 
 			Expect(c.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)).To(Succeed())
 			Expect(managedResource).To(DeepEqual(&resourcesv1alpha1.ManagedResource{
@@ -203,10 +205,12 @@ var _ = Describe("Vali", func() {
 			Expect(c.Get(ctx, client.ObjectKeyFromObject(managedResourceSecret), managedResourceSecret)).To(BeNotFoundError())
 
 			Expect(c.Create(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: valitailShootAccessSecretName, Namespace: namespace}})).To(Succeed())
+			Expect(c.Create(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: kubeRBacProxyShootAccessSecretName, Namespace: namespace}})).To(Succeed())
 
 			Expect(valiDeployer.Deploy(ctx)).To(Succeed())
 
 			Expect(c.Get(ctx, client.ObjectKey{Name: valitailShootAccessSecretName, Namespace: namespace}, &corev1.Secret{})).To(BeNotFoundError())
+			Expect(c.Get(ctx, client.ObjectKey{Name: kubeRBacProxyShootAccessSecretName, Namespace: namespace}, &corev1.Secret{})).To(BeNotFoundError())
 
 			Expect(c.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)).To(Succeed())
 			Expect(managedResource).To(DeepEqual(&resourcesv1alpha1.ManagedResource{
@@ -416,6 +420,7 @@ var _ = Describe("Vali", func() {
 					}),
 				// Delete shoot access secrets
 				runtimeClient.EXPECT().Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: valitailShootAccessSecretName, Namespace: gardenNamespace}}),
+				runtimeClient.EXPECT().Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: kubeRBacProxyShootAccessSecretName, Namespace: gardenNamespace}}),
 				// Create Managed resource
 				runtimeClient.EXPECT().Get(ctx, kubernetesutils.Key(gardenNamespace, managedResourceSecretName), objectOfTypeSecret),
 				runtimeClient.EXPECT().Update(ctx, objectOfTypeSecret),
@@ -448,6 +453,7 @@ var _ = Describe("Vali", func() {
 					}),
 				// Delete shoot access secrets
 				runtimeClient.EXPECT().Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: valitailShootAccessSecretName, Namespace: gardenNamespace}}),
+				runtimeClient.EXPECT().Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: kubeRBacProxyShootAccessSecretName, Namespace: gardenNamespace}}),
 				// Create Managed resource
 				runtimeClient.EXPECT().Get(ctx, kubernetesutils.Key(gardenNamespace, managedResourceSecretName), objectOfTypeSecret),
 				runtimeClient.EXPECT().Update(ctx, objectOfTypeSecret),
@@ -469,6 +475,7 @@ var _ = Describe("Vali", func() {
 					}),
 				// Delete shoot access secrets
 				runtimeClient.EXPECT().Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: valitailShootAccessSecretName, Namespace: gardenNamespace}}),
+				runtimeClient.EXPECT().Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: kubeRBacProxyShootAccessSecretName, Namespace: gardenNamespace}}),
 				// Create Managed resource
 				runtimeClient.EXPECT().Get(ctx, kubernetesutils.Key(gardenNamespace, managedResourceSecretName), objectOfTypeSecret),
 				runtimeClient.EXPECT().Update(ctx, objectOfTypeSecret),
@@ -490,6 +497,7 @@ var _ = Describe("Vali", func() {
 					}),
 				// Delete shoot access secrets
 				runtimeClient.EXPECT().Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: valitailShootAccessSecretName, Namespace: gardenNamespace}}),
+				runtimeClient.EXPECT().Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: kubeRBacProxyShootAccessSecretName, Namespace: gardenNamespace}}),
 				// Create Managed resource
 				runtimeClient.EXPECT().Get(ctx, kubernetesutils.Key(gardenNamespace, managedResourceSecretName), objectOfTypeSecret),
 				runtimeClient.EXPECT().Update(ctx, objectOfTypeSecret),
@@ -521,6 +529,7 @@ var _ = Describe("Vali", func() {
 					}),
 				// Delete shoot access secrets
 				runtimeClient.EXPECT().Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: valitailShootAccessSecretName, Namespace: gardenNamespace}}),
+				runtimeClient.EXPECT().Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: kubeRBacProxyShootAccessSecretName, Namespace: gardenNamespace}}),
 				// Create Managed resource
 				runtimeClient.EXPECT().Get(ctx, kubernetesutils.Key(gardenNamespace, managedResourceSecretName), objectOfTypeSecret),
 				runtimeClient.EXPECT().Update(ctx, objectOfTypeSecret),
@@ -553,6 +562,7 @@ var _ = Describe("Vali", func() {
 					}),
 				// Delete shoot access secrets
 				runtimeClient.EXPECT().Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: valitailShootAccessSecretName, Namespace: gardenNamespace}}),
+				runtimeClient.EXPECT().Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: kubeRBacProxyShootAccessSecretName, Namespace: gardenNamespace}}),
 				// Create Managed resource
 				runtimeClient.EXPECT().Get(ctx, kubernetesutils.Key(gardenNamespace, managedResourceSecretName), objectOfTypeSecret),
 				runtimeClient.EXPECT().Update(ctx, objectOfTypeSecret),
@@ -585,6 +595,7 @@ var _ = Describe("Vali", func() {
 					}),
 				// Delete shoot access secrets
 				runtimeClient.EXPECT().Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: valitailShootAccessSecretName, Namespace: gardenNamespace}}),
+				runtimeClient.EXPECT().Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: kubeRBacProxyShootAccessSecretName, Namespace: gardenNamespace}}),
 				// Create Managed resource
 				runtimeClient.EXPECT().Get(ctx, kubernetesutils.Key(gardenNamespace, managedResourceSecretName), objectOfTypeSecret),
 				runtimeClient.EXPECT().Update(ctx, objectOfTypeSecret),

--- a/pkg/component/logging/vali/vali_test.go
+++ b/pkg/component/logging/vali/vali_test.go
@@ -218,10 +218,11 @@ var _ = Describe("Vali", func() {
 
 			Expect(c.Get(ctx, client.ObjectKeyFromObject(managedResourceSecretTarget), managedResourceSecretTarget)).To(Succeed())
 			Expect(managedResourceSecretTarget.Type).To(Equal(corev1.SecretTypeOpaque))
-			Expect(managedResourceSecretTarget.Data).To(HaveLen(2))
+			Expect(managedResourceSecretTarget.Data).To(HaveLen(3))
 
 			Expect(string(managedResourceSecretTarget.Data["clusterrolebinding____gardener.cloud_logging_kube-rbac-proxy.yaml"])).To(Equal(test.Serialize(getKubeRBACProxyClusterRoleBinding())))
 			Expect(string(managedResourceSecretTarget.Data["clusterrole____gardener.cloud_logging_valitail.yaml"])).To(Equal(test.Serialize(getValitailClusterRole())))
+			Expect(string(managedResourceSecretTarget.Data["clusterrolebinding____gardener.cloud_logging_valitail.yaml"])).To(Equal(test.Serialize(getValitailClusterRoleBinding())))
 		})
 
 		It("should successfully deploy all resources for seed", func() {
@@ -1583,6 +1584,25 @@ func getValitailClusterRole() *rbacv1.ClusterRole {
 				Verbs:           []string{"create"},
 			},
 		},
+	}
+}
+
+func getValitailClusterRoleBinding() *rbacv1.ClusterRoleBinding {
+	return &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "gardener.cloud:logging:valitail",
+			Labels: map[string]string{"app": "gardener-valitail"},
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "ClusterRole",
+			Name:     "gardener.cloud:logging:valitail",
+		},
+		Subjects: []rbacv1.Subject{{
+			Kind:      "ServiceAccount",
+			Name:      "gardener-valitail",
+			Namespace: "kube-system",
+		}},
 	}
 }
 

--- a/pkg/component/shared/vali.go
+++ b/pkg/component/shared/vali.go
@@ -76,21 +76,21 @@ func NewVali(
 	}
 
 	deployer := vali.New(c, namespace, secretsManager, vali.Values{
-		ValiImage:             valiImage.String(),
-		CuratorImage:          curatorImage.String(),
-		RenameLokiToValiImage: alpineImage.String(),
-		InitLargeDirImage:     tune2fsImage.String(),
-		KubeRBACProxyImage:    kubeRBACProxyImage.String(),
-		TelegrafImage:         telegrafImage.String(),
-		Replicas:              replicas,
-		HVPAEnabled:           hvpaEnabled,
-		MaintenanceTimeWindow: maintenanceTimeWindow,
-		KubeRBACProxyEnabled:  isShootNodeLoggingEnabled,
-		PriorityClassName:     priorityClassName,
-		Storage:               storage,
-		AuthEnabled:           authEnabled,
-		ClusterType:           clusterType,
-		IngressHost:           ingressHost,
+		ValiImage:               valiImage.String(),
+		CuratorImage:            curatorImage.String(),
+		RenameLokiToValiImage:   alpineImage.String(),
+		InitLargeDirImage:       tune2fsImage.String(),
+		KubeRBACProxyImage:      kubeRBACProxyImage.String(),
+		TelegrafImage:           telegrafImage.String(),
+		Replicas:                replicas,
+		HVPAEnabled:             hvpaEnabled,
+		MaintenanceTimeWindow:   maintenanceTimeWindow,
+		ShootNodeLoggingEnabled: isShootNodeLoggingEnabled,
+		PriorityClassName:       priorityClassName,
+		Storage:                 storage,
+		AuthEnabled:             authEnabled,
+		ClusterType:             clusterType,
+		IngressHost:             ingressHost,
 	})
 
 	return deployer, nil

--- a/pkg/operation/botanist/botanist.go
+++ b/pkg/operation/botanist/botanist.go
@@ -219,7 +219,7 @@ func New(ctx context.Context, o *operation.Operation) (*Botanist, error) {
 	if err != nil {
 		return nil, err
 	}
-	o.Shoot.Components.Logging.ShootEventLogger, err = b.DefaultEventLogger()
+	o.Shoot.Components.Logging.EventLogger, err = b.DefaultEventLogger()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/operation/botanist/logging.go
+++ b/pkg/operation/botanist/logging.go
@@ -55,11 +55,11 @@ func (b *Botanist) DeploySeedLogging(ctx context.Context) error {
 	}
 
 	if b.isShootEventLoggerEnabled() {
-		if err := b.Shoot.Components.Logging.ShootEventLogger.Deploy(ctx); err != nil {
+		if err := b.Shoot.Components.Logging.EventLogger.Deploy(ctx); err != nil {
 			return err
 		}
 	} else {
-		if err := b.Shoot.Components.Logging.ShootEventLogger.Destroy(ctx); err != nil {
+		if err := b.Shoot.Components.Logging.EventLogger.Destroy(ctx); err != nil {
 			return err
 		}
 	}
@@ -94,7 +94,7 @@ func (b *Botanist) DestroySeedLogging(ctx context.Context) error {
 		return err
 	}
 
-	if err := b.Shoot.Components.Logging.ShootEventLogger.Destroy(ctx); err != nil {
+	if err := b.Shoot.Components.Logging.EventLogger.Destroy(ctx); err != nil {
 		return err
 	}
 
@@ -115,7 +115,7 @@ func (b *Botanist) destroyLokiBasedShootLoggingStackRetainingPvc(ctx context.Con
 	}
 
 	// The EventLogger is not dependent on Loki/Vali and therefore doesn't need to be deleted.
-	// if err := b.Shoot.Components.Logging.ShootEventLogger.Destroy(ctx); err != nil {
+	// if err := b.Shoot.Components.Logging.EventLogger.Destroy(ctx); err != nil {
 	// 	return err
 	// }
 

--- a/pkg/operation/shoot/types.go
+++ b/pkg/operation/shoot/types.go
@@ -172,9 +172,9 @@ type SystemComponents struct {
 
 // Logging contains references to logging deployers
 type Logging struct {
-	ShootRBACProxy   component.Deployer
-	ShootEventLogger component.Deployer
-	Vali             vali.Interface
+	ShootRBACProxy component.Deployer
+	EventLogger    component.Deployer
+	Vali           vali.Interface
 }
 
 // Addons contains references for the addons.

--- a/pkg/operation/shoot/types.go
+++ b/pkg/operation/shoot/types.go
@@ -172,6 +172,7 @@ type SystemComponents struct {
 
 // Logging contains references to logging deployers
 type Logging struct {
+	// TODO(rfranzke): Drop the `ShootRBACProxy` field after gardener/gardener@v1.78 has been released.
 	ShootRBACProxy component.Deployer
 	EventLogger    component.Deployer
 	Vali           vali.Interface


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind cleanup

**What this PR does / why we need it**:
`kube-rbac-proxy` and also `valitail` actually belong to the `vali` component since `kube-rbac-proxy` is actually a sidecar container in the `vali` `StatefulSet` and no separate/dedicated deployment. Back then (when `kuberbacproxy` component was introduced) the Vali deployment was still managed via Helm charts, but since recently this has been refactored to Golang (ref #8061), so we can finally move the code now.

**Special notes for your reviewer**:
/cc @shafeeqes @acumino

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
