### PR TITLE
Add documentation for `ManagedSeed` controller

### DIFF
--- a/docs/concepts/gardenlet.md
+++ b/docs/concepts/gardenlet.md
@@ -310,11 +310,11 @@ This condition is taken into account by the `ControllerRegistration` controller 
 
 ### [`ManagedSeed` Controller](../../pkg/gardenlet/controller/managedseed)
 
-The `ManagedSeed` controller in the `gardenlet` reconciles `ManagedSeed` that refers to `Shoot` scheduled on `Seed` the gardenlet is responsible for. Additionally, the controller monitors `Seed`s, which are owned by `ManagedSeed`s referencing `Shoot`s scheduled on Seeds for which the gardenlet is designated as responsible.
+The `ManagedSeed` controller in the `gardenlet` reconciles `ManagedSeed` that refers to `Shoot` scheduled on `Seed` the gardenlet is responsible for. Additionally, the controller monitors `Seed`s, which are owned by `ManagedSeed`s for which the gardenlet is responsible.
 
-The controller waits for the referenced Shoot to undergo a reconciliation process. Once the Shoot is successfully reconciled, the controller sets the `ShootReconciled` status of the ManagedSeed to `true`. It creates `garden` namespace within the target Shoot cluster. The controller also manages secrets related to Seeds, such as `backups` and `kubeconfig`. It ensures that these secrets are created and updated in accordance with the specifications provided. Finally, it deploys the `gardenlet` within the specified Shoot cluster which will register the `Seed` cluster.
+On `ManagedSeed` reconciliation, the controller first waits for the referenced Shoot to undergo a reconciliation process. Once the Shoot is successfully reconciled, the controller sets the `ShootReconciled` status of the ManagedSeed to `true`. Then, it creates `garden` namespace within the target Shoot cluster. The controller also manages secrets related to Seeds, such as the `backup` and `kubeconfig` secrets. It ensures that these secrets are created and updated according to the ManagedSeed spec. Finally, it deploys the `gardenlet` within the specified Shoot cluster which registers the `Seed` cluster.
 
-On delete operation of `ManagedSeed`, it removes the corresponding `Seed` that was originally created by the controller. Subsequently it removes the `gardenlet` instance within the Shoot cluster. The controller also ensures the deletion of related Seed `secrets`, including backups and kubeconfig. Finally, the dedicated `garden` namespace within the Shoot cluster is deleted.
+On `ManagedSeed` deletion, the controller first deletes the corresponding `Seed` that was originally created by the controller. Subsequently, it deletes the `gardenlet` instance within the Shoot cluster. The controller also ensures the deletion of related Seed secrets. Finally, the dedicated `garden` namespace within the Shoot cluster is deleted.
 
 ### [`NetworkPolicy` Controller](../../pkg/gardenlet/controller/networkpolicy)
 

--- a/docs/concepts/gardenlet.md
+++ b/docs/concepts/gardenlet.md
@@ -308,6 +308,14 @@ If there are no extension resources anymore, its status will be `False`.
 
 This condition is taken into account by the `ControllerRegistration` controller part of `gardener-controller-manager` when it computes which extensions have to be deployed to which seed cluster. See [Gardener Controller Manager](controller-manager.md#controllerregistration-controller) for more details.
 
+### [`ManagedSeed` Controller](../../pkg/gardenlet/controller/managedseed)
+
+The `ManagedSeed` controller in the `gardenlet` reconciles `ManagedSeed` that refers to `Shoot` scheduled on `Seed` the gardenlet is responsible for. Additionally, the controller monitors `Seed`s, which are owned by `ManagedSeed`s referencing `Shoot`s scheduled on Seeds for which the gardenlet is designated as responsible.
+
+The controller waits for the referenced Shoot to undergo a reconciliation process. Once the Shoot is successfully reconciled, the controller sets the `ShootReconciled` status of the ManagedSeed to `true`. It creates `garden` namespace within the target Shoot cluster. The controller also manages secrets related to Seeds, such as `backups` and `kubeconfig`. It ensures that these secrets are created and updated in accordance with the specifications provided. Finally, it deploys the `gardenlet` within the specified Shoot cluster which will register the `Seed` cluster.
+
+On delete operation of `ManagedSeed`, it removes the corresponding `Seed` that was originally created by the controller. Subsequently it removes the `gardenlet` instance within the Shoot cluster. The controller also ensures the deletion of related Seed `secrets`, including backups and kubeconfig. Finally, the dedicated `garden` namespace within the Shoot cluster is deleted.
+
 ### [`NetworkPolicy` Controller](../../pkg/gardenlet/controller/networkpolicy)
 
 The `NetworkPolicy` controller reconciles `NetworkPolicy`s in all relevant namespaces in the seed cluster and provides so-called "general" policies for access to the runtime cluster's API server, DNS, public networks, etc.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area documentation
/kind enhancement

**What this PR does / why we need it**:
Adds documentation for gardenlet `ManagedSeed` controller.

**Which issue(s) this PR fixes**:
Left out of  #7108 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
