### PR TITLE
Update `MCM` related CRDs

### DIFF
--- a/pkg/component/machinecontrollermanager/templates/crd-machinedeployments.tpl.yaml
+++ b/pkg/component/machinecontrollermanager/templates/crd-machinedeployments.tpl.yaml
@@ -6,7 +6,6 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.9.2
   labels:
     gardener.cloud/deletion-protected: "true"
-  creationTimestamp: null
   name: machinedeployments.machine.sapcloud.io
 spec:
   group: machine.sapcloud.io

--- a/pkg/component/machinecontrollermanager/templates/crd-machinedeployments.tpl.yaml
+++ b/pkg/component/machinecontrollermanager/templates/crd-machinedeployments.tpl.yaml
@@ -4,6 +4,8 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.9.2
+  labels:
+    gardener.cloud/deletion-protected: "true"
   creationTimestamp: null
   name: machinedeployments.machine.sapcloud.io
 spec:

--- a/pkg/component/machinecontrollermanager/templates/crd-machinedeployments.tpl.yaml
+++ b/pkg/component/machinecontrollermanager/templates/crd-machinedeployments.tpl.yaml
@@ -4,8 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.9.2
-  labels:
-    gardener.cloud/deletion-protected: "true"
+  creationTimestamp: null
   name: machinedeployments.machine.sapcloud.io
 spec:
   group: machine.sapcloud.io
@@ -46,7 +45,8 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: Deployment enables declarative updates for machines and MachineSets.
+        description: MachineDeployment enables declarative updates for machines and
+          MachineSets.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -81,7 +81,7 @@ spec:
                   a condition with a ProgressDeadlineExceeded reason will be surfaced
                   in the MachineDeployment status. Note that progress will not be
                   estimated during the time a MachineDeployment is paused. This is
-                  not set by default.
+                  not set by default, which is treated as infinite deadline.
                 format: int32
                 type: integer
               replicas:
@@ -150,6 +150,7 @@ spec:
                       are ANDed.
                     type: object
                 type: object
+                x-kubernetes-map-type: atomic
               strategy:
                 description: The MachineDeployment strategy to use to replace existing
                   machines with new ones.
@@ -204,7 +205,7 @@ spec:
                 description: Template describes the machines that will be created.
                 properties:
                   metadata:
-                    description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
+                    description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
                     type: object
                     x-kubernetes-preserve-unknown-fields: true
                   spec:
@@ -259,10 +260,9 @@ spec:
                               node is created with.
                             properties:
                               configSource:
-                                description: If specified, the source to get node
-                                  configuration from The DynamicKubeletConfig feature
-                                  gate must be enabled for the Kubelet to use this
-                                  field
+                                description: 'Deprecated: Previously used to specify
+                                      the source of the node''s configuration for the
+                                      DynamicKubeletConfig feature. This feature is removed.'
                                 properties:
                                   configMap:
                                     description: ConfigMap is a reference to a Node's
@@ -430,6 +430,9 @@ spec:
                       properties:
                         description:
                           description: Description of the current operation
+                          type: string
+                        errorCode:
+                          description: ErrorCode of the current operation if any
                           type: string
                         lastUpdateTime:
                           description: Last update time of current operation

--- a/pkg/component/machinecontrollermanager/templates/crd-machinedeployments.tpl.yaml
+++ b/pkg/component/machinecontrollermanager/templates/crd-machinedeployments.tpl.yaml
@@ -1,3 +1,4 @@
+# Source: https://github.com/gardener/machine-controller-manager/blob/5b9a383788ef0723ca12eb86c688cdf3b157277d/kubernetes/crds/machine.sapcloud.io_machinedeployments.yaml
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -51,13 +52,13 @@ spec:
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
-                  of an object. Servers should convert recognized schemas to the latest
-                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
             description: 'Kind is a string value representing the REST resource this
-                  object represents. Servers may infer this from the endpoint the client
-                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -158,43 +159,43 @@ spec:
                 properties:
                   rollingUpdate:
                     description: 'Rolling update config params. Present only if MachineDeploymentStrategyType
-                          = RollingUpdate. --- TODO: Update this to follow our convention
-                          for oneOf, whatever we decide it to be.'
+                      = RollingUpdate. --- TODO: Update this to follow our convention
+                      for oneOf, whatever we decide it to be.'
                     properties:
                       maxSurge:
                         anyOf:
                         - type: integer
                         - type: string
                         description: 'The maximum number of machines that can be scheduled
-                              above the desired number of machines. Value can be an absolute
-                              number (ex: 5) or a percentage of desired machines (ex:
-                              10%). This can not be 0 if MaxUnavailable is 0. Absolute
-                              number is calculated from percentage by rounding up. By
-                              default, a value of 1 is used. Example: when this is set
-                              to 30%, the new MC can be scaled up immediately when the
-                              rolling update starts, such that the total number of old
-                              and new machines do not exceed 130% of desired machines.
-                              Once old machines have been killed, new MC can be scaled
-                              up further, ensuring that total number of machines running
-                              at any time during the update is atmost 130% of desired
-                              machines.'
+                          above the desired number of machines. Value can be an absolute
+                          number (ex: 5) or a percentage of desired machines (ex:
+                          10%). This can not be 0 if MaxUnavailable is 0. Absolute
+                          number is calculated from percentage by rounding up. By
+                          default, a value of 1 is used. Example: when this is set
+                          to 30%, the new MC can be scaled up immediately when the
+                          rolling update starts, such that the total number of old
+                          and new machines do not exceed 130% of desired machines.
+                          Once old machines have been killed, new MC can be scaled
+                          up further, ensuring that total number of machines running
+                          at any time during the update is atmost 130% of desired
+                          machines.'
                         x-kubernetes-int-or-string: true
                       maxUnavailable:
                         anyOf:
                         - type: integer
                         - type: string
                         description: 'The maximum number of machines that can be unavailable
-                              during the update. Value can be an absolute number (ex:
-                              5) or a percentage of desired machines (ex: 10%). Absolute
-                              number is calculated from percentage by rounding down. This
-                              can not be 0 if MaxSurge is 0. By default, a fixed value
-                              of 1 is used. Example: when this is set to 30%, the old
-                              MC can be scaled down to 70% of desired machines immediately
-                              when the rolling update starts. Once new machines are ready,
-                              old MC can be scaled down further, followed by scaling up
-                              the new MC, ensuring that the total number of machines available
-                              at all times during the update is at least 70% of desired
-                              machines.'
+                          during the update. Value can be an absolute number (ex:
+                          5) or a percentage of desired machines (ex: 10%). Absolute
+                          number is calculated from percentage by rounding down. This
+                          can not be 0 if MaxSurge is 0. By default, a fixed value
+                          of 1 is used. Example: when this is set to 30%, the old
+                          MC can be scaled down to 70% of desired machines immediately
+                          when the rolling update starts. Once new machines are ready,
+                          old MC can be scaled down further, followed by scaling up
+                          the new MC, ensuring that the total number of machines available
+                          at all times during the update is at least 70% of desired
+                          machines.'
                         x-kubernetes-int-or-string: true
                     type: object
                   type:
@@ -211,7 +212,7 @@ spec:
                     x-kubernetes-preserve-unknown-fields: true
                   spec:
                     description: 'Specification of the desired behavior of the machine.
-                          More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status'
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
                     properties:
                       class:
                         description: Class contains the machineclass attributes of
@@ -262,8 +263,8 @@ spec:
                             properties:
                               configSource:
                                 description: 'Deprecated: Previously used to specify
-                                      the source of the node''s configuration for the
-                                      DynamicKubeletConfig feature. This feature is removed.'
+                                  the source of the node''s configuration for the
+                                  DynamicKubeletConfig feature. This feature is removed.'
                                 properties:
                                   configMap:
                                     description: ConfigMap is a reference to a Node's
@@ -304,7 +305,7 @@ spec:
                                 type: object
                               externalID:
                                 description: 'Deprecated. Not all kubelets will set
-                                      this field. Remove field after 1.13. see: https://issues.k8s.io/61966'
+                                  this field. Remove field after 1.13. see: https://issues.k8s.io/61966'
                                 type: string
                               podCIDR:
                                 description: PodCIDR represents the pod IP range assigned
@@ -321,7 +322,7 @@ spec:
                                 type: array
                               providerID:
                                 description: 'ID of the node assigned by the cloud
-                                      provider in the format: <ProviderName>://<ProviderSpecificNodeID>'
+                                  provider in the format: <ProviderName>://<ProviderSpecificNodeID>'
                                 type: string
                               taints:
                                 description: If specified, the node's taints.
@@ -357,8 +358,8 @@ spec:
                                 type: array
                               unschedulable:
                                 description: 'Unschedulable controls node schedulability
-                                      of new pods. By default, node is schedulable. More
-                                      info: https://kubernetes.io/docs/concepts/nodes/node/#manual-node-administration'
+                                  of new pods. By default, node is schedulable. More
+                                  info: https://kubernetes.io/docs/concepts/nodes/node/#manual-node-administration'
                                 type: boolean
                             type: object
                         type: object

--- a/pkg/component/machinecontrollermanager/templates/crd-machines.tpl.yaml
+++ b/pkg/component/machinecontrollermanager/templates/crd-machines.tpl.yaml
@@ -4,8 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.9.2
-  labels:
-    gardener.cloud/deletion-protected: "true"
+  creationTimestamp: null
   name: machines.machine.sapcloud.io
 spec:
   group: machine.sapcloud.io
@@ -104,10 +103,9 @@ spec:
                       created with.
                     properties:
                       configSource:
-                        description: 'Deprecated. If specified, the source of the
-                              node''s configuration. The DynamicKubeletConfig feature
-                              gate must be enabled for the Kubelet to use this field.
-                              This field is deprecated as of 1.22: https://git.k8s.io/enhancements/keps/sig-node/281-dynamic-kubelet-configuration'
+                        description: 'Deprecated: Previously used to specify the source
+                        of the node''s configuration for the DynamicKubeletConfig
+                        feature. This feature is removed.'
                         properties:
                           configMap:
                             description: ConfigMap is a reference to a Node's ConfigMap
@@ -265,6 +263,9 @@ spec:
                   description:
                     description: Description of the current operation
                     type: string
+                  errorCode:
+                    description: ErrorCode of the current operation if any
+                    type: string
                   lastUpdateTime:
                     description: Last update time of current operation
                     format: date-time
@@ -276,9 +277,6 @@ spec:
                     description: Type of operation
                     type: string
                 type: object
-              node:
-                description: Node string
-                type: string
             type: object
         type: object
     served: true

--- a/pkg/component/machinecontrollermanager/templates/crd-machines.tpl.yaml
+++ b/pkg/component/machinecontrollermanager/templates/crd-machines.tpl.yaml
@@ -1,3 +1,4 @@
+# Source: https://github.com/gardener/machine-controller-manager/blob/5b9a383788ef0723ca12eb86c688cdf3b157277d/kubernetes/crds/machine.sapcloud.io_machines.yaml
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -24,7 +25,7 @@ spec:
       name: Status
       type: string
     - description: |-
-        CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC
+        CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.
         Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
       jsonPath: .metadata.creationTimestamp
       name: Age
@@ -45,13 +46,13 @@ spec:
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
-                  of an object. Servers should convert recognized schemas to the latest
-                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
             description: 'Kind is a string value representing the REST resource this
-                  object represents. Servers may infer this from the endpoint the client
-                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -105,8 +106,8 @@ spec:
                     properties:
                       configSource:
                         description: 'Deprecated: Previously used to specify the source
-                        of the node''s configuration for the DynamicKubeletConfig
-                        feature. This feature is removed.'
+                          of the node''s configuration for the DynamicKubeletConfig
+                          feature. This feature is removed.'
                         properties:
                           configMap:
                             description: ConfigMap is a reference to a Node's ConfigMap
@@ -143,7 +144,7 @@ spec:
                         type: object
                       externalID:
                         description: 'Deprecated. Not all kubelets will set this field.
-                              Remove field after 1.13. see: https://issues.k8s.io/61966'
+                          Remove field after 1.13. see: https://issues.k8s.io/61966'
                         type: string
                       podCIDR:
                         description: PodCIDR represents the pod IP range assigned
@@ -159,7 +160,7 @@ spec:
                         type: array
                       providerID:
                         description: 'ID of the node assigned by the cloud provider
-                              in the format: <ProviderName>://<ProviderSpecificNodeID>'
+                          in the format: <ProviderName>://<ProviderSpecificNodeID>'
                         type: string
                       taints:
                         description: If specified, the node's taints.
@@ -193,7 +194,7 @@ spec:
                         type: array
                       unschedulable:
                         description: 'Unschedulable controls node schedulability of
-                              new pods. By default, node is schedulable. More info: https://kubernetes.io/docs/concepts/nodes/node/#manual-node-administration'
+                          new pods. By default, node is schedulable. More info: https://kubernetes.io/docs/concepts/nodes/node/#manual-node-administration'
                         type: boolean
                     type: object
                 type: object

--- a/pkg/component/machinecontrollermanager/templates/crd-machines.tpl.yaml
+++ b/pkg/component/machinecontrollermanager/templates/crd-machines.tpl.yaml
@@ -4,6 +4,8 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.9.2
+  labels:
+    gardener.cloud/deletion-protected: "true"
   creationTimestamp: null
   name: machines.machine.sapcloud.io
 spec:

--- a/pkg/component/machinecontrollermanager/templates/crd-machines.tpl.yaml
+++ b/pkg/component/machinecontrollermanager/templates/crd-machines.tpl.yaml
@@ -6,7 +6,6 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.9.2
   labels:
     gardener.cloud/deletion-protected: "true"
-  creationTimestamp: null
   name: machines.machine.sapcloud.io
 spec:
   group: machine.sapcloud.io

--- a/pkg/component/machinecontrollermanager/templates/crd-machinesets.tpl.yaml
+++ b/pkg/component/machinecontrollermanager/templates/crd-machinesets.tpl.yaml
@@ -4,6 +4,8 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.9.2
+  labels:
+    gardener.cloud/deletion-protected: "true"
   creationTimestamp: null
   name: machinesets.machine.sapcloud.io
 spec:

--- a/pkg/component/machinecontrollermanager/templates/crd-machinesets.tpl.yaml
+++ b/pkg/component/machinecontrollermanager/templates/crd-machinesets.tpl.yaml
@@ -1,3 +1,4 @@
+# Source: https://github.com/gardener/machine-controller-manager/blob/5b9a383788ef0723ca12eb86c688cdf3b157277d/kubernetes/crds/machine.sapcloud.io_machinesets.yaml
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -44,13 +45,13 @@ spec:
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
-                  of an object. Servers should convert recognized schemas to the latest
-                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
             description: 'Kind is a string value representing the REST resource this
-                  object represents. Servers may infer this from the endpoint the client
-                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -134,7 +135,7 @@ spec:
                     x-kubernetes-preserve-unknown-fields: true
                   spec:
                     description: 'Specification of the desired behavior of the machine.
-                          More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status'
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
                     properties:
                       class:
                         description: Class contains the machineclass attributes of
@@ -185,8 +186,8 @@ spec:
                             properties:
                               configSource:
                                 description: 'Deprecated: Previously used to specify
-                                      the source of the node''s configuration for the
-                                      DynamicKubeletConfig feature. This feature is removed.'
+                                  the source of the node''s configuration for the
+                                  DynamicKubeletConfig feature. This feature is removed.'
                                 properties:
                                   configMap:
                                     description: ConfigMap is a reference to a Node's
@@ -227,7 +228,7 @@ spec:
                                 type: object
                               externalID:
                                 description: 'Deprecated. Not all kubelets will set
-                                      this field. Remove field after 1.13. see: https://issues.k8s.io/61966'
+                                  this field. Remove field after 1.13. see: https://issues.k8s.io/61966'
                                 type: string
                               podCIDR:
                                 description: PodCIDR represents the pod IP range assigned
@@ -244,7 +245,7 @@ spec:
                                 type: array
                               providerID:
                                 description: 'ID of the node assigned by the cloud
-                                      provider in the format: <ProviderName>://<ProviderSpecificNodeID>'
+                                  provider in the format: <ProviderName>://<ProviderSpecificNodeID>'
                                 type: string
                               taints:
                                 description: If specified, the node's taints.
@@ -280,8 +281,8 @@ spec:
                                 type: array
                               unschedulable:
                                 description: 'Unschedulable controls node schedulability
-                                      of new pods. By default, node is schedulable. More
-                                      info: https://kubernetes.io/docs/concepts/nodes/node/#manual-node-administration'
+                                  of new pods. By default, node is schedulable. More
+                                  info: https://kubernetes.io/docs/concepts/nodes/node/#manual-node-administration'
                                 type: boolean
                             type: object
                         type: object

--- a/pkg/component/machinecontrollermanager/templates/crd-machinesets.tpl.yaml
+++ b/pkg/component/machinecontrollermanager/templates/crd-machinesets.tpl.yaml
@@ -4,8 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.9.2
-  labels:
-    gardener.cloud/deletion-protected: "true"
+  creationTimestamp: null
   name: machinesets.machine.sapcloud.io
 spec:
   group: machine.sapcloud.io
@@ -123,12 +122,13 @@ spec:
                       are ANDed.
                     type: object
                 type: object
+                x-kubernetes-map-type: atomic
               template:
                 description: MachineTemplateSpec describes the data a machine should
                   have when created from a template
                 properties:
                   metadata:
-                    description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
+                    description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
                     type: object
                     x-kubernetes-preserve-unknown-fields: true
                   spec:
@@ -183,10 +183,9 @@ spec:
                               node is created with.
                             properties:
                               configSource:
-                                description: If specified, the source to get node
-                                  configuration from The DynamicKubeletConfig feature
-                                  gate must be enabled for the Kubelet to use this
-                                  field
+                                description: 'Deprecated: Previously used to specify
+                                      the source of the node''s configuration for the
+                                      DynamicKubeletConfig feature. This feature is removed.'
                                 properties:
                                   configMap:
                                     description: ConfigMap is a reference to a Node's
@@ -314,6 +313,9 @@ spec:
                         description:
                           description: Description of the current operation
                           type: string
+                        errorCode:
+                          description: ErrorCode of the current operation if any
+                          type: string
                         lastUpdateTime:
                           description: Last update time of current operation
                           format: date-time
@@ -347,6 +349,9 @@ spec:
                 properties:
                   description:
                     description: Description of the current operation
+                    type: string
+                  errorCode:
+                    description: ErrorCode of the current operation if any
                     type: string
                   lastUpdateTime:
                     description: Last update time of current operation

--- a/pkg/component/machinecontrollermanager/templates/crd-machinesets.tpl.yaml
+++ b/pkg/component/machinecontrollermanager/templates/crd-machinesets.tpl.yaml
@@ -6,7 +6,6 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.9.2
   labels:
     gardener.cloud/deletion-protected: "true"
-  creationTimestamp: null
   name: machinesets.machine.sapcloud.io
 spec:
   group: machine.sapcloud.io

--- a/pkg/provider-local/imagevector/images.yaml
+++ b/pkg/provider-local/imagevector/images.yaml
@@ -2,11 +2,11 @@ images:
 - name: machine-controller-manager
   sourceRepository: github.com/gardener/machine-controller-manager
   repository: eu.gcr.io/gardener-project/gardener/machine-controller-manager
-  tag: "v0.47.0"
+  tag: "v0.49.3"
 - name: machine-controller-manager-provider-local
   sourceRepository: github.com/gardener/machine-controller-manager-provider-local
   repository: ghcr.io/gardener/machine-controller-manager-provider-local
-  tag: sha-8881d39
+  tag: sha-8e34e10
 - name: local-path-provisioner
   sourceRepository: github.com/kubernetes-sigs/kind/tree/main/images/local-path-provisioner
   repository: eu.gcr.io/gardener-project/3rd/kindest/local-path-provisioner


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement

**What this PR does / why we need it**:
This PR updates the MCM related crds (machine, machinedeployment and machineset) to the latest ones. 

**Which issue(s) this PR fixes** 
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
