### PR TITLE
gardenlet: Prevent transient errors of type `duplicate filename in registry`

### DIFF
--- a/pkg/component/clusteridentity/clusteridentity.go
+++ b/pkg/component/clusteridentity/clusteridentity.go
@@ -50,7 +50,6 @@ type clusterIdentity struct {
 	namespace               string
 	identity                string
 	identityType            string
-	managedResourceRegistry *managedresources.Registry
 	managedResourceName     string
 	managedResourceDeleteFn func(ctx context.Context, client client.Client, namespace string, name string) error
 }
@@ -60,7 +59,6 @@ func newComponent(
 	namespace string,
 	identity string,
 	identityType string,
-	managedResourceRegistry *managedresources.Registry,
 	managedResourceName string,
 	managedResourceDeleteFn func(ctx context.Context, client client.Client, namespace string, name string) error,
 ) Interface {
@@ -69,7 +67,6 @@ func newComponent(
 		namespace:               namespace,
 		identity:                identity,
 		identityType:            identityType,
-		managedResourceRegistry: managedResourceRegistry,
 		managedResourceName:     managedResourceName,
 		managedResourceDeleteFn: managedResourceDeleteFn,
 	}
@@ -82,7 +79,6 @@ func NewForSeed(c client.Client, namespace, identity string) Interface {
 		namespace,
 		identity,
 		v1beta1constants.ClusterIdentityOriginSeed,
-		managedresources.NewRegistry(kubernetes.SeedScheme, kubernetes.SeedCodec, kubernetes.SeedSerializer),
 		ManagedResourceControlName,
 		managedresources.DeleteForSeed,
 	)
@@ -95,7 +91,6 @@ func NewForShoot(c client.Client, namespace, identity string) Interface {
 		namespace,
 		identity,
 		v1beta1constants.ClusterIdentityOriginShoot,
-		managedresources.NewRegistry(kubernetes.ShootScheme, kubernetes.ShootCodec, kubernetes.ShootSerializer),
 		ShootManagedResourceName,
 		managedresources.DeleteForShoot,
 	)
@@ -114,7 +109,14 @@ func (c *clusterIdentity) Deploy(ctx context.Context) error {
 		},
 	}
 
-	resources, err := c.managedResourceRegistry.AddAllAndSerialize(configMap)
+	var registry *managedresources.Registry
+	if c.identityType == v1beta1constants.ClusterIdentityOriginShoot {
+		registry = managedresources.NewRegistry(kubernetes.ShootScheme, kubernetes.ShootCodec, kubernetes.ShootSerializer)
+	} else {
+		registry = managedresources.NewRegistry(kubernetes.SeedScheme, kubernetes.SeedCodec, kubernetes.SeedSerializer)
+	}
+
+	resources, err := registry.AddAllAndSerialize(configMap)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity
/kind bug

**What this PR does / why we need it**:
Explanations for the errors from: https://github.com/gardener/gardener/issues/8461

Currently components like VPA, kube-state-metrics, cluster-identity have the `managedresources.Registry` as a struct field:
https://github.com/gardener/gardener/blob/3de1a044951e695cc8066f94da0c57dddd2ce44a/pkg/component/vpa/vpa.go#L90

It means that the `managedresources.Registry` is shared across multiple invocations of the `Deploy` func.

The `Deploy` func can be invoked many times as we run the corresponding task with a `RetryUntilTimeout`:
https://github.com/gardener/gardener/blob/6f8ce7692f793e583734f533cfdee7b9d93fb815/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go#L419

The flow is:
1. Deploy of the component gets called
2. In the component `registry.Add(...)` is called and resources are added in the registry's map
3. After the `registry.Add(...)` the component fails with another (transient maybe) error
4. Deploy of the component gets called again due to the `RetryUntilTimeout` of the flow task
5. `registry.Add(...)` is invoked again for the same resources and for the same registry (registry is shared as outlined above). This fail with `duplicate filename in registry` until the task times out. Then the whole flow is retried.

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener/issues/8461

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
7. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
An issue causing several tasks from the Shoot reconciliation flow to fail with transient errors of type `duplicate filename in registry` is now fixed.
```
