### PR TITLE
Downgrade docforge to `v0.34.0`

### DIFF
--- a/docs/concepts/backup-restore.md
+++ b/docs/concepts/backup-restore.md
@@ -35,6 +35,6 @@ etcd-backup-restore supports full snapshot and delta snapshots over full snapsho
     - To find the backups list, an admin can checkout the `BackupEntry` resource associated with the Shoot which holds the bucket and prefix details on the object store.
 
 ## Restoration
-The restoration process of etcd is automated through the etcd-backup-restore component from the latest snapshot. Gardener doesn't support Point-In-Time-Recovery (PITR) of etcd. In case of an etcd disaster, the etcd is recovered from the latest backup automatically. For further details, please refer the [Restoration](https://github.com/gardener/etcd-backup-restore/blob/master/doc/proposals/restoration.md) topic. Post restoration of etcd, the Shoot reconciliation loop brings the cluster back to its previous state.
+The restoration process of etcd is automated through the etcd-backup-restore component from the latest snapshot. Gardener doesn't support Point-In-Time-Recovery (PITR) of etcd. In case of an etcd disaster, the etcd is recovered from the latest backup automatically. For further details, please refer the [Restoration](https://github.com/gardener/etcd-backup-restore/blob/master/docs/proposals/restoration.md) topic. Post restoration of etcd, the Shoot reconciliation loop brings the cluster back to its previous state.
 
 Again, the Shoot owner is responsible for maintaining the backup/restore of his workload. Gardener only takes care of the cluster's etcd.

--- a/docs/deployment/deploy_gardenlet_manually.md
+++ b/docs/deployment/deploy_gardenlet_manually.md
@@ -348,7 +348,7 @@ The seed cluster can be set up with backup and restore
 for the main `etcds` of shoot clusters.
 
 Gardener uses [etcd-backup-restore](https://github.com/gardener/etcd-backup-restore)
-that [integrates with different storage providers](https://github.com/gardener/etcd-backup-restore/blob/master/docs/operations/getting_started.md)
+that [integrates with different storage providers](https://github.com/gardener/etcd-backup-restore/blob/master/docs/deployment/getting_started.md)
 to store the shoot cluster's main `etcd` backups.
 Make sure to obtain client credentials that have sufficient permissions with the chosen storage provider.
 

--- a/hack/tools.mk
+++ b/hack/tools.mk
@@ -58,7 +58,7 @@ YAML2JSON                  := $(TOOLS_BIN_DIR)/yaml2json
 YQ                         := $(TOOLS_BIN_DIR)/yq
 
 # default tool versions
-DOCFORGE_VERSION ?= v0.35.0
+DOCFORGE_VERSION ?= v0.34.0
 GOLANGCI_LINT_VERSION ?= v1.54.2
 GO_APIDIFF_VERSION ?= v0.6.0
 GO_ADD_LICENSE_VERSION ?= v1.1.1


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind bug

**What this PR does / why we need it**:
Downgrade docforge to `v0.34.0`. `v0.35.0` produces errors like
```
Error: no suitable reader found for https://github.com/gardener/gardener/blob/check-manifest/.docforge/manifest.yaml. Is this path correct?
```
Ref https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/8398/pull-gardener-unit/1696176735168499712#1:build-log.txt%3A575

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
