### PR TITLE
Automatically enable admission controller for provider extensions in local extension setup.

### DIFF
--- a/example/provider-extensions/garden/configure-admission.sh
+++ b/example/provider-extensions/garden/configure-admission.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+#
+# Copyright 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses~LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+REPO_ROOT_DIR="$(realpath "$SCRIPT_DIR"/../../..)"
+
+usage() {
+  echo "Usage:"
+  echo "> configure-admission.sh [ -h | <garden-kubeconfig> <apply|delete> ]"
+  echo
+  echo ">> For example: configure-admission.sh ~/.kube/garden-kubeconfig.yaml apply"
+
+  exit 0
+}
+
+if [ "$1" == "-h" ] || [ "$#" -ne 2 ]; then
+  usage
+fi
+
+if [ "$2" != "apply" ] && [ "$2" != "delete" ]; then
+  usage
+fi
+
+garden_kubeconfig=$1
+command=$2
+
+for p in $(yq '. | select(.kind == "ControllerDeployment") | select(.metadata.name == "provider-*") | .metadata.name' $REPO_ROOT_DIR/example/provider-extensions/garden/controllerregistrations/* | grep -v -E "^---$"); do
+  echo "Found \"$p\" in $REPO_ROOT_DIR/example/provider-extensions/garden/controllerregistrations. Trying to configure its admission controller..."
+  if PROVIDER_RELEASES=$(curl --fail -s -L -H "Accept: application/vnd.github+json" https://api.github.com/repos/gardener/gardener-extension-$p/releases); then
+    LATEST_RELEASE=$(jq -r '.[].tag_name' <<< $PROVIDER_RELEASES | head -n 1)
+    ADMISSION_NAME=${p/provider/admission}
+    echo "Identified $LATEST_RELEASE as latest release of $ADMISSION_NAME. Trying to deploy it..."
+    ADMISSION_GIT_ROOT=$(mktemp -d)
+    git clone https://github.com/gardener/gardener-extension-$p $ADMISSION_GIT_ROOT
+    git -C $ADMISSION_GIT_ROOT checkout $LATEST_RELEASE
+    CA_BUNDLE=$(yq ".webhooks[0].clientConfig.caBundle" $ADMISSION_GIT_ROOT/example/50-mutatingwebhookconfiguration.yaml | base64 -d)
+    TLS_CRT=$(cat $ADMISSION_GIT_ROOT/example/$ADMISSION_NAME-certs/tls.crt)
+    TLS_KEY=$(cat $ADMISSION_GIT_ROOT/example/$ADMISSION_NAME-certs/tls.key)
+    helm template --namespace garden --set global.webhookConfig.caBundle="$CA_BUNDLE" --set global.webhookConfig.tls.crt="$TLS_CRT" --set global.webhookConfig.tls.key="$TLS_KEY" gardener-extension-$ADMISSION_NAME $ADMISSION_GIT_ROOT/charts/gardener-extension-$ADMISSION_NAME/charts/application > $ADMISSION_GIT_ROOT/virtual-resources.yaml
+    helm template --namespace garden --set global.webhookConfig.caBundle="$CA_BUNDLE" --set global.webhookConfig.tls.crt="$TLS_CRT" --set global.webhookConfig.tls.key="$TLS_KEY" --set global.kubeconfig="$(cat $garden_kubeconfig | sed 's/127.0.0.1:.*$/kubernetes.default.svc.cluster.local/g')" --set global.vpa.enabled="false" gardener-extension-$ADMISSION_NAME $ADMISSION_GIT_ROOT/charts/gardener-extension-$ADMISSION_NAME/charts/runtime > $ADMISSION_GIT_ROOT/runtime-resources.yaml
+    kubectl --kubeconfig $garden_kubeconfig $command -f $ADMISSION_GIT_ROOT/virtual-resources.yaml
+    kubectl --kubeconfig $garden_kubeconfig $command -f $ADMISSION_GIT_ROOT/runtime-resources.yaml
+    rm -rf $ADMISSION_GIT_ROOT
+    echo "Successfully deployed $ADMISSION_NAME:$LATEST_RELEASE."
+  else
+    echo "Github repository releases of \"$p\" not found."
+  fi
+done

--- a/hack/gardener-extensions-down.sh
+++ b/hack/gardener-extensions-down.sh
@@ -59,6 +59,8 @@ remaining_seeds=$(kubectl --kubeconfig="$PATH_GARDEN_KUBECONFIG" get seed --no-h
 if [[ "$remaining_seeds" != "" ]]; then
   echo "No clean up of kind cluster because of remaining seeds: ${remaining_seeds//$'\n'/,}"
 else
+  echo "Cleaning up admission controllers"
+  "$SCRIPT_DIR"/../example/provider-extensions/garden/configure-admission.sh "$PATH_GARDEN_KUBECONFIG" delete
   echo "Cleaning up kind cluster"
   kubectl --kubeconfig="$PATH_GARDEN_KUBECONFIG" delete validatingwebhookconfiguration/gardener-admission-controller --ignore-not-found
   kubectl --kubeconfig="$PATH_GARDEN_KUBECONFIG" annotate project local garden confirmation.gardener.cloud/deletion=true

--- a/hack/gardener-extensions-up.sh
+++ b/hack/gardener-extensions-up.sh
@@ -48,6 +48,8 @@ echo "Configure seed cluster"
 "$SCRIPT_DIR"/../example/provider-extensions/seed/configure-seed.sh "$PATH_GARDEN_KUBECONFIG" "$PATH_SEED_KUBECONFIG" "$SEED_NAME"
 echo "Start bootstrapping Gardener"
 SKAFFOLD_DEFAULT_REPO=localhost:5001 SKAFFOLD_PUSH=true skaffold run -m etcd,controlplane,extensions-env -p extensions
+echo "Configure admission controllers"
+"$SCRIPT_DIR"/../example/provider-extensions/garden/configure-admission.sh "$PATH_GARDEN_KUBECONFIG" apply
 echo "Registering controllers"
 kubectl --kubeconfig "$PATH_GARDEN_KUBECONFIG" --server-side=true --force-conflicts=true apply -f "$SCRIPT_DIR"/../example/provider-extensions/garden/controllerregistrations
 echo "Creating CloudProfiles"


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
Automatically enable admission controller for provider extensions in local extension setup.

Some of the validation logic is only available in the admission controllers of provider extensions. Therefore, it is helpful if those admission controllers are installed in the local extension setup as well.
This change attempts to identify the latest admission controller matching to the provider extension in use. The version might not match, but admission controllers are fairly stable. In case a provider extension from a non-gardener repository is used no attempt at discovering its repository is tried.

**Which issue(s) this PR fixes**:
None.

**Special notes for your reviewer**:
/cc @oliver-goetz 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The admission controllers of common provider extensions are automatically installed in the local extensions development setup
```
