### PR TITLE
Allow skipping state update by the worker-state controller

### DIFF
--- a/extensions/pkg/controller/worker/controller.go
+++ b/extensions/pkg/controller/worker/controller.go
@@ -104,6 +104,7 @@ func addStateUpdatingController(ctx context.Context, mgr manager.Manager, option
 		}
 		workerPredicates = []predicate.Predicate{
 			extensionspredicate.HasType(extensionType),
+			WorkerStateUpdateIsNotSkipped(),
 		}
 	)
 

--- a/extensions/pkg/controller/worker/predicate.go
+++ b/extensions/pkg/controller/worker/predicate.go
@@ -19,6 +19,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	"github.com/gardener/gardener/pkg/api/extensions"
 )
 
 // MachineNodeInfoHasChanged is a predicate deciding whether the information about the backing node of a Machine has
@@ -53,4 +55,21 @@ func MachineNodeInfoHasChanged() predicate.Predicate {
 			return true
 		},
 	}
+}
+
+// WorkerSkipStateUpdateAnnotation is a Worker annotation that instructs the worker-state controller to do not reconcile the corresponding Worker.
+const WorkerSkipStateUpdateAnnotation = "worker.gardener.cloud/skip-state-update"
+
+// WorkerStateUpdateIsNotSkipped is a predicate deciding whether the Worker is not annotated to skip state updates.
+func WorkerStateUpdateIsNotSkipped() predicate.Predicate {
+	return predicate.NewPredicateFuncs(func(obj client.Object) bool {
+		acc, err := extensions.Accessor(obj)
+		if err != nil {
+			// We assume by default that the Worker is not annotated to skip state updates.
+			return true
+		}
+
+		_, found := acc.GetAnnotations()[WorkerSkipStateUpdateAnnotation]
+		return !found
+	})
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind enhancement

**What this PR does / why we need it**:
For a Shoot with high amount of worker pools (> 60), we see that the Worker resource can no longer be updated with:
```
task "Configuring shoot worker pools" failed: retry failed with context deadline exceeded, last error: etcdserver: request is too large
```

We hit the etcd's request limit of 1.5MiB. See https://etcd.io/docs/v3.4/dev-guide/limit.

This PR introduces support for skipping state update for a Worker annotated with `worker.gardener.cloud/skip-state-update` as short-term mitigation for dealing with the above problem. In long-term, the worker-state update controller is planned to be dropped. See https://github.com/gardener/gardener/blob/7fbf64f49acec19cbd8398c8121830705db5388e/extensions/pkg/controller/worker/state_reconciler.go#L41-L42

**Which issue(s) this PR fixes**:
See above.

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
extension library: State update for a Worker object can be now skipped by annotating it with `worker.gardener.cloud/skip-state-update=true`.
```
