### PR TITLE
Implement orphan file deletion in the cloud-config executor script

### DIFF
--- a/docs/api-reference/extensions.md
+++ b/docs/api-reference/extensions.md
@@ -3718,7 +3718,7 @@ restarted when a new version has been downloaded.</p>
 </td>
 <td>
 <em>(Optional)</em>
-<p>Files is a list of file path that are part of the generated Cloud Config and shall be
+<p>Files is a list of file paths that are part of the generated Cloud Config and shall be
 written to the host&rsquo;s file system.</p>
 </td>
 </tr>

--- a/docs/api-reference/extensions.md
+++ b/docs/api-reference/extensions.md
@@ -3709,6 +3709,19 @@ in the .spec.reloadConfigFilePath field.</p>
 restarted when a new version has been downloaded.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>files</code></br>
+<em>
+[]string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Files is a list of file path that are part of the generated Cloud Config and shall be
+written to the host&rsquo;s file system.</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="extensions.gardener.cloud/v1alpha1.Purpose">Purpose

--- a/example/seed-crds/10-crd-extensions.gardener.cloud_operatingsystemconfigs.yaml
+++ b/example/seed-crds/10-crd-extensions.gardener.cloud_operatingsystemconfigs.yaml
@@ -273,7 +273,7 @@ spec:
                   type: object
                 type: array
               files:
-                description: Files is a list of file path that are part of the generated
+                description: Files is a list of file paths that are part of the generated
                   Cloud Config and shall be written to the host's file system.
                 items:
                   type: string

--- a/example/seed-crds/10-crd-extensions.gardener.cloud_operatingsystemconfigs.yaml
+++ b/example/seed-crds/10-crd-extensions.gardener.cloud_operatingsystemconfigs.yaml
@@ -272,6 +272,12 @@ spec:
                   - type
                   type: object
                 type: array
+              files:
+                description: Files is a list of file path that are part of the generated
+                  Cloud Config and shall be written to the host's file system.
+                items:
+                  type: string
+                type: array
               lastError:
                 description: LastError holds information about the last occurred error
                   during an operation.

--- a/extensions/pkg/controller/operatingsystemconfig/actuator.go
+++ b/extensions/pkg/controller/operatingsystemconfig/actuator.go
@@ -25,11 +25,11 @@ import (
 // Actuator acts upon OperatingSystemConfig resources.
 type Actuator interface {
 	// Reconcile the operating system config.
-	Reconcile(context.Context, logr.Logger, *extensionsv1alpha1.OperatingSystemConfig) ([]byte, *string, []string, error)
+	Reconcile(context.Context, logr.Logger, *extensionsv1alpha1.OperatingSystemConfig) ([]byte, *string, []string, []string, error)
 	// Delete the operating system config.
 	Delete(context.Context, logr.Logger, *extensionsv1alpha1.OperatingSystemConfig) error
 	// Restore the operating system config.
-	Restore(context.Context, logr.Logger, *extensionsv1alpha1.OperatingSystemConfig) ([]byte, *string, []string, error)
+	Restore(context.Context, logr.Logger, *extensionsv1alpha1.OperatingSystemConfig) ([]byte, *string, []string, []string, error)
 	// Migrate the operating system config.
 	Migrate(context.Context, logr.Logger, *extensionsv1alpha1.OperatingSystemConfig) error
 }

--- a/extensions/pkg/controller/operatingsystemconfig/oscommon/actuator/actuator_reconcile.go
+++ b/extensions/pkg/controller/operatingsystemconfig/oscommon/actuator/actuator_reconcile.go
@@ -24,11 +24,11 @@ import (
 )
 
 // Reconcile reconciles the update of a OperatingSystemConfig regenerating the os-specific format
-func (a *Actuator) Reconcile(ctx context.Context, log logr.Logger, config *extensionsv1alpha1.OperatingSystemConfig) ([]byte, *string, []string, error) {
+func (a *Actuator) Reconcile(ctx context.Context, log logr.Logger, config *extensionsv1alpha1.OperatingSystemConfig) ([]byte, *string, []string, []string, error) {
 	cloudConfig, cmd, err := CloudConfigFromOperatingSystemConfig(ctx, log, a.client, config, a.generator)
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("could not generate cloud config: %w", err)
+		return nil, nil, nil, nil, fmt.Errorf("could not generate cloud config: %w", err)
 	}
 
-	return cloudConfig, cmd, OperatingSystemConfigUnitNames(config), nil
+	return cloudConfig, cmd, OperatingSystemConfigUnitNames(config), OperatingSystemConfigFilePaths(config), nil
 }

--- a/extensions/pkg/controller/operatingsystemconfig/oscommon/actuator/actuator_restore.go
+++ b/extensions/pkg/controller/operatingsystemconfig/oscommon/actuator/actuator_restore.go
@@ -23,6 +23,6 @@ import (
 )
 
 // Restore reconciles the update of a OperatingSystemConfig regenerating the os-specific format
-func (a *Actuator) Restore(ctx context.Context, log logr.Logger, config *extensionsv1alpha1.OperatingSystemConfig) ([]byte, *string, []string, error) {
+func (a *Actuator) Restore(ctx context.Context, log logr.Logger, config *extensionsv1alpha1.OperatingSystemConfig) ([]byte, *string, []string, []string, error) {
 	return a.Reconcile(ctx, log, config)
 }

--- a/extensions/pkg/controller/operatingsystemconfig/oscommon/actuator/actuator_util.go
+++ b/extensions/pkg/controller/operatingsystemconfig/oscommon/actuator/actuator_util.go
@@ -96,3 +96,12 @@ func OperatingSystemConfigUnitNames(config *extensionsv1alpha1.OperatingSystemCo
 	}
 	return unitNames
 }
+
+// OperatingSystemConfigFilePaths returns the paths of the files in the OperatingSystemConfig
+func OperatingSystemConfigFilePaths(config *extensionsv1alpha1.OperatingSystemConfig) []string {
+	filePaths := make([]string, 0, len(config.Spec.Files))
+	for _, file := range config.Spec.Files {
+		filePaths = append(filePaths, file.Path)
+	}
+	return filePaths
+}

--- a/extensions/pkg/controller/operatingsystemconfig/reconciler.go
+++ b/extensions/pkg/controller/operatingsystemconfig/reconciler.go
@@ -142,7 +142,7 @@ func (r *reconciler) reconcile(
 	}
 
 	log.Info("Starting the reconciliation of OperatingSystemConfig")
-	userData, command, units, err := r.actuator.Reconcile(ctx, log, osc)
+	userData, command, units, files, err := r.actuator.Reconcile(ctx, log, osc)
 	if err != nil {
 		_ = r.statusUpdater.Error(ctx, log, osc, reconcilerutils.ReconcileErrCauseOrErr(err), operationType, "Error reconciling OperatingSystemConfig")
 		return reconcilerutils.ReconcileErr(err)
@@ -155,7 +155,7 @@ func (r *reconciler) reconcile(
 	}
 
 	patch := client.MergeFrom(osc.DeepCopy())
-	setOSCStatus(osc, secret, command, units)
+	setOSCStatus(osc, secret, command, units, files)
 	if err := r.client.Status().Patch(ctx, osc, patch); err != nil {
 		_ = r.statusUpdater.Error(ctx, log, osc, reconcilerutils.ReconcileErrCauseOrErr(err), gardencorev1beta1.LastOperationTypeRestore, "Could not update units and secret ref.")
 		return reconcilerutils.ReconcileErr(err)
@@ -187,7 +187,7 @@ func (r *reconciler) restore(
 	}
 
 	log.Info("Starting the restoration of OperatingSystemConfig")
-	userData, command, units, err := r.actuator.Restore(ctx, log, osc)
+	userData, command, units, files, err := r.actuator.Restore(ctx, log, osc)
 	if err != nil {
 		_ = r.statusUpdater.Error(ctx, log, osc, reconcilerutils.ReconcileErrCauseOrErr(err), gardencorev1beta1.LastOperationTypeRestore, "Error restoring OperatingSystemConfig")
 		return reconcilerutils.ReconcileErr(err)
@@ -200,7 +200,7 @@ func (r *reconciler) restore(
 	}
 
 	patch := client.MergeFrom(osc.DeepCopy())
-	setOSCStatus(osc, secret, command, units)
+	setOSCStatus(osc, secret, command, units, files)
 	if err := r.client.Status().Patch(ctx, osc, patch); err != nil {
 		_ = r.statusUpdater.Error(ctx, log, osc, reconcilerutils.ReconcileErrCauseOrErr(err), gardencorev1beta1.LastOperationTypeRestore, "Could not update units and secret ref.")
 		return reconcilerutils.ReconcileErr(err)
@@ -307,7 +307,7 @@ func (r *reconciler) reconcileOSCResultSecret(ctx context.Context, osc *extensio
 	return secret, nil
 }
 
-func setOSCStatus(osc *extensionsv1alpha1.OperatingSystemConfig, secret *corev1.Secret, command *string, units []string) {
+func setOSCStatus(osc *extensionsv1alpha1.OperatingSystemConfig, secret *corev1.Secret, command *string, units, files []string) {
 	osc.Status.CloudConfig = &extensionsv1alpha1.CloudConfig{
 		SecretRef: corev1.SecretReference{
 			Name:      secret.Name,
@@ -315,6 +315,7 @@ func setOSCStatus(osc *extensionsv1alpha1.OperatingSystemConfig, secret *corev1.
 		},
 	}
 	osc.Status.Units = units
+	osc.Status.Files = files
 	if command != nil {
 		osc.Status.Command = command
 	}

--- a/pkg/apis/extensions/v1alpha1/types_operatingsystemconfig.go
+++ b/pkg/apis/extensions/v1alpha1/types_operatingsystemconfig.go
@@ -191,7 +191,7 @@ type OperatingSystemConfigStatus struct {
 	// restarted when a new version has been downloaded.
 	// +optional
 	Units []string `json:"units,omitempty"`
-	// Files is a list of file path that are part of the generated Cloud Config and shall be
+	// Files is a list of file paths that are part of the generated Cloud Config and shall be
 	// written to the host's file system.
 	// +optional
 	Files []string `json:"files,omitempty"`

--- a/pkg/apis/extensions/v1alpha1/types_operatingsystemconfig.go
+++ b/pkg/apis/extensions/v1alpha1/types_operatingsystemconfig.go
@@ -191,6 +191,10 @@ type OperatingSystemConfigStatus struct {
 	// restarted when a new version has been downloaded.
 	// +optional
 	Units []string `json:"units,omitempty"`
+	// Files is a list of file path that are part of the generated Cloud Config and shall be
+	// written to the host's file system.
+	// +optional
+	Files []string `json:"files,omitempty"`
 }
 
 // CloudConfig contains the generated output for the given operating system

--- a/pkg/apis/extensions/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/extensions/v1alpha1/zz_generated.deepcopy.go
@@ -1483,6 +1483,11 @@ func (in *OperatingSystemConfigStatus) DeepCopyInto(out *OperatingSystemConfigSt
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.Files != nil {
+		in, out := &in.Files, &out.Files
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/component/extensions/crds/assets/crd-extensions.gardener.cloud_operatingsystemconfigs.yaml
+++ b/pkg/component/extensions/crds/assets/crd-extensions.gardener.cloud_operatingsystemconfigs.yaml
@@ -274,6 +274,12 @@ spec:
                   - type
                   type: object
                 type: array
+              files:
+                description: Files is a list of file path that are part of the generated
+                  Cloud Config and shall be written to the host's file system.
+                items:
+                  type: string
+                type: array
               lastError:
                 description: LastError holds information about the last occurred error
                   during an operation.

--- a/pkg/component/extensions/crds/assets/crd-extensions.gardener.cloud_operatingsystemconfigs.yaml
+++ b/pkg/component/extensions/crds/assets/crd-extensions.gardener.cloud_operatingsystemconfigs.yaml
@@ -275,7 +275,7 @@ spec:
                   type: object
                 type: array
               files:
-                description: Files is a list of file path that are part of the generated
+                description: Files is a list of file paths that are part of the generated
                   Cloud Config and shall be written to the host's file system.
                 items:
                   type: string

--- a/pkg/component/extensions/operatingsystemconfig/executor/executor.go
+++ b/pkg/component/extensions/operatingsystemconfig/executor/executor.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	_ "embed"
 	"fmt"
+	"strings"
 	"text/template"
 
 	"github.com/Masterminds/sprig"
@@ -99,6 +100,7 @@ func Script(
 	kubeletDataVolume *gardencorev1beta1.DataVolume,
 	reloadConfigCommand string,
 	units []string,
+	files []string,
 ) (
 	[]byte,
 	error,
@@ -147,6 +149,7 @@ func Script(
 		"reloadConfigCommand":                      reloadConfigCommand,
 		"scriptCopyKubernetesBinary":               utils.EncodeBase64(scriptCopyKubernetesBinary.Bytes()),
 		"units":                                    units,
+		"cloudConfigFiles":                         strings.Join(files, "\n"),
 		"unitNameCloudConfigDownloader":            downloader.UnitName,
 		"unitNameDocker":                           docker.UnitName,
 		"unitNameVarLibMount":                      varlibmount.UnitName,

--- a/pkg/component/extensions/operatingsystemconfig/executor/executor_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/executor/executor_test.go
@@ -15,6 +15,8 @@
 package executor_test
 
 import (
+	"strings"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
@@ -37,6 +39,7 @@ var _ = Describe("Executor", func() {
 			cloudConfigExecutionMaxDelaySeconds int
 			hyperkubeImage                      *imagevector.Image
 			reloadConfigCommand                 string
+			files                               []string
 			units                               []string
 
 			defaultKubeletDataVolume     = &gardencorev1beta1.DataVolume{VolumeSize: "64Gi"}
@@ -48,6 +51,10 @@ var _ = Describe("Executor", func() {
 			cloudConfigExecutionMaxDelaySeconds = 300
 			hyperkubeImage = &imagevector.Image{Repository: "bar", Tag: pointer.String("v1.0")}
 			reloadConfigCommand = "/var/bin/reload"
+			files = []string{
+				"f1",
+				"f2",
+			}
 			units = []string{
 				docker.UnitName,
 				"unit1",
@@ -61,9 +68,9 @@ var _ = Describe("Executor", func() {
 
 		DescribeTable("should correctly render the executor script",
 			func(kubernetesVersion string, copyKubernetesBinariesFn func(*imagevector.Image) string, kubeletDataVol *gardencorev1beta1.DataVolume, kubeletDataVolSize *string) {
-				script, err := executor.Script(cloudConfigUserData, cloudConfigExecutionMaxDelaySeconds, hyperkubeImage, kubernetesVersion, kubeletDataVol, reloadConfigCommand, units)
+				script, err := executor.Script(cloudConfigUserData, cloudConfigExecutionMaxDelaySeconds, hyperkubeImage, kubernetesVersion, kubeletDataVol, reloadConfigCommand, units, files)
 				Expect(err).ToNot(HaveOccurred())
-				testScript := scriptFor(cloudConfigUserData, hyperkubeImage, kubernetesVersion, copyKubernetesBinariesFn, kubeletDataVolSize, reloadConfigCommand, units)
+				testScript := scriptFor(cloudConfigUserData, hyperkubeImage, kubernetesVersion, copyKubernetesBinariesFn, kubeletDataVolSize, reloadConfigCommand, units, files)
 				Expect(string(script)).To(Equal(testScript))
 			},
 
@@ -74,7 +81,7 @@ var _ = Describe("Executor", func() {
 		It("should return an error because the data volume size cannot be parsed", func() {
 			kubeletDataVolume := &gardencorev1beta1.DataVolume{VolumeSize: "not-parsable"}
 
-			script, err := executor.Script(cloudConfigUserData, cloudConfigExecutionMaxDelaySeconds, hyperkubeImage, "1.2.3", kubeletDataVolume, reloadConfigCommand, units)
+			script, err := executor.Script(cloudConfigUserData, cloudConfigExecutionMaxDelaySeconds, hyperkubeImage, "1.2.3", kubeletDataVolume, reloadConfigCommand, units, files)
 			Expect(script).To(BeNil())
 			Expect(err).To(MatchError(ContainSubstring("quantities must match the regular expression")))
 		})
@@ -117,6 +124,7 @@ func scriptFor(
 	kubeletDataVolumeSize *string,
 	reloadConfigCommand string,
 	units []string,
+	files []string,
 ) string {
 	headerPart := `#!/bin/bash -eu
 
@@ -124,6 +132,8 @@ PATH_CLOUDCONFIG_DOWNLOADER_SERVER="/var/lib/cloud-config-downloader/credentials
 PATH_CLOUDCONFIG_DOWNLOADER_CA_CERT="/var/lib/cloud-config-downloader/credentials/ca.crt"
 PATH_CLOUDCONFIG="/var/lib/cloud-config-downloader/downloads/cloud_config"
 PATH_CLOUDCONFIG_OLD="${PATH_CLOUDCONFIG}.old"
+PATH_CLOUDCONFIG_FILES="/var/lib/cloud-config-downloader/downloads/cloud_config_files"
+PATH_CLOUDCONFIG_FILES_OLD="${PATH_CLOUDCONFIG}_files.old"
 PATH_CHECKSUM="/var/lib/cloud-config-downloader/downloads/execute-cloud-config-checksum"
 PATH_CCD_SCRIPT="/var/lib/cloud-config-downloader/download-cloud-config.sh"
 PATH_CCD_SCRIPT_CHECKSUM="/var/lib/cloud-config-downloader/download-cloud-config.md5"
@@ -136,6 +146,17 @@ PATH_HYPERKUBE_IMAGE_USED_FOR_LAST_COPY_KUBELET="/opt/bin/hyperkube_image_used_f
 PATH_HYPERKUBE_IMAGE_USED_FOR_LAST_COPY_KUBECTL="/opt/bin/hyperkube_image_used_for_last_copy_of_kubectl"
 
 mkdir -p "/var/lib/kubelet" "$PATH_HYPERKUBE_DOWNLOADS"
+
+deleteOrphan() {
+  if [[ ! -f "$PATH_CLOUDCONFIG_FILES_OLD" ]]; then
+    touch "$PATH_CLOUDCONFIG_FILES_OLD"
+  fi
+  # sort for join to work
+  sort -o "$PATH_CLOUDCONFIG_FILES" "$PATH_CLOUDCONFIG_FILES"
+  # calculates old_files - new_files and deletes them
+  join -t $'\n' -v 1 "$PATH_CLOUDCONFIG_FILES_OLD" "$PATH_CLOUDCONFIG_FILES" | xargs -L1 rm -f
+  mv "$PATH_CLOUDCONFIG_FILES" "$PATH_CLOUDCONFIG_FILES_OLD"
+}
 
 `
 
@@ -347,6 +368,12 @@ if [[ -f "/var/lib/kubelet/kubeconfig-real" ]]; then
     fi
   fi
 fi
+
+cat << 'EOF' > "$PATH_CLOUDCONFIG_FILES"
+` + strings.Join(files, "\n") + `
+EOF
+
+deleteOrphan
 
 # Apply most recent cloud-config user-data, reload the systemd daemon and restart the units to make the changes
 # effective.

--- a/pkg/component/extensions/operatingsystemconfig/executor/templates/scripts/execute-cloud-config.tpl.sh
+++ b/pkg/component/extensions/operatingsystemconfig/executor/templates/scripts/execute-cloud-config.tpl.sh
@@ -4,6 +4,8 @@ PATH_CLOUDCONFIG_DOWNLOADER_SERVER="{{ .pathCredentialsServer }}"
 PATH_CLOUDCONFIG_DOWNLOADER_CA_CERT="{{ .pathCredentialsCACert }}"
 PATH_CLOUDCONFIG="{{ .pathDownloadedCloudConfig }}"
 PATH_CLOUDCONFIG_OLD="${PATH_CLOUDCONFIG}.old"
+PATH_CLOUDCONFIG_FILES="{{ .pathDownloadedCloudConfig }}_files"
+PATH_CLOUDCONFIG_FILES_OLD="${PATH_CLOUDCONFIG}_files.old"
 PATH_CHECKSUM="{{ .pathDownloadedChecksum }}"
 PATH_CCD_SCRIPT="{{ .pathCCDScript }}"
 PATH_CCD_SCRIPT_CHECKSUM="{{ .pathCCDScriptChecksum }}"
@@ -16,6 +18,17 @@ PATH_HYPERKUBE_IMAGE_USED_FOR_LAST_COPY_KUBELET="{{ .pathHyperKubeImageUsedForLa
 PATH_HYPERKUBE_IMAGE_USED_FOR_LAST_COPY_KUBECTL="{{ .pathHyperKubeImageUsedForLastCopyKubectl }}"
 
 mkdir -p "{{ .pathKubeletDirectory }}" "$PATH_HYPERKUBE_DOWNLOADS"
+
+deleteOrphan() {
+  if [[ ! -f "$PATH_CLOUDCONFIG_FILES_OLD" ]]; then
+    touch "$PATH_CLOUDCONFIG_FILES_OLD"
+  fi
+  # sort for join to work
+  sort -o "$PATH_CLOUDCONFIG_FILES" "$PATH_CLOUDCONFIG_FILES"
+  # calculates old_files - new_files and deletes them
+  join -t $'\n' -v 1 "$PATH_CLOUDCONFIG_FILES_OLD" "$PATH_CLOUDCONFIG_FILES" | xargs -L1 rm -f
+  mv "$PATH_CLOUDCONFIG_FILES" "$PATH_CLOUDCONFIG_FILES_OLD"
+}
 
 {{ if .kubeletDataVolume -}}
 function format-data-device() {
@@ -224,6 +237,12 @@ if [[ -f "{{ .pathKubeletKubeconfigReal }}" ]]; then
     fi
   fi
 fi
+
+cat << 'EOF' > "$PATH_CLOUDCONFIG_FILES"
+{{ .cloudConfigFiles }}
+EOF
+
+deleteOrphan
 
 # Apply most recent cloud-config user-data, reload the systemd daemon and restart the units to make the changes
 # effective.

--- a/pkg/component/extensions/operatingsystemconfig/executor/templates/scripts/execute-cloud-config.tpl.sh
+++ b/pkg/component/extensions/operatingsystemconfig/executor/templates/scripts/execute-cloud-config.tpl.sh
@@ -19,14 +19,17 @@ PATH_HYPERKUBE_IMAGE_USED_FOR_LAST_COPY_KUBECTL="{{ .pathHyperKubeImageUsedForLa
 
 mkdir -p "{{ .pathKubeletDirectory }}" "$PATH_HYPERKUBE_DOWNLOADS"
 
-deleteOrphan() {
+delete_orphan_files() {
   if [[ ! -f "$PATH_CLOUDCONFIG_FILES_OLD" ]]; then
     touch "$PATH_CLOUDCONFIG_FILES_OLD"
   fi
+  cat << 'EOF' > "$PATH_CLOUDCONFIG_FILES"
+{{ .cloudConfigFiles }}
+EOF
   # sort for join to work
   sort -o "$PATH_CLOUDCONFIG_FILES" "$PATH_CLOUDCONFIG_FILES"
   # calculates old_files - new_files and deletes them
-  join -t $'\n' -v 1 "$PATH_CLOUDCONFIG_FILES_OLD" "$PATH_CLOUDCONFIG_FILES" | xargs -L1 rm -f
+  join -t $'\n' -v 1 "$PATH_CLOUDCONFIG_FILES_OLD" "$PATH_CLOUDCONFIG_FILES" | xargs -L1 rm -vf
   mv "$PATH_CLOUDCONFIG_FILES" "$PATH_CLOUDCONFIG_FILES_OLD"
 }
 
@@ -238,12 +241,6 @@ if [[ -f "{{ .pathKubeletKubeconfigReal }}" ]]; then
   fi
 fi
 
-cat << 'EOF' > "$PATH_CLOUDCONFIG_FILES"
-{{ .cloudConfigFiles }}
-EOF
-
-deleteOrphan
-
 # Apply most recent cloud-config user-data, reload the systemd daemon and restart the units to make the changes
 # effective.
 if ! diff "$PATH_CLOUDCONFIG" "$PATH_CLOUDCONFIG_OLD" >/dev/null || \
@@ -267,6 +264,7 @@ if ! diff "$PATH_CLOUDCONFIG" "$PATH_CLOUDCONFIG_OLD" >/dev/null || \
     echo "failed to apply the cloud config."
     exit 1
   fi
+  delete_orphan_files
 fi
 
 echo "Cloud config is up to date."

--- a/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig.go
+++ b/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig.go
@@ -191,6 +191,8 @@ type Data struct {
 	Command *string
 	// Units is the list of systemd unit names.
 	Units []string
+	// Files is the list of file paths.
+	Files []string
 }
 
 // Deploy uses the client to create or update the OperatingSystemConfig custom resources.
@@ -257,6 +259,7 @@ func (o *operatingSystemConfig) Wait(ctx context.Context) error {
 					Content: string(secret.Data[extensionsv1alpha1.OperatingSystemConfigSecretDataKey]),
 					Command: osc.Status.Command,
 					Units:   osc.Status.Units,
+					Files:   osc.Status.Files,
 				}
 
 				o.lock.Lock()

--- a/pkg/operation/botanist/operatingsystemconfig.go
+++ b/pkg/operation/botanist/operatingsystemconfig.go
@@ -283,6 +283,7 @@ func (b *Botanist) generateCloudConfigExecutorResourcesForWorker(
 		kubeletDataVolume,
 		*oscDataOriginal.Command,
 		oscDataOriginal.Units,
+		oscDataOriginal.Files,
 	)
 	if err != nil {
 		return "", nil, err


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/area os
/kind enhancement

**What this PR does / why we need it**:

Currently, if a set of files is specified in `extensions.gardener.cloud/v1alpha1.OperatingSystemConfig` resource and within the next reconciliation some of them no longer persist in `OperatingSystemConfig`, there is no mechanism to delete them and they will remain on the Node VM. With this PR such mechanism that deletes orphan files is implemented in cloud-config executor script.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener-extension-registry-cache/issues/3

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
