### PR TITLE
Update kube-state-metrics to v2.8.2

### DIFF
--- a/imagevector/images.yaml
+++ b/imagevector/images.yaml
@@ -214,7 +214,7 @@ images:
 - name: kube-state-metrics
   sourceRepository: github.com/kubernetes/kube-state-metrics
   repository: registry.k8s.io/kube-state-metrics/kube-state-metrics
-  tag: v2.5.0
+  tag: v2.8.2
   labels:
   - name: gardener.cloud/cve-categorisation
     value:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind enhancement

**What this PR does / why we need it**:

Update kube-state-metrics to v2.8.2.

**Which issue(s) this PR fixes**:

With Kubernetes `v1.26`, the `v2beta2.HorizontalPodAutoscaler` API is removed.
The currently used `v2.5.0` version of `kube-state-metrics` was using that API and hence it could no longer expose `kube_horizontalpodautoscaler_{...}` metrics.

**Special notes for your reviewer**:

/cc @rickardsjp @andrerun @voelzmo @ialidzhikov 

Besides checking the changes described in the release notes of kube-state-metrics, I verified in a local setup that none of the previously exposed metrics (in the seed and shoot configuration in Gardener) were removed, and also the set of label keys of the previously exposed metrics did not change. I checked the various Prometheus instances and their recording + alerting rules, and the Plutono dashboards and did not notice any breaking change related to this version update.

I confirmed that ksm v2.8.2 works fine even with the older Kubernetes version v1.23.17 so there are no backwards compatibility issues.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The following images are updated:
- `registry.k8s.io/kube-state-metrics/kube-state-metrics`: `v2.5.0` -> `v2.8.2`
```
