### PR TITLE
Add failure tolerance option to `CreateShoot` test

### DIFF
--- a/.test-defs/CreateShoot.yaml
+++ b/.test-defs/CreateShoot.yaml
@@ -37,6 +37,7 @@ spec:
     -start-hibernated=$START_HIBERNATED
     -allow-privileged-containers=$ALLOW_PRIVILEGED_CONTAINERS
     -annotations=$SHOOT_ANNOTATIONS
+    -control-plane-failure-tolerance=$CONTROL_PLANE_FAILURE_TOLERANCE
 #    -machine-image-name=$MACHINE_IMAGE
 #    -machine-image-version=$MACHINE_IMAGE_VERSION
 #    -machine-type=$MACHINE_TYPE

--- a/test/framework/shoot_utils.go
+++ b/test/framework/shoot_utils.go
@@ -167,6 +167,8 @@ func CreateShootTestArtifacts(cfg *ShootCreationConfig, projectNamespace string,
 
 	setShootTolerations(shoot)
 
+	setShootControlPlaneHighAvailability(shoot, cfg)
+
 	return shoot.Name, shoot, nil
 }
 
@@ -369,4 +371,23 @@ func PrettyPrintObject(obj runtime.Object) error {
 	}
 	fmt.Print(string(d))
 	return nil
+}
+
+func setShootControlPlaneHighAvailability(shoot *gardencorev1beta1.Shoot, cfg *ShootCreationConfig) {
+	if StringSet(cfg.controlPlaneFailureTolerance) {
+		if shoot.Spec.ControlPlane == nil {
+			shoot.Spec.ControlPlane = &gardencorev1beta1.ControlPlane{
+				HighAvailability: &gardencorev1beta1.HighAvailability{
+					FailureTolerance: gardencorev1beta1.FailureTolerance{},
+				},
+			}
+		}
+
+		if shoot.Spec.ControlPlane.HighAvailability == nil {
+			shoot.Spec.ControlPlane.HighAvailability = &gardencorev1beta1.HighAvailability{
+				FailureTolerance: gardencorev1beta1.FailureTolerance{},
+			}
+		}
+		shoot.Spec.ControlPlane.HighAvailability.FailureTolerance.Type = gardencorev1beta1.FailureToleranceType(cfg.controlPlaneFailureTolerance)
+	}
 }

--- a/test/framework/shootcreationframework.go
+++ b/test/framework/shootcreationframework.go
@@ -65,6 +65,7 @@ type ShootCreationConfig struct {
 	workersConfig                 string
 	shootYamlPath                 string
 	shootAnnotations              string
+	controlPlaneFailureTolerance  string
 }
 
 // ShootCreationFramework represents the shoot test framework that includes
@@ -307,6 +308,10 @@ func mergeShootCreationConfig(base, overwrite *ShootCreationConfig) *ShootCreati
 		base.workersConfig = overwrite.workersConfig
 	}
 
+	if StringSet(overwrite.controlPlaneFailureTolerance) {
+		base.controlPlaneFailureTolerance = overwrite.controlPlaneFailureTolerance
+	}
+
 	if StringSet(overwrite.shootYamlPath) {
 		base.shootYamlPath = overwrite.shootYamlPath
 	}
@@ -342,6 +347,7 @@ func RegisterShootCreationFrameworkFlags() *ShootCreationConfig {
 	flag.StringVar(&newCfg.networkingNodes, "networking-nodes", "", "the spec.networking.nodes to use for this shoot. Optional.")
 	flag.StringVar(&newCfg.startHibernatedFlag, "start-hibernated", "", "the spec.hibernation.enabled to use for this shoot. Optional.")
 	flag.StringVar(&newCfg.allowPrivilegedContainersFlag, "allow-privileged-containers", "", "the spec.kubernetes.allowPrivilegedContainers to use for this shoot. Optional, defaults to true.")
+	flag.StringVar(&newCfg.controlPlaneFailureTolerance, "control-plane-failure-tolerance", "", "the .spec.controlPlane.HighAvailability.FailureTolerance.FailureToleranceType to use for this shoot. Optional, defaults to no failure tolerance")
 
 	if newCfg.networkingType == "" {
 		newCfg.networkingType = "calico"


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind enhancement

**What this PR does / why we need it**:
Enhance the shoot creation framework and CreateShoot test definition to deal with `failureTolerance` settings for shoot control planes.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Follow-up of https://github.com/gardener/gardener/pull/8263

/invite @dguendisch 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
Add failure tolerance option to the `CreateShoot` test.
```
