### PR TITLE
[operator] Add health checks for observability components to `garden-care` reconciler

### DIFF
--- a/charts/gardener/operator/values.yaml
+++ b/charts/gardener/operator/values.yaml
@@ -83,6 +83,8 @@ config:
         duration: 1m
       - type: VirtualGardenAPIServerAvailable
         duration: 1m
+      - type: ObservabilityComponentsHealthy
+        duration: 1m
     networkPolicy:
       concurrentSyncs: 5
     # additionalNamespaceSelectors:

--- a/example/operator/10-componentconfig.yaml
+++ b/example/operator/10-componentconfig.yaml
@@ -55,6 +55,8 @@ controllers:
       duration: 1m
     - type: VirtualGardenAPIServerAvailable
       duration: 1m
+    - type: ObservabilityComponentsHealthy
+      duration: 1m
     # backupLeaderElection:
     #   reelectionPeriod: 5s
     #   etcdConnectionTimeout: 5s

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -144,8 +144,6 @@ const (
 	// DeploymentNameGardenerResourceManager is a constant for the name of a Kubernetes deployment object that contains
 	// the gardener-resource-manager pod.
 	DeploymentNameGardenerResourceManager = "gardener-resource-manager"
-	// DeploymentNameGrafana is a constant for the name of a Kubernetes deployment object that contains the grafana pod.
-	DeploymentNameGrafana = "grafana"
 	// DeploymentNamePlutono is a constant for the name of a Kubernetes deployment object that contains the plutono pod.
 	DeploymentNamePlutono = "plutono"
 	// DeploymentNameEventLogger is a constant for the name of a Kubernetes deployment object that contains
@@ -192,9 +190,6 @@ const (
 	ETCDMain = "etcd-" + ETCDRoleMain
 	// ETCDEvents is a constant for the name of etcd-events Etcd object.
 	ETCDEvents = "etcd-" + ETCDRoleEvents
-	// StatefulSetNameLoki is a constant for the name of a Kubernetes stateful set object that contains
-	// the loki pod.
-	StatefulSetNameLoki = "loki"
 	// StatefulSetNameVali is a constant for the name of a Kubernetes stateful set object that contains
 	// the vali pod.
 	StatefulSetNameVali = "vali"

--- a/pkg/apis/operator/v1alpha1/types.go
+++ b/pkg/apis/operator/v1alpha1/types.go
@@ -577,6 +577,8 @@ const (
 	VirtualComponentsHealthy gardencorev1beta1.ConditionType = "VirtualComponentsHealthy"
 	// VirtualGardenAPIServerAvailable is a constant for a condition type indicating that the virtual garden's API server is available.
 	VirtualGardenAPIServerAvailable gardencorev1beta1.ConditionType = "VirtualGardenAPIServerAvailable"
+	// ObservabilityComponentsHealthy is a constant for a condition type indicating the health of observability components.
+	ObservabilityComponentsHealthy gardencorev1beta1.ConditionType = "ObservabilityComponentsHealthy"
 )
 
 // AvailableOperationAnnotations is the set of available operation annotations for Garden resources.

--- a/pkg/operation/care/checker.go
+++ b/pkg/operation/care/checker.go
@@ -96,7 +96,6 @@ type HealthChecker struct {
 	managedResourceProgressingThreshold *metav1.Duration
 	lastOperation                       *gardencorev1beta1.LastOperation
 	kubernetesVersion                   *semver.Version
-	gardenerVersion                     *semver.Version
 }
 
 // NewHealthChecker creates a new health checker.
@@ -108,7 +107,6 @@ func NewHealthChecker(
 	managedResourceProgressingThreshold *metav1.Duration,
 	lastOperation *gardencorev1beta1.LastOperation,
 	kubernetesVersion *semver.Version,
-	gardenerVersion *semver.Version,
 ) *HealthChecker {
 	return &HealthChecker{
 		reader:                              reader,
@@ -118,7 +116,6 @@ func NewHealthChecker(
 		managedResourceProgressingThreshold: managedResourceProgressingThreshold,
 		lastOperation:                       lastOperation,
 		kubernetesVersion:                   kubernetesVersion,
-		gardenerVersion:                     gardenerVersion,
 	}
 }
 
@@ -475,7 +472,7 @@ func computeRequiredControlPlaneDeployments(shoot *gardencorev1beta1.Shoot) (set
 	return requiredControlPlaneDeployments, nil
 }
 
-func computeRequiredMonitoringSeedDeployments(shoot *gardencorev1beta1.Shoot, gardenerVersion *semver.Version) sets.Set[string] {
+func computeRequiredMonitoringSeedDeployments(shoot *gardencorev1beta1.Shoot) sets.Set[string] {
 	requiredDeployments := requiredMonitoringDeployments.Clone()
 	if v1beta1helper.IsWorkerless(shoot) {
 		requiredDeployments.Delete(v1beta1constants.DeploymentNameKubeStateMetrics)
@@ -760,7 +757,7 @@ func (b *HealthChecker) CheckShootMonitoringControlPlane(
 		return nil, nil
 	}
 
-	return b.checkMonitoringControlPlane(ctx, namespace, computeRequiredMonitoringSeedDeployments(shoot, b.gardenerVersion), computeRequiredMonitoringStatefulSets(wantsAlertmanager), monitoringSelector, condition)
+	return b.checkMonitoringControlPlane(ctx, namespace, computeRequiredMonitoringSeedDeployments(shoot), computeRequiredMonitoringStatefulSets(wantsAlertmanager), monitoringSelector, condition)
 }
 
 // CheckLoggingControlPlane checks whether the logging components in the given listers are complete and healthy.

--- a/pkg/operation/care/checker.go
+++ b/pkg/operation/care/checker.go
@@ -54,6 +54,7 @@ var (
 	)
 
 	requiredMonitoringDeployments = sets.New(
+		v1beta1constants.DeploymentNameKubeStateMetrics,
 		v1beta1constants.DeploymentNamePlutono,
 	)
 
@@ -446,7 +447,7 @@ func shootControlPlaneNotRunningMessage(lastOperation *gardencorev1beta1.LastOpe
 
 // This is a hack to quickly do a cloud provider specific check for the required control plane deployments.
 func computeRequiredControlPlaneDeployments(shoot *gardencorev1beta1.Shoot) (sets.Set[string], error) {
-	requiredControlPlaneDeployments := sets.New(requiredShootControlPlaneDeployments.UnsortedList()...)
+	requiredControlPlaneDeployments := requiredShootControlPlaneDeployments.Clone()
 
 	if !v1beta1helper.IsWorkerless(shoot) {
 		requiredControlPlaneDeployments.Insert(v1beta1constants.DeploymentNameKubeScheduler)
@@ -476,8 +477,8 @@ func computeRequiredControlPlaneDeployments(shoot *gardencorev1beta1.Shoot) (set
 
 func computeRequiredMonitoringSeedDeployments(shoot *gardencorev1beta1.Shoot, gardenerVersion *semver.Version) sets.Set[string] {
 	requiredDeployments := requiredMonitoringDeployments.Clone()
-	if !v1beta1helper.IsWorkerless(shoot) {
-		requiredDeployments.Insert(v1beta1constants.DeploymentNameKubeStateMetrics)
+	if v1beta1helper.IsWorkerless(shoot) {
+		requiredDeployments.Delete(v1beta1constants.DeploymentNameKubeStateMetrics)
 	}
 
 	return requiredDeployments

--- a/pkg/operation/care/garden_health.go
+++ b/pkg/operation/care/garden_health.go
@@ -79,7 +79,7 @@ var (
 		virtualGardenPrefix+v1beta1constants.ETCDEvents,
 	)
 
-	virtualGardenmonitoringSelector = labels.SelectorFromSet(map[string]string{v1beta1constants.LabelRole: v1beta1constants.LabelMonitoring})
+	virtualGardenMonitoringSelector = labels.SelectorFromSet(map[string]string{v1beta1constants.LabelRole: v1beta1constants.LabelMonitoring})
 )
 
 // GardenHealth contains information needed to execute health checks for garden.
@@ -240,9 +240,8 @@ func (h *GardenHealth) checkManagedResources(
 // checkObservabilityComponents checks whether the  observability components of the virtual garden control plane (Prometheus, Vali, Plutono..) are healthy.
 func (h *GardenHealth) checkObservabilityComponents(ctx context.Context, checker *HealthChecker, condition gardencorev1beta1.Condition) (*gardencorev1beta1.Condition, error) {
 	requiredDeployments := requiredMonitoringDeployments.Clone()
-	requiredDeployments.Insert(v1beta1constants.DeploymentNameKubeStateMetrics)
 
-	if exitCondition, err := checker.checkMonitoringControlPlane(ctx, h.gardenNamespace, requiredDeployments, sets.New[string](), virtualGardenmonitoringSelector, condition); err != nil || exitCondition != nil {
+	if exitCondition, err := checker.checkMonitoringControlPlane(ctx, h.gardenNamespace, requiredDeployments, sets.New[string](), virtualGardenMonitoringSelector, condition); err != nil || exitCondition != nil {
 		return exitCondition, err
 	}
 

--- a/pkg/operation/care/garden_health.go
+++ b/pkg/operation/care/garden_health.go
@@ -128,7 +128,7 @@ func (h *GardenHealth) CheckGarden(
 		}
 	}
 
-	checker := NewHealthChecker(h.runtimeClient, h.clock, thresholdMappings, nil, nil, lastOperation, nil, nil)
+	checker := NewHealthChecker(h.runtimeClient, h.clock, thresholdMappings, nil, nil, lastOperation, nil)
 
 	taskFns := []flow.TaskFn{
 		func(ctx context.Context) error {

--- a/pkg/operation/care/garden_health.go
+++ b/pkg/operation/care/garden_health.go
@@ -113,7 +113,7 @@ func (h *GardenHealth) CheckGarden(
 		apiServerAvailability      gardencorev1beta1.Condition
 		runtimeComponentsCondition gardencorev1beta1.Condition
 		virtualComponentsCondition gardencorev1beta1.Condition
-		observabilityComponents    gardencorev1beta1.Condition
+		observabilityCondition     gardencorev1beta1.Condition
 	)
 	for _, cond := range conditions {
 		switch cond.Type {
@@ -124,7 +124,7 @@ func (h *GardenHealth) CheckGarden(
 		case operatorv1alpha1.VirtualComponentsHealthy:
 			virtualComponentsCondition = cond
 		case operatorv1alpha1.ObservabilityComponentsHealthy:
-			observabilityComponents = cond
+			observabilityCondition = cond
 		}
 	}
 
@@ -146,8 +146,8 @@ func (h *GardenHealth) CheckGarden(
 			return nil
 		},
 		func(ctx context.Context) error {
-			newObservabilityComponents, err := h.checkObservabilityComponents(ctx, checker, observabilityComponents)
-			observabilityComponents = NewConditionOrError(h.clock, observabilityComponents, newObservabilityComponents, err)
+			newObservabilityCondition, err := h.checkObservabilityComponents(ctx, checker, observabilityCondition)
+			observabilityCondition = NewConditionOrError(h.clock, observabilityCondition, newObservabilityCondition, err)
 			return nil
 		},
 	}
@@ -158,7 +158,7 @@ func (h *GardenHealth) CheckGarden(
 		runtimeComponentsCondition,
 		virtualComponentsCondition,
 		apiServerAvailability,
-		observabilityComponents,
+		observabilityCondition,
 	}
 }
 

--- a/pkg/operation/care/health.go
+++ b/pkg/operation/care/health.go
@@ -396,7 +396,7 @@ func (h *Health) checkObservabilityComponents(
 ) (*gardencorev1beta1.Condition, error) {
 	wantsAlertmanager := h.shoot.WantsAlertmanager
 	wantsShootMonitoring := gardenlethelper.IsMonitoringEnabled(h.gardenletConfiguration) && h.shoot.Purpose != gardencorev1beta1.ShootPurposeTesting
-	if exitCondition, err := checker.CheckMonitoringControlPlane(ctx, h.shoot.GetInfo(), h.shoot.SeedNamespace, wantsShootMonitoring, wantsAlertmanager, condition); err != nil || exitCondition != nil {
+	if exitCondition, err := checker.CheckShootMonitoringControlPlane(ctx, h.shoot.GetInfo(), h.shoot.SeedNamespace, wantsShootMonitoring, wantsAlertmanager, condition); err != nil || exitCondition != nil {
 		return exitCondition, err
 	}
 

--- a/pkg/operation/care/health.go
+++ b/pkg/operation/care/health.go
@@ -294,7 +294,7 @@ func (h *Health) healthChecks(
 		h.log.Error(err, "Error getting extension conditions")
 	}
 
-	checker := NewHealthChecker(h.seedClient.Client(), h.clock, thresholdMappings, healthCheckOutdatedThreshold, gardenlethelper.GetManagedResourceProgressingThreshold(h.gardenletConfiguration), h.shoot.GetInfo().Status.LastOperation, h.shoot.KubernetesVersion, h.shoot.GardenerVersion)
+	checker := NewHealthChecker(h.seedClient.Client(), h.clock, thresholdMappings, healthCheckOutdatedThreshold, gardenlethelper.GetManagedResourceProgressingThreshold(h.gardenletConfiguration), h.shoot.GetInfo().Status.LastOperation, h.shoot.KubernetesVersion)
 
 	shootClient, apiServerRunning, err := h.initializeShootClients()
 	if err != nil || !apiServerRunning {

--- a/pkg/operation/care/health_check_test.go
+++ b/pkg/operation/care/health_check_test.go
@@ -883,7 +883,7 @@ var _ = Describe("health check", func() {
 				s = workerlessShoot.DeepCopy()
 			}
 
-			exitCondition, err := checker.CheckMonitoringControlPlane(ctx, s, seedNamespace, wantsShootMonitoring, wantsAlertmanager, condition)
+			exitCondition, err := checker.CheckShootMonitoringControlPlane(ctx, s, seedNamespace, wantsShootMonitoring, wantsAlertmanager, condition)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(exitCondition).To(conditionMatcher)
 		},

--- a/pkg/operation/care/health_check_test.go
+++ b/pkg/operation/care/health_check_test.go
@@ -250,17 +250,10 @@ var _ = Describe("health check", func() {
 			etcdEvents,
 		}
 
-		// TODO(rickardsjp, istvanballok): Remove in release v1.77
-		grafanaDeployment               = newDeployment(seedNamespace, v1beta1constants.DeploymentNameGrafana, v1beta1constants.GardenRoleMonitoring, true)
 		plutonoDeployment               = newDeployment(seedNamespace, v1beta1constants.DeploymentNamePlutono, v1beta1constants.GardenRoleMonitoring, true)
 		kubeStateMetricsShootDeployment = newDeployment(seedNamespace, v1beta1constants.DeploymentNameKubeStateMetrics, v1beta1constants.GardenRoleMonitoring, true)
 
-		requiredMonitoringControlPlaneDeploymentsLessThan171 = []*appsv1.Deployment{
-			grafanaDeployment,
-			kubeStateMetricsShootDeployment,
-		}
-
-		requiredMonitoringControlPlaneDeploymentsGreaterEqual171 = []*appsv1.Deployment{
+		requiredMonitoringControlPlaneDeployments = []*appsv1.Deployment{
 			plutonoDeployment,
 			kubeStateMetricsShootDeployment,
 		}
@@ -273,14 +266,9 @@ var _ = Describe("health check", func() {
 			prometheusStatefulSet,
 		}
 
-		lokiStatefulSet = newStatefulSet(seedNamespace, v1beta1constants.StatefulSetNameLoki, v1beta1constants.GardenRoleLogging, true)
 		valiStatefulSet = newStatefulSet(seedNamespace, v1beta1constants.StatefulSetNameVali, v1beta1constants.GardenRoleLogging, true)
 
-		requiredLoggingControlPlaneStatefulSetsLessThan171 = []*appsv1.StatefulSet{
-			lokiStatefulSet,
-		}
-
-		requiredLoggingControlPlaneStatefulSetsGreaterEqual171 = []*appsv1.StatefulSet{
+		requiredLoggingControlPlaneStatefulSets = []*appsv1.StatefulSet{
 			valiStatefulSet,
 		}
 
@@ -879,10 +867,8 @@ var _ = Describe("health check", func() {
 		)
 	})
 
-	gardenerVersion170 := semver.MustParse("1.70.0-mod1")
-	gardenerVersion171 := semver.MustParse("1.71.0")
 	DescribeTable("#CheckMonitoringControlPlane",
-		func(deployments []*appsv1.Deployment, statefulSets []*appsv1.StatefulSet, workerless, wantsShootMonitoring, wantsAlertmanager bool, gardenerVersion *semver.Version, conditionMatcher types.GomegaMatcher) {
+		func(deployments []*appsv1.Deployment, statefulSets []*appsv1.StatefulSet, workerless, wantsShootMonitoring, wantsAlertmanager bool, conditionMatcher types.GomegaMatcher) {
 			for _, obj := range deployments {
 				Expect(fakeClient.Create(ctx, obj.DeepCopy())).To(Succeed(), "creating deployment "+client.ObjectKeyFromObject(obj).String())
 			}
@@ -901,33 +887,14 @@ var _ = Describe("health check", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(exitCondition).To(conditionMatcher)
 		},
-		Entry("all healthy (1.70)",
-			requiredMonitoringControlPlaneDeploymentsLessThan171,
+		Entry("all healthy",
+			requiredMonitoringControlPlaneDeployments,
 			requiredMonitoringControlPlaneStatefulSets,
 			false,
 			true,
 			true,
-			gardenerVersion170,
 			BeNil()),
-		Entry("all healthy (1.70, workerless)",
-			[]*appsv1.Deployment{
-				grafanaDeployment,
-			},
-			requiredMonitoringControlPlaneStatefulSets,
-			true,
-			true,
-			true,
-			gardenerVersion170,
-			BeNil()),
-		Entry("all healthy (1.71)",
-			requiredMonitoringControlPlaneDeploymentsGreaterEqual171,
-			requiredMonitoringControlPlaneStatefulSets,
-			false,
-			true,
-			true,
-			gardenerVersion171,
-			BeNil()),
-		Entry("all healthy (1.71, workerless)",
+		Entry("all healthy (workerless)",
 			[]*appsv1.Deployment{
 				plutonoDeployment,
 			},
@@ -935,7 +902,6 @@ var _ = Describe("health check", func() {
 			true,
 			true,
 			true,
-			gardenerVersion171,
 			BeNil()),
 		Entry("required deployment missing",
 			[]*appsv1.Deployment{
@@ -945,7 +911,6 @@ var _ = Describe("health check", func() {
 			false,
 			true,
 			true,
-			gardenerVersion171,
 			PointTo(beConditionWithMissingRequiredDeployment([]*appsv1.Deployment{kubeStateMetricsShootDeployment}))),
 		Entry("required deployment missing (workerless Shoot)",
 			[]*appsv1.Deployment{},
@@ -953,17 +918,15 @@ var _ = Describe("health check", func() {
 			true,
 			true,
 			true,
-			gardenerVersion171,
 			PointTo(beConditionWithMissingRequiredDeployment([]*appsv1.Deployment{plutonoDeployment}))),
 		Entry("required stateful set set missing",
-			requiredMonitoringControlPlaneDeploymentsGreaterEqual171,
+			requiredMonitoringControlPlaneDeployments,
 			[]*appsv1.StatefulSet{
 				prometheusStatefulSet,
 			},
 			false,
 			true,
 			true,
-			gardenerVersion171,
 			PointTo(beConditionWithStatus(gardencorev1beta1.ConditionFalse))),
 		Entry("deployment unhealthy",
 			[]*appsv1.Deployment{
@@ -974,10 +937,9 @@ var _ = Describe("health check", func() {
 			false,
 			true,
 			true,
-			gardenerVersion171,
 			PointTo(beConditionWithStatus(gardencorev1beta1.ConditionFalse))),
 		Entry("stateful set unhealthy",
-			requiredMonitoringControlPlaneDeploymentsGreaterEqual171,
+			requiredMonitoringControlPlaneDeployments,
 			[]*appsv1.StatefulSet{
 				newStatefulSet(alertManagerStatefulSet.Namespace, alertManagerStatefulSet.Name, roleOf(alertManagerStatefulSet), false),
 				prometheusStatefulSet,
@@ -985,7 +947,6 @@ var _ = Describe("health check", func() {
 			false,
 			true,
 			true,
-			gardenerVersion171,
 			PointTo(beConditionWithStatus(gardencorev1beta1.ConditionFalse))),
 		Entry("shoot has monitoring disabled, omit all checks",
 			[]*appsv1.Deployment{},
@@ -993,7 +954,6 @@ var _ = Describe("health check", func() {
 			false,
 			false,
 			true,
-			gardenerVersion171,
 			BeNil()),
 	)
 
@@ -1012,23 +972,14 @@ var _ = Describe("health check", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(exitCondition).To(conditionMatcher)
 		},
-		Entry("all healthy (1.70)",
+		Entry("all healthy",
 			requiredLoggingControlPlaneDeployments,
-			requiredLoggingControlPlaneStatefulSetsLessThan171,
+			requiredLoggingControlPlaneStatefulSets,
 			false,
 			true,
 			true,
 			BeNil(),
-			gardenerVersion170,
-		),
-		Entry("all healthy (1.71)",
-			requiredLoggingControlPlaneDeployments,
-			requiredLoggingControlPlaneStatefulSetsGreaterEqual171,
-			false,
-			true,
-			true,
-			BeNil(),
-			gardenerVersion171,
+			gardenerVersion,
 		),
 		Entry("required stateful set missing",
 			requiredLoggingControlPlaneDeployments,
@@ -1037,16 +988,16 @@ var _ = Describe("health check", func() {
 			true,
 			true,
 			PointTo(beConditionWithStatus(gardencorev1beta1.ConditionFalse)),
-			gardenerVersion171,
+			gardenerVersion,
 		),
 		Entry("required deployment is missing",
 			nil,
-			requiredLoggingControlPlaneStatefulSetsGreaterEqual171,
+			requiredLoggingControlPlaneStatefulSets,
 			false,
 			true,
 			true,
 			PointTo(beConditionWithStatus(gardencorev1beta1.ConditionFalse)),
-			gardenerVersion171,
+			gardenerVersion,
 		),
 		Entry("stateful set unhealthy",
 			requiredLoggingControlPlaneDeployments,
@@ -1057,18 +1008,18 @@ var _ = Describe("health check", func() {
 			true,
 			true,
 			PointTo(beConditionWithStatus(gardencorev1beta1.ConditionFalse)),
-			gardenerVersion171,
+			gardenerVersion,
 		),
 		Entry("stateful set unhealthy",
 			[]*appsv1.Deployment{
 				newDeployment(eventLoggerDepployment.Namespace, eventLoggerDepployment.Name, roleOf(eventLoggerDepployment), false),
 			},
-			requiredLoggingControlPlaneStatefulSetsGreaterEqual171,
+			requiredLoggingControlPlaneStatefulSets,
 			false,
 			true,
 			true,
 			PointTo(beConditionWithStatus(gardencorev1beta1.ConditionFalse)),
-			gardenerVersion171,
+			gardenerVersion,
 		),
 		Entry("shoot purpose is testing, omit all checks",
 			[]*appsv1.Deployment{},
@@ -1077,7 +1028,7 @@ var _ = Describe("health check", func() {
 			true,
 			true,
 			BeNil(),
-			gardenerVersion171,
+			gardenerVersion,
 		),
 		Entry("vali is disabled in gardenlet config, omit stateful set check",
 			requiredLoggingControlPlaneDeployments,
@@ -1086,16 +1037,16 @@ var _ = Describe("health check", func() {
 			true,
 			false,
 			BeNil(),
-			gardenerVersion171,
+			gardenerVersion,
 		),
 		Entry("event logging is disabled in gardenlet config, omit deployment check",
 			[]*appsv1.Deployment{},
-			requiredLoggingControlPlaneStatefulSetsGreaterEqual171,
+			requiredLoggingControlPlaneStatefulSets,
 			false,
 			false,
 			true,
 			BeNil(),
-			gardenerVersion171,
+			gardenerVersion,
 		),
 	)
 

--- a/pkg/operation/care/health_check_test.go
+++ b/pkg/operation/care/health_check_test.go
@@ -866,7 +866,7 @@ var _ = Describe("health check", func() {
 		)
 	})
 
-	DescribeTable("#CheckMonitoringControlPlane",
+	DescribeTable("#CheckShootMonitoringControlPlane",
 		func(deployments []*appsv1.Deployment, statefulSets []*appsv1.StatefulSet, workerless, wantsShootMonitoring, wantsAlertmanager bool, conditionMatcher types.GomegaMatcher) {
 			for _, obj := range deployments {
 				Expect(fakeClient.Create(ctx, obj.DeepCopy())).To(Succeed(), "creating deployment "+client.ObjectKeyFromObject(obj).String())

--- a/pkg/operation/care/seed_health.go
+++ b/pkg/operation/care/seed_health.go
@@ -91,7 +91,7 @@ func (h *SeedHealth) CheckSeed(
 		}
 	}
 
-	checker := NewHealthChecker(h.seedClient, h.clock, thresholdMappings, nil, nil, lastOperation, nil, nil)
+	checker := NewHealthChecker(h.seedClient, h.clock, thresholdMappings, nil, nil, lastOperation, nil)
 	newSystemComponentsCondition, err := h.checkSeedSystemComponents(ctx, checker, systemComponentsCondition)
 	return []gardencorev1beta1.Condition{NewConditionOrError(h.clock, systemComponentsCondition, newSystemComponentsCondition, err)}
 }

--- a/pkg/operator/controller/garden/care/reconciler.go
+++ b/pkg/operator/controller/garden/care/reconciler.go
@@ -76,6 +76,7 @@ func (r *Reconciler) Reconcile(reconcileCtx context.Context, req reconcile.Reque
 		operatorv1alpha1.VirtualGardenAPIServerAvailable,
 		operatorv1alpha1.RuntimeComponentsHealthy,
 		operatorv1alpha1.VirtualComponentsHealthy,
+		operatorv1alpha1.ObservabilityComponentsHealthy,
 	}
 	var conditions []gardencorev1beta1.Condition
 	for _, cond := range conditionTypes {

--- a/test/integration/gardenlet/shoot/care/care_test.go
+++ b/test/integration/gardenlet/shoot/care/care_test.go
@@ -153,7 +153,7 @@ var _ = Describe("Shoot Care controller tests", func() {
 
 		By("Patch shoot status")
 		patch := client.MergeFrom(shoot.DeepCopy())
-		shoot.Status.Gardener.Version = "1.71.0"
+		shoot.Status.Gardener.Version = "1.2.3"
 		shoot.Status.TechnicalID = testNamespace.Name
 		Expect(testClient.Status().Patch(ctx, shoot, patch)).To(Succeed())
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity
/kind enhancement

**What this PR does / why we need it**:
This PR adds health checks for observability components to `garden-care` controller.
Therefor the `ObservabilityComponentsHealthy` condition was added to the status of `garden`.

**Which issue(s) this PR fixes**:
Part of #7016

**Special notes for your reviewer**:
Additionally, this PR removes migration code from loki/grafana to vali/plutono which was more work than initially expected 😅
@rickardsjp, @istvanballok please check if this is correct.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Status of `garden` now includes the `ObservabilityComponentsHealthy` condition which show the health of observability components in the garden runtime-cluster.
```
