### PR TITLE
Add an `OpenAPIV3Config` to `gardener-apiserver`

### DIFF
--- a/cmd/gardener-apiserver/app/gardener_apiserver.go
+++ b/cmd/gardener-apiserver/app/gardener_apiserver.go
@@ -377,7 +377,7 @@ func (o *Options) ApplyTo(config *apiserver.Config) error {
 	gardenerAPIServerConfig := config.GenericConfig
 
 	gardenerVersion := version.Get()
-	// There might be an upstream bug which requires OpenAPIConfig and OpenAPIV3Config to be available. Otherwise, there will be a nil pointer exception.
+	// There is an upstream bug which requires OpenAPIConfig and OpenAPIV3Config to be available. Otherwise, there will be a nil pointer exception.
 	// ref: https://github.com/kubernetes/apiserver/blob/b9faf8358c6ec35a3ca611244052efcc394c8e44/pkg/server/genericapiserver.go#L962
 	gardenerAPIServerConfig.OpenAPIConfig = genericapiserver.DefaultOpenAPIConfig(openapi.GetOpenAPIDefinitions, openapinamer.NewDefinitionNamer(api.Scheme))
 	gardenerAPIServerConfig.OpenAPIConfig.Info.Title = "Gardener"

--- a/cmd/gardener-apiserver/app/gardener_apiserver.go
+++ b/cmd/gardener-apiserver/app/gardener_apiserver.go
@@ -377,9 +377,14 @@ func (o *Options) ApplyTo(config *apiserver.Config) error {
 	gardenerAPIServerConfig := config.GenericConfig
 
 	gardenerVersion := version.Get()
+	// There might be an upstream bug which requires OpenAPIConfig and OpenAPIV3Config to be available. Otherwise, there will be a nil pointer exception.
+	// ref: https://github.com/kubernetes/apiserver/blob/b9faf8358c6ec35a3ca611244052efcc394c8e44/pkg/server/genericapiserver.go#L962
 	gardenerAPIServerConfig.OpenAPIConfig = genericapiserver.DefaultOpenAPIConfig(openapi.GetOpenAPIDefinitions, openapinamer.NewDefinitionNamer(api.Scheme))
 	gardenerAPIServerConfig.OpenAPIConfig.Info.Title = "Gardener"
 	gardenerAPIServerConfig.OpenAPIConfig.Info.Version = gardenerVersion.GitVersion
+	gardenerAPIServerConfig.OpenAPIV3Config = genericapiserver.DefaultOpenAPIV3Config(openapi.GetOpenAPIDefinitions, openapinamer.NewDefinitionNamer(api.Scheme))
+	gardenerAPIServerConfig.OpenAPIV3Config.Info.Title = "Gardener"
+	gardenerAPIServerConfig.OpenAPIV3Config.Info.Version = gardenerVersion.GitVersion
 	gardenerAPIServerConfig.Version = &gardenerVersion
 
 	if err := o.ServerRunOptions.ApplyTo(&gardenerAPIServerConfig.Config); err != nil {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind regression

**What this PR does / why we need it**:
This PR adds an `OpenAPIV3Config` to `gardener-apiserver`.
After upgrading Kubernetes dependencies to `v0.27` with PR #8245 `server-side-apply` of Gardener objects fails.
This happens because it is required to add an `OpenAPIV3Config` to `apiserver`s  for `server-side-apply`. This was introduced with Kubernetes upstream PR https://github.com/kubernetes/kubernetes/pull/115324, but not mentioned as breaking change in the release notes.

**Which issue(s) this PR fixes**:
Fixes #8467 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Applying Gardener resources server-side has caused the `the server is currently unable to handle the request` error which is now fixed.
```
