### PR TITLE
Enhance KubePodNotReadyControlPlane alert definition

### DIFF
--- a/pkg/component/monitoring/charts/seed-monitoring/charts/core/charts/prometheus/rules/worker/kube-pods.rules.yaml
+++ b/pkg/component/monitoring/charts/seed-monitoring/charts/core/charts/prometheus/rules/worker/kube-pods.rules.yaml
@@ -35,7 +35,7 @@ groups:
       description: Pod {{ $labels.pod }} is not ready for more than 1 hour.
       summary: Shoot pod is in a not ready state
   - alert: KubePodNotReadyControlPlane
-    expr: kube_pod_status_ready{condition="true", type="seed", pod!~"(.+)(curator|compact-job)(.+)"} == 0
+    expr: kube_pod_status_ready{condition="true", type="seed", pod!~"(.+)compact-job(.+)"} == 0
     for: 30m
     labels:
       service: kube-kubelet

--- a/pkg/component/monitoring/charts/seed-monitoring/charts/core/charts/prometheus/rules/worker/kube-pods.rules.yaml
+++ b/pkg/component/monitoring/charts/seed-monitoring/charts/core/charts/prometheus/rules/worker/kube-pods.rules.yaml
@@ -35,7 +35,7 @@ groups:
       description: Pod {{ $labels.pod }} is not ready for more than 1 hour.
       summary: Shoot pod is in a not ready state
   - alert: KubePodNotReadyControlPlane
-    expr: kube_pod_status_ready{condition="true", type="seed", pod!~"(.+)curator(.+)"} == 0
+    expr: kube_pod_status_ready{condition="true", type="seed", pod!~"(.+)(curator|compact-job)(.+)"} == 0
     for: 30m
     labels:
       service: kube-kubelet

--- a/pkg/component/monitoring/charts/seed-monitoring/charts/core/charts/prometheus/rules/workerless/kube-pods.rules.yaml
+++ b/pkg/component/monitoring/charts/seed-monitoring/charts/core/charts/prometheus/rules/workerless/kube-pods.rules.yaml
@@ -13,7 +13,7 @@ groups:
       description: Pod {{ $labels.pod }} is stuck in "Pending" state for more than 30 minutes.
       summary: Control plane pod stuck in "Pending" state
   - alert: KubePodNotReadyControlPlane
-    expr: kube_pod_status_ready{condition="true", type="seed", pod!~"(.+)curator(.+)"} == 0
+    expr: kube_pod_status_ready{condition="true", type="seed", pod!~"(.+)(curator|compact-job)(.+)"} == 0
     for: 30m
     labels:
       service: kube-kubelet

--- a/pkg/component/monitoring/charts/seed-monitoring/charts/core/charts/prometheus/rules/workerless/kube-pods.rules.yaml
+++ b/pkg/component/monitoring/charts/seed-monitoring/charts/core/charts/prometheus/rules/workerless/kube-pods.rules.yaml
@@ -13,7 +13,7 @@ groups:
       description: Pod {{ $labels.pod }} is stuck in "Pending" state for more than 30 minutes.
       summary: Control plane pod stuck in "Pending" state
   - alert: KubePodNotReadyControlPlane
-    expr: kube_pod_status_ready{condition="true", type="seed", pod!~"(.+)(curator|compact-job)(.+)"} == 0
+    expr: kube_pod_status_ready{condition="true", type="seed", pod!~"(.+)compact-job(.+)"} == 0
     for: 30m
     labels:
       service: kube-kubelet


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind bugfix

**What this PR does / why we need it**:
Prior to this change, this alert could fire when an etcd compaction job was started, because its status could be e.g. `Completed`, rather than Ready.

**Special notes for your reviewer**:
/cc @istvanballok 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
A bug is fixed in the Prometheus alert definitions that caused false positive KubePodNotReadyControlPlane alerts related to the etcd compaction job.
```
