### PR TITLE
Adapt `gardener-resource-manager` to disabled APIs in workerless/virtual cluster

### DIFF
--- a/pkg/resourcemanager/controller/health/progressing/add.go
+++ b/pkg/resourcemanager/controller/health/progressing/add.go
@@ -20,7 +20,9 @@ import (
 	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/utils/clock"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -85,28 +87,40 @@ func (r *Reconciler) AddToManager(ctx context.Context, mgr manager.Manager, sour
 			MaxConcurrentReconciles: pointer.IntDeref(r.Config.ConcurrentSyncs, 0),
 		})
 
-	// Watch relevant objects for Progressing condition in order to immediately update the condition as soon as there is
-	// a change on managed resources.
-	pod := &metav1.PartialObjectMetadata{}
-	pod.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("Pod"))
+	for resource, obj := range map[string]client.Object{
+		"deployments":  &appsv1.Deployment{},
+		"statefulsets": &appsv1.StatefulSet{},
+		"daemonsets":   &appsv1.DaemonSet{},
+	} {
+		gvr := schema.GroupVersionResource{Group: appsv1.SchemeGroupVersion.Group, Version: appsv1.SchemeGroupVersion.Version, Resource: resource}
 
-	b = b.WatchesRawSource(
-		source.Kind(targetCluster.GetCache(), &appsv1.Deployment{}),
-		mapper.EnqueueRequestsFrom(ctx, mgr.GetCache(), utils.MapToOriginManagedResource(clusterID), mapper.UpdateWithNew, c.GetLogger()),
-		builder.WithPredicates(r.ProgressingStatusChanged(ctx)),
-	).WatchesRawSource(
-		source.Kind(targetCluster.GetCache(), pod),
-		mapper.EnqueueRequestsFrom(ctx, mgr.GetCache(), r.MapPodToDeploymentToOriginManagedResource(clusterID), mapper.UpdateWithNew, c.GetLogger()),
-		builder.WithPredicates(predicateutils.ForEventTypes(predicateutils.Create, predicateutils.Delete)),
-	).WatchesRawSource(
-		source.Kind(targetCluster.GetCache(), &appsv1.StatefulSet{}),
-		mapper.EnqueueRequestsFrom(ctx, mgr.GetCache(), utils.MapToOriginManagedResource(clusterID), mapper.UpdateWithNew, c.GetLogger()),
-		builder.WithPredicates(r.ProgressingStatusChanged(ctx)),
-	).WatchesRawSource(
-		source.Kind(targetCluster.GetCache(), &appsv1.DaemonSet{}),
-		mapper.EnqueueRequestsFrom(ctx, mgr.GetCache(), utils.MapToOriginManagedResource(clusterID), mapper.UpdateWithNew, c.GetLogger()),
-		builder.WithPredicates(r.ProgressingStatusChanged(ctx)),
-	)
+		if _, err := targetCluster.GetRESTMapper().KindFor(gvr); err != nil {
+			if !meta.IsNoMatchError(err) {
+				return err
+			}
+			mgr.GetLogger().Info("Resource is not available/enabled API of the target cluster, skip adding watches", "gvr", gvr)
+			continue
+		}
+
+		b = b.WatchesRawSource(
+			source.Kind(targetCluster.GetCache(), obj),
+			mapper.EnqueueRequestsFrom(ctx, mgr.GetCache(), utils.MapToOriginManagedResource(clusterID), mapper.UpdateWithNew, c.GetLogger()),
+			builder.WithPredicates(r.ProgressingStatusChanged(ctx)),
+		)
+
+		if resource == "deployments" {
+			// Watch relevant objects for Progressing condition in order to immediately update the condition as soon as
+			// there is a change on managed resources.
+			pod := &metav1.PartialObjectMetadata{}
+			pod.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("Pod"))
+
+			b = b.WatchesRawSource(
+				source.Kind(targetCluster.GetCache(), pod),
+				mapper.EnqueueRequestsFrom(ctx, mgr.GetCache(), r.MapPodToDeploymentToOriginManagedResource(clusterID), mapper.UpdateWithNew, c.GetLogger()),
+				builder.WithPredicates(predicateutils.ForEventTypes(predicateutils.Create, predicateutils.Delete)),
+			)
+		}
+	}
 
 	return b.Complete(r)
 }

--- a/pkg/resourcemanager/controller/health/progressing/reconciler.go
+++ b/pkg/resourcemanager/controller/health/progressing/reconciler.go
@@ -21,6 +21,7 @@ import (
 	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/utils/clock"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -124,7 +125,7 @@ func (r *Reconciler) reconcile(ctx context.Context, log logr.Logger, mr *resourc
 		)
 
 		if err := r.TargetClient.Get(checkCtx, objectKey, obj); err != nil {
-			if apierrors.IsNotFound(err) {
+			if apierrors.IsNotFound(err) || meta.IsNoMatchError(err) {
 				// missing objects already handled by health controller, skip
 				continue
 			}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity
/kind enhancement

**What this PR does / why we need it**:
In the virtual cluster or in workerless clusters, some APIs are disabled, most notable the `apps/v1` API. Hence, let's adapt
- `garbage-collector` reconciler to not complain when trying to list `Deployment`s/`StatefulSet`s/`DaemonSet`s (this was already discussed in https://github.com/gardener/gardener/pull/8398/files#r1307551642 but abandoned for some reasons, cc @dimityrmirchev).
- `progressing` reconciler to not start watches for `Deployment`s(/`Pod`s)/`StatefulSet`s/`DaemonSet`s.

**Which issue(s) this PR fixes**:
Follow-up of https://github.com/gardener/gardener/issues/7473 / https://github.com/gardener/gardener/pull/8483

**Special notes for your reviewer**:
There are no functional issues - just logs are polluted with messages like this:

```
{"level":"error","ts":"2023-09-23T05:41:24.358Z","msg":"Reconciler error","controller":"garbage-collector","namespace":"","name":"","reconcileID":"fdea0efe-41d4-48bc-b0af-0ee1665f59ea","error":"no matches for kind \"Deployment\" in version \"apps/v1\"","stacktrace":"sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\tsigs.k8s.io/controller-runtime@v0.16.2/pkg/internal/controller/controller.go:329\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\tsigs.k8s.io/controller-runtime@v0.16.2/pkg/internal/controller/controller.go:266\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2\n\tsigs.k8s.io/controller-runtime@v0.16.2/pkg/internal/controller/controller.go:227"}
```

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
