### PR TITLE
Fix duplicated service account issuers

### DIFF
--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -1210,16 +1210,16 @@ func ValidateKubeAPIServer(kubeAPIServer *core.KubeAPIServerConfig, version stri
 			if kubeAPIServer.ServiceAccountConfig.Issuer != nil {
 				issuers.Insert(*kubeAPIServer.ServiceAccountConfig.Issuer)
 			}
-			for i, issuer := range kubeAPIServer.ServiceAccountConfig.AcceptedIssuers {
-				if issuers.Has(issuer) {
+			for i, acceptedIssuer := range kubeAPIServer.ServiceAccountConfig.AcceptedIssuers {
+				if issuers.Has(acceptedIssuer) {
 					path := fldPath.Child("serviceAccountConfig", "acceptedIssuers").Index(i)
-					if kubeAPIServer.ServiceAccountConfig.Issuer != nil && issuer == *kubeAPIServer.ServiceAccountConfig.Issuer {
-						allErrs = append(allErrs, field.Invalid(path, issuer, fmt.Sprintf("acceptedIssuers cannot contains the issuer field value: %s", issuer)))
+					if issuer := kubeAPIServer.ServiceAccountConfig.Issuer; issuer != nil && *issuer == acceptedIssuer {
+						allErrs = append(allErrs, field.Invalid(path, acceptedIssuer, fmt.Sprintf("acceptedIssuers cannot contains the issuer field value: %s", acceptedIssuer)))
 					} else {
-						allErrs = append(allErrs, field.Duplicate(path, issuer))
+						allErrs = append(allErrs, field.Duplicate(path, acceptedIssuer))
 					}
 				} else {
-					issuers.Insert(issuer)
+					issuers.Insert(acceptedIssuer)
 				}
 			}
 		}

--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -1212,7 +1212,12 @@ func ValidateKubeAPIServer(kubeAPIServer *core.KubeAPIServerConfig, version stri
 			}
 			for i, issuer := range kubeAPIServer.ServiceAccountConfig.AcceptedIssuers {
 				if issuers.Has(issuer) {
-					allErrs = append(allErrs, field.Duplicate(fldPath.Child("serviceAccountConfig", "acceptedIssuers").Index(i), issuer))
+					path := fldPath.Child("serviceAccountConfig", "acceptedIssuers").Index(i)
+					if kubeAPIServer.ServiceAccountConfig.Issuer != nil && issuer == *kubeAPIServer.ServiceAccountConfig.Issuer {
+						allErrs = append(allErrs, field.Invalid(path, issuer, fmt.Sprintf("acceptedIssuers cannot contains the issuer field value: %s", issuer)))
+					} else {
+						allErrs = append(allErrs, field.Duplicate(path, issuer))
+					}
 				} else {
 					issuers.Insert(issuer)
 				}

--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -1205,6 +1205,19 @@ func ValidateKubeAPIServer(kubeAPIServer *core.KubeAPIServerConfig, version stri
 				allErrs = append(allErrs, field.Forbidden(fldPath.Child("serviceAccountConfig", "maxTokenExpiration"), "must be at most 2160h (90d)"))
 			}
 		}
+		if len(kubeAPIServer.ServiceAccountConfig.AcceptedIssuers) > 0 {
+			issuers := sets.New[string]()
+			if kubeAPIServer.ServiceAccountConfig.Issuer != nil {
+				issuers.Insert(*kubeAPIServer.ServiceAccountConfig.Issuer)
+			}
+			for i, issuer := range kubeAPIServer.ServiceAccountConfig.AcceptedIssuers {
+				if issuers.Has(issuer) {
+					allErrs = append(allErrs, field.Duplicate(fldPath.Child("serviceAccountConfig", "acceptedIssuers").Index(i), issuer))
+				} else {
+					issuers.Insert(issuer)
+				}
+			}
+		}
 	}
 
 	if kubeAPIServer.EventTTL != nil {

--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -1912,8 +1912,8 @@ var _ = Describe("Shoot Validation Tests", func() {
 			It("should not allow to specify duplicates in accepted issuers", func() {
 				shoot.Spec.Kubernetes.KubeAPIServer.ServiceAccountConfig = &core.ServiceAccountConfig{
 					AcceptedIssuers: []string{
-						"issuer",
-						"issuer",
+						"foo",
+						"foo",
 					},
 				}
 
@@ -1927,15 +1927,16 @@ var _ = Describe("Shoot Validation Tests", func() {
 
 			It("should not allow to duplicate the issuer in accepted issuers", func() {
 				shoot.Spec.Kubernetes.KubeAPIServer.ServiceAccountConfig = &core.ServiceAccountConfig{
-					Issuer:          pointer.String("issuer"),
-					AcceptedIssuers: []string{"issuer"},
+					Issuer:          pointer.String("foo"),
+					AcceptedIssuers: []string{"foo"},
 				}
 
 				errorList := ValidateShoot(shoot)
 
 				Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":  Equal(field.ErrorTypeDuplicate),
-					"Field": Equal("spec.kubernetes.kubeAPIServer.serviceAccountConfig.acceptedIssuers[0]"),
+					"Type":   Equal(field.ErrorTypeInvalid),
+					"Field":  Equal("spec.kubernetes.kubeAPIServer.serviceAccountConfig.acceptedIssuers[0]"),
+					"Detail": ContainSubstring("acceptedIssuers cannot contains the issuer field value: foo"),
 				}))))
 			})
 		})

--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -1908,6 +1908,36 @@ var _ = Describe("Shoot Validation Tests", func() {
 					"Field": Equal("spec.kubernetes.kubeAPIServer.serviceAccountConfig.maxTokenExpiration"),
 				}))))
 			})
+
+			It("should not allow to specify duplicates in accepted issuers", func() {
+				shoot.Spec.Kubernetes.KubeAPIServer.ServiceAccountConfig = &core.ServiceAccountConfig{
+					AcceptedIssuers: []string{
+						"issuer",
+						"issuer",
+					},
+				}
+
+				errorList := ValidateShoot(shoot)
+
+				Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeDuplicate),
+					"Field": Equal("spec.kubernetes.kubeAPIServer.serviceAccountConfig.acceptedIssuers[1]"),
+				}))))
+			})
+
+			It("should not allow to duplicate the issuer in accepted issuers", func() {
+				shoot.Spec.Kubernetes.KubeAPIServer.ServiceAccountConfig = &core.ServiceAccountConfig{
+					Issuer:          pointer.String("issuer"),
+					AcceptedIssuers: []string{"issuer"},
+				}
+
+				errorList := ValidateShoot(shoot)
+
+				Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeDuplicate),
+					"Field": Equal("spec.kubernetes.kubeAPIServer.serviceAccountConfig.acceptedIssuers[0]"),
+				}))))
+			})
 		})
 
 		It("should not allow to specify a negative event ttl duration", func() {

--- a/pkg/component/shared/kubeapiserver.go
+++ b/pkg/component/shared/kubeapiserver.go
@@ -410,6 +410,15 @@ func computeKubeAPIServerServiceAccountConfig(
 	if out.Issuer != defaultIssuer && !utils.ValueExists(defaultIssuer, out.AcceptedIssuers) {
 		out.AcceptedIssuers = append(out.AcceptedIssuers, defaultIssuer)
 	}
+	if config.ServiceAccountConfig.Issuer == nil {
+		// ensure defaultIssuer is not duplicated in the accepted issuers
+		for i, val := range out.AcceptedIssuers {
+			if val == defaultIssuer {
+				out.AcceptedIssuers = append(out.AcceptedIssuers[:i], out.AcceptedIssuers[i+1:]...)
+				break
+			}
+		}
+	}
 
 	return out
 }

--- a/pkg/component/shared/kubeapiserver_test.go
+++ b/pkg/component/shared/kubeapiserver_test.go
@@ -1397,6 +1397,21 @@ exemptions:
 					false,
 					Not(HaveOccurred()),
 				),
+				Entry("Default Issuer is already part of AcceptedIssuers but no Issuer is provided",
+					func() {
+						apiServerConfig = &gardencorev1beta1.KubeAPIServerConfig{
+							ServiceAccountConfig: &gardencorev1beta1.ServiceAccountConfig{
+								AcceptedIssuers: []string{"https://" + externalHostname},
+							},
+						}
+					},
+					kubeapiserver.ServiceAccountConfig{
+						Issuer:          "https://" + externalHostname,
+						AcceptedIssuers: []string{},
+					},
+					false,
+					Not(HaveOccurred()),
+				),
 				Entry("AcceptedIssuers is not provided",
 					func() {
 						apiServerConfig = &gardencorev1beta1.KubeAPIServerConfig{

--- a/pkg/registry/core/shoot/strategy_test.go
+++ b/pkg/registry/core/shoot/strategy_test.go
@@ -131,6 +131,25 @@ var _ = Describe("Strategy", func() {
 					"Disabled": Equal(pointer.Bool(true)),
 				})))
 		})
+
+		It("should remove duplicate service account issuers", func() {
+			shoot := &core.Shoot{
+				Spec: core.ShootSpec{
+					Kubernetes: core.Kubernetes{
+						KubeAPIServer: &core.KubeAPIServerConfig{
+							ServiceAccountConfig: &core.ServiceAccountConfig{
+								Issuer:          pointer.String("foo"),
+								AcceptedIssuers: []string{"foo", "foo", "bar", "bar"},
+							},
+						},
+					},
+				},
+			}
+
+			shootregistry.NewStrategy(0).PrepareForCreate(context.TODO(), shoot)
+
+			Expect(shoot.Spec.Kubernetes.KubeAPIServer.ServiceAccountConfig.AcceptedIssuers).To(Equal([]string{"bar"}))
+		})
 	})
 
 	Describe("#PrepareForUpdate", func() {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug

**What this PR does / why we need it**:
Adds validation for `.spec.kubernetes.kubeAPIServer.serviceAccountConfig.acceptedIssuers` field of the `Shoot` manifest.  
Duplicate values in `acceptedIssuers` are no longer allowed and `acceptedIssuers` could not contains the 
value of `issuer` field.

**Which issue(s) this PR fixes**:
Fixes #8420

**Special notes for your reviewer**:
N/A
**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
The `.spec.kubernetes.kubeAPIServer.serviceAccountConfig.acceptedIssuers` field of the `Shoot` spec no longer allows duplicate values.
```
