### PR TITLE
Use simpler and equivalent logic in `class_filter.go`

### DIFF
--- a/pkg/resourcemanager/predicate/class_filter.go
+++ b/pkg/resourcemanager/predicate/class_filter.go
@@ -102,24 +102,22 @@ func (f *ClassFilter) Active(o runtime.Object) (action bool, responsible bool) {
 
 // Create implements `predicate.Predicate`.
 func (f *ClassFilter) Create(e event.CreateEvent) bool {
-	a, r := f.Active(e.Object)
-	return a || r
+	return f.Responsible(e.Object)
+
 }
 
 // Delete implements `predicate.Predicate`.
 func (f *ClassFilter) Delete(e event.DeleteEvent) bool {
-	a, r := f.Active(e.Object)
-	return a || r
+	return f.Responsible(e.Object)
+
 }
 
 // Update implements `predicate.Predicate`.
 func (f *ClassFilter) Update(e event.UpdateEvent) bool {
-	a, r := f.Active(e.ObjectNew)
-	return a || r
+	return f.Responsible(e.ObjectNew)
 }
 
 // Generic implements `predicate.Predicate`.
 func (f *ClassFilter) Generic(e event.GenericEvent) bool {
-	a, r := f.Active(e.Object)
-	return a || r
+	return f.Responsible(e.Object)
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind enhancement

**What this PR does / why we need it**:
This PR proposes a simpler and equivalent logic to be used in `Create`, `Update`, `Delete` and `Generic` methods of `ClassFilter`.
Here is the truth table for how `(!busy && responsible) || responsible` (previous) compares to the suggested `responsible`

!busy | responsible | !busy && responsible | (!busy && responsible) \|\| responsible
-- | -- | -- | --
false | **false** | false | **false**
false | **true** | false | **true**
true | **false** | false | **false**
true | **true** | true | **true**

Here we can see that `responsible` is equivalent to `(!busy && responsible) || responsible`
Therefore we can use it instead to make the code more easier to understand


**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
NONE
```
