### PR TITLE
Fix network policy in local setup in conjunction with HA VPN.

### DIFF
--- a/pkg/provider-local/controller/infrastructure/actuator.go
+++ b/pkg/provider-local/controller/infrastructure/actuator.go
@@ -60,8 +60,7 @@ func (a *actuator) Reconcile(ctx context.Context, _ logr.Logger, infrastructure 
 	networkPolicyAllowMachinePods.Spec = networkingv1.NetworkPolicySpec{
 		Ingress: []networkingv1.NetworkPolicyIngressRule{{
 			From: []networkingv1.NetworkPolicyPeer{
-				{PodSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "machine"}}},
-				{PodSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "vpn-seed-server"}}},
+				{PodSelector: &metav1.LabelSelector{MatchLabels: map[string]string{v1beta1constants.LabelNetworkPolicyToShootNetworks: v1beta1constants.LabelNetworkPolicyAllowed}}},
 			},
 		}},
 		Egress: []networkingv1.NetworkPolicyEgressRule{{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/area dev-productivity
/kind bug

**What this PR does / why we need it**:
Fix network policy in local setup in conjunction with HA VPN.

Previously, the network policy specifying the allowed traffic to the machine pods in the local setup only listed other machine pods and `vpn-seed-server` as allowed ingress sources. However, in the HA VPN case `kube-apiserver` connects to machines as well. The connection to kubelet was allowed, but everything else was blocked by policy. This meant that `kubectl proxy` would not allow proxying traffic to pods in the host network due to network policy. This change adapts the network policy to work in both VPN cases and use the more general `to-shoot-networks` labels, which were already used correctly.

**Which issue(s) this PR fixes**:
None.

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
`kubectl proxy` now works as expected in the local development setup in conjunction with highly available vpn
```

/cc @istvanballok @MartinWeindel 