### PR TITLE
Allow to enable disabled APIs in workerless shoots

### DIFF
--- a/pkg/component/kubeapiserver/deployment.go
+++ b/pkg/component/kubeapiserver/deployment.go
@@ -456,7 +456,8 @@ func (k *kubeAPIServer) computeKubeAPIServerArgs() []string {
 			disableAPIs["policy/v1beta1/podsecuritypolicies"] = false
 		}
 
-		k.values.RuntimeConfig = utils.MergeStringMaps(k.values.RuntimeConfig, disableAPIs)
+		// Allow users to explicitly enable disabled APIs via RuntimeConfig.
+		k.values.RuntimeConfig = utils.MergeStringMaps(disableAPIs, k.values.RuntimeConfig)
 	}
 
 	if k.values.RuntimeConfig != nil {

--- a/pkg/component/kubeapiserver/kube_apiserver_test.go
+++ b/pkg/component/kubeapiserver/kube_apiserver_test.go
@@ -3117,7 +3117,7 @@ rules:
 					Expect(deployment.Spec.Template.Spec.Containers[0].Args).NotTo(ContainElement(ContainSubstring("--runtime-config=")))
 				})
 
-				It("should disable apis in case of workerless shoot with k8s version < 1.25", func() {
+				It("should allow to enable apis via 'RuntimeConfig' in case of workerless shoot with k8s version < 1.25", func() {
 					runtimeConfig := map[string]bool{"apps/v1": true, "bar": false}
 
 					kapi = New(kubernetesInterface, namespace, sm, Values{
@@ -3132,11 +3132,11 @@ rules:
 					deployAndRead()
 
 					Expect(deployment.Spec.Template.Spec.Containers[0].Args).To(ContainElement(
-						"--runtime-config=apps/v1=false,autoscaling/v2=false,bar=false,batch/v1=false,policy/v1/poddisruptionbudgets=false,policy/v1beta1/podsecuritypolicies=false,storage.k8s.io/v1/csidrivers=false,storage.k8s.io/v1/csinodes=false",
+						"--runtime-config=apps/v1=true,autoscaling/v2=false,bar=false,batch/v1=false,policy/v1/poddisruptionbudgets=false,policy/v1beta1/podsecuritypolicies=false,storage.k8s.io/v1/csidrivers=false,storage.k8s.io/v1/csinodes=false",
 					))
 				})
 
-				It("should disable apis in case of workerless shoot with k8s version >= 1.25", func() {
+				It("should allow to enable apis via 'RuntimeConfig' in case of workerless shoot with k8s version >= 1.25", func() {
 					runtimeConfig := map[string]bool{"apps/v1": true, "bar": false}
 					version = semver.MustParse("v1.26.0")
 
@@ -3152,7 +3152,8 @@ rules:
 					deployAndRead()
 
 					Expect(deployment.Spec.Template.Spec.Containers[0].Args).To(ContainElement(
-						"--runtime-config=apps/v1=false,autoscaling/v2=false,bar=false,batch/v1=false,policy/v1/poddisruptionbudgets=false,storage.k8s.io/v1/csidrivers=false,storage.k8s.io/v1/csinodes=false",
+						"--runtime-config=apps/v1=true" +
+							",autoscaling/v2=false,bar=false,batch/v1=false,policy/v1/poddisruptionbudgets=false,storage.k8s.io/v1/csidrivers=false,storage.k8s.io/v1/csinodes=false",
 					))
 				})
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind enhancement

**What this PR does / why we need it**:
Some users would like to explicitly enable disabled APIs for workerless shoots, e.g. `apps/v1`, via the kubeAPIServer's `runtimeConfig`. After checking with @ary1992, there is no obvious reason to not allow this.

**Special notes for your reviewer**:
/cc @ary1992 @shafeeqes @acumino 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other user
It is now possible to enable disabled APIs for workerless shoot clusters via `spec.kubernetes.kubeAPIServer.runtimeConfig`.
```
