### PR TITLE
Enhance Prometheus scrape job configs

### DIFF
--- a/pkg/component/apiserverproxy/monitoring.go
+++ b/pkg/component/apiserverproxy/monitoring.go
@@ -73,6 +73,7 @@ tls_config:
 authorization:
   type: Bearer
   credentials_file: /var/run/secrets/gardener.cloud/shoot/token/token
+follow_redirects: false
 kubernetes_sd_configs:
 - role: endpoints
   api_server: https://` + v1beta1constants.DeploymentNameKubeAPIServer + `:` + strconv.Itoa(kubeapiserverconstants.Port) + `

--- a/pkg/component/apiserverproxy/monitoring_test.go
+++ b/pkg/component/apiserverproxy/monitoring_test.go
@@ -43,6 +43,7 @@ tls_config:
 authorization:
   type: Bearer
   credentials_file: /var/run/secrets/gardener.cloud/shoot/token/token
+follow_redirects: false
 kubernetes_sd_configs:
 - role: endpoints
   api_server: https://kube-apiserver:443

--- a/pkg/component/blackboxexporter/monitoring.go
+++ b/pkg/component/blackboxexporter/monitoring.go
@@ -84,6 +84,7 @@ tls_config:
 authorization:
   type: Bearer
   credentials_file: /var/run/secrets/gardener.cloud/shoot/token/token
+follow_redirects: false
 kubernetes_sd_configs:
 - role: service
   namespaces:

--- a/pkg/component/blackboxexporter/monitoring_test.go
+++ b/pkg/component/blackboxexporter/monitoring_test.go
@@ -59,6 +59,7 @@ tls_config:
 authorization:
   type: Bearer
   credentials_file: /var/run/secrets/gardener.cloud/shoot/token/token
+follow_redirects: false
 kubernetes_sd_configs:
 - role: service
   namespaces:

--- a/pkg/component/coredns/monitoring.go
+++ b/pkg/component/coredns/monitoring.go
@@ -86,9 +86,12 @@ authorization:
   type: Bearer
   credentials_file: /var/run/secrets/gardener.cloud/shoot/token/token
 honor_labels: false
+follow_redirects: false
 kubernetes_sd_configs:
 - role: endpoints
   api_server: https://` + v1beta1constants.DeploymentNameKubeAPIServer + `:` + strconv.Itoa(kubeapiserverconstants.Port) + `
+  namespaces:
+    names: [ kube-system ]
   tls_config:
     ca_file: /etc/prometheus/seed/ca.crt
   authorization:

--- a/pkg/component/coredns/monitoring_test.go
+++ b/pkg/component/coredns/monitoring_test.go
@@ -53,9 +53,12 @@ authorization:
   type: Bearer
   credentials_file: /var/run/secrets/gardener.cloud/shoot/token/token
 honor_labels: false
+follow_redirects: false
 kubernetes_sd_configs:
 - role: endpoints
   api_server: https://kube-apiserver:443
+  namespaces:
+    names: [ kube-system ]
   tls_config:
     ca_file: /etc/prometheus/seed/ca.crt
   authorization:

--- a/pkg/component/kubeproxy/monitoring.go
+++ b/pkg/component/kubeproxy/monitoring.go
@@ -81,9 +81,12 @@ tls_config:
 authorization:
   type: Bearer
   credentials_file: /var/run/secrets/gardener.cloud/shoot/token/token
+follow_redirects: false
 kubernetes_sd_configs:
 - role: endpoints
   api_server: https://` + v1beta1constants.DeploymentNameKubeAPIServer + `:` + strconv.Itoa(kubeapiserverconstants.Port) + `
+  namespaces:
+    names: [ kube-system ]
   tls_config:
     ca_file: /etc/prometheus/seed/ca.crt
   authorization:

--- a/pkg/component/kubeproxy/monitoring_test.go
+++ b/pkg/component/kubeproxy/monitoring_test.go
@@ -51,9 +51,12 @@ tls_config:
 authorization:
   type: Bearer
   credentials_file: /var/run/secrets/gardener.cloud/shoot/token/token
+follow_redirects: false
 kubernetes_sd_configs:
 - role: endpoints
   api_server: https://kube-apiserver:443
+  namespaces:
+    names: [ kube-system ]
   tls_config:
     ca_file: /etc/prometheus/seed/ca.crt
   authorization:

--- a/pkg/component/monitoring/charts/seed-monitoring/charts/core/charts/prometheus/templates/config.yaml
+++ b/pkg/component/monitoring/charts/seed-monitoring/charts/core/charts/prometheus/templates/config.yaml
@@ -195,9 +195,12 @@ data:
       honor_labels: false
       scheme: https
 {{ include "prometheus.kube-auth" . | indent 6 }}
+      follow_redirects: false
       kubernetes_sd_configs:
       - role: node
         api_server: https://kube-apiserver:443
+        namespaces:
+          names: [ kube-system ]
 {{ include "prometheus.kube-auth" . | indent 8 }}
       relabel_configs:
       - action: labelmap
@@ -251,9 +254,12 @@ data:
       honor_labels: false
       scheme: https
 {{ include "prometheus.kube-auth" . | indent 6 }}
+      follow_redirects: false
       kubernetes_sd_configs:
       - role: node
         api_server: https://kube-apiserver:443
+        namespaces:
+          names: [ kube-system ]
 {{ include "prometheus.kube-auth" . | indent 8 }}
       relabel_configs:
       - source_labels: [ __meta_kubernetes_node_address_InternalIP ]

--- a/pkg/component/nodeexporter/monitoring.go
+++ b/pkg/component/nodeexporter/monitoring.go
@@ -183,6 +183,7 @@ tls_config:
 authorization:
   type: Bearer
   credentials_file: /var/run/secrets/gardener.cloud/shoot/token/token
+follow_redirects: false
 kubernetes_sd_configs:
 - role: endpoints
   api_server: https://` + v1beta1constants.DeploymentNameKubeAPIServer + `:` + strconv.Itoa(kubeapiserverconstants.Port) + `
@@ -191,6 +192,8 @@ kubernetes_sd_configs:
   authorization:
     type: Bearer
     credentials_file: /var/run/secrets/gardener.cloud/shoot/token/token
+  namespaces:
+    names: [ kube-system ]
 relabel_configs:
 - target_label: type
   replacement: shoot

--- a/pkg/component/nodeexporter/monitoring_test.go
+++ b/pkg/component/nodeexporter/monitoring_test.go
@@ -54,6 +54,7 @@ tls_config:
 authorization:
   type: Bearer
   credentials_file: /var/run/secrets/gardener.cloud/shoot/token/token
+follow_redirects: false
 kubernetes_sd_configs:
 - role: endpoints
   api_server: https://kube-apiserver:443
@@ -62,6 +63,8 @@ kubernetes_sd_configs:
   authorization:
     type: Bearer
     credentials_file: /var/run/secrets/gardener.cloud/shoot/token/token
+  namespaces:
+    names: [ kube-system ]
 relabel_configs:
 - target_label: type
   replacement: shoot

--- a/pkg/component/vpnshoot/monitoring.go
+++ b/pkg/component/vpnshoot/monitoring.go
@@ -69,6 +69,7 @@ metrics_path: /probe
 params:
   module:
   - http_apiserver
+follow_redirects: false
 kubernetes_sd_configs:
 - role: pod
   namespaces:

--- a/pkg/component/vpnshoot/monitoring_test.go
+++ b/pkg/component/vpnshoot/monitoring_test.go
@@ -51,6 +51,7 @@ metrics_path: /probe
 params:
   module:
   - http_apiserver
+follow_redirects: false
 kubernetes_sd_configs:
 - role: pod
   namespaces:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind enhancement

**What this PR does / why we need it**:
This PR enhances Prometheus scrape configs. For scrape targets that run in the shoot cluster, it restricts the target discovery to the `kube-system` namespace. For the blackbox-exporter, cadvisor and node-exporter, it also disables Prometheus' default behavior of following redirects.

**Special notes for your reviewer**:
/cc @istvanballok 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Prometheus scrape job configs for targets in the shoot cluster have been improved.
```
