### PR TITLE
Allow multiple expanders to be specified for `cluster-autoscaler`

### DIFF
--- a/example/90-shoot.yaml
+++ b/example/90-shoot.yaml
@@ -277,7 +277,7 @@ spec:
   #   featureGates:
   #     SomeKubernetesFeature: true
   # clusterAutoscaler:
-  #   expander: "least-waste" # see: https://github.com/gardener/autoscaler/blob/machine-controller-manager-provider/cluster-autoscaler/FAQ.md#what-are-expanders
+  #   expander: "priority,least-waste" # see: https://github.com/gardener/autoscaler/blob/machine-controller-manager-provider/cluster-autoscaler/FAQ.md#what-are-expanders
   #   maxGracefulTerminationSeconds: 600
   #   maxNodeProvisionTime: 20m
   #   scaleDownUtilizationThreshold: 0.5

--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -1034,8 +1034,13 @@ func ValidateClusterAutoscaler(autoScaler core.ClusterAutoscaler, k8sVersion str
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("maxGracefulTerminationSeconds"), *maxGracefulTerminationSeconds, "can not be negative"))
 	}
 
-	if expander := autoScaler.Expander; expander != nil && !availableClusterAutoscalerExpanderModes.Has(string(*expander)) {
-		allErrs = append(allErrs, field.NotSupported(fldPath.Child("expander"), *expander, sets.List(availableClusterAutoscalerExpanderModes)))
+	if expander := autoScaler.Expander; expander != nil {
+		expanderArray := strings.Split(string(*expander), ",")
+		for _, exp := range expanderArray {
+			if !availableClusterAutoscalerExpanderModes.Has(exp) {
+				allErrs = append(allErrs, field.NotSupported(fldPath.Child("expander"), *expander, sets.List(availableClusterAutoscalerExpanderModes)))
+			}
+		}
 	}
 
 	if ignoreTaints := autoScaler.IgnoreTaints; ignoreTaints != nil {

--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -2656,11 +2656,11 @@ var _ = Describe("Shoot Validation Tests", func() {
 						"Field": Equal("expander"),
 					}))),
 				),
-				Entry("incorrect multiple expander string", 
+				Entry("incorrect multiple expander string",
 					core.ClusterAutoscaler{
 						Expander: &invalidMultipleExpanderString,
-					}, 
-					version, 
+					},
+					version,
 					ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 						"Type":  Equal(field.ErrorTypeNotSupported),
 						"Field": Equal("expander"),

--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -2591,7 +2591,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 		)
 
 		Context("ClusterAutoscaler validation", func() {
-			FDescribeTable("cluster autoscaler values",
+			DescribeTable("cluster autoscaler values",
 				func(clusterAutoscaler core.ClusterAutoscaler, supportedVersionForIgnoreTaints string, matcher gomegatypes.GomegaMatcher) {
 					Expect(ValidateClusterAutoscaler(clusterAutoscaler, supportedVersionForIgnoreTaints, nil)).To(matcher)
 				},

--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -2574,21 +2574,24 @@ var _ = Describe("Shoot Validation Tests", func() {
 		})
 
 		var (
-			negativeDuration            = metav1.Duration{Duration: -time.Second}
-			negativeInteger       int32 = -100
-			positiveInteger       int32 = 100
-			expanderLeastWaste          = core.ClusterAutoscalerExpanderLeastWaste
-			expanderMostPods            = core.ClusterAutoscalerExpanderMostPods
-			expanderPriority            = core.ClusterAutoscalerExpanderPriority
-			expanderRandom              = core.ClusterAutoscalerExpanderRandom
-			ignoreTaintsUnique          = []string{"taint-1", "taint-2"}
-			ignoreTaintsDuplicate       = []string{"taint-1", "taint-1"}
-			ignoreTaintsInvalid         = []string{"taint 1", "taint-1"}
-			version                     = "1.24"
+			negativeDuration                    = metav1.Duration{Duration: -time.Second}
+			negativeInteger               int32 = -100
+			positiveInteger               int32 = 100
+			expanderLeastWaste                  = core.ClusterAutoscalerExpanderLeastWaste
+			expanderMostPods                    = core.ClusterAutoscalerExpanderMostPods
+			expanderPriority                    = core.ClusterAutoscalerExpanderPriority
+			expanderRandom                      = core.ClusterAutoscalerExpanderRandom
+			expanderPriorityAndLeastWaste       = core.ExpanderMode(core.ClusterAutoscalerExpanderPriority + "," + core.ClusterAutoscalerExpanderLeastWaste)
+			invalidExpander                     = core.ExpanderMode(core.ClusterAutoscalerExpanderPriority + ", test-expander")
+			invalidMultipleExpanderString       = core.ExpanderMode(core.ClusterAutoscalerExpanderPriority + ", " + core.ClusterAutoscalerExpanderLeastWaste)
+			ignoreTaintsUnique                  = []string{"taint-1", "taint-2"}
+			ignoreTaintsDuplicate               = []string{"taint-1", "taint-1"}
+			ignoreTaintsInvalid                 = []string{"taint 1", "taint-1"}
+			version                             = "1.24"
 		)
 
 		Context("ClusterAutoscaler validation", func() {
-			DescribeTable("cluster autoscaler values",
+			FDescribeTable("cluster autoscaler values",
 				func(clusterAutoscaler core.ClusterAutoscaler, supportedVersionForIgnoreTaints string, matcher gomegatypes.GomegaMatcher) {
 					Expect(ValidateClusterAutoscaler(clusterAutoscaler, supportedVersionForIgnoreTaints, nil)).To(matcher)
 				},
@@ -2640,6 +2643,27 @@ var _ = Describe("Shoot Validation Tests", func() {
 					ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 						"Type":  Equal(field.ErrorTypeInvalid),
 						"Field": Equal("ignoreTaints[0]"),
+					}))),
+				),
+				Entry("valid with expander priority and least-waste", core.ClusterAutoscaler{Expander: &expanderPriorityAndLeastWaste}, version, BeEmpty()),
+				Entry("invalid expander in multiple expander string",
+					core.ClusterAutoscaler{
+						Expander: &invalidExpander,
+					},
+					version,
+					ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":  Equal(field.ErrorTypeNotSupported),
+						"Field": Equal("expander"),
+					}))),
+				),
+				Entry("incorrect multiple expander string", 
+					core.ClusterAutoscaler{
+						Expander: &invalidMultipleExpanderString,
+					}, 
+					version, 
+					ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":  Equal(field.ErrorTypeNotSupported),
+						"Field": Equal("expander"),
 					}))),
 				),
 			)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area auto-scaling
/kind enhancement

**What this PR does / why we need it**:
From `v1.23.0` onwards, `cluster-autoscaler` supports multiple expanders
This PR support this by letting multiple expanders be specified from the shoot spec

**Which issue(s) this PR fixes**:
Fixes gardener/autoscaler#128

**Special notes for your reviewer**:
ref: [cluster-autoscaler/what-are-expanders](https://github.com/gardener/autoscaler/blob/machine-controller-manager-provider/cluster-autoscaler/FAQ.md#what-are-expanders)

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Multiple expanders for `cluster-autoscaler` can now be specified in the `Shoot` API via the `.spec.kubernetes.clusterAutoscaler.expander` field.
```
