### PR TITLE
guestbook test: Use `.spec.ingressClassName` to specify the IngressClass name

### DIFF
--- a/test/framework/resources/templates/guestbook-app.yaml.tpl
+++ b/test/framework/resources/templates/guestbook-app.yaml.tpl
@@ -48,9 +48,8 @@ kind: Ingress
 metadata:
   name: guestbook
   namespace: {{ .HelmDeployNamespace }}
-  annotations:
-    kubernetes.io/ingress.class: nginx
 spec:
+  ingressClassName: nginx
   rules:
   - host: {{ .ShootDNSHost }}
     http:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind cleanup

**What this PR does / why we need it**:
Across the logs I noticed:
```
{"level":"info","ts":"2023-08-10T09:38:59.525Z","logger":"KubeAPIWarningLogger","msg":"annotation \"kubernetes.io/ingress.class\" is deprecated, please use 'spec.ingressClassName' instead"}
```

`.spec.ingressClassName` seems to be available since K8s 1.18 - ref https://github.com/kubernetes/kubernetes/pull/88509.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
