### PR TITLE
[operator] Dashboard improvements

### DIFF
--- a/pkg/component/plutono/dashboards/garden-shoot/apiserver-admission-details.json
+++ b/pkg/component/plutono/dashboards/garden-shoot/apiserver-admission-details.json
@@ -211,7 +211,7 @@
       "type": "row"
     }
   ],
-  "schemaVersion": 26,
+  "schemaVersion": 27,
   "style": "dark",
   "tags": [
     "apiserver-details",
@@ -224,7 +224,6 @@
         "allValue": ".*",
         "current": {
           "selected": true,
-          "tags": [],
           "text": [
             "All"
           ],
@@ -234,6 +233,7 @@
         },
         "datasource": "prometheus",
         "definition": "label_values(apiserver_request_total,job)",
+        "description": null,
         "error": null,
         "hide": 0,
         "includeAll": true,
@@ -241,7 +241,10 @@
         "multi": true,
         "name": "apiserver",
         "options": [],
-        "query": "label_values(apiserver_request_total,job)",
+        "query": {
+          "query": "label_values(apiserver_request_total,job)",
+          "refId": "prometheus-apiserver-Variable-Query"
+        },
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
@@ -264,6 +267,7 @@
             "$__all"
           ]
         },
+        "description": null,
         "error": null,
         "hide": 0,
         "includeAll": true,
@@ -301,7 +305,6 @@
         "allValue": ".*",
         "current": {
           "selected": true,
-          "tags": [],
           "text": [
             "All"
           ],
@@ -311,6 +314,7 @@
         },
         "datasource": "prometheus",
         "definition": "label_values(apiserver_admission_controller_admission_duration_seconds_bucket,name)",
+        "description": null,
         "error": null,
         "hide": 0,
         "includeAll": true,
@@ -318,7 +322,10 @@
         "multi": true,
         "name": "plugin_name",
         "options": [],
-        "query": "label_values(apiserver_admission_controller_admission_duration_seconds_bucket,name)",
+        "query": {
+          "query": "label_values(apiserver_admission_controller_admission_duration_seconds_bucket,name)",
+          "refId": "prometheus-plugin_name-Variable-Query"
+        },
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
@@ -338,6 +345,7 @@
         },
         "datasource": "prometheus",
         "definition": "label_values(apiserver_admission_webhook_admission_duration_seconds_bucket,name)",
+        "description": null,
         "error": null,
         "hide": 0,
         "includeAll": true,
@@ -345,7 +353,10 @@
         "multi": true,
         "name": "webhook_name",
         "options": [],
-        "query": "label_values(apiserver_admission_webhook_admission_duration_seconds_bucket,name)",
+        "query": {
+          "query": "label_values(apiserver_admission_webhook_admission_duration_seconds_bucket,name)",
+          "refId": "prometheus-webhook_name-Variable-Query"
+        },
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
@@ -365,5 +376,6 @@
   "timepicker": {},
   "timezone": "",
   "title": "API Server (Admission Details)",
-  "uid": "apiserver-admission-details"
+  "uid": "apiserver-admission-details",
+  "version": 1
 }

--- a/pkg/component/plutono/dashboards/garden-shoot/apiserver-overview.json
+++ b/pkg/component/plutono/dashboards/garden-shoot/apiserver-overview.json
@@ -89,7 +89,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.22",
+      "pluginVersion": "7.5.23",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -196,7 +196,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.22",
+      "pluginVersion": "7.5.23",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -296,7 +296,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.22",
+      "pluginVersion": "7.5.23",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -395,7 +395,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.22",
+      "pluginVersion": "7.5.23",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -504,7 +504,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.22",
+      "pluginVersion": "7.5.23",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -599,7 +599,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.22",
+      "pluginVersion": "7.5.23",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -708,7 +708,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.22",
+      "pluginVersion": "7.5.23",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -807,7 +807,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.22",
+      "pluginVersion": "7.5.23",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -932,7 +932,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.22",
+      "pluginVersion": "7.5.23",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -1044,7 +1044,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.22",
+      "pluginVersion": "7.5.23",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -1158,7 +1158,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.22",
+      "pluginVersion": "7.5.23",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -1264,7 +1264,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.22",
+      "pluginVersion": "7.5.23",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1375,7 +1375,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.22",
+      "pluginVersion": "7.5.23",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -1488,7 +1488,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.22",
+      "pluginVersion": "7.5.23",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -1601,7 +1601,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.22",
+      "pluginVersion": "7.5.23",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -1701,7 +1701,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.22",
+      "pluginVersion": "7.5.23",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1796,7 +1796,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.22",
+      "pluginVersion": "7.5.23",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1904,7 +1904,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.22",
+      "pluginVersion": "7.5.23",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -2003,7 +2003,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.22",
+      "pluginVersion": "7.5.23",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -2106,7 +2106,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.22",
+      "pluginVersion": "7.5.23",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -2216,7 +2216,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.22",
+      "pluginVersion": "7.5.23",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -2315,7 +2315,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.22",
+      "pluginVersion": "7.5.23",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -2414,7 +2414,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.22",
+      "pluginVersion": "7.5.23",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -2513,7 +2513,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.22",
+      "pluginVersion": "7.5.23",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -2621,7 +2621,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.22",
+      "pluginVersion": "7.5.23",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -2738,7 +2738,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.22",
+      "pluginVersion": "7.5.23",
       "pointradius": 0.5,
       "points": false,
       "renderer": "flot",
@@ -2841,7 +2841,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.22",
+      "pluginVersion": "7.5.23",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -2948,7 +2948,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.22",
+      "pluginVersion": "7.5.23",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -3048,7 +3048,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.22",
+      "pluginVersion": "7.5.23",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -3149,7 +3149,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.22",
+      "pluginVersion": "7.5.23",
       "pointradius": 0.5,
       "points": false,
       "renderer": "flot",
@@ -3251,7 +3251,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.22",
+      "pluginVersion": "7.5.23",
       "pointradius": 0.5,
       "points": false,
       "renderer": "flot",
@@ -3324,7 +3324,6 @@
         "allValue": ".*",
         "current": {
           "selected": true,
-          "tags": [],
           "text": [
             "All"
           ],
@@ -3360,7 +3359,6 @@
         "allValue": ".*",
         "current": {
           "selected": true,
-          "tags": [],
           "text": [
             "All"
           ],
@@ -3584,5 +3582,6 @@
   },
   "timezone": "utc",
   "title": "API Server",
-  "uid": "apiserver-overview"
+  "uid": "apiserver-overview",
+  "version": 1
 }

--- a/pkg/component/plutono/dashboards/garden-shoot/apiserver-overview.json
+++ b/pkg/component/plutono/dashboards/garden-shoot/apiserver-overview.json
@@ -3332,7 +3332,7 @@
           ]
         },
         "datasource": "prometheus",
-        "definition": "label_values(apiserver_request_total,job)",
+        "definition": "label_values(apiserver_storage_objects,job)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -3342,7 +3342,7 @@
         "name": "job",
         "options": [],
         "query": {
-          "query": "label_values(apiserver_request_total,job)",
+          "query": "label_values(apiserver_storage_objects,job)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 1,
@@ -3367,7 +3367,7 @@
           ]
         },
         "datasource": "prometheus",
-        "definition": "label_values(apiserver_request_total{job=~\"$job\"},pod)",
+        "definition": "label_values(apiserver_storage_objects{job=~\"$job\"},pod)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -3377,7 +3377,7 @@
         "name": "pod",
         "options": [],
         "query": {
-          "query": "label_values(apiserver_request_total{job=~\"$job\"},pod)",
+          "query": "label_values(apiserver_storage_objects{job=~\"$job\"},pod)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 1,
@@ -3393,7 +3393,7 @@
       {
         "allValue": ".*",
         "current": {
-          "selected": false,
+          "selected": true,
           "text": [
             "All"
           ],
@@ -3524,11 +3524,9 @@
         "allValue": null,
         "current": {
           "selected": false,
-          "text": "0.99",
-          "value": "0.99"
+          "text": "0.5",
+          "value": "0.5"
         },
-        "datasource": null,
-        "definition": "label_values(apiserver_latency_seconds:quantile, quantile)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -3536,20 +3534,26 @@
         "label": null,
         "multi": false,
         "name": "quantile",
-        "options": [],
-        "query": {
-          "query": "label_values(apiserver_latency_seconds:quantile, quantile)",
-          "refId": "StandardVariableQuery"
-        },
-        "refresh": 1,
-        "regex": "",
+        "options": [
+          {
+            "selected": true,
+            "text": "0.5",
+            "value": "0.5"
+          },
+          {
+            "selected": false,
+            "text": "0.9",
+            "value": "0.9"
+          },
+          {
+            "selected": false,
+            "text": "0.99",
+            "value": "0.99"
+          }
+        ],
+        "query": "0.5,0.9,0.99",
         "skipUrlSync": false,
-        "sort": 0,
-        "tagValuesQuery": "",
-        "tags": [],
-        "tagsQuery": "",
-        "type": "query",
-        "useTags": false
+        "type": "custom"
       }
     ]
   },

--- a/pkg/component/plutono/dashboards/garden-shoot/apiserver-request-details.json
+++ b/pkg/component/plutono/dashboards/garden-shoot/apiserver-request-details.json
@@ -207,7 +207,7 @@
       "type": "row"
     }
   ],
-  "schemaVersion": 26,
+  "schemaVersion": 27,
   "style": "dark",
   "tags": [
     "apiserver-details",
@@ -220,7 +220,6 @@
         "allValue": ".*",
         "current": {
           "selected": true,
-          "tags": [],
           "text": [
             "All"
           ],
@@ -230,6 +229,7 @@
         },
         "datasource": "prometheus",
         "definition": "label_values(apiserver_request_total,job)",
+        "description": null,
         "error": null,
         "hide": 0,
         "includeAll": true,
@@ -237,7 +237,10 @@
         "multi": true,
         "name": "apiserver",
         "options": [],
-        "query": "label_values(apiserver_request_total,job)",
+        "query": {
+          "query": "label_values(apiserver_request_total,job)",
+          "refId": "prometheus-apiserver-Variable-Query"
+        },
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
@@ -260,6 +263,7 @@
             "$__all"
           ]
         },
+        "description": null,
         "error": null,
         "hide": 0,
         "includeAll": true,
@@ -337,7 +341,6 @@
         "allValue": ".*",
         "current": {
           "selected": true,
-          "tags": [],
           "text": [
             "All"
           ],
@@ -347,6 +350,7 @@
         },
         "datasource": "prometheus",
         "definition": "label_values(apiserver_response_sizes_bucket,resource)",
+        "description": null,
         "error": null,
         "hide": 0,
         "includeAll": true,
@@ -354,7 +358,10 @@
         "multi": true,
         "name": "resource",
         "options": [],
-        "query": "label_values(apiserver_response_sizes_bucket,resource)",
+        "query": {
+          "query": "label_values(apiserver_response_sizes_bucket,resource)",
+          "refId": "prometheus-resource-Variable-Query"
+        },
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
@@ -369,7 +376,6 @@
         "allValue": ".*",
         "current": {
           "selected": true,
-          "tags": [],
           "text": [
             "All"
           ],
@@ -379,6 +385,7 @@
         },
         "datasource": "prometheus",
         "definition": "label_values(apiserver_response_sizes_bucket,subresource)",
+        "description": null,
         "error": null,
         "hide": 0,
         "includeAll": true,
@@ -386,7 +393,10 @@
         "multi": true,
         "name": "subresource",
         "options": [],
-        "query": "label_values(apiserver_response_sizes_bucket,subresource)",
+        "query": {
+          "query": "label_values(apiserver_response_sizes_bucket,subresource)",
+          "refId": "prometheus-subresource-Variable-Query"
+        },
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
@@ -406,5 +416,6 @@
   "timepicker": {},
   "timezone": "",
   "title": "API Server (Request Details)",
-  "uid": "apiserver-request-details"
+  "uid": "apiserver-request-details",
+  "version": 1
 }

--- a/pkg/component/plutono/dashboards/garden-shoot/apiserver-request-duration-and-response-size.json
+++ b/pkg/component/plutono/dashboards/garden-shoot/apiserver-request-duration-and-response-size.json
@@ -33,12 +33,8 @@
       "scopedVars": {
         "resource": {
           "selected": true,
-          "text": [
-            "All"
-          ],
-          "value": [
-            "$__all"
-          ]
+          "text": "apiservices",
+          "value": "apiservices"
         }
       },
       "title": "Request Duration ($resource)",
@@ -65,7 +61,7 @@
       },
       "gridPos": {
         "h": 9,
-        "w": 24,
+        "w": 6,
         "x": 0,
         "y": 1
       },
@@ -82,22 +78,779 @@
       "reverseYBuckets": false,
       "scopedVars": {
         "ApiServer": {
-          "selected": true,
-          "text": [
-            "All"
-          ],
-          "value": [
-            "$__all"
-          ]
+          "selected": false,
+          "text": "gardener-apiserver-7994c5c76c-45kzw",
+          "value": "gardener-apiserver-7994c5c76c-45kzw"
         },
         "resource": {
           "selected": true,
-          "text": [
-            "All"
-          ],
-          "value": [
-            "$__all"
-          ]
+          "text": "apiservices",
+          "value": "apiservices"
+        }
+      },
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum(rate(apiserver_request_duration_seconds_bucket{resource=~\"$resource\",subresource=\"\",verb=\"LIST\",pod=~\"$ApiServer\"}[$__rate_interval])) by (le)",
+          "format": "heatmap",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "{{le}}",
+          "refId": "A"
+        }
+      ],
+      "title": "$ApiServer $resource",
+      "tooltip": {
+        "show": true,
+        "showHistogram": true
+      },
+      "tooltipDecimals": 2,
+      "type": "heatmap",
+      "xAxis": {
+        "show": true
+      },
+      "xBucketNumber": null,
+      "xBucketSize": null,
+      "yAxis": {
+        "decimals": null,
+        "format": "s",
+        "logBase": 1,
+        "max": null,
+        "min": null,
+        "show": true,
+        "splitFactor": null
+      },
+      "yBucketBound": "auto",
+      "yBucketNumber": null,
+      "yBucketSize": null
+    },
+    {
+      "cards": {
+        "cardPadding": 1,
+        "cardRound": null
+      },
+      "color": {
+        "cardColor": "#b4ff00",
+        "colorScale": "sqrt",
+        "colorScheme": "interpolateOranges",
+        "exponent": 0.5,
+        "mode": "opacity"
+      },
+      "dataFormat": "tsbuckets",
+      "datasource": null,
+      "description": "",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 6,
+        "x": 6,
+        "y": 1
+      },
+      "heatmap": {},
+      "hideZeroBuckets": true,
+      "highlightCards": true,
+      "id": 23,
+      "legend": {
+        "show": true
+      },
+      "pluginVersion": "7.5.11",
+      "repeatDirection": "h",
+      "repeatIteration": 1692362960588,
+      "repeatPanelId": 6,
+      "reverseYBuckets": false,
+      "scopedVars": {
+        "ApiServer": {
+          "selected": false,
+          "text": "gardener-apiserver-7994c5c76c-br97q",
+          "value": "gardener-apiserver-7994c5c76c-br97q"
+        },
+        "resource": {
+          "selected": true,
+          "text": "apiservices",
+          "value": "apiservices"
+        }
+      },
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum(rate(apiserver_request_duration_seconds_bucket{resource=~\"$resource\",subresource=\"\",verb=\"LIST\",pod=~\"$ApiServer\"}[$__rate_interval])) by (le)",
+          "format": "heatmap",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "{{le}}",
+          "refId": "A"
+        }
+      ],
+      "title": "$ApiServer $resource",
+      "tooltip": {
+        "show": true,
+        "showHistogram": true
+      },
+      "tooltipDecimals": 2,
+      "type": "heatmap",
+      "xAxis": {
+        "show": true
+      },
+      "xBucketNumber": null,
+      "xBucketSize": null,
+      "yAxis": {
+        "decimals": null,
+        "format": "s",
+        "logBase": 1,
+        "max": null,
+        "min": null,
+        "show": true,
+        "splitFactor": null
+      },
+      "yBucketBound": "auto",
+      "yBucketNumber": null,
+      "yBucketSize": null
+    },
+    {
+      "cards": {
+        "cardPadding": 1,
+        "cardRound": null
+      },
+      "color": {
+        "cardColor": "#b4ff00",
+        "colorScale": "sqrt",
+        "colorScheme": "interpolateOranges",
+        "exponent": 0.5,
+        "mode": "opacity"
+      },
+      "dataFormat": "tsbuckets",
+      "datasource": null,
+      "description": "",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 6,
+        "x": 12,
+        "y": 1
+      },
+      "heatmap": {},
+      "hideZeroBuckets": true,
+      "highlightCards": true,
+      "id": 24,
+      "legend": {
+        "show": true
+      },
+      "pluginVersion": "7.5.11",
+      "repeatDirection": "h",
+      "repeatIteration": 1692362960588,
+      "repeatPanelId": 6,
+      "reverseYBuckets": false,
+      "scopedVars": {
+        "ApiServer": {
+          "selected": false,
+          "text": "gardener-apiserver-7994c5c76c-cnb2f",
+          "value": "gardener-apiserver-7994c5c76c-cnb2f"
+        },
+        "resource": {
+          "selected": true,
+          "text": "apiservices",
+          "value": "apiservices"
+        }
+      },
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum(rate(apiserver_request_duration_seconds_bucket{resource=~\"$resource\",subresource=\"\",verb=\"LIST\",pod=~\"$ApiServer\"}[$__rate_interval])) by (le)",
+          "format": "heatmap",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "{{le}}",
+          "refId": "A"
+        }
+      ],
+      "title": "$ApiServer $resource",
+      "tooltip": {
+        "show": true,
+        "showHistogram": true
+      },
+      "tooltipDecimals": 2,
+      "type": "heatmap",
+      "xAxis": {
+        "show": true
+      },
+      "xBucketNumber": null,
+      "xBucketSize": null,
+      "yAxis": {
+        "decimals": null,
+        "format": "s",
+        "logBase": 1,
+        "max": null,
+        "min": null,
+        "show": true,
+        "splitFactor": null
+      },
+      "yBucketBound": "auto",
+      "yBucketNumber": null,
+      "yBucketSize": null
+    },
+    {
+      "cards": {
+        "cardPadding": 1,
+        "cardRound": null
+      },
+      "color": {
+        "cardColor": "#b4ff00",
+        "colorScale": "sqrt",
+        "colorScheme": "interpolateOranges",
+        "exponent": 0.5,
+        "mode": "opacity"
+      },
+      "dataFormat": "tsbuckets",
+      "datasource": null,
+      "description": "",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 6,
+        "x": 18,
+        "y": 1
+      },
+      "heatmap": {},
+      "hideZeroBuckets": true,
+      "highlightCards": true,
+      "id": 25,
+      "legend": {
+        "show": true
+      },
+      "pluginVersion": "7.5.11",
+      "repeatDirection": "h",
+      "repeatIteration": 1692362960588,
+      "repeatPanelId": 6,
+      "reverseYBuckets": false,
+      "scopedVars": {
+        "ApiServer": {
+          "selected": false,
+          "text": "gardener-apiserver-7994c5c76c-zjfjj",
+          "value": "gardener-apiserver-7994c5c76c-zjfjj"
+        },
+        "resource": {
+          "selected": true,
+          "text": "apiservices",
+          "value": "apiservices"
+        }
+      },
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum(rate(apiserver_request_duration_seconds_bucket{resource=~\"$resource\",subresource=\"\",verb=\"LIST\",pod=~\"$ApiServer\"}[$__rate_interval])) by (le)",
+          "format": "heatmap",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "{{le}}",
+          "refId": "A"
+        }
+      ],
+      "title": "$ApiServer $resource",
+      "tooltip": {
+        "show": true,
+        "showHistogram": true
+      },
+      "tooltipDecimals": 2,
+      "type": "heatmap",
+      "xAxis": {
+        "show": true
+      },
+      "xBucketNumber": null,
+      "xBucketSize": null,
+      "yAxis": {
+        "decimals": null,
+        "format": "s",
+        "logBase": 1,
+        "max": null,
+        "min": null,
+        "show": true,
+        "splitFactor": null
+      },
+      "yBucketBound": "auto",
+      "yBucketNumber": null,
+      "yBucketSize": null
+    },
+    {
+      "cards": {
+        "cardPadding": 1,
+        "cardRound": null
+      },
+      "color": {
+        "cardColor": "#b4ff00",
+        "colorScale": "sqrt",
+        "colorScheme": "interpolateOranges",
+        "exponent": 0.5,
+        "mode": "opacity"
+      },
+      "dataFormat": "tsbuckets",
+      "datasource": null,
+      "description": "",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 6,
+        "x": 0,
+        "y": 10
+      },
+      "heatmap": {},
+      "hideZeroBuckets": true,
+      "highlightCards": true,
+      "id": 26,
+      "legend": {
+        "show": true
+      },
+      "pluginVersion": "7.5.11",
+      "repeatDirection": "h",
+      "repeatIteration": 1692362960588,
+      "repeatPanelId": 6,
+      "reverseYBuckets": false,
+      "scopedVars": {
+        "ApiServer": {
+          "selected": false,
+          "text": "virtual-garden-kube-apiserver-7b7dfc7f54-2lmgg",
+          "value": "virtual-garden-kube-apiserver-7b7dfc7f54-2lmgg"
+        },
+        "resource": {
+          "selected": true,
+          "text": "apiservices",
+          "value": "apiservices"
+        }
+      },
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum(rate(apiserver_request_duration_seconds_bucket{resource=~\"$resource\",subresource=\"\",verb=\"LIST\",pod=~\"$ApiServer\"}[$__rate_interval])) by (le)",
+          "format": "heatmap",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "{{le}}",
+          "refId": "A"
+        }
+      ],
+      "title": "$ApiServer $resource",
+      "tooltip": {
+        "show": true,
+        "showHistogram": true
+      },
+      "tooltipDecimals": 2,
+      "type": "heatmap",
+      "xAxis": {
+        "show": true
+      },
+      "xBucketNumber": null,
+      "xBucketSize": null,
+      "yAxis": {
+        "decimals": null,
+        "format": "s",
+        "logBase": 1,
+        "max": null,
+        "min": null,
+        "show": true,
+        "splitFactor": null
+      },
+      "yBucketBound": "auto",
+      "yBucketNumber": null,
+      "yBucketSize": null
+    },
+    {
+      "cards": {
+        "cardPadding": 1,
+        "cardRound": null
+      },
+      "color": {
+        "cardColor": "#b4ff00",
+        "colorScale": "sqrt",
+        "colorScheme": "interpolateOranges",
+        "exponent": 0.5,
+        "mode": "opacity"
+      },
+      "dataFormat": "tsbuckets",
+      "datasource": null,
+      "description": "",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 6,
+        "x": 6,
+        "y": 10
+      },
+      "heatmap": {},
+      "hideZeroBuckets": true,
+      "highlightCards": true,
+      "id": 27,
+      "legend": {
+        "show": true
+      },
+      "pluginVersion": "7.5.11",
+      "repeatDirection": "h",
+      "repeatIteration": 1692362960588,
+      "repeatPanelId": 6,
+      "reverseYBuckets": false,
+      "scopedVars": {
+        "ApiServer": {
+          "selected": false,
+          "text": "virtual-garden-kube-apiserver-7b7dfc7f54-9nrr2",
+          "value": "virtual-garden-kube-apiserver-7b7dfc7f54-9nrr2"
+        },
+        "resource": {
+          "selected": true,
+          "text": "apiservices",
+          "value": "apiservices"
+        }
+      },
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum(rate(apiserver_request_duration_seconds_bucket{resource=~\"$resource\",subresource=\"\",verb=\"LIST\",pod=~\"$ApiServer\"}[$__rate_interval])) by (le)",
+          "format": "heatmap",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "{{le}}",
+          "refId": "A"
+        }
+      ],
+      "title": "$ApiServer $resource",
+      "tooltip": {
+        "show": true,
+        "showHistogram": true
+      },
+      "tooltipDecimals": 2,
+      "type": "heatmap",
+      "xAxis": {
+        "show": true
+      },
+      "xBucketNumber": null,
+      "xBucketSize": null,
+      "yAxis": {
+        "decimals": null,
+        "format": "s",
+        "logBase": 1,
+        "max": null,
+        "min": null,
+        "show": true,
+        "splitFactor": null
+      },
+      "yBucketBound": "auto",
+      "yBucketNumber": null,
+      "yBucketSize": null
+    },
+    {
+      "cards": {
+        "cardPadding": 1,
+        "cardRound": null
+      },
+      "color": {
+        "cardColor": "#b4ff00",
+        "colorScale": "sqrt",
+        "colorScheme": "interpolateOranges",
+        "exponent": 0.5,
+        "mode": "opacity"
+      },
+      "dataFormat": "tsbuckets",
+      "datasource": null,
+      "description": "",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 6,
+        "x": 12,
+        "y": 10
+      },
+      "heatmap": {},
+      "hideZeroBuckets": true,
+      "highlightCards": true,
+      "id": 28,
+      "legend": {
+        "show": true
+      },
+      "pluginVersion": "7.5.11",
+      "repeatDirection": "h",
+      "repeatIteration": 1692362960588,
+      "repeatPanelId": 6,
+      "reverseYBuckets": false,
+      "scopedVars": {
+        "ApiServer": {
+          "selected": false,
+          "text": "virtual-garden-kube-apiserver-7b7dfc7f54-f585g",
+          "value": "virtual-garden-kube-apiserver-7b7dfc7f54-f585g"
+        },
+        "resource": {
+          "selected": true,
+          "text": "apiservices",
+          "value": "apiservices"
+        }
+      },
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum(rate(apiserver_request_duration_seconds_bucket{resource=~\"$resource\",subresource=\"\",verb=\"LIST\",pod=~\"$ApiServer\"}[$__rate_interval])) by (le)",
+          "format": "heatmap",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "{{le}}",
+          "refId": "A"
+        }
+      ],
+      "title": "$ApiServer $resource",
+      "tooltip": {
+        "show": true,
+        "showHistogram": true
+      },
+      "tooltipDecimals": 2,
+      "type": "heatmap",
+      "xAxis": {
+        "show": true
+      },
+      "xBucketNumber": null,
+      "xBucketSize": null,
+      "yAxis": {
+        "decimals": null,
+        "format": "s",
+        "logBase": 1,
+        "max": null,
+        "min": null,
+        "show": true,
+        "splitFactor": null
+      },
+      "yBucketBound": "auto",
+      "yBucketNumber": null,
+      "yBucketSize": null
+    },
+    {
+      "cards": {
+        "cardPadding": 1,
+        "cardRound": null
+      },
+      "color": {
+        "cardColor": "#b4ff00",
+        "colorScale": "sqrt",
+        "colorScheme": "interpolateOranges",
+        "exponent": 0.5,
+        "mode": "opacity"
+      },
+      "dataFormat": "tsbuckets",
+      "datasource": null,
+      "description": "",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 6,
+        "x": 18,
+        "y": 10
+      },
+      "heatmap": {},
+      "hideZeroBuckets": true,
+      "highlightCards": true,
+      "id": 29,
+      "legend": {
+        "show": true
+      },
+      "pluginVersion": "7.5.11",
+      "repeatDirection": "h",
+      "repeatIteration": 1692362960588,
+      "repeatPanelId": 6,
+      "reverseYBuckets": false,
+      "scopedVars": {
+        "ApiServer": {
+          "selected": false,
+          "text": "virtual-garden-kube-apiserver-7b7dfc7f54-hnx7b",
+          "value": "virtual-garden-kube-apiserver-7b7dfc7f54-hnx7b"
+        },
+        "resource": {
+          "selected": true,
+          "text": "apiservices",
+          "value": "apiservices"
+        }
+      },
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum(rate(apiserver_request_duration_seconds_bucket{resource=~\"$resource\",subresource=\"\",verb=\"LIST\",pod=~\"$ApiServer\"}[$__rate_interval])) by (le)",
+          "format": "heatmap",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "{{le}}",
+          "refId": "A"
+        }
+      ],
+      "title": "$ApiServer $resource",
+      "tooltip": {
+        "show": true,
+        "showHistogram": true
+      },
+      "tooltipDecimals": 2,
+      "type": "heatmap",
+      "xAxis": {
+        "show": true
+      },
+      "xBucketNumber": null,
+      "xBucketSize": null,
+      "yAxis": {
+        "decimals": null,
+        "format": "s",
+        "logBase": 1,
+        "max": null,
+        "min": null,
+        "show": true,
+        "splitFactor": null
+      },
+      "yBucketBound": "auto",
+      "yBucketNumber": null,
+      "yBucketSize": null
+    },
+    {
+      "cards": {
+        "cardPadding": 1,
+        "cardRound": null
+      },
+      "color": {
+        "cardColor": "#b4ff00",
+        "colorScale": "sqrt",
+        "colorScheme": "interpolateOranges",
+        "exponent": 0.5,
+        "mode": "opacity"
+      },
+      "dataFormat": "tsbuckets",
+      "datasource": null,
+      "description": "",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 6,
+        "x": 0,
+        "y": 19
+      },
+      "heatmap": {},
+      "hideZeroBuckets": true,
+      "highlightCards": true,
+      "id": 30,
+      "legend": {
+        "show": true
+      },
+      "pluginVersion": "7.5.11",
+      "repeatDirection": "h",
+      "repeatIteration": 1692362960588,
+      "repeatPanelId": 6,
+      "reverseYBuckets": false,
+      "scopedVars": {
+        "ApiServer": {
+          "selected": false,
+          "text": "virtual-garden-kube-apiserver-7b7dfc7f54-j7jf5",
+          "value": "virtual-garden-kube-apiserver-7b7dfc7f54-j7jf5"
+        },
+        "resource": {
+          "selected": true,
+          "text": "apiservices",
+          "value": "apiservices"
+        }
+      },
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum(rate(apiserver_request_duration_seconds_bucket{resource=~\"$resource\",subresource=\"\",verb=\"LIST\",pod=~\"$ApiServer\"}[$__rate_interval])) by (le)",
+          "format": "heatmap",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "{{le}}",
+          "refId": "A"
+        }
+      ],
+      "title": "$ApiServer $resource",
+      "tooltip": {
+        "show": true,
+        "showHistogram": true
+      },
+      "tooltipDecimals": 2,
+      "type": "heatmap",
+      "xAxis": {
+        "show": true
+      },
+      "xBucketNumber": null,
+      "xBucketSize": null,
+      "yAxis": {
+        "decimals": null,
+        "format": "s",
+        "logBase": 1,
+        "max": null,
+        "min": null,
+        "show": true,
+        "splitFactor": null
+      },
+      "yBucketBound": "auto",
+      "yBucketNumber": null,
+      "yBucketSize": null
+    },
+    {
+      "cards": {
+        "cardPadding": 1,
+        "cardRound": null
+      },
+      "color": {
+        "cardColor": "#b4ff00",
+        "colorScale": "sqrt",
+        "colorScheme": "interpolateOranges",
+        "exponent": 0.5,
+        "mode": "opacity"
+      },
+      "dataFormat": "tsbuckets",
+      "datasource": null,
+      "description": "",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 6,
+        "x": 6,
+        "y": 19
+      },
+      "heatmap": {},
+      "hideZeroBuckets": true,
+      "highlightCards": true,
+      "id": 31,
+      "legend": {
+        "show": true
+      },
+      "pluginVersion": "7.5.11",
+      "repeatDirection": "h",
+      "repeatIteration": 1692362960588,
+      "repeatPanelId": 6,
+      "reverseYBuckets": false,
+      "scopedVars": {
+        "ApiServer": {
+          "selected": false,
+          "text": "virtual-garden-kube-apiserver-7b7dfc7f54-zpftp",
+          "value": "virtual-garden-kube-apiserver-7b7dfc7f54-zpftp"
+        },
+        "resource": {
+          "selected": true,
+          "text": "apiservices",
+          "value": "apiservices"
         }
       },
       "targets": [
@@ -143,7 +896,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 29
+        "y": 28
       },
       "id": 22,
       "panels": [],
@@ -151,12 +904,8 @@
       "scopedVars": {
         "resource": {
           "selected": true,
-          "text": [
-            "All"
-          ],
-          "value": [
-            "$__all"
-          ]
+          "text": "apiservices",
+          "value": "apiservices"
         }
       },
       "title": "Response Size ($resource)",
@@ -183,9 +932,9 @@
       },
       "gridPos": {
         "h": 9,
-        "w": 24,
+        "w": 6,
         "x": 0,
-        "y": 30
+        "y": 29
       },
       "heatmap": {},
       "hideZeroBuckets": true,
@@ -199,22 +948,770 @@
       "reverseYBuckets": false,
       "scopedVars": {
         "ApiServer": {
-          "selected": true,
-          "text": [
-            "All"
-          ],
-          "value": [
-            "$__all"
-          ]
+          "selected": false,
+          "text": "gardener-apiserver-7994c5c76c-45kzw",
+          "value": "gardener-apiserver-7994c5c76c-45kzw"
         },
         "resource": {
           "selected": true,
-          "text": [
-            "All"
-          ],
-          "value": [
-            "$__all"
-          ]
+          "text": "apiservices",
+          "value": "apiservices"
+        }
+      },
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum(rate(apiserver_response_sizes_bucket{resource=~\"$resource\",subresource=\"\",verb=\"LIST\",pod=~\"$ApiServer\"}[$__rate_interval])) by (le)",
+          "format": "heatmap",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "{{le}}",
+          "refId": "A"
+        }
+      ],
+      "title": "$ApiServer $resource",
+      "tooltip": {
+        "show": true,
+        "showHistogram": true
+      },
+      "tooltipDecimals": 2,
+      "type": "heatmap",
+      "xAxis": {
+        "show": true
+      },
+      "xBucketNumber": null,
+      "xBucketSize": null,
+      "yAxis": {
+        "decimals": null,
+        "format": "bytes",
+        "logBase": 1,
+        "max": null,
+        "min": null,
+        "show": true,
+        "splitFactor": null
+      },
+      "yBucketBound": "auto",
+      "yBucketNumber": null,
+      "yBucketSize": null
+    },
+    {
+      "cards": {
+        "cardPadding": 1,
+        "cardRound": null
+      },
+      "color": {
+        "cardColor": "#b4ff00",
+        "colorScale": "sqrt",
+        "colorScheme": "interpolateOranges",
+        "exponent": 0.5,
+        "mode": "opacity"
+      },
+      "dataFormat": "tsbuckets",
+      "datasource": null,
+      "description": "",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 6,
+        "x": 6,
+        "y": 29
+      },
+      "heatmap": {},
+      "hideZeroBuckets": true,
+      "highlightCards": true,
+      "id": 32,
+      "legend": {
+        "show": true
+      },
+      "pluginVersion": "7.5.11",
+      "repeatIteration": 1692362960588,
+      "repeatPanelId": 20,
+      "reverseYBuckets": false,
+      "scopedVars": {
+        "ApiServer": {
+          "selected": false,
+          "text": "gardener-apiserver-7994c5c76c-br97q",
+          "value": "gardener-apiserver-7994c5c76c-br97q"
+        },
+        "resource": {
+          "selected": true,
+          "text": "apiservices",
+          "value": "apiservices"
+        }
+      },
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum(rate(apiserver_response_sizes_bucket{resource=~\"$resource\",subresource=\"\",verb=\"LIST\",pod=~\"$ApiServer\"}[$__rate_interval])) by (le)",
+          "format": "heatmap",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "{{le}}",
+          "refId": "A"
+        }
+      ],
+      "title": "$ApiServer $resource",
+      "tooltip": {
+        "show": true,
+        "showHistogram": true
+      },
+      "tooltipDecimals": 2,
+      "type": "heatmap",
+      "xAxis": {
+        "show": true
+      },
+      "xBucketNumber": null,
+      "xBucketSize": null,
+      "yAxis": {
+        "decimals": null,
+        "format": "bytes",
+        "logBase": 1,
+        "max": null,
+        "min": null,
+        "show": true,
+        "splitFactor": null
+      },
+      "yBucketBound": "auto",
+      "yBucketNumber": null,
+      "yBucketSize": null
+    },
+    {
+      "cards": {
+        "cardPadding": 1,
+        "cardRound": null
+      },
+      "color": {
+        "cardColor": "#b4ff00",
+        "colorScale": "sqrt",
+        "colorScheme": "interpolateOranges",
+        "exponent": 0.5,
+        "mode": "opacity"
+      },
+      "dataFormat": "tsbuckets",
+      "datasource": null,
+      "description": "",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 6,
+        "x": 12,
+        "y": 29
+      },
+      "heatmap": {},
+      "hideZeroBuckets": true,
+      "highlightCards": true,
+      "id": 33,
+      "legend": {
+        "show": true
+      },
+      "pluginVersion": "7.5.11",
+      "repeatIteration": 1692362960588,
+      "repeatPanelId": 20,
+      "reverseYBuckets": false,
+      "scopedVars": {
+        "ApiServer": {
+          "selected": false,
+          "text": "gardener-apiserver-7994c5c76c-cnb2f",
+          "value": "gardener-apiserver-7994c5c76c-cnb2f"
+        },
+        "resource": {
+          "selected": true,
+          "text": "apiservices",
+          "value": "apiservices"
+        }
+      },
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum(rate(apiserver_response_sizes_bucket{resource=~\"$resource\",subresource=\"\",verb=\"LIST\",pod=~\"$ApiServer\"}[$__rate_interval])) by (le)",
+          "format": "heatmap",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "{{le}}",
+          "refId": "A"
+        }
+      ],
+      "title": "$ApiServer $resource",
+      "tooltip": {
+        "show": true,
+        "showHistogram": true
+      },
+      "tooltipDecimals": 2,
+      "type": "heatmap",
+      "xAxis": {
+        "show": true
+      },
+      "xBucketNumber": null,
+      "xBucketSize": null,
+      "yAxis": {
+        "decimals": null,
+        "format": "bytes",
+        "logBase": 1,
+        "max": null,
+        "min": null,
+        "show": true,
+        "splitFactor": null
+      },
+      "yBucketBound": "auto",
+      "yBucketNumber": null,
+      "yBucketSize": null
+    },
+    {
+      "cards": {
+        "cardPadding": 1,
+        "cardRound": null
+      },
+      "color": {
+        "cardColor": "#b4ff00",
+        "colorScale": "sqrt",
+        "colorScheme": "interpolateOranges",
+        "exponent": 0.5,
+        "mode": "opacity"
+      },
+      "dataFormat": "tsbuckets",
+      "datasource": null,
+      "description": "",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 6,
+        "x": 18,
+        "y": 29
+      },
+      "heatmap": {},
+      "hideZeroBuckets": true,
+      "highlightCards": true,
+      "id": 34,
+      "legend": {
+        "show": true
+      },
+      "pluginVersion": "7.5.11",
+      "repeatIteration": 1692362960588,
+      "repeatPanelId": 20,
+      "reverseYBuckets": false,
+      "scopedVars": {
+        "ApiServer": {
+          "selected": false,
+          "text": "gardener-apiserver-7994c5c76c-zjfjj",
+          "value": "gardener-apiserver-7994c5c76c-zjfjj"
+        },
+        "resource": {
+          "selected": true,
+          "text": "apiservices",
+          "value": "apiservices"
+        }
+      },
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum(rate(apiserver_response_sizes_bucket{resource=~\"$resource\",subresource=\"\",verb=\"LIST\",pod=~\"$ApiServer\"}[$__rate_interval])) by (le)",
+          "format": "heatmap",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "{{le}}",
+          "refId": "A"
+        }
+      ],
+      "title": "$ApiServer $resource",
+      "tooltip": {
+        "show": true,
+        "showHistogram": true
+      },
+      "tooltipDecimals": 2,
+      "type": "heatmap",
+      "xAxis": {
+        "show": true
+      },
+      "xBucketNumber": null,
+      "xBucketSize": null,
+      "yAxis": {
+        "decimals": null,
+        "format": "bytes",
+        "logBase": 1,
+        "max": null,
+        "min": null,
+        "show": true,
+        "splitFactor": null
+      },
+      "yBucketBound": "auto",
+      "yBucketNumber": null,
+      "yBucketSize": null
+    },
+    {
+      "cards": {
+        "cardPadding": 1,
+        "cardRound": null
+      },
+      "color": {
+        "cardColor": "#b4ff00",
+        "colorScale": "sqrt",
+        "colorScheme": "interpolateOranges",
+        "exponent": 0.5,
+        "mode": "opacity"
+      },
+      "dataFormat": "tsbuckets",
+      "datasource": null,
+      "description": "",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 6,
+        "x": 0,
+        "y": 38
+      },
+      "heatmap": {},
+      "hideZeroBuckets": true,
+      "highlightCards": true,
+      "id": 35,
+      "legend": {
+        "show": true
+      },
+      "pluginVersion": "7.5.11",
+      "repeatIteration": 1692362960588,
+      "repeatPanelId": 20,
+      "reverseYBuckets": false,
+      "scopedVars": {
+        "ApiServer": {
+          "selected": false,
+          "text": "virtual-garden-kube-apiserver-7b7dfc7f54-2lmgg",
+          "value": "virtual-garden-kube-apiserver-7b7dfc7f54-2lmgg"
+        },
+        "resource": {
+          "selected": true,
+          "text": "apiservices",
+          "value": "apiservices"
+        }
+      },
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum(rate(apiserver_response_sizes_bucket{resource=~\"$resource\",subresource=\"\",verb=\"LIST\",pod=~\"$ApiServer\"}[$__rate_interval])) by (le)",
+          "format": "heatmap",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "{{le}}",
+          "refId": "A"
+        }
+      ],
+      "title": "$ApiServer $resource",
+      "tooltip": {
+        "show": true,
+        "showHistogram": true
+      },
+      "tooltipDecimals": 2,
+      "type": "heatmap",
+      "xAxis": {
+        "show": true
+      },
+      "xBucketNumber": null,
+      "xBucketSize": null,
+      "yAxis": {
+        "decimals": null,
+        "format": "bytes",
+        "logBase": 1,
+        "max": null,
+        "min": null,
+        "show": true,
+        "splitFactor": null
+      },
+      "yBucketBound": "auto",
+      "yBucketNumber": null,
+      "yBucketSize": null
+    },
+    {
+      "cards": {
+        "cardPadding": 1,
+        "cardRound": null
+      },
+      "color": {
+        "cardColor": "#b4ff00",
+        "colorScale": "sqrt",
+        "colorScheme": "interpolateOranges",
+        "exponent": 0.5,
+        "mode": "opacity"
+      },
+      "dataFormat": "tsbuckets",
+      "datasource": null,
+      "description": "",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 6,
+        "x": 6,
+        "y": 38
+      },
+      "heatmap": {},
+      "hideZeroBuckets": true,
+      "highlightCards": true,
+      "id": 36,
+      "legend": {
+        "show": true
+      },
+      "pluginVersion": "7.5.11",
+      "repeatIteration": 1692362960588,
+      "repeatPanelId": 20,
+      "reverseYBuckets": false,
+      "scopedVars": {
+        "ApiServer": {
+          "selected": false,
+          "text": "virtual-garden-kube-apiserver-7b7dfc7f54-9nrr2",
+          "value": "virtual-garden-kube-apiserver-7b7dfc7f54-9nrr2"
+        },
+        "resource": {
+          "selected": true,
+          "text": "apiservices",
+          "value": "apiservices"
+        }
+      },
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum(rate(apiserver_response_sizes_bucket{resource=~\"$resource\",subresource=\"\",verb=\"LIST\",pod=~\"$ApiServer\"}[$__rate_interval])) by (le)",
+          "format": "heatmap",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "{{le}}",
+          "refId": "A"
+        }
+      ],
+      "title": "$ApiServer $resource",
+      "tooltip": {
+        "show": true,
+        "showHistogram": true
+      },
+      "tooltipDecimals": 2,
+      "type": "heatmap",
+      "xAxis": {
+        "show": true
+      },
+      "xBucketNumber": null,
+      "xBucketSize": null,
+      "yAxis": {
+        "decimals": null,
+        "format": "bytes",
+        "logBase": 1,
+        "max": null,
+        "min": null,
+        "show": true,
+        "splitFactor": null
+      },
+      "yBucketBound": "auto",
+      "yBucketNumber": null,
+      "yBucketSize": null
+    },
+    {
+      "cards": {
+        "cardPadding": 1,
+        "cardRound": null
+      },
+      "color": {
+        "cardColor": "#b4ff00",
+        "colorScale": "sqrt",
+        "colorScheme": "interpolateOranges",
+        "exponent": 0.5,
+        "mode": "opacity"
+      },
+      "dataFormat": "tsbuckets",
+      "datasource": null,
+      "description": "",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 6,
+        "x": 12,
+        "y": 38
+      },
+      "heatmap": {},
+      "hideZeroBuckets": true,
+      "highlightCards": true,
+      "id": 37,
+      "legend": {
+        "show": true
+      },
+      "pluginVersion": "7.5.11",
+      "repeatIteration": 1692362960588,
+      "repeatPanelId": 20,
+      "reverseYBuckets": false,
+      "scopedVars": {
+        "ApiServer": {
+          "selected": false,
+          "text": "virtual-garden-kube-apiserver-7b7dfc7f54-f585g",
+          "value": "virtual-garden-kube-apiserver-7b7dfc7f54-f585g"
+        },
+        "resource": {
+          "selected": true,
+          "text": "apiservices",
+          "value": "apiservices"
+        }
+      },
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum(rate(apiserver_response_sizes_bucket{resource=~\"$resource\",subresource=\"\",verb=\"LIST\",pod=~\"$ApiServer\"}[$__rate_interval])) by (le)",
+          "format": "heatmap",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "{{le}}",
+          "refId": "A"
+        }
+      ],
+      "title": "$ApiServer $resource",
+      "tooltip": {
+        "show": true,
+        "showHistogram": true
+      },
+      "tooltipDecimals": 2,
+      "type": "heatmap",
+      "xAxis": {
+        "show": true
+      },
+      "xBucketNumber": null,
+      "xBucketSize": null,
+      "yAxis": {
+        "decimals": null,
+        "format": "bytes",
+        "logBase": 1,
+        "max": null,
+        "min": null,
+        "show": true,
+        "splitFactor": null
+      },
+      "yBucketBound": "auto",
+      "yBucketNumber": null,
+      "yBucketSize": null
+    },
+    {
+      "cards": {
+        "cardPadding": 1,
+        "cardRound": null
+      },
+      "color": {
+        "cardColor": "#b4ff00",
+        "colorScale": "sqrt",
+        "colorScheme": "interpolateOranges",
+        "exponent": 0.5,
+        "mode": "opacity"
+      },
+      "dataFormat": "tsbuckets",
+      "datasource": null,
+      "description": "",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 6,
+        "x": 18,
+        "y": 38
+      },
+      "heatmap": {},
+      "hideZeroBuckets": true,
+      "highlightCards": true,
+      "id": 38,
+      "legend": {
+        "show": true
+      },
+      "pluginVersion": "7.5.11",
+      "repeatIteration": 1692362960588,
+      "repeatPanelId": 20,
+      "reverseYBuckets": false,
+      "scopedVars": {
+        "ApiServer": {
+          "selected": false,
+          "text": "virtual-garden-kube-apiserver-7b7dfc7f54-hnx7b",
+          "value": "virtual-garden-kube-apiserver-7b7dfc7f54-hnx7b"
+        },
+        "resource": {
+          "selected": true,
+          "text": "apiservices",
+          "value": "apiservices"
+        }
+      },
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum(rate(apiserver_response_sizes_bucket{resource=~\"$resource\",subresource=\"\",verb=\"LIST\",pod=~\"$ApiServer\"}[$__rate_interval])) by (le)",
+          "format": "heatmap",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "{{le}}",
+          "refId": "A"
+        }
+      ],
+      "title": "$ApiServer $resource",
+      "tooltip": {
+        "show": true,
+        "showHistogram": true
+      },
+      "tooltipDecimals": 2,
+      "type": "heatmap",
+      "xAxis": {
+        "show": true
+      },
+      "xBucketNumber": null,
+      "xBucketSize": null,
+      "yAxis": {
+        "decimals": null,
+        "format": "bytes",
+        "logBase": 1,
+        "max": null,
+        "min": null,
+        "show": true,
+        "splitFactor": null
+      },
+      "yBucketBound": "auto",
+      "yBucketNumber": null,
+      "yBucketSize": null
+    },
+    {
+      "cards": {
+        "cardPadding": 1,
+        "cardRound": null
+      },
+      "color": {
+        "cardColor": "#b4ff00",
+        "colorScale": "sqrt",
+        "colorScheme": "interpolateOranges",
+        "exponent": 0.5,
+        "mode": "opacity"
+      },
+      "dataFormat": "tsbuckets",
+      "datasource": null,
+      "description": "",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 6,
+        "x": 0,
+        "y": 47
+      },
+      "heatmap": {},
+      "hideZeroBuckets": true,
+      "highlightCards": true,
+      "id": 39,
+      "legend": {
+        "show": true
+      },
+      "pluginVersion": "7.5.11",
+      "repeatIteration": 1692362960588,
+      "repeatPanelId": 20,
+      "reverseYBuckets": false,
+      "scopedVars": {
+        "ApiServer": {
+          "selected": false,
+          "text": "virtual-garden-kube-apiserver-7b7dfc7f54-j7jf5",
+          "value": "virtual-garden-kube-apiserver-7b7dfc7f54-j7jf5"
+        },
+        "resource": {
+          "selected": true,
+          "text": "apiservices",
+          "value": "apiservices"
+        }
+      },
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum(rate(apiserver_response_sizes_bucket{resource=~\"$resource\",subresource=\"\",verb=\"LIST\",pod=~\"$ApiServer\"}[$__rate_interval])) by (le)",
+          "format": "heatmap",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "{{le}}",
+          "refId": "A"
+        }
+      ],
+      "title": "$ApiServer $resource",
+      "tooltip": {
+        "show": true,
+        "showHistogram": true
+      },
+      "tooltipDecimals": 2,
+      "type": "heatmap",
+      "xAxis": {
+        "show": true
+      },
+      "xBucketNumber": null,
+      "xBucketSize": null,
+      "yAxis": {
+        "decimals": null,
+        "format": "bytes",
+        "logBase": 1,
+        "max": null,
+        "min": null,
+        "show": true,
+        "splitFactor": null
+      },
+      "yBucketBound": "auto",
+      "yBucketNumber": null,
+      "yBucketSize": null
+    },
+    {
+      "cards": {
+        "cardPadding": 1,
+        "cardRound": null
+      },
+      "color": {
+        "cardColor": "#b4ff00",
+        "colorScale": "sqrt",
+        "colorScheme": "interpolateOranges",
+        "exponent": 0.5,
+        "mode": "opacity"
+      },
+      "dataFormat": "tsbuckets",
+      "datasource": null,
+      "description": "",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 6,
+        "x": 6,
+        "y": 47
+      },
+      "heatmap": {},
+      "hideZeroBuckets": true,
+      "highlightCards": true,
+      "id": 40,
+      "legend": {
+        "show": true
+      },
+      "pluginVersion": "7.5.11",
+      "repeatIteration": 1692362960588,
+      "repeatPanelId": 20,
+      "reverseYBuckets": false,
+      "scopedVars": {
+        "ApiServer": {
+          "selected": false,
+          "text": "virtual-garden-kube-apiserver-7b7dfc7f54-zpftp",
+          "value": "virtual-garden-kube-apiserver-7b7dfc7f54-zpftp"
+        },
+        "resource": {
+          "selected": true,
+          "text": "apiservices",
+          "value": "apiservices"
         }
       },
       "targets": [
@@ -301,10 +1798,10 @@
           "selected": true,
           "tags": [],
           "text": [
-            "All"
+            "apiservices"
           ],
           "value": [
-            "$__all"
+            "apiservices"
           ]
         },
         "datasource": null,

--- a/pkg/component/plutono/dashboards/garden-shoot/apiserver-storage-details.json
+++ b/pkg/component/plutono/dashboards/garden-shoot/apiserver-storage-details.json
@@ -114,7 +114,7 @@
       "type": "row"
     }
   ],
-  "schemaVersion": 26,
+  "schemaVersion": 27,
   "style": "dark",
   "tags": [
     "apiserver-details",
@@ -127,7 +127,6 @@
         "allValue": ".*",
         "current": {
           "selected": true,
-          "tags": [],
           "text": [
             "All"
           ],
@@ -137,6 +136,7 @@
         },
         "datasource": "prometheus",
         "definition": "label_values(apiserver_request_total,job)",
+        "description": null,
         "error": null,
         "hide": 0,
         "includeAll": true,
@@ -144,7 +144,10 @@
         "multi": true,
         "name": "apiserver",
         "options": [],
-        "query": "label_values(apiserver_request_total,job)",
+        "query": {
+          "query": "label_values(apiserver_request_total,job)",
+          "refId": "prometheus-apiserver-Variable-Query"
+        },
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
@@ -159,7 +162,6 @@
         "allValue": ".*",
         "current": {
           "selected": true,
-          "tags": [],
           "text": [
             "All"
           ],
@@ -169,6 +171,7 @@
         },
         "datasource": "prometheus",
         "definition": "label_values(etcd_request_duration_seconds_bucket,type)",
+        "description": null,
         "error": null,
         "hide": 0,
         "includeAll": true,
@@ -176,7 +179,10 @@
         "multi": true,
         "name": "type",
         "options": [],
-        "query": "label_values(etcd_request_duration_seconds_bucket,type)",
+        "query": {
+          "query": "label_values(etcd_request_duration_seconds_bucket,type)",
+          "refId": "prometheus-type-Variable-Query"
+        },
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
@@ -191,7 +197,6 @@
         "allValue": ".*",
         "current": {
           "selected": true,
-          "tags": [],
           "text": [
             "All"
           ],
@@ -201,6 +206,7 @@
         },
         "datasource": "prometheus",
         "definition": "label_values(etcd_request_duration_seconds_bucket,operation)",
+        "description": null,
         "error": null,
         "hide": 0,
         "includeAll": true,
@@ -208,7 +214,10 @@
         "multi": true,
         "name": "operation",
         "options": [],
-        "query": "label_values(etcd_request_duration_seconds_bucket,operation)",
+        "query": {
+          "query": "label_values(etcd_request_duration_seconds_bucket,operation)",
+          "refId": "prometheus-operation-Variable-Query"
+        },
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
@@ -228,5 +237,6 @@
   "timepicker": {},
   "timezone": "",
   "title": "API Server (Storage Details)",
-  "uid": "apiserver-storage-details"
+  "uid": "apiserver-storage-details",
+  "version": 1
 }

--- a/pkg/component/plutono/dashboards/garden-shoot/apiserver-watch-details.json
+++ b/pkg/component/plutono/dashboards/garden-shoot/apiserver-watch-details.json
@@ -114,7 +114,7 @@
       "type": "row"
     }
   ],
-  "schemaVersion": 26,
+  "schemaVersion": 27,
   "style": "dark",
   "tags": [
     "apiserver-details",
@@ -127,7 +127,6 @@
         "allValue": ".*",
         "current": {
           "selected": true,
-          "tags": [],
           "text": [
             "All"
           ],
@@ -137,6 +136,7 @@
         },
         "datasource": "prometheus",
         "definition": "label_values(apiserver_request_total,job)",
+        "description": null,
         "error": null,
         "hide": 0,
         "includeAll": true,
@@ -144,7 +144,10 @@
         "multi": true,
         "name": "apiserver",
         "options": [],
-        "query": "label_values(apiserver_request_total,job)",
+        "query": {
+          "query": "label_values(apiserver_request_total,job)",
+          "refId": "prometheus-apiserver-Variable-Query"
+        },
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
@@ -168,6 +171,7 @@
         },
         "datasource": "prometheus",
         "definition": "label_values(apiserver_watch_events_sizes_bucket,kind)",
+        "description": null,
         "error": null,
         "hide": 0,
         "includeAll": true,
@@ -175,7 +179,10 @@
         "multi": true,
         "name": "kind",
         "options": [],
-        "query": "label_values(apiserver_watch_events_sizes_bucket,kind)",
+        "query": {
+          "query": "label_values(apiserver_watch_events_sizes_bucket,kind)",
+          "refId": "prometheus-kind-Variable-Query"
+        },
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
@@ -195,5 +202,6 @@
   "timepicker": {},
   "timezone": "",
   "title": "API Server (Watch Details)",
-  "uid": "apiserver-watch-details"
+  "uid": "apiserver-watch-details",
+  "version": 1
 }

--- a/pkg/component/plutono/dashboards/garden/garden/garden-alertmanager-dashboard.json
+++ b/pkg/component/plutono/dashboards/garden/garden/garden-alertmanager-dashboard.json
@@ -1981,6 +1981,6 @@
   "timepicker": {},
   "timezone": "",
   "title": "Gardener Alertmanager HA",
-  "uid": "2OohXGYMk",
+  "uid": "gardener-alertmanager-ha",
   "version": 1
 }

--- a/pkg/component/plutono/dashboards/garden/garden/garden-alertmanager-dashboard.json
+++ b/pkg/component/plutono/dashboards/garden/garden/garden-alertmanager-dashboard.json
@@ -37,7 +37,6 @@
       "datasource": null,
       "fieldConfig": {
         "defaults": {
-          "custom": {},
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
@@ -72,13 +71,16 @@
         "justifyMode": "auto",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["last"],
+          "calcs": [
+            "last"
+          ],
           "fields": "",
           "values": false
         },
+        "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "7.3.1",
+      "pluginVersion": "7.5.23",
       "targets": [
         {
           "expr": "count(up{job=\"gardener-alertmanager\"})",
@@ -96,7 +98,6 @@
       "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {
-          "custom": {},
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
@@ -135,13 +136,16 @@
         "justifyMode": "auto",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["last"],
+          "calcs": [
+            "last"
+          ],
           "fields": "",
           "values": false
         },
+        "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "7.3.1",
+      "pluginVersion": "7.5.23",
       "targets": [
         {
           "expr": "alertmanager_cluster_members{instance=~\"$instance\"}",
@@ -228,7 +232,7 @@
         "showHeader": true,
         "sortBy": []
       },
-      "pluginVersion": "7.3.1",
+      "pluginVersion": "7.5.23",
       "targets": [
         {
           "expr": "time() - (alertmanager_build_info{instance=~\"$instance\"} * on (instance, cluster, job) group_left process_start_time_seconds{instance=~\"$instance\"})",
@@ -257,7 +261,12 @@
           "id": "filterFieldsByName",
           "options": {
             "include": {
-              "names": ["version", "Value #A", "Value #B", "instance"]
+              "names": [
+                "version",
+                "Value #A",
+                "Value #B",
+                "instance"
+              ]
             }
           }
         },
@@ -271,7 +280,12 @@
           "id": "filterFieldsByName",
           "options": {
             "include": {
-              "names": ["instance", "version 1", "Value #A", "Value #B"]
+              "names": [
+                "instance",
+                "version 1",
+                "Value #A",
+                "Value #B"
+              ]
             }
           }
         }
@@ -285,9 +299,7 @@
       "dashes": false,
       "datasource": "$datasource",
       "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
+        "defaults": {},
         "overrides": []
       },
       "fill": 1,
@@ -317,7 +329,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.3.1",
+      "pluginVersion": "7.5.23",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -384,9 +396,7 @@
       "dashes": false,
       "datasource": "$datasource",
       "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
+        "defaults": {},
         "overrides": []
       },
       "fill": 1,
@@ -415,7 +425,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.3.1",
+      "pluginVersion": "7.5.23",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -481,23 +491,7 @@
       "dashes": false,
       "datasource": "$datasource",
       "fieldConfig": {
-        "defaults": {
-          "custom": {},
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
+        "defaults": {},
         "overrides": []
       },
       "fill": 1,
@@ -526,7 +520,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.3.1",
+      "pluginVersion": "7.5.23",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -607,9 +601,7 @@
       "datasource": "$datasource",
       "decimals": 0,
       "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
+        "defaults": {},
         "overrides": []
       },
       "fill": 1,
@@ -641,7 +633,7 @@
         "alertThreshold": false
       },
       "percentage": false,
-      "pluginVersion": "7.3.1",
+      "pluginVersion": "7.5.23",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -649,8 +641,8 @@
       "scopedVars": {
         "instance": {
           "selected": false,
-          "text": "10.40.0.133:9093",
-          "value": "10.40.0.133:9093"
+          "text": "10.36.0.188:9093",
+          "value": "10.36.0.188:9093"
         }
       },
       "seriesOverrides": [],
@@ -716,9 +708,7 @@
       "datasource": "$datasource",
       "decimals": 0,
       "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
+        "defaults": {},
         "overrides": []
       },
       "fill": 1,
@@ -733,15 +723,15 @@
       "id": 205,
       "interval": "",
       "legend": {
-        "alignAsTable": true,
+        "alignAsTable": false,
         "avg": false,
-        "current": true,
+        "current": false,
         "max": false,
         "min": false,
         "rightSide": false,
         "show": true,
-        "total": true,
-        "values": true
+        "total": false,
+        "values": false
       },
       "lines": false,
       "linewidth": 1,
@@ -750,17 +740,17 @@
         "alertThreshold": false
       },
       "percentage": false,
-      "pluginVersion": "7.3.1",
+      "pluginVersion": "7.5.23",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
-      "repeatIteration": 1613999739583,
+      "repeatIteration": 1692363702031,
       "repeatPanelId": 40,
       "scopedVars": {
         "instance": {
           "selected": false,
-          "text": "10.40.1.138:9093",
-          "value": "10.40.1.138:9093"
+          "text": "10.36.3.163:9093",
+          "value": "10.36.3.163:9093"
         }
       },
       "seriesOverrides": [],
@@ -839,9 +829,7 @@
       "dashes": false,
       "datasource": "$datasource",
       "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
+        "defaults": {},
         "overrides": []
       },
       "fill": 1,
@@ -870,7 +858,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.3.1",
+      "pluginVersion": "7.5.23",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -878,8 +866,8 @@
       "scopedVars": {
         "instance": {
           "selected": false,
-          "text": "10.40.0.133:9093",
-          "value": "10.40.0.133:9093"
+          "text": "10.36.0.188:9093",
+          "value": "10.36.0.188:9093"
         }
       },
       "seriesOverrides": [],
@@ -944,9 +932,7 @@
       "dashes": false,
       "datasource": "$datasource",
       "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
+        "defaults": {},
         "overrides": []
       },
       "fill": 1,
@@ -975,17 +961,17 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.3.1",
+      "pluginVersion": "7.5.23",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
-      "repeatIteration": 1613999739583,
+      "repeatIteration": 1692363702031,
       "repeatPanelId": 24,
       "scopedVars": {
         "instance": {
           "selected": false,
-          "text": "10.40.1.138:9093",
-          "value": "10.40.1.138:9093"
+          "text": "10.36.3.163:9093",
+          "value": "10.36.3.163:9093"
         }
       },
       "seriesOverrides": [],
@@ -1065,9 +1051,7 @@
       "datasource": "$datasource",
       "decimals": null,
       "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
+        "defaults": {},
         "overrides": []
       },
       "fill": 1,
@@ -1099,7 +1083,7 @@
         "alertThreshold": false
       },
       "percentage": false,
-      "pluginVersion": "7.3.1",
+      "pluginVersion": "7.5.23",
       "pointradius": 0.5,
       "points": false,
       "renderer": "flot",
@@ -1107,8 +1091,8 @@
       "scopedVars": {
         "instance": {
           "selected": false,
-          "text": "10.40.0.133:9093",
-          "value": "10.40.0.133:9093"
+          "text": "10.36.0.188:9093",
+          "value": "10.36.0.188:9093"
         }
       },
       "seriesOverrides": [],
@@ -1173,11 +1157,9 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$datasource",
-      "decimals": 0,
+      "decimals": null,
       "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
+        "defaults": {},
         "overrides": []
       },
       "fill": 1,
@@ -1191,16 +1173,16 @@
       "hiddenSeries": false,
       "id": 207,
       "legend": {
-        "alignAsTable": true,
+        "alignAsTable": false,
         "avg": false,
-        "current": true,
+        "current": false,
         "hideEmpty": true,
         "hideZero": true,
         "max": false,
         "min": false,
         "show": true,
-        "total": true,
-        "values": true
+        "total": false,
+        "values": false
       },
       "lines": false,
       "linewidth": 1,
@@ -1209,17 +1191,17 @@
         "alertThreshold": false
       },
       "percentage": false,
-      "pluginVersion": "7.3.1",
+      "pluginVersion": "7.5.23",
       "pointradius": 0.5,
       "points": false,
       "renderer": "flot",
-      "repeatIteration": 1613999739583,
+      "repeatIteration": 1692363702031,
       "repeatPanelId": 31,
       "scopedVars": {
         "instance": {
           "selected": false,
-          "text": "10.40.1.138:9093",
-          "value": "10.40.1.138:9093"
+          "text": "10.36.3.163:9093",
+          "value": "10.36.3.163:9093"
         }
       },
       "seriesOverrides": [],
@@ -1299,9 +1281,7 @@
       "dashes": false,
       "datasource": "$datasource",
       "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
+        "defaults": {},
         "overrides": []
       },
       "fill": 1,
@@ -1330,7 +1310,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.3.1",
+      "pluginVersion": "7.5.23",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1338,8 +1318,8 @@
       "scopedVars": {
         "instance": {
           "selected": false,
-          "text": "10.40.0.133:9093",
-          "value": "10.40.0.133:9093"
+          "text": "10.36.0.188:9093",
+          "value": "10.36.0.188:9093"
         }
       },
       "seriesOverrides": [],
@@ -1404,9 +1384,7 @@
       "dashes": false,
       "datasource": "$datasource",
       "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
+        "defaults": {},
         "overrides": []
       },
       "fill": 1,
@@ -1435,17 +1413,17 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.3.1",
+      "pluginVersion": "7.5.23",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
-      "repeatIteration": 1613999739583,
+      "repeatIteration": 1692363702031,
       "repeatPanelId": 26,
       "scopedVars": {
         "instance": {
           "selected": false,
-          "text": "10.40.1.138:9093",
-          "value": "10.40.1.138:9093"
+          "text": "10.36.3.163:9093",
+          "value": "10.36.3.163:9093"
         }
       },
       "seriesOverrides": [],
@@ -1525,7 +1503,6 @@
       "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {
-          "custom": {},
           "unit": "bytes"
         },
         "overrides": []
@@ -1556,7 +1533,7 @@
         "alertThreshold": false
       },
       "percentage": false,
-      "pluginVersion": "7.3.1",
+      "pluginVersion": "7.5.23",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1564,8 +1541,8 @@
       "scopedVars": {
         "instance": {
           "selected": false,
-          "text": "10.40.0.133:9093",
-          "value": "10.40.0.133:9093"
+          "text": "10.36.0.188:9093",
+          "value": "10.36.0.188:9093"
         }
       },
       "seriesOverrides": [],
@@ -1630,7 +1607,6 @@
       "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {
-          "custom": {},
           "unit": "bytes"
         },
         "overrides": []
@@ -1661,17 +1637,17 @@
         "alertThreshold": false
       },
       "percentage": false,
-      "pluginVersion": "7.3.1",
+      "pluginVersion": "7.5.23",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
-      "repeatIteration": 1613999739583,
+      "repeatIteration": 1692363702031,
       "repeatPanelId": 47,
       "scopedVars": {
         "instance": {
           "selected": false,
-          "text": "10.40.1.138:9093",
-          "value": "10.40.1.138:9093"
+          "text": "10.36.3.163:9093",
+          "value": "10.36.3.163:9093"
         }
       },
       "seriesOverrides": [],
@@ -1711,7 +1687,7 @@
           "label": null,
           "logBase": 1,
           "max": null,
-          "min": null,
+          "min": "0",
           "show": true
         },
         {
@@ -1735,9 +1711,7 @@
       "dashes": false,
       "datasource": "$datasource",
       "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
+        "defaults": {},
         "overrides": []
       },
       "fill": 1,
@@ -1766,7 +1740,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.3.1",
+      "pluginVersion": "7.5.23",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1774,8 +1748,8 @@
       "scopedVars": {
         "instance": {
           "selected": false,
-          "text": "10.40.0.133:9093",
-          "value": "10.40.0.133:9093"
+          "text": "10.36.0.188:9093",
+          "value": "10.36.0.188:9093"
         }
       },
       "seriesOverrides": [],
@@ -1839,9 +1813,7 @@
       "dashes": false,
       "datasource": "$datasource",
       "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
+        "defaults": {},
         "overrides": []
       },
       "fill": 1,
@@ -1870,17 +1842,17 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.3.1",
+      "pluginVersion": "7.5.23",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
-      "repeatIteration": 1613999739583,
+      "repeatIteration": 1692363702031,
       "repeatPanelId": 50,
       "scopedVars": {
         "instance": {
           "selected": false,
-          "text": "10.40.1.138:9093",
-          "value": "10.40.1.138:9093"
+          "text": "10.36.3.163:9093",
+          "value": "10.36.3.163:9093"
         }
       },
       "seriesOverrides": [],
@@ -1920,7 +1892,7 @@
           "label": null,
           "logBase": 1,
           "max": null,
-          "min": null,
+          "min": "0",
           "show": true
         },
         {
@@ -1939,7 +1911,7 @@
     }
   ],
   "refresh": "",
-  "schemaVersion": 26,
+  "schemaVersion": 27,
   "style": "dark",
   "tags": [],
   "templating": {
@@ -1950,6 +1922,7 @@
           "text": "prometheus",
           "value": "prometheus"
         },
+        "description": null,
         "error": null,
         "hide": 0,
         "includeAll": false,
@@ -1968,11 +1941,16 @@
         "allValue": null,
         "current": {
           "selected": true,
-          "text": ["All"],
-          "value": ["$__all"]
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
         },
         "datasource": "$datasource",
         "definition": "label_values(up{job=\"gardener-alertmanager\"},instance)",
+        "description": null,
         "error": null,
         "hide": 0,
         "includeAll": true,
@@ -1980,7 +1958,10 @@
         "multi": true,
         "name": "instance",
         "options": [],
-        "query": "label_values(up{job=\"gardener-alertmanager\"},instance)",
+        "query": {
+          "query": "label_values(up{job=\"gardener-alertmanager\"},instance)",
+          "refId": "prometheus-instance-Variable-Query"
+        },
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
@@ -2001,5 +1982,5 @@
   "timezone": "",
   "title": "Gardener Alertmanager HA",
   "uid": "2OohXGYMk",
-  "version": 9
+  "version": 1
 }

--- a/pkg/component/plutono/dashboards/garden/garden/garden-availability-dashboard.json
+++ b/pkg/component/plutono/dashboards/garden/garden/garden-availability-dashboard.json
@@ -94,8 +94,8 @@
       "pluginVersion": "7.5.23",
       "targets": [
         {
-          "expr": "probe_success{purpose=\"availability\",job=\"blackbox-apiserver\"}",
           "exemplar": true,
+          "expr": "min(probe_success{purpose=\"availability\",job=\"blackbox-apiserver\"})",
           "format": "time_series",
           "hide": false,
           "instant": false,
@@ -270,8 +270,8 @@
       "pluginVersion": "7.5.23",
       "targets": [
         {
-          "expr": "up{job=\"gardener-controller-manager\"}",
           "exemplar": true,
+          "expr": "min(up{job=\"gardener-controller-manager\"})",
           "format": "time_series",
           "hide": false,
           "instant": false,

--- a/pkg/component/plutono/dashboards/garden/garden/garden-availability-dashboard.json
+++ b/pkg/component/plutono/dashboards/garden/garden/garden-availability-dashboard.json
@@ -1,9 +1,23 @@
 {
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Plutono --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
   "description": "Landscape Availability Information",
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": 8,
+  "id": 18,
+  "iteration": 1692360202947,
   "links": [],
   "panels": [
     {
@@ -12,8 +26,17 @@
       "colorPostfix": false,
       "colorPrefix": false,
       "colorValue": false,
-      "colors": ["#d44a3a", "rgba(237, 129, 40, 0.89)", "#299c46"],
+      "colors": [
+        "#d44a3a",
+        "rgba(237, 129, 40, 0.89)",
+        "#299c46"
+      ],
+      "datasource": null,
       "description": "Current Availability of the Kube API Server.",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
       "format": "none",
       "gauge": {
         "maxValue": 100,
@@ -45,7 +68,6 @@
       "maxDataPoints": 100,
       "nullPointMode": "connected",
       "nullText": null,
-      "options": {},
       "postfix": "",
       "postfixFontSize": "50%",
       "prefix": "",
@@ -99,8 +121,17 @@
       "colorPostfix": false,
       "colorPrefix": false,
       "colorValue": false,
-      "colors": ["#d44a3a", "rgba(237, 129, 40, 0.89)", "#299c46"],
+      "colors": [
+        "#d44a3a",
+        "rgba(237, 129, 40, 0.89)",
+        "#299c46"
+      ],
+      "datasource": null,
       "description": "Current Availability of the Gardener API Server.",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
       "format": "none",
       "gauge": {
         "maxValue": 100,
@@ -132,7 +163,6 @@
       "maxDataPoints": 100,
       "nullPointMode": "connected",
       "nullText": null,
-      "options": {},
       "postfix": "",
       "postfixFontSize": "50%",
       "prefix": "",
@@ -186,8 +216,17 @@
       "colorPostfix": false,
       "colorPrefix": false,
       "colorValue": false,
-      "colors": ["#d44a3a", "rgba(237, 129, 40, 0.89)", "#299c46"],
+      "colors": [
+        "#d44a3a",
+        "rgba(237, 129, 40, 0.89)",
+        "#299c46"
+      ],
+      "datasource": null,
       "description": "Current Availability of the Gardener Controller Manager.",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
       "format": "none",
       "gauge": {
         "maxValue": 100,
@@ -219,7 +258,6 @@
       "maxDataPoints": 100,
       "nullPointMode": "connected",
       "nullText": null,
-      "options": {},
       "postfix": "",
       "postfixFontSize": "50%",
       "prefix": "",
@@ -273,8 +311,17 @@
       "colorPostfix": false,
       "colorPrefix": false,
       "colorValue": false,
-      "colors": ["#d44a3a", "rgba(237, 129, 40, 0.89)", "#299c46"],
+      "colors": [
+        "#d44a3a",
+        "rgba(237, 129, 40, 0.89)",
+        "#299c46"
+      ],
+      "datasource": null,
       "description": "Current Availability of the Gardener Dashboard.",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
       "format": "none",
       "gauge": {
         "maxValue": 100,
@@ -306,7 +353,6 @@
       "maxDataPoints": 100,
       "nullPointMode": "connected",
       "nullText": null,
-      "options": {},
       "postfix": "",
       "postfixFontSize": "50%",
       "prefix": "",
@@ -360,8 +406,17 @@
       "colorPostfix": false,
       "colorPrefix": false,
       "colorValue": false,
-      "colors": ["#d44a3a", "rgba(237, 129, 40, 0.89)", "#299c46"],
+      "colors": [
+        "#d44a3a",
+        "rgba(237, 129, 40, 0.89)",
+        "#299c46"
+      ],
+      "datasource": null,
       "description": "Current Availability of the Terminal Controller Manager",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
       "format": "none",
       "gauge": {
         "maxValue": 100,
@@ -393,7 +448,6 @@
       "maxDataPoints": 100,
       "nullPointMode": "connected",
       "nullText": null,
-      "options": {},
       "postfix": "",
       "postfixFontSize": "50%",
       "prefix": "",
@@ -449,6 +503,12 @@
       "datasource": "prometheus",
       "decimals": 0,
       "description": "### State Meaning\n1 : Up  \n0 : Down (Http health probe for component failed or returned with unhealthy status code)",
+      "fieldConfig": {
+        "defaults": {
+          "links": []
+        },
+        "overrides": []
+      },
       "fill": 0,
       "fillGradient": 0,
       "gridPos": {
@@ -457,6 +517,7 @@
         "x": 0,
         "y": 3
       },
+      "hiddenSeries": false,
       "id": 2,
       "legend": {
         "avg": false,
@@ -472,9 +533,10 @@
       "links": [],
       "nullPointMode": "null",
       "options": {
-        "dataLinks": []
+        "alertThreshold": true
       },
       "percentage": false,
+      "pluginVersion": "7.5.23",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -547,6 +609,12 @@
       "datasource": "prometheus",
       "decimals": null,
       "description": "Health check response times of the Garden cluster or Gardener components.",
+      "fieldConfig": {
+        "defaults": {
+          "links": []
+        },
+        "overrides": []
+      },
       "fill": 0,
       "fillGradient": 0,
       "gridPos": {
@@ -555,6 +623,7 @@
         "x": 12,
         "y": 3
       },
+      "hiddenSeries": false,
       "id": 3,
       "legend": {
         "avg": false,
@@ -570,9 +639,10 @@
       "links": [],
       "nullPointMode": "null",
       "options": {
-        "dataLinks": []
+        "alertThreshold": true
       },
       "percentage": false,
+      "pluginVersion": "7.5.23",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -639,6 +709,7 @@
     },
     {
       "collapsed": false,
+      "datasource": null,
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -655,8 +726,15 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
+      "datasource": null,
       "decimals": 0,
       "description": "### State Meaning\n1 : Up  \n2 : Progressing (in transition to down)  \n0 :  Down  \n-1 :  Unknown",
+      "fieldConfig": {
+        "defaults": {
+          "links": []
+        },
+        "overrides": []
+      },
       "fill": 0,
       "fillGradient": 0,
       "gridPos": {
@@ -665,6 +743,7 @@
         "x": 0,
         "y": 12
       },
+      "hiddenSeries": false,
       "id": 17,
       "legend": {
         "alignAsTable": true,
@@ -683,9 +762,10 @@
       "links": [],
       "nullPointMode": "null",
       "options": {
-        "dataLinks": []
+        "alertThreshold": true
       },
       "percentage": false,
+      "pluginVersion": "7.5.23",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -748,26 +828,37 @@
     }
   ],
   "refresh": "1m",
-  "schemaVersion": 19,
+  "schemaVersion": 27,
   "style": "dark",
-  "tags": ["Landscape", "Gardener", "Shoot", "Seed"],
+  "tags": [
+    "Landscape",
+    "Gardener",
+    "Shoot",
+    "Seed"
+  ],
   "templating": {
     "list": [
       {
         "allValue": "",
         "current": {
+          "selected": false,
           "text": "production",
           "value": "production"
         },
         "datasource": "prometheus",
         "definition": "label_values(garden_shoot_condition, purpose)",
+        "description": null,
+        "error": null,
         "hide": 0,
         "includeAll": true,
         "label": "Cluster Purpose",
         "multi": false,
         "name": "purpose",
         "options": [],
-        "query": "label_values(garden_shoot_condition, purpose)",
+        "query": {
+          "query": "label_values(garden_shoot_condition, purpose)",
+          "refId": "prometheus-purpose-Variable-Query"
+        },
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
@@ -781,18 +872,24 @@
       {
         "allValue": "",
         "current": {
+          "selected": false,
           "text": "All",
           "value": "$__all"
         },
         "datasource": "prometheus",
         "definition": "label_values(garden_shoot_info, iaas)",
+        "description": null,
+        "error": null,
         "hide": 0,
         "includeAll": true,
         "label": "Infrastructure",
         "multi": false,
         "name": "iaas",
         "options": [],
-        "query": "label_values(garden_shoot_info, iaas)",
+        "query": {
+          "query": "label_values(garden_shoot_info, iaas)",
+          "refId": "prometheus-iaas-Variable-Query"
+        },
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
@@ -806,18 +903,24 @@
       {
         "allValue": null,
         "current": {
+          "selected": false,
           "text": "All",
           "value": "$__all"
         },
         "datasource": "prometheus",
         "definition": "label_values(garden_shoot_info{iaas=~\"$iaas\"}, seed)",
+        "description": null,
+        "error": null,
         "hide": 0,
         "includeAll": true,
         "label": "Seed",
         "multi": false,
         "name": "seed",
         "options": [],
-        "query": "label_values(garden_shoot_info{iaas=~\"$iaas\"}, seed)",
+        "query": {
+          "query": "label_values(garden_shoot_info{iaas=~\"$iaas\"}, seed)",
+          "refId": "prometheus-seed-Variable-Query"
+        },
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
@@ -831,18 +934,24 @@
       {
         "allValue": null,
         "current": {
+          "selected": false,
           "text": "All",
           "value": "$__all"
         },
         "datasource": "prometheus",
         "definition": "label_values(garden_shoot_info{iaas=~\"$iaas\", seed=~\"$seed\"}, region)",
+        "description": null,
+        "error": null,
         "hide": 0,
         "includeAll": true,
         "label": "Region",
         "multi": false,
         "name": "region",
         "options": [],
-        "query": "label_values(garden_shoot_info{iaas=~\"$iaas\", seed=~\"$seed\"}, region)",
+        "query": {
+          "query": "label_values(garden_shoot_info{iaas=~\"$iaas\", seed=~\"$seed\"}, region)",
+          "refId": "prometheus-region-Variable-Query"
+        },
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
@@ -860,10 +969,24 @@
     "to": "now"
   },
   "timepicker": {
-    "refresh_intervals": ["30s", "1m", "5m"],
-    "time_options": ["5m", "15m", "1h", "6h", "12h", "24h", "2d", "10d"]
+    "refresh_intervals": [
+      "30s",
+      "1m",
+      "5m"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "10d"
+    ]
   },
   "timezone": "browser",
   "title": "Garden Availability",
-  "version": 0
+  "uid": "garden-availability",
+  "version": 1
 }

--- a/pkg/component/plutono/dashboards/garden/garden/garden-availability-dashboard.json
+++ b/pkg/component/plutono/dashboards/garden/garden/garden-availability-dashboard.json
@@ -22,28 +22,49 @@
   "panels": [
     {
       "cacheTimeout": null,
-      "colorBackground": true,
-      "colorPostfix": false,
-      "colorPrefix": false,
-      "colorValue": false,
-      "colors": [
-        "#d44a3a",
-        "rgba(237, 129, 40, 0.89)",
-        "#299c46"
-      ],
       "datasource": null,
       "description": "Current Availability of the Kube API Server.",
       "fieldConfig": {
-        "defaults": {},
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "id": 0,
+              "op": "=",
+              "text": "Down",
+              "type": 1,
+              "value": "0"
+            },
+            {
+              "id": 1,
+              "op": "=",
+              "text": "Up",
+              "type": 1,
+              "value": "1"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#d44a3a",
+                "value": null
+              },
+              {
+                "color": "rgba(237, 129, 40, 0.89)",
+                "value": 1
+              },
+              {
+                "color": "#299c46",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "none"
+        },
         "overrides": []
-      },
-      "format": "none",
-      "gauge": {
-        "maxValue": 100,
-        "minValue": 0,
-        "show": false,
-        "thresholdLabels": false,
-        "thresholdMarkers": true
       },
       "gridPos": {
         "h": 3,
@@ -54,91 +75,84 @@
       "id": 5,
       "interval": null,
       "links": [],
-      "mappingType": 1,
-      "mappingTypes": [
-        {
-          "name": "value to text",
-          "value": 1
-        },
-        {
-          "name": "range to text",
-          "value": 2
-        }
-      ],
       "maxDataPoints": 100,
-      "nullPointMode": "connected",
-      "nullText": null,
-      "postfix": "",
-      "postfixFontSize": "50%",
-      "prefix": "",
-      "prefixFontSize": "50%",
-      "rangeMaps": [
-        {
-          "from": "null",
-          "text": "N/A",
-          "to": "null"
-        }
-      ],
-      "sparkline": {
-        "fillColor": "rgba(31, 118, 189, 0.18)",
-        "full": false,
-        "lineColor": "rgb(31, 120, 193)",
-        "show": false
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
       },
-      "tableColumn": "",
+      "pluginVersion": "7.5.23",
       "targets": [
         {
           "expr": "probe_success{purpose=\"availability\",job=\"blackbox-apiserver\"}",
+          "exemplar": true,
           "format": "time_series",
           "hide": false,
           "instant": false,
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "",
           "refId": "A"
         }
       ],
-      "thresholds": "1,1",
       "title": "Kube API Server",
-      "type": "singlestat",
-      "valueFontSize": "80%",
-      "valueMaps": [
-        {
-          "op": "=",
-          "text": "Down",
-          "value": "0"
-        },
-        {
-          "op": "=",
-          "text": "Up",
-          "value": "1"
-        }
-      ],
-      "valueName": "current"
+      "type": "stat"
     },
     {
       "cacheTimeout": null,
-      "colorBackground": true,
-      "colorPostfix": false,
-      "colorPrefix": false,
-      "colorValue": false,
-      "colors": [
-        "#d44a3a",
-        "rgba(237, 129, 40, 0.89)",
-        "#299c46"
-      ],
       "datasource": null,
       "description": "Current Availability of the Gardener API Server.",
       "fieldConfig": {
-        "defaults": {},
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "id": 0,
+              "op": "=",
+              "text": "Down",
+              "type": 1,
+              "value": "0"
+            },
+            {
+              "id": 1,
+              "op": "=",
+              "text": "Up",
+              "type": 1,
+              "value": "1"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#d44a3a",
+                "value": null
+              },
+              {
+                "color": "rgba(237, 129, 40, 0.89)",
+                "value": 1
+              },
+              {
+                "color": "#299c46",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "none"
+        },
         "overrides": []
-      },
-      "format": "none",
-      "gauge": {
-        "maxValue": 100,
-        "minValue": 0,
-        "show": false,
-        "thresholdLabels": false,
-        "thresholdMarkers": true
       },
       "gridPos": {
         "h": 3,
@@ -149,91 +163,84 @@
       "id": 6,
       "interval": null,
       "links": [],
-      "mappingType": 1,
-      "mappingTypes": [
-        {
-          "name": "value to text",
-          "value": 1
-        },
-        {
-          "name": "range to text",
-          "value": 2
-        }
-      ],
       "maxDataPoints": 100,
-      "nullPointMode": "connected",
-      "nullText": null,
-      "postfix": "",
-      "postfixFontSize": "50%",
-      "prefix": "",
-      "prefixFontSize": "50%",
-      "rangeMaps": [
-        {
-          "from": "null",
-          "text": "N/A",
-          "to": "null"
-        }
-      ],
-      "sparkline": {
-        "fillColor": "rgba(31, 118, 189, 0.18)",
-        "full": false,
-        "lineColor": "rgb(31, 120, 193)",
-        "show": false
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
       },
-      "tableColumn": "",
+      "pluginVersion": "7.5.23",
       "targets": [
         {
+          "exemplar": true,
           "expr": "probe_success{purpose=\"availability\", job=\"blackbox-gardener-apiserver\"}",
           "format": "time_series",
           "hide": false,
           "instant": false,
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "",
           "refId": "A"
         }
       ],
-      "thresholds": "1,1",
       "title": "Gardener API Server",
-      "type": "singlestat",
-      "valueFontSize": "80%",
-      "valueMaps": [
-        {
-          "op": "=",
-          "text": "Down",
-          "value": "0"
-        },
-        {
-          "op": "=",
-          "text": "Up",
-          "value": "1"
-        }
-      ],
-      "valueName": "current"
+      "type": "stat"
     },
     {
       "cacheTimeout": null,
-      "colorBackground": true,
-      "colorPostfix": false,
-      "colorPrefix": false,
-      "colorValue": false,
-      "colors": [
-        "#d44a3a",
-        "rgba(237, 129, 40, 0.89)",
-        "#299c46"
-      ],
       "datasource": null,
       "description": "Current Availability of the Gardener Controller Manager.",
       "fieldConfig": {
-        "defaults": {},
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "id": 0,
+              "op": "=",
+              "text": "Down",
+              "type": 1,
+              "value": "0"
+            },
+            {
+              "id": 1,
+              "op": "=",
+              "text": "Up",
+              "type": 1,
+              "value": "1"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#d44a3a",
+                "value": null
+              },
+              {
+                "color": "rgba(237, 129, 40, 0.89)",
+                "value": 1
+              },
+              {
+                "color": "#299c46",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "none"
+        },
         "overrides": []
-      },
-      "format": "none",
-      "gauge": {
-        "maxValue": 100,
-        "minValue": 0,
-        "show": false,
-        "thresholdLabels": false,
-        "thresholdMarkers": true
       },
       "gridPos": {
         "h": 3,
@@ -244,91 +251,84 @@
       "id": 7,
       "interval": null,
       "links": [],
-      "mappingType": 1,
-      "mappingTypes": [
-        {
-          "name": "value to text",
-          "value": 1
-        },
-        {
-          "name": "range to text",
-          "value": 2
-        }
-      ],
       "maxDataPoints": 100,
-      "nullPointMode": "connected",
-      "nullText": null,
-      "postfix": "",
-      "postfixFontSize": "50%",
-      "prefix": "",
-      "prefixFontSize": "50%",
-      "rangeMaps": [
-        {
-          "from": "null",
-          "text": "N/A",
-          "to": "null"
-        }
-      ],
-      "sparkline": {
-        "fillColor": "rgba(31, 118, 189, 0.18)",
-        "full": false,
-        "lineColor": "rgb(31, 120, 193)",
-        "show": false
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
       },
-      "tableColumn": "",
+      "pluginVersion": "7.5.23",
       "targets": [
         {
           "expr": "up{job=\"gardener-controller-manager\"}",
+          "exemplar": true,
           "format": "time_series",
           "hide": false,
           "instant": false,
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "",
           "refId": "A"
         }
       ],
-      "thresholds": "1,1",
       "title": "Gardener Controller Manager",
-      "type": "singlestat",
-      "valueFontSize": "80%",
-      "valueMaps": [
-        {
-          "op": "=",
-          "text": "Down",
-          "value": "0"
-        },
-        {
-          "op": "=",
-          "text": "Up",
-          "value": "1"
-        }
-      ],
-      "valueName": "current"
+      "type": "stat"
     },
     {
       "cacheTimeout": null,
-      "colorBackground": true,
-      "colorPostfix": false,
-      "colorPrefix": false,
-      "colorValue": false,
-      "colors": [
-        "#d44a3a",
-        "rgba(237, 129, 40, 0.89)",
-        "#299c46"
-      ],
       "datasource": null,
       "description": "Current Availability of the Gardener Dashboard.",
       "fieldConfig": {
-        "defaults": {},
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "id": 0,
+              "op": "=",
+              "text": "Down",
+              "type": 1,
+              "value": "0"
+            },
+            {
+              "id": 1,
+              "op": "=",
+              "text": "Up",
+              "type": 1,
+              "value": "1"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#d44a3a",
+                "value": null
+              },
+              {
+                "color": "rgba(237, 129, 40, 0.89)",
+                "value": 1
+              },
+              {
+                "color": "#299c46",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "none"
+        },
         "overrides": []
-      },
-      "format": "none",
-      "gauge": {
-        "maxValue": 100,
-        "minValue": 0,
-        "show": false,
-        "thresholdLabels": false,
-        "thresholdMarkers": true
       },
       "gridPos": {
         "h": 3,
@@ -339,38 +339,23 @@
       "id": 8,
       "interval": null,
       "links": [],
-      "mappingType": 1,
-      "mappingTypes": [
-        {
-          "name": "value to text",
-          "value": 1
-        },
-        {
-          "name": "range to text",
-          "value": 2
-        }
-      ],
       "maxDataPoints": 100,
-      "nullPointMode": "connected",
-      "nullText": null,
-      "postfix": "",
-      "postfixFontSize": "50%",
-      "prefix": "",
-      "prefixFontSize": "50%",
-      "rangeMaps": [
-        {
-          "from": "null",
-          "text": "N/A",
-          "to": "null"
-        }
-      ],
-      "sparkline": {
-        "fillColor": "rgba(31, 118, 189, 0.18)",
-        "full": false,
-        "lineColor": "rgb(31, 120, 193)",
-        "show": false
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
       },
-      "tableColumn": "",
+      "pluginVersion": "7.5.23",
       "targets": [
         {
           "expr": "probe_success{purpose=\"availability\", job=\"blackbox-dashboard\"}",
@@ -382,48 +367,54 @@
           "refId": "A"
         }
       ],
-      "thresholds": "1,1",
       "title": "Gardener Dashboard",
-      "type": "singlestat",
-      "valueFontSize": "80%",
-      "valueMaps": [
-        {
-          "op": "=",
-          "text": "Down",
-          "value": "0"
-        },
-        {
-          "op": "=",
-          "text": "Up",
-          "value": "1"
-        }
-      ],
-      "valueName": "current"
+      "type": "stat"
     },
     {
       "cacheTimeout": null,
-      "colorBackground": true,
-      "colorPostfix": false,
-      "colorPrefix": false,
-      "colorValue": false,
-      "colors": [
-        "#d44a3a",
-        "rgba(237, 129, 40, 0.89)",
-        "#299c46"
-      ],
       "datasource": null,
       "description": "Current Availability of the Terminal Controller Manager",
       "fieldConfig": {
-        "defaults": {},
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "id": 0,
+              "op": "=",
+              "text": "Down",
+              "type": 1,
+              "value": "0"
+            },
+            {
+              "id": 1,
+              "op": "=",
+              "text": "Up",
+              "type": 1,
+              "value": "1"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#d44a3a",
+                "value": null
+              },
+              {
+                "color": "rgba(237, 129, 40, 0.89)",
+                "value": 1
+              },
+              {
+                "color": "#299c46",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "none"
+        },
         "overrides": []
-      },
-      "format": "none",
-      "gauge": {
-        "maxValue": 100,
-        "minValue": 0,
-        "show": false,
-        "thresholdLabels": false,
-        "thresholdMarkers": true
       },
       "gridPos": {
         "h": 3,
@@ -434,66 +425,38 @@
       "id": 18,
       "interval": null,
       "links": [],
-      "mappingType": 1,
-      "mappingTypes": [
-        {
-          "name": "value to text",
-          "value": 1
-        },
-        {
-          "name": "range to text",
-          "value": 2
-        }
-      ],
       "maxDataPoints": 100,
-      "nullPointMode": "connected",
-      "nullText": null,
-      "postfix": "",
-      "postfixFontSize": "50%",
-      "prefix": "",
-      "prefixFontSize": "50%",
-      "rangeMaps": [
-        {
-          "from": "null",
-          "text": "N/A",
-          "to": "null"
-        }
-      ],
-      "sparkline": {
-        "fillColor": "rgba(31, 118, 189, 0.18)",
-        "full": false,
-        "lineColor": "rgb(31, 120, 193)",
-        "show": false
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
       },
-      "tableColumn": "",
+      "pluginVersion": "7.5.23",
       "targets": [
         {
+          "exemplar": true,
           "expr": "up{job=\"terminal-controller-manager\"}",
           "format": "time_series",
           "hide": false,
-          "instant": true,
+          "instant": false,
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "",
           "refId": "A"
         }
       ],
-      "thresholds": "1,1",
       "title": "Terminal Controller Manager",
-      "type": "singlestat",
-      "valueFontSize": "80%",
-      "valueMaps": [
-        {
-          "op": "=",
-          "text": "Down",
-          "value": "0"
-        },
-        {
-          "op": "=",
-          "text": "Up",
-          "value": "1"
-        }
-      ],
-      "valueName": "current"
+      "type": "stat"
     },
     {
       "aliasColors": {},

--- a/pkg/component/plutono/dashboards/garden/garden/gardener-admission-controller-dashboard.json
+++ b/pkg/component/plutono/dashboards/garden/garden/gardener-admission-controller-dashboard.json
@@ -36,9 +36,7 @@
       "dashes": false,
       "datasource": null,
       "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
+        "defaults": {},
         "overrides": []
       },
       "fill": 0,
@@ -78,7 +76,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.4.0",
+      "pluginVersion": "7.5.23",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -144,9 +142,7 @@
       "dashes": false,
       "datasource": null,
       "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
+        "defaults": {},
         "overrides": []
       },
       "fill": 0,
@@ -186,7 +182,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.4.0",
+      "pluginVersion": "7.5.23",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -266,9 +262,7 @@
       "decimals": 0,
       "description": "Number of resources rejected by the Gardener Admission Controller.",
       "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
+        "defaults": {},
         "overrides": []
       },
       "fill": 0,
@@ -299,7 +293,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.4.0",
+      "pluginVersion": "7.5.23",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -361,15 +355,22 @@
   "refresh": "30s",
   "schemaVersion": 27,
   "style": "dark",
-  "tags": ["controlplane", "garden"],
+  "tags": [
+    "controlplane",
+    "garden"
+  ],
   "templating": {
     "list": [
       {
         "allValue": ".+",
         "current": {
           "selected": true,
-          "text": ["All"],
-          "value": ["$__all"]
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
         },
         "datasource": "prometheus",
         "definition": "label_values(gardener_admission_controller_rejected_resources_total, namespace)",
@@ -399,8 +400,12 @@
         "allValue": ".+",
         "current": {
           "selected": true,
-          "text": ["All"],
-          "value": ["$__all"]
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
         },
         "datasource": "prometheus",
         "definition": "label_values(gardener_admission_controller_rejected_resources_total, kind)",
@@ -430,8 +435,12 @@
         "allValue": ".+",
         "current": {
           "selected": true,
-          "text": ["All"],
-          "value": ["$__all"]
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
         },
         "datasource": "prometheus",
         "definition": "label_values(gardener_admission_controller_rejected_resources_total, operation)",
@@ -461,8 +470,12 @@
         "allValue": ".+",
         "current": {
           "selected": true,
-          "text": ["All"],
-          "value": ["$__all"]
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
         },
         "datasource": "prometheus",
         "definition": "label_values(gardener_admission_controller_rejected_resources_total, reason)",
@@ -492,9 +505,12 @@
         "allValue": ".*",
         "current": {
           "selected": true,
-          "tags": [],
-          "text": ["All"],
-          "value": ["$__all"]
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
         },
         "datasource": "prometheus",
         "definition": "label_values(gardener_admission_controller_seed_authorizer_graph_update_duration_seconds_bucket, kind)",
@@ -524,8 +540,12 @@
         "allValue": ".*",
         "current": {
           "selected": true,
-          "text": ["All"],
-          "value": ["$__all"]
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
         },
         "datasource": "prometheus",
         "definition": "label_values(gardener_admission_controller_seed_authorizer_graph_update_duration_seconds_bucket, operation)",
@@ -560,5 +580,6 @@
   "timepicker": {},
   "timezone": "",
   "title": "Gardener Admission Controller",
-  "uid": "gardener-admission-controller"
+  "uid": "gardener-admission-controller",
+  "version": 1
 }

--- a/pkg/component/plutono/dashboards/garden/garden/gardener-admission-controller-seedauthorizer-details.json
+++ b/pkg/component/plutono/dashboards/garden/garden/gardener-admission-controller-seedauthorizer-details.json
@@ -207,15 +207,23 @@
   ],
   "schemaVersion": 27,
   "style": "dark",
-  "tags": ["admission-controller-details", "controlplane", "garden"],
+  "tags": [
+    "admission-controller-details",
+    "controlplane",
+    "garden"
+  ],
   "templating": {
     "list": [
       {
         "allValue": ".*",
         "current": {
           "selected": true,
-          "text": ["All"],
-          "value": ["$__all"]
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
         },
         "datasource": "prometheus",
         "definition": "label_values(gardener_admission_controller_seed_authorizer_graph_update_duration_seconds_bucket,kind)",
@@ -245,8 +253,12 @@
         "allValue": ".*",
         "current": {
           "selected": true,
-          "text": ["All"],
-          "value": ["$__all"]
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
         },
         "datasource": "prometheus",
         "definition": "label_values(gardener_admission_controller_seed_authorizer_graph_path_check_duration_seconds_bucket,fromKind)",
@@ -281,5 +293,6 @@
   "timepicker": {},
   "timezone": "",
   "title": "Gardener Admission Controller (SeedAuthorizer Details)",
-  "uid": "gardener-admission-ctr-seedauth-details"
+  "uid": "gardener-admission-ctr-seedauth-details",
+  "version": 1
 }

--- a/pkg/component/plutono/dashboards/garden/garden/gardener-controlplane.json
+++ b/pkg/component/plutono/dashboards/garden/garden/gardener-controlplane.json
@@ -1724,6 +1724,6 @@
   },
   "timezone": "utc",
   "title": "Gardener Control Plane",
-  "uid": "control-plane"
+  "uid": "gardener-control-plane",
   "version": 1
 }

--- a/pkg/component/plutono/dashboards/garden/garden/gardener-controlplane.json
+++ b/pkg/component/plutono/dashboards/garden/garden/gardener-controlplane.json
@@ -67,14 +67,16 @@
         "displayMode": "gradient",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
         "showUnfilled": true,
         "text": {}
       },
-      "pluginVersion": "7.5.13",
+      "pluginVersion": "7.5.23",
       "targets": [
         {
           "exemplar": true,
@@ -133,7 +135,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.13",
+      "pluginVersion": "7.5.23",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -237,7 +239,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.13",
+      "pluginVersion": "7.5.23",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -338,7 +340,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.13",
+      "pluginVersion": "7.5.23",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -440,7 +442,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.13",
+      "pluginVersion": "7.5.23",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -541,7 +543,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.13",
+      "pluginVersion": "7.5.23",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -657,7 +659,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.13",
+      "pluginVersion": "7.5.23",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -773,7 +775,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.13",
+      "pluginVersion": "7.5.23",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -874,7 +876,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.13",
+      "pluginVersion": "7.5.23",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -975,7 +977,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.13",
+      "pluginVersion": "7.5.23",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1076,7 +1078,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.13",
+      "pluginVersion": "7.5.23",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1179,7 +1181,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.13",
+      "pluginVersion": "7.5.23",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1282,7 +1284,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.13",
+      "pluginVersion": "7.5.23",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1384,7 +1386,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.13",
+      "pluginVersion": "7.5.23",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1486,7 +1488,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.13",
+      "pluginVersion": "7.5.23",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1588,8 +1590,12 @@
         "allValue": null,
         "current": {
           "selected": true,
-          "text": ["All"],
-          "value": ["$__all"]
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
         },
         "datasource": "prometheus",
         "definition": "label_values(controller_runtime_reconcile_total, result)",
@@ -1619,8 +1625,12 @@
         "allValue": null,
         "current": {
           "selected": true,
-          "text": ["All"],
-          "value": ["$__all"]
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
         },
         "datasource": "prometheus",
         "definition": "label_values(rest_client_requests_total, code)",
@@ -1689,7 +1699,16 @@
     "to": "now"
   },
   "timepicker": {
-    "refresh_intervals": ["5s", "10s", "30s", "1m", "5m", "15m", "30m", "1h"],
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h"
+    ],
     "time_options": [
       "5m",
       "15m",
@@ -1706,4 +1725,5 @@
   "timezone": "utc",
   "title": "Gardener Control Plane",
   "uid": "control-plane"
+  "version": 1
 }

--- a/pkg/component/plutono/dashboards/garden/garden/kubernetes-pods-dashboard.json
+++ b/pkg/component/plutono/dashboards/garden/garden/kubernetes-pods-dashboard.json
@@ -28,9 +28,7 @@
       "editable": true,
       "error": false,
       "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
+        "defaults": {},
         "overrides": []
       },
       "fill": 0,
@@ -63,7 +61,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.3.1",
+      "pluginVersion": "7.5.23",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -134,9 +132,7 @@
       "editable": true,
       "error": false,
       "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
+        "defaults": {},
         "overrides": []
       },
       "fill": 0,
@@ -169,7 +165,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.3.1",
+      "pluginVersion": "7.5.23",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -239,9 +235,7 @@
       "editable": true,
       "error": false,
       "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
+        "defaults": {},
         "overrides": []
       },
       "fill": 7,
@@ -274,7 +268,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.3.1",
+      "pluginVersion": "7.5.23",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -351,7 +345,7 @@
         "h": 21,
         "w": 24,
         "x": 0,
-        "y": 30
+        "y": 21
       },
       "id": 6,
       "maxDataPoints": "",
@@ -376,15 +370,25 @@
     }
   ],
   "refresh": "30s",
-  "schemaVersion": 26,
+  "schemaVersion": 27,
   "style": "dark",
-  "tags": ["kubernetes", "seed", "shoot"],
+  "tags": [
+    "kubernetes",
+    "seed",
+    "shoot"
+  ],
   "templating": {
     "list": [
       {
         "allValue": null,
+        "current": {
+          "selected": false,
+          "text": "vpa-admission-controller-6774d7c855-qvp7q",
+          "value": "vpa-admission-controller-6774d7c855-qvp7q"
+        },
         "datasource": "prometheus",
         "definition": "label_values(container_cpu_usage_seconds_total, pod)",
+        "description": null,
         "error": null,
         "hide": 0,
         "includeAll": false,
@@ -392,7 +396,10 @@
         "multi": true,
         "name": "pod",
         "options": [],
-        "query": "label_values(container_cpu_usage_seconds_total, pod)",
+        "query": {
+          "query": "label_values(container_cpu_usage_seconds_total, pod)",
+          "refId": "prometheus-pod-Variable-Query"
+        },
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
@@ -405,8 +412,14 @@
       },
       {
         "allValue": ".*",
+        "current": {
+          "selected": false,
+          "text": "admission-controller",
+          "value": "admission-controller"
+        },
         "datasource": "prometheus",
         "definition": "label_values(container_cpu_usage_seconds_total{pod=~\"$pod\", container!=\"POD\"}, container)",
+        "description": null,
         "error": null,
         "hide": 0,
         "includeAll": false,
@@ -414,7 +427,10 @@
         "multi": true,
         "name": "container",
         "options": [],
-        "query": "label_values(container_cpu_usage_seconds_total{pod=~\"$pod\", container!=\"POD\"}, container)",
+        "query": {
+          "query": "label_values(container_cpu_usage_seconds_total{pod=~\"$pod\", container!=\"POD\"}, container)",
+          "refId": "prometheus-container-Variable-Query"
+        },
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
@@ -454,8 +470,27 @@
     "to": "now"
   },
   "timepicker": {
-    "refresh_intervals": ["30s", "1m", "5m", "15m", "30m", "1h", "2h", "1d"],
-    "time_options": ["5m", "15m", "1h", "6h", "12h", "24h", "2d", "7d", "30d"]
+    "refresh_intervals": [
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
   },
   "timezone": "browser",
   "title": "Kubernetes Pods",

--- a/pkg/component/plutono/dashboards/garden/garden/kubernetes-pods-dashboard.json
+++ b/pkg/component/plutono/dashboards/garden/garden/kubernetes-pods-dashboard.json
@@ -494,6 +494,6 @@
   },
   "timezone": "browser",
   "title": "Kubernetes Pods",
-  "uid": "kube-pods",
+  "uid": "gardener-kube-pods",
   "version": 1
 }

--- a/pkg/component/plutono/dashboards/garden/garden/virtual-garden-etcd-backup-dashboard.json
+++ b/pkg/component/plutono/dashboards/garden/garden/virtual-garden-etcd-backup-dashboard.json
@@ -12,8 +12,8 @@
       }
     ]
   },
-  "editable": false,
   "description": "Dashboard with information about the virtual garden etcd backups.",
+  "editable": false,
   "gnetId": null,
   "graphTooltip": 0,
   "id": 1,
@@ -365,7 +365,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.17",
+      "pluginVersion": "7.5.23",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -489,7 +489,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.17",
+      "pluginVersion": "7.5.23",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -613,7 +613,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.17",
+      "pluginVersion": "7.5.23",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -732,7 +732,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.17",
+      "pluginVersion": "7.5.23",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -850,7 +850,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.17",
+      "pluginVersion": "7.5.23",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -973,7 +973,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.17",
+      "pluginVersion": "7.5.23",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -1098,7 +1098,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.17",
+      "pluginVersion": "7.5.23",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -1234,7 +1234,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.17",
+      "pluginVersion": "7.5.23",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -1344,7 +1344,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.17",
+      "pluginVersion": "7.5.23",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -1415,7 +1415,9 @@
   "refresh": "30s",
   "schemaVersion": 27,
   "style": "dark",
-  "tags": ["Gardener"],
+  "tags": [
+    "Gardener"
+  ],
   "templating": {
     "list": [
       {

--- a/pkg/component/plutono/dashboards/garden/garden/virtual-garden-etcd-backup-dashboard.json
+++ b/pkg/component/plutono/dashboards/garden/garden/virtual-garden-etcd-backup-dashboard.json
@@ -1496,6 +1496,6 @@
   },
   "timezone": "browser",
   "title": "Virtual Garden ETCD Backup Dashboard",
-  "uid": "etcd-backup-restore",
+  "uid": "virtual-garden-etcd-backup-restore",
   "version": 1
 }

--- a/pkg/component/plutono/dashboards/garden/garden/virtual-garden-etcd-dashboard.json
+++ b/pkg/component/plutono/dashboards/garden/garden/virtual-garden-etcd-dashboard.json
@@ -1524,6 +1524,6 @@
   },
   "timezone": "browser",
   "title": "Virtual Garden ETCD",
-  "uid": "etcd",
+  "uid": "virtual-garden-etcd",
   "version": 1
 }

--- a/pkg/component/plutono/dashboards/garden/garden/virtual-garden-etcd-dashboard.json
+++ b/pkg/component/plutono/dashboards/garden/garden/virtual-garden-etcd-dashboard.json
@@ -167,7 +167,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.17",
+      "pluginVersion": "7.5.23",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -280,7 +280,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.17",
+      "pluginVersion": "7.5.23",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -393,7 +393,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.17",
+      "pluginVersion": "7.5.23",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -498,7 +498,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.17",
+      "pluginVersion": "7.5.23",
       "pointradius": 1,
       "points": false,
       "renderer": "flot",
@@ -608,7 +608,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.17",
+      "pluginVersion": "7.5.23",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -713,7 +713,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.17",
+      "pluginVersion": "7.5.23",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -815,7 +815,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.17",
+      "pluginVersion": "7.5.23",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -917,7 +917,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.17",
+      "pluginVersion": "7.5.23",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -1252,7 +1252,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.17",
+      "pluginVersion": "7.5.23",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -1356,7 +1356,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.17",
+      "pluginVersion": "7.5.23",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -1444,7 +1444,9 @@
   "refresh": "30s",
   "schemaVersion": 27,
   "style": "dark",
-  "tags": ["Gardener"],
+  "tags": [
+    "Gardener"
+  ],
   "templating": {
     "list": [
       {
@@ -1523,5 +1525,5 @@
   "timezone": "browser",
   "title": "Virtual Garden ETCD",
   "uid": "etcd",
-  "version": 2
+  "version": 1
 }

--- a/pkg/component/plutono/dashboards/garden/global/alerts-dashboard.json
+++ b/pkg/component/plutono/dashboards/garden/global/alerts-dashboard.json
@@ -21,6 +21,7 @@
   "panels": [
     {
       "collapsed": false,
+      "datasource": null,
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -33,7 +34,34 @@
       "type": "row"
     },
     {
+      "datasource": null,
       "description": "Shows the number of alerts by infrastructure.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 0,
+          "displayName": "",
+          "mappings": [],
+          "max": 100,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
       "gridPos": {
         "h": 8,
         "w": 9,
@@ -43,31 +71,18 @@
       "id": 26,
       "options": {
         "displayMode": "gradient",
-        "fieldOptions": {
-          "calcs": ["lastNotNull"],
-          "defaults": {
-            "decimals": 0,
-            "mappings": [],
-            "max": 100,
-            "min": 0,
-            "thresholds": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ],
-            "title": ""
-          },
-          "override": {},
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
           "values": false
         },
-        "orientation": "horizontal"
+        "showUnfilled": true,
+        "text": {}
       },
-      "pluginVersion": "6.3.2",
+      "pluginVersion": "7.5.23",
       "targets": [
         {
           "expr": "count(ALERTS{severity=~\"$Severity\", alertstate=~\"$AlertState\", alertname=~\"$Alertname\", shoot_infra=~\"$Infra\"}) by (shoot_infra)",
@@ -85,9 +100,18 @@
       "cacheTimeout": null,
       "colorBackground": false,
       "colorValue": true,
-      "colors": ["#F2495C", "#F2495C", "#F2495C"],
+      "colors": [
+        "#F2495C",
+        "#F2495C",
+        "#F2495C"
+      ],
+      "datasource": null,
       "decimals": 0,
       "description": "Shows how many alerts are currently firing for shoots using this seed.",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
       "format": "none",
       "gauge": {
         "maxValue": 100,
@@ -119,7 +143,6 @@
       "maxDataPoints": 100,
       "nullPointMode": "connected",
       "nullText": null,
-      "options": {},
       "postfix": "Firing Alert(s)",
       "postfixFontSize": "50%",
       "prefix": "",
@@ -166,9 +189,18 @@
       "cacheTimeout": null,
       "colorBackground": false,
       "colorValue": true,
-      "colors": ["#FF9830", "#FF9830", "#FF9830"],
+      "colors": [
+        "#FF9830",
+        "#FF9830",
+        "#FF9830"
+      ],
+      "datasource": null,
       "decimals": 0,
       "description": "Shows how many alerts are currently pending for shoots using this seed.",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
       "format": "none",
       "gauge": {
         "maxValue": 100,
@@ -200,7 +232,6 @@
       "maxDataPoints": 100,
       "nullPointMode": "connected",
       "nullText": null,
-      "options": {},
       "postfix": " Pending Alert(s)",
       "postfixFontSize": "50%",
       "prefix": "",
@@ -245,7 +276,53 @@
     },
     {
       "cacheTimeout": null,
+      "datasource": null,
       "description": "Shows the percentage of clusters that have at least 1 firing or pending alert.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": null,
+          "mappings": [
+            {
+              "from": "",
+              "id": 1,
+              "operator": "",
+              "text": "0",
+              "to": "",
+              "type": 1,
+              "value": "null"
+            },
+            {
+              "from": "",
+              "id": 2,
+              "operator": "",
+              "text": "0",
+              "to": "",
+              "type": 1,
+              "value": "No data"
+            }
+          ],
+          "max": 100,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 50
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
       "gridPos": {
         "h": 4,
         "w": 5,
@@ -255,52 +332,19 @@
       "id": 16,
       "links": [],
       "options": {
-        "fieldOptions": {
-          "calcs": ["mean"],
-          "defaults": {
-            "decimals": null,
-            "mappings": [
-              {
-                "from": "",
-                "id": 1,
-                "operator": "",
-                "text": "0",
-                "to": "",
-                "type": 1,
-                "value": "null"
-              },
-              {
-                "from": "",
-                "id": 2,
-                "operator": "",
-                "text": "0",
-                "to": "",
-                "type": 1,
-                "value": "No data"
-              }
-            ],
-            "max": 100,
-            "min": 0,
-            "thresholds": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 50
-              }
-            ],
-            "unit": "percent"
-          },
-          "override": {},
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "fields": "",
           "values": false
         },
-        "orientation": "auto",
         "showThresholdLabels": false,
-        "showThresholdMarkers": false
+        "showThresholdMarkers": false,
+        "text": {}
       },
-      "pluginVersion": "6.3.2",
+      "pluginVersion": "7.5.23",
       "targets": [
         {
           "expr": "count(count(ALERTS) by (shoot_name)) / count(count(shoot:availability) by (shoot_name)) * 100",
@@ -319,9 +363,18 @@
       "cacheTimeout": null,
       "colorBackground": false,
       "colorValue": true,
-      "colors": ["#F2495C", "#F2495C", "#F2495C"],
+      "colors": [
+        "#F2495C",
+        "#F2495C",
+        "#F2495C"
+      ],
+      "datasource": null,
       "decimals": 0,
       "description": "Shows how many clusters have at least 1 firing alert.",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
       "format": "none",
       "gauge": {
         "maxValue": 100,
@@ -353,7 +406,6 @@
       "maxDataPoints": 100,
       "nullPointMode": "connected",
       "nullText": null,
-      "options": {},
       "postfix": "Cluster(s)",
       "postfixFontSize": "50%",
       "prefix": "",
@@ -401,9 +453,18 @@
       "cacheTimeout": null,
       "colorBackground": false,
       "colorValue": true,
-      "colors": ["#FF9830", "#FF9830", "#FF9830"],
+      "colors": [
+        "#FF9830",
+        "#FF9830",
+        "#FF9830"
+      ],
+      "datasource": null,
       "decimals": 0,
       "description": "Shows how many clusters currently have at least 1 pending alert.",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
       "format": "none",
       "gauge": {
         "maxValue": 100,
@@ -435,7 +496,6 @@
       "maxDataPoints": 100,
       "nullPointMode": "connected",
       "nullText": null,
-      "options": {},
       "postfix": " Cluster(s)",
       "postfixFontSize": "50%",
       "prefix": "",
@@ -483,8 +543,17 @@
       "cacheTimeout": null,
       "colorBackground": false,
       "colorValue": false,
-      "colors": ["#299c46", "rgba(237, 129, 40, 0.89)", "#d44a3a"],
+      "colors": [
+        "#299c46",
+        "rgba(237, 129, 40, 0.89)",
+        "#d44a3a"
+      ],
+      "datasource": null,
       "description": "Shows the total number of shoots with a control plane on this seed.",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
       "format": "none",
       "gauge": {
         "maxValue": 100,
@@ -516,7 +585,6 @@
       "maxDataPoints": 100,
       "nullPointMode": "connected",
       "nullText": null,
-      "options": {},
       "postfix": "Cluster(s)",
       "postfixFontSize": "50%",
       "prefix": "",
@@ -565,8 +633,15 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
+      "datasource": null,
       "decimals": 0,
       "description": "Shows alerts that are/were active with the selected severity and alert state from the selected clusters. Includes the alertnames of the alerts.",
+      "fieldConfig": {
+        "defaults": {
+          "links": []
+        },
+        "overrides": []
+      },
       "fill": 0,
       "fillGradient": 0,
       "gridPos": {
@@ -575,6 +650,7 @@
         "x": 0,
         "y": 9
       },
+      "hiddenSeries": false,
       "id": 24,
       "legend": {
         "alignAsTable": true,
@@ -592,9 +668,10 @@
       "links": [],
       "nullPointMode": "null",
       "options": {
-        "dataLinks": []
+        "alertThreshold": true
       },
       "percentage": false,
+      "pluginVersion": "7.5.23",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -655,6 +732,7 @@
     },
     {
       "collapsed": false,
+      "datasource": null,
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -671,8 +749,15 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
+      "datasource": null,
       "decimals": 0,
       "description": "Shows the number of alerts in each cluster.",
+      "fieldConfig": {
+        "defaults": {
+          "links": []
+        },
+        "overrides": []
+      },
       "fill": 0,
       "fillGradient": 0,
       "gridPos": {
@@ -681,6 +766,7 @@
         "x": 0,
         "y": 18
       },
+      "hiddenSeries": false,
       "id": 4,
       "interval": "",
       "legend": {
@@ -699,9 +785,10 @@
       "links": [],
       "nullPointMode": "null",
       "options": {
-        "dataLinks": []
+        "alertThreshold": true
       },
       "percentage": false,
+      "pluginVersion": "7.5.23",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -763,7 +850,12 @@
     },
     {
       "columns": [],
+      "datasource": null,
       "description": "Shows all alerts that are currently active from the selected clusters, severity, and alert state.",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
       "fontSize": "100%",
       "gridPos": {
         "h": 12,
@@ -773,7 +865,6 @@
       },
       "id": 7,
       "links": [],
-      "options": {},
       "pageSize": null,
       "scroll": true,
       "showHeader": true,
@@ -784,12 +875,14 @@
       "styles": [
         {
           "alias": "Time",
+          "align": "auto",
           "dateFormat": "YYYY-MM-DD HH:mm:ss",
           "pattern": "Time",
           "type": "hidden"
         },
         {
           "alias": "",
+          "align": "auto",
           "colorMode": null,
           "colors": [
             "rgba(245, 54, 54, 0.9)",
@@ -806,6 +899,7 @@
         },
         {
           "alias": "",
+          "align": "auto",
           "colorMode": null,
           "colors": [
             "rgba(245, 54, 54, 0.9)",
@@ -825,6 +919,7 @@
         },
         {
           "alias": "",
+          "align": "auto",
           "colorMode": null,
           "colors": [
             "rgba(245, 54, 54, 0.9)",
@@ -852,31 +947,43 @@
       "timeShift": null,
       "title": "Cluster Alerts ($Severity|$AlertState|$Alertname|$Infra)",
       "transform": "table",
-      "type": "table"
+      "type": "table-old"
     }
   ],
   "refresh": false,
-  "schemaVersion": 19,
+  "schemaVersion": 27,
   "style": "dark",
-  "tags": ["monitoring", "seed"],
+  "tags": [
+    "monitoring",
+    "seed"
+  ],
   "templating": {
     "list": [
       {
         "allValue": null,
         "current": {
-          "tags": [],
-          "text": "All",
-          "value": ["$__all"]
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
         },
         "datasource": "prometheus",
         "definition": "label_values(ALERTS,severity)",
+        "description": null,
+        "error": null,
         "hide": 0,
         "includeAll": true,
         "label": null,
         "multi": true,
         "name": "Severity",
         "options": [],
-        "query": "label_values(ALERTS,severity)",
+        "query": {
+          "query": "label_values(ALERTS,severity)",
+          "refId": "prometheus-Severity-Variable-Query"
+        },
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
@@ -890,18 +997,28 @@
       {
         "allValue": null,
         "current": {
-          "text": "All",
-          "value": ["$__all"]
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
         },
         "datasource": "prometheus",
         "definition": "label_values(ALERTS,alertstate)",
+        "description": null,
+        "error": null,
         "hide": 0,
         "includeAll": true,
         "label": "Alert State",
         "multi": true,
         "name": "AlertState",
         "options": [],
-        "query": "label_values(ALERTS,alertstate)",
+        "query": {
+          "query": "label_values(ALERTS,alertstate)",
+          "refId": "prometheus-AlertState-Variable-Query"
+        },
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
@@ -915,18 +1032,28 @@
       {
         "allValue": null,
         "current": {
-          "text": "All",
-          "value": ["$__all"]
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
         },
         "datasource": "prometheus",
         "definition": "label_values(ALERTS, alertname)",
+        "description": null,
+        "error": null,
         "hide": 0,
         "includeAll": true,
         "label": null,
         "multi": true,
         "name": "Alertname",
         "options": [],
-        "query": "label_values(ALERTS, alertname)",
+        "query": {
+          "query": "label_values(ALERTS, alertname)",
+          "refId": "prometheus-Alertname-Variable-Query"
+        },
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
@@ -940,18 +1067,28 @@
       {
         "allValue": null,
         "current": {
-          "text": "All",
-          "value": ["$__all"]
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
         },
         "datasource": "prometheus",
         "definition": "label_values(ALERTS, shoot_infra)",
+        "description": null,
+        "error": null,
         "hide": 0,
         "includeAll": true,
         "label": null,
         "multi": true,
         "name": "Infra",
         "options": [],
-        "query": "label_values(ALERTS, shoot_infra)",
+        "query": {
+          "query": "label_values(ALERTS, shoot_infra)",
+          "refId": "prometheus-Infra-Variable-Query"
+        },
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
@@ -981,7 +1118,17 @@
       "2h",
       "1d"
     ],
-    "time_options": ["5m", "15m", "1h", "6h", "12h", "24h", "2d", "7d", "30d"]
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
   },
   "timezone": "",
   "title": "Alerts",

--- a/pkg/component/plutono/dashboards/garden/global/container-runtime.json
+++ b/pkg/component/plutono/dashboards/garden/global/container-runtime.json
@@ -263,6 +263,6 @@
   "timepicker": {},
   "timezone": "",
   "title": "Container Runtimes",
-  "uid": "SOvz2vHnk",
+  "uid": "container-runtimes",
   "version": 1
 }

--- a/pkg/component/plutono/dashboards/garden/global/container-runtime.json
+++ b/pkg/component/plutono/dashboards/garden/global/container-runtime.json
@@ -56,7 +56,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.10",
+      "pluginVersion": "7.5.23",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -177,7 +177,7 @@
       "options": {
         "showHeader": true
       },
-      "pluginVersion": "7.5.10",
+      "pluginVersion": "7.5.23",
       "scopedVars": {
         "cri": {
           "selected": false,
@@ -204,205 +204,12 @@
           "id": "filterFieldsByName",
           "options": {
             "include": {
-              "names": ["cri", "image", "project", "Value"]
-            }
-          }
-        }
-      ],
-      "type": "table"
-    },
-    {
-      "collapsed": false,
-      "datasource": null,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 17
-      },
-      "id": 6,
-      "panels": [],
-      "repeatIteration": 1632311738934,
-      "repeatPanelId": 5,
-      "scopedVars": {
-        "cri": {
-          "selected": false,
-          "text": "docker",
-          "value": "docker"
-        }
-      },
-      "title": "$cri",
-      "type": "row"
-    },
-    {
-      "datasource": "availability-prometheus",
-      "description": "Shoots that are configured with listed runtimes",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "custom": {
-            "align": null,
-            "filterable": false
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 24,
-        "x": 0,
-        "y": 18
-      },
-      "id": 7,
-      "options": {
-        "showHeader": true
-      },
-      "pluginVersion": "7.5.10",
-      "repeatIteration": 1632311738934,
-      "repeatPanelId": 3,
-      "repeatedByRow": true,
-      "scopedVars": {
-        "cri": {
-          "selected": false,
-          "text": "docker",
-          "value": "docker"
-        }
-      },
-      "targets": [
-        {
-          "exemplar": true,
-          "expr": "topk(10,(count by (cri, project, image) (count by (cri, name, project, image) (garden_shoot_node_info{cri=~\"$cri\"})))) ",
-          "format": "table",
-          "instant": true,
-          "interval": "",
-          "legendFormat": "",
-          "refId": "A"
-        }
-      ],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "Total Container Runtimes",
-      "transformations": [
-        {
-          "id": "filterFieldsByName",
-          "options": {
-            "include": {
-              "names": ["cri", "image", "project", "Value"]
-            }
-          }
-        }
-      ],
-      "type": "table"
-    },
-    {
-      "collapsed": false,
-      "datasource": null,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 26
-      },
-      "id": 8,
-      "panels": [],
-      "repeatIteration": 1632311738934,
-      "repeatPanelId": 5,
-      "scopedVars": {
-        "cri": {
-          "selected": false,
-          "text": "docker (default)",
-          "value": "docker (default)"
-        }
-      },
-      "title": "$cri",
-      "type": "row"
-    },
-    {
-      "datasource": "availability-prometheus",
-      "description": "Shoots that are configured with listed runtimes",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "custom": {
-            "align": null,
-            "filterable": false
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 24,
-        "x": 0,
-        "y": 27
-      },
-      "id": 9,
-      "options": {
-        "showHeader": true
-      },
-      "pluginVersion": "7.5.10",
-      "repeatIteration": 1632311738934,
-      "repeatPanelId": 3,
-      "repeatedByRow": true,
-      "scopedVars": {
-        "cri": {
-          "selected": false,
-          "text": "docker (default)",
-          "value": "docker (default)"
-        }
-      },
-      "targets": [
-        {
-          "exemplar": true,
-          "expr": "topk(10,(count by (cri, project, image) (count by (cri, name, project, image) (garden_shoot_node_info{cri=~\"$cri\"})))) ",
-          "format": "table",
-          "instant": true,
-          "interval": "",
-          "legendFormat": "",
-          "refId": "A"
-        }
-      ],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "Total Container Runtimes",
-      "transformations": [
-        {
-          "id": "filterFieldsByName",
-          "options": {
-            "include": {
-              "names": ["cri", "image", "project", "Value"]
+              "names": [
+                "cri",
+                "image",
+                "project",
+                "Value"
+              ]
             }
           }
         }
@@ -419,7 +226,7 @@
       {
         "allValue": null,
         "current": {
-          "selected": true,
+          "selected": false,
           "text": "All",
           "value": "$__all"
         },

--- a/pkg/component/plutono/dashboards/garden/global/seed-resource-usage-dashboard.json
+++ b/pkg/component/plutono/dashboards/garden/global/seed-resource-usage-dashboard.json
@@ -41,7 +41,6 @@
           "color": {
             "mode": "thresholds"
           },
-          "custom": {},
           "mappings": [],
           "max": 100,
           "min": 0,
@@ -72,13 +71,16 @@
         "displayMode": "gradient",
         "orientation": "horizontal",
         "reduceOptions": {
-          "calcs": ["last"],
+          "calcs": [
+            "last"
+          ],
           "fields": "",
           "values": false
         },
-        "showUnfilled": true
+        "showUnfilled": true,
+        "text": {}
       },
-      "pluginVersion": "7.0.3",
+      "pluginVersion": "7.5.23",
       "targets": [
         {
           "expr": "count(garden_shoot_info{seed=~\"$seed\"}) by (seed)",
@@ -102,7 +104,7 @@
       "description": "Shows the number of shoots per seed (does not count hibernated shoots).",
       "fieldConfig": {
         "defaults": {
-          "custom": {}
+          "links": []
         },
         "overrides": []
       },
@@ -131,9 +133,10 @@
       "linewidth": 1,
       "nullPointMode": "null",
       "options": {
-        "dataLinks": []
+        "alertThreshold": true
       },
       "percentage": false,
+      "pluginVersion": "7.5.23",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -201,7 +204,7 @@
       "description": "How much of the seed CPU is utilized for control planes.",
       "fieldConfig": {
         "defaults": {
-          "custom": {}
+          "links": []
         },
         "overrides": []
       },
@@ -230,9 +233,10 @@
       "linewidth": 1,
       "nullPointMode": "null",
       "options": {
-        "dataLinks": []
+        "alertThreshold": true
       },
       "percentage": false,
+      "pluginVersion": "7.5.23",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -298,7 +302,7 @@
       "description": "How much of the seed memory is utilized for control planes.",
       "fieldConfig": {
         "defaults": {
-          "custom": {}
+          "links": []
         },
         "overrides": []
       },
@@ -327,9 +331,10 @@
       "linewidth": 1,
       "nullPointMode": "null",
       "options": {
-        "dataLinks": []
+        "alertThreshold": true
       },
       "percentage": false,
+      "pluginVersion": "7.5.23",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -395,7 +400,7 @@
       "description": "How much of the seed CPU is utilized based on requests.",
       "fieldConfig": {
         "defaults": {
-          "custom": {}
+          "links": []
         },
         "overrides": []
       },
@@ -424,9 +429,10 @@
       "linewidth": 1,
       "nullPointMode": "null",
       "options": {
-        "dataLinks": []
+        "alertThreshold": true
       },
       "percentage": false,
+      "pluginVersion": "7.5.23",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -493,7 +499,7 @@
       "description": "How much of the seed memory is utilized based on requests.",
       "fieldConfig": {
         "defaults": {
-          "custom": {}
+          "links": []
         },
         "overrides": []
       },
@@ -522,9 +528,10 @@
       "linewidth": 1,
       "nullPointMode": "null",
       "options": {
-        "dataLinks": []
+        "alertThreshold": true
       },
       "percentage": false,
+      "pluginVersion": "7.5.23",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -605,7 +612,7 @@
       "description": "Shows the total CPU usage of each seed.",
       "fieldConfig": {
         "defaults": {
-          "custom": {}
+          "links": []
         },
         "overrides": []
       },
@@ -635,9 +642,10 @@
       "linewidth": 1,
       "nullPointMode": "null",
       "options": {
-        "dataLinks": []
+        "alertThreshold": true
       },
       "percentage": false,
+      "pluginVersion": "7.5.23",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -703,7 +711,7 @@
       "description": "Shows the total memory usage of each seed.",
       "fieldConfig": {
         "defaults": {
-          "custom": {}
+          "links": []
         },
         "overrides": []
       },
@@ -733,9 +741,10 @@
       "linewidth": 1,
       "nullPointMode": "null",
       "options": {
-        "dataLinks": []
+        "alertThreshold": true
       },
       "percentage": false,
+      "pluginVersion": "7.5.23",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -800,7 +809,6 @@
           "color": {
             "mode": "thresholds"
           },
-          "custom": {},
           "decimals": 0,
           "mappings": [],
           "max": 100,
@@ -832,13 +840,16 @@
         "displayMode": "gradient",
         "orientation": "horizontal",
         "reduceOptions": {
-          "calcs": ["mean"],
+          "calcs": [
+            "mean"
+          ],
           "fields": "",
           "values": false
         },
-        "showUnfilled": true
+        "showUnfilled": true,
+        "text": {}
       },
-      "pluginVersion": "7.0.3",
+      "pluginVersion": "7.5.23",
       "targets": [
         {
           "expr": "sum(shoot:kube_node_info:count{project=\"garden\", shoot_name=~\"$seed\"}) by (shoot_name)",
@@ -862,7 +873,7 @@
       "description": "Shows the total number of nodes for each seed.",
       "fieldConfig": {
         "defaults": {
-          "custom": {}
+          "links": []
         },
         "overrides": []
       },
@@ -891,9 +902,10 @@
       "linewidth": 1,
       "nullPointMode": "null",
       "options": {
-        "dataLinks": []
+        "alertThreshold": true
       },
       "percentage": false,
+      "pluginVersion": "7.5.23",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -960,7 +972,7 @@
       "description": "Shows how many controlplanes are hosted on each node on average.",
       "fieldConfig": {
         "defaults": {
-          "custom": {}
+          "links": []
         },
         "overrides": []
       },
@@ -989,9 +1001,10 @@
       "linewidth": 1,
       "nullPointMode": "null",
       "options": {
-        "dataLinks": []
+        "alertThreshold": true
       },
       "percentage": false,
+      "pluginVersion": "7.5.23",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1567,7 +1580,7 @@
       "description": "Shows how many CPU cores each extension uses.",
       "fieldConfig": {
         "defaults": {
-          "custom": {}
+          "links": []
         },
         "overrides": []
       },
@@ -1595,10 +1608,8 @@
       "lines": true,
       "linewidth": 1,
       "nullPointMode": "null",
-      "options": {
-        "dataLinks": []
-      },
       "percentage": false,
+      "pluginVersion": "7.5.23",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1664,7 +1675,7 @@
       "description": "Shows how much memory each extension is using.",
       "fieldConfig": {
         "defaults": {
-          "custom": {}
+          "links": []
         },
         "overrides": []
       },
@@ -1692,10 +1703,8 @@
       "lines": true,
       "linewidth": 1,
       "nullPointMode": "null",
-      "options": {
-        "dataLinks": []
-      },
       "percentage": false,
+      "pluginVersion": "7.5.23",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1754,27 +1763,39 @@
     }
   ],
   "refresh": false,
-  "schemaVersion": 25,
+  "schemaVersion": 27,
   "style": "dark",
-  "tags": ["seed", "usage"],
+  "tags": [
+    "seed",
+    "usage"
+  ],
   "templating": {
     "list": [
       {
         "allValue": null,
         "current": {
           "selected": true,
-          "text": "All",
-          "value": ["$__all"]
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
         },
         "datasource": "prometheus",
         "definition": "label_values(seed:container_cpu_usage_seconds_total:sum, seed)",
+        "description": null,
+        "error": null,
         "hide": 0,
         "includeAll": true,
         "label": null,
         "multi": true,
         "name": "seed",
         "options": [],
-        "query": "label_values(seed:container_cpu_usage_seconds_total:sum, seed)",
+        "query": {
+          "query": "label_values(seed:container_cpu_usage_seconds_total:sum, seed)",
+          "refId": "prometheus-seed-Variable-Query"
+        },
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,

--- a/pkg/component/plutono/dashboards/garden/global/seed-resource-usage-dashboard.json
+++ b/pkg/component/plutono/dashboards/garden/global/seed-resource-usage-dashboard.json
@@ -1828,6 +1828,6 @@
   },
   "timezone": "",
   "title": "Seed Resource Usage",
-  "uid": "jkiMo_2Zz",
+  "uid": "seed-resource-usage",
   "version": 1
 }

--- a/pkg/component/plutono/dashboards/garden/global/shoot-availability-dashboard.json
+++ b/pkg/component/plutono/dashboards/garden/global/shoot-availability-dashboard.json
@@ -579,6 +579,6 @@
   },
   "timezone": "",
   "title": "Shoot Availability",
-  "uid": "Wt3LO42Zk",
+  "uid": "shoot-availability",
   "version": 1
 }

--- a/pkg/component/plutono/dashboards/garden/global/shoot-availability-dashboard.json
+++ b/pkg/component/plutono/dashboards/garden/global/shoot-availability-dashboard.json
@@ -19,6 +19,28 @@
   "links": [],
   "panels": [
     {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 0,
+          "mappings": [],
+          "max": 100,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
       "gridPos": {
         "h": 6,
         "w": 11,
@@ -28,26 +50,18 @@
       "id": 13,
       "options": {
         "displayMode": "gradient",
-        "fieldOptions": {
-          "calcs": ["last"],
-          "defaults": {
-            "decimals": 0,
-            "mappings": [],
-            "max": 100,
-            "min": 0,
-            "thresholds": [
-              {
-                "color": "green",
-                "value": null
-              }
-            ]
-          },
-          "override": {},
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "last"
+          ],
+          "fields": "",
           "values": false
         },
-        "orientation": "horizontal"
+        "showUnfilled": true,
+        "text": {}
       },
-      "pluginVersion": "6.3.2",
+      "pluginVersion": "7.5.23",
       "targets": [
         {
           "expr": "count(garden_shoot_info) by (iaas)",
@@ -61,22 +75,19 @@
       "type": "bargauge"
     },
     {
+      "datasource": null,
       "description": "Shows the current % of available shoots.",
-      "gridPos": {
-        "h": 6,
-        "w": 5,
-        "x": 11,
-        "y": 0
-      },
-      "id": 2,
-      "options": {
-        "fieldOptions": {
-          "calcs": ["mean"],
-          "defaults": {
-            "mappings": [],
-            "max": 100,
-            "min": 0,
-            "thresholds": [
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "max": 100,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
               {
                 "color": "red",
                 "value": null
@@ -85,17 +96,33 @@
                 "color": "green",
                 "value": 95
               }
-            ],
-            "unit": "percent"
+            ]
           },
-          "override": {},
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 5,
+        "x": 11,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "fields": "",
           "values": false
         },
-        "orientation": "auto",
         "showThresholdLabels": false,
-        "showThresholdMarkers": true
+        "showThresholdMarkers": true,
+        "text": {}
       },
-      "pluginVersion": "6.3.2",
+      "pluginVersion": "7.5.23",
       "targets": [
         {
           "expr": "count(garden_shoot_condition{condition=\"APIServerAvailable\"} == 1) / count(garden_shoot_info) * 100",
@@ -108,22 +135,20 @@
       "type": "gauge"
     },
     {
+      "datasource": null,
       "description": "Shows the total number of shoot clusters (including shooted seeds).",
-      "gridPos": {
-        "h": 6,
-        "w": 4,
-        "x": 16,
-        "y": 0
-      },
-      "id": 4,
-      "options": {
-        "fieldOptions": {
-          "calcs": ["mean"],
-          "defaults": {
-            "mappings": [],
-            "max": 0,
-            "min": 0,
-            "thresholds": [
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "displayName": "Shoots",
+          "mappings": [],
+          "max": 0,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
               {
                 "color": "green",
                 "value": null
@@ -132,17 +157,32 @@
                 "color": "red",
                 "value": 80
               }
-            ],
-            "title": "Shoots"
-          },
-          "override": {},
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 16,
+        "y": 0
+      },
+      "id": 4,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "fields": "",
           "values": false
         },
-        "orientation": "auto",
         "showThresholdLabels": false,
-        "showThresholdMarkers": true
+        "showThresholdMarkers": true,
+        "text": {}
       },
-      "pluginVersion": "6.3.2",
+      "pluginVersion": "7.5.23",
       "targets": [
         {
           "expr": "count(garden_shoot_info)",
@@ -155,23 +195,21 @@
       "type": "gauge"
     },
     {
+      "datasource": null,
       "description": "Shows the total number of unavailable shoot clusters (including shooted seeds).",
-      "gridPos": {
-        "h": 6,
-        "w": 4,
-        "x": 20,
-        "y": 0
-      },
-      "id": 5,
-      "options": {
-        "fieldOptions": {
-          "calcs": ["mean"],
-          "defaults": {
-            "decimals": 0,
-            "mappings": [],
-            "max": 0,
-            "min": 0,
-            "thresholds": [
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 0,
+          "displayName": "Shoots",
+          "mappings": [],
+          "max": 0,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
               {
                 "color": "red",
                 "value": null
@@ -180,17 +218,32 @@
                 "color": "red",
                 "value": 80
               }
-            ],
-            "title": "Shoots"
-          },
-          "override": {},
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 20,
+        "y": 0
+      },
+      "id": 5,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "fields": "",
           "values": false
         },
-        "orientation": "auto",
         "showThresholdLabels": false,
-        "showThresholdMarkers": true
+        "showThresholdMarkers": true,
+        "text": {}
       },
-      "pluginVersion": "6.3.2",
+      "pluginVersion": "7.5.23",
       "targets": [
         {
           "expr": "count(garden_shoot_condition{condition=\"APIServerAvailable\"} == 0)",
@@ -207,7 +260,14 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
+      "datasource": null,
       "description": "Shows the availability of all shoot clusters.",
+      "fieldConfig": {
+        "defaults": {
+          "links": []
+        },
+        "overrides": []
+      },
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -216,6 +276,7 @@
         "x": 0,
         "y": 6
       },
+      "hiddenSeries": false,
       "id": 7,
       "legend": {
         "alignAsTable": true,
@@ -232,9 +293,10 @@
       "linewidth": 1,
       "nullPointMode": "null",
       "options": {
-        "dataLinks": []
+        "alertThreshold": true
       },
       "percentage": false,
+      "pluginVersion": "7.5.23",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -297,7 +359,14 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
+      "datasource": null,
       "description": "Shows the availability of all shoots.",
+      "fieldConfig": {
+        "defaults": {
+          "links": []
+        },
+        "overrides": []
+      },
       "fill": 0,
       "fillGradient": 0,
       "gridPos": {
@@ -306,6 +375,7 @@
         "x": 11,
         "y": 6
       },
+      "hiddenSeries": false,
       "id": 11,
       "legend": {
         "alignAsTable": true,
@@ -322,9 +392,10 @@
       "linewidth": 1,
       "nullPointMode": "null",
       "options": {
-        "dataLinks": []
+        "alertThreshold": true
       },
       "percentage": false,
+      "pluginVersion": "7.5.23",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -384,7 +455,12 @@
     },
     {
       "columns": [],
+      "datasource": null,
       "description": "List of shoots that are unavailable.",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
       "fontSize": "100%",
       "gridPos": {
         "h": 8,
@@ -393,7 +469,6 @@
         "y": 13
       },
       "id": 9,
-      "options": {},
       "pageSize": null,
       "scroll": true,
       "showHeader": true,
@@ -404,6 +479,7 @@
       "styles": [
         {
           "alias": "",
+          "align": "auto",
           "colorMode": null,
           "colors": [
             "rgba(245, 54, 54, 0.9)",
@@ -424,6 +500,7 @@
         },
         {
           "alias": "",
+          "align": "auto",
           "colorMode": null,
           "colors": [
             "rgba(245, 54, 54, 0.9)",
@@ -440,6 +517,7 @@
         },
         {
           "alias": "",
+          "align": "auto",
           "colorMode": null,
           "colors": [
             "rgba(245, 54, 54, 0.9)",
@@ -469,12 +547,15 @@
       "timeShift": null,
       "title": "Unavailable Shoots",
       "transform": "table",
-      "type": "table"
+      "type": "table-old"
     }
   ],
-  "schemaVersion": 19,
+  "schemaVersion": 27,
   "style": "dark",
-  "tags": ["shoot", "landscape"],
+  "tags": [
+    "shoot",
+    "landscape"
+  ],
   "templating": {
     "list": []
   },

--- a/pkg/component/plutono/dashboards/garden/global/shoot-details-dashboard.json
+++ b/pkg/component/plutono/dashboards/garden/global/shoot-details-dashboard.json
@@ -39,14 +39,16 @@
       "cacheTimeout": null,
       "colorBackground": true,
       "colorValue": false,
-      "colors": ["#d44a3a", "rgba(40, 40, 40, 0.89)", "#299c46"],
+      "colors": [
+        "#d44a3a",
+        "rgba(40, 40, 40, 0.89)",
+        "#299c46"
+      ],
       "datasource": "prometheus",
       "decimals": null,
       "description": "",
       "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
+        "defaults": {},
         "overrides": []
       },
       "format": "none",
@@ -127,14 +129,16 @@
       "cacheTimeout": null,
       "colorBackground": true,
       "colorValue": false,
-      "colors": ["#d44a3a", "rgba(40, 40, 40, 0.89)", "#299c46"],
+      "colors": [
+        "#d44a3a",
+        "rgba(40, 40, 40, 0.89)",
+        "#299c46"
+      ],
       "datasource": "prometheus",
       "decimals": null,
       "description": "",
       "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
+        "defaults": {},
         "overrides": []
       },
       "format": "none",
@@ -215,14 +219,16 @@
       "cacheTimeout": null,
       "colorBackground": true,
       "colorValue": false,
-      "colors": ["#d44a3a", "rgba(40, 40, 40, 0.89)", "#299c46"],
+      "colors": [
+        "#d44a3a",
+        "rgba(40, 40, 40, 0.89)",
+        "#299c46"
+      ],
       "datasource": "prometheus",
       "decimals": null,
       "description": "",
       "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
+        "defaults": {},
         "overrides": []
       },
       "format": "none",
@@ -303,14 +309,16 @@
       "cacheTimeout": null,
       "colorBackground": true,
       "colorValue": false,
-      "colors": ["#d44a3a", "rgba(40, 40, 40, 0.89)", "#299c46"],
+      "colors": [
+        "#d44a3a",
+        "rgba(40, 40, 40, 0.89)",
+        "#299c46"
+      ],
       "datasource": "prometheus",
       "decimals": null,
       "description": "",
       "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
+        "defaults": {},
         "overrides": []
       },
       "format": "none",
@@ -391,12 +399,14 @@
       "cacheTimeout": null,
       "colorBackground": true,
       "colorValue": false,
-      "colors": ["#299c46", "rgba(40, 40, 40, 0.89)", "#d44a3a"],
+      "colors": [
+        "#299c46",
+        "rgba(40, 40, 40, 0.89)",
+        "#d44a3a"
+      ],
       "datasource": "prometheus",
       "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
+        "defaults": {},
         "overrides": []
       },
       "format": "none",
@@ -481,7 +491,6 @@
       "description": "Shows if the API Server is reachable from the shoot cluster.",
       "fieldConfig": {
         "defaults": {
-          "custom": {},
           "links": []
         },
         "overrides": []
@@ -512,7 +521,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.16",
+      "pluginVersion": "7.5.23",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -608,7 +617,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.16",
+      "pluginVersion": "7.5.23",
       "pointradius": 10,
       "points": false,
       "renderer": "flot",
@@ -626,7 +635,9 @@
         }
       ],
       "thresholds": [],
+      "timeFrom": null,
       "timeRegions": [],
+      "timeShift": null,
       "title": "K8s Versions",
       "tooltip": {
         "shared": true,
@@ -674,7 +685,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 8
+        "y": 9
       },
       "id": 12,
       "panels": [
@@ -807,7 +818,9 @@
           "points": false,
           "renderer": "flot",
           "repeat": null,
-          "seriesOverrides": [{}],
+          "seriesOverrides": [
+            {}
+          ],
           "spaceLength": 10,
           "stack": false,
           "steppedLine": false,
@@ -1092,7 +1105,6 @@
       "description": "Shows pending and firing alerts in the cluster.",
       "fieldConfig": {
         "defaults": {
-          "custom": {},
           "links": []
         },
         "overrides": []
@@ -1126,7 +1138,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.3.1",
+      "pluginVersion": "7.5.23",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1188,19 +1200,23 @@
   "refresh": "30s",
   "schemaVersion": 27,
   "style": "dark",
-  "tags": ["Shoot", "Gardener"],
+  "tags": [
+    "Shoot",
+    "Gardener"
+  ],
   "templating": {
     "list": [
       {
         "allFormat": "glob",
         "allValue": null,
         "current": {
-          "selected": true,
+          "selected": false,
           "text": "garden",
           "value": "garden"
         },
         "datasource": "prometheus",
         "definition": "",
+        "description": null,
         "error": null,
         "hide": 0,
         "includeAll": false,
@@ -1208,7 +1224,10 @@
         "multi": false,
         "name": "project",
         "options": [],
-        "query": "label_values(garden_shoot_info, project)",
+        "query": {
+          "query": "label_values(garden_shoot_info, project)",
+          "refId": "prometheus-project-Variable-Query"
+        },
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
@@ -1229,6 +1248,7 @@
         },
         "datasource": "prometheus",
         "definition": "",
+        "description": null,
         "error": null,
         "hide": 0,
         "includeAll": false,
@@ -1236,7 +1256,10 @@
         "multi": false,
         "name": "shoot",
         "options": [],
-        "query": "label_values(garden_shoot_info{project=\"$project\"}, name)",
+        "query": {
+          "query": "label_values(garden_shoot_info{project=\"$project\"}, name)",
+          "refId": "prometheus-shoot-Variable-Query"
+        },
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
@@ -1254,8 +1277,20 @@
     "to": "now"
   },
   "timepicker": {
-    "refresh_intervals": ["30s"],
-    "time_options": ["5m", "15m", "1h", "6h", "12h", "24h", "2d", "7d", "30d"]
+    "refresh_intervals": [
+      "30s"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
   },
   "timezone": "browser",
   "title": "Shoot Details",

--- a/pkg/component/plutono/dashboards/garden/global/shoot-sla-dashboard.json
+++ b/pkg/component/plutono/dashboards/garden/global/shoot-sla-dashboard.json
@@ -23,9 +23,7 @@
       "datasource": "availability-prometheus",
       "description": "",
       "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
+        "defaults": {},
         "overrides": []
       },
       "gridPos": {
@@ -39,7 +37,7 @@
         "content": "[99.95%][] allows for 5 minutes of downtime per week\n\n[99.95%]: https://uptime.is/99.95\n\n\n",
         "mode": "markdown"
       },
-      "pluginVersion": "7.3.1",
+      "pluginVersion": "7.5.23",
       "timeFrom": null,
       "timeShift": null,
       "title": "SLA (over the last 7 days)",
@@ -51,9 +49,6 @@
       "description": "",
       "fieldConfig": {
         "defaults": {
-          "custom": {
-            "align": null
-          },
           "mappings": [],
           "max": 30,
           "min": 0,
@@ -83,13 +78,16 @@
         "justifyMode": "auto",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["mean"],
+          "calcs": [
+            "mean"
+          ],
           "fields": "",
           "values": false
         },
+        "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "7.3.1",
+      "pluginVersion": "7.5.23",
       "targets": [
         {
           "expr": "count(\n  count_over_time(\n    garden_shoot_condition{condition=\"APIServerAvailable\",operation=\"Reconcile\",project=~\"$project\",name=~\"$name\",iaas=\"$iaas\", purpose=~\"$purpose\"}[7d:]\n  )\n)",
@@ -111,9 +109,6 @@
       "description": "",
       "fieldConfig": {
         "defaults": {
-          "custom": {
-            "align": null
-          },
           "mappings": [],
           "max": 30,
           "min": 0,
@@ -143,13 +138,16 @@
         "justifyMode": "auto",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["mean"],
+          "calcs": [
+            "mean"
+          ],
           "fields": "",
           "values": false
         },
+        "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "7.3.1",
+      "pluginVersion": "7.5.23",
       "targets": [
         {
           "expr": "count(\n  count_over_time(\n    (garden_shoot_condition{condition=\"APIServerAvailable\",operation=\"Reconcile\",project=~\"$project\",name=~\"$name\",iaas=\"$iaas\", purpose=~\"$purpose\"} < 1)[7d:]\n  ) > 5\n)",
@@ -171,9 +169,6 @@
       "description": "",
       "fieldConfig": {
         "defaults": {
-          "custom": {
-            "align": null
-          },
           "decimals": 2,
           "mappings": [],
           "max": 30,
@@ -208,13 +203,16 @@
         "justifyMode": "auto",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["mean"],
+          "calcs": [
+            "mean"
+          ],
           "fields": "",
           "values": false
         },
+        "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "7.3.1",
+      "pluginVersion": "7.5.23",
       "targets": [
         {
           "expr": "count(\n  count_over_time(\n    (garden_shoot_condition{condition=\"APIServerAvailable\",operation=\"Reconcile\",iaas=\"$iaas\",project=~\"$project\",name=~\"$name\",purpose=~\"$purpose\"} < 1)[7d:]\n  ) > 5\n)\n/\ncount(\n  count_over_time(\n    (garden_shoot_condition{condition=\"APIServerAvailable\",operation=\"Reconcile\",iaas=\"$iaas\",project=~\"$project\",name=~\"$name\",purpose=~\"$purpose\"})[7d :]\n  )\n)",
@@ -289,7 +287,7 @@
         "showHeader": true,
         "sortBy": []
       },
-      "pluginVersion": "7.3.1",
+      "pluginVersion": "7.5.23",
       "targets": [
         {
           "expr": "sum by (project, name) (\n  count_over_time(\n    (garden_shoot_condition{condition=\"APIServerAvailable\",operation=\"Reconcile\",iaas=\"$iaas\",project=~\"$project\",name=~\"$name\",purpose=~\"$purpose\"} < 1)[7d:]\n  ) > 5\n)",
@@ -308,7 +306,11 @@
           "id": "filterFieldsByName",
           "options": {
             "include": {
-              "names": ["name", "project", "Value"]
+              "names": [
+                "name",
+                "project",
+                "Value"
+              ]
             }
           }
         },
@@ -338,26 +340,7 @@
       "description": "",
       "fieldConfig": {
         "defaults": {
-          "custom": {
-            "align": null
-          },
           "links": [],
-          "mappings": [],
-          "max": 30,
-          "min": 0,
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 5
-              }
-            ]
-          },
           "unit": "none"
         },
         "overrides": []
@@ -392,7 +375,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.3.1",
+      "pluginVersion": "7.5.23",
       "pointradius": 3,
       "points": true,
       "renderer": "flot",
@@ -462,20 +445,7 @@
       "description": "",
       "fieldConfig": {
         "defaults": {
-          "custom": {
-            "align": null
-          },
           "links": [],
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              }
-            ]
-          },
           "unit": "none"
         },
         "overrides": []
@@ -510,7 +480,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.3.1",
+      "pluginVersion": "7.5.23",
       "pointradius": 0.5,
       "points": true,
       "renderer": "flot",
@@ -581,7 +551,7 @@
     }
   ],
   "refresh": false,
-  "schemaVersion": 26,
+  "schemaVersion": 27,
   "style": "dark",
   "tags": [],
   "templating": {
@@ -595,6 +565,7 @@
         },
         "datasource": "prometheus",
         "definition": "label_values(garden_shoot_condition, iaas)",
+        "description": null,
         "error": null,
         "hide": 0,
         "includeAll": false,
@@ -663,11 +634,16 @@
         "allValue": ".+",
         "current": {
           "selected": true,
-          "text": ["All"],
-          "value": ["$__all"]
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
         },
         "datasource": "prometheus",
         "definition": "label_values(garden_shoot_condition{condition=\"APIServerAvailable\",operation=\"Reconcile\",iaas=\"$iaas\"}, project)",
+        "description": null,
         "error": null,
         "hide": 0,
         "includeAll": true,
@@ -675,7 +651,10 @@
         "multi": true,
         "name": "project",
         "options": [],
-        "query": "label_values(garden_shoot_condition{condition=\"APIServerAvailable\",operation=\"Reconcile\",iaas=\"$iaas\"}, project)",
+        "query": {
+          "query": "label_values(garden_shoot_condition{condition=\"APIServerAvailable\",operation=\"Reconcile\",iaas=\"$iaas\"}, project)",
+          "refId": "prometheus-project-Variable-Query"
+        },
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
@@ -690,11 +669,16 @@
         "allValue": ".+",
         "current": {
           "selected": true,
-          "text": ["All"],
-          "value": ["$__all"]
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
         },
         "datasource": "prometheus",
         "definition": "label_values(garden_shoot_condition{condition=\"APIServerAvailable\",operation=\"Reconcile\",iaas=\"$iaas\", project=~\"$project\"}, name)",
+        "description": null,
         "error": null,
         "hide": 0,
         "includeAll": true,
@@ -702,7 +686,10 @@
         "multi": true,
         "name": "name",
         "options": [],
-        "query": "label_values(garden_shoot_condition{condition=\"APIServerAvailable\",operation=\"Reconcile\",iaas=\"$iaas\", project=~\"$project\"}, name)",
+        "query": {
+          "query": "label_values(garden_shoot_condition{condition=\"APIServerAvailable\",operation=\"Reconcile\",iaas=\"$iaas\", project=~\"$project\"}, name)",
+          "refId": "prometheus-name-Variable-Query"
+        },
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
@@ -718,11 +705,16 @@
         "current": {
           "selected": true,
           "tags": [],
-          "text": ["All"],
-          "value": ["$__all"]
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
         },
         "datasource": "prometheus",
         "definition": "label_values(garden_shoot_condition{condition=\"APIServerAvailable\",operation=\"Reconcile\"}, purpose)",
+        "description": null,
         "error": null,
         "hide": 0,
         "includeAll": true,

--- a/pkg/component/plutono/dashboards/garden/global/shoot-sli-dashboard.json
+++ b/pkg/component/plutono/dashboards/garden/global/shoot-sli-dashboard.json
@@ -4123,6 +4123,6 @@
   "timepicker": {},
   "timezone": "utc",
   "title": "Shoot SLI",
-  "uid": "_2l9zIYGk",
+  "uid": "shoot-sli",
   "version": 1
 }

--- a/pkg/component/plutono/dashboards/garden/global/shoot-sli-dashboard.json
+++ b/pkg/component/plutono/dashboards/garden/global/shoot-sli-dashboard.json
@@ -1,6 +1,16 @@
 {
   "annotations": {
-    "list": []
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Plutono --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
   },
   "editable": true,
   "gnetId": null,
@@ -13,9 +23,7 @@
       "datasource": null,
       "description": "",
       "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
+        "defaults": {},
         "overrides": []
       },
       "gridPos": {
@@ -29,7 +37,7 @@
         "content": "This dashboard is one possible\nvisualisation for the error budgets\nof the shoots, grouped by the infrastructure.\n\nQuestions/comments: #gardener-monitoring",
         "mode": "markdown"
       },
-      "pluginVersion": "7.3.1",
+      "pluginVersion": "7.5.23",
       "timeFrom": null,
       "timeShift": null,
       "title": "Welcome",
@@ -40,7 +48,6 @@
       "description": "",
       "fieldConfig": {
         "defaults": {
-          "custom": {},
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
@@ -68,13 +75,16 @@
         "justifyMode": "auto",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["last"],
+          "calcs": [
+            "last"
+          ],
           "fields": "",
           "values": false
         },
+        "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "7.3.1",
+      "pluginVersion": "7.5.23",
       "targets": [
         {
           "expr": "min_over_time((1- quantile(0.9, probe_failure:run:time:total:percent{iaas=~\"$iaas\"}) by (iaas))[24h:10m])",
@@ -379,7 +389,12 @@
               "id": "filterFieldsByName",
               "options": {
                 "include": {
-                  "names": ["iaas", "name", "project", "Value"]
+                  "names": [
+                    "iaas",
+                    "name",
+                    "project",
+                    "Value"
+                  ]
                 }
               }
             },
@@ -2810,7 +2825,7 @@
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
-          "repeatIteration": 1612436590043,
+          "repeatIteration": 1692364751761,
           "repeatPanelId": 103,
           "repeatedByRow": true,
           "scopedVars": {
@@ -2948,7 +2963,7 @@
           }
         }
       ],
-      "repeatIteration": 1612436590043,
+      "repeatIteration": 1692364751761,
       "repeatPanelId": 60,
       "scopedVars": {
         "iaas": {
@@ -3032,7 +3047,7 @@
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
-          "repeatIteration": 1612436590043,
+          "repeatIteration": 1692364751761,
           "repeatPanelId": 103,
           "repeatedByRow": true,
           "scopedVars": {
@@ -3170,7 +3185,7 @@
           }
         }
       ],
-      "repeatIteration": 1612436590043,
+      "repeatIteration": 1692364751761,
       "repeatPanelId": 60,
       "scopedVars": {
         "iaas": {
@@ -3254,7 +3269,7 @@
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
-          "repeatIteration": 1612436590043,
+          "repeatIteration": 1692364751761,
           "repeatPanelId": 103,
           "repeatedByRow": true,
           "scopedVars": {
@@ -3392,7 +3407,7 @@
           }
         }
       ],
-      "repeatIteration": 1612436590043,
+      "repeatIteration": 1692364751761,
       "repeatPanelId": 60,
       "scopedVars": {
         "iaas": {
@@ -3476,229 +3491,7 @@
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
-          "repeatIteration": 1612436590043,
-          "repeatPanelId": 103,
-          "repeatedByRow": true,
-          "scopedVars": {
-            "iaas": {
-              "selected": false,
-              "text": "metal",
-              "value": "metal"
-            }
-          },
-          "seriesOverrides": [
-            {
-              "alias": "/min|max/",
-              "dashes": true
-            },
-            {
-              "alias": "90%",
-              "fillBelowTo": "50%"
-            },
-            {
-              "alias": "50%",
-              "fillBelowTo": "10%"
-            },
-            {
-              "alias": "SLO",
-              "linewidth": 2,
-              "zindex": 1
-            },
-            {
-              "alias": "# of shoots",
-              "yaxis": 2
-            }
-          ],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "expr": "1- max(probe_failure:run:time:total:percent{iaas=~\"$iaas\",purpose=~\"$purpose\",project=~\"$project\",term=~\"$term\",window=\"$window\"})",
-              "hide": false,
-              "interval": "",
-              "legendFormat": "min",
-              "refId": "A"
-            },
-            {
-              "expr": "$SLO/100",
-              "hide": false,
-              "interval": "",
-              "legendFormat": "SLO",
-              "refId": "B"
-            },
-            {
-              "expr": "1- min(probe_failure:run:time:total:percent{iaas=~\"$iaas\",purpose=~\"$purpose\",project=~\"$project\",term=~\"$term\",window=\"$window\"})",
-              "hide": false,
-              "interval": "",
-              "legendFormat": "max",
-              "refId": "D"
-            },
-            {
-              "expr": "1- quantile(0.1, probe_failure:run:time:total:percent{iaas=~\"$iaas\",purpose=~\"$purpose\",project=~\"$project\",term=~\"$term\",window=\"$window\"})",
-              "hide": false,
-              "interval": "",
-              "legendFormat": "90%",
-              "refId": "E"
-            },
-            {
-              "expr": "1- quantile(0.9, probe_failure:run:time:total:percent{iaas=~\"$iaas\",purpose=~\"$purpose\",project=~\"$project\",term=~\"$term\",window=\"$window\"})",
-              "hide": false,
-              "interval": "",
-              "legendFormat": "10%",
-              "refId": "F"
-            },
-            {
-              "expr": "1- quantile(0.5, probe_failure:run:time:total:percent{iaas=~\"$iaas\",purpose=~\"$purpose\",project=~\"$project\",term=~\"$term\",window=\"$window\"})",
-              "hide": false,
-              "interval": "",
-              "legendFormat": "50%",
-              "refId": "G"
-            },
-            {
-              "expr": "1- avg(probe_failure:run:time:total:percent{iaas=~\"$iaas\",purpose=~\"$purpose\",project=~\"$project\",term=~\"$term\",window=\"$window\"})",
-              "hide": false,
-              "interval": "",
-              "legendFormat": "avg",
-              "refId": "H"
-            },
-            {
-              "expr": "count(probe_failure:run{iaas=~\"$iaas\",purpose=~\"$purpose\",project=~\"$project\"})",
-              "hide": false,
-              "interval": "",
-              "legendFormat": "# of shoots",
-              "refId": "C"
-            }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeRegions": [],
-          "timeShift": null,
-          "title": "Funnel for $iaas",
-          "tooltip": {
-            "shared": false,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "decimals": 3,
-              "format": "percentunit",
-              "label": "",
-              "logBase": 1,
-              "max": "1",
-              "min": null,
-              "show": true
-            },
-            {
-              "decimals": 0,
-              "format": "none",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false,
-            "alignLevel": null
-          }
-        }
-      ],
-      "repeatIteration": 1612436590043,
-      "repeatPanelId": 60,
-      "scopedVars": {
-        "iaas": {
-          "selected": false,
-          "text": "metal",
-          "value": "metal"
-        }
-      },
-      "title": "Funnel for $iaas",
-      "type": "row"
-    },
-    {
-      "collapsed": true,
-      "datasource": null,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 13
-      },
-      "id": 145,
-      "panels": [
-        {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "availability-prometheus",
-          "decimals": 2,
-          "description": "",
-          "fieldConfig": {
-            "defaults": {
-              "custom": {}
-            },
-            "overrides": [
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "# of shoots"
-                },
-                "properties": [
-                  {
-                    "id": "unit",
-                    "value": "none"
-                  }
-                ]
-              }
-            ]
-          },
-          "fill": 0,
-          "fillGradient": 0,
-          "gridPos": {
-            "h": 12,
-            "w": 24,
-            "x": 0,
-            "y": 28
-          },
-          "hiddenSeries": false,
-          "id": 146,
-          "legend": {
-            "alignAsTable": true,
-            "avg": false,
-            "current": true,
-            "max": false,
-            "min": true,
-            "rightSide": true,
-            "show": true,
-            "sort": "min",
-            "sortDesc": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "nullPointMode": "null",
-          "options": {
-            "alertThreshold": true
-          },
-          "percentage": false,
-          "pluginVersion": "7.3.7",
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
-          "repeatIteration": 1612436590043,
+          "repeatIteration": 1692364751761,
           "repeatPanelId": 103,
           "repeatedByRow": true,
           "scopedVars": {
@@ -3836,7 +3629,7 @@
           }
         }
       ],
-      "repeatIteration": 1612436590043,
+      "repeatIteration": 1692364751761,
       "repeatPanelId": 60,
       "scopedVars": {
         "iaas": {
@@ -3855,9 +3648,9 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 14
+        "y": 13
       },
-      "id": 147,
+      "id": 145,
       "panels": [
         {
           "aliasColors": {},
@@ -3895,7 +3688,7 @@
             "y": 28
           },
           "hiddenSeries": false,
-          "id": 148,
+          "id": 146,
           "legend": {
             "alignAsTable": true,
             "avg": false,
@@ -3920,451 +3713,7 @@
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
-          "repeatIteration": 1612436590043,
-          "repeatPanelId": 103,
-          "repeatedByRow": true,
-          "scopedVars": {
-            "iaas": {
-              "selected": false,
-              "text": "ovh",
-              "value": "ovh"
-            }
-          },
-          "seriesOverrides": [
-            {
-              "alias": "/min|max/",
-              "dashes": true
-            },
-            {
-              "alias": "90%",
-              "fillBelowTo": "50%"
-            },
-            {
-              "alias": "50%",
-              "fillBelowTo": "10%"
-            },
-            {
-              "alias": "SLO",
-              "linewidth": 2,
-              "zindex": 1
-            },
-            {
-              "alias": "# of shoots",
-              "yaxis": 2
-            }
-          ],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "expr": "1- max(probe_failure:run:time:total:percent{iaas=~\"$iaas\",purpose=~\"$purpose\",project=~\"$project\",term=~\"$term\",window=\"$window\"})",
-              "hide": false,
-              "interval": "",
-              "legendFormat": "min",
-              "refId": "A"
-            },
-            {
-              "expr": "$SLO/100",
-              "hide": false,
-              "interval": "",
-              "legendFormat": "SLO",
-              "refId": "B"
-            },
-            {
-              "expr": "1- min(probe_failure:run:time:total:percent{iaas=~\"$iaas\",purpose=~\"$purpose\",project=~\"$project\",term=~\"$term\",window=\"$window\"})",
-              "hide": false,
-              "interval": "",
-              "legendFormat": "max",
-              "refId": "D"
-            },
-            {
-              "expr": "1- quantile(0.1, probe_failure:run:time:total:percent{iaas=~\"$iaas\",purpose=~\"$purpose\",project=~\"$project\",term=~\"$term\",window=\"$window\"})",
-              "hide": false,
-              "interval": "",
-              "legendFormat": "90%",
-              "refId": "E"
-            },
-            {
-              "expr": "1- quantile(0.9, probe_failure:run:time:total:percent{iaas=~\"$iaas\",purpose=~\"$purpose\",project=~\"$project\",term=~\"$term\",window=\"$window\"})",
-              "hide": false,
-              "interval": "",
-              "legendFormat": "10%",
-              "refId": "F"
-            },
-            {
-              "expr": "1- quantile(0.5, probe_failure:run:time:total:percent{iaas=~\"$iaas\",purpose=~\"$purpose\",project=~\"$project\",term=~\"$term\",window=\"$window\"})",
-              "hide": false,
-              "interval": "",
-              "legendFormat": "50%",
-              "refId": "G"
-            },
-            {
-              "expr": "1- avg(probe_failure:run:time:total:percent{iaas=~\"$iaas\",purpose=~\"$purpose\",project=~\"$project\",term=~\"$term\",window=\"$window\"})",
-              "hide": false,
-              "interval": "",
-              "legendFormat": "avg",
-              "refId": "H"
-            },
-            {
-              "expr": "count(probe_failure:run{iaas=~\"$iaas\",purpose=~\"$purpose\",project=~\"$project\"})",
-              "hide": false,
-              "interval": "",
-              "legendFormat": "# of shoots",
-              "refId": "C"
-            }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeRegions": [],
-          "timeShift": null,
-          "title": "Funnel for $iaas",
-          "tooltip": {
-            "shared": false,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "decimals": 3,
-              "format": "percentunit",
-              "label": "",
-              "logBase": 1,
-              "max": "1",
-              "min": null,
-              "show": true
-            },
-            {
-              "decimals": 0,
-              "format": "none",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false,
-            "alignLevel": null
-          }
-        }
-      ],
-      "repeatIteration": 1612436590043,
-      "repeatPanelId": 60,
-      "scopedVars": {
-        "iaas": {
-          "selected": false,
-          "text": "ovh",
-          "value": "ovh"
-        }
-      },
-      "title": "Funnel for $iaas",
-      "type": "row"
-    },
-    {
-      "collapsed": true,
-      "datasource": null,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 15
-      },
-      "id": 149,
-      "panels": [
-        {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "availability-prometheus",
-          "decimals": 2,
-          "description": "",
-          "fieldConfig": {
-            "defaults": {
-              "custom": {}
-            },
-            "overrides": [
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "# of shoots"
-                },
-                "properties": [
-                  {
-                    "id": "unit",
-                    "value": "none"
-                  }
-                ]
-              }
-            ]
-          },
-          "fill": 0,
-          "fillGradient": 0,
-          "gridPos": {
-            "h": 12,
-            "w": 24,
-            "x": 0,
-            "y": 28
-          },
-          "hiddenSeries": false,
-          "id": 150,
-          "legend": {
-            "alignAsTable": true,
-            "avg": false,
-            "current": true,
-            "max": false,
-            "min": true,
-            "rightSide": true,
-            "show": true,
-            "sort": "min",
-            "sortDesc": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "nullPointMode": "null",
-          "options": {
-            "alertThreshold": true
-          },
-          "percentage": false,
-          "pluginVersion": "7.3.7",
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
-          "repeatIteration": 1612436590043,
-          "repeatPanelId": 103,
-          "repeatedByRow": true,
-          "scopedVars": {
-            "iaas": {
-              "selected": false,
-              "text": "sen",
-              "value": "sen"
-            }
-          },
-          "seriesOverrides": [
-            {
-              "alias": "/min|max/",
-              "dashes": true
-            },
-            {
-              "alias": "90%",
-              "fillBelowTo": "50%"
-            },
-            {
-              "alias": "50%",
-              "fillBelowTo": "10%"
-            },
-            {
-              "alias": "SLO",
-              "linewidth": 2,
-              "zindex": 1
-            },
-            {
-              "alias": "# of shoots",
-              "yaxis": 2
-            }
-          ],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "expr": "1- max(probe_failure:run:time:total:percent{iaas=~\"$iaas\",purpose=~\"$purpose\",project=~\"$project\",term=~\"$term\",window=\"$window\"})",
-              "hide": false,
-              "interval": "",
-              "legendFormat": "min",
-              "refId": "A"
-            },
-            {
-              "expr": "$SLO/100",
-              "hide": false,
-              "interval": "",
-              "legendFormat": "SLO",
-              "refId": "B"
-            },
-            {
-              "expr": "1- min(probe_failure:run:time:total:percent{iaas=~\"$iaas\",purpose=~\"$purpose\",project=~\"$project\",term=~\"$term\",window=\"$window\"})",
-              "hide": false,
-              "interval": "",
-              "legendFormat": "max",
-              "refId": "D"
-            },
-            {
-              "expr": "1- quantile(0.1, probe_failure:run:time:total:percent{iaas=~\"$iaas\",purpose=~\"$purpose\",project=~\"$project\",term=~\"$term\",window=\"$window\"})",
-              "hide": false,
-              "interval": "",
-              "legendFormat": "90%",
-              "refId": "E"
-            },
-            {
-              "expr": "1- quantile(0.9, probe_failure:run:time:total:percent{iaas=~\"$iaas\",purpose=~\"$purpose\",project=~\"$project\",term=~\"$term\",window=\"$window\"})",
-              "hide": false,
-              "interval": "",
-              "legendFormat": "10%",
-              "refId": "F"
-            },
-            {
-              "expr": "1- quantile(0.5, probe_failure:run:time:total:percent{iaas=~\"$iaas\",purpose=~\"$purpose\",project=~\"$project\",term=~\"$term\",window=\"$window\"})",
-              "hide": false,
-              "interval": "",
-              "legendFormat": "50%",
-              "refId": "G"
-            },
-            {
-              "expr": "1- avg(probe_failure:run:time:total:percent{iaas=~\"$iaas\",purpose=~\"$purpose\",project=~\"$project\",term=~\"$term\",window=\"$window\"})",
-              "hide": false,
-              "interval": "",
-              "legendFormat": "avg",
-              "refId": "H"
-            },
-            {
-              "expr": "count(probe_failure:run{iaas=~\"$iaas\",purpose=~\"$purpose\",project=~\"$project\"})",
-              "hide": false,
-              "interval": "",
-              "legendFormat": "# of shoots",
-              "refId": "C"
-            }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeRegions": [],
-          "timeShift": null,
-          "title": "Funnel for $iaas",
-          "tooltip": {
-            "shared": false,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "decimals": 3,
-              "format": "percentunit",
-              "label": "",
-              "logBase": 1,
-              "max": "1",
-              "min": null,
-              "show": true
-            },
-            {
-              "decimals": 0,
-              "format": "none",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false,
-            "alignLevel": null
-          }
-        }
-      ],
-      "repeatIteration": 1612436590043,
-      "repeatPanelId": 60,
-      "scopedVars": {
-        "iaas": {
-          "selected": false,
-          "text": "sen",
-          "value": "sen"
-        }
-      },
-      "title": "Funnel for $iaas",
-      "type": "row"
-    },
-    {
-      "collapsed": true,
-      "datasource": null,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 16
-      },
-      "id": 151,
-      "panels": [
-        {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "availability-prometheus",
-          "decimals": 2,
-          "description": "",
-          "fieldConfig": {
-            "defaults": {
-              "custom": {}
-            },
-            "overrides": [
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "# of shoots"
-                },
-                "properties": [
-                  {
-                    "id": "unit",
-                    "value": "none"
-                  }
-                ]
-              }
-            ]
-          },
-          "fill": 0,
-          "fillGradient": 0,
-          "gridPos": {
-            "h": 12,
-            "w": 24,
-            "x": 0,
-            "y": 28
-          },
-          "hiddenSeries": false,
-          "id": 152,
-          "legend": {
-            "alignAsTable": true,
-            "avg": false,
-            "current": true,
-            "max": false,
-            "min": true,
-            "rightSide": true,
-            "show": true,
-            "sort": "min",
-            "sortDesc": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "nullPointMode": "null",
-          "options": {
-            "alertThreshold": true
-          },
-          "percentage": false,
-          "pluginVersion": "7.3.7",
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
-          "repeatIteration": 1612436590043,
+          "repeatIteration": 1692364751761,
           "repeatPanelId": 103,
           "repeatedByRow": true,
           "scopedVars": {
@@ -4502,7 +3851,7 @@
           }
         }
       ],
-      "repeatIteration": 1612436590043,
+      "repeatIteration": 1692364751761,
       "repeatPanelId": 60,
       "scopedVars": {
         "iaas": {
@@ -4516,7 +3865,7 @@
     }
   ],
   "refresh": false,
-  "schemaVersion": 26,
+  "schemaVersion": 27,
   "style": "dark",
   "tags": [],
   "templating": {
@@ -4525,12 +3874,16 @@
         "allValue": "(.+)",
         "current": {
           "selected": true,
-          "tags": [],
-          "text": ["All"],
-          "value": ["$__all"]
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
         },
         "datasource": "availability-prometheus",
         "definition": "label_values(probe_failure, iaas)",
+        "description": null,
         "error": null,
         "hide": 0,
         "includeAll": true,
@@ -4538,7 +3891,10 @@
         "multi": true,
         "name": "iaas",
         "options": [],
-        "query": "label_values(probe_failure, iaas)",
+        "query": {
+          "query": "label_values(probe_failure, iaas)",
+          "refId": "availability-prometheus-iaas-Variable-Query"
+        },
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
@@ -4552,12 +3908,17 @@
       {
         "allValue": "(.+)",
         "current": {
-          "selected": false,
-          "text": ["All"],
-          "value": ["$__all"]
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
         },
         "datasource": "availability-prometheus",
         "definition": "label_values(probe_failure, purpose)",
+        "description": null,
         "error": null,
         "hide": 0,
         "includeAll": true,
@@ -4565,7 +3926,10 @@
         "multi": true,
         "name": "purpose",
         "options": [],
-        "query": "label_values(probe_failure, purpose)",
+        "query": {
+          "query": "label_values(probe_failure, purpose)",
+          "refId": "availability-prometheus-purpose-Variable-Query"
+        },
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
@@ -4579,12 +3943,17 @@
       {
         "allValue": "(.+)",
         "current": {
-          "selected": false,
-          "text": ["All"],
-          "value": ["$__all"]
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
         },
         "datasource": "availability-prometheus",
         "definition": "label_values(probe_failure, project)",
+        "description": null,
         "error": null,
         "hide": 0,
         "includeAll": true,
@@ -4592,7 +3961,10 @@
         "multi": true,
         "name": "project",
         "options": [],
-        "query": "label_values(probe_failure, project)",
+        "query": {
+          "query": "label_values(probe_failure, project)",
+          "refId": "availability-prometheus-project-Variable-Query"
+        },
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
@@ -4612,6 +3984,7 @@
         },
         "datasource": "availability-prometheus",
         "definition": "label_values(probe_failure:run:time:total:percent, window)",
+        "description": null,
         "error": null,
         "hide": 0,
         "includeAll": false,
@@ -4650,6 +4023,7 @@
         },
         "datasource": "availability-prometheus",
         "definition": "label_values(probe_failure:run:time:total:percent,term)",
+        "description": null,
         "error": null,
         "hide": 0,
         "includeAll": false,
@@ -4696,6 +4070,7 @@
           "text": "99.95",
           "value": "99.95"
         },
+        "description": null,
         "error": null,
         "hide": 0,
         "includeAll": false,


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind enhancement

**What this PR does / why we need it**:

Various dashboard improvements. Work in progress.

- Update the dashboards to the current Plutono schema
- Use human readable dashboard UIDs
- Reduce the dashboard load times by improving the variable definitions

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

/cc @rickardsjp @acumino 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
