### PR TITLE
[operator] Cleanup virtual-garden `ManagedResources` before destroying `virtual-garden-kube-apiserver`

### DIFF
--- a/pkg/component/gardeneraccess/access.go
+++ b/pkg/component/gardeneraccess/access.go
@@ -123,11 +123,8 @@ func (g *gardener) Destroy(ctx context.Context) error {
 	return managedresources.DeleteForShoot(ctx, g.client, g.namespace, ManagedResourceName)
 }
 
-var (
-	// TimeoutWaitForManagedResource is the timeout used while waiting for the ManagedResources to become healthy
-	// or deleted.
-	TimeoutWaitForManagedResource = 1 * time.Minute
-)
+// TimeoutWaitForManagedResource is the timeout used while waiting for the ManagedResources to become healthy or deleted.
+var TimeoutWaitForManagedResource = 2 * time.Minute
 
 func (g *gardener) Wait(ctx context.Context) error {
 	timeoutCtx, cancel := context.WithTimeout(ctx, TimeoutWaitForManagedResource)

--- a/pkg/operator/controller/garden/garden/components.go
+++ b/pkg/operator/controller/garden/garden/components.go
@@ -86,7 +86,7 @@ type components struct {
 	kubeAPIServer                        kubeapiserver.Interface
 	kubeControllerManager                kubecontrollermanager.Interface
 	virtualGardenGardenerResourceManager resourcemanager.Interface
-	virtualGardenGardenerAccess          component.Deployer
+	virtualGardenGardenerAccess          component.DeployWaiter
 
 	kubeStateMetrics              component.DeployWaiter
 	fluentOperator                component.DeployWaiter
@@ -686,7 +686,7 @@ func (r *Reconciler) newSNI(garden *operatorv1alpha1.Garden, ingressGatewayValue
 	), nil
 }
 
-func (r *Reconciler) newGardenerAccess(secretsManager secretsmanager.Interface, domain string) component.Deployer {
+func (r *Reconciler) newGardenerAccess(secretsManager secretsmanager.Interface, domain string) component.DeployWaiter {
 	return gardeneraccess.New(
 		r.RuntimeClientSet.Client(),
 		r.GardenNamespace,

--- a/pkg/operator/controller/garden/garden/reconciler_reconcile.go
+++ b/pkg/operator/controller/garden/garden/reconciler_reconcile.go
@@ -260,7 +260,7 @@ func (r *Reconciler) reconcile(
 		})
 		deployVirtualGardenGardenerAccess = g.Add(flow.Task{
 			Name:         "Deploying resources for gardener-operator access to virtual garden",
-			Fn:           c.virtualGardenGardenerAccess.Deploy,
+			Fn:           component.OpWait(c.virtualGardenGardenerAccess).Deploy,
 			Dependencies: flow.NewTaskIDs(waitUntilVirtualGardenGardenerResourceManagerIsReady),
 		})
 		renewVirtualClusterAccess = g.Add(flow.Task{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind flake

**What this PR does / why we need it**:
When deleting a `garden` there is a race between the deletion of managed-resources deployed in the virtual-garden and the deletion of `virtual-garden-kube-apiserver`. When the later is deleted first, this results in the MRs not being cleaned up.
You can see it in the examples attached to issue #8367.

This PR introduces more sync points the deletion flow of `operator`.
1. Destroy managed resources deployed to the virtual-garden
2. Destroy `virtual-garden-resource-manager`
3. Destroy `virtual-garden-kube-apiserver`

**Which issue(s) this PR fixes**:
Fixes #8367

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
4. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
`operator` now deletes `ManagedResources` deployed to the virtual-garden before deleting `virtual-garden-kube-apiserver`.
```
