### PR TITLE
Fix GRM secret leak

### DIFF
--- a/extensions/pkg/controller/controlplane/genericactuator/actuator_test.go
+++ b/extensions/pkg/controller/controlplane/genericactuator/actuator_test.go
@@ -50,7 +50,6 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
-	"github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	mockchartrenderer "github.com/gardener/gardener/pkg/chartrenderer/mock"
 	kubernetesmock "github.com/gardener/gardener/pkg/client/kubernetes/mock"
@@ -594,7 +593,7 @@ webhooks:
 				c.EXPECT().Delete(ctx, deletedMRForCPShootCRDsChart).Return(nil)
 				c.EXPECT().Delete(ctx, deletedMRSecretForCPShootCRDsChart).Return(nil)
 				c.EXPECT().Get(gomock.Any(), resourceKeyCPShootCRDsChart, gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})).Return(apierrors.NewNotFound(schema.GroupResource{}, deletedMRForCPShootCRDsChart.Name))
-				c.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&corev1.SecretList{}), client.InNamespace(resourceKeyCPShootCRDsChart.Namespace), client.MatchingLabels(map[string]string{v1alpha1.ReferencedBy: resourceKeyCPShootCRDsChart.Name}))
+				c.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&corev1.SecretList{}), client.InNamespace(resourceKeyCPShootCRDsChart.Namespace), client.MatchingLabels(map[string]string{resourcesv1alpha1.ReferencedBy: resourceKeyCPShootCRDsChart.Name}))
 
 			}
 
@@ -603,9 +602,9 @@ webhooks:
 			c.EXPECT().Delete(ctx, deletedMRSecretForCPShootChart).Return(nil)
 
 			c.EXPECT().Get(gomock.Any(), resourceKeyStorageClassesChart, gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})).Return(apierrors.NewNotFound(schema.GroupResource{}, deletedMRForStorageClassesChart.Name))
-			c.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&corev1.SecretList{}), client.InNamespace(resourceKeyStorageClassesChart.Namespace), client.MatchingLabels(map[string]string{v1alpha1.ReferencedBy: resourceKeyStorageClassesChart.Name}))
+			c.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&corev1.SecretList{}), client.InNamespace(resourceKeyStorageClassesChart.Namespace), client.MatchingLabels(map[string]string{resourcesv1alpha1.ReferencedBy: resourceKeyStorageClassesChart.Name}))
 			c.EXPECT().Get(gomock.Any(), resourceKeyCPShootChart, gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})).Return(apierrors.NewNotFound(schema.GroupResource{}, deletedMRForCPShootChart.Name))
-			c.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&corev1.SecretList{}), client.InNamespace(resourceKeyCPShootChart.Namespace), client.MatchingLabels(map[string]string{v1alpha1.ReferencedBy: resourceKeyCPShootChart.Name}))
+			c.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&corev1.SecretList{}), client.InNamespace(resourceKeyCPShootChart.Namespace), client.MatchingLabels(map[string]string{resourcesv1alpha1.ReferencedBy: resourceKeyCPShootChart.Name}))
 
 			// Create mock charts
 			var configChart chart.Interface
@@ -625,7 +624,7 @@ webhooks:
 				c.EXPECT().Delete(ctx, deletedMRForShootWebhooks).Return(nil)
 				c.EXPECT().Delete(ctx, deletedMRSecretForShootWebhooks).Return(nil)
 				c.EXPECT().Get(gomock.Any(), resourceKeyShootWebhooks, gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})).Return(apierrors.NewNotFound(schema.GroupResource{}, deletedMRForShootWebhooks.Name))
-				c.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&corev1.SecretList{}), client.InNamespace(resourceKeyShootWebhooks.Namespace), client.MatchingLabels(map[string]string{v1alpha1.ReferencedBy: resourceKeyShootWebhooks.Name}))
+				c.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&corev1.SecretList{}), client.InNamespace(resourceKeyShootWebhooks.Namespace), client.MatchingLabels(map[string]string{resourcesv1alpha1.ReferencedBy: resourceKeyShootWebhooks.Name}))
 
 			}
 

--- a/pkg/apis/resources/v1alpha1/types.go
+++ b/pkg/apis/resources/v1alpha1/types.go
@@ -57,6 +57,10 @@ const (
 	// It is set by the ManagedResource controller depending on its configuration. By default it is set to "gardener".
 	ManagedBy = "resources.gardener.cloud/managed-by"
 
+	// ReferencedBy is a constant for a label on a secret that points to the name of the ManagedResource that the given secret is being referenced by
+	// It is set by the secret reconciler
+	ReferencedBy = "resources.gardener.cloud/referenced-by"
+
 	// GardenerManager is a constant for the default value of the 'ManagedBy' label.
 	GardenerManager = "gardener"
 

--- a/pkg/component/etcd/bootstrap_test.go
+++ b/pkg/component/etcd/bootstrap_test.go
@@ -34,6 +34,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	"github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	"github.com/gardener/gardener/pkg/component"
 	. "github.com/gardener/gardener/pkg/component/etcd"
@@ -889,6 +890,7 @@ status:
 
 			It("should successfully delete all resources", func() {
 				c.EXPECT().Get(gomock.Any(), kubernetesutils.Key(namespace, managedResourceName), gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})).Return(apierrors.NewNotFound(schema.GroupResource{}, ""))
+				c.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&corev1.SecretList{}), client.InNamespace(namespace), client.MatchingLabels(map[string]string{v1alpha1.ReferencedBy: managedResourceName}))
 
 				Expect(bootstrapper.WaitCleanup(ctx)).To(Succeed())
 			})

--- a/pkg/component/etcd/bootstrap_test.go
+++ b/pkg/component/etcd/bootstrap_test.go
@@ -34,7 +34,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
-	"github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	"github.com/gardener/gardener/pkg/component"
 	. "github.com/gardener/gardener/pkg/component/etcd"
@@ -890,7 +889,7 @@ status:
 
 			It("should successfully delete all resources", func() {
 				c.EXPECT().Get(gomock.Any(), kubernetesutils.Key(namespace, managedResourceName), gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})).Return(apierrors.NewNotFound(schema.GroupResource{}, ""))
-				c.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&corev1.SecretList{}), client.InNamespace(namespace), client.MatchingLabels(map[string]string{v1alpha1.ReferencedBy: managedResourceName}))
+				c.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&corev1.SecretList{}), client.InNamespace(namespace), client.MatchingLabels(map[string]string{resourcesv1alpha1.ReferencedBy: managedResourceName}))
 
 				Expect(bootstrapper.WaitCleanup(ctx)).To(Succeed())
 			})

--- a/pkg/component/resourcemanager/resource_manager_test.go
+++ b/pkg/component/resourcemanager/resource_manager_test.go
@@ -49,6 +49,7 @@ import (
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	"github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	"github.com/gardener/gardener/pkg/component"
 	. "github.com/gardener/gardener/pkg/component/resourcemanager"
@@ -2342,6 +2343,7 @@ subjects:
 						c.EXPECT().Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: deployNamespace, Name: "managedresource-shoot-core-gardener-resource-manager"}}),
 						c.EXPECT().Delete(ctx, &resourcesv1alpha1.ManagedResource{ObjectMeta: metav1.ObjectMeta{Namespace: deployNamespace, Name: "shoot-core-gardener-resource-manager"}}),
 						c.EXPECT().Get(gomock.Any(), client.ObjectKey{Namespace: deployNamespace, Name: "shoot-core-gardener-resource-manager"}, gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
+						c.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&corev1.SecretList{}), client.InNamespace(deployNamespace), client.MatchingLabels(map[string]string{v1alpha1.ReferencedBy: "shoot-core-gardener-resource-manager"})),
 						c.EXPECT().Delete(ctx, &policyv1.PodDisruptionBudget{ObjectMeta: metav1.ObjectMeta{Namespace: deployNamespace, Name: "gardener-resource-manager"}}),
 						c.EXPECT().Delete(ctx, &vpaautoscalingv1.VerticalPodAutoscaler{ObjectMeta: metav1.ObjectMeta{Namespace: deployNamespace, Name: "gardener-resource-manager-vpa"}}),
 						c.EXPECT().Delete(ctx, &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Namespace: deployNamespace, Name: "gardener-resource-manager"}}),
@@ -2381,6 +2383,7 @@ subjects:
 					c.EXPECT().Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: deployNamespace, Name: "managedresource-shoot-core-gardener-resource-manager"}}),
 					c.EXPECT().Delete(ctx, &resourcesv1alpha1.ManagedResource{ObjectMeta: metav1.ObjectMeta{Namespace: deployNamespace, Name: "shoot-core-gardener-resource-manager"}}),
 					c.EXPECT().Get(gomock.Any(), client.ObjectKey{Namespace: deployNamespace, Name: "shoot-core-gardener-resource-manager"}, gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
+					c.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&corev1.SecretList{}), client.InNamespace(deployNamespace), client.MatchingLabels(map[string]string{v1alpha1.ReferencedBy: "shoot-core-gardener-resource-manager"})),
 					c.EXPECT().Delete(ctx, &policyv1.PodDisruptionBudget{ObjectMeta: metav1.ObjectMeta{Namespace: deployNamespace, Name: "gardener-resource-manager"}}).Return(fakeErr),
 				)
 
@@ -2393,6 +2396,7 @@ subjects:
 					c.EXPECT().Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: deployNamespace, Name: "managedresource-shoot-core-gardener-resource-manager"}}),
 					c.EXPECT().Delete(ctx, &resourcesv1alpha1.ManagedResource{ObjectMeta: metav1.ObjectMeta{Namespace: deployNamespace, Name: "shoot-core-gardener-resource-manager"}}),
 					c.EXPECT().Get(gomock.Any(), client.ObjectKey{Namespace: deployNamespace, Name: "shoot-core-gardener-resource-manager"}, gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
+					c.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&corev1.SecretList{}), client.InNamespace(deployNamespace), client.MatchingLabels(map[string]string{v1alpha1.ReferencedBy: "shoot-core-gardener-resource-manager"})),
 					c.EXPECT().Delete(ctx, &policyv1.PodDisruptionBudget{ObjectMeta: metav1.ObjectMeta{Namespace: deployNamespace, Name: "gardener-resource-manager"}}),
 					c.EXPECT().Delete(ctx, &vpaautoscalingv1.VerticalPodAutoscaler{ObjectMeta: metav1.ObjectMeta{Namespace: deployNamespace, Name: "gardener-resource-manager-vpa"}}).Return(fakeErr),
 				)
@@ -2406,6 +2410,7 @@ subjects:
 					c.EXPECT().Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: deployNamespace, Name: "managedresource-shoot-core-gardener-resource-manager"}}),
 					c.EXPECT().Delete(ctx, &resourcesv1alpha1.ManagedResource{ObjectMeta: metav1.ObjectMeta{Namespace: deployNamespace, Name: "shoot-core-gardener-resource-manager"}}),
 					c.EXPECT().Get(gomock.Any(), client.ObjectKey{Namespace: deployNamespace, Name: "shoot-core-gardener-resource-manager"}, gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
+					c.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&corev1.SecretList{}), client.InNamespace(deployNamespace), client.MatchingLabels(map[string]string{v1alpha1.ReferencedBy: "shoot-core-gardener-resource-manager"})),
 					c.EXPECT().Delete(ctx, &policyv1.PodDisruptionBudget{ObjectMeta: metav1.ObjectMeta{Namespace: deployNamespace, Name: "gardener-resource-manager"}}),
 					c.EXPECT().Delete(ctx, &vpaautoscalingv1.VerticalPodAutoscaler{ObjectMeta: metav1.ObjectMeta{Namespace: deployNamespace, Name: "gardener-resource-manager-vpa"}}),
 					c.EXPECT().Delete(ctx, &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Namespace: deployNamespace, Name: "gardener-resource-manager"}}).Return(fakeErr),
@@ -2420,6 +2425,7 @@ subjects:
 					c.EXPECT().Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: deployNamespace, Name: "managedresource-shoot-core-gardener-resource-manager"}}),
 					c.EXPECT().Delete(ctx, &resourcesv1alpha1.ManagedResource{ObjectMeta: metav1.ObjectMeta{Namespace: deployNamespace, Name: "shoot-core-gardener-resource-manager"}}),
 					c.EXPECT().Get(gomock.Any(), client.ObjectKey{Namespace: deployNamespace, Name: "shoot-core-gardener-resource-manager"}, gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
+					c.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&corev1.SecretList{}), client.InNamespace(deployNamespace), client.MatchingLabels(map[string]string{v1alpha1.ReferencedBy: "shoot-core-gardener-resource-manager"})),
 					c.EXPECT().Delete(ctx, &policyv1.PodDisruptionBudget{ObjectMeta: metav1.ObjectMeta{Namespace: deployNamespace, Name: "gardener-resource-manager"}}),
 					c.EXPECT().Delete(ctx, &vpaautoscalingv1.VerticalPodAutoscaler{ObjectMeta: metav1.ObjectMeta{Namespace: deployNamespace, Name: "gardener-resource-manager-vpa"}}),
 					c.EXPECT().Delete(ctx, &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Namespace: deployNamespace, Name: "gardener-resource-manager"}}),
@@ -2435,6 +2441,7 @@ subjects:
 					c.EXPECT().Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: deployNamespace, Name: "managedresource-shoot-core-gardener-resource-manager"}}),
 					c.EXPECT().Delete(ctx, &resourcesv1alpha1.ManagedResource{ObjectMeta: metav1.ObjectMeta{Namespace: deployNamespace, Name: "shoot-core-gardener-resource-manager"}}),
 					c.EXPECT().Get(gomock.Any(), client.ObjectKey{Namespace: deployNamespace, Name: "shoot-core-gardener-resource-manager"}, gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
+					c.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&corev1.SecretList{}), client.InNamespace(deployNamespace), client.MatchingLabels(map[string]string{v1alpha1.ReferencedBy: "shoot-core-gardener-resource-manager"})),
 					c.EXPECT().Delete(ctx, &policyv1.PodDisruptionBudget{ObjectMeta: metav1.ObjectMeta{Namespace: deployNamespace, Name: "gardener-resource-manager"}}),
 					c.EXPECT().Delete(ctx, &vpaautoscalingv1.VerticalPodAutoscaler{ObjectMeta: metav1.ObjectMeta{Namespace: deployNamespace, Name: "gardener-resource-manager-vpa"}}),
 					c.EXPECT().Delete(ctx, &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Namespace: deployNamespace, Name: "gardener-resource-manager"}}),
@@ -2451,6 +2458,7 @@ subjects:
 					c.EXPECT().Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: deployNamespace, Name: "managedresource-shoot-core-gardener-resource-manager"}}),
 					c.EXPECT().Delete(ctx, &resourcesv1alpha1.ManagedResource{ObjectMeta: metav1.ObjectMeta{Namespace: deployNamespace, Name: "shoot-core-gardener-resource-manager"}}),
 					c.EXPECT().Get(gomock.Any(), client.ObjectKey{Namespace: deployNamespace, Name: "shoot-core-gardener-resource-manager"}, gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
+					c.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&corev1.SecretList{}), client.InNamespace(deployNamespace), client.MatchingLabels(map[string]string{v1alpha1.ReferencedBy: "shoot-core-gardener-resource-manager"})),
 					c.EXPECT().Delete(ctx, &policyv1.PodDisruptionBudget{ObjectMeta: metav1.ObjectMeta{Namespace: deployNamespace, Name: "gardener-resource-manager"}}),
 					c.EXPECT().Delete(ctx, &vpaautoscalingv1.VerticalPodAutoscaler{ObjectMeta: metav1.ObjectMeta{Namespace: deployNamespace, Name: "gardener-resource-manager-vpa"}}),
 					c.EXPECT().Delete(ctx, &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Namespace: deployNamespace, Name: "gardener-resource-manager"}}),
@@ -2468,6 +2476,7 @@ subjects:
 					c.EXPECT().Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: deployNamespace, Name: "managedresource-shoot-core-gardener-resource-manager"}}),
 					c.EXPECT().Delete(ctx, &resourcesv1alpha1.ManagedResource{ObjectMeta: metav1.ObjectMeta{Namespace: deployNamespace, Name: "shoot-core-gardener-resource-manager"}}),
 					c.EXPECT().Get(gomock.Any(), client.ObjectKey{Namespace: deployNamespace, Name: "shoot-core-gardener-resource-manager"}, gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
+					c.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&corev1.SecretList{}), client.InNamespace(deployNamespace), client.MatchingLabels(map[string]string{v1alpha1.ReferencedBy: "shoot-core-gardener-resource-manager"})),
 					c.EXPECT().Delete(ctx, &policyv1.PodDisruptionBudget{ObjectMeta: metav1.ObjectMeta{Namespace: deployNamespace, Name: "gardener-resource-manager"}}),
 					c.EXPECT().Delete(ctx, &vpaautoscalingv1.VerticalPodAutoscaler{ObjectMeta: metav1.ObjectMeta{Namespace: deployNamespace, Name: "gardener-resource-manager-vpa"}}),
 					c.EXPECT().Delete(ctx, &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Namespace: deployNamespace, Name: "gardener-resource-manager"}}),
@@ -2486,6 +2495,7 @@ subjects:
 					c.EXPECT().Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: deployNamespace, Name: "managedresource-shoot-core-gardener-resource-manager"}}),
 					c.EXPECT().Delete(ctx, &resourcesv1alpha1.ManagedResource{ObjectMeta: metav1.ObjectMeta{Namespace: deployNamespace, Name: "shoot-core-gardener-resource-manager"}}),
 					c.EXPECT().Get(gomock.Any(), client.ObjectKey{Namespace: deployNamespace, Name: "shoot-core-gardener-resource-manager"}, gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
+					c.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&corev1.SecretList{}), client.InNamespace(deployNamespace), client.MatchingLabels(map[string]string{v1alpha1.ReferencedBy: "shoot-core-gardener-resource-manager"})),
 					c.EXPECT().Delete(ctx, &policyv1.PodDisruptionBudget{ObjectMeta: metav1.ObjectMeta{Namespace: deployNamespace, Name: "gardener-resource-manager"}}),
 					c.EXPECT().Delete(ctx, &vpaautoscalingv1.VerticalPodAutoscaler{ObjectMeta: metav1.ObjectMeta{Namespace: deployNamespace, Name: "gardener-resource-manager-vpa"}}),
 					c.EXPECT().Delete(ctx, &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Namespace: deployNamespace, Name: "gardener-resource-manager"}}),

--- a/pkg/component/resourcemanager/resource_manager_test.go
+++ b/pkg/component/resourcemanager/resource_manager_test.go
@@ -49,7 +49,6 @@ import (
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
-	"github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	"github.com/gardener/gardener/pkg/component"
 	. "github.com/gardener/gardener/pkg/component/resourcemanager"
@@ -2343,7 +2342,7 @@ subjects:
 						c.EXPECT().Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: deployNamespace, Name: "managedresource-shoot-core-gardener-resource-manager"}}),
 						c.EXPECT().Delete(ctx, &resourcesv1alpha1.ManagedResource{ObjectMeta: metav1.ObjectMeta{Namespace: deployNamespace, Name: "shoot-core-gardener-resource-manager"}}),
 						c.EXPECT().Get(gomock.Any(), client.ObjectKey{Namespace: deployNamespace, Name: "shoot-core-gardener-resource-manager"}, gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
-						c.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&corev1.SecretList{}), client.InNamespace(deployNamespace), client.MatchingLabels(map[string]string{v1alpha1.ReferencedBy: "shoot-core-gardener-resource-manager"})),
+						c.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&corev1.SecretList{}), client.InNamespace(deployNamespace), client.MatchingLabels(map[string]string{ReferencedBy: "shoot-core-gardener-resource-manager"})),
 						c.EXPECT().Delete(ctx, &policyv1.PodDisruptionBudget{ObjectMeta: metav1.ObjectMeta{Namespace: deployNamespace, Name: "gardener-resource-manager"}}),
 						c.EXPECT().Delete(ctx, &vpaautoscalingv1.VerticalPodAutoscaler{ObjectMeta: metav1.ObjectMeta{Namespace: deployNamespace, Name: "gardener-resource-manager-vpa"}}),
 						c.EXPECT().Delete(ctx, &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Namespace: deployNamespace, Name: "gardener-resource-manager"}}),
@@ -2383,7 +2382,7 @@ subjects:
 					c.EXPECT().Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: deployNamespace, Name: "managedresource-shoot-core-gardener-resource-manager"}}),
 					c.EXPECT().Delete(ctx, &resourcesv1alpha1.ManagedResource{ObjectMeta: metav1.ObjectMeta{Namespace: deployNamespace, Name: "shoot-core-gardener-resource-manager"}}),
 					c.EXPECT().Get(gomock.Any(), client.ObjectKey{Namespace: deployNamespace, Name: "shoot-core-gardener-resource-manager"}, gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
-					c.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&corev1.SecretList{}), client.InNamespace(deployNamespace), client.MatchingLabels(map[string]string{v1alpha1.ReferencedBy: "shoot-core-gardener-resource-manager"})),
+					c.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&corev1.SecretList{}), client.InNamespace(deployNamespace), client.MatchingLabels(map[string]string{ReferencedBy: "shoot-core-gardener-resource-manager"})),
 					c.EXPECT().Delete(ctx, &policyv1.PodDisruptionBudget{ObjectMeta: metav1.ObjectMeta{Namespace: deployNamespace, Name: "gardener-resource-manager"}}).Return(fakeErr),
 				)
 
@@ -2396,7 +2395,7 @@ subjects:
 					c.EXPECT().Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: deployNamespace, Name: "managedresource-shoot-core-gardener-resource-manager"}}),
 					c.EXPECT().Delete(ctx, &resourcesv1alpha1.ManagedResource{ObjectMeta: metav1.ObjectMeta{Namespace: deployNamespace, Name: "shoot-core-gardener-resource-manager"}}),
 					c.EXPECT().Get(gomock.Any(), client.ObjectKey{Namespace: deployNamespace, Name: "shoot-core-gardener-resource-manager"}, gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
-					c.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&corev1.SecretList{}), client.InNamespace(deployNamespace), client.MatchingLabels(map[string]string{v1alpha1.ReferencedBy: "shoot-core-gardener-resource-manager"})),
+					c.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&corev1.SecretList{}), client.InNamespace(deployNamespace), client.MatchingLabels(map[string]string{ReferencedBy: "shoot-core-gardener-resource-manager"})),
 					c.EXPECT().Delete(ctx, &policyv1.PodDisruptionBudget{ObjectMeta: metav1.ObjectMeta{Namespace: deployNamespace, Name: "gardener-resource-manager"}}),
 					c.EXPECT().Delete(ctx, &vpaautoscalingv1.VerticalPodAutoscaler{ObjectMeta: metav1.ObjectMeta{Namespace: deployNamespace, Name: "gardener-resource-manager-vpa"}}).Return(fakeErr),
 				)
@@ -2410,7 +2409,7 @@ subjects:
 					c.EXPECT().Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: deployNamespace, Name: "managedresource-shoot-core-gardener-resource-manager"}}),
 					c.EXPECT().Delete(ctx, &resourcesv1alpha1.ManagedResource{ObjectMeta: metav1.ObjectMeta{Namespace: deployNamespace, Name: "shoot-core-gardener-resource-manager"}}),
 					c.EXPECT().Get(gomock.Any(), client.ObjectKey{Namespace: deployNamespace, Name: "shoot-core-gardener-resource-manager"}, gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
-					c.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&corev1.SecretList{}), client.InNamespace(deployNamespace), client.MatchingLabels(map[string]string{v1alpha1.ReferencedBy: "shoot-core-gardener-resource-manager"})),
+					c.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&corev1.SecretList{}), client.InNamespace(deployNamespace), client.MatchingLabels(map[string]string{ReferencedBy: "shoot-core-gardener-resource-manager"})),
 					c.EXPECT().Delete(ctx, &policyv1.PodDisruptionBudget{ObjectMeta: metav1.ObjectMeta{Namespace: deployNamespace, Name: "gardener-resource-manager"}}),
 					c.EXPECT().Delete(ctx, &vpaautoscalingv1.VerticalPodAutoscaler{ObjectMeta: metav1.ObjectMeta{Namespace: deployNamespace, Name: "gardener-resource-manager-vpa"}}),
 					c.EXPECT().Delete(ctx, &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Namespace: deployNamespace, Name: "gardener-resource-manager"}}).Return(fakeErr),
@@ -2425,7 +2424,7 @@ subjects:
 					c.EXPECT().Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: deployNamespace, Name: "managedresource-shoot-core-gardener-resource-manager"}}),
 					c.EXPECT().Delete(ctx, &resourcesv1alpha1.ManagedResource{ObjectMeta: metav1.ObjectMeta{Namespace: deployNamespace, Name: "shoot-core-gardener-resource-manager"}}),
 					c.EXPECT().Get(gomock.Any(), client.ObjectKey{Namespace: deployNamespace, Name: "shoot-core-gardener-resource-manager"}, gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
-					c.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&corev1.SecretList{}), client.InNamespace(deployNamespace), client.MatchingLabels(map[string]string{v1alpha1.ReferencedBy: "shoot-core-gardener-resource-manager"})),
+					c.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&corev1.SecretList{}), client.InNamespace(deployNamespace), client.MatchingLabels(map[string]string{ReferencedBy: "shoot-core-gardener-resource-manager"})),
 					c.EXPECT().Delete(ctx, &policyv1.PodDisruptionBudget{ObjectMeta: metav1.ObjectMeta{Namespace: deployNamespace, Name: "gardener-resource-manager"}}),
 					c.EXPECT().Delete(ctx, &vpaautoscalingv1.VerticalPodAutoscaler{ObjectMeta: metav1.ObjectMeta{Namespace: deployNamespace, Name: "gardener-resource-manager-vpa"}}),
 					c.EXPECT().Delete(ctx, &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Namespace: deployNamespace, Name: "gardener-resource-manager"}}),
@@ -2441,7 +2440,7 @@ subjects:
 					c.EXPECT().Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: deployNamespace, Name: "managedresource-shoot-core-gardener-resource-manager"}}),
 					c.EXPECT().Delete(ctx, &resourcesv1alpha1.ManagedResource{ObjectMeta: metav1.ObjectMeta{Namespace: deployNamespace, Name: "shoot-core-gardener-resource-manager"}}),
 					c.EXPECT().Get(gomock.Any(), client.ObjectKey{Namespace: deployNamespace, Name: "shoot-core-gardener-resource-manager"}, gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
-					c.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&corev1.SecretList{}), client.InNamespace(deployNamespace), client.MatchingLabels(map[string]string{v1alpha1.ReferencedBy: "shoot-core-gardener-resource-manager"})),
+					c.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&corev1.SecretList{}), client.InNamespace(deployNamespace), client.MatchingLabels(map[string]string{ReferencedBy: "shoot-core-gardener-resource-manager"})),
 					c.EXPECT().Delete(ctx, &policyv1.PodDisruptionBudget{ObjectMeta: metav1.ObjectMeta{Namespace: deployNamespace, Name: "gardener-resource-manager"}}),
 					c.EXPECT().Delete(ctx, &vpaautoscalingv1.VerticalPodAutoscaler{ObjectMeta: metav1.ObjectMeta{Namespace: deployNamespace, Name: "gardener-resource-manager-vpa"}}),
 					c.EXPECT().Delete(ctx, &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Namespace: deployNamespace, Name: "gardener-resource-manager"}}),
@@ -2458,7 +2457,7 @@ subjects:
 					c.EXPECT().Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: deployNamespace, Name: "managedresource-shoot-core-gardener-resource-manager"}}),
 					c.EXPECT().Delete(ctx, &resourcesv1alpha1.ManagedResource{ObjectMeta: metav1.ObjectMeta{Namespace: deployNamespace, Name: "shoot-core-gardener-resource-manager"}}),
 					c.EXPECT().Get(gomock.Any(), client.ObjectKey{Namespace: deployNamespace, Name: "shoot-core-gardener-resource-manager"}, gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
-					c.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&corev1.SecretList{}), client.InNamespace(deployNamespace), client.MatchingLabels(map[string]string{v1alpha1.ReferencedBy: "shoot-core-gardener-resource-manager"})),
+					c.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&corev1.SecretList{}), client.InNamespace(deployNamespace), client.MatchingLabels(map[string]string{ReferencedBy: "shoot-core-gardener-resource-manager"})),
 					c.EXPECT().Delete(ctx, &policyv1.PodDisruptionBudget{ObjectMeta: metav1.ObjectMeta{Namespace: deployNamespace, Name: "gardener-resource-manager"}}),
 					c.EXPECT().Delete(ctx, &vpaautoscalingv1.VerticalPodAutoscaler{ObjectMeta: metav1.ObjectMeta{Namespace: deployNamespace, Name: "gardener-resource-manager-vpa"}}),
 					c.EXPECT().Delete(ctx, &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Namespace: deployNamespace, Name: "gardener-resource-manager"}}),
@@ -2476,7 +2475,7 @@ subjects:
 					c.EXPECT().Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: deployNamespace, Name: "managedresource-shoot-core-gardener-resource-manager"}}),
 					c.EXPECT().Delete(ctx, &resourcesv1alpha1.ManagedResource{ObjectMeta: metav1.ObjectMeta{Namespace: deployNamespace, Name: "shoot-core-gardener-resource-manager"}}),
 					c.EXPECT().Get(gomock.Any(), client.ObjectKey{Namespace: deployNamespace, Name: "shoot-core-gardener-resource-manager"}, gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
-					c.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&corev1.SecretList{}), client.InNamespace(deployNamespace), client.MatchingLabels(map[string]string{v1alpha1.ReferencedBy: "shoot-core-gardener-resource-manager"})),
+					c.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&corev1.SecretList{}), client.InNamespace(deployNamespace), client.MatchingLabels(map[string]string{ReferencedBy: "shoot-core-gardener-resource-manager"})),
 					c.EXPECT().Delete(ctx, &policyv1.PodDisruptionBudget{ObjectMeta: metav1.ObjectMeta{Namespace: deployNamespace, Name: "gardener-resource-manager"}}),
 					c.EXPECT().Delete(ctx, &vpaautoscalingv1.VerticalPodAutoscaler{ObjectMeta: metav1.ObjectMeta{Namespace: deployNamespace, Name: "gardener-resource-manager-vpa"}}),
 					c.EXPECT().Delete(ctx, &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Namespace: deployNamespace, Name: "gardener-resource-manager"}}),
@@ -2495,7 +2494,7 @@ subjects:
 					c.EXPECT().Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: deployNamespace, Name: "managedresource-shoot-core-gardener-resource-manager"}}),
 					c.EXPECT().Delete(ctx, &resourcesv1alpha1.ManagedResource{ObjectMeta: metav1.ObjectMeta{Namespace: deployNamespace, Name: "shoot-core-gardener-resource-manager"}}),
 					c.EXPECT().Get(gomock.Any(), client.ObjectKey{Namespace: deployNamespace, Name: "shoot-core-gardener-resource-manager"}, gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
-					c.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&corev1.SecretList{}), client.InNamespace(deployNamespace), client.MatchingLabels(map[string]string{v1alpha1.ReferencedBy: "shoot-core-gardener-resource-manager"})),
+					c.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&corev1.SecretList{}), client.InNamespace(deployNamespace), client.MatchingLabels(map[string]string{ReferencedBy: "shoot-core-gardener-resource-manager"})),
 					c.EXPECT().Delete(ctx, &policyv1.PodDisruptionBudget{ObjectMeta: metav1.ObjectMeta{Namespace: deployNamespace, Name: "gardener-resource-manager"}}),
 					c.EXPECT().Delete(ctx, &vpaautoscalingv1.VerticalPodAutoscaler{ObjectMeta: metav1.ObjectMeta{Namespace: deployNamespace, Name: "gardener-resource-manager-vpa"}}),
 					c.EXPECT().Delete(ctx, &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Namespace: deployNamespace, Name: "gardener-resource-manager"}}),

--- a/pkg/resourcemanager/controller/secret/reconciler.go
+++ b/pkg/resourcemanager/controller/secret/reconciler.go
@@ -68,7 +68,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 			// check if we are responsible for this MR, class might have changed, then we need to remove our finalizer
 			if ref.Name == secret.Name && r.ClassFilter.Responsible(&resource) {
 				secretIsReferenced = true
-				if _, ok := secret.Labels[v1alpha1.ReferencedBy]; !ok {
+				if !metav1.HasLabel(secret.ObjectMeta, resourcesv1alpha1.ReferencedBy) {
 					patch := client.MergeFromWithOptions(secret.DeepCopy(), client.MergeFromWithOptimisticLock{})
 					metav1.SetMetaDataLabel(&secret.ObjectMeta, v1alpha1.ReferencedBy, resource.Name)
 					if err := r.SourceClient.Patch(ctx, secret, patch); err != nil {

--- a/pkg/resourcemanager/controller/secret/reconciler.go
+++ b/pkg/resourcemanager/controller/secret/reconciler.go
@@ -72,7 +72,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 					patch := client.MergeFromWithOptions(secret.DeepCopy(), client.MergeFromWithOptimisticLock{})
 					metav1.SetMetaDataLabel(&secret.ObjectMeta, v1alpha1.ReferencedBy, resource.Name)
 					if err := r.SourceClient.Patch(ctx, secret, patch); err != nil {
-						log.Info(fmt.Errorf("failed to add label to secret: %w", err).Error())
+						return reconcile.Result{}, fmt.Errorf("failed to add the %s label to secret: %w", resourcesv1alpha1.ReferencedBy, err)
 					}
 				}
 				break

--- a/pkg/resourcemanager/controller/secret/reconciler.go
+++ b/pkg/resourcemanager/controller/secret/reconciler.go
@@ -89,8 +89,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		}
 	} else if !secretIsReferenced && hasFinalizer {
 		log.Info("Removing finalizer")
-		//log.Info("Artificially slow down finalizer removal for secret")
-		//time.Sleep(10 * time.Second)
 		if err := controllerutils.RemoveFinalizers(ctx, r.SourceClient, secret, controllerFinalizer); err != nil {
 			return reconcile.Result{}, fmt.Errorf("failed to remove finalizer: %w", err)
 		}

--- a/pkg/resourcemanager/controller/secret/reconciler.go
+++ b/pkg/resourcemanager/controller/secret/reconciler.go
@@ -29,6 +29,7 @@ import (
 	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/resourcemanager/apis/config"
 	"github.com/gardener/gardener/pkg/resourcemanager/predicate"
+	"github.com/gardener/gardener/pkg/utils"
 )
 
 // Reconciler adds/removes finalizers to/from secrets referenced by ManagedResources.
@@ -66,6 +67,10 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 			// check if we are responsible for this MR, class might have changed, then we need to remove our finalizer
 			if ref.Name == secret.Name && r.ClassFilter.Responsible(&resource) {
 				secretIsReferenced = true
+				if _, ok := secret.Labels["managed-by"]; !ok {
+					secret.SetLabels(utils.MergeStringMaps(secret.GetLabels(), map[string]string{"managed-by": resource.Name}))
+					r.SourceClient.Update(ctx, secret)
+				}
 				break
 			}
 		}

--- a/pkg/resourcemanager/controller/secret/reconciler_test.go
+++ b/pkg/resourcemanager/controller/secret/reconciler_test.go
@@ -30,7 +30,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	"github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
 	secretcontroller "github.com/gardener/gardener/pkg/resourcemanager/controller/secret"
@@ -219,7 +218,7 @@ var _ = Describe("SecretReconciler", func() {
 				})
 
 			secretAfter := secret.DeepCopy()
-			secretAfter.SetLabels(map[string]string{v1alpha1.ReferencedBy: "MR1"})
+			secretAfter.SetLabels(map[string]string{resourcesv1alpha1.ReferencedBy: "MR1"})
 			test.EXPECTPatchWithOptimisticLock(gomock.Any(), c, secretAfter, secret, types.MergePatchType)
 
 			res, err := r.Reconcile(ctx, secretReq)
@@ -254,7 +253,7 @@ var _ = Describe("SecretReconciler", func() {
 				})
 
 			secretAfter := secret.DeepCopy()
-			secretAfter.SetLabels(map[string]string{v1alpha1.ReferencedBy: "MR1"})
+			secretAfter.SetLabels(map[string]string{resourcesv1alpha1.ReferencedBy: "MR1"})
 			test.EXPECTPatchWithOptimisticLock(gomock.Any(), c, secretAfter, secret, types.MergePatchType)
 
 			secretAfter2 := secretAfter.DeepCopy()

--- a/pkg/utils/managedresources/managedresources.go
+++ b/pkg/utils/managedresources/managedresources.go
@@ -31,7 +31,6 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
-	"github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	"github.com/gardener/gardener/pkg/chartrenderer"
 	"github.com/gardener/gardener/pkg/utils/chart"
@@ -331,10 +330,7 @@ func WaitUntilDeleted(ctx context.Context, c client.Client, namespace, name stri
 		return err
 	}
 
-	if err := kubernetesutils.WaitUntilResourcesDeleted(ctx, c, &corev1.SecretList{}, IntervalWait, client.InNamespace(namespace), client.MatchingLabels{v1alpha1.ReferencedBy: name}); err != nil {
-		return err
-	}
-	return nil
+	return kubernetesutils.WaitUntilResourcesDeleted(ctx, c, &corev1.SecretList{}, IntervalWait, client.InNamespace(namespace), client.MatchingLabels{resourcesv1alpha1.ReferencedBy: name})
 }
 
 // SetKeepObjects updates the keepObjects field of the managed resource with the given name in the given namespace.

--- a/pkg/utils/managedresources/managedresources.go
+++ b/pkg/utils/managedresources/managedresources.go
@@ -331,7 +331,7 @@ func WaitUntilDeleted(ctx context.Context, c client.Client, namespace, name stri
 		return err
 	}
 
-	if err := kubernetesutils.WaitUntilResourcesDeleted(ctx, c, &corev1.SecretList{}, IntervalWait, client.InNamespace(namespace), client.MatchingLabels(map[string]string{v1alpha1.ReferencedBy: name})); err != nil {
+	if err := kubernetesutils.WaitUntilResourcesDeleted(ctx, c, &corev1.SecretList{}, IntervalWait, client.InNamespace(namespace), client.MatchingLabels{v1alpha1.ReferencedBy: name}); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/utils/managedresources/managedresources.go
+++ b/pkg/utils/managedresources/managedresources.go
@@ -31,6 +31,7 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
+	"github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	"github.com/gardener/gardener/pkg/chartrenderer"
 	"github.com/gardener/gardener/pkg/utils/chart"
@@ -330,14 +331,8 @@ func WaitUntilDeleted(ctx context.Context, c client.Client, namespace, name stri
 		return err
 	}
 
-	secrets := &corev1.SecretList{}
-	if err := c.List(ctx, secrets, client.InNamespace(namespace), client.MatchingLabels(map[string]string{"managed-by": name})); err != nil {
+	if err := kubernetesutils.WaitUntilResourcesDeleted(ctx, c, &corev1.SecretList{}, IntervalWait, client.InNamespace(namespace), client.MatchingLabels(map[string]string{v1alpha1.ReferencedBy: name})); err != nil {
 		return err
-	}
-	for _, secret := range secrets.Items {
-		if err := kubernetesutils.WaitUntilResourceDeleted(ctx, c, &secret, IntervalWait); err != nil {
-			return err
-		}
 	}
 	return nil
 }

--- a/pkg/utils/managedresources/managedresources_test.go
+++ b/pkg/utils/managedresources/managedresources_test.go
@@ -503,6 +503,7 @@ var _ = Describe("managedresources", func() {
 		})
 	})
 
+<<<<<<< HEAD
 	Describe("#WaitUntilHealthyAndNotProgressing()", func() {
 		It("should fail when the managed resource cannot be read", func() {
 			errClient := &errorClient{err: fakeErr, failMRGet: true, Client: fakeClient}
@@ -635,6 +636,33 @@ var _ = Describe("managedresources", func() {
 			}()
 
 			timeoutCtx, cancel := context.WithTimeout(ctx, time.Second*5)
+=======
+	Describe("#WaitUntilDeleted", func() {
+		It("should not return error if managed resource and corresponding secret does not exist", func() {
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name + "-secret",
+					Namespace: namespace,
+					Labels:    map[string]string{resourcesv1alpha1.ReferencedBy: "other-MR"},
+				},
+			}
+			Expect(fakeClient.Create(ctx, secret)).To(Succeed())
+			newContenxt, cancel := context.WithTimeout(ctx, 20*time.Second)
+			defer cancel()
+			Expect(WaitUntilDeleted(newContenxt, fakeClient, namespace, name)).To(Succeed())
+		})
+
+		It("should not return error if managed resource and secret does not exist", func() {
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					Namespace: namespace,
+					Labels:    map[string]string{resourcesv1alpha1.ReferencedBy: name},
+				},
+			}
+			Expect(fakeClient.Create(ctx, secret)).To(Succeed())
+			newContenxt, cancel := context.WithTimeout(ctx, 20*time.Second)
+>>>>>>> 000d83a57 (Removing imports, pathing outside loop and following linter suggestion)
 			defer cancel()
 			Expect(WaitUntilHealthyAndNotProgressing(timeoutCtx, fakeClient, namespace, name)).To(Succeed())
 			Expect(shouldFail.Load()).To(BeFalse()) // to ensure that the goroutine actually applies all patches

--- a/pkg/utils/managedresources/managedresources_test.go
+++ b/pkg/utils/managedresources/managedresources_test.go
@@ -503,7 +503,6 @@ var _ = Describe("managedresources", func() {
 		})
 	})
 
-<<<<<<< HEAD
 	Describe("#WaitUntilHealthyAndNotProgressing()", func() {
 		It("should fail when the managed resource cannot be read", func() {
 			errClient := &errorClient{err: fakeErr, failMRGet: true, Client: fakeClient}
@@ -636,7 +635,12 @@ var _ = Describe("managedresources", func() {
 			}()
 
 			timeoutCtx, cancel := context.WithTimeout(ctx, time.Second*5)
-=======
+			defer cancel()
+			Expect(WaitUntilHealthyAndNotProgressing(timeoutCtx, fakeClient, namespace, name)).To(Succeed())
+			Expect(shouldFail.Load()).To(BeFalse()) // to ensure that the goroutine actually applies all patches
+		})
+	})
+
 	Describe("#WaitUntilDeleted", func() {
 		It("should not return error if managed resource and corresponding secret does not exist", func() {
 			secret := &corev1.Secret{
@@ -662,16 +666,8 @@ var _ = Describe("managedresources", func() {
 			}
 			Expect(fakeClient.Create(ctx, secret)).To(Succeed())
 			newContenxt, cancel := context.WithTimeout(ctx, 20*time.Second)
->>>>>>> 000d83a57 (Removing imports, pathing outside loop and following linter suggestion)
 			defer cancel()
-			Expect(WaitUntilHealthyAndNotProgressing(timeoutCtx, fakeClient, namespace, name)).To(Succeed())
-			Expect(shouldFail.Load()).To(BeFalse()) // to ensure that the goroutine actually applies all patches
-		})
-	})
-
-	Describe("#WaitUntilDeleted", func() {
-		It("should not return error if managed resource does not exist", func() {
-			Expect(WaitUntilDeleted(ctx, fakeClient, namespace, name)).To(Succeed())
+			Expect(WaitUntilDeleted(newContenxt, fakeClient, namespace, name)).To(MatchError(ContainSubstring(fmt.Sprintf("resource(s) [%s] still exists", name))))
 		})
 
 		It("should return a severe error if managed resource retrieval fails", func() {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind bug

**What this PR does / why we need it**:
This PR changes the secret reconciliation loop to add the label `managed-by` to every referenced by MR secret. This allows the secret to be referenced when waiting for the MR to be deleted in `WaitUntilDeleted`. This is needed because there is no better way from a MR name to get the corresponding secret (secret could have `managedresource-` prefix without a defined pattern of when this happens and we can not extract the secret by MR name -> MR -> secret (using `secretRefs` field) because at that time the MR could have been deleted)

**Which issue(s) this PR fixes**:
Fixes #8190

**Special notes for your reviewer**:
In the local setup we can test if this solves the issue by adding `time.Sleep(10 * time.Second)` before the `RemoveFinalizers` function:https://github.com/gardener/gardener/blob/5a083e41b6df1058cde87c2fc1c83489baf01761/pkg/resourcemanager/controller/secret/reconciler.go#L83-L85
Without the PR changes shoot deletion should fail and with the changes shoot deletion should work
**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
NONE
```
