### PR TITLE
Add Prometheus alert for pending seed pods

### DIFF
--- a/pkg/component/monitoring/charts/bootstrap/aggregate-prometheus-rules/fluent-bit.rules.yaml
+++ b/pkg/component/monitoring/charts/bootstrap/aggregate-prometheus-rules/fluent-bit.rules.yaml
@@ -1,7 +1,7 @@
 groups:
   - name: fluent-bit.rules
     rules:
-  
+
     - alert: FluentBitDown
       expr: |
         absent(

--- a/pkg/component/monitoring/charts/bootstrap/aggregate-prometheus-rules/seed.rules.yaml
+++ b/pkg/component/monitoring/charts/bootstrap/aggregate-prometheus-rules/seed.rules.yaml
@@ -1,0 +1,16 @@
+groups:
+- name: seed.rules
+  rules:
+  - alert: PodStuckInPending
+    expr: |
+      sum_over_time(kube_pod_status_phase{phase="Pending"}[5m]) > 0
+    for: 10m
+    labels:
+      severity: warning
+      type: seed
+      visibility: operator
+    annotations:
+      summary: Some pod is stuck in pending
+      description: >
+        Pod in namespace {{$labels.namespace}} was stuck
+        in Pending state for more than 10 minutes.

--- a/pkg/component/monitoring/charts/bootstrap/aggregate-prometheus-rules/seed.rules.yaml
+++ b/pkg/component/monitoring/charts/bootstrap/aggregate-prometheus-rules/seed.rules.yaml
@@ -10,7 +10,7 @@ groups:
       type: seed
       visibility: operator
     annotations:
-      summary: Some pod is stuck in pending
+      summary: A pod is stuck in pending
       description: >
-        Pod in namespace {{$labels.namespace}} was stuck
+        Pod {{$labels.pod}} in namespace {{$labels.namespace}} was stuck
         in Pending state for more than 10 minutes.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
That PR adds Prometheus alerts for Seed pods stuck in Pending for more than 10 minutes.

/area monitoring
/kind enhancement

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/invite @istvanballok @rickardsjp 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Add Prometheus alert for pending seed pods
```
