### PR TITLE
Update printer columns for `Garden` resources

### DIFF
--- a/charts/gardener/operator/templates/customresouredefintion.yaml
+++ b/charts/gardener/operator/templates/customresouredefintion.yaml
@@ -18,9 +18,31 @@ spec:
   scope: Cluster
   versions:
   - additionalPrinterColumns:
-    - description: Indicates whether the garden has been reconciled.
-      jsonPath: .status.conditions[?(@.type=="Reconciled")].status
-      name: Reconciled
+    - description: Kubernetes version of virtual cluster.
+      jsonPath: .spec.virtualCluster.kubernetes.version
+      name: K8S Version
+      type: string
+    - description: Version of the Gardener components.
+      jsonPath: .status.gardener.version
+      name: Gardener Version
+      type: string
+    - description: Status of the last operation
+      jsonPath: .status.lastOperation.state
+      name: Last Operation
+      type: string
+    - description: Indicates whether the components related to the runtime cluster
+        are healthy.
+      jsonPath: .status.conditions[?(@.type=="RuntimeComponentsHealthy")].status
+      name: Runtime
+      type: string
+    - description: Indicates whether the components related to the virtual cluster
+        are healthy.
+      jsonPath: .status.conditions[?(@.type=="VirtualComponentsHealthy")].status
+      name: Virtual
+      type: string
+    - description: Indicates whether the API server of the virtual cluster is available.
+      jsonPath: .status.conditions[?(@.type=="VirtualGardenAPIServerAvailable")].status
+      name: API Server
       type: string
     - description: creation timestamp
       jsonPath: .metadata.creationTimestamp

--- a/example/operator/10-crd-operator.gardener.cloud_gardens.yaml
+++ b/example/operator/10-crd-operator.gardener.cloud_gardens.yaml
@@ -18,9 +18,31 @@ spec:
   scope: Cluster
   versions:
   - additionalPrinterColumns:
-    - description: Indicates whether the garden has been reconciled.
-      jsonPath: .status.conditions[?(@.type=="Reconciled")].status
-      name: Reconciled
+    - description: Kubernetes version of virtual cluster.
+      jsonPath: .spec.virtualCluster.kubernetes.version
+      name: K8S Version
+      type: string
+    - description: Version of the Gardener components.
+      jsonPath: .status.gardener.version
+      name: Gardener Version
+      type: string
+    - description: Status of the last operation
+      jsonPath: .status.lastOperation.state
+      name: Last Operation
+      type: string
+    - description: Indicates whether the components related to the runtime cluster
+        are healthy.
+      jsonPath: .status.conditions[?(@.type=="RuntimeComponentsHealthy")].status
+      name: Runtime
+      type: string
+    - description: Indicates whether the components related to the virtual cluster
+        are healthy.
+      jsonPath: .status.conditions[?(@.type=="VirtualComponentsHealthy")].status
+      name: Virtual
+      type: string
+    - description: Indicates whether the API server of the virtual cluster is available.
+      jsonPath: .status.conditions[?(@.type=="VirtualGardenAPIServerAvailable")].status
+      name: API Server
       type: string
     - description: creation timestamp
       jsonPath: .metadata.creationTimestamp

--- a/pkg/apis/operator/v1alpha1/types.go
+++ b/pkg/apis/operator/v1alpha1/types.go
@@ -29,7 +29,12 @@ import (
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:resource:scope=Cluster,shortName="grdn"
 // +kubebuilder:subresource:status
-// +kubebuilder:printcolumn:name="Reconciled",type=string,JSONPath=`.status.conditions[?(@.type=="Reconciled")].status`,description="Indicates whether the garden has been reconciled."
+// +kubebuilder:printcolumn:name="K8S Version",type=string,JSONPath=`.spec.virtualCluster.kubernetes.version`,description="Kubernetes version of virtual cluster."
+// +kubebuilder:printcolumn:name="Gardener Version",type=string,JSONPath=`.status.gardener.version`,description="Version of the Gardener components."
+// +kubebuilder:printcolumn:name="Last Operation",type=string,JSONPath=`.status.lastOperation.state`,description="Status of the last operation"
+// +kubebuilder:printcolumn:name="Runtime",type=string,JSONPath=`.status.conditions[?(@.type=="RuntimeComponentsHealthy")].status`,description="Indicates whether the components related to the runtime cluster are healthy."
+// +kubebuilder:printcolumn:name="Virtual",type=string,JSONPath=`.status.conditions[?(@.type=="VirtualComponentsHealthy")].status`,description="Indicates whether the components related to the virtual cluster are healthy."
+// +kubebuilder:printcolumn:name="API Server",type=string,JSONPath=`.status.conditions[?(@.type=="VirtualGardenAPIServerAvailable")].status`,description="Indicates whether the API server of the virtual cluster is available."
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`,description="creation timestamp"
 
 // Garden describes a list of gardens.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity
/kind enhancement

**What this PR does / why we need it**:
Update printer columns for `Garden` resources.

Before:
```
$ kg get garden
NAME    RECONCILED   AGE
local                74m
```

Now:
```
$ k get garden
NAME    K8S VERSION   GARDENER VERSION   LAST OPERATION   RUNTIME   VIRTUAL   API SERVER   AGE
local   1.26.1        v1.77.0-dev        Succeeded        True      True      True         74m
```

**Which issue(s) this PR fixes**:
Part of #7016
Follow-up of #8238

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
`kubectl get garden` now features additional printer columns providing more information about the substantial configuration values and statuses.
```
