### PR TITLE
Fix `Bastion` deletion when `SSHAccess` is disabled

### DIFF
--- a/plugin/pkg/bastion/validator/admission.go
+++ b/plugin/pkg/bastion/validator/admission.go
@@ -150,7 +150,7 @@ func (v *Bastion) Admit(ctx context.Context, a admission.Attributes, _ admission
 	}
 
 	// ensure shoot SSH access is not disabled
-	if shoot.Spec.Provider.WorkersSettings != nil && shoot.Spec.Provider.WorkersSettings.SSHAccess != nil && !shoot.Spec.Provider.WorkersSettings.SSHAccess.Enabled {
+	if shoot.Spec.Provider.WorkersSettings != nil && shoot.Spec.Provider.WorkersSettings.SSHAccess != nil && !shoot.Spec.Provider.WorkersSettings.SSHAccess.Enabled && bastion.DeletionTimestamp == nil {
 		fieldErr := field.Invalid(shootPath, shootName, "ssh access is disabled for worker nodes")
 		return apierrors.NewInvalid(gk, bastion.Name, field.ErrorList{fieldErr})
 	}

--- a/plugin/pkg/bastion/validator/admission.go
+++ b/plugin/pkg/bastion/validator/admission.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/apiserver/pkg/admission"
 
+	gardencorehelper "github.com/gardener/gardener/pkg/apis/core/helper"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/apis/operations"
@@ -150,7 +151,7 @@ func (v *Bastion) Admit(ctx context.Context, a admission.Attributes, _ admission
 	}
 
 	// ensure shoot SSH access is not disabled
-	if shoot.Spec.Provider.WorkersSettings != nil && shoot.Spec.Provider.WorkersSettings.SSHAccess != nil && !shoot.Spec.Provider.WorkersSettings.SSHAccess.Enabled && bastion.DeletionTimestamp == nil {
+	if bastion.DeletionTimestamp == nil && !gardencorehelper.ShootEnablesSSHAccess(shoot) {
 		fieldErr := field.Invalid(shootPath, shootName, "ssh access is disabled for worker nodes")
 		return apierrors.NewInvalid(gk, bastion.Name, field.ErrorList{fieldErr})
 	}

--- a/plugin/pkg/bastion/validator/admission_test.go
+++ b/plugin/pkg/bastion/validator/admission_test.go
@@ -44,6 +44,7 @@ const (
 	bastionName = "foo"
 	shootName   = "foo"
 	seedName    = "foo"
+	workerName  = "foo"
 	namespace   = "garden"
 	provider    = "foo-provider"
 	region      = "foo-region"
@@ -71,6 +72,11 @@ var _ = Describe("Bastion", func() {
 					SeedName: pointer.String(seedName),
 					Provider: gardencore.Provider{
 						Type: provider,
+						Workers: []gardencore.Worker{
+							{
+								Name: workerName,
+							},
+						},
 					},
 					Region: region,
 				},
@@ -259,7 +265,7 @@ var _ = Describe("Bastion", func() {
 
 			oldBastion := bastion.DeepCopy()
 			oldBastion.ObjectMeta.Finalizers = []string{"foo"}
-			bastion.ObjectMeta.Finalizers = []string{""}
+			bastion.ObjectMeta.Finalizers = nil
 
 			err := admissionHandler.Admit(context.TODO(), getBastionAttributes(bastion, oldBastion, admission.Update), nil)
 			Expect(err).To(Succeed())
@@ -278,7 +284,7 @@ var _ = Describe("Bastion", func() {
 
 			oldBastion := bastion.DeepCopy()
 			oldBastion.ObjectMeta.Finalizers = []string{"foo"}
-			bastion.ObjectMeta.Finalizers = []string{""}
+			bastion.ObjectMeta.Finalizers = nil
 
 			err := admissionHandler.Admit(context.TODO(), getBastionAttributes(bastion, oldBastion, admission.Update), nil)
 			Expect(err).To(Succeed())


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind bug

**What this PR does / why we need it**:
This PR fixes a bug which was causing `Bastion` resources in the garden cluster to not be deleted when the Shoots `SSHAccess` is disabled. When disabling `SSHAccess` we delete all `Bastion` resources in the shoot namespace on the seed and wait for their deletion. The `Bastion` resources in the garden cluster are marked for deletion and have a finalizer which cannot be removed since the `Bastion` admission plugin currently does not allow mutate operation on `Bastion` resource when `SSHAccess` is disabled on the Shoot cluster.

This PR fixes this issue by allowing mutate operation on `Bastion` resources when they have `DeletionTimestamp` set.
 
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
A bug was fixed which was causing existing `Bastion` resources on the garden cluster to not be deleted when `SSHAccess` is disabled on a Shoot cluster.
```
