### PR TITLE
`Garden` controller waits for `etcd-druid` deployment

### DIFF
--- a/pkg/component/etcd/bootstrap.go
+++ b/pkg/component/etcd/bootstrap.go
@@ -440,7 +440,7 @@ func (b *bootstrapper) Wait(ctx context.Context) error {
 	timeoutCtx, cancel := context.WithTimeout(ctx, TimeoutWaitForManagedResource)
 	defer cancel()
 
-	return managedresources.WaitUntilHealthy(timeoutCtx, b.client, b.namespace, managedResourceControlName)
+	return managedresources.WaitUntilHealthyAndNotProgressing(timeoutCtx, b.client, b.namespace, managedResourceControlName)
 }
 
 func (b *bootstrapper) WaitCleanup(ctx context.Context) error {

--- a/pkg/component/gardenerapiserver/gardener_apiserver_test.go
+++ b/pkg/component/gardenerapiserver/gardener_apiserver_test.go
@@ -1520,7 +1520,7 @@ kubeConfigFile: /etc/kubernetes/admission-kubeconfigs/validatingadmissionwebhook
 					Status: unhealthyManagedResourceStatus,
 				})).To(Succeed())
 
-				Expect(deployer.Wait(ctx)).To(MatchError(ContainSubstring("is unhealthy")))
+				Expect(deployer.Wait(ctx)).To(MatchError(ContainSubstring("is not healthy")))
 			})
 
 			It("should fail because the runtime ManagedResource is still progressing", func() {

--- a/pkg/operator/controller/garden/garden/reconciler_reconcile.go
+++ b/pkg/operator/controller/garden/garden/reconciler_reconcile.go
@@ -178,7 +178,7 @@ func (r *Reconciler) reconcile(
 		})
 		deployEtcdDruid = g.Add(flow.Task{
 			Name:         "Deploying ETCD Druid",
-			Fn:           c.etcdDruid.Deploy,
+			Fn:           component.OpWait(c.etcdDruid).Deploy,
 			Dependencies: flow.NewTaskIDs(deployGardenerResourceManager),
 		})
 		deployIstio = g.Add(flow.Task{

--- a/test/integration/operator/garden/garden/garden_test.go
+++ b/test/integration/operator/garden/garden/garden_test.go
@@ -376,6 +376,11 @@ var _ = Describe("Garden controller tests", func() {
 			Eventually(makeManagedResourceHealthy(name, "istio-system")).Should(Succeed())
 		}
 
+		// The garden controller waits for the etcd-druid ManagedResources to be healthy, but it is not really running
+		// in this test, so let's fake this here.
+		By("Patch etcd-druid ManagedResources to report healthiness")
+		Eventually(makeManagedResourceHealthy("etcd-druid", testNamespace.Name)).Should(Succeed())
+
 		By("Verify that the virtual garden control plane components have been deployed")
 		Eventually(func(g Gomega) []druidv1alpha1.Etcd {
 			etcdList := &druidv1alpha1.EtcdList{}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind enhancement

**What this PR does / why we need it**:
`Garden` controller waits for `etcd-druid` deployment.

Otherwise, it might proceed with reconciliation of the `Etcd` resources even if `etcd-druid` is still in the phase of getting rolled out/updated. This can be especially dangerous/problematic when the images in the `etcd-druid`s image vector change. Without this, the configuration in the `Etcd` resource might not match the images or the `etcd-druid` version, leading to issues with the resulting ETCD `StatefulSet`s.

**Special notes for your reviewer**:
/cc @ScheererJ 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
