### PR TITLE
Fix `import-tools-bin` make target on Linux

### DIFF
--- a/hack/tools.mk
+++ b/hack/tools.mk
@@ -105,7 +105,7 @@ clean-tools-bin:
 import-tools-bin:
 ifeq ($(shell if [ -d $(TOOLS_BIN_SOURCE_DIR) ]; then echo "found"; fi),found)
 	@echo "Copying tool binaries from $(TOOLS_BIN_SOURCE_DIR)"
-	@cp -rp $(TOOLS_BIN_SOURCE_DIR)/* $(TOOLS_BIN_SOURCE_DIR)/.* $(TOOLS_BIN_DIR)
+	@cp -rpT $(TOOLS_BIN_SOURCE_DIR) $(TOOLS_BIN_DIR)
 endif
 
 .PHONY: create-tools-bin

--- a/hack/tools.mk
+++ b/hack/tools.mk
@@ -109,7 +109,7 @@ ifeq ($(shell if [ -d $(TOOLS_BIN_SOURCE_DIR) ]; then echo "found"; fi),found)
 endif
 
 .PHONY: create-tools-bin
-create-tools-bin: $(CONTROLLER_GEN) $(DOCFORGE) $(GEN_CRD_API_REFERENCE_DOCS) $(GINKGO) $(GOIMPORTS) $(GOIMPORTSREVISER) $(GOLANGCI_LINT) $(GOMEGACHECK) $(GO_ADD_LICENSE) $(GO_APIDIFF) $(GO_VULN_CHECK) $(GO_TO_PROTOBUF) $(HELM) $(IMPORT_BOSS) $(KIND) $(KUBECTL) $(LOGCHECK) $(MOCKGEN) $(OPENAPI_GEN) $(PROMTOOL) $(PROTOC) $(PROTOC_GEN_GOGO) $(REPORT_COLLECTOR) $(SETUP_ENVTEST) $(SKAFFOLD) $(YAML2JSON) $(YQ)
+create-tools-bin: $(DOCFORGE) $(GOIMPORTSREVISER) $(GO_ADD_LICENSE) $(GO_APIDIFF) $(GO_VULN_CHECK) $(HELM) $(KIND) $(KUBECTL) $(PROTOC) $(SKAFFOLD) $(YQ)
 
 #########################################
 # Tools                                 #
@@ -147,7 +147,7 @@ $(GOMEGACHECK): go.mod
 	CGO_ENABLED=1 go build -o $(GOMEGACHECK) -buildmode=plugin github.com/gardener/gardener/hack/tools/gomegacheck/plugin
 endif
 
-$(GO_ADD_LICENSE):
+$(GO_ADD_LICENSE):  $(call tool_version_file,$(GO_ADD_LICENSE),$(GO_ADD_LICENSE_VERSION))
 	GOBIN=$(abspath $(TOOLS_BIN_DIR)) go install github.com/google/addlicense@$(GO_ADD_LICENSE_VERSION)
 
 $(GO_APIDIFF): $(call tool_version_file,$(GO_APIDIFF),$(GO_APIDIFF_VERSION))


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind bug

**What this PR does / why we need it**:
`import-tools-bin` make target does not work on Linux ([ref](https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/8506/pull-gardener-e2e-kind-ha-multi-zone/1704777191234998272)).
This PR fixes it by copying the entire directory instead of its contents.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
