### PR TITLE
Fix unwanted garbage collection of immutable secrets

### DIFF
--- a/charts/gardener/resource-manager/values.yaml
+++ b/charts/gardener/resource-manager/values.yaml
@@ -76,7 +76,6 @@ global:
       garbageCollector:
         enabled: false
       # syncPeriod: 1h
-      # considerManagedResources: true
       health:
         concurrentSyncs: 5
         syncPeriod: 1m

--- a/docs/concepts/resource-manager.md
+++ b/docs/concepts/resource-manager.md
@@ -257,8 +257,6 @@ The following algorithm is implemented in the GC controller:
         - If the annotation key follows the `reference.resources.gardener.cloud/{configmap,secret}-<hash>` scheme and the value equals `<name>`, then consider it as "in-use".
 1. Delete all `ConfigMap`s and `Secret`s not considered as "in-use".
 
-Note: Managed resource secrets are garbage collected only if the GC controller is configured to do so. This is the case when the GC controller acts on a seed cluster. 
-
 Consequently, clients need to:
 
 1. Create immutable `ConfigMap`s/`Secret`s with unique names (e.g., a checksum suffix based on the `.data`).

--- a/example/resource-manager/10-componentconfig.yaml
+++ b/example/resource-manager/10-componentconfig.yaml
@@ -40,7 +40,6 @@ controllers:
   garbageCollector:
     enabled: true
     syncPeriod: 1h
-  # considerManagedResources: true
   health:
     concurrentSyncs: 5
     syncPeriod: 1m

--- a/pkg/component/resourcemanager/resource_manager.go
+++ b/pkg/component/resourcemanager/resource_manager.go
@@ -333,14 +333,12 @@ type VPAConfig struct {
 }
 
 func (r *resourceManager) Deploy(ctx context.Context) error {
-	considerManagedResourceSecretsForGC := false
 	if r.values.TargetDiffersFromSourceCluster {
 		r.secrets.shootAccess = r.newShootAccessSecret()
 		if err := r.secrets.shootAccess.WithTokenExpirationDuration("24h").Reconcile(ctx, r.client); err != nil {
 			return err
 		}
 	} else {
-		considerManagedResourceSecretsForGC = true
 		if err := r.ensureCustomResourceDefinition(ctx); err != nil {
 			return err
 		}
@@ -351,7 +349,7 @@ func (r *resourceManager) Deploy(ctx context.Context) error {
 	fns := []flow.TaskFn{
 		r.ensureServiceAccount,
 		func(ctx context.Context) error {
-			return r.ensureConfigMap(ctx, configMap, considerManagedResourceSecretsForGC)
+			return r.ensureConfigMap(ctx, configMap)
 		},
 		r.ensureRBAC,
 		r.ensureService,
@@ -513,7 +511,7 @@ func (r *resourceManager) emptyClusterRoleBinding() *rbacv1.ClusterRoleBinding {
 	return &rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: r.values.NamePrefix + clusterRoleName}}
 }
 
-func (r *resourceManager) ensureConfigMap(ctx context.Context, configMap *corev1.ConfigMap, considerManagedResourceSecretsForGC bool) error {
+func (r *resourceManager) ensureConfigMap(ctx context.Context, configMap *corev1.ConfigMap) error {
 	config := &resourcemanagerv1alpha1.ResourceManagerConfiguration{
 		SourceClientConnection: resourcemanagerv1alpha1.SourceClientConnection{
 			Namespace: r.values.WatchedNamespace,
@@ -545,9 +543,8 @@ func (r *resourceManager) ensureConfigMap(ctx context.Context, configMap *corev1
 			ClusterID:     r.values.ClusterIdentity,
 			ResourceClass: r.values.ResourceClass,
 			GarbageCollector: resourcemanagerv1alpha1.GarbageCollectorControllerConfig{
-				Enabled:                  true,
-				SyncPeriod:               &metav1.Duration{Duration: 12 * time.Hour},
-				ConsiderManagedResources: &considerManagedResourceSecretsForGC,
+				Enabled:    true,
+				SyncPeriod: &metav1.Duration{Duration: 12 * time.Hour},
 			},
 			Health: resourcemanagerv1alpha1.HealthControllerConfig{
 				ConcurrentSyncs: r.values.MaxConcurrentHealthWorkers,

--- a/pkg/resourcemanager/apis/config/types.go
+++ b/pkg/resourcemanager/apis/config/types.go
@@ -144,9 +144,6 @@ type GarbageCollectorControllerConfig struct {
 	Enabled bool
 	// SyncPeriod is the duration how often the controller performs its reconciliation.
 	SyncPeriod *metav1.Duration
-	// ConsiderManagedResources specifies if managed resources should be considered
-	// as owners of garbage collectable secrets.
-	ConsiderManagedResources *bool
 }
 
 // HealthControllerConfig is the configuration for the health controller.

--- a/pkg/resourcemanager/apis/config/v1alpha1/defaults_test.go
+++ b/pkg/resourcemanager/apis/config/v1alpha1/defaults_test.go
@@ -266,15 +266,13 @@ var _ = Describe("Defaults", func() {
 
 		It("should not overwrite existing values", func() {
 			obj := &GarbageCollectorControllerConfig{
-				Enabled:                  true,
-				SyncPeriod:               &metav1.Duration{Duration: time.Second},
-				ConsiderManagedResources: pointer.Bool(true),
+				Enabled:    true,
+				SyncPeriod: &metav1.Duration{Duration: time.Second},
 			}
 
 			SetDefaults_GarbageCollectorControllerConfig(obj)
 
 			Expect(obj.SyncPeriod).To(PointTo(Equal(metav1.Duration{Duration: time.Second})))
-			Expect(obj.ConsiderManagedResources).To(Equal(pointer.Bool(true)))
 		})
 	})
 

--- a/pkg/resourcemanager/apis/config/v1alpha1/types.go
+++ b/pkg/resourcemanager/apis/config/v1alpha1/types.go
@@ -158,10 +158,6 @@ type GarbageCollectorControllerConfig struct {
 	// SyncPeriod is the duration how often the controller performs its reconciliation.
 	// +optional
 	SyncPeriod *metav1.Duration `json:"syncPeriod,omitempty"`
-	// ConsiderManagedResources specifies if managed resources should be considered
-	// as owners of garbage collectable secrets.
-	// +optional
-	ConsiderManagedResources *bool `json:"considerManagedResources,omitempty"`
 }
 
 // HealthControllerConfig is the configuration for the health controller.

--- a/pkg/resourcemanager/apis/config/v1alpha1/zz_generated.conversion.go
+++ b/pkg/resourcemanager/apis/config/v1alpha1/zz_generated.conversion.go
@@ -406,7 +406,6 @@ func Convert_config_ExtensionValidation_To_v1alpha1_ExtensionValidation(in *conf
 func autoConvert_v1alpha1_GarbageCollectorControllerConfig_To_config_GarbageCollectorControllerConfig(in *GarbageCollectorControllerConfig, out *config.GarbageCollectorControllerConfig, s conversion.Scope) error {
 	out.Enabled = in.Enabled
 	out.SyncPeriod = (*v1.Duration)(unsafe.Pointer(in.SyncPeriod))
-	out.ConsiderManagedResources = (*bool)(unsafe.Pointer(in.ConsiderManagedResources))
 	return nil
 }
 
@@ -418,7 +417,6 @@ func Convert_v1alpha1_GarbageCollectorControllerConfig_To_config_GarbageCollecto
 func autoConvert_config_GarbageCollectorControllerConfig_To_v1alpha1_GarbageCollectorControllerConfig(in *config.GarbageCollectorControllerConfig, out *GarbageCollectorControllerConfig, s conversion.Scope) error {
 	out.Enabled = in.Enabled
 	out.SyncPeriod = (*v1.Duration)(unsafe.Pointer(in.SyncPeriod))
-	out.ConsiderManagedResources = (*bool)(unsafe.Pointer(in.ConsiderManagedResources))
 	return nil
 }
 

--- a/pkg/resourcemanager/apis/config/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/resourcemanager/apis/config/v1alpha1/zz_generated.deepcopy.go
@@ -84,11 +84,6 @@ func (in *GarbageCollectorControllerConfig) DeepCopyInto(out *GarbageCollectorCo
 		*out = new(v1.Duration)
 		**out = **in
 	}
-	if in.ConsiderManagedResources != nil {
-		in, out := &in.ConsiderManagedResources, &out.ConsiderManagedResources
-		*out = new(bool)
-		**out = **in
-	}
 	return
 }
 

--- a/pkg/resourcemanager/apis/config/zz_generated.deepcopy.go
+++ b/pkg/resourcemanager/apis/config/zz_generated.deepcopy.go
@@ -84,11 +84,6 @@ func (in *GarbageCollectorControllerConfig) DeepCopyInto(out *GarbageCollectorCo
 		*out = new(v1.Duration)
 		**out = **in
 	}
-	if in.ConsiderManagedResources != nil {
-		in, out := &in.ConsiderManagedResources, &out.ConsiderManagedResources
-		*out = new(bool)
-		**out = **in
-	}
 	return
 }
 

--- a/pkg/resourcemanager/controller/garbagecollector/reconciler_test.go
+++ b/pkg/resourcemanager/controller/garbagecollector/reconciler_test.go
@@ -28,7 +28,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	testclock "k8s.io/utils/clock/testing"
-	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -57,7 +56,7 @@ var _ = Describe("Collector", func() {
 		gc = &Reconciler{
 			TargetReader:            c,
 			TargetWriter:            c,
-			Config:                  config.GarbageCollectorControllerConfig{SyncPeriod: &metav1.Duration{}, ConsiderManagedResources: pointer.Bool(true)},
+			Config:                  config.GarbageCollectorControllerConfig{SyncPeriod: &metav1.Duration{}},
 			Clock:                   fakeClock,
 			MinimumObjectLifetime:   &minimumObjectLifetime,
 			TargetKubernetesVersion: semver.MustParse("1.24.0"),

--- a/test/integration/resourcemanager/garbagecollector/garbagecollector_suite_test.go
+++ b/test/integration/resourcemanager/garbagecollector/garbagecollector_suite_test.go
@@ -114,8 +114,7 @@ var _ = BeforeSuite(func() {
 	By("Register controller")
 	Expect((&garbagecollector.Reconciler{
 		Config: config.GarbageCollectorControllerConfig{
-			SyncPeriod:               &metav1.Duration{Duration: 100 * time.Millisecond},
-			ConsiderManagedResources: pointer.Bool(true),
+			SyncPeriod: &metav1.Duration{Duration: 100 * time.Millisecond},
 		},
 		Clock:                 clock.RealClock{},
 		MinimumObjectLifetime: pointer.Duration(0),


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness quality
/kind bug

**What this PR does / why we need it**:
A bug was introduced with https://github.com/gardener/gardener/pull/8116 which caused managed resource secrets to be wrongfully garbage collected by the GC controller. The previous PR was configuring the GC controller to not consider managed resources when targeting a shoot cluster, not considering the fact that the shoot cluster can also be a seed. This sets the GC controller in a way that will always consider `managedresources` if they are available in the target cluster.
 
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @rfranzke @timuthy @shafeeqes 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
A bug has been fixed which was causing the garbage collector in `gardener-resource-manager` to wrongfully collect `Secret`s related to `ManagedResource`s when the source and the target cluster are equal.
```
