### PR TITLE
Allow the alertmanager in the garden ns to send email notifications

### DIFF
--- a/pkg/component/monitoring/charts/bootstrap/templates/alertmanager/alertmanager.yaml
+++ b/pkg/component/monitoring/charts/bootstrap/templates/alertmanager/alertmanager.yaml
@@ -59,6 +59,9 @@ spec:
       labels:
         component: alertmanager
         role: monitoring
+        networking.gardener.cloud/to-dns: allowed
+        networking.gardener.cloud/to-public-networks: allowed
+        networking.gardener.cloud/to-private-networks: allowed
     spec:
       priorityClassName: gardener-system-600
       containers:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind regression

**What this PR does / why we need it**:

Allow the alertmanager in the garden namespace to send email notifications

The alertmanager in the garden namespace of a seed can be configured to send email notifications about the alerts of the shoot control plane Prometheus-es and the alerts of the aggregate Prometheus in the garden namespace.

See `charts/gardener/controlplane/values.yaml`, `global.alerting`.

We noticed it with quite some delay that probably since the recent improvements of the network policies, the `garden/alertmanager-0` pod does not have DNS and public/private network access and hence could not send out the email notifications.

```
k logs -n garden alertmanager-0 | tail -n 1

ts=2023-08-04T12:16:18.450Z
caller=dispatch.go:354
level=error
component=dispatcher
msg="Notify for alerts failed"
num_alerts=1
err="email-kubernetes-ops/email[0]:
     notify retry canceled after 2 attempts:
     establish connection to server:
     dial tcp 52.x.y.z:587: i/o timeout"
```

(DNS resolution works but the SMTP server can not be contacted)

or

```
err="establish connection to server: dial tcp: lookup email-smtp.foo.bar.com on 10.1.2.3:53:
read udp 10.4.5.6:42060->10.1.2.3:53:
i/o timeout"
```

(DNS resolution does not work)

This change grants DNS and public/private network access to the alertmanager in the garden namespace so that it can successfully send email notifications.

Note that the mail server could be either in a public or in a private network, hence both network paths: to the public and to the private network need to be allowed.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

cc @rfranzke @acumino @abdasgupta @rickardsjp 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
gardenlet: A regression preventing the alertmanager in the garden namespace from sending email notifications is now fixed.
```
