### PR TITLE
Drop completed cleanup codes

### DIFF
--- a/cmd/gardenlet/app/app.go
+++ b/cmd/gardenlet/app/app.go
@@ -53,10 +53,8 @@ import (
 	gardencore "github.com/gardener/gardener/pkg/apis/core"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
-	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	"github.com/gardener/gardener/pkg/apis/operations"
 	operationsv1alpha1 "github.com/gardener/gardener/pkg/apis/operations/v1alpha1"
-	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	clientmapbuilder "github.com/gardener/gardener/pkg/client/kubernetes/clientmap/builder"
 	"github.com/gardener/gardener/pkg/controllerutils"
@@ -72,9 +70,7 @@ import (
 	"github.com/gardener/gardener/pkg/utils"
 	"github.com/gardener/gardener/pkg/utils/flow"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
-	"github.com/gardener/gardener/pkg/utils/gardener/shootstate"
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
-	secretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager"
 )
 
 // Name is a const for the name of this component.
@@ -354,17 +350,6 @@ func (g *garden) Start(ctx context.Context) error {
 		return err
 	}
 
-	// TODO(rfranzke): Remove this code after v1.74 has been released.
-	{
-		log.Info("Removing legacy ShootState controller finalizer from persistable secrets in seed cluster")
-		if err := removeLegacyShootStateControllerFinalizerFromSecrets(ctx, g.mgr.GetClient()); err != nil {
-			return err
-		}
-		if err := g.cleanupStaleShootStates(ctx, gardenCluster.GetClient()); err != nil {
-			return err
-		}
-	}
-
 	log.Info("Setting up shoot client map")
 	shootClientMap, err := clientmapbuilder.
 		NewShootClientMapBuilder().
@@ -484,73 +469,6 @@ func (g *garden) updateProcessingShootStatusToAborted(ctx context.Context, garde
 			}
 
 			return nil
-		})
-	}
-
-	return flow.Parallel(taskFns...)(ctx)
-}
-
-func removeLegacyShootStateControllerFinalizerFromSecrets(ctx context.Context, seedClient client.Client) error {
-	secretList := &metav1.PartialObjectMetadataList{}
-	secretList.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("SecretList"))
-	if err := seedClient.List(ctx, secretList, client.MatchingLabels{
-		secretsmanager.LabelKeyManagedBy: secretsmanager.LabelValueSecretsManager,
-		secretsmanager.LabelKeyPersist:   secretsmanager.LabelValueTrue,
-	}); err != nil {
-		return fmt.Errorf("failed listing all secrets that must be persisted: %w", err)
-	}
-
-	var taskFns []flow.TaskFn
-
-	for _, s := range secretList.Items {
-		secret := s
-
-		taskFns = append(taskFns, func(ctx context.Context) error {
-			if err := controllerutils.RemoveFinalizers(ctx, seedClient, &secret, "gardenlet.gardener.cloud/secret-controller"); err != nil {
-				return fmt.Errorf("failed to remove legacy ShootState controller finalizer from secret %q: %w", client.ObjectKeyFromObject(&secret), err)
-			}
-			return nil
-		})
-	}
-
-	return flow.Parallel(taskFns...)(ctx)
-}
-
-func (g *garden) cleanupStaleShootStates(ctx context.Context, gardenClient client.Client) error {
-	if err := gardenClient.Get(ctx, client.ObjectKey{Name: g.config.SeedConfig.Name, Namespace: v1beta1constants.GardenNamespace}, &seedmanagementv1alpha1.ManagedSeed{}); err != nil {
-		if !apierrors.IsNotFound(err) {
-			return fmt.Errorf("failed checking whether gardenlet is responsible for a managed seed: %w", err)
-		}
-		return nil
-	}
-
-	g.mgr.GetLogger().Info("Removing stale ShootState resources from garden cluster since I'm responsible for a managed seed (GEP-22)")
-
-	shootList := &gardencorev1beta1.ShootList{}
-	if err := gardenClient.List(ctx, shootList, client.MatchingFields{gardencore.ShootSeedName: g.config.SeedConfig.Name}); err != nil {
-		return err
-	}
-
-	var taskFns []flow.TaskFn
-
-	for _, s := range shootList.Items {
-		shoot := s
-
-		// If status.seedName is different than seed name gardenlet is responsible for, then a migration takes place.
-		// In this case, we don't want to delete the shoot state. It will be deleted eventually after successful
-		// restoration by the shoot controller itself.
-		if shoot.Status.SeedName != nil && *shoot.Status.SeedName != g.config.SeedConfig.Name {
-			continue
-		}
-
-		// We don't want to delete the shoot state when the last operation type is 'Restore' (it might not be completed
-		// yet). It will be deleted eventually after successful restoration by the shoot controller itself.
-		if v1beta1helper.ShootHasOperationType(shoot.Status.LastOperation, gardencorev1beta1.LastOperationTypeRestore) {
-			continue
-		}
-
-		taskFns = append(taskFns, func(ctx context.Context) error {
-			return shootstate.Delete(ctx, gardenClient, &shoot)
 		})
 	}
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability quality
/kind cleanup

**What this PR does / why we need it**:
https://github.com/gardener/gardener/pull/8233 was (will be) released with `v1.76` and cherry-picked to `v1.75`.
We can cleanup this code in `v1.77`.

The cleanup of shootstates can also be dropped now.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Should only be merged after `v1.76` is released. Hence in draft.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
