### PR TITLE
Don't touch `Shoot` `spec.extensions` if there is no duplicated extension

### DIFF
--- a/pkg/registry/core/shoot/strategy.go
+++ b/pkg/registry/core/shoot/strategy.go
@@ -170,17 +170,15 @@ func mustIncreaseGenerationForSpecChanges(oldShoot, newShoot *core.Shoot) bool {
 func removeDuplicateExtensions(shoot *core.Shoot) {
 	if len(shoot.Spec.Extensions) > 1 {
 		typeToExtension := make(map[string]core.Extension)
-		extensionsType := sets.New[string]()
 		for _, extension := range shoot.Spec.Extensions {
-			extensionsType.Insert(extension.Type)
 			typeToExtension[extension.Type] = extension
 		}
 
 		extensionsList := make([]core.Extension, 0, len(typeToExtension))
 		for _, extension := range shoot.Spec.Extensions {
-			if extensionsType.Has(extension.Type) {
-				extensionsType.Delete(extension.Type)
-				extensionsList = append(extensionsList, typeToExtension[extension.Type])
+			if ext, ok := typeToExtension[extension.Type]; ok {
+				extensionsList = append(extensionsList, ext)
+				delete(typeToExtension, extension.Type)
 			}
 		}
 

--- a/pkg/registry/core/shoot/strategy.go
+++ b/pkg/registry/core/shoot/strategy.go
@@ -80,14 +80,14 @@ func (shootStrategy) PrepareForUpdate(_ context.Context, obj, old runtime.Object
 	newShoot.Status = oldShoot.Status               // can only be changed by shoots/status subresource
 	newShoot.Spec.SeedName = oldShoot.Spec.SeedName // can only be changed by shoots/binding subresource
 
-	if mustIncreaseGeneration(oldShoot, newShoot) {
-		newShoot.Generation = oldShoot.Generation + 1
-	}
-
 	// TODO(acumino): Drop this after v1.83 has been released.
 	removeDuplicateExtensions(newShoot)
 	// TODO(dimitar-kostadinov): Drop this after v1.83 has been released.
 	removeDuplicateServiceAccountIssuers(newShoot)
+
+	if mustIncreaseGeneration(oldShoot, newShoot) {
+		newShoot.Generation = oldShoot.Generation + 1
+	}
 }
 
 func mustIncreaseGeneration(oldShoot, newShoot *core.Shoot) bool {

--- a/pkg/registry/core/shoot/strategy.go
+++ b/pkg/registry/core/shoot/strategy.go
@@ -15,10 +15,8 @@
 package shoot
 
 import (
-	"cmp"
 	"context"
 	"fmt"
-	"slices"
 	"time"
 
 	"github.com/Masterminds/semver/v3"
@@ -171,19 +169,21 @@ func mustIncreaseGenerationForSpecChanges(oldShoot, newShoot *core.Shoot) bool {
 
 func removeDuplicateExtensions(shoot *core.Shoot) {
 	if len(shoot.Spec.Extensions) > 1 {
-		typeToExtension := make(map[string]core.Extension, len(shoot.Spec.Extensions))
+		typeToExtension := make(map[string]core.Extension)
+		extensionsType := sets.New[string]()
 		for _, extension := range shoot.Spec.Extensions {
+			extensionsType.Insert(extension.Type)
 			typeToExtension[extension.Type] = extension
 		}
 
 		extensionsList := make([]core.Extension, 0, len(typeToExtension))
-		for _, extension := range typeToExtension {
-			extensionsList = append(extensionsList, extension)
+		for _, extension := range shoot.Spec.Extensions {
+			if extensionsType.Has(extension.Type) {
+				extensionsType.Delete(extension.Type)
+				extensionsList = append(extensionsList, typeToExtension[extension.Type])
+			}
 		}
 
-		slices.SortFunc(extensionsList, func(a, b core.Extension) int {
-			return cmp.Compare(a.Type, b.Type)
-		})
 		shoot.Spec.Extensions = extensionsList
 	}
 }

--- a/pkg/registry/core/shoot/strategy_test.go
+++ b/pkg/registry/core/shoot/strategy_test.go
@@ -502,16 +502,12 @@ var _ = Describe("Strategy", func() {
 					Spec: core.ShootSpec{
 						Extensions: []core.Extension{
 							{
-								Type:     "arbitrary",
-								Disabled: pointer.Bool(false),
-							},
-							{
-								Type:     "arbitrary",
-								Disabled: pointer.Bool(true),
-							},
-							{
 								Type:     "arbitrary-1",
 								Disabled: pointer.Bool(true),
+							},
+							{
+								Type:     "arbitrary",
+								Disabled: pointer.Bool(false),
 							},
 						},
 					},
@@ -519,7 +515,21 @@ var _ = Describe("Strategy", func() {
 				newShoot = oldShoot.DeepCopy()
 			})
 
+			It("should not change order of extensions if there are no duplicate extensions", func() {
+				shootregistry.NewStrategy(0).PrepareForUpdate(context.TODO(), newShoot, oldShoot)
+
+				Expect(newShoot.Spec.Extensions).To(HaveLen(2))
+				Expect(newShoot.Spec.Extensions[0]).To(Equal(oldShoot.Spec.Extensions[0]))
+				Expect(newShoot.Spec.Extensions[1]).To(Equal(oldShoot.Spec.Extensions[1]))
+			})
+
 			It("should remove duplicated extensions and take the latest configuration of duplicate extensions", func() {
+				oldShoot.Spec.Extensions = append(oldShoot.Spec.Extensions, core.Extension{
+					Type:     "arbitrary",
+					Disabled: pointer.Bool(true),
+				})
+				newShoot = oldShoot.DeepCopy()
+
 				shootregistry.NewStrategy(0).PrepareForUpdate(context.TODO(), newShoot, oldShoot)
 
 				Expect(newShoot.Spec.Extensions).To(HaveLen(2))


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind bug

**What this PR does / why we need it**:
https://github.com/gardener/gardener/pull/8457 Introduced removal of duplicated extensions from `shoot.spec.extensions`, but in case extensions are not duplicated it still can cause reorder or extensions leading to unnecessary change.

With this PR order of extension is only changed if a duplicated extension is removed.


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
A bug causing unnecessary reorder of extension in `Shoot` `spec.extensions` is fixed.
```
