### PR TITLE
`gardener-scheduler` populates scheduling failure reasons to `Shoot` status

### DIFF
--- a/charts/gardener/controlplane/charts/application/templates/clusterrole-scheduler.yaml
+++ b/charts/gardener/controlplane/charts/application/templates/clusterrole-scheduler.yaml
@@ -50,6 +50,7 @@ rules:
   - core.gardener.cloud
   resources:
   - shoots
+  - shoots/status
   verbs:
   - get
   - list

--- a/docs/concepts/scheduler.md
+++ b/docs/concepts/scheduler.md
@@ -153,6 +153,7 @@ This mechanism works as follows:
 ## Failure to Determine a Suitable Seed
 
 In case the scheduler fails to find a suitable seed, the operation is being retried with exponential backoff.
+The reason for the failure will be reported in the `Shoot`'s `.status.lastOperation` field as well as a Kubernetes event (which can be retrieved via `kubectl -n <namespace> describe shoot <shoot-name>`).
 
 ## Current Limitation / Future Plans
 

--- a/pkg/component/gardenerscheduler/gardener_scheduler_test.go
+++ b/pkg/component/gardenerscheduler/gardener_scheduler_test.go
@@ -222,6 +222,7 @@ var _ = Describe("GardenerScheduler", func() {
 					APIGroups: []string{gardencorev1beta1.GroupName},
 					Resources: []string{
 						"shoots",
+						"shoots/status",
 					},
 					Verbs: []string{"get", "list", "watch", "patch", "update"},
 				},

--- a/pkg/component/gardenerscheduler/rbac.go
+++ b/pkg/component/gardenerscheduler/rbac.go
@@ -57,6 +57,7 @@ func (g *gardenerScheduler) clusterRole() *rbacv1.ClusterRole {
 				APIGroups: []string{gardencorev1beta1.GroupName},
 				Resources: []string{
 					"shoots",
+					"shoots/status",
 				},
 				Verbs: []string{"get", "list", "watch", "patch", "update"},
 			},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity
/kind enhancement

**What this PR does / why we need it**:
Today, fetching the reasons for scheduling failures is difficult because `gardener-scheduler` only populates `Event`s which are not as straight-forward to fetch programmatically compared to simply reading the `Shoot`'s status (which already is a common operation for most users).

This PR changes this and makes `gardener-scheduler` set the `.status.lastOperation` field such that it contains information about the failure reason:

```yaml
status:
  lastOperation:
    description: 'Failed to schedule Shoot: none out of the 1 seeds has the matching
      labels required by seed selector of ''Shoot'' (selector: ''foo=bar'')'
    lastUpdateTime: "2023-09-21T11:58:37Z"
    progress: 0
    state: Pending
    type: Create
```

`kubectl describe shoot` also still works:

```
Events:
  Type     Reason            Age                 From             Message
  ----     ------            ----                ----             -------
  Warning  SchedulingFailed  18s (x16 over 46s)  shoot-scheduler  Failed to schedule Shoot: none out of the 1 seeds has the matching labels required by seed selector of 'Shoot' (selector: 'foo=bar')
```

**Special notes for your reviewer**:
/cc @grolu @petersutter @holgerkoser @dguendisch 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
The `gardener-scheduler` now populates scheduling failure reasons to the `Shoot`'s `.status.lastOperation.description` field.
```
