### PR TITLE
Split `make generate` targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -190,7 +190,9 @@ generate:
 	@echo "$$GENERATE_HELP_INFO"
 else
 generate: tools-for-generate
+	@echo ""
 	@echo "For more info on the generate command, Run 'make generate PRINT_HELP=y'"
+	@echo ""
 	@REPO_ROOT=$(REPO_ROOT) LOGCHECK_DIR=$(LOGCHECK_DIR) GOMEGACHECK_DIR=$(GOMEGACHECK_DIR) hack/generate.sh --what "$(WHAT)" --which "$(WHICH)" --mode "$(MODE)"
 	$(MAKE) format
 endif

--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,7 @@ DEV_SETUP_WITH_WEBHOOKS                    := false
 IPFAMILY                                   := ipv4
 PARALLEL_E2E_TESTS                         := 15
 GARDENER_RELEASE_DOWNLOAD_PATH             := $(REPO_ROOT)/dev
+PRINT_HELP ?=
 
 ifneq ($(SEED_NAME),provider-extensions)
 	SEED_KUBECONFIG := $(REPO_ROOT)/example/provider-extensions/seed/kubeconfig-$(SEED_NAME)
@@ -167,25 +168,32 @@ check: $(GO_ADD_LICENSE) $(GOIMPORTS) $(GOLANGCI_LINT) $(HELM) $(IMPORT_BOSS) $(
 
 tools-for-generate: $(CONTROLLER_GEN) $(GEN_CRD_API_REFERENCE_DOCS) $(GOIMPORTS) $(GO_TO_PROTOBUF) $(HELM) $(MOCKGEN) $(OPENAPI_GEN) $(PROTOC) $(PROTOC_GEN_GOGO) $(YAML2JSON) $(YQ)
 
+define GENERATE_HELP_INFO
+# Usage: make generate [WHAT="<targets>"] [MODE="<mode>"] [WHICH="<folders>"]
+#
+# Options:
+#   WHAT   - Specify the targets to run (e.g., "protobuf codegen manifests logcheck gomegacheck monitoring-docs")
+#   WHICH  - Specify which folders to run the "manifests" target in, not applicable for other targets (e.g., "charts cmd example extensions pkg plugin test")
+#   MODE   - Specify the mode for the 'manifests' target (e.g., "sequential" or "parallel")
+#
+# Examples:
+#   make generate
+#   make generate WHAT="codegen protobuf"
+#   make generate WHAT="codegen protobuf" MODE="sequential"
+#   make generate WHAT="manifests" WHICH="pkg plugin" MODE="sequential"
+#
+endef
+export GENERATE_HELP_INFO
 .PHONY: generate
+ifeq ($(PRINT_HELP),y)
+generate:
+	@echo "$$GENERATE_HELP_INFO"
+else
 generate: tools-for-generate
-	@hack/update-protobuf.sh
-	@hack/update-codegen.sh
-	@hack/generate-parallel.sh charts cmd example extensions pkg plugin test
-	@cd $(LOGCHECK_DIR); go generate ./...
-	@cd $(GOMEGACHECK_DIR); go generate ./...
-	@hack/generate-monitoring-docs.sh
+	@echo "For more info on the generate command, Run 'make generate PRINT_HELP=y'"
+	@REPO_ROOT=$(REPO_ROOT) LOGCHECK_DIR=$(LOGCHECK_DIR) GOMEGACHECK_DIR=$(GOMEGACHECK_DIR) hack/generate.sh --what "$(WHAT)" --which "$(WHICH)" --mode "$(MODE)"
 	$(MAKE) format
-
-.PHONY: generate-sequential
-generate-sequential: tools-for-generate
-	@hack/update-protobuf.sh
-	@hack/update-codegen.sh
-	@hack/generate.sh ./charts/... ./cmd/... ./example/... ./extensions/... ./pkg/... ./plugin/... ./test/...
-	@cd $(LOGCHECK_DIR); go generate ./...
-	@cd $(GOMEGACHECK_DIR); go generate ./...
-	@hack/generate-monitoring-docs.sh
-	$(MAKE) format
+endif
 
 .PHONY: format
 format: $(GOIMPORTS) $(GOIMPORTSREVISER)

--- a/Makefile
+++ b/Makefile
@@ -190,9 +190,7 @@ generate:
 	@echo "$$GENERATE_HELP_INFO"
 else
 generate: tools-for-generate
-	@echo ""
-	@echo "For more info on the generate command, Run 'make generate PRINT_HELP=y'"
-	@echo ""
+	@printf "\nFor more info on the generate command, Run 'make generate PRINT_HELP=y'\n\n"
 	@REPO_ROOT=$(REPO_ROOT) LOGCHECK_DIR=$(LOGCHECK_DIR) GOMEGACHECK_DIR=$(GOMEGACHECK_DIR) hack/generate.sh --what "$(WHAT)" --which "$(WHICH)" --mode "$(MODE)"
 	$(MAKE) format
 endif

--- a/Makefile
+++ b/Makefile
@@ -173,7 +173,7 @@ define GENERATE_HELP_INFO
 #
 # Options:
 #   WHAT   - Specify the targets to run (e.g., "protobuf codegen manifests logcheck gomegacheck monitoring-docs")
-#   WHICH  - Specify which folders to run the "manifests" target in, not applicable for other targets (e.g., "charts cmd example extensions pkg plugin test")
+#   WHICH  - Specify which folders to run the 'manifests' target in, not applicable for other targets (e.g., "charts cmd example extensions pkg plugin test")
 #   MODE   - Specify the mode for the 'manifests' target (e.g., "sequential" or "parallel")
 #
 # Examples:

--- a/hack/generate-sequential.sh
+++ b/hack/generate-sequential.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+#
+# Copyright 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+echo "> Generate"
+
+go generate $@

--- a/hack/generate-sequential.sh
+++ b/hack/generate-sequential.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+# Copyright 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/hack/generate.sh
+++ b/hack/generate.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+# Copyright 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/hack/generate.sh
+++ b/hack/generate.sh
@@ -83,8 +83,7 @@ run_target() {
       $REPO_ROOT/hack/generate-monitoring-docs.sh
       ;;
     *)
-      echo "Unknown target: $target. Available targets are 'protobuf', 'codegen', 'manifests', 'logcheck', 'gomegacheck', 'monitoring-docs'."
-      echo ""
+      printf "Unknown target: $target. Available targets are 'protobuf', 'codegen', 'manifests', 'logcheck', 'gomegacheck', 'monitoring-docs'.\n\n"
       ;;
   esac
 }

--- a/hack/generate.sh
+++ b/hack/generate.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+# Copyright 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,6 +16,82 @@
 
 set -e
 
-echo "> Generate"
+WHAT="protobuf codegen manifests logcheck gomegacheck monitoring-docs"
+WHICH="charts cmd example extensions pkg plugin test"
+MODE="paralell"
 
-go generate $@
+parse_flags() {
+  while test $# -gt 0; do
+    case "$1" in
+      --what)
+        shift
+        if [[ -n "$1" ]]; then
+          WHAT="$1"
+        fi
+        ;;
+      --mode)
+        shift
+        if [[ -n "$1" ]]; then
+        MODE="$1"
+        fi
+        ;;
+      --which)
+        shift
+        if [[ -n "$1" ]]; then
+          WHICH="$1"
+        fi
+        ;;
+      *)
+        echo "Unknown argument: $1"
+        exit 1
+        ;;
+    esac
+    shift
+  done
+}
+
+overwrite_paths() {
+  IFS=' ' read -ra entries <<< "$WHICH"
+  for entry in "${entries[@]}"; do
+    WHICH=${WHICH//$entry/./$entry/...}
+  done
+}
+
+run_target() {
+  local target=$1
+  case "$target" in
+    protobuf)
+      $REPO_ROOT/hack/update-protobuf.sh
+      ;;
+    codegen)
+      $REPO_ROOT/hack/update-codegen.sh
+      ;;
+    manifests)
+      if [[ "$MODE" == "sequential" ]]; then
+        # For sequential mode, we need paths to be of the form ./charts/.., ./extensions/.. etc.
+        overwrite_paths
+        $REPO_ROOT/hack/generate-sequential.sh $WHICH
+      else
+        $REPO_ROOT/hack/generate-parallel.sh $WHICH
+      fi
+      ;;
+    logcheck)
+      cd "$REPO_ROOT/$LOGCHECK_DIR" && go generate ./...
+      ;;
+    gomegacheck)
+      cd "$REPO_ROOT/$GOMEGACHECK_DIR" && go generate ./...
+      ;;
+    monitoring-docs)
+      $REPO_ROOT/hack/generate-monitoring-docs.sh
+      ;;
+    *)
+      echo "Unknown target: $target"
+      ;;
+  esac
+}
+
+parse_flags "$@"
+
+for target in $WHAT; do
+  run_target "$target"
+done


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
This PR splits the `generate` target based on the targets, ie; WHAT to run, and the MODE ie; "parallel" or "sequential", and WHICH folder to run the targets for.

For detailed steps, you can run `make generate PRINT_HELP=y`, This info is also printed with every generate command.
```
$ make generate WHAT="manifests protobuf" WHICH="extensions charts" MODE="sequential"

For more info on the generate command, Run 'make generate PRINT_HELP=y'
> Generate
```

```
$ make generate PRINT_HELP=y

# Usage: make generate [WHAT="<targets>"] [MODE="<mode>"] [WHICH="<folders>"]
#
# Options:
#   WHAT   - Specify the targets to run (e.g., "protobuf codegen manifests logcheck gomegacheck monitoring-docs")
#   WHICH  - Specify which folders to run the "manifests" target in, not applicable for other targets (e.g., "charts cmd example extensions pkg plugin test")
#   MODE   - Specify the mode for the 'manifests' target (e.g., "sequential" or "parallel")
#
# Examples:
#   make generate
#   make generate WHAT="codegen protobuf"
#   make generate WHAT="codegen protobuf" MODE="sequential"
#   make generate WHAT="manifests" WHICH="pkg plugin" MODE="sequential"
#
```

**Which issue(s) this PR fixes**:
Fixes part of #6016

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking dependency
`hack/generate.sh` has been renamed to `hack/generate-sequential.sh`.
```
