### PR TITLE
Deflake `garden` controller integration test

### DIFF
--- a/test/integration/gardenlet/seed/seed/seed_test.go
+++ b/test/integration/gardenlet/seed/seed/seed_test.go
@@ -525,6 +525,7 @@ var _ = Describe("Seed controller tests", func() {
 							// etcd-druid
 							MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("etcds.druid.gardener.cloud")})}),
 							MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("etcdcopybackupstasks.druid.gardener.cloud")})}),
+							MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("managedresources.resources.gardener.cloud")})}),
 							// istio
 							MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("destinationrules.networking.istio.io")})}),
 							MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("envoyfilters.networking.istio.io")})}),

--- a/test/integration/operator/garden/garden/garden_suite_test.go
+++ b/test/integration/operator/garden/garden/garden_suite_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
@@ -51,6 +52,10 @@ var (
 )
 
 var _ = BeforeSuite(func() {
+	// a lot of CPU-intensive stuff is happening in this test, so to
+	// prevent flakes we have to increase the timeout here manually
+	SetDefaultEventuallyTimeout(10 * time.Second)
+
 	logf.SetLogger(logger.MustNewZapLogger(logger.DebugLevel, logger.FormatJSON, zap.WriteTo(GinkgoWriter)))
 	log = logf.Log.WithName(testID)
 

--- a/test/integration/operator/garden/garden/garden_test.go
+++ b/test/integration/operator/garden/garden/garden_test.go
@@ -43,9 +43,11 @@ import (
 	fakeclientmap "github.com/gardener/gardener/pkg/client/kubernetes/clientmap/fake"
 	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap/keys"
 	"github.com/gardener/gardener/pkg/component/etcd"
+	"github.com/gardener/gardener/pkg/component/istio"
 	"github.com/gardener/gardener/pkg/component/kubeapiserver"
 	"github.com/gardener/gardener/pkg/component/kubeapiserverexposure"
 	"github.com/gardener/gardener/pkg/component/kubecontrollermanager"
+	"github.com/gardener/gardener/pkg/component/nginxingress"
 	"github.com/gardener/gardener/pkg/component/resourcemanager"
 	"github.com/gardener/gardener/pkg/component/shared"
 	"github.com/gardener/gardener/pkg/controllerutils"
@@ -77,6 +79,7 @@ var _ = Describe("Garden controller tests", func() {
 		DeferCleanup(test.WithVars(
 			&etcd.DefaultInterval, 100*time.Millisecond,
 			&etcd.DefaultTimeout, 500*time.Millisecond,
+			&istio.TimeoutWaitForManagedResource, 500*time.Millisecond,
 			&kubeapiserverexposure.DefaultInterval, 100*time.Millisecond,
 			&kubeapiserverexposure.DefaultTimeout, 500*time.Millisecond,
 			&kubeapiserver.IntervalWaitForDeployment, 100*time.Millisecond,
@@ -85,6 +88,7 @@ var _ = Describe("Garden controller tests", func() {
 			&kubecontrollermanager.IntervalWaitForDeployment, 100*time.Millisecond,
 			&kubecontrollermanager.TimeoutWaitForDeployment, 500*time.Millisecond,
 			&kubecontrollermanager.Until, untilInTest,
+			&nginxingress.TimeoutWaitForManagedResource, 500*time.Millisecond,
 			&resourcemanager.SkipWebhookDeployment, true,
 			&resourcemanager.IntervalWaitForDeployment, 100*time.Millisecond,
 			&resourcemanager.TimeoutWaitForDeployment, 500*time.Millisecond,
@@ -205,6 +209,9 @@ var _ = Describe("Garden controller tests", func() {
 							},
 						},
 					},
+				},
+				FeatureGates: map[string]bool{
+					"HVPA": true,
 				},
 			},
 			Identity:        &gardencorev1beta1.Gardener{Name: "test-gardener"},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind flake

**What this PR does / why we need it**:
This PR fixes the flake of `garden` controller integration test. It enhances the following things - 
- Overwrite timeout variables so the operation can be retried fast enough.
- Increase overall timeout of a test similar to the seed controller test.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
❯ stress -ignore "unable to grab random port" -p 16 ./test/integration/operator/garden/garden/garden.test
```
...
2m30s: 112 runs so far, 7 failures (6.25%)
.
.
4m20s: 197 runs so far, 16 failures (8.12%)
.
9m40s: 456 runs so far, 36 failures (7.89%)
```
After:

❯ stress -ignore "unable to grab random port" -p 16 ./test/integration/operator/garden/garden/garden.test
```
8m55s: 400 runs so far, 0 failures
9m0s: 400 runs so far, 0 failures
.
12m0s: 528 runs so far, 0 failures
12m5s: 543 runs so far, 0 failures
.
.
16m45s: 752 runs so far, 0 failures
16m50s: 752 runs so far, 0 failures
```

Recent flakes - 
- https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/8324/pull-gardener-integration/1688932278568226816
- https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/8322/pull-gardener-integration/1688916460862181376
- https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/8319/pull-gardener-integration/1688850050190413824
- https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/8331/pull-gardener-integration/1689222015673700352
- https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/8326/pull-gardener-integration/1689162201157341184


**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
