### PR TITLE
Drop deprecated `node-local-dns` annotations

### DIFF
--- a/extensions/pkg/controller/worker/machines.go
+++ b/extensions/pkg/controller/worker/machines.go
@@ -167,7 +167,7 @@ func WorkerPoolHash(pool extensionsv1alpha1.WorkerPool, cluster *extensionscontr
 	}
 
 	// Do not consider the shoot annotations here to prevent unintended node roll-outs.
-	if helper.IsNodeLocalDNSEnabled(cluster.Shoot.Spec.SystemComponents, map[string]string{}) {
+	if helper.IsNodeLocalDNSEnabled(cluster.Shoot.Spec.SystemComponents) {
 		data = append(data, "node-local-dns")
 	}
 

--- a/extensions/pkg/controller/worker/machines.go
+++ b/extensions/pkg/controller/worker/machines.go
@@ -166,7 +166,6 @@ func WorkerPoolHash(pool extensionsv1alpha1.WorkerPool, cluster *extensionscontr
 		}
 	}
 
-	// Do not consider the shoot annotations here to prevent unintended node roll-outs.
 	if helper.IsNodeLocalDNSEnabled(cluster.Shoot.Spec.SystemComponents) {
 		data = append(data, "node-local-dns")
 	}

--- a/extensions/pkg/controller/worker/machines_test.go
+++ b/extensions/pkg/controller/worker/machines_test.go
@@ -192,14 +192,6 @@ var _ = Describe("Machines", func() {
 					{Name: "test-worker", CRI: &gardencorev1beta1.CRI{Name: gardencorev1beta1.CRINameDocker}}}}
 			})
 
-			It("when disabling node local dns via annotations", func() {
-				c.Shoot.Annotations = map[string]string{"alpha.featuregates.shoot.gardener.cloud/node-local-dns": "false"}
-			})
-
-			It("when enabling node local dns via annotations", func() {
-				c.Shoot.Annotations = map[string]string{"alpha.featuregates.shoot.gardener.cloud/node-local-dns": "true"}
-			})
-
 			It("when disabling node local dns via specification", func() {
 				c.Shoot.Spec.SystemComponents = &gardencorev1beta1.SystemComponents{NodeLocalDNS: &gardencorev1beta1.NodeLocalDNS{Enabled: false}}
 			})

--- a/pkg/api/core/shoot/warnings.go
+++ b/pkg/api/core/shoot/warnings.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/gardener/gardener/pkg/apis/core"
 	"github.com/gardener/gardener/pkg/apis/core/helper"
-	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	versionutils "github.com/gardener/gardener/pkg/utils/version"
 )
 
@@ -39,9 +38,6 @@ func GetWarnings(_ context.Context, shoot, oldShoot *core.Shoot, credentialsRota
 	if pointer.BoolDeref(shoot.Spec.Kubernetes.EnableStaticTokenKubeconfig, true) {
 		warnings = append(warnings, "you should consider disabling the static token kubeconfig, see https://github.com/gardener/gardener/blob/master/docs/usage/shoot_access.md for details")
 	}
-
-	// TODO(acumino): Drop this warning in v1.78, with dropping of annotation to enable node-local-dns.
-	warnings = append(warnings, getWarningsForDeprecatedNodeLocalDNSLabels(shoot)...)
 
 	if oldShoot != nil {
 		warnings = append(warnings, getWarningsForDueCredentialsRotations(shoot, credentialsRotationInterval)...)
@@ -59,24 +55,6 @@ func GetWarnings(_ context.Context, shoot, oldShoot *core.Shoot, credentialsRota
 
 	if kubeControllerManager := shoot.Spec.Kubernetes.KubeControllerManager; kubeControllerManager != nil && kubeControllerManager.PodEvictionTimeout != nil {
 		warnings = append(warnings, "you are setting the spec.kubernetes.kubeControllerManager.podEvictionTimeout field. The field does not have effect since Kubernetes 1.13. Instead, use the spec.kubernetes.kubeAPIServer.(defaultNotReadyTolerationSeconds/defaultUnreachableTolerationSeconds) fields.")
-	}
-
-	return warnings
-}
-
-func getWarningsForDeprecatedNodeLocalDNSLabels(shoot *core.Shoot) []string {
-	var warnings []string
-
-	if _, ok := shoot.Annotations[v1beta1constants.AnnotationNodeLocalDNS]; ok {
-		warnings = append(warnings, fmt.Sprintf("annotation %v is deprecated. Use field `.spec.systemComponents.nodeLocalDNS.enabled` in Shoot instead. Switching on node-local-dns via shoot specification will roll the nodes even if node-local-dns was enabled beforehand via annotation.", v1beta1constants.AnnotationNodeLocalDNS))
-	}
-
-	if _, ok := shoot.Annotations[v1beta1constants.AnnotationNodeLocalDNSForceTcpToClusterDns]; ok {
-		warnings = append(warnings, fmt.Sprintf("annotation %v is deprecated. Use field `.spec.systemComponents.nodeLocalDNS.forceTCPToClusterDNS` in Shoot instead.", v1beta1constants.AnnotationNodeLocalDNSForceTcpToClusterDns))
-	}
-
-	if _, ok := shoot.Annotations[v1beta1constants.AnnotationNodeLocalDNSForceTcpToUpstreamDns]; ok {
-		warnings = append(warnings, fmt.Sprintf("annotation %v is deprecated. Use field `.spec.systemComponents.nodeLocalDNS.forceTCPToUpstreamDNS` in Shoot instead.", v1beta1constants.AnnotationNodeLocalDNSForceTcpToUpstreamDns))
 	}
 
 	return warnings

--- a/pkg/api/core/shoot/warnings_test.go
+++ b/pkg/api/core/shoot/warnings_test.go
@@ -26,7 +26,6 @@ import (
 
 	. "github.com/gardener/gardener/pkg/api/core/shoot"
 	"github.com/gardener/gardener/pkg/apis/core"
-	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 )
 
 var _ = Describe("Warnings", func() {
@@ -335,33 +334,6 @@ var _ = Describe("Warnings", func() {
 
 				warnings := GetWarnings(ctx, shoot, shoot, credentialsRotationInterval)
 				Expect(warnings).To(BeEmpty())
-			})
-		})
-
-		Context("node-local-dns annotations", func() {
-			It("should return a warning when annotation `alpha.featuregates.shoot.gardener.cloud/node-local-dns` is present", func() {
-				shoot.Annotations = map[string]string{
-					v1beta1constants.AnnotationNodeLocalDNS: "true",
-				}
-				Expect(GetWarnings(ctx, shoot, nil, credentialsRotationInterval)).To(ContainElement(Equal("annotation alpha.featuregates.shoot.gardener.cloud/node-local-dns is deprecated. Use field `.spec.systemComponents.nodeLocalDNS.enabled` in Shoot instead. Switching on node-local-dns via shoot specification will roll the nodes even if node-local-dns was enabled beforehand via annotation.")))
-			})
-
-			It("should return a warning when annotation `alpha.featuregates.shoot.gardener.cloud/node-local-dns-force-tcp-to-cluster-dns` is present", func() {
-				shoot.Annotations = map[string]string{
-					v1beta1constants.AnnotationNodeLocalDNSForceTcpToClusterDns: "true",
-				}
-				Expect(GetWarnings(ctx, shoot, nil, credentialsRotationInterval)).To(ContainElement(Equal("annotation alpha.featuregates.shoot.gardener.cloud/node-local-dns-force-tcp-to-cluster-dns is deprecated. Use field `.spec.systemComponents.nodeLocalDNS.forceTCPToClusterDNS` in Shoot instead.")))
-			})
-
-			It("should return a warning when annotation `alpha.featuregates.shoot.gardener.cloud/node-local-dns-force-tcp-to-upstream-dns` is present", func() {
-				shoot.Annotations = map[string]string{
-					v1beta1constants.AnnotationNodeLocalDNSForceTcpToUpstreamDns: "true",
-				}
-				Expect(GetWarnings(ctx, shoot, nil, credentialsRotationInterval)).To(ContainElement(Equal("annotation alpha.featuregates.shoot.gardener.cloud/node-local-dns-force-tcp-to-upstream-dns is deprecated. Use field `.spec.systemComponents.nodeLocalDNS.forceTCPToUpstreamDNS` in Shoot instead.")))
-			})
-
-			It("should not return a warning when the node-local-dns related annotation is not present", func() {
-				Expect(GetWarnings(ctx, shoot, nil, credentialsRotationInterval)).To(BeEmpty())
 			})
 		})
 

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -607,18 +607,6 @@ const (
 	// Note that changing this value only applies to new nodes. Existing nodes which already computed their individual
 	// delays will not recompute it.
 	AnnotationShootCloudConfigExecutionMaxDelaySeconds = "shoot.gardener.cloud/cloud-config-execution-max-delay-seconds"
-	// AnnotationNodeLocalDNS enables a per node dns cache on the shoot cluster.
-	// Deprecated: This annotation is deprecated and will be removed in a future version.
-	// Use field `.spec.systemComponents.nodeLocalDNS.enabled` in Shoot instead.
-	AnnotationNodeLocalDNS = "alpha.featuregates.shoot.gardener.cloud/node-local-dns"
-	// AnnotationNodeLocalDNSForceTcpToClusterDns enforces upgrade to tcp connections for communication between node local and cluster dns.
-	// Deprecated: This annotation is deprecated and will be removed in a future version.
-	// Use field `.spec.systemComponents.nodeLocalDNS.forceTCPToClusterDNS` in Shoot instead.
-	AnnotationNodeLocalDNSForceTcpToClusterDns = "alpha.featuregates.shoot.gardener.cloud/node-local-dns-force-tcp-to-cluster-dns"
-	// AnnotationNodeLocalDNSForceTcpToUpstreamDns enforces upgrade to tcp connections for communication between node local and upstream dns.
-	// Deprecated: This annotation is deprecated and will be removed in a future version.
-	// Use field `.spec.systemComponents.nodeLocalDNS.forceTCPToUpstreamDNS` in Shoot instead.
-	AnnotationNodeLocalDNSForceTcpToUpstreamDns = "alpha.featuregates.shoot.gardener.cloud/node-local-dns-force-tcp-to-upstream-dns"
 	// AnnotationCoreDNSRewritingDisabled disables core dns query rewriting even if the corresponding feature gate is enabled.
 	AnnotationCoreDNSRewritingDisabled = "alpha.featuregates.shoot.gardener.cloud/core-dns-rewriting-disabled"
 

--- a/pkg/apis/core/v1beta1/helper/helper.go
+++ b/pkg/apis/core/v1beta1/helper/helper.go
@@ -1134,17 +1134,11 @@ func IsCoreDNSRewritingEnabled(featureGate bool, annotations map[string]string) 
 }
 
 // IsNodeLocalDNSEnabled indicates whether the node local DNS cache is enabled or not.
-// It can be enabled via the annotation (legacy) or via the shoot specification.
-func IsNodeLocalDNSEnabled(systemComponents *gardencorev1beta1.SystemComponents, annotations map[string]string) bool {
-	fromSpec := false
+func IsNodeLocalDNSEnabled(systemComponents *gardencorev1beta1.SystemComponents) bool {
 	if systemComponents != nil && systemComponents.NodeLocalDNS != nil {
-		fromSpec = systemComponents.NodeLocalDNS.Enabled
+		return systemComponents.NodeLocalDNS.Enabled
 	}
-	fromAnnotation := false
-	if annotationValue, err := strconv.ParseBool(annotations[v1beta1constants.AnnotationNodeLocalDNS]); err == nil {
-		fromAnnotation = annotationValue
-	}
-	return fromSpec || fromAnnotation
+	return false
 }
 
 // GetNodeLocalDNS returns a pointer to the NodeLocalDNS spec.

--- a/pkg/apis/core/v1beta1/helper/helper.go
+++ b/pkg/apis/core/v1beta1/helper/helper.go
@@ -1135,10 +1135,7 @@ func IsCoreDNSRewritingEnabled(featureGate bool, annotations map[string]string) 
 
 // IsNodeLocalDNSEnabled indicates whether the node local DNS cache is enabled or not.
 func IsNodeLocalDNSEnabled(systemComponents *gardencorev1beta1.SystemComponents) bool {
-	if systemComponents != nil && systemComponents.NodeLocalDNS != nil {
-		return systemComponents.NodeLocalDNS.Enabled
-	}
-	return false
+	return systemComponents != nil && systemComponents.NodeLocalDNS != nil && systemComponents.NodeLocalDNS.Enabled
 }
 
 // GetNodeLocalDNS returns a pointer to the NodeLocalDNS spec.

--- a/pkg/apis/core/v1beta1/helper/helper_test.go
+++ b/pkg/apis/core/v1beta1/helper/helper_test.go
@@ -2657,10 +2657,10 @@ var _ = Describe("helper", func() {
 		},
 
 		Entry("should return false when shoot provider has zero workers", nil, nil, false),
-		Entry("should return true when shoot provider has no WorkersSettings", []gardencorev1beta1.Worker{gardencorev1beta1.Worker{}}, nil, true),
-		Entry("should return true when shoot worker settings has no SSHAccess", []gardencorev1beta1.Worker{gardencorev1beta1.Worker{}}, &gardencorev1beta1.WorkersSettings{}, true),
-		Entry("should return true when shoot worker settings has SSHAccess set to true", []gardencorev1beta1.Worker{gardencorev1beta1.Worker{}}, &gardencorev1beta1.WorkersSettings{SSHAccess: &gardencorev1beta1.SSHAccess{Enabled: true}}, true),
-		Entry("should return false when shoot worker settings has SSHAccess set to false", []gardencorev1beta1.Worker{gardencorev1beta1.Worker{}}, &gardencorev1beta1.WorkersSettings{SSHAccess: &gardencorev1beta1.SSHAccess{Enabled: false}}, false),
+		Entry("should return true when shoot provider has no WorkersSettings", []gardencorev1beta1.Worker{{}}, nil, true),
+		Entry("should return true when shoot worker settings has no SSHAccess", []gardencorev1beta1.Worker{{}}, &gardencorev1beta1.WorkersSettings{}, true),
+		Entry("should return true when shoot worker settings has SSHAccess set to true", []gardencorev1beta1.Worker{{}}, &gardencorev1beta1.WorkersSettings{SSHAccess: &gardencorev1beta1.SSHAccess{Enabled: true}}, true),
+		Entry("should return false when shoot worker settings has SSHAccess set to false", []gardencorev1beta1.Worker{{}}, &gardencorev1beta1.WorkersSettings{SSHAccess: &gardencorev1beta1.SSHAccess{Enabled: false}}, false),
 	)
 
 	Describe("#GetFailureToleranceType", func() {

--- a/pkg/apis/core/v1beta1/helper/helper_test.go
+++ b/pkg/apis/core/v1beta1/helper/helper_test.go
@@ -2234,22 +2234,14 @@ var _ = Describe("helper", func() {
 	})
 
 	DescribeTable("#IsNodeLocalDNSEnabled",
-		func(systemComponents *gardencorev1beta1.SystemComponents, annotations map[string]string, expected bool) {
-			Expect(IsNodeLocalDNSEnabled(systemComponents, annotations)).To(Equal(expected))
+		func(systemComponents *gardencorev1beta1.SystemComponents, expected bool) {
+			Expect(IsNodeLocalDNSEnabled(systemComponents)).To(Equal(expected))
 		},
 
-		Entry("with nil (disabled)", nil, nil, false),
-		Entry("with empty system components and no proper annotation (disabled)", &gardencorev1beta1.SystemComponents{}, map[string]string{"something": "wrong"}, false),
-		Entry("with system components and no proper annotation (disabled)", &gardencorev1beta1.SystemComponents{NodeLocalDNS: &gardencorev1beta1.NodeLocalDNS{}}, map[string]string{"something": "wrong"}, false),
-		Entry("with system components and no proper annotation (enabled)", &gardencorev1beta1.SystemComponents{NodeLocalDNS: &gardencorev1beta1.NodeLocalDNS{Enabled: true}}, map[string]string{"something": "wrong"}, true),
-		Entry("with system components and no proper annotation (disabled)", &gardencorev1beta1.SystemComponents{NodeLocalDNS: &gardencorev1beta1.NodeLocalDNS{Enabled: false}}, map[string]string{"something": "wrong"}, false),
-		Entry("with empty system components and proper annotation (disabled)", &gardencorev1beta1.SystemComponents{}, map[string]string{v1beta1constants.AnnotationNodeLocalDNS: "false"}, false),
-		Entry("with empty system components and proper annotation (enabled)", &gardencorev1beta1.SystemComponents{}, map[string]string{v1beta1constants.AnnotationNodeLocalDNS: "true"}, true),
-		Entry("with empty system components and proper annotation, but wrong value (disabled)", &gardencorev1beta1.SystemComponents{}, map[string]string{v1beta1constants.AnnotationNodeLocalDNS: "test"}, false),
-		Entry("with system components and proper annotation (enabled)", &gardencorev1beta1.SystemComponents{NodeLocalDNS: &gardencorev1beta1.NodeLocalDNS{Enabled: true}}, map[string]string{v1beta1constants.AnnotationNodeLocalDNS: "true"}, true),
-		Entry("with system components and proper annotation (disabled)", &gardencorev1beta1.SystemComponents{NodeLocalDNS: &gardencorev1beta1.NodeLocalDNS{Enabled: false}}, map[string]string{v1beta1constants.AnnotationNodeLocalDNS: "false"}, false),
-		Entry("with system components and proper annotation (enabled)", &gardencorev1beta1.SystemComponents{NodeLocalDNS: &gardencorev1beta1.NodeLocalDNS{Enabled: true}}, map[string]string{v1beta1constants.AnnotationNodeLocalDNS: "false"}, true),
-		Entry("with system components and proper annotation (enabled)", &gardencorev1beta1.SystemComponents{NodeLocalDNS: &gardencorev1beta1.NodeLocalDNS{Enabled: false}}, map[string]string{v1beta1constants.AnnotationNodeLocalDNS: "true"}, true),
+		Entry("with nil (disabled)", nil, false),
+		Entry("with empty system components", &gardencorev1beta1.SystemComponents{}, false),
+		Entry("with system components and node-local-dns is disabled", &gardencorev1beta1.SystemComponents{NodeLocalDNS: &gardencorev1beta1.NodeLocalDNS{Enabled: true}}, true),
+		Entry("with system components is enabled", &gardencorev1beta1.SystemComponents{NodeLocalDNS: &gardencorev1beta1.NodeLocalDNS{Enabled: false}}, false),
 	)
 
 	DescribeTable("#GetNodeLocalDNS",

--- a/pkg/apis/core/v1beta1/helper/helper_test.go
+++ b/pkg/apis/core/v1beta1/helper/helper_test.go
@@ -2240,8 +2240,8 @@ var _ = Describe("helper", func() {
 
 		Entry("with nil (disabled)", nil, false),
 		Entry("with empty system components", &gardencorev1beta1.SystemComponents{}, false),
-		Entry("with system components and node-local-dns is disabled", &gardencorev1beta1.SystemComponents{NodeLocalDNS: &gardencorev1beta1.NodeLocalDNS{Enabled: true}}, true),
-		Entry("with system components is enabled", &gardencorev1beta1.SystemComponents{NodeLocalDNS: &gardencorev1beta1.NodeLocalDNS{Enabled: false}}, false),
+		Entry("with system components and node-local-dns is enabled", &gardencorev1beta1.SystemComponents{NodeLocalDNS: &gardencorev1beta1.NodeLocalDNS{Enabled: true}}, true),
+		Entry("with system components and node-local-dns is disabled", &gardencorev1beta1.SystemComponents{NodeLocalDNS: &gardencorev1beta1.NodeLocalDNS{Enabled: false}}, false),
 	)
 
 	DescribeTable("#GetNodeLocalDNS",

--- a/pkg/component/nodelocaldns/nodelocaldns.go
+++ b/pkg/component/nodelocaldns/nodelocaldns.go
@@ -78,8 +78,6 @@ type Values struct {
 	VPAEnabled bool
 	// Config is the node local configuration for the shoot spec
 	Config *gardencorev1beta1.NodeLocalDNS
-	// ShootAnnotations is a map of shoot annotations
-	ShootAnnotations map[string]string
 	// ClusterDNS is the ClusterIP of kube-system/coredns Service
 	ClusterDNS string
 	// DNSServer is the ClusterIP of kube-system/coredns Service
@@ -583,34 +581,14 @@ func (c *nodeLocalDNS) containerArg() string {
 }
 
 func (c *nodeLocalDNS) forceTcpToClusterDNS() string {
-	fromSpec := true
-	if c.values.Config != nil && c.values.Config.ForceTCPToClusterDNS != nil {
-		fromSpec = *c.values.Config.ForceTCPToClusterDNS
-	}
-
-	fromAnnotation := true
-	if annotationValue, err := strconv.ParseBool(c.values.ShootAnnotations[v1beta1constants.AnnotationNodeLocalDNSForceTcpToClusterDns]); err == nil {
-		fromAnnotation = annotationValue
-	}
-
-	if fromAnnotation && fromSpec {
+	if c.values.Config != nil && c.values.Config.ForceTCPToClusterDNS != nil && *c.values.Config.ForceTCPToClusterDNS {
 		return "force_tcp"
 	}
 	return "prefer_udp"
 }
 
 func (c *nodeLocalDNS) forceTcpToUpstreamDNS() string {
-	fromSpec := true
-	if c.values.Config != nil && c.values.Config.ForceTCPToUpstreamDNS != nil {
-		fromSpec = *c.values.Config.ForceTCPToUpstreamDNS
-	}
-
-	fromAnnotation := true
-	if annotationValue, err := strconv.ParseBool(c.values.ShootAnnotations[v1beta1constants.AnnotationNodeLocalDNSForceTcpToUpstreamDns]); err == nil {
-		fromAnnotation = annotationValue
-	}
-
-	if fromAnnotation && fromSpec {
+	if c.values.Config != nil && c.values.Config.ForceTCPToUpstreamDNS != nil && *c.values.Config.ForceTCPToUpstreamDNS {
 		return "force_tcp"
 	}
 	return "prefer_udp"

--- a/pkg/component/nodelocaldns/nodelocaldns.go
+++ b/pkg/component/nodelocaldns/nodelocaldns.go
@@ -581,14 +581,14 @@ func (c *nodeLocalDNS) containerArg() string {
 }
 
 func (c *nodeLocalDNS) forceTcpToClusterDNS() string {
-	if c.values.Config != nil && c.values.Config.ForceTCPToClusterDNS != nil && *c.values.Config.ForceTCPToClusterDNS {
+	if c.values.Config == nil || c.values.Config.ForceTCPToClusterDNS == nil || *c.values.Config.ForceTCPToClusterDNS {
 		return "force_tcp"
 	}
 	return "prefer_udp"
 }
 
 func (c *nodeLocalDNS) forceTcpToUpstreamDNS() string {
-	if c.values.Config != nil && c.values.Config.ForceTCPToUpstreamDNS != nil && *c.values.Config.ForceTCPToUpstreamDNS {
+	if c.values.Config == nil || c.values.Config.ForceTCPToUpstreamDNS == nil || *c.values.Config.ForceTCPToUpstreamDNS {
 		return "force_tcp"
 	}
 	return "prefer_udp"

--- a/pkg/component/nodelocaldns/nodelocaldns_test.go
+++ b/pkg/component/nodelocaldns/nodelocaldns_test.go
@@ -578,7 +578,6 @@ ip6.arpa:53 {
 `,
 					}
 					configMapHash = utils.ComputeConfigMapChecksum(configMapData)[:8]
-					values.ShootAnnotations = map[string]string{}
 				})
 
 				Context("ForceTcpToClusterDNS : true and ForceTcpToUpstreamDNS : true", func() {
@@ -754,79 +753,6 @@ ip6.arpa:53 {
 						upstreamDNSAddress = values.ClusterDNS
 						forceTcpToClusterDNS = "force_tcp"
 						forceTcpToUpstreamDNS = "force_tcp"
-					})
-
-					It("should succesfully deploy all resources", func() {
-						Expect(string(managedResourceSecret.Data["configmap__kube-system__node-local-dns-"+configMapHash+".yaml"])).To(Equal(configMapYAMLFor()))
-						managedResourceDaemonset, _, err := kubernetes.ShootCodec.UniversalDecoder().Decode(managedResourceSecret.Data["daemonset__kube-system__node-local-dns.yaml"], nil, &appsv1.DaemonSet{})
-						Expect(err).ToNot(HaveOccurred())
-						daemonset := daemonSetYAMLFor()
-						utilruntime.Must(references.InjectAnnotations(daemonset))
-						Expect(daemonset).To(DeepEqual(managedResourceDaemonset))
-					})
-				})
-
-				Context("Annotation ForceTcpToClusterDNS", func() {
-					BeforeEach(func() {
-						values.Config = &gardencorev1beta1.NodeLocalDNS{Enabled: true,
-							ForceTCPToClusterDNS:        pointer.Bool(true),
-							ForceTCPToUpstreamDNS:       pointer.Bool(true),
-							DisableForwardToUpstreamDNS: pointer.Bool(true),
-						}
-						values.VPAEnabled = true
-						upstreamDNSAddress = values.ClusterDNS
-						values.ShootAnnotations = map[string]string{v1beta1constants.AnnotationNodeLocalDNSForceTcpToClusterDns: "false"}
-
-						forceTcpToClusterDNS = "prefer_udp"
-						forceTcpToUpstreamDNS = "force_tcp"
-					})
-
-					It("should succesfully deploy all resources", func() {
-						Expect(string(managedResourceSecret.Data["configmap__kube-system__node-local-dns-"+configMapHash+".yaml"])).To(Equal(configMapYAMLFor()))
-						managedResourceDaemonset, _, err := kubernetes.ShootCodec.UniversalDecoder().Decode(managedResourceSecret.Data["daemonset__kube-system__node-local-dns.yaml"], nil, &appsv1.DaemonSet{})
-						Expect(err).ToNot(HaveOccurred())
-						daemonset := daemonSetYAMLFor()
-						utilruntime.Must(references.InjectAnnotations(daemonset))
-						Expect(daemonset).To(DeepEqual(managedResourceDaemonset))
-					})
-				})
-				Context("Annotation ForceTcpToClusterDNS", func() {
-					BeforeEach(func() {
-						values.Config = &gardencorev1beta1.NodeLocalDNS{Enabled: true,
-							ForceTCPToClusterDNS:        pointer.Bool(true),
-							ForceTCPToUpstreamDNS:       pointer.Bool(true),
-							DisableForwardToUpstreamDNS: pointer.Bool(true),
-						}
-						values.VPAEnabled = true
-						upstreamDNSAddress = values.ClusterDNS
-						values.ShootAnnotations = map[string]string{v1beta1constants.AnnotationNodeLocalDNSForceTcpToUpstreamDns: "false"}
-
-						forceTcpToClusterDNS = "force_tcp"
-						forceTcpToUpstreamDNS = "prefer_udp"
-					})
-
-					It("should succesfully deploy all resources", func() {
-						Expect(string(managedResourceSecret.Data["configmap__kube-system__node-local-dns-"+configMapHash+".yaml"])).To(Equal(configMapYAMLFor()))
-						managedResourceDaemonset, _, err := kubernetes.ShootCodec.UniversalDecoder().Decode(managedResourceSecret.Data["daemonset__kube-system__node-local-dns.yaml"], nil, &appsv1.DaemonSet{})
-						Expect(err).ToNot(HaveOccurred())
-						daemonset := daemonSetYAMLFor()
-						utilruntime.Must(references.InjectAnnotations(daemonset))
-						Expect(daemonset).To(DeepEqual(managedResourceDaemonset))
-					})
-				})
-				Context("Annotation ForceTcpToClusterDNS", func() {
-					BeforeEach(func() {
-						values.Config = &gardencorev1beta1.NodeLocalDNS{Enabled: true,
-							ForceTCPToClusterDNS:        pointer.Bool(true),
-							ForceTCPToUpstreamDNS:       pointer.Bool(true),
-							DisableForwardToUpstreamDNS: pointer.Bool(true),
-						}
-						values.VPAEnabled = true
-						upstreamDNSAddress = values.ClusterDNS
-						values.ShootAnnotations = map[string]string{v1beta1constants.AnnotationNodeLocalDNSForceTcpToClusterDns: "false", v1beta1constants.AnnotationNodeLocalDNSForceTcpToUpstreamDns: "false"}
-
-						forceTcpToClusterDNS = "prefer_udp"
-						forceTcpToUpstreamDNS = "prefer_udp"
 					})
 
 					It("should succesfully deploy all resources", func() {

--- a/pkg/operation/botanist/nodelocaldns.go
+++ b/pkg/operation/botanist/nodelocaldns.go
@@ -53,7 +53,6 @@ func (b *Botanist) DefaultNodeLocalDNS() (nodelocaldns.Interface, error) {
 			Image:             image.String(),
 			VPAEnabled:        b.Shoot.WantsVerticalPodAutoscaler,
 			Config:            v1beta1helper.GetNodeLocalDNS(b.Shoot.GetInfo().Spec.SystemComponents),
-			ShootAnnotations:  b.Shoot.GetInfo().Annotations,
 			ClusterDNS:        clusterDNS,
 			DNSServer:         dnsServer,
 			PSPDisabled:       b.Shoot.PSPDisabled,

--- a/pkg/operation/botanist/nodelocaldns_test.go
+++ b/pkg/operation/botanist/nodelocaldns_test.go
@@ -49,11 +49,6 @@ var _ = Describe("NodeLocalDNS", func() {
 		botanist = &Botanist{Operation: &operation.Operation{}}
 		botanist.Shoot = &shootpkg.Shoot{}
 		botanist.Shoot.SetInfo(&gardencorev1beta1.Shoot{
-			ObjectMeta: metav1.ObjectMeta{
-				Annotations: map[string]string{
-					v1beta1constants.AnnotationNodeLocalDNS: "true",
-				},
-			},
 			Spec: gardencorev1beta1.ShootSpec{
 				SystemComponents: &gardencorev1beta1.SystemComponents{
 					NodeLocalDNS: &gardencorev1beta1.NodeLocalDNS{

--- a/pkg/operation/botanist/operatingsystemconfig.go
+++ b/pkg/operation/botanist/operatingsystemconfig.go
@@ -82,7 +82,7 @@ func (b *Botanist) DefaultOperatingSystemConfig() (operatingsystemconfig.Interfa
 				SSHAccessEnabled:    v1beta1helper.ShootEnablesSSHAccess(b.Shoot.GetInfo()),
 				ValitailEnabled:     valitailEnabled,
 				ValiIngressHostName: valiIngressHost,
-				NodeLocalDNSEnabled: v1beta1helper.IsNodeLocalDNSEnabled(b.Shoot.GetInfo().Spec.SystemComponents, b.Shoot.GetInfo().Annotations),
+				NodeLocalDNSEnabled: v1beta1helper.IsNodeLocalDNSEnabled(b.Shoot.GetInfo().Spec.SystemComponents),
 			},
 		},
 		operatingsystemconfig.DefaultInterval,

--- a/pkg/operation/botanist/worker.go
+++ b/pkg/operation/botanist/worker.go
@@ -52,7 +52,7 @@ func (b *Botanist) DefaultWorker() worker.Interface {
 			Workers:             b.Shoot.GetInfo().Spec.Provider.Workers,
 			KubernetesVersion:   b.Shoot.KubernetesVersion,
 			MachineTypes:        b.Shoot.CloudProfile.Spec.MachineTypes,
-			NodeLocalDNSEnabled: v1beta1helper.IsNodeLocalDNSEnabled(b.Shoot.GetInfo().Spec.SystemComponents, b.Shoot.GetInfo().Annotations),
+			NodeLocalDNSEnabled: v1beta1helper.IsNodeLocalDNSEnabled(b.Shoot.GetInfo().Spec.SystemComponents),
 		},
 		worker.DefaultInterval,
 		worker.DefaultSevereThreshold,

--- a/pkg/operation/shoot/shoot.go
+++ b/pkg/operation/shoot/shoot.go
@@ -231,7 +231,7 @@ func (b *Builder) Build(ctx context.Context, c client.Reader) (*Shoot, error) {
 		shoot.Networks = networks
 	}
 
-	shoot.NodeLocalDNSEnabled = v1beta1helper.IsNodeLocalDNSEnabled(shoot.GetInfo().Spec.SystemComponents, shoot.GetInfo().Annotations)
+	shoot.NodeLocalDNSEnabled = v1beta1helper.IsNodeLocalDNSEnabled(shoot.GetInfo().Spec.SystemComponents)
 	shoot.Purpose = v1beta1helper.GetPurpose(shootObject)
 
 	shoot.PSPDisabled = v1beta1helper.IsPSPDisabled(shoot.GetInfo())


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind cleanup

**What this PR does / why we need it**:
This PR drops the deprecated `node-local-dns` annotation.

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener/issues/7581

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking user
Deprecated annotation `alpha.featuregates.shoot.gardener.cloud/node-local-dns` is removed. Use field `.spec.systemComponents.nodeLocalDNS.enabled` in `Shoot` instead. Switching on node-local-dns via shoot specification will roll the nodes even if node-local-dns was enabled beforehand via annotation.
```
```breaking user
Deprecated annotation `alpha.featuregates.shoot.gardener.cloud/node-local-dns-force-tcp-to-{cluster-dns, upstream-dns}` is removed. Use field `.spec.systemComponents.nodeLocalDNS.{forceTCPToClusterDNS, forceTCPToUpstreamDNS}` in `Shoot` instead.
```

