### PR TITLE
Enforce requirements for shoot k8s upgrade to `v1.25` and `v1.27` in `maintenance-controller` 

### DIFF
--- a/docs/development/new-kubernetes-version.md
+++ b/docs/development/new-kubernetes-version.md
@@ -85,6 +85,7 @@ There is a CI/CD job that runs periodically and releases a new `hyperkube` image
   - Sometimes default values for shoots are intentionally changed with the introduction of a new Kubernetes version.
   - The final Kubernetes version for a shoot is determined in the [Shoot Validator Admission Plugin](https://github.com/gardener/gardener/blob/17dfefaffed6c5e125e35b6614c8dcad801839f1/plugin/pkg/shoot/validator/admission.go).
   - Any defaulting logic that depends on the version should be placed in this admission plugin ([example](https://github.com/gardener/gardener/blob/f754c071e6cf8e45f7ac7bc5924acaf81b96dc06/plugin/pkg/shoot/validator/admission.go#L782)).
+- Ensure that [maintenance-controller](https://github.com/gardener/gardener/tree/master/pkg/controllermanager/controller/shoot/maintenance) is able to auto-update shoots to the new Kubernetes version. Changes to the shoot spec required for the Kubernetes update should be enforced in such cases ([examples](https://github.com/gardener/gardener/blob/bdfc06dc5cb4e5764800fd31ba1dd07727ad78bf/pkg/controllermanager/controller/shoot/maintenance/reconciler.go#L146-L162)).
 - Bump the used Kubernetes version for local e2e test.
   - See [this](https://github.com/gardener/gardener/pull/5255/commits/5707c4c7a4fd265b176387178b755cabeea89ffe) example commit.
 

--- a/pkg/controllermanager/controller/shoot/maintenance/reconciler.go
+++ b/pkg/controllermanager/controller/shoot/maintenance/reconciler.go
@@ -145,11 +145,7 @@ func (r *Reconciler) reconcile(ctx context.Context, log logr.Logger, shoot *gard
 
 	// Force containerd when shoot cluster is updated to k8s version >= 1.23
 	if versionutils.ConstraintK8sLess123.Check(oldShootKubernetesVersion) && versionutils.ConstraintK8sGreaterEqual123.Check(shootKubernetesVersion) {
-		reasonsForContainerdUpdate, err := updateToContainerd(maintainedShoot, fmt.Sprintf("Updating Kubernetes to %q", shootKubernetesVersion.String()))
-		if err != nil {
-			// continue execution to allow other updates
-			log.Error(err, "Failed updating worker pools' CRI to containerd")
-		}
+		reasonsForContainerdUpdate := updateToContainerd(maintainedShoot, fmt.Sprintf("Updating Kubernetes to %q", shootKubernetesVersion.String()))
 		operations = append(operations, reasonsForContainerdUpdate...)
 	}
 
@@ -633,7 +629,7 @@ func ExpirationDateExpired(timestamp *metav1.Time) bool {
 }
 
 // updateToContainerd updates the CRI of a Shoot's worker pools to containerd
-func updateToContainerd(shoot *gardencorev1beta1.Shoot, reason string) ([]string, error) {
+func updateToContainerd(shoot *gardencorev1beta1.Shoot, reason string) []string {
 	var reasonsForUpdate []string
 
 	for i, worker := range shoot.Spec.Provider.Workers {
@@ -644,5 +640,5 @@ func updateToContainerd(shoot *gardencorev1beta1.Shoot, reason string) ([]string
 		reasonsForUpdate = append(reasonsForUpdate, fmt.Sprintf("CRI of worker-pool %q upgraded from %q to %q. Reason: %s", worker.Name, gardencorev1beta1.CRINameDocker, gardencorev1beta1.CRINameContainerD, reason))
 	}
 
-	return reasonsForUpdate, nil
+	return reasonsForUpdate
 }

--- a/pkg/controllermanager/controller/shoot/maintenance/reconciler.go
+++ b/pkg/controllermanager/controller/shoot/maintenance/reconciler.go
@@ -641,9 +641,7 @@ func ExpirationDateExpired(timestamp *metav1.Time) bool {
 
 // disablePodSecurityPolicyAdmissionController disables the PodSecurityPolicy Admission Controller of a shoot
 func disablePodSecurityPolicyAdmissionController(shoot *gardencorev1beta1.Shoot, reason string) []string {
-	var (
-		reasonsForUpdate []string
-	)
+	var reasonsForUpdate []string
 
 	if shoot.Spec.Kubernetes.KubeAPIServer == nil {
 		shoot.Spec.Kubernetes.KubeAPIServer = &gardencorev1beta1.KubeAPIServerConfig{}
@@ -671,11 +669,13 @@ func disablePodSecurityPolicyAdmissionController(shoot *gardencorev1beta1.Shoot,
 
 // ensureSufficientMaxWorkers ensures that the number of max workers of a worker group is greater or equal to its number of zones
 func ensureSufficientMaxWorkers(shoot *gardencorev1beta1.Shoot, reason string) []string {
-	var (
-		reasonsForUpdate []string
-	)
+	var reasonsForUpdate []string
 
 	for i, worker := range shoot.Spec.Provider.Workers {
+		if !v1beta1helper.SystemComponentsAllowed(&worker) {
+			continue
+		}
+
 		if int(worker.Maximum) >= len(worker.Zones) {
 			continue
 		}

--- a/pkg/controllermanager/controller/shoot/maintenance/reconciler.go
+++ b/pkg/controllermanager/controller/shoot/maintenance/reconciler.go
@@ -156,11 +156,13 @@ func (r *Reconciler) reconcile(ctx context.Context, log logr.Logger, shoot *gard
 	}
 
 	// Reset the `EnableStaticTokenKubeconfig` value to false, when shoot cluster is updated to  k8s version >= 1.27.
-	if versionutils.ConstraintK8sLess127.Check(oldShootKubernetesVersion) && pointer.BoolDeref(maintainedShoot.Spec.Kubernetes.EnableStaticTokenKubeconfig, false) && versionutils.ConstraintK8sGreaterEqual127.Check(shootKubernetesVersion) {
-		maintainedShoot.Spec.Kubernetes.EnableStaticTokenKubeconfig = pointer.Bool(false)
+	if versionutils.ConstraintK8sLess127.Check(oldShootKubernetesVersion) && versionutils.ConstraintK8sGreaterEqual127.Check(shootKubernetesVersion) {
+		if pointer.BoolDeref(maintainedShoot.Spec.Kubernetes.EnableStaticTokenKubeconfig, false) {
+			maintainedShoot.Spec.Kubernetes.EnableStaticTokenKubeconfig = pointer.Bool(false)
 
-		reason := "EnableStaticTokenKubeconfig is set to false. Reason: The static token kubeconfig can no longer be enabled for Shoot clusters using Kubernetes version 1.27 and higher"
-		operations = append(operations, reason)
+			reason := "EnableStaticTokenKubeconfig is set to false. Reason: The static token kubeconfig can no longer be enabled for Shoot clusters using Kubernetes version 1.27 and higher"
+			operations = append(operations, reason)
+		}
 
 		reasonsForIncreasingMaxWorkers := ensureSufficientMaxWorkers(maintainedShoot, fmt.Sprintf("Maximum number of workers of a worker group must be greater or equal to its number of zones for updating Kubernetes to %q", shootKubernetesVersion.String()))
 		operations = append(operations, reasonsForIncreasingMaxWorkers...)

--- a/pkg/controllermanager/controller/shoot/maintenance/reconciler_test.go
+++ b/pkg/controllermanager/controller/shoot/maintenance/reconciler_test.go
@@ -780,6 +780,15 @@ var _ = Describe("Shoot Maintenance", func() {
 			}
 		})
 
+		It("should not change worker groups which do not allow system components", func() {
+			shoot.Spec.Provider.Workers[1].SystemComponents = &gardencorev1beta1.WorkerSystemComponents{Allow: false}
+			shoot.Spec.Provider.Workers[1].Zones = append(shoot.Spec.Provider.Workers[1].Zones, "barZone")
+			result := ensureSufficientMaxWorkers(shoot, "foobar")
+			Expect(result).To(HaveLen(0))
+			Expect(shoot.Spec.Provider.Workers[0].Maximum).To(Equal(int32(3)))
+			Expect(shoot.Spec.Provider.Workers[1].Maximum).To(Equal(int32(1)))
+		})
+
 		It("should not change anything if the maximum workers are high enough", func() {
 			result := ensureSufficientMaxWorkers(shoot, "foobar")
 			Expect(result).To(HaveLen(0))
@@ -787,7 +796,7 @@ var _ = Describe("Shoot Maintenance", func() {
 			Expect(shoot.Spec.Provider.Workers[1].Maximum).To(Equal(int32(1)))
 		})
 
-		It("should increase there are more zones than maximum workers", func() {
+		It("should increase values if there are more zones than maximum workers", func() {
 			shoot.Spec.Provider.Workers[1].Zones = append(shoot.Spec.Provider.Workers[1].Zones, "barZone")
 			result := ensureSufficientMaxWorkers(shoot, "foobar")
 			Expect(result).To(HaveLen(1))

--- a/pkg/controllermanager/controller/shoot/maintenance/reconciler_test.go
+++ b/pkg/controllermanager/controller/shoot/maintenance/reconciler_test.go
@@ -753,6 +753,49 @@ var _ = Describe("Shoot Maintenance", func() {
 		})
 	})
 
+	Describe("#EnsureSufficientMaxWorkers", func() {
+		var (
+			shoot *gardencorev1beta1.Shoot
+		)
+
+		BeforeEach(func() {
+			shoot = &gardencorev1beta1.Shoot{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "shoot",
+				},
+				Spec: gardencorev1beta1.ShootSpec{
+					Provider: gardencorev1beta1.Provider{Workers: []gardencorev1beta1.Worker{
+						{
+							Name:    "cpu-worker",
+							Maximum: 3,
+							Zones:   []string{"fooZone", "barZone"},
+						},
+						{
+							Name:    "cpu-worker2",
+							Maximum: 1,
+							Zones:   []string{"fooZone"},
+						},
+					}},
+				},
+			}
+		})
+
+		It("should not change anything if the maximum workers are high enough", func() {
+			result := ensureSufficientMaxWorkers(shoot, "foobar")
+			Expect(result).To(HaveLen(0))
+			Expect(shoot.Spec.Provider.Workers[0].Maximum).To(Equal(int32(3)))
+			Expect(shoot.Spec.Provider.Workers[1].Maximum).To(Equal(int32(1)))
+		})
+
+		It("should increase there are more zones than maximum workers", func() {
+			shoot.Spec.Provider.Workers[1].Zones = append(shoot.Spec.Provider.Workers[1].Zones, "barZone")
+			result := ensureSufficientMaxWorkers(shoot, "foobar")
+			Expect(result).To(HaveLen(1))
+			Expect(shoot.Spec.Provider.Workers[0].Maximum).To(Equal(int32(3)))
+			Expect(shoot.Spec.Provider.Workers[1].Maximum).To(Equal(int32(2)))
+		})
+	})
+
 	Describe("#UpdateToContainerd", func() {
 		var (
 			shoot *gardencorev1beta1.Shoot

--- a/pkg/controllermanager/controller/shoot/maintenance/reconciler_test.go
+++ b/pkg/controllermanager/controller/shoot/maintenance/reconciler_test.go
@@ -711,14 +711,6 @@ var _ = Describe("Shoot Maintenance", func() {
 					Name: "shoot",
 				},
 				Spec: gardencorev1beta1.ShootSpec{
-					Kubernetes: gardencorev1beta1.Kubernetes{
-						Version: "1.23.16",
-					},
-					Maintenance: &gardencorev1beta1.Maintenance{
-						AutoUpdate: &gardencorev1beta1.MaintenanceAutoUpdate{
-							MachineImageVersion: pointer.Bool(true),
-						},
-					},
 					Provider: gardencorev1beta1.Provider{Workers: []gardencorev1beta1.Worker{
 						{
 							Name: "cpu-worker",
@@ -732,24 +724,24 @@ var _ = Describe("Shoot Maintenance", func() {
 		})
 
 		It("should not change anything if CRI is not set", func() {
-			_, err := updateToContainerd(shoot, "foobar")
-			Expect(err).NotTo(HaveOccurred())
+			result := updateToContainerd(shoot, "foobar")
+			Expect(result).To(HaveLen(0))
 			Expect(shoot.Spec.Provider.Workers[0].CRI).To(BeNil())
 			Expect(shoot.Spec.Provider.Workers[1].CRI).To(BeNil())
 		})
 
 		It("should change docker to containerd", func() {
 			shoot.Spec.Provider.Workers[1].CRI = &gardencorev1beta1.CRI{Name: "docker"}
-			_, err := updateToContainerd(shoot, "foobar")
-			Expect(err).NotTo(HaveOccurred())
+			result := updateToContainerd(shoot, "foobar")
+			Expect(result).To(HaveLen(1))
 			Expect(shoot.Spec.Provider.Workers[1].CRI.Name).To(Equal(gardencorev1beta1.CRINameContainerD))
 			Expect(shoot.Spec.Provider.Workers[0].CRI).To(BeNil())
 		})
 
 		It("should keep containerd if it is already set", func() {
 			shoot.Spec.Provider.Workers[0].CRI = &gardencorev1beta1.CRI{Name: "containerd"}
-			_, err := updateToContainerd(shoot, "foobar")
-			Expect(err).NotTo(HaveOccurred())
+			result := updateToContainerd(shoot, "foobar")
+			Expect(result).To(HaveLen(0))
 			Expect(shoot.Spec.Provider.Workers[0].CRI.Name).To(Equal(gardencorev1beta1.CRINameContainerD))
 			Expect(shoot.Spec.Provider.Workers[1].CRI).To(BeNil())
 		})


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity
/kind enhancement

**What this PR does / why we need it**:
With this PR `maintenance-controller` enforces additional requirements for shoot Kubernetes upgrades:
- to `v1.25`: Disable `PodSecurityPolicy` admission controller
- to `v1.27`: Ensure for every worker group that maximum workers is greater or equal to its number of zones

**Which issue(s) this PR fixes**:
Fixes part of #8271 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
`maintenance-controller` now disables `PodSecurityPolicy` admission controller when forcefully upgrading the Kubernetes version of a `Shoot` to `v1.25`. It also ensures maximum workers of each for group is greater or equal to its number of zone for forceful upgrades to `v1.27`.
```
