### PR TITLE
Set `kindest/node` image, Shoot K8s version for e2e tests and `envtest` version to Kubernetes v1.28

### DIFF
--- a/example/gardener-local/kind/cluster/values.yaml
+++ b/example/gardener-local/kind/cluster/values.yaml
@@ -1,5 +1,4 @@
-# TODO(oliver-goetz): Update to 1.28.0 after the merge of https://github.com/gardener/gardener/pull/8479 has been merged and released (after 1.80 has been released).
-image: kindest/node:v1.27.3
+image: kindest/node:v1.28.0
 
 gardener:
   apiserverRelay:

--- a/hack/kind-up.sh
+++ b/hack/kind-up.sh
@@ -171,7 +171,7 @@ fi
 
 kind create cluster \
   --name "$CLUSTER_NAME" \
-  --image "kindest/node:v1.27.3" \
+  --image "kindest/node:v1.28.0" \
   --config <(helm template $CHART --values "$PATH_CLUSTER_VALUES" $ADDITIONAL_ARGS --set "gardener.repositoryRoot"=$(dirname "$0")/..)
 
 # adjust Kind's CRI default OCI runtime spec for new containers to include the cgroup namespace

--- a/hack/prepare-envtest.sh
+++ b/hack/prepare-envtest.sh
@@ -18,7 +18,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-ENVTEST_K8S_VERSION=${ENVTEST_K8S_VERSION:-"1.27"}
+ENVTEST_K8S_VERSION=${ENVTEST_K8S_VERSION:-"1.28"}
 
 echo "> Installing envtest tools@${ENVTEST_K8S_VERSION} with setup-envtest if necessary"
 if ! command -v setup-envtest &> /dev/null ; then

--- a/test/e2e/gardener/common.go
+++ b/test/e2e/gardener/common.go
@@ -76,8 +76,7 @@ func DefaultShoot(name string) *gardencorev1beta1.Shoot {
 			SecretBindingName: pointer.String("local"),
 			CloudProfileName:  "local",
 			Kubernetes: gardencorev1beta1.Kubernetes{
-				// TODO(oliver-goetz): Update to 1.28.2 after the merge of https://github.com/gardener/gardener/pull/8479 has been merged and released (after 1.80 has been released).
-				Version:                     "1.27.1",
+				Version:                     "1.28.2",
 				EnableStaticTokenKubeconfig: pointer.Bool(false),
 				Kubelet: &gardencorev1beta1.KubeletConfig{
 					SerializeImagePulls: pointer.Bool(false),

--- a/test/e2e/gardener/shoot/create_update_delete.go
+++ b/test/e2e/gardener/shoot/create_update_delete.go
@@ -43,8 +43,7 @@ var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
 
 		// explicitly use one version below the latest supported minor version so that Kubernetes version update test can be
 		// performed
-		// TODO(oliver-goetz): Update to 1.27.1 after the merge of https://github.com/gardener/gardener/pull/8479 has been merged and released (after 1.80 has been released).
-		f.Shoot.Spec.Kubernetes.Version = "1.26.0"
+		f.Shoot.Spec.Kubernetes.Version = "1.27.1"
 
 		if !v1beta1helper.IsWorkerless(f.Shoot) {
 			// create two additional worker pools which explicitly specify the kubernetes version
@@ -53,8 +52,7 @@ var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
 			pool2.Name += "2"
 			pool2.Kubernetes = &gardencorev1beta1.WorkerKubernetes{Version: &f.Shoot.Spec.Kubernetes.Version}
 			pool3.Name += "3"
-			// TODO(oliver-goetz): Update to 1.26.0 after the merge of https://github.com/gardener/gardener/pull/8479 has been merged and released (after 1.80 has been released).
-			pool3.Kubernetes = &gardencorev1beta1.WorkerKubernetes{Version: pointer.String("1.25.4")}
+			pool3.Kubernetes = &gardencorev1beta1.WorkerKubernetes{Version: pointer.String("1.26.0")}
 			f.Shoot.Spec.Provider.Workers = append(f.Shoot.Spec.Provider.Workers, *pool2, *pool3)
 		}
 

--- a/test/integration/resourcemanager/garbagecollector/garbagecollector_suite_test.go
+++ b/test/integration/resourcemanager/garbagecollector/garbagecollector_suite_test.go
@@ -123,7 +123,7 @@ var _ = BeforeSuite(func() {
 		Clock:                 clock.RealClock{},
 		MinimumObjectLifetime: pointer.Duration(0),
 		// Use the same version as the envtest package
-		TargetKubernetesVersion: semver.MustParse("1.27.0"),
+		TargetKubernetesVersion: semver.MustParse("1.28.0"),
 	}).AddToManager(mgr, mgr)).To(Succeed())
 
 	By("Start manager")


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area open-source
/kind enhancement

**What this PR does / why we need it**:
Since PR #8479 Gardener supports Kubernetes v1.28.
As a follow up, this PR updates e2e and envtest related Kubernetes versions to v1.28.

**Which issue(s) this PR fixes**:
Part of #8291

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
