### PR TITLE
[operator] Introduce `gardensystem/virtual` Golang component

### DIFF
--- a/pkg/component/gardensystem/runtime/runtime.go
+++ b/pkg/component/gardensystem/runtime/runtime.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package gardensystem
+package runtime
 
 import (
 	"context"
@@ -31,7 +31,7 @@ import (
 // ManagedResourceName is the name of the ManagedResource containing the resource specifications.
 const ManagedResourceName = "garden-system"
 
-// New creates a new instance of DeployWaiter for garden system resources.
+// New creates a new instance of DeployWaiter for runtime garden system resources.
 func New(client client.Client, namespace string) component.DeployWaiter {
 	return &gardenSystem{
 		client:    client,

--- a/pkg/component/gardensystem/runtime/runtime_suite_test.go
+++ b/pkg/component/gardensystem/runtime/runtime_suite_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package gardensystem_test
+package runtime_test
 
 import (
 	"testing"
@@ -21,7 +21,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestGardenSystem(t *testing.T) {
+func TestRuntime(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Component GardenSystem Suite")
+	RunSpecs(t, "Component GardenSystem Runtime Suite")
 }

--- a/pkg/component/gardensystem/runtime/runtime_test.go
+++ b/pkg/component/gardensystem/runtime/runtime_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package gardensystem_test
+package runtime_test
 
 import (
 	"context"
@@ -30,7 +30,7 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	"github.com/gardener/gardener/pkg/component"
-	. "github.com/gardener/gardener/pkg/component/gardensystem"
+	. "github.com/gardener/gardener/pkg/component/gardensystem/runtime"
 	operatorclient "github.com/gardener/gardener/pkg/operator/client"
 	"github.com/gardener/gardener/pkg/resourcemanager/controller/garbagecollector/references"
 	"github.com/gardener/gardener/pkg/utils/retry"
@@ -39,7 +39,7 @@ import (
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 )
 
-var _ = Describe("GardenSystem", func() {
+var _ = Describe("Runtime", func() {
 	var (
 		ctx = context.TODO()
 

--- a/pkg/component/gardensystem/virtual/virtual.go
+++ b/pkg/component/gardensystem/virtual/virtual.go
@@ -1,0 +1,81 @@
+// Copyright 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package virtual
+
+import (
+	"context"
+	"time"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	"github.com/gardener/gardener/pkg/component"
+	"github.com/gardener/gardener/pkg/utils/managedresources"
+)
+
+// ManagedResourceName is the name of the ManagedResource containing the resource specifications.
+const ManagedResourceName = "garden-system-virtual"
+
+// New creates a new instance of DeployWaiter for virtual garden system resources.
+func New(client client.Client, namespace string) component.DeployWaiter {
+	return &gardenSystem{
+		client:    client,
+		namespace: namespace,
+	}
+}
+
+type gardenSystem struct {
+	client    client.Client
+	namespace string
+}
+
+func (g *gardenSystem) Deploy(ctx context.Context) error {
+	data, err := g.computeResourcesData()
+	if err != nil {
+		return err
+	}
+
+	return managedresources.CreateForSeed(ctx, g.client, g.namespace, ManagedResourceName, false, data)
+}
+
+func (g *gardenSystem) Destroy(ctx context.Context) error {
+	return managedresources.DeleteForSeed(ctx, g.client, g.namespace, ManagedResourceName)
+}
+
+// TimeoutWaitForManagedResource is the timeout used while waiting for the ManagedResources to become healthy
+// or deleted.
+var TimeoutWaitForManagedResource = 2 * time.Minute
+
+func (g *gardenSystem) Wait(ctx context.Context) error {
+	timeoutCtx, cancel := context.WithTimeout(ctx, TimeoutWaitForManagedResource)
+	defer cancel()
+
+	return managedresources.WaitUntilHealthy(timeoutCtx, g.client, g.namespace, ManagedResourceName)
+}
+
+func (g *gardenSystem) WaitCleanup(ctx context.Context) error {
+	timeoutCtx, cancel := context.WithTimeout(ctx, TimeoutWaitForManagedResource)
+	defer cancel()
+
+	return managedresources.WaitUntilDeleted(timeoutCtx, g.client, g.namespace, ManagedResourceName)
+}
+
+func (g *gardenSystem) computeResourcesData() (map[string][]byte, error) {
+	var (
+		registry = managedresources.NewRegistry(kubernetes.SeedScheme, kubernetes.SeedCodec, kubernetes.SeedSerializer)
+	)
+
+	return registry.SerializedObjects(), nil
+}

--- a/pkg/component/gardensystem/virtual/virtual.go
+++ b/pkg/component/gardensystem/virtual/virtual.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	certificatesv1 "k8s.io/api/certificates/v1"
+	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	bootstraptokenapi "k8s.io/cluster-bootstrap/token/api"
@@ -89,6 +90,12 @@ func (g *gardenSystem) computeResourcesData() (map[string][]byte, error) {
 	var (
 		registry = managedresources.NewRegistry(kubernetes.SeedScheme, kubernetes.SeedCodec, kubernetes.SeedSerializer)
 
+		namespaceGarden = &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   v1beta1constants.GardenNamespace,
+				Labels: map[string]string{v1beta1constants.LabelApp: v1beta1constants.LabelGardener},
+			},
+		}
 		clusterRoleSeedBootstrapper = &rbacv1.ClusterRole{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "gardener.cloud:system:seed-bootstrapper",
@@ -124,6 +131,7 @@ func (g *gardenSystem) computeResourcesData() (map[string][]byte, error) {
 	)
 
 	if err := registry.Add(
+		namespaceGarden,
 		clusterRoleSeedBootstrapper,
 		clusterRoleBindingSeedBootstrapper,
 	); err != nil {

--- a/pkg/component/gardensystem/virtual/virtual_suite_test.go
+++ b/pkg/component/gardensystem/virtual/virtual_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package virtual_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestVirtual(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Component GardenSystem Virtual Suite")
+}

--- a/pkg/component/gardensystem/virtual/virtual_test.go
+++ b/pkg/component/gardensystem/virtual/virtual_test.go
@@ -54,6 +54,7 @@ var _ = Describe("Virtual", func() {
 		managedResource       *resourcesv1alpha1.ManagedResource
 		managedResourceSecret *corev1.Secret
 
+		namespaceGarden                    *corev1.Namespace
 		clusterRoleSeedBootstrapper        *rbacv1.ClusterRole
 		clusterRoleBindingSeedBootstrapper *rbacv1.ClusterRoleBinding
 		clusterRoleSeeds                   *rbacv1.ClusterRole
@@ -78,6 +79,12 @@ var _ = Describe("Virtual", func() {
 			},
 		}
 
+		namespaceGarden = &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   "garden",
+				Labels: map[string]string{"app": "gardener"},
+			},
+		}
 		clusterRoleSeedBootstrapper = &rbacv1.ClusterRole{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "gardener.cloud:system:seed-bootstrapper",
@@ -174,7 +181,8 @@ var _ = Describe("Virtual", func() {
 		})
 
 		It("should successfully deploy the resources when seed authorizer is disabled", func() {
-			Expect(managedResourceSecret.Data).To(HaveLen(4))
+			Expect(managedResourceSecret.Data).To(HaveLen(5))
+			Expect(string(managedResourceSecret.Data["namespace____garden.yaml"])).To(Equal(componenttest.Serialize(namespaceGarden)))
 			Expect(string(managedResourceSecret.Data["clusterrole____gardener.cloud_system_seed-bootstrapper.yaml"])).To(Equal(componenttest.Serialize(clusterRoleSeedBootstrapper)))
 			Expect(string(managedResourceSecret.Data["clusterrolebinding____gardener.cloud_system_seed-bootstrapper.yaml"])).To(Equal(componenttest.Serialize(clusterRoleBindingSeedBootstrapper)))
 			Expect(string(managedResourceSecret.Data["clusterrole____gardener.cloud_system_seeds.yaml"])).To(Equal(componenttest.Serialize(clusterRoleSeeds)))

--- a/pkg/component/gardensystem/virtual/virtual_test.go
+++ b/pkg/component/gardensystem/virtual/virtual_test.go
@@ -1,0 +1,214 @@
+// Copyright 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package virtual_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
+	"github.com/gardener/gardener/pkg/component"
+	. "github.com/gardener/gardener/pkg/component/gardensystem/virtual"
+	operatorclient "github.com/gardener/gardener/pkg/operator/client"
+	"github.com/gardener/gardener/pkg/resourcemanager/controller/garbagecollector/references"
+	"github.com/gardener/gardener/pkg/utils/retry"
+	retryfake "github.com/gardener/gardener/pkg/utils/retry/fake"
+	"github.com/gardener/gardener/pkg/utils/test"
+	. "github.com/gardener/gardener/pkg/utils/test/matchers"
+)
+
+var _ = Describe("Virtual", func() {
+	var (
+		ctx = context.TODO()
+
+		managedResourceName = "garden-system-virtual"
+		namespace           = "some-namespace"
+
+		c         client.Client
+		component component.DeployWaiter
+
+		managedResource       *resourcesv1alpha1.ManagedResource
+		managedResourceSecret *corev1.Secret
+	)
+
+	BeforeEach(func() {
+		c = fakeclient.NewClientBuilder().WithScheme(operatorclient.RuntimeScheme).Build()
+		component = New(c, namespace)
+
+		managedResource = &resourcesv1alpha1.ManagedResource{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      managedResourceName,
+				Namespace: namespace,
+			},
+		}
+		managedResourceSecret = &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "managedresource-" + managedResource.Name,
+				Namespace: namespace,
+			},
+		}
+	})
+
+	Describe("#Deploy", func() {
+		JustBeforeEach(func() {
+			Expect(c.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)).To(BeNotFoundError())
+
+			Expect(component.Deploy(ctx)).To(Succeed())
+
+			Expect(c.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)).To(Succeed())
+			expectedMr := &resourcesv1alpha1.ManagedResource{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: resourcesv1alpha1.SchemeGroupVersion.String(),
+					Kind:       "ManagedResource",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            managedResource.Name,
+					Namespace:       managedResource.Namespace,
+					Labels:          map[string]string{"gardener.cloud/role": "seed-system-component"},
+					ResourceVersion: "1",
+				},
+				Spec: resourcesv1alpha1.ManagedResourceSpec{
+					Class: pointer.String("seed"),
+					SecretRefs: []corev1.LocalObjectReference{{
+						Name: managedResource.Spec.SecretRefs[0].Name,
+					}},
+					KeepObjects: pointer.Bool(false),
+				},
+			}
+			utilruntime.Must(references.InjectAnnotations(expectedMr))
+			Expect(managedResource).To(DeepEqual(expectedMr))
+
+			managedResourceSecret.Name = managedResource.Spec.SecretRefs[0].Name
+			Expect(c.Get(ctx, client.ObjectKeyFromObject(managedResourceSecret), managedResourceSecret)).To(Succeed())
+			Expect(managedResourceSecret.Type).To(Equal(corev1.SecretTypeOpaque))
+			Expect(managedResourceSecret.Immutable).To(Equal(pointer.Bool(true)))
+			Expect(managedResourceSecret.Labels["resources.gardener.cloud/garbage-collectable-reference"]).To(Equal("true"))
+		})
+
+		It("should successfully deploy the resources", func() {
+			Expect(managedResourceSecret.Data).To(HaveLen(0))
+		})
+	})
+
+	Describe("#Destroy", func() {
+		It("should successfully destroy all resources", func() {
+			Expect(c.Create(ctx, managedResource)).To(Succeed())
+			Expect(c.Create(ctx, managedResourceSecret)).To(Succeed())
+
+			Expect(c.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)).To(Succeed())
+			Expect(c.Get(ctx, client.ObjectKeyFromObject(managedResourceSecret), managedResourceSecret)).To(Succeed())
+
+			Expect(component.Destroy(ctx)).To(Succeed())
+
+			Expect(c.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)).To(BeNotFoundError())
+			Expect(c.Get(ctx, client.ObjectKeyFromObject(managedResourceSecret), managedResourceSecret)).To(BeNotFoundError())
+		})
+	})
+
+	Context("waiting functions", func() {
+		var fakeOps *retryfake.Ops
+
+		BeforeEach(func() {
+			fakeOps = &retryfake.Ops{MaxAttempts: 1}
+			DeferCleanup(test.WithVars(
+				&retry.Until, fakeOps.Until,
+				&retry.UntilTimeout, fakeOps.UntilTimeout,
+			))
+		})
+
+		Describe("#Wait", func() {
+			It("should fail because reading the ManagedResource fails", func() {
+				Expect(component.Wait(ctx)).To(MatchError(ContainSubstring("not found")))
+			})
+
+			It("should fail because the ManagedResource doesn't become healthy", func() {
+				fakeOps.MaxAttempts = 2
+
+				Expect(c.Create(ctx, &resourcesv1alpha1.ManagedResource{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       managedResourceName,
+						Namespace:  namespace,
+						Generation: 1,
+					},
+					Status: resourcesv1alpha1.ManagedResourceStatus{
+						ObservedGeneration: 1,
+						Conditions: []gardencorev1beta1.Condition{
+							{
+								Type:   resourcesv1alpha1.ResourcesApplied,
+								Status: gardencorev1beta1.ConditionFalse,
+							},
+							{
+								Type:   resourcesv1alpha1.ResourcesHealthy,
+								Status: gardencorev1beta1.ConditionFalse,
+							},
+						},
+					},
+				})).To(Succeed())
+
+				Expect(component.Wait(ctx)).To(MatchError(ContainSubstring("is not healthy")))
+			})
+
+			It("should successfully wait for the managed resource to become healthy", func() {
+				fakeOps.MaxAttempts = 2
+
+				Expect(c.Create(ctx, &resourcesv1alpha1.ManagedResource{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       managedResourceName,
+						Namespace:  namespace,
+						Generation: 1,
+					},
+					Status: resourcesv1alpha1.ManagedResourceStatus{
+						ObservedGeneration: 1,
+						Conditions: []gardencorev1beta1.Condition{
+							{
+								Type:   resourcesv1alpha1.ResourcesApplied,
+								Status: gardencorev1beta1.ConditionTrue,
+							},
+							{
+								Type:   resourcesv1alpha1.ResourcesHealthy,
+								Status: gardencorev1beta1.ConditionTrue,
+							},
+						},
+					},
+				})).To(Succeed())
+
+				Expect(component.Wait(ctx)).To(Succeed())
+			})
+		})
+
+		Describe("#WaitCleanup", func() {
+			It("should fail when the wait for the managed resource deletion times out", func() {
+				fakeOps.MaxAttempts = 2
+
+				Expect(c.Create(ctx, managedResource)).To(Succeed())
+
+				Expect(component.WaitCleanup(ctx)).To(MatchError(ContainSubstring("still exists")))
+			})
+
+			It("should not return an error when it's already removed", func() {
+				Expect(component.WaitCleanup(ctx)).To(Succeed())
+			})
+		})
+	})
+})

--- a/pkg/operation/care/garden_health.go
+++ b/pkg/operation/care/garden_health.go
@@ -33,7 +33,7 @@ import (
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/component/etcd"
 	"github.com/gardener/gardener/pkg/component/gardeneraccess"
-	"github.com/gardener/gardener/pkg/component/gardensystem"
+	runtimegardensystem "github.com/gardener/gardener/pkg/component/gardensystem/runtime"
 	"github.com/gardener/gardener/pkg/component/hvpa"
 	"github.com/gardener/gardener/pkg/component/istio"
 	"github.com/gardener/gardener/pkg/component/kubecontrollermanager"
@@ -53,7 +53,7 @@ const virtualGardenPrefix = "virtual-garden-"
 var (
 	requiredGardenRuntimeManagedResources = sets.New(
 		etcd.Druid,
-		gardensystem.ManagedResourceName,
+		runtimegardensystem.ManagedResourceName,
 		kubestatemetrics.ManagedResourceName,
 		fluentoperator.OperatorManagedResourceName,
 		fluentoperator.CustomResourcesManagedResourceName+"-garden",

--- a/pkg/operation/care/garden_health_test.go
+++ b/pkg/operation/care/garden_health_test.go
@@ -32,7 +32,7 @@ import (
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/component/etcd"
 	"github.com/gardener/gardener/pkg/component/gardeneraccess"
-	"github.com/gardener/gardener/pkg/component/gardensystem"
+	runtimegardensystem "github.com/gardener/gardener/pkg/component/gardensystem/runtime"
 	"github.com/gardener/gardener/pkg/component/hvpa"
 	"github.com/gardener/gardener/pkg/component/kubecontrollermanager"
 	"github.com/gardener/gardener/pkg/component/kubestatemetrics"
@@ -49,7 +49,7 @@ import (
 var (
 	gardenManagedResources = []string{
 		etcd.Druid,
-		gardensystem.ManagedResourceName,
+		runtimegardensystem.ManagedResourceName,
 		hvpa.ManagedResourceName,
 		"istio-system",
 		"virtual-garden-istio",

--- a/pkg/operator/controller/garden/garden/components.go
+++ b/pkg/operator/controller/garden/garden/components.go
@@ -42,7 +42,7 @@ import (
 	"github.com/gardener/gardener/pkg/component/apiserver"
 	"github.com/gardener/gardener/pkg/component/etcd"
 	"github.com/gardener/gardener/pkg/component/gardeneraccess"
-	"github.com/gardener/gardener/pkg/component/gardensystem"
+	runtimegardensystem "github.com/gardener/gardener/pkg/component/gardensystem/runtime"
 	"github.com/gardener/gardener/pkg/component/hvpa"
 	"github.com/gardener/gardener/pkg/component/istio"
 	"github.com/gardener/gardener/pkg/component/kubeapiserver"
@@ -288,7 +288,7 @@ func (r *Reconciler) newEtcdDruid() (component.DeployWaiter, error) {
 }
 
 func (r *Reconciler) newSystem() component.DeployWaiter {
-	return gardensystem.New(r.RuntimeClientSet.Client(), r.GardenNamespace)
+	return runtimegardensystem.New(r.RuntimeClientSet.Client(), r.GardenNamespace)
 }
 
 func (r *Reconciler) newEtcd(

--- a/skaffold-operator.yaml
+++ b/skaffold-operator.yaml
@@ -96,7 +96,7 @@ build:
         - pkg/component/extensions/worker
         - pkg/component/gardeneraccess
         - pkg/component/gardenerapiserver
-        - pkg/component/gardensystem
+        - pkg/component/gardensystem/runtime
         - pkg/component/hvpa
         - pkg/component/istio
         - pkg/component/kubeapiserver

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -792,7 +792,7 @@ build:
         - pkg/client/kubernetes/clientmap/builder
         - pkg/client/kubernetes/clientmap/internal
         - pkg/client/kubernetes/clientmap/keys
-        - pkg/component/gardensystem
+        - pkg/component/gardensystem/runtime
         - pkg/controller/networkpolicy
         - pkg/controller/networkpolicy/helper
         - pkg/controller/networkpolicy/hostnameresolver

--- a/test/integration/operator/garden/care/care_test.go
+++ b/test/integration/operator/garden/care/care_test.go
@@ -31,7 +31,7 @@ import (
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	"github.com/gardener/gardener/pkg/component/etcd"
 	"github.com/gardener/gardener/pkg/component/gardeneraccess"
-	"github.com/gardener/gardener/pkg/component/gardensystem"
+	runtimegardensystem "github.com/gardener/gardener/pkg/component/gardensystem/runtime"
 	"github.com/gardener/gardener/pkg/component/hvpa"
 	"github.com/gardener/gardener/pkg/component/kubecontrollermanager"
 	"github.com/gardener/gardener/pkg/component/kubestatemetrics"
@@ -46,7 +46,7 @@ var _ = Describe("Garden Care controller tests", func() {
 	var (
 		requiredRuntimeClusterManagedResources = []string{
 			etcd.Druid,
-			gardensystem.ManagedResourceName,
+			runtimegardensystem.ManagedResourceName,
 			hvpa.ManagedResourceName,
 			vpa.ManagedResourceControlName,
 			"istio-system",


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind enhancement

**What this PR does / why we need it**:
This PR introduces the Golang component for the `gardensystem/virtual` resources also residing in https://github.com/gardener/gardener/tree/master/charts/gardener/controlplane/charts/application/templates.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/7016

**Special notes for your reviewer**:
/cc @oliver-goetz @ScheererJ @timuthy 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
