### PR TITLE
[operator] Introduce `lastOperation` in `Garden` status

### DIFF
--- a/charts/gardener/operator/templates/customresouredefintion.yaml
+++ b/charts/gardener/operator/templates/customresouredefintion.yaml
@@ -1118,6 +1118,38 @@ spec:
                 - name
                 - version
                 type: object
+              lastOperation:
+                description: LastOperation holds information about the last operation
+                  on the Shoot.
+                properties:
+                  description:
+                    description: A human readable message indicating details about
+                      the last operation.
+                    type: string
+                  lastUpdateTime:
+                    description: Last time the operation state transitioned from one
+                      to another.
+                    format: date-time
+                    type: string
+                  progress:
+                    description: The progress in percentage (0-100) of the last operation.
+                    format: int32
+                    type: integer
+                  state:
+                    description: Status of the last operation, one of Aborted, Processing,
+                      Succeeded, Error, Failed.
+                    type: string
+                  type:
+                    description: Type of the last operation, one of Create, Reconcile,
+                      Delete, Migrate, Restore.
+                    type: string
+                required:
+                - description
+                - lastUpdateTime
+                - progress
+                - state
+                - type
+                type: object
               observedGeneration:
                 description: ObservedGeneration is the most recent generation observed
                   for this resource.

--- a/charts/gardener/operator/templates/customresouredefintion.yaml
+++ b/charts/gardener/operator/templates/customresouredefintion.yaml
@@ -1120,7 +1120,7 @@ spec:
                 type: object
               lastOperation:
                 description: LastOperation holds information about the last operation
-                  on the Shoot.
+                  on the Garden.
                 properties:
                   description:
                     description: A human readable message indicating details about

--- a/docs/api-reference/operator.md
+++ b/docs/api-reference/operator.md
@@ -784,7 +784,7 @@ github.com/gardener/gardener/pkg/apis/core/v1beta1.LastOperation
 </td>
 <td>
 <em>(Optional)</em>
-<p>LastOperation holds information about the last operation on the Shoot.</p>
+<p>LastOperation holds information about the last operation on the Garden.</p>
 </td>
 </tr>
 <tr>

--- a/docs/api-reference/operator.md
+++ b/docs/api-reference/operator.md
@@ -777,6 +777,18 @@ github.com/gardener/gardener/pkg/apis/core/v1beta1.Gardener
 </tr>
 <tr>
 <td>
+<code>lastOperation</code></br>
+<em>
+github.com/gardener/gardener/pkg/apis/core/v1beta1.LastOperation
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>LastOperation holds information about the last operation on the Shoot.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>observedGeneration</code></br>
 <em>
 int64

--- a/docs/concepts/operator.md
+++ b/docs/concepts/operator.md
@@ -186,7 +186,7 @@ Note that this kubeconfig uses a token that has validity of `12h` only, hence it
 ### Deleting the `Garden`
 
 ```shell
-./hack/usage/delete garden garden
+./hack/usage/delete garden local
 ```
 
 ### Tear Down the Gardener Operator Environment

--- a/docs/concepts/operator.md
+++ b/docs/concepts/operator.md
@@ -256,7 +256,7 @@ The DNS domain is used for the `server` in the kubeconfig, and for configuring t
 It is also mandatory to provide an IPv4 CIDR for the service network of the virtual cluster via `.spec.virtualCluster.networking.services`.
 This range is used by the API server to compute the cluster IPs of `Service`s.
 
-The controller maintains the `Reconciled` condition which indicates the status of an operation.
+The controller maintains the `.status.lastOperation` which indicates the status of an operation.
 
 #### [`Care` Reconciler](../../pkg/operator/controller/garden/care)
 

--- a/example/operator/10-crd-operator.gardener.cloud_gardens.yaml
+++ b/example/operator/10-crd-operator.gardener.cloud_gardens.yaml
@@ -1118,6 +1118,38 @@ spec:
                 - name
                 - version
                 type: object
+              lastOperation:
+                description: LastOperation holds information about the last operation
+                  on the Shoot.
+                properties:
+                  description:
+                    description: A human readable message indicating details about
+                      the last operation.
+                    type: string
+                  lastUpdateTime:
+                    description: Last time the operation state transitioned from one
+                      to another.
+                    format: date-time
+                    type: string
+                  progress:
+                    description: The progress in percentage (0-100) of the last operation.
+                    format: int32
+                    type: integer
+                  state:
+                    description: Status of the last operation, one of Aborted, Processing,
+                      Succeeded, Error, Failed.
+                    type: string
+                  type:
+                    description: Type of the last operation, one of Create, Reconcile,
+                      Delete, Migrate, Restore.
+                    type: string
+                required:
+                - description
+                - lastUpdateTime
+                - progress
+                - state
+                - type
+                type: object
               observedGeneration:
                 description: ObservedGeneration is the most recent generation observed
                   for this resource.

--- a/example/operator/10-crd-operator.gardener.cloud_gardens.yaml
+++ b/example/operator/10-crd-operator.gardener.cloud_gardens.yaml
@@ -1120,7 +1120,7 @@ spec:
                 type: object
               lastOperation:
                 description: LastOperation holds information about the last operation
-                  on the Shoot.
+                  on the Garden.
                 properties:
                   description:
                     description: A human readable message indicating details about

--- a/example/operator/20-garden.yaml
+++ b/example/operator/20-garden.yaml
@@ -11,11 +11,11 @@ stringData:
 apiVersion: operator.gardener.cloud/v1alpha1
 kind: Garden
 metadata:
-  name: garden
+  name: local
 spec:
   runtimeCluster:
     ingress:
-      domain: ingress.dev.garden.example.com
+      domain: ingress.runtime-garden.local.gardener.cloud
       controller:
         kind: nginx
       # providerConfig:

--- a/pkg/apis/operator/v1alpha1/types.go
+++ b/pkg/apis/operator/v1alpha1/types.go
@@ -436,8 +436,6 @@ type CredentialsRotation struct {
 }
 
 const (
-	// GardenReconciled is a constant for a condition type indicating that the garden has been reconciled.
-	GardenReconciled gardencorev1beta1.ConditionType = "Reconciled"
 	// RuntimeComponentsHealthy is a constant for a condition type indicating the runtime components health.
 	RuntimeComponentsHealthy gardencorev1beta1.ConditionType = "RuntimeComponentsHealthy"
 	// VirtualComponentsHealthy is a constant for a condition type indicating the virtual garden components health.

--- a/pkg/apis/operator/v1alpha1/types.go
+++ b/pkg/apis/operator/v1alpha1/types.go
@@ -405,6 +405,9 @@ type GardenStatus struct {
 	Gardener *gardencorev1beta1.Gardener `json:"gardener,omitempty"`
 	// Conditions is a list of conditions.
 	Conditions []gardencorev1beta1.Condition `json:"conditions,omitempty"`
+	// LastOperation holds information about the last operation on the Shoot.
+	// +optional
+	LastOperation *gardencorev1beta1.LastOperation `json:"lastOperation,omitempty"`
 	// ObservedGeneration is the most recent generation observed for this resource.
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 	// Credentials contains information about the virtual garden cluster credentials.

--- a/pkg/apis/operator/v1alpha1/types.go
+++ b/pkg/apis/operator/v1alpha1/types.go
@@ -405,7 +405,7 @@ type GardenStatus struct {
 	Gardener *gardencorev1beta1.Gardener `json:"gardener,omitempty"`
 	// Conditions is a list of conditions.
 	Conditions []gardencorev1beta1.Condition `json:"conditions,omitempty"`
-	// LastOperation holds information about the last operation on the Shoot.
+	// LastOperation holds information about the last operation on the Garden.
 	// +optional
 	LastOperation *gardencorev1beta1.LastOperation `json:"lastOperation,omitempty"`
 	// ObservedGeneration is the most recent generation observed for this resource.

--- a/pkg/apis/operator/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/operator/v1alpha1/zz_generated.deepcopy.go
@@ -435,6 +435,11 @@ func (in *GardenStatus) DeepCopyInto(out *GardenStatus) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.LastOperation != nil {
+		in, out := &in.LastOperation, &out.LastOperation
+		*out = new(v1beta1.LastOperation)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.Credentials != nil {
 		in, out := &in.Credentials, &out.Credentials
 		*out = new(Credentials)

--- a/pkg/operation/care/garden_health.go
+++ b/pkg/operation/care/garden_health.go
@@ -98,6 +98,7 @@ func (h *GardenHealth) CheckGarden(
 	ctx context.Context,
 	conditions []gardencorev1beta1.Condition,
 	thresholdMappings map[gardencorev1beta1.ConditionType]time.Duration,
+	lastOperation *gardencorev1beta1.LastOperation,
 ) []gardencorev1beta1.Condition {
 	var (
 		apiServerAvailability      gardencorev1beta1.Condition
@@ -115,7 +116,7 @@ func (h *GardenHealth) CheckGarden(
 		}
 	}
 
-	checker := NewHealthChecker(h.runtimeClient, h.clock, thresholdMappings, nil, nil, nil, nil, nil)
+	checker := NewHealthChecker(h.runtimeClient, h.clock, thresholdMappings, nil, nil, lastOperation, nil, nil)
 
 	taskFns := []flow.TaskFn{
 		func(ctx context.Context) error {

--- a/pkg/operation/care/garden_health_test.go
+++ b/pkg/operation/care/garden_health_test.go
@@ -117,7 +117,7 @@ var _ = Describe("Garden health", func() {
 	})
 
 	Describe("#CheckGarden", func() {
-		Context("When all managed resources, deployments and ETCDs are deployed successfully", func() {
+		Context("when all managed resources, deployments and ETCDs are deployed successfully", func() {
 			JustBeforeEach(func() {
 				for _, name := range append(gardenManagedResources, virtualGardenManagedResources...) {
 					Expect(runtimeClient.Create(ctx, healthyManagedResource(name))).To(Succeed())
@@ -136,7 +136,7 @@ var _ = Describe("Garden health", func() {
 					apiserverAvailabilityCondition,
 					runtimeComponentsHealthyCondition,
 					virtualComponentsHealthyCondition,
-				}, nil)
+				}, nil, nil)
 				Expect(len(updatedConditions)).ToNot(BeZero())
 				Expect(updatedConditions).To(ContainElements(
 					beConditionWithStatusReasonAndMessage(gardencorev1beta1.ConditionTrue, "RuntimeComponentsRunning", "All runtime components are healthy."),
@@ -145,7 +145,7 @@ var _ = Describe("Garden health", func() {
 			})
 		})
 
-		Context("When optional managed resources are turned off, and required resources are deployed successfully", func() {
+		Context("when optional managed resources are turned off, and required resources are deployed successfully", func() {
 			JustBeforeEach(func() {
 				DeferCleanup(test.WithFeatureGate(features.DefaultFeatureGate, features.HVPA, false))
 				garden.Spec.RuntimeCluster.Settings = &operatorv1alpha1.Settings{
@@ -171,7 +171,7 @@ var _ = Describe("Garden health", func() {
 					apiserverAvailabilityCondition,
 					runtimeComponentsHealthyCondition,
 					virtualComponentsHealthyCondition,
-				}, nil)
+				}, nil, nil)
 				Expect(len(updatedConditions)).ToNot(BeZero())
 				Expect(updatedConditions).To(ContainElements(
 					beConditionWithStatusReasonAndMessage(gardencorev1beta1.ConditionTrue, "RuntimeComponentsRunning", "All runtime components are healthy."),
@@ -180,7 +180,7 @@ var _ = Describe("Garden health", func() {
 			})
 		})
 
-		Context("When optional managed resources are turned on, and all resources are deployed successfully", func() {
+		Context("when optional managed resources are turned on, and all resources are deployed successfully", func() {
 			JustBeforeEach(func() {
 				garden.Spec.RuntimeCluster.Settings = &operatorv1alpha1.Settings{
 					VerticalPodAutoscaler: &operatorv1alpha1.SettingVerticalPodAutoscaler{
@@ -207,7 +207,7 @@ var _ = Describe("Garden health", func() {
 					apiserverAvailabilityCondition,
 					runtimeComponentsHealthyCondition,
 					virtualComponentsHealthyCondition,
-				}, nil)
+				}, nil, nil)
 				Expect(len(updatedConditions)).ToNot(BeZero())
 				Expect(updatedConditions).To(ContainElements(
 					beConditionWithStatusReasonAndMessage(gardencorev1beta1.ConditionTrue, "RuntimeComponentsRunning", "All runtime components are healthy."),
@@ -216,7 +216,7 @@ var _ = Describe("Garden health", func() {
 			})
 		})
 
-		Context("When there are issues with garden managed resources", func() {
+		Context("when there are issues with garden managed resources", func() {
 			var (
 				tests = func(reason, message string) {
 					It("should set RuntimeComponentsHealthy and VirtualComponentsHealthy conditions to False if there is no Progressing threshold duration mapping", func() {
@@ -225,7 +225,7 @@ var _ = Describe("Garden health", func() {
 							apiserverAvailabilityCondition,
 							runtimeComponentsHealthyCondition,
 							virtualComponentsHealthyCondition,
-						}, nil)
+						}, nil, nil)
 						Expect(len(updatedConditions)).ToNot(BeZero())
 						Expect(updatedConditions).To(ContainElements(
 							beConditionWithStatusReasonAndMessage(gardencorev1beta1.ConditionFalse, reason, message),
@@ -250,6 +250,7 @@ var _ = Describe("Garden health", func() {
 								operatorv1alpha1.RuntimeComponentsHealthy: time.Minute,
 								operatorv1alpha1.VirtualComponentsHealthy: time.Minute,
 							},
+							nil,
 						)
 
 						Expect(len(updatedConditions)).ToNot(BeZero())
@@ -276,6 +277,7 @@ var _ = Describe("Garden health", func() {
 								operatorv1alpha1.RuntimeComponentsHealthy: time.Minute,
 								operatorv1alpha1.VirtualComponentsHealthy: time.Minute,
 							},
+							nil,
 						)
 
 						Expect(len(updatedConditions)).ToNot(BeZero())
@@ -302,6 +304,7 @@ var _ = Describe("Garden health", func() {
 								operatorv1alpha1.RuntimeComponentsHealthy: time.Minute,
 								operatorv1alpha1.VirtualComponentsHealthy: time.Minute,
 							},
+							nil,
 						)
 
 						Expect(len(updatedConditions)).ToNot(BeZero())
@@ -328,6 +331,7 @@ var _ = Describe("Garden health", func() {
 								operatorv1alpha1.RuntimeComponentsHealthy: time.Minute,
 								operatorv1alpha1.VirtualComponentsHealthy: time.Minute,
 							},
+							nil,
 						)
 
 						Expect(len(updatedConditions)).ToNot(BeZero())
@@ -339,7 +343,7 @@ var _ = Describe("Garden health", func() {
 				}
 			)
 
-			Context("When managed resources are not deployed", func() {
+			Context("when managed resources are not deployed", func() {
 				JustBeforeEach(func() {
 					for _, name := range virtualGardenDeployments {
 						Expect(runtimeClient.Create(ctx, newDeployment(gardenNamespace, name, "controlplane", true))).To(Succeed())
@@ -352,7 +356,7 @@ var _ = Describe("Garden health", func() {
 				tests("ResourceNotFound", "not found")
 			})
 
-			Context("When all managed resources are deployed, but not healthy", func() {
+			Context("when all managed resources are deployed, but not healthy", func() {
 				JustBeforeEach(func() {
 					for _, name := range append(gardenManagedResources, virtualGardenManagedResources...) {
 						Expect(runtimeClient.Create(ctx, notHealthyManagedResource(name))).To(Succeed())
@@ -368,7 +372,7 @@ var _ = Describe("Garden health", func() {
 				tests("NotHealthy", "Resources are not healthy")
 			})
 
-			Context("When all managed resources are deployed but their resources are not applied", func() {
+			Context("when all managed resources are deployed but their resources are not applied", func() {
 				JustBeforeEach(func() {
 					for _, name := range append(gardenManagedResources, virtualGardenManagedResources...) {
 						Expect(runtimeClient.Create(ctx, notAppliedManagedResource(name))).To(Succeed())
@@ -384,7 +388,7 @@ var _ = Describe("Garden health", func() {
 				tests("NotApplied", "Resources are not applied")
 			})
 
-			Context("When all managed resources are deployed but their resources are still progressing", func() {
+			Context("when all managed resources are deployed but their resources are still progressing", func() {
 				JustBeforeEach(func() {
 					for _, name := range append(gardenManagedResources, virtualGardenManagedResources...) {
 						Expect(runtimeClient.Create(ctx, progressingManagedResource(name))).To(Succeed())
@@ -400,7 +404,7 @@ var _ = Describe("Garden health", func() {
 				tests("ResourcesProgressing", "Resources are progressing")
 			})
 
-			Context("When all managed resources are deployed but not all required conditions are present", func() {
+			Context("when all managed resources are deployed but not all required conditions are present", func() {
 				JustBeforeEach(func() {
 					for _, name := range append(gardenManagedResources, virtualGardenManagedResources...) {
 						Expect(runtimeClient.Create(ctx, managedResource(name, []gardencorev1beta1.Condition{{
@@ -420,14 +424,14 @@ var _ = Describe("Garden health", func() {
 			})
 		})
 
-		Context("When there are issues with deployments for virtual garden", func() {
+		Context("when there are issues with deployments for virtual garden", func() {
 			It("should set VirtualComponentsHealthy conditions to false when the deployments are missing", func() {
 				healthCheck := care.NewHealthForGarden(garden, runtimeClient, gardenClientSet, fakeClock, gardenNamespace)
 				updatedConditions := healthCheck.CheckGarden(ctx, []gardencorev1beta1.Condition{
 					apiserverAvailabilityCondition,
 					runtimeComponentsHealthyCondition,
 					virtualComponentsHealthyCondition,
-				}, nil)
+				}, nil, nil)
 				Expect(len(updatedConditions)).ToNot(BeZero())
 				Expect(updatedConditions).To(ContainElements(
 					beConditionWithStatusReasonAndMessage(gardencorev1beta1.ConditionFalse, "DeploymentMissing", "Missing required deployments: [virtual-garden-gardener-resource-manager virtual-garden-kube-apiserver virtual-garden-kube-controller-manager]"),
@@ -444,7 +448,7 @@ var _ = Describe("Garden health", func() {
 					apiserverAvailabilityCondition,
 					runtimeComponentsHealthyCondition,
 					virtualComponentsHealthyCondition,
-				}, nil)
+				}, nil, nil)
 				Expect(len(updatedConditions)).ToNot(BeZero())
 				Expect(updatedConditions).To(ContainElements(
 					beConditionWithStatusReasonAndMessage(gardencorev1beta1.ConditionFalse, "DeploymentUnhealthy", "is unhealthy: condition \"Available\" is missing"),
@@ -452,7 +456,7 @@ var _ = Describe("Garden health", func() {
 			})
 		})
 
-		Context("When there are issues with ETCDs for virtual garden", func() {
+		Context("when there are issues with ETCDs for virtual garden", func() {
 			JustBeforeEach(func() {
 				for _, name := range virtualGardenDeployments {
 					Expect(runtimeClient.Create(ctx, newDeployment(gardenNamespace, name, "controlplane", true))).To(Succeed())
@@ -465,7 +469,7 @@ var _ = Describe("Garden health", func() {
 					apiserverAvailabilityCondition,
 					runtimeComponentsHealthyCondition,
 					virtualComponentsHealthyCondition,
-				}, nil)
+				}, nil, nil)
 				Expect(len(updatedConditions)).ToNot(BeZero())
 				Expect(updatedConditions).To(ContainElements(
 					beConditionWithStatusReasonAndMessage(gardencorev1beta1.ConditionFalse, "EtcdMissing", "Missing required etcds: [virtual-garden-etcd-events virtual-garden-etcd-main]"),
@@ -482,7 +486,7 @@ var _ = Describe("Garden health", func() {
 					apiserverAvailabilityCondition,
 					runtimeComponentsHealthyCondition,
 					virtualComponentsHealthyCondition,
-				}, nil)
+				}, nil, nil)
 				Expect(len(updatedConditions)).ToNot(BeZero())
 				Expect(updatedConditions).To(ContainElements(
 					beConditionWithStatusReasonAndMessage(gardencorev1beta1.ConditionFalse, "EtcdUnhealthy", "Etcd extension resource \"virtual-garden-etcd-events\" is unhealthy: etcd \"virtual-garden-etcd-events\" is not ready yet"),

--- a/pkg/operation/operation.go
+++ b/pkg/operation/operation.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 	"regexp"
-	"strings"
 
 	"github.com/Masterminds/semver"
 	"github.com/go-logr/logr"
@@ -371,21 +370,11 @@ func (o *Operation) GetSecretKeysOfRole(kind string) []string {
 	return common.FilterEntriesByPrefix(kind, o.AllSecretKeys())
 }
 
-func makeDescription(stats *flow.Stats) string {
-	if stats.ProgressPercent() == 0 {
-		return "Starting " + stats.FlowName
-	}
-	if stats.ProgressPercent() == 100 {
-		return stats.FlowName + " finished"
-	}
-	return strings.Join(stats.Running.StringList(), ", ")
-}
-
 // ReportShootProgress will update the last operation object in the Shoot manifest `status` section
 // by the current progress of the Flow execution.
 func (o *Operation) ReportShootProgress(ctx context.Context, stats *flow.Stats) {
 	var (
-		description    = makeDescription(stats)
+		description    = flow.MakeDescription(stats)
 		progress       = stats.ProgressPercent()
 		lastUpdateTime = metav1.Now()
 	)

--- a/pkg/operator/controller/garden/care/reconciler.go
+++ b/pkg/operator/controller/garden/care/reconciler.go
@@ -94,9 +94,11 @@ func (r *Reconciler) Reconcile(reconcileCtx context.Context, req reconcile.Reque
 		// Rebuild garden conditions to ensure that only the conditions with the
 		// correct types will be updated, and any other conditions will remain intact
 		conditions = v1beta1helper.BuildConditions(garden.Status.Conditions, updatedConditions, conditionTypes)
+		// TODO(rfranzke): Drop this line after v1.78 has been released.
+		conditions = v1beta1helper.RemoveConditions(conditions, "Reconciled")
 
 		log.Info("Updating garden status conditions")
-		patch := client.MergeFromWithOptions(garden.DeepCopy(), client.MergeFromWithOptimisticLock{})
+		patch := client.MergeFrom(garden.DeepCopy())
 		garden.Status.Conditions = conditions
 		if err := r.RuntimeClient.Status().Patch(reconcileCtx, garden, patch); err != nil {
 			log.Error(err, "Could not update garden status")

--- a/pkg/operator/controller/garden/care/reconciler.go
+++ b/pkg/operator/controller/garden/care/reconciler.go
@@ -87,7 +87,8 @@ func (r *Reconciler) Reconcile(reconcileCtx context.Context, req reconcile.Reque
 		log.V(1).Info("Could not get garden client", "error", err)
 	}
 
-	updatedConditions := NewHealthCheck(garden, r.RuntimeClient, gardenClientSet, r.Clock, r.GardenNamespace).CheckGarden(ctx, conditions, r.conditionThresholdsToProgressingMapping())
+	updatedConditions := NewHealthCheck(garden, r.RuntimeClient, gardenClientSet, r.Clock, r.GardenNamespace).
+		CheckGarden(ctx, conditions, r.conditionThresholdsToProgressingMapping(), garden.Status.LastOperation)
 
 	// Update Garden status conditions if necessary
 	if v1beta1helper.ConditionsNeedUpdate(conditions, updatedConditions) {

--- a/pkg/operator/controller/garden/care/reconciler_test.go
+++ b/pkg/operator/controller/garden/care/reconciler_test.go
@@ -214,8 +214,11 @@ func healthCheckFunc(fn resultingConditionFunc) NewHealthCheckFunc {
 	}
 }
 
-func (c resultingConditionFunc) CheckGarden(_ context.Context,
+func (c resultingConditionFunc) CheckGarden(
+	_ context.Context,
 	conditions []gardencorev1beta1.Condition,
-	_ map[gardencorev1beta1.ConditionType]time.Duration) []gardencorev1beta1.Condition {
+	_ map[gardencorev1beta1.ConditionType]time.Duration,
+	_ *gardencorev1beta1.LastOperation,
+) []gardencorev1beta1.Condition {
 	return c(conditions)
 }

--- a/pkg/operator/controller/garden/care/types.go
+++ b/pkg/operator/controller/garden/care/types.go
@@ -37,5 +37,5 @@ var defaultNewHealthCheck NewHealthCheckFunc = func(garden *operatorv1alpha1.Gar
 
 // HealthCheck is an interface used to perform health checks.
 type HealthCheck interface {
-	CheckGarden(ctx context.Context, condition []gardencorev1beta1.Condition, thresholdMappings map[gardencorev1beta1.ConditionType]time.Duration) []gardencorev1beta1.Condition
+	CheckGarden(ctx context.Context, condition []gardencorev1beta1.Condition, thresholdMappings map[gardencorev1beta1.ConditionType]time.Duration, lastOperation *gardencorev1beta1.LastOperation) []gardencorev1beta1.Condition
 }

--- a/pkg/operator/controller/garden/garden/reconciler.go
+++ b/pkg/operator/controller/garden/garden/reconciler.go
@@ -231,32 +231,15 @@ func (r *Reconciler) updateStatusOperationStart(ctx context.Context, garden *ope
 
 func (r *Reconciler) updateStatusOperationSuccess(ctx context.Context, garden *operatorv1alpha1.Garden, operationType gardencorev1beta1.LastOperationType) error {
 	var (
-		now                        = metav1.NewTime(r.Clock.Now().UTC())
-		description                string
-		setConditionsToProgressing bool
+		now         = metav1.NewTime(r.Clock.Now().UTC())
+		description string
 	)
 
 	switch operationType {
 	case gardencorev1beta1.LastOperationTypeReconcile:
 		description = "Garden cluster has been successfully reconciled."
-		setConditionsToProgressing = true
 	case gardencorev1beta1.LastOperationTypeDelete:
 		description = "Garden cluster has been successfully deleted."
-		setConditionsToProgressing = false
-	}
-
-	if setConditionsToProgressing {
-		for i, cond := range garden.Status.Conditions {
-			switch cond.Type {
-			case operatorv1alpha1.RuntimeComponentsHealthy,
-				operatorv1alpha1.VirtualComponentsHealthy,
-				operatorv1alpha1.VirtualGardenAPIServerAvailable:
-				if cond.Status != gardencorev1beta1.ConditionFalse {
-					garden.Status.Conditions[i].Status = gardencorev1beta1.ConditionProgressing
-					garden.Status.Conditions[i].LastUpdateTime = metav1.Now()
-				}
-			}
-		}
 	}
 
 	garden.Status.LastOperation = &gardencorev1beta1.LastOperation{

--- a/pkg/utils/flow/progress_reporter.go
+++ b/pkg/utils/flow/progress_reporter.go
@@ -16,6 +16,7 @@ package flow
 
 import (
 	"context"
+	"strings"
 )
 
 // ProgressReporterFn is continuously called on progress in a flow.
@@ -29,4 +30,15 @@ type ProgressReporter interface {
 	Stop()
 	// Report reports the progress using the current statistics.
 	Report(context.Context, *Stats)
+}
+
+// MakeDescription returns a description based on the stats.
+func MakeDescription(stats *Stats) string {
+	if stats.ProgressPercent() == 0 {
+		return "Starting " + stats.FlowName
+	}
+	if stats.ProgressPercent() == 100 {
+		return stats.FlowName + " finished"
+	}
+	return strings.Join(stats.Running.StringList(), ", ")
 }

--- a/pkg/utils/flow/progress_reporter_test.go
+++ b/pkg/utils/flow/progress_reporter_test.go
@@ -1,0 +1,56 @@
+// Copyright 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package flow_test
+
+import (
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	. "github.com/gardener/gardener/pkg/utils/flow"
+)
+
+var _ = Describe("ProgressReporter", func() {
+	Describe("#MakeDescription", func() {
+		var (
+			tasks = map[TaskID]struct{}{"Foo": {}, "Bar": {}, "Baz": {}}
+			stats *Stats
+		)
+
+		BeforeEach(func() {
+			stats = &Stats{
+				FlowName: "test",
+				Running:  tasks,
+				All:      tasks,
+			}
+		})
+
+		It("should yield the correct description when progress is 0", func() {
+			Expect(MakeDescription(stats)).To(Equal("Starting test"))
+		})
+
+		It("should yield the correct description when 0 < progress < 100", func() {
+			stats.Running = map[TaskID]struct{}{"Foo": {}, "Baz": {}}
+			stats.Succeeded = map[TaskID]struct{}{"Bar": {}}
+			Expect(strings.Split(MakeDescription(stats), ", ")).To(ConsistOf("Foo", "Baz"))
+		})
+
+		It("should yield the correct description when progress is 100", func() {
+			stats.Succeeded = tasks
+			Expect(MakeDescription(stats)).To(Equal("test finished"))
+		})
+	})
+})

--- a/test/e2e/operator/garden/common.go
+++ b/test/e2e/operator/garden/common.go
@@ -80,7 +80,7 @@ func defaultGarden(backupSecret *corev1.Secret) *operatorv1alpha1.Garden {
 					Services: "10.2.0.0/16",
 				},
 				Ingress: gardencorev1beta1.Ingress{
-					Domain: "ingress.dev.my-garden.example.com",
+					Domain: "ingress.runtime-garden.local.gardener.cloud",
 					Controller: gardencorev1beta1.IngressController{
 						Kind: "nginx",
 					},

--- a/test/integration/operator/garden/care/care_test.go
+++ b/test/integration/operator/garden/care/care_test.go
@@ -85,7 +85,7 @@ var _ = Describe("Garden Care controller tests", func() {
 						Services: "10.2.0.0/16",
 					},
 					Ingress: gardencorev1beta1.Ingress{
-						Domain: "ingress.dev.garden.example.com",
+						Domain: "ingress.runtime-garden.local.gardener.cloud",
 						Controller: gardencorev1beta1.IngressController{
 							Kind: "nginx",
 						},

--- a/test/integration/operator/garden/garden/garden_test.go
+++ b/test/integration/operator/garden/garden/garden_test.go
@@ -250,14 +250,14 @@ var _ = Describe("Garden controller tests", func() {
 			return garden.Finalizers
 		}).Should(ConsistOf("gardener.cloud/operator"))
 
-		By("Wait for Reconciled condition to be set to Progressing")
-		Eventually(func(g Gomega) []gardencorev1beta1.Condition {
+		By("Wait for last operation state to be set to Progressing")
+		Eventually(func(g Gomega) gardencorev1beta1.LastOperationState {
 			g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(garden), garden)).To(Succeed())
-			return garden.Status.Conditions
-		}).Should(ContainCondition(
-			OfType(operatorv1alpha1.GardenReconciled),
-			WithStatus(gardencorev1beta1.ConditionProgressing),
-		))
+			if garden.Status.LastOperation == nil {
+				return ""
+			}
+			return garden.Status.LastOperation.State
+		}).Should(Equal(gardencorev1beta1.LastOperationStateProcessing))
 		Expect(garden.Status.Gardener).NotTo(BeNil())
 
 		By("Verify that the custom resource definitions have been created")
@@ -633,11 +633,14 @@ var _ = Describe("Garden controller tests", func() {
 			g.Expect(testClient.Status().Patch(ctx, deployment, patch)).To(Succeed())
 		}).Should(Succeed())
 
-		By("Wait for Reconciled condition to be set to True")
-		Eventually(func(g Gomega) []gardencorev1beta1.Condition {
+		By("Wait for last operation state to be set to Succeeded")
+		Eventually(func(g Gomega) gardencorev1beta1.LastOperationState {
 			g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(garden), garden)).To(Succeed())
-			return garden.Status.Conditions
-		}).Should(ContainCondition(OfType(operatorv1alpha1.GardenReconciled), WithStatus(gardencorev1beta1.ConditionTrue)))
+			if garden.Status.LastOperation == nil {
+				return ""
+			}
+			return garden.Status.LastOperation.State
+		}).Should(Equal(gardencorev1beta1.LastOperationStateSucceeded))
 
 		By("Delete Garden")
 		Expect(testClient.Delete(ctx, garden)).To(Succeed())

--- a/test/integration/operator/garden/garden/garden_test.go
+++ b/test/integration/operator/garden/garden/garden_test.go
@@ -149,7 +149,7 @@ var _ = Describe("Garden controller tests", func() {
 						Services: "10.2.0.0/16",
 					},
 					Ingress: gardencorev1beta1.Ingress{
-						Domain: "ingress.dev.garden.example.com",
+						Domain: "ingress.runtime-garden.local.gardener.cloud",
 						Controller: gardencorev1beta1.IngressController{
 							Kind: "nginx",
 						},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind enhancement

**What this PR does / why we need it**:
`.status.lastOperation`, similar to how it's done for `Shoot`s.

**Which issue(s) this PR fixes**:
Part of #7016

**Special notes for your reviewer**:
After #8158, both `garden-garden` and `garden-care` reconcilers were mutating the `.status.conditions` of the `Garden`. This required them to perform their patches with optimistic locking, effectively resulting in quite some conflicts during a reconciliation. This locking was required because `Garden` is a CRD and no strategic merge-patch is supported here. For `Seed`s, the same approach is followed, however here strategic merge-patch is indeed supported since the `Seed` API is served by `gardener-apiserver` and not by a CRD.

Due to this and with the motivation to streamline things between `Shoot`s and `Garden`s, we decided to change this and only let the `garden-care` reconciler maintain the conditions while `garden-garden` reconciler maintains the last operation. This way, no optimistic locking is required anymore which also allowed us to drop this "retry" workaround code in the `garden-care` reconciler introduced with #8158.

/cc @timuthy @oliver-goetz 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
`gardener-operator` no longer reports the `Reconciled` condition. Instead, it now reports the progress in `.status.lastOperation`, similar to how it's done for `Shoot`s.
```
