### PR TITLE
Add `Observability` to garden resource printer column

### DIFF
--- a/charts/gardener/operator/templates/customresouredefintion.yaml
+++ b/charts/gardener/operator/templates/customresouredefintion.yaml
@@ -44,6 +44,11 @@ spec:
       jsonPath: .status.conditions[?(@.type=="VirtualGardenAPIServerAvailable")].status
       name: API Server
       type: string
+    - description: Indicates whether the observability components related to the runtime
+        cluster are healthy.
+      jsonPath: .status.conditions[?(@.type=="ObservabilityComponentsHealthy")].status
+      name: Observability
+      type: string
     - description: creation timestamp
       jsonPath: .metadata.creationTimestamp
       name: Age

--- a/example/operator/10-crd-operator.gardener.cloud_gardens.yaml
+++ b/example/operator/10-crd-operator.gardener.cloud_gardens.yaml
@@ -44,6 +44,11 @@ spec:
       jsonPath: .status.conditions[?(@.type=="VirtualGardenAPIServerAvailable")].status
       name: API Server
       type: string
+    - description: Indicates whether the observability components related to the runtime
+        cluster are healthy.
+      jsonPath: .status.conditions[?(@.type=="ObservabilityComponentsHealthy")].status
+      name: Observability
+      type: string
     - description: creation timestamp
       jsonPath: .metadata.creationTimestamp
       name: Age

--- a/pkg/apis/operator/v1alpha1/types.go
+++ b/pkg/apis/operator/v1alpha1/types.go
@@ -35,6 +35,7 @@ import (
 // +kubebuilder:printcolumn:name="Runtime",type=string,JSONPath=`.status.conditions[?(@.type=="RuntimeComponentsHealthy")].status`,description="Indicates whether the components related to the runtime cluster are healthy."
 // +kubebuilder:printcolumn:name="Virtual",type=string,JSONPath=`.status.conditions[?(@.type=="VirtualComponentsHealthy")].status`,description="Indicates whether the components related to the virtual cluster are healthy."
 // +kubebuilder:printcolumn:name="API Server",type=string,JSONPath=`.status.conditions[?(@.type=="VirtualGardenAPIServerAvailable")].status`,description="Indicates whether the API server of the virtual cluster is available."
+// +kubebuilder:printcolumn:name="Observability",type=string,JSONPath=`.status.conditions[?(@.type=="ObservabilityComponentsHealthy")].status`,description="Indicates whether the observability components related to the runtime cluster are healthy."
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`,description="creation timestamp"
 
 // Garden describes a list of gardens.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity
/kind enhancement

**What this PR does / why we need it**:
This PR adds `Observability` to the garden printer column.

Before:
```
$ k get garden    
                                                                                                                                          
NAME     K8S VERSION   GARDENER VERSION                                       LAST OPERATION   RUNTIME   VIRTUAL   API SERVER   AGE
garden   1.25.12       v1.77.0-dev-0055f0be8b22193ee458a3bb39325b74da0930ab   Succeeded        True      True      True         25m
```

Now:
```
$ k get garden  

NAME    K8S VERSION   GARDENER VERSION   LAST OPERATION   RUNTIME   VIRTUAL       API SERVER   OBSERVABILITY   AGE
local   1.26.1        v1.78.0-dev        Succeeded        True      Progressing   True         True            4m59s
```


/cc @oliver-goetz 

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/7016
Follow up after - https://github.com/gardener/gardener/pull/8346

**Special notes for your reviewer**:
Similar to https://github.com/gardener/gardener/pull/8279

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
`kubectl get garden` now features additional printer column `Observability` providing information about the Observability components of the runtime cluster.
```
