### PR TITLE
Report `node`s without `checksum/cloud-config-data` annotation

### DIFF
--- a/pkg/gardenlet/controller/shoot/care/health_test.go
+++ b/pkg/gardenlet/controller/shoot/care/health_test.go
@@ -355,7 +355,7 @@ var _ = Describe("health check", func() {
 			},
 			Entry("all healthy",
 				[]corev1.Node{
-					newNode(nodeName, true, labels.Set{"worker.gardener.cloud/pool": workerPoolName1, "worker.gardener.cloud/kubernetes-version": "1.24.0"}, nil, kubernetesVersion.Original()),
+					newNode(nodeName, true, labels.Set{"worker.gardener.cloud/pool": workerPoolName1, "worker.gardener.cloud/kubernetes-version": "1.24.0"}, map[string]string{"checksum/cloud-config-data": cloudConfigSecretChecksum1}, kubernetesVersion.Original()),
 				},
 				[]gardencorev1beta1.Worker{
 					{
@@ -461,7 +461,7 @@ var _ = Describe("health check", func() {
 				PointTo(beConditionWithStatusAndMsg(gardencorev1beta1.ConditionFalse, "KubeletVersionMismatch", fmt.Sprintf("The kubelet version for node %q (v1.23.2) does not match the desired Kubernetes version (v%s)", nodeName, kubernetesVersion.Original())))),
 			Entry("same Kubernetes patch version",
 				[]corev1.Node{
-					newNode(nodeName, true, labels.Set{"worker.gardener.cloud/pool": workerPoolName1, "worker.gardener.cloud/kubernetes-version": "1.24.0"}, nil, "v1.23.3"),
+					newNode(nodeName, true, labels.Set{"worker.gardener.cloud/pool": workerPoolName1, "worker.gardener.cloud/kubernetes-version": "1.24.0"}, map[string]string{"checksum/cloud-config-data": cloudConfigSecretChecksum1}, "v1.23.3"),
 				},
 				[]gardencorev1beta1.Worker{
 					{
@@ -490,7 +490,7 @@ var _ = Describe("health check", func() {
 				PointTo(beConditionWithStatusAndMsg(gardencorev1beta1.ConditionFalse, "KubeletVersionMismatch", fmt.Sprintf("The kubelet version for node %q (v1.22.2) does not match the desired Kubernetes version (v1.22.3)", nodeName)))),
 			Entry("different Kubernetes minor version (all healthy)",
 				[]corev1.Node{
-					newNode(nodeName, true, labels.Set{"worker.gardener.cloud/pool": workerPoolName1, "worker.gardener.cloud/kubernetes-version": "1.24.0"}, nil, "v1.22.2"),
+					newNode(nodeName, true, labels.Set{"worker.gardener.cloud/pool": workerPoolName1, "worker.gardener.cloud/kubernetes-version": "1.24.0"}, map[string]string{"checksum/cloud-config-data": cloudConfigSecretChecksum1}, "v1.22.2"),
 				},
 				[]gardencorev1beta1.Worker{
 					{
@@ -526,7 +526,7 @@ var _ = Describe("health check", func() {
 					},
 				},
 				cloudConfigSecretMeta,
-				BeNil()),
+				PointTo(beConditionWithStatusAndMsg(gardencorev1beta1.ConditionFalse, "CloudConfigOutdated", fmt.Sprintf("the last successfully applied cloud config on node %q hasn't been reported yet", nodeName)))),
 			Entry("outdated cloud-config secret checksum for a worker pool",
 				[]corev1.Node{
 					newNode(nodeName, true, labels.Set{"worker.gardener.cloud/pool": workerPoolName1, "worker.gardener.cloud/kubernetes-version": "1.24.0"}, map[string]string{executor.AnnotationKeyChecksum: "outdated"}, "v1.22.2"),

--- a/pkg/operation/botanist/worker.go
+++ b/pkg/operation/botanist/worker.go
@@ -150,8 +150,12 @@ func CloudConfigUpdatedForAllWorkerPools(
 				continue
 			}
 
-			if nodeChecksum, ok := node.Annotations[executor.AnnotationKeyChecksum]; ok && nodeChecksum != secretChecksum {
-				result = multierror.Append(result, fmt.Errorf("the last successfully applied cloud config on node %q is outdated (current: %s, desired: %s)", node.Name, nodeChecksum, secretChecksum))
+			if nodeChecksum, ok := node.Annotations[executor.AnnotationKeyChecksum]; nodeChecksum != secretChecksum {
+				if !ok {
+					result = multierror.Append(result, fmt.Errorf("the last successfully applied cloud config on node %q hasn't been reported yet", node.Name))
+				} else {
+					result = multierror.Append(result, fmt.Errorf("the last successfully applied cloud config on node %q is outdated (current: %s, desired: %s)", node.Name, nodeChecksum, secretChecksum))
+				}
 			}
 		}
 	}

--- a/pkg/operation/botanist/worker_test.go
+++ b/pkg/operation/botanist/worker_test.go
@@ -283,6 +283,17 @@ var _ = Describe("Worker", func() {
 			nil,
 			MatchError(ContainSubstring("missing cloud config secret metadata")),
 		),
+		Entry("checksum annotation missing",
+			[]gardencorev1beta1.Worker{{Name: "pool1"}},
+			map[string][]corev1.Node{"pool1": {{ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{"worker.gardener.cloud/kubernetes-version": "1.24.0"},
+			}}}},
+			map[string]metav1.ObjectMeta{"pool1": {
+				Name:        "cloud-config--c63c0",
+				Annotations: map[string]string{"checksum/data-script": "foo"},
+			}},
+			MatchError(ContainSubstring("hasn't been reported yet")),
+		),
 		Entry("checksum annotation outdated",
 			[]gardencorev1beta1.Worker{{Name: "pool1"}},
 			map[string][]corev1.Node{"pool1": {{ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind enhancement

**What this PR does / why we need it**:
This PR enhances the `cloud-config-data` handling when `node`s without a `checksum/cloud-config-data` annotation were found. Earlier, failing cloud-config-executor runs pass unnoticed because we treated a missing `checksum/cloud-config-data` annotation as acceptable.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy user
Gardener now reports `node`s for which the `checksum/cloud-config-data` hasn't been populated yet. This could point towards an error on the node and that not all Gardener related configuration happened successfully.
```
