### PR TITLE
Fix `gardener.cloud:apiserver:auth-reader` `RoleBinding` in `gardenerapiserver` component

### DIFF
--- a/pkg/component/gardenerapiserver/gardener_apiserver_test.go
+++ b/pkg/component/gardenerapiserver/gardener_apiserver_test.go
@@ -712,7 +712,7 @@ var _ = Describe("GardenerAPIServer", func() {
 			},
 			RoleRef: rbacv1.RoleRef{
 				APIGroup: "rbac.authorization.k8s.io",
-				Kind:     "ClusterRole",
+				Kind:     "Role",
 				Name:     "extension-apiserver-authentication-reader",
 			},
 			Subjects: []rbacv1.Subject{{

--- a/pkg/component/gardenerapiserver/rbac.go
+++ b/pkg/component/gardenerapiserver/rbac.go
@@ -84,7 +84,7 @@ func (g *gardenerAPIServer) roleBindingAuthReader(serviceAccountName string) *rb
 		},
 		RoleRef: rbacv1.RoleRef{
 			APIGroup: rbacv1.GroupName,
-			Kind:     "ClusterRole",
+			Kind:     "Role",
 			Name:     "extension-apiserver-authentication-reader",
 		},
 		Subjects: []rbacv1.Subject{{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind bug

**What this PR does / why we need it**:
Actually, it should reference the `Role` and not the `ClusterRole`. See https://github.com/gardener/gardener/blob/6103ef63c2a28a11eefe20d090b3ecf981bc27f8/charts/gardener/controlplane/charts/application/templates/rolebinding-apiserver-auth-reader.yaml#L14-L17

**Which issue(s) this PR fixes**:
Introduced with #8215 

**Special notes for your reviewer**:
/cc @ScheererJ 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
