### PR TITLE
Enable dependabot to create update PRs for `golang` docker image

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+# Create PRs for golang version updates
+- package-ecosystem: docker
+  directory: /
+  schedule:
+    interval: daily
+- package-ecosystem: docker
+  directory: /.test-defs
+  schedule:
+    interval: daily


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
This PR enables `dependabot` to create update PRs for Golang (and other) docker images similar to how it is done in other gardener repositories ([ref](https://github.com/gardener/gardener-extension-os-gardenlinux/blob/020f32da8659e91bf5877fde7cd26e0259537cd5/.github/dependabot.yaml#L11-L15)).
According to the [latest Golang update PR](https://github.com/gardener/gardener/pull/8224), there are Golang images in `Dockerfile` and in several files of `.test-defs` folder.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
This PR changes a file in `.github` directory. It cannot be merged by `Tide` but needs to be merged manually

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
