### PR TITLE
[operator] Manage `gardener-metrics-exporter`

### DIFF
--- a/docs/concepts/operator.md
+++ b/docs/concepts/operator.md
@@ -278,9 +278,10 @@ The reconciler also manages a few observability-related components (more planned
 
 - `fluent-operator`
 - `fluent-bit`
-- `vali`
-- `plutono`
+- `gardener-metrics-exporter`
 - `kube-state-metrics`
+- `plutono`
+- `vali`
 
 It is also mandatory to provide an IPv4 CIDR for the service network of the virtual cluster via `.spec.virtualCluster.networking.services`.
 This range is used by the API server to compute the cluster IPs of `Service`s.

--- a/docs/development/priority-classes.md
+++ b/docs/development/priority-classes.md
@@ -26,7 +26,7 @@ When using the `gardener-operator` for managing the garden runtime and virtual c
 | `gardener-garden-system-400`      | 999999400 | `virtual-garden-gardener-resource-manager`, `gardener-admission-controller`                                     |
 | `gardener-garden-system-300`      | 999999300 | `virtual-garden-kube-controller-manager`, `vpa-admission-controller`, `etcd-druid`, `nginx-ingress-controller`  |
 | `gardener-garden-system-200`      | 999999200 | `vpa-recommender`, `vpa-updater`, `hvpa-controller`, `gardener-scheduler`, `gardener-controller-manager`        |
-| `gardener-garden-system-100`      | 999999100 | `fluent-operator`, `fluent-bit`, `kube-state-metrics`, `plutono`, `vali`                                        |
+| `gardener-garden-system-100`      | 999999100 | `fluent-operator`, `fluent-bit`, `gardener-metrics-exporter`, `kube-state-metrics`, `plutono`, `vali`           |
 
 ## Seed Clusters
 

--- a/imagevector/images.go
+++ b/imagevector/images.go
@@ -57,6 +57,8 @@ const (
 	ImageNameGardenerApiserver = "gardener-apiserver"
 	// ImageNameGardenerControllerManager is a constant for an image in the image vector with name 'gardener-controller-manager'.
 	ImageNameGardenerControllerManager = "gardener-controller-manager"
+	// ImageNameGardenerMetricsExporter is a constant for an image in the image vector with name 'gardener-metrics-exporter'.
+	ImageNameGardenerMetricsExporter = "gardener-metrics-exporter"
 	// ImageNameGardenerResourceManager is a constant for an image in the image vector with name 'gardener-resource-manager'.
 	ImageNameGardenerResourceManager = "gardener-resource-manager"
 	// ImageNameGardenerScheduler is a constant for an image in the image vector with name 'gardener-scheduler'.

--- a/imagevector/images.yaml
+++ b/imagevector/images.yaml
@@ -33,6 +33,12 @@ images:
   repository: eu.gcr.io/gardener-project/gardener/resource-manager
   resourceId:
     name: resource-manager
+- name: gardener-metrics-exporter
+  resourceId:
+    name: metrics-exporter
+  sourceRepository: github.com/gardener/gardener-metrics-exporter
+  repository: eu.gcr.io/gardener-project/gardener/metrics-exporter
+  tag: "0.27.0"
 
 # Seed bootstrap
 - name: pause-container

--- a/imagevector/images.yaml
+++ b/imagevector/images.yaml
@@ -33,12 +33,6 @@ images:
   repository: eu.gcr.io/gardener-project/gardener/resource-manager
   resourceId:
     name: resource-manager
-- name: gardener-metrics-exporter
-  resourceId:
-    name: metrics-exporter
-  sourceRepository: github.com/gardener/gardener-metrics-exporter
-  repository: eu.gcr.io/gardener-project/gardener/metrics-exporter
-  tag: "0.27.0"
 
 # Seed bootstrap
 - name: pause-container
@@ -251,6 +245,12 @@ images:
     value:
     - type: 'githubTeam'
       teamname: 'gardener/monitoring-maintainers'
+- name: gardener-metrics-exporter
+  resourceId:
+    name: metrics-exporter
+  sourceRepository: github.com/gardener/gardener-metrics-exporter
+  repository: eu.gcr.io/gardener-project/gardener/metrics-exporter
+  tag: "0.27.0"
 - name: node-exporter
   sourceRepository: github.com/prometheus/node_exporter
   repository: quay.io/prometheus/node-exporter

--- a/imagevector/images.yaml
+++ b/imagevector/images.yaml
@@ -246,8 +246,6 @@ images:
     - type: 'githubTeam'
       teamname: 'gardener/monitoring-maintainers'
 - name: gardener-metrics-exporter
-  resourceId:
-    name: metrics-exporter
   sourceRepository: github.com/gardener/gardener-metrics-exporter
   repository: eu.gcr.io/gardener-project/gardener/metrics-exporter
   tag: "0.27.0"

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -158,6 +158,9 @@ const (
 	// DeploymentNameKubeStateMetrics is a constant for the name of a Kubernetes deployment object that contains
 	// the kube-state-metrics pod.
 	DeploymentNameKubeStateMetrics = "kube-state-metrics"
+	// DeploymentNameGardenerMetricsExporter is a constant for the name of a Kubernetes deployment object that contains
+	// the gardener-metrics-exporter pod.
+	DeploymentNameGardenerMetricsExporter = "gardener-metrics-exporter"
 
 	// DeploymentNameVPAAdmissionController is a constant for the name of the VPA admission controller deployment.
 	DeploymentNameVPAAdmissionController = "vpa-admission-controller"

--- a/pkg/component/gardenermetricsexporter/deployment.go
+++ b/pkg/component/gardenermetricsexporter/deployment.go
@@ -1,0 +1,115 @@
+// Copyright 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gardenermetricsexporter
+
+import (
+	"fmt"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/utils/pointer"
+
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	kubeapiserverconstants "github.com/gardener/gardener/pkg/component/kubeapiserver/constants"
+	"github.com/gardener/gardener/pkg/resourcemanager/controller/garbagecollector/references"
+	"github.com/gardener/gardener/pkg/utils"
+	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
+)
+
+func (g *gardenerMetricsExporter) deployment(secretGenericTokenKubeconfig, secretVirtualGardenAccess string) *appsv1.Deployment {
+	deployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      deploymentName,
+			Namespace: g.namespace,
+			Labels:    GetLabels(),
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: pointer.Int32(1),
+			Selector: &metav1.LabelSelector{
+				MatchLabels: GetLabels(),
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: utils.MergeStringMaps(GetLabels(), map[string]string{
+						v1beta1constants.LabelNetworkPolicyToDNS: v1beta1constants.LabelNetworkPolicyAllowed,
+						gardenerutils.NetworkPolicyLabel("virtual-garden-"+v1beta1constants.DeploymentNameKubeAPIServer, kubeapiserverconstants.Port): v1beta1constants.LabelNetworkPolicyAllowed,
+					}),
+				},
+				Spec: corev1.PodSpec{
+					PriorityClassName:            v1beta1constants.PriorityClassNameGardenSystem100,
+					AutomountServiceAccountToken: pointer.Bool(false),
+					Containers: []corev1.Container{
+						{
+							Name:            deploymentName,
+							Image:           g.values.Image,
+							ImagePullPolicy: corev1.PullIfNotPresent,
+							Command: []string{
+								"/gardener-metrics-exporter",
+								"--kubeconfig=" + gardenerutils.PathGenericKubeconfig,
+								"--bind-address=0.0.0.0",
+								"--port=" + fmt.Sprint(probePort),
+							},
+							SecurityContext: &corev1.SecurityContext{
+								ReadOnlyRootFilesystem: pointer.Bool(true),
+							},
+							Resources: corev1.ResourceRequirements{
+								Requests: map[corev1.ResourceName]resource.Quantity{
+									corev1.ResourceCPU:    resource.MustParse("100m"),
+									corev1.ResourceMemory: resource.MustParse("128Mi"),
+								},
+							},
+							Ports: []corev1.ContainerPort{
+								{
+									Name:          "port",
+									ContainerPort: probePort,
+									Protocol:      corev1.ProtocolTCP,
+								},
+							},
+							LivenessProbe: &corev1.Probe{
+								ProbeHandler: corev1.ProbeHandler{
+									HTTPGet: &corev1.HTTPGetAction{
+										Path:   "/",
+										Port:   intstr.FromInt(probePort),
+										Scheme: corev1.URISchemeHTTP,
+									},
+								},
+								PeriodSeconds: 5,
+							},
+							ReadinessProbe: &corev1.Probe{
+								ProbeHandler: corev1.ProbeHandler{
+									HTTPGet: &corev1.HTTPGetAction{
+										Path:   "/metrics",
+										Port:   intstr.FromInt(probePort),
+										Scheme: corev1.URISchemeHTTP,
+									},
+								},
+								PeriodSeconds: 5,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	utilruntime.Must(gardenerutils.InjectGenericKubeconfig(deployment, secretGenericTokenKubeconfig, secretVirtualGardenAccess))
+	utilruntime.Must(references.InjectAnnotations(deployment))
+
+	return deployment
+}

--- a/pkg/component/gardenermetricsexporter/deployment.go
+++ b/pkg/component/gardenermetricsexporter/deployment.go
@@ -40,7 +40,8 @@ func (g *gardenerMetricsExporter) deployment(secretGenericTokenKubeconfig, secre
 			Labels:    GetLabels(),
 		},
 		Spec: appsv1.DeploymentSpec{
-			Replicas: pointer.Int32(1),
+			Replicas:             pointer.Int32(1),
+			RevisionHistoryLimit: pointer.Int32(2),
 			Selector: &metav1.LabelSelector{
 				MatchLabels: GetLabels(),
 			},

--- a/pkg/component/gardenermetricsexporter/gardener_metrics_exporter.go
+++ b/pkg/component/gardenermetricsexporter/gardener_metrics_exporter.go
@@ -17,8 +17,9 @@ package gardenermetricsexporter
 import (
 	"context"
 
-	"github.com/gardener/gardener/pkg/component"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/gardener/gardener/pkg/component"
 )
 
 // Interface contains functions for a gardener-metrics-exporter deployer.

--- a/pkg/component/gardenermetricsexporter/gardener_metrics_exporter.go
+++ b/pkg/component/gardenermetricsexporter/gardener_metrics_exporter.go
@@ -16,16 +16,36 @@ package gardenermetricsexporter
 
 import (
 	"context"
+	"fmt"
+	"time"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/component"
+	operatorclient "github.com/gardener/gardener/pkg/operator/client"
+	"github.com/gardener/gardener/pkg/utils/flow"
+	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
+	"github.com/gardener/gardener/pkg/utils/managedresources"
+	secretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager"
 )
 
-// Interface contains functions for a gardener-metrics-exporter deployer.
-type Interface interface {
-	component.DeployWaiter
-}
+const (
+	deploymentName = "gardener-metrics-exporter"
+	serviceName    = deploymentName
+
+	probePort = 2718
+	// ManagedResourceNameRuntime is the name of the ManagedResource for the runtime resources.
+	ManagedResourceNameRuntime = "gardener-metrics-exporter-runtime"
+	// ManagedResourceNameVirtual is the name of the ManagedResource for the virtual resources.
+	ManagedResourceNameVirtual = "gardener-metrics-exporter-virtual"
+
+	roleName = "metrics-exporter"
+)
+
+// TimeoutWaitForManagedResource is the timeout used while waiting for the ManagedResources to become healthy or
+// deleted.
+var TimeoutWaitForManagedResource = 5 * time.Minute
 
 // Values is a set of configuration values for the gardener-metrics-exporter component.
 type Values struct {
@@ -37,22 +57,108 @@ type Values struct {
 func New(
 	client client.Client,
 	namespace string,
+	secretsManager secretsmanager.Interface,
 	values Values,
-) Interface {
+) component.DeployWaiter {
 	return &gardenerMetricsExporter{
-		client:    client,
-		namespace: namespace,
-		values:    values,
+		client:         client,
+		namespace:      namespace,
+		secretsManager: secretsManager,
+		values:         values,
 	}
 }
 
 type gardenerMetricsExporter struct {
-	client    client.Client
-	namespace string
-	values    Values
+	client         client.Client
+	namespace      string
+	secretsManager secretsmanager.Interface
+	values         Values
 }
 
-func (g *gardenerMetricsExporter) Deploy(ctx context.Context) error      { return nil }
-func (g *gardenerMetricsExporter) Destroy(ctx context.Context) error     { return nil }
-func (g *gardenerMetricsExporter) Wait(ctx context.Context) error        { return nil }
-func (g *gardenerMetricsExporter) WaitCleanup(ctx context.Context) error { return nil }
+func (g *gardenerMetricsExporter) Deploy(ctx context.Context) error {
+	var (
+		runtimeRegistry           = managedresources.NewRegistry(operatorclient.RuntimeScheme, operatorclient.RuntimeCodec, operatorclient.RuntimeSerializer)
+		virtualGardenAccessSecret = g.newVirtualGardenAccessSecret()
+	)
+
+	if err := virtualGardenAccessSecret.Reconcile(ctx, g.client); err != nil {
+		return err
+	}
+
+	secretGenericTokenKubeconfig, found := g.secretsManager.Get(v1beta1constants.SecretNameGenericTokenKubeconfig)
+	if !found {
+		return fmt.Errorf("secret %q not found", v1beta1constants.SecretNameGenericTokenKubeconfig)
+	}
+
+	runtimeResources, err := runtimeRegistry.AddAllAndSerialize(
+		g.deployment(secretGenericTokenKubeconfig.Name, virtualGardenAccessSecret.Secret.Name),
+		g.service(),
+	)
+	if err != nil {
+		return err
+	}
+
+	if err := managedresources.CreateForSeed(ctx, g.client, g.namespace, ManagedResourceNameRuntime, false, runtimeResources); err != nil {
+		return err
+	}
+
+	var virtualRegistry = managedresources.NewRegistry(operatorclient.VirtualScheme, operatorclient.VirtualCodec, operatorclient.VirtualSerializer)
+
+	virtualResources, err := virtualRegistry.AddAllAndSerialize(
+		g.clusterRole(),
+		g.clusterRoleBinding(virtualGardenAccessSecret.ServiceAccountName),
+	)
+	if err != nil {
+		return err
+	}
+
+	return managedresources.CreateForShoot(ctx, g.client, g.namespace, ManagedResourceNameVirtual, managedresources.LabelValueGardener, false, virtualResources)
+}
+
+func (g *gardenerMetricsExporter) Destroy(ctx context.Context) error {
+	if err := managedresources.DeleteForShoot(ctx, g.client, g.namespace, ManagedResourceNameVirtual); err != nil {
+		return err
+	}
+
+	if err := managedresources.DeleteForSeed(ctx, g.client, g.namespace, ManagedResourceNameRuntime); err != nil {
+		return err
+	}
+
+	return kubernetesutils.DeleteObjects(ctx, g.client, g.newVirtualGardenAccessSecret().Secret)
+}
+
+func (g *gardenerMetricsExporter) Wait(ctx context.Context) error {
+	timeoutCtx, cancel := context.WithTimeout(ctx, TimeoutWaitForManagedResource)
+	defer cancel()
+
+	return flow.Parallel(
+		func(ctx context.Context) error {
+			return managedresources.WaitUntilHealthy(ctx, g.client, g.namespace, ManagedResourceNameRuntime)
+		},
+		func(ctx context.Context) error {
+			return managedresources.WaitUntilHealthy(ctx, g.client, g.namespace, ManagedResourceNameVirtual)
+		},
+	)(timeoutCtx)
+}
+
+func (g *gardenerMetricsExporter) WaitCleanup(ctx context.Context) error {
+	timeoutCtx, cancel := context.WithTimeout(ctx, TimeoutWaitForManagedResource)
+	defer cancel()
+
+	return flow.Parallel(
+		func(ctx context.Context) error {
+			return managedresources.WaitUntilDeleted(ctx, g.client, g.namespace, ManagedResourceNameRuntime)
+		},
+		func(ctx context.Context) error {
+			return managedresources.WaitUntilDeleted(ctx, g.client, g.namespace, ManagedResourceNameVirtual)
+		},
+	)(timeoutCtx)
+}
+
+// GetLabels returns the labels for the gardener-metrics-exporter.
+func GetLabels() map[string]string {
+	return map[string]string{
+		v1beta1constants.LabelApp:  v1beta1constants.LabelGardener,
+		v1beta1constants.LabelRole: roleName,
+	}
+}

--- a/pkg/component/gardenermetricsexporter/gardener_metrics_exporter.go
+++ b/pkg/component/gardenermetricsexporter/gardener_metrics_exporter.go
@@ -1,0 +1,57 @@
+// Copyright 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gardenermetricsexporter
+
+import (
+	"context"
+
+	"github.com/gardener/gardener/pkg/component"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Interface contains functions for a gardener-metrics-exporter deployer.
+type Interface interface {
+	component.DeployWaiter
+}
+
+// Values is a set of configuration values for the gardener-metrics-exporter component.
+type Values struct {
+	// Image is the container image used for gardener-metrics-exporter.
+	Image string
+}
+
+// New creates a new instance of DeployWaiter for gardener-metrics-exporter.
+func New(
+	client client.Client,
+	namespace string,
+	values Values,
+) Interface {
+	return &gardenerMetricsExporter{
+		client:    client,
+		namespace: namespace,
+		values:    values,
+	}
+}
+
+type gardenerMetricsExporter struct {
+	client    client.Client
+	namespace string
+	values    Values
+}
+
+func (g *gardenerMetricsExporter) Deploy(ctx context.Context) error      { return nil }
+func (g *gardenerMetricsExporter) Destroy(ctx context.Context) error     { return nil }
+func (g *gardenerMetricsExporter) Wait(ctx context.Context) error        { return nil }
+func (g *gardenerMetricsExporter) WaitCleanup(ctx context.Context) error { return nil }

--- a/pkg/component/gardenermetricsexporter/gardener_metrics_exporter.go
+++ b/pkg/component/gardenermetricsexporter/gardener_metrics_exporter.go
@@ -102,7 +102,7 @@ func (g *gardenerMetricsExporter) Deploy(ctx context.Context) error {
 		return err
 	}
 
-	var virtualRegistry = managedresources.NewRegistry(operatorclient.VirtualScheme, operatorclient.VirtualCodec, operatorclient.VirtualSerializer)
+	virtualRegistry := managedresources.NewRegistry(operatorclient.VirtualScheme, operatorclient.VirtualCodec, operatorclient.VirtualSerializer)
 
 	virtualResources, err := virtualRegistry.AddAllAndSerialize(
 		g.clusterRole(),

--- a/pkg/component/gardenermetricsexporter/gardener_metrics_exporter_suite_test.go
+++ b/pkg/component/gardenermetricsexporter/gardener_metrics_exporter_suite_test.go
@@ -21,7 +21,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestGardenerScheduler(t *testing.T) {
+func TestGardenerMetricsExporter(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Component GardenerMetricsExporter Suite")
 }

--- a/pkg/component/gardenermetricsexporter/gardener_metrics_exporter_suite_test.go
+++ b/pkg/component/gardenermetricsexporter/gardener_metrics_exporter_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gardenermetricsexporter_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestGardenerScheduler(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Component GardenerMetricsExporter Suite")
+}

--- a/pkg/component/gardenermetricsexporter/gardener_metrics_exporter_test.go
+++ b/pkg/component/gardenermetricsexporter/gardener_metrics_exporter_test.go
@@ -13,3 +13,722 @@
 // limitations under the License.
 
 package gardenermetricsexporter_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
+	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
+	"github.com/gardener/gardener/pkg/component"
+	. "github.com/gardener/gardener/pkg/component/gardenermetricsexporter"
+	componenttest "github.com/gardener/gardener/pkg/component/test"
+	operatorclient "github.com/gardener/gardener/pkg/operator/client"
+	"github.com/gardener/gardener/pkg/resourcemanager/controller/garbagecollector/references"
+	gardenerutils "github.com/gardener/gardener/pkg/utils"
+	"github.com/gardener/gardener/pkg/utils/retry"
+	retryfake "github.com/gardener/gardener/pkg/utils/retry/fake"
+	secretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager"
+	fakesecretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager/fake"
+	"github.com/gardener/gardener/pkg/utils/test"
+	. "github.com/gardener/gardener/pkg/utils/test/matchers"
+)
+
+var _ = Describe("GardenerMetricsExporter", func() {
+	var (
+		ctx context.Context
+
+		managedResourceNameRuntime = "gardener-metrics-exporter-runtime"
+		managedResourceNameVirtual = "gardener-metrics-exporter-virtual"
+		namespace                  = "some-namespace"
+
+		fakeClient        client.Client
+		fakeSecretManager secretsmanager.Interface
+		deployer          component.DeployWaiter
+		values            Values
+
+		fakeOps *retryfake.Ops
+
+		managedResourceRuntime       *resourcesv1alpha1.ManagedResource
+		managedResourceVirtual       *resourcesv1alpha1.ManagedResource
+		managedResourceSecretRuntime *corev1.Secret
+		managedResourceSecretVirtual *corev1.Secret
+
+		serviceRuntime *corev1.Service
+
+		clusterRole        *rbacv1.ClusterRole
+		clusterRoleBinding *rbacv1.ClusterRoleBinding
+	)
+
+	BeforeEach(func() {
+		ctx = context.TODO()
+
+		fakeClient = fakeclient.NewClientBuilder().WithScheme(operatorclient.RuntimeScheme).Build()
+		fakeSecretManager = fakesecretsmanager.New(fakeClient, namespace)
+		values = Values{}
+
+		fakeOps = &retryfake.Ops{MaxAttempts: 2}
+		DeferCleanup(test.WithVars(
+			&retry.Until, fakeOps.Until,
+			&retry.UntilTimeout, fakeOps.UntilTimeout,
+		))
+
+		managedResourceRuntime = &resourcesv1alpha1.ManagedResource{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      managedResourceNameRuntime,
+				Namespace: namespace,
+			},
+		}
+		managedResourceVirtual = &resourcesv1alpha1.ManagedResource{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      managedResourceNameVirtual,
+				Namespace: namespace,
+			},
+		}
+		managedResourceSecretRuntime = &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "managedresource-" + managedResourceRuntime.Name,
+				Namespace: namespace,
+			},
+		}
+		managedResourceSecretVirtual = &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "managedresource-" + managedResourceVirtual.Name,
+				Namespace: namespace,
+			},
+		}
+		serviceRuntime = &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "gardener-metrics-exporter",
+				Namespace: namespace,
+				Labels: map[string]string{
+					"app":  "gardener",
+					"role": "metrics-exporter",
+				},
+			},
+			Spec: corev1.ServiceSpec{
+				Type:            corev1.ServiceTypeClusterIP,
+				SessionAffinity: corev1.ServiceAffinityNone,
+				Selector: map[string]string{
+					"app":  "gardener",
+					"role": "metrics-exporter",
+				},
+				Ports: []corev1.ServicePort{{
+					Port:       2718,
+					Protocol:   corev1.ProtocolTCP,
+					TargetPort: intstr.FromInt(2718),
+				}},
+			},
+		}
+		clusterRole = &rbacv1.ClusterRole{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "gardener.cloud:metrics-exporter",
+				Labels: map[string]string{
+					"app":  "gardener",
+					"role": "metrics-exporter",
+				},
+			},
+			Rules: []rbacv1.PolicyRule{
+				{
+					APIGroups: []string{gardencorev1beta1.GroupName},
+					Resources: []string{
+						"secretbindings",
+						"seeds",
+						"shoots",
+						"projects",
+					},
+					Verbs: []string{"get", "list", "watch"},
+				},
+				{
+					APIGroups: []string{seedmanagementv1alpha1.GroupName},
+					Resources: []string{
+						"managedseeds",
+					},
+					Verbs: []string{"get", "list", "watch"},
+				},
+			},
+		}
+		clusterRoleBinding = &rbacv1.ClusterRoleBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "gardener.cloud:metrics-exporter",
+				Labels: map[string]string{
+					"app":  "gardener",
+					"role": "metrics-exporter",
+				},
+			},
+			RoleRef: rbacv1.RoleRef{
+				APIGroup: rbacv1.GroupName,
+				Kind:     "ClusterRole",
+				Name:     "gardener.cloud:metrics-exporter",
+			},
+			Subjects: []rbacv1.Subject{{
+				Kind:      "ServiceAccount",
+				Name:      "gardener-metrics-exporter",
+				Namespace: "kube-system",
+			}},
+		}
+
+		Expect(fakeClient.Create(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "generic-token-kubeconfig", Namespace: namespace}})).To(Succeed())
+	})
+
+	JustBeforeEach(func() {
+		deployer = New(fakeClient, namespace, fakeSecretManager, values)
+	})
+
+	Describe("#Deploy", func() {
+		Context("resources generation", func() {
+			BeforeEach(func() {
+				Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(managedResourceRuntime), managedResourceRuntime)).To(BeNotFoundError())
+				Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(managedResourceVirtual), managedResourceVirtual)).To(BeNotFoundError())
+				Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(managedResourceSecretRuntime), managedResourceSecretRuntime)).To(BeNotFoundError())
+				Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(managedResourceSecretVirtual), managedResourceSecretVirtual)).To(BeNotFoundError())
+
+				Expect(fakeClient.Create(ctx, &resourcesv1alpha1.ManagedResource{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       managedResourceNameRuntime,
+						Namespace:  namespace,
+						Generation: 1,
+					},
+					Status: healthyManagedResourceStatus,
+				})).To(Succeed())
+
+				Expect(fakeClient.Create(ctx, &resourcesv1alpha1.ManagedResource{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       managedResourceNameVirtual,
+						Namespace:  namespace,
+						Generation: 1,
+					},
+					Status: healthyManagedResourceStatus,
+				})).To(Succeed())
+			})
+
+			It("should successfully deploy all resources", func() {
+				Expect(deployer.Deploy(ctx)).To(Succeed())
+
+				Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(managedResourceRuntime), managedResourceRuntime)).To(Succeed())
+				expectedRuntimeMr := &resourcesv1alpha1.ManagedResource{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: resourcesv1alpha1.SchemeGroupVersion.String(),
+						Kind:       "ManagedResource",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            managedResourceRuntime.Name,
+						Namespace:       managedResourceRuntime.Namespace,
+						ResourceVersion: "2",
+						Generation:      1,
+						Labels:          map[string]string{"gardener.cloud/role": "seed-system-component"},
+					},
+					Spec: resourcesv1alpha1.ManagedResourceSpec{
+						Class:       pointer.String("seed"),
+						SecretRefs:  []corev1.LocalObjectReference{{Name: managedResourceRuntime.Spec.SecretRefs[0].Name}},
+						KeepObjects: pointer.Bool(false),
+					},
+					Status: healthyManagedResourceStatus,
+				}
+				utilruntime.Must(references.InjectAnnotations(expectedRuntimeMr))
+				Expect(managedResourceRuntime).To(Equal(expectedRuntimeMr))
+
+				managedResourceSecretRuntime.Name = managedResourceRuntime.Spec.SecretRefs[0].Name
+				Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(managedResourceSecretRuntime), managedResourceSecretRuntime)).To(Succeed())
+
+				Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(managedResourceVirtual), managedResourceVirtual)).To(Succeed())
+				expectedVirtualMr := &resourcesv1alpha1.ManagedResource{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: resourcesv1alpha1.SchemeGroupVersion.String(),
+						Kind:       "ManagedResource",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            managedResourceVirtual.Name,
+						Namespace:       managedResourceVirtual.Namespace,
+						ResourceVersion: "2",
+						Generation:      1,
+						Labels:          map[string]string{"origin": "gardener"},
+					},
+					Spec: resourcesv1alpha1.ManagedResourceSpec{
+						InjectLabels: map[string]string{"shoot.gardener.cloud/no-cleanup": "true"},
+						SecretRefs:   []corev1.LocalObjectReference{{Name: managedResourceVirtual.Spec.SecretRefs[0].Name}},
+						KeepObjects:  pointer.Bool(false),
+					},
+					Status: healthyManagedResourceStatus,
+				}
+				utilruntime.Must(references.InjectAnnotations(expectedVirtualMr))
+				Expect(managedResourceVirtual).To(Equal(expectedVirtualMr))
+
+				managedResourceSecretVirtual.Name = expectedVirtualMr.Spec.SecretRefs[0].Name
+				Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(managedResourceSecretVirtual), managedResourceSecretVirtual)).To(Succeed())
+
+				Expect(managedResourceSecretRuntime.Type).To(Equal(corev1.SecretTypeOpaque))
+				Expect(managedResourceSecretRuntime.Data).To(HaveLen(2))
+				Expect(string(managedResourceSecretRuntime.Data["service__some-namespace__gardener-metrics-exporter.yaml"])).To(Equal(componenttest.Serialize(serviceRuntime)))
+				Expect(string(managedResourceSecretRuntime.Data["deployment__some-namespace__gardener-metrics-exporter.yaml"])).To(Equal(deployment(namespace, values)))
+				Expect(managedResourceSecretRuntime.Immutable).To(Equal(pointer.Bool(true)))
+				Expect(managedResourceSecretRuntime.Labels["resources.gardener.cloud/garbage-collectable-reference"]).To(Equal("true"))
+
+				Expect(managedResourceSecretVirtual.Type).To(Equal(corev1.SecretTypeOpaque))
+				Expect(managedResourceSecretVirtual.Data).To(HaveLen(2))
+				Expect(string(managedResourceSecretVirtual.Data["clusterrole____gardener.cloud_metrics-exporter.yaml"])).To(Equal(componenttest.Serialize(clusterRole)))
+				Expect(string(managedResourceSecretVirtual.Data["clusterrolebinding____gardener.cloud_metrics-exporter.yaml"])).To(Equal(componenttest.Serialize(clusterRoleBinding)))
+				Expect(managedResourceSecretVirtual.Immutable).To(Equal(pointer.Bool(true)))
+				Expect(managedResourceSecretVirtual.Labels["resources.gardener.cloud/garbage-collectable-reference"]).To(Equal("true"))
+			})
+		})
+
+		Context("secrets", func() {
+			It("should successfully deploy the access secret for the virtual garden", func() {
+				accessSecret := &corev1.Secret{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+						Kind:       "Secret",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "shoot-access-gardener-metrics-exporter",
+						Namespace: namespace,
+						Labels: map[string]string{
+							"resources.gardener.cloud/purpose": "token-requestor",
+							"resources.gardener.cloud/class":   "shoot",
+						},
+						Annotations: map[string]string{
+							"serviceaccount.resources.gardener.cloud/name":      "gardener-metrics-exporter",
+							"serviceaccount.resources.gardener.cloud/namespace": "kube-system",
+						},
+					},
+					Type: corev1.SecretTypeOpaque,
+				}
+
+				Expect(deployer.Deploy(ctx)).To(Succeed())
+
+				actualShootAccessSecret := &corev1.Secret{}
+				Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(accessSecret), actualShootAccessSecret)).To(Succeed())
+				accessSecret.ResourceVersion = "1"
+				Expect(actualShootAccessSecret).To(Equal(accessSecret))
+			})
+		})
+	})
+
+	Describe("#Destroy", func() {
+		It("should successfully destroy all resources", func() {
+			Expect(fakeClient.Create(ctx, managedResourceRuntime)).To(Succeed())
+			Expect(fakeClient.Create(ctx, managedResourceVirtual)).To(Succeed())
+			Expect(fakeClient.Create(ctx, managedResourceSecretRuntime)).To(Succeed())
+			Expect(fakeClient.Create(ctx, managedResourceSecretVirtual)).To(Succeed())
+
+			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(managedResourceRuntime), managedResourceRuntime)).To(Succeed())
+			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(managedResourceVirtual), managedResourceVirtual)).To(Succeed())
+			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(managedResourceSecretRuntime), managedResourceSecretRuntime)).To(Succeed())
+			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(managedResourceSecretVirtual), managedResourceSecretVirtual)).To(Succeed())
+
+			Expect(deployer.Destroy(ctx)).To(Succeed())
+
+			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(managedResourceRuntime), managedResourceRuntime)).To(BeNotFoundError())
+			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(managedResourceVirtual), managedResourceVirtual)).To(BeNotFoundError())
+			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(managedResourceSecretRuntime), managedResourceSecretRuntime)).To(BeNotFoundError())
+			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(managedResourceSecretVirtual), managedResourceSecretVirtual)).To(BeNotFoundError())
+		})
+	})
+
+	Context("waiting functions", func() {
+		Describe("#Wait", func() {
+			It("should fail because reading the runtime ManagedResource fails", func() {
+				Expect(deployer.Wait(ctx)).To(MatchError(ContainSubstring("not found")))
+			})
+
+			It("should fail because the runtime and virtual ManagedResources are unhealthy", func() {
+				Expect(fakeClient.Create(ctx, &resourcesv1alpha1.ManagedResource{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       managedResourceNameRuntime,
+						Namespace:  namespace,
+						Generation: 1,
+					},
+					Status: unhealthyManagedResourceStatus,
+				})).To(Succeed())
+
+				Expect(fakeClient.Create(ctx, &resourcesv1alpha1.ManagedResource{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       managedResourceNameVirtual,
+						Namespace:  namespace,
+						Generation: 1,
+					},
+					Status: unhealthyManagedResourceStatus,
+				})).To(Succeed())
+
+				Expect(deployer.Wait(ctx)).To(MatchError(ContainSubstring("is not healthy")))
+			})
+
+			It("should fail because the runtime ManagedResource is unhealthy", func() {
+				Expect(fakeClient.Create(ctx, &resourcesv1alpha1.ManagedResource{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       managedResourceNameRuntime,
+						Namespace:  namespace,
+						Generation: 1,
+					},
+					Status: unhealthyManagedResourceStatus,
+				})).To(Succeed())
+
+				Expect(fakeClient.Create(ctx, &resourcesv1alpha1.ManagedResource{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       managedResourceNameVirtual,
+						Namespace:  namespace,
+						Generation: 1,
+					},
+					Status: resourcesv1alpha1.ManagedResourceStatus{
+						ObservedGeneration: 1,
+						Conditions: []gardencorev1beta1.Condition{
+							{
+								Type:   resourcesv1alpha1.ResourcesApplied,
+								Status: gardencorev1beta1.ConditionTrue,
+							},
+							{
+								Type:   resourcesv1alpha1.ResourcesHealthy,
+								Status: gardencorev1beta1.ConditionTrue,
+							},
+							{
+								Type:   resourcesv1alpha1.ResourcesProgressing,
+								Status: gardencorev1beta1.ConditionFalse,
+							},
+						},
+					},
+				})).To(Succeed())
+
+				Expect(deployer.Wait(ctx)).To(MatchError(ContainSubstring("is not healthy")))
+			})
+
+			It("should fail because the virtual ManagedResource is unhealthy", func() {
+				Expect(fakeClient.Create(ctx, &resourcesv1alpha1.ManagedResource{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       managedResourceNameRuntime,
+						Namespace:  namespace,
+						Generation: 1,
+					},
+					Status: resourcesv1alpha1.ManagedResourceStatus{
+						ObservedGeneration: 1,
+						Conditions: []gardencorev1beta1.Condition{
+							{
+								Type:   resourcesv1alpha1.ResourcesApplied,
+								Status: gardencorev1beta1.ConditionTrue,
+							},
+							{
+								Type:   resourcesv1alpha1.ResourcesHealthy,
+								Status: gardencorev1beta1.ConditionTrue,
+							},
+							{
+								Type:   resourcesv1alpha1.ResourcesProgressing,
+								Status: gardencorev1beta1.ConditionFalse,
+							},
+						},
+					},
+				})).To(Succeed())
+
+				Expect(fakeClient.Create(ctx, &resourcesv1alpha1.ManagedResource{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       managedResourceNameVirtual,
+						Namespace:  namespace,
+						Generation: 1,
+					},
+					Status: unhealthyManagedResourceStatus,
+				})).To(Succeed())
+
+				Expect(deployer.Wait(ctx)).To(MatchError(ContainSubstring("is not healthy")))
+			})
+
+			It("should succeed because the runtime and virtual ManagedResource are healthy and progressing", func() {
+				Expect(fakeClient.Create(ctx, &resourcesv1alpha1.ManagedResource{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       managedResourceNameRuntime,
+						Namespace:  namespace,
+						Generation: 1,
+					},
+					Status: resourcesv1alpha1.ManagedResourceStatus{
+						ObservedGeneration: 1,
+						Conditions: []gardencorev1beta1.Condition{
+							{
+								Type:   resourcesv1alpha1.ResourcesApplied,
+								Status: gardencorev1beta1.ConditionTrue,
+							},
+							{
+								Type:   resourcesv1alpha1.ResourcesHealthy,
+								Status: gardencorev1beta1.ConditionTrue,
+							},
+							{
+								Type:   resourcesv1alpha1.ResourcesProgressing,
+								Status: gardencorev1beta1.ConditionTrue,
+							},
+						},
+					},
+				})).To(Succeed())
+
+				Expect(fakeClient.Create(ctx, &resourcesv1alpha1.ManagedResource{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       managedResourceNameVirtual,
+						Namespace:  namespace,
+						Generation: 1,
+					},
+					Status: resourcesv1alpha1.ManagedResourceStatus{
+						ObservedGeneration: 1,
+						Conditions: []gardencorev1beta1.Condition{
+							{
+								Type:   resourcesv1alpha1.ResourcesApplied,
+								Status: gardencorev1beta1.ConditionTrue,
+							},
+							{
+								Type:   resourcesv1alpha1.ResourcesHealthy,
+								Status: gardencorev1beta1.ConditionTrue,
+							},
+							{
+								Type:   resourcesv1alpha1.ResourcesProgressing,
+								Status: gardencorev1beta1.ConditionTrue,
+							},
+						},
+					},
+				})).To(Succeed())
+
+				Expect(deployer.Wait(ctx)).To(Succeed())
+			})
+
+			It("should succeed because the both ManagedResource are healthy and progressed", func() {
+				Expect(fakeClient.Create(ctx, &resourcesv1alpha1.ManagedResource{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       managedResourceNameRuntime,
+						Namespace:  namespace,
+						Generation: 1,
+					},
+					Status: resourcesv1alpha1.ManagedResourceStatus{
+						ObservedGeneration: 1,
+						Conditions: []gardencorev1beta1.Condition{
+							{
+								Type:   resourcesv1alpha1.ResourcesApplied,
+								Status: gardencorev1beta1.ConditionTrue,
+							},
+							{
+								Type:   resourcesv1alpha1.ResourcesHealthy,
+								Status: gardencorev1beta1.ConditionTrue,
+							},
+							{
+								Type:   resourcesv1alpha1.ResourcesProgressing,
+								Status: gardencorev1beta1.ConditionFalse,
+							},
+						},
+					},
+				})).To(Succeed())
+
+				Expect(fakeClient.Create(ctx, &resourcesv1alpha1.ManagedResource{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       managedResourceNameVirtual,
+						Namespace:  namespace,
+						Generation: 1,
+					},
+					Status: resourcesv1alpha1.ManagedResourceStatus{
+						ObservedGeneration: 1,
+						Conditions: []gardencorev1beta1.Condition{
+							{
+								Type:   resourcesv1alpha1.ResourcesApplied,
+								Status: gardencorev1beta1.ConditionTrue,
+							},
+							{
+								Type:   resourcesv1alpha1.ResourcesHealthy,
+								Status: gardencorev1beta1.ConditionTrue,
+							},
+							{
+								Type:   resourcesv1alpha1.ResourcesProgressing,
+								Status: gardencorev1beta1.ConditionFalse,
+							},
+						},
+					},
+				})).To(Succeed())
+
+				Expect(deployer.Wait(ctx)).To(Succeed())
+			})
+		})
+
+		Describe("#WaitCleanup", func() {
+			It("should fail when the wait for the runtime managed resource deletion times out", func() {
+				Expect(fakeClient.Create(ctx, managedResourceRuntime)).To(Succeed())
+
+				Expect(deployer.WaitCleanup(ctx)).To(MatchError(ContainSubstring("still exists")))
+			})
+
+			It("should fail when the wait for the virtual managed resource deletion times out", func() {
+				Expect(fakeClient.Create(ctx, managedResourceVirtual)).To(Succeed())
+
+				Expect(deployer.WaitCleanup(ctx)).To(MatchError(ContainSubstring("still exists")))
+			})
+
+			It("should not return an error when they are already removed", func() {
+				Expect(deployer.WaitCleanup(ctx)).To(Succeed())
+			})
+		})
+	})
+})
+
+var (
+	healthyManagedResourceStatus = resourcesv1alpha1.ManagedResourceStatus{
+		ObservedGeneration: 1,
+		Conditions: []gardencorev1beta1.Condition{
+			{
+				Type:   resourcesv1alpha1.ResourcesApplied,
+				Status: gardencorev1beta1.ConditionTrue,
+			},
+			{
+				Type:   resourcesv1alpha1.ResourcesHealthy,
+				Status: gardencorev1beta1.ConditionTrue,
+			},
+		},
+	}
+	unhealthyManagedResourceStatus = resourcesv1alpha1.ManagedResourceStatus{
+		ObservedGeneration: 1,
+		Conditions: []gardencorev1beta1.Condition{
+			{
+				Type:   resourcesv1alpha1.ResourcesApplied,
+				Status: gardencorev1beta1.ConditionFalse,
+			},
+			{
+				Type:   resourcesv1alpha1.ResourcesHealthy,
+				Status: gardencorev1beta1.ConditionFalse,
+			},
+		},
+	}
+)
+
+func deployment(namespace string, testValues Values) string {
+	deployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "gardener-metrics-exporter",
+			Namespace: namespace,
+			Labels: map[string]string{
+				"app":  "gardener",
+				"role": "metrics-exporter",
+			},
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: pointer.Int32(1),
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app":  "gardener",
+					"role": "metrics-exporter",
+				},
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: gardenerutils.MergeStringMaps(GetLabels(), map[string]string{
+						"app":                              "gardener",
+						"role":                             "metrics-exporter",
+						"networking.gardener.cloud/to-dns": "allowed",
+						"networking.resources.gardener.cloud/to-virtual-garden-kube-apiserver-tcp-443": "allowed",
+					}),
+				},
+				Spec: corev1.PodSpec{
+					PriorityClassName:            "gardener-garden-system-100",
+					AutomountServiceAccountToken: pointer.Bool(false),
+					Containers: []corev1.Container{
+						{
+							Name:            "gardener-metrics-exporter",
+							Image:           testValues.Image,
+							ImagePullPolicy: corev1.PullIfNotPresent,
+							Command: []string{
+								"/gardener-metrics-exporter",
+								"--kubeconfig=/var/run/secrets/gardener.cloud/shoot/generic-kubeconfig/kubeconfig",
+								"--bind-address=0.0.0.0",
+								"--port=2718",
+							},
+							SecurityContext: &corev1.SecurityContext{
+								ReadOnlyRootFilesystem: pointer.Bool(true),
+							},
+							Resources: corev1.ResourceRequirements{
+								Requests: map[corev1.ResourceName]resource.Quantity{
+									corev1.ResourceCPU:    resource.MustParse("100m"),
+									corev1.ResourceMemory: resource.MustParse("128Mi"),
+								},
+							},
+							Ports: []corev1.ContainerPort{
+								{
+									Name:          "port",
+									ContainerPort: 2718,
+									Protocol:      corev1.ProtocolTCP,
+								},
+							},
+							LivenessProbe: &corev1.Probe{
+								ProbeHandler: corev1.ProbeHandler{
+									HTTPGet: &corev1.HTTPGetAction{
+										Path:   "/",
+										Port:   intstr.FromInt(2718),
+										Scheme: corev1.URISchemeHTTP,
+									},
+								},
+								PeriodSeconds: 5,
+							},
+							ReadinessProbe: &corev1.Probe{
+								ProbeHandler: corev1.ProbeHandler{
+									HTTPGet: &corev1.HTTPGetAction{
+										Path:   "/metrics",
+										Port:   intstr.FromInt(2718),
+										Scheme: corev1.URISchemeHTTP,
+									},
+								},
+								PeriodSeconds: 5,
+							},
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name:      "kubeconfig",
+									MountPath: "/var/run/secrets/gardener.cloud/shoot/generic-kubeconfig",
+									ReadOnly:  true,
+								},
+							},
+						},
+					},
+					Volumes: []corev1.Volume{
+						{
+							Name: "kubeconfig",
+							VolumeSource: corev1.VolumeSource{
+								Projected: &corev1.ProjectedVolumeSource{
+									DefaultMode: pointer.Int32(420),
+									Sources: []corev1.VolumeProjection{
+										{
+											Secret: &corev1.SecretProjection{
+												LocalObjectReference: corev1.LocalObjectReference{
+													Name: "generic-token-kubeconfig",
+												},
+												Items: []corev1.KeyToPath{{
+													Key:  "kubeconfig",
+													Path: "kubeconfig",
+												}},
+												Optional: pointer.Bool(false),
+											},
+										},
+										{
+											Secret: &corev1.SecretProjection{
+												LocalObjectReference: corev1.LocalObjectReference{
+													Name: "shoot-access-gardener-metrics-exporter",
+												},
+												Items: []corev1.KeyToPath{{
+													Key:  "token",
+													Path: "token",
+												}},
+												Optional: pointer.Bool(false),
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	utilruntime.Must(references.InjectAnnotations(deployment))
+
+	return componenttest.Serialize(deployment)
+}

--- a/pkg/component/gardenermetricsexporter/gardener_metrics_exporter_test.go
+++ b/pkg/component/gardenermetricsexporter/gardener_metrics_exporter_test.go
@@ -612,7 +612,8 @@ func deployment(namespace string, testValues Values) string {
 			},
 		},
 		Spec: appsv1.DeploymentSpec{
-			Replicas: pointer.Int32(1),
+			Replicas:             pointer.Int32(1),
+			RevisionHistoryLimit: pointer.Int32(2),
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					"app":  "gardener",

--- a/pkg/component/gardenermetricsexporter/gardener_metrics_exporter_test.go
+++ b/pkg/component/gardenermetricsexporter/gardener_metrics_exporter_test.go
@@ -1,0 +1,15 @@
+// Copyright 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gardenermetricsexporter_test

--- a/pkg/component/gardenermetricsexporter/rbac.go
+++ b/pkg/component/gardenermetricsexporter/rbac.go
@@ -1,0 +1,75 @@
+// Copyright 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gardenermetricsexporter
+
+import (
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
+)
+
+const (
+	clusterRoleName        = "gardener.cloud:metrics-exporter"
+	clusterRoleBindingName = "gardener.cloud:metrics-exporter"
+)
+
+func (g *gardenerMetricsExporter) clusterRole() *rbacv1.ClusterRole {
+	return &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   clusterRoleName,
+			Labels: GetLabels(),
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups: []string{gardencorev1beta1.GroupName},
+				Resources: []string{
+					"secretbindings",
+					"seeds",
+					"shoots",
+					"projects",
+				},
+				Verbs: []string{"get", "list", "watch"},
+			},
+			{
+				APIGroups: []string{seedmanagementv1alpha1.GroupName},
+				Resources: []string{
+					"managedseeds",
+				},
+				Verbs: []string{"get", "list", "watch"},
+			},
+		},
+	}
+}
+
+func (g *gardenerMetricsExporter) clusterRoleBinding(serviceAccountName string) *rbacv1.ClusterRoleBinding {
+	return &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   clusterRoleBindingName,
+			Labels: GetLabels(),
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: rbacv1.GroupName,
+			Kind:     "ClusterRole",
+			Name:     clusterRoleName,
+		},
+		Subjects: []rbacv1.Subject{{
+			Kind:      "ServiceAccount",
+			Name:      serviceAccountName,
+			Namespace: metav1.NamespaceSystem,
+		}},
+	}
+}

--- a/pkg/component/gardenermetricsexporter/secrets.go
+++ b/pkg/component/gardenermetricsexporter/secrets.go
@@ -1,0 +1,23 @@
+// Copyright 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gardenermetricsexporter
+
+import (
+	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
+)
+
+func (g *gardenerMetricsExporter) newVirtualGardenAccessSecret() *gardenerutils.AccessSecret {
+	return gardenerutils.NewShootAccessSecret(deploymentName, g.namespace)
+}

--- a/pkg/component/gardenermetricsexporter/service.go
+++ b/pkg/component/gardenermetricsexporter/service.go
@@ -1,0 +1,45 @@
+// Copyright 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gardenermetricsexporter
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+func (g *gardenerMetricsExporter) service() *corev1.Service {
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      serviceName,
+			Namespace: g.namespace,
+			Labels:    GetLabels(),
+		},
+		Spec: corev1.ServiceSpec{
+			Type:            corev1.ServiceTypeClusterIP,
+			SessionAffinity: corev1.ServiceAffinityNone,
+			Selector:        GetLabels(),
+			Ports: []corev1.ServicePort{
+				{
+					Protocol:   corev1.ProtocolTCP,
+					Port:       probePort,
+					TargetPort: intstr.FromInt(probePort),
+				},
+			},
+		},
+	}
+
+	return svc
+}

--- a/pkg/component/gardenermetricsexporter/service.go
+++ b/pkg/component/gardenermetricsexporter/service.go
@@ -21,7 +21,7 @@ import (
 )
 
 func (g *gardenerMetricsExporter) service() *corev1.Service {
-	svc := &corev1.Service{
+	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      serviceName,
 			Namespace: g.namespace,
@@ -40,6 +40,4 @@ func (g *gardenerMetricsExporter) service() *corev1.Service {
 			},
 		},
 	}
-
-	return svc
 }

--- a/pkg/operator/controller/garden/care/health.go
+++ b/pkg/operator/controller/garden/care/health.go
@@ -97,6 +97,7 @@ var (
 	requiredMonitoringDeployments = sets.New(
 		v1beta1constants.DeploymentNameKubeStateMetrics,
 		v1beta1constants.DeploymentNamePlutono,
+		v1beta1constants.DeploymentNameGardenerMetricsExporter,
 	)
 
 	virtualGardenMonitoringSelector = labels.SelectorFromSet(map[string]string{v1beta1constants.LabelRole: v1beta1constants.LabelMonitoring})

--- a/pkg/operator/controller/garden/care/health_test.go
+++ b/pkg/operator/controller/garden/care/health_test.go
@@ -101,6 +101,7 @@ var (
 	monitoringDeployments = []string{
 		"kube-state-metrics",
 		"plutono",
+		"gardener-metrics-exporter",
 	}
 
 	loggingStatefulSets = []string{
@@ -639,7 +640,7 @@ var _ = Describe("Garden health", func() {
 				)
 				Expect(len(updatedConditions)).ToNot(BeZero())
 				Expect(updatedConditions).To(ContainElements(
-					beConditionWithStatusReasonAndMessage(gardencorev1beta1.ConditionFalse, "DeploymentMissing", "Missing required deployments: [kube-state-metrics plutono]"),
+					beConditionWithStatusReasonAndMessage(gardencorev1beta1.ConditionFalse, "DeploymentMissing", "Missing required deployments: [gardener-metrics-exporter kube-state-metrics plutono"),
 				))
 			})
 
@@ -686,7 +687,7 @@ var _ = Describe("Garden health", func() {
 				)
 				Expect(len(updatedConditions)).ToNot(BeZero())
 				Expect(updatedConditions).To(ContainElements(
-					beConditionWithStatusReasonAndMessage(gardencorev1beta1.ConditionFalse, "DeploymentUnhealthy", "Deployment \"kube-state-metrics\" is unhealthy: condition \"Available\" is missing"),
+					beConditionWithStatusReasonAndMessage(gardencorev1beta1.ConditionFalse, "DeploymentUnhealthy", "Deployment \"gardener-metrics-exporter\" is unhealthy: condition \"Available\" is missing"),
 				))
 			})
 

--- a/pkg/operator/controller/garden/garden/components.go
+++ b/pkg/operator/controller/garden/garden/components.go
@@ -53,6 +53,7 @@ import (
 	"github.com/gardener/gardener/pkg/component/gardeneradmissioncontroller"
 	"github.com/gardener/gardener/pkg/component/gardenerapiserver"
 	"github.com/gardener/gardener/pkg/component/gardenercontrollermanager"
+	"github.com/gardener/gardener/pkg/component/gardenermetricsexporter"
 	"github.com/gardener/gardener/pkg/component/gardenerscheduler"
 	runtimegardensystem "github.com/gardener/gardener/pkg/component/gardensystem/runtime"
 	virtualgardensystem "github.com/gardener/gardener/pkg/component/gardensystem/virtual"
@@ -111,6 +112,7 @@ type components struct {
 	gardenerControllerManager   component.DeployWaiter
 	gardenerScheduler           component.DeployWaiter
 
+	gardenerMetricsExporter       component.DeployWaiter
 	kubeStateMetrics              component.DeployWaiter
 	fluentOperator                component.DeployWaiter
 	fluentBit                     component.DeployWaiter
@@ -220,6 +222,10 @@ func (r *Reconciler) instantiateComponents(
 	}
 
 	// observability components
+	c.gardenerMetricsExporter, err = r.newGardenerMetricsExporter(secretsManager)
+	if err != nil {
+		return
+	}
 	c.kubeStateMetrics, err = r.newKubeStateMetrics()
 	if err != nil {
 		return
@@ -794,6 +800,15 @@ func (r *Reconciler) newNginxIngressController(garden *operatorv1alpha1.Garden) 
 		"",
 		v1beta1constants.SeedNginxIngressClass,
 	)
+}
+
+func (r *Reconciler) newGardenerMetricsExporter(secretsManager secretsmanager.Interface) (component.DeployWaiter, error) {
+	image, err := imagevector.ImageVector().FindImage(imagevector.ImageNameGardenerMetricsExporter)
+	if err != nil {
+		return nil, err
+	}
+
+	return gardenermetricsexporter.New(r.RuntimeClientSet.Client(), r.GardenNamespace, secretsManager, gardenermetricsexporter.Values{Image: image.String()}), nil
 }
 
 func (r *Reconciler) newPlutono(secretsManager secretsmanager.Interface, ingressDomain string, wildcardCert *corev1.Secret) (plutono.Interface, error) {

--- a/pkg/operator/controller/garden/garden/reconciler_delete.go
+++ b/pkg/operator/controller/garden/garden/reconciler_delete.go
@@ -62,6 +62,10 @@ func (r *Reconciler) delete(
 			Fn:   component.OpDestroyAndWait(c.plutono).Destroy,
 		})
 		_ = g.Add(flow.Task{
+			Name: "Destroying Gardener Metrics Exporter",
+			Fn:   component.OpDestroyAndWait(c.gardenerMetricsExporter).Destroy,
+		})
+		_ = g.Add(flow.Task{
 			Name: "Destroying Kube State Metrics",
 			Fn:   component.OpDestroyAndWait(c.kubeStateMetrics).Destroy,
 		})

--- a/pkg/operator/controller/garden/garden/reconciler_reconcile.go
+++ b/pkg/operator/controller/garden/garden/reconciler_reconcile.go
@@ -368,6 +368,11 @@ func (r *Reconciler) reconcile(
 			Dependencies: flow.NewTaskIDs(deployGardenerResourceManager),
 		})
 		_ = g.Add(flow.Task{
+			Name:         "Deploying Gardener Metrics Exporter",
+			Fn:           c.gardenerMetricsExporter.Deploy,
+			Dependencies: flow.NewTaskIDs(waitUntilKubeAPIServerIsReady, deployGardenerResourceManager),
+		})
+		_ = g.Add(flow.Task{
 			Name:         "Deploying Plutono",
 			Fn:           c.plutono.Deploy,
 			Dependencies: flow.NewTaskIDs(deployGardenerResourceManager),

--- a/pkg/operator/controller/garden/garden/reconciler_reconcile.go
+++ b/pkg/operator/controller/garden/garden/reconciler_reconcile.go
@@ -365,12 +365,12 @@ func (r *Reconciler) reconcile(
 		_ = g.Add(flow.Task{
 			Name:         "Deploying Kube State Metrics",
 			Fn:           c.kubeStateMetrics.Deploy,
-			Dependencies: flow.NewTaskIDs(deployGardenerResourceManager),
+			Dependencies: flow.NewTaskIDs(deployGardenerResourceManager, waitUntilKubeAPIServerIsReady),
 		})
 		_ = g.Add(flow.Task{
 			Name:         "Deploying Gardener Metrics Exporter",
 			Fn:           c.gardenerMetricsExporter.Deploy,
-			Dependencies: flow.NewTaskIDs(waitUntilKubeAPIServerIsReady, deployGardenerResourceManager),
+			Dependencies: flow.NewTaskIDs(deployGardenerResourceManager, waitUntilKubeAPIServerIsReady, waitUntilGardenerAPIServerReady),
 		})
 		_ = g.Add(flow.Task{
 			Name:         "Deploying Plutono",

--- a/skaffold-operator.yaml
+++ b/skaffold-operator.yaml
@@ -70,6 +70,7 @@ build:
         - pkg/component/extensions/operatingsystemconfig/utils
         - pkg/component/gardeneraccess
         - pkg/component/gardenerapiserver
+        - pkg/component/gardenermetricsexporter
         - pkg/component/gardensystem/runtime
         - pkg/component/gardensystem/virtual
         - pkg/component/gardeneradmissioncontroller

--- a/test/e2e/operator/garden/create_delete.go
+++ b/test/e2e/operator/garden/create_delete.go
@@ -113,6 +113,8 @@ var _ = Describe("Garden Tests", Label("Garden", "default"), func() {
 				healthyManagedResource("gardener-controller-manager-virtual"),
 				healthyManagedResource("gardener-scheduler-runtime"),
 				healthyManagedResource("gardener-scheduler-virtual"),
+				healthyManagedResource("gardener-metrics-exporter-runtime"),
+				healthyManagedResource("gardener-metrics-exporter-virtual"),
 			))
 
 			g.Expect(runtimeClient.List(ctx, managedResourceList, client.InNamespace("istio-system"))).To(Succeed())

--- a/test/integration/operator/garden/care/care_test.go
+++ b/test/integration/operator/garden/care/care_test.go
@@ -92,6 +92,7 @@ var _ = Describe("Garden Care controller tests", func() {
 		requiredMonitoringDeployments = []string{
 			"kube-state-metrics",
 			"plutono",
+			"gardener-metrics-exporter",
 		}
 
 		requiredLoggingStatefulSets = []string{

--- a/test/integration/operator/garden/garden/garden_test.go
+++ b/test/integration/operator/garden/garden/garden_test.go
@@ -361,7 +361,6 @@ var _ = Describe("Garden controller tests", func() {
 			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("vpa")})}),
 			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("hvpa")})}),
 			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("etcd-druid")})}),
-			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("kube-state-metrics")})}),
 			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("nginx-ingress")})}),
 			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("fluent-operator")})}),
 			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("fluent-bit")})}),
@@ -681,6 +680,9 @@ var _ = Describe("Garden controller tests", func() {
 			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("gardener-scheduler-runtime")})}),
 			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("gardener-scheduler-virtual")})}),
 			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("garden-system-virtual")})}),
+			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("kube-state-metrics")})}),
+			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("gardener-metrics-exporter-runtime")})}),
+			MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("gardener-metrics-exporter-virtual")})}),
 		))
 
 		By("Wait for last operation state to be set to Succeeded")


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind enhancement

**What this PR does / why we need it**:
With this PR, `gardener-operator` is enhanced to manage `gardener-metrics-exporter`.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/7016

**Special notes for your reviewer**:
~~In draft until https://github.com/gardener/gardener/pull/8309 this is merged.~~

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
`gardener-operator` now takes over management of `gardener-metrics-exporter`.
```