### PR TITLE
Remove unneeded import from `hack/tools.go`

### DIFF
--- a/hack/tools.go
+++ b/hack/tools.go
@@ -22,7 +22,6 @@ import (
 	_ "github.com/ahmetb/gen-crd-api-reference-docs"
 	_ "github.com/bronze1man/yaml2json"
 	_ "github.com/onsi/ginkgo/v2/ginkgo"
-	_ "go.uber.org/mock/gomock"
 	_ "go.uber.org/mock/mockgen"
 	_ "golang.org/x/tools/cmd/goimports"
 	_ "k8s.io/code-generator"

--- a/pkg/provider-local/webhook/controlplane/registry_mirror.go
+++ b/pkg/provider-local/webhook/controlplane/registry_mirror.go
@@ -27,10 +27,10 @@ type RegistryMirror struct {
 
 // HostsTOML returns hosts.toml configuration.
 func (r *RegistryMirror) HostsTOML() string {
-	const hostsTOMLYAMLTemplate = `server = "%s"
+	const hostsTOMLTemplate = `server = "%s"
 
 [host."%s"]
   capabilities = ["pull", "resolve"]
 `
-	return fmt.Sprintf(hostsTOMLYAMLTemplate, r.UpstreamServer, r.MirrorHost)
+	return fmt.Sprintf(hostsTOMLTemplate, r.UpstreamServer, r.MirrorHost)
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind cleanup

**What this PR does / why we need it**:
We use `hack/tools.go` to import tool dependencies that we later build on with `go build ...`. There is no binary (main func) in `go.uber.org/mock/gomock`, hence we don't need to import it as tools dependency.

**Which issue(s) this PR fixes**:
Follow-up after https://github.com/gardener/gardener/pull/8269

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
