### PR TITLE
Enhance fallback client

### DIFF
--- a/cmd/gardenlet/app/app.go
+++ b/cmd/gardenlet/app/app.go
@@ -277,6 +277,8 @@ func (g *garden) Start(ctx context.Context) error {
 			},
 		}
 
+		seedNamespace := gardenerutils.ComputeGardenNamespace(g.config.SeedConfig.SeedTemplate.Name)
+
 		opts.NewCache = func(config *rest.Config, opts cache.Options) (cache.Cache, error) {
 			// gardenlet should watch only objects which are related to the seed it is responsible for.
 			opts.ByObject = map[client.Object]cache.ByObject{
@@ -288,7 +290,6 @@ func (g *garden) Start(ctx context.Context) error {
 				},
 			}
 
-			seedNamespace := gardenerutils.ComputeGardenNamespace(g.config.SeedConfig.SeedTemplate.Name)
 			return kubernetes.AggregatorCacheFunc(
 				kubernetes.NewRuntimeCache,
 				map[client.Object]cache.NewCacheFunc{
@@ -339,7 +340,6 @@ func (g *garden) Start(ctx context.Context) error {
 				return nil, err
 			}
 
-			seedNamespace := gardenerutils.ComputeGardenNamespace(g.config.SeedConfig.SeedTemplate.Name)
 			return &kubernetes.FallbackClient{
 				Client: cachedClient,
 				Reader: uncachedClient,


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind enhancement

**What this PR does / why we need it**:
This PR enhances the Get method in the fallback client, making it more adaptive to cache configurations based on KindToNamespaces.

It checks whether specific namespaces are configured for the kind of object in the cache. If the object's kind has specific namespaces configured in the cache but the object's namespace is not cached, the code falls back to using the API reader to fetch the object.
Otherwise, it attempts to retrieve the object from the cache, and in case of a cache error, it gracefully falls back to the API reader.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/8382

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
