### PR TITLE
Backupbucket/backupentry controllers: Watch secret metadata only

### DIFF
--- a/extensions/pkg/controller/backupbucket/controller.go
+++ b/extensions/pkg/controller/backupbucket/controller.go
@@ -17,7 +17,7 @@ package backupbucket
 import (
 	"context"
 
-	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -78,7 +78,12 @@ func add(ctx context.Context, mgr manager.Manager, args AddArgs, predicates []pr
 
 	if args.IgnoreOperationAnnotation {
 		if err := ctrl.Watch(
-			&source.Kind{Type: &corev1.Secret{}},
+			&source.Kind{Type: &metav1.PartialObjectMetadata{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Secret",
+					APIVersion: "v1",
+				},
+			}},
 			mapper.EnqueueRequestsFrom(ctx, mgr.GetCache(), SecretToBackupBucketMapper(predicates), mapper.UpdateWithNew, ctrl.GetLogger()),
 		); err != nil {
 			return err

--- a/extensions/pkg/controller/backupbucket/reconciler.go
+++ b/extensions/pkg/controller/backupbucket/reconciler.go
@@ -89,14 +89,14 @@ func (r *reconciler) reconcile(ctx context.Context, log logr.Logger, bb *extensi
 		return reconcile.Result{}, err
 	}
 
-	secret, err := kubernetesutils.GetSecretByReference(ctx, r.client, &bb.Spec.SecretRef)
+	secretMetadata, err := kubernetesutils.GetSecretMetadataByReference(ctx, r.client, &bb.Spec.SecretRef)
 	if err != nil {
 		return reconcile.Result{}, fmt.Errorf("failed to get backup bucket secret: %+v", err)
 	}
 
-	if !controllerutil.ContainsFinalizer(secret, FinalizerName) {
-		log.Info("Adding finalizer to secret", "secret", client.ObjectKeyFromObject(secret))
-		if err := controllerutils.AddFinalizers(ctx, r.client, secret, FinalizerName); err != nil {
+	if !controllerutil.ContainsFinalizer(secretMetadata, FinalizerName) {
+		log.Info("Adding finalizer to secret", "secret", client.ObjectKeyFromObject(secretMetadata))
+		if err := controllerutils.AddFinalizers(ctx, r.client, secretMetadata, FinalizerName); err != nil {
 			return reconcile.Result{}, fmt.Errorf("failed to add finalizer to secret: %w", err)
 		}
 	}
@@ -135,14 +135,14 @@ func (r *reconciler) delete(ctx context.Context, log logr.Logger, bb *extensions
 		return reconcile.Result{}, err
 	}
 
-	secret, err := kubernetesutils.GetSecretByReference(ctx, r.client, &bb.Spec.SecretRef)
+	secretMetadata, err := kubernetesutils.GetSecretMetadataByReference(ctx, r.client, &bb.Spec.SecretRef)
 	if err != nil {
 		return reconcile.Result{}, fmt.Errorf("failed to get backup bucket secret: %+v", err)
 	}
 
-	if controllerutil.ContainsFinalizer(secret, FinalizerName) {
-		log.Info("Removing finalizer from secret", "secret", client.ObjectKeyFromObject(secret))
-		if err := controllerutils.RemoveFinalizers(ctx, r.client, secret, FinalizerName); err != nil {
+	if controllerutil.ContainsFinalizer(secretMetadata, FinalizerName) {
+		log.Info("Removing finalizer from secret", "secret", client.ObjectKeyFromObject(secretMetadata))
+		if err := controllerutils.RemoveFinalizers(ctx, r.client, secretMetadata, FinalizerName); err != nil {
 			return reconcile.Result{}, fmt.Errorf("failed to remove finalizer from secret: %w", err)
 		}
 	}

--- a/extensions/pkg/controller/backupentry/controller.go
+++ b/extensions/pkg/controller/backupentry/controller.go
@@ -18,6 +18,7 @@ import (
 	"context"
 
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -84,7 +85,12 @@ func add(ctx context.Context, mgr manager.Manager, args AddArgs, predicates []pr
 		}
 
 		if err := ctrl.Watch(
-			&source.Kind{Type: &corev1.Secret{}},
+			&source.Kind{Type: &metav1.PartialObjectMetadata{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Secret",
+					APIVersion: "v1",
+				},
+			}},
 			mapper.EnqueueRequestsFrom(ctx, mgr.GetCache(), SecretToBackupEntryMapper(predicates), mapper.UpdateWithNew, ctrl.GetLogger()),
 		); err != nil {
 			return err

--- a/extensions/pkg/controller/backupentry/mapper.go
+++ b/extensions/pkg/controller/backupentry/mapper.go
@@ -39,11 +39,6 @@ func (m *secretToBackupEntryMapper) Map(ctx context.Context, _ logr.Logger, read
 	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 
-	secret, ok := obj.(*corev1.Secret)
-	if !ok {
-		return nil
-	}
-
 	backupEntryList := &extensionsv1alpha1.BackupEntryList{}
 	if err := reader.List(ctx, backupEntryList); err != nil {
 		return nil
@@ -51,7 +46,7 @@ func (m *secretToBackupEntryMapper) Map(ctx context.Context, _ logr.Logger, read
 
 	var requests []reconcile.Request
 	for _, backupEntry := range backupEntryList.Items {
-		if backupEntry.Spec.SecretRef.Name == secret.Name && backupEntry.Spec.SecretRef.Namespace == secret.Namespace {
+		if backupEntry.Spec.SecretRef.Name == obj.GetName() && backupEntry.Spec.SecretRef.Namespace == obj.GetNamespace() {
 			if predicateutils.EvalGeneric(&backupEntry, m.predicates...) {
 				requests = append(requests, reconcile.Request{
 					NamespacedName: types.NamespacedName{

--- a/extensions/pkg/controller/backupentry/reconciler.go
+++ b/extensions/pkg/controller/backupentry/reconciler.go
@@ -120,14 +120,14 @@ func (r *reconciler) reconcile(
 		return reconcile.Result{}, err
 	}
 
-	secret, err := kubernetesutils.GetSecretByReference(ctx, r.client, &be.Spec.SecretRef)
+	secretMetadata, err := kubernetesutils.GetSecretMetadataByReference(ctx, r.client, &be.Spec.SecretRef)
 	if err != nil {
 		return reconcile.Result{}, fmt.Errorf("failed to get backup entry secret: %+v", err)
 	}
 
-	if !controllerutil.ContainsFinalizer(secret, FinalizerName) {
-		log.Info("Adding finalizer to secret", "secret", client.ObjectKeyFromObject(secret))
-		if err := controllerutils.AddFinalizers(ctx, r.client, secret, FinalizerName); err != nil {
+	if !controllerutil.ContainsFinalizer(secretMetadata, FinalizerName) {
+		log.Info("Adding finalizer to secret", "secret", client.ObjectKeyFromObject(secretMetadata))
+		if err := controllerutils.AddFinalizers(ctx, r.client, secretMetadata, FinalizerName); err != nil {
 			return reconcile.Result{}, fmt.Errorf("failed to add finalizer to secret: %w", err)
 		}
 	}
@@ -157,14 +157,14 @@ func (r *reconciler) restore(ctx context.Context, log logr.Logger, be *extension
 		return reconcile.Result{}, err
 	}
 
-	secret, err := kubernetesutils.GetSecretByReference(ctx, r.client, &be.Spec.SecretRef)
+	secretMetadata, err := kubernetesutils.GetSecretMetadataByReference(ctx, r.client, &be.Spec.SecretRef)
 	if err != nil {
 		return reconcile.Result{}, fmt.Errorf("failed to get backup entry secret: %+v", err)
 	}
 
-	if !controllerutil.ContainsFinalizer(secret, FinalizerName) {
-		log.Info("Adding finalizer to secret", "secret", client.ObjectKeyFromObject(secret))
-		if err := controllerutils.AddFinalizers(ctx, r.client, secret, FinalizerName); err != nil {
+	if !controllerutil.ContainsFinalizer(secretMetadata, FinalizerName) {
+		log.Info("Adding finalizer to secret", "secret", client.ObjectKeyFromObject(secretMetadata))
+		if err := controllerutils.AddFinalizers(ctx, r.client, secretMetadata, FinalizerName); err != nil {
 			return reconcile.Result{}, fmt.Errorf("failed to add finalizer to secret: %w", err)
 		}
 	}
@@ -199,7 +199,7 @@ func (r *reconciler) delete(ctx context.Context, log logr.Logger, be *extensions
 
 	log.Info("Starting the deletion of BackupEntry")
 
-	secret, err := kubernetesutils.GetSecretByReference(ctx, r.client, &be.Spec.SecretRef)
+	secretMetadata, err := kubernetesutils.GetSecretMetadataByReference(ctx, r.client, &be.Spec.SecretRef)
 	if err != nil {
 		if !apierrors.IsNotFound(err) {
 			return reconcile.Result{}, fmt.Errorf("failed to get backup entry secret: %+v", err)
@@ -226,9 +226,9 @@ func (r *reconciler) delete(ctx context.Context, log logr.Logger, be *extensions
 		return reconcile.Result{}, err
 	}
 
-	if controllerutil.ContainsFinalizer(secret, FinalizerName) {
-		log.Info("Removing finalizer from secret", "secret", client.ObjectKeyFromObject(secret))
-		if err := controllerutils.RemoveFinalizers(ctx, r.client, secret, FinalizerName); err != nil {
+	if controllerutil.ContainsFinalizer(secretMetadata, FinalizerName) {
+		log.Info("Removing finalizer from secret", "secret", client.ObjectKeyFromObject(secretMetadata))
+		if err := controllerutils.RemoveFinalizers(ctx, r.client, secretMetadata, FinalizerName); err != nil {
 			return reconcile.Result{}, fmt.Errorf("failed to remove finalizer from secret: %w", err)
 		}
 	}
@@ -258,14 +258,14 @@ func (r *reconciler) migrate(ctx context.Context, log logr.Logger, be *extension
 		return reconcile.Result{}, err
 	}
 
-	secret, err := kubernetesutils.GetSecretByReference(ctx, r.client, &be.Spec.SecretRef)
+	secretMetadata, err := kubernetesutils.GetSecretMetadataByReference(ctx, r.client, &be.Spec.SecretRef)
 	if err != nil {
 		return reconcile.Result{}, fmt.Errorf("failed to get backup entry secret: %+v", err)
 	}
 
-	if controllerutil.ContainsFinalizer(secret, FinalizerName) {
-		log.Info("Removing finalizer from secret", "secret", client.ObjectKeyFromObject(secret))
-		if err := controllerutils.RemoveFinalizers(ctx, r.client, secret, FinalizerName); err != nil {
+	if controllerutil.ContainsFinalizer(secretMetadata, FinalizerName) {
+		log.Info("Removing finalizer from secret", "secret", client.ObjectKeyFromObject(secretMetadata))
+		if err := controllerutils.RemoveFinalizers(ctx, r.client, secretMetadata, FinalizerName); err != nil {
 			return reconcile.Result{}, fmt.Errorf("failed to remove finalizer from secret: %w", err)
 		}
 	}

--- a/pkg/utils/kubernetes/secretref.go
+++ b/pkg/utils/kubernetes/secretref.go
@@ -31,6 +31,19 @@ func GetSecretByReference(ctx context.Context, c client.Reader, ref *corev1.Secr
 	return secret, nil
 }
 
+// GetSecretMetadataByReference returns the secret referenced by the given secret reference.
+func GetSecretMetadataByReference(ctx context.Context, c client.Reader, ref *corev1.SecretReference) (*metav1.PartialObjectMetadata, error) {
+	metadata := &metav1.PartialObjectMetadata{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Secret",
+			APIVersion: "v1",
+		}}
+	if err := c.Get(ctx, Key(ref.Namespace, ref.Name), metadata); err != nil {
+		return nil, err
+	}
+	return metadata, nil
+}
+
 // DeleteSecretByReference deletes the secret referenced by the given secret reference.
 func DeleteSecretByReference(ctx context.Context, c client.Client, ref *corev1.SecretReference) error {
 	secret := &corev1.Secret{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement

**What this PR does / why we need it**:
If the backupbucket and backupentry controllers are watching secrets, they should watch their metadata only to avoid caching of the complete secrets resources. On very large seeds caching secrets can consume GBs of memory.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
This is only a minor improvement, as typically these two controllers are running with `IgnoreOperationAnnotation=false` and in this case do not watch secrets at all. 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other dependency
Backupbucket/backupentry controllers: watch secret metadata only
```
