### PR TITLE
Ensure `extension-worker-mcm-shoot` MR is removed during migrate

### DIFF
--- a/extensions/pkg/controller/worker/genericactuator/actuator_migrate.go
+++ b/extensions/pkg/controller/worker/genericactuator/actuator_migrate.go
@@ -44,12 +44,12 @@ func (a *genericActuator) Migrate(ctx context.Context, log logr.Logger, worker *
 		return fmt.Errorf("could not keep objects of managed resource containing mcm chart for worker '%s': %w", kubernetesutils.ObjectName(worker), err)
 	}
 
-	if a.mcmManaged {
-		// Make sure machine-controller-manager is deleted before deleting the machines.
-		if err := a.deleteMachineControllerManager(ctx, log, worker); err != nil {
-			return fmt.Errorf("failed deleting machine-controller-manager: %w", err)
-		}
+	// Make sure machine-controller-manager is deleted before deleting the machines.
+	if err := a.deleteMachineControllerManager(ctx, log, worker); err != nil {
+		return fmt.Errorf("failed deleting machine-controller-manager: %w", err)
+	}
 
+	if a.mcmManaged {
 		if err := a.waitUntilMachineControllerManagerIsDeleted(ctx, log, worker.Namespace); err != nil {
 			return fmt.Errorf("failed deleting machine-controller-manager: %w", err)
 		}

--- a/extensions/pkg/controller/worker/genericactuator/machine_controller_manager.go
+++ b/extensions/pkg/controller/worker/genericactuator/machine_controller_manager.go
@@ -92,7 +92,7 @@ func (a *genericActuator) deployMachineControllerManager(ctx context.Context, lo
 
 func (a *genericActuator) deleteMachineControllerManager(ctx context.Context, logger logr.Logger, workerObj *extensionsv1alpha1.Worker) error {
 	if !a.mcmManaged {
-		logger.Info("Skip machine-controller-manager deployment since gardenlet manages it - deleting monitoring ConfigMap and extension-worker-mcm-shoot ManagedResource")
+		logger.Info("Skip machine-controller-manager deletion since gardenlet manages it - deleting monitoring ConfigMap and extension-worker-mcm-shoot ManagedResource")
 		if err := a.client.Delete(ctx, &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "machine-controller-manager-monitoring-config", Namespace: workerObj.Namespace}}); client.IgnoreNotFound(err) != nil {
 			return err
 		}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane-migration
/kind bug

**What this PR does / why we need it**:

This PR fixes the migrate procedure for the Worker extension resource by making sure that the `extension-worker-mcm-shoot` ManagedResource is removed if the `MachineControllerManagerDeployment` feature gate is enabled while a shoot cluster is being migrated.

This could happen previously because the `extension-worker-mcm-shoot` ManagedResource is deployed  when the feature gate is disabled. However, it is not removed in the `Migrate(...)` method of the worker's generic actuator when the feature gate is enabled. For instance, the migrate phase of control plane migration would get stuck if the following happens:
1. A cluster is created when the feature gate is enabled.
2. Control plane migration is triggered but gets stuck in migrate procedure due to a different error.
3. The feature gate is enabled.
4. The initial error in the migrate flow is fixed.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
3. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fixed a possibility for the `migrate` phase of control plane migration to become permanently stuck if the shoot was created when the `MachineControllerManagerDeployment` feature gate is disabled, control plane migration is triggered for the shoot and the feature gate is enabled during the migration phase.
```
