### PR TITLE
[GEP-21] provider-local single-stack ipv6 implementation

### DIFF
--- a/docs/usage/ipv6.md
+++ b/docs/usage/ipv6.md
@@ -9,12 +9,19 @@ This documentation will be enhanced while implementing GEP-21, see [gardener/gar
 
 To use IPv6 single-stack networking, the [feature gate](../deployment/feature_gates.md) `IPv6SingleStack` must be enabled on gardener-apiserver and gardenlet.
 
-## Development Setup
+## Development/Testing Setup
 
 Developing or testing IPv6-related features requires a Linux machine (docker only supports IPv6 on Linux) and native IPv6 connectivity to the internet.
 If you're on a different OS or don't have IPv6 connectivity in your office environment or via your home ISP, make sure to check out [gardener-community/dev-box-gcp](https://github.com/gardener-community/dev-box-gcp), which allows you to circumvent these limitations.
 
-You can follow the guide on [Deploying Gardener Locally](../deployment/getting_started_locally.md) for setting up an IPv6 gardener for testing or development purposes.
+To get started with the IPv6 setup and create a local IPv6 single-stack shoot cluster, run the following commands:
+
+```bash
+make kind-up gardener-up IPFAMILY=ipv6
+k apply -f example/provider-local/shoot-ipv6.yaml
+```
+
+Please also take a look at the guide on [Deploying Gardener Locally](../deployment/getting_started_locally.md) for more details on setting up an IPv6 gardener for testing or development purposes.
 
 ## Container Images
 

--- a/example/gardener-local/gardenlet/values-ipv6.yaml
+++ b/example/gardener-local/gardenlet/values-ipv6.yaml
@@ -1,4 +1,7 @@
 config:
+  # loki is unable to cope with IPv6, hence disable logging entirely
+  logging:
+    enabled: false
   seedConfig:
     spec:
       networks:

--- a/example/provider-local/shoot-ipv6.yaml
+++ b/example/provider-local/shoot-ipv6.yaml
@@ -1,0 +1,45 @@
+apiVersion: core.gardener.cloud/v1beta1
+kind: Shoot
+metadata:
+  name: local
+  namespace: garden-local
+  annotations:
+    shoot.gardener.cloud/infrastructure-cleanup-wait-period-seconds: "0"
+    shoot.gardener.cloud/cloud-config-execution-max-delay-seconds: "0"
+spec:
+  seedName: local
+  cloudProfileName: local
+  secretBindingName: local # dummy, doesn't contain any credentials
+  region: local
+  networking:
+    type: calico
+    pods: 2002:db8:1::/48
+#    nodes: 2002:db8:2::/64 -> it doesn't make sense to specify this, node IPs are given by the seed cluster's pod CIDR
+    services: 2002:db8:3::/108
+    ipFamilies:
+    - IPv6
+    # TODO(scheererj): Drop this once v1.32 has been released and https://github.com/gardener/gardener-extension-networking-calico/pull/250 is available as release
+    providerConfig:
+      apiVersion: calico.networking.extensions.gardener.cloud/v1alpha1
+      kind: NetworkConfig
+  provider:
+    type: local
+    workers:
+    - name: local
+      machine:
+        type: local
+      cri:
+        name: containerd
+      minimum: 1
+      maximum: 1 # currently, only single-node clusters are supported
+      maxSurge: 1
+      maxUnavailable: 0
+  kubernetes:
+    version: 1.26.0
+    kubelet:
+      seccompDefault: true
+      serializeImagePulls: false
+      registryPullQPS: 10
+      registryBurst: 20
+      protectKernelDefaults: true
+      streamingConnectionIdleTimeout: 5m

--- a/example/provider-local/shoot-ipv6.yaml
+++ b/example/provider-local/shoot-ipv6.yaml
@@ -7,21 +7,15 @@ metadata:
     shoot.gardener.cloud/infrastructure-cleanup-wait-period-seconds: "0"
     shoot.gardener.cloud/cloud-config-execution-max-delay-seconds: "0"
 spec:
-  seedName: local
   cloudProfileName: local
   secretBindingName: local # dummy, doesn't contain any credentials
   region: local
   networking:
     type: calico
-    pods: 2002:db8:1::/48
-#    nodes: 2002:db8:2::/64 -> it doesn't make sense to specify this, node IPs are given by the seed cluster's pod CIDR
-    services: 2002:db8:3::/108
     ipFamilies:
     - IPv6
-    # TODO(scheererj): Drop this once v1.32 has been released and https://github.com/gardener/gardener-extension-networking-calico/pull/250 is available as release
-    providerConfig:
-      apiVersion: calico.networking.extensions.gardener.cloud/v1alpha1
-      kind: NetworkConfig
+    pods: 2002:db8:1::/48
+    services: 2002:db8:3::/108
   provider:
     type: local
     workers:
@@ -31,11 +25,10 @@ spec:
       cri:
         name: containerd
       minimum: 1
-      maximum: 1 # currently, only single-node clusters are supported
+      maximum: 2
       maxSurge: 1
       maxUnavailable: 0
   kubernetes:
-    version: 1.26.0
     kubelet:
       seccompDefault: true
       serializeImagePulls: false

--- a/example/provider-local/shoot-ipv6.yaml
+++ b/example/provider-local/shoot-ipv6.yaml
@@ -14,8 +14,8 @@ spec:
     type: calico
     ipFamilies:
     - IPv6
-    pods: 2002:db8:1::/48
-    services: 2002:db8:3::/108
+    pods: 2001:db8:1::/48
+    services: 2001:db8:3::/108
   provider:
     type: local
     workers:

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -715,8 +715,10 @@ const (
 	// or the specified namespace was not present.
 	NamespaceCreatedByProjectController = "namespace.gardener.cloud/created-by-project-controller"
 
-	// DefaultVPNRange is the default network range for the VPN between seed and shoot cluster.
+	// DefaultVPNRange is the default IPv4 network range for the VPN between seed and shoot cluster.
 	DefaultVPNRange = "192.168.123.0/24"
+	// DefaultVPNRangeV6 is the default IPv6 network range for the VPN between seed and shoot cluster.
+	DefaultVPNRangeV6 = "fd8f:6d53:b97a:1::/120"
 
 	// BackupSecretName is the name of secret having credentials for etcd backups.
 	BackupSecretName string = "etcd-backup"

--- a/pkg/apis/core/validation/seed.go
+++ b/pkg/apis/core/validation/seed.go
@@ -289,6 +289,8 @@ func validateSeedNetworks(seedNetworks core.SeedNetworks, fldPath *field.Path, i
 
 	vpnRange := cidrvalidation.NewCIDR(v1beta1constants.DefaultVPNRange, field.NewPath(""))
 	allErrs = append(allErrs, vpnRange.ValidateNotOverlap(networks...)...)
+	vpnRangeV6 := cidrvalidation.NewCIDR(v1beta1constants.DefaultVPNRangeV6, field.NewPath(""))
+	allErrs = append(allErrs, vpnRangeV6.ValidateNotOverlap(networks...)...)
 
 	return allErrs
 }

--- a/pkg/apis/extensions/validation/network.go
+++ b/pkg/apis/extensions/validation/network.go
@@ -15,6 +15,7 @@
 package validation
 
 import (
+	"slices"
 	"strings"
 
 	"github.com/go-test/deep"
@@ -99,7 +100,13 @@ func ValidateNetworkSpecUpdate(new, old *extensionsv1alpha1.NetworkSpec, deletio
 	allErrs = append(allErrs, apivalidation.ValidateImmutableField(new.Type, old.Type, fldPath.Child("type"))...)
 	allErrs = append(allErrs, apivalidation.ValidateImmutableField(new.PodCIDR, old.PodCIDR, fldPath.Child("podCIDR"))...)
 	allErrs = append(allErrs, apivalidation.ValidateImmutableField(new.ServiceCIDR, old.ServiceCIDR, fldPath.Child("serviceCIDR"))...)
-	allErrs = append(allErrs, apivalidation.ValidateImmutableField(new.IPFamilies, old.IPFamilies, fldPath.Child("ipFamilies"))...)
+
+	// allow upgrades from empty IPFamilies to the default of IPv4
+	// the if condition can be removed once the network extension of all shoots have been updated
+	// TODO: Remove in Gardener 1.87
+	if !(old.IPFamilies == nil && slices.Equal(new.IPFamilies, []extensionsv1alpha1.IPFamily{extensionsv1alpha1.IPFamilyIPv4})) {
+		allErrs = append(allErrs, apivalidation.ValidateImmutableField(new.IPFamilies, old.IPFamilies, fldPath.Child("ipFamilies"))...)
+	}
 
 	return allErrs
 }

--- a/pkg/component/apiserverproxy/apiserver_proxy.go
+++ b/pkg/component/apiserverproxy/apiserver_proxy.go
@@ -87,6 +87,8 @@ type Values struct {
 	PSPDisabled         bool
 	Image               string
 	SidecarImage        string
+	ListenIPAddress     string
+	DNSLookupFamily     string
 
 	advertiseIPAddress string
 }
@@ -158,6 +160,8 @@ func (a *apiserverProxy) computeResourcesData() (map[string][]byte, error) {
 	var envoyYAML bytes.Buffer
 	if err := tplEnvoy.Execute(&envoyYAML, map[string]interface{}{
 		"advertiseIPAddress":  a.values.advertiseIPAddress,
+		"listenAddress":       a.values.ListenIPAddress,
+		"dnsLookupFamily":     a.values.DNSLookupFamily,
 		"adminPort":           adminPort,
 		"proxySeedServerHost": a.values.ProxySeedServerHost,
 		"proxySeedServerPort": proxySeedServerPort,

--- a/pkg/component/apiserverproxy/templates/envoy.yaml.tpl
+++ b/pkg/component/apiserverproxy/templates/envoy.yaml.tpl
@@ -61,7 +61,7 @@ static_resources:
   - name: metrics
     address:
       socket_address:
-        address: 0.0.0.0
+        address: {{ .listenAddress | quote }}
         port_value: {{ .adminPort }}
     filter_chains:
     - filters:
@@ -108,7 +108,7 @@ static_resources:
     connect_timeout: 5s
     per_connection_buffer_limit_bytes: 32768 # 32 KiB
     type: LOGICAL_DNS
-    dns_lookup_family: V4_ONLY
+    dns_lookup_family: {{ .dnsLookupFamily }}
     lb_policy: ROUND_ROBIN
     load_assignment:
       cluster_name: kube_apiserver

--- a/pkg/component/coredns/coredns.go
+++ b/pkg/component/coredns/coredns.go
@@ -240,7 +240,7 @@ func (c *coreDNS) computeResourcesData() (map[string][]byte, error) {
       fallthrough in-addr.arpa ip6.arpa
       ttl 30
   }
-  prometheus 0.0.0.0:` + strconv.Itoa(portMetrics) + `
+  prometheus :` + strconv.Itoa(portMetrics) + `
   forward . /etc/resolv.conf
   cache 30
   loop

--- a/pkg/component/coredns/coredns_test.go
+++ b/pkg/component/coredns/coredns_test.go
@@ -150,7 +150,7 @@ data:
           fallthrough in-addr.arpa ip6.arpa
           ttl 30
       }
-      prometheus 0.0.0.0:9153
+      prometheus :9153
       forward . /etc/resolv.conf
       cache 30
       loop

--- a/pkg/component/extensions/network/network.go
+++ b/pkg/component/extensions/network/network.go
@@ -53,6 +53,8 @@ type Values struct {
 	Name string
 	// Type is the type of Network plugin/extension (e.g calico)
 	Type string
+	// IPFamilies specifies the IP protocol versions to use for shoot networking.
+	IPFamilies []extensionsv1alpha1.IPFamily
 	// ProviderConfig contains the provider config for the Network extension.
 	ProviderConfig *runtime.RawExtension
 	// PodCIDR is the Shoot's pod CIDR in the Shoot VPC
@@ -183,6 +185,7 @@ func (n *network) deploy(ctx context.Context, operation string) (extensionsv1alp
 				Type:           n.values.Type,
 				ProviderConfig: n.values.ProviderConfig,
 			},
+			IPFamilies:  n.values.IPFamilies,
 			PodCIDR:     n.values.PodCIDR.String(),
 			ServiceCIDR: n.values.ServiceCIDR.String(),
 		}

--- a/pkg/component/extensions/network/network_test.go
+++ b/pkg/component/extensions/network/network_test.go
@@ -54,9 +54,9 @@ var _ = Describe("#Network", func() {
 		networkServiceIp   = "100.64.0.0"
 		networkServiceMask = 13
 
-		networkPodV6IP       = "2002:db8:1::"
+		networkPodV6IP       = "2001:db8:1::"
 		networkPodV6Mask     = 48
-		networkServiceV6IP   = "2002:db8:3::"
+		networkServiceV6IP   = "2001:db8:3::"
 		networkServiceV6Mask = 108
 	)
 	var (

--- a/pkg/component/extensions/operatingsystemconfig/original/components/kernelconfig/component.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/kernelconfig/component.go
@@ -117,6 +117,9 @@ var data = map[string]string{
 	// explicitly enable IPv4 forwarding for all interfaces by default if not enabled by the OS image already
 	"net.ipv4.conf.all.forwarding":     "1",
 	"net.ipv4.conf.default.forwarding": "1",
+	// explicitly enable IPv6 forwarding for all interfaces by default if not enabled by the OS image already
+	"net.ipv6.conf.all.forwarding":     "1",
+	"net.ipv6.conf.default.forwarding": "1",
 	// enable martian packets
 	"net.ipv4.conf.default.log_martians": "1",
 	// Increase the maximum total buffer-space allocatable

--- a/pkg/component/extensions/operatingsystemconfig/original/components/kernelconfig/component_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/kernelconfig/component_test.go
@@ -146,6 +146,9 @@ net.core.wmem_max = 16777216
 # explicitly enable IPv4 forwarding for all interfaces by default if not enabled by the OS image already
 net.ipv4.conf.all.forwarding = 1
 net.ipv4.conf.default.forwarding = 1
+# explicitly enable IPv6 forwarding for all interfaces by default if not enabled by the OS image already
+net.ipv6.conf.all.forwarding = 1
+net.ipv6.conf.default.forwarding = 1
 # enable martian packets
 net.ipv4.conf.default.log_martians = 1
 # Increase the maximum total buffer-space allocatable

--- a/pkg/component/istio/charts/istio/istio-ingress/templates/vpn-envoy-filter.yaml
+++ b/pkg/component/istio/charts/istio/istio-ingress/templates/vpn-envoy-filter.yaml
@@ -13,7 +13,6 @@ spec:
         filterChain:
           filter:
             name: envoy.filters.network.http_connection_manager
-        name: 0.0.0.0_8132
         portNumber: 8132
     patch:
       operation: MERGE
@@ -38,7 +37,6 @@ spec:
     match:
       context: GATEWAY
       listener:
-        name: 0.0.0.0_8132
         portNumber: 8132
         filterChain:
           filter:
@@ -72,7 +70,6 @@ spec:
     match:
       context: GATEWAY
       listener:
-        name: 0.0.0.0_8132
         portNumber: 8132
         filterChain:
           filter:

--- a/pkg/component/istio/test_charts/ingress_vpn_envoy_filter.yaml
+++ b/pkg/component/istio/test_charts/ingress_vpn_envoy_filter.yaml
@@ -12,7 +12,6 @@ spec:
         filterChain:
           filter:
             name: envoy.filters.network.http_connection_manager
-        name: 0.0.0.0_8132
         portNumber: 8132
     patch:
       operation: MERGE
@@ -37,7 +36,6 @@ spec:
     match:
       context: GATEWAY
       listener:
-        name: 0.0.0.0_8132
         portNumber: 8132
         filterChain:
           filter:
@@ -73,7 +71,6 @@ spec:
     match:
       context: GATEWAY
       listener:
-        name: 0.0.0.0_8132
         portNumber: 8132
         filterChain:
           filter:

--- a/pkg/component/kubeapiserver/secrets.go
+++ b/pkg/component/kubeapiserver/secrets.go
@@ -164,6 +164,7 @@ func (k *kubeAPIServer) reconcileSecretServer(ctx context.Context) (*corev1.Secr
 
 	if k.values.SNI.Enabled || (k.values.VPN.Enabled && k.values.VPN.HighAvailabilityEnabled) {
 		ipAddresses = append(ipAddresses, net.ParseIP("127.0.0.1"))
+		ipAddresses = append(ipAddresses, net.ParseIP("::1"))
 	}
 
 	if !k.values.IsWorkerless {

--- a/pkg/component/kubeapiserverexposure/kube_apiserver_sni.go
+++ b/pkg/component/kubeapiserverexposure/kube_apiserver_sni.go
@@ -38,6 +38,7 @@ import (
 	kubeapiserverconstants "github.com/gardener/gardener/pkg/component/kubeapiserver/constants"
 	"github.com/gardener/gardener/pkg/controllerutils"
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
+	netutils "github.com/gardener/gardener/pkg/utils/net"
 )
 
 var (
@@ -56,9 +57,10 @@ func init() {
 
 // SNIValues configure the kube-apiserver service SNI.
 type SNIValues struct {
-	Hosts               []string
-	APIServerProxy      *APIServerProxy
-	IstioIngressGateway IstioIngressGateway
+	Hosts                       []string
+	APIServerProxy              *APIServerProxy
+	IstioIngressGateway         IstioIngressGateway
+	APIServerClusterIPPrefixLen int
 }
 
 // APIServerProxy contains values for the APIServer proxy protocol configuration.
@@ -105,11 +107,12 @@ type sni struct {
 
 type envoyFilterTemplateValues struct {
 	*APIServerProxy
-	IngressGatewayLabels map[string]string
-	Name                 string
-	Namespace            string
-	Host                 string
-	Port                 int
+	IngressGatewayLabels        map[string]string
+	Name                        string
+	Namespace                   string
+	Host                        string
+	Port                        int
+	APIServerClusterIPPrefixLen int
 }
 
 func (s *sni) Deploy(ctx context.Context) error {
@@ -124,16 +127,20 @@ func (s *sni) Deploy(ctx context.Context) error {
 		envoyFilterSpec bytes.Buffer
 	)
 
+	sniValues := s.valuesFunc()
+
 	if values.APIServerProxy != nil {
 		envoyFilter := s.emptyEnvoyFilter()
+		sniValues.APIServerClusterIPPrefixLen = netutils.GetBitLen(values.APIServerProxy.APIServerClusterIP)
 
 		if err := envoyFilterSpecTemplate.Execute(&envoyFilterSpec, envoyFilterTemplateValues{
-			APIServerProxy:       values.APIServerProxy,
-			IngressGatewayLabels: values.IstioIngressGateway.Labels,
-			Name:                 envoyFilter.Name,
-			Namespace:            envoyFilter.Namespace,
-			Host:                 hostName,
-			Port:                 kubeapiserverconstants.Port,
+			APIServerProxy:              values.APIServerProxy,
+			IngressGatewayLabels:        values.IstioIngressGateway.Labels,
+			Name:                        envoyFilter.Name,
+			Namespace:                   envoyFilter.Namespace,
+			Host:                        hostName,
+			Port:                        kubeapiserverconstants.Port,
+			APIServerClusterIPPrefixLen: sniValues.APIServerClusterIPPrefixLen,
 		}); err != nil {
 			return err
 		}
@@ -180,9 +187,9 @@ func (s *sni) Deploy(ctx context.Context) error {
 	if _, err := controllerutils.GetAndCreateOrMergePatch(ctx, s.client, gateway, func() error {
 		gateway.Labels = getLabels()
 		gateway.Spec = istioapinetworkingv1beta1.Gateway{
-			Selector: s.valuesFunc().IstioIngressGateway.Labels,
+			Selector: sniValues.IstioIngressGateway.Labels,
 			Servers: []*istioapinetworkingv1beta1.Server{{
-				Hosts: s.valuesFunc().Hosts,
+				Hosts: sniValues.Hosts,
 				Port: &istioapinetworkingv1beta1.Port{
 					Number:   kubeapiserverconstants.Port,
 					Name:     "tls",
@@ -202,12 +209,12 @@ func (s *sni) Deploy(ctx context.Context) error {
 		virtualService.Labels = getLabels()
 		virtualService.Spec = istioapinetworkingv1beta1.VirtualService{
 			ExportTo: []string{"*"},
-			Hosts:    s.valuesFunc().Hosts,
+			Hosts:    sniValues.Hosts,
 			Gateways: []string{gateway.Name},
 			Tls: []*istioapinetworkingv1beta1.TLSRoute{{
 				Match: []*istioapinetworkingv1beta1.TLSMatchAttributes{{
 					Port:     kubeapiserverconstants.Port,
-					SniHosts: s.valuesFunc().Hosts,
+					SniHosts: sniValues.Hosts,
 				}},
 				Route: []*istioapinetworkingv1beta1.RouteDestination{{
 					Destination: &istioapinetworkingv1beta1.Destination{

--- a/pkg/component/kubeapiserverexposure/kube_apiserver_sni.go
+++ b/pkg/component/kubeapiserverexposure/kube_apiserver_sni.go
@@ -57,10 +57,9 @@ func init() {
 
 // SNIValues configure the kube-apiserver service SNI.
 type SNIValues struct {
-	Hosts                       []string
-	APIServerProxy              *APIServerProxy
-	IstioIngressGateway         IstioIngressGateway
-	APIServerClusterIPPrefixLen int
+	Hosts               []string
+	APIServerProxy      *APIServerProxy
+	IstioIngressGateway IstioIngressGateway
 }
 
 // APIServerProxy contains values for the APIServer proxy protocol configuration.
@@ -129,7 +128,7 @@ func (s *sni) Deploy(ctx context.Context) error {
 
 	if values.APIServerProxy != nil {
 		envoyFilter := s.emptyEnvoyFilter()
-		values.APIServerClusterIPPrefixLen = netutils.GetBitLen(values.APIServerProxy.APIServerClusterIP)
+		apiServerClusterIPPrefixLen := netutils.GetBitLen(values.APIServerProxy.APIServerClusterIP)
 
 		if err := envoyFilterSpecTemplate.Execute(&envoyFilterSpec, envoyFilterTemplateValues{
 			APIServerProxy:              values.APIServerProxy,
@@ -138,7 +137,7 @@ func (s *sni) Deploy(ctx context.Context) error {
 			Namespace:                   envoyFilter.Namespace,
 			Host:                        hostName,
 			Port:                        kubeapiserverconstants.Port,
-			APIServerClusterIPPrefixLen: values.APIServerClusterIPPrefixLen,
+			APIServerClusterIPPrefixLen: apiServerClusterIPPrefixLen,
 		}); err != nil {
 			return err
 		}

--- a/pkg/component/kubeapiserverexposure/kube_apiserver_sni.go
+++ b/pkg/component/kubeapiserverexposure/kube_apiserver_sni.go
@@ -128,7 +128,10 @@ func (s *sni) Deploy(ctx context.Context) error {
 
 	if values.APIServerProxy != nil {
 		envoyFilter := s.emptyEnvoyFilter()
-		apiServerClusterIPPrefixLen := netutils.GetBitLen(values.APIServerProxy.APIServerClusterIP)
+		apiServerClusterIPPrefixLen, err := netutils.GetBitLen(values.APIServerProxy.APIServerClusterIP)
+		if err != nil {
+			return err
+		}
 
 		if err := envoyFilterSpecTemplate.Execute(&envoyFilterSpec, envoyFilterTemplateValues{
 			APIServerProxy:              values.APIServerProxy,

--- a/pkg/component/kubeapiserverexposure/kube_apiserver_sni_test.go
+++ b/pkg/component/kubeapiserverexposure/kube_apiserver_sni_test.go
@@ -17,6 +17,7 @@ package kubeapiserverexposure_test
 import (
 	"context"
 
+	netutils "github.com/gardener/gardener/pkg/utils/net"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"google.golang.org/protobuf/types/known/durationpb"
@@ -205,7 +206,7 @@ var _ = Describe("#SNI", func() {
 
 	JustBeforeEach(func() {
 		defaultDepWaiter = NewSNI(c, applier, v1beta1constants.DeploymentNameKubeAPIServer, namespace, func() *SNIValues {
-			return &SNIValues{
+			val := &SNIValues{
 				Hosts:          hosts,
 				APIServerProxy: apiServerProxyValues,
 				IstioIngressGateway: IstioIngressGateway{
@@ -213,6 +214,10 @@ var _ = Describe("#SNI", func() {
 					Labels:    istioLabels,
 				},
 			}
+			if apiServerProxyValues != nil {
+				val.APIServerClusterIPPrefixLen = netutils.GetBitLen(apiServerProxyValues.APIServerClusterIP)
+			}
+			return val
 		})
 	})
 

--- a/pkg/component/kubeapiserverexposure/kube_apiserver_sni_test.go
+++ b/pkg/component/kubeapiserverexposure/kube_apiserver_sni_test.go
@@ -17,7 +17,6 @@ package kubeapiserverexposure_test
 import (
 	"context"
 
-	netutils "github.com/gardener/gardener/pkg/utils/net"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"google.golang.org/protobuf/types/known/durationpb"
@@ -42,6 +41,7 @@ import (
 	. "github.com/gardener/gardener/pkg/component/kubeapiserverexposure"
 	comptest "github.com/gardener/gardener/pkg/component/test"
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
+	netutils "github.com/gardener/gardener/pkg/utils/net"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 )
 

--- a/pkg/component/kubeapiserverexposure/kube_apiserver_sni_test.go
+++ b/pkg/component/kubeapiserverexposure/kube_apiserver_sni_test.go
@@ -41,7 +41,6 @@ import (
 	. "github.com/gardener/gardener/pkg/component/kubeapiserverexposure"
 	comptest "github.com/gardener/gardener/pkg/component/test"
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
-	netutils "github.com/gardener/gardener/pkg/utils/net"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 )
 
@@ -213,9 +212,6 @@ var _ = Describe("#SNI", func() {
 					Namespace: istioNamespace,
 					Labels:    istioLabels,
 				},
-			}
-			if apiServerProxyValues != nil {
-				val.APIServerClusterIPPrefixLen = netutils.GetBitLen(apiServerProxyValues.APIServerClusterIP)
 			}
 			return val
 		})

--- a/pkg/component/kubeapiserverexposure/templates/envoyfilter.yaml
+++ b/pkg/component/kubeapiserverexposure/templates/envoyfilter.yaml
@@ -36,4 +36,4 @@ spec:
           destination_port: {{ .Port }}
           prefix_ranges:
           - address_prefix: {{ .APIServerClusterIP }}
-            prefix_len: 32
+            prefix_len: {{ .APIServerClusterIPPrefixLen }}

--- a/pkg/component/monitoring/charts/bootstrap/charts/monitoring/templates/statefulset.yaml
+++ b/pkg/component/monitoring/charts/bootstrap/charts/monitoring/templates/statefulset.yaml
@@ -41,7 +41,7 @@ spec:
           - --storage.tsdb.no-lockfile
           - --storage.tsdb.retention.size={{ .Values.prometheus.retention.size }}
           - --web.enable-admin-api
-          - --web.listen-address=0.0.0.0:{{ .Values.prometheus.port }}
+          - --web.listen-address=:{{ .Values.prometheus.port }}
           - --web.enable-lifecycle
         # Since v2.0.0-beta.3 prometheus runs as nobody user (fsGroup 65534/runAsUser 0)
         # data volume needs to be mounted with the same permissions,

--- a/pkg/component/monitoring/charts/bootstrap/templates/aggregate-prometheus/statefulset.yaml
+++ b/pkg/component/monitoring/charts/bootstrap/templates/aggregate-prometheus/statefulset.yaml
@@ -40,7 +40,7 @@ spec:
           - --storage.tsdb.retention.time=30d
           - --storage.tsdb.retention.size=15GB
           - --web.enable-admin-api
-          - --web.listen-address=0.0.0.0:{{ .Values.aggregatePrometheus.port }}
+          - --web.listen-address=:{{ .Values.aggregatePrometheus.port }}
           - --web.enable-lifecycle
         # Since v2.0.0-beta.3 prometheus runs as nobody user (fsGroup 65534/runAsUser 0)
         # data volume needs to be mounted with the same permissions,

--- a/pkg/component/monitoring/charts/bootstrap/templates/prometheus/statefulset.yaml
+++ b/pkg/component/monitoring/charts/bootstrap/templates/prometheus/statefulset.yaml
@@ -35,7 +35,7 @@ spec:
           - --storage.tsdb.path=/var/prometheus/data
           - --storage.tsdb.retention.time=1d
           - --storage.tsdb.retention.size=5GB
-          - --web.listen-address=0.0.0.0:{{ .Values.prometheus.port }}
+          - --web.listen-address=:{{ .Values.prometheus.port }}
           - --web.enable-lifecycle
         # Since v2.0.0-beta.3 prometheus runs as nobody user (fsGroup 65534/runAsUser 0)
         # data volume needs to be mounted with the same permissions,

--- a/pkg/component/monitoring/charts/seed-monitoring/charts/core/charts/prometheus/templates/prometheus.yaml
+++ b/pkg/component/monitoring/charts/seed-monitoring/charts/core/charts/prometheus/templates/prometheus.yaml
@@ -84,7 +84,7 @@ spec:
         - --storage.tsdb.retention.size=15GB
         - --web.route-prefix=/
         - --web.enable-lifecycle
-        - --web.listen-address=0.0.0.0:{{ .Values.port }}
+        - --web.listen-address=:{{ .Values.port }}
         - --web.external-url=https://{{ .Values.ingress.host }}
         # Since v2.0.0-beta.3 prometheus runs as nobody user (fsGroup 65534/runAsUser 0)
         # data volume needs to be mounted with the same permissions,

--- a/pkg/component/nodeproblemdetector/node_problem_detector.go
+++ b/pkg/component/nodeproblemdetector/node_problem_detector.go
@@ -52,7 +52,6 @@ const (
 	vpaName                                = "node-problem-detector"
 	daemonSetTerminationGracePeriodSeconds = 30
 	daemonSetPrometheusPort                = 20257
-	daemonSetPrometheusAddress             = "0.0.0.0"
 	podSecurityPolicyName                  = "node-problem-detector"
 	labelValue                             = "node-problem-detector"
 )
@@ -226,7 +225,7 @@ func (c *nodeProblemDetector) computeResourcesData() (map[string][]byte, error) 
 								Command: []string{
 									"/bin/sh",
 									"-c",
-									"exec /node-problem-detector --logtostderr --config.system-log-monitor=/config/kernel-monitor.json,/config/docker-monitor.json,/config/systemd-monitor.json .. --config.custom-plugin-monitor=/config/kernel-monitor-counter.json,/config/systemd-monitor-counter.json .. --config.system-stats-monitor=/config/system-stats-monitor.json --prometheus-address=" + daemonSetPrometheusAddress + " --prometheus-port=" + strconv.Itoa(daemonSetPrometheusPort),
+									"exec /node-problem-detector --logtostderr --config.system-log-monitor=/config/kernel-monitor.json,/config/docker-monitor.json,/config/systemd-monitor.json .. --config.custom-plugin-monitor=/config/kernel-monitor-counter.json,/config/systemd-monitor-counter.json .. --config.system-stats-monitor=/config/system-stats-monitor.json --prometheus-port=" + strconv.Itoa(daemonSetPrometheusPort),
 								},
 								SecurityContext: &corev1.SecurityContext{
 									Privileged: pointer.Bool(true),

--- a/pkg/component/nodeproblemdetector/node_problem_detector_test.go
+++ b/pkg/component/nodeproblemdetector/node_problem_detector_test.go
@@ -51,13 +51,12 @@ var _ = Describe("NodeProblemDetector", func() {
 		namespace           = "some-namespace"
 		image               = "some-image:some-tag"
 
-		c                          client.Client
-		component                  component.DeployWaiter
-		daemonSetPrometheusPort    = 20257
-		daemonSetPrometheusAddress = "0.0.0.0"
-		managedResource            *resourcesv1alpha1.ManagedResource
-		managedResourceSecret      *corev1.Secret
-		values                     Values
+		c                       client.Client
+		component               component.DeployWaiter
+		daemonSetPrometheusPort = 20257
+		managedResource         *resourcesv1alpha1.ManagedResource
+		managedResourceSecret   *corev1.Secret
+		values                  Values
 	)
 
 	BeforeEach(func() {
@@ -257,8 +256,7 @@ spec:
         - -c
         - exec /node-problem-detector --logtostderr --config.system-log-monitor=/config/kernel-monitor.json,/config/docker-monitor.json,/config/systemd-monitor.json
           .. --config.custom-plugin-monitor=/config/kernel-monitor-counter.json,/config/systemd-monitor-counter.json
-          .. --config.system-stats-monitor=/config/system-stats-monitor.json --prometheus-address=` + daemonSetPrometheusAddress + `
-          --prometheus-port=` + strconv.Itoa(daemonSetPrometheusPort) + `
+          .. --config.system-stats-monitor=/config/system-stats-monitor.json --prometheus-port=` + strconv.Itoa(daemonSetPrometheusPort) + `
         env:
         - name: NODE_NAME
           valueFrom:

--- a/pkg/component/shootsystem/shootsystem.go
+++ b/pkg/component/shootsystem/shootsystem.go
@@ -173,6 +173,9 @@ func (s *shootSystem) computeResourcesData() (map[string][]byte, error) {
 								IPBlock: &networkingv1.IPBlock{CIDR: "0.0.0.0/0"},
 							},
 							{
+								IPBlock: &networkingv1.IPBlock{CIDR: "::/0"},
+							},
+							{
 								PodSelector: &metav1.LabelSelector{
 									MatchExpressions: []metav1.LabelSelectorRequirement{{
 										Key:      corednsconstants.LabelKey,
@@ -218,7 +221,10 @@ func (s *shootSystem) computeResourcesData() (map[string][]byte, error) {
 			},
 			Spec: networkingv1.NetworkPolicySpec{
 				PodSelector: metav1.LabelSelector{MatchLabels: map[string]string{v1beta1constants.LabelNetworkPolicyToPublicNetworks: v1beta1constants.LabelNetworkPolicyAllowed}},
-				Egress:      []networkingv1.NetworkPolicyEgressRule{{To: []networkingv1.NetworkPolicyPeer{{IPBlock: &networkingv1.IPBlock{CIDR: "0.0.0.0/0"}}}}},
+				Egress: []networkingv1.NetworkPolicyEgressRule{{To: []networkingv1.NetworkPolicyPeer{
+					{IPBlock: &networkingv1.IPBlock{CIDR: "0.0.0.0/0"}},
+					{IPBlock: &networkingv1.IPBlock{CIDR: "::/0"}},
+				}}},
 				PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeEgress},
 			},
 		}

--- a/pkg/component/shootsystem/shootsystem_test.go
+++ b/pkg/component/shootsystem/shootsystem_test.go
@@ -349,6 +349,8 @@ spec:
     to:
     - ipBlock:
         cidr: 0.0.0.0/0
+    - ipBlock:
+        cidr: ::/0
     - podSelector:
         matchExpressions:
         - key: k8s-app
@@ -395,6 +397,8 @@ spec:
   - to:
     - ipBlock:
         cidr: 0.0.0.0/0
+    - ipBlock:
+        cidr: ::/0
   podSelector:
     matchLabels:
       networking.gardener.cloud/to-public-networks: allowed

--- a/pkg/component/vpnseedserver/vpn_seed_server.go
+++ b/pkg/component/vpnseedserver/vpn_seed_server.go
@@ -20,7 +20,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 	istionetworkingv1beta1 "istio.io/api/networking/v1beta1"
@@ -40,6 +39,7 @@ import (
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	"github.com/gardener/gardener/pkg/component"
@@ -876,7 +876,6 @@ func (v *vpnSeedServer) emptyEnvoyFilter() *networkingv1alpha3.EnvoyFilter {
 	return &networkingv1alpha3.EnvoyFilter{ObjectMeta: metav1.ObjectMeta{Name: v.namespace + "-vpn", Namespace: v.istioNamespaceFunc()}}
 }
 
-//TODO: unused function?
 func getLabels() map[string]string {
 	return map[string]string{
 		v1beta1constants.GardenRole: v1beta1constants.GardenRoleControlPlane,
@@ -903,7 +902,7 @@ func (v *vpnSeedServer) getEnvoyConfig() string {
     address:
       socket_address:
         protocol: TCP
-        address: ` + fmt.Sprintf("%q", listenAddress) + `
+        address: "` + listenAddress + `"
         port_value: ` + fmt.Sprintf("%d", EnvoyPort) + `
     listener_filters:
     - name: "envoy.filters.listener.tls_inspector"
@@ -980,7 +979,7 @@ func (v *vpnSeedServer) getEnvoyConfig() string {
   - name: metrics_listener
     address:
       socket_address:
-        address: ` + fmt.Sprintf("%q", listenAddress) + `
+        address: "` + listenAddress + `"
         port_value: ` + fmt.Sprintf("%d", MetricsPort) + `
     filter_chains:
     - filters:

--- a/pkg/component/vpnseedserver/vpn_seed_server_test.go
+++ b/pkg/component/vpnseedserver/vpn_seed_server_test.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 
-	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"go.uber.org/mock/gomock"
@@ -39,6 +38,7 @@ import (
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/component"
 	"github.com/gardener/gardener/pkg/component/test"

--- a/pkg/component/vpnshoot/vpnshoot.go
+++ b/pkg/component/vpnshoot/vpnshoot.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 	"time"
 
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -81,6 +82,8 @@ type ReversedVPNValues struct {
 	Endpoint string
 	// OpenVPNPort is the port for the ReversedVPN.
 	OpenVPNPort int32
+	// IPFamilies are the IPFamilies of the shoot
+	IPFamilies []gardencorev1beta1.IPFamily
 }
 
 // Values is a set of configuration values for the VPNShoot component.
@@ -640,8 +643,18 @@ func (v *vpnShoot) indexedReversedHeader(index *int) string {
 }
 
 func (v *vpnShoot) getEnvVars(index *int) []corev1.EnvVar {
-	var envVariables []corev1.EnvVar
+	var (
+		envVariables []corev1.EnvVar
+		ipFamilies   []string
+	)
+	for _, v := range v.values.ReversedVPN.IPFamilies {
+		ipFamilies = append(ipFamilies, string(v))
+	}
 	envVariables = append(envVariables,
+		corev1.EnvVar{
+			Name:  "IP_FAMILIES",
+			Value: strings.Join(ipFamilies, ","),
+		},
 		corev1.EnvVar{
 			Name:  "ENDPOINT",
 			Value: v.values.ReversedVPN.Endpoint,

--- a/pkg/component/vpnshoot/vpnshoot.go
+++ b/pkg/component/vpnshoot/vpnshoot.go
@@ -82,7 +82,7 @@ type ReversedVPNValues struct {
 	Endpoint string
 	// OpenVPNPort is the port for the ReversedVPN.
 	OpenVPNPort int32
-	// IPFamilies are the IPFamilies of the shoot
+	// IPFamilies are the IPFamilies of the shoot.
 	IPFamilies []gardencorev1beta1.IPFamily
 }
 

--- a/pkg/component/vpnshoot/vpnshoot.go
+++ b/pkg/component/vpnshoot/vpnshoot.go
@@ -21,7 +21,6 @@ import (
 	"strings"
 	"time"
 
-	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -37,6 +36,7 @@ import (
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"

--- a/pkg/component/vpnshoot/vpnshoot_test.go
+++ b/pkg/component/vpnshoot/vpnshoot_test.go
@@ -709,7 +709,6 @@ status: {}
 				Expect(runtime.DecodeInto(newCodec(), managedResourceSecret.Data["deployment__kube-system__vpn-shoot.yaml"], deployment)).To(Succeed())
 				Expect(deployment).To(DeepEqual(deploymentFor(secretNameCA, secretNameClient, secretNameTLSAuth, values.VPAEnabled)))
 			})
-
 		})
 
 		Context("VPNShoot with ReversedVPN enabled", func() {

--- a/pkg/controller/networkpolicy/helper/helper.go
+++ b/pkg/controller/networkpolicy/helper/helper.go
@@ -21,6 +21,8 @@ import (
 	networkingv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/sets"
+
+	netutils "github.com/gardener/gardener/pkg/utils/net"
 )
 
 // GetEgressRules creates Network Policy egress rules from endpoint subsets.
@@ -40,7 +42,7 @@ func GetEgressRules(subsets ...corev1.EndpointSubset) []networkingv1.NetworkPoli
 
 			egressRule.To = append(egressRule.To, networkingv1.NetworkPolicyPeer{
 				IPBlock: &networkingv1.IPBlock{
-					CIDR: fmt.Sprintf("%s/32", address.IP),
+					CIDR: fmt.Sprintf("%s/%d", address.IP, netutils.GetBitLen(address.IP)),
 				},
 			})
 		}

--- a/pkg/controller/networkpolicy/helper/helper_test.go
+++ b/pkg/controller/networkpolicy/helper/helper_test.go
@@ -76,7 +76,7 @@ var _ = Describe("helper", func() {
 				}
 			)
 
-			egressRules := GetEgressRules(subsets...)
+			egressRules, err := GetEgressRules(subsets...)
 			expectedRules := []networkingv1.NetworkPolicyEgressRule{
 				{
 					To: []networkingv1.NetworkPolicyPeer{
@@ -112,6 +112,7 @@ var _ = Describe("helper", func() {
 					},
 				},
 			}
+			Expect(err).ToNot(HaveOccurred())
 			Expect(egressRules).To(Equal(expectedRules))
 		})
 
@@ -149,7 +150,7 @@ var _ = Describe("helper", func() {
 				}
 			)
 
-			egressRules := GetEgressRules(subsets...)
+			egressRules, err := GetEgressRules(subsets...)
 
 			port443 := intstr.FromInt32(443)
 			expectedRules := []networkingv1.NetworkPolicyEgressRule{
@@ -184,6 +185,7 @@ var _ = Describe("helper", func() {
 					},
 				},
 			}
+			Expect(err).ToNot(HaveOccurred())
 			Expect(egressRules).To(Equal(expectedRules))
 		})
 
@@ -211,7 +213,7 @@ var _ = Describe("helper", func() {
 				}
 			)
 
-			egressRules := GetEgressRules(subsets...)
+			egressRules, err := GetEgressRules(subsets...)
 			port443 := intstr.FromInt32(443)
 			port161 := intstr.FromInt32(161)
 			expectedRules := []networkingv1.NetworkPolicyEgressRule{
@@ -232,6 +234,7 @@ var _ = Describe("helper", func() {
 					},
 				},
 			}
+			Expect(err).ToNot(HaveOccurred())
 			Expect(egressRules).To(Equal(expectedRules))
 		})
 	})

--- a/pkg/controller/networkpolicy/peers.go
+++ b/pkg/controller/networkpolicy/peers.go
@@ -34,6 +34,17 @@ func allPrivateNetworkBlocksV4() []net.IPNet {
 	}
 }
 
+// allPrivateNetworkBlocksV6 returns a list of all private reserved IPv6 network blocks.
+// See https://en.wikipedia.org/wiki/Reserved_IP_addresses#IPv6.
+func allPrivateNetworkBlocksV6() []net.IPNet {
+	return []net.IPNet{
+		// fe80::/10 (Link Local)
+		{IP: net.IP{0xfe, 0x80, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, Mask: net.CIDRMask(10, 128)},
+		// fc00::/7 (Unique Local (ULA))
+		{IP: net.IP{0xfc, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, Mask: net.CIDRMask(7, 128)},
+	}
+}
+
 // toCIDRStrings takes a list of net.IPNet and returns their CIDR representations in a string slice.
 func toCIDRStrings(networks ...net.IPNet) []string {
 	var out []string
@@ -71,7 +82,7 @@ func networkPolicyPeersWithExceptions(networks []string, except ...string) ([]ne
 	var ipNets []net.IPNet
 
 	for _, n := range networks {
-		_, net, err := net.ParseCIDR(string(n))
+		_, net, err := net.ParseCIDR(n)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/controller/networkpolicy/peers.go
+++ b/pkg/controller/networkpolicy/peers.go
@@ -20,34 +20,27 @@ import (
 	networkingv1 "k8s.io/api/networking/v1"
 )
 
-// private8BitBlock returns a private network (RFC1918) 10.0.0.0/8 IPv4 block.
-func private8BitBlock() *net.IPNet {
-	return &net.IPNet{IP: net.IP{10, 0, 0, 0}, Mask: net.CIDRMask(8, 32)}
-}
-
-// private12BitBlock returns a private network (RFC1918) 172.16.0.0/12 IPv4 block.
-func private12BitBlock() *net.IPNet {
-	return &net.IPNet{IP: net.IP{172, 16, 0, 0}, Mask: net.CIDRMask(12, 32)}
-}
-
-// private16BitBlock returns a private network (RFC1918) 192.168.0.0/16 IPv4 block.
-func private16BitBlock() *net.IPNet {
-	return &net.IPNet{IP: net.IP{192, 168, 0, 0}, Mask: net.CIDRMask(16, 32)}
-}
-
-// carrierGradeNATBlock returns a Carrier-grade NAT (RFC6598) 100.64.0.0/10 IPv4 block.
-func carrierGradeNATBlock() *net.IPNet {
-	return &net.IPNet{IP: net.IP{100, 64, 0, 0}, Mask: net.CIDRMask(10, 32)}
-}
-
-// allPrivateNetworkBlocks returns a list of all Private network (RFC1918) and Carrier-grade NAT (RFC6598) IPv4 blocks.
-func allPrivateNetworkBlocks() []net.IPNet {
+// allPrivateNetworkBlocksV4 returns a list of all Private network (RFC1918) and Carrier-grade NAT (RFC6598) IPv4 blocks.
+func allPrivateNetworkBlocksV4() []net.IPNet {
 	return []net.IPNet{
-		*private8BitBlock(),
-		*private12BitBlock(),
-		*private16BitBlock(),
-		*carrierGradeNATBlock(),
+		// 10.0.0.0/8 (private network (RFC1918))
+		{IP: net.IP{10, 0, 0, 0}, Mask: net.CIDRMask(8, 32)},
+		// 172.16.0.0/12 (private network (RFC1918))
+		{IP: net.IP{172, 16, 0, 0}, Mask: net.CIDRMask(12, 32)},
+		// 192.168.0.0/16 (private network (RFC1918))
+		{IP: net.IP{192, 168, 0, 0}, Mask: net.CIDRMask(16, 32)},
+		// 100.64.0.0/10 (Carrier-grade NAT (RFC6598))
+		{IP: net.IP{100, 64, 0, 0}, Mask: net.CIDRMask(10, 32)},
 	}
+}
+
+// toCIDRStrings takes a list of net.IPNet and returns their CIDR representations in a string slice.
+func toCIDRStrings(networks ...net.IPNet) []string {
+	var out []string
+	for _, network := range networks {
+		out = append(out, network.String())
+	}
+	return out
 }
 
 // toNetworkPolicyPeersWithExceptions returns a list of networkingv1.NetworkPolicyPeers whose ipBlock.cidr points to

--- a/pkg/controller/networkpolicy/reconciler.go
+++ b/pkg/controller/networkpolicy/reconciler.go
@@ -493,7 +493,7 @@ func (r *Reconciler) reconcileNetworkPolicyAllowToDNS(ctx context.Context, log l
 					// required for node local dns feature, allows egress traffic to node local dns cache
 					{
 						IPBlock: &networkingv1.IPBlock{
-							// TODO: support node-local-dns with IPv6 single-stack networking
+							// node local dns feature is only supported for shoots with IPv4 single-stack networking
 							CIDR: fmt.Sprintf("%s/32", nodelocaldnsconstants.IPVSAddress),
 						},
 					},

--- a/pkg/controller/networkpolicy/reconciler.go
+++ b/pkg/controller/networkpolicy/reconciler.go
@@ -285,12 +285,10 @@ func (r *Reconciler) reconcileNetworkPolicyAllowToPublicNetworks(ctx context.Con
 				To: []networkingv1.NetworkPolicyPeer{{
 					IPBlock: &networkingv1.IPBlock{
 						CIDR: "0.0.0.0/0",
-						Except: append([]string{
-							private8BitBlock().String(),
-							private12BitBlock().String(),
-							private16BitBlock().String(),
-							carrierGradeNATBlock().String(),
-						}, r.RuntimeNetworks.BlockCIDRs...),
+						Except: append(
+							toCIDRStrings(allPrivateNetworkBlocksV4()...),
+							r.RuntimeNetworks.BlockCIDRs...,
+						),
 					},
 				}, {
 					IPBlock: &networkingv1.IPBlock{

--- a/pkg/controller/networkpolicy/reconciler.go
+++ b/pkg/controller/networkpolicy/reconciler.go
@@ -391,7 +391,7 @@ func (r *Reconciler) reconcileNetworkPolicyAllowToPrivateNetworks(ctx context.Co
 			if gardencorev1beta1.IsIPv4SingleStack(shoot.Spec.Networking.IPFamilies) {
 				blockedNetworkPeersV4 = append(blockedNetworkPeersV4, shootNetworks...)
 			} else {
-				blockedNetworkPeersV6 = append(blockedNetworkPeersV4, shootNetworks...)
+				blockedNetworkPeersV6 = append(blockedNetworkPeersV6, shootNetworks...)
 			}
 		}
 	}

--- a/pkg/controller/networkpolicy/reconciler.go
+++ b/pkg/controller/networkpolicy/reconciler.go
@@ -75,9 +75,9 @@ type RuntimeNetworkConfig struct {
 	BlockCIDRs []string
 }
 
-// GetBlockedNetworkPeers returns a list of CIDRs to exclude from a NetworkPolicy IPBlock. ipFamily should match the
+// getBlockedNetworkPeers returns a list of CIDRs to exclude from a NetworkPolicy IPBlock. `ipFamily` should match the
 // IP family of the IPBlock.CIDR value. The resulting list still needs to be filtered for subsets of IPBlock.CIDR.
-func (r RuntimeNetworkConfig) GetBlockedNetworkPeers(ipFamily gardencore.IPFamily) []string {
+func (r RuntimeNetworkConfig) getBlockedNetworkPeers(ipFamily gardencore.IPFamily) []string {
 	// NB: BlockCIDRs can contain both IPv4 and IPv6 CIDRs.
 	var peers = append([]string(nil), r.BlockCIDRs...)
 
@@ -307,7 +307,7 @@ func (r *Reconciler) reconcileNetworkPolicyAllowToPublicNetworks(ctx context.Con
 		// In IPv6 however, cluster networks might be "public" (e.g., if using prefix delegation from provider).
 		// As this NetworkPolicy should only allow communication with public networks *outside* the cluster,
 		// we exclude the cluster networks.
-		r.RuntimeNetworks.GetBlockedNetworkPeers(gardencore.IPFamilyIPv6)...,
+		r.RuntimeNetworks.getBlockedNetworkPeers(gardencore.IPFamilyIPv6)...,
 	)...)
 	if err != nil {
 		return err
@@ -357,8 +357,8 @@ func (r *Reconciler) reconcileNetworkPolicyAllowToBlockedCIDRs(ctx context.Conte
 }
 
 func (r *Reconciler) reconcileNetworkPolicyAllowToPrivateNetworks(ctx context.Context, log logr.Logger, networkPolicy *networkingv1.NetworkPolicy) error {
-	blockedNetworkPeersV4 := r.RuntimeNetworks.GetBlockedNetworkPeers(gardencore.IPFamilyIPv4)
-	blockedNetworkPeersV6 := r.RuntimeNetworks.GetBlockedNetworkPeers(gardencore.IPFamilyIPv6)
+	blockedNetworkPeersV4 := r.RuntimeNetworks.getBlockedNetworkPeers(gardencore.IPFamilyIPv4)
+	blockedNetworkPeersV6 := r.RuntimeNetworks.getBlockedNetworkPeers(gardencore.IPFamilyIPv6)
 
 	if strings.HasPrefix(networkPolicy.Namespace, v1beta1constants.TechnicalIDPrefix) {
 		cluster := &extensionsv1alpha1.Cluster{}

--- a/pkg/gardenlet/controller/networkpolicy/add.go
+++ b/pkg/gardenlet/controller/networkpolicy/add.go
@@ -66,6 +66,7 @@ func AddToManager(
 		AdditionalNamespaceSelectors: cfg.AdditionalNamespaceSelectors,
 		Resolver:                     resolver,
 		RuntimeNetworks: networkpolicy.RuntimeNetworkConfig{
+			IPFamilies: networks.IPFamilies,
 			Pods:       networks.Pods,
 			Services:   networks.Services,
 			Nodes:      networks.Nodes,

--- a/pkg/operation/botanist/apiserverproxy.go
+++ b/pkg/operation/botanist/apiserverproxy.go
@@ -18,6 +18,7 @@ import (
 	"context"
 
 	"github.com/gardener/gardener/imagevector"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	"github.com/gardener/gardener/pkg/component/apiserverproxy"
 	imagevectorutils "github.com/gardener/gardener/pkg/utils/imagevector"
 )
@@ -34,11 +35,25 @@ func (b *Botanist) DefaultAPIServerProxy() (apiserverproxy.Interface, error) {
 		return nil, err
 	}
 
+	var (
+		listenAddress = "0.0.0.0"
+		// we don't want to use AUTO for single-stack clusters as it causes an unnecessary failed lookup
+		// ref https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto#enum-config-cluster-v3-cluster-dnslookupfamily
+		dnsLookupFamily = "V4_ONLY"
+	)
+
+	if gardencorev1beta1.IsIPv6SingleStack(b.Shoot.GetInfo().Spec.Networking.IPFamilies) {
+		listenAddress = "::"
+		dnsLookupFamily = "V6_ONLY"
+	}
+
 	values := apiserverproxy.Values{
 		Image:               image.String(),
 		SidecarImage:        sidecarImage.String(),
 		ProxySeedServerHost: b.outOfClusterAPIServerFQDN(),
 		PSPDisabled:         b.Shoot.PSPDisabled,
+		ListenIPAddress:     listenAddress,
+		DNSLookupFamily:     dnsLookupFamily,
 	}
 
 	return apiserverproxy.New(b.SeedClientSet.Client(), b.Shoot.SeedNamespace, b.SecretsManager, values), nil

--- a/pkg/operation/botanist/network.go
+++ b/pkg/operation/botanist/network.go
@@ -17,12 +17,18 @@ package botanist
 import (
 	"context"
 
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/component"
 	"github.com/gardener/gardener/pkg/component/extensions/network"
 )
 
 // DefaultNetwork creates the default deployer for the Network custom resource.
 func (b *Botanist) DefaultNetwork() component.DeployMigrateWaiter {
+	var ipFamilies []extensionsv1alpha1.IPFamily
+	for _, ipFamily := range b.Shoot.GetInfo().Spec.Networking.IPFamilies {
+		ipFamilies = append(ipFamilies, extensionsv1alpha1.IPFamily(ipFamily))
+	}
+
 	return network.New(
 		b.Logger,
 		b.SeedClientSet.Client(),
@@ -30,6 +36,7 @@ func (b *Botanist) DefaultNetwork() component.DeployMigrateWaiter {
 			Namespace:      b.Shoot.SeedNamespace,
 			Name:           b.Shoot.GetInfo().Name,
 			Type:           *b.Shoot.GetInfo().Spec.Networking.Type,
+			IPFamilies:     ipFamilies,
 			ProviderConfig: b.Shoot.GetInfo().Spec.Networking.ProviderConfig,
 			PodCIDR:        b.Shoot.Networks.Pods,
 			ServiceCIDR:    b.Shoot.Networks.Services,

--- a/pkg/operation/botanist/vpnseedserver.go
+++ b/pkg/operation/botanist/vpnseedserver.go
@@ -79,6 +79,7 @@ func (b *Botanist) DefaultVPNSeedServer() (vpnseedserver.Interface, error) {
 			PodCIDR:     b.Shoot.Networks.Pods.String(),
 			ServiceCIDR: b.Shoot.Networks.Services.String(),
 			NodeCIDR:    pointer.StringDeref(b.Shoot.GetInfo().Spec.Networking.Nodes, ""),
+			IPFamilies:  b.Shoot.GetInfo().Spec.Networking.IPFamilies,
 		},
 		Replicas:                             b.Shoot.GetReplicas(1),
 		HighAvailabilityEnabled:              b.Shoot.VPNHighAvailabilityEnabled,

--- a/pkg/operation/botanist/vpnshoot.go
+++ b/pkg/operation/botanist/vpnshoot.go
@@ -35,6 +35,7 @@ func (b *Botanist) DefaultVPNShoot() (vpnshoot.Interface, error) {
 			Header:      "outbound|1194||" + vpnseedserver.ServiceName + "." + b.Shoot.SeedNamespace + ".svc.cluster.local",
 			Endpoint:    b.outOfClusterAPIServerFQDN(),
 			OpenVPNPort: 8132,
+			IPFamilies:  b.Shoot.GetInfo().Spec.Networking.IPFamilies,
 		},
 		HighAvailabilityEnabled:              b.Shoot.VPNHighAvailabilityEnabled,
 		HighAvailabilityNumberOfSeedServers:  b.Shoot.VPNHighAvailabilityNumberOfSeedServers,

--- a/pkg/operation/botanist/vpnshoot_test.go
+++ b/pkg/operation/botanist/vpnshoot_test.go
@@ -59,6 +59,9 @@ var _ = Describe("VPNShoot", func() {
 					Kubernetes: gardencorev1beta1.Kubernetes{
 						Version: "1.26.1",
 					},
+					Networking: &gardencorev1beta1.Networking{
+						IPFamilies: []gardencorev1beta1.IPFamily{gardencorev1beta1.IPFamilyIPv4},
+					},
 				},
 			})
 		})

--- a/pkg/operator/controller/networkpolicyregistrar/reconciler.go
+++ b/pkg/operator/controller/networkpolicyregistrar/reconciler.go
@@ -23,6 +23,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	gardencore "github.com/gardener/gardener/pkg/apis/core"
 	operatorv1alpha1 "github.com/gardener/gardener/pkg/apis/operator/v1alpha1"
 	"github.com/gardener/gardener/pkg/controller/networkpolicy"
 	"github.com/gardener/gardener/pkg/operator/apis/config"
@@ -57,6 +58,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		ConcurrentSyncs:              r.Config.ConcurrentSyncs,
 		AdditionalNamespaceSelectors: r.Config.AdditionalNamespaceSelectors,
 		RuntimeNetworks: networkpolicy.RuntimeNetworkConfig{
+			// gardener-operator only supports IPv4 single-stack networking in the runtime cluster for now.
+			IPFamilies: []gardencore.IPFamily{gardencore.IPFamilyIPv4},
 			Nodes:      garden.Spec.RuntimeCluster.Networking.Nodes,
 			Pods:       garden.Spec.RuntimeCluster.Networking.Pods,
 			Services:   garden.Spec.RuntimeCluster.Networking.Services,

--- a/pkg/utils/net/ip.go
+++ b/pkg/utils/net/ip.go
@@ -1,0 +1,28 @@
+// Copyright (c) 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package net
+
+import (
+	"net/netip"
+)
+
+// GetBitLen returns the bit length of the given IP address.
+func GetBitLen(address string) int {
+	ip, err := netip.ParseAddr(address)
+	if err != nil {
+		return 32
+	}
+	return ip.BitLen()
+}

--- a/pkg/utils/net/ip.go
+++ b/pkg/utils/net/ip.go
@@ -19,10 +19,10 @@ import (
 )
 
 // GetBitLen returns the bit length of the given IP address.
-func GetBitLen(address string) int {
+func GetBitLen(address string) (int, error) {
 	ip, err := netip.ParseAddr(address)
 	if err != nil {
-		return 32
+		return 0, err
 	}
-	return ip.BitLen()
+	return ip.BitLen(), nil
 }

--- a/pkg/utils/net/ip_test.go
+++ b/pkg/utils/net/ip_test.go
@@ -1,0 +1,25 @@
+package net
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("#GetBitLen", func() {
+	It("should parse IPv4 address correctly", func() {
+		ip := "10.10.0.26"
+		Expect(GetBitLen(ip)).To(Equal(32))
+	})
+	It("should parse IPv6 address correctly", func() {
+		ip := "2002:db8:3::"
+		Expect(GetBitLen(ip)).To(Equal(128))
+	})
+	It("should fail parsing IPv4 address and return the default 32", func() {
+		ip := "500.500.500.123"
+		Expect(GetBitLen(ip)).To(Equal(32))
+	})
+	It("should fail parsing IPv6 address and return the default 32", func() {
+		ip := "XYZ:db8:3::"
+		Expect(GetBitLen(ip)).To(Equal(32))
+	})
+})

--- a/pkg/utils/net/ip_test.go
+++ b/pkg/utils/net/ip_test.go
@@ -1,3 +1,17 @@
+// Copyright 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package net
 
 import (

--- a/pkg/utils/net/ip_test.go
+++ b/pkg/utils/net/ip_test.go
@@ -30,10 +30,14 @@ var _ = Describe("#GetBitLen", func() {
 	})
 	It("should fail parsing IPv4 address and return the default 32", func() {
 		ip := "500.500.500.123"
-		Expect(GetBitLen(ip)).To(Equal(32))
+		bitLen, err := GetBitLen(ip)
+		Expect(err).To(HaveOccurred())
+		Expect(bitLen).To(Equal(0))
 	})
 	It("should fail parsing IPv6 address and return the default 32", func() {
 		ip := "XYZ:db8:3::"
-		Expect(GetBitLen(ip)).To(Equal(32))
+		bitLen, err := GetBitLen(ip)
+		Expect(err).To(HaveOccurred())
+		Expect(bitLen).To(Equal(0))
 	})
 })

--- a/pkg/utils/net/net_suite_test.go
+++ b/pkg/utils/net/net_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package net
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestRetry(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Net Suite")
+}

--- a/pkg/utils/net/net_suite_test.go
+++ b/pkg/utils/net/net_suite_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+// Copyright 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestRetry(t *testing.T) {
+func TestNet(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Net Suite")
+	RunSpecs(t, "Utils Net Suite")
 }

--- a/pkg/utils/validation/cidr/disjoint.go
+++ b/pkg/utils/validation/cidr/disjoint.go
@@ -49,6 +49,9 @@ func validateOverlapWithSeed(fldPath *field.Path, shootNetwork *string, networkT
 		if NetworksIntersect(v1beta1constants.DefaultVPNRange, *shootNetwork) {
 			allErrs = append(allErrs, field.Invalid(fldPath, *shootNetwork, fmt.Sprintf("shoot %s network intersects with default vpn network (%s)", networkType, v1beta1constants.DefaultVPNRange)))
 		}
+		if NetworksIntersect(v1beta1constants.DefaultVPNRangeV6, *shootNetwork) {
+			allErrs = append(allErrs, field.Invalid(fldPath, *shootNetwork, fmt.Sprintf("shoot %s network intersects with default vpn network (%s)", networkType, v1beta1constants.DefaultVPNRangeV6)))
+		}
 	} else if networkRequired {
 		allErrs = append(allErrs, field.Required(fldPath, fmt.Sprintf("%ss is required", networkType)))
 	}

--- a/pkg/utils/validation/cidr/disjoint_test.go
+++ b/pkg/utils/validation/cidr/disjoint_test.go
@@ -173,8 +173,9 @@ var _ = Describe("utils", func() {
 			)
 
 			Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
-				"Type":  Equal(field.ErrorTypeInvalid),
-				"Field": Equal("[].pods"),
+				"Type":   Equal(field.ErrorTypeInvalid),
+				"Field":  Equal("[].pods"),
+				"Detail": ContainSubstring("pod network intersects with default vpn network"),
 			}))))
 		})
 
@@ -197,8 +198,9 @@ var _ = Describe("utils", func() {
 			)
 
 			Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
-				"Type":  Equal(field.ErrorTypeInvalid),
-				"Field": Equal("[].services"),
+				"Type":   Equal(field.ErrorTypeInvalid),
+				"Field":  Equal("[].services"),
+				"Detail": ContainSubstring("service network intersects with default vpn network"),
 			}))))
 		})
 
@@ -221,8 +223,9 @@ var _ = Describe("utils", func() {
 			)
 
 			Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
-				"Type":  Equal(field.ErrorTypeInvalid),
-				"Field": Equal("[].nodes"),
+				"Type":   Equal(field.ErrorTypeInvalid),
+				"Field":  Equal("[].nodes"),
+				"Detail": ContainSubstring("node network intersects with default vpn network"),
 			}))))
 		})
 
@@ -390,7 +393,126 @@ var _ = Describe("utils", func() {
 			)
 		})
 
-		It("should fail due to range overlap of seed node netwok and shoot pod and service network", func() {
+		It("should fail due to missing fields", func() {
+			errorList := ValidateNetworkDisjointedness(
+				field.NewPath(""),
+				nil,
+				nil,
+				nil,
+				&seedNodesCIDRIPv6,
+				seedPodsCIDRIPv6,
+				seedServicesCIDRIPv6,
+				false,
+			)
+
+			Expect(errorList).To(ConsistOf(
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeRequired),
+					"Field": Equal("[].services"),
+				})),
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeRequired),
+					"Field": Equal("[].pods"),
+				})),
+			))
+		})
+
+		It("should fail due to missing fields (workerless Shoots)", func() {
+			errorList := ValidateNetworkDisjointedness(
+				field.NewPath(""),
+				nil,
+				nil,
+				nil,
+				&seedNodesCIDRIPv6,
+				seedPodsCIDRIPv6,
+				seedServicesCIDRIPv6,
+				true,
+			)
+
+			Expect(errorList).To(ConsistOf(
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeRequired),
+					"Field": Equal("[].services"),
+				})),
+			))
+		})
+
+		It("should fail due to default vpn range overlap in pod cidr", func() {
+			var (
+				podsCIDR     = "fd8f:6d53:b97a:1::/120"
+				servicesCIDR = "2001:0db8:45a3::/113"
+				nodesCIDR    = "2001:0db8:55a3::/112"
+			)
+
+			errorList := ValidateNetworkDisjointedness(
+				field.NewPath(""),
+				&nodesCIDR,
+				&podsCIDR,
+				&servicesCIDR,
+				&seedNodesCIDRIPv6,
+				seedPodsCIDRIPv6,
+				seedServicesCIDRIPv6,
+				false,
+			)
+
+			Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+				"Type":   Equal(field.ErrorTypeInvalid),
+				"Field":  Equal("[].pods"),
+				"Detail": ContainSubstring("pod network intersects with default vpn network"),
+			}))))
+		})
+
+		It("should fail due to default vpn range overlap in services cidr", func() {
+			var (
+				podsCIDR     = "2001:0db8:35a3::/113"
+				servicesCIDR = "fd8f:6d53:b97a:1::/120"
+				nodesCIDR    = "2001:0db8:55a3::/112"
+			)
+
+			errorList := ValidateNetworkDisjointedness(
+				field.NewPath(""),
+				&nodesCIDR,
+				&podsCIDR,
+				&servicesCIDR,
+				&seedNodesCIDRIPv6,
+				seedPodsCIDRIPv6,
+				seedServicesCIDRIPv6,
+				false,
+			)
+
+			Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+				"Type":   Equal(field.ErrorTypeInvalid),
+				"Field":  Equal("[].services"),
+				"Detail": ContainSubstring("service network intersects with default vpn network"),
+			}))))
+		})
+
+		It("should fail due to default vpn range overlap in nodes cidr", func() {
+			var (
+				podsCIDR     = "2001:0db8:35a3::/113"
+				servicesCIDR = "2001:0db8:45a3::/113"
+				nodesCIDR    = "fd8f:6d53:b97a:1::/120"
+			)
+
+			errorList := ValidateNetworkDisjointedness(
+				field.NewPath(""),
+				&nodesCIDR,
+				&podsCIDR,
+				&servicesCIDR,
+				&seedNodesCIDRIPv6,
+				seedPodsCIDRIPv6,
+				seedServicesCIDRIPv6,
+				false,
+			)
+
+			Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+				"Type":   Equal(field.ErrorTypeInvalid),
+				"Field":  Equal("[].nodes"),
+				"Detail": ContainSubstring("node network intersects with default vpn network"),
+			}))))
+		})
+
+		It("should fail due to range overlap of seed node network and shoot pod and service network", func() {
 			var (
 				podsCIDR     = seedNodesCIDRIPv6
 				servicesCIDR = seedNodesCIDRIPv6
@@ -416,6 +538,30 @@ var _ = Describe("utils", func() {
 				"Field": Equal("[].services"),
 			})),
 			))
+		})
+
+		It("should fail due to seed service network and shoot node network overlap", func() {
+			var (
+				podsCIDR     = "2001:0db8:35a3::/113"
+				servicesCIDR = "2001:0db8:45a3::/113"
+				nodesCIDR    = seedServicesCIDRIPv6
+			)
+
+			errorList := ValidateNetworkDisjointedness(
+				field.NewPath(""),
+				&nodesCIDR,
+				&podsCIDR,
+				&servicesCIDR,
+				&seedNodesCIDRIPv6,
+				seedPodsCIDRIPv6,
+				seedServicesCIDRIPv6,
+				false,
+			)
+
+			Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+				"Type":  Equal(field.ErrorTypeInvalid),
+				"Field": Equal("[].nodes"),
+			}))))
 		})
 
 		It("should fail due to seed pod network and shoot node network overlap", func() {
@@ -480,6 +626,21 @@ var _ = Describe("utils", func() {
 				"Field": Equal("[].pods"),
 			})),
 			))
+		})
+
+		It("should fail due to missing fields (workerless Shoot)", func() {
+			errorList := ValidateShootNetworkDisjointedness(
+				field.NewPath(""),
+				nil,
+				nil,
+				nil,
+				true,
+			)
+
+			Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+				"Type":  Equal(field.ErrorTypeRequired),
+				"Field": Equal("[].services"),
+			}))))
 		})
 
 		It("should fail due to disjointedness of node, service and pod networks", func() {

--- a/skaffold-operator.yaml
+++ b/skaffold-operator.yaml
@@ -162,6 +162,7 @@ build:
             - pkg/utils/kubernetes/unstructured
             - pkg/utils/managedresources
             - pkg/utils/managedresources/builder
+            - pkg/utils/net
             - pkg/utils/retry
             - pkg/utils/secrets
             - pkg/utils/secrets/manager

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -969,6 +969,7 @@ build:
             - pkg/utils/kubernetes/unstructured
             - pkg/utils/managedresources
             - pkg/utils/managedresources/builder
+            - pkg/utils/net
             - pkg/utils/retry
             - pkg/utils/secrets
             - pkg/utils/secrets/manager

--- a/test/integration/gardenlet/networkpolicy/networkpolicy_suite_test.go
+++ b/test/integration/gardenlet/networkpolicy/networkpolicy_suite_test.go
@@ -173,6 +173,7 @@ var _ = BeforeSuite(func() {
 			AdditionalNamespaceSelectors: []metav1.LabelSelector{{MatchLabels: map[string]string{"custom": "namespace"}}},
 		},
 		gardencore.SeedNetworks{
+			IPFamilies: []gardencore.IPFamily{gardencore.IPFamilyIPv4},
 			Pods:       "10.0.0.0/16",
 			Services:   "10.1.0.0/16",
 			Nodes:      pointer.String("10.2.0.0/16"),

--- a/test/integration/gardenlet/networkpolicy/networkpolicy_test.go
+++ b/test/integration/gardenlet/networkpolicy/networkpolicy_test.go
@@ -373,8 +373,11 @@ var _ = Describe("NetworkPolicy controller tests", func() {
 			kubernetesEndpoint := &corev1.Endpoints{ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "kubernetes"}}
 			Expect(testClient.Get(ctx, client.ObjectKeyFromObject(kubernetesEndpoint), kubernetesEndpoint)).To(Succeed())
 
+			egressRules, err := networkpolicyhelper.GetEgressRules(kubernetesEndpoint.Subsets...)
+			Expect(err).ToNot(HaveOccurred())
+
 			expectedNetworkPolicySpec = networkingv1.NetworkPolicySpec{
-				Egress:      networkpolicyhelper.GetEgressRules(kubernetesEndpoint.Subsets...),
+				Egress:      egressRules,
 				PodSelector: metav1.LabelSelector{MatchLabels: map[string]string{"networking.gardener.cloud/to-runtime-apiserver": "allowed"}},
 				PolicyTypes: []networkingv1.PolicyType{"Egress"},
 			}

--- a/test/integration/gardenlet/networkpolicy/networkpolicy_test.go
+++ b/test/integration/gardenlet/networkpolicy/networkpolicy_test.go
@@ -408,6 +408,14 @@ var _ = Describe("NetworkPolicy controller tests", func() {
 								blockedCIDR,
 							},
 						},
+					}, {
+						IPBlock: &networkingv1.IPBlock{
+							CIDR: "::/0",
+							Except: []string{
+								"fe80::/10",
+								"fc00::/7",
+							},
+						},
 					}},
 				}},
 				PolicyTypes: []networkingv1.PolicyType{"Egress"},
@@ -437,8 +445,13 @@ var _ = Describe("NetworkPolicy controller tests", func() {
 							{IPBlock: &networkingv1.IPBlock{CIDR: "172.16.0.0/12"}},
 							{IPBlock: &networkingv1.IPBlock{CIDR: "192.168.0.0/16"}},
 							{IPBlock: &networkingv1.IPBlock{CIDR: "100.64.0.0/10"}},
-						}},
-					},
+						},
+					}, {
+						To: []networkingv1.NetworkPolicyPeer{
+							{IPBlock: &networkingv1.IPBlock{CIDR: "fe80::/10"}},
+							{IPBlock: &networkingv1.IPBlock{CIDR: "fc00::/7"}},
+						},
+					}},
 				}
 
 				if strings.HasPrefix(namespaceName, "shoot--") {


### PR DESCRIPTION
**How to categorize this PR?**
/area networking
/kind api-change
/kind enhancement

**What this PR does / why we need it**:

This PR introduces the rest of the code necessary for completing #7051.
This PR forms a unit with https://github.com/gardener/vpn2/pull/45 and https://github.com/gardener/gardener-extension-networking-calico/pull/301, the IPv6 feature only works together with all 3 PRs.

**Which issue(s) this PR fixes**:
Part of #7051 

**Special notes for your reviewer**:

Testing is fairly straightforward. However you will need to select the new gardener-extension-networking-calico aswell as the new vpn2 implementation. We did this by patching the following file.
```yaml
# example/provider-local/garden/base/kustomization.yaml
patches:
- patch: |
    apiVersion: core.gardener.cloud/v1beta1
    kind: ControllerDeployment
    metadata:
      name: networking-calico
    type: helm
    providerConfig:
      values:
        image:
          # snapshot including https://github.com/gardener/gardener-extension-networking-calico/pull/301
          repository: europe-docker.pkg.dev/gardener-project/snapshots/gardener/extensions/networking-calico
          tag: v1.38.0-dev-696ad3e056970c3c8e117ac9e98801f9b2f470d5
``` 

As well as modifying the following file to fetch our modified vpn2.

```diff
# imagevector/images.yaml
  name: vpn-seed-server
- tag: "0.19.0"
+ # snapshot including https://github.com/gardener/vpn2/pull/45
+ tag: "0.20.0-dev"

  name: vpn-shoot-client
  sourceRepository: github.com/gardener/vpn2
- tag: "0.19.0"
+ # snapshot including https://github.com/gardener/vpn2/pull/45
+ tag: "0.20.0-dev-580f1f2bc496d0847387908a09cb5e80f0c4c695"
```
**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature developer
Add full single-stack IPv6 support for gardener provider-local 
```
