### PR TITLE
Improved alerts for ETCD backup failures.

### DIFF
--- a/pkg/component/etcd/monitoring.go
+++ b/pkg/component/etcd/monitoring.go
@@ -173,7 +173,20 @@ const (
   {{- if .backupEnabled }}
   # etcd backup failure alerts
   - alert: KubeEtcdDeltaBackupFailed
-    expr: ((time() - ` + monitoringMetricBackupRestoreSnapshotLatestTimestamp + `{job="` + monitoringPrometheusJobBackupRestoreNamePrefix + `-{{ .role }}",kind="Incr"} > bool 900) + (etcdbr_snapshot_required{job="` + monitoringPrometheusJobBackupRestoreNamePrefix + `-{{ .role }}", kind="Incr"} >= bool 1) == 2) + on(pod,role) group_left 0 * (` + monitoringMetricEtcdServerIsLeader + `{job="` + monitoringPrometheusJobEtcdNamePrefix + `-{{ .role }}"} == 1 )
+    expr:
+        (
+            (
+                time() - ` + monitoringMetricBackupRestoreSnapshotLatestTimestamp + `{job="` + monitoringPrometheusJobBackupRestoreNamePrefix + `-{{ .role }}",kind="Incr"}
+              > bool
+                900
+            )
+          +
+            (etcdbr_snapshot_required{job="` + monitoringPrometheusJobBackupRestoreNamePrefix + `-{{ .role }}",kind="Incr"} >= bool 1)
+          ==
+            2
+        )
+      + on (pod, role) group_left ()
+        0 * (` + monitoringMetricEtcdServerIsLeader + `{job="` + monitoringPrometheusJobEtcdNamePrefix + `-{{ .role }}"} == 1)
     for: 15m
     labels:
       service: etcd
@@ -184,7 +197,20 @@ const (
       description: No delta snapshot for the past at least 30 minutes taken by backup-restore leader.
       summary: Etcd delta snapshot failure.
   - alert: KubeEtcdFullBackupFailed
-    expr: ((time() - ` + monitoringMetricBackupRestoreSnapshotLatestTimestamp + `{job="` + monitoringPrometheusJobBackupRestoreNamePrefix + `-{{ .role }}",kind="Full"} > bool 86400) + (etcdbr_snapshot_required{job="` + monitoringPrometheusJobBackupRestoreNamePrefix + `-{{ .role }}", kind="Full"} >= bool 1) == 2) + on(pod,role) group_left 0 * (` + monitoringMetricEtcdServerIsLeader + `{job="` + monitoringPrometheusJobEtcdNamePrefix + `-{{ .role }}"} == 1 )
+    expr:
+        (
+            (
+                time() - ` + monitoringMetricBackupRestoreSnapshotLatestTimestamp + `{job="` + monitoringPrometheusJobBackupRestoreNamePrefix + `-{{ .role }}",kind="Full"}
+              > bool
+                86400
+            )
+          +
+            (etcdbr_snapshot_required{job="` + monitoringPrometheusJobBackupRestoreNamePrefix + `-{{ .role }}",kind="Full"} >= bool 1)
+          ==
+            2
+        )
+      + on (pod, role) group_left ()
+        0 * (` + monitoringMetricEtcdServerIsLeader + `{job="` + monitoringPrometheusJobEtcdNamePrefix + `-{{ .role }}"} == 1)
     for: 15m
     labels:
       service: etcd

--- a/pkg/component/etcd/monitoring.go
+++ b/pkg/component/etcd/monitoring.go
@@ -174,19 +174,19 @@ const (
   # etcd backup failure alerts
   - alert: KubeEtcdDeltaBackupFailed
     expr:
-        (
             (
-                time() - ` + monitoringMetricBackupRestoreSnapshotLatestTimestamp + `{job="` + monitoringPrometheusJobBackupRestoreNamePrefix + `-{{ .role }}",kind="Incr"}
-              > bool
-                900
+                (
+                    time() - ` + monitoringMetricBackupRestoreSnapshotLatestTimestamp + `{job="` + monitoringPrometheusJobBackupRestoreNamePrefix + `-{{ .role }}",kind="Incr"}
+                  > bool
+                    900
+                )
+              *
+                etcdbr_snapshot_required{job="` + monitoringPrometheusJobBackupRestoreNamePrefix + `-{{ .role }}",kind="Incr"}
             )
-          +
-            (etcdbr_snapshot_required{job="` + monitoringPrometheusJobBackupRestoreNamePrefix + `-{{ .role }}",kind="Incr"} >= bool 1)
-          ==
-            2
-        )
-      + on (pod, role) group_left ()
-        0 * (` + monitoringMetricEtcdServerIsLeader + `{job="` + monitoringPrometheusJobEtcdNamePrefix + `-{{ .role }}"} == 1)
+          * on (pod, role)
+            ` + monitoringMetricEtcdServerIsLeader + `{job="` + monitoringPrometheusJobEtcdNamePrefix + `-{{ .role }}"}
+        >
+          0
     for: 15m
     labels:
       service: etcd
@@ -194,23 +194,23 @@ const (
       type: seed
       visibility: operator
     annotations:
-      description: No delta snapshot for the past at least 30 minutes taken by backup-restore leader.
+      description: No delta snapshot for the past 30 minutes have been taken by backup-restore leader.
       summary: Etcd delta snapshot failure.
   - alert: KubeEtcdFullBackupFailed
     expr:
-        (
             (
-                time() - ` + monitoringMetricBackupRestoreSnapshotLatestTimestamp + `{job="` + monitoringPrometheusJobBackupRestoreNamePrefix + `-{{ .role }}",kind="Full"}
-              > bool
-                86400
+                (
+                    time() - ` + monitoringMetricBackupRestoreSnapshotLatestTimestamp + `{job="` + monitoringPrometheusJobBackupRestoreNamePrefix + `-{{ .role }}",kind="Full"}
+                  > bool
+                    86400
+                )
+              *
+                etcdbr_snapshot_required{job="` + monitoringPrometheusJobBackupRestoreNamePrefix + `-{{ .role }}",kind="Full"}
             )
-          +
-            (etcdbr_snapshot_required{job="` + monitoringPrometheusJobBackupRestoreNamePrefix + `-{{ .role }}",kind="Full"} >= bool 1)
-          ==
-            2
-        )
-      + on (pod, role) group_left ()
-        0 * (` + monitoringMetricEtcdServerIsLeader + `{job="` + monitoringPrometheusJobEtcdNamePrefix + `-{{ .role }}"} == 1)
+          * on (pod, role)
+            ` + monitoringMetricEtcdServerIsLeader + `{job="` + monitoringPrometheusJobEtcdNamePrefix + `-{{ .role }}"}
+        >
+          0
     for: 15m
     labels:
       service: etcd
@@ -218,7 +218,7 @@ const (
       type: seed
       visibility: operator
     annotations:
-      description: No full snapshot taken in the past day taken by backup-restore leader.
+      description: No full snapshot for at least last 24 hours have been taken by backup-restore leader.
       summary: Etcd full snapshot failure.
 
   # etcd data restoration failure alert

--- a/pkg/component/etcd/monitoring_test.go
+++ b/pkg/component/etcd/monitoring_test.go
@@ -404,7 +404,20 @@ static_configs:
 
 	alertingRulesBackup = `  # etcd backup failure alerts
   - alert: KubeEtcdDeltaBackupFailed
-    expr: ((time() - etcdbr_snapshot_latest_timestamp{job="kube-etcd3-backup-restore-` + testRole + `",kind="Incr"} > bool 900) + (etcdbr_snapshot_required{job="kube-etcd3-backup-restore-` + testRole + `", kind="Incr"} >= bool 1) == 2) + on(pod,role) group_left 0 * (etcd_server_is_leader{job="kube-etcd3-` + testRole + `"} == 1 )
+    expr:
+        (
+            (
+                time() - etcdbr_snapshot_latest_timestamp{job="kube-etcd3-backup-restore-` + testRole + `",kind="Incr"}
+              > bool
+                900
+            )
+          +
+            (etcdbr_snapshot_required{job="kube-etcd3-backup-restore-` + testRole + `",kind="Incr"} >= bool 1)
+          ==
+            2
+        )
+      + on (pod, role) group_left ()
+        0 * (etcd_server_is_leader{job="kube-etcd3-` + testRole + `"} == 1)
     for: 15m
     labels:
       service: etcd
@@ -415,7 +428,20 @@ static_configs:
       description: No delta snapshot for the past at least 30 minutes taken by backup-restore leader.
       summary: Etcd delta snapshot failure.
   - alert: KubeEtcdFullBackupFailed
-    expr: ((time() - etcdbr_snapshot_latest_timestamp{job="kube-etcd3-backup-restore-` + testRole + `",kind="Full"} > bool 86400) + (etcdbr_snapshot_required{job="kube-etcd3-backup-restore-` + testRole + `", kind="Full"} >= bool 1) == 2) + on(pod,role) group_left 0 * (etcd_server_is_leader{job="kube-etcd3-` + testRole + `"} == 1 )
+    expr:
+        (
+            (
+                time() - etcdbr_snapshot_latest_timestamp{job="kube-etcd3-backup-restore-` + testRole + `",kind="Full"}
+              > bool
+                86400
+            )
+          +
+            (etcdbr_snapshot_required{job="kube-etcd3-backup-restore-` + testRole + `",kind="Full"} >= bool 1)
+          ==
+            2
+        )
+      + on (pod, role) group_left ()
+        0 * (etcd_server_is_leader{job="kube-etcd3-` + testRole + `"} == 1)
     for: 15m
     labels:
       service: etcd

--- a/pkg/component/etcd/monitoring_test.go
+++ b/pkg/component/etcd/monitoring_test.go
@@ -405,19 +405,19 @@ static_configs:
 	alertingRulesBackup = `  # etcd backup failure alerts
   - alert: KubeEtcdDeltaBackupFailed
     expr:
-        (
             (
-                time() - etcdbr_snapshot_latest_timestamp{job="kube-etcd3-backup-restore-` + testRole + `",kind="Incr"}
-              > bool
-                900
+                (
+                    time() - etcdbr_snapshot_latest_timestamp{job="kube-etcd3-backup-restore-` + testRole + `",kind="Incr"}
+                  > bool
+                    900
+                )
+              *
+                etcdbr_snapshot_required{job="kube-etcd3-backup-restore-` + testRole + `",kind="Incr"}
             )
-          +
-            (etcdbr_snapshot_required{job="kube-etcd3-backup-restore-` + testRole + `",kind="Incr"} >= bool 1)
-          ==
-            2
-        )
-      + on (pod, role) group_left ()
-        0 * (etcd_server_is_leader{job="kube-etcd3-` + testRole + `"} == 1)
+          * on (pod, role)
+            etcd_server_is_leader{job="kube-etcd3-` + testRole + `"}
+        >
+          0
     for: 15m
     labels:
       service: etcd
@@ -425,23 +425,23 @@ static_configs:
       type: seed
       visibility: operator
     annotations:
-      description: No delta snapshot for the past at least 30 minutes taken by backup-restore leader.
+      description: No delta snapshot for the past 30 minutes have been taken by backup-restore leader.
       summary: Etcd delta snapshot failure.
   - alert: KubeEtcdFullBackupFailed
     expr:
-        (
             (
-                time() - etcdbr_snapshot_latest_timestamp{job="kube-etcd3-backup-restore-` + testRole + `",kind="Full"}
-              > bool
-                86400
+                (
+                    time() - etcdbr_snapshot_latest_timestamp{job="kube-etcd3-backup-restore-` + testRole + `",kind="Full"}
+                  > bool
+                    86400
+                )
+              *
+                etcdbr_snapshot_required{job="kube-etcd3-backup-restore-` + testRole + `",kind="Full"}
             )
-          +
-            (etcdbr_snapshot_required{job="kube-etcd3-backup-restore-` + testRole + `",kind="Full"} >= bool 1)
-          ==
-            2
-        )
-      + on (pod, role) group_left ()
-        0 * (etcd_server_is_leader{job="kube-etcd3-` + testRole + `"} == 1)
+          * on (pod, role)
+            etcd_server_is_leader{job="kube-etcd3-` + testRole + `"}
+        >
+          0
     for: 15m
     labels:
       service: etcd
@@ -449,7 +449,7 @@ static_configs:
       type: seed
       visibility: operator
     annotations:
-      description: No full snapshot taken in the past day taken by backup-restore leader.
+      description: No full snapshot for at least last 24 hours have been taken by backup-restore leader.
       summary: Etcd full snapshot failure.
 
   # etcd data restoration failure alert

--- a/pkg/component/etcd/testdata/monitoring_alertingrules_important_multinode_with_backup.yaml
+++ b/pkg/component/etcd/testdata/monitoring_alertingrules_important_multinode_with_backup.yaml
@@ -102,14 +102,12 @@ tests:
     - exp_labels:
         pod: etcd
         role: test
-        job: kube-etcd3-backup-restore-main
-        kind: Incr
         service: etcd
         severity: critical
         type: seed
         visibility: operator
       exp_annotations:
-        description: No delta snapshot for the past at least 30 minutes taken by backup-restore leader.
+        description: No delta snapshot for the past 30 minutes have been taken by backup-restore leader.
         summary: Etcd delta snapshot failure.
   - eval_time: 1456m
     alertname: KubeEtcdFullBackupFailed
@@ -117,14 +115,12 @@ tests:
     - exp_labels:
         pod: etcd
         role: test
-        job: kube-etcd3-backup-restore-main
-        kind: Full
         service: etcd
         severity: critical
         type: seed
         visibility: operator
       exp_annotations:
-        description: No full snapshot taken in the past day taken by backup-restore leader.
+        description: No full snapshot for at least last 24 hours have been taken by backup-restore leader.
         summary: Etcd full snapshot failure.
   - eval_time: 5m
     alertname: KubeEtcdRestorationFailed

--- a/pkg/component/etcd/testdata/monitoring_alertingrules_important_singlenode_with_backup.yaml
+++ b/pkg/component/etcd/testdata/monitoring_alertingrules_important_singlenode_with_backup.yaml
@@ -102,14 +102,12 @@ tests:
     - exp_labels:
         pod: etcd
         role: test
-        job: kube-etcd3-backup-restore-main
-        kind: Incr
         service: etcd
         severity: critical
         type: seed
         visibility: operator
       exp_annotations:
-        description: No delta snapshot for the past at least 30 minutes taken by backup-restore leader.
+        description: No delta snapshot for the past 30 minutes have been taken by backup-restore leader.
         summary: Etcd delta snapshot failure.
   - eval_time: 1456m
     alertname: KubeEtcdFullBackupFailed
@@ -117,14 +115,12 @@ tests:
     - exp_labels:
         pod: etcd
         role: test
-        job: kube-etcd3-backup-restore-main
-        kind: Full
         service: etcd
         severity: critical
         type: seed
         visibility: operator
       exp_annotations:
-        description: No full snapshot taken in the past day taken by backup-restore leader.
+        description: No full snapshot for at least last 24 hours have been taken by backup-restore leader.
         summary: Etcd full snapshot failure.
   - eval_time: 5m
     alertname: KubeEtcdRestorationFailed

--- a/pkg/component/etcd/testdata/monitoring_alertingrules_normal_multinode_with_backup.yaml
+++ b/pkg/component/etcd/testdata/monitoring_alertingrules_normal_multinode_with_backup.yaml
@@ -108,14 +108,12 @@ tests:
     - exp_labels:
         pod: etcd
         role: test
-        job: kube-etcd3-backup-restore-main
-        kind: Incr
         service: etcd
         severity: critical
         type: seed
         visibility: operator
       exp_annotations:
-        description: No delta snapshot for the past at least 30 minutes taken by backup-restore leader.
+        description: No delta snapshot for the past 30 minutes have been taken by backup-restore leader.
         summary: Etcd delta snapshot failure.
   - eval_time: 1456m
     alertname: KubeEtcdFullBackupFailed
@@ -123,14 +121,12 @@ tests:
     - exp_labels:
         pod: etcd
         role: test
-        job: kube-etcd3-backup-restore-main
-        kind: Full
         service: etcd
         severity: critical
         type: seed
         visibility: operator
       exp_annotations:
-        description: No full snapshot taken in the past day taken by backup-restore leader.
+        description: No full snapshot for at least last 24 hours have been taken by backup-restore leader.
         summary: Etcd full snapshot failure.
   - eval_time: 5m
     alertname: KubeEtcdRestorationFailed

--- a/pkg/component/etcd/testdata/monitoring_alertingrules_normal_singlenode_with_backup.yaml
+++ b/pkg/component/etcd/testdata/monitoring_alertingrules_normal_singlenode_with_backup.yaml
@@ -108,14 +108,12 @@ tests:
     - exp_labels:
         pod: etcd
         role: test
-        job: kube-etcd3-backup-restore-main
-        kind: Incr
         service: etcd
         severity: critical
         type: seed
         visibility: operator
       exp_annotations:
-        description: No delta snapshot for the past at least 30 minutes taken by backup-restore leader.
+        description: No delta snapshot for the past 30 minutes have been taken by backup-restore leader.
         summary: Etcd delta snapshot failure.
   - eval_time: 1456m
     alertname: KubeEtcdFullBackupFailed
@@ -123,14 +121,12 @@ tests:
     - exp_labels:
         pod: etcd
         role: test
-        job: kube-etcd3-backup-restore-main
-        kind: Full
         service: etcd
         severity: critical
         type: seed
         visibility: operator
       exp_annotations:
-        description: No full snapshot taken in the past day taken by backup-restore leader.
+        description: No full snapshot for at least last 24 hours have been taken by backup-restore leader.
         summary: Etcd full snapshot failure.
   - eval_time: 5m
     alertname: KubeEtcdRestorationFailed


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind enhancement

**What this PR does / why we need it**:
This PR simplified and increased the readability of the promQL for alerts of ETCD backup failures. 
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Can we also remove the field `etcdbr_snapshot_required` from the promQL of the alert?
**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
