### PR TITLE
Add a utility method to force-delete Shoot in e2e test

### DIFF
--- a/test/framework/gardener_utils.go
+++ b/test/framework/gardener_utils.go
@@ -136,7 +136,7 @@ func (f *GardenerFramework) CreateShoot(ctx context.Context, shoot *gardencorev1
 	return nil
 }
 
-// DeleteShootAndWaitForDeletion deletes the test shoot and waits until it cannot be found any more
+// DeleteShootAndWaitForDeletion deletes the test shoot and waits until it cannot be found anymore.
 func (f *GardenerFramework) DeleteShootAndWaitForDeletion(ctx context.Context, shoot *gardencorev1beta1.Shoot) (rErr error) {
 	if f.Config.ExistingShootName != "" {
 		f.Logger.Info("Skip deletion of existing shoot", "shoot", client.ObjectKey{Name: f.Config.ExistingShootName, Namespace: f.ProjectNamespace})
@@ -172,7 +172,7 @@ func (f *GardenerFramework) DeleteShootAndWaitForDeletion(ctx context.Context, s
 	return nil
 }
 
-// ForceDeleteShootAndWaitForDeletion forcefully deletes the test shoot and waits until it cannot be found any more
+// ForceDeleteShootAndWaitForDeletion forcefully deletes the test shoot and waits until it cannot be found anymore.
 func (f *GardenerFramework) ForceDeleteShootAndWaitForDeletion(ctx context.Context, shoot *gardencorev1beta1.Shoot) (rErr error) {
 	log := f.Logger.WithValues("shoot", client.ObjectKeyFromObject(shoot))
 

--- a/test/framework/gardener_utils.go
+++ b/test/framework/gardener_utils.go
@@ -172,6 +172,54 @@ func (f *GardenerFramework) DeleteShootAndWaitForDeletion(ctx context.Context, s
 	return nil
 }
 
+// ForceDeleteShootAndWaitForDeletion forcefully deletes the test shoot and waits until it cannot be found any more
+func (f *GardenerFramework) ForceDeleteShootAndWaitForDeletion(ctx context.Context, shoot *gardencorev1beta1.Shoot) (rErr error) {
+	log := f.Logger.WithValues("shoot", client.ObjectKeyFromObject(shoot))
+
+	if err := f.AnnotateShoot(ctx, shoot, map[string]string{v1beta1constants.ShootIgnore: "true"}); err != nil {
+		return fmt.Errorf("failed patching Shoot to be ignored")
+	}
+
+	if err := f.DeleteShoot(ctx, shoot); err != nil {
+		return err
+	}
+
+	patch := client.MergeFrom(shoot.DeepCopy())
+	shoot.Status.LastErrors = []gardencorev1beta1.LastError{{
+		Codes: []gardencorev1beta1.ErrorCode{gardencorev1beta1.ErrorInfraDependencies},
+	}}
+	if err := f.GardenClient.Client().Status().Patch(ctx, shoot, patch); err != nil {
+		return err
+	}
+
+	if err := f.AnnotateShoot(ctx, shoot, map[string]string{
+		v1beta1constants.AnnotationConfirmationForceDeletion: "true",
+		v1beta1constants.ShootIgnore:                         "false",
+	}); err != nil {
+		return fmt.Errorf("failed annotating Shoot with force-delete and to not be ignored")
+	}
+
+	if err := f.WaitForShootToBeDeleted(ctx, shoot); err != nil {
+		return fmt.Errorf("failed waiting for Shoot to be deleted")
+	}
+
+	defer func() {
+		if rErr != nil {
+			dumpCtx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+			defer cancel()
+
+			if shootFramework, err := f.NewShootFramework(dumpCtx, shoot); err != nil {
+				log.Error(err, "Cannot dump shoot state")
+			} else {
+				shootFramework.DumpState(dumpCtx)
+			}
+		}
+	}()
+
+	log.Info("Shoot was force-deleted successfully")
+	return nil
+}
+
 // DeleteShoot deletes the test shoot
 func (f *GardenerFramework) DeleteShoot(ctx context.Context, shoot *gardencorev1beta1.Shoot) error {
 	err := retry.UntilTimeout(ctx, 20*time.Second, 5*time.Minute, func(ctx context.Context) (done bool, err error) {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind enhancement

**What this PR does / why we need it**:
This PR adds a utility method to force-delete Shoot in e2e test so that it can be re-used in extensions, eg: https://github.com/gardener/gardener-extension-networking-calico/pull/302

**Which issue(s) this PR fixes**:
Part of #3110 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
