### PR TITLE
Allow worker pool Kubernetes version to be behind up to three minor versions when control plane version is `>= 1.28`

### DIFF
--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -684,12 +684,12 @@ func validateWorkerGroupAndControlPlaneKubernetesVersion(controlPlaneVersion, wo
 	var (
 		k8sGreaterEqual128, _ = versionutils.CheckVersionMeetsConstraint(controlPlaneVersion, ">= 1.28")
 		minorSkewVersion      = workerVersion.IncMinor().IncMinor().IncMinor()
-		errorString           = "worker group kubernetes version must be at most two minor versions behind control plane version"
+		maxSkew               = "two"
 	)
 
 	if k8sGreaterEqual128 {
 		minorSkewVersion = workerVersion.IncMinor().IncMinor().IncMinor().IncMinor()
-		errorString = "worker group kubernetes version must be at most three minor versions behind control plane version"
+		maxSkew = "three"
 	}
 
 	versionSkewViolation, err := versionutils.CompareVersions(controlPlaneVersion, ">=", minorSkewVersion.String())
@@ -697,7 +697,7 @@ func validateWorkerGroupAndControlPlaneKubernetesVersion(controlPlaneVersion, wo
 		allErrs = append(allErrs, field.Invalid(fldPath, controlPlaneVersion, err.Error()))
 	}
 	if versionSkewViolation {
-		allErrs = append(allErrs, field.Forbidden(fldPath, errorString))
+		allErrs = append(allErrs, field.Forbidden(fldPath, "worker group kubernetes version must be at most "+maxSkew+" minor versions behind control plane version"))
 	}
 
 	return allErrs

--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -680,14 +680,24 @@ func validateWorkerGroupAndControlPlaneKubernetesVersion(controlPlaneVersion, wo
 	if err != nil {
 		allErrs = append(allErrs, field.Invalid(fldPath, workerGroupVersion, err.Error()))
 	}
-	threeMinorSkewVersion := workerVersion.IncMinor().IncMinor().IncMinor()
 
-	versionSkewViolation, err := versionutils.CompareVersions(controlPlaneVersion, ">=", threeMinorSkewVersion.String())
+	var (
+		k8sGreaterEqual128, _ = versionutils.CheckVersionMeetsConstraint(controlPlaneVersion, ">= 1.28")
+		minorSkewVersion      = workerVersion.IncMinor().IncMinor().IncMinor()
+		errorString           = "worker group kubernetes version must be at most two minor versions behind control plane version"
+	)
+
+	if k8sGreaterEqual128 {
+		minorSkewVersion = workerVersion.IncMinor().IncMinor().IncMinor().IncMinor()
+		errorString = "worker group kubernetes version must be at most three minor versions behind control plane version"
+	}
+
+	versionSkewViolation, err := versionutils.CompareVersions(controlPlaneVersion, ">=", minorSkewVersion.String())
 	if err != nil {
 		allErrs = append(allErrs, field.Invalid(fldPath, controlPlaneVersion, err.Error()))
 	}
 	if versionSkewViolation {
-		allErrs = append(allErrs, field.Forbidden(fldPath, "worker group kubernetes version must be at most two minor versions behind control plane version"))
+		allErrs = append(allErrs, field.Forbidden(fldPath, errorString))
 	}
 
 	return allErrs


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind enhancement

**What this PR does / why we need it**:
See https://github.com/gardener/gardener/issues/8399 for the motivation.
When the Kubernetes control plane version is at least v1.28, users can set the worker pool Kubernetes version to be at most three versions behind the control plane version (today, its at most two versions difference).

**Which issue(s) this PR fixes**:
Fixes #8399

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
When the Kubernetes control plane version is at least `v1.28`, it is now possible to set the worker pool Kubernetes version to be at most three versions behind the control plane version. Earlier, only a skew of at most two versions was allowed. Find more details [here](https://kubernetes.io/blog/2023/08/15/kubernetes-v1-28-release/#changes-to-supported-skew-between-control-plane-and-node-versions).
```
