### PR TITLE
Allow feature gates to be added to `etcd-druid` and vendor `etcd-druid@v0.19.1`

### DIFF
--- a/charts/gardener/gardenlet/values.yaml
+++ b/charts/gardener/gardenlet/values.yaml
@@ -188,6 +188,8 @@ config:
 #   backupLeaderElection:
 #     reelectionPeriod: 5s
 #     etcdConnectionTimeout: 5s
+#   featureGates:
+#     UseEtcdWrapper: true
 # logging:
 #   enabled: false
 # monitoring:

--- a/charts/gardener/operator/values.yaml
+++ b/charts/gardener/operator/values.yaml
@@ -72,6 +72,8 @@ config:
       # backupLeaderElection:
       #   reelectionPeriod: 5s
       #   etcdConnectionTimeout: 5s
+      # featureGates:
+      #   UseEtcdWrapper: true
     gardenCare:
       syncPeriod: 1m
       conditionThresholds:

--- a/example/20-componentconfig-gardenlet.yaml
+++ b/example/20-componentconfig-gardenlet.yaml
@@ -178,6 +178,8 @@ etcdConfig:
 # backupLeaderElection:
 #   reelectionPeriod: 5s
 #   etcdConnectionTimeout: 5s
+# featureGates:
+#   UseEtcdWrapper: true
 # monitoring:
 #   shoot:
 #     enabled: true

--- a/example/gardener-local/gardenlet/values.yaml
+++ b/example/gardener-local/gardenlet/values.yaml
@@ -51,7 +51,7 @@ config:
     ContainerdRegistryHostsDir: true
   etcdConfig:
     featureGates:
-      UseEtcdWrapper: true
+      UseEtcdWrapper: false
   logging:
     enabled: true
     vali:

--- a/example/gardener-local/gardenlet/values.yaml
+++ b/example/gardener-local/gardenlet/values.yaml
@@ -49,6 +49,9 @@ config:
     # If disabled, a Shoot cluster in local setup won't be able to use the registry cache
     # (it will be still able to pull images but registry cache won't be used).
     ContainerdRegistryHostsDir: true
+  etcdConfig:
+    featureGates:
+      UseEtcdWrapper: true
   logging:
     enabled: true
     vali:

--- a/example/operator/10-componentconfig.yaml
+++ b/example/operator/10-componentconfig.yaml
@@ -44,6 +44,8 @@ controllers:
         enableBackupCompaction: false
         eventsThreshold: 1000000
         activeDeadlineDuration: "3h"
+    # featureGates:
+    #   UseEtcdWrapper: true
   gardenCare:
     syncPeriod: 1m
     conditionThresholds:

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/coreos/go-systemd/v22 v22.3.2
 	github.com/fluent/fluent-operator/v2 v2.2.0
 	github.com/gardener/dependency-watchdog v1.1.1
-	github.com/gardener/etcd-druid v0.18.4
+	github.com/gardener/etcd-druid v0.19.0
 	github.com/gardener/hvpa-controller/api v0.5.0
 	github.com/gardener/machine-controller-manager v0.48.1
 	github.com/go-logr/logr v1.2.4

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/coreos/go-systemd/v22 v22.3.2
 	github.com/fluent/fluent-operator/v2 v2.2.0
 	github.com/gardener/dependency-watchdog v1.1.1
-	github.com/gardener/etcd-druid v0.19.0
+	github.com/gardener/etcd-druid v0.19.1
 	github.com/gardener/hvpa-controller/api v0.5.0
 	github.com/gardener/machine-controller-manager v0.48.1
 	github.com/go-logr/logr v1.2.4

--- a/go.sum
+++ b/go.sum
@@ -170,8 +170,8 @@ github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4
 github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbSClcnxKAGw=
 github.com/gardener/dependency-watchdog v1.1.1 h1:jS5KcZJ/XKBdHniL3NYy2mRUOtGsrNqK0NWuj1L24mI=
 github.com/gardener/dependency-watchdog v1.1.1/go.mod h1:mShlo0jeS+YD0lq/GYVj/VU55B7lT0mfjqC2knFAnLk=
-github.com/gardener/etcd-druid v0.18.4 h1:CyDQRRBPDXYSoNPaSnrs4lw3Ht+aD3LuQZQliJz+Gw0=
-github.com/gardener/etcd-druid v0.18.4/go.mod h1:NfBcP/xYSrbbtbPPFzEQ7CSQ73l+GtNQgx466Gv7FW0=
+github.com/gardener/etcd-druid v0.19.0 h1:rKQ5xR2TvIYalyaUpc20PAiAW+9H/4wmIDeN8PI1dQ0=
+github.com/gardener/etcd-druid v0.19.0/go.mod h1:l4pOUbvQS7lWAcLssOtM7jtFex8YtwoT7o5LggNSz/Y=
 github.com/gardener/hvpa-controller/api v0.5.0 h1:f4F3O7YUrenwh4S3TgPREPiB287JjjUiUL18OqPLyAA=
 github.com/gardener/hvpa-controller/api v0.5.0/go.mod h1:QQl3ELkCaki+8RhXl0FZMfvnm0WCGwGJlGmrxJj6lvM=
 github.com/gardener/machine-controller-manager v0.48.1 h1:Oxr5e6gRm7P40Ds4nGlga/0nmfF7cH4rOfjthR6Mm38=

--- a/go.sum
+++ b/go.sum
@@ -170,8 +170,8 @@ github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4
 github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbSClcnxKAGw=
 github.com/gardener/dependency-watchdog v1.1.1 h1:jS5KcZJ/XKBdHniL3NYy2mRUOtGsrNqK0NWuj1L24mI=
 github.com/gardener/dependency-watchdog v1.1.1/go.mod h1:mShlo0jeS+YD0lq/GYVj/VU55B7lT0mfjqC2knFAnLk=
-github.com/gardener/etcd-druid v0.19.0 h1:rKQ5xR2TvIYalyaUpc20PAiAW+9H/4wmIDeN8PI1dQ0=
-github.com/gardener/etcd-druid v0.19.0/go.mod h1:l4pOUbvQS7lWAcLssOtM7jtFex8YtwoT7o5LggNSz/Y=
+github.com/gardener/etcd-druid v0.19.1 h1:ENy1GTYNz6CREr6czLBhQPlACtlOsWYkZlvcg9Ne/lQ=
+github.com/gardener/etcd-druid v0.19.1/go.mod h1:l4pOUbvQS7lWAcLssOtM7jtFex8YtwoT7o5LggNSz/Y=
 github.com/gardener/hvpa-controller/api v0.5.0 h1:f4F3O7YUrenwh4S3TgPREPiB287JjjUiUL18OqPLyAA=
 github.com/gardener/hvpa-controller/api v0.5.0/go.mod h1:QQl3ELkCaki+8RhXl0FZMfvnm0WCGwGJlGmrxJj6lvM=
 github.com/gardener/machine-controller-manager v0.48.1 h1:Oxr5e6gRm7P40Ds4nGlga/0nmfF7cH4rOfjthR6Mm38=

--- a/pkg/component/etcd/bootstrap.go
+++ b/pkg/component/etcd/bootstrap.go
@@ -401,6 +401,11 @@ func getDruidDeployCommands(etcdConfig *config.ETCDConfig) []string {
 		command = append(command, "--active-deadline-duration="+etcdConfig.BackupCompactionController.ActiveDeadlineDuration.Duration.String())
 	}
 
+	// Add feature gates to the etcd druid command
+	if etcdConfig.FeatureGates != nil {
+		command = append(command, kubernetesutils.FeatureGatesToCommandLineParameter(etcdConfig.FeatureGates))
+	}
+
 	return command
 }
 

--- a/pkg/component/etcd/bootstrap_test.go
+++ b/pkg/component/etcd/bootstrap_test.go
@@ -60,6 +60,7 @@ var _ = Describe("Etcd", func() {
 		imageVectorOverwriteEmpty *string
 		imageVectorOverwriteFull  = pointer.String("some overwrite")
 		priorityClassName         = "some-priority-class"
+		useEtcdWrapper            = "UseEtcdWrapper"
 
 		managedResourceName       = "etcd-druid"
 		managedResourceSecretName = "managedresource-" + managedResourceName
@@ -434,6 +435,58 @@ spec:
         name: imagevector-overwrite
 status: {}
 `
+			deploymentWithFeatureGates = `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  labels:
+    gardener.cloud/role: etcd-druid
+    high-availability-config.resources.gardener.cloud/type: controller
+  name: etcd-druid
+  namespace: ` + namespace + `
+spec:
+  replicas: 1
+  revisionHistoryLimit: 1
+  selector:
+    matchLabels:
+      gardener.cloud/role: etcd-druid
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        gardener.cloud/role: etcd-druid
+        networking.gardener.cloud/to-dns: allowed
+        networking.gardener.cloud/to-runtime-apiserver: allowed
+    spec:
+      containers:
+      - command:
+        - /etcd-druid
+        - --enable-leader-election=true
+        - --ignore-operation-annotation=false
+        - --disable-etcd-serviceaccount-automount=true
+        - --workers=25
+        - --custodian-workers=3
+        - --compaction-workers=3
+        - --enable-backup-compaction=true
+        - --etcd-events-threshold=1000000
+        - --active-deadline-duration=3h0m0s
+        - --feature-gates=UseEtcdWrapper=true
+        image: ` + etcdDruidImage + `
+        imagePullPolicy: IfNotPresent
+        name: etcd-druid
+        ports:
+        - containerPort: 8080
+        resources:
+          limits:
+            memory: 512Mi
+          requests:
+            cpu: 50m
+            memory: 128Mi
+      priorityClassName: ` + priorityClassName + `
+      serviceAccountName: etcd-druid
+status: {}
+`
 			serviceYAML = `apiVersion: v1
 kind: Service
 metadata:
@@ -568,6 +621,31 @@ status:
 				c.EXPECT().Get(ctx, kubernetesutils.Key(namespace, managedResourceSecret.Name), gomock.AssignableToTypeOf(&corev1.Secret{})),
 				c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&corev1.Secret{})).Do(func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) {
 					Expect(obj).To(DeepEqual(managedResourceSecret))
+				}),
+				c.EXPECT().Get(ctx, kubernetesutils.Key(namespace, managedResourceName), gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})),
+				c.EXPECT().Get(ctx, kubernetesutils.Key(namespace, managedResourceSecret.Name), gomock.AssignableToTypeOf(&corev1.Secret{})),
+				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&corev1.Secret{}), gomock.Any()),
+				c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})).Do(func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) {
+					managedResource.Spec.SecretRefs = []corev1.LocalObjectReference{{Name: managedResourceSecret.Name}}
+					utilruntime.Must(references.InjectAnnotations(managedResource))
+					Expect(obj).To(DeepEqual(managedResource))
+				}),
+			)
+
+			Expect(bootstrapper.Deploy(ctx)).To(Succeed())
+		})
+
+		It("should successfully deploy all the resources (w/ feature gates being present in etcd config)", func() {
+			etcdConfig.FeatureGates = map[string]bool{
+				useEtcdWrapper: true,
+			}
+			managedResourceSecret.Data["deployment__"+namespace+"__etcd-druid.yaml"] = []byte(deploymentWithFeatureGates)
+
+			utilruntime.Must(kubernetesutils.MakeUnique(managedResourceSecret))
+			gomock.InOrder(
+				c.EXPECT().Get(ctx, kubernetesutils.Key(namespace, managedResourceSecret.Name), gomock.AssignableToTypeOf(&corev1.Secret{})),
+				c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&corev1.Secret{})).Do(func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) {
+					Expect(obj).To(Equal(managedResourceSecret))
 				}),
 				c.EXPECT().Get(ctx, kubernetesutils.Key(namespace, managedResourceName), gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})),
 				c.EXPECT().Get(ctx, kubernetesutils.Key(namespace, managedResourceSecret.Name), gomock.AssignableToTypeOf(&corev1.Secret{})),

--- a/pkg/component/etcd/crds/templates/crd-druid.gardener.cloud_etcdcopybackupstasks.yaml
+++ b/pkg/component/etcd/crds/templates/crd-druid.gardener.cloud_etcdcopybackupstasks.yaml
@@ -1,4 +1,4 @@
-# Source: https://github.com/gardener/etcd-druid/blob/v0.19.0/charts/druid/charts/crds/templates/10-crd-druid.gardener.cloud_etcdcopybackupstasks.yaml
+# Source: https://github.com/gardener/etcd-druid/blob/v0.19.1/charts/druid/charts/crds/templates/10-crd-druid.gardener.cloud_etcdcopybackupstasks.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/pkg/component/etcd/crds/templates/crd-druid.gardener.cloud_etcdcopybackupstasks.yaml
+++ b/pkg/component/etcd/crds/templates/crd-druid.gardener.cloud_etcdcopybackupstasks.yaml
@@ -1,4 +1,4 @@
-# Source: https://github.com/gardener/etcd-druid/blob/v0.18.4/charts/druid/charts/crds/templates/10-crd-druid.gardener.cloud_etcdcopybackupstasks.yaml
+# Source: https://github.com/gardener/etcd-druid/blob/v0.19.0/charts/druid/charts/crds/templates/10-crd-druid.gardener.cloud_etcdcopybackupstasks.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/pkg/component/etcd/crds/templates/crd-druid.gardener.cloud_etcds.yaml
+++ b/pkg/component/etcd/crds/templates/crd-druid.gardener.cloud_etcds.yaml
@@ -1,4 +1,4 @@
-# Source: https://github.com/gardener/etcd-druid/blob/v0.19.0/charts/druid/charts/crds/templates/10-crd-druid.gardener.cloud_etcds.yaml
+# Source: https://github.com/gardener/etcd-druid/blob/v0.19.1/charts/druid/charts/crds/templates/10-crd-druid.gardener.cloud_etcds.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/pkg/component/etcd/crds/templates/crd-druid.gardener.cloud_etcds.yaml
+++ b/pkg/component/etcd/crds/templates/crd-druid.gardener.cloud_etcds.yaml
@@ -1,4 +1,4 @@
-# Source: https://github.com/gardener/etcd-druid/blob/v0.18.4/charts/druid/charts/crds/templates/10-crd-druid.gardener.cloud_etcds.yaml
+# Source: https://github.com/gardener/etcd-druid/blob/v0.19.0/charts/druid/charts/crds/templates/10-crd-druid.gardener.cloud_etcds.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/pkg/gardenlet/apis/config/types.go
+++ b/pkg/gardenlet/apis/config/types.go
@@ -457,6 +457,11 @@ type ETCDConfig struct {
 	BackupCompactionController *BackupCompactionController
 	// BackupLeaderElection contains configuration for the leader election for the etcd backup-restore sidecar.
 	BackupLeaderElection *ETCDBackupLeaderElection
+	// FeatureGates is a map of feature names to bools that enable or disable alpha/experimental
+	// features. This field modifies piecemeal the built-in default values from
+	// "github.com/gardener/etcd-druid/pkg/features/features.go".
+	// Default: nil
+	FeatureGates map[string]bool
 }
 
 // ETCDController contains config specific to ETCD controller

--- a/pkg/gardenlet/apis/config/v1alpha1/types.go
+++ b/pkg/gardenlet/apis/config/v1alpha1/types.go
@@ -555,6 +555,11 @@ type ETCDConfig struct {
 	// BackupLeaderElection contains configuration for the leader election for the etcd backup-restore sidecar.
 	// +optional
 	BackupLeaderElection *ETCDBackupLeaderElection `json:"backupLeaderElection,omitempty"`
+	// FeatureGates is a map of feature names to bools that enable or disable alpha/experimental
+	// features. This field modifies piecemeal the built-in default values from
+	// "github.com/gardener/etcd-druid/pkg/features/features.go".
+	// Default: nil
+	FeatureGates map[string]bool `json:"featureGates,omitempty"`
 }
 
 // ETCDController contains config specific to ETCD controller

--- a/pkg/gardenlet/apis/config/v1alpha1/types.go
+++ b/pkg/gardenlet/apis/config/v1alpha1/types.go
@@ -559,6 +559,7 @@ type ETCDConfig struct {
 	// features. This field modifies piecemeal the built-in default values from
 	// "github.com/gardener/etcd-druid/pkg/features/features.go".
 	// Default: nil
+	// +optional
 	FeatureGates map[string]bool `json:"featureGates,omitempty"`
 }
 

--- a/pkg/gardenlet/apis/config/v1alpha1/zz_generated.conversion.go
+++ b/pkg/gardenlet/apis/config/v1alpha1/zz_generated.conversion.go
@@ -717,6 +717,7 @@ func autoConvert_v1alpha1_ETCDConfig_To_config_ETCDConfig(in *ETCDConfig, out *c
 	out.CustodianController = (*config.CustodianController)(unsafe.Pointer(in.CustodianController))
 	out.BackupCompactionController = (*config.BackupCompactionController)(unsafe.Pointer(in.BackupCompactionController))
 	out.BackupLeaderElection = (*config.ETCDBackupLeaderElection)(unsafe.Pointer(in.BackupLeaderElection))
+	out.FeatureGates = *(*map[string]bool)(unsafe.Pointer(&in.FeatureGates))
 	return nil
 }
 
@@ -730,6 +731,7 @@ func autoConvert_config_ETCDConfig_To_v1alpha1_ETCDConfig(in *config.ETCDConfig,
 	out.CustodianController = (*CustodianController)(unsafe.Pointer(in.CustodianController))
 	out.BackupCompactionController = (*BackupCompactionController)(unsafe.Pointer(in.BackupCompactionController))
 	out.BackupLeaderElection = (*ETCDBackupLeaderElection)(unsafe.Pointer(in.BackupLeaderElection))
+	out.FeatureGates = *(*map[string]bool)(unsafe.Pointer(&in.FeatureGates))
 	return nil
 }
 

--- a/pkg/gardenlet/apis/config/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/gardenlet/apis/config/v1alpha1/zz_generated.deepcopy.go
@@ -293,6 +293,13 @@ func (in *ETCDConfig) DeepCopyInto(out *ETCDConfig) {
 		*out = new(ETCDBackupLeaderElection)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.FeatureGates != nil {
+		in, out := &in.FeatureGates, &out.FeatureGates
+		*out = make(map[string]bool, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	return
 }
 

--- a/pkg/gardenlet/apis/config/zz_generated.deepcopy.go
+++ b/pkg/gardenlet/apis/config/zz_generated.deepcopy.go
@@ -293,6 +293,13 @@ func (in *ETCDConfig) DeepCopyInto(out *ETCDConfig) {
 		*out = new(ETCDBackupLeaderElection)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.FeatureGates != nil {
+		in, out := &in.FeatureGates, &out.FeatureGates
+		*out = make(map[string]bool, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	return
 }
 

--- a/vendor/github.com/gardener/etcd-druid/pkg/utils/lease.go
+++ b/vendor/github.com/gardener/etcd-druid/pkg/utils/lease.go
@@ -1,3 +1,17 @@
+// Copyright 2023 SAP SE or an SAP affiliate company
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package utils
 
 import (

--- a/vendor/github.com/gardener/etcd-druid/pkg/utils/statefulset.go
+++ b/vendor/github.com/gardener/etcd-druid/pkg/utils/statefulset.go
@@ -21,6 +21,7 @@ import (
 	druidv1alpha1 "github.com/gardener/etcd-druid/api/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -47,12 +48,8 @@ func IsStatefulSetReady(etcdReplicas int32, statefulSet *appsv1.StatefulSet) (bo
 
 // GetStatefulSet fetches StatefulSet created for the etcd.
 func GetStatefulSet(ctx context.Context, cl client.Client, etcd *druidv1alpha1.Etcd) (*appsv1.StatefulSet, error) {
-	selector, err := metav1.LabelSelectorAsSelector(etcd.Spec.Selector)
-	if err != nil {
-		return nil, err
-	}
 	statefulSets := &appsv1.StatefulSetList{}
-	if err = cl.List(ctx, statefulSets, client.InNamespace(etcd.Namespace), client.MatchingLabelsSelector{Selector: selector}); err != nil {
+	if err := cl.List(ctx, statefulSets, client.InNamespace(etcd.Namespace), client.MatchingLabelsSelector{Selector: labels.Set(etcd.GetDefaultLabels()).AsSelector()}); err != nil {
 		return nil, err
 	}
 
@@ -62,5 +59,5 @@ func GetStatefulSet(ctx context.Context, cl client.Client, etcd *druidv1alpha1.E
 		}
 	}
 
-	return nil, err
+	return nil, nil
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -96,7 +96,7 @@ github.com/fsnotify/fsnotify
 ## explicit; go 1.20
 github.com/gardener/dependency-watchdog/api/prober
 github.com/gardener/dependency-watchdog/api/weeder
-# github.com/gardener/etcd-druid v0.18.4
+# github.com/gardener/etcd-druid v0.19.0
 ## explicit; go 1.20
 github.com/gardener/etcd-druid/api/v1alpha1
 github.com/gardener/etcd-druid/api/validation

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -96,7 +96,7 @@ github.com/fsnotify/fsnotify
 ## explicit; go 1.20
 github.com/gardener/dependency-watchdog/api/prober
 github.com/gardener/dependency-watchdog/api/weeder
-# github.com/gardener/etcd-druid v0.19.0
+# github.com/gardener/etcd-druid v0.19.1
 ## explicit; go 1.20
 github.com/gardener/etcd-druid/api/v1alpha1
 github.com/gardener/etcd-druid/api/validation


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area backup
/kind api-change enhancement

**What this PR does / why we need it**:
With the release of `etcd-druid:v0.19.0`, feature gates are now supported in etcd-druid.
This PR updates the gardenlet config to allow featureGates to be specified in `GardenletConfiguration.EtcdConfig` and allows those feature gates to be passed on to the `etcd-druid` command

This PR also updated the vendored `etcd-druid` to `v0.19.0`

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
This PR should be merged only after #8299 has been merged

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy operator
Gardenlet can now set feature gates for `etcd-druid`. They can be specified via the gardenlet configuration `GardenletConfiguration.EtcdConfig.FeatureGates`
```
