### PR TITLE
[release-v1.79] Automated cherry pick of #8511: Fix incompatible (outdated) kind image version for cgroup v1/SLES15SP5

### DIFF
--- a/example/gardener-local/kind/cluster/values.yaml
+++ b/example/gardener-local/kind/cluster/values.yaml
@@ -1,4 +1,4 @@
-image: kindest/node:v1.27.1
+image: kindest/node:v1.27.3
 
 gardener:
   apiserverRelay:

--- a/hack/kind-up.sh
+++ b/hack/kind-up.sh
@@ -171,7 +171,7 @@ fi
 
 kind create cluster \
   --name "$CLUSTER_NAME" \
-  --image "kindest/node:v1.27.1" \
+  --image "kindest/node:v1.27.3" \
   --config <(helm template $CHART --values "$PATH_CLUSTER_VALUES" $ADDITIONAL_ARGS --set "gardener.repositoryRoot"=$(dirname "$0")/..)
 
 # adjust Kind's CRI default OCI runtime spec for new containers to include the cgroup namespace


### PR DESCRIPTION
/kind bug
/area testing

Cherry pick of #8511 on release-v1.79.

#8511: Fix incompatible (outdated) kind image version for cgroup v1/SLES15SP5

**Release Notes:**
```other operator
NONE
```