### PR TITLE
add VPNShootNoPods in HA cluster 

### DIFF
--- a/pkg/component/vpnshoot/monitoring.go
+++ b/pkg/component/vpnshoot/monitoring.go
@@ -43,7 +43,7 @@ const (
       description: vpn-shoot deployment in Shoot cluster has 0 available pods. VPN won't work.
       summary: VPN Shoot deployment no pods
 
-  - alert: VPNShootNoPods
+  - alert: VPNHAShootNoPods
     expr: kube_statefulset_status_replicas_ready{statefulset="` + deploymentName + `"} == 0
     for: 30m
     labels:

--- a/pkg/component/vpnshoot/monitoring.go
+++ b/pkg/component/vpnshoot/monitoring.go
@@ -43,6 +43,18 @@ const (
       description: vpn-shoot deployment in Shoot cluster has 0 available pods. VPN won't work.
       summary: VPN Shoot deployment no pods
 
+  - alert: VPNHAShootNoPods
+    expr: kube_statefulset_replicas{statefulset="` + deploymentName + `"} == 0
+    for: 30m
+    labels:
+      service: vpn
+      severity: critical
+      type: shoot
+      visibility: operator
+    annotations:
+      description: vpn-shoot statefulset in HA Shoot cluster has 0 available pods. VPN won't work.
+      summary: VPN HA Shoot statefulset no pods
+
   - alert: VPNProbeAPIServerProxyFailed
     expr: absent(probe_success{job="tunnel-probe-apiserver-proxy"}) == 1 or probe_success{job="tunnel-probe-apiserver-proxy"} == 0 or probe_http_status_code{job="tunnel-probe-apiserver-proxy"} != 200
     for: 30m

--- a/pkg/component/vpnshoot/monitoring.go
+++ b/pkg/component/vpnshoot/monitoring.go
@@ -43,8 +43,8 @@ const (
       description: vpn-shoot deployment in Shoot cluster has 0 available pods. VPN won't work.
       summary: VPN Shoot deployment no pods
 
-  - alert: VPNHAShootNoPods
-    expr: kube_statefulset_replicas{statefulset="` + deploymentName + `"} == 0
+  - alert: VPNShootNoPods
+    expr: kube_statefulset_status_replicas_ready{statefulset="` + deploymentName + `"} == 0
     for: 30m
     labels:
       service: vpn

--- a/pkg/component/vpnshoot/monitoring_test.go
+++ b/pkg/component/vpnshoot/monitoring_test.go
@@ -111,7 +111,7 @@ metric_relabel_configs:
     annotations:
       description: vpn-shoot statefulset in HA Shoot cluster has 0 available pods. VPN won't work.
       summary: VPN HA Shoot statefulset no pods
-  
+
   - alert: VPNProbeAPIServerProxyFailed
     expr: absent(probe_success{job="tunnel-probe-apiserver-proxy"}) == 1 or probe_success{job="tunnel-probe-apiserver-proxy"} == 0 or probe_http_status_code{job="tunnel-probe-apiserver-proxy"} != 200
     for: 30m

--- a/pkg/component/vpnshoot/monitoring_test.go
+++ b/pkg/component/vpnshoot/monitoring_test.go
@@ -100,6 +100,18 @@ metric_relabel_configs:
       description: vpn-shoot deployment in Shoot cluster has 0 available pods. VPN won't work.
       summary: VPN Shoot deployment no pods
 
+  - alert: VPNHAShootNoPods
+  expr: kube_statefulset_replicas{statefulset="vpn-shoot"} == 0
+  for: 30m
+  labels:
+    service: vpn
+    severity: critical
+    type: shoot
+    visibility: operator
+  annotations:
+    description: vpn-shoot statefulset in HA Shoot cluster has 0 available pods. VPN won't work.
+    summary: VPN HA Shoot statefulset no pods
+  
   - alert: VPNProbeAPIServerProxyFailed
     expr: absent(probe_success{job="tunnel-probe-apiserver-proxy"}) == 1 or probe_success{job="tunnel-probe-apiserver-proxy"} == 0 or probe_http_status_code{job="tunnel-probe-apiserver-proxy"} != 200
     for: 30m

--- a/pkg/component/vpnshoot/monitoring_test.go
+++ b/pkg/component/vpnshoot/monitoring_test.go
@@ -101,16 +101,16 @@ metric_relabel_configs:
       summary: VPN Shoot deployment no pods
 
   - alert: VPNHAShootNoPods
-  expr: kube_statefulset_replicas{statefulset="vpn-shoot"} == 0
-  for: 30m
-  labels:
-    service: vpn
-    severity: critical
-    type: shoot
-    visibility: operator
-  annotations:
-    description: vpn-shoot statefulset in HA Shoot cluster has 0 available pods. VPN won't work.
-    summary: VPN HA Shoot statefulset no pods
+    expr: kube_statefulset_status_replicas_ready{statefulset="vpn-shoot"} == 0
+    for: 30m
+    labels:
+      service: vpn
+      severity: critical
+      type: shoot
+      visibility: operator
+    annotations:
+      description: vpn-shoot statefulset in HA Shoot cluster has 0 available pods. VPN won't work.
+      summary: VPN HA Shoot statefulset no pods
   
   - alert: VPNProbeAPIServerProxyFailed
     expr: absent(probe_success{job="tunnel-probe-apiserver-proxy"}) == 1 or probe_success{job="tunnel-probe-apiserver-proxy"} == 0 or probe_http_status_code{job="tunnel-probe-apiserver-proxy"} != 200

--- a/pkg/component/vpnshoot/testdata/monitoring_alertingrules.yaml
+++ b/pkg/component/vpnshoot/testdata/monitoring_alertingrules.yaml
@@ -26,7 +26,7 @@ tests:
 - interval: 30s
   input_series:
   # VPNHAShootNoPods
-  - series: 'kube_statefulset_replicas{statefulset="vpn-shoot"}'
+  - series: 'kube_statefulset_status_replicas_ready{statefulset="vpn-shoot"}'
     values: '0+0x60'
   alert_rule_test:
   - eval_time: 30m

--- a/pkg/component/vpnshoot/testdata/monitoring_alertingrules.yaml
+++ b/pkg/component/vpnshoot/testdata/monitoring_alertingrules.yaml
@@ -30,7 +30,7 @@ tests:
     values: '0+0x60'
   alert_rule_test:
   - eval_time: 30m
-    alertname: VPNHAShootNoPods1
+    alertname: VPNHAShootNoPods
     exp_alerts:
     - exp_labels:
         service: vpn

--- a/pkg/component/vpnshoot/testdata/monitoring_alertingrules.yaml
+++ b/pkg/component/vpnshoot/testdata/monitoring_alertingrules.yaml
@@ -37,7 +37,7 @@ tests:
         severity: critical
         type: shoot
         visibility: operator
-        deployment: vpn-shoot
+        statefulset: vpn-shoot
       exp_annotations:
         description: vpn-shoot statefulset in HA Shoot cluster has 0 available pods. VPN won't work.
         summary: VPN HA Shoot statefulset no pods

--- a/pkg/component/vpnshoot/testdata/monitoring_alertingrules.yaml
+++ b/pkg/component/vpnshoot/testdata/monitoring_alertingrules.yaml
@@ -25,6 +25,25 @@ tests:
 
 - interval: 30s
   input_series:
+  # VPNHAShootNoPods
+  - series: 'kube_statefulset_replicas{statefulset="vpn-shoot"}'
+    values: '0+0x60'
+  alert_rule_test:
+  - eval_time: 30m
+    alertname: VPNHAShootNoPods1
+    exp_alerts:
+    - exp_labels:
+        service: vpn
+        severity: critical
+        type: shoot
+        visibility: operator
+        deployment: vpn-shoot
+      exp_annotations:
+        description: vpn-shoot statefulset in HA Shoot cluster has 0 available pods. VPN won't work.
+        summary: VPN HA Shoot statefulset no pods
+
+- interval: 30s
+  input_series:
   # VPNConnectionDown
   - series: 'probe_success{job="tunnel-probe-apiserver-proxy"}'
     values: '0+0x20'


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind enhancement

**What this PR does / why we need it**:
Add VPNShootNoPods alerts for HA mode 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Add an alert for VPNHAShootNoPods when shoot in HA (high availability) mode.
```
