### PR TITLE
Skaffold enhancements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -319,7 +319,7 @@ export SKAFFOLD_BUILD_CONCURRENCY = 0
 
 gardener%up gardener%dev gardener%debug gardenlet%up gardenlet%dev gardenlet%debug operator-up operator-dev operator-debug: export SKAFFOLD_DEFAULT_REPO = localhost:5001
 gardener%up gardener%dev gardener%debug gardenlet%up gardenlet%dev gardenlet%debug operator-up operator-dev operator-debug: export SKAFFOLD_PUSH = true
-gardener%up gardener%dev gardener%debug gardenlet%up gardenlet%dev gardenlet%debug operator-up operator-dev operator-debug: export SOURCE_DATE_EPOCH = $(shell date +%s)
+gardener%up gardener%dev gardener%debug gardenlet%up gardenlet%dev gardenlet%debug operator-up operator-dev operator-debug: export SOURCE_DATE_EPOCH ?= $(shell date +%s)
 # use static label for skaffold to prevent rolling all gardener components on every `skaffold` invocation
 gardener%up gardener%dev gardener%debug gardener%down gardenlet%up gardenlet%dev gardenlet%debug gardenlet%down: export SKAFFOLD_LABEL = skaffold.dev/run-id=gardener-local
 # skaffold dev and debug clean up deployed modules by default, disable this

--- a/Makefile
+++ b/Makefile
@@ -316,7 +316,7 @@ kind-operator-down: $(KIND)
 
 # speed-up skaffold deployments by building all images concurrently
 export SKAFFOLD_BUILD_CONCURRENCY = 0
-export SKAFFOLD_DISABLE_HEALTH_CHECKS ?= ""
+
 gardener%up gardener%dev gardener%debug gardenlet%up gardenlet%dev gardenlet%debug operator-up operator-dev operator-debug: export SKAFFOLD_DEFAULT_REPO = localhost:5001
 gardener%up gardener%dev gardener%debug gardenlet%up gardenlet%dev gardenlet%debug operator-up operator-dev operator-debug: export SKAFFOLD_PUSH = true
 gardener%up gardener%dev gardener%debug gardenlet%up gardenlet%dev gardenlet%debug operator-up operator-dev operator-debug: export SOURCE_DATE_EPOCH = $(shell date +%s)
@@ -331,10 +331,6 @@ gardener%dev gardenlet%dev operator-dev: export SKAFFOLD_TRIGGER = manual
 # However, these artifacts do not include the gcflags which `skaffold debug` sets automatically, so delve would not work.
 # Disabling the skaffold cache for debugging ensures that you run artifacts with gcflags required for debugging.
 gardener%debug gardenlet%debug operator-debug: export SKAFFOLD_CACHE_ARTIFACTS = false
-# Health checks may be disabled on a per-controller basis. To boot a garden from scratch, some controllers may be launched before
-# their attendant resources are installed. Those controllers will need to be restarted by health checks after the resources are available.
-# Developers who prefer to do this manually may provide comma-separated controller names from {admission,controller,scheduler,gardenlet,operator}.
-gardener%dev gardener%debug gardenlet%dev gardenlet%debug operator-dev operator-debug: export SKAFFOLD_DISABLE_HEALTH_CHECKS ?= ""
 
 gardener-ha-single-zone%: export SKAFFOLD_PROFILE=ha-single-zone
 gardener-ha-multi-zone%: export SKAFFOLD_PROFILE=ha-multi-zone

--- a/charts/gardener/controlplane/charts/runtime/templates/admission-controller/deployment.yaml
+++ b/charts/gardener/controlplane/charts/runtime/templates/admission-controller/deployment.yaml
@@ -78,6 +78,16 @@ spec:
         resources:
 {{ toYaml .Values.global.admission.resources | indent 10 }}
         {{- end }}
+        ports:
+          - name: https
+            containerPort: {{ required ".Values.global.admission.config.server.webhooks.port is required" .Values.global.admission.config.server.webhooks.port }}
+            protocol: TCP
+          - name: health
+            containerPort: {{ required ".Values.global.admission.config.server.healthProbes.port is required" .Values.global.admission.config.server.healthProbes.port }}
+            protocol: TCP
+          - name: metrics
+            containerPort: {{ required ".Values.global.admission.config.server.metrics.port is required" .Values.global.admission.config.server.metrics.port }}
+            protocol: TCP
         {{- if .Values.global.admission.config.server.healthProbes.enable }}
         livenessProbe:
           httpGet:

--- a/docs/development/getting_started_locally.md
+++ b/docs/development/getting_started_locally.md
@@ -1,7 +1,145 @@
 # Developing Gardener Locally
 
-[This document](../deployment/getting_started_locally.md) explains how to setup a kind based environment for developing Gardener locally.
+[This document](../deployment/getting_started_locally.md) explains how to set up a KinD-based environment for developing Gardener locally.
 
 For the best development experience you should especially check the [Developing Gardener](../deployment/getting_started_locally.md#developing-gardener) section.
 
 In case you plan a debugging session please check the [Debugging Gardener](../deployment/getting_started_locally.md#debugging-gardener) section.
+
+## Benefiting from Google Cloud Code
+
+Google Cloud Code is a set of IDE plugins for popular IDEs that make it easier to create, deploy and integrate applications with Google Cloud. Supported environments include VSCode, the Jetbrains suite (IntelliJ, PyCharm, GoLand, 
+WebStorm), and Cloud Shell Editor. Gardener environments increasingly leverage Skaffold for developer productivity, Cloud Code exposes it's power under a friendly user experience.
+
+There are several benefits to this environment:
+
+* Several containers are built in the lifecycle, each time they are rebuilt and restarted, the Delve debugger connection must be re-established from the IDE 
+to the new container.
+* Skaffold can be additionally configured to specify how changes to the source artifacts trigger rebuilds of the respective containers.
+* Logs are consolidated into a master-detail user interface orientation that helps users rapidly navigate to, watch and act on the information they need
+
+### Developer Lifecycle
+
+There are two primary lifecycles that the developer will need to consider. The first is a cold boot of the system, the second is iterative changes and individual container restarts. This documentation is currently provided for users 
+running MacOS with a Jetbrains IDE. Contributions are welcome for other platforms. 
+
+As prerequisites to these instructions, the user should have a working deployment environment [as above](../deployment/getting_started_locally.md). They should confirm that they are able to create a stable environment using
+the `make kind-up && make gardener-up` sequence.
+
+#### Cold Booting
+
+Before iterative container lifecycle development using this technique may begin, system inception must be performed:
+* Any leftover environment from a previous inception must be destroyed. For this example, we choose `gardener-local`, but this name is properly determined by the next step.
+* The environment must be (re)created. Using `make kind-up` will create a cluster in KinD with the name `gardener-local`. The [project `Makefile`](../../Makefile) can also generate other cluster configurations with KinD, these will have 
+  other names that must be substituted as necessary.
+* Once the baseline cluster is running, we start the additional Gardener components via Google Cloud Code.
+
+These steps can be automated with the following "external tool" configurations in Jetbrains products. This configuration is clipped from `~/Library/Application Support/JetBrains/<release/>/tools/External Tools.xml`
+
+```xml
+<toolSet name="External Tools">
+  <tool name="Kind Kubeconfig" showInMainMenu="false" showInEditor="false" showInProject="false" showInSearchPopup="false" disabled="false" useConsole="false" showConsoleOnStdOut="false" showConsoleOnStdErr="false" synchronizeAfterRun="true">
+    <exec>
+      <option name="COMMAND" value="/opt/homebrew/bin/kind" />
+      <option name="PARAMETERS" value="export kubeconfig --name gardener-local" />
+      <option name="WORKING_DIRECTORY" value="$GOPATH$/src/github.com/gardener/gardener" />
+    </exec>
+  </tool>
+  <tool name="Delete cluster" showInMainMenu="false" showInEditor="false" showInProject="false" showInSearchPopup="false" disabled="false" useConsole="false" showConsoleOnStdOut="false" showConsoleOnStdErr="false" synchronizeAfterRun="true">
+    <exec>
+      <option name="COMMAND" value="/opt/homebrew/bin/kind" />
+      <option name="PARAMETERS" value="delete cluster --name gardener-local" />
+      <option name="WORKING_DIRECTORY" value="$GOPATH$/src/github.com/gardener/gardener" />
+    </exec>
+  </tool>
+  <tool name="Create cluster" showInMainMenu="false" showInEditor="false" showInProject="false" showInSearchPopup="false" disabled="false" useConsole="true" showConsoleOnStdOut="false" showConsoleOnStdErr="false" synchronizeAfterRun="true">
+    <exec>
+      <option name="COMMAND" value="/opt/homebrew/bin/make" />
+      <option name="PARAMETERS" value="kind-up" />
+      <option name="WORKING_DIRECTORY" value="$GOPATH$/src/github.com/gardener/gardener" />
+    </exec>
+  </tool>
+</toolSet>
+```
+
+Referencing these tools, a run configuration must be created that references these three tools. This configuration is found in `$(PROJECT_ROOT)/runConfigurations`:
+
+```xml
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Skaffold g/g" type="google-container-tools-skaffold-run-config" factoryName="google-container-tools-skaffold-run-config-dev" activateToolWindowBeforeRun="false" show_console_on_std_err="false" show_console_on_std_out="false">
+    <option name="allowRunningInParallel" value="false" />
+    <option name="buildEnvironment" />
+    <option name="cleanupDeployments" value="true" />
+    <option name="deployToCurrentContext" value="true" />
+    <option name="deployToMinikube" value="false" />
+    <option name="envVariables">
+      <map>
+        <entry key="ENABLE_HEALTH_CHECKS" value="admission,controller,scheduler,gardenlet,operator" />
+        <entry key="SKAFFOLD_BUILD_CONCURRENCY" value="0" />
+        <entry key="SKAFFOLD_CACHE_ARTIFACTS" value="false" />
+        <entry key="SKAFFOLD_CLEANUP" value="false" />
+        <entry key="SKAFFOLD_DEFAULT_REPO" value="localhost:5001" />
+        <entry key="SKAFFOLD_LABEL" value="skaffold.dev/run-id=gardener-local" />
+        <entry key="SKAFFOLD_PUSH" value="true" />
+      </map>
+    </option>
+    <option name="imageRepositoryOverride" value="localhost:5001" />
+    <option name="kubernetesContext" />
+    <option name="mappings">
+      <list />
+    </option>
+    <option name="moduleDeploymentType" value="DEPLOY_EVERYTHING" />
+    <option name="projectPathOnTarget" />
+    <option name="resourceDeletionTimeoutMins" value="2" />
+    <option name="selectedOptions">
+      <list />
+    </option>
+    <option name="skaffoldConfigurationFilePath" value="$PROJECT_DIR$/src/github.com/gardener/gardener/skaffold.yaml" />
+    <option name="skaffoldModules">
+      <list>
+        <option value="etcd" />
+        <option value="controlplane" />
+        <option value="gardenlet" />
+      </list>
+    </option>
+    <option name="skaffoldNamespace" />
+    <option name="skaffoldProfile" />
+    <option name="skaffoldWatchMode" value="ON_DEMAND" />
+    <option name="statusCheck" value="true" />
+    <option name="verbosity" value="INFO" />
+    <method v="2">
+      <option name="ToolBeforeRunTask" enabled="true" actionId="Tool_External Tools_Delete cluster" />
+      <option name="ToolBeforeRunTask" enabled="true" actionId="Tool_External Tools_Create cluster" />
+      <option name="ToolBeforeRunTask" enabled="true" actionId="Tool_External Tools_Kind Kubeconfig" />
+    </method>
+  </configuration>
+</component>
+```
+
+Note the environment variables in `/component/configuration/option[@name='envVariables'>]`. These environment variables come from two places:
+1. The `ENABLE_HEALTH_CHECKS` entry is described [here](../getting_started_locally.md#readiness-and-leader-election-checks). This starter configuration will help ensure that the Gardener stack fully boots without health checks 
+   distracting from initial success.
+2. The rest of the environment entries are copied and pasted from the output of the `Makefile` target. The appear as such when Skaffold is launched:
+   ```text
+   $ make gardener-up
+   env | grep SKAFFOLD_ | tr '\n' ';'
+   SKAFFOLD_BUILD_CONCURRENCY=0;SKAFFOLD_LABEL=skaffold.dev/run-id=gardener-local;SKAFFOLD_PUSH=true;SKAFFOLD_DEFAULT_REPO=localhost:5001;hack/tools/bin/skaffold run
+   ```
+ The last line of output are the variables configuring Skaffold and can be copied verbatim into the Cloud Code configuration in the environment variables section.
+
+#### Iterative Development
+
+At this point, your IDE will contain a "Run Configuration" that will accomplish the steps outlined above. The only thing left to do is run it! 
+
+In the "Run" menu, select either "Run..." or "Debug...". In the selection window, select the name you gave to your Run Configuration in the previous section. 
+
+Sequentially, this will execute the pre-build steps, which sequentially:
+1. Deletes any existing KinD cluster
+1. Creates a new one
+1. Finally, extract the Kubeconfig for the _new_ cluster and set it to default
+1. Execute either `skaffold run` or `skaffold debug` as requested, using the `SKAFFOLD_*` environment variables
+
+You will want to tune some parameters as you gain some experience with the environment:
+* "Watch Mode" defines either that container builds should happen on a manual rebuild basis or automatically. The default is manually.
+* `ENABLE_HEALTH_CHECKS` is set to a conservative default. As defined [here](../getting_started_locally.md#readiness-and-leader-election-checks), containers that are paused in the debugger **_WILL BE RESTARTED_** if they are stopped in 
+  the debugger too long. As documented, some developers will prefer this, most will want to see the system running and [experiment by breaking things](https://www.knowledgehut.com/blog/devops/chaos-engineering) to turn them off. 

--- a/skaffold-operator.yaml
+++ b/skaffold-operator.yaml
@@ -761,4 +761,4 @@ profiles:
     value:
       replicaCount: 1
       config.leaderElection.leaderElect: false
-      config.server.healthProbes.enable: "{{ default \"\" .SKAFFOLD_DISABLE_HEALTH_CHECKS | lower | splitList \",\" | has \"operator\" | ternary \"false\" \"true\" }}"
+      config.server.healthProbes.enable: '{{ default "" .ENABLE_HEALTH_CHECKS | lower | splitList "," | has "operator" }}'

--- a/skaffold-operator.yaml
+++ b/skaffold-operator.yaml
@@ -178,7 +178,7 @@ build:
         - vendor
         - VERSION
       ldflags:
-      - '{{.LD_FLAGS}}'
+      - '{{default now .SOURCE_DATE_EPOCH | date "2006-01-02T15:04:05-0700" | cmd "hack/get-build-ld-flags.sh" "k8s.io/component-base" "VERSION" "Gardener"}}'
       main: ./cmd/gardener-operator
   - image: eu.gcr.io/gardener-project/gardener/resource-manager
     ko:
@@ -278,7 +278,7 @@ build:
         - vendor
         - VERSION
       ldflags:
-      - '{{.LD_FLAGS}}'
+      - '{{default now .SOURCE_DATE_EPOCH | date "2006-01-02T15:04:05-0700" | cmd "hack/get-build-ld-flags.sh" "k8s.io/component-base" "VERSION" "Gardener"}}'
       main: ./cmd/gardener-resource-manager
   - image: eu.gcr.io/gardener-project/gardener/apiserver
     ko:
@@ -757,8 +757,8 @@ profiles:
   - command: debug
   patches:
   - op: add
-    path: /deploy/helm/releases/0/setValues
+    path: /deploy/helm/releases/0/setValueTemplates
     value:
       replicaCount: 1
       config.leaderElection.leaderElect: false
-      config.server.healthProbes.enable: false
+      config.server.healthProbes.enable: "{{ default \"\" .SKAFFOLD_DISABLE_HEALTH_CHECKS | lower | splitList \",\" | has \"operator\" | ternary \"false\" \"true\" }}"

--- a/skaffold-operator.yaml
+++ b/skaffold-operator.yaml
@@ -178,7 +178,7 @@ build:
         - vendor
         - VERSION
       ldflags:
-      - '{{default now .SOURCE_DATE_EPOCH | date "2006-01-02T15:04:05-0700" | cmd "hack/get-build-ld-flags.sh" "k8s.io/component-base" "VERSION" "Gardener"}}'
+      - '{{default now .SOURCE_DATE_EPOCH | date "2006-01-02T15:04:05-07:00" | cmd "hack/get-build-ld-flags.sh" "k8s.io/component-base" "VERSION" "Gardener"}}'
       main: ./cmd/gardener-operator
   - image: eu.gcr.io/gardener-project/gardener/resource-manager
     ko:
@@ -278,7 +278,7 @@ build:
         - vendor
         - VERSION
       ldflags:
-      - '{{default now .SOURCE_DATE_EPOCH | date "2006-01-02T15:04:05-0700" | cmd "hack/get-build-ld-flags.sh" "k8s.io/component-base" "VERSION" "Gardener"}}'
+      - '{{default now .SOURCE_DATE_EPOCH | date "2006-01-02T15:04:05-07:00" | cmd "hack/get-build-ld-flags.sh" "k8s.io/component-base" "VERSION" "Gardener"}}'
       main: ./cmd/gardener-resource-manager
   - image: eu.gcr.io/gardener-project/gardener/apiserver
     ko:
@@ -464,7 +464,7 @@ build:
         - vendor
         - VERSION
       ldflags:
-      - '{{.LD_FLAGS}}'
+        - '{{default now .SOURCE_DATE_EPOCH | date "2006-01-02T15:04:05-07:00" | cmd "hack/get-build-ld-flags.sh" "k8s.io/component-base" "VERSION" "Gardener"}}'
       main: ./cmd/gardener-apiserver
   - image: eu.gcr.io/gardener-project/gardener/controller-manager
     ko:
@@ -571,7 +571,7 @@ build:
         - vendor
         - VERSION
       ldflags:
-      - '{{.LD_FLAGS}}'
+        - '{{default now .SOURCE_DATE_EPOCH | date "2006-01-02T15:04:05-07:00" | cmd "hack/get-build-ld-flags.sh" "k8s.io/component-base" "VERSION" "Gardener"}}'
       main: ./cmd/gardener-controller-manager
   - image: eu.gcr.io/gardener-project/gardener/scheduler
     ko:
@@ -635,7 +635,7 @@ build:
         - vendor
         - VERSION
       ldflags:
-      - '{{.LD_FLAGS}}'
+        - '{{default now .SOURCE_DATE_EPOCH | date "2006-01-02T15:04:05-07:00" | cmd "hack/get-build-ld-flags.sh" "k8s.io/component-base" "VERSION" "Gardener"}}'
       main: ./cmd/gardener-scheduler
   - image: eu.gcr.io/gardener-project/gardener/admission-controller
     ko:
@@ -713,7 +713,7 @@ build:
         - vendor
         - VERSION
       ldflags:
-      - '{{.LD_FLAGS}}'
+        - '{{default now .SOURCE_DATE_EPOCH | date "2006-01-02T15:04:05-07:00" | cmd "hack/get-build-ld-flags.sh" "k8s.io/component-base" "VERSION" "Gardener"}}'
       main: ./cmd/gardener-admission-controller
 deploy:
   helm:

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -204,7 +204,7 @@ build:
         - vendor
         - VERSION
       ldflags:
-        - '{{default now .SOURCE_DATE_EPOCH | date "2006-01-02T15:04:05-0700" | cmd "hack/get-build-ld-flags.sh" "k8s.io/component-base" "VERSION" "Gardener"}}'
+        - '{{default now .SOURCE_DATE_EPOCH | date "2006-01-02T15:04:05-07:00" | cmd "hack/get-build-ld-flags.sh" "k8s.io/component-base" "VERSION" "Gardener"}}'
       main: ./cmd/gardener-apiserver
   - image: eu.gcr.io/gardener-project/gardener/controller-manager
     ko:
@@ -311,7 +311,7 @@ build:
         - vendor
         - VERSION
       ldflags:
-        - '{{default now .SOURCE_DATE_EPOCH | date "2006-01-02T15:04:05-0700" | cmd "hack/get-build-ld-flags.sh" "k8s.io/component-base" "VERSION" "Gardener"}}'
+        - '{{default now .SOURCE_DATE_EPOCH | date "2006-01-02T15:04:05-07:00" | cmd "hack/get-build-ld-flags.sh" "k8s.io/component-base" "VERSION" "Gardener"}}'
       main: ./cmd/gardener-controller-manager
   - image: eu.gcr.io/gardener-project/gardener/scheduler
     ko:
@@ -375,7 +375,7 @@ build:
         - vendor
         - VERSION
       ldflags:
-        - '{{default now .SOURCE_DATE_EPOCH | date "2006-01-02T15:04:05-0700" | cmd "hack/get-build-ld-flags.sh" "k8s.io/component-base" "VERSION" "Gardener"}}'
+        - '{{default now .SOURCE_DATE_EPOCH | date "2006-01-02T15:04:05-07:00" | cmd "hack/get-build-ld-flags.sh" "k8s.io/component-base" "VERSION" "Gardener"}}'
       main: ./cmd/gardener-scheduler
   - image: eu.gcr.io/gardener-project/gardener/admission-controller
     ko:
@@ -453,7 +453,7 @@ build:
         - vendor
         - VERSION
       ldflags:
-        - '{{default now .SOURCE_DATE_EPOCH | date "2006-01-02T15:04:05-0700" | cmd "hack/get-build-ld-flags.sh" "k8s.io/component-base" "VERSION" "Gardener"}}'
+        - '{{default now .SOURCE_DATE_EPOCH | date "2006-01-02T15:04:05-07:00" | cmd "hack/get-build-ld-flags.sh" "k8s.io/component-base" "VERSION" "Gardener"}}'
       main: ./cmd/gardener-admission-controller
 deploy:
   helm:
@@ -682,7 +682,7 @@ build:
         - vendor
         - VERSION
       ldflags:
-        - '{{default now .SOURCE_DATE_EPOCH | date "2006-01-02T15:04:05-0700" | cmd "hack/get-build-ld-flags.sh" "k8s.io/component-base" "VERSION" "Gardener"}}'
+        - '{{default now .SOURCE_DATE_EPOCH | date "2006-01-02T15:04:05-07:00" | cmd "hack/get-build-ld-flags.sh" "k8s.io/component-base" "VERSION" "Gardener"}}'
       main: ./cmd/gardener-extension-provider-local
 resourceSelector:
   allow:
@@ -991,7 +991,7 @@ build:
         - vendor
         - VERSION
       ldflags:
-        - '{{default now .SOURCE_DATE_EPOCH | date "2006-01-02T15:04:05-0700" | cmd "hack/get-build-ld-flags.sh" "k8s.io/component-base" "VERSION" "Gardener"}}'
+        - '{{default now .SOURCE_DATE_EPOCH | date "2006-01-02T15:04:05-07:00" | cmd "hack/get-build-ld-flags.sh" "k8s.io/component-base" "VERSION" "Gardener"}}'
       main: ./cmd/gardenlet
   - image: eu.gcr.io/gardener-project/gardener/resource-manager
     ko:
@@ -1091,7 +1091,7 @@ build:
         - vendor
         - VERSION
       ldflags:
-        - '{{default now .SOURCE_DATE_EPOCH | date "2006-01-02T15:04:05-0700" | cmd "hack/get-build-ld-flags.sh" "k8s.io/component-base" "VERSION" "Gardener"}}'
+        - '{{default now .SOURCE_DATE_EPOCH | date "2006-01-02T15:04:05-07:00" | cmd "hack/get-build-ld-flags.sh" "k8s.io/component-base" "VERSION" "Gardener"}}'
       main: ./cmd/gardener-resource-manager
 deploy:
   helm:

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -204,7 +204,7 @@ build:
         - vendor
         - VERSION
       ldflags:
-      - '{{.LD_FLAGS}}'
+        - '{{default now .SOURCE_DATE_EPOCH | date "2006-01-02T15:04:05-0700" | cmd "hack/get-build-ld-flags.sh" "k8s.io/component-base" "VERSION" "Gardener"}}'
       main: ./cmd/gardener-apiserver
   - image: eu.gcr.io/gardener-project/gardener/controller-manager
     ko:
@@ -311,7 +311,7 @@ build:
         - vendor
         - VERSION
       ldflags:
-      - '{{.LD_FLAGS}}'
+        - '{{default now .SOURCE_DATE_EPOCH | date "2006-01-02T15:04:05-0700" | cmd "hack/get-build-ld-flags.sh" "k8s.io/component-base" "VERSION" "Gardener"}}'
       main: ./cmd/gardener-controller-manager
   - image: eu.gcr.io/gardener-project/gardener/scheduler
     ko:
@@ -375,7 +375,7 @@ build:
         - vendor
         - VERSION
       ldflags:
-      - '{{.LD_FLAGS}}'
+        - '{{default now .SOURCE_DATE_EPOCH | date "2006-01-02T15:04:05-0700" | cmd "hack/get-build-ld-flags.sh" "k8s.io/component-base" "VERSION" "Gardener"}}'
       main: ./cmd/gardener-scheduler
   - image: eu.gcr.io/gardener-project/gardener/admission-controller
     ko:
@@ -453,7 +453,7 @@ build:
         - vendor
         - VERSION
       ldflags:
-      - '{{.LD_FLAGS}}'
+        - '{{default now .SOURCE_DATE_EPOCH | date "2006-01-02T15:04:05-0700" | cmd "hack/get-build-ld-flags.sh" "k8s.io/component-base" "VERSION" "Gardener"}}'
       main: ./cmd/gardener-admission-controller
 deploy:
   helm:
@@ -519,19 +519,19 @@ profiles:
   - command: debug
   patches:
   - op: add
-    path: /deploy/helm/releases/0/setValues
+    path: /deploy/helm/releases/0/setValueTemplates
     value:
       global.apiserver.replicaCount: 1
       global.apiserver.livenessProbe.enable: false
       global.apiserver.readinessProbe.enable: false
       global.admission.replicaCount: 1
-      global.admission.config.server.healthProbes.enable: false
+      global.admission.config.server.healthProbes.enable: "{{ default \"\" .SKAFFOLD_DISABLE_HEALTH_CHECKS | lower | splitList \",\" | has \"admission\" | ternary \"false\" \"true\" }}"
       global.controller.replicaCount: 1
       global.controller.config.leaderElection.leaderElect: false
-      global.controller.config.server.healthProbes.enable: false
+      global.controller.config.server.healthProbes.enable: "{{ default \"\" .SKAFFOLD_DISABLE_HEALTH_CHECKS | lower | splitList \",\" | has \"controller\" | ternary \"false\" \"true\" }}"
       global.scheduler.replicaCount: 1
       global.scheduler.config.leaderElection.leaderElect: false
-      global.scheduler.config.server.healthProbes.enable: false
+      global.scheduler.config.server.healthProbes.enable: "{{ default \"\" .SKAFFOLD_DISABLE_HEALTH_CHECKS | lower | splitList \",\" | has \"scheduler\" | ternary \"false\" \"true\" }}"
 ---
 apiVersion: skaffold/v4beta7
 kind: Config
@@ -682,7 +682,7 @@ build:
         - vendor
         - VERSION
       ldflags:
-      - '{{.LD_FLAGS}}'
+        - '{{default now .SOURCE_DATE_EPOCH | date "2006-01-02T15:04:05-0700" | cmd "hack/get-build-ld-flags.sh" "k8s.io/component-base" "VERSION" "Gardener"}}'
       main: ./cmd/gardener-extension-provider-local
 resourceSelector:
   allow:
@@ -991,7 +991,7 @@ build:
         - vendor
         - VERSION
       ldflags:
-      - '{{.LD_FLAGS}}'
+        - '{{default now .SOURCE_DATE_EPOCH | date "2006-01-02T15:04:05-0700" | cmd "hack/get-build-ld-flags.sh" "k8s.io/component-base" "VERSION" "Gardener"}}'
       main: ./cmd/gardenlet
   - image: eu.gcr.io/gardener-project/gardener/resource-manager
     ko:
@@ -1091,7 +1091,7 @@ build:
         - vendor
         - VERSION
       ldflags:
-      - '{{.LD_FLAGS}}'
+        - '{{default now .SOURCE_DATE_EPOCH | date "2006-01-02T15:04:05-0700" | cmd "hack/get-build-ld-flags.sh" "k8s.io/component-base" "VERSION" "Gardener"}}'
       main: ./cmd/gardener-resource-manager
 deploy:
   helm:
@@ -1195,8 +1195,8 @@ profiles:
   - command: debug
   patches:
   - op: add
-    path: /deploy/helm/releases/0/setValues
+    path: /deploy/helm/releases/0/setValueTemplates
     value:
       replicaCount: 1
       config.leaderElection.leaderElect: false
-      config.server.healthProbes.enable: false
+      config.server.healthProbes.enable: "{{ default \"\" .SKAFFOLD_DISABLE_HEALTH_CHECKS | lower | splitList \",\" | has \"gardenlet\" | ternary \"false\" \"true\" }}"

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -525,13 +525,13 @@ profiles:
       global.apiserver.livenessProbe.enable: false
       global.apiserver.readinessProbe.enable: false
       global.admission.replicaCount: 1
-      global.admission.config.server.healthProbes.enable: "{{ default \"\" .SKAFFOLD_DISABLE_HEALTH_CHECKS | lower | splitList \",\" | has \"admission\" | ternary \"false\" \"true\" }}"
+      global.admission.config.server.healthProbes.enable: '{{ default "" .ENABLE_HEALTH_CHECKS | lower | splitList "," | has "admission" }}'
       global.controller.replicaCount: 1
       global.controller.config.leaderElection.leaderElect: false
-      global.controller.config.server.healthProbes.enable: "{{ default \"\" .SKAFFOLD_DISABLE_HEALTH_CHECKS | lower | splitList \",\" | has \"controller\" | ternary \"false\" \"true\" }}"
+      global.controller.config.server.healthProbes.enable: '{{ default "" .ENABLE_HEALTH_CHECKS | lower | splitList "," | has "controller" }}'
       global.scheduler.replicaCount: 1
       global.scheduler.config.leaderElection.leaderElect: false
-      global.scheduler.config.server.healthProbes.enable: "{{ default \"\" .SKAFFOLD_DISABLE_HEALTH_CHECKS | lower | splitList \",\" | has \"scheduler\" | ternary \"false\" \"true\" }}"
+      global.scheduler.config.server.healthProbes.enable: '{{ default "" .ENABLE_HEALTH_CHECKS | lower | splitList "," | has "scheduler" }}'
 ---
 apiVersion: skaffold/v4beta7
 kind: Config
@@ -1199,4 +1199,4 @@ profiles:
     value:
       replicaCount: 1
       config.leaderElection.leaderElect: false
-      config.server.healthProbes.enable: "{{ default \"\" .SKAFFOLD_DISABLE_HEALTH_CHECKS | lower | splitList \",\" | has \"gardenlet\" | ternary \"false\" \"true\" }}"
+      config.server.healthProbes.enable: '{{ default "" .ENABLE_HEALTH_CHECKS | lower | splitList "," | has "gardenlet" }}'


### PR DESCRIPTION
**How to categorize this PR?**
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
Out of box, the Gardener build cannot use `make gardener-debug` or be plugged into an IDE that supports the [Google Cloud Code](https://cloud.google.com/code) plugin. The benefit of this plugin is the automation of connections between the debugger and the Delve debugger nubs that are attached as sidecars to the deployed Gardener artifacts. This PR fixes both.

This patch enables this in a few ways:
* The deployment for admission-controller is updated so the health check ports are exposed. This is necessary for Skaffold to remap the port exposures when it deploys the app with Delve.
* Allow enablement of health checks via `ENABLE_HEALTH_CHECKS` environment variable. When boot complexity causes some components to be loaded before all of its dependencies, the components tend to accept their state and report unhealthy rather than restart themselves. Without the health probe watchdog from k8s, the controllers will remain stuck in that state, even as the necessary resources are eventually added. The singular health check disable is easier to manage and document.
* Remove the `BUILD_DATE` injection from the Makefile to Skaffold via environment variables. This is replaced by Go templates in the Skaffold config, enabled by https://github.com/GoogleContainerTools/skaffold/pull/9005 and released in Skaffold v2.7.0. In doing so, there are only static environment variables that must be encoded in the Google Cloud Code plugin. These do not need to be changed with build iterations.
* Provide documentation. The documentation includes information about how to set up Google Cloud Code and the Makefile now emits the necessary static environment variables to do so. In case the variables change, this reduces the burden on future documentation updates. 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy developer
Enhance Skaffold experience to make `make gardener-debug` work out-of-box and also be usable from within Google Cloud Code IDE plugins.
```
