### PR TITLE
[release-v1.80] Automated cherry pick of #8545: Enable cache in `garden` namespace for `virtual-garden-gardener-resource-manager`

### DIFF
--- a/pkg/operator/controller/garden/garden/components.go
+++ b/pkg/operator/controller/garden/garden/components.go
@@ -325,7 +325,7 @@ func (r *Reconciler) newVirtualGardenGardenerResourceManager(secretsManager secr
 		false,
 		nil,
 		true,
-		[]string{metav1.NamespaceSystem},
+		[]string{v1beta1constants.GardenNamespace, metav1.NamespaceSystem},
 	)
 }
 


### PR DESCRIPTION
/kind bug
/area usability

Cherry pick of #8545 on release-v1.80.

#8545: Enable cache in `garden` namespace for `virtual-garden-gardener-resource-manager`

**Release Notes:**
```other operator
NONE
```