### PR TITLE
Revert "add labels to workers identifying the os image (#8295)"

### DIFF
--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -666,10 +666,6 @@ const (
 	LabelPodMaintenanceRestart = "maintenance.gardener.cloud/restart"
 	// LabelWorkerPool is a constant for a label that indicates the worker pool the node belongs to
 	LabelWorkerPool = "worker.gardener.cloud/pool"
-	// LabelWorkerPoolImageName is a label that indicates the name of the OS image for that worker pool
-	LabelWorkerPoolImageName = "worker.gardener.cloud/image-name"
-	// LabelWorkerPoolImageVersion is a label that indicates the version of the OS image for that worker pool
-	LabelWorkerPoolImageVersion = "worker.gardener.cloud/image-version"
 	// LabelWorkerKubernetesVersion is a constant for a label that indicates the Kubernetes version used for the worker pool nodes.
 	LabelWorkerKubernetesVersion = "worker.gardener.cloud/kubernetes-version"
 	// LabelWorkerPoolDeprecated is a deprecated constant for a label that indicates the worker pool the node belongs to

--- a/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig_test.go
@@ -139,7 +139,6 @@ var _ = Describe("OperatingSystemConfig", func() {
 						Architecture: pointer.String(v1beta1constants.ArchitectureAMD64),
 						Image: &gardencorev1beta1.ShootMachineImage{
 							Name:           "type1",
-							Version:        pointer.String("1.2.3"),
 							ProviderConfig: &runtime.RawExtension{Raw: []byte(`{"foo":"bar"}`)},
 						},
 					},
@@ -150,8 +149,7 @@ var _ = Describe("OperatingSystemConfig", func() {
 					Machine: gardencorev1beta1.Machine{
 						Architecture: pointer.String(v1beta1constants.ArchitectureAMD64),
 						Image: &gardencorev1beta1.ShootMachineImage{
-							Name:    "type2",
-							Version: pointer.String("1.2.3"),
+							Name: "type2",
 						},
 					},
 					CRI: &gardencorev1beta1.CRI{

--- a/pkg/component/extensions/worker/worker_test.go
+++ b/pkg/component/extensions/worker/worker_test.go
@@ -281,8 +281,6 @@ var _ = Describe("Worker", func() {
 						"worker.gardener.cloud/cri-name":  string(worker1CRIName),
 						"containerruntime.worker.gardener.cloud/" + worker1CRIContainerRuntime1Type: "true",
 						"networking.gardener.cloud/node-local-dns-enabled":                          "false",
-						"worker.gardener.cloud/image-name":                                          worker1MachineImageName,
-						"worker.gardener.cloud/image-version":                                       worker1MachineImageVersion,
 					}),
 					Taints:      worker1Taints,
 					MachineType: worker1MachineType,
@@ -326,8 +324,6 @@ var _ = Describe("Worker", func() {
 						"worker.gardener.cloud/pool":                       worker2Name,
 						"worker.garden.sapcloud.io/group":                  worker2Name,
 						"networking.gardener.cloud/node-local-dns-enabled": "false",
-						"worker.gardener.cloud/image-name":                 worker2MachineImageName,
-						"worker.gardener.cloud/image-version":              worker2MachineImageVersion,
 					},
 					MachineType: worker2MachineType,
 					MachineImage: extensionsv1alpha1.MachineImage{

--- a/pkg/utils/gardener/shoot.go
+++ b/pkg/utils/gardener/shoot.go
@@ -185,10 +185,6 @@ func NodeLabelsForWorkerPool(workerPool gardencorev1beta1.Worker, nodeLocalDNSEn
 	labels[v1beta1constants.LabelWorkerPool] = workerPool.Name
 	labels[v1beta1constants.LabelWorkerPoolDeprecated] = workerPool.Name
 
-	// worker pool image labels
-	labels[v1beta1constants.LabelWorkerPoolImageName] = workerPool.Machine.Image.Name
-	labels[v1beta1constants.LabelWorkerPoolImageVersion] = *workerPool.Machine.Image.Version
-
 	// add CRI labels selected by the RuntimeClass
 	if workerPool.CRI != nil {
 		labels[extensionsv1alpha1.CRINameWorkerLabel] = string(workerPool.CRI.Name)

--- a/pkg/utils/gardener/shoot_test.go
+++ b/pkg/utils/gardener/shoot_test.go
@@ -288,10 +288,6 @@ var _ = Describe("Shoot", func() {
 				Name: "worker",
 				Machine: gardencorev1beta1.Machine{
 					Architecture: pointer.String("arm64"),
-					Image: &gardencorev1beta1.ShootMachineImage{
-						Name:    "gardenlinux",
-						Version: pointer.String("1.2.3"),
-					},
 				},
 				SystemComponents: &gardencorev1beta1.WorkerSystemComponents{
 					Allow: true,
@@ -353,13 +349,6 @@ var _ = Describe("Shoot", func() {
 				HaveKeyWithValue("worker.gardener.cloud/cri-name", "containerd"),
 				HaveKeyWithValue("containerruntime.worker.gardener.cloud/gvisor", "true"),
 				HaveKeyWithValue("containerruntime.worker.gardener.cloud/kata", "true"),
-			))
-		})
-
-		It("should correctly add the labels that identify the worker image", func() {
-			Expect(NodeLabelsForWorkerPool(workerPool, false)).To(And(
-				HaveKeyWithValue("worker.gardener.cloud/image-name", "gardenlinux"),
-				HaveKeyWithValue("worker.gardener.cloud/image-version", "1.2.3"),
 			))
 		})
 	})


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area os
/kind regression

**What this PR does / why we need it**:

The two additional labels `worker.gardener.cloud/image-name` and `worker.gardener.cloud/image-version` that were previously introduced in PR #8295 and attached to worker nodes are removed again to fix a regression that causes the kubelet to restart on nodes that are due to be upgraded to a new OS but not rolled yet which causes their Pods to become temporarily unready.

This reverts commit 6045eccbe74c63730b64c08a782e55b3a6ece3af from PR #8295 to fix #8512.

**Which issue(s) this PR fixes**:
Fixes #8512

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy user
The two additional labels `worker.gardener.cloud/image-name` and `worker.gardener.cloud/image-version` that were previously introduced and attached to worker nodes are removed again to fix a regression that causes the `kubelet` to restart on nodes that are due to be upgraded to a new OS but not rolled yet which causes their `Pod`s to become temporarily unready.
```
