### PR TITLE
Add DNS value rewrite.

### DIFF
--- a/pkg/component/coredns/coredns.go
+++ b/pkg/component/coredns/coredns.go
@@ -786,11 +786,13 @@ func getSearchPathRewrites(enabled bool, clusterDomain string, commonSuffixes []
   rewrite stop {
     name regex (.*)\.` + regexp.QuoteMeta(suffix) + `\.svc\.` + quotedClusterDomain + ` {1}.` + suffix + `
     answer name (.*)\.` + regexp.QuoteMeta(suffix) + ` {1}.` + suffix + `.svc.` + clusterDomain + `
+    answer value (.*)\.` + regexp.QuoteMeta(suffix) + ` {1}.` + suffix + `.svc.` + clusterDomain + `
   }`
 	}
 	return `
   rewrite stop {
     name regex ([^\.]+)\.([^\.]+)\.svc\.` + quotedClusterDomain + `\.svc\.` + quotedClusterDomain + ` {1}.{2}.svc.` + clusterDomain + `
     answer name ([^\.]+)\.([^\.]+)\.svc\.` + quotedClusterDomain + ` {1}.{2}.svc.` + clusterDomain + `.svc.` + clusterDomain + `
+    answer value ([^\.]+)\.([^\.]+)\.svc\.` + quotedClusterDomain + ` {1}.{2}.svc.` + clusterDomain + `.svc.` + clusterDomain + `
   }` + suffixRewrites
 }

--- a/pkg/component/coredns/coredns_test.go
+++ b/pkg/component/coredns/coredns_test.go
@@ -132,12 +132,14 @@ data:
       rewrite stop {
         name regex ([^\.]+)\.([^\.]+)\.svc\.foo\.bar\.svc\.foo\.bar {1}.{2}.svc.foo.bar
         answer name ([^\.]+)\.([^\.]+)\.svc\.foo\.bar {1}.{2}.svc.foo.bar.svc.foo.bar
+        answer value ([^\.]+)\.([^\.]+)\.svc\.foo\.bar {1}.{2}.svc.foo.bar.svc.foo.bar
       }`
 				for _, suffix := range commonSuffixes {
 					out += `
       rewrite stop {
         name regex (.*)\.` + regexp.QuoteMeta(suffix) + `\.svc\.foo\.bar {1}.` + suffix + `
         answer name (.*)\.` + regexp.QuoteMeta(suffix) + ` {1}.` + suffix + `.svc.foo.bar
+        answer value (.*)\.` + regexp.QuoteMeta(suffix) + ` {1}.` + suffix + `.svc.foo.bar
       }`
 				}
 			}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind bug

**What this PR does / why we need it**:
This PR fixes an issue with the DNS rewrite mechanism.
In the context of CNAME, a DNS response typically includes two answers: one that resolves the original name to a CNAME, and another that resolves the CNAME to the A record. However, certain DNS clients may encounter an error if the CNAME in the first response does not correspond with the name in the second response. Here's an example to illustrate this:
```
Answers:
   - simple-server-2.test-dns.svc.cluster.local.svc.cluster.local: type CNAME, class IN, cname simple-server-1.test-dns.svc.cluster.local
   - simple-server-1.test-dns.svc.cluster.local.svc.cluster.local: type A, class IN, addr X.X.X.X
 ```
To address this, the PR extends the rewrite functionality to the value. This ensures that the CNAME in the first response is rewritten in the same manner as the name in the second response.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
An issue has been fixed which caused CoreDNS to not rewrite CNAME values in DNS answers.
```
