### PR TITLE
Improve local extension setup with regards to ssh tunnel stability

### DIFF
--- a/example/provider-extensions/ssh-reverse-tunnel/base/ssh/ssh_deployment.yaml
+++ b/example/provider-extensions/ssh-reverse-tunnel/base/ssh/ssh_deployment.yaml
@@ -43,6 +43,6 @@ spec:
           name: gardener-apiserver-ssh
           defaultMode: 0700
       - name: gardener-apiserver-ssh-keys
-        configMap:
-          name: gardener-apiserver-ssh-keys
+        secret:
+          secretName: gardener-apiserver-ssh-keys
           defaultMode: 0600

--- a/example/provider-extensions/ssh-reverse-tunnel/base/ssh/ssh_deployment.yaml
+++ b/example/provider-extensions/ssh-reverse-tunnel/base/ssh/ssh_deployment.yaml
@@ -18,6 +18,13 @@ spec:
       - command: ["/gardener_apiserver_ssh/entrypoint.sh"]
         image: alpine:3.17
         name: ssh
+        # apk sometimes just hangs => restart container if there is no connection to target port
+        livenessProbe:
+          exec:
+            command:
+            - sh
+            - "-c"
+            - "netstat | grep 6222"
         volumeMounts:
         - name: gardener-apiserver-ssh
           mountPath: /gardener_apiserver_ssh

--- a/example/provider-extensions/ssh-reverse-tunnel/base/sshd/sshd_deployment.yaml
+++ b/example/provider-extensions/ssh-reverse-tunnel/base/sshd/sshd_deployment.yaml
@@ -47,8 +47,8 @@ spec:
           name: gardener-apiserver-sshd
           defaultMode: 0700
       - name: gardener-apiserver-sshd-keys
-        configMap:
-          name: gardener-apiserver-sshd-keys
+        secret:
+          secretName: gardener-apiserver-sshd-keys
           defaultMode: 0600
 
 ---

--- a/example/provider-extensions/ssh-reverse-tunnel/seed-template/ssh/kustomization.yaml
+++ b/example/provider-extensions/ssh-reverse-tunnel/seed-template/ssh/kustomization.yaml
@@ -7,7 +7,7 @@ resources:
 
 namespace: relay
 
-configMapGenerator:
+secretGenerator:
 - name: gardener-apiserver-ssh-keys
   files:
   - client-keys/host

--- a/example/provider-extensions/ssh-reverse-tunnel/seed-template/sshd/kustomization.yaml
+++ b/example/provider-extensions/ssh-reverse-tunnel/seed-template/sshd/kustomization.yaml
@@ -4,7 +4,7 @@ kind: Kustomization
 resources:
 - ../../../base/sshd
 
-configMapGenerator:
+secretGenerator:
 - name: gardener-apiserver-sshd-keys
   namespace: relay
   files:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/area dev-productivity
/area robustness
/kind enhancement

**What this PR does / why we need it**:
Improve local extension setup with regards to ssh tunnel stability.

Add liveness probe to ssh container to enforce container restart if `apk` hangs.

Sometimes `apk` does not finish and just hangs forever. Therefore, the ssh tunnel will never be established and `gardenlet` will get into a crash-loop trying to contact `garden-apiserver`. Adding a liveness probe checking for an existing connection ensures that in those situations the container is restarted.
The default values, i.e. a test every 10 seconds and restart after 3 consecutive failures, are fine in this scenario.

Use `secrets` instead of `configmaps` for ssh keys.

**Which issue(s) this PR fixes**:
None.

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Stability of the ssh tunnel in the local extension setup should improve due to better failure handling.
```

/cc @oliver-goetz 