### PR TITLE
Allow shoot to be deleted even if ignored

### DIFF
--- a/plugin/pkg/global/deletionconfirmation/admission_test.go
+++ b/plugin/pkg/global/deletionconfirmation/admission_test.go
@@ -27,7 +27,6 @@ import (
 	"k8s.io/client-go/tools/cache"
 
 	"github.com/gardener/gardener/pkg/apis/core"
-	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	internalClientSet "github.com/gardener/gardener/pkg/client/core/clientset/internalversion/fake"
 	gardencoreinformers "github.com/gardener/gardener/pkg/client/core/informers/internalversion"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
@@ -165,22 +164,6 @@ var _ = Describe("deleteconfirmation", func() {
 					err := admissionHandler.Validate(context.TODO(), attrs, nil)
 
 					Expect(err).NotTo(HaveOccurred())
-				})
-			})
-
-			Context("no ignore annotation", func() {
-				It("should reject if the ignore-shoot annotation is set", func() {
-					attrs = admission.NewAttributesRecord(nil, nil, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Delete, &metav1.DeleteOptions{}, false, nil)
-
-					shoot.Annotations = map[string]string{
-						gardenerutils.ConfirmationDeletion: "true",
-						v1beta1constants.ShootIgnore:       "true",
-					}
-					Expect(shootStore.Add(&shoot)).NotTo(HaveOccurred())
-
-					err := admissionHandler.Validate(context.TODO(), attrs, nil)
-
-					Expect(err).To(BeForbiddenError())
 				})
 			})
 

--- a/test/framework/gardener_utils.go
+++ b/test/framework/gardener_utils.go
@@ -175,14 +175,6 @@ func (f *GardenerFramework) DeleteShootAndWaitForDeletion(ctx context.Context, s
 // DeleteShoot deletes the test shoot
 func (f *GardenerFramework) DeleteShoot(ctx context.Context, shoot *gardencorev1beta1.Shoot) error {
 	err := retry.UntilTimeout(ctx, 20*time.Second, 5*time.Minute, func(ctx context.Context) (done bool, err error) {
-		err = f.RemoveShootAnnotation(ctx, shoot, v1beta1constants.ShootIgnore)
-		if err != nil {
-			if apierrors.IsNotFound(err) {
-				return retry.Ok()
-			}
-			return retry.MinorError(err)
-		}
-
 		// First we annotate the shoot to be deleted.
 		err = f.AnnotateShoot(ctx, shoot, map[string]string{
 			gardenerutils.ConfirmationDeletion: "true",


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind enhancement

**What this PR does / why we need it**:
This PR removes the validation for ignore annotation during deletion. Now it is possible to delete a Shoot even if ignored. gardenlet will not act on the object unless the ignore annotation is removed.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
See https://github.com/gardener/gardener/pull/8414#discussion_r1315707366 for initial discussion.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other user
It is possible to delete a Shoot even if `shoot.gardener.cloud/ignore` annotation is set to true.
```
