### PR TITLE
Improve the Prometheus recording rules related to metering

### DIFF
--- a/hack/test-prometheus.sh
+++ b/hack/test-prometheus.sh
@@ -29,3 +29,8 @@ echo "Executing aggregate Prometheus alert tests"
 pushd "$(dirname $0)/../pkg/component/monitoring/charts/bootstrap/aggregate-prometheus-rules-tests" > /dev/null
 promtool test rules *test.yaml
 popd > /dev/null
+
+echo "Executing cache Prometheus recording rules tests"
+pushd "$(dirname $0)/../pkg/component/monitoring/charts/bootstrap/prometheus-rules-tests" > /dev/null
+promtool test rules *test.yaml
+popd > /dev/null

--- a/pkg/component/monitoring/charts/bootstrap/aggregate-prometheus-rules-tests/metering.rules.stateful.test.yaml
+++ b/pkg/component/monitoring/charts/bootstrap/aggregate-prometheus-rules-tests/metering.rules.stateful.test.yaml
@@ -1,0 +1,276 @@
+rule_files:
+- ../prometheus-rules/metering.rules.stateful.yaml
+
+tests:
+
+# _year_month2 contains the year and month labels of the evaluation time. The
+# suffix 2 is added to avoid rules with the same name if both the "stateless" and
+# "stateful" recording rules are loaded.
+- name: _year_month2
+  promql_expr_test:
+  - expr: _year_month2
+    exp_samples:
+    - labels: _year_month2{
+                  year  = "1970",
+                  month = "1"}
+      value: 0
+
+# metering:node_capacity:sum_by_instance_type:sum_over_time
+# metering:node_capacity:sum_by_instance_type:count_over_time
+# metering:node_capacity:sum_by_instance_type:count_over_time:this_month
+# metering:node_capacity:sum_by_instance_type:avg_over_time
+# metering:node_capacity:sum_by_instance_type:avg_over_time:this_month
+- name: metering:node_capacity:sum_by_instance_type:*
+  interval: 1m
+  input_series:
+  - series: metering:node_capacity:sum_by_instance_type{type="complete", year="1970", month="1"}
+    values: 1x60
+  - series: metering:node_capacity:sum_by_instance_type{type="data gaps", year="1970", month="1"}
+    values: 1+0x9 stale _x24 1+0x4 0x13 stale _x4 0 # can cope with gaps up to 30 minutes
+  - series: metering:node_capacity:sum_by_instance_type{type="no longer existing", year="1970", month="1"}
+    values: 1+0x29 stale _x29
+  promql_expr_test:
+  - expr: metering:node_capacity:sum_by_instance_type:sum_over_time
+    eval_time: 59m
+    exp_samples:
+    - labels: metering:node_capacity:sum_by_instance_type:sum_over_time{type="complete", year="1970", month="1"}
+      value: 60
+    - labels: metering:node_capacity:sum_by_instance_type:sum_over_time{type="data gaps", year="1970", month="1"}
+      value: 15
+  - expr: metering:node_capacity:sum_by_instance_type:count_over_time
+    eval_time: 59m
+    exp_samples:
+    - labels: metering:node_capacity:sum_by_instance_type:count_over_time{type="complete", year="1970", month="1"}
+      value: 60
+    - labels: metering:node_capacity:sum_by_instance_type:count_over_time{type="data gaps", year="1970", month="1"}
+      value: 30
+  - expr: metering:node_capacity:sum_by_instance_type:avg_over_time
+    eval_time: 59m
+    exp_samples:
+    - labels: metering:node_capacity:sum_by_instance_type:avg_over_time{type="complete", year="1970", month="1"}
+      value: 1
+    - labels: metering:node_capacity:sum_by_instance_type:avg_over_time{type="data gaps", year="1970", month="1"}
+      value: 0.5
+
+  - expr: metering:node_capacity:sum_by_instance_type:count_over_time:this_month
+    eval_time: 59m
+    exp_samples:
+    - labels: metering:node_capacity:sum_by_instance_type:count_over_time:this_month{type="complete", year="1970", month="1"}
+      value: 60
+    - labels: metering:node_capacity:sum_by_instance_type:count_over_time:this_month{type="data gaps", year="1970", month="1"}
+      value: 30
+    - labels: metering:node_capacity:sum_by_instance_type:count_over_time:this_month{type="no longer existing", year="1970", month="1"}
+      value: 30
+  - expr: metering:node_capacity:sum_by_instance_type:avg_over_time:this_month
+    eval_time: 59m
+    exp_samples:
+    - labels: metering:node_capacity:sum_by_instance_type:avg_over_time:this_month{type="complete", year="1970", month="1"}
+      value: 1
+    - labels: metering:node_capacity:sum_by_instance_type:avg_over_time:this_month{type="data gaps", year="1970", month="1"}
+      value: 0.5
+    - labels: metering:node_capacity:sum_by_instance_type:avg_over_time:this_month{type="no longer existing", year="1970", month="1"}
+      value: 1
+
+# metering:node_cp_usage:sum_by_instance_type:sum_over_time
+# metering:node_cp_usage:sum_by_instance_type:count_over_time
+# metering:node_cp_usage:sum_by_instance_type:count_over_time:this_month
+# metering:node_cp_usage:sum_by_instance_type:avg_over_time
+# metering:node_cp_usage:sum_by_instance_type:avg_over_time:this_month
+- name: metering:node_cp_usage:sum_by_instance_type:*
+  interval: 1m
+  input_series:
+  - series: metering:node_cp_usage:sum_by_instance_type{type="complete", year="1970", month="1"}
+    values: 1x60
+  - series: metering:node_cp_usage:sum_by_instance_type{type="data gaps", year="1970", month="1"}
+    values: 1+0x9 stale _x24 1+0x4 0x13 stale _x4 0 # can cope with gaps up to 30 minutes
+  - series: metering:node_cp_usage:sum_by_instance_type{type="no longer existing", year="1970", month="1"}
+    values: 1+0x29 stale _x29
+  promql_expr_test:
+  - expr: metering:node_cp_usage:sum_by_instance_type:sum_over_time
+    eval_time: 59m
+    exp_samples:
+    - labels: metering:node_cp_usage:sum_by_instance_type:sum_over_time{type="complete", year="1970", month="1"}
+      value: 60
+    - labels: metering:node_cp_usage:sum_by_instance_type:sum_over_time{type="data gaps", year="1970", month="1"}
+      value: 15
+  - expr: metering:node_cp_usage:sum_by_instance_type:count_over_time
+    eval_time: 59m
+    exp_samples:
+    - labels: metering:node_cp_usage:sum_by_instance_type:count_over_time{type="complete", year="1970", month="1"}
+      value: 60
+    - labels: metering:node_cp_usage:sum_by_instance_type:count_over_time{type="data gaps", year="1970", month="1"}
+      value: 30
+  - expr: metering:node_cp_usage:sum_by_instance_type:avg_over_time
+    eval_time: 59m
+    exp_samples:
+    - labels: metering:node_cp_usage:sum_by_instance_type:avg_over_time{type="complete", year="1970", month="1"}
+      value: 1
+    - labels: metering:node_cp_usage:sum_by_instance_type:avg_over_time{type="data gaps", year="1970", month="1"}
+      value: 0.5
+
+  - expr: metering:node_cp_usage:sum_by_instance_type:count_over_time:this_month
+    eval_time: 59m
+    exp_samples:
+    - labels: metering:node_cp_usage:sum_by_instance_type:count_over_time:this_month{type="complete", year="1970", month="1"}
+      value: 60
+    - labels: metering:node_cp_usage:sum_by_instance_type:count_over_time:this_month{type="data gaps", year="1970", month="1"}
+      value: 30
+    - labels: metering:node_cp_usage:sum_by_instance_type:count_over_time:this_month{type="no longer existing", year="1970", month="1"}
+      value: 30
+  - expr: metering:node_cp_usage:sum_by_instance_type:avg_over_time:this_month
+    eval_time: 59m
+    exp_samples:
+    - labels: metering:node_cp_usage:sum_by_instance_type:avg_over_time:this_month{type="complete", year="1970", month="1"}
+      value: 1
+    - labels: metering:node_cp_usage:sum_by_instance_type:avg_over_time:this_month{type="data gaps", year="1970", month="1"}
+      value: 0.5
+    - labels: metering:node_cp_usage:sum_by_instance_type:avg_over_time:this_month{type="no longer existing", year="1970", month="1"}
+      value: 1
+
+# metering:memory_usage_seconds
+# metering:memory_usage_seconds:this_month
+- name: metering:memory_usage_seconds*
+  interval: 1m
+  input_series:
+  - series: metering:working_set_memory:sum_by_namespace{type="complete", year="1970", month="1"}
+    values: 1x60
+  - series: metering:working_set_memory:sum_by_namespace{type="data gaps", year="1970", month="1"}
+    values: 1+0x9 stale _x24 1+0x4 0x13 stale _x4 0 # can cope with gaps up to 30 minutes
+  - series: metering:working_set_memory:sum_by_namespace{type="no longer existing", year="1970", month="1"}
+    values: 1+0x29 stale _x29
+  promql_expr_test:
+  - expr: metering:memory_usage_seconds
+    eval_time: 59m
+    exp_samples:
+    - labels: metering:memory_usage_seconds{type="complete", year="1970", month="1"}
+      value: 3600
+    - labels: metering:memory_usage_seconds{type="data gaps", year="1970", month="1"}
+      value: 900
+  - expr: metering:memory_usage_seconds:this_month
+    eval_time: 59m
+    exp_samples:
+    - labels: metering:memory_usage_seconds:this_month{type="complete", year="1970", month="1"}
+      value: 3600
+    - labels: metering:memory_usage_seconds:this_month{type="data gaps", year="1970", month="1"}
+      value: 900
+    - labels: metering:memory_usage_seconds:this_month{type="no longer existing", year="1970", month="1"}
+      value: 1800
+
+# metering:disk_usage_seconds
+# metering:disk_usage_seconds:this_month
+- name: metering:disk_usage_seconds*
+  interval: 1m
+  input_series:
+  - series: metering:persistent_volume_claims:sum_by_namespace{type="complete", year="1970", month="1"}
+    values: 1x60
+  - series: metering:persistent_volume_claims:sum_by_namespace{type="data gaps", year="1970", month="1"}
+    values: 1+0x9 stale _x24 1+0x4 0x13 stale _x4 0 # can cope with gaps up to 30 minutes
+  - series: metering:persistent_volume_claims:sum_by_namespace{type="no longer existing", year="1970", month="1"}
+    values: 1+0x29 stale _x29
+  promql_expr_test:
+  - expr: metering:disk_usage_seconds
+    eval_time: 59m
+    exp_samples:
+    - labels: metering:disk_usage_seconds{type="complete", year="1970", month="1"}
+      value: 3600
+    - labels: metering:disk_usage_seconds{type="data gaps", year="1970", month="1"}
+      value: 900
+  - expr: metering:disk_usage_seconds:this_month
+    eval_time: 59m
+    exp_samples:
+    - labels: metering:disk_usage_seconds:this_month{type="complete", year="1970", month="1"}
+      value: 3600
+    - labels: metering:disk_usage_seconds:this_month{type="data gaps", year="1970", month="1"}
+      value: 900
+    - labels: metering:disk_usage_seconds:this_month{type="no longer existing", year="1970", month="1"}
+      value: 1800
+
+# metering:persistent_volume_claims:sum_by_namespace:sum_over_time
+# metering:persistent_volume_claims:sum_by_namespace:avg_over_time
+# metering:persistent_volume_claims:sum_by_namespace:avg_over_time:this_month
+- name: metering:persistent_volume_claims:sum_by_namespace:*
+  interval: 1m
+  input_series:
+  - series: metering:persistent_volume_claims:sum_by_namespace{type="complete", year="1970", month="1"}
+    values: 1x60
+  - series: metering:persistent_volume_claims:sum_by_namespace{type="data gaps", year="1970", month="1"}
+    values: 1+0x9 stale _x24 1+0x4 0x13 stale _x4 0 # can cope with gaps up to 30 minutes
+  - series: metering:persistent_volume_claims:sum_by_namespace{type="no longer existing", year="1970", month="1"}
+    values: 1+0x29 stale _x29
+  promql_expr_test:
+  - expr: metering:persistent_volume_claims:sum_by_namespace:sum_over_time
+    eval_time: 59m
+    exp_samples:
+    - labels: metering:persistent_volume_claims:sum_by_namespace:sum_over_time{type="complete", year="1970", month="1"}
+      value: 60
+    - labels: metering:persistent_volume_claims:sum_by_namespace:sum_over_time{type="data gaps", year="1970", month="1"}
+      value: 15
+  - expr: metering:persistent_volume_claims:sum_by_namespace:avg_over_time
+    eval_time: 59m
+    exp_samples:
+    - labels: metering:persistent_volume_claims:sum_by_namespace:avg_over_time{type="complete", year="1970", month="1"}
+      value: 1
+    - labels: metering:persistent_volume_claims:sum_by_namespace:avg_over_time{type="data gaps", year="1970", month="1"}
+      value: 1
+  - expr: metering:persistent_volume_claims:sum_by_namespace:avg_over_time:this_month
+    eval_time: 59m
+    exp_samples:
+    - labels: metering:persistent_volume_claims:sum_by_namespace:avg_over_time:this_month{type="complete", year="1970", month="1"}
+      value: 1
+    - labels: metering:persistent_volume_claims:sum_by_namespace:avg_over_time:this_month{type="data gaps", year="1970", month="1"}
+      value: 1
+    - labels: metering:persistent_volume_claims:sum_by_namespace:avg_over_time:this_month{type="no longer existing", year="1970", month="1"}
+      value: 1
+
+# metering:cpu_usage:sum_by_namespace:sum_over_time
+# metering:cpu_usage:sum_by_namespace:avg_over_time
+# metering:cpu_usage:sum_by_namespace:avg_over_time:this_month
+- name: metering:cpu_usage:sum_by_namespace:*
+  interval: 1m
+  input_series:
+  - series: metering:cpu_usage:sum_by_namespace{type="complete", year="1970", month="1"}
+    values: 1x60
+  - series: metering:memory_usage_seconds{type="complete", year="1970", month="1"}
+    values: 60+60x60
+  - series: metering:cpu_usage:sum_by_namespace{type="data gaps", year="1970", month="1"}
+    values: 1+0x9 stale _x24 1+0x4 0x13 stale _x4 0 # can cope with gaps up to 30 minutes
+  - series: metering:working_set_memory:sum_by_namespace{type="data gaps", year="1970", month="1"}
+    values: 1+0x9 stale _x24 1+0x4 1x13 stale _x4 1
+  - series: metering:cpu_usage:sum_by_namespace{type="no longer existing", year="1970", month="1"}
+    values: 1+0x29 stale _x29
+  - series: metering:working_set_memory:sum_by_namespace{type="no longer existing", year="1970", month="1"}
+    values: 1+0x9 stale _x29
+  - series: metering:cpu_usage:sum_by_namespace{type="avg calculation bug", year="1970", month="1"}
+    values: 1x60
+  - series: metering:working_set_memory:sum_by_namespace{type="avg calculation bug", year="1970", month="1"}
+    values: 1x58 stale
+  promql_expr_test:
+  - expr: metering:cpu_usage:sum_by_namespace:sum_over_time
+    eval_time: 59m
+    exp_samples:
+    - labels: metering:cpu_usage:sum_by_namespace:sum_over_time{type="complete", year="1970", month="1"}
+      value: 60
+    - labels: metering:cpu_usage:sum_by_namespace:sum_over_time{type="data gaps", year="1970", month="1"}
+      value: 15
+    - labels: metering:cpu_usage:sum_by_namespace:sum_over_time{type="avg calculation bug", year="1970", month="1"}
+      value: 60
+  - expr: metering:cpu_usage:sum_by_namespace:avg_over_time
+    eval_time: 59m
+    exp_samples:
+    - labels: metering:cpu_usage:sum_by_namespace:avg_over_time{type="complete", year="1970", month="1"}
+      value: 1
+    - labels: metering:cpu_usage:sum_by_namespace:avg_over_time{type="data gaps", year="1970", month="1"}
+      value: 0.5
+  - expr: metering:cpu_usage:sum_by_namespace:avg_over_time:this_month
+    eval_time: 59m
+    exp_samples:
+    - labels: metering:cpu_usage:sum_by_namespace:avg_over_time:this_month{type="complete", year="1970", month="1"}
+      value: 1
+    - labels: metering:cpu_usage:sum_by_namespace:avg_over_time:this_month{type="data gaps", year="1970", month="1"}
+      value: 0.5
+    - labels: metering:cpu_usage:sum_by_namespace:avg_over_time:this_month{type="no longer existing", year="1970", month="1"}
+      value: 1
+    - labels: metering:cpu_usage:sum_by_namespace:avg_over_time:this_month{type="avg calculation bug", year="1970", month="1"}
+      value: 1
+
+# The remaining recording rules are similar

--- a/pkg/component/monitoring/charts/bootstrap/aggregate-prometheus-rules/metering.rules.stateful.yaml
+++ b/pkg/component/monitoring/charts/bootstrap/aggregate-prometheus-rules/metering.rules.stateful.yaml
@@ -15,6 +15,8 @@ groups:
         0
 
 # - metering  :node_capacity             :sum_by_instance_type   :sum_over_time
+# - metering  :node_capacity             :sum_by_instance_type   :count_over_time
+# - metering  :node_capacity             :sum_by_instance_type   :count_over_time :this_month
 # - metering  :node_capacity             :sum_by_instance_type   :avg_over_time
 # - metering  :node_capacity             :sum_by_instance_type   :avg_over_time   :this_month
 
@@ -38,6 +40,14 @@ groups:
             metering:node_capacity:sum_by_instance_type * 0
         )
 
+  - record: metering:node_capacity:sum_by_instance_type:count_over_time:this_month
+    expr: |2
+        metering:node_capacity:sum_by_instance_type:count_over_time
+      or
+          last_over_time(metering:node_capacity:sum_by_instance_type:count_over_time:this_month[30m])
+        + on (year, month) group_left ()
+          _year_month2
+
   - record: metering:node_capacity:sum_by_instance_type:avg_over_time
     expr: |2
         metering:node_capacity:sum_by_instance_type:sum_over_time
@@ -53,6 +63,8 @@ groups:
           _year_month2
 
 # - metering  :node_cp_usage             :sum_by_instance_type   :sum_over_time
+# - metering  :node_cp_usage             :sum_by_instance_type   :count_over_time
+# - metering  :node_cp_usage             :sum_by_instance_type   :count_over_time :this_month
 # - metering  :node_cp_usage             :sum_by_instance_type   :avg_over_time
 # - metering  :node_cp_usage             :sum_by_instance_type   :avg_over_time   :this_month
 
@@ -75,6 +87,14 @@ groups:
           or
             metering:node_cp_usage:sum_by_instance_type * 0
         )
+
+  - record: metering:node_cp_usage:sum_by_instance_type:count_over_time:this_month
+    expr: |2
+        metering:node_cp_usage:sum_by_instance_type:count_over_time
+      or
+          last_over_time(metering:node_cp_usage:sum_by_instance_type:count_over_time:this_month[30m])
+        + on (year, month) group_left ()
+          _year_month2
 
   - record: metering:node_cp_usage:sum_by_instance_type:avg_over_time
     expr: |2

--- a/pkg/component/monitoring/charts/bootstrap/aggregate-prometheus-rules/metering.rules.stateful.yaml
+++ b/pkg/component/monitoring/charts/bootstrap/aggregate-prometheus-rules/metering.rules.stateful.yaml
@@ -23,7 +23,7 @@ groups:
         metering:node_capacity:sum_by_instance_type
       +
         (
-            last_over_time(metering:node_capacity:sum_by_instance_type:sum_over_time[10m])
+            last_over_time(metering:node_capacity:sum_by_instance_type:sum_over_time[30m])
           or
             metering:node_capacity:sum_by_instance_type * 0
         )
@@ -33,7 +33,7 @@ groups:
         1 + metering:node_capacity:sum_by_instance_type * 0
       +
         (
-            last_over_time(metering:node_capacity:sum_by_instance_type:count_over_time[10m])
+            last_over_time(metering:node_capacity:sum_by_instance_type:count_over_time[30m])
           or
             metering:node_capacity:sum_by_instance_type * 0
         )
@@ -48,7 +48,7 @@ groups:
     expr: |2
         metering:node_capacity:sum_by_instance_type:avg_over_time
       or
-          last_over_time(metering:node_capacity:sum_by_instance_type:avg_over_time:this_month[10m])
+          last_over_time(metering:node_capacity:sum_by_instance_type:avg_over_time:this_month[30m])
         + on (year, month) group_left ()
           _year_month2
 
@@ -61,7 +61,7 @@ groups:
         metering:node_cp_usage:sum_by_instance_type
       +
         (
-            last_over_time(metering:node_cp_usage:sum_by_instance_type:sum_over_time[10m])
+            last_over_time(metering:node_cp_usage:sum_by_instance_type:sum_over_time[30m])
           or
             metering:node_cp_usage:sum_by_instance_type * 0
         )
@@ -71,7 +71,7 @@ groups:
         1 + metering:node_cp_usage:sum_by_instance_type * 0
       +
         (
-            last_over_time(metering:node_cp_usage:sum_by_instance_type:count_over_time[10m])
+            last_over_time(metering:node_cp_usage:sum_by_instance_type:count_over_time[30m])
           or
             metering:node_cp_usage:sum_by_instance_type * 0
         )
@@ -86,7 +86,7 @@ groups:
     expr: |2
         metering:node_cp_usage:sum_by_instance_type:avg_over_time
       or
-          last_over_time(metering:node_cp_usage:sum_by_instance_type:avg_over_time:this_month[10m])
+          last_over_time(metering:node_cp_usage:sum_by_instance_type:avg_over_time:this_month[30m])
         + on (year, month) group_left ()
           _year_month2
 
@@ -100,7 +100,7 @@ groups:
         (metering:working_set_memory:sum_by_namespace > bool 0) * 60
       +
         (
-            last_over_time(metering:memory_usage_seconds[10m])
+            last_over_time(metering:memory_usage_seconds[30m])
           or
             metering:working_set_memory:sum_by_namespace * 0
         )
@@ -110,7 +110,7 @@ groups:
         (metering:persistent_volume_claims:sum_by_namespace > bool 0) * 60
       +
         (
-            last_over_time(metering:disk_usage_seconds[10m])
+            last_over_time(metering:disk_usage_seconds[30m])
           or
             metering:persistent_volume_claims:sum_by_namespace * 0
         )
@@ -119,7 +119,7 @@ groups:
     expr: |2
         metering:memory_usage_seconds
       or
-          last_over_time(metering:memory_usage_seconds:this_month[10m])
+          last_over_time(metering:memory_usage_seconds:this_month[30m])
         + on (year, month) group_left ()
           _year_month2
 
@@ -127,7 +127,7 @@ groups:
     expr: |2
         metering:disk_usage_seconds
       or
-          last_over_time(metering:disk_usage_seconds:this_month[10m])
+          last_over_time(metering:disk_usage_seconds:this_month[30m])
         + on (year, month) group_left ()
           _year_month2
 
@@ -140,7 +140,7 @@ groups:
         metering:persistent_volume_claims:sum_by_namespace
       +
         (
-            last_over_time(metering:persistent_volume_claims:sum_by_namespace:sum_over_time[10m])
+            last_over_time(metering:persistent_volume_claims:sum_by_namespace:sum_over_time[30m])
           or
             metering:persistent_volume_claims:sum_by_namespace * 0
         )
@@ -155,7 +155,7 @@ groups:
     expr: |2
         metering:persistent_volume_claims:sum_by_namespace:avg_over_time
       or
-          last_over_time(metering:persistent_volume_claims:sum_by_namespace:avg_over_time:this_month[10m])
+          last_over_time(metering:persistent_volume_claims:sum_by_namespace:avg_over_time:this_month[30m])
         + on (year, month) group_left ()
           _year_month2
 
@@ -191,7 +191,7 @@ groups:
         metering:cpu_usage:sum_by_namespace
       +
         (
-            last_over_time(metering:cpu_usage:sum_by_namespace:sum_over_time[10m])
+            last_over_time(metering:cpu_usage:sum_by_namespace:sum_over_time[30m])
           or
             metering:cpu_usage:sum_by_namespace * 0
         )
@@ -206,7 +206,7 @@ groups:
     expr: |2
         metering:cpu_usage:sum_by_namespace:avg_over_time
       or
-          last_over_time(metering:cpu_usage:sum_by_namespace:avg_over_time:this_month[10m])
+          last_over_time(metering:cpu_usage:sum_by_namespace:avg_over_time:this_month[30m])
         + on (year, month) group_left ()
           _year_month2
 
@@ -215,7 +215,7 @@ groups:
         metering:cpu_requests:sum_by_namespace
       +
         (
-            last_over_time(metering:cpu_requests:sum_by_namespace:sum_over_time[10m])
+            last_over_time(metering:cpu_requests:sum_by_namespace:sum_over_time[30m])
           or
             metering:cpu_requests:sum_by_namespace * 0
         )
@@ -230,7 +230,7 @@ groups:
     expr: |2
         metering:cpu_requests:sum_by_namespace:avg_over_time
       or
-          last_over_time(metering:cpu_requests:sum_by_namespace:avg_over_time:this_month[10m])
+          last_over_time(metering:cpu_requests:sum_by_namespace:avg_over_time:this_month[30m])
         + on (year, month) group_left ()
           _year_month2
 
@@ -239,7 +239,7 @@ groups:
         metering:memory_usage:sum_by_namespace
       +
         (
-            last_over_time(metering:memory_usage:sum_by_namespace:sum_over_time[10m])
+            last_over_time(metering:memory_usage:sum_by_namespace:sum_over_time[30m])
           or
             metering:memory_usage:sum_by_namespace * 0
         )
@@ -254,7 +254,7 @@ groups:
     expr: |2
         metering:memory_usage:sum_by_namespace:avg_over_time
       or
-          last_over_time(metering:memory_usage:sum_by_namespace:avg_over_time:this_month[10m])
+          last_over_time(metering:memory_usage:sum_by_namespace:avg_over_time:this_month[30m])
         + on (year, month) group_left ()
           _year_month2
 
@@ -263,7 +263,7 @@ groups:
         metering:working_set_memory:sum_by_namespace
       +
         (
-            last_over_time(metering:working_set_memory:sum_by_namespace:sum_over_time[10m])
+            last_over_time(metering:working_set_memory:sum_by_namespace:sum_over_time[30m])
           or
             metering:working_set_memory:sum_by_namespace * 0
         )
@@ -278,7 +278,7 @@ groups:
     expr: |2
         metering:working_set_memory:sum_by_namespace:avg_over_time
       or
-          last_over_time(metering:working_set_memory:sum_by_namespace:avg_over_time:this_month[10m])
+          last_over_time(metering:working_set_memory:sum_by_namespace:avg_over_time:this_month[30m])
         + on (year, month) group_left ()
           _year_month2
 
@@ -287,7 +287,7 @@ groups:
         metering:memory_requests:sum_by_namespace
       +
         (
-            last_over_time(metering:memory_requests:sum_by_namespace:sum_over_time[10m])
+            last_over_time(metering:memory_requests:sum_by_namespace:sum_over_time[30m])
           or
             metering:memory_requests:sum_by_namespace * 0
         )
@@ -302,7 +302,7 @@ groups:
     expr: |2
         metering:memory_requests:sum_by_namespace:avg_over_time
       or
-          last_over_time(metering:memory_requests:sum_by_namespace:avg_over_time:this_month[10m])
+          last_over_time(metering:memory_requests:sum_by_namespace:avg_over_time:this_month[30m])
         + on (year, month) group_left ()
           _year_month2
 
@@ -311,7 +311,7 @@ groups:
         metering:network_transmit:sum_by_namespace
       +
         (
-            last_over_time(metering:network_transmit:sum_by_namespace:sum_over_time[10m])
+            last_over_time(metering:network_transmit:sum_by_namespace:sum_over_time[30m])
           or
             metering:network_transmit:sum_by_namespace * 0
         )
@@ -326,7 +326,7 @@ groups:
     expr: |2
         metering:network_transmit:sum_by_namespace:avg_over_time
       or
-          last_over_time(metering:network_transmit:sum_by_namespace:avg_over_time:this_month[10m])
+          last_over_time(metering:network_transmit:sum_by_namespace:avg_over_time:this_month[30m])
         + on (year, month) group_left ()
           _year_month2
 
@@ -335,7 +335,7 @@ groups:
         metering:network_receive:sum_by_namespace
       +
         (
-            last_over_time(metering:network_receive:sum_by_namespace:sum_over_time[10m])
+            last_over_time(metering:network_receive:sum_by_namespace:sum_over_time[30m])
           or
             metering:network_receive:sum_by_namespace * 0
         )
@@ -350,7 +350,7 @@ groups:
     expr: |2
         metering:network_receive:sum_by_namespace:avg_over_time
       or
-          last_over_time(metering:network_receive:sum_by_namespace:avg_over_time:this_month[10m])
+          last_over_time(metering:network_receive:sum_by_namespace:avg_over_time:this_month[30m])
         + on (year, month) group_left ()
           _year_month2
 
@@ -359,7 +359,7 @@ groups:
         metering:persistent_volume_usage:sum_by_namespace
       +
         (
-            last_over_time(metering:persistent_volume_usage:sum_by_namespace:sum_over_time[10m])
+            last_over_time(metering:persistent_volume_usage:sum_by_namespace:sum_over_time[30m])
           or
             metering:persistent_volume_usage:sum_by_namespace * 0
         )
@@ -374,6 +374,6 @@ groups:
     expr: |2
         metering:persistent_volume_usage:sum_by_namespace:avg_over_time
       or
-          last_over_time(metering:persistent_volume_usage:sum_by_namespace:avg_over_time:this_month[10m])
+          last_over_time(metering:persistent_volume_usage:sum_by_namespace:avg_over_time:this_month[30m])
         + on (year, month) group_left ()
           _year_month2

--- a/pkg/component/monitoring/charts/bootstrap/aggregate-prometheus-rules/metering.rules.stateful.yaml
+++ b/pkg/component/monitoring/charts/bootstrap/aggregate-prometheus-rules/metering.rules.stateful.yaml
@@ -1,5 +1,6 @@
 groups:
 - name: metering.rules.stateful
+  interval: 60s
   rules:
 
 # - _year_month2
@@ -8,22 +9,63 @@ groups:
     expr: |2
         count_values without () (
           "year",
-          year(timestamp(count_values without () ("month", month(timestamp(vector(0))))))
+          year(timestamp(count_values ("month", month(timestamp(vector(0))))))
         )
       *
         0
+
+# - metering  :node_capacity             :sum_by_instance_type   :sum_over_time
+# - metering  :node_capacity             :sum_by_instance_type   :avg_over_time
+# - metering  :node_capacity             :sum_by_instance_type   :avg_over_time   :this_month
+
+  - record: metering:node_capacity:sum_by_instance_type:sum_over_time
+    expr: |2
+        metering:node_capacity:sum_by_instance_type
+      +
+        (
+            last_over_time(metering:node_capacity:sum_by_instance_type:sum_over_time[10m])
+          or
+            metering:node_capacity:sum_by_instance_type * 0
+        )
+
+  - record: metering:node_capacity:sum_by_instance_type:count_over_time
+    expr: |2
+        1 + metering:node_capacity:sum_by_instance_type * 0
+      +
+        (
+            last_over_time(metering:node_capacity:sum_by_instance_type:count_over_time[10m])
+          or
+            metering:node_capacity:sum_by_instance_type * 0
+        )
+
+  - record: metering:node_capacity:sum_by_instance_type:avg_over_time
+    expr: |2
+        metering:node_capacity:sum_by_instance_type:sum_over_time
+      /
+        metering:node_capacity:sum_by_instance_type:count_over_time
+
+  - record: metering:node_capacity:sum_by_instance_type:avg_over_time:this_month
+    expr: |2
+        metering:node_capacity:sum_by_instance_type:avg_over_time
+      or
+          last_over_time(metering:node_capacity:sum_by_instance_type:avg_over_time:this_month[10m])
+        + on (year, month) group_left ()
+          _year_month2
 
 # - metering   :memory_usage_seconds
 # - metering   :disk_usage_seconds
 # - metering   :memory_usage_seconds  :this_month
 # - metering   :disk_usage_seconds    :this_month
 
-
   - record: metering:memory_usage_seconds
     expr: |2
         (metering:working_set_memory:sum_by_namespace > bool 0) * 60
       +
-        (last_over_time(metering:memory_usage_seconds[10m]) or metering:working_set_memory:sum_by_namespace * 0)
+        (
+            last_over_time(metering:memory_usage_seconds[10m])
+          or
+            metering:working_set_memory:sum_by_namespace * 0
+        )
 
   - record: metering:disk_usage_seconds
     expr: |2
@@ -67,12 +109,9 @@ groups:
 
   - record: metering:persistent_volume_claims:sum_by_namespace:avg_over_time
     expr: |2
-          metering:persistent_volume_claims:sum_by_namespace:sum_over_time * 60
-        /
-          (metering:disk_usage_seconds != 0)
-      or
-        metering:persistent_volume_claims:sum_by_namespace:sum_over_time
-
+        metering:persistent_volume_claims:sum_by_namespace:sum_over_time * 60
+      /
+        (metering:disk_usage_seconds != 0)
 
   - record: metering:persistent_volume_claims:sum_by_namespace:avg_over_time:this_month
     expr: |2
@@ -121,12 +160,9 @@ groups:
 
   - record: metering:cpu_usage:sum_by_namespace:avg_over_time
     expr: |2
-          metering:cpu_usage:sum_by_namespace:sum_over_time * 60
-        /
-          (metering:memory_usage_seconds != 0)
-      or
-        metering:cpu_usage:sum_by_namespace:sum_over_time
-
+        metering:cpu_usage:sum_by_namespace:sum_over_time * 60
+      /
+        (metering:memory_usage_seconds != 0)
 
   - record: metering:cpu_usage:sum_by_namespace:avg_over_time:this_month
     expr: |2
@@ -148,12 +184,9 @@ groups:
 
   - record: metering:cpu_requests:sum_by_namespace:avg_over_time
     expr: |2
-          metering:cpu_requests:sum_by_namespace:sum_over_time * 60
-        /
-          (metering:memory_usage_seconds != 0)
-      or
-        metering:cpu_requests:sum_by_namespace:sum_over_time
-
+        metering:cpu_requests:sum_by_namespace:sum_over_time * 60
+      /
+        (metering:memory_usage_seconds != 0)
 
   - record: metering:cpu_requests:sum_by_namespace:avg_over_time:this_month
     expr: |2
@@ -175,12 +208,9 @@ groups:
 
   - record: metering:memory_usage:sum_by_namespace:avg_over_time
     expr: |2
-          metering:memory_usage:sum_by_namespace:sum_over_time * 60
-        /
-          (metering:memory_usage_seconds != 0)
-      or
-        metering:memory_usage:sum_by_namespace:sum_over_time
-
+        metering:memory_usage:sum_by_namespace:sum_over_time * 60
+      /
+        (metering:memory_usage_seconds != 0)
 
   - record: metering:memory_usage:sum_by_namespace:avg_over_time:this_month
     expr: |2
@@ -202,12 +232,9 @@ groups:
 
   - record: metering:working_set_memory:sum_by_namespace:avg_over_time
     expr: |2
-          metering:working_set_memory:sum_by_namespace:sum_over_time * 60
-        /
-          (metering:memory_usage_seconds != 0)
-      or
-        metering:working_set_memory:sum_by_namespace:sum_over_time
-
+        metering:working_set_memory:sum_by_namespace:sum_over_time * 60
+      /
+        (metering:memory_usage_seconds != 0)
 
   - record: metering:working_set_memory:sum_by_namespace:avg_over_time:this_month
     expr: |2
@@ -229,12 +256,9 @@ groups:
 
   - record: metering:memory_requests:sum_by_namespace:avg_over_time
     expr: |2
-          metering:memory_requests:sum_by_namespace:sum_over_time * 60
-        /
-          (metering:memory_usage_seconds != 0)
-      or
-        metering:memory_requests:sum_by_namespace:sum_over_time
-
+        metering:memory_requests:sum_by_namespace:sum_over_time * 60
+      /
+        (metering:memory_usage_seconds != 0)
 
   - record: metering:memory_requests:sum_by_namespace:avg_over_time:this_month
     expr: |2
@@ -256,12 +280,9 @@ groups:
 
   - record: metering:network_transmit:sum_by_namespace:avg_over_time
     expr: |2
-          metering:network_transmit:sum_by_namespace:sum_over_time * 60
-        /
-          (metering:memory_usage_seconds != 0)
-      or
-        metering:network_transmit:sum_by_namespace:sum_over_time
-
+        metering:network_transmit:sum_by_namespace:sum_over_time * 60
+      /
+        (metering:memory_usage_seconds != 0)
 
   - record: metering:network_transmit:sum_by_namespace:avg_over_time:this_month
     expr: |2
@@ -283,12 +304,9 @@ groups:
 
   - record: metering:network_receive:sum_by_namespace:avg_over_time
     expr: |2
-          metering:network_receive:sum_by_namespace:sum_over_time * 60
-        /
-          (metering:memory_usage_seconds != 0)
-      or
-        metering:network_receive:sum_by_namespace:sum_over_time
-
+        metering:network_receive:sum_by_namespace:sum_over_time * 60
+      /
+        (metering:memory_usage_seconds != 0)
 
   - record: metering:network_receive:sum_by_namespace:avg_over_time:this_month
     expr: |2
@@ -310,12 +328,9 @@ groups:
 
   - record: metering:persistent_volume_usage:sum_by_namespace:avg_over_time
     expr: |2
-          metering:persistent_volume_usage:sum_by_namespace:sum_over_time * 60
-        /
-          (metering:memory_usage_seconds != 0)
-      or
-        metering:persistent_volume_usage:sum_by_namespace:sum_over_time
-
+        metering:persistent_volume_usage:sum_by_namespace:sum_over_time * 60
+      /
+        (metering:memory_usage_seconds != 0)
 
   - record: metering:persistent_volume_usage:sum_by_namespace:avg_over_time:this_month
     expr: |2

--- a/pkg/component/monitoring/charts/bootstrap/aggregate-prometheus-rules/metering.rules.stateful.yaml
+++ b/pkg/component/monitoring/charts/bootstrap/aggregate-prometheus-rules/metering.rules.stateful.yaml
@@ -110,6 +110,54 @@ groups:
         + on (year, month) group_left ()
           _year_month2
 
+# - metering  :node_cp_requests             :sum_by_instance_type   :sum_over_time
+# - metering  :node_cp_requests             :sum_by_instance_type   :count_over_time
+# - metering  :node_cp_requests             :sum_by_instance_type   :count_over_time :this_month
+# - metering  :node_cp_requests             :sum_by_instance_type   :avg_over_time
+# - metering  :node_cp_requests             :sum_by_instance_type   :avg_over_time   :this_month
+
+  - record: metering:node_cp_requests:sum_by_instance_type:sum_over_time
+    expr: |2
+        metering:node_cp_requests:sum_by_instance_type
+      +
+        (
+            last_over_time(metering:node_cp_requests:sum_by_instance_type:sum_over_time[30m])
+          or
+            metering:node_cp_requests:sum_by_instance_type * 0
+        )
+
+  - record: metering:node_cp_requests:sum_by_instance_type:count_over_time
+    expr: |2
+        1 + metering:node_cp_requests:sum_by_instance_type * 0
+      +
+        (
+            last_over_time(metering:node_cp_requests:sum_by_instance_type:count_over_time[30m])
+          or
+            metering:node_cp_requests:sum_by_instance_type * 0
+        )
+
+  - record: metering:node_cp_requests:sum_by_instance_type:count_over_time:this_month
+    expr: |2
+        metering:node_cp_requests:sum_by_instance_type:count_over_time
+      or
+          last_over_time(metering:node_cp_requests:sum_by_instance_type:count_over_time:this_month[30m])
+        + on (year, month) group_left ()
+          _year_month2
+
+  - record: metering:node_cp_requests:sum_by_instance_type:avg_over_time
+    expr: |2
+        metering:node_cp_requests:sum_by_instance_type:sum_over_time
+      /
+        metering:node_cp_requests:sum_by_instance_type:count_over_time
+
+  - record: metering:node_cp_requests:sum_by_instance_type:avg_over_time:this_month
+    expr: |2
+        metering:node_cp_requests:sum_by_instance_type:avg_over_time
+      or
+          last_over_time(metering:node_cp_requests:sum_by_instance_type:avg_over_time:this_month[30m])
+        + on (year, month) group_left ()
+          _year_month2
+
 # - metering   :memory_usage_seconds
 # - metering   :disk_usage_seconds
 # - metering   :memory_usage_seconds  :this_month

--- a/pkg/component/monitoring/charts/bootstrap/aggregate-prometheus-rules/metering.rules.stateful.yaml
+++ b/pkg/component/monitoring/charts/bootstrap/aggregate-prometheus-rules/metering.rules.stateful.yaml
@@ -52,6 +52,44 @@ groups:
         + on (year, month) group_left ()
           _year_month2
 
+# - metering  :node_cp_usage             :sum_by_instance_type   :sum_over_time
+# - metering  :node_cp_usage             :sum_by_instance_type   :avg_over_time
+# - metering  :node_cp_usage             :sum_by_instance_type   :avg_over_time   :this_month
+
+  - record: metering:node_cp_usage:sum_by_instance_type:sum_over_time
+    expr: |2
+        metering:node_cp_usage:sum_by_instance_type
+      +
+        (
+            last_over_time(metering:node_cp_usage:sum_by_instance_type:sum_over_time[10m])
+          or
+            metering:node_cp_usage:sum_by_instance_type * 0
+        )
+
+  - record: metering:node_cp_usage:sum_by_instance_type:count_over_time
+    expr: |2
+        1 + metering:node_cp_usage:sum_by_instance_type * 0
+      +
+        (
+            last_over_time(metering:node_cp_usage:sum_by_instance_type:count_over_time[10m])
+          or
+            metering:node_cp_usage:sum_by_instance_type * 0
+        )
+
+  - record: metering:node_cp_usage:sum_by_instance_type:avg_over_time
+    expr: |2
+        metering:node_cp_usage:sum_by_instance_type:sum_over_time
+      /
+        metering:node_cp_usage:sum_by_instance_type:count_over_time
+
+  - record: metering:node_cp_usage:sum_by_instance_type:avg_over_time:this_month
+    expr: |2
+        metering:node_cp_usage:sum_by_instance_type:avg_over_time
+      or
+          last_over_time(metering:node_cp_usage:sum_by_instance_type:avg_over_time:this_month[10m])
+        + on (year, month) group_left ()
+          _year_month2
+
 # - metering   :memory_usage_seconds
 # - metering   :disk_usage_seconds
 # - metering   :memory_usage_seconds  :this_month

--- a/pkg/component/monitoring/charts/bootstrap/prometheus-rules-tests/metering.rules.stateful.test.yaml
+++ b/pkg/component/monitoring/charts/bootstrap/prometheus-rules-tests/metering.rules.stateful.test.yaml
@@ -127,6 +127,62 @@ tests:
     - labels: metering:node_cp_usage:sum_by_instance_type:avg_over_time:this_month{type="no longer existing", year="1970", month="1"}
       value: 1
 
+# metering:node_cp_requests:sum_by_instance_type:sum_over_time
+# metering:node_cp_requests:sum_by_instance_type:count_over_time
+# metering:node_cp_requests:sum_by_instance_type:count_over_time:this_month
+# metering:node_cp_requests:sum_by_instance_type:avg_over_time
+# metering:node_cp_requests:sum_by_instance_type:avg_over_time:this_month
+- name: metering:node_cp_requests:sum_by_instance_type:*
+  interval: 1m
+  input_series:
+  - series: metering:node_cp_requests:sum_by_instance_type{type="complete", year="1970", month="1"}
+    values: 1x60
+  - series: metering:node_cp_requests:sum_by_instance_type{type="data gaps", year="1970", month="1"}
+    values: 1+0x9 stale _x24 1+0x4 0x13 stale _x4 0 # can cope with gaps up to 30 minutes
+  - series: metering:node_cp_requests:sum_by_instance_type{type="no longer existing", year="1970", month="1"}
+    values: 1+0x29 stale _x29
+  promql_expr_test:
+  - expr: metering:node_cp_requests:sum_by_instance_type:sum_over_time
+    eval_time: 59m
+    exp_samples:
+    - labels: metering:node_cp_requests:sum_by_instance_type:sum_over_time{type="complete", year="1970", month="1"}
+      value: 60
+    - labels: metering:node_cp_requests:sum_by_instance_type:sum_over_time{type="data gaps", year="1970", month="1"}
+      value: 15
+  - expr: metering:node_cp_requests:sum_by_instance_type:count_over_time
+    eval_time: 59m
+    exp_samples:
+    - labels: metering:node_cp_requests:sum_by_instance_type:count_over_time{type="complete", year="1970", month="1"}
+      value: 60
+    - labels: metering:node_cp_requests:sum_by_instance_type:count_over_time{type="data gaps", year="1970", month="1"}
+      value: 30
+  - expr: metering:node_cp_requests:sum_by_instance_type:avg_over_time
+    eval_time: 59m
+    exp_samples:
+    - labels: metering:node_cp_requests:sum_by_instance_type:avg_over_time{type="complete", year="1970", month="1"}
+      value: 1
+    - labels: metering:node_cp_requests:sum_by_instance_type:avg_over_time{type="data gaps", year="1970", month="1"}
+      value: 0.5
+
+  - expr: metering:node_cp_requests:sum_by_instance_type:count_over_time:this_month
+    eval_time: 59m
+    exp_samples:
+    - labels: metering:node_cp_requests:sum_by_instance_type:count_over_time:this_month{type="complete", year="1970", month="1"}
+      value: 60
+    - labels: metering:node_cp_requests:sum_by_instance_type:count_over_time:this_month{type="data gaps", year="1970", month="1"}
+      value: 30
+    - labels: metering:node_cp_requests:sum_by_instance_type:count_over_time:this_month{type="no longer existing", year="1970", month="1"}
+      value: 30
+  - expr: metering:node_cp_requests:sum_by_instance_type:avg_over_time:this_month
+    eval_time: 59m
+    exp_samples:
+    - labels: metering:node_cp_requests:sum_by_instance_type:avg_over_time:this_month{type="complete", year="1970", month="1"}
+      value: 1
+    - labels: metering:node_cp_requests:sum_by_instance_type:avg_over_time:this_month{type="data gaps", year="1970", month="1"}
+      value: 0.5
+    - labels: metering:node_cp_requests:sum_by_instance_type:avg_over_time:this_month{type="no longer existing", year="1970", month="1"}
+      value: 1
+
 # metering:memory_usage_seconds
 # metering:memory_usage_seconds:this_month
 - name: metering:memory_usage_seconds*

--- a/pkg/component/monitoring/charts/bootstrap/prometheus-rules-tests/metering.rules.stateful.test.yaml
+++ b/pkg/component/monitoring/charts/bootstrap/prometheus-rules-tests/metering.rules.stateful.test.yaml
@@ -1,0 +1,276 @@
+rule_files:
+- ../prometheus-rules/metering.rules.stateful.yaml
+
+tests:
+
+# _year_month2 contains the year and month labels of the evaluation time. The
+# suffix 2 is added to avoid rules with the same name if both the "stateless" and
+# "stateful" recording rules are loaded.
+- name: _year_month2
+  promql_expr_test:
+  - expr: _year_month2
+    exp_samples:
+    - labels: _year_month2{
+                  year  = "1970",
+                  month = "1"}
+      value: 0
+
+# metering:node_capacity:sum_by_instance_type:sum_over_time
+# metering:node_capacity:sum_by_instance_type:count_over_time
+# metering:node_capacity:sum_by_instance_type:count_over_time:this_month
+# metering:node_capacity:sum_by_instance_type:avg_over_time
+# metering:node_capacity:sum_by_instance_type:avg_over_time:this_month
+- name: metering:node_capacity:sum_by_instance_type:*
+  interval: 1m
+  input_series:
+  - series: metering:node_capacity:sum_by_instance_type{type="complete", year="1970", month="1"}
+    values: 1x60
+  - series: metering:node_capacity:sum_by_instance_type{type="data gaps", year="1970", month="1"}
+    values: 1+0x9 stale _x24 1+0x4 0x13 stale _x4 0 # can cope with gaps up to 30 minutes
+  - series: metering:node_capacity:sum_by_instance_type{type="no longer existing", year="1970", month="1"}
+    values: 1+0x29 stale _x29
+  promql_expr_test:
+  - expr: metering:node_capacity:sum_by_instance_type:sum_over_time
+    eval_time: 59m
+    exp_samples:
+    - labels: metering:node_capacity:sum_by_instance_type:sum_over_time{type="complete", year="1970", month="1"}
+      value: 60
+    - labels: metering:node_capacity:sum_by_instance_type:sum_over_time{type="data gaps", year="1970", month="1"}
+      value: 15
+  - expr: metering:node_capacity:sum_by_instance_type:count_over_time
+    eval_time: 59m
+    exp_samples:
+    - labels: metering:node_capacity:sum_by_instance_type:count_over_time{type="complete", year="1970", month="1"}
+      value: 60
+    - labels: metering:node_capacity:sum_by_instance_type:count_over_time{type="data gaps", year="1970", month="1"}
+      value: 30
+  - expr: metering:node_capacity:sum_by_instance_type:avg_over_time
+    eval_time: 59m
+    exp_samples:
+    - labels: metering:node_capacity:sum_by_instance_type:avg_over_time{type="complete", year="1970", month="1"}
+      value: 1
+    - labels: metering:node_capacity:sum_by_instance_type:avg_over_time{type="data gaps", year="1970", month="1"}
+      value: 0.5
+
+  - expr: metering:node_capacity:sum_by_instance_type:count_over_time:this_month
+    eval_time: 59m
+    exp_samples:
+    - labels: metering:node_capacity:sum_by_instance_type:count_over_time:this_month{type="complete", year="1970", month="1"}
+      value: 60
+    - labels: metering:node_capacity:sum_by_instance_type:count_over_time:this_month{type="data gaps", year="1970", month="1"}
+      value: 30
+    - labels: metering:node_capacity:sum_by_instance_type:count_over_time:this_month{type="no longer existing", year="1970", month="1"}
+      value: 30
+  - expr: metering:node_capacity:sum_by_instance_type:avg_over_time:this_month
+    eval_time: 59m
+    exp_samples:
+    - labels: metering:node_capacity:sum_by_instance_type:avg_over_time:this_month{type="complete", year="1970", month="1"}
+      value: 1
+    - labels: metering:node_capacity:sum_by_instance_type:avg_over_time:this_month{type="data gaps", year="1970", month="1"}
+      value: 0.5
+    - labels: metering:node_capacity:sum_by_instance_type:avg_over_time:this_month{type="no longer existing", year="1970", month="1"}
+      value: 1
+
+# metering:node_cp_usage:sum_by_instance_type:sum_over_time
+# metering:node_cp_usage:sum_by_instance_type:count_over_time
+# metering:node_cp_usage:sum_by_instance_type:count_over_time:this_month
+# metering:node_cp_usage:sum_by_instance_type:avg_over_time
+# metering:node_cp_usage:sum_by_instance_type:avg_over_time:this_month
+- name: metering:node_cp_usage:sum_by_instance_type:*
+  interval: 1m
+  input_series:
+  - series: metering:node_cp_usage:sum_by_instance_type{type="complete", year="1970", month="1"}
+    values: 1x60
+  - series: metering:node_cp_usage:sum_by_instance_type{type="data gaps", year="1970", month="1"}
+    values: 1+0x9 stale _x24 1+0x4 0x13 stale _x4 0 # can cope with gaps up to 30 minutes
+  - series: metering:node_cp_usage:sum_by_instance_type{type="no longer existing", year="1970", month="1"}
+    values: 1+0x29 stale _x29
+  promql_expr_test:
+  - expr: metering:node_cp_usage:sum_by_instance_type:sum_over_time
+    eval_time: 59m
+    exp_samples:
+    - labels: metering:node_cp_usage:sum_by_instance_type:sum_over_time{type="complete", year="1970", month="1"}
+      value: 60
+    - labels: metering:node_cp_usage:sum_by_instance_type:sum_over_time{type="data gaps", year="1970", month="1"}
+      value: 15
+  - expr: metering:node_cp_usage:sum_by_instance_type:count_over_time
+    eval_time: 59m
+    exp_samples:
+    - labels: metering:node_cp_usage:sum_by_instance_type:count_over_time{type="complete", year="1970", month="1"}
+      value: 60
+    - labels: metering:node_cp_usage:sum_by_instance_type:count_over_time{type="data gaps", year="1970", month="1"}
+      value: 30
+  - expr: metering:node_cp_usage:sum_by_instance_type:avg_over_time
+    eval_time: 59m
+    exp_samples:
+    - labels: metering:node_cp_usage:sum_by_instance_type:avg_over_time{type="complete", year="1970", month="1"}
+      value: 1
+    - labels: metering:node_cp_usage:sum_by_instance_type:avg_over_time{type="data gaps", year="1970", month="1"}
+      value: 0.5
+
+  - expr: metering:node_cp_usage:sum_by_instance_type:count_over_time:this_month
+    eval_time: 59m
+    exp_samples:
+    - labels: metering:node_cp_usage:sum_by_instance_type:count_over_time:this_month{type="complete", year="1970", month="1"}
+      value: 60
+    - labels: metering:node_cp_usage:sum_by_instance_type:count_over_time:this_month{type="data gaps", year="1970", month="1"}
+      value: 30
+    - labels: metering:node_cp_usage:sum_by_instance_type:count_over_time:this_month{type="no longer existing", year="1970", month="1"}
+      value: 30
+  - expr: metering:node_cp_usage:sum_by_instance_type:avg_over_time:this_month
+    eval_time: 59m
+    exp_samples:
+    - labels: metering:node_cp_usage:sum_by_instance_type:avg_over_time:this_month{type="complete", year="1970", month="1"}
+      value: 1
+    - labels: metering:node_cp_usage:sum_by_instance_type:avg_over_time:this_month{type="data gaps", year="1970", month="1"}
+      value: 0.5
+    - labels: metering:node_cp_usage:sum_by_instance_type:avg_over_time:this_month{type="no longer existing", year="1970", month="1"}
+      value: 1
+
+# metering:memory_usage_seconds
+# metering:memory_usage_seconds:this_month
+- name: metering:memory_usage_seconds*
+  interval: 1m
+  input_series:
+  - series: metering:working_set_memory:sum_by_namespace{type="complete", year="1970", month="1"}
+    values: 1x60
+  - series: metering:working_set_memory:sum_by_namespace{type="data gaps", year="1970", month="1"}
+    values: 1+0x9 stale _x24 1+0x4 0x13 stale _x4 0 # can cope with gaps up to 30 minutes
+  - series: metering:working_set_memory:sum_by_namespace{type="no longer existing", year="1970", month="1"}
+    values: 1+0x29 stale _x29
+  promql_expr_test:
+  - expr: metering:memory_usage_seconds
+    eval_time: 59m
+    exp_samples:
+    - labels: metering:memory_usage_seconds{type="complete", year="1970", month="1"}
+      value: 3600
+    - labels: metering:memory_usage_seconds{type="data gaps", year="1970", month="1"}
+      value: 900
+  - expr: metering:memory_usage_seconds:this_month
+    eval_time: 59m
+    exp_samples:
+    - labels: metering:memory_usage_seconds:this_month{type="complete", year="1970", month="1"}
+      value: 3600
+    - labels: metering:memory_usage_seconds:this_month{type="data gaps", year="1970", month="1"}
+      value: 900
+    - labels: metering:memory_usage_seconds:this_month{type="no longer existing", year="1970", month="1"}
+      value: 1800
+
+# metering:disk_usage_seconds
+# metering:disk_usage_seconds:this_month
+- name: metering:disk_usage_seconds*
+  interval: 1m
+  input_series:
+  - series: metering:persistent_volume_claims:sum_by_namespace{type="complete", year="1970", month="1"}
+    values: 1x60
+  - series: metering:persistent_volume_claims:sum_by_namespace{type="data gaps", year="1970", month="1"}
+    values: 1+0x9 stale _x24 1+0x4 0x13 stale _x4 0 # can cope with gaps up to 30 minutes
+  - series: metering:persistent_volume_claims:sum_by_namespace{type="no longer existing", year="1970", month="1"}
+    values: 1+0x29 stale _x29
+  promql_expr_test:
+  - expr: metering:disk_usage_seconds
+    eval_time: 59m
+    exp_samples:
+    - labels: metering:disk_usage_seconds{type="complete", year="1970", month="1"}
+      value: 3600
+    - labels: metering:disk_usage_seconds{type="data gaps", year="1970", month="1"}
+      value: 900
+  - expr: metering:disk_usage_seconds:this_month
+    eval_time: 59m
+    exp_samples:
+    - labels: metering:disk_usage_seconds:this_month{type="complete", year="1970", month="1"}
+      value: 3600
+    - labels: metering:disk_usage_seconds:this_month{type="data gaps", year="1970", month="1"}
+      value: 900
+    - labels: metering:disk_usage_seconds:this_month{type="no longer existing", year="1970", month="1"}
+      value: 1800
+
+# metering:persistent_volume_claims:sum_by_namespace:sum_over_time
+# metering:persistent_volume_claims:sum_by_namespace:avg_over_time
+# metering:persistent_volume_claims:sum_by_namespace:avg_over_time:this_month
+- name: metering:persistent_volume_claims:sum_by_namespace:*
+  interval: 1m
+  input_series:
+  - series: metering:persistent_volume_claims:sum_by_namespace{type="complete", year="1970", month="1"}
+    values: 1x60
+  - series: metering:persistent_volume_claims:sum_by_namespace{type="data gaps", year="1970", month="1"}
+    values: 1+0x9 stale _x24 1+0x4 0x13 stale _x4 0 # can cope with gaps up to 30 minutes
+  - series: metering:persistent_volume_claims:sum_by_namespace{type="no longer existing", year="1970", month="1"}
+    values: 1+0x29 stale _x29
+  promql_expr_test:
+  - expr: metering:persistent_volume_claims:sum_by_namespace:sum_over_time
+    eval_time: 59m
+    exp_samples:
+    - labels: metering:persistent_volume_claims:sum_by_namespace:sum_over_time{type="complete", year="1970", month="1"}
+      value: 60
+    - labels: metering:persistent_volume_claims:sum_by_namespace:sum_over_time{type="data gaps", year="1970", month="1"}
+      value: 15
+  - expr: metering:persistent_volume_claims:sum_by_namespace:avg_over_time
+    eval_time: 59m
+    exp_samples:
+    - labels: metering:persistent_volume_claims:sum_by_namespace:avg_over_time{type="complete", year="1970", month="1"}
+      value: 1
+    - labels: metering:persistent_volume_claims:sum_by_namespace:avg_over_time{type="data gaps", year="1970", month="1"}
+      value: 1
+  - expr: metering:persistent_volume_claims:sum_by_namespace:avg_over_time:this_month
+    eval_time: 59m
+    exp_samples:
+    - labels: metering:persistent_volume_claims:sum_by_namespace:avg_over_time:this_month{type="complete", year="1970", month="1"}
+      value: 1
+    - labels: metering:persistent_volume_claims:sum_by_namespace:avg_over_time:this_month{type="data gaps", year="1970", month="1"}
+      value: 1
+    - labels: metering:persistent_volume_claims:sum_by_namespace:avg_over_time:this_month{type="no longer existing", year="1970", month="1"}
+      value: 1
+
+# metering:cpu_usage:sum_by_namespace:sum_over_time
+# metering:cpu_usage:sum_by_namespace:avg_over_time
+# metering:cpu_usage:sum_by_namespace:avg_over_time:this_month
+- name: metering:cpu_usage:sum_by_namespace:*
+  interval: 1m
+  input_series:
+  - series: metering:cpu_usage:sum_by_namespace{type="complete", year="1970", month="1"}
+    values: 1x60
+  - series: metering:memory_usage_seconds{type="complete", year="1970", month="1"}
+    values: 60+60x60
+  - series: metering:cpu_usage:sum_by_namespace{type="data gaps", year="1970", month="1"}
+    values: 1+0x9 stale _x24 1+0x4 0x13 stale _x4 0 # can cope with gaps up to 30 minutes
+  - series: metering:working_set_memory:sum_by_namespace{type="data gaps", year="1970", month="1"}
+    values: 1+0x9 stale _x24 1+0x4 1x13 stale _x4 1
+  - series: metering:cpu_usage:sum_by_namespace{type="no longer existing", year="1970", month="1"}
+    values: 1+0x29 stale _x29
+  - series: metering:working_set_memory:sum_by_namespace{type="no longer existing", year="1970", month="1"}
+    values: 1+0x9 stale _x29
+  - series: metering:cpu_usage:sum_by_namespace{type="avg calculation bug", year="1970", month="1"}
+    values: 1x60
+  - series: metering:working_set_memory:sum_by_namespace{type="avg calculation bug", year="1970", month="1"}
+    values: 1x58 stale
+  promql_expr_test:
+  - expr: metering:cpu_usage:sum_by_namespace:sum_over_time
+    eval_time: 59m
+    exp_samples:
+    - labels: metering:cpu_usage:sum_by_namespace:sum_over_time{type="complete", year="1970", month="1"}
+      value: 60
+    - labels: metering:cpu_usage:sum_by_namespace:sum_over_time{type="data gaps", year="1970", month="1"}
+      value: 15
+    - labels: metering:cpu_usage:sum_by_namespace:sum_over_time{type="avg calculation bug", year="1970", month="1"}
+      value: 60
+  - expr: metering:cpu_usage:sum_by_namespace:avg_over_time
+    eval_time: 59m
+    exp_samples:
+    - labels: metering:cpu_usage:sum_by_namespace:avg_over_time{type="complete", year="1970", month="1"}
+      value: 1
+    - labels: metering:cpu_usage:sum_by_namespace:avg_over_time{type="data gaps", year="1970", month="1"}
+      value: 0.5
+  - expr: metering:cpu_usage:sum_by_namespace:avg_over_time:this_month
+    eval_time: 59m
+    exp_samples:
+    - labels: metering:cpu_usage:sum_by_namespace:avg_over_time:this_month{type="complete", year="1970", month="1"}
+      value: 1
+    - labels: metering:cpu_usage:sum_by_namespace:avg_over_time:this_month{type="data gaps", year="1970", month="1"}
+      value: 0.5
+    - labels: metering:cpu_usage:sum_by_namespace:avg_over_time:this_month{type="no longer existing", year="1970", month="1"}
+      value: 1
+    - labels: metering:cpu_usage:sum_by_namespace:avg_over_time:this_month{type="avg calculation bug", year="1970", month="1"}
+      value: 1
+
+# The remaining recording rules are similar

--- a/pkg/component/monitoring/charts/bootstrap/prometheus-rules-tests/metering.rules.test.yaml
+++ b/pkg/component/monitoring/charts/bootstrap/prometheus-rules-tests/metering.rules.test.yaml
@@ -1,0 +1,577 @@
+rule_files:
+- ../prometheus-rules/metering.rules.yaml
+
+tests:
+
+# _node_instance_type is a mapping from the node label to the instance_type label
+- name: _node_instance_type
+  input_series:
+  - series: kube_node_labels{
+                node                                   = "node1",
+                label_node_kubernetes_io_instance_type = "small"}
+    values: 1
+  - series: kube_node_labels{
+                node                                   = "node2",
+                label_node_kubernetes_io_instance_type = "smaller"}
+    values: 1
+  promql_expr_test:
+  - expr: _node_instance_type
+    exp_samples:
+    - labels: _node_instance_type{
+                  node          = "node1",
+                  instance_type = "small"}
+      value: 0
+    - labels: _node_instance_type{
+                  node          = "node2",
+                  instance_type = "smaller"}
+      value: 0
+
+# _kube_pod_owner_with_instance_type enriches kube_pod_owner with the
+# instance_type of the node that the pod is running on
+- name: _kube_pod_owner_with_instance_type
+  input_series:
+  - series: _node_instance_type{
+                node          = "node1",
+                instance_type = "small"}
+    values: 0
+  - series: _node_instance_type{
+                node          = "node2",
+                instance_type = "smaller"}
+    values: 0
+
+  - series: kube_pod_info{
+                namespace = "shoot--local--local",
+                pod       = "etcd-main-0",
+                node      = "node1"}
+    values: 1
+  - series: kube_pod_info{
+                namespace = "shoot--local--local",
+                pod       = "kube-apiserver-hash1-hash2",
+                node      = "node2"}
+    values: 1
+
+  - series: kube_pod_owner{
+                namespace  = "shoot--local--local",
+                owner_kind = "StatefulSet",
+                owner_name = "etcd-main",
+                pod        = "etcd-main-0"}
+    values: 1
+  - series: kube_pod_owner{
+                namespace  = "shoot--local--local",
+                owner_kind = "ReplicaSet",
+                owner_name = "kube-apiserver-hash1",
+                pod        = "kube-apiserver-hash1-hash2"}
+    values: 1
+
+  promql_expr_test:
+  - expr: _kube_pod_owner_with_instance_type
+    exp_samples:
+    - labels: _kube_pod_owner_with_instance_type{
+                  namespace     = "shoot--local--local",
+                  owner_kind    = "StatefulSet",
+                  owner_name    = "etcd-main",
+                  pod           = "etcd-main-0",
+                  instance_type = "small"}
+      value: 0
+    - labels: _kube_pod_owner_with_instance_type{
+                  namespace     = "shoot--local--local",
+                  owner_kind    = "ReplicaSet",
+                  owner_name    = "kube-apiserver-hash1",
+                  pod           = "kube-apiserver-hash1-hash2",
+                  instance_type = "smaller"}
+      value: 0
+
+# _namespace_to_shoot_uid is a mapping from the namespace label to the shoot_uid label
+- name: _namespace_to_shoot_uid
+  input_series:
+  - series: kube_namespace_annotations{
+                namespace                           = "shoot--local--local",
+                annotation_shoot_gardener_cloud_uid = "uid1"}
+    values: 1
+  - series: kube_namespace_annotations{
+                namespace                           = "shoot--local--local2",
+                annotation_shoot_gardener_cloud_uid = "uid2"}
+    values: 1
+  promql_expr_test:
+  - expr: _namespace_to_shoot_uid
+    exp_samples:
+    - labels: _namespace_to_shoot_uid{
+                  namespace = "shoot--local--local",
+                  shoot_uid = "uid1"}
+      value: 0
+    - labels: _namespace_to_shoot_uid{
+                  namespace = "shoot--local--local2",
+                  shoot_uid = "uid2"}
+      value: 0
+
+# _year_month contains the year and month labels of the evaluation time
+- name: _year_month
+  promql_expr_test:
+  - expr: _year_month
+    exp_samples:
+    - labels: _year_month{
+                  year  = "1970",
+                  month = "1"}
+      value: 0
+
+# _namespace_to_shoot_uid_and_date enriches _namespace_to_shoot_uid with the
+# year and month labels
+- name: _namespace_to_shoot_uid_and_date
+  input_series:
+  - series: _namespace_to_shoot_uid{
+                namespace = "shoot--local--local",
+                shoot_uid = "uid1"}
+    values: 0
+  - series: _namespace_to_shoot_uid{
+                namespace = "shoot--local--local2",
+                shoot_uid = "uid2"}
+    values: 0
+
+  promql_expr_test:
+  - expr: _namespace_to_shoot_uid_and_date
+    exp_samples:
+    - labels: _namespace_to_shoot_uid_and_date{
+                  namespace = "shoot--local--local",
+                  shoot_uid = "uid1",
+                  year      = "1970",
+                  month     = "1"}
+      value: 0
+    - labels: _namespace_to_shoot_uid_and_date{
+                  namespace = "shoot--local--local2",
+                  shoot_uid = "uid2",
+                  year      = "1970",
+                  month     = "1"}
+      value: 0
+
+# _pod_to_owner_instance_type is a mapping from a pod in a namespace to its
+# owner, also carrying the instance_type of the node the pod is running on. The
+# owner is used later as a stable name for a group of pods.
+- name: _pod_to_owner_instance_type
+  input_series:
+  - series: _kube_pod_owner_with_instance_type{
+                namespace     = "shoot--local--local",
+                owner_kind    = "StatefulSet",
+                owner_name    = "etcd-main",
+                pod           = "etcd-main-0",
+                instance_type = "small"}
+    values: 0
+  - series: _kube_pod_owner_with_instance_type{
+                namespace     = "shoot--local--local",
+                owner_kind    = "ReplicaSet",
+                owner_name    = "kube-apiserver-hash1",
+                pod           = "kube-apiserver-hash1-hash2",
+                instance_type = "smaller"}
+    values: 0
+  - series: kube_replicaset_owner{
+                namespace  = "shoot--local--local",
+                owner_kind = "Deployment",
+                owner_name = "kube-apiserver",
+                replicaset = "kube-apiserver-hash1"}
+    values: 0
+
+  promql_expr_test:
+  - expr: _pod_to_owner_instance_type
+    exp_samples:
+    - labels: _pod_to_owner_instance_type{
+                  namespace     = "shoot--local--local",
+                  pod           = "etcd-main-0",
+                  instance_type = "small",
+                  owner         = "etcd-main"}
+      value: 0
+    - labels: _pod_to_owner_instance_type{
+                  namespace     = "shoot--local--local",
+                  pod           = "kube-apiserver-hash1-hash2",
+                  instance_type = "smaller",
+                  owner         = "kube-apiserver"}
+      value: 0
+
+# metering:node_capacity:sum_by_instance_type sum up the node capacity by
+# instance type and carries the year and month labels
+- name: metering:node_capacity:sum_by_instance_type
+  input_series:
+  - series: kube_node_status_capacity{
+                node     = "node1",
+                resource = "cpu",
+                unit     = "core"}
+    values: 4
+  - series: kube_node_status_capacity{
+                node     = "node1b",
+                resource = "cpu",
+                unit     = "core"}
+    values: 4
+  - series: kube_node_status_capacity{
+                node     = "node2",
+                resource = "cpu",
+                unit     = "core"}
+    values: 2
+  - series: kube_node_status_capacity{
+                node     = "node1",
+                resource = "memory",
+                unit     = "byte"}
+    values: 68719476736
+  - series: kube_node_status_capacity{
+                node     = "node1b",
+                resource = "memory",
+                unit     = "byte"}
+    values: 68719476736
+  - series: kube_node_status_capacity{
+                node     = "node2",
+                resource = "memory",
+                unit     = "byte"}
+    values: 34359738368
+  - series: _node_instance_type{
+                node          = "node1",
+                instance_type = "small"}
+    values: 0
+  - series: _node_instance_type{
+                node          = "node1b",
+                instance_type = "small"}
+    values: 0
+  - series: _node_instance_type{
+                node          = "node2",
+                instance_type = "smaller"}
+    values: 0
+
+  promql_expr_test:
+  - expr: metering:node_capacity:sum_by_instance_type
+    exp_samples:
+    - labels: metering:node_capacity:sum_by_instance_type{
+                  resource      = "cpu",
+                  unit          = "core",
+                  instance_type = "small",
+                  year          = "1970",
+                  month         = "1"}
+      value: 8
+    - labels: metering:node_capacity:sum_by_instance_type{
+                  resource      = "cpu",
+                  unit          = "core",
+                  instance_type = "smaller",
+                  year          = "1970",
+                  month         = "1"}
+      value: 2
+    - labels: metering:node_capacity:sum_by_instance_type{
+                  resource      = "memory",
+                  unit          = "byte",
+                  instance_type = "small",
+                  year          = "1970",
+                  month         = "1"}
+      value: 137438953472
+    - labels: metering:node_capacity:sum_by_instance_type{
+                  resource      = "memory",
+                  unit          = "byte",
+                  instance_type = "smaller",
+                  year          = "1970",
+                  month         = "1"}
+      value: 34359738368
+
+# metering:cpu_usage:sum_by_namespace_owner_container_instance_type
+- name: metering:cpu_usage:sum_by_namespace_owner_container_instance_type
+  interval: 1m
+  input_series:
+  - series: container_cpu_usage_seconds_total{
+                namespace      = "shoot--local--local",
+                pod            = "etcd-main-0",
+                container      = "etcd"}
+    values: 0x5 90+90x4
+  - series: container_cpu_usage_seconds_total{
+                namespace      = "shoot--local--local",
+                pod            = "etcd-main-1",
+                container      = "etcd"}
+    values: 0x5 90+90x4
+  - series: _pod_to_owner_instance_type{
+                namespace     = "shoot--local--local",
+                pod           = "etcd-main-0",
+                instance_type = "small",
+                owner         = "etcd-main"}
+    values: 0x10
+  - series: _pod_to_owner_instance_type{
+                namespace     = "shoot--local--local",
+                pod           = "etcd-main-1",
+                instance_type = "small",
+                owner         = "etcd-main"}
+    values: 0x10
+  - series: _namespace_to_shoot_uid{
+                namespace = "shoot--local--local",
+                shoot_uid = "uid1"}
+    values: 0x10
+  promql_expr_test:
+  - expr: metering:cpu_usage:sum_by_namespace_owner_container_instance_type
+    eval_time: 10m
+    exp_samples:
+    - labels: metering:cpu_usage:sum_by_namespace_owner_container_instance_type{
+                  namespace     = "shoot--local--local",
+                  shoot_uid     = "uid1",
+                  owner         = "etcd-main",
+                  container     = "etcd",
+                  instance_type = "small"}
+      value: 3
+
+# metering:cpu_requests:sum_by_namespace_owner_container_instance_type
+- name: metering:cpu_requests:sum_by_namespace_owner_container_instance_type
+  input_series:
+  - series: kube_pod_container_resource_requests{
+                namespace      = "shoot--local--local",
+                resource       = "cpu",
+                unit           = "core",
+                pod            = "etcd-main-0",
+                container      = "etcd"}
+    values: 2
+  - series: kube_pod_container_resource_requests{
+                namespace      = "shoot--local--local",
+                resource       = "cpu",
+                unit           = "core",
+                pod            = "etcd-main-1",
+                container      = "etcd"}
+    values: 3
+  - series: _pod_to_owner_instance_type{
+                namespace     = "shoot--local--local",
+                pod           = "etcd-main-0",
+                instance_type = "small",
+                owner         = "etcd-main"}
+    values: 0
+  - series: _pod_to_owner_instance_type{
+                namespace     = "shoot--local--local",
+                pod           = "etcd-main-1",
+                instance_type = "small",
+                owner         = "etcd-main"}
+    values: 0
+  - series: _namespace_to_shoot_uid{
+                namespace = "shoot--local--local",
+                shoot_uid = "uid1"}
+    values: 0
+  promql_expr_test:
+  - expr: metering:cpu_requests:sum_by_namespace_owner_container_instance_type
+    exp_samples:
+    - labels: metering:cpu_requests:sum_by_namespace_owner_container_instance_type{
+                  namespace     = "shoot--local--local",
+                  shoot_uid     = "uid1",
+                  owner         = "etcd-main",
+                  container     = "etcd",
+                  instance_type = "small"}
+      value: 5
+
+# The following similar recording rules are not covered in unit tests for brevity
+#   metering:memory_usage:sum_by_namespace_owner_container_instance_type
+#   metering:working_set_memory:sum_by_namespace_owner_container_instance_type
+#   metering:memory_requests:sum_by_namespace_owner_container_instance_type
+#   metering:network_transmit:sum_by_namespace_owner_instance_type
+#   metering:network_receive:sum_by_namespace_owner_instance_type
+#   metering:persistent_volume_claims:sum_by_namespace_owner_instance_type
+#   metering:persistent_volume_usage:sum_by_namespace_owner_instance_type
+
+# metering:cpu_usage:sum_by_namespace_owner_container
+- name: metering:cpu_usage:sum_by_namespace_owner_container
+  input_series:
+  - series: metering:cpu_usage:sum_by_namespace_owner_container_instance_type{
+                namespace     = "shoot--local--local",
+                shoot_uid     = "uid1",
+                owner         = "etcd-main",
+                container     = "etcd",
+                instance_type = "small"}
+    values: 1
+  - series: metering:cpu_usage:sum_by_namespace_owner_container_instance_type{
+                namespace     = "shoot--local--local",
+                shoot_uid     = "uid1",
+                owner         = "etcd-main",
+                container     = "etcd",
+                instance_type = "smaller"}
+    values: 2
+  promql_expr_test:
+  - expr: metering:cpu_usage:sum_by_namespace_owner_container
+    exp_samples:
+    - labels: metering:cpu_usage:sum_by_namespace_owner_container{
+                  namespace     = "shoot--local--local",
+                  shoot_uid     = "uid1",
+                  owner         = "etcd-main",
+                  container     = "etcd"}
+      value: 3
+
+# The following similar recording rules are not covered in unit tests for brevity
+#   metering:cpu_requests:sum_by_namespace_owner_container
+#   metering:memory_usage:sum_by_namespace_owner_container
+#   metering:working_set_memory:sum_by_namespace_owner_container
+#   metering:memory_requests:sum_by_namespace_owner_container
+#   metering:network_transmit:sum_by_namespace_owner
+#   metering:network_receive:sum_by_namespace_owner
+#   metering:persistent_volume_claims:sum_by_namespace_owner
+#   metering:persistent_volume_usage:sum_by_namespace_owner
+
+# metering:cpu_usage:sum_by_namespace_instance_type
+- name: metering:cpu_usage:sum_by_namespace_instance_type
+  input_series:
+  - series: metering:cpu_usage:sum_by_namespace_owner_container_instance_type{
+                namespace     = "shoot--local--local",
+                shoot_uid     = "uid1",
+                owner         = "etcd-main",
+                container     = "etcd",
+                instance_type = "small"}
+    values: 1
+  - series: metering:cpu_usage:sum_by_namespace_owner_container_instance_type{
+                namespace     = "shoot--local--local",
+                shoot_uid     = "uid1",
+                owner         = "etcd-main",
+                container     = "backup-restore",
+                instance_type = "small"}
+    values: 2
+  - series: _namespace_to_shoot_uid_and_date{
+                namespace = "shoot--local--local",
+                shoot_uid = "uid1",
+                year      = "1970",
+                month     = "1"}
+    values: 0
+  - series: _namespace_to_shoot_uid_and_date{
+                namespace = "shoot--local--local2",
+                shoot_uid = "uid2",
+                year      = "1970",
+                month     = "1"}
+    values: 0
+  promql_expr_test:
+  - expr: metering:cpu_usage:sum_by_namespace_instance_type
+    exp_samples:
+    - labels: metering:cpu_usage:sum_by_namespace_instance_type{
+                  namespace     = "shoot--local--local",
+                  shoot_uid     = "uid1",
+                  year          = "1970",
+                  month         = "1",
+                  instance_type = "small"}
+      value: 3
+    - labels: metering:cpu_usage:sum_by_namespace_instance_type{
+                  namespace     = "shoot--local--local2",
+                  shoot_uid     = "uid2",
+                  year          = "1970",
+                  month         = "1"}
+      value: 0
+
+# The following similar recording rules are not covered in unit tests for brevity
+#   metering:cpu_requests:sum_by_namespace_instance_type
+#   metering:memory_usage:sum_by_namespace_instance_type
+#   metering:working_set_memory:sum_by_namespace_instance_type
+#   metering:memory_requests:sum_by_namespace_instance_type
+#   metering:network_transmit:sum_by_namespace_instance_type
+#   metering:network_receive:sum_by_namespace_instance_type
+#   metering:persistent_volume_claims:sum_by_namespace_instance_type
+#   metering:persistent_volume_usage:sum_by_namespace_instance_type
+
+# metering:cpu_usage:sum_by_namespace
+- name: metering:cpu_usage:sum_by_namespace
+  input_series:
+  - series: metering:cpu_usage:sum_by_namespace_instance_type{
+                namespace     = "shoot--local--local",
+                shoot_uid     = "uid1",
+                year          = "1970",
+                month         = "1",
+                instance_type = "small"}
+    values: 1
+  - series: metering:cpu_usage:sum_by_namespace_instance_type{
+                namespace     = "shoot--local--local",
+                shoot_uid     = "uid1",
+                year          = "1970",
+                month         = "1",
+                instance_type = "smaller"}
+    values: 2
+  - series: metering:cpu_usage:sum_by_namespace_instance_type{
+                namespace     = "shoot--local--local2",
+                shoot_uid     = "uid2",
+                year          = "1970",
+                month         = "1"}
+    values: 0
+  promql_expr_test:
+  - expr: metering:cpu_usage:sum_by_namespace
+    exp_samples:
+    - labels: metering:cpu_usage:sum_by_namespace{
+                  namespace     = "shoot--local--local",
+                  shoot_uid     = "uid1",
+                  year          = "1970",
+                  month         = "1"}
+      value: 3
+    - labels: metering:cpu_usage:sum_by_namespace{
+                  namespace     = "shoot--local--local2",
+                  shoot_uid     = "uid2",
+                  year          = "1970",
+                  month         = "1"}
+      value: 0
+
+# The following similar recording rules are not covered in unit tests for brevity
+#   metering:cpu_requests:sum_by_namespace
+#   metering:memory_usage:sum_by_namespace
+#   metering:working_set_memory:sum_by_namespace
+#   metering:memory_requests:sum_by_namespace
+#   metering:network_transmit:sum_by_namespace
+#   metering:network_receive:sum_by_namespace
+#   metering:persistent_volume_claims:sum_by_namespace
+#   metering:persistent_volume_usage:sum_by_namespace
+
+# metering:node_cp_usage:sum_by_instance_type
+- name: metering:node_cp_usage:sum_by_instance_type
+  input_series:
+  - series: metering:cpu_usage:sum_by_namespace_instance_type{
+                namespace     = "shoot--local--local",
+                shoot_uid     = "uid1",
+                year          = "1970",
+                month         = "1",
+                instance_type = "small"}
+    values: 1
+  - series: metering:cpu_usage:sum_by_namespace_instance_type{
+                namespace     = "shoot--local--local",
+                shoot_uid     = "uid1",
+                year          = "1970",
+                month         = "1",
+                instance_type = "smaller"}
+    values: 2
+  - series: metering:cpu_usage:sum_by_namespace_instance_type{
+                namespace     = "shoot--local--local2",
+                shoot_uid     = "uid2",
+                year          = "1970",
+                month         = "1"}
+    values: 3
+  - series: metering:memory_usage:sum_by_namespace_instance_type{
+                namespace     = "shoot--local--local",
+                shoot_uid     = "uid1",
+                year          = "1970",
+                month         = "1",
+                instance_type = "small"}
+    values: 100
+  - series: metering:memory_usage:sum_by_namespace_instance_type{
+                namespace     = "shoot--local--local",
+                shoot_uid     = "uid1",
+                year          = "1970",
+                month         = "1",
+                instance_type = "smaller"}
+    values: 200
+  - series: metering:memory_usage:sum_by_namespace_instance_type{
+                namespace     = "shoot--local--local2",
+                shoot_uid     = "uid2",
+                year          = "1970",
+                month         = "1"}
+    values: 300
+  promql_expr_test:
+  - expr: metering:node_cp_usage:sum_by_instance_type
+    exp_samples:
+    - labels: metering:node_cp_usage:sum_by_instance_type{
+                  resource      = "cpu",
+                  unit          = "core",
+                  year          = "1970",
+                  month         = "1",
+                  instance_type = "small"}
+      value: 1
+    - labels: metering:node_cp_usage:sum_by_instance_type{
+                  resource      = "cpu",
+                  unit          = "core",
+                  year          = "1970",
+                  month         = "1",
+                  instance_type = "smaller"}
+      value: 2
+    - labels: metering:node_cp_usage:sum_by_instance_type{
+                  resource      = "memory",
+                  unit          = "byte",
+                  year          = "1970",
+                  month         = "1",
+                  instance_type = "small"}
+      value: 100
+    - labels: metering:node_cp_usage:sum_by_instance_type{
+                  resource      = "memory",
+                  unit          = "byte",
+                  year          = "1970",
+                  month         = "1",
+                  instance_type = "smaller"}
+      value: 200

--- a/pkg/component/monitoring/charts/bootstrap/prometheus-rules-tests/metering.rules.test.yaml
+++ b/pkg/component/monitoring/charts/bootstrap/prometheus-rules-tests/metering.rules.test.yaml
@@ -575,3 +575,78 @@ tests:
                   month         = "1",
                   instance_type = "smaller"}
       value: 200
+
+# metering:node_cp_requests:sum_by_instance_type
+- name: metering:node_cp_requests:sum_by_instance_type
+  input_series:
+  - series: metering:cpu_requests:sum_by_namespace_instance_type{
+                namespace     = "shoot--local--local",
+                shoot_uid     = "uid1",
+                year          = "1970",
+                month         = "1",
+                instance_type = "small"}
+    values: 1
+  - series: metering:cpu_requests:sum_by_namespace_instance_type{
+                namespace     = "shoot--local--local",
+                shoot_uid     = "uid1",
+                year          = "1970",
+                month         = "1",
+                instance_type = "smaller"}
+    values: 2
+  - series: metering:cpu_requests:sum_by_namespace_instance_type{
+                namespace     = "shoot--local--local2",
+                shoot_uid     = "uid2",
+                year          = "1970",
+                month         = "1"}
+    values: 3
+  - series: metering:memory_requests:sum_by_namespace_instance_type{
+                namespace     = "shoot--local--local",
+                shoot_uid     = "uid1",
+                year          = "1970",
+                month         = "1",
+                instance_type = "small"}
+    values: 100
+  - series: metering:memory_requests:sum_by_namespace_instance_type{
+                namespace     = "shoot--local--local",
+                shoot_uid     = "uid1",
+                year          = "1970",
+                month         = "1",
+                instance_type = "smaller"}
+    values: 200
+  - series: metering:memory_requests:sum_by_namespace_instance_type{
+                namespace     = "shoot--local--local2",
+                shoot_uid     = "uid2",
+                year          = "1970",
+                month         = "1"}
+    values: 300
+  promql_expr_test:
+  - expr: metering:node_cp_requests:sum_by_instance_type
+    exp_samples:
+    - labels: metering:node_cp_requests:sum_by_instance_type{
+                  resource      = "cpu",
+                  unit          = "core",
+                  year          = "1970",
+                  month         = "1",
+                  instance_type = "small"}
+      value: 1
+    - labels: metering:node_cp_requests:sum_by_instance_type{
+                  resource      = "cpu",
+                  unit          = "core",
+                  year          = "1970",
+                  month         = "1",
+                  instance_type = "smaller"}
+      value: 2
+    - labels: metering:node_cp_requests:sum_by_instance_type{
+                  resource      = "memory",
+                  unit          = "byte",
+                  year          = "1970",
+                  month         = "1",
+                  instance_type = "small"}
+      value: 100
+    - labels: metering:node_cp_requests:sum_by_instance_type{
+                  resource      = "memory",
+                  unit          = "byte",
+                  year          = "1970",
+                  month         = "1",
+                  instance_type = "smaller"}
+      value: 200

--- a/pkg/component/monitoring/charts/bootstrap/prometheus-rules/metering.rules.stateful.sh
+++ b/pkg/component/monitoring/charts/bootstrap/prometheus-rules/metering.rules.stateful.sh
@@ -31,7 +31,7 @@ cat <<EOF
         metering:$NAME:sum_by_namespace
       +
         (
-            last_over_time(metering:$NAME:sum_by_namespace:sum_over_time[10m])
+            last_over_time(metering:$NAME:sum_by_namespace:sum_over_time[30m])
           or
             metering:$NAME:sum_by_namespace * 0
         )
@@ -46,7 +46,7 @@ cat <<EOF
     expr: |2
         metering:$NAME:sum_by_namespace:avg_over_time
       or
-          last_over_time(metering:$NAME:sum_by_namespace:avg_over_time:this_month[10m])
+          last_over_time(metering:$NAME:sum_by_namespace:avg_over_time:this_month[30m])
         + on (year, month) group_left ()
           _year_month2
 

--- a/pkg/component/monitoring/charts/bootstrap/prometheus-rules/metering.rules.stateful.sh
+++ b/pkg/component/monitoring/charts/bootstrap/prometheus-rules/metering.rules.stateful.sh
@@ -38,12 +38,9 @@ cat <<EOF
 
   - record: metering:$NAME:sum_by_namespace:avg_over_time
     expr: |2
-          metering:$NAME:sum_by_namespace:sum_over_time * 60
-        /
-          (metering:memory_usage_seconds != 0)
-      or
-        metering:$NAME:sum_by_namespace:sum_over_time
-
+        metering:$NAME:sum_by_namespace:sum_over_time * 60
+      /
+        (metering:memory_usage_seconds != 0)
 
   - record: metering:$NAME:sum_by_namespace:avg_over_time:this_month
     expr: |2

--- a/pkg/component/monitoring/charts/bootstrap/prometheus-rules/metering.rules.stateful.yaml
+++ b/pkg/component/monitoring/charts/bootstrap/prometheus-rules/metering.rules.stateful.yaml
@@ -15,6 +15,8 @@ groups:
         0
 
 # - metering  :node_capacity             :sum_by_instance_type   :sum_over_time
+# - metering  :node_capacity             :sum_by_instance_type   :count_over_time
+# - metering  :node_capacity             :sum_by_instance_type   :count_over_time :this_month
 # - metering  :node_capacity             :sum_by_instance_type   :avg_over_time
 # - metering  :node_capacity             :sum_by_instance_type   :avg_over_time   :this_month
 
@@ -38,6 +40,14 @@ groups:
             metering:node_capacity:sum_by_instance_type * 0
         )
 
+  - record: metering:node_capacity:sum_by_instance_type:count_over_time:this_month
+    expr: |2
+        metering:node_capacity:sum_by_instance_type:count_over_time
+      or
+          last_over_time(metering:node_capacity:sum_by_instance_type:count_over_time:this_month[30m])
+        + on (year, month) group_left ()
+          _year_month2
+
   - record: metering:node_capacity:sum_by_instance_type:avg_over_time
     expr: |2
         metering:node_capacity:sum_by_instance_type:sum_over_time
@@ -53,6 +63,8 @@ groups:
           _year_month2
 
 # - metering  :node_cp_usage             :sum_by_instance_type   :sum_over_time
+# - metering  :node_cp_usage             :sum_by_instance_type   :count_over_time
+# - metering  :node_cp_usage             :sum_by_instance_type   :count_over_time :this_month
 # - metering  :node_cp_usage             :sum_by_instance_type   :avg_over_time
 # - metering  :node_cp_usage             :sum_by_instance_type   :avg_over_time   :this_month
 
@@ -75,6 +87,14 @@ groups:
           or
             metering:node_cp_usage:sum_by_instance_type * 0
         )
+
+  - record: metering:node_cp_usage:sum_by_instance_type:count_over_time:this_month
+    expr: |2
+        metering:node_cp_usage:sum_by_instance_type:count_over_time
+      or
+          last_over_time(metering:node_cp_usage:sum_by_instance_type:count_over_time:this_month[30m])
+        + on (year, month) group_left ()
+          _year_month2
 
   - record: metering:node_cp_usage:sum_by_instance_type:avg_over_time
     expr: |2

--- a/pkg/component/monitoring/charts/bootstrap/prometheus-rules/metering.rules.stateful.yaml
+++ b/pkg/component/monitoring/charts/bootstrap/prometheus-rules/metering.rules.stateful.yaml
@@ -13,6 +13,44 @@ groups:
       *
         0
 
+# - metering  :node_capacity             :sum_by_instance_type   :sum_over_time
+# - metering  :node_capacity             :sum_by_instance_type   :avg_over_time
+# - metering  :node_capacity             :sum_by_instance_type   :avg_over_time   :this_month
+
+  - record: metering:node_capacity:sum_by_instance_type:sum_over_time
+    expr: |2
+        metering:node_capacity:sum_by_instance_type
+      +
+        (
+            last_over_time(metering:node_capacity:sum_by_instance_type:sum_over_time[10m])
+          or
+            metering:node_capacity:sum_by_instance_type * 0
+        )
+
+  - record: metering:node_capacity:sum_by_instance_type:count_over_time
+    expr: |2
+        1 + metering:node_capacity:sum_by_instance_type * 0
+      +
+        (
+            last_over_time(metering:node_capacity:sum_by_instance_type:count_over_time[10m])
+          or
+            metering:node_capacity:sum_by_instance_type * 0
+        )
+
+  - record: metering:node_capacity:sum_by_instance_type:avg_over_time
+    expr: |2
+        metering:node_capacity:sum_by_instance_type:sum_over_time
+      /
+        metering:node_capacity:sum_by_instance_type:count_over_time
+
+  - record: metering:node_capacity:sum_by_instance_type:avg_over_time:this_month
+    expr: |2
+        metering:node_capacity:sum_by_instance_type:avg_over_time
+      or
+          last_over_time(metering:node_capacity:sum_by_instance_type:avg_over_time:this_month[10m])
+        + on (year, month) group_left ()
+          _year_month2
+
 # - metering   :memory_usage_seconds
 # - metering   :disk_usage_seconds
 # - metering   :memory_usage_seconds  :this_month

--- a/pkg/component/monitoring/charts/bootstrap/prometheus-rules/metering.rules.stateful.yaml
+++ b/pkg/component/monitoring/charts/bootstrap/prometheus-rules/metering.rules.stateful.yaml
@@ -23,7 +23,7 @@ groups:
         metering:node_capacity:sum_by_instance_type
       +
         (
-            last_over_time(metering:node_capacity:sum_by_instance_type:sum_over_time[10m])
+            last_over_time(metering:node_capacity:sum_by_instance_type:sum_over_time[30m])
           or
             metering:node_capacity:sum_by_instance_type * 0
         )
@@ -33,7 +33,7 @@ groups:
         1 + metering:node_capacity:sum_by_instance_type * 0
       +
         (
-            last_over_time(metering:node_capacity:sum_by_instance_type:count_over_time[10m])
+            last_over_time(metering:node_capacity:sum_by_instance_type:count_over_time[30m])
           or
             metering:node_capacity:sum_by_instance_type * 0
         )
@@ -48,7 +48,7 @@ groups:
     expr: |2
         metering:node_capacity:sum_by_instance_type:avg_over_time
       or
-          last_over_time(metering:node_capacity:sum_by_instance_type:avg_over_time:this_month[10m])
+          last_over_time(metering:node_capacity:sum_by_instance_type:avg_over_time:this_month[30m])
         + on (year, month) group_left ()
           _year_month2
 
@@ -61,7 +61,7 @@ groups:
         metering:node_cp_usage:sum_by_instance_type
       +
         (
-            last_over_time(metering:node_cp_usage:sum_by_instance_type:sum_over_time[10m])
+            last_over_time(metering:node_cp_usage:sum_by_instance_type:sum_over_time[30m])
           or
             metering:node_cp_usage:sum_by_instance_type * 0
         )
@@ -71,7 +71,7 @@ groups:
         1 + metering:node_cp_usage:sum_by_instance_type * 0
       +
         (
-            last_over_time(metering:node_cp_usage:sum_by_instance_type:count_over_time[10m])
+            last_over_time(metering:node_cp_usage:sum_by_instance_type:count_over_time[30m])
           or
             metering:node_cp_usage:sum_by_instance_type * 0
         )
@@ -86,7 +86,7 @@ groups:
     expr: |2
         metering:node_cp_usage:sum_by_instance_type:avg_over_time
       or
-          last_over_time(metering:node_cp_usage:sum_by_instance_type:avg_over_time:this_month[10m])
+          last_over_time(metering:node_cp_usage:sum_by_instance_type:avg_over_time:this_month[30m])
         + on (year, month) group_left ()
           _year_month2
 
@@ -100,7 +100,7 @@ groups:
         (metering:working_set_memory:sum_by_namespace > bool 0) * 60
       +
         (
-            last_over_time(metering:memory_usage_seconds[10m])
+            last_over_time(metering:memory_usage_seconds[30m])
           or
             metering:working_set_memory:sum_by_namespace * 0
         )
@@ -110,7 +110,7 @@ groups:
         (metering:persistent_volume_claims:sum_by_namespace > bool 0) * 60
       +
         (
-            last_over_time(metering:disk_usage_seconds[10m])
+            last_over_time(metering:disk_usage_seconds[30m])
           or
             metering:persistent_volume_claims:sum_by_namespace * 0
         )
@@ -119,7 +119,7 @@ groups:
     expr: |2
         metering:memory_usage_seconds
       or
-          last_over_time(metering:memory_usage_seconds:this_month[10m])
+          last_over_time(metering:memory_usage_seconds:this_month[30m])
         + on (year, month) group_left ()
           _year_month2
 
@@ -127,7 +127,7 @@ groups:
     expr: |2
         metering:disk_usage_seconds
       or
-          last_over_time(metering:disk_usage_seconds:this_month[10m])
+          last_over_time(metering:disk_usage_seconds:this_month[30m])
         + on (year, month) group_left ()
           _year_month2
 
@@ -140,7 +140,7 @@ groups:
         metering:persistent_volume_claims:sum_by_namespace
       +
         (
-            last_over_time(metering:persistent_volume_claims:sum_by_namespace:sum_over_time[10m])
+            last_over_time(metering:persistent_volume_claims:sum_by_namespace:sum_over_time[30m])
           or
             metering:persistent_volume_claims:sum_by_namespace * 0
         )
@@ -155,7 +155,7 @@ groups:
     expr: |2
         metering:persistent_volume_claims:sum_by_namespace:avg_over_time
       or
-          last_over_time(metering:persistent_volume_claims:sum_by_namespace:avg_over_time:this_month[10m])
+          last_over_time(metering:persistent_volume_claims:sum_by_namespace:avg_over_time:this_month[30m])
         + on (year, month) group_left ()
           _year_month2
 
@@ -191,7 +191,7 @@ groups:
         metering:cpu_usage:sum_by_namespace
       +
         (
-            last_over_time(metering:cpu_usage:sum_by_namespace:sum_over_time[10m])
+            last_over_time(metering:cpu_usage:sum_by_namespace:sum_over_time[30m])
           or
             metering:cpu_usage:sum_by_namespace * 0
         )
@@ -206,7 +206,7 @@ groups:
     expr: |2
         metering:cpu_usage:sum_by_namespace:avg_over_time
       or
-          last_over_time(metering:cpu_usage:sum_by_namespace:avg_over_time:this_month[10m])
+          last_over_time(metering:cpu_usage:sum_by_namespace:avg_over_time:this_month[30m])
         + on (year, month) group_left ()
           _year_month2
 
@@ -215,7 +215,7 @@ groups:
         metering:cpu_requests:sum_by_namespace
       +
         (
-            last_over_time(metering:cpu_requests:sum_by_namespace:sum_over_time[10m])
+            last_over_time(metering:cpu_requests:sum_by_namespace:sum_over_time[30m])
           or
             metering:cpu_requests:sum_by_namespace * 0
         )
@@ -230,7 +230,7 @@ groups:
     expr: |2
         metering:cpu_requests:sum_by_namespace:avg_over_time
       or
-          last_over_time(metering:cpu_requests:sum_by_namespace:avg_over_time:this_month[10m])
+          last_over_time(metering:cpu_requests:sum_by_namespace:avg_over_time:this_month[30m])
         + on (year, month) group_left ()
           _year_month2
 
@@ -239,7 +239,7 @@ groups:
         metering:memory_usage:sum_by_namespace
       +
         (
-            last_over_time(metering:memory_usage:sum_by_namespace:sum_over_time[10m])
+            last_over_time(metering:memory_usage:sum_by_namespace:sum_over_time[30m])
           or
             metering:memory_usage:sum_by_namespace * 0
         )
@@ -254,7 +254,7 @@ groups:
     expr: |2
         metering:memory_usage:sum_by_namespace:avg_over_time
       or
-          last_over_time(metering:memory_usage:sum_by_namespace:avg_over_time:this_month[10m])
+          last_over_time(metering:memory_usage:sum_by_namespace:avg_over_time:this_month[30m])
         + on (year, month) group_left ()
           _year_month2
 
@@ -263,7 +263,7 @@ groups:
         metering:working_set_memory:sum_by_namespace
       +
         (
-            last_over_time(metering:working_set_memory:sum_by_namespace:sum_over_time[10m])
+            last_over_time(metering:working_set_memory:sum_by_namespace:sum_over_time[30m])
           or
             metering:working_set_memory:sum_by_namespace * 0
         )
@@ -278,7 +278,7 @@ groups:
     expr: |2
         metering:working_set_memory:sum_by_namespace:avg_over_time
       or
-          last_over_time(metering:working_set_memory:sum_by_namespace:avg_over_time:this_month[10m])
+          last_over_time(metering:working_set_memory:sum_by_namespace:avg_over_time:this_month[30m])
         + on (year, month) group_left ()
           _year_month2
 
@@ -287,7 +287,7 @@ groups:
         metering:memory_requests:sum_by_namespace
       +
         (
-            last_over_time(metering:memory_requests:sum_by_namespace:sum_over_time[10m])
+            last_over_time(metering:memory_requests:sum_by_namespace:sum_over_time[30m])
           or
             metering:memory_requests:sum_by_namespace * 0
         )
@@ -302,7 +302,7 @@ groups:
     expr: |2
         metering:memory_requests:sum_by_namespace:avg_over_time
       or
-          last_over_time(metering:memory_requests:sum_by_namespace:avg_over_time:this_month[10m])
+          last_over_time(metering:memory_requests:sum_by_namespace:avg_over_time:this_month[30m])
         + on (year, month) group_left ()
           _year_month2
 
@@ -311,7 +311,7 @@ groups:
         metering:network_transmit:sum_by_namespace
       +
         (
-            last_over_time(metering:network_transmit:sum_by_namespace:sum_over_time[10m])
+            last_over_time(metering:network_transmit:sum_by_namespace:sum_over_time[30m])
           or
             metering:network_transmit:sum_by_namespace * 0
         )
@@ -326,7 +326,7 @@ groups:
     expr: |2
         metering:network_transmit:sum_by_namespace:avg_over_time
       or
-          last_over_time(metering:network_transmit:sum_by_namespace:avg_over_time:this_month[10m])
+          last_over_time(metering:network_transmit:sum_by_namespace:avg_over_time:this_month[30m])
         + on (year, month) group_left ()
           _year_month2
 
@@ -335,7 +335,7 @@ groups:
         metering:network_receive:sum_by_namespace
       +
         (
-            last_over_time(metering:network_receive:sum_by_namespace:sum_over_time[10m])
+            last_over_time(metering:network_receive:sum_by_namespace:sum_over_time[30m])
           or
             metering:network_receive:sum_by_namespace * 0
         )
@@ -350,7 +350,7 @@ groups:
     expr: |2
         metering:network_receive:sum_by_namespace:avg_over_time
       or
-          last_over_time(metering:network_receive:sum_by_namespace:avg_over_time:this_month[10m])
+          last_over_time(metering:network_receive:sum_by_namespace:avg_over_time:this_month[30m])
         + on (year, month) group_left ()
           _year_month2
 
@@ -359,7 +359,7 @@ groups:
         metering:persistent_volume_usage:sum_by_namespace
       +
         (
-            last_over_time(metering:persistent_volume_usage:sum_by_namespace:sum_over_time[10m])
+            last_over_time(metering:persistent_volume_usage:sum_by_namespace:sum_over_time[30m])
           or
             metering:persistent_volume_usage:sum_by_namespace * 0
         )
@@ -374,6 +374,6 @@ groups:
     expr: |2
         metering:persistent_volume_usage:sum_by_namespace:avg_over_time
       or
-          last_over_time(metering:persistent_volume_usage:sum_by_namespace:avg_over_time:this_month[10m])
+          last_over_time(metering:persistent_volume_usage:sum_by_namespace:avg_over_time:this_month[30m])
         + on (year, month) group_left ()
           _year_month2

--- a/pkg/component/monitoring/charts/bootstrap/prometheus-rules/metering.rules.stateful.yaml
+++ b/pkg/component/monitoring/charts/bootstrap/prometheus-rules/metering.rules.stateful.yaml
@@ -109,12 +109,9 @@ groups:
 
   - record: metering:persistent_volume_claims:sum_by_namespace:avg_over_time
     expr: |2
-          metering:persistent_volume_claims:sum_by_namespace:sum_over_time * 60
-        /
-          (metering:disk_usage_seconds != 0)
-      or
-        metering:persistent_volume_claims:sum_by_namespace:sum_over_time
-
+        metering:persistent_volume_claims:sum_by_namespace:sum_over_time * 60
+      /
+        (metering:disk_usage_seconds != 0)
 
   - record: metering:persistent_volume_claims:sum_by_namespace:avg_over_time:this_month
     expr: |2

--- a/pkg/component/monitoring/charts/bootstrap/prometheus-rules/metering.rules.stateful.yaml
+++ b/pkg/component/monitoring/charts/bootstrap/prometheus-rules/metering.rules.stateful.yaml
@@ -8,7 +8,7 @@ groups:
     expr: |2
         count_values without () (
           "year",
-          year(timestamp(count_values without () ("month", month(timestamp(vector(0))))))
+          year(timestamp(count_values ("month", month(timestamp(vector(0))))))
         )
       *
         0

--- a/pkg/component/monitoring/charts/bootstrap/prometheus-rules/metering.rules.stateful.yaml
+++ b/pkg/component/monitoring/charts/bootstrap/prometheus-rules/metering.rules.stateful.yaml
@@ -160,12 +160,9 @@ groups:
 
   - record: metering:cpu_usage:sum_by_namespace:avg_over_time
     expr: |2
-          metering:cpu_usage:sum_by_namespace:sum_over_time * 60
-        /
-          (metering:memory_usage_seconds != 0)
-      or
-        metering:cpu_usage:sum_by_namespace:sum_over_time
-
+        metering:cpu_usage:sum_by_namespace:sum_over_time * 60
+      /
+        (metering:memory_usage_seconds != 0)
 
   - record: metering:cpu_usage:sum_by_namespace:avg_over_time:this_month
     expr: |2
@@ -187,12 +184,9 @@ groups:
 
   - record: metering:cpu_requests:sum_by_namespace:avg_over_time
     expr: |2
-          metering:cpu_requests:sum_by_namespace:sum_over_time * 60
-        /
-          (metering:memory_usage_seconds != 0)
-      or
-        metering:cpu_requests:sum_by_namespace:sum_over_time
-
+        metering:cpu_requests:sum_by_namespace:sum_over_time * 60
+      /
+        (metering:memory_usage_seconds != 0)
 
   - record: metering:cpu_requests:sum_by_namespace:avg_over_time:this_month
     expr: |2
@@ -214,12 +208,9 @@ groups:
 
   - record: metering:memory_usage:sum_by_namespace:avg_over_time
     expr: |2
-          metering:memory_usage:sum_by_namespace:sum_over_time * 60
-        /
-          (metering:memory_usage_seconds != 0)
-      or
-        metering:memory_usage:sum_by_namespace:sum_over_time
-
+        metering:memory_usage:sum_by_namespace:sum_over_time * 60
+      /
+        (metering:memory_usage_seconds != 0)
 
   - record: metering:memory_usage:sum_by_namespace:avg_over_time:this_month
     expr: |2
@@ -241,12 +232,9 @@ groups:
 
   - record: metering:working_set_memory:sum_by_namespace:avg_over_time
     expr: |2
-          metering:working_set_memory:sum_by_namespace:sum_over_time * 60
-        /
-          (metering:memory_usage_seconds != 0)
-      or
-        metering:working_set_memory:sum_by_namespace:sum_over_time
-
+        metering:working_set_memory:sum_by_namespace:sum_over_time * 60
+      /
+        (metering:memory_usage_seconds != 0)
 
   - record: metering:working_set_memory:sum_by_namespace:avg_over_time:this_month
     expr: |2
@@ -268,12 +256,9 @@ groups:
 
   - record: metering:memory_requests:sum_by_namespace:avg_over_time
     expr: |2
-          metering:memory_requests:sum_by_namespace:sum_over_time * 60
-        /
-          (metering:memory_usage_seconds != 0)
-      or
-        metering:memory_requests:sum_by_namespace:sum_over_time
-
+        metering:memory_requests:sum_by_namespace:sum_over_time * 60
+      /
+        (metering:memory_usage_seconds != 0)
 
   - record: metering:memory_requests:sum_by_namespace:avg_over_time:this_month
     expr: |2
@@ -295,12 +280,9 @@ groups:
 
   - record: metering:network_transmit:sum_by_namespace:avg_over_time
     expr: |2
-          metering:network_transmit:sum_by_namespace:sum_over_time * 60
-        /
-          (metering:memory_usage_seconds != 0)
-      or
-        metering:network_transmit:sum_by_namespace:sum_over_time
-
+        metering:network_transmit:sum_by_namespace:sum_over_time * 60
+      /
+        (metering:memory_usage_seconds != 0)
 
   - record: metering:network_transmit:sum_by_namespace:avg_over_time:this_month
     expr: |2
@@ -322,12 +304,9 @@ groups:
 
   - record: metering:network_receive:sum_by_namespace:avg_over_time
     expr: |2
-          metering:network_receive:sum_by_namespace:sum_over_time * 60
-        /
-          (metering:memory_usage_seconds != 0)
-      or
-        metering:network_receive:sum_by_namespace:sum_over_time
-
+        metering:network_receive:sum_by_namespace:sum_over_time * 60
+      /
+        (metering:memory_usage_seconds != 0)
 
   - record: metering:network_receive:sum_by_namespace:avg_over_time:this_month
     expr: |2
@@ -349,12 +328,9 @@ groups:
 
   - record: metering:persistent_volume_usage:sum_by_namespace:avg_over_time
     expr: |2
-          metering:persistent_volume_usage:sum_by_namespace:sum_over_time * 60
-        /
-          (metering:memory_usage_seconds != 0)
-      or
-        metering:persistent_volume_usage:sum_by_namespace:sum_over_time
-
+        metering:persistent_volume_usage:sum_by_namespace:sum_over_time * 60
+      /
+        (metering:memory_usage_seconds != 0)
 
   - record: metering:persistent_volume_usage:sum_by_namespace:avg_over_time:this_month
     expr: |2

--- a/pkg/component/monitoring/charts/bootstrap/prometheus-rules/metering.rules.stateful.yaml
+++ b/pkg/component/monitoring/charts/bootstrap/prometheus-rules/metering.rules.stateful.yaml
@@ -56,12 +56,15 @@ groups:
 # - metering   :memory_usage_seconds  :this_month
 # - metering   :disk_usage_seconds    :this_month
 
-
   - record: metering:memory_usage_seconds
     expr: |2
         (metering:working_set_memory:sum_by_namespace > bool 0) * 60
       +
-        (last_over_time(metering:memory_usage_seconds[10m]) or metering:working_set_memory:sum_by_namespace * 0)
+        (
+            last_over_time(metering:memory_usage_seconds[10m])
+          or
+            metering:working_set_memory:sum_by_namespace * 0
+        )
 
   - record: metering:disk_usage_seconds
     expr: |2

--- a/pkg/component/monitoring/charts/bootstrap/prometheus-rules/metering.rules.stateful.yaml
+++ b/pkg/component/monitoring/charts/bootstrap/prometheus-rules/metering.rules.stateful.yaml
@@ -110,6 +110,54 @@ groups:
         + on (year, month) group_left ()
           _year_month2
 
+# - metering  :node_cp_requests             :sum_by_instance_type   :sum_over_time
+# - metering  :node_cp_requests             :sum_by_instance_type   :count_over_time
+# - metering  :node_cp_requests             :sum_by_instance_type   :count_over_time :this_month
+# - metering  :node_cp_requests             :sum_by_instance_type   :avg_over_time
+# - metering  :node_cp_requests             :sum_by_instance_type   :avg_over_time   :this_month
+
+  - record: metering:node_cp_requests:sum_by_instance_type:sum_over_time
+    expr: |2
+        metering:node_cp_requests:sum_by_instance_type
+      +
+        (
+            last_over_time(metering:node_cp_requests:sum_by_instance_type:sum_over_time[30m])
+          or
+            metering:node_cp_requests:sum_by_instance_type * 0
+        )
+
+  - record: metering:node_cp_requests:sum_by_instance_type:count_over_time
+    expr: |2
+        1 + metering:node_cp_requests:sum_by_instance_type * 0
+      +
+        (
+            last_over_time(metering:node_cp_requests:sum_by_instance_type:count_over_time[30m])
+          or
+            metering:node_cp_requests:sum_by_instance_type * 0
+        )
+
+  - record: metering:node_cp_requests:sum_by_instance_type:count_over_time:this_month
+    expr: |2
+        metering:node_cp_requests:sum_by_instance_type:count_over_time
+      or
+          last_over_time(metering:node_cp_requests:sum_by_instance_type:count_over_time:this_month[30m])
+        + on (year, month) group_left ()
+          _year_month2
+
+  - record: metering:node_cp_requests:sum_by_instance_type:avg_over_time
+    expr: |2
+        metering:node_cp_requests:sum_by_instance_type:sum_over_time
+      /
+        metering:node_cp_requests:sum_by_instance_type:count_over_time
+
+  - record: metering:node_cp_requests:sum_by_instance_type:avg_over_time:this_month
+    expr: |2
+        metering:node_cp_requests:sum_by_instance_type:avg_over_time
+      or
+          last_over_time(metering:node_cp_requests:sum_by_instance_type:avg_over_time:this_month[30m])
+        + on (year, month) group_left ()
+          _year_month2
+
 # - metering   :memory_usage_seconds
 # - metering   :disk_usage_seconds
 # - metering   :memory_usage_seconds  :this_month

--- a/pkg/component/monitoring/charts/bootstrap/prometheus-rules/metering.rules.stateful.yaml
+++ b/pkg/component/monitoring/charts/bootstrap/prometheus-rules/metering.rules.stateful.yaml
@@ -52,6 +52,44 @@ groups:
         + on (year, month) group_left ()
           _year_month2
 
+# - metering  :node_cp_usage             :sum_by_instance_type   :sum_over_time
+# - metering  :node_cp_usage             :sum_by_instance_type   :avg_over_time
+# - metering  :node_cp_usage             :sum_by_instance_type   :avg_over_time   :this_month
+
+  - record: metering:node_cp_usage:sum_by_instance_type:sum_over_time
+    expr: |2
+        metering:node_cp_usage:sum_by_instance_type
+      +
+        (
+            last_over_time(metering:node_cp_usage:sum_by_instance_type:sum_over_time[10m])
+          or
+            metering:node_cp_usage:sum_by_instance_type * 0
+        )
+
+  - record: metering:node_cp_usage:sum_by_instance_type:count_over_time
+    expr: |2
+        1 + metering:node_cp_usage:sum_by_instance_type * 0
+      +
+        (
+            last_over_time(metering:node_cp_usage:sum_by_instance_type:count_over_time[10m])
+          or
+            metering:node_cp_usage:sum_by_instance_type * 0
+        )
+
+  - record: metering:node_cp_usage:sum_by_instance_type:avg_over_time
+    expr: |2
+        metering:node_cp_usage:sum_by_instance_type:sum_over_time
+      /
+        metering:node_cp_usage:sum_by_instance_type:count_over_time
+
+  - record: metering:node_cp_usage:sum_by_instance_type:avg_over_time:this_month
+    expr: |2
+        metering:node_cp_usage:sum_by_instance_type:avg_over_time
+      or
+          last_over_time(metering:node_cp_usage:sum_by_instance_type:avg_over_time:this_month[10m])
+        + on (year, month) group_left ()
+          _year_month2
+
 # - metering   :memory_usage_seconds
 # - metering   :disk_usage_seconds
 # - metering   :memory_usage_seconds  :this_month

--- a/pkg/component/monitoring/charts/bootstrap/prometheus-rules/metering.rules.stateful.yaml
+++ b/pkg/component/monitoring/charts/bootstrap/prometheus-rules/metering.rules.stateful.yaml
@@ -1,5 +1,6 @@
 groups:
 - name: metering.rules.stateful
+  interval: 60s
   rules:
 
 # - _year_month2

--- a/pkg/component/monitoring/charts/bootstrap/prometheus-rules/metering.rules.yaml
+++ b/pkg/component/monitoring/charts/bootstrap/prometheus-rules/metering.rules.yaml
@@ -375,3 +375,65 @@ groups:
           _namespace_to_shoot_uid_and_date
       or ignoring(instance_type)
         _namespace_to_shoot_uid_and_date
+
+# - metering  :cpu_usage                 :sum_by_namespace
+# - metering  :cpu_requests              :sum_by_namespace
+# - metering  :memory_usage              :sum_by_namespace
+# - metering  :working_set_memory        :sum_by_namespace
+# - metering  :memory_requests           :sum_by_namespace
+# - metering  :network_transmit          :sum_by_namespace
+# - metering  :network_receive           :sum_by_namespace
+# - metering  :persistent_volume_claims  :sum_by_namespace
+# - metering  :persistent_volume_usage   :sum_by_namespace
+
+
+  - record: metering:cpu_usage:sum_by_namespace
+    expr: |
+      sum without (instance_type) (metering:cpu_usage:sum_by_namespace_instance_type)
+
+  - record: metering:cpu_requests:sum_by_namespace
+    expr: |
+      sum without (instance_type) (metering:cpu_requests:sum_by_namespace_instance_type)
+
+  - record: metering:memory_usage:sum_by_namespace
+    expr: |
+      sum without (instance_type) (metering:memory_usage:sum_by_namespace_instance_type)
+
+  - record: metering:working_set_memory:sum_by_namespace
+    expr: |
+      sum without (instance_type) (
+        metering:working_set_memory:sum_by_namespace_instance_type
+      )
+
+  - record: metering:memory_requests:sum_by_namespace
+    expr: |
+      sum without (instance_type) (
+        metering:memory_requests:sum_by_namespace_instance_type
+      )
+
+  - record: metering:network_transmit:sum_by_namespace
+    expr: |
+      sum without (instance_type) (
+        metering:network_transmit:sum_by_namespace_instance_type
+      )
+
+  - record: metering:network_receive:sum_by_namespace
+    expr: |
+      sum without (instance_type) (
+        metering:network_receive:sum_by_namespace_instance_type
+      )
+
+   # follows a different pattern: the query for pvc-s should work even if there are no pods in the namespace
+  - record: metering:persistent_volume_claims:sum_by_namespace
+    expr: |2
+          sum by (namespace) (kube_persistentvolumeclaim_resource_requests_storage_bytes)
+        + on (namespace) group_right ()
+          _namespace_to_shoot_uid_and_date
+      or
+        _namespace_to_shoot_uid_and_date
+
+  - record: metering:persistent_volume_usage:sum_by_namespace
+    expr: |
+      sum without (instance_type) (
+        metering:persistent_volume_usage:sum_by_namespace_instance_type
+      )

--- a/pkg/component/monitoring/charts/bootstrap/prometheus-rules/metering.rules.yaml
+++ b/pkg/component/monitoring/charts/bootstrap/prometheus-rules/metering.rules.yaml
@@ -294,84 +294,84 @@ groups:
         metering:persistent_volume_usage:sum_by_namespace_owner_instance_type
       )
 
-# - metering  :cpu_usage                 :sum_by_namespace
-# - metering  :cpu_requests              :sum_by_namespace
-# - metering  :memory_usage              :sum_by_namespace
-# - metering  :working_set_memory        :sum_by_namespace
-# - metering  :memory_requests           :sum_by_namespace
-# - metering  :network_transmit          :sum_by_namespace
-# - metering  :network_receive           :sum_by_namespace
-# - metering  :persistent_volume_claims  :sum_by_namespace
-# - metering  :persistent_volume_usage   :sum_by_namespace
+# - metering  :cpu_usage                 :sum_by_namespace_instance_type
+# - metering  :cpu_requests              :sum_by_namespace_instance_type
+# - metering  :memory_usage              :sum_by_namespace_instance_type
+# - metering  :working_set_memory        :sum_by_namespace_instance_type
+# - metering  :memory_requests           :sum_by_namespace_instance_type
+# - metering  :network_transmit          :sum_by_namespace_instance_type
+# - metering  :network_receive           :sum_by_namespace_instance_type
+# - metering  :persistent_volume_claims  :sum_by_namespace_instance_type
+# - metering  :persistent_volume_usage   :sum_by_namespace_instance_type
 
-  - record: metering:cpu_usage:sum_by_namespace
+  - record: metering:cpu_usage:sum_by_namespace_instance_type
     expr: |2
-            sum by (namespace) (rate(container_cpu_usage_seconds_total[5m]))
-          + on (namespace) group_right
-            _namespace_to_shoot_uid_and_date
-        or
+          sum without (owner, container) (metering:cpu_usage:sum_by_namespace_owner_container_instance_type)
+        + on (namespace) group_left (year, month)
           _namespace_to_shoot_uid_and_date
+      or ignoring(instance_type)
+        _namespace_to_shoot_uid_and_date
 
-  - record: metering:cpu_requests:sum_by_namespace
+  - record: metering:cpu_requests:sum_by_namespace_instance_type
     expr: |2
-            sum by (namespace) (kube_pod_container_resource_requests{resource="cpu",unit="core"})
-          + on (namespace) group_right
-            _namespace_to_shoot_uid_and_date
-        or
+          sum without (owner, container) (metering:cpu_requests:sum_by_namespace_owner_container_instance_type)
+        + on (namespace) group_left (year, month)
           _namespace_to_shoot_uid_and_date
+      or ignoring(instance_type)
+        _namespace_to_shoot_uid_and_date
 
-  - record: metering:memory_usage:sum_by_namespace
+  - record: metering:memory_usage:sum_by_namespace_instance_type
     expr: |2
-            sum by (namespace) (container_memory_usage_bytes)
-          + on (namespace) group_right
-            _namespace_to_shoot_uid_and_date
-        or
+          sum without (owner, container) (metering:memory_usage:sum_by_namespace_owner_container_instance_type)
+        + on (namespace) group_left (year, month)
           _namespace_to_shoot_uid_and_date
+      or ignoring(instance_type)
+        _namespace_to_shoot_uid_and_date
 
-  - record: metering:working_set_memory:sum_by_namespace
+  - record: metering:working_set_memory:sum_by_namespace_instance_type
     expr: |2
-            sum by (namespace) (container_memory_working_set_bytes)
-          + on (namespace) group_right
-            _namespace_to_shoot_uid_and_date
-        or
+          sum without (owner, container) (metering:working_set_memory:sum_by_namespace_owner_container_instance_type)
+        + on (namespace) group_left (year, month)
           _namespace_to_shoot_uid_and_date
+      or ignoring(instance_type)
+        _namespace_to_shoot_uid_and_date
 
-  - record: metering:memory_requests:sum_by_namespace
+  - record: metering:memory_requests:sum_by_namespace_instance_type
     expr: |2
-            sum by (namespace) (kube_pod_container_resource_requests{resource="memory",unit="byte"})
-          + on (namespace) group_right
-            _namespace_to_shoot_uid_and_date
-        or
+          sum without (owner, container) (metering:memory_requests:sum_by_namespace_owner_container_instance_type)
+        + on (namespace) group_left (year, month)
           _namespace_to_shoot_uid_and_date
+      or ignoring(instance_type)
+        _namespace_to_shoot_uid_and_date
 
-  - record: metering:network_transmit:sum_by_namespace
+  - record: metering:network_transmit:sum_by_namespace_instance_type
     expr: |2
-            sum by (namespace) (rate(container_network_transmit_bytes_total{host_network=""}[5m]))
-          + on (namespace) group_right
-            _namespace_to_shoot_uid_and_date
-        or
+          sum without (owner) (metering:network_transmit:sum_by_namespace_owner_instance_type)
+        + on (namespace) group_left (year, month)
           _namespace_to_shoot_uid_and_date
+      or ignoring(instance_type)
+        _namespace_to_shoot_uid_and_date
 
-  - record: metering:network_receive:sum_by_namespace
+  - record: metering:network_receive:sum_by_namespace_instance_type
     expr: |2
-            sum by (namespace) (rate(container_network_receive_bytes_total{host_network=""}[5m]))
-          + on (namespace) group_right
-            _namespace_to_shoot_uid_and_date
-        or
+          sum without (owner) (metering:network_receive:sum_by_namespace_owner_instance_type)
+        + on (namespace) group_left (year, month)
           _namespace_to_shoot_uid_and_date
+      or ignoring(instance_type)
+        _namespace_to_shoot_uid_and_date
 
-  - record: metering:persistent_volume_claims:sum_by_namespace
+  - record: metering:persistent_volume_claims:sum_by_namespace_instance_type
     expr: |2
-            sum by (namespace) (kube_persistentvolumeclaim_resource_requests_storage_bytes)
-          + on (namespace) group_right
-            _namespace_to_shoot_uid_and_date
-        or
+          sum without (owner) (metering:persistent_volume_claims:sum_by_namespace_owner_instance_type)
+        + on (namespace) group_left (year, month)
           _namespace_to_shoot_uid_and_date
+      or ignoring(instance_type)
+        _namespace_to_shoot_uid_and_date
 
-  - record: metering:persistent_volume_usage:sum_by_namespace
+  - record: metering:persistent_volume_usage:sum_by_namespace_instance_type
     expr: |2
-            sum by (namespace) (max by(namespace, persistentvolumeclaim) (kubelet_volume_stats_used_bytes))
-          + on (namespace) group_right
-            _namespace_to_shoot_uid_and_date
-        or
+          sum without (owner) (metering:persistent_volume_usage:sum_by_namespace_owner_instance_type)
+        + on (namespace) group_left (year, month)
           _namespace_to_shoot_uid_and_date
+      or ignoring(instance_type)
+        _namespace_to_shoot_uid_and_date

--- a/pkg/component/monitoring/charts/bootstrap/prometheus-rules/metering.rules.yaml
+++ b/pkg/component/monitoring/charts/bootstrap/prometheus-rules/metering.rules.yaml
@@ -13,7 +13,7 @@ groups:
 # - _replicaset_to_deployment
 # - _pod_to_deployment
 # - _pod_to_other
-# - _pod_to_owner
+# - _pod_to_owner_instance_type
 
   - record: _node_instance_type
     expr: |2
@@ -68,16 +68,26 @@ groups:
 
   - record: _pod_to_daemonset
     expr: |
-      count by (namespace, pod, owner_name) (kube_pod_owner{owner_kind="DaemonSet"})
+      count by (namespace, pod, owner_name, instance_type) (
+        _kube_pod_owner_with_instance_type{owner_kind="DaemonSet"}
+      )
 
   - record: _pod_to_statefulset
     expr: |
-      count by (namespace, pod, owner_name) (kube_pod_owner{owner_kind="StatefulSet"})
+      count by (namespace, pod, owner_name, instance_type) (
+        _kube_pod_owner_with_instance_type{owner_kind="StatefulSet"}
+      )
 
   - record: _pod_to_replicaset
     expr: |
-      count by (namespace, pod, replicaset) (
-        label_replace(kube_pod_owner{owner_kind="ReplicaSet"}, "replicaset", "$1", "owner_name", "(.*)")
+      count by (namespace, pod, replicaset, instance_type) (
+        label_replace(
+          _kube_pod_owner_with_instance_type{owner_kind="ReplicaSet"},
+          "replicaset",
+          "$1",
+          "owner_name",
+          "(.*)"
+        )
       )
 
   - record: _replicaset_to_deployment
@@ -86,19 +96,19 @@ groups:
 
   - record: _pod_to_deployment
     expr: |
-      count by (namespace, pod, owner_name) (
+      count by (namespace, pod, owner_name, instance_type) (
         _pod_to_replicaset + on (namespace, replicaset) group_left (owner_name) _replicaset_to_deployment
       )
 
   - record: _pod_to_other
     expr: |
-      count by (namespace, pod, owner_name) (
-        kube_pod_owner{owner_kind!~"DaemonSet|StatefulSet|ReplicaSet"}
+      count by (namespace, pod, owner_name, instance_type) (
+        _kube_pod_owner_with_instance_type{owner_kind!~"DaemonSet|StatefulSet|ReplicaSet"}
       )
 
-  - record: _pod_to_owner
+  - record: _pod_to_owner_instance_type
     expr: |2
-        count by (namespace, pod, owner) (
+        count by (namespace, pod, owner, instance_type) (
           label_replace(
             _pod_to_statefulset or _pod_to_daemonset or _pod_to_deployment or _pod_to_other,
             "owner",

--- a/pkg/component/monitoring/charts/bootstrap/prometheus-rules/metering.rules.yaml
+++ b/pkg/component/monitoring/charts/bootstrap/prometheus-rules/metering.rules.yaml
@@ -2,6 +2,7 @@ groups:
 - name: metering.rules
   rules:
 
+# - _node_instance_type
 # - _namespace_to_shoot_uid
 # - _year_month
 # - _namespace_to_shoot_uid_and_date
@@ -12,6 +13,20 @@ groups:
 # - _pod_to_deployment
 # - _pod_to_other
 # - _pod_to_owner
+
+  - record: _node_instance_type
+    expr: |2
+        sum by (node, instance_type) (
+          label_replace(
+            kube_node_labels,
+            "instance_type",
+            "$1",
+            "label_node_kubernetes_io_instance_type",
+            "(.*)"
+          )
+        )
+      *
+        0
 
   - record: _namespace_to_shoot_uid
     expr: |2
@@ -83,6 +98,18 @@ groups:
         )
       *
         0
+
+# - metering  :node_capacity             :sum_by_instance_type
+
+  - record: metering:node_capacity:sum_by_instance_type
+    expr: |2
+        sum by (instance_type, resource, unit) (
+            kube_node_status_capacity{resource=~"memory|cpu"}
+          + on (node) group_left (instance_type)
+            _node_instance_type
+        )
+      + on () group_left (year, month)
+        _year_month
 
 # - metering  :cpu_usage                 :sum_by_namespace
 # - metering  :cpu_requests              :sum_by_namespace

--- a/pkg/component/monitoring/charts/bootstrap/prometheus-rules/metering.rules.yaml
+++ b/pkg/component/monitoring/charts/bootstrap/prometheus-rules/metering.rules.yaml
@@ -214,100 +214,106 @@ groups:
         or
           _namespace_to_shoot_uid_and_date
 
-# - metering  :cpu_usage                 :sum_by_namespace_owner_container
-# - metering  :cpu_requests              :sum_by_namespace_owner_container
-# - metering  :memory_usage              :sum_by_namespace_owner_container
-# - metering  :working_set_memory        :sum_by_namespace_owner_container
-# - metering  :memory_requests           :sum_by_namespace_owner_container
-# - metering  :network_transmit          :sum_by_namespace_owner
-# - metering  :network_receive           :sum_by_namespace_owner
-# - metering  :persistent_volume_claims  :sum_by_namespace_owner
-# - metering  :persistent_volume_usage   :sum_by_namespace_owner
+# - metering  :cpu_usage                 :sum_by_namespace_owner_container_instance_type
+# - metering  :cpu_requests              :sum_by_namespace_owner_container_instance_type
+# - metering  :memory_usage              :sum_by_namespace_owner_container_instance_type
+# - metering  :working_set_memory        :sum_by_namespace_owner_container_instance_type
+# - metering  :memory_requests           :sum_by_namespace_owner_container_instance_type
+# - metering  :network_transmit          :sum_by_namespace_owner_instance_type
+# - metering  :network_receive           :sum_by_namespace_owner_instance_type
+# - metering  :persistent_volume_claims  :sum_by_namespace_owner_instance_type
+# - metering  :persistent_volume_usage   :sum_by_namespace_owner_instance_type
 
-  - record: metering:cpu_usage:sum_by_namespace_owner_container
+  - record: metering:cpu_usage:sum_by_namespace_owner_container_instance_type
     expr: |2
-        sum by (namespace, owner, container) (
-          rate(container_cpu_usage_seconds_total[5m]) + on (namespace, pod) group_left (owner) _pod_to_owner
+        sum by (namespace, owner, container, instance_type) (
+            rate(container_cpu_usage_seconds_total[5m])
+          + on (namespace, pod) group_left (owner, instance_type)
+            _pod_to_owner_instance_type
         )
       + on (namespace) group_left (shoot_uid)
         _namespace_to_shoot_uid
 
-  - record: metering:cpu_requests:sum_by_namespace_owner_container
+  - record: metering:cpu_requests:sum_by_namespace_owner_container_instance_type
     expr: |2
-        sum by (namespace, owner, container) (
+        sum by (namespace, owner, container, instance_type) (
             kube_pod_container_resource_requests{resource="cpu",unit="core"}
-          + on (namespace, pod) group_left (owner)
-            _pod_to_owner
+          + on (namespace, pod) group_left (owner, instance_type)
+            _pod_to_owner_instance_type
         )
       + on (namespace) group_left (shoot_uid)
         _namespace_to_shoot_uid
 
-  - record: metering:memory_usage:sum_by_namespace_owner_container
+  - record: metering:memory_usage:sum_by_namespace_owner_container_instance_type
     expr: |2
-        sum by (namespace, owner, container) (
-          container_memory_usage_bytes + on (namespace, pod) group_left (owner) _pod_to_owner
+        sum by (namespace, owner, container, instance_type) (
+            container_memory_usage_bytes
+          + on (namespace, pod) group_left (owner, instance_type)
+            _pod_to_owner_instance_type
         )
       + on (namespace) group_left (shoot_uid)
         _namespace_to_shoot_uid
 
-  - record: metering:working_set_memory:sum_by_namespace_owner_container
+  - record: metering:working_set_memory:sum_by_namespace_owner_container_instance_type
     expr: |2
-        sum by (namespace, owner, container) (
-          container_memory_working_set_bytes + on (namespace, pod) group_left (owner) _pod_to_owner
+        sum by (namespace, owner, container, instance_type) (
+            container_memory_working_set_bytes
+          + on (namespace, pod) group_left (owner, instance_type)
+            _pod_to_owner_instance_type
         )
       + on (namespace) group_left (shoot_uid)
         _namespace_to_shoot_uid
 
-  - record: metering:memory_requests:sum_by_namespace_owner_container
+  - record: metering:memory_requests:sum_by_namespace_owner_container_instance_type
     expr: |2
-        sum by (namespace, owner, container) (
+        sum by (namespace, owner, container, instance_type) (
             kube_pod_container_resource_requests{resource="memory",unit="byte"}
-          + on (namespace, pod) group_left (owner)
-            _pod_to_owner
+          + on (namespace, pod) group_left (owner, instance_type)
+            _pod_to_owner_instance_type
         )
       + on (namespace) group_left (shoot_uid)
         _namespace_to_shoot_uid
 
-  - record: metering:network_transmit:sum_by_namespace_owner
+  - record: metering:network_transmit:sum_by_namespace_owner_instance_type
     expr: |2
-        sum by (namespace, owner) (
+        sum by (namespace, owner, instance_type) (
             rate(container_network_transmit_bytes_total{host_network=""}[5m])
-          + on (namespace, pod) group_left (owner)
-            _pod_to_owner
+          + on (namespace, pod) group_left (owner, instance_type)
+            _pod_to_owner_instance_type
         )
       + on (namespace) group_left (shoot_uid)
         _namespace_to_shoot_uid
 
-  - record: metering:network_receive:sum_by_namespace_owner
+  - record: metering:network_receive:sum_by_namespace_owner_instance_type
     expr: |2
-        sum by (namespace, owner) (
+        sum by (namespace, owner, instance_type) (
             rate(container_network_receive_bytes_total{host_network=""}[5m])
-          + on (namespace, pod) group_left (owner)
-            _pod_to_owner
+          + on (namespace, pod) group_left (owner, instance_type)
+            _pod_to_owner_instance_type
         )
       + on (namespace) group_left (shoot_uid)
         _namespace_to_shoot_uid
 
-  - record: metering:persistent_volume_claims:sum_by_namespace_owner
+  - record: metering:persistent_volume_claims:sum_by_namespace_owner_instance_type
     expr: |2
-        sum by (namespace, owner) (
+        sum by (namespace, owner, instance_type) (
                 kube_persistentvolumeclaim_resource_requests_storage_bytes
               + on (namespace, persistentvolumeclaim) group_right
                 kube_pod_spec_volumes_persistentvolumeclaims_info * 0
-          + on (namespace, pod) group_left (owner)
-            _pod_to_owner
+          + on (namespace, pod) group_left (owner, instance_type)
+            _pod_to_owner_instance_type
         )
       + on (namespace) group_left (shoot_uid)
         _namespace_to_shoot_uid
 
-  - record: metering:persistent_volume_usage:sum_by_namespace_owner
+  - record: metering:persistent_volume_usage:sum_by_namespace_owner_instance_type
     expr: |2
-        sum by (namespace, owner) (
+        sum by (namespace, owner, instance_type) (
                 max by (namespace, persistentvolumeclaim) (kubelet_volume_stats_used_bytes)
               + on (namespace, persistentvolumeclaim) group_right
                 kube_pod_spec_volumes_persistentvolumeclaims_info * 0
-          + on (namespace, pod) group_left (owner)
-            _pod_to_owner
+          + on (namespace, pod) group_left (owner, instance_type)
+            _pod_to_owner_instance_type
         )
       + on (namespace) group_left (shoot_uid)
         _namespace_to_shoot_uid

--- a/pkg/component/monitoring/charts/bootstrap/prometheus-rules/metering.rules.yaml
+++ b/pkg/component/monitoring/charts/bootstrap/prometheus-rules/metering.rules.yaml
@@ -317,3 +317,61 @@ groups:
         )
       + on (namespace) group_left (shoot_uid)
         _namespace_to_shoot_uid
+
+# - metering  :cpu_usage                 :sum_by_namespace_owner_container
+# - metering  :cpu_requests              :sum_by_namespace_owner_container
+# - metering  :memory_usage              :sum_by_namespace_owner_container
+# - metering  :working_set_memory        :sum_by_namespace_owner_container
+# - metering  :memory_requests           :sum_by_namespace_owner_container
+# - metering  :network_transmit          :sum_by_namespace_owner
+# - metering  :network_receive           :sum_by_namespace_owner
+# - metering  :persistent_volume_claims  :sum_by_namespace_owner
+# - metering  :persistent_volume_usage   :sum_by_namespace_owner
+
+  - record: metering:cpu_usage:sum_by_namespace_owner_container
+    expr: |
+      sum without (instance_type) (metering:cpu_usage:sum_by_namespace_owner_container_instance_type)
+
+  - record: metering:cpu_requests:sum_by_namespace_owner_container
+    expr: |
+      sum without (instance_type) (metering:cpu_requests:sum_by_namespace_owner_container_instance_type)
+
+  - record: metering:memory_usage:sum_by_namespace_owner_container
+    expr: |
+      sum without (instance_type) (metering:memory_usage:sum_by_namespace_owner_container_instance_type)
+
+  - record: metering:working_set_memory:sum_by_namespace_owner_container
+    expr: |
+      sum without (instance_type) (
+        metering:working_set_memory:sum_by_namespace_owner_container_instance_type
+      )
+
+  - record: metering:memory_requests:sum_by_namespace_owner_container
+    expr: |
+      sum without (instance_type) (
+        metering:memory_requests:sum_by_namespace_owner_container_instance_type
+      )
+
+  - record: metering:network_transmit:sum_by_namespace_owner
+    expr: |
+      sum without (instance_type) (
+        metering:network_transmit:sum_by_namespace_owner_instance_type
+      )
+
+  - record: metering:network_receive:sum_by_namespace_owner
+    expr: |
+      sum without (instance_type) (
+        metering:network_receive:sum_by_namespace_owner_instance_type
+      )
+
+  - record: metering:persistent_volume_claims:sum_by_namespace_owner
+    expr: |
+      sum without (instance_type) (
+        metering:persistent_volume_claims:sum_by_namespace_owner_instance_type
+      )
+
+  - record: metering:persistent_volume_usage:sum_by_namespace_owner
+    expr: |
+      sum without (instance_type) (
+        metering:persistent_volume_usage:sum_by_namespace_owner_instance_type
+      )

--- a/pkg/component/monitoring/charts/bootstrap/prometheus-rules/metering.rules.yaml
+++ b/pkg/component/monitoring/charts/bootstrap/prometheus-rules/metering.rules.yaml
@@ -3,6 +3,7 @@ groups:
   rules:
 
 # - _node_instance_type
+# - _kube_pod_owner_with_instance_type
 # - _namespace_to_shoot_uid
 # - _year_month
 # - _namespace_to_shoot_uid_and_date
@@ -24,6 +25,16 @@ groups:
             "label_node_kubernetes_io_instance_type",
             "(.*)"
           )
+        )
+      *
+        0
+
+  - record: _kube_pod_owner_with_instance_type
+    expr: |2
+        sum by (namespace, pod, owner_kind, owner_name, instance_type) (
+            kube_pod_owner + on (namespace, pod) group_left (node) kube_pod_info
+          + on (node) group_left (instance_type)
+            _node_instance_type
         )
       *
         0

--- a/pkg/component/monitoring/charts/bootstrap/prometheus-rules/metering.rules.yaml
+++ b/pkg/component/monitoring/charts/bootstrap/prometheus-rules/metering.rules.yaml
@@ -437,3 +437,23 @@ groups:
       sum without (instance_type) (
         metering:persistent_volume_usage:sum_by_namespace_instance_type
       )
+
+# - metering  :node_cp_usage             :sum_by_instance_type
+
+  - record: metering:node_cp_usage:sum_by_instance_type
+    labels:
+      resource: cpu
+      unit: core
+    expr: |2
+        sum by (instance_type) (metering:cpu_usage:sum_by_namespace_instance_type{instance_type!=""})
+      + on () group_left (year, month)
+        _year_month
+
+  - record: metering:node_cp_usage:sum_by_instance_type
+    labels:
+      resource: memory
+      unit: byte
+    expr: |2
+        sum by (instance_type) (metering:memory_usage:sum_by_namespace_instance_type{instance_type!=""})
+      + on () group_left (year, month)
+        _year_month

--- a/pkg/component/monitoring/charts/bootstrap/prometheus-rules/metering.rules.yaml
+++ b/pkg/component/monitoring/charts/bootstrap/prometheus-rules/metering.rules.yaml
@@ -57,7 +57,7 @@ groups:
     expr: |2
         count_values without () (
           "year",
-          year(timestamp(count_values without () ("month", month(timestamp(vector(0))))))
+          year(timestamp(count_values ("month", month(timestamp(vector(0))))))
         )
       *
         0

--- a/pkg/component/monitoring/charts/bootstrap/prometheus-rules/metering.rules.yaml
+++ b/pkg/component/monitoring/charts/bootstrap/prometheus-rules/metering.rules.yaml
@@ -452,3 +452,19 @@ groups:
       unit: byte
     expr: |
       sum by (instance_type, year, month) (metering:memory_usage:sum_by_namespace_instance_type{instance_type!=""})
+
+# - metering  :node_cp_requests          :sum_by_instance_type
+
+  - record: metering:node_cp_requests:sum_by_instance_type
+    labels:
+      resource: cpu
+      unit: core
+    expr: |
+      sum by (instance_type, year, month) (metering:cpu_requests:sum_by_namespace_instance_type{instance_type!=""})
+
+  - record: metering:node_cp_requests:sum_by_instance_type
+    labels:
+      resource: memory
+      unit: byte
+    expr: |
+      sum by (instance_type, year, month) (metering:memory_requests:sum_by_namespace_instance_type{instance_type!=""})

--- a/pkg/component/monitoring/charts/bootstrap/prometheus-rules/metering.rules.yaml
+++ b/pkg/component/monitoring/charts/bootstrap/prometheus-rules/metering.rules.yaml
@@ -386,7 +386,6 @@ groups:
 # - metering  :persistent_volume_claims  :sum_by_namespace
 # - metering  :persistent_volume_usage   :sum_by_namespace
 
-
   - record: metering:cpu_usage:sum_by_namespace
     expr: |
       sum without (instance_type) (metering:cpu_usage:sum_by_namespace_instance_type)
@@ -444,16 +443,12 @@ groups:
     labels:
       resource: cpu
       unit: core
-    expr: |2
-        sum by (instance_type) (metering:cpu_usage:sum_by_namespace_instance_type{instance_type!=""})
-      + on () group_left (year, month)
-        _year_month
+    expr: |
+      sum by (instance_type, year, month) (metering:cpu_usage:sum_by_namespace_instance_type{instance_type!=""})
 
   - record: metering:node_cp_usage:sum_by_instance_type
     labels:
       resource: memory
       unit: byte
-    expr: |2
-        sum by (instance_type) (metering:memory_usage:sum_by_namespace_instance_type{instance_type!=""})
-      + on () group_left (year, month)
-        _year_month
+    expr: |
+      sum by (instance_type, year, month) (metering:memory_usage:sum_by_namespace_instance_type{instance_type!=""})

--- a/pkg/component/monitoring/charts/bootstrap/prometheus-rules/metering.rules.yaml
+++ b/pkg/component/monitoring/charts/bootstrap/prometheus-rules/metering.rules.yaml
@@ -132,88 +132,6 @@ groups:
       + on () group_left (year, month)
         _year_month
 
-# - metering  :cpu_usage                 :sum_by_namespace
-# - metering  :cpu_requests              :sum_by_namespace
-# - metering  :memory_usage              :sum_by_namespace
-# - metering  :working_set_memory        :sum_by_namespace
-# - metering  :memory_requests           :sum_by_namespace
-# - metering  :network_transmit          :sum_by_namespace
-# - metering  :network_receive           :sum_by_namespace
-# - metering  :persistent_volume_claims  :sum_by_namespace
-# - metering  :persistent_volume_usage   :sum_by_namespace
-
-  - record: metering:cpu_usage:sum_by_namespace
-    expr: |2
-            sum by (namespace) (rate(container_cpu_usage_seconds_total[5m]))
-          + on (namespace) group_right
-            _namespace_to_shoot_uid_and_date
-        or
-          _namespace_to_shoot_uid_and_date
-
-  - record: metering:cpu_requests:sum_by_namespace
-    expr: |2
-            sum by (namespace) (kube_pod_container_resource_requests{resource="cpu",unit="core"})
-          + on (namespace) group_right
-            _namespace_to_shoot_uid_and_date
-        or
-          _namespace_to_shoot_uid_and_date
-
-  - record: metering:memory_usage:sum_by_namespace
-    expr: |2
-            sum by (namespace) (container_memory_usage_bytes)
-          + on (namespace) group_right
-            _namespace_to_shoot_uid_and_date
-        or
-          _namespace_to_shoot_uid_and_date
-
-  - record: metering:working_set_memory:sum_by_namespace
-    expr: |2
-            sum by (namespace) (container_memory_working_set_bytes)
-          + on (namespace) group_right
-            _namespace_to_shoot_uid_and_date
-        or
-          _namespace_to_shoot_uid_and_date
-
-  - record: metering:memory_requests:sum_by_namespace
-    expr: |2
-            sum by (namespace) (kube_pod_container_resource_requests{resource="memory",unit="byte"})
-          + on (namespace) group_right
-            _namespace_to_shoot_uid_and_date
-        or
-          _namespace_to_shoot_uid_and_date
-
-  - record: metering:network_transmit:sum_by_namespace
-    expr: |2
-            sum by (namespace) (rate(container_network_transmit_bytes_total{host_network=""}[5m]))
-          + on (namespace) group_right
-            _namespace_to_shoot_uid_and_date
-        or
-          _namespace_to_shoot_uid_and_date
-
-  - record: metering:network_receive:sum_by_namespace
-    expr: |2
-            sum by (namespace) (rate(container_network_receive_bytes_total{host_network=""}[5m]))
-          + on (namespace) group_right
-            _namespace_to_shoot_uid_and_date
-        or
-          _namespace_to_shoot_uid_and_date
-
-  - record: metering:persistent_volume_claims:sum_by_namespace
-    expr: |2
-            sum by (namespace) (kube_persistentvolumeclaim_resource_requests_storage_bytes)
-          + on (namespace) group_right
-            _namespace_to_shoot_uid_and_date
-        or
-          _namespace_to_shoot_uid_and_date
-
-  - record: metering:persistent_volume_usage:sum_by_namespace
-    expr: |2
-            sum by (namespace) (max by(namespace, persistentvolumeclaim) (kubelet_volume_stats_used_bytes))
-          + on (namespace) group_right
-            _namespace_to_shoot_uid_and_date
-        or
-          _namespace_to_shoot_uid_and_date
-
 # - metering  :cpu_usage                 :sum_by_namespace_owner_container_instance_type
 # - metering  :cpu_requests              :sum_by_namespace_owner_container_instance_type
 # - metering  :memory_usage              :sum_by_namespace_owner_container_instance_type
@@ -375,3 +293,85 @@ groups:
       sum without (instance_type) (
         metering:persistent_volume_usage:sum_by_namespace_owner_instance_type
       )
+
+# - metering  :cpu_usage                 :sum_by_namespace
+# - metering  :cpu_requests              :sum_by_namespace
+# - metering  :memory_usage              :sum_by_namespace
+# - metering  :working_set_memory        :sum_by_namespace
+# - metering  :memory_requests           :sum_by_namespace
+# - metering  :network_transmit          :sum_by_namespace
+# - metering  :network_receive           :sum_by_namespace
+# - metering  :persistent_volume_claims  :sum_by_namespace
+# - metering  :persistent_volume_usage   :sum_by_namespace
+
+  - record: metering:cpu_usage:sum_by_namespace
+    expr: |2
+            sum by (namespace) (rate(container_cpu_usage_seconds_total[5m]))
+          + on (namespace) group_right
+            _namespace_to_shoot_uid_and_date
+        or
+          _namespace_to_shoot_uid_and_date
+
+  - record: metering:cpu_requests:sum_by_namespace
+    expr: |2
+            sum by (namespace) (kube_pod_container_resource_requests{resource="cpu",unit="core"})
+          + on (namespace) group_right
+            _namespace_to_shoot_uid_and_date
+        or
+          _namespace_to_shoot_uid_and_date
+
+  - record: metering:memory_usage:sum_by_namespace
+    expr: |2
+            sum by (namespace) (container_memory_usage_bytes)
+          + on (namespace) group_right
+            _namespace_to_shoot_uid_and_date
+        or
+          _namespace_to_shoot_uid_and_date
+
+  - record: metering:working_set_memory:sum_by_namespace
+    expr: |2
+            sum by (namespace) (container_memory_working_set_bytes)
+          + on (namespace) group_right
+            _namespace_to_shoot_uid_and_date
+        or
+          _namespace_to_shoot_uid_and_date
+
+  - record: metering:memory_requests:sum_by_namespace
+    expr: |2
+            sum by (namespace) (kube_pod_container_resource_requests{resource="memory",unit="byte"})
+          + on (namespace) group_right
+            _namespace_to_shoot_uid_and_date
+        or
+          _namespace_to_shoot_uid_and_date
+
+  - record: metering:network_transmit:sum_by_namespace
+    expr: |2
+            sum by (namespace) (rate(container_network_transmit_bytes_total{host_network=""}[5m]))
+          + on (namespace) group_right
+            _namespace_to_shoot_uid_and_date
+        or
+          _namespace_to_shoot_uid_and_date
+
+  - record: metering:network_receive:sum_by_namespace
+    expr: |2
+            sum by (namespace) (rate(container_network_receive_bytes_total{host_network=""}[5m]))
+          + on (namespace) group_right
+            _namespace_to_shoot_uid_and_date
+        or
+          _namespace_to_shoot_uid_and_date
+
+  - record: metering:persistent_volume_claims:sum_by_namespace
+    expr: |2
+            sum by (namespace) (kube_persistentvolumeclaim_resource_requests_storage_bytes)
+          + on (namespace) group_right
+            _namespace_to_shoot_uid_and_date
+        or
+          _namespace_to_shoot_uid_and_date
+
+  - record: metering:persistent_volume_usage:sum_by_namespace
+    expr: |2
+            sum by (namespace) (max by(namespace, persistentvolumeclaim) (kubelet_volume_stats_used_bytes))
+          + on (namespace) group_right
+            _namespace_to_shoot_uid_and_date
+        or
+          _namespace_to_shoot_uid_and_date

--- a/pkg/component/plutono/dashboards/common/shoot-control-plane-resource-usage-by-owner-container.json
+++ b/pkg/component/plutono/dashboards/common/shoot-control-plane-resource-usage-by-owner-container.json
@@ -633,7 +633,7 @@
           "exemplar": true,
           "expr": "metering:cpu_usage:sum_by_namespace{shoot_uid!=\"\",namespace=~\"$namespace\"}",
           "interval": "",
-          "legendFormat": "Total {{shoot_uid}}",
+          "legendFormat": "Total ({{year}}/{{month}})",
           "refId": "A"
         },
         {
@@ -743,7 +743,7 @@
           "exemplar": true,
           "expr": "metering:cpu_requests:sum_by_namespace{shoot_uid!=\"\",namespace=~\"$namespace\"}",
           "interval": "",
-          "legendFormat": "Total {{shoot_uid}}",
+          "legendFormat": "Total ({{year}}/{{month}})",
           "refId": "A"
         },
         {
@@ -866,7 +866,7 @@
           "exemplar": true,
           "expr": "metering:memory_usage:sum_by_namespace{shoot_uid!=\"\",namespace=~\"$namespace\"}",
           "interval": "",
-          "legendFormat": "Total {{shoot_uid}}",
+          "legendFormat": "Total ({{year}}/{{month}})",
           "refId": "A"
         },
         {
@@ -975,7 +975,7 @@
           "exemplar": true,
           "expr": "metering:working_set_memory:sum_by_namespace{shoot_uid!=\"\",namespace=~\"$namespace\"}",
           "interval": "",
-          "legendFormat": "Total {{shoot_uid}}",
+          "legendFormat": "Total ({{year}}/{{month}})",
           "refId": "A"
         },
         {
@@ -1084,7 +1084,7 @@
           "exemplar": true,
           "expr": "metering:memory_requests:sum_by_namespace{shoot_uid!=\"\",namespace=~\"$namespace\"}",
           "interval": "",
-          "legendFormat": "Total {{shoot_uid}}",
+          "legendFormat": "Total ({{year}}/{{month}})",
           "refId": "A"
         },
         {
@@ -1207,7 +1207,7 @@
           "exemplar": true,
           "expr": "metering:network_receive:sum_by_namespace{shoot_uid!=\"\",namespace=~\"$namespace\"}",
           "interval": "",
-          "legendFormat": "Total {{shoot_uid}}",
+          "legendFormat": "Total ({{year}}/{{month}})",
           "refId": "A"
         },
         {
@@ -1317,7 +1317,7 @@
           "exemplar": true,
           "expr": "metering:network_transmit:sum_by_namespace{shoot_uid!=\"\",namespace=~\"$namespace\"}",
           "interval": "",
-          "legendFormat": "Total {{shoot_uid}}",
+          "legendFormat": "Total ({{year}}/{{month}})",
           "refId": "A"
         },
         {
@@ -1440,7 +1440,7 @@
           "exemplar": true,
           "expr": "metering:persistent_volume_usage:sum_by_namespace{shoot_uid!=\"\",namespace=~\"$namespace\"}",
           "interval": "",
-          "legendFormat": "Total {{shoot_uid}}",
+          "legendFormat": "Total ({{year}}/{{month}})",
           "refId": "A"
         },
         {
@@ -1550,7 +1550,7 @@
           "exemplar": true,
           "expr": "metering:persistent_volume_claims:sum_by_namespace{shoot_uid!=\"\",namespace=~\"$namespace\"}",
           "interval": "",
-          "legendFormat": "Total {{shoot_uid}}",
+          "legendFormat": "Total ({{year}}/{{month}})",
           "refId": "A"
         },
         {

--- a/pkg/component/plutono/dashboards/common/shoot-control-plane-resource-usage-by-owner-container.json
+++ b/pkg/component/plutono/dashboards/common/shoot-control-plane-resource-usage-by-owner-container.json
@@ -76,7 +76,7 @@
         "text": {},
         "textMode": "name"
       },
-      "pluginVersion": "7.5.17",
+      "pluginVersion": "7.5.23",
       "targets": [
         {
           "exemplar": true,
@@ -137,7 +137,7 @@
         "text": {},
         "textMode": "value_and_name"
       },
-      "pluginVersion": "7.5.17",
+      "pluginVersion": "7.5.23",
       "targets": [
         {
           "exemplar": true,
@@ -282,7 +282,7 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "7.5.17",
+      "pluginVersion": "7.5.23",
       "targets": [
         {
           "exemplar": true,
@@ -484,7 +484,7 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "7.5.17",
+      "pluginVersion": "7.5.23",
       "targets": [
         {
           "exemplar": true,
@@ -620,7 +620,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.17",
+      "pluginVersion": "7.5.23",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -730,7 +730,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.17",
+      "pluginVersion": "7.5.23",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -853,7 +853,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.17",
+      "pluginVersion": "7.5.23",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -962,7 +962,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.17",
+      "pluginVersion": "7.5.23",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1071,7 +1071,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.17",
+      "pluginVersion": "7.5.23",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1194,7 +1194,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.17",
+      "pluginVersion": "7.5.23",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1304,7 +1304,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.17",
+      "pluginVersion": "7.5.23",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1427,7 +1427,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.17",
+      "pluginVersion": "7.5.23",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1537,7 +1537,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.17",
+      "pluginVersion": "7.5.23",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1615,7 +1615,7 @@
       {
         "allValue": ".*",
         "current": {
-          "selected": true,
+          "selected": false,
           "text": "shoot--local--local",
           "value": "shoot--local--local"
         },

--- a/pkg/component/plutono/dashboards/common/shoot-control-plane-resource-usage-by-owner-container.json
+++ b/pkg/component/plutono/dashboards/common/shoot-control-plane-resource-usage-by-owner-container.json
@@ -1609,7 +1609,9 @@
   "refresh": false,
   "schemaVersion": 27,
   "style": "dark",
-  "tags": [],
+  "tags": [
+    "metering"
+  ],
   "templating": {
     "list": [
       {

--- a/pkg/component/plutono/dashboards/common/shoot-control-plane-resource-usage-by-owner-container.json
+++ b/pkg/component/plutono/dashboards/common/shoot-control-plane-resource-usage-by-owner-container.json
@@ -643,6 +643,14 @@
           "interval": "",
           "legendFormat": "{{owner}} / {{container}}",
           "refId": "B"
+        },
+        {
+          "exemplar": true,
+          "expr": "metering:cpu_usage:sum_by_namespace:avg_over_time{shoot_uid!=\"\",namespace=~\"$namespace\"}",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Monthly average ({{year}}/{{month}})",
+          "refId": "C"
         }
       ],
       "thresholds": [],
@@ -753,6 +761,14 @@
           "interval": "",
           "legendFormat": "{{owner}} / {{container}}",
           "refId": "B"
+        },
+        {
+          "exemplar": true,
+          "expr": "metering:cpu_requests:sum_by_namespace:avg_over_time{shoot_uid!=\"\",namespace=~\"$namespace\"}",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Monthly average ({{year}}/{{month}})",
+          "refId": "C"
         }
       ],
       "thresholds": [],
@@ -876,6 +892,14 @@
           "interval": "",
           "legendFormat": "{{owner}} / {{container}}",
           "refId": "B"
+        },
+        {
+          "exemplar": true,
+          "expr": "metering:memory_usage:sum_by_namespace:avg_over_time{shoot_uid!=\"\",namespace=~\"$namespace\"}",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Monthly average ({{year}}/{{month}})",
+          "refId": "C"
         }
       ],
       "thresholds": [],
@@ -985,6 +1009,14 @@
           "interval": "",
           "legendFormat": "{{owner}} / {{container}}",
           "refId": "B"
+        },
+        {
+          "exemplar": true,
+          "expr": "metering:working_set_memory:sum_by_namespace:avg_over_time{shoot_uid!=\"\",namespace=~\"$namespace\"}",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Monthly average ({{year}}/{{month}})",
+          "refId": "C"
         }
       ],
       "thresholds": [],
@@ -1094,6 +1126,14 @@
           "interval": "",
           "legendFormat": "{{owner}} / {{container}}",
           "refId": "B"
+        },
+        {
+          "exemplar": true,
+          "expr": "metering:memory_requests:sum_by_namespace:avg_over_time{shoot_uid!=\"\",namespace=~\"$namespace\"}",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Monthly average ({{year}}/{{month}})",
+          "refId": "C"
         }
       ],
       "thresholds": [],
@@ -1217,6 +1257,14 @@
           "interval": "",
           "legendFormat": "{{owner}}",
           "refId": "B"
+        },
+        {
+          "exemplar": true,
+          "expr": "metering:network_receive:sum_by_namespace:avg_over_time{shoot_uid!=\"\",namespace=~\"$namespace\"}",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Monthly average ({{year}}/{{month}})",
+          "refId": "C"
         }
       ],
       "thresholds": [],
@@ -1327,6 +1375,14 @@
           "interval": "",
           "legendFormat": "{{owner}}",
           "refId": "B"
+        },
+        {
+          "exemplar": true,
+          "expr": "metering:network_transmit:sum_by_namespace:avg_over_time{shoot_uid!=\"\",namespace=~\"$namespace\"}",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Monthly average ({{year}}/{{month}})",
+          "refId": "C"
         }
       ],
       "thresholds": [],
@@ -1450,6 +1506,14 @@
           "interval": "",
           "legendFormat": "{{owner}}",
           "refId": "B"
+        },
+        {
+          "exemplar": true,
+          "expr": "metering:persistent_volume_usage:sum_by_namespace:avg_over_time{shoot_uid!=\"\",namespace=~\"$namespace\"}",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Monthly average ({{year}}/{{month}})",
+          "refId": "C"
         }
       ],
       "thresholds": [],
@@ -1560,6 +1624,14 @@
           "interval": "",
           "legendFormat": "{{owner}}",
           "refId": "B"
+        },
+        {
+          "exemplar": true,
+          "expr": "metering:persistent_volume_claims:sum_by_namespace:avg_over_time{shoot_uid!=\"\",namespace=~\"$namespace\"}",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Monthly average ({{year}}/{{month}})",
+          "refId": "C"
         }
       ],
       "thresholds": [],

--- a/pkg/component/plutono/dashboards/seed/gardener-resource-usage-by-container.json
+++ b/pkg/component/plutono/dashboards/seed/gardener-resource-usage-by-container.json
@@ -1064,7 +1064,9 @@
   "refresh": false,
   "schemaVersion": 27,
   "style": "dark",
-  "tags": [],
+  "tags": [
+    "metering"
+  ],
   "templating": {
     "list": [
       {

--- a/pkg/component/plutono/dashboards/seed/gardener-resource-usage-by-container.json
+++ b/pkg/component/plutono/dashboards/seed/gardener-resource-usage-by-container.json
@@ -75,7 +75,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.17",
+      "pluginVersion": "7.5.23",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -185,7 +185,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.17",
+      "pluginVersion": "7.5.23",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -308,7 +308,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.17",
+      "pluginVersion": "7.5.23",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -417,7 +417,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.17",
+      "pluginVersion": "7.5.23",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -526,7 +526,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.17",
+      "pluginVersion": "7.5.23",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -649,7 +649,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.17",
+      "pluginVersion": "7.5.23",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -759,7 +759,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.17",
+      "pluginVersion": "7.5.23",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -882,7 +882,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.17",
+      "pluginVersion": "7.5.23",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -992,7 +992,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.17",
+      "pluginVersion": "7.5.23",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",

--- a/pkg/component/plutono/dashboards/seed/gardener-resource-usage.json
+++ b/pkg/component/plutono/dashboards/seed/gardener-resource-usage.json
@@ -75,7 +75,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.17",
+      "pluginVersion": "7.5.23",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -177,7 +177,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.17",
+      "pluginVersion": "7.5.23",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -292,7 +292,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.17",
+      "pluginVersion": "7.5.23",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -393,7 +393,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.17",
+      "pluginVersion": "7.5.23",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -494,7 +494,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.17",
+      "pluginVersion": "7.5.23",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -609,7 +609,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.17",
+      "pluginVersion": "7.5.23",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -710,7 +710,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.17",
+      "pluginVersion": "7.5.23",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -825,7 +825,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.17",
+      "pluginVersion": "7.5.23",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -926,7 +926,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.17",
+      "pluginVersion": "7.5.23",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",

--- a/pkg/component/plutono/dashboards/seed/gardener-resource-usage.json
+++ b/pkg/component/plutono/dashboards/seed/gardener-resource-usage.json
@@ -989,7 +989,9 @@
   ],
   "schemaVersion": 27,
   "style": "dark",
-  "tags": [],
+  "tags": [
+    "metering"
+  ],
   "templating": {
     "list": [
       {

--- a/pkg/component/plutono/dashboards/seed/seed-resource-usage.json
+++ b/pkg/component/plutono/dashboards/seed/seed-resource-usage.json
@@ -1,14 +1,26 @@
 {
   "annotations": {
-    "list": []
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Plutono --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
   },
   "editable": true,
   "gnetId": null,
   "graphTooltip": 1,
+  "id": 16,
   "links": [],
   "panels": [
     {
       "collapsed": false,
+      "datasource": null,
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -25,7 +37,14 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
+      "datasource": null,
       "description": "The CPU Usage of the seed.",
+      "fieldConfig": {
+        "defaults": {
+          "links": []
+        },
+        "overrides": []
+      },
       "fill": 0,
       "fillGradient": 0,
       "gridPos": {
@@ -34,6 +53,7 @@
         "x": 0,
         "y": 1
       },
+      "hiddenSeries": false,
       "id": 9,
       "legend": {
         "avg": false,
@@ -49,9 +69,10 @@
       "links": [],
       "nullPointMode": "null",
       "options": {
-        "dataLinks": []
+        "alertThreshold": true
       },
       "percentage": false,
+      "pluginVersion": "7.5.23",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -115,7 +136,14 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
+      "datasource": null,
       "description": "Shows the total memory usage of the seed.",
+      "fieldConfig": {
+        "defaults": {
+          "links": []
+        },
+        "overrides": []
+      },
       "fill": 0,
       "fillGradient": 0,
       "gridPos": {
@@ -124,6 +152,7 @@
         "x": 12,
         "y": 1
       },
+      "hiddenSeries": false,
       "id": 8,
       "legend": {
         "avg": false,
@@ -139,9 +168,10 @@
       "links": [],
       "nullPointMode": "null",
       "options": {
-        "dataLinks": []
+        "alertThreshold": true
       },
       "percentage": false,
+      "pluginVersion": "7.5.23",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -202,6 +232,7 @@
     },
     {
       "collapsed": false,
+      "datasource": null,
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -218,7 +249,14 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
+      "datasource": null,
       "description": "Shows how many CPU cores are required for the control planes on the seed.",
+      "fieldConfig": {
+        "defaults": {
+          "links": []
+        },
+        "overrides": []
+      },
       "fill": 0,
       "fillGradient": 0,
       "gridPos": {
@@ -227,6 +265,7 @@
         "x": 0,
         "y": 11
       },
+      "hiddenSeries": false,
       "id": 4,
       "legend": {
         "avg": false,
@@ -242,9 +281,10 @@
       "links": [],
       "nullPointMode": "null",
       "options": {
-        "dataLinks": []
+        "alertThreshold": true
       },
       "percentage": false,
+      "pluginVersion": "7.5.23",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -308,7 +348,14 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
+      "datasource": null,
       "description": "Shows the total memory usage of all control planes on the seed.",
+      "fieldConfig": {
+        "defaults": {
+          "links": []
+        },
+        "overrides": []
+      },
       "fill": 0,
       "fillGradient": 0,
       "gridPos": {
@@ -317,6 +364,7 @@
         "x": 12,
         "y": 11
       },
+      "hiddenSeries": false,
       "id": 13,
       "legend": {
         "avg": false,
@@ -332,9 +380,10 @@
       "links": [],
       "nullPointMode": "null",
       "options": {
-        "dataLinks": []
+        "alertThreshold": true
       },
       "percentage": false,
+      "pluginVersion": "7.5.23",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -394,7 +443,7 @@
       }
     }
   ],
-  "schemaVersion": 19,
+  "schemaVersion": 27,
   "style": "dark",
   "tags": [
     "seed",

--- a/pkg/component/plutono/dashboards/seed/shoot-control-plane-resource-usage-overview.json
+++ b/pkg/component/plutono/dashboards/seed/shoot-control-plane-resource-usage-overview.json
@@ -1079,7 +1079,9 @@
   "refresh": false,
   "schemaVersion": 27,
   "style": "dark",
-  "tags": [],
+  "tags": [
+    "metering"
+  ],
   "templating": {
     "list": [
       {

--- a/pkg/component/plutono/dashboards/seed/shoot-control-plane-resource-usage-overview.json
+++ b/pkg/component/plutono/dashboards/seed/shoot-control-plane-resource-usage-overview.json
@@ -22,6 +22,155 @@
   "panels": [
     {
       "datasource": null,
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "/CPU/"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "core"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "/Memory/"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "bytes"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 34,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "value_and_name"
+      },
+      "pluginVersion": "7.5.23",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "metering:node_capacity:sum_by_instance_type:avg_over_time:this_month{resource=\"cpu\"}",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "{{instance_type}} CPU",
+          "refId": "A"
+        },
+        {
+          "exemplar": true,
+          "expr": "metering:node_capacity:sum_by_instance_type:avg_over_time:this_month{resource=\"memory\"}",
+          "hide": false,
+          "instant": true,
+          "interval": "",
+          "legendFormat": "{{instance_type}} Memory",
+          "refId": "B"
+        }
+      ],
+      "title": "Seed capacity by instance type (average this month)",
+      "type": "stat"
+    },
+    {
+      "datasource": null,
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 35,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "value_and_name"
+      },
+      "pluginVersion": "7.5.23",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "metering:node_cp_usage:sum_by_instance_type:avg_over_time:this_month / metering:node_capacity:sum_by_instance_type:avg_over_time:this_month * 100",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "{{instance_type}} {{resource}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Seed utilization for shoot control planes by instance type (average this month)",
+      "type": "stat"
+    },
+    {
+      "datasource": null,
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -44,7 +193,7 @@
         "h": 8,
         "w": 5,
         "x": 0,
-        "y": 0
+        "y": 4
       },
       "id": 27,
       "options": {
@@ -114,7 +263,7 @@
         "h": 4,
         "w": 10,
         "x": 5,
-        "y": 0
+        "y": 4
       },
       "id": 29,
       "options": {
@@ -198,7 +347,7 @@
         "h": 4,
         "w": 9,
         "x": 15,
-        "y": 0
+        "y": 4
       },
       "id": 30,
       "options": {
@@ -282,7 +431,7 @@
         "h": 4,
         "w": 10,
         "x": 5,
-        "y": 4
+        "y": 8
       },
       "id": 31,
       "options": {
@@ -366,7 +515,7 @@
         "h": 4,
         "w": 9,
         "x": 15,
-        "y": 4
+        "y": 8
       },
       "id": 32,
       "options": {
@@ -574,7 +723,7 @@
         "h": 11,
         "w": 24,
         "x": 0,
-        "y": 8
+        "y": 12
       },
       "id": 22,
       "options": {
@@ -899,7 +1048,7 @@
         "h": 11,
         "w": 24,
         "x": 0,
-        "y": 19
+        "y": 23
       },
       "id": 25,
       "options": {

--- a/pkg/component/plutono/dashboards/seed/shoot-control-plane-resource-usage-overview.json
+++ b/pkg/component/plutono/dashboards/seed/shoot-control-plane-resource-usage-overview.json
@@ -62,7 +62,7 @@
         "text": {},
         "textMode": "value_and_name"
       },
-      "pluginVersion": "7.5.17",
+      "pluginVersion": "7.5.23",
       "targets": [
         {
           "exemplar": true,
@@ -132,7 +132,7 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "7.5.17",
+      "pluginVersion": "7.5.23",
       "targets": [
         {
           "exemplar": true,
@@ -216,7 +216,7 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "7.5.17",
+      "pluginVersion": "7.5.23",
       "targets": [
         {
           "exemplar": true,
@@ -300,7 +300,7 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "7.5.17",
+      "pluginVersion": "7.5.23",
       "targets": [
         {
           "exemplar": true,
@@ -384,7 +384,7 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "7.5.17",
+      "pluginVersion": "7.5.23",
       "targets": [
         {
           "exemplar": true,
@@ -581,7 +581,7 @@
         "showHeader": true,
         "sortBy": []
       },
-      "pluginVersion": "7.5.17",
+      "pluginVersion": "7.5.23",
       "targets": [
         {
           "exemplar": false,
@@ -906,7 +906,7 @@
         "showHeader": true,
         "sortBy": []
       },
-      "pluginVersion": "7.5.17",
+      "pluginVersion": "7.5.23",
       "targets": [
         {
           "exemplar": false,

--- a/pkg/component/plutono/dashboards/seed/shoot-control-plane-resource-usage.json
+++ b/pkg/component/plutono/dashboards/seed/shoot-control-plane-resource-usage.json
@@ -75,7 +75,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.17",
+      "pluginVersion": "7.5.23",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -177,7 +177,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.17",
+      "pluginVersion": "7.5.23",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -292,7 +292,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.17",
+      "pluginVersion": "7.5.23",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -393,7 +393,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.17",
+      "pluginVersion": "7.5.23",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -494,7 +494,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.17",
+      "pluginVersion": "7.5.23",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -609,7 +609,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.17",
+      "pluginVersion": "7.5.23",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -710,7 +710,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.17",
+      "pluginVersion": "7.5.23",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -825,7 +825,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.17",
+      "pluginVersion": "7.5.23",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -926,7 +926,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.17",
+      "pluginVersion": "7.5.23",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -996,7 +996,6 @@
         "allValue": ".*",
         "current": {
           "selected": true,
-          "tags": [],
           "text": [
             "All"
           ],

--- a/pkg/component/plutono/dashboards/seed/shoot-control-plane-resource-usage.json
+++ b/pkg/component/plutono/dashboards/seed/shoot-control-plane-resource-usage.json
@@ -989,7 +989,9 @@
   ],
   "schemaVersion": 27,
   "style": "dark",
-  "tags": [],
+  "tags": [
+    "metering"
+  ],
   "templating": {
     "list": [
       {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind enhancement

**What this PR does / why we need it**:

The "cache" Prometheus in the garden namespace captures the momentary resource usage (CPU, Memory, Network and Disk) of the shoot control plane and garden components. It also calculates a monthly lifetime average value for these measurements. These metrics are federated to the shoot control plane Prometheus and can be visualized in the "Shoot control plane resource usage by owner and container" dashboard. They can also be used to collect a Gardener landscape wide overview of the shoot control plane resource usage (not part of gardener/gardener).

There was a bug in the monthly average usage calculation which under some conditions yielded bogus average values: the sum was returned instead of sum/count. This is fixed with this PR. Note that this bug probably only affected the landscape wide calculations (which is not part of gardener/gardener). These recording rules here are used to capture the raw metering metrics and the edge case was not triggered in this environment. However, the calculation was still "incorrect" and that is fixed now. 

Furthermore, the seed node capacity, request and usage (for shoot control plane "cp" components) is also captured now, broken down by VM instance type. This could be useful to determine the utilization of the different VM instance types and to understand which components (owner and container) are running on which VM type. Note that this increases the cardinality of the _owner_ metrics by a factor of ~ 2 (with and without instance type) so if these metrics are federated to the landscape level (not part of gardener/gardener) then these new metrics could be excluded from the federation to keep these details only to the seed scope.

The metering related dashboards are slightly adjusted: the seed node utilization is displayed on the Resource Usage Overview dashboard and the running monthly average resource usage is shown on the "Shoot control plane resource usage by owner and container" dashboard. Showing the monthly lifetime average value and the momentary measurement helps to get a visual idea of how consistent the resource usage of the control plane components is.

<details>
<summary>Screenshot showing the CPU usage of the control plane components in a local setup</summary>

The roll over for the average calculation is at the end of the month by default. For local development, it was changed to reset the average calculation at the end of the hour, and hence the colorful Total series which also show how the average is slowly tracking the momentary value.

<img width="300" alt="image" src="https://github.com/gardener/gardener/assets/23032437/451a47ff-0d83-47a0-9dc6-317d97b50965">

</details>

A [Prometheus unit test](https://prometheus.io/docs/prometheus/latest/configuration/unit_testing_rules/) is added for the intricate set of metering recording rules.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

/cc @rickardsjp @acumino 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
