### PR TITLE
Disable cache only for `Secrets` and `ConfigMap` if DisableCachedClient is true

### DIFF
--- a/cmd/gardener-resource-manager/app/app.go
+++ b/cmd/gardener-resource-manager/app/app.go
@@ -226,6 +226,10 @@ func run(ctx context.Context, log logr.Logger, cfg *config.ResourceManagerConfig
 
 			if *cfg.TargetClientConnection.DisableCachedClient {
 				opts.NewClient = func(config *rest.Config, opts client.Options) (client.Client, error) {
+					opts.Cache.DisableFor = append(opts.Cache.DisableFor,
+						&corev1.ConfigMap{},
+						&corev1.Secret{},
+					)
 					return client.New(config, opts)
 				}
 			}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement

**What this PR does / why we need it**:
Motivation for this PR https://github.com/gardener/gardener/issues/7473
Also succeeds PR https://github.com/gardener/gardener/pull/8472

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/7473

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy operator
`gardener-resource-manager` now disables cache only for `Secrets` and `ConfigMap` if `DisableCachedClient` set to true.
```
