### PR TITLE
Bump up vali and valitail versions from v2.2.6 to v2.2.8

### DIFF
--- a/imagevector/images.yaml
+++ b/imagevector/images.yaml
@@ -445,7 +445,7 @@ images:
 - name: vali
   sourceRepository: github.com/credativ/vali
   repository: ghcr.io/credativ/vali
-  tag: "v2.2.6"
+  tag: "v2.2.8"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:
@@ -497,7 +497,7 @@ images:
 - name: valitail
   sourceRepository: github.com/credativ/vali
   repository: ghcr.io/credativ/valitail
-  tag: "v2.2.6"
+  tag: "v2.2.8"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:


### PR DESCRIPTION
/area logging
/kind enhancement

This update brings `vali` release [v2.2.8](https://github.com/credativ/vali/releases/tag/v2.2.8). It contains updates to `vali` dependencies fixing security vulnerabilities in those components.

```other operator
The logging components: vali and valitail are now updated to v2.2.8.
```
