### PR TITLE
Replace the metering.rules.stateful.yaml symlink with its content

### DIFF
--- a/pkg/component/monitoring/charts/bootstrap/aggregate-prometheus-rules/metering.rules.stateful.yaml
+++ b/pkg/component/monitoring/charts/bootstrap/aggregate-prometheus-rules/metering.rules.stateful.yaml
@@ -1,1 +1,326 @@
-../prometheus-rules/metering.rules.stateful.yaml
+groups:
+- name: metering.rules.stateful
+  rules:
+
+# - _year_month2
+
+  - record: _year_month2
+    expr: |2
+        count_values without () (
+          "year",
+          year(timestamp(count_values without () ("month", month(timestamp(vector(0))))))
+        )
+      *
+        0
+
+# - metering   :memory_usage_seconds
+# - metering   :disk_usage_seconds
+# - metering   :memory_usage_seconds  :this_month
+# - metering   :disk_usage_seconds    :this_month
+
+
+  - record: metering:memory_usage_seconds
+    expr: |2
+        (metering:working_set_memory:sum_by_namespace > bool 0) * 60
+      +
+        (last_over_time(metering:memory_usage_seconds[10m]) or metering:working_set_memory:sum_by_namespace * 0)
+
+  - record: metering:disk_usage_seconds
+    expr: |2
+        (metering:persistent_volume_claims:sum_by_namespace > bool 0) * 60
+      +
+        (
+            last_over_time(metering:disk_usage_seconds[10m])
+          or
+            metering:persistent_volume_claims:sum_by_namespace * 0
+        )
+
+  - record: metering:memory_usage_seconds:this_month
+    expr: |2
+        metering:memory_usage_seconds
+      or
+          last_over_time(metering:memory_usage_seconds:this_month[10m])
+        + on (year, month) group_left ()
+          _year_month2
+
+  - record: metering:disk_usage_seconds:this_month
+    expr: |2
+        metering:disk_usage_seconds
+      or
+          last_over_time(metering:disk_usage_seconds:this_month[10m])
+        + on (year, month) group_left ()
+          _year_month2
+
+# - metering  :persistent_volume_claims   :sum_by_namespace   :sum_over_time
+# - metering  :persistent_volume_claims   :sum_by_namespace   :avg_over_time
+# - metering  :persistent_volume_claims   :sum_by_namespace   :avg_over_time   :this_month
+
+  - record: metering:persistent_volume_claims:sum_by_namespace:sum_over_time
+    expr: |2
+        metering:persistent_volume_claims:sum_by_namespace
+      +
+        (
+            last_over_time(metering:persistent_volume_claims:sum_by_namespace:sum_over_time[10m])
+          or
+            metering:persistent_volume_claims:sum_by_namespace * 0
+        )
+
+  - record: metering:persistent_volume_claims:sum_by_namespace:avg_over_time
+    expr: |2
+          metering:persistent_volume_claims:sum_by_namespace:sum_over_time * 60
+        /
+          (metering:disk_usage_seconds != 0)
+      or
+        metering:persistent_volume_claims:sum_by_namespace:sum_over_time
+
+
+  - record: metering:persistent_volume_claims:sum_by_namespace:avg_over_time:this_month
+    expr: |2
+        metering:persistent_volume_claims:sum_by_namespace:avg_over_time
+      or
+          last_over_time(metering:persistent_volume_claims:sum_by_namespace:avg_over_time:this_month[10m])
+        + on (year, month) group_left ()
+          _year_month2
+
+# Generated with metering.rules.stateful.sh
+
+# - metering  :cpu_usage                 :sum_by_namespace   :sum_over_time
+# - metering  :cpu_usage                 :sum_by_namespace   :avg_over_time
+# - metering  :cpu_usage                 :sum_by_namespace   :avg_over_time   :this_month
+# - metering  :cpu_requests              :sum_by_namespace   :sum_over_time
+# - metering  :cpu_requests              :sum_by_namespace   :avg_over_time
+# - metering  :cpu_requests              :sum_by_namespace   :avg_over_time   :this_month
+# - metering  :memory_usage              :sum_by_namespace   :sum_over_time
+# - metering  :memory_usage              :sum_by_namespace   :avg_over_time
+# - metering  :memory_usage              :sum_by_namespace   :avg_over_time   :this_month
+# - metering  :working_set_memory        :sum_by_namespace   :sum_over_time
+# - metering  :working_set_memory        :sum_by_namespace   :avg_over_time
+# - metering  :working_set_memory        :sum_by_namespace   :avg_over_time   :this_month
+# - metering  :memory_requests           :sum_by_namespace   :sum_over_time
+# - metering  :memory_requests           :sum_by_namespace   :avg_over_time
+# - metering  :memory_requests           :sum_by_namespace   :avg_over_time   :this_month
+# - metering  :network_transmit          :sum_by_namespace   :sum_over_time
+# - metering  :network_transmit          :sum_by_namespace   :avg_over_time
+# - metering  :network_transmit          :sum_by_namespace   :avg_over_time   :this_month
+# - metering  :network_receive           :sum_by_namespace   :sum_over_time
+# - metering  :network_receive           :sum_by_namespace   :avg_over_time
+# - metering  :network_receive           :sum_by_namespace   :avg_over_time   :this_month
+# - metering  :persistent_volume_usage   :sum_by_namespace   :sum_over_time
+# - metering  :persistent_volume_usage   :sum_by_namespace   :avg_over_time
+# - metering  :persistent_volume_usage   :sum_by_namespace   :avg_over_time   :this_month
+
+  - record: metering:cpu_usage:sum_by_namespace:sum_over_time
+    expr: |2
+        metering:cpu_usage:sum_by_namespace
+      +
+        (
+            last_over_time(metering:cpu_usage:sum_by_namespace:sum_over_time[10m])
+          or
+            metering:cpu_usage:sum_by_namespace * 0
+        )
+
+  - record: metering:cpu_usage:sum_by_namespace:avg_over_time
+    expr: |2
+          metering:cpu_usage:sum_by_namespace:sum_over_time * 60
+        /
+          (metering:memory_usage_seconds != 0)
+      or
+        metering:cpu_usage:sum_by_namespace:sum_over_time
+
+
+  - record: metering:cpu_usage:sum_by_namespace:avg_over_time:this_month
+    expr: |2
+        metering:cpu_usage:sum_by_namespace:avg_over_time
+      or
+          last_over_time(metering:cpu_usage:sum_by_namespace:avg_over_time:this_month[10m])
+        + on (year, month) group_left ()
+          _year_month2
+
+  - record: metering:cpu_requests:sum_by_namespace:sum_over_time
+    expr: |2
+        metering:cpu_requests:sum_by_namespace
+      +
+        (
+            last_over_time(metering:cpu_requests:sum_by_namespace:sum_over_time[10m])
+          or
+            metering:cpu_requests:sum_by_namespace * 0
+        )
+
+  - record: metering:cpu_requests:sum_by_namespace:avg_over_time
+    expr: |2
+          metering:cpu_requests:sum_by_namespace:sum_over_time * 60
+        /
+          (metering:memory_usage_seconds != 0)
+      or
+        metering:cpu_requests:sum_by_namespace:sum_over_time
+
+
+  - record: metering:cpu_requests:sum_by_namespace:avg_over_time:this_month
+    expr: |2
+        metering:cpu_requests:sum_by_namespace:avg_over_time
+      or
+          last_over_time(metering:cpu_requests:sum_by_namespace:avg_over_time:this_month[10m])
+        + on (year, month) group_left ()
+          _year_month2
+
+  - record: metering:memory_usage:sum_by_namespace:sum_over_time
+    expr: |2
+        metering:memory_usage:sum_by_namespace
+      +
+        (
+            last_over_time(metering:memory_usage:sum_by_namespace:sum_over_time[10m])
+          or
+            metering:memory_usage:sum_by_namespace * 0
+        )
+
+  - record: metering:memory_usage:sum_by_namespace:avg_over_time
+    expr: |2
+          metering:memory_usage:sum_by_namespace:sum_over_time * 60
+        /
+          (metering:memory_usage_seconds != 0)
+      or
+        metering:memory_usage:sum_by_namespace:sum_over_time
+
+
+  - record: metering:memory_usage:sum_by_namespace:avg_over_time:this_month
+    expr: |2
+        metering:memory_usage:sum_by_namespace:avg_over_time
+      or
+          last_over_time(metering:memory_usage:sum_by_namespace:avg_over_time:this_month[10m])
+        + on (year, month) group_left ()
+          _year_month2
+
+  - record: metering:working_set_memory:sum_by_namespace:sum_over_time
+    expr: |2
+        metering:working_set_memory:sum_by_namespace
+      +
+        (
+            last_over_time(metering:working_set_memory:sum_by_namespace:sum_over_time[10m])
+          or
+            metering:working_set_memory:sum_by_namespace * 0
+        )
+
+  - record: metering:working_set_memory:sum_by_namespace:avg_over_time
+    expr: |2
+          metering:working_set_memory:sum_by_namespace:sum_over_time * 60
+        /
+          (metering:memory_usage_seconds != 0)
+      or
+        metering:working_set_memory:sum_by_namespace:sum_over_time
+
+
+  - record: metering:working_set_memory:sum_by_namespace:avg_over_time:this_month
+    expr: |2
+        metering:working_set_memory:sum_by_namespace:avg_over_time
+      or
+          last_over_time(metering:working_set_memory:sum_by_namespace:avg_over_time:this_month[10m])
+        + on (year, month) group_left ()
+          _year_month2
+
+  - record: metering:memory_requests:sum_by_namespace:sum_over_time
+    expr: |2
+        metering:memory_requests:sum_by_namespace
+      +
+        (
+            last_over_time(metering:memory_requests:sum_by_namespace:sum_over_time[10m])
+          or
+            metering:memory_requests:sum_by_namespace * 0
+        )
+
+  - record: metering:memory_requests:sum_by_namespace:avg_over_time
+    expr: |2
+          metering:memory_requests:sum_by_namespace:sum_over_time * 60
+        /
+          (metering:memory_usage_seconds != 0)
+      or
+        metering:memory_requests:sum_by_namespace:sum_over_time
+
+
+  - record: metering:memory_requests:sum_by_namespace:avg_over_time:this_month
+    expr: |2
+        metering:memory_requests:sum_by_namespace:avg_over_time
+      or
+          last_over_time(metering:memory_requests:sum_by_namespace:avg_over_time:this_month[10m])
+        + on (year, month) group_left ()
+          _year_month2
+
+  - record: metering:network_transmit:sum_by_namespace:sum_over_time
+    expr: |2
+        metering:network_transmit:sum_by_namespace
+      +
+        (
+            last_over_time(metering:network_transmit:sum_by_namespace:sum_over_time[10m])
+          or
+            metering:network_transmit:sum_by_namespace * 0
+        )
+
+  - record: metering:network_transmit:sum_by_namespace:avg_over_time
+    expr: |2
+          metering:network_transmit:sum_by_namespace:sum_over_time * 60
+        /
+          (metering:memory_usage_seconds != 0)
+      or
+        metering:network_transmit:sum_by_namespace:sum_over_time
+
+
+  - record: metering:network_transmit:sum_by_namespace:avg_over_time:this_month
+    expr: |2
+        metering:network_transmit:sum_by_namespace:avg_over_time
+      or
+          last_over_time(metering:network_transmit:sum_by_namespace:avg_over_time:this_month[10m])
+        + on (year, month) group_left ()
+          _year_month2
+
+  - record: metering:network_receive:sum_by_namespace:sum_over_time
+    expr: |2
+        metering:network_receive:sum_by_namespace
+      +
+        (
+            last_over_time(metering:network_receive:sum_by_namespace:sum_over_time[10m])
+          or
+            metering:network_receive:sum_by_namespace * 0
+        )
+
+  - record: metering:network_receive:sum_by_namespace:avg_over_time
+    expr: |2
+          metering:network_receive:sum_by_namespace:sum_over_time * 60
+        /
+          (metering:memory_usage_seconds != 0)
+      or
+        metering:network_receive:sum_by_namespace:sum_over_time
+
+
+  - record: metering:network_receive:sum_by_namespace:avg_over_time:this_month
+    expr: |2
+        metering:network_receive:sum_by_namespace:avg_over_time
+      or
+          last_over_time(metering:network_receive:sum_by_namespace:avg_over_time:this_month[10m])
+        + on (year, month) group_left ()
+          _year_month2
+
+  - record: metering:persistent_volume_usage:sum_by_namespace:sum_over_time
+    expr: |2
+        metering:persistent_volume_usage:sum_by_namespace
+      +
+        (
+            last_over_time(metering:persistent_volume_usage:sum_by_namespace:sum_over_time[10m])
+          or
+            metering:persistent_volume_usage:sum_by_namespace * 0
+        )
+
+  - record: metering:persistent_volume_usage:sum_by_namespace:avg_over_time
+    expr: |2
+          metering:persistent_volume_usage:sum_by_namespace:sum_over_time * 60
+        /
+          (metering:memory_usage_seconds != 0)
+      or
+        metering:persistent_volume_usage:sum_by_namespace:sum_over_time
+
+
+  - record: metering:persistent_volume_usage:sum_by_namespace:avg_over_time:this_month
+    expr: |2
+        metering:persistent_volume_usage:sum_by_namespace:avg_over_time
+      or
+          last_over_time(metering:persistent_volume_usage:sum_by_namespace:avg_over_time:this_month[10m])
+        + on (year, month) group_left ()
+          _year_month2


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind bug

**What this PR does / why we need it**:

Replace the metering.rules.stateful.yaml symlink with its content

In PR #8237, the monitoring related helm chart was refactored and the deprecated

```
ChartApplier
// Deprecated: Use ApplyFromEmbeddedFS for new code!
Apply(ctx context.Context, chartPath, namespace, name string, opts ...ApplyOption) error
```

function is no longer used to render the helm chart.

The new, `ApplyFromEmbeddedFS` function is used instead, which uses the `//go:embed` embedded file system.

The previously used deprecated method called `os.Open` at the end to read the files that were written to the gardenlet's container's file system. With that approach, symbolic links were resolved regularly.

There is a caveat though: `go:embed` does not support symbolic links.
https://pkg.go.dev/embed

This led to the regression that the `metering.rules.stateful.yaml` file was silently missing when the chart was applied and hence the aggregate prometheus did not get these recording rule definitions.

This PR "resolves" the symbolic link with its content to mitigate this issue.

The other symbolic links (see `find . -type l`) are not related to monitoring and probably not used inside embedded file systems, so there are probably no other similar issues.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

cc @rfranzke, @rickardsjp 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
gardenlet: A regression causing metering related recording rules for the aggregate-prometheus not to be applied is now fixed.
```