### PR TITLE
Fix incompatible (outdated) kind image version for cgroup v1/SLES15SP5

### DIFF
--- a/example/gardener-local/kind/cluster/values.yaml
+++ b/example/gardener-local/kind/cluster/values.yaml
@@ -1,5 +1,5 @@
 # TODO(oliver-goetz): Update to 1.28.0 after the merge of https://github.com/gardener/gardener/pull/8479 has been merged and released (after 1.80 has been released).
-image: kindest/node:v1.27.1
+image: kindest/node:v1.27.3
 
 gardener:
   apiserverRelay:

--- a/hack/kind-up.sh
+++ b/hack/kind-up.sh
@@ -171,7 +171,7 @@ fi
 
 kind create cluster \
   --name "$CLUSTER_NAME" \
-  --image "kindest/node:v1.27.1" \
+  --image "kindest/node:v1.27.3" \
   --config <(helm template $CHART --values "$PATH_CLUSTER_VALUES" $ADDITIONAL_ARGS --set "gardener.repositoryRoot"=$(dirname "$0")/..)
 
 # adjust Kind's CRI default OCI runtime spec for new containers to include the cgroup namespace


### PR DESCRIPTION
**How to categorize this PR?**

/area testing
/kind bug

**What this PR does / why we need it**:

After Gardener upgrade to 1.79.0 which brings kind version 0.20.0 - I can no longer setup local kind with `make kind-up` because it timeouts on "Starting control-plane..." - **[kubelet-check] It seems like the kubelet isn't running or healthy.**

Following error can be found kind/kubelet.log (on SLES 15SP5 with cgroup v1 unified):

```
Sep 13 14:33:10 gardener-local2-control-plane kubelet[839]: E0913
14:33:10.989403     839 run.go:74] "command failed" err="failed to run
   Kubelet: invalid configuration: cgroup [\"kubelet\"] has some missing
paths: /sys/fs/cgroup/cpuset/kubelet.slice,
/sys/fs/cgroup/hugetlb/kubelet.slice"
```

I suspect some race condition happening with change of cgroupns from host to private but haven't confirmed that.

As suggested by kind [changelog](https://github.com/kubernetes-sigs/kind/releases/tag/v0.20.0) it is necessary to switch to proper image (default is v1.27.3) It solves the issue.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

Only the change in kind-up.sh was required to fix issue but I updated `example/gardener-local/kind/cluster/values.yaml` to keep it with sync, but there is already a TODO about upgrading to 1.28.0.

**Release note**:

```other operator
NONE
```
