### PR TITLE
[operator] Manage `fluent-operator` and `vali`

### DIFF
--- a/docs/concepts/operator.md
+++ b/docs/concepts/operator.md
@@ -219,8 +219,9 @@ Other system components are:
 - Istio
 
 Few observability components are also managed by the gardener-operator:
-    - Fluent-operator
-    - Vali
+
+- Fluent-operator
+- Vali
 
 As soon as all system components are up, the reconciler deploys the virtual garden cluster.
 It comprises out of two ETCDs (one "main" etcd, one "events" etcd) which are managed by ETCD Druid via `druid.gardener.cloud/v1alpha1.Etcd` custom resources.

--- a/docs/concepts/operator.md
+++ b/docs/concepts/operator.md
@@ -218,6 +218,10 @@ Other system components are:
 - ETCD Druid
 - Istio
 
+Few observability components are also managed by the gardener-operator:
+    - Fluent-operator
+    - Vali
+
 As soon as all system components are up, the reconciler deploys the virtual garden cluster.
 It comprises out of two ETCDs (one "main" etcd, one "events" etcd) which are managed by ETCD Druid via `druid.gardener.cloud/v1alpha1.Etcd` custom resources.
 The whole management works similar to how it works for `Shoot`s, so you can take a look at [this document](etcd.md) for more information in general.

--- a/docs/concepts/operator.md
+++ b/docs/concepts/operator.md
@@ -143,7 +143,7 @@ kubectl apply -f example/operator/20-garden.yaml
 You can wait for the `Garden` to be ready by running:
 
 ```shell
-./hack/usage/wait-for.sh garden garden Reconciled
+./hack/usage/wait-for.sh garden local Reconciled
 ```
 
 Alternatively, you can run `kubectl get garden` and wait for the `RECONCILED` status to reach `True`:
@@ -214,13 +214,13 @@ Other system components are:
 
 - garden system resources ([`PriorityClass`es](../development/priority-classes.md) for the workload resources)
 - Vertical Pod Autoscaler (if enabled via `.spec.runtimeCluster.settings.verticalPodAutoscaler.enabled=true` in the `Garden`)
-- HVPA controller (when `HVPA` feature gate is enabled)
+- HVPA Controller (when `HVPA` feature gate is enabled)
 - ETCD Druid
 - Istio
 
-Few observability components are also managed by the gardener-operator:
+The reconciler also manages a few observability-related components (more planned as part of [GEP-19](../proposals/19-migrating-observability-stack-to-operators.md)):
 
-- Fluent-operator
+- Fluent Operator
 - Vali
 
 As soon as all system components are up, the reconciler deploys the virtual garden cluster.

--- a/docs/development/priority-classes.md
+++ b/docs/development/priority-classes.md
@@ -38,7 +38,7 @@ When using the `gardener-operator` for managing the garden runtime and virtual c
 | `gardener-system-900`              | 999998900 | Extensions, `reversed-vpn-auth-server`                                                                                                                                             |
 | `gardener-system-800`              | 999998800 | `dependency-watchdog-endpoint`, `dependency-watchdog-probe`, `etcd-druid`, `(auditlog-)mutator`, `vpa-admission-controller`                                                        |
 | `gardener-system-700`              | 999998700 | `auditlog-seed-controller`, `hvpa-controller`, `vpa-recommender`, `vpa-updater`                                                                                                    |
-| `gardener-system-600`              | 999998600 | `aggregate-alertmanager`, `alertmanager`, `fluent-bit`, `plutono`, `kube-state-metrics`, `nginx-ingress-controller`, `nginx-k8s-backend`, `prometheus`, `vali`,  `seed-prometheus` |
+| `gardener-system-600`              | 999998600 | `aggregate-alertmanager`, `alertmanager`, `fluent-operator`, `fluent-bit`, `plutono`, `kube-state-metrics`, `nginx-ingress-controller`, `nginx-k8s-backend`, `prometheus`, `vali`,  `seed-prometheus` |
 | `gardener-reserve-excess-capacity` | -5        | `reserve-excess-capacity` ([ref](https://github.com/gardener/gardener/pull/6135))                                                                                                  |
 
 ### `PriorityClass`es for Shoot Control Plane Components

--- a/docs/development/priority-classes.md
+++ b/docs/development/priority-classes.md
@@ -19,15 +19,14 @@ When using the `gardener-operator` for managing the garden runtime and virtual c
 
 ### `PriorityClass`es for Garden Control Plane Components
 
-| Name                              | Priority  | Associated Components (Examples)                                                                               |
-|---------------------------------- |-----------|----------------------------------------------------------------------------------------------------------------|
-| `gardener-garden-system-critical` | 999999550 | `gardener-operator`, `gardener-resource-manager`, `istio`                                                      |
-| `gardener-garden-system-500`      | 999999500 | `virtual-garden-etcd-events`, `virtual-garden-etcd-main`, `virtual-garden-kube-apiserver`, `gardener-apiserver`|
-| `gardener-garden-system-400`      | 999999400 | `virtual-garden-gardener-resource-manager`, `gardener-admission-controller`                                    |
-| `gardener-garden-system-300`      | 999999300 | `virtual-garden-kube-controller-manager`, `vpa-admission-controller`, `etcd-druid`, `nginx-ingress-controller` |
-| `gardener-garden-system-200`      | 999999200 | `vpa-recommender`, `vpa-updater`, `hvpa-controller`, `gardener-scheduler`                                      |
-| `gardener-garden-system-100`      | 999999100 | `kube-state-metrics`                                                                                           |
-
+| Name                              | Priority  | Associated Components (Examples)                                                                                |
+|-----------------------------------|-----------|-----------------------------------------------------------------------------------------------------------------|
+| `gardener-garden-system-critical` | 999999550 | `gardener-operator`, `gardener-resource-manager`, `istio`                                                       |
+| `gardener-garden-system-500`      | 999999500 | `virtual-garden-etcd-events`, `virtual-garden-etcd-main`, `virtual-garden-kube-apiserver`, `gardener-apiserver` |
+| `gardener-garden-system-400`      | 999999400 | `virtual-garden-gardener-resource-manager`, `gardener-admission-controller`                                     |
+| `gardener-garden-system-300`      | 999999300 | `virtual-garden-kube-controller-manager`, `vpa-admission-controller`, `etcd-druid`, `nginx-ingress-controller`  |
+| `gardener-garden-system-200`      | 999999200 | `vpa-recommender`, `vpa-updater`, `hvpa-controller`,                                                            |
+| `gardener-garden-system-100`      | 999999100 | `kube-state-metrics`, `fluent-operator`, `fluent-bit`, `vali`                                                   |
 ## Seed Clusters
 
 ### `PriorityClass`es for Seed System Components

--- a/docs/development/priority-classes.md
+++ b/docs/development/priority-classes.md
@@ -31,14 +31,14 @@ When using the `gardener-operator` for managing the garden runtime and virtual c
 
 ### `PriorityClass`es for Seed System Components
 
-| Name                               | Priority  | Associated Components (Examples)                                                                                                                                                   |
-|------------------------------------|-----------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `gardener-system-critical`         | 999998950 | `gardenlet`, `gardener-resource-manager`, `istio-ingressgateway`, `istiod`                                                                                                         |
-| `gardener-system-900`              | 999998900 | Extensions, `reversed-vpn-auth-server`                                                                                                                                             |
-| `gardener-system-800`              | 999998800 | `dependency-watchdog-endpoint`, `dependency-watchdog-probe`, `etcd-druid`, `(auditlog-)mutator`, `vpa-admission-controller`                                                        |
-| `gardener-system-700`              | 999998700 | `auditlog-seed-controller`, `hvpa-controller`, `vpa-recommender`, `vpa-updater`                                                                                                    |
+| Name                               | Priority  | Associated Components (Examples)                                                                                                                                                                      |
+|------------------------------------|-----------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `gardener-system-critical`         | 999998950 | `gardenlet`, `gardener-resource-manager`, `istio-ingressgateway`, `istiod`                                                                                                                            |
+| `gardener-system-900`              | 999998900 | Extensions, `reversed-vpn-auth-server`                                                                                                                                                                |
+| `gardener-system-800`              | 999998800 | `dependency-watchdog-endpoint`, `dependency-watchdog-probe`, `etcd-druid`, `(auditlog-)mutator`, `vpa-admission-controller`                                                                           |
+| `gardener-system-700`              | 999998700 | `auditlog-seed-controller`, `hvpa-controller`, `vpa-recommender`, `vpa-updater`                                                                                                                       |
 | `gardener-system-600`              | 999998600 | `aggregate-alertmanager`, `alertmanager`, `fluent-operator`, `fluent-bit`, `plutono`, `kube-state-metrics`, `nginx-ingress-controller`, `nginx-k8s-backend`, `prometheus`, `vali`,  `seed-prometheus` |
-| `gardener-reserve-excess-capacity` | -5        | `reserve-excess-capacity` ([ref](https://github.com/gardener/gardener/pull/6135))                                                                                                  |
+| `gardener-reserve-excess-capacity` | -5        | `reserve-excess-capacity` ([ref](https://github.com/gardener/gardener/pull/6135))                                                                                                                     |
 
 ### `PriorityClass`es for Shoot Control Plane Components
 

--- a/docs/development/priority-classes.md
+++ b/docs/development/priority-classes.md
@@ -27,6 +27,7 @@ When using the `gardener-operator` for managing the garden runtime and virtual c
 | `gardener-garden-system-300`      | 999999300 | `virtual-garden-kube-controller-manager`, `vpa-admission-controller`, `etcd-druid`, `nginx-ingress-controller`  |
 | `gardener-garden-system-200`      | 999999200 | `vpa-recommender`, `vpa-updater`, `hvpa-controller`,                                                            |
 | `gardener-garden-system-100`      | 999999100 | `kube-state-metrics`, `fluent-operator`, `fluent-bit`, `vali`                                                   |
+
 ## Seed Clusters
 
 ### `PriorityClass`es for Seed System Components
@@ -48,7 +49,7 @@ When using the `gardener-operator` for managing the garden runtime and virtual c
 | `gardener-system-400` | 999998400 | `gardener-resource-manager`                                                                                                                                                            |
 | `gardener-system-300` | 999998300 | `cloud-controller-manager`, `cluster-autoscaler`, `csi-driver-controller`, `kube-controller-manager`, `kube-scheduler`, `machine-controller-manager`, `terraformer`, `vpn-seed-server` |
 | `gardener-system-200` | 999998200 | `csi-snapshot-controller`, `csi-snapshot-validation`, `cert-controller-manager`, `shoot-dns-service`, `vpa-admission-controller`, `vpa-recommender`, `vpa-updater`                     |
-| `gardener-system-100` | 999998100 | `alertmanager`, `plutono`, `kube-state-metrics`, `prometheus`, `vali`, `event-logger`                                                                       |
+| `gardener-system-100` | 999998100 | `alertmanager`, `plutono`, `kube-state-metrics`, `prometheus`, `vali`, `event-logger`                                                                                                  |
 
 ## Shoot Clusters
 

--- a/imagevector/images.yaml
+++ b/imagevector/images.yaml
@@ -406,7 +406,7 @@ images:
     name: fluent-bit-to-vali
   sourceRepository: github.com/gardener/logging
   repository: eu.gcr.io/gardener-project/gardener/fluent-bit-to-vali
-  tag: "v0.55.3"
+  tag: "v0.55.4"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:

--- a/imagevector/images.yaml
+++ b/imagevector/images.yaml
@@ -441,7 +441,7 @@ images:
 - name: vali-curator
   sourceRepository: github.com/gardener/logging
   repository: eu.gcr.io/gardener-project/gardener/vali-curator
-  tag: "v0.55.3"
+  tag: "v0.55.4"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:
@@ -496,7 +496,7 @@ images:
     name: telegraf-iptables
   sourceRepository: github.com/gardener/logging
   repository: eu.gcr.io/gardener-project/gardener/telegraf-iptables
-  tag: "v0.55.3"
+  tag: "v0.55.4"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:
@@ -516,7 +516,7 @@ images:
 - name: event-logger
   sourceRepository: github.com/gardener/logging
   repository: eu.gcr.io/gardener-project/gardener/event-logger
-  tag: "v0.55.3"
+  tag: "v0.55.4"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:
@@ -533,7 +533,7 @@ images:
 - name: tune2fs
   sourceRepository: github.com/gardener/logging
   repository: eu.gcr.io/gardener-project/gardener/tune2fs
-  tag: "v0.55.3"
+  tag: "v0.55.4"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:

--- a/pkg/component/logging/configs.go
+++ b/pkg/component/logging/configs.go
@@ -1,0 +1,51 @@
+// Copyright 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logging
+
+import (
+	"github.com/gardener/gardener/pkg/component"
+	"github.com/gardener/gardener/pkg/component/etcd"
+	"github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/original/components/containerd"
+	"github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/original/components/docker"
+	"github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/original/components/kubelet"
+	"github.com/gardener/gardener/pkg/component/hvpa"
+	"github.com/gardener/gardener/pkg/component/kubeapiserver"
+	"github.com/gardener/gardener/pkg/component/kubecontrollermanager"
+	"github.com/gardener/gardener/pkg/component/kubestatemetrics"
+	"github.com/gardener/gardener/pkg/component/logging/vali"
+	"github.com/gardener/gardener/pkg/component/nginxingress"
+	"github.com/gardener/gardener/pkg/component/resourcemanager"
+	"github.com/gardener/gardener/pkg/component/vpa"
+)
+
+// GardenCentralLoggingConfigurations is a list of central logging configuration for components running in the garden
+// cluster.
+var GardenCentralLoggingConfigurations = []component.CentralLoggingConfiguration{
+	// Ensure kubelet/container runtime logs get parsed and forwarded to vali
+	kubelet.CentralLoggingConfiguration,
+	docker.CentralLoggingConfiguration,
+	containerd.CentralLoggingConfiguration,
+	// garden system components
+	resourcemanager.CentralLoggingConfiguration,
+	nginxingress.CentralLoggingConfiguration,
+	hvpa.CentralLoggingConfiguration,
+	vpa.CentralLoggingConfiguration,
+	vali.CentralLoggingConfiguration,
+	kubestatemetrics.CentralLoggingConfiguration,
+	// virtual garden control plane components
+	etcd.CentralLoggingConfiguration,
+	kubeapiserver.CentralLoggingConfiguration,
+	kubecontrollermanager.CentralLoggingConfiguration,
+}

--- a/pkg/component/logging/fluentoperator/crds_test.go
+++ b/pkg/component/logging/fluentoperator/crds_test.go
@@ -33,7 +33,7 @@ import (
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 )
 
-var _ = Describe("#CRDs", func() {
+var _ = Describe("CRDs", func() {
 	var (
 		ctx         context.Context
 		c           client.Client

--- a/pkg/component/logging/fluentoperator/custom_resources.go
+++ b/pkg/component/logging/fluentoperator/custom_resources.go
@@ -18,47 +18,32 @@ import (
 	"context"
 
 	fluentbitv1alpha2 "github.com/fluent/fluent-operator/v2/apis/fluentbit/v1alpha2"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/component"
-	"github.com/gardener/gardener/pkg/component/logging/fluentoperator/customresources"
-	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/managedresources"
 )
 
 const (
 	// CustomResourcesManagedResourceName is the name of the managed resource which deploys the custom resources of the operator.
-	CustomResourcesManagedResourceName = OperatorManagedResourceName + "-custom-resources"
+	CustomResourcesManagedResourceName = "flb-custom-resources"
 )
 
 // CustomResourcesValues are the values for the custom resources.
 type CustomResourcesValues struct {
-	// FluentBit represents the fluent-bit values.
-	FluentBit FluentBit
-}
-
-// FluentBit holds the fluent-bit configurations
-type FluentBit struct {
-	// Image is the fluent-bit image.
-	Image string
-	// InitContainerImage is the fluent-bit init container image.
-	InitContainerImage string
-	// PriorityClass is the name of the priority class of the fluent-bit.
-	PriorityClass string
+	Prefix  string
+	Inputs  []*fluentbitv1alpha2.ClusterInput
+	Filters []*fluentbitv1alpha2.ClusterFilter
+	Parsers []*fluentbitv1alpha2.ClusterParser
+	Outputs []*fluentbitv1alpha2.ClusterOutput
 }
 
 type customResources struct {
-	client            client.Client
-	namespace         string
-	values            CustomResourcesValues
-	additionalInputs  []*fluentbitv1alpha2.ClusterInput
-	additionalFilters []*fluentbitv1alpha2.ClusterFilter
-	additionalParsers []*fluentbitv1alpha2.ClusterParser
+	client    client.Client
+	namespace string
+	values    CustomResourcesValues
 }
 
 // NewCustomResources creates a new instance of Fluent Operator Custom Resources.
@@ -66,120 +51,33 @@ func NewCustomResources(
 	client client.Client,
 	namespace string,
 	values CustomResourcesValues,
-	additionalInputs []*fluentbitv1alpha2.ClusterInput,
-	additionalFilters []*fluentbitv1alpha2.ClusterFilter,
-	additionalParsers []*fluentbitv1alpha2.ClusterParser,
 ) component.DeployWaiter {
 	return &customResources{
-		client:            client,
-		namespace:         namespace,
-		values:            values,
-		additionalInputs:  additionalInputs,
-		additionalFilters: additionalFilters,
-		additionalParsers: additionalParsers,
+		client:    client,
+		namespace: namespace,
+		values:    values,
 	}
 }
 
 func (c *customResources) Deploy(ctx context.Context) error {
 	var (
-		registry = managedresources.NewRegistry(kubernetes.SeedScheme, kubernetes.SeedCodec, kubernetes.SeedSerializer)
-
-		configMap = &corev1.ConfigMap{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      v1beta1constants.DaemonSetNameFluentBit + "-lua-config",
-				Namespace: c.namespace,
-			},
-			Data: map[string]string{
-				"modify_severity.lua": `
-function cb_modify(tag, timestamp, record)
-  local unified_severity = cb_modify_unify_severity(record)
-
-  if not unified_severity then
-    return 0, 0, 0
-  end
-
-  return 1, timestamp, record
-end
-
-function cb_modify_unify_severity(record)
-  local modified = false
-  local severity = record["severity"]
-  if severity == nil or severity == "" then
-	return modified
-  end
-
-  severity = trim(severity):upper()
-
-  if severity == "I" or severity == "INF" or severity == "INFO" then
-    record["severity"] = "INFO"
-    modified = true
-  elseif severity == "W" or severity == "WRN" or severity == "WARN" or severity == "WARNING" then
-    record["severity"] = "WARN"
-    modified = true
-  elseif severity == "E" or severity == "ERR" or severity == "ERROR" or severity == "EROR" then
-    record["severity"] = "ERR"
-    modified = true
-  elseif severity == "D" or severity == "DBG" or severity == "DEBUG" then
-    record["severity"] = "DBG"
-    modified = true
-  elseif severity == "N" or severity == "NOTICE" then
-    record["severity"] = "NOTICE"
-    modified = true
-  elseif severity == "F" or severity == "FATAL" then
-    record["severity"] = "FATAL"
-    modified = true
-  end
-
-  return modified
-end
-
-function trim(s)
-  return (s:gsub("^%s*(.-)%s*$", "%1"))
-end`,
-				"add_tag_to_record.lua": `
-function add_tag_to_record(tag, timestamp, record)
-  record["tag"] = tag
-  return 1, timestamp, record
-end`,
-			},
-		}
+		registry  = managedresources.NewRegistry(kubernetes.SeedScheme, kubernetes.SeedCodec, kubernetes.SeedSerializer)
+		resources []client.Object
 	)
 
-	utilruntime.Must(kubernetesutils.MakeUnique(configMap))
-
-	resources := []client.Object{configMap}
-
-	fluentBit := customresources.GetFluentBit(getFluentBitLabels(), v1beta1constants.DaemonSetNameFluentBit, c.namespace, c.values.FluentBit.Image, c.values.FluentBit.InitContainerImage, c.values.FluentBit.PriorityClass)
-	resources = append(resources, fluentBit)
-
-	clusterFluentBitConfig := customresources.GetClusterFluentBitConfig(v1beta1constants.DaemonSetNameFluentBit, getCustomResourcesLabels())
-	resources = append(resources, clusterFluentBitConfig)
-
-	for _, clusterInput := range customresources.GetClusterInputs(getCustomResourcesLabels()) {
+	for _, clusterInput := range c.values.Inputs {
 		resources = append(resources, clusterInput)
 	}
 
-	for _, clusterFilter := range customresources.GetClusterFilters(configMap.Name, getCustomResourcesLabels()) {
+	for _, clusterFilter := range c.values.Filters {
 		resources = append(resources, clusterFilter)
 	}
 
-	for _, clusterParser := range customresources.GetClusterParsers(getCustomResourcesLabels()) {
+	for _, clusterParser := range c.values.Parsers {
 		resources = append(resources, clusterParser)
 	}
 
-	for _, clusterOutput := range customresources.GetClusterOutputs(getCustomResourcesLabels()) {
-		resources = append(resources, clusterOutput)
-	}
-
-	for _, clusterInput := range c.additionalInputs {
-		resources = append(resources, clusterInput)
-	}
-
-	for _, clusterFilter := range c.additionalFilters {
-		resources = append(resources, clusterFilter)
-	}
-
-	for _, clusterParser := range c.additionalParsers {
+	for _, clusterParser := range c.values.Outputs {
 		resources = append(resources, clusterParser)
 	}
 
@@ -188,25 +86,29 @@ end`,
 		return err
 	}
 
-	return managedresources.CreateForSeed(ctx, c.client, c.namespace, CustomResourcesManagedResourceName, false, serializedResources)
+	return managedresources.CreateForSeed(ctx, c.client, c.namespace, c.getManagedResourceName(), false, serializedResources)
 }
 
 func (c *customResources) Destroy(ctx context.Context) error {
-	return managedresources.DeleteForSeed(ctx, c.client, c.namespace, CustomResourcesManagedResourceName)
+	return managedresources.DeleteForSeed(ctx, c.client, c.namespace, c.getManagedResourceName())
 }
 
 func (c *customResources) Wait(ctx context.Context) error {
 	timeoutCtx, cancel := context.WithTimeout(ctx, timeoutWaitForManagedResources)
 	defer cancel()
 
-	return managedresources.WaitUntilHealthy(timeoutCtx, c.client, c.namespace, CustomResourcesManagedResourceName)
+	return managedresources.WaitUntilHealthy(timeoutCtx, c.client, c.namespace, c.getManagedResourceName())
 }
 
 func (c *customResources) WaitCleanup(ctx context.Context) error {
 	timeoutCtx, cancel := context.WithTimeout(ctx, timeoutWaitForManagedResources)
 	defer cancel()
 
-	return managedresources.WaitUntilDeleted(timeoutCtx, c.client, c.namespace, CustomResourcesManagedResourceName)
+	return managedresources.WaitUntilDeleted(timeoutCtx, c.client, c.namespace, c.getManagedResourceName())
+}
+
+func (c *customResources) getManagedResourceName() string {
+	return c.values.Prefix + "-" + CustomResourcesManagedResourceName
 }
 
 func getCustomResourcesLabels() map[string]string {

--- a/pkg/component/logging/fluentoperator/custom_resources.go
+++ b/pkg/component/logging/fluentoperator/custom_resources.go
@@ -28,12 +28,12 @@ import (
 
 const (
 	// CustomResourcesManagedResourceName is the name of the managed resource which deploys the custom resources of the operator.
-	CustomResourcesManagedResourceName = "flb-custom-resources"
+	CustomResourcesManagedResourceName = OperatorManagedResourceName + "-custom-resources"
 )
 
 // CustomResourcesValues are the values for the custom resources.
 type CustomResourcesValues struct {
-	Prefix  string
+	Suffix  string
 	Inputs  []*fluentbitv1alpha2.ClusterInput
 	Filters []*fluentbitv1alpha2.ClusterFilter
 	Parsers []*fluentbitv1alpha2.ClusterParser
@@ -108,7 +108,10 @@ func (c *customResources) WaitCleanup(ctx context.Context) error {
 }
 
 func (c *customResources) getManagedResourceName() string {
-	return c.values.Prefix + "-" + CustomResourcesManagedResourceName
+	if len(c.values.Suffix) > 0 {
+		return CustomResourcesManagedResourceName + "-" + c.values.Suffix
+	}
+	return CustomResourcesManagedResourceName
 }
 
 func getCustomResourcesLabels() map[string]string {

--- a/pkg/component/logging/fluentoperator/custom_resources_test.go
+++ b/pkg/component/logging/fluentoperator/custom_resources_test.go
@@ -44,13 +44,13 @@ import (
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 )
 
-var _ = Describe("Fluent Operator Custom Resources", func() {
+var _ = Describe("Custom Resources", func() {
 	var (
 		ctx = context.TODO()
 
 		namespace = "some-namespace"
 		values    = CustomResourcesValues{
-			Suffix: "garden",
+			Suffix: "-garden",
 			Inputs: []*fluentbitv1alpha2.ClusterInput{
 				{
 					ObjectMeta: metav1.ObjectMeta{
@@ -128,7 +128,7 @@ var _ = Describe("Fluent Operator Custom Resources", func() {
 			Outputs: []*fluentbitv1alpha2.ClusterOutput{
 				{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:   "journald",
+						Name:   "journald2",
 						Labels: map[string]string{v1beta1constants.LabelKeyCustomLoggingResource: v1beta1constants.LabelValueCustomLoggingResource},
 					},
 					Spec: fluentbitv1alpha2.OutputSpec{
@@ -203,12 +203,22 @@ var _ = Describe("Fluent Operator Custom Resources", func() {
 			}))
 			Expect(c.Get(ctx, client.ObjectKeyFromObject(customResourcesManagedResourceSecret), customResourcesManagedResourceSecret)).To(Succeed())
 			Expect(customResourcesManagedResourceSecret.Type).To(Equal(corev1.SecretTypeOpaque))
-			Expect(customResourcesManagedResourceSecret.Data).To(HaveLen(5))
+			Expect(customResourcesManagedResourceSecret.Data).To(HaveLen(14))
+			Expect(customResourcesManagedResourceSecret.Data).To(HaveKey("clusterfluentbitconfig____fluent-bit-config.yaml"))
+			Expect(customResourcesManagedResourceSecret.Data).To(HaveKey("clusterfilter____01-docker.yaml"))
+			Expect(customResourcesManagedResourceSecret.Data).To(HaveKey("clusterfilter____02-containerd.yaml"))
+			Expect(customResourcesManagedResourceSecret.Data).To(HaveKey("clusterfilter____03-add-tag-to-record.yaml"))
+			Expect(customResourcesManagedResourceSecret.Data).To(HaveKey("clusterfilter____zz-modify-severity.yaml"))
+			Expect(customResourcesManagedResourceSecret.Data).To(HaveKey("clusterparser____docker-parser.yaml"))
+			Expect(customResourcesManagedResourceSecret.Data).To(HaveKey("clusterparser____containerd-parser.yaml"))
+			Expect(customResourcesManagedResourceSecret.Data).To(HaveKey("clusterinput____tail-kubernetes.yaml"))
+			Expect(customResourcesManagedResourceSecret.Data).To(HaveKey("clusteroutput____journald.yaml"))
+
 			Expect(customResourcesManagedResourceSecret.Data).To(HaveKey("clusterinput____journald-kubelet.yaml"))
 			Expect(customResourcesManagedResourceSecret.Data).To(HaveKey("clusterinput____journald-kubelet-monitor.yaml"))
 			Expect(customResourcesManagedResourceSecret.Data).To(HaveKey("clusterfilter____gardener-extension.yaml"))
 			Expect(customResourcesManagedResourceSecret.Data).To(HaveKey("clusterparser____extensions-parser.yaml"))
-			Expect(customResourcesManagedResourceSecret.Data).To(HaveKey("clusteroutput____journald.yaml"))
+			Expect(customResourcesManagedResourceSecret.Data).To(HaveKey("clusteroutput____journald2.yaml"))
 		})
 	})
 

--- a/pkg/component/logging/fluentoperator/custom_resources_test.go
+++ b/pkg/component/logging/fluentoperator/custom_resources_test.go
@@ -50,7 +50,7 @@ var _ = Describe("Fluent Operator Custom Resources", func() {
 
 		namespace = "some-namespace"
 		values    = CustomResourcesValues{
-			Prefix: "seed",
+			Suffix: "garden",
 			Inputs: []*fluentbitv1alpha2.ClusterInput{
 				{
 					ObjectMeta: metav1.ObjectMeta{
@@ -149,7 +149,7 @@ var _ = Describe("Fluent Operator Custom Resources", func() {
 		c         client.Client
 		component component.DeployWaiter
 
-		customResourcesManagedResourceName   = "seed-flb-custom-resources"
+		customResourcesManagedResourceName   = "fluent-operator-custom-resources-garden"
 		customResourcesManagedResource       *resourcesv1alpha1.ManagedResource
 		customResourcesManagedResourceSecret *corev1.Secret
 	)

--- a/pkg/component/logging/fluentoperator/customresources/cluster_outputs.go
+++ b/pkg/component/logging/fluentoperator/customresources/cluster_outputs.go
@@ -74,7 +74,7 @@ QueueName seed-journald
 func GetDynamicClusterOutput(labels map[string]string) *fluentbitv1alpha2.ClusterOutput {
 	return &fluentbitv1alpha2.ClusterOutput{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:   "dynamic-vali",
+			Name:   "gardener-vali",
 			Labels: labels,
 		},
 		Spec: fluentbitv1alpha2.OutputSpec{

--- a/pkg/component/logging/fluentoperator/customresources/cluster_outputs.go
+++ b/pkg/component/logging/fluentoperator/customresources/cluster_outputs.go
@@ -20,88 +20,102 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// GetClusterOutputs returns the ClusterOutputs used by the Fluent Operator.
-func GetClusterOutputs(labels map[string]string) []*fluentbitv1alpha2.ClusterOutput {
-	return []*fluentbitv1alpha2.ClusterOutput{
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:   "gardener-vali",
-				Labels: labels,
-			},
-			Spec: fluentbitv1alpha2.OutputSpec{
-				CustomPlugin: &custom.CustomPlugin{
-					Config: `Name gardenervali
-Match kubernetes.*
+const (
+	commonSettings = `LogLevel info
 Url http://logging.garden.svc:3100/vali/api/v1/push
-LogLevel info
 BatchWait 60s
 BatchSize 30720
-Labels {origin="seed"}
 LineFormat json
 SortByTimestamp true
 DropSingleKey false
 AutoKubernetesLabels false
-LabelSelector gardener.cloud/role:shoot
-RemoveKeys kubernetes,stream,time,tag,gardenuser,job
+HostnameKeyValue nodename ${NODE_NAME}
+MaxRetries 3
+Timeout 10s
+MinBackoff 30s
+Buffer true
+BufferType dque
+QueueSegmentSize 300
+QueueSync normal
+NumberOfBatchIDs 5
+`
+
+	staticDynamicCommonSettings = `RemoveKeys kubernetes,stream,time,tag,gardenuser,job
 LabelMapPath {"kubernetes": {"container_name":"container_name","container_id":"container_id","namespace_name":"namespace_name","pod_name":"pod_name"},"severity": "severity","job": "job"}
+FallbackToTagWhenMetadataIsMissing true
+TagKey tag
+DropLogEntryWithoutK8sMetadata true
+`
+)
+
+// GetDefaultClusterOutput returns the default ClusterOutput used by the Fluent Operator.
+func GetDefaultClusterOutput(labels map[string]string) *fluentbitv1alpha2.ClusterOutput {
+	return &fluentbitv1alpha2.ClusterOutput{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "journald",
+			Labels: labels,
+		},
+		Spec: fluentbitv1alpha2.OutputSpec{
+			CustomPlugin: &custom.CustomPlugin{
+				Config: `Name gardenervali
+Match journald.*
+Labels {origin="seed-journald"}
+RemoveKeys kubernetes,stream,hostname,unit
+LabelMapPath {"hostname":"host_name","unit":"systemd_component"}
+QueueDir /fluent-bit/buffers
+QueueName seed-journald
+` + commonSettings,
+			},
+		},
+	}
+}
+
+// GetDynamicClusterOutput returns the dynamic fluent-bit-to-vali output used by the Fluent Operator.
+func GetDynamicClusterOutput(labels map[string]string) *fluentbitv1alpha2.ClusterOutput {
+	return &fluentbitv1alpha2.ClusterOutput{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "dynamic-vali",
+			Labels: labels,
+		},
+		Spec: fluentbitv1alpha2.OutputSpec{
+			CustomPlugin: &custom.CustomPlugin{
+				Config: `Name gardenervali
+Match kubernetes.*
+Labels {origin="seed"}
+DropSingleKey false
+LabelSelector gardener.cloud/role:shoot
 DynamicHostPath {"kubernetes": {"namespace_name": "namespace"}}
 DynamicHostPrefix http://logging.
 DynamicHostSuffix .svc:3100/vali/api/v1/push
 DynamicHostRegex ^shoot-
-DynamicTenant user gardenuser user
-HostnameKeyValue nodename ${NODE_NAME}
-MaxRetries 3
-Timeout 10s
-MinBackoff 30s
-Buffer true
-BufferType dque
 QueueDir /fluent-bit/buffers/seed
-QueueSegmentSize 300
-QueueSync normal
-QueueName gardener-kubernetes-operator
-FallbackToTagWhenMetadataIsMissing true
-TagKey tag
-DropLogEntryWithoutK8sMetadata true
+QueueName seed-dynamic
 SendDeletedClustersLogsToDefaultClient true
 CleanExpiredClientsPeriod 1h
 ControllerSyncTimeout 120s
 PreservedLabels origin,namespace_name,pod_name
-NumberOfBatchIDs 5
-TenantID operator`,
-				},
+TenantID operator
+` + commonSettings + staticDynamicCommonSettings,
 			},
 		},
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:   "journald",
-				Labels: labels,
-			},
-			Spec: fluentbitv1alpha2.OutputSpec{
-				CustomPlugin: &custom.CustomPlugin{
-					Config: `Name gardenervali
-Match journald.*
-Url http://logging.garden.svc:3100/vali/api/v1/push
-LogLevel info
-BatchWait 60s
-BatchSize 30720
-Labels {origin="seed-journald"}
-LineFormat json
-SortByTimestamp true
-DropSingleKey false
-RemoveKeys kubernetes,stream,hostname,unit
-LabelMapPath {"hostname":"host_name","unit":"systemd_component"}
-HostnameKeyValue nodename ${NODE_NAME}
-MaxRetries 3
-Timeout 10s
-MinBackoff 30s
-Buffer true
-BufferType dque
-QueueDir /fluent-bit/buffers
-QueueSegmentSize 300
-QueueSync normal
-QueueName seed-journald
-NumberOfBatchIDs 5`,
-				},
+	}
+}
+
+// GetStaticClusterOutput returns the static fluent-bit-to-vali output used by the Fluent Operator.
+func GetStaticClusterOutput(labels map[string]string) *fluentbitv1alpha2.ClusterOutput {
+	return &fluentbitv1alpha2.ClusterOutput{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "static-vali",
+			Labels: labels,
+		},
+		Spec: fluentbitv1alpha2.OutputSpec{
+			CustomPlugin: &custom.CustomPlugin{
+				Config: `Name gardenervali
+Match kubernetes.*
+Labels {origin="garden"}
+QueueDir /fluent-bit/buffers/garden
+QueueName gardener-operator-static
+` + commonSettings + staticDynamicCommonSettings,
 			},
 		},
 	}

--- a/pkg/component/logging/fluentoperator/customresources/cluster_outputs_test.go
+++ b/pkg/component/logging/fluentoperator/customresources/cluster_outputs_test.go
@@ -84,7 +84,7 @@ NumberOfBatchIDs 5
 			Expect(fluentBitClusterOutputs).To(Equal(
 				&fluentbitv1alpha2.ClusterOutput{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:   "dynamic-vali",
+						Name:   "gardener-vali",
 						Labels: labels,
 					},
 					Spec: fluentbitv1alpha2.OutputSpec{

--- a/pkg/component/logging/fluentoperator/customresources/cluster_outputs_test.go
+++ b/pkg/component/logging/fluentoperator/customresources/cluster_outputs_test.go
@@ -25,95 +25,160 @@ import (
 )
 
 var _ = Describe("Logging", func() {
-	Describe("#GetClusterOutputs", func() {
+	Describe("#GetDefaultClusterOutputs", func() {
 		var (
 			labels = map[string]string{"some-key": "some-value"}
 		)
 
-		It("should return the expected ClusterOutput custom resources", func() {
-			fluentBitClusterOutputs := GetClusterOutputs(labels)
+		It("should return the expected DefaultClusterOutput custom resources", func() {
+			fluentBitClusterOutputs := GetDefaultClusterOutput(labels)
 
 			Expect(fluentBitClusterOutputs).To(Equal(
-				[]*fluentbitv1alpha2.ClusterOutput{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:   "gardener-vali",
-							Labels: labels,
-						},
-						Spec: fluentbitv1alpha2.OutputSpec{
-							CustomPlugin: &custom.CustomPlugin{
-								Config: `Name gardenervali
-Match kubernetes.*
-Url http://logging.garden.svc:3100/vali/api/v1/push
+				&fluentbitv1alpha2.ClusterOutput{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:   "journald",
+						Labels: labels,
+					},
+					Spec: fluentbitv1alpha2.OutputSpec{
+						CustomPlugin: &custom.CustomPlugin{
+							Config: `Name gardenervali
+Match journald.*
+Labels {origin="seed-journald"}
+RemoveKeys kubernetes,stream,hostname,unit
+LabelMapPath {"hostname":"host_name","unit":"systemd_component"}
+QueueDir /fluent-bit/buffers
+QueueName seed-journald
 LogLevel info
+Url http://logging.garden.svc:3100/vali/api/v1/push
 BatchWait 60s
 BatchSize 30720
-Labels {origin="seed"}
 LineFormat json
 SortByTimestamp true
 DropSingleKey false
 AutoKubernetesLabels false
+HostnameKeyValue nodename ${NODE_NAME}
+MaxRetries 3
+Timeout 10s
+MinBackoff 30s
+Buffer true
+BufferType dque
+QueueSegmentSize 300
+QueueSync normal
+NumberOfBatchIDs 5
+`,
+						},
+					},
+				},
+			))
+		})
+	})
+
+	Describe("#GetDynamicClusterOutput", func() {
+		var (
+			labels = map[string]string{"some-key": "some-value"}
+		)
+
+		It("should return the expected DynamicClusterOutput custom resources", func() {
+			fluentBitClusterOutputs := GetDynamicClusterOutput(labels)
+
+			Expect(fluentBitClusterOutputs).To(Equal(
+				&fluentbitv1alpha2.ClusterOutput{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:   "dynamic-vali",
+						Labels: labels,
+					},
+					Spec: fluentbitv1alpha2.OutputSpec{
+						CustomPlugin: &custom.CustomPlugin{
+							Config: `Name gardenervali
+Match kubernetes.*
+Labels {origin="seed"}
+DropSingleKey false
 LabelSelector gardener.cloud/role:shoot
-RemoveKeys kubernetes,stream,time,tag,gardenuser,job
-LabelMapPath {"kubernetes": {"container_name":"container_name","container_id":"container_id","namespace_name":"namespace_name","pod_name":"pod_name"},"severity": "severity","job": "job"}
 DynamicHostPath {"kubernetes": {"namespace_name": "namespace"}}
 DynamicHostPrefix http://logging.
 DynamicHostSuffix .svc:3100/vali/api/v1/push
 DynamicHostRegex ^shoot-
-DynamicTenant user gardenuser user
-HostnameKeyValue nodename ${NODE_NAME}
-MaxRetries 3
-Timeout 10s
-MinBackoff 30s
-Buffer true
-BufferType dque
 QueueDir /fluent-bit/buffers/seed
-QueueSegmentSize 300
-QueueSync normal
-QueueName gardener-kubernetes-operator
-FallbackToTagWhenMetadataIsMissing true
-TagKey tag
-DropLogEntryWithoutK8sMetadata true
+QueueName seed-dynamic
 SendDeletedClustersLogsToDefaultClient true
 CleanExpiredClientsPeriod 1h
 ControllerSyncTimeout 120s
 PreservedLabels origin,namespace_name,pod_name
-NumberOfBatchIDs 5
-TenantID operator`,
-							},
-						},
-					},
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:   "journald",
-							Labels: labels,
-						},
-						Spec: fluentbitv1alpha2.OutputSpec{
-							CustomPlugin: &custom.CustomPlugin{
-								Config: `Name gardenervali
-Match journald.*
-Url http://logging.garden.svc:3100/vali/api/v1/push
+TenantID operator
 LogLevel info
+Url http://logging.garden.svc:3100/vali/api/v1/push
 BatchWait 60s
 BatchSize 30720
-Labels {origin="seed-journald"}
 LineFormat json
 SortByTimestamp true
 DropSingleKey false
-RemoveKeys kubernetes,stream,hostname,unit
-LabelMapPath {"hostname":"host_name","unit":"systemd_component"}
+AutoKubernetesLabels false
 HostnameKeyValue nodename ${NODE_NAME}
 MaxRetries 3
 Timeout 10s
 MinBackoff 30s
 Buffer true
 BufferType dque
-QueueDir /fluent-bit/buffers
 QueueSegmentSize 300
 QueueSync normal
-QueueName seed-journald
-NumberOfBatchIDs 5`,
-							},
+NumberOfBatchIDs 5
+RemoveKeys kubernetes,stream,time,tag,gardenuser,job
+LabelMapPath {"kubernetes": {"container_name":"container_name","container_id":"container_id","namespace_name":"namespace_name","pod_name":"pod_name"},"severity": "severity","job": "job"}
+FallbackToTagWhenMetadataIsMissing true
+TagKey tag
+DropLogEntryWithoutK8sMetadata true
+`,
+						},
+					},
+				},
+			))
+		})
+	})
+
+	Describe("#GetStaticClusterOutput", func() {
+		var (
+			labels = map[string]string{"some-key": "some-value"}
+		)
+
+		It("should return the expected DynamicClusterOutput custom resources", func() {
+			fluentBitClusterOutputs := GetStaticClusterOutput(labels)
+
+			Expect(fluentBitClusterOutputs).To(Equal(
+				&fluentbitv1alpha2.ClusterOutput{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:   "static-vali",
+						Labels: labels,
+					},
+					Spec: fluentbitv1alpha2.OutputSpec{
+						CustomPlugin: &custom.CustomPlugin{
+							Config: `Name gardenervali
+Match kubernetes.*
+Labels {origin="garden"}
+QueueDir /fluent-bit/buffers/garden
+QueueName gardener-operator-static
+LogLevel info
+Url http://logging.garden.svc:3100/vali/api/v1/push
+BatchWait 60s
+BatchSize 30720
+LineFormat json
+SortByTimestamp true
+DropSingleKey false
+AutoKubernetesLabels false
+HostnameKeyValue nodename ${NODE_NAME}
+MaxRetries 3
+Timeout 10s
+MinBackoff 30s
+Buffer true
+BufferType dque
+QueueSegmentSize 300
+QueueSync normal
+NumberOfBatchIDs 5
+RemoveKeys kubernetes,stream,time,tag,gardenuser,job
+LabelMapPath {"kubernetes": {"container_name":"container_name","container_id":"container_id","namespace_name":"namespace_name","pod_name":"pod_name"},"severity": "severity","job": "job"}
+FallbackToTagWhenMetadataIsMissing true
+TagKey tag
+DropLogEntryWithoutK8sMetadata true
+`,
 						},
 					},
 				},

--- a/pkg/component/logging/fluentoperator/customresources/fluent_bit.go
+++ b/pkg/component/logging/fluentoperator/customresources/fluent_bit.go
@@ -37,7 +37,7 @@ func GetFluentBit(labels map[string]string, fluentBitName, namespace, image, ini
 
 	return &fluentbitv1alpha2.FluentBit{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("%v-%v", fluentBitName, utils.ComputeSHA256Hex([]byte(fmt.Sprintf("%v%v", labels, annotations)))[:6]),
+			Name:      fmt.Sprintf("%v-%v", fluentBitName, utils.ComputeSHA256Hex([]byte(fmt.Sprintf("%v%v", labels, annotations)))[:5]),
 			Namespace: namespace,
 			Labels:    labels,
 		},

--- a/pkg/component/logging/fluentoperator/customresources/fluent_bit_test.go
+++ b/pkg/component/logging/fluentoperator/customresources/fluent_bit_test.go
@@ -49,7 +49,7 @@ var _ = Describe("Logging", func() {
 			Expect(fluentBitCustomResource).To(Equal(
 				&fluentbitv1alpha2.FluentBit{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      fmt.Sprintf("%v-%v", name, utils.ComputeSHA256Hex([]byte(fmt.Sprintf("%v%v", labels, annotations)))[:6]),
+						Name:      fmt.Sprintf("%v-%v", name, utils.ComputeSHA256Hex([]byte(fmt.Sprintf("%v%v", labels, annotations)))[:5]),
 						Namespace: namespace,
 						Labels:    labels,
 					},

--- a/pkg/component/logging/fluentoperator/fluent_bit.go
+++ b/pkg/component/logging/fluentoperator/fluent_bit.go
@@ -1,0 +1,180 @@
+// Copyright 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fluentoperator
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	"github.com/gardener/gardener/pkg/component"
+	"github.com/gardener/gardener/pkg/component/logging/fluentoperator/customresources"
+	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
+	"github.com/gardener/gardener/pkg/utils/managedresources"
+)
+
+const (
+	// FluentBitManagedResourceName is the name of the managed resource which deploys the custom resources of the operator.
+	FluentBitManagedResourceName = "fluent-bit"
+)
+
+// FluentBitValues is the values for fluent-bit configurations
+type FluentBitValues struct {
+	// Image is the fluent-bit image.
+	Image string
+	// InitContainerImage is the fluent-bit init container image.
+	InitContainerImage string
+	// PriorityClass is the name of the priority class of the fluent-bit.
+	PriorityClass string
+}
+
+type fluentBit struct {
+	client    client.Client
+	namespace string
+	values    FluentBitValues
+}
+
+// NewFluentBit creates a new instance of Fluent-bit deployer.
+func NewFluentBit(
+	client client.Client,
+	namespace string,
+	values FluentBitValues,
+) component.DeployWaiter {
+	return &fluentBit{
+		client:    client,
+		namespace: namespace,
+		values:    values,
+	}
+}
+
+func (f *fluentBit) Deploy(ctx context.Context) error {
+	var (
+		registry = managedresources.NewRegistry(kubernetes.SeedScheme, kubernetes.SeedCodec, kubernetes.SeedSerializer)
+
+		configMap = &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      v1beta1constants.DaemonSetNameFluentBit + "-lua-config",
+				Namespace: f.namespace,
+			},
+			Data: map[string]string{
+				"modify_severity.lua": `
+function cb_modify(tag, timestamp, record)
+  local unified_severity = cb_modify_unify_severity(record)
+
+  if not unified_severity then
+    return 0, 0, 0
+  end
+
+  return 1, timestamp, record
+end
+
+function cb_modify_unify_severity(record)
+  local modified = false
+  local severity = record["severity"]
+  if severity == nil or severity == "" then
+	return modified
+  end
+
+  severity = trim(severity):upper()
+
+  if severity == "I" or severity == "INF" or severity == "INFO" then
+    record["severity"] = "INFO"
+    modified = true
+  elseif severity == "W" or severity == "WRN" or severity == "WARN" or severity == "WARNING" then
+    record["severity"] = "WARN"
+    modified = true
+  elseif severity == "E" or severity == "ERR" or severity == "ERROR" or severity == "EROR" then
+    record["severity"] = "ERR"
+    modified = true
+  elseif severity == "D" or severity == "DBG" or severity == "DEBUG" then
+    record["severity"] = "DBG"
+    modified = true
+  elseif severity == "N" or severity == "NOTICE" then
+    record["severity"] = "NOTICE"
+    modified = true
+  elseif severity == "F" or severity == "FATAL" then
+    record["severity"] = "FATAL"
+    modified = true
+  end
+
+  return modified
+end
+
+function trim(s)
+  return (s:gsub("^%s*(.-)%s*$", "%1"))
+end`,
+				"add_tag_to_record.lua": `
+function add_tag_to_record(tag, timestamp, record)
+  record["tag"] = tag
+  return 1, timestamp, record
+end`,
+			},
+		}
+	)
+
+	utilruntime.Must(kubernetesutils.MakeUnique(configMap))
+
+	resources := []client.Object{configMap}
+
+	fluentBit := customresources.GetFluentBit(getFluentBitLabels(), v1beta1constants.DaemonSetNameFluentBit, f.namespace, f.values.Image, f.values.InitContainerImage, f.values.PriorityClass)
+	resources = append(resources, fluentBit)
+
+	clusterFluentBitConfig := customresources.GetClusterFluentBitConfig(v1beta1constants.DaemonSetNameFluentBit, getCustomResourcesLabels())
+	resources = append(resources, clusterFluentBitConfig)
+
+	for _, clusterInput := range customresources.GetClusterInputs(getCustomResourcesLabels()) {
+		resources = append(resources, clusterInput)
+	}
+
+	for _, clusterFilter := range customresources.GetClusterFilters(configMap.Name, getCustomResourcesLabels()) {
+		resources = append(resources, clusterFilter)
+	}
+
+	for _, clusterParser := range customresources.GetClusterParsers(getCustomResourcesLabels()) {
+		resources = append(resources, clusterParser)
+	}
+
+	resources = append(resources, customresources.GetDefaultClusterOutput(getCustomResourcesLabels()))
+
+	serializedResources, err := registry.AddAllAndSerialize(resources...)
+	if err != nil {
+		return err
+	}
+
+	return managedresources.CreateForSeed(ctx, f.client, f.namespace, FluentBitManagedResourceName, false, serializedResources)
+}
+
+func (f *fluentBit) Destroy(ctx context.Context) error {
+	return managedresources.DeleteForSeed(ctx, f.client, f.namespace, FluentBitManagedResourceName)
+}
+
+func (f *fluentBit) Wait(ctx context.Context) error {
+	timeoutCtx, cancel := context.WithTimeout(ctx, timeoutWaitForManagedResources)
+	defer cancel()
+
+	return managedresources.WaitUntilHealthy(timeoutCtx, f.client, f.namespace, FluentBitManagedResourceName)
+}
+
+func (f *fluentBit) WaitCleanup(ctx context.Context) error {
+	timeoutCtx, cancel := context.WithTimeout(ctx, timeoutWaitForManagedResources)
+	defer cancel()
+
+	return managedresources.WaitUntilDeleted(timeoutCtx, f.client, f.namespace, FluentBitManagedResourceName)
+}

--- a/pkg/component/logging/fluentoperator/fluent_bit.go
+++ b/pkg/component/logging/fluentoperator/fluent_bit.go
@@ -124,20 +124,20 @@ end`,
 function add_tag_to_record(tag, timestamp, record)
   record["tag"] = tag
   return 1, timestamp, record
-end`,
+end
+`,
 			},
 		}
 	)
 
 	utilruntime.Must(kubernetesutils.MakeUnique(configMap))
 
-	resources := []client.Object{configMap}
-
-	fluentBit := customresources.GetFluentBit(getFluentBitLabels(), v1beta1constants.DaemonSetNameFluentBit, f.namespace, f.values.Image, f.values.InitContainerImage, f.values.PriorityClass)
-	resources = append(resources, fluentBit)
-
-	clusterFluentBitConfig := customresources.GetClusterFluentBitConfig(v1beta1constants.DaemonSetNameFluentBit, getCustomResourcesLabels())
-	resources = append(resources, clusterFluentBitConfig)
+	resources := []client.Object{
+		configMap,
+		customresources.GetFluentBit(getFluentBitLabels(), v1beta1constants.DaemonSetNameFluentBit, f.namespace, f.values.Image, f.values.InitContainerImage, f.values.PriorityClass),
+		customresources.GetClusterFluentBitConfig(v1beta1constants.DaemonSetNameFluentBit, getCustomResourcesLabels()),
+		customresources.GetDefaultClusterOutput(getCustomResourcesLabels()),
+	}
 
 	for _, clusterInput := range customresources.GetClusterInputs(getCustomResourcesLabels()) {
 		resources = append(resources, clusterInput)
@@ -150,8 +150,6 @@ end`,
 	for _, clusterParser := range customresources.GetClusterParsers(getCustomResourcesLabels()) {
 		resources = append(resources, clusterParser)
 	}
-
-	resources = append(resources, customresources.GetDefaultClusterOutput(getCustomResourcesLabels()))
 
 	serializedResources, err := registry.AddAllAndSerialize(resources...)
 	if err != nil {

--- a/pkg/component/logging/fluentoperator/fluent_bit_test.go
+++ b/pkg/component/logging/fluentoperator/fluent_bit_test.go
@@ -39,7 +39,7 @@ import (
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 )
 
-var _ = Describe("Fluent Operator Custom Resources", func() {
+var _ = Describe("Fluent Bit", func() {
 	var (
 		ctx = context.TODO()
 
@@ -111,7 +111,7 @@ var _ = Describe("Fluent Operator Custom Resources", func() {
 			Expect(customResourcesManagedResourceSecret.Type).To(Equal(corev1.SecretTypeOpaque))
 			Expect(customResourcesManagedResourceSecret.Data).To(HaveLen(11))
 			Expect(customResourcesManagedResourceSecret.Data).To(HaveKey(MatchRegexp("configmap__" + namespace + "__fluent-bit-lua-config-.*" + ".yaml")))
-			Expect(customResourcesManagedResourceSecret.Data).To(HaveKey("fluentbit__" + namespace + "__fluent-bit-8259c5.yaml"))
+			Expect(customResourcesManagedResourceSecret.Data).To(HaveKey("fluentbit__" + namespace + "__fluent-bit-8259c.yaml"))
 			Expect(customResourcesManagedResourceSecret.Data).To(HaveKey("clusterfluentbitconfig____fluent-bit-config.yaml"))
 			Expect(customResourcesManagedResourceSecret.Data).To(HaveKey("clusterinput____tail-kubernetes.yaml"))
 			Expect(customResourcesManagedResourceSecret.Data).To(HaveKey("clusterfilter____01-docker.yaml"))

--- a/pkg/component/logging/fluentoperator/fluent_bit_test.go
+++ b/pkg/component/logging/fluentoperator/fluent_bit_test.go
@@ -17,11 +17,6 @@ package fluentoperator_test
 import (
 	"context"
 
-	fluentbitv1alpha2 "github.com/fluent/fluent-operator/v2/apis/fluentbit/v1alpha2"
-	"github.com/fluent/fluent-operator/v2/apis/fluentbit/v1alpha2/plugins/custom"
-	fluentbitv1alpha2filter "github.com/fluent/fluent-operator/v2/apis/fluentbit/v1alpha2/plugins/filter"
-	fluentbitv1alpha2input "github.com/fluent/fluent-operator/v2/apis/fluentbit/v1alpha2/plugins/input"
-	fluentbitv1alpha2parser "github.com/fluent/fluent-operator/v2/apis/fluentbit/v1alpha2/plugins/parser"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
@@ -48,121 +43,32 @@ var _ = Describe("Fluent Operator Custom Resources", func() {
 	var (
 		ctx = context.TODO()
 
-		namespace = "some-namespace"
-		values    = CustomResourcesValues{
-			Prefix: "seed",
-			Inputs: []*fluentbitv1alpha2.ClusterInput{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:   "journald-kubelet",
-						Labels: map[string]string{v1beta1constants.LabelKeyCustomLoggingResource: v1beta1constants.LabelValueCustomLoggingResource},
-					},
-					Spec: fluentbitv1alpha2.InputSpec{
-						Systemd: &fluentbitv1alpha2input.Systemd{
-							Tag:           "journald.kubelet",
-							ReadFromTail:  "on",
-							SystemdFilter: []string{"_SYSTEMD_UNIT=kubelet.service"},
-						},
-					},
-				},
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:   "journald-kubelet-monitor",
-						Labels: map[string]string{v1beta1constants.LabelKeyCustomLoggingResource: v1beta1constants.LabelValueCustomLoggingResource},
-					},
-					Spec: fluentbitv1alpha2.InputSpec{
-						Systemd: &fluentbitv1alpha2input.Systemd{
-							Tag:           "journald.kubelet-monitor",
-							ReadFromTail:  "on",
-							SystemdFilter: []string{"_SYSTEMD_UNIT=kubelet-monitor.service"},
-						},
-					},
-				},
-			},
-			Filters: []*fluentbitv1alpha2.ClusterFilter{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:   "gardener-extension",
-						Labels: map[string]string{v1beta1constants.LabelKeyCustomLoggingResource: v1beta1constants.LabelValueCustomLoggingResource},
-					},
-					Spec: fluentbitv1alpha2.FilterSpec{
-						Match: "kubernetes.*gardener-extension*",
-						FilterItems: []fluentbitv1alpha2.FilterItem{
-							{
-								Parser: &fluentbitv1alpha2filter.Parser{
-									KeyName:     "log",
-									Parser:      "extensions-parser",
-									ReserveData: pointer.Bool(true),
-								},
-							},
-							{
-								Modify: &fluentbitv1alpha2filter.Modify{
-									Rules: []fluentbitv1alpha2filter.Rule{
-										{
-											Rename: map[string]string{
-												"level":  "severity",
-												"msg":    "log",
-												"logger": "source",
-											}},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-			Parsers: []*fluentbitv1alpha2.ClusterParser{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:   "extensions-parser",
-						Labels: map[string]string{v1beta1constants.LabelKeyCustomLoggingResource: v1beta1constants.LabelValueCustomLoggingResource},
-					},
-					Spec: fluentbitv1alpha2.ParserSpec{
-						JSON: &fluentbitv1alpha2parser.JSON{
-							TimeKey:    "ts",
-							TimeFormat: "%Y-%m-%dT%H:%M:%S",
-						},
-					},
-				},
-			},
-			Outputs: []*fluentbitv1alpha2.ClusterOutput{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:   "journald",
-						Labels: map[string]string{v1beta1constants.LabelKeyCustomLoggingResource: v1beta1constants.LabelValueCustomLoggingResource},
-					},
-					Spec: fluentbitv1alpha2.OutputSpec{
-						CustomPlugin: &custom.CustomPlugin{
-							Config: `Name gardenervali
-		Match journald.*
-		Labels {origin="seed-journald"}
-		RemoveKeys kubernetes,stream,hostname,unit
-		LabelMapPath {"hostname":"host_name","unit":"systemd_component"}
-		QueueDir /fluent-bit/buffers
-		QueueName seed-journald
-		`},
-					},
-				},
-			},
+		namespace         = "some-namespace"
+		image             = "some-image:some-tag"
+		priorityClassName = "some-priority-class"
+		values            = FluentBitValues{
+			Image:              image,
+			InitContainerImage: image,
+			PriorityClass:      priorityClassName,
 		}
 
 		c         client.Client
 		component component.DeployWaiter
 
-		customResourcesManagedResourceName   = "seed-flb-custom-resources"
+		customResourcesManagedResourceName   = "fluent-bit"
 		customResourcesManagedResource       *resourcesv1alpha1.ManagedResource
 		customResourcesManagedResourceSecret *corev1.Secret
 	)
 
 	BeforeEach(func() {
 		c = fakeclient.NewClientBuilder().WithScheme(kubernetes.SeedScheme).Build()
-		component = NewCustomResources(c, namespace, values)
+		component = NewFluentBit(c, namespace, values)
 	})
 
 	JustBeforeEach(func() {
 		customResourcesManagedResource = &resourcesv1alpha1.ManagedResource{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      customResourcesManagedResourceName,
+				Name:      "fluent-bit",
 				Namespace: namespace,
 			},
 		}
@@ -188,7 +94,7 @@ var _ = Describe("Fluent Operator Custom Resources", func() {
 					Kind:       "ManagedResource",
 				},
 				ObjectMeta: metav1.ObjectMeta{
-					Name:            customResourcesManagedResourceName,
+					Name:            "fluent-bit",
 					Namespace:       namespace,
 					Labels:          map[string]string{v1beta1constants.GardenRole: "seed-system-component"},
 					ResourceVersion: "1",
@@ -203,11 +109,17 @@ var _ = Describe("Fluent Operator Custom Resources", func() {
 			}))
 			Expect(c.Get(ctx, client.ObjectKeyFromObject(customResourcesManagedResourceSecret), customResourcesManagedResourceSecret)).To(Succeed())
 			Expect(customResourcesManagedResourceSecret.Type).To(Equal(corev1.SecretTypeOpaque))
-			Expect(customResourcesManagedResourceSecret.Data).To(HaveLen(5))
-			Expect(customResourcesManagedResourceSecret.Data).To(HaveKey("clusterinput____journald-kubelet.yaml"))
-			Expect(customResourcesManagedResourceSecret.Data).To(HaveKey("clusterinput____journald-kubelet-monitor.yaml"))
-			Expect(customResourcesManagedResourceSecret.Data).To(HaveKey("clusterfilter____gardener-extension.yaml"))
-			Expect(customResourcesManagedResourceSecret.Data).To(HaveKey("clusterparser____extensions-parser.yaml"))
+			Expect(customResourcesManagedResourceSecret.Data).To(HaveLen(11))
+			Expect(customResourcesManagedResourceSecret.Data).To(HaveKey(MatchRegexp("configmap__" + namespace + "__fluent-bit-lua-config-.*" + ".yaml")))
+			Expect(customResourcesManagedResourceSecret.Data).To(HaveKey("fluentbit__" + namespace + "__fluent-bit-8259c5.yaml"))
+			Expect(customResourcesManagedResourceSecret.Data).To(HaveKey("clusterfluentbitconfig____fluent-bit-config.yaml"))
+			Expect(customResourcesManagedResourceSecret.Data).To(HaveKey("clusterinput____tail-kubernetes.yaml"))
+			Expect(customResourcesManagedResourceSecret.Data).To(HaveKey("clusterfilter____01-docker.yaml"))
+			Expect(customResourcesManagedResourceSecret.Data).To(HaveKey("clusterfilter____02-containerd.yaml"))
+			Expect(customResourcesManagedResourceSecret.Data).To(HaveKey("clusterfilter____03-add-tag-to-record.yaml"))
+			Expect(customResourcesManagedResourceSecret.Data).To(HaveKey("clusterfilter____zz-modify-severity.yaml"))
+			Expect(customResourcesManagedResourceSecret.Data).To(HaveKey("clusterparser____docker-parser.yaml"))
+			Expect(customResourcesManagedResourceSecret.Data).To(HaveKey("clusterparser____containerd-parser.yaml"))
 			Expect(customResourcesManagedResourceSecret.Data).To(HaveKey("clusteroutput____journald.yaml"))
 		})
 	})

--- a/pkg/component/logging/fluentoperator/fluent_operator.go
+++ b/pkg/component/logging/fluentoperator/fluent_operator.go
@@ -219,7 +219,17 @@ func (f *fluentOperator) Deploy(ctx context.Context) error {
 									"--leader-elect=true",
 									"--disable-component-controllers=fluentd",
 								},
-								Env: f.computeEnv(),
+								Env: []corev1.EnvVar{
+									{
+										Name: "NAMESPACE",
+										ValueFrom: &corev1.EnvVarSource{
+											FieldRef: &corev1.ObjectFieldSelector{
+												APIVersion: "v1",
+												FieldPath:  "metadata.namespace",
+											},
+										},
+									},
+								},
 								Resources: corev1.ResourceRequirements{
 									Requests: corev1.ResourceList{
 										corev1.ResourceCPU:    resource.MustParse("20m"),
@@ -311,20 +321,6 @@ func (f *fluentOperator) WaitCleanup(ctx context.Context) error {
 	defer cancel()
 
 	return managedresources.WaitUntilDeleted(timeoutCtx, f.client, f.namespace, OperatorManagedResourceName)
-}
-
-func (f *fluentOperator) computeEnv() []corev1.EnvVar {
-	return []corev1.EnvVar{
-		{
-			Name: "NAMESPACE",
-			ValueFrom: &corev1.EnvVarSource{
-				FieldRef: &corev1.ObjectFieldSelector{
-					APIVersion: "v1",
-					FieldPath:  "metadata.namespace",
-				},
-			},
-		},
-	}
 }
 
 func getLabels() map[string]string {

--- a/pkg/component/logging/vali/vali.go
+++ b/pkg/component/logging/vali/vali.go
@@ -57,7 +57,8 @@ const (
 	// ServiceName is the name of the logging service.
 	ServiceName = "logging"
 
-	managedResourceNameRuntime = "vali"
+	// ManagedResourceNameRuntime is the name of the managed resource which deploys Vali statefulSet.
+	ManagedResourceNameRuntime = "vali"
 	managedResourceNameTarget  = "vali-target"
 
 	valiName                = "vali"
@@ -273,7 +274,7 @@ func (v *vali) Deploy(ctx context.Context) error {
 		return err
 	}
 
-	return managedresources.CreateForSeed(ctx, v.client, v.namespace, managedResourceNameRuntime, false, registry.SerializedObjects())
+	return managedresources.CreateForSeed(ctx, v.client, v.namespace, ManagedResourceNameRuntime, false, registry.SerializedObjects())
 }
 
 func (v *vali) Destroy(ctx context.Context) error {
@@ -281,7 +282,7 @@ func (v *vali) Destroy(ctx context.Context) error {
 		return err
 	}
 
-	if err := managedresources.DeleteForSeed(ctx, v.client, v.namespace, managedResourceNameRuntime); err != nil {
+	if err := managedresources.DeleteForSeed(ctx, v.client, v.namespace, ManagedResourceNameRuntime); err != nil {
 		return err
 	}
 
@@ -1010,7 +1011,7 @@ func getLabels() map[string]string {
 // current one.
 // Caution: If the passed storage capacity is less than the current one the existing PVC and its PV will be deleted.
 func (v *vali) resizeOrDeleteValiDataVolumeIfStorageNotTheSame(ctx context.Context) error {
-	managedResource := &resourcesv1alpha1.ManagedResource{ObjectMeta: metav1.ObjectMeta{Name: managedResourceNameRuntime, Namespace: v.namespace}}
+	managedResource := &resourcesv1alpha1.ManagedResource{ObjectMeta: metav1.ObjectMeta{Name: ManagedResourceNameRuntime, Namespace: v.namespace}}
 	addOrRemoveIgnoreAnnotationFromManagedResource := func(addIgnoreAnnotation bool) error {
 		// In order to not create the managed resource here first check if exists.
 		if err := v.client.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource); err != nil {

--- a/pkg/component/shared/fluent_bit.go
+++ b/pkg/component/shared/fluent_bit.go
@@ -17,29 +17,27 @@ package shared
 import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/gardener/gardener/imagevector"
 	"github.com/gardener/gardener/pkg/component"
 	"github.com/gardener/gardener/pkg/component/logging/fluentoperator"
-	"github.com/gardener/gardener/pkg/utils/images"
-	"github.com/gardener/gardener/pkg/utils/imagevector"
 )
 
 // NewFluentBit instantiates a new `Fluent-bit` component.
 func NewFluentBit(
 	c client.Client,
 	gardenNamespaceName string,
-	imageVector imagevector.ImageVector,
 	enabled bool,
 	priorityClassName string,
 ) (
 	deployer component.DeployWaiter,
 	err error,
 ) {
-	fluentBitImage, err := imageVector.FindImage(images.ImageNameFluentBit)
+	fluentBitImage, err := imagevector.ImageVector().FindImage(imagevector.ImageNameFluentBit)
 	if err != nil {
 		return nil, err
 	}
 
-	fluentBitInitImage, err := imageVector.FindImage(images.ImageNameFluentBitPluginInstaller)
+	fluentBitInitImage, err := imagevector.ImageVector().FindImage(imagevector.ImageNameFluentBitPluginInstaller)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/component/shared/fluent_bit.go
+++ b/pkg/component/shared/fluent_bit.go
@@ -15,36 +15,42 @@
 package shared
 
 import (
-	fluentbitv1alpha2 "github.com/fluent/fluent-operator/v2/apis/fluentbit/v1alpha2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/gardener/gardener/pkg/component"
 	"github.com/gardener/gardener/pkg/component/logging/fluentoperator"
+	"github.com/gardener/gardener/pkg/utils/images"
+	"github.com/gardener/gardener/pkg/utils/imagevector"
 )
 
-// NewFluentOperatorCustomResources instantiates a new `Fluent Operator Custom Resources` component.
-func NewFluentOperatorCustomResources(
+// NewFluentBit instantiates a new `Fluent-bit` component.
+func NewFluentBit(
 	c client.Client,
 	gardenNamespaceName string,
+	imageVector imagevector.ImageVector,
 	enabled bool,
-	prefix string,
-	inputs []*fluentbitv1alpha2.ClusterInput,
-	filters []*fluentbitv1alpha2.ClusterFilter,
-	parsers []*fluentbitv1alpha2.ClusterParser,
-	outputs []*fluentbitv1alpha2.ClusterOutput,
+	priorityClassName string,
 ) (
 	deployer component.DeployWaiter,
 	err error,
 ) {
-	deployer = fluentoperator.NewCustomResources(
+	fluentBitImage, err := imageVector.FindImage(images.ImageNameFluentBit)
+	if err != nil {
+		return nil, err
+	}
+
+	fluentBitInitImage, err := imageVector.FindImage(images.ImageNameFluentBitPluginInstaller)
+	if err != nil {
+		return nil, err
+	}
+
+	deployer = fluentoperator.NewFluentBit(
 		c,
 		gardenNamespaceName,
-		fluentoperator.CustomResourcesValues{
-			Prefix:  prefix,
-			Inputs:  inputs,
-			Filters: filters,
-			Parsers: parsers,
-			Outputs: outputs,
+		fluentoperator.FluentBitValues{
+			Image:              fluentBitImage.String(),
+			InitContainerImage: fluentBitInitImage.String(),
+			PriorityClass:      priorityClassName,
 		},
 	)
 

--- a/pkg/component/shared/fluent_operator_custom_resources.go
+++ b/pkg/component/shared/fluent_operator_custom_resources.go
@@ -27,7 +27,7 @@ func NewFluentOperatorCustomResources(
 	c client.Client,
 	gardenNamespaceName string,
 	enabled bool,
-	prefix string,
+	suffix string,
 	inputs []*fluentbitv1alpha2.ClusterInput,
 	filters []*fluentbitv1alpha2.ClusterFilter,
 	parsers []*fluentbitv1alpha2.ClusterParser,
@@ -40,7 +40,7 @@ func NewFluentOperatorCustomResources(
 		c,
 		gardenNamespaceName,
 		fluentoperator.CustomResourcesValues{
-			Prefix:  prefix,
+			Suffix:  suffix,
 			Inputs:  inputs,
 			Filters: filters,
 			Parsers: parsers,

--- a/pkg/gardenlet/controller/seed/seed/components.go
+++ b/pkg/gardenlet/controller/seed/seed/components.go
@@ -559,7 +559,7 @@ func getFluentOperatorCustomResources(
 		c,
 		namespace,
 		loggingEnabled,
-		"seed",
+		"",
 		inputs,
 		filters,
 		parsers,

--- a/pkg/gardenlet/controller/seed/seed/components.go
+++ b/pkg/gardenlet/controller/seed/seed/components.go
@@ -18,7 +18,6 @@ import (
 	"context"
 
 	"github.com/Masterminds/semver"
-	fluentbitv1alpha2 "github.com/fluent/fluent-operator/v2/apis/fluentbit/v1alpha2"
 	proberapi "github.com/gardener/dependency-watchdog/api/prober"
 	weederapi "github.com/gardener/dependency-watchdog/api/weeder"
 	hvpav1alpha1 "github.com/gardener/hvpa-controller/api/v1alpha1"
@@ -42,31 +41,22 @@ import (
 	"github.com/gardener/gardener/pkg/component/etcd"
 	"github.com/gardener/gardener/pkg/component/extensions"
 	"github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/downloader"
-	"github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/original/components/containerd"
-	"github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/original/components/docker"
-	"github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/original/components/kubelet"
-	"github.com/gardener/gardener/pkg/component/hvpa"
 	"github.com/gardener/gardener/pkg/component/kubeapiserver"
 	kubeapiserverconstants "github.com/gardener/gardener/pkg/component/kubeapiserver/constants"
-	"github.com/gardener/gardener/pkg/component/kubecontrollermanager"
 	"github.com/gardener/gardener/pkg/component/kubeproxy"
 	"github.com/gardener/gardener/pkg/component/kubernetesdashboard"
 	"github.com/gardener/gardener/pkg/component/kubescheduler"
-	"github.com/gardener/gardener/pkg/component/kubestatemetrics"
+	"github.com/gardener/gardener/pkg/component/logging"
 	"github.com/gardener/gardener/pkg/component/logging/eventlogger"
 	"github.com/gardener/gardener/pkg/component/logging/fluentoperator/customresources"
-	"github.com/gardener/gardener/pkg/component/logging/vali"
 	"github.com/gardener/gardener/pkg/component/machinecontrollermanager"
 	"github.com/gardener/gardener/pkg/component/metricsserver"
 	"github.com/gardener/gardener/pkg/component/monitoring"
-	"github.com/gardener/gardener/pkg/component/nginxingress"
 	"github.com/gardener/gardener/pkg/component/nodeexporter"
 	"github.com/gardener/gardener/pkg/component/nodeproblemdetector"
 	"github.com/gardener/gardener/pkg/component/plutono"
-	"github.com/gardener/gardener/pkg/component/resourcemanager"
 	"github.com/gardener/gardener/pkg/component/seedsystem"
 	"github.com/gardener/gardener/pkg/component/shared"
-	"github.com/gardener/gardener/pkg/component/vpa"
 	"github.com/gardener/gardener/pkg/component/vpnauthzserver"
 	"github.com/gardener/gardener/pkg/component/vpnseedserver"
 	"github.com/gardener/gardener/pkg/component/vpnshoot"
@@ -472,97 +462,45 @@ func getFluentOperatorCustomResources(
 	deployer component.DeployWaiter,
 	err error,
 ) {
-	var (
-		inputs  []*fluentbitv1alpha2.ClusterInput
-		filters []*fluentbitv1alpha2.ClusterFilter
-		parsers []*fluentbitv1alpha2.ClusterParser
-		outputs []*fluentbitv1alpha2.ClusterOutput
-	)
-
-	componentsFunctions := []component.CentralLoggingConfiguration{
-		// journald components
-		downloader.CentralLoggingConfiguration,
+	centralLoggingConfigurations := []component.CentralLoggingConfiguration{
 		// seed system components
 		extensions.CentralLoggingConfiguration,
 		dependencywatchdog.CentralLoggingConfiguration,
 		monitoring.CentralLoggingConfiguration,
+		plutono.CentralLoggingConfiguration,
 		// shoot control plane components
 		clusterautoscaler.CentralLoggingConfiguration,
 		vpnseedserver.CentralLoggingConfiguration,
+		kubescheduler.CentralLoggingConfiguration,
+		// shoot worker components
+		downloader.CentralLoggingConfiguration,
 		// shoot system components
 		nodeexporter.CentralLoggingConfiguration,
 		nodeproblemdetector.CentralLoggingConfiguration,
 		vpnshoot.CentralLoggingConfiguration,
+		coredns.CentralLoggingConfiguration,
+		kubeproxy.CentralLoggingConfiguration,
+		metricsserver.CentralLoggingConfiguration,
 		// shoot addon components
 		kubernetesdashboard.CentralLoggingConfiguration,
 	}
 
 	if !seedIsGarden {
-		componentsFunctions = append(componentsFunctions, []component.CentralLoggingConfiguration{
-			// journald components
-			kubelet.CentralLoggingConfiguration,
-			docker.CentralLoggingConfiguration,
-			containerd.CentralLoggingConfiguration,
-			// seed system components
-			resourcemanager.CentralLoggingConfiguration,
-			vali.CentralLoggingConfiguration,
-			// shoot control plane components
-			etcd.CentralLoggingConfiguration,
-			kubeapiserver.CentralLoggingConfiguration,
-			kubescheduler.CentralLoggingConfiguration,
-			kubecontrollermanager.CentralLoggingConfiguration,
-			kubestatemetrics.CentralLoggingConfiguration,
-			hvpa.CentralLoggingConfiguration,
-			vpa.CentralLoggingConfiguration,
-			// shoot system components
-			coredns.CentralLoggingConfiguration,
-			kubeproxy.CentralLoggingConfiguration,
-			metricsserver.CentralLoggingConfiguration,
-			// shoot addon components
-			nginxingress.CentralLoggingConfiguration,
-		}...)
+		centralLoggingConfigurations = append(centralLoggingConfigurations, logging.GardenCentralLoggingConfigurations...)
 	}
-
 	if isEventLoggingEnabled {
-		componentsFunctions = append(componentsFunctions, eventlogger.CentralLoggingConfiguration)
+		centralLoggingConfigurations = append(centralLoggingConfigurations, eventlogger.CentralLoggingConfiguration)
 	}
-
 	if isMCMDeploymentEnabled {
-		componentsFunctions = append(componentsFunctions, machinecontrollermanager.CentralLoggingConfiguration)
+		centralLoggingConfigurations = append(centralLoggingConfigurations, machinecontrollermanager.CentralLoggingConfiguration)
 	}
-
-	// Fetch component specific logging configurations
-	for _, componentFn := range componentsFunctions {
-		loggingConfig, err := componentFn()
-		if err != nil {
-			return nil, err
-		}
-
-		if len(loggingConfig.Inputs) > 0 {
-			inputs = append(inputs, loggingConfig.Inputs...)
-		}
-
-		if len(loggingConfig.Filters) > 0 {
-			filters = append(filters, loggingConfig.Filters...)
-		}
-
-		if len(loggingConfig.Parsers) > 0 {
-			parsers = append(parsers, loggingConfig.Parsers...)
-		}
-	}
-
-	outputs = []*fluentbitv1alpha2.ClusterOutput{customresources.GetDynamicClusterOutput(map[string]string{
-		v1beta1constants.LabelKeyCustomLoggingResource: v1beta1constants.LabelValueCustomLoggingResource,
-	})}
 
 	return shared.NewFluentOperatorCustomResources(
 		c,
 		namespace,
 		loggingEnabled,
 		"",
-		inputs,
-		filters,
-		parsers,
-		outputs,
+		centralLoggingConfigurations,
+		customresources.GetDynamicClusterOutput(map[string]string{v1beta1constants.LabelKeyCustomLoggingResource: v1beta1constants.LabelValueCustomLoggingResource}),
 	)
 }

--- a/pkg/gardenlet/controller/seed/seed/reconciler_delete.go
+++ b/pkg/gardenlet/controller/seed/seed/reconciler_delete.go
@@ -214,7 +214,7 @@ func (r *Reconciler) runDeleteSeedFlow(
 			IngressGateway: istioIngressGateway,
 		})
 		mcmCRDs                       = machinecontrollermanager.NewCRD(r.SeedClientSet.Client(), r.SeedClientSet.Applier())
-		fluentOperatorCustomResources = fluentoperator.NewCustomResources(seedClient, r.GardenNamespace, fluentoperator.CustomResourcesValues{Prefix: "seed"})
+		fluentOperatorCustomResources = fluentoperator.NewCustomResources(seedClient, r.GardenNamespace, fluentoperator.CustomResourcesValues{})
 	)
 
 	var (

--- a/pkg/gardenlet/controller/seed/seed/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/seed/seed/reconciler_reconcile.go
@@ -472,6 +472,18 @@ func (r *Reconciler) runReconcileSeedFlow(
 		return err
 	}
 
+	fluentOperatorCustomResources, err := getFluentOperatorCustomResources(
+		seedClient,
+		r.GardenNamespace,
+		loggingEnabled,
+		seedIsGarden,
+		gardenlethelper.IsEventLoggingEnabled(&r.Config),
+		features.DefaultFeatureGate.Enabled(features.MachineControllerManagerDeployment),
+	)
+	if err != nil {
+		return err
+	}
+
 	var (
 		g = flow.NewGraph("Seed cluster creation")
 		_ = g.Add(flow.Task{
@@ -530,6 +542,10 @@ func (r *Reconciler) runReconcileSeedFlow(
 					return nil
 				})
 			}).DoIf(seed.GetInfo().Annotations[v1beta1constants.GardenerOperation] == v1beta1constants.SeedOperationRenewGardenAccessSecrets),
+		})
+		deployFluentOperatorCustomResources = g.Add(flow.Task{
+			Name: "Deploying Fluent Operator custom resources",
+			Fn:   component.OpWait(fluentOperatorCustomResources).Deploy,
 		})
 	)
 
@@ -659,7 +675,7 @@ func (r *Reconciler) runReconcileSeedFlow(
 			_ = g.Add(flow.Task{
 				Name:         "Deploying Fluent Bit",
 				Fn:           component.OpWait(fluentBit).Deploy,
-				Dependencies: flow.NewTaskIDs(deployFluentOperator),
+				Dependencies: flow.NewTaskIDs(deployFluentOperator, deployFluentOperatorCustomResources),
 			})
 			_ = g.Add(flow.Task{
 				Name: "Deploying Plutono",
@@ -703,25 +719,6 @@ func (r *Reconciler) runReconcileSeedFlow(
 			})
 		)
 	}
-
-	fluentOperatorCustomResources, err := getFluentOperatorCustomResources(
-		seedClient,
-		r.GardenNamespace,
-		loggingEnabled,
-		seedIsGarden,
-		gardenlethelper.IsEventLoggingEnabled(&r.Config),
-		features.DefaultFeatureGate.Enabled(features.MachineControllerManagerDeployment),
-	)
-	if err != nil {
-		return err
-	}
-
-	var (
-		_ = g.Add(flow.Task{
-			Name: "Deploying Fluent Operator custom resources",
-			Fn:   fluentOperatorCustomResources.Deploy,
-		})
-	)
 
 	if err := g.Compile().Run(ctx, flow.Opts{Log: log}); err != nil {
 		return flow.Errors(err)

--- a/pkg/gardenlet/controller/seed/seed/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/seed/seed/reconciler_reconcile.go
@@ -306,10 +306,6 @@ func (r *Reconciler) runReconcileSeedFlow(
 
 	// Deploy the CRDs in the seed cluster.
 	log.Info("Deploying custom resource definitions")
-	if err := fluentoperator.NewCRDs(applier).Deploy(ctx); err != nil {
-		return err
-	}
-
 	if err := machinecontrollermanager.NewCRD(seedClient, applier).Deploy(ctx); err != nil {
 		return err
 	}
@@ -337,6 +333,10 @@ func (r *Reconciler) runReconcileSeedFlow(
 			if err := hvpa.NewCRD(applier).Deploy(ctx); err != nil {
 				return err
 			}
+		}
+
+		if err := fluentoperator.NewCRDs(applier).Deploy(ctx); err != nil {
+			return err
 		}
 
 		// When the seed is the garden cluster then gardener-resource-manager is reconciled by the gardener-operator.
@@ -581,11 +581,11 @@ func (r *Reconciler) runReconcileSeedFlow(
 			return err
 		}
 
-		fluentOperatorCustomResources, err := defaultFluentOperatorCustomResources(
+		fluentBit, err := sharedcomponent.NewFluentBit(
 			seedClient,
 			r.GardenNamespace,
 			loggingEnabled,
-			gardenlethelper.IsEventLoggingEnabled(&r.Config),
+			v1beta1constants.PriorityClassNameSeedSystem600,
 		)
 		if err != nil {
 			return err
@@ -652,14 +652,14 @@ func (r *Reconciler) runReconcileSeedFlow(
 				Name: "Deploying kube-state-metrics",
 				Fn:   kubeStateMetrics.Deploy,
 			})
-			reconcileFluentOperatorResources = g.Add(flow.Task{
-				Name: "Deploying Fluent Operator resources",
-				Fn:   component.OpWait(fluentOperatorCustomResources).Deploy,
+			deployFluentOperator = g.Add(flow.Task{
+				Name: "Deploying Fluent Operator",
+				Fn:   component.OpWait(fluentOperator).Deploy,
 			})
 			_ = g.Add(flow.Task{
-				Name:         "Deploying Fluent Operator",
-				Fn:           component.OpWait(fluentOperator).Deploy,
-				Dependencies: flow.NewTaskIDs(reconcileFluentOperatorResources),
+				Name:         "Deploying Fluent Bit",
+				Fn:           component.OpWait(fluentBit).Deploy,
+				Dependencies: flow.NewTaskIDs(deployFluentOperator),
 			})
 			_ = g.Add(flow.Task{
 				Name: "Deploying Plutono",
@@ -703,6 +703,25 @@ func (r *Reconciler) runReconcileSeedFlow(
 			})
 		)
 	}
+
+	fluentOperatorCustomResources, err := getFluentOperatorCustomResources(
+		seedClient,
+		r.GardenNamespace,
+		loggingEnabled,
+		seedIsGarden,
+		gardenlethelper.IsEventLoggingEnabled(&r.Config),
+		features.DefaultFeatureGate.Enabled(features.MachineControllerManagerDeployment),
+	)
+	if err != nil {
+		return err
+	}
+
+	var (
+		_ = g.Add(flow.Task{
+			Name: "Deploying Fluent Operator custom resources",
+			Fn:   fluentOperatorCustomResources.Deploy,
+		})
+	)
 
 	if err := g.Compile().Run(ctx, flow.Opts{Log: log}); err != nil {
 		return flow.Errors(err)

--- a/pkg/operation/care/garden_health.go
+++ b/pkg/operation/care/garden_health.go
@@ -38,6 +38,8 @@ import (
 	"github.com/gardener/gardener/pkg/component/istio"
 	"github.com/gardener/gardener/pkg/component/kubecontrollermanager"
 	"github.com/gardener/gardener/pkg/component/kubestatemetrics"
+	"github.com/gardener/gardener/pkg/component/logging/fluentoperator"
+	"github.com/gardener/gardener/pkg/component/logging/vali"
 	"github.com/gardener/gardener/pkg/component/resourcemanager"
 	"github.com/gardener/gardener/pkg/component/vpa"
 	"github.com/gardener/gardener/pkg/features"
@@ -51,8 +53,12 @@ const virtualGardenPrefix = "virtual-garden-"
 var (
 	requiredGardenRuntimeManagedResources = sets.New(
 		etcd.Druid,
-		kubestatemetrics.ManagedResourceName,
 		gardensystem.ManagedResourceName,
+		kubestatemetrics.ManagedResourceName,
+		fluentoperator.OperatorManagedResourceName,
+		fluentoperator.CustomResourcesManagedResourceName+"-garden",
+		fluentoperator.FluentBitManagedResourceName,
+		vali.ManagedResourceNameRuntime,
 	)
 
 	requiredVirtualGardenManagedResources = sets.New(

--- a/pkg/operation/care/garden_health_test.go
+++ b/pkg/operation/care/garden_health_test.go
@@ -36,6 +36,8 @@ import (
 	"github.com/gardener/gardener/pkg/component/hvpa"
 	"github.com/gardener/gardener/pkg/component/kubecontrollermanager"
 	"github.com/gardener/gardener/pkg/component/kubestatemetrics"
+	"github.com/gardener/gardener/pkg/component/logging/fluentoperator"
+	"github.com/gardener/gardener/pkg/component/logging/vali"
 	"github.com/gardener/gardener/pkg/component/resourcemanager"
 	"github.com/gardener/gardener/pkg/component/vpa"
 	"github.com/gardener/gardener/pkg/features"
@@ -47,11 +49,15 @@ import (
 var (
 	gardenManagedResources = []string{
 		etcd.Druid,
-		kubestatemetrics.ManagedResourceName,
 		gardensystem.ManagedResourceName,
 		hvpa.ManagedResourceName,
 		"istio-system",
 		"virtual-garden-istio",
+		kubestatemetrics.ManagedResourceName,
+		fluentoperator.OperatorManagedResourceName,
+		fluentoperator.CustomResourcesManagedResourceName + "-garden",
+		fluentoperator.FluentBitManagedResourceName,
+		vali.ManagedResourceNameRuntime,
 	}
 
 	virtualGardenManagedResources = []string{

--- a/pkg/operation/care/seed_health.go
+++ b/pkg/operation/care/seed_health.go
@@ -36,6 +36,7 @@ import (
 	"github.com/gardener/gardener/pkg/component/istio"
 	"github.com/gardener/gardener/pkg/component/kubestatemetrics"
 	"github.com/gardener/gardener/pkg/component/logging/fluentoperator"
+	"github.com/gardener/gardener/pkg/component/logging/vali"
 	"github.com/gardener/gardener/pkg/component/nginxingress"
 	"github.com/gardener/gardener/pkg/component/seedsystem"
 	"github.com/gardener/gardener/pkg/component/vpa"
@@ -124,7 +125,9 @@ func (h *SeedHealth) checkSeedSystemComponents(
 	}
 	if h.loggingEnabled {
 		managedResources = append(managedResources, fluentoperator.OperatorManagedResourceName)
-		managedResources = append(managedResources, fluentoperator.CustomResourcesManagedResourceName)
+		managedResources = append(managedResources, "seed-"+fluentoperator.CustomResourcesManagedResourceName)
+		managedResources = append(managedResources, fluentoperator.FluentBitManagedResourceName)
+		managedResources = append(managedResources, vali.ManagedResourceNameRuntime)
 	}
 
 	for _, name := range managedResources {

--- a/pkg/operation/care/seed_health.go
+++ b/pkg/operation/care/seed_health.go
@@ -125,7 +125,7 @@ func (h *SeedHealth) checkSeedSystemComponents(
 	}
 	if h.loggingEnabled {
 		managedResources = append(managedResources, fluentoperator.OperatorManagedResourceName)
-		managedResources = append(managedResources, "seed-"+fluentoperator.CustomResourcesManagedResourceName)
+		managedResources = append(managedResources, fluentoperator.CustomResourcesManagedResourceName)
 		managedResources = append(managedResources, fluentoperator.FluentBitManagedResourceName)
 		managedResources = append(managedResources, vali.ManagedResourceNameRuntime)
 	}

--- a/pkg/operation/care/seed_health_test.go
+++ b/pkg/operation/care/seed_health_test.go
@@ -65,7 +65,7 @@ var (
 		dependencywatchdog.ManagedResourceDependencyWatchdogProber,
 		hvpa.ManagedResourceName,
 		"istio-system",
-		"seed-" + fluentoperator.CustomResourcesManagedResourceName,
+		fluentoperator.CustomResourcesManagedResourceName,
 		fluentoperator.OperatorManagedResourceName,
 		fluentoperator.FluentBitManagedResourceName,
 		vali.ManagedResourceNameRuntime,

--- a/pkg/operation/care/seed_health_test.go
+++ b/pkg/operation/care/seed_health_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/gardener/gardener/pkg/component/hvpa"
 	"github.com/gardener/gardener/pkg/component/kubestatemetrics"
 	"github.com/gardener/gardener/pkg/component/logging/fluentoperator"
+	"github.com/gardener/gardener/pkg/component/logging/vali"
 	"github.com/gardener/gardener/pkg/component/nginxingress"
 	"github.com/gardener/gardener/pkg/component/seedsystem"
 	"github.com/gardener/gardener/pkg/component/vpa"
@@ -64,8 +65,10 @@ var (
 		dependencywatchdog.ManagedResourceDependencyWatchdogProber,
 		hvpa.ManagedResourceName,
 		"istio-system",
-		fluentoperator.CustomResourcesManagedResourceName,
+		"seed-" + fluentoperator.CustomResourcesManagedResourceName,
 		fluentoperator.OperatorManagedResourceName,
+		fluentoperator.FluentBitManagedResourceName,
+		vali.ManagedResourceNameRuntime,
 	}
 )
 

--- a/pkg/operator/controller/garden/garden/components.go
+++ b/pkg/operator/controller/garden/garden/components.go
@@ -199,7 +199,6 @@ func (r *Reconciler) instantiateComponents(
 	c.fluentOperator, err = sharedcomponent.NewFluentOperator(
 		r.RuntimeClientSet.Client(),
 		r.GardenNamespace,
-		r.ImageVector,
 		true,
 		v1beta1constants.PriorityClassNameGardenSystem100,
 	)
@@ -210,7 +209,6 @@ func (r *Reconciler) instantiateComponents(
 	c.fluentBit, err = sharedcomponent.NewFluentBit(
 		r.RuntimeClientSet.Client(),
 		r.GardenNamespace,
-		r.ImageVector,
 		true,
 		v1beta1constants.PriorityClassNameGardenSystem100,
 	)
@@ -226,7 +224,6 @@ func (r *Reconciler) instantiateComponents(
 	c.vali, err = sharedcomponent.NewVali(
 		r.RuntimeClientSet.Client(),
 		r.GardenNamespace,
-		r.ImageVector,
 		nil,
 		component.ClusterTypeSeed,
 		1,
@@ -808,14 +805,11 @@ func (r *Reconciler) newFluentCustomResources(ctx context.Context) (component.De
 	)
 
 	componentsFunctions := []component.CentralLoggingConfiguration{
-		// journald components
 		kubelet.CentralLoggingConfiguration,
 		docker.CentralLoggingConfiguration,
 		containerd.CentralLoggingConfiguration,
-		// seed system components
 		resourcemanager.CentralLoggingConfiguration,
 		vali.CentralLoggingConfiguration,
-		// shoot control plane components
 		etcd.CentralLoggingConfiguration,
 		kubeapiserver.CentralLoggingConfiguration,
 		kubescheduler.CentralLoggingConfiguration,
@@ -823,11 +817,9 @@ func (r *Reconciler) newFluentCustomResources(ctx context.Context) (component.De
 		kubestatemetrics.CentralLoggingConfiguration,
 		hvpa.CentralLoggingConfiguration,
 		vpa.CentralLoggingConfiguration,
-		// shoot system components
 		coredns.CentralLoggingConfiguration,
 		kubeproxy.CentralLoggingConfiguration,
 		metricsserver.CentralLoggingConfiguration,
-		// shoot addon components
 		nginxingress.CentralLoggingConfiguration,
 	}
 

--- a/pkg/operator/controller/garden/garden/components.go
+++ b/pkg/operator/controller/garden/garden/components.go
@@ -201,7 +201,7 @@ func (r *Reconciler) instantiateComponents(
 		r.GardenNamespace,
 		r.ImageVector,
 		true,
-		v1beta1constants.PriorityClassNameGardenSystem200,
+		v1beta1constants.PriorityClassNameGardenSystem100,
 	)
 	if err != nil {
 		return
@@ -212,7 +212,7 @@ func (r *Reconciler) instantiateComponents(
 		r.GardenNamespace,
 		r.ImageVector,
 		true,
-		v1beta1constants.PriorityClassNameGardenSystem200,
+		v1beta1constants.PriorityClassNameGardenSystem100,
 	)
 	if err != nil {
 		return
@@ -231,7 +231,7 @@ func (r *Reconciler) instantiateComponents(
 		component.ClusterTypeSeed,
 		1,
 		false,
-		v1beta1constants.PriorityClassNameGardenSystem200,
+		v1beta1constants.PriorityClassNameGardenSystem100,
 		nil,
 		"",
 		false,

--- a/pkg/operator/controller/garden/garden/reconciler_delete.go
+++ b/pkg/operator/controller/garden/garden/reconciler_delete.go
@@ -143,12 +143,36 @@ func (r *Reconciler) delete(
 			Fn:           component.OpDestroyAndWait(c.nginxIngressController).Destroy,
 			Dependencies: flow.NewTaskIDs(syncPointVirtualGardenControlPlaneDestroyed),
 		})
+		destroyFluentOperatorCustomResources = g.Add(flow.Task{
+			Name:         "Destroying fluent operator custom resources",
+			Fn:           component.OpDestroyAndWait(c.fluentOperatorCustomResources).Destroy,
+			Dependencies: flow.NewTaskIDs(syncPointVirtualGardenControlPlaneDestroyed),
+		})
+		destroyFluentBit = g.Add(flow.Task{
+			Name:         "Destroying Fluent-bit",
+			Fn:           component.OpDestroyAndWait(c.fluentBit).Destroy,
+			Dependencies: flow.NewTaskIDs(syncPointVirtualGardenControlPlaneDestroyed),
+		})
+		destroyFluentOperator = g.Add(flow.Task{
+			Name:         "Destroying Fluent Operator",
+			Fn:           component.OpDestroyAndWait(c.fluentOperator).Destroy,
+			Dependencies: flow.NewTaskIDs(destroyFluentOperatorCustomResources, destroyFluentBit),
+		})
+		destroyVali = g.Add(flow.Task{
+			Name:         "Destroying Vali",
+			Fn:           component.OpDestroyAndWait(c.vali).Destroy,
+			Dependencies: flow.NewTaskIDs(destroyFluentOperatorCustomResources),
+		})
 		syncPointCleanedUp = flow.NewTaskIDs(
 			destroyEtcdDruid,
 			destroyIstio,
 			destroyHVPAController,
 			destroyVerticalPodAutoscaler,
 			destroyNginxIngressController,
+			destroyFluentOperatorCustomResources,
+			destroyFluentBit,
+			destroyFluentOperator,
+			destroyVali,
 		)
 
 		destroySystemResources = g.Add(flow.Task{

--- a/pkg/operator/controller/garden/garden/reconciler_delete.go
+++ b/pkg/operator/controller/garden/garden/reconciler_delete.go
@@ -144,17 +144,17 @@ func (r *Reconciler) delete(
 			Dependencies: flow.NewTaskIDs(syncPointVirtualGardenControlPlaneDestroyed),
 		})
 		destroyFluentOperatorCustomResources = g.Add(flow.Task{
-			Name:         "Destroying fluent operator custom resources",
+			Name:         "Destroying fluent-operator custom resources",
 			Fn:           component.OpDestroyAndWait(c.fluentOperatorCustomResources).Destroy,
 			Dependencies: flow.NewTaskIDs(syncPointVirtualGardenControlPlaneDestroyed),
 		})
 		destroyFluentBit = g.Add(flow.Task{
-			Name:         "Destroying Fluent-bit",
+			Name:         "Destroying fluent-bit",
 			Fn:           component.OpDestroyAndWait(c.fluentBit).Destroy,
 			Dependencies: flow.NewTaskIDs(syncPointVirtualGardenControlPlaneDestroyed),
 		})
 		destroyFluentOperator = g.Add(flow.Task{
-			Name:         "Destroying Fluent Operator",
+			Name:         "Destroying fluent-operator",
 			Fn:           component.OpDestroyAndWait(c.fluentOperator).Destroy,
 			Dependencies: flow.NewTaskIDs(destroyFluentOperatorCustomResources, destroyFluentBit),
 		})
@@ -189,6 +189,11 @@ func (r *Reconciler) delete(
 			Name:         "Destroying and waiting for gardener-resource-manager to be deleted",
 			Fn:           component.OpWait(c.gardenerResourceManager).Destroy,
 			Dependencies: flow.NewTaskIDs(ensureNoManagedResourcesExistAnymore),
+		})
+		_ = g.Add(flow.Task{
+			Name:         "Destroying custom resource definition for fluent-operator",
+			Fn:           c.fluentCRD.Destroy,
+			Dependencies: flow.NewTaskIDs(destroyGardenerResourceManager),
 		})
 		_ = g.Add(flow.Task{
 			Name:         "Destroying custom resource definition for Istio",

--- a/pkg/operator/controller/garden/garden/reconciler_reconcile.go
+++ b/pkg/operator/controller/garden/garden/reconciler_reconcile.go
@@ -118,19 +118,19 @@ func (r *Reconciler) reconcile(
 			Fn:   c.etcdCRD.Deploy,
 		})
 		deployVPACRD = g.Add(flow.Task{
-			Name: "Deploying custom resource definition for VPA",
+			Name: "Deploying custom resource definitions for VPA",
 			Fn:   flow.TaskFn(c.vpaCRD.Deploy).DoIf(vpaEnabled(garden.Spec.RuntimeCluster.Settings)),
 		})
 		reconcileHVPACRD = g.Add(flow.Task{
-			Name: "Reconciling custom resource definition for HVPA",
+			Name: "Reconciling custom resource definitions for HVPA",
 			Fn:   c.hvpaCRD.Deploy,
 		})
 		deployIstioCRD = g.Add(flow.Task{
-			Name: "Deploying custom resource definition for Istio",
+			Name: "Deploying custom resource definitions for Istio",
 			Fn:   c.istioCRD.Deploy,
 		})
 		deployFluentCRD = g.Add(flow.Task{
-			Name: "Deploying custom resource definition for Fluent-bit Operator",
+			Name: "Deploying custom resource definitions for fluent-operator",
 			Fn:   c.fluentCRD.Deploy,
 		})
 		deployGardenerResourceManager = g.Add(flow.Task{
@@ -168,18 +168,18 @@ func (r *Reconciler) reconcile(
 			Fn:           component.OpWait(c.istio).Deploy,
 			Dependencies: flow.NewTaskIDs(deployGardenerResourceManager),
 		})
+		deployFluentOperator = g.Add(flow.Task{
+			Name:         "Deploying fluent-operator",
+			Fn:           c.fluentOperator.Deploy,
+			Dependencies: flow.NewTaskIDs(deployGardenerResourceManager, deployFluentCRD),
+		})
 		deployFluentOperatorCustomResources = g.Add(flow.Task{
-			Name:         "Deploying Fluent operator CustomResources",
+			Name:         "Deploying fluent-operator CustomResources",
 			Fn:           c.fluentOperatorCustomResources.Deploy,
 			Dependencies: flow.NewTaskIDs(deployGardenerResourceManager, deployFluentCRD),
 		})
-		deployFluentOperator = g.Add(flow.Task{
-			Name:         "Deploying Fluent Operator",
-			Fn:           component.OpWait(c.fluentOperator).Deploy,
-			Dependencies: flow.NewTaskIDs(deployGardenerResourceManager, deployFluentCRD),
-		})
 		deployFluentBit = g.Add(flow.Task{
-			Name:         "Deploying Fluent Bit",
+			Name:         "Deploying fluent-bit",
 			Fn:           c.fluentBit.Deploy,
 			Dependencies: flow.NewTaskIDs(deployGardenerResourceManager, deployFluentCRD),
 		})
@@ -192,13 +192,13 @@ func (r *Reconciler) reconcile(
 			generateGenericTokenKubeconfig,
 			deploySystemResources,
 			deployFluentCRD,
-			deployFluentOperatorCustomResources,
 			deployVPA,
 			deployHVPA,
 			deployEtcdDruid,
 			deployIstio,
 			deployNginxIngressController,
 			deployFluentOperator,
+			deployFluentOperatorCustomResources,
 			deployFluentBit,
 			deployVali,
 		)

--- a/skaffold-operator.yaml
+++ b/skaffold-operator.yaml
@@ -107,8 +107,12 @@ build:
         - pkg/component/kubernetesdashboard
         - pkg/component/kubescheduler
         - pkg/component/kubestatemetrics
+        - pkg/component/logging
         - pkg/component/logging/eventlogger
+        - pkg/component/logging/fluentoperator
+        - pkg/component/logging/fluentoperator/customresources
         - pkg/component/logging/kuberbacproxy
+        - pkg/component/logging/vali
         - pkg/component/machinecontrollermanager
         - pkg/component/metricsserver
         - pkg/component/monitoring
@@ -118,9 +122,6 @@ build:
         - pkg/component/nodelocaldns
         - pkg/component/nodelocaldns/constants
         - pkg/component/nodeproblemdetector
-        - pkg/component/logging/fluentoperator
-        - pkg/component/logging/fluentoperator/customresources
-        - pkg/component/logging/vali
         - pkg/component/plutono
         - pkg/component/resourcemanager
         - pkg/component/resourcemanager/constants

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -890,10 +890,11 @@ build:
         - pkg/component/kubernetesdashboard
         - pkg/component/kubescheduler
         - pkg/component/kubestatemetrics
+        - pkg/component/logging
         - pkg/component/logging/eventlogger
-        - pkg/component/logging/kuberbacproxy
         - pkg/component/logging/fluentoperator
         - pkg/component/logging/fluentoperator/customresources
+        - pkg/component/logging/kuberbacproxy
         - pkg/component/logging/vali
         - pkg/component/machinecontrollermanager
         - pkg/component/metricsserver

--- a/test/e2e/operator/garden/create_delete.go
+++ b/test/e2e/operator/garden/create_delete.go
@@ -95,6 +95,10 @@ var _ = Describe("Garden Tests", Label("Garden", "default"), func() {
 				healthyManagedResource("shoot-core-gardener-resource-manager"),
 				healthyManagedResource("shoot-core-gardeneraccess"),
 				healthyManagedResource("nginx-ingress"),
+				healthyManagedResource("fluent-bit"),
+				healthyManagedResource("fluent-operator"),
+				healthyManagedResource("garden-flb-custom-resources"),
+				healthyManagedResource("vali"),
 			))
 
 			g.Expect(runtimeClient.List(ctx, managedResourceList, client.InNamespace("istio-system"))).To(Succeed())

--- a/test/e2e/operator/garden/create_delete.go
+++ b/test/e2e/operator/garden/create_delete.go
@@ -97,7 +97,7 @@ var _ = Describe("Garden Tests", Label("Garden", "default"), func() {
 				healthyManagedResource("nginx-ingress"),
 				healthyManagedResource("fluent-bit"),
 				healthyManagedResource("fluent-operator"),
-				healthyManagedResource("garden-flb-custom-resources"),
+				healthyManagedResource("fluent-operator-custom-resources-garden"),
 				healthyManagedResource("vali"),
 			))
 

--- a/test/integration/operator/garden/care/care_test.go
+++ b/test/integration/operator/garden/care/care_test.go
@@ -35,6 +35,8 @@ import (
 	"github.com/gardener/gardener/pkg/component/hvpa"
 	"github.com/gardener/gardener/pkg/component/kubecontrollermanager"
 	"github.com/gardener/gardener/pkg/component/kubestatemetrics"
+	"github.com/gardener/gardener/pkg/component/logging/fluentoperator"
+	"github.com/gardener/gardener/pkg/component/logging/vali"
 	"github.com/gardener/gardener/pkg/component/resourcemanager"
 	"github.com/gardener/gardener/pkg/component/vpa"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
@@ -46,10 +48,14 @@ var _ = Describe("Garden Care controller tests", func() {
 			etcd.Druid,
 			gardensystem.ManagedResourceName,
 			hvpa.ManagedResourceName,
-			kubestatemetrics.ManagedResourceName,
 			vpa.ManagedResourceControlName,
 			"istio-system",
 			"virtual-garden-istio",
+			kubestatemetrics.ManagedResourceName,
+			fluentoperator.OperatorManagedResourceName,
+			fluentoperator.CustomResourcesManagedResourceName + "-garden",
+			fluentoperator.FluentBitManagedResourceName,
+			vali.ManagedResourceNameRuntime,
 		}
 
 		requiredVirtualGardenManagedResources = []string{

--- a/test/integration/operator/garden/garden/garden_test.go
+++ b/test/integration/operator/garden/garden/garden_test.go
@@ -394,32 +394,6 @@ var _ = Describe("Garden controller tests", func() {
 			g.Expect(testClient.Status().Patch(ctx, mr, patch)).To(Succeed(), "for "+mr.Name)
 		}).Should(Succeed())
 
-		// The garden controller waits for the fluent-operator ManagedResources to be healthy, but fluent-operator is not really running in
-		// this test, so let's fake this here.
-		By("Patch fluent-operator ManagedResources to report healthiness")
-		Eventually(func(g Gomega) {
-			mr := &resourcesv1alpha1.ManagedResource{ObjectMeta: metav1.ObjectMeta{Name: "fluent-operator", Namespace: testNamespace.Name}}
-			g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(mr), mr)).To(Succeed(), "for "+mr.Name)
-
-			patch := client.MergeFrom(mr.DeepCopy())
-			mr.Status.ObservedGeneration = mr.Generation
-			mr.Status.Conditions = []gardencorev1beta1.Condition{
-				{
-					Type:               "ResourcesHealthy",
-					Status:             "True",
-					LastUpdateTime:     metav1.NewTime(time.Unix(0, 0)),
-					LastTransitionTime: metav1.NewTime(time.Unix(0, 0)),
-				},
-				{
-					Type:               "ResourcesApplied",
-					Status:             "True",
-					LastUpdateTime:     metav1.NewTime(time.Unix(0, 0)),
-					LastTransitionTime: metav1.NewTime(time.Unix(0, 0)),
-				},
-			}
-			g.Expect(testClient.Status().Patch(ctx, mr, patch)).To(Succeed(), "for "+mr.Name)
-		}).Should(Succeed())
-
 		By("Verify that the virtual garden control plane components have been deployed")
 		Eventually(func(g Gomega) []druidv1alpha1.Etcd {
 			etcdList := &druidv1alpha1.EtcdList{}

--- a/test/integration/operator/garden/garden/garden_test.go
+++ b/test/integration/operator/garden/garden/garden_test.go
@@ -281,6 +281,18 @@ var _ = Describe("Garden controller tests", func() {
 			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("wasmplugins.extensions.istio.io")})}),
 			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("workloadentries.networking.istio.io")})}),
 			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("workloadgroups.networking.istio.io")})}),
+			// fluent-operator
+			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("clusterfilters.fluentbit.fluent.io")})}),
+			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("clusterfluentbitconfigs.fluentbit.fluent.io")})}),
+			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("clusterinputs.fluentbit.fluent.io")})}),
+			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("clusteroutputs.fluentbit.fluent.io")})}),
+			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("clusterparsers.fluentbit.fluent.io")})}),
+			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("fluentbits.fluentbit.fluent.io")})}),
+			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("collectors.fluentbit.fluent.io")})}),
+			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("fluentbitconfigs.fluentbit.fluent.io")})}),
+			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("filters.fluentbit.fluent.io")})}),
+			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("parsers.fluentbit.fluent.io")})}),
+			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("outputs.fluentbit.fluent.io")})}),
 		))
 
 		By("Verify that garden runtime CA secret was generated")
@@ -322,6 +334,10 @@ var _ = Describe("Garden controller tests", func() {
 			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("etcd-druid")})}),
 			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("kube-state-metrics")})}),
 			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("nginx-ingress")})}),
+			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("fluent-operator")})}),
+			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("fluent-bit")})}),
+			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("garden-flb-custom-resources")})}),
+			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("vali")})}),
 		))
 
 		// The garden controller waits for the Istio ManagedResources to be healthy, but Istio is not really running in
@@ -357,6 +373,32 @@ var _ = Describe("Garden controller tests", func() {
 		By("Patch nginx-ingress ManagedResources to report healthiness")
 		Eventually(func(g Gomega) {
 			mr := &resourcesv1alpha1.ManagedResource{ObjectMeta: metav1.ObjectMeta{Name: "nginx-ingress", Namespace: testNamespace.Name}}
+			g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(mr), mr)).To(Succeed(), "for "+mr.Name)
+
+			patch := client.MergeFrom(mr.DeepCopy())
+			mr.Status.ObservedGeneration = mr.Generation
+			mr.Status.Conditions = []gardencorev1beta1.Condition{
+				{
+					Type:               "ResourcesHealthy",
+					Status:             "True",
+					LastUpdateTime:     metav1.NewTime(time.Unix(0, 0)),
+					LastTransitionTime: metav1.NewTime(time.Unix(0, 0)),
+				},
+				{
+					Type:               "ResourcesApplied",
+					Status:             "True",
+					LastUpdateTime:     metav1.NewTime(time.Unix(0, 0)),
+					LastTransitionTime: metav1.NewTime(time.Unix(0, 0)),
+				},
+			}
+			g.Expect(testClient.Status().Patch(ctx, mr, patch)).To(Succeed(), "for "+mr.Name)
+		}).Should(Succeed())
+
+		// The garden controller waits for the fluent-operator ManagedResources to be healthy, but fluent-operator is not really running in
+		// this test, so let's fake this here.
+		By("Patch fluent-operator ManagedResources to report healthiness")
+		Eventually(func(g Gomega) {
+			mr := &resourcesv1alpha1.ManagedResource{ObjectMeta: metav1.ObjectMeta{Name: "fluent-operator", Namespace: testNamespace.Name}}
 			g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(mr), mr)).To(Succeed(), "for "+mr.Name)
 
 			patch := client.MergeFrom(mr.DeepCopy())
@@ -693,6 +735,18 @@ var _ = Describe("Garden controller tests", func() {
 			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("wasmplugins.extensions.istio.io")})}),
 			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("workloadentries.networking.istio.io")})}),
 			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("workloadgroups.networking.istio.io")})}),
+			// fluent-operator
+			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("clusterfilters.fluentbit.fluent.io")})}),
+			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("clusterfluentbitconfigs.fluentbit.fluent.io")})}),
+			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("clusterinputs.fluentbit.fluent.io")})}),
+			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("clusteroutputs.fluentbit.fluent.io")})}),
+			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("clusterparsers.fluentbit.fluent.io")})}),
+			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("fluentbits.fluentbit.fluent.io")})}),
+			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("collectors.fluentbit.fluent.io")})}),
+			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("fluentbitconfigs.fluentbit.fluent.io")})}),
+			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("filters.fluentbit.fluent.io")})}),
+			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("parsers.fluentbit.fluent.io")})}),
+			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("outputs.fluentbit.fluent.io")})}),
 		))
 
 		By("Verify that gardener-resource-manager has been deleted")

--- a/test/integration/operator/garden/garden/garden_test.go
+++ b/test/integration/operator/garden/garden/garden_test.go
@@ -336,7 +336,7 @@ var _ = Describe("Garden controller tests", func() {
 			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("nginx-ingress")})}),
 			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("fluent-operator")})}),
 			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("fluent-bit")})}),
-			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("garden-flb-custom-resources")})}),
+			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("fluent-operator-custom-resources-garden")})}),
 			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("vali")})}),
 		))
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area logging
/kind enhancement

**What this PR does / why we need it**:
With this PR the Gardener Operator deploys the Fluent-bit operator and the Vali.

**Which issue(s) this PR fixes**:
Part of #7016

**Special notes for your reviewer**:
To view the logs in Plutono the reviewer has to deploy Plutono:
```yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: plutono
  namespace: garden
spec:
  replicas: 1
  selector:
    matchLabels:
      component: plutono
  template:
    metadata:
      labels:
        component: plutono
        gardener.cloud/role: monitoring
        networking.gardener.cloud/to-dns: allowed
        networking.resources.gardener.cloud/to-logging-tcp-3100: allowed
        networking.resources.gardener.cloud/to-prometheus-web-tcp-9090: allowed
    spec:
      containers:
      - env:
        - name: PL_ALERTING_ENABLED
          value: "false"
        - name: PL_AUTH_ANONYMOUS_ENABLED
          value: "true"
        - name: PL_AUTH_BASIC_ENABLED
          value: "true"
        - name: PL_AUTH_DISABLE_LOGIN_FORM
          value: "false"
        - name: PL_AUTH_DISABLE_SIGNOUT_MENU
          value: "true"
        - name: PL_DATE_FORMATS_DEFAULT_TIMEZONE
          value: UTC
        - name: PL_SNAPSHOTS_EXTERNAL_ENABLED
          value: "false"
        - name: PL_USERS_VIEWERS_CAN_EDIT
          value: "true"
        image: eu.gcr.io/sap-se-gcr-k8s-public/ghcr_io/credativ/plutono@sha256:dc9eb0b56bf45ba04732e662d002bcd72aaaa96854bf7266123112a8b75c66f7
        imagePullPolicy: IfNotPresent
        name: plutono
        ports:
        - containerPort: 3000
          name: web
          protocol: TCP
        resources:
          limits:
            memory: 400Mi
          requests:
            cpu: 10m
            memory: 32Mi
        volumeMounts:
        - mountPath: /var/lib/plutono
          name: plutono-storage
        - mountPath: /etc/plutono/provisioning/datasources
          name: plutono-datasources
      tolerations:
      - effect: NoExecute
        key: node.kubernetes.io/not-ready
        operator: Exists
        tolerationSeconds: 60
      - effect: NoExecute
        key: node.kubernetes.io/unreachable
        operator: Exists
        tolerationSeconds: 60
      volumes:
      - emptyDir:
          sizeLimit: 100Mi
        name: plutono-storage
      - configMap:
          defaultMode: 420
          name: plutono-datasources
        name: plutono-datasources
```
```yaml
apiVersion: v1
data:
  datasources.yaml: |-
    # config file version
    apiVersion: 1

    # list of datasources to insert/update depending
    # whats available in the database
    datasources:
    - name: vali
      type: vali
      access: proxy
      url: http://logging.garden.svc:3100
      jsonData:
        maxLines: 5000
kind: ConfigMap
metadata:
  labels:
    component: plutono
  name: plutono-datasources
  namespace: garden
```
**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
`gardener-operator` now takes over management of `fluent-operator` and `vali`.
```
