### PR TITLE
Update shoot creation framework to support HA

### DIFF
--- a/.test-defs/CreateShoot.yaml
+++ b/.test-defs/CreateShoot.yaml
@@ -36,6 +36,7 @@ spec:
     -start-hibernated=$START_HIBERNATED
     -allow-privileged-containers=$ALLOW_PRIVILEGED_CONTAINERS
     -annotations=$SHOOT_ANNOTATIONS
+    -failure-tolerance-type=$FAILURE_TOLERANCE_TYPE
 #    -machine-image-name=$MACHINE_IMAGE
 #    -machine-image-version=$MACHINE_IMAGE_VERSION
 #    -machine-type=$MACHINE_TYPE

--- a/test/framework/shoot_utils.go
+++ b/test/framework/shoot_utils.go
@@ -163,6 +163,8 @@ func CreateShootTestArtifacts(cfg *ShootCreationConfig, projectNamespace string,
 
 	setShootGeneralSettings(shoot, cfg, clearExtensions)
 
+	setShootHighAvailabilitySettings(shoot, cfg)
+
 	setShootNetworkingSettings(shoot, cfg, clearDNS)
 
 	setShootTolerations(shoot)
@@ -274,6 +276,14 @@ func setShootGeneralSettings(shoot *gardencorev1beta1.Shoot, cfg *ShootCreationC
 	if clearExtensions {
 		shoot.Spec.Extensions = nil
 	}
+}
+
+// setShootHighAvailabilitySettings sets the Shoot's HighAvailability settings from the given config
+func setShootHighAvailabilitySettings(shoot *gardencorev1beta1.Shoot, cfg *ShootCreationConfig) {
+	if StringSet(cfg.failureToleranceType) {
+		shoot.Spec.ControlPlane.HighAvailability.FailureTolerance.Type = cfg.failureToleranceType
+	}
+
 }
 
 // setShootNetworkingSettings sets the Shoot's networking settings from the given config

--- a/test/framework/shootcreationframework.go
+++ b/test/framework/shootcreationframework.go
@@ -65,6 +65,7 @@ type ShootCreationConfig struct {
 	workersConfig                 string
 	shootYamlPath                 string
 	shootAnnotations              string
+	failureToleranceType          string
 }
 
 // ShootCreationFramework represents the shoot test framework that includes
@@ -181,6 +182,12 @@ func validateShootCreationConfig(cfg *ShootCreationConfig) {
 			ginkgo.Fail(fmt.Sprintf("path to the worker config of the Shoot is invalid: %s", cfg.workersConfig))
 		}
 	}
+
+	if StringSet(cfg.failureToleranceType) {
+		if cfg.failureToleranceType != "node" && cfg.failureToleranceType != "zone" {
+			ginkgo.Fail("failureToleranceType must be 'node' or 'zone'")
+		}
+	}
 }
 
 func mergeShootCreationConfig(base, overwrite *ShootCreationConfig) *ShootCreationConfig {
@@ -225,6 +232,10 @@ func mergeShootCreationConfig(base, overwrite *ShootCreationConfig) *ShootCreati
 
 	if StringSet(overwrite.shootMachineImageVersion) {
 		base.shootMachineImageVersion = overwrite.shootMachineImageVersion
+	}
+
+	if StringSet(overwrite.failureToleranceType) {
+		base.failureToleranceType = overwrite.failureToleranceType
 	}
 
 	if StringSet(overwrite.cloudProfile) {
@@ -342,6 +353,7 @@ func RegisterShootCreationFrameworkFlags() *ShootCreationConfig {
 	flag.StringVar(&newCfg.networkingNodes, "networking-nodes", "", "the spec.networking.nodes to use for this shoot. Optional.")
 	flag.StringVar(&newCfg.startHibernatedFlag, "start-hibernated", "", "the spec.hibernation.enabled to use for this shoot. Optional.")
 	flag.StringVar(&newCfg.allowPrivilegedContainersFlag, "allow-privileged-containers", "", "the spec.kubernetes.allowPrivilegedContainers to use for this shoot. Optional, defaults to true.")
+	flag.StringVar(&newCfg.failureToleranceType, "failure-tolerance-type", "", "the spec.controlPlane.highAvailability.failureTolerance.type to use for this shoot. Optional.")
 
 	if newCfg.networkingType == "" {
 		newCfg.networkingType = "calico"


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing high-availability
/kind enhancement

**What this PR does / why we need it**:

Currently Shoot creation framework only creates shoot of non-HA, this PR is to enhance the shoot creation framework adding HighAvailability config for the shoot creation. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
