### PR TITLE
`ResourcesProgressing` condition checks for non-terminated `Pod`s before reporting status `False`

### DIFF
--- a/docs/concepts/resource-manager.md
+++ b/docs/concepts/resource-manager.md
@@ -166,7 +166,7 @@ A `ManagedResource` has a `ManagedResourceStatus`, which has an array of Conditi
 
 `ResourcesProgressing` may be `True` when:
 - a `Deployment`, `StatefulSet` or `DaemonSet` has not been fully rolled out yet, i.e. not all replicas have been updated with the latest changes to `spec.template`.
-- there are still old `Pod`s belonging to an older `ReplicaSet` of a `Deployment` which are not terminated yet
+- there are still old `Pod`s belonging to an older `ReplicaSet` of a `Deployment` which are not terminated yet.
 
 Each Kubernetes resources has different notion for being healthy. For example, a Deployment is considered healthy if the controller observed its current revision and if the number of updated replicas is equal to the number of replicas.
 

--- a/docs/concepts/resource-manager.md
+++ b/docs/concepts/resource-manager.md
@@ -166,6 +166,7 @@ A `ManagedResource` has a `ManagedResourceStatus`, which has an array of Conditi
 
 `ResourcesProgressing` may be `True` when:
 - a `Deployment`, `StatefulSet` or `DaemonSet` has not been fully rolled out yet, i.e. not all replicas have been updated with the latest changes to `spec.template`.
+- there are still old `Pod`s belonging to an older `ReplicaSet` of a `Deployment` which are not terminated yet
 
 Each Kubernetes resources has different notion for being healthy. For example, a Deployment is considered healthy if the controller observed its current revision and if the number of updated replicas is equal to the number of replicas.
 

--- a/pkg/component/kubeapiserver/kube_apiserver_test.go
+++ b/pkg/component/kubeapiserver/kube_apiserver_test.go
@@ -3785,6 +3785,7 @@ rules:
 
 			timer := time.AfterFunc(10*time.Millisecond, func() {
 				deploy.Generation = 24
+				deploy.Spec.Replicas = pointer.Int32(0)
 				deploy.Status.Conditions = []appsv1.DeploymentCondition{
 					{Type: appsv1.DeploymentProgressing, Status: "True", Reason: "NewReplicaSetAvailable"},
 					{Type: appsv1.DeploymentAvailable, Status: "True"},

--- a/pkg/component/kubeapiserver/kube_apiserver_test.go
+++ b/pkg/component/kubeapiserver/kube_apiserver_test.go
@@ -3785,7 +3785,6 @@ rules:
 
 			timer := time.AfterFunc(10*time.Millisecond, func() {
 				deploy.Generation = 24
-				deploy.Spec.Replicas = pointer.Int32(1)
 				deploy.Status.Conditions = []appsv1.DeploymentCondition{
 					{Type: appsv1.DeploymentProgressing, Status: "True", Reason: "NewReplicaSetAvailable"},
 					{Type: appsv1.DeploymentAvailable, Status: "True"},

--- a/pkg/resourcemanager/controller/health/progressing/add.go
+++ b/pkg/resourcemanager/controller/health/progressing/add.go
@@ -87,11 +87,6 @@ func (r *Reconciler) AddToManager(ctx context.Context, mgr manager.Manager, sour
 
 	// Watch relevant objects for Progressing condition in order to immediately update the condition as soon as there is
 	// a change on managed resources.
-	// If the target cache is disabled (e.g. for Shoots), we don't want to watch workload objects (Deployment, DaemonSet,
-	// StatefulSet) because this would cache all of them in the entire cluster. This can potentially be a lot of objects
-	// in Shoot clusters, because they are controlled by the end user. In this case, we rely on periodic syncs only.
-	// If we want to have immediate updates for managed resources in Shoots in the future as well, we could consider
-	// adding labels to managed resources and watch them explicitly.
 	pod := &metav1.PartialObjectMetadata{}
 	pod.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("Pod"))
 

--- a/pkg/resourcemanager/controller/health/progressing/add_test.go
+++ b/pkg/resourcemanager/controller/health/progressing/add_test.go
@@ -124,6 +124,12 @@ var _ = Describe("Add", func() {
 					func(obj client.Object) {
 						deploy := obj.(*appsv1.Deployment)
 						deploy.Generation++
+
+						pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{GenerateName: "pod-", Labels: map[string]string{"foo": "bar"}}}
+						Expect(fakeClient.Create(ctx, pod)).To(Succeed())
+						DeferCleanup(func() {
+							Expect(fakeClient.Delete(ctx, pod)).To(Succeed())
+						})
 					},
 					func(obj client.Object) {
 						deploy := obj.(*appsv1.Deployment)

--- a/pkg/resourcemanager/controller/health/progressing/reconciler.go
+++ b/pkg/resourcemanager/controller/health/progressing/reconciler.go
@@ -131,12 +131,9 @@ func (r *Reconciler) reconcile(ctx context.Context, log logr.Logger, mr *resourc
 			return reconcile.Result{}, err
 		}
 
-		progressing, description, err := r.checkProgressing(ctx, obj)
-		if err != nil {
+		if progressing, description, err := r.checkProgressing(ctx, obj); err != nil {
 			return reconcile.Result{}, err
-		}
-
-		if progressing {
+		} else if progressing {
 			var (
 				reason  = ref.Kind + "Progressing"
 				message = fmt.Sprintf("%s %q is progressing: %s", ref.Kind, objectKey.String(), description)

--- a/pkg/utils/kubernetes/health/deployment.go
+++ b/pkg/utils/kubernetes/health/deployment.go
@@ -109,7 +109,7 @@ func IsDeploymentProgressing(deployment *appsv1.Deployment) (bool, string) {
 	if condition.Status != corev1.ConditionTrue || condition.Reason != "NewReplicaSetAvailable" {
 		// only if Progressing is in status True with reason NewReplicaSetAvailable, the Deployment has been fully rolled out
 		// note: old pods or excess pods (scale-down) might still be terminating, but there is no way to tell this from the
-		// Deployment's status
+		// Deployment's status, see https://github.com/kubernetes/kubernetes/issues/110171
 		return true, condition.Message
 	}
 
@@ -135,16 +135,26 @@ func IsDeploymentUpdated(reader client.Reader, deployment *appsv1.Deployment) fu
 		}
 
 		// Now there might be still pods in the system belonging to an older ReplicaSet of the Deployment.
-		podList := &metav1.PartialObjectMetadataList{}
-		podList.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("PodList"))
-		if err := reader.List(ctx, podList, client.InNamespace(deployment.Namespace), client.MatchingLabels(deployment.Spec.Selector.MatchLabels)); err != nil {
+		exactNumberOfPods, err := DeploymentHasExactNumberOfPods(ctx, reader, deployment)
+		if err != nil {
 			return retry.SevereError(err)
 		}
-
-		if int32(len(podList.Items)) != pointer.Int32Deref(deployment.Spec.Replicas, 1) {
+		if !exactNumberOfPods {
 			return retry.MinorError(errors.New("there are still non-terminated old pods"))
 		}
 
 		return retry.Ok()
 	}
+}
+
+// DeploymentHasExactNumberOfPods returns true when there are exactly as many pods as the .spec.replicas field of the
+// deployment mandates.
+func DeploymentHasExactNumberOfPods(ctx context.Context, reader client.Reader, deployment *appsv1.Deployment) (bool, error) {
+	podList := &metav1.PartialObjectMetadataList{}
+	podList.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("PodList"))
+	if err := reader.List(ctx, podList, client.InNamespace(deployment.Namespace), client.MatchingLabels(deployment.Spec.Selector.MatchLabels)); err != nil {
+		return false, err
+	}
+
+	return int32(len(podList.Items)) == pointer.Int32Deref(deployment.Spec.Replicas, 0), nil
 }

--- a/pkg/utils/kubernetes/health/deployment.go
+++ b/pkg/utils/kubernetes/health/deployment.go
@@ -156,5 +156,5 @@ func DeploymentHasExactNumberOfPods(ctx context.Context, reader client.Reader, d
 		return false, err
 	}
 
-	return int32(len(podList.Items)) == pointer.Int32Deref(deployment.Spec.Replicas, 0), nil
+	return int32(len(podList.Items)) == pointer.Int32Deref(deployment.Spec.Replicas, 1), nil
 }

--- a/pkg/utils/kubernetes/health/deployment_test.go
+++ b/pkg/utils/kubernetes/health/deployment_test.go
@@ -89,9 +89,7 @@ var _ = Describe("Deployment", func() {
 	)
 
 	Describe("#IsDeploymentProgressing", func() {
-		var (
-			deployment *appsv1.Deployment
-		)
+		var deployment *appsv1.Deployment
 
 		BeforeEach(func() {
 			deployment = &appsv1.Deployment{
@@ -270,6 +268,59 @@ var _ = Describe("Deployment", func() {
 
 			ok, err := health.IsDeploymentUpdated(fakeClient, deployment)(ctx)
 			Expect(err).To(MatchError(ContainSubstring("whatever message")))
+			Expect(ok).To(BeFalse())
+		})
+	})
+
+	Describe("#DeploymentHasExactNumberOfPods", func() {
+		var (
+			ctx        = context.TODO()
+			fakeClient client.Client
+
+			deployment *appsv1.Deployment
+			pod        *corev1.Pod
+		)
+
+		BeforeEach(func() {
+			fakeClient = fakeclient.NewClientBuilder().WithScheme(kubernetes.SeedScheme).Build()
+
+			deployment = &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "deploy",
+					Namespace: "namespace",
+				},
+				Spec: appsv1.DeploymentSpec{
+					Replicas: pointer.Int32(1),
+					Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"foo": "bar"}},
+				},
+			}
+			pod = &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "pod-",
+					Namespace:    deployment.Namespace,
+					Labels:       deployment.Spec.Selector.MatchLabels,
+				},
+			}
+
+			Expect(fakeClient.Create(ctx, deployment)).To(Succeed())
+		})
+
+		It("should consider the deployment as updated", func() {
+			Expect(fakeClient.Create(ctx, pod)).To(Succeed())
+
+			ok, err := health.DeploymentHasExactNumberOfPods(ctx, fakeClient, deployment)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ok).To(BeTrue())
+		})
+
+		It("should not consider the deployment as updated since there are still terminating pods", func() {
+			for i := 0; i < 2; i++ {
+				p := pod.DeepCopy()
+				Expect(fakeClient.Create(ctx, p)).To(Succeed())
+			}
+
+			ok, err := health.DeploymentHasExactNumberOfPods(ctx, fakeClient, deployment)
+			Expect(err).NotTo(HaveOccurred())
 			Expect(ok).To(BeFalse())
 		})
 	})


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind enhancement

**What this PR does / why we need it**:
Today, the `ResourcesProgressing` condition in `ManagedResource`s might report `False` even if the rollout of a `Deployment` is not yet fully finished (i.e., there are still terminating `Pod`s belonging to an older `ReplicaSet` of the `Deployment`) since it is not possible to observe this based on the `Deployment` status alone: https://github.com/gardener/gardener/blob/ea780afa5c14eac1a9e8df9366eb21b239f6e804/pkg/utils/kubernetes/health/deployment.go#L110-L112
There is also an upstream issue we reported: https://github.com/kubernetes/kubernetes/issues/110171

As part of #8215 (activated in the `Garden` reconciler with #8309), we heavily rely on the `ResourcesProgressing` condition, especially during a credentials rotation. Given that currently the condition's status might be reported as `False` too early, we see failing behaviour in the e2e tests for credentials rotation ([example](https://prow.gardener.cloud/view/gs/gardener-prow/logs/ci-gardener-e2e-kind-operator/1704393585048162304)). This can lead to encrypted resources **NOT** getting re-encrypted with the new encryption key. When the old encryption key is then removed in the `Completing` phase, `gardener-operator` fails with the following error (causing the e2e test to fail/timeout):

```
Removing label from re-encrypted resources after rotation of ETCD encryption key","error":"retry failed with context deadline exceeded, last error: Internal error occurred: unable to transform key \"/registry-gardener/core.gardener.cloud/controllerdeployments/test-foo-lv49h\": no matching key was found for the provided AES transformer
```

This PR fixes the too-early-aborting waiting for the `gardener-apiserver` pod rollout by extending the `ResourcesProgressing` condition check logic such that it remains `True` as long as there are still old non-terminated `Pod`s.

/cc @oliver-goetz 

**Which issue(s) this PR fixes**:
Part of #8507 

**Special notes for your reviewer**:
This feature was already discussed in the initial introduction PR of the condition, see https://github.com/gardener/gardener/pull/5904#issuecomment-1125802915:

> [...] It would still be required to ensure that the newly introduced `Progressing` condition in the `ManagedResource` status considers still existing old `Pod`s which are in `Terminating` status. Accordingly, I added this as action item to https://github.com/gardener/gardener/issues/5850#issuecomment-1108251803.

Looking at https://github.com/gardener/gardener/issues/5850#issuecomment-1108251803, the summary is:

> [...] In the GQF meeting we decided to do not implement this feature for now as it will come with a certain cost. The concern is that if we add similar handling GRM will have to list Pods for every Deployment it manages (or have a watch all Pods in the cluster) which will lead to additional load on apiserver side (or increased memory usage on GRM side due to the watch). For most of the cases it should not be a mission critical failure if a request hits the `Terminating` replica. I also created a feature request to K8s to track such information in the Deployment status if possible - ref https://github.com/kubernetes/kubernetes/issues/110171.

Now we have hit a mission critical case 😉. Meanwhile, with #8483 the cache for the target cluster is enabled in `gardener-resource-manager` and restricted to the `kube-system`/`kubernetes-dashboard` namespaces (i.e., no user-workload namespaces). So, additional load on the API server is no longer a concern, neither memory usage is (since watching the `Pod`s with a metadata-only watch in such namespaces should not be too costly, even if users create thousands of `Pod`s in `kube-system` (what they shouldn't do anyways 😉)).

FYI @ialidzhikov @timebertt 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
The `ResourcesProgressing` condition appearing in the status of `ManagedResource`s now checks for non-terminated `Pod`s before reporting `status=False`.
```
