### PR TITLE
Add node-local-dns label to configmap

### DIFF
--- a/pkg/component/nodelocaldns/nodelocaldns.go
+++ b/pkg/component/nodelocaldns/nodelocaldns.go
@@ -153,6 +153,9 @@ func (c *nodeLocalDNS) computeResourcesData() (map[string][]byte, error) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "node-local-dns",
 				Namespace: metav1.NamespaceSystem,
+				Labels: map[string]string{
+					labelKey: nodelocaldnsconstants.LabelValue,
+				},
 			},
 			Data: map[string]string{
 				configDataKey: domain + `:53 {

--- a/pkg/component/nodelocaldns/nodelocaldns_test.go
+++ b/pkg/component/nodelocaldns/nodelocaldns_test.go
@@ -240,6 +240,7 @@ kind: ConfigMap
 metadata:
   creationTimestamp: null
   labels:
+    k8s-app: node-local-dns
     resources.gardener.cloud/garbage-collectable-reference: "true"
   name: node-local-dns-` + configMapHash + `
   namespace: kube-system


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement

**What this PR does / why we need it**:
Add node-local-dns label to configmap.

Extensions might want to adapt the configmap via a mutating webhook. The blast radius is reduced if a label filter can be applied.

**Which issue(s) this PR fixes**:
None.

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The `node-local-dns` `ConfigMap` now has a label `k8s-app=node-local-dns` for identifying it.
```
