### PR TITLE
Add network disjointness check between shoot node network and seed pod network.

### DIFF
--- a/pkg/utils/validation/cidr/disjoint.go
+++ b/pkg/utils/validation/cidr/disjoint.go
@@ -24,56 +24,33 @@ import (
 
 // ValidateNetworkDisjointedness validates that the given <seedNetworks> and <k8sNetworks> are disjoint.
 func ValidateNetworkDisjointedness(fldPath *field.Path, shootNodes, shootPods, shootServices, seedNodes *string, seedPods, seedServices string, workerless bool) field.ErrorList {
-	var (
-		allErrs = field.ErrorList{}
+	allErrs := field.ErrorList{}
 
-		pathNodes    = fldPath.Child("nodes")
-		pathServices = fldPath.Child("services")
-		pathPods     = fldPath.Child("pods")
-	)
+	allErrs = append(allErrs, validateOverlapWithSeed(fldPath.Child("nodes"), shootNodes, "node", false, seedNodes, seedPods, seedServices)...)
+	allErrs = append(allErrs, validateOverlapWithSeed(fldPath.Child("services"), shootServices, "service", true, seedNodes, seedPods, seedServices)...)
+	allErrs = append(allErrs, validateOverlapWithSeed(fldPath.Child("pods"), shootPods, "pod", !workerless, seedNodes, seedPods, seedServices)...)
 
-	if shootNodes != nil && seedNodes != nil && NetworksIntersect(*shootNodes, *seedNodes) {
-		allErrs = append(allErrs, field.Invalid(pathNodes, *shootNodes, "shoot node network intersects with seed node network"))
-	}
-	if shootNodes != nil && NetworksIntersect(*shootNodes, seedServices) {
-		allErrs = append(allErrs, field.Invalid(pathNodes, *shootNodes, "shoot node network intersects with seed service network"))
-	}
-	if shootNodes != nil && NetworksIntersect(*shootNodes, v1beta1constants.DefaultVPNRange) {
-		allErrs = append(allErrs, field.Invalid(pathNodes, *shootNodes, fmt.Sprintf("shoot node network intersects with default vpn network (%s)", v1beta1constants.DefaultVPNRange)))
-	}
+	return allErrs
+}
 
-	if shootServices != nil {
-		if NetworksIntersect(seedServices, *shootServices) {
-			allErrs = append(allErrs, field.Invalid(pathServices, *shootServices, "shoot service network intersects with seed service network"))
-		}
-		if NetworksIntersect(seedPods, *shootServices) {
-			allErrs = append(allErrs, field.Invalid(pathServices, *shootServices, "shoot service network intersects with seed pod network"))
-		}
-		if seedNodes != nil && NetworksIntersect(*seedNodes, *shootServices) {
-			allErrs = append(allErrs, field.Invalid(pathServices, *seedNodes, "shoot service network intersects with seed node network"))
-		}
-		if NetworksIntersect(v1beta1constants.DefaultVPNRange, *shootServices) {
-			allErrs = append(allErrs, field.Invalid(pathServices, *shootServices, fmt.Sprintf("shoot service network intersects with default vpn network (%s)", v1beta1constants.DefaultVPNRange)))
-		}
-	} else {
-		allErrs = append(allErrs, field.Required(pathServices, "services is required"))
-	}
+func validateOverlapWithSeed(fldPath *field.Path, shootNetwork *string, networkType string, networkRequired bool, seedNodes *string, seedPods, seedServices string) field.ErrorList {
+	allErrs := field.ErrorList{}
 
-	if shootPods != nil {
-		if NetworksIntersect(seedPods, *shootPods) {
-			allErrs = append(allErrs, field.Invalid(pathPods, *shootPods, "shoot pod network intersects with seed pod network"))
+	if shootNetwork != nil {
+		if NetworksIntersect(seedServices, *shootNetwork) {
+			allErrs = append(allErrs, field.Invalid(fldPath, *shootNetwork, fmt.Sprintf("shoot %s network intersects with seed service network", networkType)))
 		}
-		if NetworksIntersect(seedServices, *shootPods) {
-			allErrs = append(allErrs, field.Invalid(pathPods, *shootPods, "shoot pod network intersects with seed service network"))
+		if NetworksIntersect(seedPods, *shootNetwork) {
+			allErrs = append(allErrs, field.Invalid(fldPath, *shootNetwork, fmt.Sprintf("shoot %s network intersects with seed pod network", networkType)))
 		}
-		if seedNodes != nil && NetworksIntersect(*seedNodes, *shootPods) {
-			allErrs = append(allErrs, field.Invalid(pathPods, *seedNodes, "shoot pod network intersects with seed node network"))
+		if seedNodes != nil && NetworksIntersect(*seedNodes, *shootNetwork) {
+			allErrs = append(allErrs, field.Invalid(fldPath, *shootNetwork, fmt.Sprintf("shoot %s network intersects with seed node network", networkType)))
 		}
-		if NetworksIntersect(v1beta1constants.DefaultVPNRange, *shootPods) {
-			allErrs = append(allErrs, field.Invalid(pathPods, *shootPods, fmt.Sprintf("shoot pod network intersects with default vpn network (%s)", v1beta1constants.DefaultVPNRange)))
+		if NetworksIntersect(v1beta1constants.DefaultVPNRange, *shootNetwork) {
+			allErrs = append(allErrs, field.Invalid(fldPath, *shootNetwork, fmt.Sprintf("shoot %s network intersects with default vpn network (%s)", networkType, v1beta1constants.DefaultVPNRange)))
 		}
-	} else if !workerless {
-		allErrs = append(allErrs, field.Required(pathPods, "pods is required"))
+	} else if networkRequired {
+		allErrs = append(allErrs, field.Required(fldPath, fmt.Sprintf("%ss is required", networkType)))
 	}
 
 	return allErrs

--- a/pkg/utils/validation/cidr/disjoint_test.go
+++ b/pkg/utils/validation/cidr/disjoint_test.go
@@ -258,7 +258,31 @@ var _ = Describe("utils", func() {
 			var (
 				podsCIDR     = "10.242.128.0/17"
 				servicesCIDR = "10.242.0.0/17"
-				nodesCIDR    = "10.241.0.0/16"
+				nodesCIDR    = "10.241.0.0/17"
+			)
+
+			errorList := ValidateNetworkDisjointedness(
+				field.NewPath(""),
+				&nodesCIDR,
+				&podsCIDR,
+				&servicesCIDR,
+				&seedNodesCIDR,
+				seedPodsCIDR,
+				seedServicesCIDR,
+				false,
+			)
+
+			Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+				"Type":  Equal(field.ErrorTypeInvalid),
+				"Field": Equal("[].nodes"),
+			}))))
+		})
+
+		It("should fail due to seed pod network and shoot node network overlap", func() {
+			var (
+				podsCIDR     = "10.242.128.0/17"
+				servicesCIDR = "10.242.0.0/17"
+				nodesCIDR    = seedPodsCIDR
 			)
 
 			errorList := ValidateNetworkDisjointedness(
@@ -341,7 +365,7 @@ var _ = Describe("utils", func() {
 			var (
 				podsCIDR     = seedPodsCIDRIPv6
 				servicesCIDR = seedServicesCIDRIPv6
-				nodesCIDR    = "2001:0db8:65a3::/113"
+				nodesCIDR    = "2001:0db8:55a3::/112"
 			)
 
 			errorList := ValidateNetworkDisjointedness(
@@ -369,7 +393,7 @@ var _ = Describe("utils", func() {
 			var (
 				podsCIDR     = seedNodesCIDRIPv6
 				servicesCIDR = seedNodesCIDRIPv6
-				nodesCIDR    = "2001:0db8:65a3::/113"
+				nodesCIDR    = "2001:0db8:55a3::/112"
 			)
 
 			errorList := ValidateNetworkDisjointedness(
@@ -391,6 +415,30 @@ var _ = Describe("utils", func() {
 				"Field": Equal("[].services"),
 			})),
 			))
+		})
+
+		It("should fail due to seed pod network and shoot node network overlap", func() {
+			var (
+				podsCIDR     = "2001:0db8:35a3::/113"
+				servicesCIDR = "2001:0db8:45a3::/113"
+				nodesCIDR    = seedPodsCIDRIPv6
+			)
+
+			errorList := ValidateNetworkDisjointedness(
+				field.NewPath(""),
+				&nodesCIDR,
+				&podsCIDR,
+				&servicesCIDR,
+				&seedNodesCIDRIPv6,
+				seedPodsCIDRIPv6,
+				seedServicesCIDRIPv6,
+				false,
+			)
+
+			Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+				"Type":  Equal(field.ErrorTypeInvalid),
+				"Field": Equal("[].nodes"),
+			}))))
 		})
 	})
 

--- a/pkg/utils/validation/cidr/disjoint_test.go
+++ b/pkg/utils/validation/cidr/disjoint_test.go
@@ -297,8 +297,9 @@ var _ = Describe("utils", func() {
 			)
 
 			Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
-				"Type":  Equal(field.ErrorTypeInvalid),
-				"Field": Equal("[].nodes"),
+				"Type":   Equal(field.ErrorTypeInvalid),
+				"Field":  Equal("[].nodes"),
+				"Detail": Equal("shoot node network intersects with seed pod network"),
 			}))))
 		})
 	})
@@ -436,8 +437,9 @@ var _ = Describe("utils", func() {
 			)
 
 			Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
-				"Type":  Equal(field.ErrorTypeInvalid),
-				"Field": Equal("[].nodes"),
+				"Type":   Equal(field.ErrorTypeInvalid),
+				"Field":  Equal("[].nodes"),
+				"Detail": Equal("shoot node network intersects with seed pod network"),
 			}))))
 		})
 	})


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/area control-plane
/kind bug

**What this PR does / why we need it**:
Add network disjointness check between shoot node network and seed pod network.

In case there is an overlap between the shoot node network and the seed pod network there can be strange network issues due to incorrect layer 3 routing. For the default VPN, the affected connections are from kube-apiserver to vpn-seed-server and from istio-ingressgateway to vpn-seed-server. In both cases the reply (SYN-ACK) may be incorrectly sent into the VPN tunnel when the source pod IP overlaps with the shoot node network as the shoot node network is added as a special route along with the shoot service and shoot pod networks.
In the highly-available VPN, the affected connections are from any pod in the seed to kube-apiserver of the shoot cluster. SYN-ACK packets may be sent incorrectly into the VPN tunnel as kube-apiserver has similar special route for shoot nodes, pods and services.
This issue is not new, but was present also with the previous VPN solution.

**Which issue(s) this PR fixes**:
None.

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Shoot node network and seed pod network need to be disjoint. This will be checked during scheduling of a shoot cluster, i.e. during initial admission or on control-plane migration.
```
