### PR TITLE
Add labels to worker nodes that identify the OS image

### DIFF
--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -674,6 +674,10 @@ const (
 	LabelPodMaintenanceRestart = "maintenance.gardener.cloud/restart"
 	// LabelWorkerPool is a constant for a label that indicates the worker pool the node belongs to
 	LabelWorkerPool = "worker.gardener.cloud/pool"
+	// LabelWorkerPoolImageName is a label that indicates the name of the OS image for that worker pool
+	LabelWorkerPoolImageName = "worker.gardener.cloud/image-name"
+	// LabelWorkerPoolImageVersion is a label that indicates the version of the OS image for that worker pool
+	LabelWorkerPoolImageVersion = "worker.gardener.cloud/image-version"
 	// LabelWorkerKubernetesVersion is a constant for a label that indicates the Kubernetes version used for the worker pool nodes.
 	LabelWorkerKubernetesVersion = "worker.gardener.cloud/kubernetes-version"
 	// LabelWorkerPoolDeprecated is a deprecated constant for a label that indicates the worker pool the node belongs to

--- a/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig_test.go
@@ -140,6 +140,7 @@ var _ = Describe("OperatingSystemConfig", func() {
 						Architecture: pointer.String(v1beta1constants.ArchitectureAMD64),
 						Image: &gardencorev1beta1.ShootMachineImage{
 							Name:           "type1",
+							Version:        pointer.String("1.2.3"),
 							ProviderConfig: &runtime.RawExtension{Raw: []byte(`{"foo":"bar"}`)},
 						},
 					},
@@ -150,7 +151,8 @@ var _ = Describe("OperatingSystemConfig", func() {
 					Machine: gardencorev1beta1.Machine{
 						Architecture: pointer.String(v1beta1constants.ArchitectureAMD64),
 						Image: &gardencorev1beta1.ShootMachineImage{
-							Name: "type2",
+							Name:    "type2",
+							Version: pointer.String("1.2.3"),
 						},
 					},
 					CRI: &gardencorev1beta1.CRI{

--- a/pkg/component/extensions/worker/worker_test.go
+++ b/pkg/component/extensions/worker/worker_test.go
@@ -281,6 +281,8 @@ var _ = Describe("Worker", func() {
 						"worker.gardener.cloud/cri-name":  string(worker1CRIName),
 						"containerruntime.worker.gardener.cloud/" + worker1CRIContainerRuntime1Type: "true",
 						"networking.gardener.cloud/node-local-dns-enabled":                          "false",
+						"worker.gardener.cloud/image-name":                                          worker1MachineImageName,
+						"worker.gardener.cloud/image-version":                                       worker1MachineImageVersion,
 					}),
 					Taints:      worker1Taints,
 					MachineType: worker1MachineType,
@@ -324,6 +326,8 @@ var _ = Describe("Worker", func() {
 						"worker.gardener.cloud/pool":                       worker2Name,
 						"worker.garden.sapcloud.io/group":                  worker2Name,
 						"networking.gardener.cloud/node-local-dns-enabled": "false",
+						"worker.gardener.cloud/image-name":                 worker2MachineImageName,
+						"worker.gardener.cloud/image-version":              worker2MachineImageVersion,
 					},
 					MachineType: worker2MachineType,
 					MachineImage: extensionsv1alpha1.MachineImage{

--- a/pkg/utils/gardener/shoot.go
+++ b/pkg/utils/gardener/shoot.go
@@ -185,6 +185,10 @@ func NodeLabelsForWorkerPool(workerPool gardencorev1beta1.Worker, nodeLocalDNSEn
 	labels[v1beta1constants.LabelWorkerPool] = workerPool.Name
 	labels[v1beta1constants.LabelWorkerPoolDeprecated] = workerPool.Name
 
+	// worker pool image labels
+	labels[v1beta1constants.LabelWorkerPoolImageName] = workerPool.Machine.Image.Name
+	labels[v1beta1constants.LabelWorkerPoolImageVersion] = *workerPool.Machine.Image.Version
+
 	// add CRI labels selected by the RuntimeClass
 	if workerPool.CRI != nil {
 		labels[extensionsv1alpha1.CRINameWorkerLabel] = string(workerPool.CRI.Name)

--- a/pkg/utils/gardener/shoot_test.go
+++ b/pkg/utils/gardener/shoot_test.go
@@ -287,6 +287,10 @@ var _ = Describe("Shoot", func() {
 				Name: "worker",
 				Machine: gardencorev1beta1.Machine{
 					Architecture: pointer.String("arm64"),
+					Image: &gardencorev1beta1.ShootMachineImage{
+						Name:    "gardenlinux",
+						Version: pointer.String("1.2.3"),
+					},
 				},
 				SystemComponents: &gardencorev1beta1.WorkerSystemComponents{
 					Allow: true,
@@ -348,6 +352,13 @@ var _ = Describe("Shoot", func() {
 				HaveKeyWithValue("worker.gardener.cloud/cri-name", "containerd"),
 				HaveKeyWithValue("containerruntime.worker.gardener.cloud/gvisor", "true"),
 				HaveKeyWithValue("containerruntime.worker.gardener.cloud/kata", "true"),
+			))
+		})
+
+		It("should correctly add the labels that identify the worker image", func() {
+			Expect(NodeLabelsForWorkerPool(workerPool, false)).To(And(
+				HaveKeyWithValue("worker.gardener.cloud/image-name", "gardenlinux"),
+				HaveKeyWithValue("worker.gardener.cloud/image-version", "1.2.3"),
 			))
 		})
 	})


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area os
/kind enhancement

**What this PR does / why we need it**:

Certain applications like machine learning require deployment of drivers for GPUs or other dedicated hardware on worker nodes. This is usually done by DaemonSets.
The driver packages must be compiled exactly for the OS that the worker node runs and once immutable OS images with features like SecureBoot enter the stage, the driver packages must even be signed with a key that is unique to a certain OS image.
Right now, there are no labels on worker nodes that identify the OS image a worker node uses so it is not easily possible to use Selectors to explicitly deploy certain DaemonSets only to nodes with e.g. Garden Linux. While it is possible to add those labels manually in the Shoot manifest, it would be good if Gardener would add those labels by itself as it knows best which machine image is used for workers.
This PR introduces two more labels for worker nodes: `worker.gardener.cloud/image-name` and `worker.gardener.cloud/image-version` whose value will be the content of a worker pools `Machine.Image.Name` and `Machine.Image.Version` field respectively.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Two additional labels `worker.gardener.cloud/image-name` and `worker.gardener.cloud/image-version` are attached to worker nodes to identify which operating system they are running. This can then be used in selectors that target only workers with a specific operating system and is helpful for e.g. driver deployment.
```
