### PR TITLE
[operator] Add start-up check for Gardener version verification

### DIFF
--- a/cmd/gardener-operator/app/app.go
+++ b/cmd/gardener-operator/app/app.go
@@ -41,6 +41,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	controllerwebhook "sigs.k8s.io/controller-runtime/pkg/webhook"
 
+	"github.com/gardener/gardener/cmd/gardener-operator/app/bootstrappers"
 	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
 	"github.com/gardener/gardener/extensions/pkg/webhook/certificates"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
@@ -168,6 +169,11 @@ func run(ctx context.Context, log logr.Logger, cfg *config.OperatorConfiguration
 	}
 	if err := mgr.AddReadyzCheck("webhook-server", mgr.GetWebhookServer().StartedChecker()); err != nil {
 		return err
+	}
+
+	log.Info("Perform Gardener version verification")
+	if err := bootstrappers.VerifyGardenerVersion(ctx, mgr.GetLogger(), mgr.GetAPIReader()); err != nil {
+		return fmt.Errorf("failed verifying Gardener version: %w", err)
 	}
 
 	log.Info("Adding certificate management to manager")

--- a/cmd/gardener-operator/app/bootstrappers/bootstrappers_suite_test.go
+++ b/cmd/gardener-operator/app/bootstrappers/bootstrappers_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bootstrappers_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestBootstrappers(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Command Operator App Bootstrappers Suite")
+}

--- a/cmd/gardener-operator/app/bootstrappers/verify_version.go
+++ b/cmd/gardener-operator/app/bootstrappers/verify_version.go
@@ -1,0 +1,73 @@
+// Copyright 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bootstrappers
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/Masterminds/semver"
+	"github.com/go-logr/logr"
+	"k8s.io/component-base/version"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	operatorv1alpha1 "github.com/gardener/gardener/pkg/apis/operator/v1alpha1"
+	versionutils "github.com/gardener/gardener/pkg/utils/version"
+)
+
+// GetCurrentVersion returns the current version. Exposed for testing.
+var GetCurrentVersion = version.Get
+
+// VerifyGardenerVersion verifies that the operator's version is not lower and not more than one version higher than
+// the version last operated on a Garden.
+func VerifyGardenerVersion(ctx context.Context, log logr.Logger, client client.Reader) error {
+	gardenList := &operatorv1alpha1.GardenList{}
+	if err := client.List(ctx, gardenList); err != nil {
+		return fmt.Errorf("failed listing Gardens: %w", err)
+	}
+
+	if length := len(gardenList.Items); length == 0 {
+		return nil
+	} else if length > 1 {
+		return fmt.Errorf("expected at most one Garden but got %d", length)
+	}
+
+	garden := gardenList.Items[0]
+	if garden.Status.Gardener == nil {
+		return nil
+	}
+
+	oldGardenerVersion, err := semver.NewVersion(garden.Status.Gardener.Version)
+	if err != nil {
+		return fmt.Errorf("failed parsing old Garden version %q: %w", garden.Status.Gardener.Version, err)
+	}
+	currentGardenerVersion := GetCurrentVersion().GitVersion
+
+	if downgrade, err := versionutils.CompareVersions(currentGardenerVersion, "<", oldGardenerVersion.String()); err != nil {
+		return fmt.Errorf("failed comparing versions for downgrade check: %w", err)
+	} else if downgrade {
+		return fmt.Errorf("downgrading Gardener is not supported (old version was %s, my version is %s), please consult https://github.com/gardener/gardener/blob/master/docs/deployment/version_skew_policy.md", oldGardenerVersion.String(), currentGardenerVersion)
+	}
+
+	minorVersionSkew := oldGardenerVersion.IncMinor().IncMinor()
+	if upgradeMoreThanOneVersion, err := versionutils.CompareVersions(currentGardenerVersion, ">=", minorVersionSkew.String()); err != nil {
+		return fmt.Errorf("failed comparing versions for upgrade check: %w", err)
+	} else if upgradeMoreThanOneVersion {
+		return fmt.Errorf("skipping Gardener versions is unsupported (old version was %s, my version is %s),, please consult https://github.com/gardener/gardener/blob/master/docs/deployment/version_skew_policy.md", oldGardenerVersion.String(), currentGardenerVersion)
+	}
+
+	log.Info("Successfully verified Gardener version skew")
+	return nil
+}

--- a/cmd/gardener-operator/app/bootstrappers/verify_version.go
+++ b/cmd/gardener-operator/app/bootstrappers/verify_version.go
@@ -65,7 +65,7 @@ func VerifyGardenerVersion(ctx context.Context, log logr.Logger, client client.R
 	if upgradeMoreThanOneVersion, err := versionutils.CompareVersions(currentGardenerVersion, ">=", minorVersionSkew.String()); err != nil {
 		return fmt.Errorf("failed comparing versions for upgrade check: %w", err)
 	} else if upgradeMoreThanOneVersion {
-		return fmt.Errorf("skipping Gardener versions is unsupported (old version was %s, my version is %s),, please consult https://github.com/gardener/gardener/blob/master/docs/deployment/version_skew_policy.md", oldGardenerVersion.String(), currentGardenerVersion)
+		return fmt.Errorf("skipping Gardener versions is unsupported (old version was %s, my version is %s), please consult https://github.com/gardener/gardener/blob/master/docs/deployment/version_skew_policy.md", oldGardenerVersion.String(), currentGardenerVersion)
 	}
 
 	log.Info("Successfully verified Gardener version skew")

--- a/cmd/gardener-operator/app/bootstrappers/verify_version_test.go
+++ b/cmd/gardener-operator/app/bootstrappers/verify_version_test.go
@@ -47,7 +47,7 @@ var _ = Describe("VerifyVersion", func() {
 		fakeClient = fakeclient.NewClientBuilder().WithScheme(operatorclient.RuntimeScheme).WithStatusSubresource(garden).Build()
 	})
 
-	Describe("#Start", func() {
+	Describe("#VerifyGardenerVersion", func() {
 		It("should do nothing because no Gardens exist", func() {
 			Expect(VerifyGardenerVersion(ctx, log, fakeClient)).To(Succeed())
 		})

--- a/cmd/gardener-operator/app/bootstrappers/verify_version_test.go
+++ b/cmd/gardener-operator/app/bootstrappers/verify_version_test.go
@@ -1,0 +1,103 @@
+// Copyright 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bootstrappers_test
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	gomegatypes "github.com/onsi/gomega/types"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	apimachineryversion "k8s.io/apimachinery/pkg/version"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	. "github.com/gardener/gardener/cmd/gardener-operator/app/bootstrappers"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	operatorv1alpha1 "github.com/gardener/gardener/pkg/apis/operator/v1alpha1"
+	operatorclient "github.com/gardener/gardener/pkg/operator/client"
+	"github.com/gardener/gardener/pkg/utils/test"
+)
+
+var _ = Describe("VerifyVersion", func() {
+	var (
+		ctx        = context.Background()
+		log        logr.Logger
+		fakeClient client.Client
+		garden     *operatorv1alpha1.Garden
+	)
+
+	BeforeEach(func() {
+		log = logr.Discard()
+		garden = &operatorv1alpha1.Garden{ObjectMeta: metav1.ObjectMeta{GenerateName: "garden-"}}
+		fakeClient = fakeclient.NewClientBuilder().WithScheme(operatorclient.RuntimeScheme).WithStatusSubresource(garden).Build()
+	})
+
+	Describe("#Start", func() {
+		It("should do nothing because no Gardens exist", func() {
+			Expect(VerifyGardenerVersion(ctx, log, fakeClient)).To(Succeed())
+		})
+
+		It("should fail because more than one Garden exist", func() {
+			Expect(fakeClient.Create(ctx, garden.DeepCopy())).To(Succeed())
+			Expect(fakeClient.Create(ctx, garden.DeepCopy())).To(Succeed())
+
+			Expect(VerifyGardenerVersion(ctx, log, fakeClient)).To(MatchError(ContainSubstring("expected at most one Garden")))
+		})
+
+		It("should do nothing because old Garden version is not maintained", func() {
+			Expect(fakeClient.Create(ctx, garden)).To(Succeed())
+
+			Expect(VerifyGardenerVersion(ctx, log, fakeClient)).To(Succeed())
+		})
+
+		DescribeTable("tests",
+			func(oldVersion, currentVersion string, matcher gomegatypes.GomegaMatcher) {
+				Expect(fakeClient.Create(ctx, garden)).To(Succeed())
+				garden.Status.Gardener = &gardencorev1beta1.Gardener{Version: oldVersion}
+				Expect(fakeClient.Status().Update(ctx, garden)).To(Succeed())
+
+				DeferCleanup(test.WithVar(&GetCurrentVersion, func() apimachineryversion.Info { return apimachineryversion.Info{GitVersion: currentVersion} }))
+
+				Expect(VerifyGardenerVersion(ctx, log, fakeClient)).To(matcher)
+			},
+
+			Entry("fail because old version cannot be parsed", "unparseable$version", "v1.2.3", MatchError(ContainSubstring("failed parsing old Garden version"))),
+			Entry("fail because current version cannot be parsed", "v1.2.3", "unparseable$version", MatchError(ContainSubstring("failed comparing versions for downgrade check"))),
+
+			Entry("fail because downgrade is unsupported", "v1.2.3", "v1.1.1", MatchError(ContainSubstring("downgrading Gardener is not supported"))),
+			Entry("fail because downgrade is unsupported (old version suffixed with '-dev')", "v1.2.3-dev", "v1.1.1", MatchError(ContainSubstring("downgrading Gardener is not supported"))),
+			Entry("fail because downgrade is unsupported (new version suffixed with '-dev')", "v1.2.3", "v1.1.1-dev", MatchError(ContainSubstring("downgrading Gardener is not supported"))),
+			Entry("fail because downgrade is unsupported (both version suffixed with '-dev')", "v1.2.3-dev", "v1.1.1-dev", MatchError(ContainSubstring("downgrading Gardener is not supported"))),
+
+			Entry("fail because upgrading more than one minor version is unsupported", "v1.2.3", "v1.4.4", MatchError(ContainSubstring("skipping Gardener versions is unsupported"))),
+			Entry("fail because upgrading more than one minor version is unsupported (old version suffixed with '-dev')", "v1.2.3-dev", "v1.4.4", MatchError(ContainSubstring("skipping Gardener versions is unsupported"))),
+			Entry("fail because upgrading more than one minor version is unsupported (new version suffixed with '-dev')", "v1.2.3", "v1.4.4-dev", MatchError(ContainSubstring("skipping Gardener versions is unsupported"))),
+			Entry("fail because upgrading more than one minor version is unsupported (both version suffixed with '-dev')", "v1.2.3-dev", "v1.4.4-dev", MatchError(ContainSubstring("skipping Gardener versions is unsupported"))),
+
+			Entry("succeed because minor version did not change", "v1.2.3", "v1.2.4", Succeed()),
+			Entry("succeed because minor version did not change (old version suffixed with '-dev'", "v1.2.3-dev", "v1.2.4", Succeed()),
+			Entry("succeed because minor version did not change (new version suffixed with '-dev'", "v1.2.3", "v1.2.4-dev", Succeed()),
+			Entry("succeed because minor version did not change (both version suffixed with '-dev'", "v1.2.3-dev", "v1.2.4-dev", Succeed()),
+
+			Entry("succeed because minor version differs by only one 1", "v1.2.3", "v1.3.0", Succeed()),
+			Entry("succeed because minor version differs by only one 1 (old version suffixed with '-dev')", "v1.2.3-dev", "v1.3.0", Succeed()),
+			Entry("succeed because minor version differs by only one 1 (new version suffixed with '-dev')", "v1.2.3", "v1.3.0-dev", Succeed()),
+			Entry("succeed because minor version differs by only one 1 (both version suffixed with '-dev')", "v1.2.3-dev", "v1.3.0-dev", Succeed()),
+		)
+	})
+})

--- a/docs/deployment/version_skew_policy.md
+++ b/docs/deployment/version_skew_policy.md
@@ -16,8 +16,8 @@ For more information, see the [Releases document](../development/process.md#rele
 ### Supported Version Skew
 
 Technically, we follow the same [policy](https://kubernetes.io/releases/version-skew-policy/) as the Kubernetes project.
-However, given that our release cadence is much more frequent compared to Kubernetes (every `14d` vs. every `120d`), in many cases it might be possible to skip versions.
-Still, to be on the safe side, it is highly recommended to follow the described policy.
+However, given that our release cadence is much more frequent compared to Kubernetes (every `14d` vs. every `120d`), in many cases it might be possible to skip versions, though we do not test these upgrade paths.
+Consequently, in general it might not work, and to be on the safe side, it is highly recommended to follow the described policy.
 
 🚨 Note that downgrading Gardener versions is generally not tested during development and should be considered unsupported.
 

--- a/docs/deployment/version_skew_policy.md
+++ b/docs/deployment/version_skew_policy.md
@@ -40,6 +40,16 @@ Example:
 - `gardener-apiserver` is at **v1.37**
 - `gardener-controller-manager`, `gardener-scheduler`, `gardener-admission-controller`, and `gardenlet` are supported at **1.37** and **v1.36**
 
+#### gardener-operator
+
+Since `gardener-operator` manages the Gardener control plane components (`gardener-apiserver`, `gardener-controller-manager`, `gardener-scheduler`, `gardener-admission-controller`), it follows the same policy as for [`gardener-apiserver`](#gardener-apiserver).
+
+It implements additional start-up checks to ensure adherence to this policy.
+Concretely, `gardener-operator` will crash when
+
+- its gets downgraded.
+- its version gets upgraded and skips at least one minor version.
+
 ### Supported Component Upgrade Order
 
 The supported version skew between components has implications on the order in which components must be upgraded.
@@ -61,11 +71,21 @@ Actions:
 
 Prerequisites:
 
-- The `gardener-apiserver` instances these components communicate with are at **1.38** (in multi-instance setups in which these components can communicate with any `gardener-apiserver` instance in the cluster, all `gardener-apiserver` instances must be upgraded before upgrading these components)
+- The `gardener-apiserver` instances these components communicate with are at **1.38** (in multi-instance setups in which these components can communicate with any `gardener-apiserver` instance in the cluster, all `gardener-apiserver` instances must be upgraded before upgrading these components).
 
 Actions:
 
 - Upgrade `gardener-controller-manager`, `gardener-scheduler`, `gardener-admission-controller`, and `gardenlet` to **1.38**
+
+#### gardener-operator
+
+Prerequisites:
+
+- All `gardener-operator` instances are at **1.37**.
+
+Actions:
+
+- Upgrade `gardener-operator` to **1.38**.
 
 ## Supported Kubernetes Versions
 

--- a/docs/deployment/version_skew_policy.md
+++ b/docs/deployment/version_skew_policy.md
@@ -16,8 +16,10 @@ For more information, see the [Releases document](../development/process.md#rele
 ### Supported Version Skew
 
 Technically, we follow the same [policy](https://kubernetes.io/releases/version-skew-policy/) as the Kubernetes project.
-However, given that our release cadence is much more frequent compared to Kubernetes (every `14d` vs. every `120d`), in many cases it is possible to skip a version.
+However, given that our release cadence is much more frequent compared to Kubernetes (every `14d` vs. every `120d`), in many cases it might be possible to skip versions.
 Still, to be on the safe side, it is highly recommended to follow the described policy.
+
+🚨 Note that downgrading Gardener versions is generally not tested during development and should be considered unsupported.
 
 #### gardener-apiserver
 

--- a/skaffold-operator.yaml
+++ b/skaffold-operator.yaml
@@ -9,6 +9,7 @@ build:
       dependencies:
         paths:
         - cmd/gardener-operator/app
+        - cmd/gardener-operator/app/bootstrappers
         - cmd/utils
         - extensions/pkg/apis/config
         - extensions/pkg/controller


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind enhancement

**What this PR does / why we need it**:
To ensure adherence to the [version skew policy](https://github.com/gardener/gardener/blob/master/docs/deployment/version_skew_policy.md), this PR adds a start-up check to `gardener-operator` which prevents

- version downgrades
- minor version upgrading skipping versions

**Which issue(s) this PR fixes**:
Part of #7016

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
`gardener-operator` now refuses to start if operators attempt to downgrade or skip minor Gardener versions. Please see [this document](https://github.com/gardener/gardener/blob/master/docs/deployment/version_skew_policy.md) for more information.
```
