### PR TITLE
Switch `virtual-garden-kube-apiserver` service from `LoadBalancer` to `ClusterIP`

### DIFF
--- a/charts/gardener/gardenlet/templates/deployment.yaml
+++ b/charts/gardener/gardenlet/templates/deployment.yaml
@@ -65,6 +65,7 @@ spec:
         seccompprofile.resources.gardener.cloud/skip: "true"
         topology-spread-constraints.resources.gardener.cloud/skip: "true"
         networking.resources.gardener.cloud/to-all-shoots-etcd-main-client-tcp-8080: allowed
+        networking.resources.gardener.cloud/to-all-shoots-kube-apiserver-tcp-443: allowed
         {{- if .Values.podLabels }}
 {{ toYaml .Values.podLabels | indent 8 }}
         {{- end }}

--- a/charts/gardener/operator/templates/deployment.yaml
+++ b/charts/gardener/operator/templates/deployment.yaml
@@ -56,6 +56,7 @@ spec:
         seccompprofile.resources.gardener.cloud/skip: "true"
         topology-spread-constraints.resources.gardener.cloud/skip: "true"
         networking.resources.gardener.cloud/to-virtual-garden-etcd-main-client-tcp-8080: allowed
+        networking.resources.gardener.cloud/to-virtual-garden-kube-apiserver-tcp-443: allowed
         {{- if .Values.podLabels }}
 {{ toYaml .Values.podLabels | indent 8 }}
         {{- end }}

--- a/cmd/gardenlet/app/app.go
+++ b/cmd/gardenlet/app/app.go
@@ -55,6 +55,7 @@ import (
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/apis/operations"
 	operationsv1alpha1 "github.com/gardener/gardener/pkg/apis/operations/v1alpha1"
+	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	clientmapbuilder "github.com/gardener/gardener/pkg/client/kubernetes/clientmap/builder"
 	"github.com/gardener/gardener/pkg/controllerutils"
@@ -350,6 +351,11 @@ func (g *garden) Start(ctx context.Context) error {
 		return err
 	}
 
+	log.Info("Removing 'from-world-to-ports' annotation from kube-apiserver services")
+	if err := removeFromWorldToPortsAnnotations(ctx, g.mgr.GetClient()); err != nil {
+		return fmt.Errorf("failed to remove 'from-world-to-ports' annotation from kube-apiserver services: %w", err)
+	}
+
 	log.Info("Setting up shoot client map")
 	shootClientMap, err := clientmapbuilder.
 		NewShootClientMapBuilder().
@@ -397,6 +403,34 @@ func (g *garden) Start(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+// TODO(timuthy): Remove this code after v1.77 is released.
+func removeFromWorldToPortsAnnotations(ctx context.Context, seedClient client.Client) error {
+	serviceList := &corev1.ServiceList{}
+	if err := seedClient.List(ctx, serviceList, client.MatchingLabels{
+		v1beta1constants.LabelApp:  v1beta1constants.LabelKubernetes,
+		v1beta1constants.LabelRole: v1beta1constants.LabelAPIServer,
+	}); err != nil {
+		return err
+	}
+
+	var taskFns []flow.TaskFn
+	for _, service := range serviceList.Items {
+		if !metav1.HasAnnotation(service.ObjectMeta, resourcesv1alpha1.NetworkingFromWorldToPorts) {
+			continue
+		}
+
+		svc := service
+		patch := client.MergeFrom(svc.DeepCopy())
+
+		taskFns = append(taskFns, func(ctx context.Context) error {
+			delete(svc.Annotations, resourcesv1alpha1.NetworkingFromWorldToPorts)
+			return seedClient.Patch(ctx, &svc, patch)
+		})
+	}
+
+	return flow.Parallel(taskFns...)(ctx)
 }
 
 func (g *garden) registerSeed(ctx context.Context, gardenClient client.Client) error {

--- a/pkg/component/kubeapiserverexposure/kube_apiserver_service.go
+++ b/pkg/component/kubeapiserverexposure/kube_apiserver_service.go
@@ -66,7 +66,7 @@ type ServiceValues struct {
 // from the outside.
 type serviceValues struct {
 	annotationsFunc             func() map[string]string
-	nameprefix                  string
+	namePrefix                  string
 	topologyAwareRoutingEnabled bool
 	runtimeKubernetesVersion    *semver.Version
 	clusterIP                   string
@@ -109,7 +109,7 @@ func NewService(
 		loadBalancerServiceKeyFunc = sniServiceKeyFunc
 
 		internalValues.annotationsFunc = values.AnnotationsFunc
-		internalValues.nameprefix = values.NamePrefix
+		internalValues.namePrefix = values.NamePrefix
 		internalValues.topologyAwareRoutingEnabled = values.TopologyAwareRoutingEnabled
 		internalValues.runtimeKubernetesVersion = values.RuntimeKubernetesVersion
 	}
@@ -228,7 +228,7 @@ func (s *service) WaitCleanup(ctx context.Context) error {
 }
 
 func (s *service) emptyService() *corev1.Service {
-	return &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: s.values.nameprefix + v1beta1constants.DeploymentNameKubeAPIServer, Namespace: s.namespace}}
+	return &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: s.values.namePrefix + v1beta1constants.DeploymentNameKubeAPIServer, Namespace: s.namespace}}
 }
 
 func getLabels() map[string]string {

--- a/pkg/component/kubeapiserverexposure/kube_apiserver_service.go
+++ b/pkg/component/kubeapiserverexposure/kube_apiserver_service.go
@@ -141,10 +141,9 @@ func (s *service) Deploy(ctx context.Context) error {
 		metav1.SetMetaDataAnnotation(&obj.ObjectMeta, "networking.istio.io/exportTo", "*")
 		utilruntime.Must(gardenerutils.InjectNetworkPolicyAnnotationsForScrapeTargets(obj, networkingv1.NetworkPolicyPort{Port: utils.IntStrPtrFromInt(kubeapiserverconstants.Port), Protocol: utils.ProtocolPtr(corev1.ProtocolTCP)}))
 
-		// TODO(timuthy): Drop this annotation once the gardener-operator no longer specifies 'LoadBalancer' as service
-		//  type (then API servers are only exposed indirectly via Istio) and the NetworkPolicy controller in
-		//  gardener-resource-manager is enabled for all relevant namespaces in the seed cluster.
-		metav1.SetMetaDataAnnotation(&obj.ObjectMeta, resourcesv1alpha1.NetworkingFromWorldToPorts, fmt.Sprintf(`[{"protocol":"TCP","port":%d}]`, kubeapiserverconstants.Port))
+		// The 'from-world-to-ports' annotation was set in previous releases. Remove it here since it's not required any more.
+		// TODO(timuthy): Remove this code after v1.77 is released.
+		delete(obj.Annotations, resourcesv1alpha1.NetworkingFromWorldToPorts)
 
 		namespaceSelectors := []metav1.LabelSelector{
 			{MatchLabels: map[string]string{v1beta1constants.GardenRole: v1beta1constants.GardenRoleIstioIngress}},

--- a/pkg/component/kubeapiserverexposure/kube_apiserver_service_test.go
+++ b/pkg/component/kubeapiserverexposure/kube_apiserver_service_test.go
@@ -217,7 +217,6 @@ var _ = Describe("#Service", func() {
 					"foo":                          "bar",
 					"networking.istio.io/exportTo": "*",
 					"networking.resources.gardener.cloud/from-all-scrape-targets-allowed-ports": `[{"protocol":"TCP","port":443}]`,
-					"networking.resources.gardener.cloud/from-world-to-ports":                   `[{"protocol":"TCP","port":443}]`,
 					"networking.resources.gardener.cloud/namespace-selectors":                   `[{"matchLabels":{"gardener.cloud/role":"istio-ingress"}},{"matchLabels":{"networking.gardener.cloud/access-target-apiserver":"allowed"}}]`,
 					"service.kubernetes.io/topology-aware-hints":                                "auto",
 				}
@@ -283,7 +282,6 @@ var _ = Describe("#Service", func() {
 func netpolAnnotations() map[string]string {
 	return map[string]string{
 		"networking.resources.gardener.cloud/from-all-scrape-targets-allowed-ports": `[{"protocol":"TCP","port":443}]`,
-		"networking.resources.gardener.cloud/from-world-to-ports":                   `[{"protocol":"TCP","port":443}]`,
 		"networking.resources.gardener.cloud/namespace-selectors":                   `[{"matchLabels":{"gardener.cloud/role":"istio-ingress"}},{"matchLabels":{"networking.gardener.cloud/access-target-apiserver":"allowed"}}]`,
 	}
 }
@@ -291,7 +289,6 @@ func netpolAnnotations() map[string]string {
 func shootNetpolAnnotations() map[string]string {
 	return map[string]string{
 		"networking.resources.gardener.cloud/from-all-scrape-targets-allowed-ports": `[{"protocol":"TCP","port":443}]`,
-		"networking.resources.gardener.cloud/from-world-to-ports":                   `[{"protocol":"TCP","port":443}]`,
 		"networking.resources.gardener.cloud/namespace-selectors":                   `[{"matchLabels":{"gardener.cloud/role":"istio-ingress"}},{"matchLabels":{"networking.gardener.cloud/access-target-apiserver":"allowed"}},{"matchLabels":{"kubernetes.io/metadata.name":"garden"}},{"matchExpressions":[{"key":"handler.exposureclass.gardener.cloud/name","operator":"Exists"}]},{"matchLabels":{"gardener.cloud/role":"extension"}}]`,
 		"networking.resources.gardener.cloud/pod-label-selector-namespace-alias":    "all-shoots",
 	}

--- a/pkg/component/kubeapiserverexposure/kube_apiserver_service_test.go
+++ b/pkg/component/kubeapiserverexposure/kube_apiserver_service_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/gardener/gardener/pkg/component"
 	. "github.com/gardener/gardener/pkg/component/kubeapiserverexposure"
 	"github.com/gardener/gardener/pkg/utils"
+	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	retryfake "github.com/gardener/gardener/pkg/utils/retry/fake"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 )
@@ -48,7 +49,9 @@ var _ = Describe("#Service", func() {
 		clusterIP        string
 		clusterIPFunc    func(string)
 		ingressIPFunc    func(string)
-		serviceObjKey    client.ObjectKey
+		namePrefix       string
+		namespace        string
+		expectedName     string
 		sniServiceObjKey client.ObjectKey
 	)
 
@@ -62,7 +65,9 @@ var _ = Describe("#Service", func() {
 
 		ingressIP = ""
 		clusterIP = ""
-		serviceObjKey = client.ObjectKey{Name: "test-deploy", Namespace: "test-namespace"}
+		namePrefix = "test-"
+		namespace = "test-namespace"
+		expectedName = "test-kube-apiserver"
 		sniServiceObjKey = client.ObjectKey{Name: "foo", Namespace: "bar"}
 		clusterIPFunc = func(c string) { clusterIP = c }
 		ingressIPFunc = func(c string) { ingressIP = c }
@@ -73,8 +78,8 @@ var _ = Describe("#Service", func() {
 				Kind:       "Service",
 			},
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      serviceObjKey.Name,
-				Namespace: serviceObjKey.Namespace,
+				Name:      expectedName,
+				Namespace: namespace,
 				Labels: map[string]string{
 					"app":                                    "kubernetes",
 					"role":                                   "apiserver",
@@ -119,10 +124,11 @@ var _ = Describe("#Service", func() {
 		defaultDepWaiter = NewService(
 			log,
 			c,
+			namespace,
 			&ServiceValues{
 				AnnotationsFunc: func() map[string]string { return map[string]string{"foo": "bar"} },
+				NamePrefix:      namePrefix,
 			},
-			func() client.ObjectKey { return serviceObjKey },
 			func() client.ObjectKey { return sniServiceObjKey },
 			&retryfake.Ops{MaxAttempts: 1},
 			clusterIPFunc,
@@ -131,12 +137,12 @@ var _ = Describe("#Service", func() {
 		)
 	})
 
-	var assertEnabledSNI = func() {
+	var assertService = func() {
 		It("deploys service", func() {
 			Expect(defaultDepWaiter.Deploy(ctx)).To(Succeed())
 
 			actual := &corev1.Service{}
-			Expect(c.Get(ctx, serviceObjKey, actual)).To(Succeed())
+			Expect(c.Get(ctx, kubernetesutils.Key(namespace, expectedName), actual)).To(Succeed())
 
 			Expect(actual).To(DeepEqual(expected))
 			Expect(clusterIP).To(Equal("1.1.1.1"))
@@ -152,18 +158,18 @@ var _ = Describe("#Service", func() {
 		It("deletes service", func() {
 			Expect(defaultDepWaiter.Destroy(ctx)).To(Succeed())
 
-			Expect(c.Get(ctx, serviceObjKey, &corev1.Service{})).To(BeNotFoundError())
+			Expect(c.Get(ctx, kubernetesutils.Key(namespace, expectedName), &corev1.Service{})).To(BeNotFoundError())
 		})
 
 		It("waits for deletion service", func() {
 			Expect(defaultDepWaiter.Destroy(ctx)).To(Succeed())
 			Expect(defaultDepWaiter.WaitCleanup(ctx)).To(Succeed())
 
-			Expect(c.Get(ctx, serviceObjKey, &corev1.Service{})).To(BeNotFoundError())
+			Expect(c.Get(ctx, kubernetesutils.Key(namespace, expectedName), &corev1.Service{})).To(BeNotFoundError())
 		})
 	}
 
-	Context("SNI enabled", func() {
+	Context("when service is not in shoot namespace", func() {
 		BeforeEach(func() {
 			expected.Annotations = utils.MergeStringMaps(map[string]string{
 				"foo":                          "bar",
@@ -171,14 +177,13 @@ var _ = Describe("#Service", func() {
 			}, netpolAnnotations())
 		})
 
-		assertEnabledSNI()
+		assertService()
 	})
 
 	Context("when service is designed for shoots", func() {
 		BeforeEach(func() {
-			namespace := "shoot-" + expected.Namespace
+			namespace = "shoot-" + expected.Namespace
 
-			serviceObjKey = client.ObjectKey{Name: serviceObjKey.Name, Namespace: namespace}
 			expected.Annotations = utils.MergeStringMaps(map[string]string{
 				"foo":                          "bar",
 				"networking.istio.io/exportTo": "*",
@@ -186,7 +191,7 @@ var _ = Describe("#Service", func() {
 			expected.Namespace = namespace
 		})
 
-		assertEnabledSNI()
+		assertService()
 	})
 
 	Describe("#Deploy", func() {
@@ -195,12 +200,13 @@ var _ = Describe("#Service", func() {
 				defaultDepWaiter = NewService(
 					log,
 					c,
+					namespace,
 					&ServiceValues{
 						AnnotationsFunc:             func() map[string]string { return map[string]string{"foo": "bar"} },
+						NamePrefix:                  namePrefix,
 						TopologyAwareRoutingEnabled: true,
 						RuntimeKubernetesVersion:    semver.MustParse("1.26.1"),
 					},
-					func() client.ObjectKey { return serviceObjKey },
 					func() client.ObjectKey { return sniServiceObjKey },
 					&retryfake.Ops{MaxAttempts: 1},
 					clusterIPFunc,
@@ -211,7 +217,7 @@ var _ = Describe("#Service", func() {
 				Expect(defaultDepWaiter.Deploy(ctx)).To(Succeed())
 
 				actual := &corev1.Service{}
-				Expect(c.Get(ctx, serviceObjKey, actual)).To(Succeed())
+				Expect(c.Get(ctx, kubernetesutils.Key(namespace, expectedName), actual)).To(Succeed())
 
 				expected.Annotations = map[string]string{
 					"foo":                          "bar",
@@ -238,10 +244,11 @@ var _ = Describe("#Service", func() {
 				defaultDepWaiter = NewService(
 					log,
 					c,
+					namespace,
 					&ServiceValues{
 						AnnotationsFunc: func() map[string]string { return nil },
+						NamePrefix:      namePrefix,
 					},
-					func() client.ObjectKey { return serviceObjKey },
 					func() client.ObjectKey { return sniServiceObjKey },
 					&retryfake.Ops{MaxAttempts: 1},
 					clusterIPFunc,
@@ -255,7 +262,7 @@ var _ = Describe("#Service", func() {
 					Expect(defaultDepWaiter.Deploy(ctx)).To(Succeed())
 
 					actual := &corev1.Service{}
-					Expect(c.Get(ctx, serviceObjKey, actual)).To(Succeed())
+					Expect(c.Get(ctx, kubernetesutils.Key(namespace, expectedName), actual)).To(Succeed())
 
 					Expect(actual.Spec.ClusterIP).To(Equal(expected.Spec.ClusterIP))
 				})
@@ -270,7 +277,7 @@ var _ = Describe("#Service", func() {
 					Expect(defaultDepWaiter.Deploy(ctx)).To(Succeed())
 
 					actual := &corev1.Service{}
-					Expect(c.Get(ctx, serviceObjKey, actual)).To(Succeed())
+					Expect(c.Get(ctx, kubernetesutils.Key(namespace, expectedName), actual)).To(Succeed())
 
 					Expect(actual.Spec.ClusterIP).To(Equal(clusterIP))
 				})

--- a/pkg/gardenlet/controller/managedseed/charttest/gardenlet_chart_test.go
+++ b/pkg/gardenlet/controller/managedseed/charttest/gardenlet_chart_test.go
@@ -68,6 +68,7 @@ var (
 		"seccompprofile.resources.gardener.cloud/skip":                                "true",
 		"topology-spread-constraints.resources.gardener.cloud/skip":                   "true",
 		"networking.resources.gardener.cloud/to-all-shoots-etcd-main-client-tcp-8080": "allowed",
+		"networking.resources.gardener.cloud/to-all-shoots-kube-apiserver-tcp-443":    "allowed",
 	})
 )
 

--- a/pkg/operation/botanist/kubeapiserverexposure.go
+++ b/pkg/operation/botanist/kubeapiserverexposure.go
@@ -31,13 +31,11 @@ func (b *Botanist) DefaultKubeAPIServerService() component.DeployWaiter {
 	return kubeapiserverexposure.NewService(
 		b.Logger,
 		b.SeedClientSet.Client(),
+		b.Shoot.SeedNamespace,
 		&kubeapiserverexposure.ServiceValues{
 			AnnotationsFunc:             func() map[string]string { return b.IstioLoadBalancerAnnotations() },
 			TopologyAwareRoutingEnabled: b.Shoot.TopologyAwareRoutingEnabled,
 			RuntimeKubernetesVersion:    b.Seed.KubernetesVersion,
-		},
-		func() client.ObjectKey {
-			return client.ObjectKey{Name: v1beta1constants.DeploymentNameKubeAPIServer, Namespace: b.Shoot.SeedNamespace}
 		},
 		func() client.ObjectKey {
 			return client.ObjectKey{Name: b.IstioServiceName(), Namespace: b.IstioNamespace()}

--- a/pkg/operator/controller/add.go
+++ b/pkg/operator/controller/add.go
@@ -23,7 +23,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
-	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	sharedcomponent "github.com/gardener/gardener/pkg/component/shared"
 	"github.com/gardener/gardener/pkg/controller/service"
 	"github.com/gardener/gardener/pkg/operator/apis/config"
@@ -50,14 +49,6 @@ func AddToManager(ctx context.Context, mgr manager.Manager, cfg *config.Operator
 	}
 
 	if os.Getenv("GARDENER_OPERATOR_LOCAL") == "true" {
-		virtualGardenKubeAPIServerPredicate, err := predicate.LabelSelectorPredicate(metav1.LabelSelector{MatchLabels: map[string]string{
-			v1beta1constants.LabelApp:  v1beta1constants.LabelKubernetes,
-			v1beta1constants.LabelRole: v1beta1constants.LabelAPIServer,
-		}})
-		if err != nil {
-			return err
-		}
-
 		virtualGardenIstioIngressPredicate, err := predicate.LabelSelectorPredicate(metav1.LabelSelector{MatchLabels: sharedcomponent.GetIstioZoneLabels(nil, nil)})
 		if err != nil {
 			return err
@@ -71,7 +62,7 @@ func AddToManager(ctx context.Context, mgr manager.Manager, cfg *config.Operator
 			return err
 		}
 
-		if err := (&service.Reconciler{}).AddToManager(mgr, predicate.Or(virtualGardenKubeAPIServerPredicate, virtualGardenIstioIngressPredicate, nginxIngressPredicate)); err != nil {
+		if err := (&service.Reconciler{}).AddToManager(mgr, predicate.Or(virtualGardenIstioIngressPredicate, nginxIngressPredicate)); err != nil {
 			return fmt.Errorf("failed adding Service controller: %w", err)
 		}
 	}

--- a/pkg/operator/controller/garden/garden/components.go
+++ b/pkg/operator/controller/garden/garden/components.go
@@ -396,13 +396,12 @@ func (r *Reconciler) newKubeAPIServerService(log logr.Logger, garden *operatorv1
 	return kubeapiserverexposure.NewService(
 		log,
 		r.RuntimeClientSet.Client(),
+		r.GardenNamespace,
 		&kubeapiserverexposure.ServiceValues{
 			AnnotationsFunc:             func() map[string]string { return annotations },
+			NamePrefix:                  namePrefix,
 			TopologyAwareRoutingEnabled: helper.TopologyAwareRoutingEnabled(garden.Spec.RuntimeCluster.Settings),
 			RuntimeKubernetesVersion:    r.RuntimeVersion,
-		},
-		func() client.ObjectKey {
-			return client.ObjectKey{Name: namePrefix + v1beta1constants.DeploymentNameKubeAPIServer, Namespace: r.GardenNamespace}
 		},
 		func() client.ObjectKey {
 			return client.ObjectKey{Name: v1beta1constants.DefaultSNIIngressServiceName, Namespace: ingressGatewayValues[0].Namespace}

--- a/pkg/operator/controller/garden/garden/components.go
+++ b/pkg/operator/controller/garden/garden/components.go
@@ -393,8 +393,6 @@ func (r *Reconciler) newKubeAPIServerService(log logr.Logger, garden *operatorv1
 		clusterIP = "10.2.10.2"
 	}
 
-	serviceType := corev1.ServiceTypeLoadBalancer
-
 	return kubeapiserverexposure.NewService(
 		log,
 		r.RuntimeClientSet.Client(),
@@ -402,7 +400,6 @@ func (r *Reconciler) newKubeAPIServerService(log logr.Logger, garden *operatorv1
 			AnnotationsFunc:             func() map[string]string { return annotations },
 			TopologyAwareRoutingEnabled: helper.TopologyAwareRoutingEnabled(garden.Spec.RuntimeCluster.Settings),
 			RuntimeKubernetesVersion:    r.RuntimeVersion,
-			ServiceType:                 &serviceType,
 		},
 		func() client.ObjectKey {
 			return client.ObjectKey{Name: namePrefix + v1beta1constants.DeploymentNameKubeAPIServer, Namespace: r.GardenNamespace}

--- a/test/integration/operator/garden/garden/garden_test.go
+++ b/test/integration/operator/garden/garden/garden_test.go
@@ -415,7 +415,6 @@ var _ = Describe("Garden controller tests", func() {
 			return service.Annotations
 		}).Should(Equal(utils.MergeStringMaps(loadBalancerServiceAnnotations, map[string]string{
 			"networking.istio.io/exportTo":                                              "*",
-			"networking.resources.gardener.cloud/from-world-to-ports":                   `[{"protocol":"TCP","port":443}]`,
 			"networking.resources.gardener.cloud/from-all-scrape-targets-allowed-ports": `[{"protocol":"TCP","port":443}]`,
 			"networking.resources.gardener.cloud/namespace-selectors":                   `[{"matchLabels":{"gardener.cloud/role":"istio-ingress"}},{"matchLabels":{"networking.gardener.cloud/access-target-apiserver":"allowed"}}]`,
 		})))


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind cleanup

**What this PR does / why we need it**:
After moving to an Istio based approach with https://github.com/gardener/gardener/pull/7953, we can now drop the `LoadBalancer` service case for the `{virtual-garden-}kube-apiserver`.

**Which issue(s) this PR fixes**:
Part of #7016

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
The `virtual-garden-kube-apiserver` service (for the `virtual-garden` cluster) was switched from type `LoadBalancer` to `ClusterIP`. Please make sure to migrate all DNS records from the `virtual-garden-kube-apiserver` to the `istio-ingressgateway` endpoint before upgrading to this Gardener version.
```
