### PR TITLE
Add configs for ETCD druid for local gardener example

### DIFF
--- a/example/gardener-local/gardenlet/values.yaml
+++ b/example/gardener-local/gardenlet/values.yaml
@@ -50,6 +50,18 @@ config:
     # (it will be still able to pull images but registry cache won't be used).
     ContainerdRegistryHostsDir: true
   etcdConfig:
+    etcdController:
+      workers: 3
+    custodianController:
+      workers: 3
+    backupCompactionController:
+      workers: 3
+      enableBackupCompaction: true
+      eventsThreshold: 1000000
+      activeDeadlineDuration: "3h"
+    backupLeaderElection:
+      reelectionPeriod: 5s
+      etcdConnectionTimeout: 5s
     featureGates:
       UseEtcdWrapper: false
   logging:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area testing
  /area test
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind test

**What this PR does / why we need it**:
This PR adds `etcdConfig` section for `example/gardener-local/gardenlet/values.yaml` so that ETCD Druid can be configured easily in a local setup.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy developer
Developers can easily configure ETCD Druid for local setup using the gardenlet config values in example directory
```
