### PR TITLE
Use seed name in the Seed template while calculating seed namespace for gardenlet cache

### DIFF
--- a/cmd/gardenlet/app/app.go
+++ b/cmd/gardenlet/app/app.go
@@ -274,8 +274,8 @@ func (g *garden) Start(ctx context.Context) error {
 					// Gardenlet should watch secrets only in the seed namespace of the seed it is responsible for. We
 					// don't use any selector mechanism here since we want to still fall back to reading secrets with
 					// the API reader (i.e., not from cache) in case the respective secret is not found in the cache.
-					&corev1.Secret{}:         cache.MultiNamespacedCacheBuilder([]string{gardenerutils.ComputeGardenNamespace(g.kubeconfigBootstrapResult.SeedName)}),
-					&corev1.ServiceAccount{}: cache.MultiNamespacedCacheBuilder([]string{gardenerutils.ComputeGardenNamespace(g.kubeconfigBootstrapResult.SeedName)}),
+					&corev1.Secret{}:         cache.MultiNamespacedCacheBuilder([]string{gardenerutils.ComputeGardenNamespace(g.config.SeedConfig.SeedTemplate.Name)}),
+					&corev1.ServiceAccount{}: cache.MultiNamespacedCacheBuilder([]string{gardenerutils.ComputeGardenNamespace(g.config.SeedConfig.SeedTemplate.Name)}),
 					// Gardenlet does not have the required RBAC permissions for listing/watching the following
 					// resources on cluster level. Hence, we need to watch them individually with the help of a
 					// SingleObject cache.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area controlplane
/kind bug

**What this PR does / why we need it**:
Gardenlet needs the permissions to watch secrets in this namespace, ref https://github.com/gardener/gardener/blob/0b0a0790fccf6ffc0d890dae4f76e93a5fcd8063/cmd/gardenlet/app/app.go#L277.
However, we were using `kubeconfigBootstrapResult.SeedName` for calculating the namespace for the cache. But `kubeconfigBootstrapResult.SeedName` can be empty if the kubeconfig already exists. See https://github.com/gardener/gardener/blob/5abed1bfedd6f2188e5dcec9af161d1b5c286236/cmd/gardenlet/app/bootstrappers/garden_kubeconfig.go#L115-L118

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @timuthy 
Cherry-picked from https://github.com/gardener/gardener/pull/8325

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
