### PR TITLE
Create `gardenertools` image which includes all files from `./hack/tools/bin` directory

### DIFF
--- a/hack/tools.mk
+++ b/hack/tools.mk
@@ -71,6 +71,9 @@ PROTOC_VERSION ?= 24.1
 SKAFFOLD_VERSION ?= v2.7.0
 YQ_VERSION ?= v4.35.1
 
+# default dir for importing tool binaries
+TOOLS_BIN_SOURCE_DIR ?= /gardenertools
+
 export TOOLS_BIN_DIR := $(TOOLS_BIN_DIR)
 export PATH := $(abspath $(TOOLS_BIN_DIR)):$(PATH)
 
@@ -97,6 +100,16 @@ $(TOOLS_BIN_DIR)/.version_%:
 .PHONY: clean-tools-bin
 clean-tools-bin:
 	rm -rf $(TOOLS_BIN_DIR)/*
+
+.PHONY: import-tools-bin
+import-tools-bin:
+ifeq ($(shell if [ -d $(TOOLS_BIN_SOURCE_DIR) ]; then echo "found"; fi),found)
+	@echo "Copying tool binaries from $(TOOLS_BIN_SOURCE_DIR)"
+	@cp -rp $(TOOLS_BIN_SOURCE_DIR)/* $(TOOLS_BIN_SOURCE_DIR)/.* $(TOOLS_BIN_DIR)
+endif
+
+.PHONY: create-tools-bin
+create-tools-bin: $(CONTROLLER_GEN) $(DOCFORGE) $(GEN_CRD_API_REFERENCE_DOCS) $(GINKGO) $(GOIMPORTS) $(GOIMPORTSREVISER) $(GOLANGCI_LINT) $(GOMEGACHECK) $(GO_ADD_LICENSE) $(GO_APIDIFF) $(GO_VULN_CHECK) $(GO_TO_PROTOBUF) $(HELM) $(IMPORT_BOSS) $(KIND) $(KUBECTL) $(LOGCHECK) $(MOCKGEN) $(OPENAPI_GEN) $(PROMTOOL) $(PROTOC) $(PROTOC_GEN_GOGO) $(REPORT_COLLECTOR) $(SETUP_ENVTEST) $(SKAFFOLD) $(YAML2JSON) $(YQ)
 
 #########################################
 # Tools                                 #

--- a/hack/tools/image/Dockerfile
+++ b/hack/tools/image/Dockerfile
@@ -1,0 +1,18 @@
+# builder
+ARG image
+FROM ${image} AS builder
+RUN set -eux; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+		unzip \
+		jq \
+		parallel \
+	; \
+	rm -rf /var/lib/apt/lists/*
+WORKDIR /go/src/github.com/gardener/gardener
+COPY . .
+RUN make create-tools-bin
+
+# gardenertools
+FROM scratch AS gardenertools
+COPY --from=builder /go/src/github.com/gardener/gardener/hack/tools/bin /gardenertools

--- a/hack/tools/image/README.md
+++ b/hack/tools/image/README.md
@@ -1,0 +1,18 @@
+# `gardenertools` image
+
+## Motivation
+
+There are lots flakes in our tests because the download of binaries like `yq` from github.com fails. Thus, we created the `gardenertools` image which contains the content of `./hack/tools/bin` directory. These are downloaded binaries like `yq`, `skaffold`, `helm` and Go binaries. This will also speed up the tests a bit, because the binaries does not have to be downloaded anymore and the Go based test tools does not have to be compiled on every test run.
+
+## Usage
+
+`gardenertools` does not have an entrypoint. It is intended to be a base image for test-images only.
+
+Before running tests, binaries could be imported by `make import-tools-bin`. If the source directory is not available, the step will be skipped. The default source directory is `/gardenertools` and can be changed by setting the `TOOLS_BIN_SOURCE_DIR` variable accordingly. 
+
+The scenario runs like this:
+- `gardenertools` image will be [built by prow](https://github.com/gardener/ci-infra/blob/bdf1542fb74296b005a69b395779bb89dbdbe703/config/jobs/gardener/gardener-build-dev-images.yaml#L56-L100) every time the content of `./hack/tools.mk` or `./hack/tools/image` changes.
+- When prow notices a new `gardenertools` image it build a new version of [golang-test](https://github.com/gardener/ci-infra/tree/master/images/golang-test) and [krte](https://github.com/gardener/ci-infra/tree/master/images/krte) images which include these binaries.
+- `import-tools-bin` make target is added as first target to each prow job.
+
+In case some binaries are updated and not part of the `gardenertools` image yet, the tests can still succeed. Each binary has a `.version_...` file in `./hack/tools/bin` directory. If the version file is outdated or does not exist yet, the respective binary is downloaded anyway while the test is executed.

--- a/hack/tools/image/variants.yaml
+++ b/hack/tools/image/variants.yaml
@@ -1,0 +1,5 @@
+variants:
+  "1.20":
+    image: "golang:1.20.8"
+  "1.21":
+    image: "golang:1.21.1"


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
Currently, lots of tests fail because the download of binaries like `yq` from github.com fails.
Thus, this PR creates the `gardenertools` image which contains the content of `./hack/tools/bin` directory. These are downloaded binaries like `yq`, `skaffold`, `helm` and go binaries too. The later are included in order to speed up the tests in prow.
The image does not have an entrypoint. It is intended to be a base image for test-images only.
Before running the tests binaries could be imported by `make import-tools-bin`. If the source directory is not available, the step will be skipped.

The scenario runs like this:
- `gardenertools` image will be built by prow every time the content of `./hack/tools.mk` or `./hack/tools/image` changes. ([PR for build job](https://github.com/gardener/ci-infra/pull/890))
- When prow notices a new `gardenertools` image it build a new version of golang-test and krte images which include these binaries ([PR for updating test images](https://github.com/gardener/ci-infra/pull/891))
- `import-tools-bin` make target is added as first target to each prow job ([PR](https://github.com/gardener/ci-infra/pull/892))

In case some binaries are updated and not part of the `gardenertools` image yet, the tests can still succeed. Each binary has a `.version_...` file in `./hack/tools/bin` directory. If the version file is outdated, the respective binary is downloaded anyway.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Please merge https://github.com/gardener/ci-infra/pull/890 first, that `gardenertools` image can be built automatically when this PR will be merged.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
