### PR TITLE
Allow local gardener API server to call webhooks

### DIFF
--- a/example/gardener-local/controlplane/values.yaml
+++ b/example/gardener-local/controlplane/values.yaml
@@ -162,6 +162,8 @@ global:
       MutableShootSpecNetworkingNodes: true
       WorkerlessShoots: true
     resources: {}
+    podLabels:
+      networking.resources.gardener.cloud/to-all-webhook-targets: allowed
 
   # Gardener admission controller configuration values
   admission:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind bug

**What this PR does / why we need it**:
Allow local gardener API server to call webhooks

Some extensions deploys admission validating/mutating gardener.cloud resources, e.g. Shoots. In this case, the admission request is send from the Gardener API server not the virtual or runtime kube-apiserver, therefore the Gardener API server deployment must be allowed to talk to all webhook targets. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix developer
A bug in the local development environment has been fixed which prevented admission of Gardener resources by extension webhooks.
```
