### PR TITLE
Do not map `ManagedResource`s to `Garden` during reconciliation

### DIFF
--- a/pkg/operator/controller/garden/care/add.go
+++ b/pkg/operator/controller/garden/care/add.go
@@ -146,7 +146,7 @@ func (r *Reconciler) MapManagedResourceToGarden(ctx context.Context, log logr.Lo
 	}
 	garden := gardenList.Items[0]
 
-	// A garden reconciliation typically touches most of the existing ManagedResources, and this will cause the
+	// A garden reconciliation typically touches most of the existing ManagedResources and this will cause the
 	// ManagedResource controller to frequently change their conditions. In this case, we don't want to spam the API
 	// server with updates on the Garden conditions.
 	if garden.Status.LastOperation != nil && garden.Status.LastOperation.State == gardencorev1beta1.LastOperationStateProcessing {

--- a/pkg/operator/controller/garden/care/add.go
+++ b/pkg/operator/controller/garden/care/add.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 
 	"github.com/go-logr/logr"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/utils/clock"
@@ -136,15 +135,23 @@ func gardenReconciledSuccessfully(oldGarden, newGarden *operatorv1alpha1.Garden)
 
 // MapManagedResourceToGarden is a mapper.MapFunc for mapping a ManagedResource to the owning Garden.
 func (r *Reconciler) MapManagedResourceToGarden(ctx context.Context, log logr.Logger, _ client.Reader, _ client.Object) []reconcile.Request {
-	gardenList := &metav1.PartialObjectMetadataList{}
-	gardenList.SetGroupVersionKind(operatorv1alpha1.SchemeGroupVersion.WithKind("GardenList"))
+	gardenList := &operatorv1alpha1.GardenList{}
 	if err := r.RuntimeClient.List(ctx, gardenList, client.Limit(1)); err != nil {
 		log.Error(err, "Could not list gardens")
 		return nil
 	}
+
 	if len(gardenList.Items) == 0 {
 		return nil
 	}
-	// Garden is a singleton
-	return []reconcile.Request{{NamespacedName: types.NamespacedName{Name: gardenList.Items[0].Name}}}
+	garden := gardenList.Items[0]
+
+	// A garden reconciliation typically touches most of the existing ManagedResources, and this will cause the
+	// ManagedResource controller to frequently change their conditions. In this case, we don't want to spam the API
+	// server with updates on the Garden conditions.
+	if garden.Status.LastOperation != nil && garden.Status.LastOperation.State == gardencorev1beta1.LastOperationStateProcessing {
+		return nil
+	}
+
+	return []reconcile.Request{{NamespacedName: types.NamespacedName{Name: garden.Name}}}
 }

--- a/pkg/operator/controller/garden/care/add_test.go
+++ b/pkg/operator/controller/garden/care/add_test.go
@@ -150,8 +150,20 @@ var _ = Describe("Add", func() {
 			Expect(runtimeClient.Create(ctx, garden)).To(Succeed())
 		})
 
-		It("should return a request with the garden name", func() {
-			Expect(reconciler.MapManagedResourceToGarden(ctx, logr.Discard(), nil, nil)).To(ConsistOf(reconcile.Request{NamespacedName: types.NamespacedName{Name: gardenName}}))
+		Context("when Garden reconciliation is not processing", func() {
+			It("should return a request with the garden name", func() {
+				Expect(reconciler.MapManagedResourceToGarden(ctx, logr.Discard(), nil, nil)).To(ConsistOf(reconcile.Request{NamespacedName: types.NamespacedName{Name: gardenName}}))
+			})
+		})
+
+		Context("when Garden reconciliation is processing", func() {
+			BeforeEach(func() {
+				garden.Status.LastOperation = &gardencorev1beta1.LastOperation{State: gardencorev1beta1.LastOperationStateProcessing}
+			})
+
+			It("should return an empty list", func() {
+				Expect(reconciler.MapManagedResourceToGarden(ctx, logr.Discard(), nil, nil)).To(BeEmpty())
+			})
 		})
 	})
 })


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area scalability
/kind enhancement

**What this PR does / why we need it**:
Do not map `ManagedResource`s to `Garden` during ongoing reconciliation.

A garden reconciliation typically touches most of the existing ManagedResources, and this will cause the
ManagedResource controller to frequently change their conditions. In this case, we don't want to spam the API
server with updates on the Garden conditions.

**Which issue(s) this PR fixes**:
Follow-up of #8158 

**Special notes for your reviewer**:
/cc @oliver-goetz 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
