### PR TITLE
Fix logging in test-machinery framework funcs

### DIFF
--- a/test/framework/dump.go
+++ b/test/framework/dump.go
@@ -216,13 +216,13 @@ func (f *CommonFramework) dumpDeploymentInfoForNamespace(ctx context.Context, lo
 		return err
 	}
 	for _, deployment := range deployments.Items {
-		log = log.WithValues("name", deployment.Name, "replicas", deployment.Status.Replicas, "availableReplicas", deployment.Status.AvailableReplicas)
+		objectLog := log.WithValues("name", deployment.Name, "replicas", deployment.Status.Replicas, "availableReplicas", deployment.Status.AvailableReplicas)
 
 		if err := health.CheckDeployment(&deployment); err != nil {
-			log.Info("Found unhealthy Deployment", "reason", err.Error(), "conditions", deployment.Status.Conditions)
+			objectLog.Info("Found unhealthy Deployment", "reason", err.Error(), "conditions", deployment.Status.Conditions)
 			continue
 		}
-		log.Info("Found healthy Deployment")
+		objectLog.Info("Found healthy Deployment")
 	}
 	return nil
 }
@@ -236,13 +236,13 @@ func (f *CommonFramework) dumpStatefulSetInfoForNamespace(ctx context.Context, l
 		return err
 	}
 	for _, statefulSet := range statefulSets.Items {
-		log = log.WithValues("name", statefulSet.Name, "replicas", statefulSet.Status.Replicas, "readyReplicas", statefulSet.Status.ReadyReplicas)
+		objectLog := log.WithValues("name", statefulSet.Name, "replicas", statefulSet.Status.Replicas, "readyReplicas", statefulSet.Status.ReadyReplicas)
 
 		if err := health.CheckStatefulSet(&statefulSet); err != nil {
-			log.Info("Found unhealthy StatefulSet", "reason", err.Error(), "conditions", statefulSet.Status.Conditions)
+			objectLog.Info("Found unhealthy StatefulSet", "reason", err.Error(), "conditions", statefulSet.Status.Conditions)
 			continue
 		}
-		log.Info("Found healthy StatefulSet")
+		objectLog.Info("Found healthy StatefulSet")
 	}
 	return nil
 }
@@ -256,13 +256,13 @@ func (f *CommonFramework) dumpDaemonSetInfoForNamespace(ctx context.Context, log
 		return err
 	}
 	for _, ds := range daemonSets.Items {
-		log = log.WithValues("name", ds.Name, "currentNumberScheduled", ds.Status.CurrentNumberScheduled, "desiredNumberScheduled", ds.Status.DesiredNumberScheduled)
+		objectLog := log.WithValues("name", ds.Name, "currentNumberScheduled", ds.Status.CurrentNumberScheduled, "desiredNumberScheduled", ds.Status.DesiredNumberScheduled)
 
 		if err := health.CheckDaemonSet(&ds); err != nil {
-			log.Info("Found unhealthy DaemonSet", "reason", err.Error(), "conditions", ds.Status.Conditions)
+			objectLog.Info("Found unhealthy DaemonSet", "reason", err.Error(), "conditions", ds.Status.Conditions)
 			continue
 		}
-		log.Info("Found healthy DaemonSet")
+		objectLog.Info("Found healthy DaemonSet")
 	}
 	return nil
 }
@@ -326,20 +326,20 @@ func (f *CommonFramework) dumpNodes(ctx context.Context, log logr.Logger, k8sCli
 		return err
 	}
 	for _, node := range nodes.Items {
-		log = log.WithValues("nodeName", node.Name)
+		objectLog := log.WithValues("nodeName", node.Name)
 		if err := health.CheckNode(&node); err != nil {
-			log.Info("Found unhealthy Node", "phase", node.Status.Phase, "reason", err.Error(), "conditions", node.Status.Conditions)
+			objectLog.Info("Found unhealthy Node", "phase", node.Status.Phase, "reason", err.Error(), "conditions", node.Status.Conditions)
 		} else {
-			log.Info("Found healthy Node", "phase", node.Status.Phase)
+			objectLog.Info("Found healthy Node", "phase", node.Status.Phase)
 		}
-		log.Info("Node resource capacity", "cpu", node.Status.Capacity.Cpu().String(), "memory", node.Status.Capacity.Memory().String())
+		objectLog.Info("Node resource capacity", "cpu", node.Status.Capacity.Cpu().String(), "memory", node.Status.Capacity.Memory().String())
 
 		nodeMetric := &metricsv1beta1.NodeMetrics{}
 		if err := k8sClient.Client().Get(ctx, client.ObjectKey{Name: node.Name}, nodeMetric); err != nil {
-			log.Error(err, "Unable to receive metrics for node")
+			objectLog.Error(err, "Unable to receive metrics for node")
 			continue
 		}
-		log.Info("Node resource usage", "cpu", nodeMetric.Usage.Cpu().String(), "memory", nodeMetric.Usage.Memory().String())
+		objectLog.Info("Node resource usage", "cpu", nodeMetric.Usage.Cpu().String(), "memory", nodeMetric.Usage.Memory().String())
 	}
 	return nil
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind bug

**What this PR does / why we need it**:
Similar to https://github.com/gardener/gardener/pull/6714.

While looking into failed integration tests logs, I noticed logs such as:
```
{"level":"info","ts":"2023-08-10T02:49:50.239Z","logger":"test","msg":"Found healthy DaemonSet","namespace":"kube-system","name":"apiserver-proxy","currentNumberScheduled":2,"desiredNumberScheduled":2,"name":"calico-node","currentNumberScheduled":2,"desiredNumberScheduled":2,"name":"csi-driver-node","currentNumberScheduled":2,"desiredNumberScheduled":2,"name":"egress-filter-applier","currentNumberScheduled":2,"desiredNumberScheduled":2,"name":"kube-proxy-worker-1-v1.26.7","currentNumberScheduled":2,"desiredNumberScheduled":2,"name":"network-problem-detector-host","currentNumberScheduled":2,"desiredNumberScheduled":2,"name":"network-problem-detector-pod","currentNumberScheduled":2,"desiredNumberScheduled":2}
```

```
{"level":"info","ts":"2023-08-10T02:49:50.480Z","logger":"test","msg":"Found healthy Node","shoot":"garden-it/tm4fp-v3e","nodeName":"shoot--it--tm4fp-v3e-worker-1-z1-6bc7c-7gwx2","nodeName":"shoot--it--tm4fp-v3e-worker-1-z1-6bc7c-bhh7t","phase":""}
```

```
{"level":"info","ts":"2023-08-10T02:49:50.524Z","logger":"test","msg":"Node resource usage","shoot":"garden-it/tm4fp-v3e","nodeName":"shoot--it--tm4fp-v3e-worker-1-z1-6bc7c-7gwx2","nodeName":"shoot--it--tm4fp-v3e-worker-1-z1-6bc7c-bhh7t","cpu":"204501416n","memory":"2205796Ki"}
```

You can see that due to wrong usage of `log.WithValues` in a loop, all keys end up added in a log entry which makes impossible to figure out for which key the log entry is.

Introduced with https://github.com/gardener/gardener/pull/6316.

**Which issue(s) this PR fixes**:
See above.

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
