### PR TITLE
Document the used PriorityClass by the registry cache Pods

### DIFF
--- a/docs/development/priority-classes.md
+++ b/docs/development/priority-classes.md
@@ -58,7 +58,7 @@ When using the `gardener-operator` for managing the garden runtime and virtual c
 | Name                                              | Priority   | Associated Components (Examples)                                                                                            |
 |---------------------------------------------------|------------|-----------------------------------------------------------------------------------------------------------------------------|
 | `system-node-critical` (created by Kubernetes)    | 2000001000 | `calico-node`, `kube-proxy`, `apiserver-proxy`, `csi-driver`, `egress-filter-applier`                                       |
-| `system-cluster-critical` (created by Kubernetes) | 2000000000 | `calico-typha`, `calico-kube-controllers`, `coredns`, `vpn-shoot`                                                           |
+| `system-cluster-critical` (created by Kubernetes) | 2000000000 | `calico-typha`, `calico-kube-controllers`, `coredns`, `vpn-shoot`, `registry-cache`                                         |
 | `gardener-shoot-system-900`                       | 999999900  | `node-problem-detector`                                                                                                     |
 | `gardener-shoot-system-800`                       | 999999800  | `calico-typha-horizontal-autoscaler`, `calico-typha-vertical-autoscaler`                                                    |
 | `gardener-shoot-system-700`                       | 999999700  | `blackbox-exporter`, `node-exporter`                                                                                        |


### PR DESCRIPTION


**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind enhancement

**What this PR does / why we need it**:
The reasoning the choosing `system-cluster-critical` is:
> - When a request against the registry cache fails, containerd will retry the request against the upstream registry. When the registry cache is unavailable, a request times out in 30s and then the retry against the upstream happens. In that case, the image pull time increases significantly because containerd performs multiple requests (HEAD request to resolve the manifest by tag, GET request for the manifest by SHA, GET requests for blobs) and each of these requests times out in 30s. For example, image pull from the upstream for `docker.io/library/alpine:3.13.2` takes ~2s while image pull of the same image with unavailable registry cache takes ~2m.2s. Another example - image pull from the upstream for `eu.gcr.io/gardener-project/gardener/ops-toolbelt:0.18.0` takes ~10s while image pull of the same image with unavailable registry cache takes ~3m.10s.

Ref https://github.com/gardener/gardener-extension-registry-cache/pull/47

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
