### PR TITLE
Split `codegen` target and further enhance `generate` script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -180,7 +180,7 @@ define GENERATE_HELP_INFO
 #   WHAT              - Specify the targets to run (e.g., "protobuf codegen manifests logcheck gomegacheck monitoring-docs")
 #   CODEGEN_GROUPS    - Specify which groups to run the 'codegen' target for, not applicable for other targets (e.g., "authentication core extensions resources operator seedmanagement operations settings operatorconfig controllermanager admissioncontroller scheduler gardenlet resourcemanager shoottolerationrestriction shootdnsrewriting provider_local extensions_config")
 #   MANIFESTS_FOLDERS - Specify which folders to run the 'manifests' target in, not applicable for other targets (e.g., "charts cmd example extensions pkg plugin test")
-#   MODE              - Specify the mode for the 'manifests' or 'codegen' target (e.g., "parallel" (default) or "sequential")
+#   MODE              - Specify the mode for the 'manifests' or 'codegen' target (e.g., "parallel" or "sequential")
 #
 # Examples:
 #   make generate

--- a/Makefile
+++ b/Makefile
@@ -174,21 +174,23 @@ check: $(GO_ADD_LICENSE) $(GOIMPORTS) $(GOLANGCI_LINT) $(HELM) $(IMPORT_BOSS) $(
 tools-for-generate: $(CONTROLLER_GEN) $(GEN_CRD_API_REFERENCE_DOCS) $(GOIMPORTS) $(GO_TO_PROTOBUF) $(HELM) $(MOCKGEN) $(OPENAPI_GEN) $(PROTOC) $(PROTOC_GEN_GOGO) $(YAML2JSON) $(YQ)
 
 define GENERATE_HELP_INFO
-# Usage: make generate [WHAT="<targets>"] [MODE="<mode>"] [CODEGEN_GROUPS="<groups>"] [MANIFESTS_FOLDERS="<folders>"]
+# Usage: make generate [WHAT="<targets>"] [MODE="<mode>"] [CODEGEN_GROUPS="<groups>"] [MANIFESTS_DIRS="<folders>"]
 #
 # Options:
 #   WHAT              - Specify the targets to run (e.g., "protobuf codegen manifests logcheck gomegacheck monitoring-docs")
-#   CODEGEN_GROUPS    - Specify which groups to run the 'codegen' target for, not applicable for other targets (e.g., "authentication core extensions resources operator seedmanagement operations settings operatorconfig controllermanager admissioncontroller scheduler gardenlet resourcemanager shoottolerationrestriction shootdnsrewriting provider_local extensions_config")
-#   MANIFESTS_FOLDERS - Specify which folders to run the 'manifests' target in, not applicable for other targets (Default folders are "charts cmd example extensions imagevector pkg plugin test")
-#   MODE              - Specify the mode for the 'manifests' or 'codegen' target (e.g., "parallel" or "sequential")
+#   CODEGEN_GROUPS    - Specify which groups to run the 'codegen' target for, not applicable for other targets (e.g., "authentication_groups core_groups extensions_groups resources_groups 
+#                       operator_groups seedmanagement_groups operations_groups settings_groups operatorconfig_groups controllermanager_groups admissioncontroller_groups scheduler_groups 
+#                       gardenlet_groups resourcemanager_groups shoottolerationrestriction_groups shootdnsrewriting_groups provider_local_groups extensions_config_groups")
+#   MANIFESTS_DIRS    - Specify which directories to run the 'manifests' target in, not applicable for other targets (Default directories are "charts cmd example extensions imagevector pkg plugin test")
+#   MODE              - Specify the mode for the 'manifests' (default=parallel) or 'codegen' (default=sequential) target (e.g., "parallel" or "sequential")
 #
 # Examples:
 #   make generate
 #   make generate WHAT="codegen protobuf"
 #   make generate WHAT="codegen protobuf" MODE="sequential"
-#   make generate WHAT="manifests" MANIFESTS_FOLDERS="pkg/component plugin" MODE="sequential"
-#   make generate WHAT="codegen" CODEGEN_GROUPS="core extensions" 
-#   make generate WHAT="codegen manifests" CODEGEN_GROUPS="operator controllermanager" MANIFESTS_FOLDERS="charts example/provider-local"
+#   make generate WHAT="manifests" MANIFESTS_DIRS="pkg/component plugin" MODE="sequential"
+#   make generate WHAT="codegen" CODEGEN_GROUPS="core_groups extensions_groups" 
+#   make generate WHAT="codegen manifests" CODEGEN_GROUPS="operator_groups controllermanager_groups" MANIFESTS_DIRS="charts extensions/pkg"
 #
 endef
 export GENERATE_HELP_INFO
@@ -198,8 +200,8 @@ generate:
 	@echo "$$GENERATE_HELP_INFO"
 else
 generate: tools-for-generate
-	@printf "\nFor more info on the generate command, Run 'make generate PRINT_HELP=y'\n\n"
-	@REPO_ROOT=$(REPO_ROOT) LOGCHECK_DIR=$(LOGCHECK_DIR) GOMEGACHECK_DIR=$(GOMEGACHECK_DIR) hack/generate.sh --what "$(WHAT)" --codegengroups "$(CODEGEN_GROUPS)" --manifestsfolders "$(MANIFESTS_FOLDERS)" --mode "$(MODE)"
+	@printf "\nFor more info on the generate command, Run 'make generate PRINT_HELP=y'\n"
+	@REPO_ROOT=$(REPO_ROOT) LOGCHECK_DIR=$(LOGCHECK_DIR) GOMEGACHECK_DIR=$(GOMEGACHECK_DIR) hack/generate.sh --what "$(WHAT)" --codegen-groups "$(CODEGEN_GROUPS)" --manifests-dirs "$(MANIFESTS_DIRS)" --mode "$(MODE)"
 	$(MAKE) format
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -174,18 +174,21 @@ check: $(GO_ADD_LICENSE) $(GOIMPORTS) $(GOLANGCI_LINT) $(HELM) $(IMPORT_BOSS) $(
 tools-for-generate: $(CONTROLLER_GEN) $(GEN_CRD_API_REFERENCE_DOCS) $(GOIMPORTS) $(GO_TO_PROTOBUF) $(HELM) $(MOCKGEN) $(OPENAPI_GEN) $(PROTOC) $(PROTOC_GEN_GOGO) $(YAML2JSON) $(YQ)
 
 define GENERATE_HELP_INFO
-# Usage: make generate [WHAT="<targets>"] [MODE="<mode>"] [WHICH="<folders>"]
+# Usage: make generate [WHAT="<targets>"] [MODE="<mode>"] [CODEGEN_GROUPS="<groups>"] [MANIFESTS_FOLDERS="<folders>"]
 #
 # Options:
-#   WHAT   - Specify the targets to run (e.g., "protobuf codegen manifests logcheck gomegacheck monitoring-docs")
-#   WHICH  - Specify which folders to run the 'manifests' target in, not applicable for other targets (e.g., "charts cmd example extensions pkg plugin test")
-#   MODE   - Specify the mode for the 'manifests' target (e.g., "sequential" or "parallel")
+#   WHAT              - Specify the targets to run (e.g., "protobuf codegen manifests logcheck gomegacheck monitoring-docs")
+#   CODEGEN_GROUPS    - Specify which groups to run the 'codegen' target for, not applicable for other targets (e.g., "authentication core extensions resources operator seedmanagement operations settings operatorconfig controllermanager admissioncontroller scheduler gardenlet resourcemanager shoottolerationrestriction shootdnsrewriting provider_local extensions_config")
+#   MANIFESTS_FOLDERS - Specify which folders to run the 'manifests' target in, not applicable for other targets (e.g., "charts cmd example extensions pkg plugin test")
+#   MODE              - Specify the mode for the 'manifests' or 'codegen' target (e.g., "parallel" (default) or "sequential")
 #
 # Examples:
 #   make generate
 #   make generate WHAT="codegen protobuf"
 #   make generate WHAT="codegen protobuf" MODE="sequential"
-#   make generate WHAT="manifests" WHICH="pkg plugin" MODE="sequential"
+#   make generate WHAT="manifests" MANIFESTS_FOLDERS="pkg/component plugin" MODE="sequential"
+#   make generate WHAT="codegen" CODEGEN_GROUPS="core extensions" 
+#   make generate CODEGEN_GROUPS="operator controllermanager" MANIFESTS_FOLDERS="charts example/provider-local"
 #
 endef
 export GENERATE_HELP_INFO
@@ -196,7 +199,7 @@ generate:
 else
 generate: tools-for-generate
 	@printf "\nFor more info on the generate command, Run 'make generate PRINT_HELP=y'\n\n"
-	@REPO_ROOT=$(REPO_ROOT) LOGCHECK_DIR=$(LOGCHECK_DIR) GOMEGACHECK_DIR=$(GOMEGACHECK_DIR) hack/generate.sh --what "$(WHAT)" --which "$(WHICH)" --mode "$(MODE)"
+	@REPO_ROOT=$(REPO_ROOT) LOGCHECK_DIR=$(LOGCHECK_DIR) GOMEGACHECK_DIR=$(GOMEGACHECK_DIR) hack/generate.sh --what "$(WHAT)" --codegengroups "$(CODEGEN_GROUPS)" --manifestsfolders "$(MANIFESTS_FOLDERS)" --mode "$(MODE)"
 	$(MAKE) format
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -179,7 +179,7 @@ define GENERATE_HELP_INFO
 # Options:
 #   WHAT              - Specify the targets to run (e.g., "protobuf codegen manifests logcheck gomegacheck monitoring-docs")
 #   CODEGEN_GROUPS    - Specify which groups to run the 'codegen' target for, not applicable for other targets (e.g., "authentication core extensions resources operator seedmanagement operations settings operatorconfig controllermanager admissioncontroller scheduler gardenlet resourcemanager shoottolerationrestriction shootdnsrewriting provider_local extensions_config")
-#   MANIFESTS_FOLDERS - Specify which folders to run the 'manifests' target in, not applicable for other targets (e.g., "charts cmd example extensions pkg plugin test")
+#   MANIFESTS_FOLDERS - Specify which folders to run the 'manifests' target in, not applicable for other targets (Default folders are "charts cmd example extensions imagevector pkg plugin test")
 #   MODE              - Specify the mode for the 'manifests' or 'codegen' target (e.g., "parallel" or "sequential")
 #
 # Examples:
@@ -188,7 +188,7 @@ define GENERATE_HELP_INFO
 #   make generate WHAT="codegen protobuf" MODE="sequential"
 #   make generate WHAT="manifests" MANIFESTS_FOLDERS="pkg/component plugin" MODE="sequential"
 #   make generate WHAT="codegen" CODEGEN_GROUPS="core extensions" 
-#   make generate CODEGEN_GROUPS="operator controllermanager" MANIFESTS_FOLDERS="charts example/provider-local"
+#   make generate WHAT="codegen manifests" CODEGEN_GROUPS="operator controllermanager" MANIFESTS_FOLDERS="charts example/provider-local"
 #
 endef
 export GENERATE_HELP_INFO

--- a/hack/generate.sh
+++ b/hack/generate.sh
@@ -20,26 +20,6 @@ WHAT="protobuf codegen manifests logcheck gomegacheck monitoring-docs"
 CODEGEN_GROUPS=""
 MANIFESTS_DIRS=""
 MODE="parallel"
-AVAILABLE_CODEGEN_OPTIONS=(
-  "authentication_groups"
-  "core_groups"
-  "extensions_groups"
-  "resources_groups"
-  "operator_groups"
-  "seedmanagement_groups"
-  "operations_groups"
-  "settings_groups"
-  "operatorconfig_groups"
-  "controllermanager_groups"
-  "admissioncontroller_groups"
-  "scheduler_groups"
-  "gardenlet_groups"
-  "resourcemanager_groups"
-  "shoottolerationrestriction_groups"
-  "shootdnsrewriting_groups"
-  "provider_local_groups"
-  "extensions_config_groups"
-)
 DEFAULT_MANIFESTS_DIRS=(
   "charts"
   "cmd"
@@ -98,45 +78,7 @@ run_target() {
       $REPO_ROOT/hack/update-protobuf.sh
       ;;
     codegen)
-      local which=$CODEGEN_GROUPS
-      local valid_options=()
-      local invalid_options=()
-
-      if [[ -z "$which" ]]; then
-        which=("${AVAILABLE_CODEGEN_OPTIONS[@]}")
-        valid_options=("${AVAILABLE_CODEGEN_OPTIONS[@]}")
-      else
-        IFS=' ' read -ra WHICH_ARRAY <<< "$which"
-        for option in "${WHICH_ARRAY[@]}"; do
-            valid=false
-
-            for valid_option in "${AVAILABLE_CODEGEN_OPTIONS[@]}"; do
-                if [[ "$option" == "$valid_option" ]]; then
-                    valid=true
-                    break
-                fi
-            done
-
-            if $valid; then
-                valid_options+=("$option")
-            else
-                invalid_options+=("$option")
-            fi
-        done
-
-        if [[ ${#invalid_options[@]} -gt 0 ]]; then
-            printf "Invalid options: %s, Available options are: %s\n\n" "${invalid_options[*]}" "${AVAILABLE_CODEGEN_OPTIONS[*]}"
-            exit 1
-        fi
-      fi
-
-      if [[ ${#valid_options[@]} -gt 0 ]]; then
-        printf "\n> Generating codegen for groups: %s\n" "${valid_options[*]}"
-        $REPO_ROOT/hack/update-codegen.sh --groups "${valid_options[*]}" --mode "$MODE"
-      else
-        printf "!! No valid groups provided for codegen, Available groups are: %s\n\n"  "${AVAILABLE_CODEGEN_OPTIONS[*]}"
-        exit 1
-      fi
+      $REPO_ROOT/hack/update-codegen.sh --groups "$CODEGEN_GROUPS" --mode "$MODE"
       ;;
     manifests)
       local which=()

--- a/hack/generate.sh
+++ b/hack/generate.sh
@@ -112,7 +112,7 @@ run_target() {
       $REPO_ROOT/hack/generate-monitoring-docs.sh
       ;;
     *)
-      printf "Unknown target: $target. Available targets are 'protobuf', 'codegen', 'manifests', 'logcheck', 'gomegacheck', 'monitoring-docs'.\n\n"
+      printf "ERROR: Unknown target: $target. Available targets are 'protobuf', 'codegen', 'manifests', 'logcheck', 'gomegacheck', 'monitoring-docs'.\n\n"
       ;;
   esac
 }

--- a/hack/generate.sh
+++ b/hack/generate.sh
@@ -62,7 +62,7 @@ run_target() {
       $REPO_ROOT/hack/update-protobuf.sh
       ;;
     codegen)
-      $REPO_ROOT/hack/update-codegen.sh
+      $REPO_ROOT/hack/update-codegen.sh --"$MODE"
       ;;
     manifests)
       if [[ "$MODE" == "sequential" ]]; then

--- a/hack/generate.sh
+++ b/hack/generate.sh
@@ -45,6 +45,7 @@ DEFAULT_MANIFESTS_FOLDERS=(
   "cmd"
   "example"
   "extensions"
+  "imagevector"
   "pkg"
   "plugin"
   "test"

--- a/hack/generate.sh
+++ b/hack/generate.sh
@@ -19,7 +19,7 @@ set -e
 WHAT="protobuf codegen manifests logcheck gomegacheck monitoring-docs"
 CODEGEN_GROUPS=""
 MANIFESTS_DIRS=""
-MODE="parallel"
+MODE=""
 DEFAULT_MANIFESTS_DIRS=(
   "charts"
   "cmd"
@@ -78,10 +78,13 @@ run_target() {
       $REPO_ROOT/hack/update-protobuf.sh
       ;;
     codegen)
-      $REPO_ROOT/hack/update-codegen.sh --groups "$CODEGEN_GROUPS" --mode "$MODE"
+      local mode="${MODE:-sequential}"  
+      $REPO_ROOT/hack/update-codegen.sh --groups "$CODEGEN_GROUPS" --mode "$mode"
       ;;
     manifests)
       local which=()
+      local mode="${MODE:-parallel}"  
+
       if [[ -z "$MANIFESTS_DIRS" ]]; then
         which=("${DEFAULT_MANIFESTS_DIRS[@]}")
       else
@@ -89,13 +92,13 @@ run_target() {
       fi
 
       printf "\n> Generating manifests for folders: %s\n" "${which[*]}"
-      if [[ "$MODE" == "sequential" ]]; then
+      if [[ "$mode" == "sequential" ]]; then
         # In sequential mode, paths need to be converted to go package notation (e.g., ./charts/...)
         $REPO_ROOT/hack/generate-sequential.sh $(overwrite_paths "${which[@]}")
-      elif [[ "$MODE" == "parallel" ]]; then
+      elif [[ "$mode" == "parallel" ]]; then
         $REPO_ROOT/hack/generate-parallel.sh "${which[@]}"
       else
-        printf "ERROR: Invalid mode ('%s'). Specify either 'parallel' or 'sequential'\n\n" "$MODE"
+        printf "ERROR: Invalid mode ('%s'). Specify either 'parallel' or 'sequential'\n\n" "$mode"
         exit 1
       fi
       ;;

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -19,7 +19,7 @@ set -o nounset
 set -o pipefail
 
 WHICH=()
-MODE="parallel"
+MODE="sequential"
 
 # Friendly reminder if workspace location is not in $GOPATH
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -525,20 +525,15 @@ else
   fi
 fi
 
-if [[ ${#valid_options[@]} -gt 0 ]]; then
-  printf "\n> Generating codegen for groups: %s\n" "${valid_options[*]}"
-  if [[ "$MODE" == "sequential" ]]; then
-    for target in "${valid_options[@]}"; do
-      "$target"
-    done
-  elif [[ "$MODE" == "parallel" ]]; then
-    parallel --will-cite ::: "${valid_options[@]}"
-  else
-    printf "ERROR: Invalid mode ('%s'). Specify either 'parallel' or 'sequential'\n\n" "$MODE"
-    exit 1
-  fi
+printf "\n> Generating codegen for groups: %s\n" "${valid_options[*]}"
+if [[ "$MODE" == "sequential" ]]; then
+  for target in "${valid_options[@]}"; do
+    "$target"
+  done
+elif [[ "$MODE" == "parallel" ]]; then
+  parallel --will-cite ::: "${valid_options[@]}"
 else
-  printf "!! No valid groups provided for codegen, Available groups are: %s\n\n"  "${AVAILABLE_CODEGEN_OPTIONS[*]}"
+  printf "ERROR: Invalid mode ('%s'). Specify either 'parallel' or 'sequential'\n\n" "$MODE"
   exit 1
 fi
 

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -520,7 +520,7 @@ else
   done
 
   if [[ ${#invalid_options[@]} -gt 0 ]]; then
-    printf "Invalid options: %s, Available options are: %s\n\n" "${invalid_options[*]}" "${AVAILABLE_CODEGEN_OPTIONS[*]}"
+    printf "ERROR: Invalid options: %s, Available options are: %s\n\n" "${invalid_options[*]}" "${AVAILABLE_CODEGEN_OPTIONS[*]}"
     exit 1
   fi
 fi

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -468,7 +468,7 @@ if [[ $# -gt 0 && "$1" == "--parallel" ]]; then
     shoottolerationrestriction_groups \
     shootdnsrewriting_groups \
     provider_local_groups \
-    extensions_config_groups
+    extensions_config_groups \
     resourcemanager_groups
 else
   authentication_groups

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -18,7 +18,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-WHICH=()
+GROUPS=()
 MODE="sequential"
 
 # Friendly reminder if workspace location is not in $GOPATH
@@ -39,17 +39,6 @@ CURRENT_DIR=$(dirname $0)
 PROJECT_ROOT="${CURRENT_DIR}"/..
 export PROJECT_ROOT
 
-get_groups() {
-  local which=("$@")
-  local groups=()
-
-  for entry in "${which[@]}"; do
-    groups+=("${entry}_groups")
-  done
-
-  echo "${groups[@]}"
-}
-
 parse_flags() {
   while test $# -gt 0; do
     case "$1" in
@@ -59,9 +48,9 @@ parse_flags() {
         MODE="$1"
         fi
         ;;
-      --which)
+      --groups)
         shift
-        WHICH="${1:-$WHICH}"
+        GROUPS="${1:-$GROUPS}"
         ;;
       *)
         echo "Unknown argument: $1"
@@ -487,15 +476,15 @@ export -f openapi_definitions
 
 parse_flags "$@"
 
-groups=($(get_groups $WHICH))
 if [[ "$MODE" == "sequential" ]]; then
-  for target in "${groups[@]}"; do
+  for target in "${GROUPS[@]}"; do
     "$target"
   done
 elif [[ "$MODE" == "parallel" ]]; then
-  parallel --will-cite ::: "${groups[@]}"
+  parallel --will-cite ::: "${GROUPS[@]}"
 else
-  printf "!! Invalid mode, Specify either 'parallel' or 'sequential'\n\n"
+  printf "ERROR: Invalid mode ('%s'). Specify either 'parallel' or 'sequential'\n\n" "$MODE"
+  exit 1
 fi
 
 openapi_definitions

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -18,6 +18,9 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+WHICH=()
+MODE="parallel"
+
 # Friendly reminder if workspace location is not in $GOPATH
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 if [ "${SCRIPT_DIR}" != "$(realpath $GOPATH)/src/github.com/gardener/gardener/hack" ]; then
@@ -35,6 +38,39 @@ rm -f ${GOPATH}/bin/*-gen
 CURRENT_DIR=$(dirname $0)
 PROJECT_ROOT="${CURRENT_DIR}"/..
 export PROJECT_ROOT
+
+get_groups() {
+  local which=("$@")
+  local groups=()
+
+  for entry in "${which[@]}"; do
+    groups+=("${entry}_groups")
+  done
+
+  echo "${groups[@]}"
+}
+
+parse_flags() {
+  while test $# -gt 0; do
+    case "$1" in
+      --mode)
+        shift
+        if [[ -n "$1" ]]; then
+        MODE="$1"
+        fi
+        ;;
+      --which)
+        shift
+        WHICH="${1:-$WHICH}"
+        ;;
+      *)
+        echo "Unknown argument: $1"
+        exit 1
+        ;;
+    esac
+    shift
+  done
+}
 
 # core.gardener.cloud APIs
 
@@ -422,9 +458,9 @@ export -f extensions_config_groups
 # OpenAPI definitions
 
 openapi_definitions() {
-  echo "Generating openapi definitions"
+  echo "> Generating openapi definitions"
   rm -Rf ./${PROJECT_ROOT}/openapi/openapi_generated.go
-  openapi-gen "$@" \
+  openapi-gen \
     --v 1 \
     --logtostderr \
     --input-dirs=github.com/gardener/gardener/pkg/apis/authentication/v1alpha1 \
@@ -449,46 +485,17 @@ openapi_definitions() {
 }
 export -f openapi_definitions
 
-if [[ $# -gt 0 && "$1" == "--parallel" ]]; then
-  shift 1
-  parallel --will-cite ::: \
-    authentication_groups \
-    core_groups \
-    extensions_groups \
-    resources_groups \
-    operator_groups \
-    seedmanagement_groups \
-    operations_groups \
-    settings_groups \
-    operatorconfig_groups \
-    controllermanager_groups \
-    admissioncontroller_groups \
-    scheduler_groups \
-    gardenlet_groups \
-    shoottolerationrestriction_groups \
-    shootdnsrewriting_groups \
-    provider_local_groups \
-    extensions_config_groups \
-    resourcemanager_groups
+parse_flags "$@"
+
+groups=($(get_groups $WHICH))
+if [[ "$MODE" == "sequential" ]]; then
+  for target in "${groups[@]}"; do
+    "$target"
+  done
+elif [[ "$MODE" == "parallel" ]]; then
+  parallel --will-cite ::: "${groups[@]}"
 else
-  authentication_groups
-  core_groups
-  extensions_groups
-  resources_groups
-  operator_groups
-  seedmanagement_groups
-  operations_groups
-  settings_groups
-  operatorconfig_groups
-  controllermanager_groups
-  admissioncontroller_groups
-  scheduler_groups
-  gardenlet_groups
-  resourcemanager_groups
-  shoottolerationrestriction_groups
-  shootdnsrewriting_groups
-  provider_local_groups
-  extensions_config_groups
+  printf "!! Invalid mode, Specify either 'parallel' or 'sequential'\n\n"
 fi
 
-openapi_definitions "$@"
+openapi_definitions


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
This PR splits the `codegen` target as well for various groups, and also fixes a minor bug to make it run in parallel. Now, `MODE` is also available for `codegen` target.

Invalid options for `codegen` are skipped.
It is possible to pass any folder path for `manifests` target.

```bash
❯ make generate PRINT_HELP=y

# Usage: make generate [WHAT="<targets>"] [MODE="<mode>"] [CODEGEN_GROUPS="<groups>"] [MANIFESTS_FOLDERS="<folders>"]
#
# Options:
#   WHAT              - Specify the targets to run (e.g., "protobuf codegen manifests logcheck gomegacheck monitoring-docs")
#   CODEGEN_GROUPS    - Specify which groups to run the 'codegen' target for, not applicable for other targets (e.g., "authentication core extensions resources operator seedmanagement operations settings operatorconfig controllermanager admissioncontroller scheduler gardenlet resourcemanager shoottolerationrestriction shootdnsrewriting provider_local extensions_config")
#   MANIFESTS_FOLDERS - Specify which folders to run the 'manifests' target in, not applicable for other targets (Default folders are "charts cmd example extensions imagevector pkg plugin test")
#   MODE              - Specify the mode for the 'manifests' or 'codegen' target (e.g., "parallel" or "sequential")
#
# Examples:
#   make generate
#   make generate WHAT="codegen protobuf"
#   make generate WHAT="codegen protobuf" MODE="sequential"
#   make generate WHAT="manifests" MANIFESTS_FOLDERS="pkg/component plugin" MODE="sequential"
#   make generate WHAT="codegen" CODEGEN_GROUPS="core extensions"
#   make generate WHAT="codegen manifests" CODEGEN_GROUPS="operator controllermanager" MANIFESTS_FOLDERS="charts example/provider-local"
#
```  

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @timuthy @seshachalam-yv 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
