### PR TITLE
Set `.spec.revisionHistoryLimit=2` for Gardener control plane `Deployment`s

### DIFF
--- a/pkg/component/gardeneradmissioncontroller/deployment.go
+++ b/pkg/component/gardeneradmissioncontroller/deployment.go
@@ -51,7 +51,8 @@ func (a *gardenerAdmissionController) deployment(secretServerCert, secretGeneric
 			}),
 		},
 		Spec: appsv1.DeploymentSpec{
-			Replicas: pointer.Int32(1),
+			Replicas:             pointer.Int32(1),
+			RevisionHistoryLimit: pointer.Int32(2),
 			Selector: &metav1.LabelSelector{
 				MatchLabels: GetLabels(),
 			},

--- a/pkg/component/gardeneradmissioncontroller/gardener_admission_controller_test.go
+++ b/pkg/component/gardeneradmissioncontroller/gardener_admission_controller_test.go
@@ -547,7 +547,8 @@ func deployment(namespace, configSecretName, serverCertSecretName string, testVa
 			},
 		},
 		Spec: appsv1.DeploymentSpec{
-			Replicas: pointer.Int32(1),
+			Replicas:             pointer.Int32(1),
+			RevisionHistoryLimit: pointer.Int32(2),
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					"app":  "gardener",

--- a/pkg/component/gardenercontrollermanager/deployment.go
+++ b/pkg/component/gardenercontrollermanager/deployment.go
@@ -48,7 +48,8 @@ func (g *gardenerControllerManager) deployment(secretGenericTokenKubeconfig, sec
 			}),
 		},
 		Spec: appsv1.DeploymentSpec{
-			Replicas: pointer.Int32(1),
+			Replicas:             pointer.Int32(1),
+			RevisionHistoryLimit: pointer.Int32(2),
 			Selector: &metav1.LabelSelector{
 				MatchLabels: GetLabels(),
 			},

--- a/pkg/component/gardenercontrollermanager/gardener_controller_manager_test.go
+++ b/pkg/component/gardenercontrollermanager/gardener_controller_manager_test.go
@@ -756,7 +756,8 @@ func deployment(namespace, configSecretName string, testValues Values) string {
 			},
 		},
 		Spec: appsv1.DeploymentSpec{
-			Replicas: pointer.Int32(1),
+			Replicas:             pointer.Int32(1),
+			RevisionHistoryLimit: pointer.Int32(2),
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					"app":  "gardener",

--- a/pkg/component/gardenerscheduler/deployment.go
+++ b/pkg/component/gardenerscheduler/deployment.go
@@ -48,7 +48,8 @@ func (g *gardenerScheduler) deployment(secretGenericTokenKubeconfig, secretVirtu
 			}),
 		},
 		Spec: appsv1.DeploymentSpec{
-			Replicas: pointer.Int32(1),
+			Replicas:             pointer.Int32(1),
+			RevisionHistoryLimit: pointer.Int32(2),
 			Selector: &metav1.LabelSelector{
 				MatchLabels: GetLabels(),
 			},

--- a/pkg/component/gardenerscheduler/gardener_scheduler_test.go
+++ b/pkg/component/gardenerscheduler/gardener_scheduler_test.go
@@ -770,7 +770,8 @@ func deployment(namespace, configSecretName string, testValues Values) string {
 			},
 		},
 		Spec: appsv1.DeploymentSpec{
-			Replicas: pointer.Int32(1),
+			Replicas:             pointer.Int32(1),
+			RevisionHistoryLimit: pointer.Int32(2),
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					"app":  "gardener",


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
According to point 3. of https://github.com/gardener/gardener/blob/master/docs/development/component-checklist.md#observability--operations-productivity

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
