### PR TITLE
Updates `etcd-druid` crds and dependency

### DIFF
--- a/example/seed-crds/10-crd-druid.gardener.cloud_etcds.yaml
+++ b/example/seed-crds/10-crd-druid.gardener.cloud_etcds.yaml
@@ -1704,7 +1704,9 @@ spec:
             description: EtcdStatus defines the observed state of Etcd.
             properties:
               clusterSize:
-                description: Cluster size is the size of the etcd cluster.
+                description: 'Cluster size is the current size of the etcd cluster.
+                  Deprecated: this field will not be populated with any value and
+                  will be removed in the future.'
                 format: int32
                 type: integer
               conditions:
@@ -1765,8 +1767,9 @@ spec:
                     type: string
                 type: object
               labelSelector:
-                description: LabelSelector is a label query over pods that should
-                  match the replica count. It must match the pod template's labels.
+                description: 'LabelSelector is a label query over pods that should
+                  match the replica count. It must match the pod template''s labels.
+                  Deprecated: this field will be removed in the future.'
                 properties:
                   matchExpressions:
                     description: matchExpressions is a list of label selector requirements.
@@ -1870,11 +1873,13 @@ spec:
                 format: int32
                 type: integer
               serviceName:
-                description: ServiceName is the name of the etcd service.
+                description: 'ServiceName is the name of the etcd service. Deprecated:
+                  this field will be removed in the future.'
                 type: string
               updatedReplicas:
-                description: UpdatedReplicas is the count of updated replicas in the
-                  etcd cluster.
+                description: 'UpdatedReplicas is the count of updated replicas in
+                  the etcd cluster. Deprecated: this field will be removed in the
+                  future.'
                 format: int32
                 type: integer
             type: object

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/coreos/go-systemd/v22 v22.3.2
 	github.com/fluent/fluent-operator/v2 v2.2.0
 	github.com/gardener/dependency-watchdog v1.0.0
-	github.com/gardener/etcd-druid v0.18.1
+	github.com/gardener/etcd-druid v0.18.4
 	github.com/gardener/hvpa-controller/api v0.5.0
 	github.com/gardener/machine-controller-manager v0.48.1
 	github.com/go-logr/logr v1.2.4

--- a/go.sum
+++ b/go.sum
@@ -161,8 +161,8 @@ github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4
 github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbSClcnxKAGw=
 github.com/gardener/dependency-watchdog v1.0.0 h1:Yo2khnlpC9DDnG1EoZxtO61onHJSW6/5auJ4hLEzAs4=
 github.com/gardener/dependency-watchdog v1.0.0/go.mod h1:SMANgb+LTMXlNSjXr8rrphumZVXOowas3AkpV05gDvM=
-github.com/gardener/etcd-druid v0.18.1 h1:dcId4WayxlZiKvDMxLZHmmvWFXjTBFVqQWmqB5/8mdM=
-github.com/gardener/etcd-druid v0.18.1/go.mod h1:Bn4doVhryu6GWdXaYlVNy7TZMjUSMr5EjChei06KX0w=
+github.com/gardener/etcd-druid v0.18.4 h1:CyDQRRBPDXYSoNPaSnrs4lw3Ht+aD3LuQZQliJz+Gw0=
+github.com/gardener/etcd-druid v0.18.4/go.mod h1:NfBcP/xYSrbbtbPPFzEQ7CSQ73l+GtNQgx466Gv7FW0=
 github.com/gardener/hvpa-controller/api v0.5.0 h1:f4F3O7YUrenwh4S3TgPREPiB287JjjUiUL18OqPLyAA=
 github.com/gardener/hvpa-controller/api v0.5.0/go.mod h1:QQl3ELkCaki+8RhXl0FZMfvnm0WCGwGJlGmrxJj6lvM=
 github.com/gardener/machine-controller-manager v0.48.1 h1:Oxr5e6gRm7P40Ds4nGlga/0nmfF7cH4rOfjthR6Mm38=

--- a/pkg/component/etcd/crds/templates/crd-druid.gardener.cloud_etcdcopybackupstasks.yaml
+++ b/pkg/component/etcd/crds/templates/crd-druid.gardener.cloud_etcdcopybackupstasks.yaml
@@ -1,4 +1,4 @@
-# Source: https://github.com/gardener/etcd-druid/blob/v0.18.1/charts/druid/charts/crds/templates/10-crd-druid.gardener.cloud_etcdcopybackupstasks.yaml
+# Source: https://github.com/gardener/etcd-druid/blob/v0.18.4/charts/druid/charts/crds/templates/10-crd-druid.gardener.cloud_etcdcopybackupstasks.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/pkg/component/etcd/crds/templates/crd-druid.gardener.cloud_etcds.yaml
+++ b/pkg/component/etcd/crds/templates/crd-druid.gardener.cloud_etcds.yaml
@@ -1,4 +1,4 @@
-# Source: https://github.com/gardener/etcd-druid/blob/v0.18.1/charts/druid/charts/crds/templates/10-crd-druid.gardener.cloud_etcds.yaml
+# Source: https://github.com/gardener/etcd-druid/blob/v0.18.4/charts/druid/charts/crds/templates/10-crd-druid.gardener.cloud_etcds.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -1703,7 +1703,9 @@ spec:
             description: EtcdStatus defines the observed state of Etcd.
             properties:
               clusterSize:
-                description: Cluster size is the size of the etcd cluster.
+                description: 'Cluster size is the current size of the etcd cluster.
+                  Deprecated: this field will not be populated with any value and
+                  will be removed in the future.'
                 format: int32
                 type: integer
               conditions:
@@ -1764,8 +1766,9 @@ spec:
                     type: string
                 type: object
               labelSelector:
-                description: LabelSelector is a label query over pods that should
-                  match the replica count. It must match the pod template's labels.
+                description: 'LabelSelector is a label query over pods that should
+                  match the replica count. It must match the pod template''s labels.
+                  Deprecated: this field will be removed in the future.'
                 properties:
                   matchExpressions:
                     description: matchExpressions is a list of label selector requirements.
@@ -1869,11 +1872,13 @@ spec:
                 format: int32
                 type: integer
               serviceName:
-                description: ServiceName is the name of the etcd service.
+                description: 'ServiceName is the name of the etcd service. Deprecated:
+                  this field will be removed in the future.'
                 type: string
               updatedReplicas:
-                description: UpdatedReplicas is the count of updated replicas in the
-                  etcd cluster.
+                description: 'UpdatedReplicas is the count of updated replicas in
+                  the etcd cluster. Deprecated: this field will be removed in the
+                  future.'
                 format: int32
                 type: integer
             type: object

--- a/vendor/github.com/gardener/etcd-druid/api/v1alpha1/types_etcd.go
+++ b/vendor/github.com/gardener/etcd-druid/api/v1alpha1/types_etcd.go
@@ -376,12 +376,14 @@ type EtcdStatus struct {
 	// +optional
 	Conditions []Condition `json:"conditions,omitempty"`
 	// ServiceName is the name of the etcd service.
+	// Deprecated: this field will be removed in the future.
 	// +optional
 	ServiceName *string `json:"serviceName,omitempty"`
 	// LastError represents the last occurred error.
 	// +optional
 	LastError *string `json:"lastError,omitempty"`
-	// Cluster size is the size of the etcd cluster.
+	// Cluster size is the current size of the etcd cluster.
+	// Deprecated: this field will not be populated with any value and will be removed in the future.
 	// +optional
 	ClusterSize *int32 `json:"clusterSize,omitempty"`
 	// CurrentReplicas is the current replica count for the etcd cluster.
@@ -397,10 +399,12 @@ type EtcdStatus struct {
 	// +optional
 	Ready *bool `json:"ready,omitempty"`
 	// UpdatedReplicas is the count of updated replicas in the etcd cluster.
+	// Deprecated: this field will be removed in the future.
 	// +optional
 	UpdatedReplicas int32 `json:"updatedReplicas,omitempty"`
 	// LabelSelector is a label query over pods that should match the replica count.
 	// It must match the pod template's labels.
+	// Deprecated: this field will be removed in the future.
 	// +optional
 	LabelSelector *metav1.LabelSelector `json:"labelSelector,omitempty"`
 	// Members represents the members of the etcd cluster

--- a/vendor/github.com/gardener/etcd-druid/pkg/utils/store.go
+++ b/vendor/github.com/gardener/etcd-druid/pkg/utils/store.go
@@ -64,7 +64,7 @@ const (
 // GetHostMountPathFromSecretRef returns the hostPath configured for the given store.
 func GetHostMountPathFromSecretRef(ctx context.Context, client client.Client, logger logr.Logger, store *druidv1alpha1.StoreSpec, namespace string) (string, error) {
 	if store.SecretRef == nil {
-		logger.Info("secretRef is not defined for store, using default hostPath")
+		logger.Info("secretRef is not defined for store, using default hostPath", "namespace", namespace)
 		return LocalProviderDefaultMountPath, nil
 	}
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -96,7 +96,7 @@ github.com/fsnotify/fsnotify
 ## explicit; go 1.19
 github.com/gardener/dependency-watchdog/api/prober
 github.com/gardener/dependency-watchdog/api/weeder
-# github.com/gardener/etcd-druid v0.18.1
+# github.com/gardener/etcd-druid v0.18.4
 ## explicit; go 1.20
 github.com/gardener/etcd-druid/api/v1alpha1
 github.com/gardener/etcd-druid/api/validation


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area open-source
/kind enhancement

**What this PR does / why we need it**:
This PR updates `etcd-druid` to v0.18.4.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/6807

**Special notes for your reviewer**:
/cc @shreyas-s-rao @aaronfern 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Following dependency has been updated:- 
- github.com/gardener/etcd-druid v0.18.1 -> v0.18.4
```
