### PR TITLE
Drop completed TODO

### DIFF
--- a/pkg/registry/core/shoot/strategy.go
+++ b/pkg/registry/core/shoot/strategy.go
@@ -68,8 +68,6 @@ func (shootStrategy) PrepareForCreate(_ context.Context, obj runtime.Object) {
 	shoot.Generation = 1
 	shoot.Status = core.ShootStatus{}
 
-	// TODO(shafeeqes): Drop this after gardener v1.80 has been released.
-	removeForbiddenFinalizers(shoot)
 	// TODO(acumino): Drop this after v1.83 has been released.
 	removeDuplicateExtensions(shoot)
 }
@@ -158,19 +156,6 @@ func mustIncreaseGenerationForSpecChanges(oldShoot, newShoot *core.Shoot) bool {
 	}
 
 	return !apiequality.Semantic.DeepEqual(oldShoot.Spec, newShoot.Spec)
-}
-
-func removeForbiddenFinalizers(shoot *core.Shoot) {
-	finalizers := []string{}
-
-	for _, finalizer := range shoot.Finalizers {
-		if validation.ForbiddenShootFinalizersOnCreation.Has(finalizer) {
-			continue
-		}
-		finalizers = append(finalizers, finalizer)
-	}
-
-	shoot.Finalizers = finalizers
 }
 
 func removeDuplicateExtensions(shoot *core.Shoot) {

--- a/pkg/registry/core/shoot/strategy_test.go
+++ b/pkg/registry/core/shoot/strategy_test.go
@@ -28,7 +28,6 @@ import (
 	"k8s.io/utils/pointer"
 
 	"github.com/gardener/gardener/pkg/apis/core"
-	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/features"
 	shootregistry "github.com/gardener/gardener/pkg/registry/core/shoot"
@@ -81,23 +80,6 @@ var _ = Describe("Strategy", func() {
 	})
 
 	Describe("#PrepareForCreate", func() {
-		It("should remove forbidden finalizers from the Shoot", func() {
-			shoot := &core.Shoot{
-				ObjectMeta: metav1.ObjectMeta{
-					Finalizers: []string{
-						"random",
-						gardencorev1beta1.GardenerName,
-						v1beta1constants.ReferenceProtectionFinalizerName,
-						"some-finalizer",
-					},
-				},
-			}
-
-			shootregistry.NewStrategy(0).PrepareForCreate(context.TODO(), shoot)
-
-			Expect(shoot.Finalizers).To(ConsistOf("random", "some-finalizer"))
-		})
-
 		It("should remove duplicated extensions and take the latest configuration of duplicate extensions", func() {
 			shoot := &core.Shoot{
 				Spec: core.ShootSpec{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind cleanup

**What this PR does / why we need it**:
Drop `gardener-apiserver` handling for removing forbidden finalizers on creation.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/hold until https://github.com/gardener/gardener/pull/8510 is merged.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
