### PR TITLE
[release-v1.77] Automated cherry pick of #8443: Fix `ControllerRegistration` controller not deleting `ControllerInstallation`s when `deletionTimestamp` is set

### DIFF
--- a/pkg/controllermanager/controller/controllerregistration/seed/reconciler.go
+++ b/pkg/controllermanager/controller/controllerregistration/seed/reconciler.go
@@ -310,12 +310,14 @@ func computeWantedControllerRegistrationNames(
 	)
 
 	for name, controllerRegistration := range controllerRegistrations {
-		if controllerRegistration.deployAlways && seedObjectMeta.DeletionTimestamp == nil {
-			wantedControllerRegistrationNames.Insert(name)
-		}
+		if controllerRegistration.obj.DeletionTimestamp == nil {
+			if controllerRegistration.deployAlways && seedObjectMeta.DeletionTimestamp == nil {
+				wantedControllerRegistrationNames.Insert(name)
+			}
 
-		if controllerRegistration.deployAlwaysExceptNoShoots && numberOfShoots > 0 {
-			wantedControllerRegistrationNames.Insert(name)
+			if controllerRegistration.deployAlwaysExceptNoShoots && numberOfShoots > 0 {
+				wantedControllerRegistrationNames.Insert(name)
+			}
 		}
 
 		for _, resource := range controllerRegistration.obj.Spec.Resources {

--- a/test/integration/controllermanager/controllerregistration/controllerregistration_suite_test.go
+++ b/test/integration/controllermanager/controllerregistration/controllerregistration_suite_test.go
@@ -57,6 +57,7 @@ var (
 	restConfig *rest.Config
 	testEnv    *gardenerenvtest.GardenerTestEnvironment
 	testClient client.Client
+	mgrClient  client.Client
 
 	testNamespace *corev1.Namespace
 	testRunID     string
@@ -115,6 +116,7 @@ var _ = BeforeSuite(func() {
 		}),
 	})
 	Expect(err).NotTo(HaveOccurred())
+	mgrClient = mgr.GetClient()
 
 	By("Setup field indexes")
 	Expect(indexer.AddBackupBucketSeedName(ctx, mgr.GetFieldIndexer())).To(Succeed())

--- a/test/integration/controllermanager/controllerregistration/controllerregistration_test.go
+++ b/test/integration/controllermanager/controllerregistration/controllerregistration_test.go
@@ -539,7 +539,7 @@ var _ = Describe("ControllerRegistration controller test", func() {
 				g.Expect(controllerInstallationList.Items).To(HaveLen(1))
 			}).Should(Succeed())
 
-			By("Delete object")
+			By("Delete Shoot")
 			Expect(testClient.Delete(ctx, shoot)).To(Succeed())
 
 			By("Expect ControllerInstallation to be deleted")

--- a/test/integration/controllermanager/controllerregistration/controllerregistration_test.go
+++ b/test/integration/controllermanager/controllerregistration/controllerregistration_test.go
@@ -38,6 +38,10 @@ var _ = Describe("ControllerRegistration controller test", func() {
 		seedNamespace              *corev1.Namespace
 		seedSecret                 *corev1.Secret
 		seedControllerRegistration *gardencorev1beta1.ControllerRegistration
+
+		shootProviderType           = "shootProvider"
+		shoot                       *gardencorev1beta1.Shoot
+		shootControllerRegistration *gardencorev1beta1.ControllerRegistration
 	)
 
 	BeforeEach(func() {
@@ -150,6 +154,76 @@ var _ = Describe("ControllerRegistration controller test", func() {
 			By("Delete Seed Namespace")
 			Expect(testClient.Delete(ctx, seedNamespace)).To(Or(Succeed(), BeNotFoundError()))
 		})
+
+		shoot = &gardencorev1beta1.Shoot{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: testID + "-",
+				Namespace:    testNamespace.Name,
+				Labels:       map[string]string{testID: testRunID},
+			},
+			Spec: gardencorev1beta1.ShootSpec{
+				SecretBindingName: pointer.String("my-provider-account"),
+				CloudProfileName:  "test-cloudprofile",
+				Region:            "foo-region",
+				Provider: gardencorev1beta1.Provider{
+					Type: shootProviderType,
+					Workers: []gardencorev1beta1.Worker{
+						{
+							Name:    "cpu-worker",
+							Minimum: 2,
+							Maximum: 2,
+							Machine: gardencorev1beta1.Machine{
+								Type: "large",
+								Image: &gardencorev1beta1.ShootMachineImage{
+									Name:    shootProviderType,
+									Version: pointer.String("0.0.0"),
+								},
+							},
+							CRI: &gardencorev1beta1.CRI{
+								Name: gardencorev1beta1.CRINameContainerD,
+								ContainerRuntimes: []gardencorev1beta1.ContainerRuntime{{
+									Type: shootProviderType,
+								}},
+							},
+						},
+					},
+				},
+				Kubernetes: gardencorev1beta1.Kubernetes{
+					Version: "1.22.1",
+				},
+				Networking: &gardencorev1beta1.Networking{
+					Type: pointer.String(shootProviderType),
+				},
+				Extensions: []gardencorev1beta1.Extension{{
+					Type: shootProviderType,
+				}},
+				DNS: &gardencorev1beta1.DNS{
+					Providers: []gardencorev1beta1.DNSProvider{{
+						Type: &shootProviderType,
+					}},
+				},
+				SeedName: &seed.Name,
+			},
+		}
+
+		shootControllerRegistration = &gardencorev1beta1.ControllerRegistration{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "ctrlreg-" + testID + "-",
+				Labels:       map[string]string{testID: testRunID},
+			},
+			Spec: gardencorev1beta1.ControllerRegistrationSpec{
+				Resources: []gardencorev1beta1.ControllerResource{
+					{Kind: extensionsv1alpha1.ControlPlaneResource, Type: shootProviderType},
+					{Kind: extensionsv1alpha1.InfrastructureResource, Type: shootProviderType},
+					{Kind: extensionsv1alpha1.WorkerResource, Type: shootProviderType},
+					{Kind: extensionsv1alpha1.NetworkResource, Type: shootProviderType},
+					{Kind: extensionsv1alpha1.ContainerRuntimeResource, Type: shootProviderType},
+					{Kind: extensionsv1alpha1.DNSRecordResource, Type: shootProviderType},
+					{Kind: extensionsv1alpha1.OperatingSystemConfigResource, Type: shootProviderType},
+					{Kind: extensionsv1alpha1.ExtensionResource, Type: shootProviderType},
+				},
+			},
+		}
 	})
 
 	Context("Seed", func() {
@@ -160,7 +234,7 @@ var _ = Describe("ControllerRegistration controller test", func() {
 				return seedControllerRegistration.Finalizers
 			}).Should(ConsistOf("core.gardener.cloud/controllerregistration"))
 
-			By("Expect ControllerInstallation be created")
+			By("Expect ControllerInstallation to be created")
 			Eventually(func(g Gomega) {
 				controllerInstallationList := &gardencorev1beta1.ControllerInstallationList{}
 				g.Expect(testClient.List(ctx, controllerInstallationList, client.MatchingFields{
@@ -173,7 +247,7 @@ var _ = Describe("ControllerRegistration controller test", func() {
 			By("Delete object")
 			Expect(testClient.Delete(ctx, seed)).To(Succeed())
 
-			By("Expect ControllerInstallation be deleted")
+			By("Expect ControllerInstallation to be deleted")
 			Eventually(func(g Gomega) {
 				controllerInstallationList := &gardencorev1beta1.ControllerInstallationList{}
 				g.Expect(testClient.List(ctx, controllerInstallationList, client.MatchingFields{
@@ -229,7 +303,7 @@ var _ = Describe("ControllerRegistration controller test", func() {
 			By("Create object")
 			Expect(testClient.Create(ctx, obj)).To(Succeed())
 
-			By("Expect ControllerInstallation be created")
+			By("Expect ControllerInstallation to be created")
 			Eventually(func(g Gomega) {
 				controllerInstallationList := &gardencorev1beta1.ControllerInstallationList{}
 				g.Expect(testClient.List(ctx, controllerInstallationList, client.MatchingFields{
@@ -242,7 +316,7 @@ var _ = Describe("ControllerRegistration controller test", func() {
 			By("Delete object")
 			Expect(testClient.Delete(ctx, obj)).To(Succeed())
 
-			By("Expect ControllerInstallation be deleted")
+			By("Expect ControllerInstallation to be deleted")
 			Eventually(func(g Gomega) {
 				controllerInstallationList := &gardencorev1beta1.ControllerInstallationList{}
 				g.Expect(testClient.List(ctx, controllerInstallationList, client.MatchingFields{
@@ -296,7 +370,7 @@ var _ = Describe("ControllerRegistration controller test", func() {
 			By("Create object")
 			Expect(testClient.Create(ctx, obj)).To(Succeed())
 
-			By("Expect ControllerInstallation be created")
+			By("Expect ControllerInstallation to be created")
 			controllerInstallation := &gardencorev1beta1.ControllerInstallation{}
 			Eventually(func(g Gomega) {
 				controllerInstallationList := &gardencorev1beta1.ControllerInstallationList{}
@@ -405,7 +479,7 @@ var _ = Describe("ControllerRegistration controller test", func() {
 			By("Create object")
 			Expect(testClient.Create(ctx, obj)).To(Succeed())
 
-			By("Expect ControllerInstallation be created")
+			By("Expect ControllerInstallation to be created")
 			Eventually(func(g Gomega) {
 				controllerInstallationList := &gardencorev1beta1.ControllerInstallationList{}
 				g.Expect(testClient.List(ctx, controllerInstallationList, client.MatchingFields{
@@ -421,7 +495,7 @@ var _ = Describe("ControllerRegistration controller test", func() {
 			By("Delete object")
 			Expect(testClient.Delete(ctx, obj)).To(Succeed())
 
-			By("Expect ControllerInstallation be deleted")
+			By("Expect ControllerInstallation to be deleted")
 			Eventually(func(g Gomega) {
 				controllerInstallationList := &gardencorev1beta1.ControllerInstallationList{}
 				g.Expect(testClient.List(ctx, controllerInstallationList, client.MatchingFields{
@@ -443,78 +517,6 @@ var _ = Describe("ControllerRegistration controller test", func() {
 
 	Context("Shoot", func() {
 		It("should reconcile the ControllerInstallations", func() {
-			shootProviderType := "shootProvider"
-
-			obj := &gardencorev1beta1.Shoot{
-				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: testID + "-",
-					Namespace:    testNamespace.Name,
-					Labels:       map[string]string{testID: testRunID},
-				},
-				Spec: gardencorev1beta1.ShootSpec{
-					SecretBindingName: pointer.String("my-provider-account"),
-					CloudProfileName:  "test-cloudprofile",
-					Region:            "foo-region",
-					Provider: gardencorev1beta1.Provider{
-						Type: shootProviderType,
-						Workers: []gardencorev1beta1.Worker{
-							{
-								Name:    "cpu-worker",
-								Minimum: 2,
-								Maximum: 2,
-								Machine: gardencorev1beta1.Machine{
-									Type: "large",
-									Image: &gardencorev1beta1.ShootMachineImage{
-										Name:    shootProviderType,
-										Version: pointer.String("0.0.0"),
-									},
-								},
-								CRI: &gardencorev1beta1.CRI{
-									Name: gardencorev1beta1.CRINameContainerD,
-									ContainerRuntimes: []gardencorev1beta1.ContainerRuntime{{
-										Type: shootProviderType,
-									}},
-								},
-							},
-						},
-					},
-					Kubernetes: gardencorev1beta1.Kubernetes{
-						Version: "1.22.1",
-					},
-					Networking: &gardencorev1beta1.Networking{
-						Type: pointer.String(shootProviderType),
-					},
-					Extensions: []gardencorev1beta1.Extension{{
-						Type: shootProviderType,
-					}},
-					DNS: &gardencorev1beta1.DNS{
-						Providers: []gardencorev1beta1.DNSProvider{{
-							Type: &shootProviderType,
-						}},
-					},
-					SeedName: &seed.Name,
-				},
-			}
-
-			shootControllerRegistration := &gardencorev1beta1.ControllerRegistration{
-				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: "ctrlreg-" + testID + "-",
-					Labels:       map[string]string{testID: testRunID},
-				},
-				Spec: gardencorev1beta1.ControllerRegistrationSpec{
-					Resources: []gardencorev1beta1.ControllerResource{
-						{Kind: extensionsv1alpha1.ControlPlaneResource, Type: shootProviderType},
-						{Kind: extensionsv1alpha1.InfrastructureResource, Type: shootProviderType},
-						{Kind: extensionsv1alpha1.WorkerResource, Type: shootProviderType},
-						{Kind: extensionsv1alpha1.NetworkResource, Type: shootProviderType},
-						{Kind: extensionsv1alpha1.ContainerRuntimeResource, Type: shootProviderType},
-						{Kind: extensionsv1alpha1.DNSRecordResource, Type: shootProviderType},
-						{Kind: extensionsv1alpha1.OperatingSystemConfigResource, Type: shootProviderType},
-						{Kind: extensionsv1alpha1.ExtensionResource, Type: shootProviderType},
-					},
-				},
-			}
-
 			By("Create ControllerRegistration")
 			Expect(testClient.Create(ctx, shootControllerRegistration)).To(Succeed())
 
@@ -525,9 +527,9 @@ var _ = Describe("ControllerRegistration controller test", func() {
 			}).Should(ConsistOf("core.gardener.cloud/controllerregistration"))
 
 			By("Create object")
-			Expect(testClient.Create(ctx, obj)).To(Succeed())
+			Expect(testClient.Create(ctx, shoot)).To(Succeed())
 
-			By("Expect ControllerInstallation be created")
+			By("Expect ControllerInstallation to be created")
 			Eventually(func(g Gomega) {
 				controllerInstallationList := &gardencorev1beta1.ControllerInstallationList{}
 				g.Expect(testClient.List(ctx, controllerInstallationList, client.MatchingFields{
@@ -538,9 +540,9 @@ var _ = Describe("ControllerRegistration controller test", func() {
 			}).Should(Succeed())
 
 			By("Delete object")
-			Expect(testClient.Delete(ctx, obj)).To(Succeed())
+			Expect(testClient.Delete(ctx, shoot)).To(Succeed())
 
-			By("Expect ControllerInstallation be deleted")
+			By("Expect ControllerInstallation to be deleted")
 			Eventually(func(g Gomega) {
 				controllerInstallationList := &gardencorev1beta1.ControllerInstallationList{}
 				g.Expect(testClient.List(ctx, controllerInstallationList, client.MatchingFields{
@@ -557,6 +559,196 @@ var _ = Describe("ControllerRegistration controller test", func() {
 			Eventually(func() error {
 				return testClient.Get(ctx, client.ObjectKeyFromObject(shootControllerRegistration), shootControllerRegistration)
 			}).Should(BeNotFoundError())
+		})
+	})
+
+	Context("ControllerRegistration w/o resources but deploy policy", func() {
+		Context("'Always' policy", func() {
+			policy := gardencorev1beta1.ControllerDeploymentPolicyAlways
+
+			It("should delete ControllerInstallations when ControllerRegistration is deleted", func() {
+				controllerRegistration := &gardencorev1beta1.ControllerRegistration{
+					ObjectMeta: metav1.ObjectMeta{
+						GenerateName: "ctrlreg-" + testID + "-",
+						Labels:       map[string]string{testID: testRunID},
+					},
+					Spec: gardencorev1beta1.ControllerRegistrationSpec{
+						Deployment: &gardencorev1beta1.ControllerRegistrationDeployment{
+							Policy: &policy,
+						},
+					},
+				}
+
+				By("Create ControllerRegistration")
+				Expect(testClient.Create(ctx, controllerRegistration)).To(Succeed())
+				log.Info("Created ControllerRegistration for test", "controllerRegistration", client.ObjectKeyFromObject(controllerRegistration))
+
+				DeferCleanup(func() {
+					By("Delete ControllerRegistration")
+					Expect(testClient.Delete(ctx, controllerRegistration)).To(Succeed())
+
+					By("Wait until manager has observed ControllerRegistration deletion")
+					Eventually(func() error {
+						return mgrClient.Get(ctx, client.ObjectKeyFromObject(controllerRegistration), controllerRegistration)
+					}).Should(BeNotFoundError())
+				})
+
+				By("Expect finalizer to be added to ControllerRegistration")
+				Eventually(func(g Gomega) []string {
+					g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(controllerRegistration), controllerRegistration)).To(Succeed())
+					return controllerRegistration.Finalizers
+				}).Should(ConsistOf("core.gardener.cloud/controllerregistration"))
+
+				By("Expect ControllerInstallation to be created")
+				Eventually(func(g Gomega) {
+					controllerInstallationList := &gardencorev1beta1.ControllerInstallationList{}
+					g.Expect(testClient.List(ctx, controllerInstallationList, client.MatchingFields{
+						core.RegistrationRefName: controllerRegistration.Name,
+						core.SeedRefName:         seed.Name,
+					})).To(Succeed())
+					g.Expect(controllerInstallationList.Items).To(HaveLen(1))
+				}).Should(Succeed())
+			})
+		})
+
+		Context("'AlwaysExceptNoShoots' policy", func() {
+			var (
+				policy                 = gardencorev1beta1.ControllerDeploymentPolicyAlwaysExceptNoShoots
+				controllerRegistration *gardencorev1beta1.ControllerRegistration
+			)
+
+			BeforeEach(func() {
+				controllerRegistration = &gardencorev1beta1.ControllerRegistration{
+					ObjectMeta: metav1.ObjectMeta{
+						GenerateName: "ctrlreg-" + testID + "-",
+						Labels:       map[string]string{testID: testRunID},
+					},
+					Spec: gardencorev1beta1.ControllerRegistrationSpec{
+						Deployment: &gardencorev1beta1.ControllerRegistrationDeployment{
+							Policy: &policy,
+						},
+					},
+				}
+
+				By("Create ControllerRegistration for Shoot")
+				Expect(testClient.Create(ctx, shootControllerRegistration)).To(Succeed())
+
+				DeferCleanup(func() {
+					By("Delete ControllerRegistration for Shoot")
+					Expect(testClient.Delete(ctx, shootControllerRegistration)).To(Succeed())
+
+					By("Wait until manager has observed ControllerRegistration for Shoot deletion")
+					Eventually(func() error {
+						return mgrClient.Get(ctx, client.ObjectKeyFromObject(shootControllerRegistration), shootControllerRegistration)
+					}).Should(BeNotFoundError())
+				})
+			})
+
+			It("should delete ControllerInstallations when ControllerRegistration is deleted (even if Shoots still exist)", func() {
+				By("Create ControllerRegistration")
+				Expect(testClient.Create(ctx, controllerRegistration)).To(Succeed())
+				log.Info("Created ControllerRegistration for test", "controllerRegistration", client.ObjectKeyFromObject(controllerRegistration))
+
+				DeferCleanup(func() {
+					By("Delete ControllerRegistration")
+					Expect(testClient.Delete(ctx, controllerRegistration)).To(Succeed())
+
+					By("Wait until manager has observed ControllerRegistration deletion")
+					Eventually(func() error {
+						return mgrClient.Get(ctx, client.ObjectKeyFromObject(controllerRegistration), controllerRegistration)
+					}).Should(BeNotFoundError())
+
+					By("Delete Shoot")
+					Expect(testClient.Delete(ctx, shoot)).To(Succeed())
+				})
+
+				By("Expect finalizer to be added to ControllerRegistration")
+				Eventually(func(g Gomega) []string {
+					g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(controllerRegistration), controllerRegistration)).To(Succeed())
+					return controllerRegistration.Finalizers
+				}).Should(ConsistOf("core.gardener.cloud/controllerregistration"))
+
+				By("Expect no ControllerInstallation to be created because no Shoot exists")
+				Consistently(func(g Gomega) {
+					controllerInstallationList := &gardencorev1beta1.ControllerInstallationList{}
+					g.Expect(testClient.List(ctx, controllerInstallationList, client.MatchingFields{
+						core.RegistrationRefName: controllerRegistration.Name,
+						core.SeedRefName:         seed.Name,
+					})).To(Succeed())
+					g.Expect(controllerInstallationList.Items).To(BeEmpty())
+				}).Should(Succeed())
+
+				By("Create object")
+				Expect(testClient.Create(ctx, shoot)).To(Succeed())
+
+				By("Expect ControllerInstallation to be created")
+				Eventually(func(g Gomega) {
+					controllerInstallationList := &gardencorev1beta1.ControllerInstallationList{}
+					g.Expect(testClient.List(ctx, controllerInstallationList, client.MatchingFields{
+						core.RegistrationRefName: controllerRegistration.Name,
+						core.SeedRefName:         seed.Name,
+					})).To(Succeed())
+					g.Expect(controllerInstallationList.Items).To(HaveLen(1))
+				}).Should(Succeed())
+			})
+
+			It("should delete ControllerInstallations after all Shoots are gone", func() {
+				By("Create ControllerRegistration")
+				Expect(testClient.Create(ctx, controllerRegistration)).To(Succeed())
+				log.Info("Created ControllerRegistration for test", "controllerRegistration", client.ObjectKeyFromObject(controllerRegistration))
+
+				DeferCleanup(func() {
+					By("Delete ControllerRegistration")
+					Expect(testClient.Delete(ctx, controllerRegistration)).To(Succeed())
+
+					By("Wait until manager has observed ControllerRegistration deletion")
+					Eventually(func() error {
+						return mgrClient.Get(ctx, client.ObjectKeyFromObject(controllerRegistration), controllerRegistration)
+					}).Should(BeNotFoundError())
+				})
+
+				By("Expect finalizer to be added to ControllerRegistration")
+				Eventually(func(g Gomega) []string {
+					g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(controllerRegistration), controllerRegistration)).To(Succeed())
+					return controllerRegistration.Finalizers
+				}).Should(ConsistOf("core.gardener.cloud/controllerregistration"))
+
+				By("Expect no ControllerInstallation to be created because no Shoot exists")
+				Consistently(func(g Gomega) {
+					controllerInstallationList := &gardencorev1beta1.ControllerInstallationList{}
+					g.Expect(testClient.List(ctx, controllerInstallationList, client.MatchingFields{
+						core.RegistrationRefName: controllerRegistration.Name,
+						core.SeedRefName:         seed.Name,
+					})).To(Succeed())
+					g.Expect(controllerInstallationList.Items).To(BeEmpty())
+				}).Should(Succeed())
+
+				By("Create Shoot")
+				Expect(testClient.Create(ctx, shoot)).To(Succeed())
+
+				By("Expect ControllerInstallation to be created")
+				Eventually(func(g Gomega) {
+					controllerInstallationList := &gardencorev1beta1.ControllerInstallationList{}
+					g.Expect(testClient.List(ctx, controllerInstallationList, client.MatchingFields{
+						core.RegistrationRefName: controllerRegistration.Name,
+						core.SeedRefName:         seed.Name,
+					})).To(Succeed())
+					g.Expect(controllerInstallationList.Items).To(HaveLen(1))
+				}).Should(Succeed())
+
+				By("Delete Shoot")
+				Expect(testClient.Delete(ctx, shoot)).To(Succeed())
+
+				By("Expect ControllerInstallation be deleted")
+				Eventually(func(g Gomega) {
+					controllerInstallationList := &gardencorev1beta1.ControllerInstallationList{}
+					g.Expect(testClient.List(ctx, controllerInstallationList, client.MatchingFields{
+						core.RegistrationRefName: controllerRegistration.Name,
+						core.SeedRefName:         seed.Name,
+					})).To(Succeed())
+					g.Expect(controllerInstallationList.Items).To(BeEmpty())
+				}).Should(Succeed())
+			})
 		})
 	})
 })


### PR DESCRIPTION
/kind bug
/area usability

Cherry pick of #8443 on release-v1.77.

#8443: Fix `ControllerRegistration` controller not deleting `ControllerInstallation`s when `deletionTimestamp` is set

**Release Notes:**
```bugfix operator
A bug has been fixed that prevented `ControllerInstallation`s from getting deleted when the backing `ControllerRegistration` with `.spec.deployment.policy={Always,AlwaysExceptNoShoots}` was deleted.
```