### PR TITLE
Fix `ControllerRegistration` controller not deleting `ControllerInstallation`s when `deletionTimestamp` is set

### DIFF
--- a/pkg/controllermanager/controller/controllerregistration/seed/reconciler.go
+++ b/pkg/controllermanager/controller/controllerregistration/seed/reconciler.go
@@ -310,12 +310,14 @@ func computeWantedControllerRegistrationNames(
 	)
 
 	for name, controllerRegistration := range controllerRegistrations {
-		if controllerRegistration.deployAlways && seedObjectMeta.DeletionTimestamp == nil {
-			wantedControllerRegistrationNames.Insert(name)
-		}
+		if controllerRegistration.obj.DeletionTimestamp == nil {
+			if controllerRegistration.deployAlways && seedObjectMeta.DeletionTimestamp == nil {
+				wantedControllerRegistrationNames.Insert(name)
+			}
 
-		if controllerRegistration.deployAlwaysExceptNoShoots && numberOfShoots > 0 {
-			wantedControllerRegistrationNames.Insert(name)
+			if controllerRegistration.deployAlwaysExceptNoShoots && numberOfShoots > 0 {
+				wantedControllerRegistrationNames.Insert(name)
+			}
 		}
 
 		for _, resource := range controllerRegistration.obj.Spec.Resources {

--- a/test/integration/controllermanager/controllerregistration/controllerregistration_test.go
+++ b/test/integration/controllermanager/controllerregistration/controllerregistration_test.go
@@ -115,7 +115,7 @@ var _ = Describe("ControllerRegistration controller test", func() {
 				return seedControllerRegistration.Finalizers
 			}).Should(ConsistOf("core.gardener.cloud/controllerregistration"))
 
-			By("Expect ControllerInstallation be created")
+			By("Expect ControllerInstallation to be created")
 			Eventually(func(g Gomega) {
 				controllerInstallationList := &gardencorev1beta1.ControllerInstallationList{}
 				g.Expect(testClient.List(ctx, controllerInstallationList, client.MatchingFields{
@@ -174,7 +174,7 @@ var _ = Describe("ControllerRegistration controller test", func() {
 			By("Create object")
 			Expect(testClient.Create(ctx, obj)).To(Succeed())
 
-			By("Expect ControllerInstallation be created")
+			By("Expect ControllerInstallation to be created")
 			Eventually(func(g Gomega) {
 				controllerInstallationList := &gardencorev1beta1.ControllerInstallationList{}
 				g.Expect(testClient.List(ctx, controllerInstallationList, client.MatchingFields{
@@ -244,7 +244,7 @@ var _ = Describe("ControllerRegistration controller test", func() {
 			By("Create object")
 			Expect(testClient.Create(ctx, obj)).To(Succeed())
 
-			By("Expect ControllerInstallation be created")
+			By("Expect ControllerInstallation to be created")
 			controllerInstallation := &gardencorev1beta1.ControllerInstallation{}
 			Eventually(func(g Gomega) {
 				controllerInstallationList := &gardencorev1beta1.ControllerInstallationList{}
@@ -363,7 +363,7 @@ var _ = Describe("ControllerRegistration controller test", func() {
 			By("Create object")
 			Expect(testClient.Create(ctx, obj)).To(Succeed())
 
-			By("Expect ControllerInstallation be created")
+			By("Expect ControllerInstallation to be created")
 			Eventually(func(g Gomega) {
 				controllerInstallationList := &gardencorev1beta1.ControllerInstallationList{}
 				g.Expect(testClient.List(ctx, controllerInstallationList, client.MatchingFields{
@@ -415,7 +415,7 @@ var _ = Describe("ControllerRegistration controller test", func() {
 			By("Create object")
 			Expect(testClient.Create(ctx, shoot)).To(Succeed())
 
-			By("Expect ControllerInstallation be created")
+			By("Expect ControllerInstallation to be created")
 			Eventually(func(g Gomega) {
 				controllerInstallationList := &gardencorev1beta1.ControllerInstallationList{}
 				g.Expect(testClient.List(ctx, controllerInstallationList, client.MatchingFields{
@@ -425,7 +425,7 @@ var _ = Describe("ControllerRegistration controller test", func() {
 				g.Expect(controllerInstallationList.Items).To(HaveLen(1))
 			}).Should(Succeed())
 
-			By("Delete object")
+			By("Delete Shoot")
 			Expect(testClient.Delete(ctx, shoot)).To(Succeed())
 
 			By("Expect ControllerInstallation be deleted")
@@ -477,7 +477,7 @@ var _ = Describe("ControllerRegistration controller test", func() {
 					return controllerRegistration.Finalizers
 				}).Should(ConsistOf("core.gardener.cloud/controllerregistration"))
 
-				By("Expect ControllerInstallation be created")
+				By("Expect ControllerInstallation to be created")
 				Eventually(func(g Gomega) {
 					controllerInstallationList := &gardencorev1beta1.ControllerInstallationList{}
 					g.Expect(testClient.List(ctx, controllerInstallationList, client.MatchingFields{
@@ -546,7 +546,7 @@ var _ = Describe("ControllerRegistration controller test", func() {
 					return controllerRegistration.Finalizers
 				}).Should(ConsistOf("core.gardener.cloud/controllerregistration"))
 
-				By("Expect no ControllerInstallation be created because no Shoot exists")
+				By("Expect no ControllerInstallation to be created because no Shoot exists")
 				Consistently(func(g Gomega) {
 					controllerInstallationList := &gardencorev1beta1.ControllerInstallationList{}
 					g.Expect(testClient.List(ctx, controllerInstallationList, client.MatchingFields{
@@ -559,7 +559,7 @@ var _ = Describe("ControllerRegistration controller test", func() {
 				By("Create object")
 				Expect(testClient.Create(ctx, shoot)).To(Succeed())
 
-				By("Expect ControllerInstallation be created")
+				By("Expect ControllerInstallation to be created")
 				Eventually(func(g Gomega) {
 					controllerInstallationList := &gardencorev1beta1.ControllerInstallationList{}
 					g.Expect(testClient.List(ctx, controllerInstallationList, client.MatchingFields{
@@ -591,7 +591,7 @@ var _ = Describe("ControllerRegistration controller test", func() {
 					return controllerRegistration.Finalizers
 				}).Should(ConsistOf("core.gardener.cloud/controllerregistration"))
 
-				By("Expect no ControllerInstallation be created because no Shoot exists")
+				By("Expect no ControllerInstallation to be created because no Shoot exists")
 				Consistently(func(g Gomega) {
 					controllerInstallationList := &gardencorev1beta1.ControllerInstallationList{}
 					g.Expect(testClient.List(ctx, controllerInstallationList, client.MatchingFields{
@@ -604,7 +604,7 @@ var _ = Describe("ControllerRegistration controller test", func() {
 				By("Create Shoot")
 				Expect(testClient.Create(ctx, shoot)).To(Succeed())
 
-				By("Expect ControllerInstallation be created")
+				By("Expect ControllerInstallation to be created")
 				Eventually(func(g Gomega) {
 					controllerInstallationList := &gardencorev1beta1.ControllerInstallationList{}
 					g.Expect(testClient.List(ctx, controllerInstallationList, client.MatchingFields{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind bug

**What this PR does / why we need it**:
Earlier, when a `ControllerRegistration` with `.spec.deployment.policy={Always,AlwaysExceptNoShoots}` gets deleted, `gardener-controller-manager` would not attempt to delete the corresponding `ControllerInstallation`s. This is because the respective controller always considers such `ControllerRegistration`s as "wanted" here, no matter whether they actually should get deleted: https://github.com/gardener/gardener/blob/3253777966d8f834916077100a648436d90fbe86/pkg/controllermanager/controller/controllerregistration/seed/reconciler.go#L312-L319

This PR first adds failing tests to reproduce the issue, and then fixes the code.

To reproduce, simply create this `ControllerRegistration`, wait for the `ControllerInstallation`s for the `Seed`s to appear, and then delete the `ControllerRegistration` again. It will remain in the system because the `ControllerInstallation`s don't get deleted:

```yaml
---
apiVersion: core.gardener.cloud/v1beta1
kind: ControllerRegistration
metadata:
  name: test
spec:
  deployment:
    policy: Always
```

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
A bug has been fixed that prevented `ControllerInstallation`s from getting deleted when the backing `ControllerRegistration` with `.spec.deployment.policy={Always,AlwaysExceptNoShoots}` was deleted.
```
