### PR TITLE
Fix DNS rewriting regex.

### DIFF
--- a/pkg/component/coredns/coredns.go
+++ b/pkg/component/coredns/coredns.go
@@ -791,8 +791,8 @@ func getSearchPathRewrites(enabled bool, clusterDomain string, commonSuffixes []
 	}
 	return `
   rewrite stop {
-    name regex ([^\.]+)\.([^\.]+)\.svc\.` + quotedClusterDomain + `\.svc\.` + quotedClusterDomain + ` {1}.{2}.svc.` + clusterDomain + `
-    answer name ([^\.]+)\.([^\.]+)\.svc\.` + quotedClusterDomain + ` {1}.{2}.svc.` + clusterDomain + `.svc.` + clusterDomain + `
-    answer value ([^\.]+)\.([^\.]+)\.svc\.` + quotedClusterDomain + ` {1}.{2}.svc.` + clusterDomain + `.svc.` + clusterDomain + `
+    name regex (^(?:[^\.]+\.)+)svc\.` + quotedClusterDomain + `\.svc\.` + quotedClusterDomain + ` {1}svc.` + clusterDomain + `
+    answer name (^(?:[^\.]+\.)+)svc\.` + quotedClusterDomain + ` {1}svc.` + clusterDomain + `.svc.` + clusterDomain + `
+    answer value (^(?:[^\.]+\.)+)svc\.` + quotedClusterDomain + ` {1}svc.` + clusterDomain + `.svc.` + clusterDomain + `
   }` + suffixRewrites
 }

--- a/pkg/component/coredns/coredns_test.go
+++ b/pkg/component/coredns/coredns_test.go
@@ -132,9 +132,9 @@ data:
 			if rewritingEnabled {
 				out += `
       rewrite stop {
-        name regex ([^\.]+)\.([^\.]+)\.svc\.foo\.bar\.svc\.foo\.bar {1}.{2}.svc.foo.bar
-        answer name ([^\.]+)\.([^\.]+)\.svc\.foo\.bar {1}.{2}.svc.foo.bar.svc.foo.bar
-        answer value ([^\.]+)\.([^\.]+)\.svc\.foo\.bar {1}.{2}.svc.foo.bar.svc.foo.bar
+        name regex (^(?:[^\.]+\.)+)svc\.foo\.bar\.svc\.foo\.bar {1}svc.foo.bar
+        answer name (^(?:[^\.]+\.)+)svc\.foo\.bar {1}svc.foo.bar.svc.foo.bar
+        answer value (^(?:[^\.]+\.)+)svc\.foo\.bar {1}svc.foo.bar.svc.foo.bar
       }`
 				for _, suffix := range commonSuffixes {
 					out += `


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind bug

**What this PR does / why we need it**:
This PR fixes an issue, where DNS lookups for non-existing pods of a StatefulSet yielded one of the existing pods even when it should not have. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
 Fix an issue, where DNS lookups for non-existing pods of a StatefulSet yielded one of the existing pods even when it should not have. 
```
