### PR TITLE
Fix `prometheus`  ingress secret for shoot cluster

### DIFF
--- a/pkg/component/monitoring/component.go
+++ b/pkg/component/monitoring/component.go
@@ -66,6 +66,8 @@ type Interface interface {
 	SetNamespaceUID(types.UID)
 	// SetComponents sets the monitoring components.
 	SetComponents([]component.MonitoringComponent)
+	// SetWildcardCertName sets the WildcardCertName components.
+	SetWildcardCertName(*string)
 }
 
 // Values is a set of configuration values for the monitoring components.
@@ -506,6 +508,7 @@ func (m *monitoring) Destroy(ctx context.Context) error {
 
 func (m *monitoring) SetNamespaceUID(uid types.UID)                   { m.values.NamespaceUID = uid }
 func (m *monitoring) SetComponents(c []component.MonitoringComponent) { m.values.Components = c }
+func (m *monitoring) SetWildcardCertName(secretName *string)          { m.values.WildcardCertName = secretName }
 
 func (m *monitoring) newShootAccessSecret() *gardenerutils.AccessSecret {
 	return gardenerutils.NewShootAccessSecret(v1beta1constants.StatefulSetNamePrometheus, m.namespace)

--- a/pkg/component/plutono/plutono.go
+++ b/pkg/component/plutono/plutono.go
@@ -74,6 +74,7 @@ var (
 // Interface contains functions for a Plutono Deployer
 type Interface interface {
 	component.DeployWaiter
+	// SetWildcardCertName sets the WildcardCertName components.
 	SetWildcardCertName(*string)
 }
 

--- a/pkg/operation/botanist/monitoring.go
+++ b/pkg/operation/botanist/monitoring.go
@@ -53,11 +53,6 @@ func (b *Botanist) DefaultMonitoring() (monitoring.Interface, error) {
 		alertingSecrets = append(alertingSecrets, b.LoadSecret(key))
 	}
 
-	var wildcardSecretName *string
-	if b.ControlPlaneWildcardCert != nil {
-		wildcardSecretName = &b.ControlPlaneWildcardCert.Name
-	}
-
 	values := monitoring.Values{
 		AlertingSecrets:              alertingSecrets,
 		AlertmanagerEnabled:          b.Shoot.WantsAlertmanager,
@@ -84,7 +79,7 @@ func (b *Botanist) DefaultMonitoring() (monitoring.Interface, error) {
 		StorageCapacityAlertmanager:  b.Seed.GetValidVolumeSize("1Gi"),
 		TargetName:                   b.Shoot.GetInfo().Name,
 		TargetProviderType:           b.Shoot.GetInfo().Spec.Provider.Type,
-		WildcardCertName:             wildcardSecretName,
+		WildcardCertName:             nil,
 	}
 
 	if b.Shoot.Networks != nil {

--- a/pkg/operation/botanist/monitoring.go
+++ b/pkg/operation/botanist/monitoring.go
@@ -119,6 +119,9 @@ func (b *Botanist) DeployMonitoring(ctx context.Context) error {
 		return b.Shoot.Components.Monitoring.Monitoring.Destroy(ctx)
 	}
 
+	if b.ControlPlaneWildcardCert != nil {
+		b.Operation.Shoot.Components.Monitoring.Monitoring.SetWildcardCertName(pointer.String(b.ControlPlaneWildcardCert.GetName()))
+	}
 	b.Shoot.Components.Monitoring.Monitoring.SetNamespaceUID(b.SeedNamespaceObject.UID)
 	b.Shoot.Components.Monitoring.Monitoring.SetComponents(b.getMonitoringComponents())
 	return b.Shoot.Components.Monitoring.Monitoring.Deploy(ctx)

--- a/pkg/operation/botanist/plutono.go
+++ b/pkg/operation/botanist/plutono.go
@@ -34,11 +34,6 @@ import (
 
 // DefaultPlutono returns a deployer for Plutono.
 func (b *Botanist) DefaultPlutono() (plutono.Interface, error) {
-	var wildcardCertName *string
-	if b.ControlPlaneWildcardCert != nil {
-		wildcardCertName = pointer.String(b.ControlPlaneWildcardCert.GetName())
-	}
-
 	return shared.NewPlutono(
 		b.SeedClientSet.Client(),
 		b.Shoot.SeedNamespace,
@@ -53,7 +48,7 @@ func (b *Botanist) DefaultPlutono() (plutono.Interface, error) {
 		b.Shoot.VPNHighAvailabilityEnabled,
 		v1beta1constants.PriorityClassNameShootControlPlane100,
 		b.Shoot.GetReplicas(1),
-		wildcardCertName,
+		nil,
 		b.Shoot.WantsVerticalPodAutoscaler,
 	)
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind bug

**What this PR does / why we need it**:
While checking for other ingress I found that prometheus was also not using wildcard-cert, which is similar to what got fixed in https://github.com/gardener/gardener/pull/8317.

Introduced with -  https://github.com/gardener/gardener/pull/8243

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
A bug preventing `prometheus` ingress to use `wildcard-certificate` is fixed.
```
