### PR TITLE
Fix the markdown formatting in `docs/usage/containerd-registry-configuration.md`

### DIFF
--- a/docs/usage/containerd-registry-configuration.md
+++ b/docs/usage/containerd-registry-configuration.md
@@ -94,12 +94,15 @@ version = 2
 
 The migration steps are as follows:
 1. The `containerd` registries configuration has to be adapted to the hosts directory pattern.
-1.1 The `/etc/containerd/config.toml` file needs to be adapted as follows:
+
+   1.1 The `/etc/containerd/config.toml` file needs to be adapted as follows:
    ```toml
    version = 2
    
    [plugins."io.containerd.grpc.v1.cri".registry]
       config_path = "/etc/containerd/certs.d"
    ```
-1.2 The appropriate directory structure and `hosts.toml` file has to be created as described in the [hosts directory pattern section](#hosts-directory-pattern).
+
+   1.2 The appropriate directory structure and `hosts.toml` file has to be created as described in the [hosts directory pattern section](#hosts-directory-pattern).
+
 2. When the `ContainerdRegistryHostsDir` feature gate is GA, then the machinery that performs step 1.1 can be removed. A Shoot cluster can rely that the `config_path` will be always set by gardenlet.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind cleanup

**What this PR does / why we need it**:
Before:
<img width="1178" alt="Screenshot 2023-08-18 at 17 38 23" src="https://github.com/gardener/gardener/assets/9372594/919e2322-66ff-493e-b01b-d318892fb15a">

After:
<img width="1163" alt="Screenshot 2023-08-18 at 17 38 56" src="https://github.com/gardener/gardener/assets/9372594/764cbf37-f6a0-4c0f-a240-5b87b588ef42">

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
