### PR TITLE
Fix vali ingress backend definition

### DIFF
--- a/pkg/component/logging/vali/vali.go
+++ b/pkg/component/logging/vali/vali.go
@@ -61,7 +61,7 @@ const (
 	managedResourceNameTarget  = "vali-target"
 
 	valiName                = "vali"
-	valiServiceName         = "vali"
+	valiServiceName         = "logging"
 	valiMetricsPortName     = "metrics"
 	valiUserAndGroupId      = 10001
 	valiConfigMapVolumeName = "config"

--- a/pkg/component/logging/vali/vali_test.go
+++ b/pkg/component/logging/vali/vali_test.go
@@ -1154,7 +1154,7 @@ func getIngress() *networkingv1.Ingress {
 								{
 									Backend: networkingv1.IngressBackend{
 										Service: &networkingv1.IngressServiceBackend{
-											Name: "vali",
+											Name: "logging",
 											Port: networkingv1.ServiceBackendPort{
 												Number: 8080,
 											},


### PR DESCRIPTION

/area logging
/kind bug

This PR fixes the vali ingress definition on shoots. It shall target the logging service.

```bugfix operator
Now the vali ingress definition points to the shoot logging service.
```
