### PR TITLE
Cleanup redundant `ctx` parameter

### DIFF
--- a/extensions/pkg/controller/containerruntime/controller.go
+++ b/extensions/pkg/controller/containerruntime/controller.go
@@ -80,7 +80,7 @@ func add(ctx context.Context, mgr manager.Manager, args AddArgs) error {
 	if args.IgnoreOperationAnnotation {
 		if err := ctrl.Watch(
 			&source.Kind{Type: &extensionsv1alpha1.Cluster{}},
-			mapper.EnqueueRequestsFrom(ctx, mgr.GetCache(), ClusterToContainerResourceMapper(ctx, mgr, predicates...), mapper.UpdateWithNew, ctrl.GetLogger()),
+			mapper.EnqueueRequestsFrom(ctx, mgr.GetCache(), ClusterToContainerResourceMapper(mgr, predicates...), mapper.UpdateWithNew, ctrl.GetLogger()),
 		); err != nil {
 			return err
 		}

--- a/extensions/pkg/controller/containerruntime/mapper.go
+++ b/extensions/pkg/controller/containerruntime/mapper.go
@@ -15,8 +15,6 @@
 package containerruntime
 
 import (
-	"context"
-
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
@@ -27,6 +25,6 @@ import (
 
 // ClusterToContainerResourceMapper returns a mapper that returns requests for Container resource whose
 // referenced clusters have been modified.
-func ClusterToContainerResourceMapper(ctx context.Context, mgr manager.Manager, predicates ...predicate.Predicate) mapper.Mapper {
-	return mapper.ClusterToObjectMapper(ctx, mgr, func() client.ObjectList { return &extensionsv1alpha1.ContainerRuntimeList{} }, predicates)
+func ClusterToContainerResourceMapper(mgr manager.Manager, predicates ...predicate.Predicate) mapper.Mapper {
+	return mapper.ClusterToObjectMapper(mgr, func() client.ObjectList { return &extensionsv1alpha1.ContainerRuntimeList{} }, predicates)
 }

--- a/extensions/pkg/controller/controlplane/controller.go
+++ b/extensions/pkg/controller/controlplane/controller.go
@@ -73,7 +73,7 @@ func Add(ctx context.Context, mgr manager.Manager, args AddArgs) error {
 	if args.IgnoreOperationAnnotation {
 		if err := ctrl.Watch(
 			&source.Kind{Type: &extensionsv1alpha1.Cluster{}},
-			mapper.EnqueueRequestsFrom(ctx, mgr.GetCache(), ClusterToControlPlaneMapper(ctx, mgr, predicates), mapper.UpdateWithNew, ctrl.GetLogger()),
+			mapper.EnqueueRequestsFrom(ctx, mgr.GetCache(), ClusterToControlPlaneMapper(mgr, predicates), mapper.UpdateWithNew, ctrl.GetLogger()),
 		); err != nil {
 			return err
 		}

--- a/extensions/pkg/controller/controlplane/mapper.go
+++ b/extensions/pkg/controller/controlplane/mapper.go
@@ -15,8 +15,6 @@
 package controlplane
 
 import (
-	"context"
-
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
@@ -27,6 +25,6 @@ import (
 
 // ClusterToControlPlaneMapper returns a mapper that returns requests for ControlPlanes whose
 // referenced clusters have been modified.
-func ClusterToControlPlaneMapper(ctx context.Context, mgr manager.Manager, predicates []predicate.Predicate) mapper.Mapper {
-	return mapper.ClusterToObjectMapper(ctx, mgr, func() client.ObjectList { return &extensionsv1alpha1.ControlPlaneList{} }, predicates)
+func ClusterToControlPlaneMapper(mgr manager.Manager, predicates []predicate.Predicate) mapper.Mapper {
+	return mapper.ClusterToObjectMapper(mgr, func() client.ObjectList { return &extensionsv1alpha1.ControlPlaneList{} }, predicates)
 }

--- a/extensions/pkg/controller/dnsrecord/controller.go
+++ b/extensions/pkg/controller/dnsrecord/controller.go
@@ -81,7 +81,7 @@ func Add(ctx context.Context, mgr manager.Manager, args AddArgs) error {
 	if args.IgnoreOperationAnnotation {
 		if err := ctrl.Watch(
 			&source.Kind{Type: &extensionsv1alpha1.Cluster{}},
-			mapper.EnqueueRequestsFrom(ctx, mgr.GetCache(), ClusterToDNSRecordMapper(ctx, mgr, predicates), mapper.UpdateWithNew, ctrl.GetLogger()),
+			mapper.EnqueueRequestsFrom(ctx, mgr.GetCache(), ClusterToDNSRecordMapper(mgr, predicates), mapper.UpdateWithNew, ctrl.GetLogger()),
 		); err != nil {
 			return err
 		}

--- a/extensions/pkg/controller/dnsrecord/mapper.go
+++ b/extensions/pkg/controller/dnsrecord/mapper.go
@@ -15,8 +15,6 @@
 package dnsrecord
 
 import (
-	"context"
-
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
@@ -27,6 +25,6 @@ import (
 
 // ClusterToDNSRecordMapper returns a mapper that returns requests for DNSRecords whose
 // referenced clusters have been modified.
-func ClusterToDNSRecordMapper(ctx context.Context, mgr manager.Manager, predicates []predicate.Predicate) mapper.Mapper {
-	return mapper.ClusterToObjectMapper(ctx, mgr, func() client.ObjectList { return &extensionsv1alpha1.DNSRecordList{} }, predicates)
+func ClusterToDNSRecordMapper(mgr manager.Manager, predicates []predicate.Predicate) mapper.Mapper {
+	return mapper.ClusterToObjectMapper(mgr, func() client.ObjectList { return &extensionsv1alpha1.DNSRecordList{} }, predicates)
 }

--- a/extensions/pkg/controller/extension/controller.go
+++ b/extensions/pkg/controller/extension/controller.go
@@ -80,7 +80,7 @@ func add(ctx context.Context, mgr manager.Manager, args AddArgs) error {
 	if args.IgnoreOperationAnnotation {
 		if err := ctrl.Watch(
 			&source.Kind{Type: &extensionsv1alpha1.Cluster{}},
-			mapper.EnqueueRequestsFrom(ctx, mgr.GetCache(), ClusterToExtensionMapper(ctx, mgr, predicates...), mapper.UpdateWithNew, mgr.GetLogger().WithName(args.Name)),
+			mapper.EnqueueRequestsFrom(ctx, mgr.GetCache(), ClusterToExtensionMapper(mgr, predicates...), mapper.UpdateWithNew, mgr.GetLogger().WithName(args.Name)),
 		); err != nil {
 			return err
 		}

--- a/extensions/pkg/controller/extension/mapper.go
+++ b/extensions/pkg/controller/extension/mapper.go
@@ -15,8 +15,6 @@
 package extension
 
 import (
-	"context"
-
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
@@ -27,6 +25,6 @@ import (
 
 // ClusterToExtensionMapper returns a mapper that returns requests for Extensions whose
 // referenced clusters have been modified.
-func ClusterToExtensionMapper(ctx context.Context, mgr manager.Manager, predicates ...predicate.Predicate) mapper.Mapper {
-	return mapper.ClusterToObjectMapper(ctx, mgr, func() client.ObjectList { return &extensionsv1alpha1.ExtensionList{} }, predicates)
+func ClusterToExtensionMapper(mgr manager.Manager, predicates ...predicate.Predicate) mapper.Mapper {
+	return mapper.ClusterToObjectMapper(mgr, func() client.ObjectList { return &extensionsv1alpha1.ExtensionList{} }, predicates)
 }

--- a/extensions/pkg/controller/healthcheck/controller.go
+++ b/extensions/pkg/controller/healthcheck/controller.go
@@ -190,7 +190,7 @@ func add(ctx context.Context, mgr manager.Manager, args AddArgs) error {
 	// this is to be notified when the Shoot is being hibernated (stop health checks) and wakes up (start health checks again)
 	return ctrl.Watch(
 		&source.Kind{Type: &extensionsv1alpha1.Cluster{}},
-		mapper.EnqueueRequestsFrom(ctx, mgr.GetCache(), mapper.ClusterToObjectMapper(ctx, mgr, args.GetExtensionObjListFunc, predicates), mapper.UpdateWithNew, ctrl.GetLogger()),
+		mapper.EnqueueRequestsFrom(ctx, mgr.GetCache(), mapper.ClusterToObjectMapper(mgr, args.GetExtensionObjListFunc, predicates), mapper.UpdateWithNew, ctrl.GetLogger()),
 	)
 }
 

--- a/extensions/pkg/controller/infrastructure/controller.go
+++ b/extensions/pkg/controller/infrastructure/controller.go
@@ -89,7 +89,7 @@ func add(ctx context.Context, mgr manager.Manager, args AddArgs) error {
 	if args.IgnoreOperationAnnotation {
 		if err := ctrl.Watch(
 			&source.Kind{Type: &extensionsv1alpha1.Cluster{}},
-			mapper.EnqueueRequestsFrom(ctx, mgr.GetCache(), ClusterToInfrastructureMapper(ctx, mgr, predicates), mapper.UpdateWithNew, ctrl.GetLogger()),
+			mapper.EnqueueRequestsFrom(ctx, mgr.GetCache(), ClusterToInfrastructureMapper(mgr, predicates), mapper.UpdateWithNew, ctrl.GetLogger()),
 		); err != nil {
 			return err
 		}

--- a/extensions/pkg/controller/infrastructure/mapper.go
+++ b/extensions/pkg/controller/infrastructure/mapper.go
@@ -15,8 +15,6 @@
 package infrastructure
 
 import (
-	"context"
-
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
@@ -27,6 +25,6 @@ import (
 
 // ClusterToInfrastructureMapper returns a mapper that returns requests for Infrastructures whose
 // referenced clusters have been modified.
-func ClusterToInfrastructureMapper(ctx context.Context, mgr manager.Manager, predicates []predicate.Predicate) mapper.Mapper {
-	return mapper.ClusterToObjectMapper(ctx, mgr, func() client.ObjectList { return &extensionsv1alpha1.InfrastructureList{} }, predicates)
+func ClusterToInfrastructureMapper(mgr manager.Manager, predicates []predicate.Predicate) mapper.Mapper {
+	return mapper.ClusterToObjectMapper(mgr, func() client.ObjectList { return &extensionsv1alpha1.InfrastructureList{} }, predicates)
 }

--- a/extensions/pkg/controller/network/controller.go
+++ b/extensions/pkg/controller/network/controller.go
@@ -78,7 +78,7 @@ func add(ctx context.Context, mgr manager.Manager, args AddArgs) error {
 	if args.IgnoreOperationAnnotation {
 		if err := ctrl.Watch(
 			&source.Kind{Type: &extensionsv1alpha1.Cluster{}},
-			mapper.EnqueueRequestsFrom(ctx, mgr.GetCache(), ClusterToNetworkMapper(ctx, mgr, predicates), mapper.UpdateWithNew, ctrl.GetLogger()),
+			mapper.EnqueueRequestsFrom(ctx, mgr.GetCache(), ClusterToNetworkMapper(mgr, predicates), mapper.UpdateWithNew, ctrl.GetLogger()),
 		); err != nil {
 			return err
 		}

--- a/extensions/pkg/controller/network/mapper.go
+++ b/extensions/pkg/controller/network/mapper.go
@@ -15,8 +15,6 @@
 package network
 
 import (
-	"context"
-
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
@@ -27,6 +25,6 @@ import (
 
 // ClusterToNetworkMapper returns a mapper that returns requests for Network whose
 // referenced clusters have been modified.
-func ClusterToNetworkMapper(ctx context.Context, mgr manager.Manager, predicates []predicate.Predicate) mapper.Mapper {
-	return mapper.ClusterToObjectMapper(ctx, mgr, func() client.ObjectList { return &extensionsv1alpha1.NetworkList{} }, predicates)
+func ClusterToNetworkMapper(mgr manager.Manager, predicates []predicate.Predicate) mapper.Mapper {
+	return mapper.ClusterToObjectMapper(mgr, func() client.ObjectList { return &extensionsv1alpha1.NetworkList{} }, predicates)
 }

--- a/extensions/pkg/controller/worker/controller.go
+++ b/extensions/pkg/controller/worker/controller.go
@@ -85,7 +85,7 @@ func add(ctx context.Context, mgr manager.Manager, args AddArgs, predicates []pr
 	if args.IgnoreOperationAnnotation {
 		if err := ctrl.Watch(
 			&source.Kind{Type: &extensionsv1alpha1.Cluster{}},
-			mapper.EnqueueRequestsFrom(ctx, mgr.GetCache(), ClusterToWorkerMapper(ctx, mgr, predicates), mapper.UpdateWithNew, ctrl.GetLogger()),
+			mapper.EnqueueRequestsFrom(ctx, mgr.GetCache(), ClusterToWorkerMapper(mgr, predicates), mapper.UpdateWithNew, ctrl.GetLogger()),
 		); err != nil {
 			return err
 		}

--- a/extensions/pkg/controller/worker/mapper.go
+++ b/extensions/pkg/controller/worker/mapper.go
@@ -32,8 +32,8 @@ import (
 
 // ClusterToWorkerMapper returns a mapper that returns requests for Worker whose
 // referenced clusters have been modified.
-func ClusterToWorkerMapper(ctx context.Context, mgr manager.Manager, predicates []predicate.Predicate) mapper.Mapper {
-	return mapper.ClusterToObjectMapper(ctx, mgr, func() client.ObjectList { return &extensionsv1alpha1.WorkerList{} }, predicates)
+func ClusterToWorkerMapper(mgr manager.Manager, predicates []predicate.Predicate) mapper.Mapper {
+	return mapper.ClusterToObjectMapper(mgr, func() client.ObjectList { return &extensionsv1alpha1.WorkerList{} }, predicates)
 }
 
 // MachineSetToWorkerMapper returns a mapper that returns requests for Worker whose

--- a/pkg/controllerutils/mapper/mapper.go
+++ b/pkg/controllerutils/mapper/mapper.go
@@ -29,7 +29,6 @@ import (
 )
 
 type clusterToObjectMapper struct {
-	ctx            context.Context
 	reader         cache.Cache
 	newObjListFunc func() client.ObjectList
 	predicates     []predicate.Predicate
@@ -53,9 +52,8 @@ func (m *clusterToObjectMapper) Map(ctx context.Context, _ logr.Logger, reader c
 
 // ClusterToObjectMapper returns a mapper that returns requests for objects whose
 // referenced clusters have been modified.
-func ClusterToObjectMapper(ctx context.Context, mgr manager.Manager, newObjListFunc func() client.ObjectList, predicates []predicate.Predicate) Mapper {
+func ClusterToObjectMapper(mgr manager.Manager, newObjListFunc func() client.ObjectList, predicates []predicate.Predicate) Mapper {
 	return &clusterToObjectMapper{
-		ctx:            ctx,
 		reader:         mgr.GetCache(),
 		newObjListFunc: newObjListFunc,
 		predicates:     predicates,

--- a/pkg/controllerutils/mapper/mapper_test.go
+++ b/pkg/controllerutils/mapper/mapper_test.go
@@ -83,7 +83,7 @@ var _ = Describe("Controller Mapper", func() {
 		var mapper Mapper
 
 		BeforeEach(func() {
-			mapper = ClusterToObjectMapper(ctx, mgr, newObjListFunc, nil)
+			mapper = ClusterToObjectMapper(mgr, newObjListFunc, nil)
 		})
 
 		It("should find all objects for the passed cluster", func() {
@@ -105,7 +105,7 @@ var _ = Describe("Controller Mapper", func() {
 					},
 				},
 			}
-			mapper = ClusterToObjectMapper(ctx, mgr, newObjListFunc, predicates)
+			mapper = ClusterToObjectMapper(mgr, newObjListFunc, predicates)
 
 			Expect(fakeClient.Create(ctx, infra)).To(Succeed())
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind cleanup

**What this PR does / why we need it**:
Since the mapper passed to `EnqueueRequestsFrom` implements `Map`, for which context gets populated [here](https://github.com/gardener/gardener/blob/9b963d4641a7f3dbcce4bab249342e7da6cc48b9/pkg/controllerutils/mapper/enqueue_mapped.go#L114), we don't need to pass `ctx` separately for each Mapper function.

Follow up after - https://github.com/gardener/gardener/pull/8217

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @ary1992 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking developer
The following mapper funcs from the extension library no longer accept a `context.Context` arg - `ClusterToContainerResourceMapper`, `ClusterToControlPlaneMapper`, `ClusterToDNSRecordMapper`, `ClusterToExtensionMapper`, `ClusterToInfrastructureMapper`, `ClusterToNetworkMapper`, `ClusterToWorkerMapper` and `ClusterToObjectMapper`. The `context.Context` arg was redundant and not used.
```
