### PR TITLE
Drop no longer needed checksum annotations from GCM deployment

### DIFF
--- a/charts/gardener/controlplane/charts/runtime/templates/controller-manager/deployment.yaml
+++ b/charts/gardener/controlplane/charts/runtime/templates/controller-manager/deployment.yaml
@@ -21,10 +21,6 @@ spec:
       annotations:
         checksum/configmap-gardener-controller-manager-config: {{ include (print $.Template.BasePath "/controller-manager/configmap-componentconfig.yaml") . | sha256sum }}
         checksum/secret-gardener-controller-manager-kubeconfig: {{ include (print $.Template.BasePath "/controller-manager/secret-kubeconfig.yaml") . | sha256sum }}
-        checksum/secret-default-domain: {{ include "gardener.secret-default-domain" . | sha256sum }}
-        checksum/secret-internal-domain: {{ include "gardener.secret-internal-domain" . | sha256sum }}
-        checksum/secret-alerting: {{ include "gardener.secret-alerting" . | sha256sum }}
-        checksum/secret-openvpn-diffie-hellman: {{ include "gardener.secret-openvpn-diffie-hellman" . | sha256sum }}
         {{- if .Values.global.controller.podAnnotations }}
 {{ toYaml .Values.global.controller.podAnnotations | indent 8 }}
         {{- end }}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area delivery
/kind regression

**What this PR does / why we need it**:
Drop no longer needed checksum annotations from GCM deployment

**Which issue(s) this PR fixes**:
Follow-up of #8243 

**Special notes for your reviewer**:
/cc @plkokanov 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
