### PR TITLE
Fix CA rotation for multi-node `etcd`s

### DIFF
--- a/pkg/component/etcd/etcd.go
+++ b/pkg/component/etcd/etcd.go
@@ -813,18 +813,13 @@ func (e *etcd) handlePeerCertificates(ctx context.Context) (caSecretName, peerSe
 		return
 	}
 
-	var signedByCAOptions []secretsmanager.SignedByCAOption
-	if e.values.CARotationPhase == gardencorev1beta1.RotationPreparing {
-		signedByCAOptions = append(signedByCAOptions, secretsmanager.UseCurrentCA)
-	}
-
 	peerServerSecret, err := e.secretsManager.Generate(ctx, &secretsutils.CertificateSecretConfig{
 		Name:                        secretNamePrefixPeerServer + e.values.Role,
 		CommonName:                  "etcd-server",
 		DNSNames:                    e.peerServiceDNSNames(),
 		CertType:                    secretsutils.ServerClientCert,
 		SkipPublishingCACertificate: true,
-	}, secretsmanager.SignedByCA(v1beta1constants.SecretNameCAETCDPeer, signedByCAOptions...), secretsmanager.Rotate(secretsmanager.InPlace))
+	}, secretsmanager.SignedByCA(v1beta1constants.SecretNameCAETCDPeer, secretsmanager.UseCurrentCA), secretsmanager.Rotate(secretsmanager.InPlace))
 	if err != nil {
 		err = fmt.Errorf("secret %q not found", v1beta1constants.SecretNameCAETCDPeer)
 		return


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug

**What this PR does / why we need it**:
Earlier, the peer client/server certificate was only signed by the current CA if the rotation phase was in `Preparing`. This will become an issue if a 'normal' reconciliation is triggered while the cluster is in `Prepared` because then the certificate is singed by the old CA again. The next phase, `Completing`, will eventually fail because `etcd` peers cannot validate their certificates anymore.

**Special notes for your reviewer**:
/cc @rfranzke

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
An issue has been fixed for highly-available `Shoot`s whose `etcd` clusters didn't get ready in the `Completing` phase of a CA credentials rotation.
```
