### PR TITLE
provider-local: Change the StorageClass name from `standard` to `default`

### DIFF
--- a/pkg/provider-local/charts/shoot-storageclasses/templates/storageclasses.yaml
+++ b/pkg/provider-local/charts/shoot-storageclasses/templates/storageclasses.yaml
@@ -1,7 +1,7 @@
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-  name: standard
+  name: default
   annotations:
     storageclass.kubernetes.io/is-default-class: "true"
 provisioner: rancher.io/local-path


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind enhancement

**What this PR does / why we need it**:
In the registry-cache extension we deploy PVCs to the Shoot. We see cases where the PVC and StorageClass creation can be racy. In K8s < 1.26 (the `RetroactiveDefaultStorageClass` feature gate disabled), when the default StorageClass is created after the PVC, the PVC hangs in Pending state with reason `no persistent volumes available for this claim and no storage class is set`. In K8s, there is a feature gate called `RetroactiveDefaultStorageClass` which makes possible the StorageClass from PVC to be set when the PVC is created before the StorageClass. See https://kubernetes.io/docs/concepts/storage/persistent-volumes/#retroactive-default-storageclass-assignment
In the registry-cache extension we decided to hard-code the StorageClass name to `default` for time being. When it is ensured that `RetroactiveDefaultStorageClass` is enabled by default in the supported K8s versions, then we can drop this. Currently, all provider-extensions name their default StorageClass with the name `default`. This PR changes the StorageClass name to `default` for provider-local.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener-extension-registry-cache/issues/3

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
