### PR TITLE
Set fixed debian version in test images

### DIFF
--- a/hack/tools/image/variants.yaml
+++ b/hack/tools/image/variants.yaml
@@ -1,5 +1,8 @@
+# Debian versions of golang images must be in sync with these images to avoid problems with different `glibc` versions:
+# - https://github.com/gardener/ci-infra/blob/master/images/golang-test/variants.yaml
+# - https://github.com/gardener/ci-infra/blob/master/images/krte/Dockerfile
 variants:
   "1.20":
-    image: "golang:1.20.8"
+    image: golang:1.20.8-bookworm
   "1.21":
-    image: "golang:1.21.1"
+    image: golang:1.21.1-bookworm


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind enhancement

**What this PR does / why we need it**:
This PR sets the `debian` version of test images explicitly to `bookworm` that we don't run into `glibc` issues in case the default base image of `golang` changes.
There is a related PR in ci-infra repo: https://github.com/gardener/ci-infra/pull/909

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
