### PR TITLE
[release-v1.74] Automated cherry pick of #8252: Fix vali ingress backend definition

### DIFF
--- a/pkg/component/logging/vali/vali.go
+++ b/pkg/component/logging/vali/vali.go
@@ -56,8 +56,8 @@ const (
 	ManagedResourceControlName = "vali"
 
 	valiName                = "vali"
-	valiServiceName         = "vali"
 	valiPort                = 3100
+	valiServiceName         = "logging"
 	valiMetricsPortName     = "metrics"
 	valiUserAndGroupId      = 10001
 	valiConfigMapVolumeName = "config"

--- a/pkg/component/logging/vali/vali_test.go
+++ b/pkg/component/logging/vali/vali_test.go
@@ -1050,7 +1050,7 @@ func getIngress() *networkingv1.Ingress {
 								{
 									Backend: networkingv1.IngressBackend{
 										Service: &networkingv1.IngressServiceBackend{
-											Name: "vali",
+											Name: "logging",
 											Port: networkingv1.ServiceBackendPort{
 												Number: 8080,
 											},


### PR DESCRIPTION
/kind bug
/area logging

Cherry pick of #8252 on release-v1.74.

#8252: Fix vali ingress backend definition

**Release Notes:**
```bugfix operator
Now the vali ingress definition points to the shoot logging service.
```