### PR TITLE
Promote `WorkerlessShoots` feature gate to beta

### DIFF
--- a/docs/deployment/feature_gates.md
+++ b/docs/deployment/feature_gates.md
@@ -26,7 +26,8 @@ The following tables are a summary of the feature gates that you can set on diff
 | CoreDNSQueryRewriting               | `false` | `Alpha` | `1.55` |        |
 | IPv6SingleStack                     | `false` | `Alpha` | `1.63` |        |
 | MutableShootSpecNetworkingNodes     | `false` | `Alpha` | `1.64` |        |
-| WorkerlessShoots                    | `false` | `Alpha` | `1.70` |        |
+| WorkerlessShoots                    | `false` | `Alpha` | `1.70` | `1.78` |
+| WorkerlessShoots                    | `false` | `Beta`  | `1.79` |        |
 | MachineControllerManagerDeployment  | `false` | `Alpha` | `1.73` |        |
 | DisableScalingClassesForShoots      | `false` | `Alpha` | `1.73` |        |
 | ContainerdRegistryHostsDir          | `false` | `Alpha` | `1.77` |        |

--- a/example/gardener-local/controlplane/values.yaml
+++ b/example/gardener-local/controlplane/values.yaml
@@ -160,7 +160,6 @@ global:
     featureGates:
       IPv6SingleStack: true
       MutableShootSpecNetworkingNodes: true
-      WorkerlessShoots: true
     resources: {}
     podLabels:
       networking.resources.gardener.cloud/to-all-webhook-targets: allowed

--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -33,7 +33,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/utils/pointer"
 
 	"github.com/gardener/gardener/pkg/apis/core"
@@ -563,7 +562,6 @@ var _ = Describe("Shoot Validation Tests", func() {
 		)
 
 		It("should forbid addon configuration if the shoot is workerless", func() {
-			DeferCleanup(test.WithFeatureGate(utilfeature.DefaultMutableFeatureGate, features.WorkerlessShoots, true))
 			shoot.Spec.Provider.Workers = []core.Worker{}
 			shoot.Spec.Addons = &core.Addons{}
 			shoot.Spec.Kubernetes.KubeControllerManager = nil
@@ -655,7 +653,6 @@ var _ = Describe("Shoot Validation Tests", func() {
 		})
 
 		It("should forbid adding secretBindingName in case of workerless shoot", func() {
-			DeferCleanup(test.WithFeatureGate(utilfeature.DefaultMutableFeatureGate, features.WorkerlessShoots, true))
 			shoot.Spec.Provider.Workers = nil
 			shoot.Spec.SecretBindingName = pointer.String("foo")
 
@@ -669,7 +666,6 @@ var _ = Describe("Shoot Validation Tests", func() {
 		})
 
 		It("should allow nil secretBindingName in case of workerless shoot", func() {
-			DeferCleanup(test.WithFeatureGate(utilfeature.DefaultMutableFeatureGate, features.WorkerlessShoots, true))
 			shoot.Spec.Provider.Workers = nil
 			shoot.Spec.Addons = nil
 			shoot.Spec.SecretBindingName = nil
@@ -1054,7 +1050,6 @@ var _ = Describe("Shoot Validation Tests", func() {
 			})
 
 			It("should prevent setting InfrastructureConfig for workerless Shoot", func() {
-				DeferCleanup(test.WithFeatureGate(utilfeature.DefaultMutableFeatureGate, features.WorkerlessShoots, true))
 				shoot.Spec.Provider.Workers = nil
 				shoot.Spec.Addons = nil
 				shoot.Spec.Kubernetes.KubeControllerManager = nil
@@ -1073,7 +1068,6 @@ var _ = Describe("Shoot Validation Tests", func() {
 			})
 
 			It("should prevent setting ControlPlaneConfig for workerless Shoot", func() {
-				DeferCleanup(test.WithFeatureGate(utilfeature.DefaultMutableFeatureGate, features.WorkerlessShoots, true))
 				shoot.Spec.Provider.Workers = nil
 				shoot.Spec.Addons = nil
 				shoot.Spec.Kubernetes.KubeControllerManager = nil
@@ -2032,7 +2026,6 @@ var _ = Describe("Shoot Validation Tests", func() {
 		Context("KubeControllerManager validation", func() {
 			Context("for workerless shoots", func() {
 				BeforeEach(func() {
-					DeferCleanup(test.WithFeatureGate(utilfeature.DefaultMutableFeatureGate, features.WorkerlessShoots, true))
 					shoot.Spec.Provider.Workers = []core.Worker{}
 				})
 
@@ -2289,8 +2282,6 @@ var _ = Describe("Shoot Validation Tests", func() {
 			})
 
 			It("should prevent setting kubescheduler config for workerless shoots", func() {
-				DeferCleanup(test.WithFeatureGate(utilfeature.DefaultMutableFeatureGate, features.WorkerlessShoots, true))
-
 				profile := core.SchedulingProfileBinPacking
 				shoot.Spec.Provider.Workers = []core.Worker{}
 				shoot.Spec.Kubernetes.KubeScheduler = &core.KubeSchedulerConfig{
@@ -2339,8 +2330,6 @@ var _ = Describe("Shoot Validation Tests", func() {
 			})
 
 			It("should prevent setting kubeproxy config for workerless shoots", func() {
-				DeferCleanup(test.WithFeatureGate(utilfeature.DefaultMutableFeatureGate, features.WorkerlessShoots, true))
-
 				shoot.Spec.Provider.Workers = []core.Worker{}
 				shoot.Spec.Kubernetes.KubeProxy = &core.KubeProxyConfig{
 					KubernetesConfig: core.KubernetesConfig{
@@ -2751,8 +2740,6 @@ var _ = Describe("Shoot Validation Tests", func() {
 			})
 
 			It("should allow upgrading to v1.25 even if PodSecurityPolicy admission plugin is not disabled for a workerless Shoot", func() {
-				DeferCleanup(test.WithFeatureGate(utilfeature.DefaultMutableFeatureGate, features.WorkerlessShoots, true))
-
 				shoot.Spec.Kubernetes.Version = "1.24.0"
 				shoot.Spec.Kubernetes.KubeControllerManager = nil
 				shoot.Spec.Provider.Workers = nil
@@ -2978,7 +2965,6 @@ var _ = Describe("Shoot Validation Tests", func() {
 		Context("networking section", func() {
 			Context("Workerless Shoots", func() {
 				It("should forbid setting networking.type, networking.providerConfig, networking.pods, networking.nodes", func() {
-					DeferCleanup(test.WithFeatureGate(utilfeature.DefaultMutableFeatureGate, features.WorkerlessShoots, true))
 					shoot.Spec.Provider.Workers = nil
 					shoot.Spec.SecretBindingName = nil
 					shoot.Spec.Addons = nil

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -61,6 +61,7 @@ const (
 	// WorkerlessShoots allows creation of Shoot clusters with no worker pools.
 	// owner: @acumino @ary1992 @shafeeqes
 	// alpha: v1.70.0
+	// beta: v1.79.0
 	WorkerlessShoots featuregate.Feature = "WorkerlessShoots"
 
 	// MachineControllerManagerDeployment enables Gardener to take over the deployment of the
@@ -124,7 +125,7 @@ var AllFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	CoreDNSQueryRewriting:              {Default: false, PreRelease: featuregate.Alpha},
 	IPv6SingleStack:                    {Default: false, PreRelease: featuregate.Alpha},
 	MutableShootSpecNetworkingNodes:    {Default: false, PreRelease: featuregate.Alpha},
-	WorkerlessShoots:                   {Default: false, PreRelease: featuregate.Alpha},
+	WorkerlessShoots:                   {Default: true, PreRelease: featuregate.Beta},
 	MachineControllerManagerDeployment: {Default: false, PreRelease: featuregate.Alpha},
 	DisableScalingClassesForShoots:     {Default: false, PreRelease: featuregate.Alpha},
 	ContainerdRegistryHostsDir:         {Default: false, PreRelease: featuregate.Alpha},

--- a/pkg/registry/core/shoot/strategy_test.go
+++ b/pkg/registry/core/shoot/strategy_test.go
@@ -25,7 +25,6 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/utils/pointer"
 
 	"github.com/gardener/gardener/pkg/apis/core"
@@ -75,8 +74,6 @@ var _ = Describe("Strategy", func() {
 		})
 
 		It("should allow an empty worker list if WorkerlessShoots featuregate is enabled", func() {
-			DeferCleanup(test.WithFeatureGate(utilfeature.DefaultMutableFeatureGate, features.WorkerlessShoots, true))
-
 			errorList := shootregistry.NewStrategy(0).Validate(context.TODO(), shoot)
 
 			Expect(errorList).To(BeEmpty())

--- a/pkg/registry/core/shoot/strategy_test.go
+++ b/pkg/registry/core/shoot/strategy_test.go
@@ -63,6 +63,8 @@ var _ = Describe("Strategy", func() {
 		})
 
 		It("should forbid an empty worker list if WorkerlessShoots featuregate is disabled", func() {
+			DeferCleanup(test.WithFeatureGate(features.DefaultFeatureGate, features.WorkerlessShoots, false))
+
 			errorList := shootregistry.NewStrategy(0).Validate(context.TODO(), shoot)
 
 			Expect(errorList).To(ContainElement(PointTo(MatchFields(IgnoreExtras, Fields{

--- a/test/integration/gardenlet/shoot/care/care_test.go
+++ b/test/integration/gardenlet/shoot/care/care_test.go
@@ -28,9 +28,7 @@ import (
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
-	"github.com/gardener/gardener/pkg/features"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
-	"github.com/gardener/gardener/pkg/utils/test"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 )
 
@@ -128,8 +126,6 @@ var _ = Describe("Shoot Care controller tests", func() {
 	})
 
 	JustBeforeEach(func() {
-		DeferCleanup(test.WithFeatureGate(features.DefaultFeatureGate, features.WorkerlessShoots, true))
-
 		// Typically, GCM creates the seed-specific namespace, but it doesn't run in this test, hence we have to do it.
 		By("Create seed-specific namespace")
 		Expect(testClient.Create(ctx, seedNamespace)).To(Succeed())

--- a/test/integration/gardenlet/shoot/state/state_suite_test.go
+++ b/test/integration/gardenlet/shoot/state/state_suite_test.go
@@ -97,7 +97,6 @@ var _ = BeforeSuite(func() {
 		GardenerAPIServer: &gardenerenvtest.GardenerAPIServer{
 			Args: []string{
 				"--disable-admission-plugins=DeletionConfirmation,ResourceReferenceManager,ExtensionValidator,ShootDNS,ShootQuotaValidator,ShootTolerationRestriction,ShootValidator",
-				"--feature-gates=WorkerlessShoots=true",
 			},
 		},
 	}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement

**What this PR does / why we need it**:
Promote WorkerlessShoots feature gate to beta and turn it on by default.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/7635

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The `WorkerlessShoots` feature gate has been promoted to beta and is now turned on by default. Before deploying this Gardener version, make sure that all your registered extensions support this feature gate.
```
