### PR TITLE
Forbid specifying an extension of same type more than once

### DIFF
--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -765,9 +765,14 @@ func validateDNS(dns *core.DNS, fldPath *field.Path) field.ErrorList {
 
 func validateExtensions(extensions []core.Extension, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
+	types := sets.Set[string]{}
 	for i, extension := range extensions {
 		if extension.Type == "" {
 			allErrs = append(allErrs, field.Required(fldPath.Index(i).Child("type"), "field must not be empty"))
+		} else if types.Has(extension.Type) {
+			allErrs = append(allErrs, field.Duplicate(fldPath.Index(i).Child("type"), extension.Type))
+		} else {
+			types.Insert(extension.Type)
 		}
 	}
 	return allErrs

--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -780,6 +780,33 @@ var _ = Describe("Shoot Validation Tests", func() {
 			Expect(errorList).To(BeEmpty())
 		})
 
+		It("should forbid passing an extension of same type more than once", func() {
+			extension := core.Extension{
+				Type: "arbitrary",
+			}
+			shoot.Spec.Extensions = append(shoot.Spec.Extensions, extension, extension)
+
+			errorList := ValidateShoot(shoot)
+
+			Expect(errorList).To(ConsistOf(
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeDuplicate),
+					"Field": Equal("spec.extensions[1].type"),
+				}))))
+		})
+
+		It("should allow passing more than one extension of different type", func() {
+			extension := core.Extension{
+				Type: "arbitrary",
+			}
+			shoot.Spec.Extensions = append(shoot.Spec.Extensions, extension, extension)
+			shoot.Spec.Extensions[1].Type = "arbitrary-2"
+
+			errorList := ValidateShoot(shoot)
+
+			Expect(errorList).To(BeEmpty())
+		})
+
 		It("should forbid resources w/o names or w/ invalid references", func() {
 			ref := core.NamedResourceReference{}
 			shoot.Spec.Resources = append(shoot.Spec.Resources, ref)

--- a/pkg/registry/core/shoot/strategy.go
+++ b/pkg/registry/core/shoot/strategy.go
@@ -70,6 +70,8 @@ func (shootStrategy) PrepareForCreate(_ context.Context, obj runtime.Object) {
 
 	// TODO(shafeeqes): Drop this after gardener v1.80 has been released.
 	removeForbiddenFinalizers(shoot)
+	// TODO(acumino): Drop this after v1.83 has been released.
+	removeDuplicateExtensions(shoot)
 }
 
 func (shootStrategy) PrepareForUpdate(_ context.Context, obj, old runtime.Object) {

--- a/pkg/registry/core/shoot/strategy.go
+++ b/pkg/registry/core/shoot/strategy.go
@@ -84,7 +84,7 @@ func (shootStrategy) PrepareForUpdate(_ context.Context, obj, old runtime.Object
 	}
 
 	// TODO(acumino): Drop this in gardener v1.84 release.
-	removeDuplicateExtension(newShoot)
+	removeDuplicateExtensions(newShoot)
 }
 
 func mustIncreaseGeneration(oldShoot, newShoot *core.Shoot) bool {
@@ -171,15 +171,15 @@ func removeForbiddenFinalizers(shoot *core.Shoot) {
 	shoot.Finalizers = finalizers
 }
 
-func removeDuplicateExtension(shoot *core.Shoot) {
+func removeDuplicateExtensions(shoot *core.Shoot) {
 	if len(shoot.Spec.Extensions) > 1 {
-		extensionsType := map[string]core.Extension{}
-		extensionsList := []core.Extension{}
+		typeToExtension := make(map[string]core.Extension, len(shoot.Spec.Extensions))
 		for _, extension := range shoot.Spec.Extensions {
-			extensionsType[extension.Type] = extension
+			typeToExtension[extension.Type] = extension
 		}
 
-		for _, extension := range extensionsType {
+		extensionsList := make([]core.Extension, 0, len(typeToExtension))
+		for _, extension := range typeToExtension {
 			extensionsList = append(extensionsList, extension)
 		}
 

--- a/pkg/registry/core/shoot/strategy.go
+++ b/pkg/registry/core/shoot/strategy.go
@@ -83,7 +83,7 @@ func (shootStrategy) PrepareForUpdate(_ context.Context, obj, old runtime.Object
 		newShoot.Generation = oldShoot.Generation + 1
 	}
 
-	// TODO(acumino): Drop this in gardener v1.84 release.
+	// TODO(acumino): Drop this after v1.83 has been released.
 	removeDuplicateExtensions(newShoot)
 }
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind bug

**What this PR does / why we need it**:
This PR enhances shoot validation to forbid specifying an extension of the same type more than once. 
For more details - https://github.com/gardener/gardener/issues/8446

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener/issues/8446

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
A bug has been fixed which was allowing users to specify an extension of the same type in `.spec.extensions[].type` more than once in the `Shoot` API.
```
