### PR TITLE
provider-local: Drop the migration code related to the ContainerdRegistryHostsDir feature gate (part 2)

### DIFF
--- a/pkg/provider-local/webhook/controlplane/ensurer.go
+++ b/pkg/provider-local/webhook/controlplane/ensurer.go
@@ -134,53 +134,10 @@ func (e *ensurer) EnsureAdditionalFiles(_ context.Context, _ extensionscontextwe
 	return nil
 }
 
-// TODO(ialidzhikov): Drop the containerd-configuration-local-setup.service unit in 1.81.
-// It is preserved only for graceful migration purposes. Currently it is a no-op unit that only sleeps 1s.
-
-const unitNameInitializer = "containerd-configuration-local-setup.service"
-
-func (e *ensurer) EnsureAdditionalUnits(_ context.Context, _ extensionscontextwebhook.GardenContext, new, _ *[]extensionsv1alpha1.Unit) error {
-	unit := extensionsv1alpha1.Unit{
-		Name:    unitNameInitializer,
-		Command: pointer.String("start"),
-		Enable:  pointer.Bool(true),
-		Content: pointer.String(`[Unit]
-Description=Containerd config configuration for local-setup
-
-[Install]
-WantedBy=multi-user.target
-
-[Unit]
-After=containerd-initializer.service
-Requires=containerd-initializer.service
-
-[Service]
-Type=oneshot
-RemainAfterExit=no
-ExecStart=sleep 1s`)}
-
-	appendUniqueUnit(new, unit)
-
-	return nil
-}
-
 func appendFileIfNotPresent(files *[]extensionsv1alpha1.File, file extensionsv1alpha1.File) {
 	if !containsFilePath(files, file.Path) {
 		*files = append(*files, file)
 	}
-}
-
-// appendUniqueUnit appends a unit only if it does not exist, otherwise overwrite content of previous unit
-func appendUniqueUnit(units *[]extensionsv1alpha1.Unit, unit extensionsv1alpha1.Unit) {
-	resFiles := make([]extensionsv1alpha1.Unit, 0, len(*units))
-
-	for _, f := range *units {
-		if f.Name != unit.Name {
-			resFiles = append(resFiles, f)
-		}
-	}
-
-	*units = append(resFiles, unit)
 }
 
 func containsFilePath(files *[]extensionsv1alpha1.File, filePath string) bool {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind cleanup

**What this PR does / why we need it**:
This PR is a follow-up after https://github.com/gardener/gardener/pull/8441. For more details, see https://github.com/gardener/gardener/pull/8441.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener-extension-registry-cache/issues/3

**Special notes for your reviewer**:
- This PR depends on https://github.com/gardener/gardener/pull/8441. It has to be rebased when https://github.com/gardener/gardener/pull/8441 is merged.
- This PR has to be included in ~~1.81~~ 1.82. Hence, it will be in draft state until ~~1.80~~ 1.81 is released.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
