### PR TITLE
Promote `MachineControllerManagerDeployment` and `DisableScalingClassesForShoots` feature gates

### DIFF
--- a/docs/deployment/feature_gates.md
+++ b/docs/deployment/feature_gates.md
@@ -18,21 +18,22 @@ The following tables are a summary of the feature gates that you can set on diff
 
 ## Feature Gates for Alpha or Beta Features
 
-| Feature                            | Default | Stage   | Since  | Until  |
-|------------------------------------|---------|---------|--------|--------|
-| HVPA                               | `false` | `Alpha` | `0.31` |        |
-| HVPAForShootedSeed                 | `false` | `Alpha` | `0.32` |        |
-| DefaultSeccompProfile              | `false` | `Alpha` | `1.54` |        |
-| CoreDNSQueryRewriting              | `false` | `Alpha` | `1.55` |        |
-| IPv6SingleStack                    | `false` | `Alpha` | `1.63` |        |
-| MutableShootSpecNetworkingNodes    | `false` | `Alpha` | `1.64` |        |
-| WorkerlessShoots                   | `false` | `Alpha` | `1.70` | `1.78` |
-| WorkerlessShoots                   | `false` | `Beta`  | `1.79` |        |
-| MachineControllerManagerDeployment | `false` | `Alpha` | `1.73` |        |
-| DisableScalingClassesForShoots     | `false` | `Alpha` | `1.73` | `1.78` |
-| DisableScalingClassesForShoots     | `true`  | `Beta`  | `1.79` |        |
-| ContainerdRegistryHostsDir         | `false` | `Alpha` | `1.77` |        |
-| ShootForceDeletion                 | `false` | `Alpha` | `1.81` |        |
+| Feature                             | Default | Stage   | Since  | Until  |
+|-------------------------------------|---------|---------|--------|--------|
+| HVPA                                | `false` | `Alpha` | `0.31` |        |
+| HVPAForShootedSeed                  | `false` | `Alpha` | `0.32` |        |
+| DefaultSeccompProfile               | `false` | `Alpha` | `1.54` |        |
+| CoreDNSQueryRewriting               | `false` | `Alpha` | `1.55` |        |
+| IPv6SingleStack                     | `false` | `Alpha` | `1.63` |        |
+| MutableShootSpecNetworkingNodes     | `false` | `Alpha` | `1.64` |        |
+| WorkerlessShoots                    | `false` | `Alpha` | `1.70` | `1.78` |
+| WorkerlessShoots                    | `false` | `Beta`  | `1.79` |        |
+| MachineControllerManagerDeployment  | `false` | `Alpha` | `1.73` |        |
+| MachineControllerManagerDeployment  | `true`  | `Beta`  | `1.81` |        |
+| DisableScalingClassesForShoots      | `false` | `Alpha` | `1.73` | `1.78` |
+| DisableScalingClassesForShoots      | `true`  | `Beta`  | `1.79` |        |
+| ContainerdRegistryHostsDir          | `false` | `Alpha` | `1.77` |        |
+| ShootForceDeletion                  | `false` | `Alpha` | `1.81` |        |
 
 ## Feature Gates for Graduated or Deprecated Features
 

--- a/docs/deployment/feature_gates.md
+++ b/docs/deployment/feature_gates.md
@@ -31,7 +31,8 @@ The following tables are a summary of the feature gates that you can set on diff
 | MachineControllerManagerDeployment  | `false` | `Alpha` | `1.73` |        |
 | MachineControllerManagerDeployment  | `true`  | `Beta`  | `1.81` |        |
 | DisableScalingClassesForShoots      | `false` | `Alpha` | `1.73` | `1.78` |
-| DisableScalingClassesForShoots      | `true`  | `Beta`  | `1.79` |        |
+| DisableScalingClassesForShoots      | `true`  | `Beta`  | `1.79` | `1.80` |
+| DisableScalingClassesForShoots      | `true`  | `GA`    | `1.81` |        |
 | ContainerdRegistryHostsDir          | `false` | `Alpha` | `1.77` |        |
 | ShootForceDeletion                  | `false` | `Alpha` | `1.81` |        |
 

--- a/example/gardener-local/gardenlet/values-provider-extensions.yaml
+++ b/example/gardener-local/gardenlet/values-provider-extensions.yaml
@@ -19,5 +19,3 @@ config:
         - name: gardenlet-bootstrap
           user:
             token: 07401d.f395accd246ae52d
-  featureGates:
-    MachineControllerManagerDeployment: false

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -312,12 +312,6 @@ const (
 	// ShootNoCleanup is a constant for a label on a resource indicating that the Gardener cleaner should not delete this
 	// resource when cleaning a shoot during the deletion flow.
 	ShootNoCleanup = "shoot.gardener.cloud/no-cleanup"
-	// ShootAlphaScalingAPIServerClass is a constant for an annotation on the shoot stating the initial API server class.
-	// It influences the size of the initial resource requests/limits.
-	// Possible values are [small, medium, large, xlarge, 2xlarge].
-	// Note that this annotation is alpha and can be removed anytime without further notice. Only use it if you know
-	// what you do.
-	ShootAlphaScalingAPIServerClass = "alpha.kube-apiserver.scaling.shoot.gardener.cloud/class"
 
 	// ShootAlphaControlPlaneScaleDownDisabled is a constant for an annotation on the Shoot resource stating that the
 	// automatic scale-down shall be disabled for the etcd, kube-apiserver, kube-controller-manager.

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -84,6 +84,7 @@ const (
 	// owner: @voelzmo, @andrerun
 	// alpha: v1.73.0
 	// beta: v1.79.0
+	// GA: v1.81.0
 	DisableScalingClassesForShoots featuregate.Feature = "DisableScalingClassesForShoots"
 
 	// ContainerdRegistryHostsDir enables registry configuration in containerd based on the hosts directory pattern.
@@ -136,7 +137,7 @@ var AllFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	WorkerlessShoots:                   {Default: true, PreRelease: featuregate.Beta},
 	ShootForceDeletion:                 {Default: false, PreRelease: featuregate.Alpha},
 	MachineControllerManagerDeployment: {Default: true, PreRelease: featuregate.Beta},
-	DisableScalingClassesForShoots:     {Default: true, PreRelease: featuregate.Beta},
+	DisableScalingClassesForShoots:     {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
 	ContainerdRegistryHostsDir:         {Default: false, PreRelease: featuregate.Alpha},
 }
 

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -75,6 +75,7 @@ const (
 	// provider-specific MCM provider sidecar container into the deployment via the `controlplane` webhook.
 	// owner: @rfranzke @JensAc @mreiger
 	// alpha: v1.73.0
+	// beta: v1.81.0
 	MachineControllerManagerDeployment featuregate.Feature = "MachineControllerManagerDeployment"
 
 	// DisableScalingClassesForShoots disables assigning a ScalingClass to Shoots based on their maximum Node count
@@ -134,7 +135,7 @@ var AllFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	MutableShootSpecNetworkingNodes:    {Default: false, PreRelease: featuregate.Alpha},
 	WorkerlessShoots:                   {Default: true, PreRelease: featuregate.Beta},
 	ShootForceDeletion:                 {Default: false, PreRelease: featuregate.Alpha},
-	MachineControllerManagerDeployment: {Default: false, PreRelease: featuregate.Alpha},
+	MachineControllerManagerDeployment: {Default: true, PreRelease: featuregate.Beta},
 	DisableScalingClassesForShoots:     {Default: true, PreRelease: featuregate.Beta},
 	ContainerdRegistryHostsDir:         {Default: false, PreRelease: featuregate.Alpha},
 }

--- a/pkg/operation/botanist/kubeapiserver_test.go
+++ b/pkg/operation/botanist/kubeapiserver_test.go
@@ -194,7 +194,7 @@ var _ = Describe("KubeAPIServer", func() {
 					nil,
 					map[featuregate.Feature]bool{features.HVPA: false},
 					apiserver.AutoscalingConfig{
-						APIServerResources:        resourcesRequirementsForKubeAPIServer(4, ""),
+						APIServerResources:        resourcesRequirementsForKubeAPIServer(4),
 						HVPAEnabled:               false,
 						MinReplicas:               1,
 						MaxReplicas:               4,
@@ -202,22 +202,7 @@ var _ = Describe("KubeAPIServer", func() {
 						ScaleDownDisabledForHvpa:  false,
 					},
 				),
-				Entry("default behaviour, HVPA is enabled and DisableScalingClassesForShoots is disabled",
-					nil,
-					map[featuregate.Feature]bool{
-						features.HVPA:                           true,
-						features.DisableScalingClassesForShoots: false,
-					},
-					apiserver.AutoscalingConfig{
-						APIServerResources:        resourcesRequirementsForKubeAPIServer(40, ""),
-						HVPAEnabled:               true,
-						MinReplicas:               1,
-						MaxReplicas:               4,
-						UseMemoryMetricForHvpaHPA: false,
-						ScaleDownDisabledForHvpa:  false,
-					},
-				),
-				Entry("default behaviour, HVPA is enabled and DisableScalingClassesForShoots is enabled",
+				Entry("default behaviour, HVPA is enabled",
 					nil,
 					map[featuregate.Feature]bool{
 						features.HVPA: true,
@@ -236,27 +221,13 @@ var _ = Describe("KubeAPIServer", func() {
 						ScaleDownDisabledForHvpa:  false,
 					},
 				),
-				Entry("default behaviour, HVPA is disabled and DisableScalingClassesForShoots is enabled",
-					nil,
-					map[featuregate.Feature]bool{
-						features.HVPA: false,
-					},
-					apiserver.AutoscalingConfig{
-						APIServerResources:        resourcesRequirementsForKubeAPIServer(4, ""),
-						HVPAEnabled:               false,
-						MinReplicas:               1,
-						MaxReplicas:               4,
-						UseMemoryMetricForHvpaHPA: false,
-						ScaleDownDisabledForHvpa:  false,
-					},
-				),
 				Entry("shoot purpose production",
 					func() {
 						botanist.Shoot.Purpose = gardencorev1beta1.ShootPurposeProduction
 					},
 					nil,
 					apiserver.AutoscalingConfig{
-						APIServerResources:        resourcesRequirementsForKubeAPIServer(4, ""),
+						APIServerResources:        resourcesRequirementsForKubeAPIServer(4),
 						HVPAEnabled:               false,
 						MinReplicas:               2,
 						MaxReplicas:               4,
@@ -270,7 +241,7 @@ var _ = Describe("KubeAPIServer", func() {
 					},
 					nil,
 					apiserver.AutoscalingConfig{
-						APIServerResources:        resourcesRequirementsForKubeAPIServer(4, ""),
+						APIServerResources:        resourcesRequirementsForKubeAPIServer(4),
 						HVPAEnabled:               false,
 						MinReplicas:               4,
 						MaxReplicas:               4,
@@ -284,7 +255,7 @@ var _ = Describe("KubeAPIServer", func() {
 					},
 					map[featuregate.Feature]bool{features.HVPAForShootedSeed: false},
 					apiserver.AutoscalingConfig{
-						APIServerResources:        resourcesRequirementsForKubeAPIServer(4, ""),
+						APIServerResources:        resourcesRequirementsForKubeAPIServer(4),
 						HVPAEnabled:               false,
 						MinReplicas:               1,
 						MaxReplicas:               4,
@@ -292,48 +263,7 @@ var _ = Describe("KubeAPIServer", func() {
 						ScaleDownDisabledForHvpa:  false,
 					},
 				),
-				Entry("shoot is a managed seed and HVPAForShootedSeed is enabled and DisableScalingClassesForShoots is disabled",
-					func() {
-						botanist.ManagedSeed = &seedmanagementv1alpha1.ManagedSeed{}
-					},
-					map[featuregate.Feature]bool{
-						features.HVPAForShootedSeed:             true,
-						features.DisableScalingClassesForShoots: false,
-					},
-					apiserver.AutoscalingConfig{
-						APIServerResources:        resourcesRequirementsForKubeAPIServer(40, ""),
-						HVPAEnabled:               true,
-						MinReplicas:               1,
-						MaxReplicas:               4,
-						UseMemoryMetricForHvpaHPA: true,
-						ScaleDownDisabledForHvpa:  false,
-					},
-				),
-				Entry("shoot is a managed seed w/ APIServer settings and HVPAForShootedSeed is enabled and DisableScalingClassesForShoots is disabled",
-					func() {
-						botanist.ManagedSeed = &seedmanagementv1alpha1.ManagedSeed{}
-						botanist.ManagedSeedAPIServer = &helper.ManagedSeedAPIServer{
-							Autoscaler: &helper.ManagedSeedAPIServerAutoscaler{
-								MinReplicas: pointer.Int32(16),
-								MaxReplicas: 32,
-							},
-							Replicas: pointer.Int32(24),
-						}
-					},
-					map[featuregate.Feature]bool{
-						features.HVPAForShootedSeed:             true,
-						features.DisableScalingClassesForShoots: false,
-					},
-					apiserver.AutoscalingConfig{
-						APIServerResources:        resourcesRequirementsForKubeAPIServer(40, ""),
-						HVPAEnabled:               true,
-						MinReplicas:               16,
-						MaxReplicas:               32,
-						UseMemoryMetricForHvpaHPA: true,
-						ScaleDownDisabledForHvpa:  false,
-					},
-				),
-				Entry("shoot is a managed seed w/ APIServer settings and HVPAForShootedSeed is enabled and DisableScalingClassesForShoots is enabled",
+				Entry("shoot is a managed seed w/ APIServer settings and HVPAForShootedSeed is enabled",
 					func() {
 						botanist.ManagedSeed = &seedmanagementv1alpha1.ManagedSeed{}
 						botanist.ManagedSeedAPIServer = &helper.ManagedSeedAPIServer{
@@ -388,7 +318,7 @@ var _ = Describe("KubeAPIServer", func() {
 						ScaleDownDisabledForHvpa:  false,
 					},
 				),
-				Entry("shoot is a managed seed w/ APIServer settings and HVPAForShootedSeed is disabled and DisableScalingClassesForShoots is enabled",
+				Entry("shoot is a managed seed w/ APIServer settings and HVPAForShootedSeed is disabled",
 					func() {
 						botanist.ManagedSeed = &seedmanagementv1alpha1.ManagedSeed{}
 						botanist.ManagedSeedAPIServer = &helper.ManagedSeedAPIServer{
@@ -427,7 +357,7 @@ var _ = Describe("KubeAPIServer", func() {
 					},
 					nil,
 					apiserver.AutoscalingConfig{
-						APIServerResources:        resourcesRequirementsForKubeAPIServer(4, ""),
+						APIServerResources:        resourcesRequirementsForKubeAPIServer(4),
 						HVPAEnabled:               false,
 						MinReplicas:               3,
 						MaxReplicas:               4,
@@ -440,8 +370,8 @@ var _ = Describe("KubeAPIServer", func() {
 	})
 
 	DescribeTable("#resourcesRequirementsForKubeAPIServer",
-		func(nodes int, storageClass, expectedCPURequest, expectedMemoryRequest string) {
-			Expect(resourcesRequirementsForKubeAPIServer(int32(nodes), storageClass)).To(Equal(
+		func(nodes int, expectedCPURequest, expectedMemoryRequest string) {
+			Expect(resourcesRequirementsForKubeAPIServer(int32(nodes))).To(Equal(
 				corev1.ResourceRequirements{
 					Requests: corev1.ResourceList{
 						corev1.ResourceCPU:    resource.MustParse(expectedCPURequest),
@@ -450,32 +380,16 @@ var _ = Describe("KubeAPIServer", func() {
 				}))
 		},
 
-		// nodes tests
-		Entry("nodes <= 2", 2, "", "800m", "800Mi"),
-		Entry("nodes <= 10", 10, "", "1000m", "1100Mi"),
-		Entry("nodes <= 50", 50, "", "1200m", "1600Mi"),
-		Entry("nodes <= 100", 100, "", "2500m", "5200Mi"),
-		Entry("nodes > 100", 1000, "", "3000m", "5200Mi"),
-
-		// scaling class tests
-		Entry("scaling class small", -1, "small", "800m", "800Mi"),
-		Entry("scaling class medium", -1, "medium", "1000m", "1100Mi"),
-		Entry("scaling class large", -1, "large", "1200m", "1600Mi"),
-		Entry("scaling class xlarge", -1, "xlarge", "2500m", "5200Mi"),
-		Entry("scaling class 2xlarge", -1, "2xlarge", "3000m", "5200Mi"),
-
-		// scaling class always decides if provided
-		Entry("nodes > 100, scaling class small", 100, "small", "800m", "800Mi"),
-		Entry("nodes <= 100, scaling class medium", 100, "medium", "1000m", "1100Mi"),
-		Entry("nodes <= 50, scaling class large", 50, "large", "1200m", "1600Mi"),
-		Entry("nodes <= 10, scaling class xlarge", 10, "xlarge", "2500m", "5200Mi"),
-		Entry("nodes <= 2, scaling class 2xlarge", 2, "2xlarge", "3000m", "5200Mi"),
+		Entry("nodes <= 2", 2, "800m", "800Mi"),
+		Entry("nodes <= 10", 10, "1000m", "1100Mi"),
+		Entry("nodes <= 50", 50, "1200m", "1600Mi"),
+		Entry("nodes <= 100", 100, "2500m", "5200Mi"),
+		Entry("nodes > 100", 1000, "3000m", "5200Mi"),
 	)
 
 	Describe("#DeployKubeAPIServer", func() {
 		Describe("SNIConfig", func() {
-
-			var secret = &corev1.Secret{
+			secret := &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "wildcard-secret",
 					Namespace: seedNamespace,

--- a/pkg/operation/shoot/shoot.go
+++ b/pkg/operation/shoot/shoot.go
@@ -401,15 +401,6 @@ func (s *Shoot) GetIngressFQDN(subDomain string) string {
 	return fmt.Sprintf("%s.%s.%s", subDomain, gardenerutils.IngressPrefix, *shoot.Spec.DNS.Domain)
 }
 
-// GetWorkerNames returns a list of names of the worker groups in the Shoot manifest.
-func (s *Shoot) GetWorkerNames() []string {
-	var workerNames []string
-	for _, worker := range s.GetInfo().Spec.Provider.Workers {
-		workerNames = append(workerNames, worker.Name)
-	}
-	return workerNames
-}
-
 // GetMinNodeCount returns the sum of all 'minimum' fields of all worker groups of the Shoot.
 func (s *Shoot) GetMinNodeCount() int32 {
 	var nodeCount int32

--- a/test/integration/gardenlet/seed/seed/seed_test.go
+++ b/test/integration/gardenlet/seed/seed/seed_test.go
@@ -631,6 +631,7 @@ var _ = Describe("Seed controller tests", func() {
 						MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("cluster-autoscaler")})}),
 						MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("dependency-watchdog-weeder")})}),
 						MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("dependency-watchdog-prober")})}),
+						MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("machine-controller-manager")})}),
 						MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("system")})}),
 					}
 

--- a/test/integration/gardenlet/shoot/care/care_test.go
+++ b/test/integration/gardenlet/shoot/care/care_test.go
@@ -283,7 +283,7 @@ var _ = Describe("Shoot Care controller tests", func() {
 						return shoot.Status.Conditions
 					}).Should(And(
 						ContainCondition(OfType(gardencorev1beta1.ShootAPIServerAvailable), WithStatus(gardencorev1beta1.ConditionProgressing), WithReason("APIServerDown")),
-						ContainCondition(OfType(gardencorev1beta1.ShootControlPlaneHealthy), WithStatus(gardencorev1beta1.ConditionProgressing), WithReason("DeploymentMissing"), WithMessageSubstrings("Missing required deployments: [gardener-resource-manager kube-apiserver kube-controller-manager kube-scheduler]")),
+						ContainCondition(OfType(gardencorev1beta1.ShootControlPlaneHealthy), WithStatus(gardencorev1beta1.ConditionProgressing), WithReason("DeploymentMissing"), WithMessageSubstrings("Missing required deployments: [gardener-resource-manager kube-apiserver kube-controller-manager kube-scheduler machine-controller-manager]")),
 						ContainCondition(OfType(gardencorev1beta1.ShootObservabilityComponentsHealthy), WithStatus(gardencorev1beta1.ConditionProgressing), WithReason("DeploymentMissing"), WithMessageSubstrings("Missing required deployments: [kube-state-metrics plutono]")),
 						ContainCondition(OfType(gardencorev1beta1.ShootEveryNodeReady), WithStatus(gardencorev1beta1.ConditionUnknown), WithReason("ConditionCheckError"), WithMessageSubstrings("Shoot control plane has not been fully created yet.")),
 						ContainCondition(OfType(gardencorev1beta1.ShootSystemComponentsHealthy), WithStatus(gardencorev1beta1.ConditionUnknown), WithReason("ConditionCheckError"), WithMessageSubstrings("Shoot control plane has not been fully created yet.")),
@@ -329,7 +329,7 @@ var _ = Describe("Shoot Care controller tests", func() {
 						return shoot.Status.Conditions
 					}).Should(And(
 						ContainCondition(OfType(gardencorev1beta1.ShootAPIServerAvailable), WithStatus(gardencorev1beta1.ConditionProgressing), WithReason("APIServerDown")),
-						ContainCondition(OfType(gardencorev1beta1.ShootControlPlaneHealthy), WithStatus(gardencorev1beta1.ConditionProgressing), WithReason("DeploymentMissing"), WithMessageSubstrings("Missing required deployments: [kube-apiserver kube-scheduler]")),
+						ContainCondition(OfType(gardencorev1beta1.ShootControlPlaneHealthy), WithStatus(gardencorev1beta1.ConditionProgressing), WithReason("DeploymentMissing"), WithMessageSubstrings("Missing required deployments: [kube-apiserver kube-scheduler machine-controller-manager]")),
 						ContainCondition(OfType(gardencorev1beta1.ShootObservabilityComponentsHealthy), WithStatus(gardencorev1beta1.ConditionProgressing), WithReason("DeploymentMissing"), WithMessageSubstrings("Missing required deployments: [kube-state-metrics plutono]")),
 						ContainCondition(OfType(gardencorev1beta1.ShootEveryNodeReady), WithStatus(gardencorev1beta1.ConditionUnknown), WithReason("ConditionCheckError"), WithMessageSubstrings("Shoot control plane has not been fully created yet.")),
 						ContainCondition(OfType(gardencorev1beta1.ShootSystemComponentsHealthy), WithStatus(gardencorev1beta1.ConditionUnknown), WithReason("ConditionCheckError"), WithMessageSubstrings("Shoot control plane has not been fully created yet.")),


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area open-source
/kind enhancement

**What this PR does / why we need it**:
- Promote `MachineControllerManagerDeployment` feature gate to beta
- Promote `DisableScalingClassesForShoots` feature gate to GA

**Which issue(s) this PR fixes**:
Follow-up of #8428 
Part of https://github.com/gardener/gardener/issues/7594

**Special notes for your reviewer**:
/hold
until https://github.com/gardener/gardener/pull/8510 was merged

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy operator
The `MachineControllerManagerDeployment` has been promoted to beta and is now enabled by default. Make sure that all registered provider extensions support this feature gate before upgrading to this version of Gardener.
```
```noteworthy operator
The `DisableScalingClassesForShoots` feature gates has been promoted to GA (and is now always enabled).
```
```breaking user
The `alpha.kube-apiserver.scaling.shoot.gardener.cloud/class` annotation on `Shoot`s has no effect anymore and should be removed.
```