### PR TITLE
Fix `updateStatusOperationError` function 

### DIFF
--- a/pkg/gardenlet/controller/seed/seed/reconciler.go
+++ b/pkg/gardenlet/controller/seed/seed/reconciler.go
@@ -248,7 +248,7 @@ func (r *Reconciler) updateStatusOperationError(ctx context.Context, seed *garde
 	seed.Status.LastOperation.Description = err.Error() + " Operation will be retried."
 	seed.Status.LastOperation.LastUpdateTime = metav1.NewTime(r.Clock.Now().UTC())
 
-	if err2 := r.GardenClient.Status().Patch(ctx, seed, patch); err != nil {
+	if err2 := r.GardenClient.Status().Patch(ctx, seed, patch); err2 != nil {
 		return fmt.Errorf("failed updating last operation to state 'Error' (due to %s): %w", err.Error(), err2)
 	}
 

--- a/pkg/operator/controller/garden/garden/reconciler.go
+++ b/pkg/operator/controller/garden/garden/reconciler.go
@@ -312,7 +312,7 @@ func (r *Reconciler) updateStatusOperationError(ctx context.Context, garden *ope
 	garden.Status.LastOperation.Description = err.Error() + " Operation will be retried."
 	garden.Status.LastOperation.LastUpdateTime = metav1.NewTime(r.Clock.Now().UTC())
 
-	if err2 := r.RuntimeClientSet.Client().Status().Patch(ctx, garden, patch); err != nil {
+	if err2 := r.RuntimeClientSet.Client().Status().Patch(ctx, garden, patch); err2 != nil {
 		return fmt.Errorf("failed updating last operation to state 'Error' (due to %s): %w", err.Error(), err2)
 	}
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug

**What this PR does / why we need it**:
`updateStatusOperationError` function in `garden` and `seed` controller wrongly returns error with `nil` even though the status patch operation is successfull.
https://github.com/gardener/gardener/blob/89debfd7475372a8f40de88804a6fe84c3085c25/pkg/operator/controller/garden/garden/reconciler.go#L303-L320

This is because instead of patch error `err2` we are checking for reconcile error `err`.
https://github.com/gardener/gardener/blob/89debfd7475372a8f40de88804a6fe84c3085c25/pkg/operator/controller/garden/garden/reconciler.go#L315-L317

As a result of this `gardenlet` shows error with `%!w(<nil>)` like this
```
{"level":"error","ts":"2023-08-24T01:47:44.313Z","msg":"Reconciler error","controller":"seed","namespace":"","name":"local","reconcileID":"7231e7fc-d152-4f28-8ef7-068ff9cf79b7",
"error":"failed updating last operation to state 'Error' (due to no matches for kind \"VerticalPodAutoscaler\" in version \"autoscaling.k8s.io/v1\"): %!w(<nil>)",
"stacktrace":"sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\tsigs.k8s.io/controller-runtime@v0.15.0/pkg/internal/controller/controller.go:324\nsigs.k8s.io/controller-runtime/pkg/internal/controller.
(*Controller).processNextWorkItem\n\tsigs.k8s.io/controller-runtime@v0.15.0/pkg/internal/controller/controller.go:265\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2\n\tsigs.k8s.io/controller-runtime@v0.15.0/pkg/internal/controller/controller.go:226"}
``` 
**Which issue(s) this PR fixes**:
Introduced with #8290 #8238 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
