### PR TITLE
Adjust the Prometheus service discovery for the etcd pods

### DIFF
--- a/pkg/component/etcd/monitoring.go
+++ b/pkg/component/etcd/monitoring.go
@@ -302,12 +302,12 @@ kubernetes_sd_configs:
     names: [{{ .namespace }}]
 relabel_configs:
 - source_labels:
-  - __meta_kubernetes_service_label_` + v1beta1constants.LabelApp + `
-  - __meta_kubernetes_service_label_` + v1beta1constants.LabelRole + `
+  - __meta_kubernetes_pod_label_` + v1beta1constants.LabelApp + `
+  - __meta_kubernetes_pod_label_` + v1beta1constants.LabelRole + `
   - __meta_kubernetes_endpoint_port_name
   action: keep
   regex: ` + LabelAppValue + `;{{ .role }};` + portNameClient + `
-- source_labels: [ __meta_kubernetes_service_label_` + v1beta1constants.LabelRole + ` ]
+- source_labels: [ __meta_kubernetes_pod_label_` + v1beta1constants.LabelRole + ` ]
   target_label: role
 - source_labels: [ __meta_kubernetes_pod_name ]
   target_label: pod
@@ -332,12 +332,12 @@ kubernetes_sd_configs:
     names: [{{ .namespace }}]
 relabel_configs:
 - source_labels:
-  - __meta_kubernetes_service_label_` + v1beta1constants.LabelApp + `
-  - __meta_kubernetes_service_label_` + v1beta1constants.LabelRole + `
+  - __meta_kubernetes_pod_label_` + v1beta1constants.LabelApp + `
+  - __meta_kubernetes_pod_label_` + v1beta1constants.LabelRole + `
   - __meta_kubernetes_endpoint_port_name
   action: keep
   regex: ` + LabelAppValue + `;{{ .role }};` + portNameBackupRestore + `
-- source_labels: [ __meta_kubernetes_service_label_role ]
+- source_labels: [ __meta_kubernetes_pod_label_role ]
   target_label: role
 - source_labels: [ __meta_kubernetes_pod_name ]
   target_label: pod

--- a/pkg/component/etcd/monitoring_test.go
+++ b/pkg/component/etcd/monitoring_test.go
@@ -175,12 +175,12 @@ kubernetes_sd_configs:
     names: [` + testNamespace + `]
 relabel_configs:
 - source_labels:
-  - __meta_kubernetes_service_label_app
-  - __meta_kubernetes_service_label_role
+  - __meta_kubernetes_pod_label_app
+  - __meta_kubernetes_pod_label_role
   - __meta_kubernetes_endpoint_port_name
   action: keep
   regex: etcd-statefulset;` + testRole + `;client
-- source_labels: [ __meta_kubernetes_service_label_role ]
+- source_labels: [ __meta_kubernetes_pod_label_role ]
   target_label: role
 - source_labels: [ __meta_kubernetes_pod_name ]
   target_label: pod
@@ -204,12 +204,12 @@ kubernetes_sd_configs:
     names: [` + testNamespace + `]
 relabel_configs:
 - source_labels:
-  - __meta_kubernetes_service_label_app
-  - __meta_kubernetes_service_label_role
+  - __meta_kubernetes_pod_label_app
+  - __meta_kubernetes_pod_label_role
   - __meta_kubernetes_endpoint_port_name
   action: keep
   regex: etcd-statefulset;` + testRole + `;backuprestore
-- source_labels: [ __meta_kubernetes_service_label_role ]
+- source_labels: [ __meta_kubernetes_pod_label_role ]
   target_label: role
 - source_labels: [ __meta_kubernetes_pod_name ]
   target_label: pod


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind bug

**What this PR does / why we need it**:

The labels on the etcd service changed with
https://github.com/gardener/etcd-druid/pull/559 that was introduced in https://github.com/gardener/gardener/pull/8299.

The `app` and `role` labels are no longer present on the service, but they are still available on the pods.

So by using the pod's labels for the service discovery, we can restore the previous behavior.

https://prometheus.io/docs/prometheus/latest/configuration/configuration/#endpoints

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

/cc @rickardsjp @aaronfern @seshachalam-yv 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
A bug is fixed that prevented scraping the metrics of etcd in the shoot control plane.
```
