### PR TITLE
Add `reconcile` operation for Seed, Reconcile backupbuckets on seed reconciliation

### DIFF
--- a/pkg/apis/core/validation/seed.go
+++ b/pkg/apis/core/validation/seed.go
@@ -39,6 +39,7 @@ var (
 	)
 	availableSeedOperations = sets.New(
 		v1beta1constants.SeedOperationRenewGardenAccessSecrets,
+		v1beta1constants.GardenerOperationReconcile,
 	)
 )
 

--- a/pkg/gardenlet/controller/managedseed/actuator.go
+++ b/pkg/gardenlet/controller/managedseed/actuator.go
@@ -45,6 +45,7 @@ import (
 	"github.com/gardener/gardener/pkg/controllerutils"
 	gardenletv1alpha1 "github.com/gardener/gardener/pkg/gardenlet/apis/config/v1alpha1"
 	gardenletbootstraputil "github.com/gardener/gardener/pkg/gardenlet/bootstrap/util"
+	"github.com/gardener/gardener/pkg/utils"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 )
@@ -487,9 +488,13 @@ func (a *actuator) reconcileSeedSecrets(ctx context.Context, log logr.Logger, sp
 
 	// If backup is specified, create or update the backup secret if it doesn't exist or is owned by the managed seed
 	if spec.Backup != nil {
+		var checksum string
+
 		// Get backup secret
 		backupSecret, err := kubernetesutils.GetSecretByReference(ctx, a.gardenClient, &spec.Backup.SecretRef)
-		if client.IgnoreNotFound(err) != nil {
+		if err == nil {
+			checksum = utils.ComputeSecretChecksum(backupSecret.Data)[:8]
+		} else if client.IgnoreNotFound(err) != nil {
 			return err
 		}
 
@@ -508,7 +513,14 @@ func (a *actuator) reconcileSeedSecrets(ctx context.Context, log logr.Logger, sp
 			}); err != nil {
 				return err
 			}
+
+			checksum = utils.ComputeSecretChecksum(secret.Data)[:8]
 		}
+
+		// Inject backup-secret hash into the pod annotations
+		managedSeed.Spec.Gardenlet.Deployment.PodAnnotations = utils.MergeStringMaps[string](managedSeed.Spec.Gardenlet.Deployment.PodAnnotations, map[string]string{
+			"checksum/backup-secret": spec.Backup.SecretRef.Name + "-" + checksum,
+		})
 	}
 
 	// If secret reference is specified and the static token kubeconfig is enabled,

--- a/pkg/gardenlet/controller/managedseed/actuator.go
+++ b/pkg/gardenlet/controller/managedseed/actuator.go
@@ -519,7 +519,7 @@ func (a *actuator) reconcileSeedSecrets(ctx context.Context, log logr.Logger, sp
 
 		// Inject backup-secret hash into the pod annotations
 		managedSeed.Spec.Gardenlet.Deployment.PodAnnotations = utils.MergeStringMaps[string](managedSeed.Spec.Gardenlet.Deployment.PodAnnotations, map[string]string{
-			"checksum/backup-secret": spec.Backup.SecretRef.Name + "-" + checksum,
+			"checksum/seed-backup-secret": spec.Backup.SecretRef.Name + "-" + checksum,
 		})
 	}
 

--- a/pkg/gardenlet/controller/seed/seed/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/seed/seed/reconciler_reconcile.go
@@ -696,6 +696,7 @@ func deployBackupBucketInGarden(ctx context.Context, k8sGardenClient client.Clie
 	ownerRef := metav1.NewControllerRef(seed, gardencorev1beta1.SchemeGroupVersion.WithKind("Seed"))
 
 	_, err := controllerutils.CreateOrGetAndStrategicMergePatch(ctx, k8sGardenClient, backupBucket, func() error {
+		metav1.SetMetaDataAnnotation(&backupBucket.ObjectMeta, v1beta1constants.GardenerOperation, v1beta1constants.GardenerOperationReconcile)
 		backupBucket.OwnerReferences = []metav1.OwnerReference{*ownerRef}
 		backupBucket.Spec = gardencorev1beta1.BackupBucketSpec{
 			Provider: gardencorev1beta1.BackupBucketProvider{

--- a/pkg/registry/core/seed/strategy.go
+++ b/pkg/registry/core/seed/strategy.go
@@ -84,6 +84,9 @@ func mustIncreaseGeneration(oldSeed, newSeed *core.Seed) bool {
 		switch newSeed.Annotations[v1beta1constants.GardenerOperation] {
 		case v1beta1constants.SeedOperationRenewGardenAccessSecrets:
 			return true
+		case v1beta1constants.GardenerOperationReconcile:
+			delete(newSeed.Annotations, v1beta1constants.GardenerOperation)
+			return true
 		}
 	}
 

--- a/pkg/registry/core/seed/strategy_test.go
+++ b/pkg/registry/core/seed/strategy_test.go
@@ -88,6 +88,15 @@ var _ = Describe("Strategy", func() {
 				Expect(newSeed.Generation).To(Equal(oldSeed.Generation + 1))
 			})
 
+			It("should bump the generation and remove the annotation if the operation annotation was set to reconcile", func() {
+				metav1.SetMetaDataAnnotation(&newSeed.ObjectMeta, "gardener.cloud/operation", "reconcile")
+
+				strategy.PrepareForUpdate(ctx, newSeed, oldSeed)
+
+				Expect(newSeed.Generation).To(Equal(oldSeed.Generation + 1))
+				Expect(newSeed.Annotations).NotTo(ContainElement("gardener.cloud/operation"))
+			})
+
 			It("should not bump the generation if the operation annotation didn't change", func() {
 				metav1.SetMetaDataAnnotation(&oldSeed.ObjectMeta, "gardener.cloud/operation", "renew-garden-access-secrets")
 				metav1.SetMetaDataAnnotation(&newSeed.ObjectMeta, "gardener.cloud/operation", "renew-garden-access-secrets")

--- a/test/integration/gardenlet/managedseed/managedseed_test.go
+++ b/test/integration/gardenlet/managedseed/managedseed_test.go
@@ -84,7 +84,7 @@ var _ = Describe("ManagedSeed controller test", func() {
 				gardenletDeployment := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "gardenlet", Namespace: gardenNamespaceShoot}}
 				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(gardenletDeployment), gardenletDeployment)).To(Succeed())
 				g.Expect(gardenletDeployment.Spec.Template.Annotations).To(HaveKeyWithValue(
-					"checksum/backup-secret", backupSecret.Name+"-"+utils.ComputeSecretChecksum(backupSecret.Data)[:8],
+					"checksum/seed-backup-secret", backupSecret.Name+"-"+utils.ComputeSecretChecksum(backupSecret.Data)[:8],
 				))
 			}).Should(Succeed())
 		}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement

**What this PR does / why we need it**:
See the discussion in https://github.com/gardener/gardener/pull/8325#issuecomment-1672752590

- This PR adds `reconcile` operation to Seed, similar to how it is present today in the Shoot.
- The backupbucket for the Seed is reconciled everytime the seed is reconciled (ideally, syncPeriod is 1 hr).
- We also add a checksum of the backupbucket secret to the gardenlet pod annotations, so that the pod is restarted and the backupbucket is reconciled. This is because of 
  > We cannot annotate the `BackupBucket` during the `ManagedSeed` reconciliation flow because the parent gardenlet doesn't have the permissions to patch the `BackupBucket` of the child seed.

  from https://github.com/gardener/gardener/issues/8256#issuecomment-1650994536
  The annotation looks like: `"checksum/backup-secret": "backup-local-246b2c5a"`

**Which issue(s) this PR fixes**:
Fixes #8256

**Special notes for your reviewer**:
/cc @timuthy 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
It is possible now to trigger a seed reconciliation by annotating the Seed with `gardener.cloud/operation=reconcile`.
```
