### PR TITLE
[operator] Introduce `gardenercontrollermanager` Golang component

### DIFF
--- a/docs/development/priority-classes.md
+++ b/docs/development/priority-classes.md
@@ -25,7 +25,7 @@ When using the `gardener-operator` for managing the garden runtime and virtual c
 | `gardener-garden-system-500`      | 999999500 | `virtual-garden-etcd-events`, `virtual-garden-etcd-main`, `virtual-garden-kube-apiserver`, `gardener-apiserver` |
 | `gardener-garden-system-400`      | 999999400 | `virtual-garden-gardener-resource-manager`, `gardener-admission-controller`                                     |
 | `gardener-garden-system-300`      | 999999300 | `virtual-garden-kube-controller-manager`, `vpa-admission-controller`, `etcd-druid`, `nginx-ingress-controller`  |
-| `gardener-garden-system-200`      | 999999200 | `vpa-recommender`, `vpa-updater`, `hvpa-controller`,                                                            |
+| `gardener-garden-system-200`      | 999999200 | `vpa-recommender`, `vpa-updater`, `hvpa-controller`, `gardener-scheduler`, `gardener-controller-manager`        |
 | `gardener-garden-system-100`      | 999999100 | `kube-state-metrics`, `fluent-operator`, `fluent-bit`, `vali`                                                   |
 
 ## Seed Clusters

--- a/pkg/component/gardenercontrollermanager/configmaps.go
+++ b/pkg/component/gardenercontrollermanager/configmaps.go
@@ -1,0 +1,168 @@
+// Copyright 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gardenercontrollermanager
+
+import (
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/apimachinery/pkg/runtime/serializer/json"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	componentbaseconfigv1alpha1 "k8s.io/component-base/config/v1alpha1"
+	"k8s.io/utils/pointer"
+
+	controllermanagerv1alpha1 "github.com/gardener/gardener/pkg/controllermanager/apis/config/v1alpha1"
+	"github.com/gardener/gardener/pkg/logger"
+	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
+	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
+)
+
+const (
+	configMapControllerManagerPrefix = "gardener-controller-manager-config"
+	dataConfigKey                    = "config.yaml"
+)
+
+var controllerManagerCodec runtime.Codec
+
+func init() {
+	controllerManagerScheme := runtime.NewScheme()
+	utilruntime.Must(controllermanagerv1alpha1.AddToScheme(controllerManagerScheme))
+
+	var (
+		ser = json.NewSerializerWithOptions(json.DefaultMetaFactory, controllerManagerScheme, controllerManagerScheme, json.SerializerOptions{
+			Yaml:   true,
+			Pretty: false,
+			Strict: false,
+		})
+		versions = schema.GroupVersions([]schema.GroupVersion{
+			controllermanagerv1alpha1.SchemeGroupVersion,
+		})
+	)
+
+	controllerManagerCodec = serializer.NewCodecFactory(controllerManagerScheme).CodecForVersions(ser, ser, versions, versions)
+}
+
+func (g *gardenerControllerManager) configMapControllerManagerConfig() (*corev1.ConfigMap, error) {
+	controllerManagerConfig := &controllermanagerv1alpha1.ControllerManagerConfiguration{
+		GardenClientConnection: componentbaseconfigv1alpha1.ClientConnectionConfiguration{
+			QPS:        100,
+			Burst:      130,
+			Kubeconfig: gardenerutils.PathGenericKubeconfig,
+		},
+		Controllers: controllermanagerv1alpha1.ControllerManagerControllerConfiguration{
+			CertificateSigningRequest: &controllermanagerv1alpha1.CertificateSigningRequestControllerConfiguration{
+				ConcurrentSyncs: pointer.Int(5),
+			},
+			ControllerRegistration: &controllermanagerv1alpha1.ControllerRegistrationControllerConfiguration{
+				ConcurrentSyncs: pointer.Int(20),
+			},
+			Project: &controllermanagerv1alpha1.ProjectControllerConfiguration{
+				ConcurrentSyncs: pointer.Int(20),
+				Quotas:          g.values.Quotas,
+			},
+			SecretBinding: &controllermanagerv1alpha1.SecretBindingControllerConfiguration{
+				ConcurrentSyncs: pointer.Int(20),
+			},
+			Seed: &controllermanagerv1alpha1.SeedControllerConfiguration{
+				ConcurrentSyncs:    pointer.Int(20),
+				SyncPeriod:         &metav1.Duration{Duration: 10 * time.Second},
+				MonitorPeriod:      &metav1.Duration{Duration: 40 * time.Second},
+				ShootMonitorPeriod: &metav1.Duration{Duration: 300 * time.Second},
+			},
+			SeedExtensionsCheck: &controllermanagerv1alpha1.SeedExtensionsCheckControllerConfiguration{
+				ConcurrentSyncs: pointer.Int(5),
+				SyncPeriod:      &metav1.Duration{Duration: 30 * time.Second},
+				ConditionThresholds: []controllermanagerv1alpha1.ConditionThreshold{{
+					Duration: metav1.Duration{Duration: 1 * time.Minute},
+					Type:     "ExtensionsReady",
+				}},
+			},
+			SeedBackupBucketsCheck: &controllermanagerv1alpha1.SeedBackupBucketsCheckControllerConfiguration{
+				ConcurrentSyncs: pointer.Int(5),
+				SyncPeriod:      &metav1.Duration{Duration: 30 * time.Second},
+				ConditionThresholds: []controllermanagerv1alpha1.ConditionThreshold{{
+					Duration: metav1.Duration{Duration: 1 * time.Minute},
+					Type:     "BackupBucketsReady",
+				}},
+			},
+			Event: &controllermanagerv1alpha1.EventControllerConfiguration{
+				ConcurrentSyncs:   pointer.Int(10),
+				TTLNonShootEvents: &metav1.Duration{Duration: 2 * time.Hour},
+			},
+			ShootMaintenance: controllermanagerv1alpha1.ShootMaintenanceControllerConfiguration{
+				ConcurrentSyncs:                  pointer.Int(20),
+				EnableShootControlPlaneRestarter: pointer.Bool(true),
+			},
+			ShootQuota: &controllermanagerv1alpha1.ShootQuotaControllerConfiguration{
+				ConcurrentSyncs: pointer.Int(5),
+				SyncPeriod:      &metav1.Duration{Duration: 60 * time.Minute},
+			},
+			ShootHibernation: controllermanagerv1alpha1.ShootHibernationControllerConfiguration{
+				ConcurrentSyncs:         pointer.Int(5),
+				TriggerDeadlineDuration: &metav1.Duration{Duration: 2 * time.Hour},
+			},
+			ShootReference: &controllermanagerv1alpha1.ShootReferenceControllerConfiguration{
+				ConcurrentSyncs: pointer.Int(20),
+			},
+			ShootRetry: &controllermanagerv1alpha1.ShootRetryControllerConfiguration{
+				ConcurrentSyncs:   pointer.Int(5),
+				RetryPeriod:       &metav1.Duration{Duration: 10 * time.Minute},
+				RetryJitterPeriod: &metav1.Duration{Duration: 5 * time.Minute},
+			},
+			ManagedSeedSet: &controllermanagerv1alpha1.ManagedSeedSetControllerConfiguration{
+				ConcurrentSyncs: pointer.Int(5),
+				SyncPeriod:      metav1.Duration{Duration: 30 * time.Minute},
+			},
+			ExposureClass: &controllermanagerv1alpha1.ExposureClassControllerConfiguration{
+				ConcurrentSyncs: pointer.Int(5),
+			},
+		},
+		LeaderElection: &componentbaseconfigv1alpha1.LeaderElectionConfiguration{
+			LeaderElect:       pointer.Bool(true),
+			ResourceName:      controllermanagerv1alpha1.ControllerManagerDefaultLockObjectName,
+			ResourceNamespace: metav1.NamespaceSystem,
+		},
+		LogLevel:  g.values.LogLevel,
+		LogFormat: logger.FormatJSON,
+		Server: controllermanagerv1alpha1.ServerConfiguration{
+			HealthProbes: &controllermanagerv1alpha1.Server{Port: probePort},
+			Metrics:      &controllermanagerv1alpha1.Server{Port: metricsPort},
+		},
+		FeatureGates: g.values.FeatureGates,
+	}
+
+	data, err := runtime.Encode(controllerManagerCodec, controllerManagerConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	configMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      configMapControllerManagerPrefix,
+			Namespace: g.namespace,
+			Labels:    GetLabels(),
+		},
+		Data: map[string]string{
+			dataConfigKey: string(data),
+		},
+	}
+
+	utilruntime.Must(kubernetesutils.MakeUnique(configMap))
+	return configMap, nil
+}

--- a/pkg/component/gardenercontrollermanager/configmaps.go
+++ b/pkg/component/gardenercontrollermanager/configmaps.go
@@ -66,9 +66,6 @@ func (g *gardenerControllerManager) configMapControllerManagerConfig() (*corev1.
 			Kubeconfig: gardenerutils.PathGenericKubeconfig,
 		},
 		Controllers: controllermanagerv1alpha1.ControllerManagerControllerConfiguration{
-			CertificateSigningRequest: &controllermanagerv1alpha1.CertificateSigningRequestControllerConfiguration{
-				ConcurrentSyncs: pointer.Int(5),
-			},
 			ControllerRegistration: &controllermanagerv1alpha1.ControllerRegistrationControllerConfiguration{
 				ConcurrentSyncs: pointer.Int(20),
 			},
@@ -81,21 +78,15 @@ func (g *gardenerControllerManager) configMapControllerManagerConfig() (*corev1.
 			},
 			Seed: &controllermanagerv1alpha1.SeedControllerConfiguration{
 				ConcurrentSyncs:    pointer.Int(20),
-				SyncPeriod:         &metav1.Duration{Duration: 10 * time.Second},
-				MonitorPeriod:      &metav1.Duration{Duration: 40 * time.Second},
 				ShootMonitorPeriod: &metav1.Duration{Duration: 300 * time.Second},
 			},
 			SeedExtensionsCheck: &controllermanagerv1alpha1.SeedExtensionsCheckControllerConfiguration{
-				ConcurrentSyncs: pointer.Int(5),
-				SyncPeriod:      &metav1.Duration{Duration: 30 * time.Second},
 				ConditionThresholds: []controllermanagerv1alpha1.ConditionThreshold{{
 					Duration: metav1.Duration{Duration: 1 * time.Minute},
 					Type:     "ExtensionsReady",
 				}},
 			},
 			SeedBackupBucketsCheck: &controllermanagerv1alpha1.SeedBackupBucketsCheckControllerConfiguration{
-				ConcurrentSyncs: pointer.Int(5),
-				SyncPeriod:      &metav1.Duration{Duration: 30 * time.Second},
 				ConditionThresholds: []controllermanagerv1alpha1.ConditionThreshold{{
 					Duration: metav1.Duration{Duration: 1 * time.Minute},
 					Type:     "BackupBucketsReady",
@@ -106,31 +97,10 @@ func (g *gardenerControllerManager) configMapControllerManagerConfig() (*corev1.
 				TTLNonShootEvents: &metav1.Duration{Duration: 2 * time.Hour},
 			},
 			ShootMaintenance: controllermanagerv1alpha1.ShootMaintenanceControllerConfiguration{
-				ConcurrentSyncs:                  pointer.Int(20),
-				EnableShootControlPlaneRestarter: pointer.Bool(true),
-			},
-			ShootQuota: &controllermanagerv1alpha1.ShootQuotaControllerConfiguration{
-				ConcurrentSyncs: pointer.Int(5),
-				SyncPeriod:      &metav1.Duration{Duration: 60 * time.Minute},
-			},
-			ShootHibernation: controllermanagerv1alpha1.ShootHibernationControllerConfiguration{
-				ConcurrentSyncs:         pointer.Int(5),
-				TriggerDeadlineDuration: &metav1.Duration{Duration: 2 * time.Hour},
+				ConcurrentSyncs: pointer.Int(20),
 			},
 			ShootReference: &controllermanagerv1alpha1.ShootReferenceControllerConfiguration{
 				ConcurrentSyncs: pointer.Int(20),
-			},
-			ShootRetry: &controllermanagerv1alpha1.ShootRetryControllerConfiguration{
-				ConcurrentSyncs:   pointer.Int(5),
-				RetryPeriod:       &metav1.Duration{Duration: 10 * time.Minute},
-				RetryJitterPeriod: &metav1.Duration{Duration: 5 * time.Minute},
-			},
-			ManagedSeedSet: &controllermanagerv1alpha1.ManagedSeedSetControllerConfiguration{
-				ConcurrentSyncs: pointer.Int(5),
-				SyncPeriod:      metav1.Duration{Duration: 30 * time.Minute},
-			},
-			ExposureClass: &controllermanagerv1alpha1.ExposureClassControllerConfiguration{
-				ConcurrentSyncs: pointer.Int(5),
 			},
 		},
 		LeaderElection: &componentbaseconfigv1alpha1.LeaderElectionConfiguration{

--- a/pkg/component/gardenercontrollermanager/deployment.go
+++ b/pkg/component/gardenercontrollermanager/deployment.go
@@ -1,0 +1,128 @@
+// Copyright 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gardenercontrollermanager
+
+import (
+	"fmt"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/utils/pointer"
+
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
+	kubeapiserverconstants "github.com/gardener/gardener/pkg/component/kubeapiserver/constants"
+	"github.com/gardener/gardener/pkg/resourcemanager/controller/garbagecollector/references"
+	"github.com/gardener/gardener/pkg/utils"
+	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
+)
+
+const (
+	volumeMountConfig = "/etc/gardener-controller-manager/config"
+	volumeNameConfig  = "gardener-controller-manager-config"
+)
+
+func (g *gardenerControllerManager) deployment(secretGenericTokenKubeconfig, secretVirtualGardenAccess, configMapControllerManagerConfig string) *appsv1.Deployment {
+	deployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      DeploymentName,
+			Namespace: g.namespace,
+			Labels: utils.MergeStringMaps(GetLabels(), map[string]string{
+				resourcesv1alpha1.HighAvailabilityConfigType: resourcesv1alpha1.HighAvailabilityConfigTypeController,
+			}),
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: pointer.Int32(1),
+			Selector: &metav1.LabelSelector{
+				MatchLabels: GetLabels(),
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: utils.MergeStringMaps(GetLabels(), map[string]string{
+						v1beta1constants.LabelNetworkPolicyToDNS: v1beta1constants.LabelNetworkPolicyAllowed,
+						gardenerutils.NetworkPolicyLabel("virtual-garden-"+v1beta1constants.DeploymentNameKubeAPIServer, kubeapiserverconstants.Port): v1beta1constants.LabelNetworkPolicyAllowed,
+					}),
+				},
+				Spec: corev1.PodSpec{
+					PriorityClassName:            v1beta1constants.PriorityClassNameGardenSystem200,
+					AutomountServiceAccountToken: pointer.Bool(false),
+					Containers: []corev1.Container{
+						{
+							Name:            DeploymentName,
+							Image:           g.values.Image,
+							ImagePullPolicy: corev1.PullIfNotPresent,
+							Args: []string{
+								fmt.Sprintf("--config=%s/%s", volumeMountConfig, dataConfigKey),
+							},
+							Resources: corev1.ResourceRequirements{
+								Requests: map[corev1.ResourceName]resource.Quantity{
+									corev1.ResourceCPU:    resource.MustParse("1"),
+									corev1.ResourceMemory: resource.MustParse("1Gi"),
+								},
+							},
+							LivenessProbe: &corev1.Probe{
+								ProbeHandler: corev1.ProbeHandler{
+									HTTPGet: &corev1.HTTPGetAction{
+										Path:   "/healthz",
+										Port:   intstr.FromInt(probePort),
+										Scheme: corev1.URISchemeHTTP,
+									},
+								},
+								InitialDelaySeconds: 30,
+								TimeoutSeconds:      5,
+							},
+							ReadinessProbe: &corev1.Probe{
+								ProbeHandler: corev1.ProbeHandler{
+									HTTPGet: &corev1.HTTPGetAction{
+										Path:   "/readyz",
+										Port:   intstr.FromInt(probePort),
+										Scheme: corev1.URISchemeHTTP,
+									},
+								},
+								InitialDelaySeconds: 10,
+								TimeoutSeconds:      5,
+							},
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name:      volumeNameConfig,
+									MountPath: volumeMountConfig,
+								},
+							},
+						},
+					},
+					Volumes: []corev1.Volume{
+						{
+							Name: volumeNameConfig,
+							VolumeSource: corev1.VolumeSource{
+								ConfigMap: &corev1.ConfigMapVolumeSource{
+									LocalObjectReference: corev1.LocalObjectReference{Name: configMapControllerManagerConfig},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	utilruntime.Must(gardenerutils.InjectGenericKubeconfig(deployment, secretGenericTokenKubeconfig, secretVirtualGardenAccess))
+	utilruntime.Must(references.InjectAnnotations(deployment))
+
+	return deployment
+}

--- a/pkg/component/gardenercontrollermanager/gardener_controller_manager.go
+++ b/pkg/component/gardenercontrollermanager/gardener_controller_manager.go
@@ -93,6 +93,7 @@ func (g *gardenerControllerManager) Deploy(ctx context.Context) error {
 		controllerManagerConfigConfigMap,
 		g.podDisruptionBudget(),
 		g.service(),
+		g.verticalPodAutoscaler(),
 	)
 	if err != nil {
 		return err

--- a/pkg/component/gardenercontrollermanager/gardener_controller_manager.go
+++ b/pkg/component/gardenercontrollermanager/gardener_controller_manager.go
@@ -23,11 +23,15 @@ import (
 	"github.com/gardener/gardener/pkg/component"
 	operatorclient "github.com/gardener/gardener/pkg/operator/client"
 	"github.com/gardener/gardener/pkg/utils/flow"
+	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/managedresources"
 	secretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager"
 )
 
 const (
+	// DeploymentName is the name of the deployment.
+	DeploymentName = "gardener-controller-manager"
+
 	managedResourceNameRuntime = "gardener-controller-manager-runtime"
 	managedResourceNameVirtual = "gardener-controller-manager-virtual"
 )
@@ -59,8 +63,13 @@ type gardenerControllerManager struct {
 
 func (g *gardenerControllerManager) Deploy(ctx context.Context) error {
 	var (
-		runtimeRegistry = managedresources.NewRegistry(operatorclient.RuntimeScheme, operatorclient.RuntimeCodec, operatorclient.RuntimeSerializer)
+		runtimeRegistry           = managedresources.NewRegistry(operatorclient.RuntimeScheme, operatorclient.RuntimeCodec, operatorclient.RuntimeSerializer)
+		virtualGardenAccessSecret = g.newVirtualGardenAccessSecret()
 	)
+
+	if err := virtualGardenAccessSecret.Reconcile(ctx, g.client); err != nil {
+		return err
+	}
 
 	runtimeResources, err := runtimeRegistry.AddAllAndSerialize()
 	if err != nil {
@@ -102,7 +111,11 @@ func (g *gardenerControllerManager) Destroy(ctx context.Context) error {
 		return err
 	}
 
-	return managedresources.DeleteForSeed(ctx, g.client, g.namespace, managedResourceNameRuntime)
+	if err := managedresources.DeleteForSeed(ctx, g.client, g.namespace, managedResourceNameRuntime); err != nil {
+		return err
+	}
+
+	return kubernetesutils.DeleteObjects(ctx, g.client, g.newVirtualGardenAccessSecret().Secret)
 }
 
 func (g *gardenerControllerManager) WaitCleanup(ctx context.Context) error {

--- a/pkg/component/gardenercontrollermanager/gardener_controller_manager.go
+++ b/pkg/component/gardenercontrollermanager/gardener_controller_manager.go
@@ -1,0 +1,120 @@
+// Copyright 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gardenercontrollermanager
+
+import (
+	"context"
+	"time"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/gardener/gardener/pkg/component"
+	operatorclient "github.com/gardener/gardener/pkg/operator/client"
+	"github.com/gardener/gardener/pkg/utils/flow"
+	"github.com/gardener/gardener/pkg/utils/managedresources"
+	secretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager"
+)
+
+const (
+	managedResourceNameRuntime = "gardener-controller-manager-runtime"
+	managedResourceNameVirtual = "gardener-controller-manager-virtual"
+)
+
+// TimeoutWaitForManagedResource is the timeout used while waiting for the ManagedResources to become healthy or
+// deleted.
+var TimeoutWaitForManagedResource = 5 * time.Minute
+
+// Values contains configuration values for the gardener-controller-manager resources.
+type Values struct {
+}
+
+// New creates a new instance of DeployWaiter for the gardener-controller-manager.
+func New(client client.Client, namespace string, secretsManager secretsmanager.Interface, values Values) component.DeployWaiter {
+	return &gardenerControllerManager{
+		client:         client,
+		namespace:      namespace,
+		secretsManager: secretsManager,
+		values:         values,
+	}
+}
+
+type gardenerControllerManager struct {
+	client         client.Client
+	namespace      string
+	secretsManager secretsmanager.Interface
+	values         Values
+}
+
+func (g *gardenerControllerManager) Deploy(ctx context.Context) error {
+	var (
+		runtimeRegistry = managedresources.NewRegistry(operatorclient.RuntimeScheme, operatorclient.RuntimeCodec, operatorclient.RuntimeSerializer)
+	)
+
+	runtimeResources, err := runtimeRegistry.AddAllAndSerialize()
+	if err != nil {
+		return err
+	}
+
+	if err := managedresources.CreateForSeed(ctx, g.client, g.namespace, managedResourceNameRuntime, false, runtimeResources); err != nil {
+		return err
+	}
+
+	var (
+		virtualRegistry = managedresources.NewRegistry(operatorclient.VirtualScheme, operatorclient.VirtualCodec, operatorclient.VirtualSerializer)
+	)
+
+	virtualResources, err := virtualRegistry.AddAllAndSerialize()
+	if err != nil {
+		return err
+	}
+
+	return managedresources.CreateForShoot(ctx, g.client, g.namespace, managedResourceNameVirtual, managedresources.LabelValueGardener, false, virtualResources)
+}
+
+func (g *gardenerControllerManager) Wait(ctx context.Context) error {
+	timeoutCtx, cancel := context.WithTimeout(ctx, TimeoutWaitForManagedResource)
+	defer cancel()
+
+	return flow.Parallel(
+		func(ctx context.Context) error {
+			return managedresources.WaitUntilHealthy(ctx, g.client, g.namespace, managedResourceNameRuntime)
+		},
+		func(ctx context.Context) error {
+			return managedresources.WaitUntilHealthy(ctx, g.client, g.namespace, managedResourceNameVirtual)
+		},
+	)(timeoutCtx)
+}
+
+func (g *gardenerControllerManager) Destroy(ctx context.Context) error {
+	if err := managedresources.DeleteForShoot(ctx, g.client, g.namespace, managedResourceNameVirtual); err != nil {
+		return err
+	}
+
+	return managedresources.DeleteForSeed(ctx, g.client, g.namespace, managedResourceNameRuntime)
+}
+
+func (g *gardenerControllerManager) WaitCleanup(ctx context.Context) error {
+	timeoutCtx, cancel := context.WithTimeout(ctx, TimeoutWaitForManagedResource)
+	defer cancel()
+
+	return flow.Parallel(
+		func(ctx context.Context) error {
+			return managedresources.WaitUntilDeleted(ctx, g.client, g.namespace, managedResourceNameRuntime)
+		},
+		func(ctx context.Context) error {
+			return managedresources.WaitUntilDeleted(ctx, g.client, g.namespace, managedResourceNameVirtual)
+		},
+	)(timeoutCtx)
+}

--- a/pkg/component/gardenercontrollermanager/gardener_controller_manager.go
+++ b/pkg/component/gardenercontrollermanager/gardener_controller_manager.go
@@ -116,7 +116,10 @@ func (g *gardenerControllerManager) Deploy(ctx context.Context) error {
 		virtualRegistry = managedresources.NewRegistry(operatorclient.VirtualScheme, operatorclient.VirtualCodec, operatorclient.VirtualSerializer)
 	)
 
-	virtualResources, err := virtualRegistry.AddAllAndSerialize()
+	virtualResources, err := virtualRegistry.AddAllAndSerialize(
+		g.clusterRole(),
+		g.clusterRoleBinding(virtualGardenAccessSecret.ServiceAccountName),
+	)
 	if err != nil {
 		return err
 	}

--- a/pkg/component/gardenercontrollermanager/gardener_controller_manager.go
+++ b/pkg/component/gardenercontrollermanager/gardener_controller_manager.go
@@ -92,6 +92,7 @@ func (g *gardenerControllerManager) Deploy(ctx context.Context) error {
 	runtimeResources, err := runtimeRegistry.AddAllAndSerialize(
 		controllerManagerConfigConfigMap,
 		g.podDisruptionBudget(),
+		g.service(),
 	)
 	if err != nil {
 		return err

--- a/pkg/component/gardenercontrollermanager/gardener_controller_manager.go
+++ b/pkg/component/gardenercontrollermanager/gardener_controller_manager.go
@@ -91,6 +91,7 @@ func (g *gardenerControllerManager) Deploy(ctx context.Context) error {
 
 	runtimeResources, err := runtimeRegistry.AddAllAndSerialize(
 		controllerManagerConfigConfigMap,
+		g.podDisruptionBudget(),
 	)
 	if err != nil {
 		return err

--- a/pkg/component/gardenercontrollermanager/gardener_controller_manager_suite_test.go
+++ b/pkg/component/gardenercontrollermanager/gardener_controller_manager_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gardenercontrollermanager_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestGardenerScheduler(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Component GardenerControllerManager Suite")
+}

--- a/pkg/component/gardenercontrollermanager/gardener_controller_manager_suite_test.go
+++ b/pkg/component/gardenercontrollermanager/gardener_controller_manager_suite_test.go
@@ -21,7 +21,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestGardenerScheduler(t *testing.T) {
+func TestGardenerControllerManager(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Component GardenerControllerManager Suite")
 }

--- a/pkg/component/gardenercontrollermanager/gardener_controller_manager_test.go
+++ b/pkg/component/gardenercontrollermanager/gardener_controller_manager_test.go
@@ -16,20 +16,30 @@ package gardenercontrollermanager_test
 
 import (
 	"context"
+	"encoding/json"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	componentbaseconfigv1alpha1 "k8s.io/component-base/config/v1alpha1"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/yaml"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	"github.com/gardener/gardener/pkg/component"
 	. "github.com/gardener/gardener/pkg/component/gardenercontrollermanager"
+	componenttest "github.com/gardener/gardener/pkg/component/test"
+	controllermanagerv1alpha1 "github.com/gardener/gardener/pkg/controllermanager/apis/config/v1alpha1"
+	"github.com/gardener/gardener/pkg/logger"
 	operatorclient "github.com/gardener/gardener/pkg/operator/client"
+	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
+	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/retry"
 	retryfake "github.com/gardener/gardener/pkg/utils/retry/fake"
 	secretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager"
@@ -105,6 +115,11 @@ var _ = Describe("GardenerControllerManager", func() {
 	Describe("#Deploy", func() {
 		Context("resources generation", func() {
 			BeforeEach(func() {
+				// test with typical values
+				values = Values{
+					LogLevel: "info",
+				}
+
 				Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(managedResourceRuntime), managedResourceRuntime)).To(BeNotFoundError())
 				Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(managedResourceVirtual), managedResourceVirtual)).To(BeNotFoundError())
 				Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(managedResourceSecretRuntime), managedResourceSecretRuntime)).To(BeNotFoundError())
@@ -179,7 +194,8 @@ var _ = Describe("GardenerControllerManager", func() {
 				Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(managedResourceSecretVirtual), managedResourceSecretVirtual)).To(Succeed())
 
 				Expect(managedResourceSecretRuntime.Type).To(Equal(corev1.SecretTypeOpaque))
-				Expect(managedResourceSecretRuntime.Data).To(HaveLen(0))
+				Expect(managedResourceSecretRuntime.Data).To(HaveLen(1))
+				Expect(string(managedResourceSecretRuntime.Data["configmap__some-namespace__gardener-controller-manager-config-7eb74c5d.yaml"])).To(Equal(configMap(namespace, values)))
 
 				Expect(managedResourceSecretVirtual.Type).To(Equal(corev1.SecretTypeOpaque))
 				Expect(managedResourceSecretVirtual.Data).To(HaveLen(0))
@@ -500,3 +516,120 @@ var (
 		},
 	}
 )
+
+func configMap(namespace string, testValues Values) string {
+	controllerManagerConfig := &controllermanagerv1alpha1.ControllerManagerConfiguration{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "controllermanager.config.gardener.cloud/v1alpha1",
+			Kind:       "ControllerManagerConfiguration",
+		},
+		GardenClientConnection: componentbaseconfigv1alpha1.ClientConnectionConfiguration{
+			QPS:        100,
+			Burst:      130,
+			Kubeconfig: gardenerutils.PathGenericKubeconfig,
+		},
+		Controllers: controllermanagerv1alpha1.ControllerManagerControllerConfiguration{
+			CertificateSigningRequest: &controllermanagerv1alpha1.CertificateSigningRequestControllerConfiguration{
+				ConcurrentSyncs: pointer.Int(5),
+			},
+			ControllerRegistration: &controllermanagerv1alpha1.ControllerRegistrationControllerConfiguration{
+				ConcurrentSyncs: pointer.Int(20),
+			},
+			Project: &controllermanagerv1alpha1.ProjectControllerConfiguration{
+				ConcurrentSyncs: pointer.Int(20),
+				Quotas:          testValues.Quotas,
+			},
+			SecretBinding: &controllermanagerv1alpha1.SecretBindingControllerConfiguration{
+				ConcurrentSyncs: pointer.Int(20),
+			},
+			Seed: &controllermanagerv1alpha1.SeedControllerConfiguration{
+				ConcurrentSyncs:    pointer.Int(20),
+				SyncPeriod:         &metav1.Duration{Duration: 10 * time.Second},
+				MonitorPeriod:      &metav1.Duration{Duration: 40 * time.Second},
+				ShootMonitorPeriod: &metav1.Duration{Duration: 300 * time.Second},
+			},
+			SeedExtensionsCheck: &controllermanagerv1alpha1.SeedExtensionsCheckControllerConfiguration{
+				ConcurrentSyncs: pointer.Int(5),
+				SyncPeriod:      &metav1.Duration{Duration: 30 * time.Second},
+				ConditionThresholds: []controllermanagerv1alpha1.ConditionThreshold{{
+					Duration: metav1.Duration{Duration: 1 * time.Minute},
+					Type:     "ExtensionsReady",
+				}},
+			},
+			SeedBackupBucketsCheck: &controllermanagerv1alpha1.SeedBackupBucketsCheckControllerConfiguration{
+				ConcurrentSyncs: pointer.Int(5),
+				SyncPeriod:      &metav1.Duration{Duration: 30 * time.Second},
+				ConditionThresholds: []controllermanagerv1alpha1.ConditionThreshold{{
+					Duration: metav1.Duration{Duration: 1 * time.Minute},
+					Type:     "BackupBucketsReady",
+				}},
+			},
+			Event: &controllermanagerv1alpha1.EventControllerConfiguration{
+				ConcurrentSyncs:   pointer.Int(10),
+				TTLNonShootEvents: &metav1.Duration{Duration: 2 * time.Hour},
+			},
+			ShootMaintenance: controllermanagerv1alpha1.ShootMaintenanceControllerConfiguration{
+				ConcurrentSyncs:                  pointer.Int(20),
+				EnableShootControlPlaneRestarter: pointer.Bool(true),
+			},
+			ShootQuota: &controllermanagerv1alpha1.ShootQuotaControllerConfiguration{
+				ConcurrentSyncs: pointer.Int(5),
+				SyncPeriod:      &metav1.Duration{Duration: 60 * time.Minute},
+			},
+			ShootHibernation: controllermanagerv1alpha1.ShootHibernationControllerConfiguration{
+				ConcurrentSyncs:         pointer.Int(5),
+				TriggerDeadlineDuration: &metav1.Duration{Duration: 2 * time.Hour},
+			},
+			ShootReference: &controllermanagerv1alpha1.ShootReferenceControllerConfiguration{
+				ConcurrentSyncs: pointer.Int(20),
+			},
+			ShootRetry: &controllermanagerv1alpha1.ShootRetryControllerConfiguration{
+				ConcurrentSyncs:   pointer.Int(5),
+				RetryPeriod:       &metav1.Duration{Duration: 10 * time.Minute},
+				RetryJitterPeriod: &metav1.Duration{Duration: 5 * time.Minute},
+			},
+			ManagedSeedSet: &controllermanagerv1alpha1.ManagedSeedSetControllerConfiguration{
+				ConcurrentSyncs: pointer.Int(5),
+				SyncPeriod:      metav1.Duration{Duration: 30 * time.Minute},
+			},
+			ExposureClass: &controllermanagerv1alpha1.ExposureClassControllerConfiguration{
+				ConcurrentSyncs: pointer.Int(5),
+			},
+		},
+		LeaderElection: &componentbaseconfigv1alpha1.LeaderElectionConfiguration{
+			LeaderElect:       pointer.Bool(true),
+			ResourceName:      controllermanagerv1alpha1.ControllerManagerDefaultLockObjectName,
+			ResourceNamespace: metav1.NamespaceSystem,
+		},
+		LogLevel:  testValues.LogLevel,
+		LogFormat: logger.FormatJSON,
+		Server: controllermanagerv1alpha1.ServerConfiguration{
+			HealthProbes: &controllermanagerv1alpha1.Server{Port: 2718},
+			Metrics:      &controllermanagerv1alpha1.Server{Port: 2719},
+		},
+		FeatureGates: testValues.FeatureGates,
+	}
+
+	data, err := json.Marshal(controllerManagerConfig)
+	utilruntime.Must(err)
+	data, err = yaml.JSONToYAML(data)
+	utilruntime.Must(err)
+
+	configMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{},
+			Labels: map[string]string{
+				"app":  "gardener",
+				"role": "controller-manager",
+			},
+			Name:      "gardener-controller-manager-config",
+			Namespace: namespace,
+		},
+		Data: map[string]string{
+			"config.yaml": string(data),
+		},
+	}
+	utilruntime.Must(kubernetesutils.MakeUnique(configMap))
+
+	return componenttest.Serialize(configMap)
+}

--- a/pkg/component/gardenercontrollermanager/gardener_controller_manager_test.go
+++ b/pkg/component/gardenercontrollermanager/gardener_controller_manager_test.go
@@ -1,0 +1,471 @@
+// Copyright 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gardenercontrollermanager_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
+	"github.com/gardener/gardener/pkg/component"
+	. "github.com/gardener/gardener/pkg/component/gardenercontrollermanager"
+	operatorclient "github.com/gardener/gardener/pkg/operator/client"
+	"github.com/gardener/gardener/pkg/utils/retry"
+	retryfake "github.com/gardener/gardener/pkg/utils/retry/fake"
+	secretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager"
+	fakesecretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager/fake"
+	"github.com/gardener/gardener/pkg/utils/test"
+	. "github.com/gardener/gardener/pkg/utils/test/matchers"
+)
+
+var _ = Describe("GardenerControllerManager", func() {
+	var (
+		ctx context.Context
+
+		managedResourceNameRuntime = "gardener-controller-manager-runtime"
+		managedResourceNameVirtual = "gardener-controller-manager-virtual"
+		namespace                  = "some-namespace"
+
+		fakeClient        client.Client
+		fakeSecretManager secretsmanager.Interface
+		deployer          component.DeployWaiter
+		values            Values
+
+		fakeOps *retryfake.Ops
+
+		managedResourceRuntime       *resourcesv1alpha1.ManagedResource
+		managedResourceVirtual       *resourcesv1alpha1.ManagedResource
+		managedResourceSecretRuntime *corev1.Secret
+		managedResourceSecretVirtual *corev1.Secret
+	)
+
+	BeforeEach(func() {
+		ctx = context.TODO()
+
+		fakeClient = fakeclient.NewClientBuilder().WithScheme(operatorclient.RuntimeScheme).Build()
+		fakeSecretManager = fakesecretsmanager.New(fakeClient, namespace)
+		values = Values{}
+
+		fakeOps = &retryfake.Ops{MaxAttempts: 2}
+		DeferCleanup(test.WithVars(
+			&retry.Until, fakeOps.Until,
+			&retry.UntilTimeout, fakeOps.UntilTimeout,
+		))
+
+		managedResourceRuntime = &resourcesv1alpha1.ManagedResource{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      managedResourceNameRuntime,
+				Namespace: namespace,
+			},
+		}
+		managedResourceVirtual = &resourcesv1alpha1.ManagedResource{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      managedResourceNameVirtual,
+				Namespace: namespace,
+			},
+		}
+		managedResourceSecretRuntime = &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "managedresource-" + managedResourceRuntime.Name,
+				Namespace: namespace,
+			},
+		}
+		managedResourceSecretVirtual = &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "managedresource-" + managedResourceVirtual.Name,
+				Namespace: namespace,
+			},
+		}
+	})
+
+	JustBeforeEach(func() {
+		deployer = New(fakeClient, namespace, fakeSecretManager, values)
+	})
+
+	Describe("#Deploy", func() {
+		Context("resources generation", func() {
+			BeforeEach(func() {
+				Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(managedResourceRuntime), managedResourceRuntime)).To(BeNotFoundError())
+				Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(managedResourceVirtual), managedResourceVirtual)).To(BeNotFoundError())
+				Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(managedResourceSecretRuntime), managedResourceSecretRuntime)).To(BeNotFoundError())
+				Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(managedResourceSecretVirtual), managedResourceSecretVirtual)).To(BeNotFoundError())
+
+				Expect(fakeClient.Create(ctx, &resourcesv1alpha1.ManagedResource{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       managedResourceNameRuntime,
+						Namespace:  namespace,
+						Generation: 1,
+					},
+					Status: healthyManagedResourceStatus,
+				})).To(Succeed())
+
+				Expect(fakeClient.Create(ctx, &resourcesv1alpha1.ManagedResource{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       managedResourceNameVirtual,
+						Namespace:  namespace,
+						Generation: 1,
+					},
+					Status: healthyManagedResourceStatus,
+				})).To(Succeed())
+			})
+
+			It("should successfully deploy all resources", func() {
+				Expect(deployer.Deploy(ctx)).To(Succeed())
+
+				Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(managedResourceRuntime), managedResourceRuntime)).To(Succeed())
+				Expect(managedResourceRuntime).To(Equal(&resourcesv1alpha1.ManagedResource{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: resourcesv1alpha1.SchemeGroupVersion.String(),
+						Kind:       "ManagedResource",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            managedResourceRuntime.Name,
+						Namespace:       managedResourceRuntime.Namespace,
+						ResourceVersion: "2",
+						Generation:      1,
+						Labels:          map[string]string{"gardener.cloud/role": "seed-system-component"},
+					},
+					Spec: resourcesv1alpha1.ManagedResourceSpec{
+						Class:       pointer.String("seed"),
+						SecretRefs:  []corev1.LocalObjectReference{{Name: managedResourceSecretRuntime.Name}},
+						KeepObjects: pointer.Bool(false),
+					},
+					Status: healthyManagedResourceStatus,
+				}))
+
+				Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(managedResourceSecretRuntime), managedResourceSecretRuntime)).To(Succeed())
+
+				Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(managedResourceVirtual), managedResourceVirtual)).To(Succeed())
+				Expect(managedResourceVirtual).To(Equal(&resourcesv1alpha1.ManagedResource{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: resourcesv1alpha1.SchemeGroupVersion.String(),
+						Kind:       "ManagedResource",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            managedResourceVirtual.Name,
+						Namespace:       managedResourceVirtual.Namespace,
+						ResourceVersion: "2",
+						Generation:      1,
+						Labels:          map[string]string{"origin": "gardener"},
+					},
+					Spec: resourcesv1alpha1.ManagedResourceSpec{
+						InjectLabels: map[string]string{"shoot.gardener.cloud/no-cleanup": "true"},
+						SecretRefs:   []corev1.LocalObjectReference{{Name: managedResourceSecretVirtual.Name}},
+						KeepObjects:  pointer.Bool(false),
+					},
+					Status: healthyManagedResourceStatus,
+				}))
+
+				Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(managedResourceSecretVirtual), managedResourceSecretVirtual)).To(Succeed())
+
+				Expect(managedResourceSecretRuntime.Type).To(Equal(corev1.SecretTypeOpaque))
+				Expect(managedResourceSecretRuntime.Data).To(HaveLen(0))
+
+				Expect(managedResourceSecretVirtual.Type).To(Equal(corev1.SecretTypeOpaque))
+				Expect(managedResourceSecretVirtual.Data).To(HaveLen(0))
+			})
+		})
+	})
+
+	Describe("#Destroy", func() {
+		It("should successfully destroy all resources", func() {
+			Expect(fakeClient.Create(ctx, managedResourceRuntime)).To(Succeed())
+			Expect(fakeClient.Create(ctx, managedResourceVirtual)).To(Succeed())
+			Expect(fakeClient.Create(ctx, managedResourceSecretRuntime)).To(Succeed())
+			Expect(fakeClient.Create(ctx, managedResourceSecretVirtual)).To(Succeed())
+
+			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(managedResourceRuntime), managedResourceRuntime)).To(Succeed())
+			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(managedResourceVirtual), managedResourceVirtual)).To(Succeed())
+			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(managedResourceSecretRuntime), managedResourceSecretRuntime)).To(Succeed())
+			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(managedResourceSecretVirtual), managedResourceSecretVirtual)).To(Succeed())
+
+			Expect(deployer.Destroy(ctx)).To(Succeed())
+
+			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(managedResourceRuntime), managedResourceRuntime)).To(BeNotFoundError())
+			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(managedResourceVirtual), managedResourceVirtual)).To(BeNotFoundError())
+			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(managedResourceSecretRuntime), managedResourceSecretRuntime)).To(BeNotFoundError())
+			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(managedResourceSecretVirtual), managedResourceSecretVirtual)).To(BeNotFoundError())
+		})
+	})
+
+	Context("waiting functions", func() {
+		Describe("#Wait", func() {
+			It("should fail because reading the runtime ManagedResource fails", func() {
+				Expect(deployer.Wait(ctx)).To(MatchError(ContainSubstring("not found")))
+			})
+
+			It("should fail because the runtime and virtual ManagedResources are unhealthy", func() {
+				Expect(fakeClient.Create(ctx, &resourcesv1alpha1.ManagedResource{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       managedResourceNameRuntime,
+						Namespace:  namespace,
+						Generation: 1,
+					},
+					Status: unhealthyManagedResourceStatus,
+				})).To(Succeed())
+
+				Expect(fakeClient.Create(ctx, &resourcesv1alpha1.ManagedResource{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       managedResourceNameVirtual,
+						Namespace:  namespace,
+						Generation: 1,
+					},
+					Status: unhealthyManagedResourceStatus,
+				})).To(Succeed())
+
+				Expect(deployer.Wait(ctx)).To(MatchError(ContainSubstring("is not healthy")))
+			})
+
+			It("should fail because the runtime ManagedResource is unhealthy", func() {
+				Expect(fakeClient.Create(ctx, &resourcesv1alpha1.ManagedResource{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       managedResourceNameRuntime,
+						Namespace:  namespace,
+						Generation: 1,
+					},
+					Status: unhealthyManagedResourceStatus,
+				})).To(Succeed())
+
+				Expect(fakeClient.Create(ctx, &resourcesv1alpha1.ManagedResource{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       managedResourceNameVirtual,
+						Namespace:  namespace,
+						Generation: 1,
+					},
+					Status: resourcesv1alpha1.ManagedResourceStatus{
+						ObservedGeneration: 1,
+						Conditions: []gardencorev1beta1.Condition{
+							{
+								Type:   resourcesv1alpha1.ResourcesApplied,
+								Status: gardencorev1beta1.ConditionTrue,
+							},
+							{
+								Type:   resourcesv1alpha1.ResourcesHealthy,
+								Status: gardencorev1beta1.ConditionTrue,
+							},
+							{
+								Type:   resourcesv1alpha1.ResourcesProgressing,
+								Status: gardencorev1beta1.ConditionFalse,
+							},
+						},
+					},
+				})).To(Succeed())
+
+				Expect(deployer.Wait(ctx)).To(MatchError(ContainSubstring("is not healthy")))
+			})
+
+			It("should fail because the virtual ManagedResource is unhealthy", func() {
+				Expect(fakeClient.Create(ctx, &resourcesv1alpha1.ManagedResource{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       managedResourceNameRuntime,
+						Namespace:  namespace,
+						Generation: 1,
+					},
+					Status: resourcesv1alpha1.ManagedResourceStatus{
+						ObservedGeneration: 1,
+						Conditions: []gardencorev1beta1.Condition{
+							{
+								Type:   resourcesv1alpha1.ResourcesApplied,
+								Status: gardencorev1beta1.ConditionTrue,
+							},
+							{
+								Type:   resourcesv1alpha1.ResourcesHealthy,
+								Status: gardencorev1beta1.ConditionTrue,
+							},
+							{
+								Type:   resourcesv1alpha1.ResourcesProgressing,
+								Status: gardencorev1beta1.ConditionFalse,
+							},
+						},
+					},
+				})).To(Succeed())
+
+				Expect(fakeClient.Create(ctx, &resourcesv1alpha1.ManagedResource{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       managedResourceNameVirtual,
+						Namespace:  namespace,
+						Generation: 1,
+					},
+					Status: unhealthyManagedResourceStatus,
+				})).To(Succeed())
+
+				Expect(deployer.Wait(ctx)).To(MatchError(ContainSubstring("is not healthy")))
+			})
+
+			It("should succeed because the runtime and virtual ManagedResource are healthy and progressing", func() {
+				Expect(fakeClient.Create(ctx, &resourcesv1alpha1.ManagedResource{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       managedResourceNameRuntime,
+						Namespace:  namespace,
+						Generation: 1,
+					},
+					Status: resourcesv1alpha1.ManagedResourceStatus{
+						ObservedGeneration: 1,
+						Conditions: []gardencorev1beta1.Condition{
+							{
+								Type:   resourcesv1alpha1.ResourcesApplied,
+								Status: gardencorev1beta1.ConditionTrue,
+							},
+							{
+								Type:   resourcesv1alpha1.ResourcesHealthy,
+								Status: gardencorev1beta1.ConditionTrue,
+							},
+							{
+								Type:   resourcesv1alpha1.ResourcesProgressing,
+								Status: gardencorev1beta1.ConditionTrue,
+							},
+						},
+					},
+				})).To(Succeed())
+
+				Expect(fakeClient.Create(ctx, &resourcesv1alpha1.ManagedResource{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       managedResourceNameVirtual,
+						Namespace:  namespace,
+						Generation: 1,
+					},
+					Status: resourcesv1alpha1.ManagedResourceStatus{
+						ObservedGeneration: 1,
+						Conditions: []gardencorev1beta1.Condition{
+							{
+								Type:   resourcesv1alpha1.ResourcesApplied,
+								Status: gardencorev1beta1.ConditionTrue,
+							},
+							{
+								Type:   resourcesv1alpha1.ResourcesHealthy,
+								Status: gardencorev1beta1.ConditionTrue,
+							},
+							{
+								Type:   resourcesv1alpha1.ResourcesProgressing,
+								Status: gardencorev1beta1.ConditionTrue,
+							},
+						},
+					},
+				})).To(Succeed())
+
+				Expect(deployer.Wait(ctx)).To(Succeed())
+			})
+
+			It("should succeed because the both ManagedResource are healthy and progressed", func() {
+				Expect(fakeClient.Create(ctx, &resourcesv1alpha1.ManagedResource{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       managedResourceNameRuntime,
+						Namespace:  namespace,
+						Generation: 1,
+					},
+					Status: resourcesv1alpha1.ManagedResourceStatus{
+						ObservedGeneration: 1,
+						Conditions: []gardencorev1beta1.Condition{
+							{
+								Type:   resourcesv1alpha1.ResourcesApplied,
+								Status: gardencorev1beta1.ConditionTrue,
+							},
+							{
+								Type:   resourcesv1alpha1.ResourcesHealthy,
+								Status: gardencorev1beta1.ConditionTrue,
+							},
+							{
+								Type:   resourcesv1alpha1.ResourcesProgressing,
+								Status: gardencorev1beta1.ConditionFalse,
+							},
+						},
+					},
+				})).To(Succeed())
+
+				Expect(fakeClient.Create(ctx, &resourcesv1alpha1.ManagedResource{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       managedResourceNameVirtual,
+						Namespace:  namespace,
+						Generation: 1,
+					},
+					Status: resourcesv1alpha1.ManagedResourceStatus{
+						ObservedGeneration: 1,
+						Conditions: []gardencorev1beta1.Condition{
+							{
+								Type:   resourcesv1alpha1.ResourcesApplied,
+								Status: gardencorev1beta1.ConditionTrue,
+							},
+							{
+								Type:   resourcesv1alpha1.ResourcesHealthy,
+								Status: gardencorev1beta1.ConditionTrue,
+							},
+							{
+								Type:   resourcesv1alpha1.ResourcesProgressing,
+								Status: gardencorev1beta1.ConditionFalse,
+							},
+						},
+					},
+				})).To(Succeed())
+
+				Expect(deployer.Wait(ctx)).To(Succeed())
+			})
+		})
+
+		Describe("#WaitCleanup", func() {
+			It("should fail when the wait for the runtime managed resource deletion times out", func() {
+				Expect(fakeClient.Create(ctx, managedResourceRuntime)).To(Succeed())
+
+				Expect(deployer.WaitCleanup(ctx)).To(MatchError(ContainSubstring("still exists")))
+			})
+
+			It("should fail when the wait for the virtual managed resource deletion times out", func() {
+				Expect(fakeClient.Create(ctx, managedResourceVirtual)).To(Succeed())
+
+				Expect(deployer.WaitCleanup(ctx)).To(MatchError(ContainSubstring("still exists")))
+			})
+
+			It("should not return an error when they are already removed", func() {
+				Expect(deployer.WaitCleanup(ctx)).To(Succeed())
+			})
+		})
+	})
+})
+
+var (
+	healthyManagedResourceStatus = resourcesv1alpha1.ManagedResourceStatus{
+		ObservedGeneration: 1,
+		Conditions: []gardencorev1beta1.Condition{
+			{
+				Type:   resourcesv1alpha1.ResourcesApplied,
+				Status: gardencorev1beta1.ConditionTrue,
+			},
+			{
+				Type:   resourcesv1alpha1.ResourcesHealthy,
+				Status: gardencorev1beta1.ConditionTrue,
+			},
+		},
+	}
+	unhealthyManagedResourceStatus = resourcesv1alpha1.ManagedResourceStatus{
+		ObservedGeneration: 1,
+		Conditions: []gardencorev1beta1.Condition{
+			{
+				Type:   resourcesv1alpha1.ResourcesApplied,
+				Status: gardencorev1beta1.ConditionFalse,
+			},
+			{
+				Type:   resourcesv1alpha1.ResourcesHealthy,
+				Status: gardencorev1beta1.ConditionFalse,
+			},
+		},
+	}
+)

--- a/pkg/component/gardenercontrollermanager/gardener_controller_manager_test.go
+++ b/pkg/component/gardenercontrollermanager/gardener_controller_manager_test.go
@@ -185,6 +185,37 @@ var _ = Describe("GardenerControllerManager", func() {
 				Expect(managedResourceSecretVirtual.Data).To(HaveLen(0))
 			})
 		})
+
+		Context("secrets", func() {
+			It("should successfully deploy the access secret for the virtual garden", func() {
+				accessSecret := &corev1.Secret{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+						Kind:       "Secret",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "shoot-access-gardener-controller-manager",
+						Namespace: namespace,
+						Labels: map[string]string{
+							"resources.gardener.cloud/purpose": "token-requestor",
+							"resources.gardener.cloud/class":   "shoot",
+						},
+						Annotations: map[string]string{
+							"serviceaccount.resources.gardener.cloud/name":      "gardener-controller-manager",
+							"serviceaccount.resources.gardener.cloud/namespace": "kube-system",
+						},
+					},
+					Type: corev1.SecretTypeOpaque,
+				}
+
+				Expect(deployer.Deploy(ctx)).To(Succeed())
+
+				actualShootAccessSecret := &corev1.Secret{}
+				Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(accessSecret), actualShootAccessSecret)).To(Succeed())
+				accessSecret.ResourceVersion = "1"
+				Expect(actualShootAccessSecret).To(Equal(accessSecret))
+			})
+		})
 	})
 
 	Describe("#Destroy", func() {

--- a/pkg/component/gardenercontrollermanager/poddisruptionbudget.go
+++ b/pkg/component/gardenercontrollermanager/poddisruptionbudget.go
@@ -1,0 +1,36 @@
+// Copyright 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gardenercontrollermanager
+
+import (
+	policyv1 "k8s.io/api/policy/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	gardenerutils "github.com/gardener/gardener/pkg/utils"
+)
+
+func (g *gardenerControllerManager) podDisruptionBudget() *policyv1.PodDisruptionBudget {
+	return &policyv1.PodDisruptionBudget{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      DeploymentName,
+			Namespace: g.namespace,
+			Labels:    GetLabels(),
+		},
+		Spec: policyv1.PodDisruptionBudgetSpec{
+			MaxUnavailable: gardenerutils.IntStrPtrFromInt(1),
+			Selector:       &metav1.LabelSelector{MatchLabels: GetLabels()},
+		},
+	}
+}

--- a/pkg/component/gardenercontrollermanager/rbac.go
+++ b/pkg/component/gardenercontrollermanager/rbac.go
@@ -1,0 +1,60 @@
+// Copyright 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gardenercontrollermanager
+
+import (
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	clusterRoleName        = "gardener.cloud:system:controller-manager"
+	clusterRoleBindingName = "gardener.cloud:system:controller-manager"
+)
+
+func (g *gardenerControllerManager) clusterRole() *rbacv1.ClusterRole {
+	return &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   clusterRoleName,
+			Labels: GetLabels(),
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups: []string{"*"},
+				Resources: []string{"*"},
+				Verbs:     []string{"*"},
+			},
+		},
+	}
+}
+
+func (g *gardenerControllerManager) clusterRoleBinding(serviceAccountName string) *rbacv1.ClusterRoleBinding {
+	return &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   clusterRoleBindingName,
+			Labels: GetLabels(),
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: rbacv1.GroupName,
+			Kind:     "ClusterRole",
+			Name:     clusterRoleName,
+		},
+		Subjects: []rbacv1.Subject{{
+			Kind:      "ServiceAccount",
+			Name:      serviceAccountName,
+			Namespace: metav1.NamespaceSystem,
+		}},
+	}
+}

--- a/pkg/component/gardenercontrollermanager/secrets.go
+++ b/pkg/component/gardenercontrollermanager/secrets.go
@@ -1,0 +1,23 @@
+// Copyright 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gardenercontrollermanager
+
+import (
+	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
+)
+
+func (g *gardenerControllerManager) newVirtualGardenAccessSecret() *gardenerutils.AccessSecret {
+	return gardenerutils.NewShootAccessSecret(DeploymentName, g.namespace)
+}

--- a/pkg/component/gardenercontrollermanager/service.go
+++ b/pkg/component/gardenercontrollermanager/service.go
@@ -1,0 +1,45 @@
+// Copyright 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gardenercontrollermanager
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+const serviceName = DeploymentName
+
+func (g *gardenerControllerManager) service() *corev1.Service {
+	service := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      serviceName,
+			Namespace: g.namespace,
+			Labels:    GetLabels(),
+		},
+		Spec: corev1.ServiceSpec{
+			Type:     corev1.ServiceTypeClusterIP,
+			Selector: GetLabels(),
+			Ports: []corev1.ServicePort{{
+				Name:       "metrics",
+				Port:       int32(metricsPort),
+				Protocol:   corev1.ProtocolTCP,
+				TargetPort: intstr.FromInt(metricsPort),
+			}},
+		},
+	}
+
+	return service
+}

--- a/pkg/component/gardenercontrollermanager/vpa.go
+++ b/pkg/component/gardenercontrollermanager/vpa.go
@@ -1,0 +1,55 @@
+// Copyright 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gardenercontrollermanager
+
+import (
+	appsv1 "k8s.io/api/apps/v1"
+	autoscalingv1 "k8s.io/api/autoscaling/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	vpaautoscalingv1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
+)
+
+func (g *gardenerControllerManager) verticalPodAutoscaler() *vpaautoscalingv1.VerticalPodAutoscaler {
+	vpaUpdateMode := vpaautoscalingv1.UpdateModeAuto
+	return &vpaautoscalingv1.VerticalPodAutoscaler{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      DeploymentName + "-vpa",
+			Namespace: g.namespace,
+			Labels:    GetLabels(),
+		},
+		Spec: vpaautoscalingv1.VerticalPodAutoscalerSpec{
+			TargetRef: &autoscalingv1.CrossVersionObjectReference{
+				APIVersion: appsv1.SchemeGroupVersion.String(),
+				Kind:       "Deployment",
+				Name:       DeploymentName,
+			},
+			UpdatePolicy: &vpaautoscalingv1.PodUpdatePolicy{
+				UpdateMode: &vpaUpdateMode,
+			},
+			ResourcePolicy: &vpaautoscalingv1.PodResourcePolicy{
+				ContainerPolicies: []vpaautoscalingv1.ContainerResourcePolicy{
+					{
+						ContainerName: vpaautoscalingv1.DefaultContainerResourcePolicy,
+						MinAllowed: corev1.ResourceList{
+							corev1.ResourceMemory: resource.MustParse("300Mi"),
+						},
+					},
+				},
+			},
+		},
+	}
+}

--- a/pkg/controllermanager/apis/.import-restrictions
+++ b/pkg/controllermanager/apis/.import-restrictions
@@ -5,6 +5,7 @@ rules:
   - k8s.io/api
   - k8s.io/component-base/config
   - k8s.io/klog
+  - k8s.io/utils/pointer
 - selectorRegexp: github[.]com/gardener
   allowedPrefixes:
   - github.com/gardener/gardener/pkg/controllermanager/apis

--- a/pkg/controllermanager/apis/config/v1alpha1/defaults.go
+++ b/pkg/controllermanager/apis/config/v1alpha1/defaults.go
@@ -20,6 +20,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	componentbaseconfigv1alpha1 "k8s.io/component-base/config/v1alpha1"
+	"k8s.io/utils/pointer"
 )
 
 func addDefaultingFuncs(scheme *runtime.Scheme) error {
@@ -138,8 +139,7 @@ func SetDefaults_ControllerManagerConfiguration(obj *ControllerManagerConfigurat
 		obj.Controllers.ShootMaintenance.ConcurrentSyncs = &v
 	}
 	if obj.Controllers.ShootMaintenance.EnableShootControlPlaneRestarter == nil {
-		b := true
-		obj.Controllers.ShootMaintenance.EnableShootControlPlaneRestarter = &b
+		obj.Controllers.ShootMaintenance.EnableShootControlPlaneRestarter = pointer.Bool(true)
 	}
 
 	if obj.Controllers.ShootQuota == nil {

--- a/pkg/controllermanager/apis/config/v1alpha1/defaults.go
+++ b/pkg/controllermanager/apis/config/v1alpha1/defaults.go
@@ -20,6 +20,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	componentbaseconfigv1alpha1 "k8s.io/component-base/config/v1alpha1"
+	"k8s.io/utils/pointer"
 )
 
 func addDefaultingFuncs(scheme *runtime.Scheme) error {
@@ -136,6 +137,9 @@ func SetDefaults_ControllerManagerConfiguration(obj *ControllerManagerConfigurat
 	if obj.Controllers.ShootMaintenance.ConcurrentSyncs == nil {
 		v := DefaultControllerConcurrentSyncs
 		obj.Controllers.ShootMaintenance.ConcurrentSyncs = &v
+	}
+	if obj.Controllers.ShootMaintenance.EnableShootControlPlaneRestarter == nil {
+		obj.Controllers.ShootMaintenance.EnableShootControlPlaneRestarter = pointer.Bool(true)
 	}
 
 	if obj.Controllers.ShootQuota == nil {

--- a/pkg/controllermanager/apis/config/v1alpha1/defaults.go
+++ b/pkg/controllermanager/apis/config/v1alpha1/defaults.go
@@ -20,7 +20,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	componentbaseconfigv1alpha1 "k8s.io/component-base/config/v1alpha1"
-	"k8s.io/utils/pointer"
 )
 
 func addDefaultingFuncs(scheme *runtime.Scheme) error {
@@ -139,7 +138,8 @@ func SetDefaults_ControllerManagerConfiguration(obj *ControllerManagerConfigurat
 		obj.Controllers.ShootMaintenance.ConcurrentSyncs = &v
 	}
 	if obj.Controllers.ShootMaintenance.EnableShootControlPlaneRestarter == nil {
-		obj.Controllers.ShootMaintenance.EnableShootControlPlaneRestarter = pointer.Bool(true)
+		b := true
+		obj.Controllers.ShootMaintenance.EnableShootControlPlaneRestarter = &b
 	}
 
 	if obj.Controllers.ShootQuota == nil {

--- a/pkg/controllermanager/apis/config/v1alpha1/defaults_test.go
+++ b/pkg/controllermanager/apis/config/v1alpha1/defaults_test.go
@@ -85,6 +85,8 @@ var _ = Describe("Defaults", func() {
 
 			Expect(obj.Controllers.ShootMaintenance.ConcurrentSyncs).NotTo(BeNil())
 			Expect(obj.Controllers.ShootMaintenance.ConcurrentSyncs).To(PointTo(Equal(5)))
+			Expect(obj.Controllers.ShootMaintenance.EnableShootControlPlaneRestarter).NotTo(BeNil())
+			Expect(obj.Controllers.ShootMaintenance.EnableShootControlPlaneRestarter).To(PointTo(Equal(true)))
 
 			Expect(obj.Controllers.ShootQuota).NotTo(BeNil())
 			Expect(obj.Controllers.ShootQuota.ConcurrentSyncs).NotTo(BeNil())


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind enhancement

**What this PR does / why we need it**:
Similar to https://github.com/gardener/gardener/pull/8215, this PR introduces the Golang component for the `gardener-controller-manager`.
API changes and component instantiation will follow in separate PRs.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/7016

**Special notes for your reviewer**:
/cc @rfranzke @oliver-goetz @timuthy

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
