### PR TITLE
Enforce `containerd` when `maintenance-controller` updates Kubernetes from `v1.22` to `v1.23`

### DIFF
--- a/pkg/controllermanager/controller/shoot/maintenance/reconciler_test.go
+++ b/pkg/controllermanager/controller/shoot/maintenance/reconciler_test.go
@@ -726,14 +726,13 @@ var _ = Describe("Shoot Maintenance", func() {
 						{
 							Name: "cpu-worker2",
 						},
-					},
-					},
+					}},
 				},
 			}
 		})
 
 		It("should not change anything if CRI is not set", func() {
-			_, err := updateToContainerd(log, shoot, "foobar")
+			_, err := updateToContainerd(shoot, "foobar")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(shoot.Spec.Provider.Workers[0].CRI).To(BeNil())
 			Expect(shoot.Spec.Provider.Workers[1].CRI).To(BeNil())
@@ -741,7 +740,7 @@ var _ = Describe("Shoot Maintenance", func() {
 
 		It("should change docker to containerd", func() {
 			shoot.Spec.Provider.Workers[1].CRI = &gardencorev1beta1.CRI{Name: "docker"}
-			_, err := updateToContainerd(log, shoot, "foobar")
+			_, err := updateToContainerd(shoot, "foobar")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(shoot.Spec.Provider.Workers[1].CRI.Name).To(Equal(gardencorev1beta1.CRINameContainerD))
 			Expect(shoot.Spec.Provider.Workers[0].CRI).To(BeNil())
@@ -749,7 +748,7 @@ var _ = Describe("Shoot Maintenance", func() {
 
 		It("should keep containerd if it is already set", func() {
 			shoot.Spec.Provider.Workers[0].CRI = &gardencorev1beta1.CRI{Name: "containerd"}
-			_, err := updateToContainerd(log, shoot, "foobar")
+			_, err := updateToContainerd(shoot, "foobar")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(shoot.Spec.Provider.Workers[0].CRI.Name).To(Equal(gardencorev1beta1.CRINameContainerD))
 			Expect(shoot.Spec.Provider.Workers[1].CRI).To(BeNil())


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity
/kind enhancement

**What this PR does / why we need it**:
When CRI on a Kubernetes v1.22 shoot is `docker` it currently prevents `maintenance-controller` from updating the shoot to Kubernetes `v1.23` because it does not support docker anymore.
With this PR `maintenance-controller` updates CRI from `docker` to `containerd` is these cases. 

**Which issue(s) this PR fixes**:
Part of #8271

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
The `Shoot` maintenance controller now updates the CRI of worker pools from `docker` to `containerd` when force-upgrading from Kubernetes `v1.22` to `v1.23`.
```
