### PR TITLE
adjust shoot validation to support min-0 worker pools

### DIFF
--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -1810,7 +1810,7 @@ func ValidateSystemComponentWorkers(workers []core.Worker, kubernetesVersion str
 			continue
 		}
 
-		if worker.Minimum == 0 || worker.Maximum == 0 {
+		if worker.Maximum == 0 {
 			continue
 		}
 		atLeastOnePoolWithAllowedSystemComponents = true

--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -962,6 +962,12 @@ var _ = Describe("Shoot Validation Tests", func() {
 				Expect(errorList).To(BeEmpty())
 			})
 
+			It("should allow workers having min=0", func() {
+				shoot.Spec.Provider.Workers[0].Minimum = 0
+				errorList := ValidateShoot(shoot)
+				Expect(errorList).To(BeEmpty())
+			})
+
 			It("should forbid too long worker names", func() {
 				shoot.Spec.Provider.Workers[0] = invalidWorkerTooLongName
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area auto-scaling
/kind enhancement

**What this PR does / why we need it**:
Adjust shoot validation to support minimum Zero Worker Pools, so such shoots are accepted. This is first step in supporting dynamic distribution of worker pools.

**Which issue(s) this PR fixes**:
Addresses Stage-1 of #7857 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other
Adjust shoot validation to support worker pools with Autoscaler Min specified as Zero. 
```
