### PR TITLE
Promote `DisablingScalingClassesForShoots` feature gate to beta

### DIFF
--- a/docs/deployment/feature_gates.md
+++ b/docs/deployment/feature_gates.md
@@ -29,7 +29,8 @@ The following tables are a summary of the feature gates that you can set on diff
 | WorkerlessShoots                    | `false` | `Alpha` | `1.70` | `1.78` |
 | WorkerlessShoots                    | `false` | `Beta`  | `1.79` |        |
 | MachineControllerManagerDeployment  | `false` | `Alpha` | `1.73` |        |
-| DisableScalingClassesForShoots      | `false` | `Alpha` | `1.73` |        |
+| DisableScalingClassesForShoots      | `false` | `Alpha` | `1.73` | `1.78` |
+| DisableScalingClassesForShoots      | `true`  | `Beta`  | `1.79` |        |
 | ContainerdRegistryHostsDir          | `false` | `Alpha` | `1.77` |        |
 
 ## Feature Gates for Graduated or Deprecated Features

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -76,6 +76,7 @@ const (
 	// depend on the ScalingClass
 	// owner: @voelzmo, @andrerun
 	// alpha: v1.73.0
+	// beta: v1.79.0
 	DisableScalingClassesForShoots featuregate.Feature = "DisableScalingClassesForShoots"
 
 	// ContainerdRegistryHostsDir enables registry configuration in containerd based on the hosts directory pattern.
@@ -127,7 +128,7 @@ var AllFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	MutableShootSpecNetworkingNodes:    {Default: false, PreRelease: featuregate.Alpha},
 	WorkerlessShoots:                   {Default: true, PreRelease: featuregate.Beta},
 	MachineControllerManagerDeployment: {Default: false, PreRelease: featuregate.Alpha},
-	DisableScalingClassesForShoots:     {Default: false, PreRelease: featuregate.Alpha},
+	DisableScalingClassesForShoots:     {Default: true, PreRelease: featuregate.Beta},
 	ContainerdRegistryHostsDir:         {Default: false, PreRelease: featuregate.Alpha},
 }
 

--- a/pkg/operation/botanist/kubeapiserver_test.go
+++ b/pkg/operation/botanist/kubeapiserver_test.go
@@ -203,9 +203,12 @@ var _ = Describe("KubeAPIServer", func() {
 						ScaleDownDisabledForHvpa:  false,
 					},
 				),
-				Entry("default behaviour, HVPA is enabled",
+				Entry("default behaviour, HVPA is enabled and DisableScalingClassesForShoots is disabled",
 					nil,
-					map[featuregate.Feature]bool{features.HVPA: true},
+					map[featuregate.Feature]bool{
+						features.HVPA:                           true,
+						features.DisableScalingClassesForShoots: false,
+					},
 					apiserver.AutoscalingConfig{
 						APIServerResources:        resourcesRequirementsForKubeAPIServer(40, ""),
 						HVPAEnabled:               true,
@@ -218,8 +221,7 @@ var _ = Describe("KubeAPIServer", func() {
 				Entry("default behaviour, HVPA is enabled and DisableScalingClassesForShoots is enabled",
 					nil,
 					map[featuregate.Feature]bool{
-						features.HVPA:                           true,
-						features.DisableScalingClassesForShoots: true,
+						features.HVPA: true,
 					},
 					apiserver.AutoscalingConfig{
 						APIServerResources: corev1.ResourceRequirements{
@@ -238,8 +240,7 @@ var _ = Describe("KubeAPIServer", func() {
 				Entry("default behaviour, HVPA is disabled and DisableScalingClassesForShoots is enabled",
 					nil,
 					map[featuregate.Feature]bool{
-						features.HVPA:                           false,
-						features.DisableScalingClassesForShoots: true,
+						features.HVPA: false,
 					},
 					apiserver.AutoscalingConfig{
 						APIServerResources:        resourcesRequirementsForKubeAPIServer(4, ""),
@@ -292,11 +293,14 @@ var _ = Describe("KubeAPIServer", func() {
 						ScaleDownDisabledForHvpa:  false,
 					},
 				),
-				Entry("shoot is a managed seed and HVPAForShootedSeed is enabled",
+				Entry("shoot is a managed seed and HVPAForShootedSeed is enabled and DisableScalingClassesForShoots is disabled",
 					func() {
 						botanist.ManagedSeed = &seedmanagementv1alpha1.ManagedSeed{}
 					},
-					map[featuregate.Feature]bool{features.HVPAForShootedSeed: true},
+					map[featuregate.Feature]bool{
+						features.HVPAForShootedSeed:             true,
+						features.DisableScalingClassesForShoots: false,
+					},
 					apiserver.AutoscalingConfig{
 						APIServerResources:        resourcesRequirementsForKubeAPIServer(40, ""),
 						HVPAEnabled:               true,
@@ -306,7 +310,7 @@ var _ = Describe("KubeAPIServer", func() {
 						ScaleDownDisabledForHvpa:  false,
 					},
 				),
-				Entry("shoot is a managed seed w/ APIServer settings and HVPAForShootedSeed is enabled",
+				Entry("shoot is a managed seed w/ APIServer settings and HVPAForShootedSeed is enabled and DisableScalingClassesForShoots is disabled",
 					func() {
 						botanist.ManagedSeed = &seedmanagementv1alpha1.ManagedSeed{}
 						botanist.ManagedSeedAPIServer = &helper.ManagedSeedAPIServer{
@@ -317,7 +321,10 @@ var _ = Describe("KubeAPIServer", func() {
 							Replicas: pointer.Int32(24),
 						}
 					},
-					map[featuregate.Feature]bool{features.HVPAForShootedSeed: true},
+					map[featuregate.Feature]bool{
+						features.HVPAForShootedSeed:             true,
+						features.DisableScalingClassesForShoots: false,
+					},
 					apiserver.AutoscalingConfig{
 						APIServerResources:        resourcesRequirementsForKubeAPIServer(40, ""),
 						HVPAEnabled:               true,
@@ -339,8 +346,7 @@ var _ = Describe("KubeAPIServer", func() {
 						}
 					},
 					map[featuregate.Feature]bool{
-						features.HVPAForShootedSeed:             true,
-						features.DisableScalingClassesForShoots: true,
+						features.HVPAForShootedSeed: true,
 					},
 					apiserver.AutoscalingConfig{
 						APIServerResources: corev1.ResourceRequirements{
@@ -395,8 +401,7 @@ var _ = Describe("KubeAPIServer", func() {
 						}
 					},
 					map[featuregate.Feature]bool{
-						features.HVPAForShootedSeed:             false,
-						features.DisableScalingClassesForShoots: true,
+						features.HVPAForShootedSeed: false,
 					},
 					apiserver.AutoscalingConfig{
 						APIServerResources: corev1.ResourceRequirements{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area open-source
/kind enhancement

**What this PR does / why we need it**:
Promote `DisablingScalingClassesForShoots` feature gate to beta

**Which issue(s) this PR fixes**:
Follow-up of #8003 

**Special notes for your reviewer**:
/cc @BeckerMax @shafeeqes 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy operator
The `DisablingScalingClassesForShoots` feature gate has been promoted to beta.
```
