### PR TITLE
🔎 Enable `unused` linter and a few more rules for the `revive` linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -49,6 +49,7 @@ linters-settings:
     - name: duplicated-imports
     - name: unused-parameter
     - name: unreachable-code
+    - name: context-as-argument
   importas:
     alias:
       # External imported packages

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -34,7 +34,6 @@ issues:
   - unexported-return # exported func .* returns unexported type .*, which can be annoying to use
   - indent-error-flow # if block ends with a return statement, so drop this else and outdent its block
   - "exported: (type|func) name will be used as .* by other packages, and that stutters;"
-  - unused-parameter # parameter '.*' seems to be unused, consider removing or renaming it as _
   # typecheck:
   - "undeclared name: `.*`"
   - "\".*\" imported but not used"
@@ -49,6 +48,7 @@ linters-settings:
   revive:
     rules:
     - name: duplicated-imports
+    - name: unused-parameter
   importas:
     alias:
       # External imported packages

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -49,6 +49,7 @@ linters-settings:
     rules:
     - name: duplicated-imports
     - name: unused-parameter
+    - name: unreachable-code
   importas:
     alias:
       # External imported packages

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -14,10 +14,9 @@ run:
   - "openapi_generated\\.go$"
 
 linters:
-  disable:
-  - unused
   enable:
   - revive
+  - unused
   - importas
   - logcheck
   - gomegacheck

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -50,6 +50,7 @@ linters-settings:
     - name: unused-parameter
     - name: unreachable-code
     - name: context-as-argument
+    - name: early-return
   importas:
     alias:
       # External imported packages

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -51,6 +51,7 @@ linters-settings:
     - name: unreachable-code
     - name: context-as-argument
     - name: early-return
+    - name: exported
   importas:
     alias:
       # External imported packages

--- a/cmd/gardenlet/app/app.go
+++ b/cmd/gardenlet/app/app.go
@@ -365,7 +365,7 @@ func (g *garden) Start(ctx context.Context) error {
 
 	log.Info("Cleaning bootstrap authentication data used to request a certificate if needed")
 	if len(g.kubeconfigBootstrapResult.CSRName) > 0 && len(g.kubeconfigBootstrapResult.SeedName) > 0 {
-		if err := bootstrap.DeleteBootstrapAuth(ctx, gardenCluster.GetClient(), gardenCluster.GetClient(), g.kubeconfigBootstrapResult.CSRName, g.kubeconfigBootstrapResult.SeedName); err != nil {
+		if err := bootstrap.DeleteBootstrapAuth(ctx, gardenCluster.GetClient(), gardenCluster.GetClient(), g.kubeconfigBootstrapResult.CSRName); err != nil {
 			return fmt.Errorf("failed cleaning bootstrap auth data: %w", err)
 		}
 	}

--- a/extensions/pkg/controller/healthcheck/reconciler.go
+++ b/extensions/pkg/controller/healthcheck/reconciler.go
@@ -176,7 +176,7 @@ func (r *reconciler) performHealthCheck(ctx context.Context, log logr.Logger, re
 
 		if healthCheckResult.Status == gardencorev1beta1.ConditionTrue {
 			logger.Info("Health check for extension resource successful", "kind", r.registeredExtension.groupVersionKind.Kind, "conditionType", healthCheckResult.HealthConditionType)
-			conditions = append(conditions, extensionConditionSuccessful(conditionBuilder, healthCheckResult.HealthConditionType, healthCheckResult))
+			conditions = append(conditions, extensionConditionSuccessful(conditionBuilder, healthCheckResult.HealthConditionType))
 			continue
 		}
 
@@ -250,7 +250,7 @@ func extensionConditionUnsuccessful(conditionBuilder v1beta1helper.ConditionBuil
 	}
 }
 
-func extensionConditionSuccessful(conditionBuilder v1beta1helper.ConditionBuilder, healthConditionType string, healthCheckResult Result) condition {
+func extensionConditionSuccessful(conditionBuilder v1beta1helper.ConditionBuilder, healthConditionType string) condition {
 	conditionBuilder.
 		WithStatus(gardencorev1beta1.ConditionTrue).
 		WithReason(ReasonSuccessful).

--- a/extensions/pkg/controller/heartbeat/reconciler.go
+++ b/extensions/pkg/controller/heartbeat/reconciler.go
@@ -50,7 +50,7 @@ func NewReconciler(mgr manager.Manager, extensionName string, namespace string, 
 }
 
 // Reconcile renews the heartbeat lease resource.
-func (r *reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
+func (r *reconciler) Reconcile(ctx context.Context, _ reconcile.Request) (reconcile.Result, error) {
 	log := logf.FromContext(ctx)
 	lease := &coordinationv1.Lease{
 		ObjectMeta: metav1.ObjectMeta{

--- a/extensions/pkg/controller/utils.go
+++ b/extensions/pkg/controller/utils.go
@@ -158,21 +158,3 @@ func ShouldSkipOperation(operationType gardencorev1beta1.LastOperationType, obj 
 func GetObjectByReference(ctx context.Context, c client.Client, ref *autoscalingv1.CrossVersionObjectReference, namespace string, obj client.Object) error {
 	return c.Get(ctx, client.ObjectKey{Namespace: namespace, Name: v1beta1constants.ReferencedResourcesPrefix + ref.Name}, obj)
 }
-
-// UseTokenRequestor returns true when the provided Gardener version is large enough for supporting acquiring tokens
-// for shoot cluster control plane components running in the seed based on the TokenRequestor controller of
-// gardener-resource-manager (https://github.com/gardener/gardener/blob/master/docs/concepts/resource-manager.md#tokenrequestor).
-// Deprecated: new extension versions need to require at least Gardener version v1.36 and use the token requestor by
-// default which makes this function obsolete.
-func UseTokenRequestor(gardenerVersion string) (bool, error) {
-	return true, nil
-}
-
-// UseServiceAccountTokenVolumeProjection returns true when the provided Gardener version is large enough for supporting
-// automatic token volume projection for components running in the seed and shoot clusters based on the respective
-// webhook part of gardener-resource-manager (https://github.com/gardener/gardener/blob/master/docs/concepts/resource-manager.md#auto-mounting-projected-serviceaccount-tokens).
-// Deprecated: new extension versions need to require at least Gardener version v1.37 and use projected service account
-// token volumes by default which makes this function obsolete.
-func UseServiceAccountTokenVolumeProjection(gardenerVersion string) (bool, error) {
-	return true, nil
-}

--- a/extensions/pkg/controller/utils_test.go
+++ b/extensions/pkg/controller/utils_test.go
@@ -19,7 +19,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	gomegatypes "github.com/onsi/gomega/types"
 	"go.uber.org/mock/gomock"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -285,36 +284,4 @@ var _ = Describe("Utils", func() {
 			Expect(secret).To(Equal(refSecret))
 		})
 	})
-
-	DescribeTable("#UseTokenRequestor",
-		func(gardenerVersion string, matcher gomegatypes.GomegaMatcher) {
-			Expect(UseTokenRequestor(gardenerVersion)).To(matcher)
-		},
-
-		Entry("return true", "v1.36.0-dev", BeTrue()),
-		Entry("return true", "v1.36.0", BeTrue()),
-		Entry("return true", "v1.36.1", BeTrue()),
-		Entry("return true", "v1.37.0", BeTrue()),
-		Entry("return true", "v1.37.1", BeTrue()),
-		Entry("return true", "v1.38.0-dev", BeTrue()),
-		Entry("return false", "v1.35.0", BeTrue()),
-		Entry("return false", "v1.35.9", BeTrue()),
-		Entry("return false", "", BeTrue()),
-	)
-
-	DescribeTable("#UseServiceAccountTokenVolumeProjection",
-		func(gardenerVersion string, matcher gomegatypes.GomegaMatcher) {
-			Expect(UseServiceAccountTokenVolumeProjection(gardenerVersion)).To(matcher)
-		},
-
-		Entry("return true", "v1.37.0-dev", BeTrue()),
-		Entry("return true", "v1.37.0", BeTrue()),
-		Entry("return true", "v1.37.1", BeTrue()),
-		Entry("return true", "v1.38.0", BeTrue()),
-		Entry("return true", "v1.38.1", BeTrue()),
-		Entry("return true", "v1.39.0-dev", BeTrue()),
-		Entry("return false", "v1.36.0", BeTrue()),
-		Entry("return false", "v1.36.9", BeTrue()),
-		Entry("return false", "", BeTrue()),
-	)
 })

--- a/extensions/pkg/controller/worker/genericactuator/actuator_delete.go
+++ b/extensions/pkg/controller/worker/genericactuator/actuator_delete.go
@@ -72,7 +72,7 @@ func (a *genericActuator) Delete(ctx context.Context, log logr.Logger, worker *e
 
 	// Wait until the machine class credentials secret has been acquired.
 	log.Info("Waiting until the machine class credentials secret has been acquired")
-	if err := a.waitUntilCredentialsSecretAcquiredOrReleased(ctx, true, worker, workerDelegate); err != nil {
+	if err := a.waitUntilCredentialsSecretAcquiredOrReleased(ctx, true, worker); err != nil {
 		return fmt.Errorf("failed while waiting for the machine class credentials secret to be acquired: %w", err)
 	}
 
@@ -111,7 +111,7 @@ func (a *genericActuator) Delete(ctx context.Context, log logr.Logger, worker *e
 
 	// Wait until the machine class credentials secret has been released.
 	log.Info("Waiting until the machine class credentials secret has been released")
-	if err := a.waitUntilCredentialsSecretAcquiredOrReleased(ctx, false, worker, workerDelegate); err != nil {
+	if err := a.waitUntilCredentialsSecretAcquiredOrReleased(ctx, false, worker); err != nil {
 		return fmt.Errorf("failed while waiting for the machine class credentials secret to be released: %w", err)
 	}
 
@@ -130,12 +130,7 @@ func (a *genericActuator) Delete(ctx context.Context, log logr.Logger, worker *e
 
 // ForceDelete simply returns nil in case of forceful deletion since cleaning up the machines would never succeed in this case.
 // So we proceed to remove the finalizer without any action.
-func (a *genericActuator) ForceDelete(
-	ctx context.Context,
-	log logr.Logger,
-	worker *extensionsv1alpha1.Worker,
-	cluster *extensionscontroller.Cluster,
-) error {
+func (a *genericActuator) ForceDelete(_ context.Context, _ logr.Logger, _ *extensionsv1alpha1.Worker, _ *extensionscontroller.Cluster) error {
 	return nil
 }
 
@@ -271,7 +266,7 @@ func (a *genericActuator) waitUntilMachineResourcesDeleted(ctx context.Context, 
 	})
 }
 
-func (a *genericActuator) waitUntilCredentialsSecretAcquiredOrReleased(ctx context.Context, acquired bool, worker *extensionsv1alpha1.Worker, workerDelegate WorkerDelegate) error {
+func (a *genericActuator) waitUntilCredentialsSecretAcquiredOrReleased(ctx context.Context, acquired bool, worker *extensionsv1alpha1.Worker) error {
 	acquiredOrReleased := false
 	return retryutils.UntilTimeout(ctx, 5*time.Second, 5*time.Minute, func(ctx context.Context) (bool, error) {
 		// Check whether the finalizer of the machine class credentials secret has been added or removed.

--- a/extensions/pkg/webhook/controlplane/genericmutator/noopensurer.go
+++ b/extensions/pkg/webhook/controlplane/genericmutator/noopensurer.go
@@ -35,81 +35,81 @@ type NoopEnsurer struct{}
 var _ Ensurer = &NoopEnsurer{}
 
 // EnsureKubeAPIServerService ensures that the kube-apiserver service conforms to the provider requirements.
-func (e *NoopEnsurer) EnsureKubeAPIServerService(ctx context.Context, gctx extensionscontextwebhook.GardenContext, new, old *corev1.Service) error {
+func (e *NoopEnsurer) EnsureKubeAPIServerService(_ context.Context, _ extensionscontextwebhook.GardenContext, _, _ *corev1.Service) error {
 	return nil
 }
 
 // EnsureKubeAPIServerDeployment ensures that the kube-apiserver deployment conforms to the provider requirements.
-func (e *NoopEnsurer) EnsureKubeAPIServerDeployment(ctx context.Context, gctx extensionscontextwebhook.GardenContext, new, old *appsv1.Deployment) error {
+func (e *NoopEnsurer) EnsureKubeAPIServerDeployment(_ context.Context, _ extensionscontextwebhook.GardenContext, _, _ *appsv1.Deployment) error {
 	return nil
 }
 
 // EnsureKubeControllerManagerDeployment ensures that the kube-controller-manager deployment conforms to the provider requirements.
-func (e *NoopEnsurer) EnsureKubeControllerManagerDeployment(ctx context.Context, gctx extensionscontextwebhook.GardenContext, new, old *appsv1.Deployment) error {
+func (e *NoopEnsurer) EnsureKubeControllerManagerDeployment(_ context.Context, _ extensionscontextwebhook.GardenContext, _, _ *appsv1.Deployment) error {
 	return nil
 }
 
 // EnsureKubeSchedulerDeployment ensures that the kube-scheduler deployment conforms to the provider requirements.
-func (e *NoopEnsurer) EnsureKubeSchedulerDeployment(ctx context.Context, gctx extensionscontextwebhook.GardenContext, new, old *appsv1.Deployment) error {
+func (e *NoopEnsurer) EnsureKubeSchedulerDeployment(_ context.Context, _ extensionscontextwebhook.GardenContext, _, _ *appsv1.Deployment) error {
 	return nil
 }
 
 // EnsureMachineControllerManagerDeployment ensures that the machine-controller-manager deployment conforms to the provider requirements.
-func (e *NoopEnsurer) EnsureMachineControllerManagerDeployment(ctx context.Context, gctx extensionscontextwebhook.GardenContext, new, old *appsv1.Deployment) error {
+func (e *NoopEnsurer) EnsureMachineControllerManagerDeployment(_ context.Context, _ extensionscontextwebhook.GardenContext, _, _ *appsv1.Deployment) error {
 	return nil
 }
 
 // EnsureMachineControllerManagerVPA ensures that the machine-controller-manager deployment conforms to the provider requirements.
-func (e *NoopEnsurer) EnsureMachineControllerManagerVPA(ctx context.Context, gctx extensionscontextwebhook.GardenContext, new, old *vpaautoscalingv1.VerticalPodAutoscaler) error {
+func (e *NoopEnsurer) EnsureMachineControllerManagerVPA(_ context.Context, _ extensionscontextwebhook.GardenContext, _, _ *vpaautoscalingv1.VerticalPodAutoscaler) error {
 	return nil
 }
 
 // EnsureClusterAutoscalerDeployment ensures that the cluster-autoscaler deployment conforms to the provider requirements.
-func (e *NoopEnsurer) EnsureClusterAutoscalerDeployment(ctx context.Context, gctx extensionscontextwebhook.GardenContext, new, old *appsv1.Deployment) error {
+func (e *NoopEnsurer) EnsureClusterAutoscalerDeployment(_ context.Context, _ extensionscontextwebhook.GardenContext, _, _ *appsv1.Deployment) error {
 	return nil
 }
 
 // EnsureETCD ensures that the etcd stateful sets conform to the provider requirements.
-func (e *NoopEnsurer) EnsureETCD(ctx context.Context, gctx extensionscontextwebhook.GardenContext, new, old *druidv1alpha1.Etcd) error {
+func (e *NoopEnsurer) EnsureETCD(_ context.Context, _ extensionscontextwebhook.GardenContext, _, _ *druidv1alpha1.Etcd) error {
 	return nil
 }
 
 // EnsureVPNSeedServerDeployment ensures that the vpn-seed-server deployment conforms to the provider requirements.
-func (e *NoopEnsurer) EnsureVPNSeedServerDeployment(ctx context.Context, gctx extensionscontextwebhook.GardenContext, new, old *appsv1.Deployment) error {
+func (e *NoopEnsurer) EnsureVPNSeedServerDeployment(_ context.Context, _ extensionscontextwebhook.GardenContext, _, _ *appsv1.Deployment) error {
 	return nil
 }
 
 // EnsureKubeletServiceUnitOptions ensures that the kubelet.service unit options conform to the provider requirements.
-func (e *NoopEnsurer) EnsureKubeletServiceUnitOptions(ctx context.Context, gctx extensionscontextwebhook.GardenContext, kubeletVersion *semver.Version, new, old []*unit.UnitOption) ([]*unit.UnitOption, error) {
+func (e *NoopEnsurer) EnsureKubeletServiceUnitOptions(_ context.Context, _ extensionscontextwebhook.GardenContext, _ *semver.Version, new, _ []*unit.UnitOption) ([]*unit.UnitOption, error) {
 	return new, nil
 }
 
 // EnsureKubeletConfiguration ensures that the kubelet configuration conforms to the provider requirements.
-func (e *NoopEnsurer) EnsureKubeletConfiguration(ctx context.Context, gctx extensionscontextwebhook.GardenContext, kubeletVersion *semver.Version, new, old *kubeletconfigv1beta1.KubeletConfiguration) error {
+func (e *NoopEnsurer) EnsureKubeletConfiguration(_ context.Context, _ extensionscontextwebhook.GardenContext, _ *semver.Version, _, _ *kubeletconfigv1beta1.KubeletConfiguration) error {
 	return nil
 }
 
 // ShouldProvisionKubeletCloudProviderConfig returns if the cloud provider config file should be added to the kubelet configuration.
-func (e *NoopEnsurer) ShouldProvisionKubeletCloudProviderConfig(ctx context.Context, gctx extensionscontextwebhook.GardenContext, kubeletVersion *semver.Version) bool {
+func (e *NoopEnsurer) ShouldProvisionKubeletCloudProviderConfig(_ context.Context, _ extensionscontextwebhook.GardenContext, _ *semver.Version) bool {
 	return false
 }
 
 // EnsureKubeletCloudProviderConfig ensures that the cloud provider config file conforms to the provider requirements.
-func (e *NoopEnsurer) EnsureKubeletCloudProviderConfig(ctx context.Context, gctx extensionscontextwebhook.GardenContext, kubeletVersion *semver.Version, configContent *string, namespace string) error {
+func (e *NoopEnsurer) EnsureKubeletCloudProviderConfig(_ context.Context, _ extensionscontextwebhook.GardenContext, _ *semver.Version, _ *string, _ string) error {
 	return nil
 }
 
 // EnsureKubernetesGeneralConfiguration ensures that the kubernetes general configuration conforms to the provider requirements.
-func (e *NoopEnsurer) EnsureKubernetesGeneralConfiguration(ctx context.Context, gctx extensionscontextwebhook.GardenContext, new, old *string) error {
+func (e *NoopEnsurer) EnsureKubernetesGeneralConfiguration(_ context.Context, _ extensionscontextwebhook.GardenContext, _, _ *string) error {
 	return nil
 }
 
 // EnsureAdditionalUnits ensures that additional required system units are added.
-func (e *NoopEnsurer) EnsureAdditionalUnits(ctx context.Context, gctx extensionscontextwebhook.GardenContext, new, old *[]extensionsv1alpha1.Unit) error {
+func (e *NoopEnsurer) EnsureAdditionalUnits(_ context.Context, _ extensionscontextwebhook.GardenContext, _, _ *[]extensionsv1alpha1.Unit) error {
 	return nil
 }
 
 // EnsureAdditionalFiles ensures that additional required system files are added.
-func (e *NoopEnsurer) EnsureAdditionalFiles(ctx context.Context, gctx extensionscontextwebhook.GardenContext, new, old *[]extensionsv1alpha1.File) error {
+func (e *NoopEnsurer) EnsureAdditionalFiles(_ context.Context, _ extensionscontextwebhook.GardenContext, _, _ *[]extensionsv1alpha1.File) error {
 	return nil
 }

--- a/extensions/pkg/webhook/network/mutator.go
+++ b/extensions/pkg/webhook/network/mutator.go
@@ -45,7 +45,7 @@ type mutator struct {
 }
 
 // Mutate validates and if needed mutates the given object.
-func (m *mutator) Mutate(ctx context.Context, new, old client.Object) error {
+func (m *mutator) Mutate(_ context.Context, new, old client.Object) error {
 	var (
 		newNetwork, oldNetwork *extensionsv1alpha1.Network
 		ok                     bool

--- a/hack/tools/gomegacheck/plugin/golangci_lint.go
+++ b/hack/tools/gomegacheck/plugin/golangci_lint.go
@@ -21,6 +21,6 @@ import (
 )
 
 // New returns the gomegacheck analyzer.
-func New(conf any) ([]*analysis.Analyzer, error) {
+func New(_ any) ([]*analysis.Analyzer, error) {
 	return []*analysis.Analyzer{gomegacheck.Analyzer}, nil
 }

--- a/hack/tools/logcheck/plugin/golangci_lint.go
+++ b/hack/tools/logcheck/plugin/golangci_lint.go
@@ -21,6 +21,6 @@ import (
 )
 
 // New returns the logcheck analyzer.
-func New(conf any) ([]*analysis.Analyzer, error) {
+func New(_ any) ([]*analysis.Analyzer, error) {
 	return []*analysis.Analyzer{logcheck.Analyzer}, nil
 }

--- a/pkg/admissioncontroller/webhook/add.go
+++ b/pkg/admissioncontroller/webhook/add.go
@@ -92,7 +92,7 @@ func AddToManager(
 	if err := (&admissionpluginsecret.Handler{
 		Logger: mgr.GetLogger().WithName("webhook").WithName(admissionpluginsecret.HandlerName),
 		Client: mgr.GetClient(),
-	}).AddToManager(ctx, mgr); err != nil {
+	}).AddToManager(mgr); err != nil {
 		return fmt.Errorf("failed adding %s webhook handler: %w", admissionpluginsecret.HandlerName, err)
 	}
 

--- a/pkg/admissioncontroller/webhook/admission/admissionpluginsecret/add.go
+++ b/pkg/admissioncontroller/webhook/admission/admissionpluginsecret/add.go
@@ -15,8 +15,6 @@
 package admissionpluginsecret
 
 import (
-	"context"
-
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
@@ -30,7 +28,7 @@ const (
 )
 
 // AddToManager adds Handler to the given manager.
-func (h *Handler) AddToManager(ctx context.Context, mgr manager.Manager) error {
+func (h *Handler) AddToManager(mgr manager.Manager) error {
 	webhook := admission.
 		WithCustomValidator(mgr.GetScheme(), &corev1.Secret{}, h).
 		WithRecoverPanic(true)

--- a/pkg/admissioncontroller/webhook/admission/admissionpluginsecret/handler.go
+++ b/pkg/admissioncontroller/webhook/admission/admissionpluginsecret/handler.go
@@ -37,7 +37,7 @@ type Handler struct {
 }
 
 // ValidateCreate returns nil (not implemented by this handler).
-func (h *Handler) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
+func (h *Handler) ValidateCreate(_ context.Context, _ runtime.Object) (admission.Warnings, error) {
 	return nil, nil
 }
 

--- a/pkg/apis/core/v1beta1/defaults.go
+++ b/pkg/apis/core/v1beta1/defaults.go
@@ -91,7 +91,7 @@ func SetDefaults_SeedNetworks(obj *SeedNetworks) {
 }
 
 // SetDefaults_SeedSettingDependencyWatchdog sets defaults for SeedSettingDependencyWatchdog objects.
-func SetDefaults_SeedSettingDependencyWatchdog(obj *SeedSettingDependencyWatchdog) {
+func SetDefaults_SeedSettingDependencyWatchdog(_ *SeedSettingDependencyWatchdog) {
 }
 
 // SetDefaults_Shoot sets default values for Shoot objects.

--- a/pkg/apis/core/validation/backupbucket.go
+++ b/pkg/apis/core/validation/backupbucket.go
@@ -73,7 +73,7 @@ func ValidateBackupBucketSpecUpdate(newSpec, oldSpec *core.BackupBucketSpec, fld
 }
 
 // ValidateBackupBucketStatusUpdate validates the status field of a BackupBucket object.
-func ValidateBackupBucketStatusUpdate(newBackupBucket, oldBackupBucket *core.BackupBucket) field.ErrorList {
+func ValidateBackupBucketStatusUpdate(_, _ *core.BackupBucket) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	return allErrs

--- a/pkg/apis/core/validation/backupentry.go
+++ b/pkg/apis/core/validation/backupentry.go
@@ -54,19 +54,19 @@ func ValidateBackupEntrySpec(spec *core.BackupEntrySpec, fldPath *field.Path) fi
 }
 
 // ValidateBackupEntrySpecUpdate validates the specification of a BackupEntry object.
-func ValidateBackupEntrySpecUpdate(newSpec, oldSpec *core.BackupEntrySpec, fldPath *field.Path) field.ErrorList {
+func ValidateBackupEntrySpecUpdate(_, _ *core.BackupEntrySpec, _ *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	return allErrs
 }
 
 // ValidateBackupEntryStatusUpdate validates the status field of a BackupEntry object.
-func ValidateBackupEntryStatusUpdate(newBackupEntry, oldBackupEntry *core.BackupEntry) field.ErrorList {
+func ValidateBackupEntryStatusUpdate(_, _ *core.BackupEntry) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	return allErrs
 }
 
-func validateBackupEntryName(name string, prefix bool) []string {
+func validateBackupEntryName(_ string, _ bool) []string {
 	return []string{}
 }

--- a/pkg/apis/core/validation/cloudprofile.go
+++ b/pkg/apis/core/validation/cloudprofile.go
@@ -61,7 +61,7 @@ func ValidateCloudProfileUpdate(newProfile, oldProfile *core.CloudProfile) field
 }
 
 // ValidateCloudProfileSpecUpdate validates the spec update of a CloudProfile
-func ValidateCloudProfileSpecUpdate(new, old *core.CloudProfileSpec, fldPath *field.Path) field.ErrorList {
+func ValidateCloudProfileSpecUpdate(_, _ *core.CloudProfileSpec, _ *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	return allErrs

--- a/pkg/apis/core/validation/controllerinstallation.go
+++ b/pkg/apis/core/validation/controllerinstallation.go
@@ -80,15 +80,8 @@ func ValidateControllerInstallationSpecUpdate(new, old *core.ControllerInstallat
 	return allErrs
 }
 
-// ValidateControllerInstallationStatus validates the status of a ControllerInstallation object.
-func ValidateControllerInstallationStatus(spec *core.ControllerInstallationStatus, fldPath *field.Path) field.ErrorList {
-	allErrs := field.ErrorList{}
-
-	return allErrs
-}
-
 // ValidateControllerInstallationStatusUpdate validates the status field of a ControllerInstallation object.
-func ValidateControllerInstallationStatusUpdate(newStatus, oldStatus core.ControllerInstallationStatus) field.ErrorList {
+func ValidateControllerInstallationStatusUpdate(_, _ core.ControllerInstallationStatus) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	return allErrs

--- a/pkg/apis/core/validation/quota.go
+++ b/pkg/apis/core/validation/quota.go
@@ -44,13 +44,6 @@ func ValidateQuotaUpdate(newQuota, oldQuota *core.Quota) field.ErrorList {
 	return allErrs
 }
 
-// ValidateQuotaStatusUpdate validates the status field of a Quota object.
-func ValidateQuotaStatusUpdate(newQuota, oldQuota *core.Quota) field.ErrorList {
-	allErrs := field.ErrorList{}
-
-	return allErrs
-}
-
 // ValidateQuotaSpec validates the specification of a Quota object.
 func ValidateQuotaSpec(quotaSpec *core.QuotaSpec, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}

--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -651,13 +651,12 @@ func ValidateKubernetesVersionUpdate(new, old string, fldPath *field.Path) field
 func validateNetworkingUpdate(newNetworking, oldNetworking *core.Networking, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
-	if oldNetworking != nil {
-		if newNetworking == nil {
-			allErrs = append(allErrs, field.Forbidden(fldPath, "networking cannot be set to nil if it's already set"))
-			return allErrs
-		}
-	} else {
+	if oldNetworking == nil {
 		// if the old networking is nil, we cannot validate immutability anyway, so exit early
+		return allErrs
+	}
+	if newNetworking == nil {
+		allErrs = append(allErrs, field.Forbidden(fldPath, "networking cannot be set to nil if it's already set"))
 		return allErrs
 	}
 

--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -238,7 +238,7 @@ func ValidateShootSpec(meta metav1.ObjectMeta, spec *core.ShootSpec, fldPath *fi
 	)
 
 	allErrs = append(allErrs, validateProvider(spec.Provider, spec.Kubernetes, spec.Networking, workerless, fldPath.Child("provider"), inTemplate)...)
-	allErrs = append(allErrs, validateAddons(spec.Addons, spec.Kubernetes, spec.Purpose, workerless, fldPath.Child("addons"))...)
+	allErrs = append(allErrs, validateAddons(spec.Addons, spec.Purpose, workerless, fldPath.Child("addons"))...)
 	allErrs = append(allErrs, validateDNS(spec.DNS, fldPath.Child("dns"))...)
 	allErrs = append(allErrs, validateExtensions(spec.Extensions, fldPath.Child("extensions"))...)
 	allErrs = append(allErrs, validateResources(spec.Resources, fldPath.Child("resources"))...)
@@ -439,7 +439,7 @@ func validateAdvertisedURL(URL string, fldPath *field.Path) field.ErrorList {
 	return allErrors
 }
 
-func validateAddons(addons *core.Addons, kubernetes core.Kubernetes, purpose *core.ShootPurpose, workerless bool, fldPath *field.Path) field.ErrorList {
+func validateAddons(addons *core.Addons, purpose *core.ShootPurpose, workerless bool, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	if workerless && addons != nil {
@@ -835,7 +835,7 @@ func validateKubernetes(kubernetes core.Kubernetes, networking *core.Networking,
 		}
 
 		if clusterAutoscaler := kubernetes.ClusterAutoscaler; clusterAutoscaler != nil {
-			allErrs = append(allErrs, ValidateClusterAutoscaler(*clusterAutoscaler, kubernetes.Version, fldPath.Child("clusterAutoscaler"))...)
+			allErrs = append(allErrs, ValidateClusterAutoscaler(*clusterAutoscaler, fldPath.Child("clusterAutoscaler"))...)
 		}
 
 		if verticalPodAutoscaler := kubernetes.VerticalPodAutoscaler; verticalPodAutoscaler != nil {
@@ -1017,7 +1017,7 @@ func ValidateAPIServerRequests(requests *core.APIServerRequests, fldPath *field.
 }
 
 // ValidateClusterAutoscaler validates the given ClusterAutoscaler fields.
-func ValidateClusterAutoscaler(autoScaler core.ClusterAutoscaler, k8sVersion string, fldPath *field.Path) field.ErrorList {
+func ValidateClusterAutoscaler(autoScaler core.ClusterAutoscaler, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 	if threshold := autoScaler.ScaleDownUtilizationThreshold; threshold != nil {
 		if *threshold < 0.0 {

--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -2590,7 +2590,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 		Context("ClusterAutoscaler validation", func() {
 			DescribeTable("cluster autoscaler values",
 				func(clusterAutoscaler core.ClusterAutoscaler, supportedVersionForIgnoreTaints string, matcher gomegatypes.GomegaMatcher) {
-					Expect(ValidateClusterAutoscaler(clusterAutoscaler, supportedVersionForIgnoreTaints, nil)).To(matcher)
+					Expect(ValidateClusterAutoscaler(clusterAutoscaler, nil)).To(matcher)
 				},
 				Entry("valid", core.ClusterAutoscaler{}, version, BeEmpty()),
 				Entry("valid with threshold", core.ClusterAutoscaler{
@@ -2651,7 +2651,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 				)
 
 				It("should allow empty ignore taints list", func() {
-					errList := ValidateClusterAutoscaler(clusterAutoscaler, version, fldPath)
+					errList := ValidateClusterAutoscaler(clusterAutoscaler, fldPath)
 
 					Expect(errList).To(BeEmpty())
 				})
@@ -2662,7 +2662,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 						"allowed-2",
 					}
 
-					errList := ValidateClusterAutoscaler(clusterAutoscaler, version, fldPath)
+					errList := ValidateClusterAutoscaler(clusterAutoscaler, fldPath)
 
 					Expect(errList).To(BeEmpty())
 				})
@@ -2673,7 +2673,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 						"allowed-1",
 					}
 
-					errList := ValidateClusterAutoscaler(clusterAutoscaler, version, fldPath)
+					errList := ValidateClusterAutoscaler(clusterAutoscaler, fldPath)
 
 					Expect(errList).To(ConsistOf(
 						PointTo(MatchFields(IgnoreExtras, Fields{

--- a/pkg/apis/core/validation/shootstate.go
+++ b/pkg/apis/core/validation/shootstate.go
@@ -77,7 +77,7 @@ func ValidateShootStateSpec(shootStateSpec *core.ShootStateSpec, fldPath *field.
 }
 
 // ValidateShootStateSpecUpdate validates the update to the specification of a ShootState
-func ValidateShootStateSpecUpdate(newShootState, oldShootState *core.ShootStateSpec) field.ErrorList {
+func ValidateShootStateSpecUpdate(_, _ *core.ShootStateSpec) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	return allErrs

--- a/pkg/apis/extensions/validation/backupbucket.go
+++ b/pkg/apis/extensions/validation/backupbucket.go
@@ -80,17 +80,3 @@ func ValidateBackupBucketSpecUpdate(new, old *extensionsv1alpha1.BackupBucketSpe
 
 	return allErrs
 }
-
-// ValidateBackupBucketStatus validates the status of a BackupBucket object.
-func ValidateBackupBucketStatus(status *extensionsv1alpha1.BackupBucketStatus, fldPath *field.Path) field.ErrorList {
-	allErrs := field.ErrorList{}
-
-	return allErrs
-}
-
-// ValidateBackupBucketStatusUpdate validates the status field of a BackupBucket object before an update.
-func ValidateBackupBucketStatusUpdate(newStatus, oldStatus *extensionsv1alpha1.BackupBucketStatus, fldPath *field.Path) field.ErrorList {
-	allErrs := field.ErrorList{}
-
-	return allErrs
-}

--- a/pkg/apis/extensions/validation/backupentry.go
+++ b/pkg/apis/extensions/validation/backupentry.go
@@ -83,17 +83,3 @@ func ValidateBackupEntrySpecUpdate(new, old *extensionsv1alpha1.BackupEntrySpec,
 
 	return allErrs
 }
-
-// ValidateBackupEntryStatus validates the status of a BackupEntry object.
-func ValidateBackupEntryStatus(status *extensionsv1alpha1.BackupEntryStatus, fldPath *field.Path) field.ErrorList {
-	allErrs := field.ErrorList{}
-
-	return allErrs
-}
-
-// ValidateBackupEntryStatusUpdate validates the status field of a BackupEntry object before an update.
-func ValidateBackupEntryStatusUpdate(newStatus, oldStatus *extensionsv1alpha1.BackupEntryStatus, fldPath *field.Path) field.ErrorList {
-	allErrs := field.ErrorList{}
-
-	return allErrs
-}

--- a/pkg/apis/extensions/validation/bastion.go
+++ b/pkg/apis/extensions/validation/bastion.go
@@ -80,17 +80,3 @@ func ValidateBastionSpecUpdate(new, old *extensionsv1alpha1.BastionSpec, deletio
 
 	return allErrs
 }
-
-// ValidateBastionStatus validates the status of a Bastion object.
-func ValidateBastionStatus(status *extensionsv1alpha1.BastionStatus, fldPath *field.Path) field.ErrorList {
-	allErrs := field.ErrorList{}
-
-	return allErrs
-}
-
-// ValidateBastionStatusUpdate validates the status field of a Bastion object before an update.
-func ValidateBastionStatusUpdate(newStatus, oldStatus *extensionsv1alpha1.BastionStatus, fldPath *field.Path) field.ErrorList {
-	allErrs := field.ErrorList{}
-
-	return allErrs
-}

--- a/pkg/apis/extensions/validation/containerruntime.go
+++ b/pkg/apis/extensions/validation/containerruntime.go
@@ -80,17 +80,3 @@ func ValidateContainerRuntimeSpecUpdate(new, old *extensionsv1alpha1.ContainerRu
 
 	return allErrs
 }
-
-// ValidateContainerRuntimeStatus validates the status of a ContainerRuntime object.
-func ValidateContainerRuntimeStatus(status *extensionsv1alpha1.ContainerRuntimeStatus, fldPath *field.Path) field.ErrorList {
-	allErrs := field.ErrorList{}
-
-	return allErrs
-}
-
-// ValidateContainerRuntimeStatusUpdate validates the status of a ContainerRuntime object before an update.
-func ValidateContainerRuntimeStatusUpdate(newStatus, oldStatus *extensionsv1alpha1.ContainerRuntimeStatus, fldPath *field.Path) field.ErrorList {
-	allErrs := field.ErrorList{}
-
-	return allErrs
-}

--- a/pkg/apis/extensions/validation/controlplane.go
+++ b/pkg/apis/extensions/validation/controlplane.go
@@ -87,17 +87,3 @@ func ValidateControlPlaneSpecUpdate(new, old *extensionsv1alpha1.ControlPlaneSpe
 
 	return allErrs
 }
-
-// ValidateControlPlaneStatus validates the status of a ControlPlane object.
-func ValidateControlPlaneStatus(status *extensionsv1alpha1.ControlPlaneStatus, fldPath *field.Path) field.ErrorList {
-	allErrs := field.ErrorList{}
-
-	return allErrs
-}
-
-// ValidateControlPlaneStatusUpdate validates the status field of a ControlPlane object before an update.
-func ValidateControlPlaneStatusUpdate(newStatus, oldStatus *extensionsv1alpha1.ControlPlaneStatus, fldPath *field.Path) field.ErrorList {
-	allErrs := field.ErrorList{}
-
-	return allErrs
-}

--- a/pkg/apis/extensions/validation/dnsrecord.go
+++ b/pkg/apis/extensions/validation/dnsrecord.go
@@ -110,20 +110,6 @@ func ValidateDNSRecordSpecUpdate(new, old *extensionsv1alpha1.DNSRecordSpec, del
 	return allErrs
 }
 
-// ValidateDNSRecordStatus validates the status of a DNSRecord object.
-func ValidateDNSRecordStatus(status *extensionsv1alpha1.DNSRecordStatus, fldPath *field.Path) field.ErrorList {
-	allErrs := field.ErrorList{}
-
-	return allErrs
-}
-
-// ValidateDNSRecordStatusUpdate validates the status field of a DNSRecord object before an update.
-func ValidateDNSRecordStatusUpdate(newStatus, oldStatus *extensionsv1alpha1.DNSRecordStatus, fldPath *field.Path) field.ErrorList {
-	allErrs := field.ErrorList{}
-
-	return allErrs
-}
-
 func validateValue(recordType extensionsv1alpha1.DNSRecordType, value string, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 	switch recordType {

--- a/pkg/apis/extensions/validation/extension.go
+++ b/pkg/apis/extensions/validation/extension.go
@@ -71,17 +71,3 @@ func ValidateExtensionSpecUpdate(new, old *extensionsv1alpha1.ExtensionSpec, del
 
 	return allErrs
 }
-
-// ValidateExtensionStatus validates the status of a Extension object.
-func ValidateExtensionStatus(status *extensionsv1alpha1.ExtensionStatus, fldPath *field.Path) field.ErrorList {
-	allErrs := field.ErrorList{}
-
-	return allErrs
-}
-
-// ValidateExtensionStatusUpdate validates the status field of a Extension object before an update.
-func ValidateExtensionStatusUpdate(newStatus, oldStatus *extensionsv1alpha1.ExtensionStatus, fldPath *field.Path) field.ErrorList {
-	allErrs := field.ErrorList{}
-
-	return allErrs
-}

--- a/pkg/apis/extensions/validation/infrastructure.go
+++ b/pkg/apis/extensions/validation/infrastructure.go
@@ -80,17 +80,3 @@ func ValidateInfrastructureSpecUpdate(new, old *extensionsv1alpha1.Infrastructur
 
 	return allErrs
 }
-
-// ValidateInfrastructureStatus validates the status of a Infrastructure object.
-func ValidateInfrastructureStatus(status *extensionsv1alpha1.InfrastructureStatus, fldPath *field.Path) field.ErrorList {
-	allErrs := field.ErrorList{}
-
-	return allErrs
-}
-
-// ValidateInfrastructureStatusUpdate validates the status field of a Infrastructure object before an update.
-func ValidateInfrastructureStatusUpdate(newStatus, oldStatus *extensionsv1alpha1.InfrastructureStatus, fldPath *field.Path) field.ErrorList {
-	allErrs := field.ErrorList{}
-
-	return allErrs
-}

--- a/pkg/apis/extensions/validation/network.go
+++ b/pkg/apis/extensions/validation/network.go
@@ -104,20 +104,6 @@ func ValidateNetworkSpecUpdate(new, old *extensionsv1alpha1.NetworkSpec, deletio
 	return allErrs
 }
 
-// ValidateNetworkStatus validates the status of a Network object.
-func ValidateNetworkStatus(status *extensionsv1alpha1.NetworkStatus, fldPath *field.Path) field.ErrorList {
-	allErrs := field.ErrorList{}
-
-	return allErrs
-}
-
-// ValidateNetworkStatusUpdate validates the status field of a Network object before an update.
-func ValidateNetworkStatusUpdate(newStatus, oldStatus *extensionsv1alpha1.NetworkStatus, fldPath *field.Path) field.ErrorList {
-	allErrs := field.ErrorList{}
-
-	return allErrs
-}
-
 var availableIPFamilies = sets.New(
 	string(extensionsv1alpha1.IPFamilyIPv4),
 	string(extensionsv1alpha1.IPFamilyIPv6),

--- a/pkg/apis/extensions/validation/operatingsystemconfig.go
+++ b/pkg/apis/extensions/validation/operatingsystemconfig.go
@@ -156,17 +156,3 @@ func ValidateOperatingSystemConfigSpecUpdate(new, old *extensionsv1alpha1.Operat
 
 	return allErrs
 }
-
-// ValidateOperatingSystemConfigStatus validates the status of a OperatingSystemConfig object.
-func ValidateOperatingSystemConfigStatus(status *extensionsv1alpha1.OperatingSystemConfigStatus, fldPath *field.Path) field.ErrorList {
-	allErrs := field.ErrorList{}
-
-	return allErrs
-}
-
-// ValidateOperatingSystemConfigStatusUpdate validates the status field of a OperatingSystemConfig object before an update.
-func ValidateOperatingSystemConfigStatusUpdate(newStatus, oldStatus *extensionsv1alpha1.OperatingSystemConfigStatus, fldPath *field.Path) field.ErrorList {
-	allErrs := field.ErrorList{}
-
-	return allErrs
-}

--- a/pkg/apis/extensions/validation/worker.go
+++ b/pkg/apis/extensions/validation/worker.go
@@ -134,17 +134,3 @@ func ValidateWorkerSpecUpdate(new, old *extensionsv1alpha1.WorkerSpec, deletionT
 
 	return allErrs
 }
-
-// ValidateWorkerStatus validates the status of a Worker object.
-func ValidateWorkerStatus(status *extensionsv1alpha1.WorkerStatus, fldPath *field.Path) field.ErrorList {
-	allErrs := field.ErrorList{}
-
-	return allErrs
-}
-
-// ValidateWorkerStatusUpdate validates the status field of a Worker object before an update.
-func ValidateWorkerStatusUpdate(newStatus, oldStatus *extensionsv1alpha1.WorkerStatus, fldPath *field.Path) field.ErrorList {
-	allErrs := field.ErrorList{}
-
-	return allErrs
-}

--- a/pkg/apis/operations/validation/bastion.go
+++ b/pkg/apis/operations/validation/bastion.go
@@ -89,7 +89,7 @@ func ValidateBastionSpecUpdate(newSpec, oldSpec *operations.BastionSpec, fldPath
 }
 
 // ValidateBastionStatusUpdate validates the status field of a Bastion object.
-func ValidateBastionStatusUpdate(newBastion, oldBastion *operations.Bastion) field.ErrorList {
+func ValidateBastionStatusUpdate(newBastion, _ *operations.Bastion) field.ErrorList {
 	allErrs := field.ErrorList{}
 	now := time.Now()
 

--- a/pkg/client/kubernetes/client.go
+++ b/pkg/client/kubernetes/client.go
@@ -403,16 +403,16 @@ func (d *FallbackClient) Get(ctx context.Context, key client.ObjectKey, obj clie
 	// If there are specific namespaces for this kind in the cache and the object's namespace is not cached,
 	// use the API reader to get the object.
 	if ok && !namespaces.Has(obj.GetNamespace()) {
-		return d.Reader.Get(ctx, key, obj)
+		return d.Reader.Get(ctx, key, obj, opts...)
 	}
 
 	// Otherwise, try to get the object from the cache.
-	err = d.Client.Get(ctx, key, obj)
+	err = d.Client.Get(ctx, key, obj, opts...)
 
 	// If an error occurs and it's a cache error, log it and use the API reader as a fallback.
 	if err != nil && errors.As(err, &cacheError) {
 		logf.Log.V(1).Info("Falling back to API reader because a cache error occurred", "error", err)
-		return d.Reader.Get(ctx, key, obj)
+		return d.Reader.Get(ctx, key, obj, opts...)
 	}
 	return err
 }

--- a/pkg/component/apiserver/deployment.go
+++ b/pkg/component/apiserver/deployment.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/Masterminds/semver/v3"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 
@@ -42,7 +41,6 @@ func InjectDefaultSettings(
 	deployment *appsv1.Deployment,
 	namePrefix string,
 	values Values,
-	k8sVersion *semver.Version,
 	secretCAETCD *corev1.Secret,
 	secretETCDClient *corev1.Secret,
 	secretServer *corev1.Secret,

--- a/pkg/component/apiserver/deployment_test.go
+++ b/pkg/component/apiserver/deployment_test.go
@@ -15,7 +15,6 @@
 package apiserver_test
 
 import (
-	"github.com/Masterminds/semver/v3"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
@@ -35,7 +34,6 @@ var _ = Describe("Deployment", func() {
 
 			var (
 				namePrefix       = "foo"
-				k8sVersion       = semver.MustParse("1.24.5")
 				secretCAETCD     = &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "ca-etcd"}}
 				secretETCDClient = &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "etcd-client"}}
 				secretServer     = &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "server"}}
@@ -59,7 +57,7 @@ var _ = Describe("Deployment", func() {
 				}
 			)
 
-			InjectDefaultSettings(deployment, namePrefix, values, k8sVersion, secretCAETCD, secretETCDClient, secretServer)
+			InjectDefaultSettings(deployment, namePrefix, values, secretCAETCD, secretETCDClient, secretServer)
 
 			Expect(deployment).To(Equal(&appsv1.Deployment{
 				Spec: appsv1.DeploymentSpec{

--- a/pkg/component/clusterautoscaler/cluster_autoscaler.go
+++ b/pkg/component/clusterautoscaler/cluster_autoscaler.go
@@ -96,9 +96,8 @@ type clusterAutoscaler struct {
 	replicas       int32
 	config         *gardencorev1beta1.ClusterAutoscaler
 
-	runtimeVersionGreaterEqual121 bool
-	namespaceUID                  types.UID
-	machineDeployments            []extensionsv1alpha1.MachineDeployment
+	namespaceUID       types.UID
+	machineDeployments []extensionsv1alpha1.MachineDeployment
 }
 
 func (c *clusterAutoscaler) Deploy(ctx context.Context) error {

--- a/pkg/component/dependencywatchdog/bootstrap.go
+++ b/pkg/component/dependencywatchdog/bootstrap.go
@@ -119,9 +119,9 @@ func (b *bootstrapper) Deploy(ctx context.Context) error {
 		return err
 	}
 	serviceAccount := b.getServiceAccount()
-	clusterRole := b.getClusterRole(serviceAccount)
+	clusterRole := b.getClusterRole()
 	clusterRoleBinding := b.getClusterRoleBinding(serviceAccount, clusterRole)
-	role := b.getRole(serviceAccount)
+	role := b.getRole()
 	roleBinding := b.getRoleBinding(serviceAccount, role)
 	deployment := b.getDeployment(serviceAccount.Name, configMap.Name)
 	vpa := b.getVPA(deployment.Name)
@@ -240,7 +240,7 @@ func (b *bootstrapper) getServiceAccount() *corev1.ServiceAccount {
 	}
 }
 
-func (b *bootstrapper) getClusterRole(serviceAccount *corev1.ServiceAccount) *rbacv1.ClusterRole {
+func (b *bootstrapper) getClusterRole() *rbacv1.ClusterRole {
 	clusterRole := &rbacv1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: fmt.Sprintf("gardener.cloud:%s", b.name()),
@@ -269,7 +269,7 @@ func (b *bootstrapper) getClusterRoleBinding(serviceAccount *corev1.ServiceAccou
 	return clusterRoleBinding
 }
 
-func (b *bootstrapper) getRole(serviceAccount *corev1.ServiceAccount) *rbacv1.Role {
+func (b *bootstrapper) getRole() *rbacv1.Role {
 	role := &rbacv1.Role{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf("gardener.cloud:%s", b.name()),

--- a/pkg/component/etcd/etcd.go
+++ b/pkg/component/etcd/etcd.go
@@ -32,8 +32,6 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/selection"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	vpaautoscalingv1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
 	"k8s.io/client-go/rest"
@@ -732,12 +730,6 @@ func (e *etcd) GetValues() Values { return e.values }
 func (e *etcd) GetReplicas() *int32 { return e.values.Replicas }
 
 func (e *etcd) SetReplicas(replicas *int32) { e.values.Replicas = replicas }
-
-func (e *etcd) podLabelSelector() labels.Selector {
-	app, _ := labels.NewRequirement(v1beta1constants.LabelApp, selection.Equals, []string{LabelAppValue})
-	role, _ := labels.NewRequirement(v1beta1constants.LabelRole, selection.Equals, []string{e.values.Role})
-	return labels.NewSelector().Add(*role, *app)
-}
 
 func (e *etcd) computeContainerResources(existingSts *appsv1.StatefulSet) (*corev1.ResourceRequirements, *corev1.ResourceRequirements) {
 	var (

--- a/pkg/component/extensions/crds/crds.go
+++ b/pkg/component/extensions/crds/crds.go
@@ -95,16 +95,16 @@ func (c *crd) Deploy(ctx context.Context) error {
 }
 
 // Destroy does nothing
-func (c *crd) Destroy(ctx context.Context) error {
+func (c *crd) Destroy(_ context.Context) error {
 	return nil
 }
 
 // Wait does nothing
-func (c *crd) Wait(ctx context.Context) error {
+func (c *crd) Wait(_ context.Context) error {
 	return nil
 }
 
 // WaitCleanup does nothing
-func (c *crd) WaitCleanup(ctx context.Context) error {
+func (c *crd) WaitCleanup(_ context.Context) error {
 	return nil
 }

--- a/pkg/component/extensions/extension/extension_test.go
+++ b/pkg/component/extensions/extension/extension_test.go
@@ -47,7 +47,7 @@ type errorClient struct {
 	err error
 }
 
-func (e *errorClient) Delete(ctx context.Context, obj client.Object, opts ...client.DeleteOption) error {
+func (e *errorClient) Delete(_ context.Context, _ client.Object, _ ...client.DeleteOption) error {
 	return e.err
 }
 

--- a/pkg/component/extensions/worker/worker.go
+++ b/pkg/component/extensions/worker/worker.go
@@ -184,7 +184,7 @@ func (w *worker) deploy(ctx context.Context, operation string) (extensionsv1alph
 			workerPoolKubernetesVersion = *workerPool.Kubernetes.Version
 		}
 
-		nodeTemplate, machineType := w.findNodeTemplateAndMachineTypeByPoolName(ctx, obj, workerPool.Name)
+		nodeTemplate, machineType := w.findNodeTemplateAndMachineTypeByPoolName(obj, workerPool.Name)
 
 		if nodeTemplate == nil || machineType != workerPool.Machine.Type {
 			// initializing nodeTemplate by fetching details from cloudprofile, if present there
@@ -368,7 +368,7 @@ func (w *worker) MachineDeployments() []extensionsv1alpha1.MachineDeployment {
 	return w.machineDeployments
 }
 
-func (w *worker) findNodeTemplateAndMachineTypeByPoolName(ctx context.Context, obj *extensionsv1alpha1.Worker, poolName string) (*extensionsv1alpha1.NodeTemplate, string) {
+func (w *worker) findNodeTemplateAndMachineTypeByPoolName(obj *extensionsv1alpha1.Worker, poolName string) (*extensionsv1alpha1.NodeTemplate, string) {
 	for _, pool := range obj.Spec.Pools {
 		if pool.Name == poolName {
 			return pool.NodeTemplate, pool.MachineType

--- a/pkg/component/gardenerapiserver/deployment.go
+++ b/pkg/component/gardenerapiserver/deployment.go
@@ -141,7 +141,7 @@ func (g *gardenerAPIServer) deployment(
 		},
 	}
 
-	apiserver.InjectDefaultSettings(deployment, "virtual-garden-", g.values.Values, nil, secretCAETCD, secretETCDClient, secretServer)
+	apiserver.InjectDefaultSettings(deployment, "virtual-garden-", g.values.Values, secretCAETCD, secretETCDClient, secretServer)
 	apiserver.InjectAuditSettings(deployment, configMapAuditPolicy, secretAuditWebhookKubeconfig, g.values.Audit)
 	apiserver.InjectAdmissionSettings(deployment, configMapAdmissionConfigs, secretAdmissionKubeconfigs, g.values.Values)
 	apiserver.InjectEncryptionSettings(deployment, secretETCDEncryptionConfiguration)

--- a/pkg/component/istio/crds.go
+++ b/pkg/component/istio/crds.go
@@ -50,10 +50,10 @@ func (c *crds) Destroy(ctx context.Context) error {
 	return c.DeleteFromEmbeddedFS(ctx, chartCRDs, chartPathCRDs, "", "istio")
 }
 
-func (c *crds) Wait(ctx context.Context) error {
+func (c *crds) Wait(_ context.Context) error {
 	return nil
 }
 
-func (c *crds) WaitCleanup(ctx context.Context) error {
+func (c *crds) WaitCleanup(_ context.Context) error {
 	return nil
 }

--- a/pkg/component/kubeapiserver/deployment.go
+++ b/pkg/component/kubeapiserver/deployment.go
@@ -367,7 +367,7 @@ func (k *kubeAPIServer) reconcileDeployment(
 			},
 		}
 
-		apiserver.InjectDefaultSettings(deployment, k.values.NamePrefix, k.values.Values, k.values.Version, secretCAETCD, secretETCDClient, secretServer)
+		apiserver.InjectDefaultSettings(deployment, k.values.NamePrefix, k.values.Values, secretCAETCD, secretETCDClient, secretServer)
 		apiserver.InjectAuditSettings(deployment, configMapAuditPolicy, secretAuditWebhookKubeconfig, k.values.Audit)
 		apiserver.InjectAdmissionSettings(deployment, configMapAdmissionConfigs, secretAdmissionKubeconfigs, k.values.Values)
 		apiserver.InjectEncryptionSettings(deployment, secretETCDEncryptionConfiguration)

--- a/pkg/component/kubescheduler/kube_scheduler.go
+++ b/pkg/component/kubescheduler/kube_scheduler.go
@@ -126,7 +126,6 @@ func New(
 	image string,
 	replicas int32,
 	config *gardencorev1beta1.KubeSchedulerConfig,
-	runtimeKubernetesVersion *semver.Version,
 ) Interface {
 	return &kubeScheduler{
 		client:         client,

--- a/pkg/component/kubescheduler/monitoring_test.go
+++ b/pkg/component/kubescheduler/monitoring_test.go
@@ -26,13 +26,13 @@ import (
 
 var _ = Describe("Monitoring", func() {
 	It("should successfully test the scrape config", func() {
-		kubeScheduler := New(nil, "", nil, semver.MustParse("1.26.0"), "", 0, nil, semver.MustParse("1.25.0"))
+		kubeScheduler := New(nil, "", nil, semver.MustParse("1.26.0"), "", 0, nil)
 
 		test.ScrapeConfigs(kubeScheduler, expectedScrapeConfig)
 	})
 
 	It("should successfully test the alerting rules", func() {
-		kubeScheduler := New(nil, "", nil, semver.MustParse("1.26.4"), "", 0, nil, semver.MustParse("1.25.0"))
+		kubeScheduler := New(nil, "", nil, semver.MustParse("1.26.4"), "", 0, nil)
 
 		test.AlertingRulesWithPromtool(
 			kubeScheduler,

--- a/pkg/component/logging/fluentoperator/crds.go
+++ b/pkg/component/logging/fluentoperator/crds.go
@@ -108,11 +108,11 @@ func (c *crds) Destroy(ctx context.Context) error {
 }
 
 // Wait does nothing
-func (c *crds) Wait(ctx context.Context) error {
+func (c *crds) Wait(_ context.Context) error {
 	return nil
 }
 
 // WaitCleanup does nothing
-func (c *crds) WaitCleanup(ctx context.Context) error {
+func (c *crds) WaitCleanup(_ context.Context) error {
 	return nil
 }

--- a/pkg/component/monitoring/bootstrap.go
+++ b/pkg/component/monitoring/bootstrap.go
@@ -272,6 +272,6 @@ func (b *bootstrapper) Deploy(ctx context.Context) error {
 	return b.chartApplier.ApplyFromEmbeddedFS(ctx, chartBootstrap, chartPathBootstrap, b.namespace, "monitoring", values, applierOptions)
 }
 
-func (b *bootstrapper) Destroy(ctx context.Context) error {
+func (b *bootstrapper) Destroy(_ context.Context) error {
 	return nil
 }

--- a/pkg/component/vpnseedserver/vpn_seed_server.go
+++ b/pkg/component/vpnseedserver/vpn_seed_server.go
@@ -233,10 +233,7 @@ func (v *vpnSeedServer) Deploy(ctx context.Context) error {
 	}
 
 	podTemplate := v.podTemplate(configMap, dhSecret, secretCAVPN, secretServer, secretTLSAuth)
-	labels := map[string]string{
-		v1beta1constants.GardenRole: v1beta1constants.GardenRoleControlPlane,
-		v1beta1constants.LabelApp:   DeploymentName,
-	}
+	labels := getLabels()
 
 	if v.values.HighAvailabilityEnabled {
 		if err := v.deployStatefulSet(ctx, labels, podTemplate); err != nil {
@@ -283,14 +280,12 @@ func (v *vpnSeedServer) podTemplate(configMap *corev1.ConfigMap, dhSecret, secre
 	hostPathCharDev := corev1.HostPathCharDev
 	template := &corev1.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{
-			Labels: map[string]string{
-				v1beta1constants.GardenRole:                          v1beta1constants.GardenRoleControlPlane,
-				v1beta1constants.LabelApp:                            DeploymentName,
-				v1beta1constants.LabelNetworkPolicyToShootNetworks:   v1beta1constants.LabelNetworkPolicyAllowed,
-				v1beta1constants.LabelNetworkPolicyToDNS:             v1beta1constants.LabelNetworkPolicyAllowed,
-				v1beta1constants.LabelNetworkPolicyToPrivateNetworks: v1beta1constants.LabelNetworkPolicyAllowed,
+			Labels: utils.MergeStringMaps(getLabels(), map[string]string{
+				v1beta1constants.LabelNetworkPolicyToShootNetworks:                                                          v1beta1constants.LabelNetworkPolicyAllowed,
+				v1beta1constants.LabelNetworkPolicyToDNS:                                                                    v1beta1constants.LabelNetworkPolicyAllowed,
+				v1beta1constants.LabelNetworkPolicyToPrivateNetworks:                                                        v1beta1constants.LabelNetworkPolicyAllowed,
 				gardenerutils.NetworkPolicyLabel(v1beta1constants.DeploymentNameKubeAPIServer, kubeapiserverconstants.Port): v1beta1constants.LabelNetworkPolicyAllowed,
-			},
+			}),
 		},
 		Spec: corev1.PodSpec{
 			AutomountServiceAccountToken: pointer.Bool(false),

--- a/pkg/component/vpnshoot/vpnshoot.go
+++ b/pkg/component/vpnshoot/vpnshoot.go
@@ -299,7 +299,7 @@ func (v *vpnShoot) computeResourcesData(secretCAVPN *corev1.Secret, secretsVPNSh
 			v1beta1constants.LabelApp:       LabelValue,
 			managedresources.LabelKeyOrigin: managedresources.LabelValueGardener,
 		}
-		template = v.podTemplate(serviceAccount, secretsVPNShoot, secretCA, secretTLSAuth, secretDH)
+		template = v.podTemplate(serviceAccount, secretsVPNShoot, secretCA, secretTLSAuth)
 
 		networkPolicyFromSeed = &networkingv1.NetworkPolicy{
 			ObjectMeta: metav1.ObjectMeta{
@@ -501,7 +501,7 @@ func (v *vpnShoot) podDisruptionBudget() (client.Object, error) {
 	}, nil
 }
 
-func (v *vpnShoot) podTemplate(serviceAccount *corev1.ServiceAccount, secrets []vpnSecret, secretCA, secretTLSAuth, secretDH *corev1.Secret) *corev1.PodTemplateSpec {
+func (v *vpnShoot) podTemplate(serviceAccount *corev1.ServiceAccount, secrets []vpnSecret, secretCA, secretTLSAuth *corev1.Secret) *corev1.PodTemplateSpec {
 	template := &corev1.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{
 			Labels: map[string]string{
@@ -522,7 +522,7 @@ func (v *vpnShoot) podTemplate(serviceAccount *corev1.ServiceAccount, secrets []
 				},
 			},
 			InitContainers: v.getInitContainers(),
-			Volumes:        v.getVolumes(secrets, secretCA, secretTLSAuth, secretDH),
+			Volumes:        v.getVolumes(secrets, secretCA, secretTLSAuth),
 		},
 	}
 
@@ -717,7 +717,7 @@ func (v *vpnShoot) getVolumeMounts(secrets []vpnSecret) []corev1.VolumeMount {
 	return volumeMounts
 }
 
-func (v *vpnShoot) getVolumes(secret []vpnSecret, secretCA, secretTLSAuth, secretDH *corev1.Secret) []corev1.Volume {
+func (v *vpnShoot) getVolumes(secret []vpnSecret, secretCA, secretTLSAuth *corev1.Secret) []corev1.Volume {
 	volumes := []corev1.Volume{}
 	for _, item := range secret {
 		volumes = append(volumes, corev1.Volume{

--- a/pkg/controllermanager/apis/config/validation/validation.go
+++ b/pkg/controllermanager/apis/config/validation/validation.go
@@ -133,32 +133,32 @@ func validateControllerManagerControllerConfiguration(conf config.ControllerMana
 	return allErrs
 }
 
-func validateBastionControllerConfiguration(conf *config.BastionControllerConfiguration, fldPath *field.Path) field.ErrorList {
+func validateBastionControllerConfiguration(_ *config.BastionControllerConfiguration, _ *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 	return allErrs
 }
 
-func validateCloudProfileControllerConfiguration(conf *config.CloudProfileControllerConfiguration, fldPath *field.Path) field.ErrorList {
+func validateCloudProfileControllerConfiguration(_ *config.CloudProfileControllerConfiguration, _ *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 	return allErrs
 }
 
-func validateControllerDeploymentControllerConfiguration(conf *config.ControllerDeploymentControllerConfiguration, fldPath *field.Path) field.ErrorList {
+func validateControllerDeploymentControllerConfiguration(_ *config.ControllerDeploymentControllerConfiguration, _ *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 	return allErrs
 }
 
-func validateControllerRegistrationControllerConfiguration(conf *config.ControllerRegistrationControllerConfiguration, fldPath *field.Path) field.ErrorList {
+func validateControllerRegistrationControllerConfiguration(_ *config.ControllerRegistrationControllerConfiguration, _ *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 	return allErrs
 }
 
-func validateEventControllerConfiguration(conf *config.EventControllerConfiguration, fldPath *field.Path) field.ErrorList {
+func validateEventControllerConfiguration(_ *config.EventControllerConfiguration, _ *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 	return allErrs
 }
 
-func validateExposureClassControllerConfiguration(conf *config.ExposureClassControllerConfiguration, fldPath *field.Path) field.ErrorList {
+func validateExposureClassControllerConfiguration(_ *config.ExposureClassControllerConfiguration, _ *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 	return allErrs
 }
@@ -183,57 +183,57 @@ func validateProjectQuotaConfiguration(conf config.QuotaConfiguration, fldPath *
 	return allErrs
 }
 
-func validateQuotaControllerConfiguration(conf *config.QuotaControllerConfiguration, fldPath *field.Path) field.ErrorList {
+func validateQuotaControllerConfiguration(_ *config.QuotaControllerConfiguration, _ *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 	return allErrs
 }
 
-func validateSecretBindingControllerConfiguration(conf *config.SecretBindingControllerConfiguration, fldPath *field.Path) field.ErrorList {
+func validateSecretBindingControllerConfiguration(_ *config.SecretBindingControllerConfiguration, _ *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 	return allErrs
 }
 
-func validateSeedControllerConfiguration(conf *config.SeedControllerConfiguration, fldPath *field.Path) field.ErrorList {
+func validateSeedControllerConfiguration(_ *config.SeedControllerConfiguration, _ *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 	return allErrs
 }
 
-func validateShootMaintenanceControllerConfiguration(conf config.ShootMaintenanceControllerConfiguration, fldPath *field.Path) field.ErrorList {
+func validateShootMaintenanceControllerConfiguration(_ config.ShootMaintenanceControllerConfiguration, _ *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 	return allErrs
 }
 
-func validateShootQuotaControllerConfiguration(conf *config.ShootQuotaControllerConfiguration, fldPath *field.Path) field.ErrorList {
+func validateShootQuotaControllerConfiguration(_ *config.ShootQuotaControllerConfiguration, _ *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 	return allErrs
 }
 
-func validateShootHibernationControllerConfiguration(conf config.ShootHibernationControllerConfiguration, fldPath *field.Path) field.ErrorList {
+func validateShootHibernationControllerConfiguration(_ config.ShootHibernationControllerConfiguration, _ *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 	return allErrs
 }
 
-func validateShootReferenceControllerConfiguration(conf *config.ShootReferenceControllerConfiguration, fldPath *field.Path) field.ErrorList {
+func validateShootReferenceControllerConfiguration(_ *config.ShootReferenceControllerConfiguration, _ *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 	return allErrs
 }
 
-func validateShootRetryControllerConfiguration(conf *config.ShootRetryControllerConfiguration, fldPath *field.Path) field.ErrorList {
+func validateShootRetryControllerConfiguration(_ *config.ShootRetryControllerConfiguration, _ *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 	return allErrs
 }
 
-func validateShootConditionsControllerConfiguration(conf *config.ShootConditionsControllerConfiguration, fldPath *field.Path) field.ErrorList {
+func validateShootConditionsControllerConfiguration(_ *config.ShootConditionsControllerConfiguration, _ *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 	return allErrs
 }
 
-func validateShootStatusLabelControllerConfiguration(conf *config.ShootStatusLabelControllerConfiguration, fldPath *field.Path) field.ErrorList {
+func validateShootStatusLabelControllerConfiguration(_ *config.ShootStatusLabelControllerConfiguration, _ *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 	return allErrs
 }
 
-func validateManagedSeedSetControllerConfiguration(conf *config.ManagedSeedSetControllerConfiguration, fldPath *field.Path) field.ErrorList {
+func validateManagedSeedSetControllerConfiguration(_ *config.ManagedSeedSetControllerConfiguration, _ *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 	return allErrs
 }

--- a/pkg/controllerutils/predicate/predicate.go
+++ b/pkg/controllerutils/predicate/predicate.go
@@ -160,12 +160,13 @@ func LastOperationChanged(getLastOperation func(client.Object) *gardencorev1beta
 			// so if the oldObject doesn't have the same annotation, don't enqueue it.
 			if v1beta1helper.HasOperationAnnotation(e.ObjectNew.GetAnnotations()) {
 				operation := e.ObjectNew.GetAnnotations()[v1beta1constants.GardenerOperation]
-				if operation == v1beta1constants.GardenerOperationMigrate || operation == v1beta1constants.GardenerOperationRestore {
-					// if the oldObject doesn't have the same annotation skip
-					if e.ObjectOld.GetAnnotations()[v1beta1constants.GardenerOperation] != operation {
-						return false
-					}
-				} else {
+
+				if operation != v1beta1constants.GardenerOperationMigrate && operation != v1beta1constants.GardenerOperationRestore {
+					return false
+				}
+
+				// if the oldObject doesn't have the same annotation skip
+				if e.ObjectOld.GetAnnotations()[v1beta1constants.GardenerOperation] != operation {
 					return false
 				}
 			}

--- a/pkg/gardenlet/bootstrap/bootstrap.go
+++ b/pkg/gardenlet/bootstrap/bootstrap.go
@@ -84,7 +84,7 @@ func RequestKubeconfigWithBootstrapClient(
 // DeleteBootstrapAuth checks which authentication mechanism was used to request a certificate
 // (either a bootstrap token or a service account token was used). If the latter is true then it
 // also deletes the corresponding ClusterRoleBinding.
-func DeleteBootstrapAuth(ctx context.Context, reader client.Reader, writer client.Writer, csrName, seedName string) error {
+func DeleteBootstrapAuth(ctx context.Context, reader client.Reader, writer client.Writer, csrName string) error {
 	csr := &certificatesv1.CertificateSigningRequest{}
 	if err := reader.Get(ctx, kubernetesutils.Key(csrName), csr); err != nil {
 		return err

--- a/pkg/gardenlet/bootstrap/bootstrap_test.go
+++ b/pkg/gardenlet/bootstrap/bootstrap_test.go
@@ -255,7 +255,7 @@ var _ = Describe("Bootstrap", func() {
 				Get(ctx, csrKey, gomock.AssignableToTypeOf(&certificatesv1.CertificateSigningRequest{})).
 				Return(apierrors.NewNotFound(schema.GroupResource{Resource: "CertificateSigningRequests"}, csrName))
 
-			Expect(DeleteBootstrapAuth(ctx, reader, writer, csrName, "")).NotTo(Succeed())
+			Expect(DeleteBootstrapAuth(ctx, reader, writer, csrName)).NotTo(Succeed())
 		})
 
 		It("should delete nothing because the username in the CSR does not match a known pattern", func() {
@@ -263,7 +263,7 @@ var _ = Describe("Bootstrap", func() {
 				Get(ctx, csrKey, gomock.AssignableToTypeOf(&certificatesv1.CertificateSigningRequest{})).
 				Return(nil)
 
-			Expect(DeleteBootstrapAuth(ctx, reader, writer, csrName, "")).To(Succeed())
+			Expect(DeleteBootstrapAuth(ctx, reader, writer, csrName)).To(Succeed())
 		})
 
 		It("should delete the bootstrap token secret", func() {
@@ -285,7 +285,7 @@ var _ = Describe("Bootstrap", func() {
 					Delete(ctx, bootstrapTokenSecret),
 			)
 
-			Expect(DeleteBootstrapAuth(ctx, reader, writer, csrName, "")).To(Succeed())
+			Expect(DeleteBootstrapAuth(ctx, reader, writer, csrName)).To(Succeed())
 		})
 
 		It("should delete the service account and cluster role binding", func() {
@@ -312,7 +312,7 @@ var _ = Describe("Bootstrap", func() {
 					Delete(ctx, clusterRoleBinding),
 			)
 
-			Expect(DeleteBootstrapAuth(ctx, reader, writer, csrName, seedName)).To(Succeed())
+			Expect(DeleteBootstrapAuth(ctx, reader, writer, csrName)).To(Succeed())
 		})
 	})
 })

--- a/pkg/gardenlet/controller/backupbucket/reconciler.go
+++ b/pkg/gardenlet/controller/backupbucket/reconciler.go
@@ -171,7 +171,7 @@ func (r *Reconciler) reconcileBackupBucket(
 	}
 
 	if mustReconcileExtensionSecret {
-		if err := r.reconcileBackupBucketExtensionSecret(seedCtx, extensionSecret, gardenSecret, backupBucket); err != nil {
+		if err := r.reconcileBackupBucketExtensionSecret(seedCtx, extensionSecret, gardenSecret); err != nil {
 			return reconcile.Result{}, err
 		}
 	}
@@ -284,7 +284,7 @@ func (r *Reconciler) deleteBackupBucket(
 	}
 
 	extensionSecret := r.emptyExtensionSecret(backupBucket.Name)
-	if err := r.reconcileBackupBucketExtensionSecret(seedCtx, extensionSecret, gardenSecret, backupBucket); err != nil {
+	if err := r.reconcileBackupBucketExtensionSecret(seedCtx, extensionSecret, gardenSecret); err != nil {
 		return reconcile.Result{}, err
 	}
 
@@ -351,7 +351,7 @@ func (r *Reconciler) emptyExtensionSecret(backupBucketName string) *corev1.Secre
 	}
 }
 
-func (r *Reconciler) reconcileBackupBucketExtensionSecret(ctx context.Context, extensionSecret, gardenSecret *corev1.Secret, backupBucket *gardencorev1beta1.BackupBucket) error {
+func (r *Reconciler) reconcileBackupBucketExtensionSecret(ctx context.Context, extensionSecret, gardenSecret *corev1.Secret) error {
 	_, err := controllerutils.GetAndCreateOrMergePatch(ctx, r.SeedClient, extensionSecret, func() error {
 		metav1.SetMetaDataAnnotation(&extensionSecret.ObjectMeta, v1beta1constants.GardenerTimestamp, r.Clock.Now().UTC().Format(time.RFC3339Nano))
 		extensionSecret.Data = gardenSecret.Data

--- a/pkg/gardenlet/controller/backupbucket/reconciler.go
+++ b/pkg/gardenlet/controller/backupbucket/reconciler.go
@@ -296,7 +296,7 @@ func (r *Reconciler) deleteBackupBucket(
 		if !apierrors.IsNotFound(err) {
 			return reconcile.Result{}, err
 		}
-	} else {
+	} else if err == nil {
 		if lastError := extensionBackupBucket.Status.LastError; lastError != nil {
 			r.Recorder.Event(backupBucket, corev1.EventTypeWarning, gardencorev1beta1.EventDeleteError, lastError.Description)
 

--- a/pkg/gardenlet/controller/backupentry/reconciler.go
+++ b/pkg/gardenlet/controller/backupentry/reconciler.go
@@ -353,7 +353,7 @@ func (r *Reconciler) deleteBackupEntry(
 			if !apierrors.IsNotFound(err) {
 				return reconcile.Result{}, err
 			}
-		} else {
+		} else if err == nil {
 			if lastError := extensionBackupEntry.Status.LastError; lastError != nil {
 				r.Recorder.Event(backupEntry, corev1.EventTypeWarning, gardencorev1beta1.EventDeleteError, lastError.Description)
 

--- a/pkg/gardenlet/controller/bastion/add.go
+++ b/pkg/gardenlet/controller/bastion/add.go
@@ -79,7 +79,7 @@ func (r *Reconciler) AddToManager(ctx context.Context, mgr manager.Manager, gard
 }
 
 // MapExtensionsBastionToOperationsBastion  is a mapper.MapFunc for mapping extensions Bastion in the seed cluster to operations Bastion in the project namespace.
-func (r *Reconciler) MapExtensionsBastionToOperationsBastion(ctx context.Context, log logr.Logger, reader client.Reader, obj client.Object) []reconcile.Request {
+func (r *Reconciler) MapExtensionsBastionToOperationsBastion(ctx context.Context, log logr.Logger, _ client.Reader, obj client.Object) []reconcile.Request {
 	shoot, err := extensions.GetShoot(ctx, r.SeedClient, obj.GetNamespace())
 	if err != nil {
 		log.Error(err, "Failed to get shoot from cluster", "shootTechnicalID", obj.GetNamespace())

--- a/pkg/gardenlet/controller/managedseed/charttest/charttest.go
+++ b/pkg/gardenlet/controller/managedseed/charttest/charttest.go
@@ -107,7 +107,7 @@ func getEmptyPriorityClass() *schedulingv1.PriorityClass {
 }
 
 // ValidateGardenletChartRBAC validates the RBAC resources of the Gardenlet chart.
-func ValidateGardenletChartRBAC(ctx context.Context, c client.Client, expectedLabels map[string]string, serviceAccountName string, featureGates map[string]bool) {
+func ValidateGardenletChartRBAC(ctx context.Context, c client.Client, expectedLabels map[string]string, serviceAccountName string) {
 	// ClusterRoles
 	gardenletClusterRole := getGardenletClusterRole(expectedLabels)
 	apiServerSNIClusterRole := getAPIServerSNIClusterRole(expectedLabels)

--- a/pkg/gardenlet/controller/managedseed/charttest/gardenlet_chart_test.go
+++ b/pkg/gardenlet/controller/managedseed/charttest/gardenlet_chart_test.go
@@ -268,7 +268,7 @@ var _ = Describe("#Gardenlet Chart Test", func() {
 				serviceAccountName = *deploymentConfiguration.ServiceAccountName
 			}
 
-			ValidateGardenletChartRBAC(ctx, c, expectedLabels, serviceAccountName, featureGates)
+			ValidateGardenletChartRBAC(ctx, c, expectedLabels, serviceAccountName)
 
 			ValidateGardenletChartServiceAccount(ctx, c, seedClientConnectionKubeconfig != nil, expectedLabels, serviceAccountName)
 

--- a/pkg/gardenlet/controller/shoot/shoot/cleaner.go
+++ b/pkg/gardenlet/controller/shoot/shoot/cleaner.go
@@ -107,7 +107,7 @@ func (c *Cleaner) WaitUntilExtensionObjectsDeleted(ctx context.Context) error {
 func (c *Cleaner) DeleteMachineResources(ctx context.Context) error {
 	return utilclient.ApplyToObjectKinds(ctx, func(kind string, objectList client.ObjectList) flow.TaskFn {
 		c.log.Info("Deleting all machine resources in namespace", "namespace", c.seedNamespace, "kind", kind)
-		return utilclient.ForceDeleteObjects(ctx, c.seedClient, kind, c.seedNamespace, objectList)
+		return utilclient.ForceDeleteObjects(c.seedClient, c.seedNamespace, objectList)
 	}, machineKindToObjectList)
 }
 
@@ -151,7 +151,7 @@ func (c *Cleaner) WaitUntilManagedResourcesDeleted(ctx context.Context) error {
 func (c *Cleaner) DeleteKubernetesResources(ctx context.Context) error {
 	return utilclient.ApplyToObjectKinds(ctx, func(kind string, objectList client.ObjectList) flow.TaskFn {
 		c.log.Info("Deleting all resources in namespace", "namespace", c.seedNamespace, "kind", kind)
-		return utilclient.ForceDeleteObjects(ctx, c.seedClient, kind, c.seedNamespace, objectList)
+		return utilclient.ForceDeleteObjects(c.seedClient, c.seedNamespace, objectList)
 	}, kubernetesKindToObjectList)
 }
 

--- a/pkg/gardenlet/controller/shoot/shoot/cleaner_test.go
+++ b/pkg/gardenlet/controller/shoot/shoot/cleaner_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package shoot_test
+package shoot
 
 import (
 	"context"
@@ -33,12 +33,11 @@ import (
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
-	. "github.com/gardener/gardener/pkg/gardenlet/controller/shoot/shoot"
 	"github.com/gardener/gardener/pkg/utils/test"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 )
 
-var _ = Describe("Cleaner", func() {
+var _ = Describe("cleaner", func() {
 	var (
 		ctx = context.Background()
 
@@ -49,7 +48,7 @@ var _ = Describe("Cleaner", func() {
 		namespace      = "some-namespace"
 		otherNamespace = "other-namespace"
 		finalizer      = "some-finalizer"
-		cleaner        *Cleaner
+		cleaner        *cleaner
 
 		secret1              *corev1.Secret
 		secret2              *corev1.Secret

--- a/pkg/operation/botanist/botanist.go
+++ b/pkg/operation/botanist/botanist.go
@@ -259,5 +259,5 @@ func (b *Botanist) RequiredExtensionsReady(ctx context.Context) error {
 // with dot "." suffix. It'll prevent extra requests to the DNS in case the record is not
 // available.
 func (b *Botanist) outOfClusterAPIServerFQDN() string {
-	return fmt.Sprintf("%s.", b.Shoot.ComputeOutOfClusterAPIServerAddress(b.APIServerAddress, true))
+	return fmt.Sprintf("%s.", b.Shoot.ComputeOutOfClusterAPIServerAddress(true))
 }

--- a/pkg/operation/botanist/dependency_watchdog.go
+++ b/pkg/operation/botanist/dependency_watchdog.go
@@ -31,7 +31,7 @@ func (b *Botanist) DefaultDependencyWatchdogAccess() component.Deployer {
 		b.SecretsManager,
 		dependencywatchdog.AccessValues{
 			ServerInCluster:    b.Shoot.ComputeInClusterAPIServerAddress(false),
-			ServerOutOfCluster: b.Shoot.ComputeOutOfClusterAPIServerAddress(b.APIServerAddress, true),
+			ServerOutOfCluster: b.Shoot.ComputeOutOfClusterAPIServerAddress(true),
 		},
 	)
 }

--- a/pkg/operation/botanist/gardeneraccess.go
+++ b/pkg/operation/botanist/gardeneraccess.go
@@ -28,7 +28,7 @@ func (b *Botanist) DefaultGardenerAccess() component.Deployer {
 		b.SecretsManager,
 		gardeneraccess.Values{
 			ServerInCluster:    b.Shoot.ComputeInClusterAPIServerAddress(false),
-			ServerOutOfCluster: b.Shoot.ComputeOutOfClusterAPIServerAddress(b.APIServerAddress, true),
+			ServerOutOfCluster: b.Shoot.ComputeOutOfClusterAPIServerAddress(true),
 		},
 	)
 }

--- a/pkg/operation/botanist/kubeapiserver.go
+++ b/pkg/operation/botanist/kubeapiserver.go
@@ -232,7 +232,7 @@ func (b *Botanist) computeKubeAPIServerSNIConfig() kubeapiserver.SNIConfig {
 
 // DeployKubeAPIServer deploys the Kubernetes API server.
 func (b *Botanist) DeployKubeAPIServer(ctx context.Context) error {
-	externalServer := b.Shoot.ComputeOutOfClusterAPIServerAddress(b.APIServerAddress, false)
+	externalServer := b.Shoot.ComputeOutOfClusterAPIServerAddress(false)
 
 	if err := shared.DeployKubeAPIServer(
 		ctx,
@@ -242,7 +242,7 @@ func (b *Botanist) DeployKubeAPIServer(ctx context.Context) error {
 		b.Shoot.GetInfo().Spec.Kubernetes.KubeAPIServer,
 		b.computeKubeAPIServerServerCertificateConfig(),
 		b.computeKubeAPIServerSNIConfig(),
-		b.Shoot.ComputeOutOfClusterAPIServerAddress(b.APIServerAddress, true),
+		b.Shoot.ComputeOutOfClusterAPIServerAddress(true),
 		externalServer,
 		v1beta1helper.GetShootETCDEncryptionKeyRotationPhase(b.Shoot.GetInfo().Status.Credentials),
 		v1beta1helper.GetShootServiceAccountKeyRotationPhase(b.Shoot.GetInfo().Status.Credentials),

--- a/pkg/operation/botanist/kubeproxy.go
+++ b/pkg/operation/botanist/kubeproxy.go
@@ -70,7 +70,7 @@ func (b *Botanist) DeployKubeProxy(ctx context.Context) error {
 	kubeconfig, err := runtime.Encode(clientcmdlatest.Codec, kubernetesutils.NewKubeconfig(
 		b.Shoot.SeedNamespace,
 		clientcmdv1.Cluster{
-			Server:                   b.Shoot.ComputeOutOfClusterAPIServerAddress(b.APIServerAddress, true),
+			Server:                   b.Shoot.ComputeOutOfClusterAPIServerAddress(true),
 			CertificateAuthorityData: caSecret.Data[secrets.DataKeyCertificateBundle],
 		},
 		clientcmdv1.AuthInfo{TokenFile: "/var/run/secrets/kubernetes.io/serviceaccount/token"},

--- a/pkg/operation/botanist/kubescheduler.go
+++ b/pkg/operation/botanist/kubescheduler.go
@@ -35,6 +35,5 @@ func (b *Botanist) DefaultKubeScheduler() (kubescheduler.Interface, error) {
 		image.String(),
 		b.Shoot.GetReplicas(1),
 		b.Shoot.GetInfo().Spec.Kubernetes.KubeScheduler,
-		b.Seed.KubernetesVersion,
 	), nil
 }

--- a/pkg/operation/botanist/operatingsystemconfig.go
+++ b/pkg/operation/botanist/operatingsystemconfig.go
@@ -99,7 +99,7 @@ func (b *Botanist) DeployOperatingSystemConfig(ctx context.Context) error {
 		return fmt.Errorf("secret %q not found", v1beta1constants.SecretNameCACluster)
 	}
 
-	b.Shoot.Components.Extensions.OperatingSystemConfig.SetAPIServerURL(fmt.Sprintf("https://%s", b.Shoot.ComputeOutOfClusterAPIServerAddress(b.APIServerAddress, true)))
+	b.Shoot.Components.Extensions.OperatingSystemConfig.SetAPIServerURL(fmt.Sprintf("https://%s", b.Shoot.ComputeOutOfClusterAPIServerAddress(true)))
 	b.Shoot.Components.Extensions.OperatingSystemConfig.SetCABundle(b.getOperatingSystemConfigCABundle(clusterCASecret.Data[secretsutils.DataKeyCertificateBundle]))
 
 	if v1beta1helper.ShootEnablesSSHAccess(b.Shoot.GetInfo()) {

--- a/pkg/operation/botanist/resource_manager.go
+++ b/pkg/operation/botanist/resource_manager.go
@@ -61,7 +61,7 @@ func (b *Botanist) DefaultResourceManager() (resourcemanager.Interface, error) {
 		v1beta1constants.SecretNameCACluster,
 		gardenerutils.ExtractSystemComponentsTolerations(b.Shoot.GetInfo().Spec.Provider.Workers),
 		b.Shoot.TopologyAwareRoutingEnabled,
-		pointer.String(b.Shoot.ComputeOutOfClusterAPIServerAddress(b.APIServerAddress, true)),
+		pointer.String(b.Shoot.ComputeOutOfClusterAPIServerAddress(true)),
 		b.Shoot.IsWorkerless,
 		[]string{metav1.NamespaceSystem, v1beta1constants.KubernetesDashboardNamespace},
 	)

--- a/pkg/operation/botanist/waiter.go
+++ b/pkg/operation/botanist/waiter.go
@@ -96,15 +96,14 @@ func (b *Botanist) WaitUntilNoPodRunning(ctx context.Context) error {
 func (b *Botanist) WaitUntilEndpointsDoNotContainPodIPs(ctx context.Context) error {
 	b.Logger.Info("Waiting until there are no Endpoints containing Pod IPs in the shoot cluster")
 
-	var podsNetwork *net.IPNet
-	if val := b.Shoot.GetInfo().Spec.Networking.Pods; val != nil {
-		var err error
-		_, podsNetwork, err = net.ParseCIDR(*val)
-		if err != nil {
-			return fmt.Errorf("unable to check if there are still Endpoints containing Pod IPs in the shoot cluster. Shoots's Pods network could not be parsed: %+v", err)
-		}
-	} else {
+	val := b.Shoot.GetInfo().Spec.Networking.Pods
+	if val == nil {
 		return fmt.Errorf("unable to check if there are still Endpoints containing Pod IPs in the shoot cluster. Shoot's Pods network is empty")
+	}
+
+	_, podsNetwork, err := net.ParseCIDR(*val)
+	if err != nil {
+		return fmt.Errorf("unable to check if there are still Endpoints containing Pod IPs in the shoot cluster. Shoots's Pods network could not be parsed: %+v", err)
 	}
 
 	return retry.Until(ctx, 5*time.Second, func(ctx context.Context) (done bool, err error) {

--- a/pkg/operation/common/utils.go
+++ b/pkg/operation/common/utils.go
@@ -240,7 +240,7 @@ func deleteValiPvc(ctx context.Context, k8sClient client.Client, namespace strin
 }
 
 // assertPvStillExists asserts that the PV formerly used by the "loki-loki-0" PVC still exists.
-func assertPvStillExists(ctx context.Context, k8sClient client.Client, namespace string, pv *corev1.PersistentVolume, log logr.Logger) (isDeleted bool, err error) {
+func assertPvStillExists(ctx context.Context, k8sClient client.Client, namespace string, pv *corev1.PersistentVolume) (isDeleted bool, err error) {
 	if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(pv), pv); err != nil {
 		if apierrors.IsNotFound(err) {
 			return true, fmt.Errorf("Loki2vali: %v: Loki PV is deleted, %w", namespace, err)
@@ -387,7 +387,7 @@ func RenameLokiPvcToValiPvc(ctx context.Context, k8sClient client.Client, namesp
 		return errs
 	}
 
-	isDeleted, err := assertPvStillExists(ctx, k8sClient, namespace, pv, log)
+	isDeleted, err := assertPvStillExists(ctx, k8sClient, namespace, pv)
 	if err != nil {
 		recoveryContext, cancel := context.WithDeadline(context.TODO(), time.Now().Add(1*time.Minute))
 		defer cancel()

--- a/pkg/operation/shoot/shoot.go
+++ b/pkg/operation/shoot/shoot.go
@@ -439,7 +439,7 @@ func (s *Shoot) ComputeInClusterAPIServerAddress(runsInShootNamespace bool) stri
 
 // ComputeOutOfClusterAPIServerAddress returns the external address for the shoot API server depending on whether
 // the caller wants to use the internal cluster domain and whether DNS is disabled on this seed.
-func (s *Shoot) ComputeOutOfClusterAPIServerAddress(apiServerAddress string, useInternalClusterDomain bool) string {
+func (s *Shoot) ComputeOutOfClusterAPIServerAddress(useInternalClusterDomain bool) string {
 	if v1beta1helper.ShootUsesUnmanagedDNS(s.GetInfo()) {
 		return gardenerutils.GetAPIServerDomain(s.InternalClusterDomain)
 	}

--- a/pkg/operation/shoot/shoot.go
+++ b/pkg/operation/shoot/shoot.go
@@ -481,13 +481,13 @@ func ToNetworks(s *gardencorev1beta1.Shoot, workerless bool) (*Networks, error) 
 		return nil, fmt.Errorf("shoot's pods cidr is empty")
 	}
 
-	if s.Spec.Networking.Services != nil {
-		_, svc, err = net.ParseCIDR(*s.Spec.Networking.Services)
-		if err != nil {
-			return nil, fmt.Errorf("cannot parse shoot's network cidr %w", err)
-		}
-	} else {
+	if s.Spec.Networking.Services == nil {
 		return nil, fmt.Errorf("shoot's service cidr is empty")
+	}
+
+	_, svc, err = net.ParseCIDR(*s.Spec.Networking.Services)
+	if err != nil {
+		return nil, fmt.Errorf("cannot parse shoot's network cidr %w", err)
 	}
 
 	apiserver, err := utils.ComputeOffsetIP(svc, 1)

--- a/pkg/operation/shoot/shoot_test.go
+++ b/pkg/operation/shoot/shoot_test.go
@@ -174,7 +174,7 @@ var _ = Describe("shoot", func() {
 					},
 				})
 
-				Expect(s.ComputeOutOfClusterAPIServerAddress("", false)).To(Equal("api." + internalDomain))
+				Expect(s.ComputeOutOfClusterAPIServerAddress(false)).To(Equal("api." + internalDomain))
 			})
 
 			It("should return the internal domain as requested (shoot's external domain is not unmanaged)", func() {
@@ -184,7 +184,7 @@ var _ = Describe("shoot", func() {
 				}
 				s.SetInfo(&gardencorev1beta1.Shoot{})
 
-				Expect(s.ComputeOutOfClusterAPIServerAddress("", true)).To(Equal("api." + internalDomain))
+				Expect(s.ComputeOutOfClusterAPIServerAddress(true)).To(Equal("api." + internalDomain))
 			})
 
 			It("should return the external domain as requested (shoot's external domain is not unmanaged)", func() {
@@ -194,7 +194,7 @@ var _ = Describe("shoot", func() {
 				}
 				s.SetInfo(&gardencorev1beta1.Shoot{})
 
-				Expect(s.ComputeOutOfClusterAPIServerAddress("", false)).To(Equal("api." + externalDomain))
+				Expect(s.ComputeOutOfClusterAPIServerAddress(false)).To(Equal("api." + externalDomain))
 			})
 		})
 	})

--- a/pkg/operation/shoot/types.go
+++ b/pkg/operation/shoot/types.go
@@ -75,8 +75,7 @@ type Shoot struct {
 	info      atomic.Value
 	infoMutex sync.Mutex
 
-	shootState      atomic.Value
-	shootStateMutex sync.Mutex
+	shootState atomic.Value
 
 	Secret       *corev1.Secret
 	CloudProfile *gardencorev1beta1.CloudProfile

--- a/pkg/provider-local/controller/extension/seed/actuator.go
+++ b/pkg/provider-local/controller/extension/seed/actuator.go
@@ -50,7 +50,7 @@ func NewActuator(mgr manager.Manager) extension.Actuator {
 }
 
 // Reconcile the extension resource.
-func (a *actuator) Reconcile(ctx context.Context, log logr.Logger, ex *extensionsv1alpha1.Extension) error {
+func (a *actuator) Reconcile(ctx context.Context, _ logr.Logger, ex *extensionsv1alpha1.Extension) error {
 	namespace := ex.Namespace
 	seedResources, err := getSeedResources(namespace)
 	if err != nil {
@@ -68,7 +68,7 @@ func (a *actuator) Reconcile(ctx context.Context, log logr.Logger, ex *extension
 }
 
 // Delete the extension resource.
-func (a *actuator) Delete(ctx context.Context, log logr.Logger, ex *extensionsv1alpha1.Extension) error {
+func (a *actuator) Delete(ctx context.Context, _ logr.Logger, ex *extensionsv1alpha1.Extension) error {
 	namespace := ex.GetNamespace()
 	twoMinutes := 2 * time.Minute
 

--- a/pkg/provider-local/controller/extension/shoot/actuator.go
+++ b/pkg/provider-local/controller/extension/shoot/actuator.go
@@ -42,8 +42,10 @@ const (
 	// ApplicationName is the name of the application.
 	ApplicationName string = "local-ext-shoot"
 	// ManagedResourceNamesShoot is the name used to describe the managed shoot resources.
-	ManagedResourceNamesShoot      string = ApplicationName
-	finalizer                      string = "extensions.gardener.cloud/local-ext-shoot"
+	ManagedResourceNamesShoot string = ApplicationName
+	finalizer                 string = "extensions.gardener.cloud/local-ext-shoot"
+	// AnnotationTestForceDeleteShoot is an annotation used in the force-deletion e2e test which makes this actuator
+	// deploy two empty NetworkPolicies with a finalizer.
 	AnnotationTestForceDeleteShoot string = "test-force-delete"
 )
 

--- a/pkg/provider-local/controller/extension/shoot/actuator.go
+++ b/pkg/provider-local/controller/extension/shoot/actuator.go
@@ -59,7 +59,7 @@ func NewActuator(mgr manager.Manager) extension.Actuator {
 }
 
 // Reconcile the extension resource.
-func (a *actuator) Reconcile(ctx context.Context, log logr.Logger, ex *extensionsv1alpha1.Extension) error {
+func (a *actuator) Reconcile(ctx context.Context, _ logr.Logger, ex *extensionsv1alpha1.Extension) error {
 	namespace := ex.Namespace
 
 	shootResources, err := getShootResources()
@@ -118,7 +118,7 @@ func (a *actuator) Reconcile(ctx context.Context, log logr.Logger, ex *extension
 }
 
 // Delete the extension resource.
-func (a *actuator) Delete(ctx context.Context, log logr.Logger, ex *extensionsv1alpha1.Extension) error {
+func (a *actuator) Delete(ctx context.Context, _ logr.Logger, ex *extensionsv1alpha1.Extension) error {
 	namespace := ex.GetNamespace()
 	twoMinutes := 2 * time.Minute
 
@@ -136,14 +136,7 @@ func (a *actuator) Delete(ctx context.Context, log logr.Logger, ex *extensionsv1
 func (a *actuator) ForceDelete(ctx context.Context, log logr.Logger, ex *extensionsv1alpha1.Extension) error {
 	log.Info("Deleting all test NetworkPolicies in namespace", "namespace", ex.Namespace)
 	return flow.Parallel(
-		utilclient.ForceDeleteObjects(
-			ctx,
-			a.client,
-			"NetworkPolicy",
-			ex.Namespace,
-			&networkingv1.NetworkPolicyList{},
-			client.MatchingLabels(getLabels()),
-		),
+		utilclient.ForceDeleteObjects(a.client, ex.Namespace, &networkingv1.NetworkPolicyList{}, client.MatchingLabels(getLabels())),
 	)(ctx)
 }
 

--- a/pkg/provider-local/controller/infrastructure/actuator.go
+++ b/pkg/provider-local/controller/infrastructure/actuator.go
@@ -42,7 +42,7 @@ func NewActuator(mgr manager.Manager) infrastructure.Actuator {
 	}
 }
 
-func (a *actuator) Reconcile(ctx context.Context, _ logr.Logger, infrastructure *extensionsv1alpha1.Infrastructure, cluster *extensionscontroller.Cluster) error {
+func (a *actuator) Reconcile(ctx context.Context, _ logr.Logger, infrastructure *extensionsv1alpha1.Infrastructure, _ *extensionscontroller.Cluster) error {
 	networkPolicyAllowToMachinePods := emptyNetworkPolicy("allow-to-machine-pods", infrastructure.Namespace)
 	networkPolicyAllowToMachinePods.Spec = networkingv1.NetworkPolicySpec{
 		Egress: []networkingv1.NetworkPolicyEgressRule{{

--- a/pkg/provider-local/webhook/controlplane/ensurer.go
+++ b/pkg/provider-local/webhook/controlplane/ensurer.go
@@ -54,7 +54,7 @@ type ensurer struct {
 }
 
 // EnsureMachineControllerManagerDeployment ensures that the machine-controller-manager deployment conforms to the provider requirements.
-func (e *ensurer) EnsureMachineControllerManagerDeployment(ctx context.Context, gctx extensionscontextwebhook.GardenContext, newObj, _ *appsv1.Deployment) error {
+func (e *ensurer) EnsureMachineControllerManagerDeployment(_ context.Context, _ extensionscontextwebhook.GardenContext, newObj, _ *appsv1.Deployment) error {
 	if !e.gardenletManagesMCM {
 		return nil
 	}
@@ -105,7 +105,7 @@ func (e *ensurer) EnsureKubeletConfiguration(_ context.Context, _ extensionscont
 	return nil
 }
 
-func (e *ensurer) EnsureAdditionalFiles(ctx context.Context, gc extensionscontextwebhook.GardenContext, new, _ *[]extensionsv1alpha1.File) error {
+func (e *ensurer) EnsureAdditionalFiles(_ context.Context, _ extensionscontextwebhook.GardenContext, new, _ *[]extensionsv1alpha1.File) error {
 	mirrors := []RegistryMirror{
 		{UpstreamHost: "localhost:5001", UpstreamServer: "http://localhost:5001", MirrorHost: "http://garden.local.gardener.cloud:5001"},
 		{UpstreamHost: "gcr.io", UpstreamServer: "https://gcr.io", MirrorHost: "http://garden.local.gardener.cloud:5003"},

--- a/pkg/registry/core/backupbucket/storage/tableconvertor.go
+++ b/pkg/registry/core/backupbucket/storage/tableconvertor.go
@@ -47,7 +47,7 @@ func newTableConvertor() rest.TableConvertor {
 }
 
 // ConvertToTable converts the output to a table.
-func (c *convertor) ConvertToTable(ctx context.Context, obj runtime.Object, tableOptions runtime.Object) (*metav1beta1.Table, error) {
+func (c *convertor) ConvertToTable(_ context.Context, obj runtime.Object, _ runtime.Object) (*metav1beta1.Table, error) {
 	var (
 		err   error
 		table = &metav1beta1.Table{

--- a/pkg/registry/core/backupbucket/strategy.go
+++ b/pkg/registry/core/backupbucket/strategy.go
@@ -46,14 +46,14 @@ func (backupBucketStrategy) NamespaceScoped() bool {
 	return false
 }
 
-func (backupBucketStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object) {
+func (backupBucketStrategy) PrepareForCreate(_ context.Context, obj runtime.Object) {
 	backupBucket := obj.(*core.BackupBucket)
 
 	backupBucket.Generation = 1
 	backupBucket.Status = core.BackupBucketStatus{}
 }
 
-func (backupBucketStrategy) PrepareForUpdate(ctx context.Context, obj, old runtime.Object) {
+func (backupBucketStrategy) PrepareForUpdate(_ context.Context, obj, old runtime.Object) {
 	newBackupBucket := obj.(*core.BackupBucket)
 	oldBackupBucket := old.(*core.BackupBucket)
 	newBackupBucket.Status = oldBackupBucket.Status
@@ -82,19 +82,19 @@ func mustIncreaseGeneration(oldBackupBucket, newBackupBucket *core.BackupBucket)
 	return false
 }
 
-func (backupBucketStrategy) Validate(ctx context.Context, obj runtime.Object) field.ErrorList {
+func (backupBucketStrategy) Validate(_ context.Context, obj runtime.Object) field.ErrorList {
 	backupBucket := obj.(*core.BackupBucket)
 	return validation.ValidateBackupBucket(backupBucket)
 }
 
-func (backupBucketStrategy) Canonicalize(obj runtime.Object) {
+func (backupBucketStrategy) Canonicalize(_ runtime.Object) {
 }
 
 func (backupBucketStrategy) AllowCreateOnUpdate() bool {
 	return false
 }
 
-func (backupBucketStrategy) ValidateUpdate(ctx context.Context, newObj, oldObj runtime.Object) field.ErrorList {
+func (backupBucketStrategy) ValidateUpdate(_ context.Context, newObj, oldObj runtime.Object) field.ErrorList {
 	oldBackupBucket, newBackupBucket := oldObj.(*core.BackupBucket), newObj.(*core.BackupBucket)
 	return validation.ValidateBackupBucketUpdate(newBackupBucket, oldBackupBucket)
 }
@@ -104,12 +104,12 @@ func (backupBucketStrategy) AllowUnconditionalUpdate() bool {
 }
 
 // WarningsOnCreate returns warnings to the client performing a create.
-func (backupBucketStrategy) WarningsOnCreate(ctx context.Context, obj runtime.Object) []string {
+func (backupBucketStrategy) WarningsOnCreate(_ context.Context, _ runtime.Object) []string {
 	return nil
 }
 
 // WarningsOnUpdate returns warnings to the client performing the update.
-func (backupBucketStrategy) WarningsOnUpdate(ctx context.Context, obj, old runtime.Object) []string {
+func (backupBucketStrategy) WarningsOnUpdate(_ context.Context, _, _ runtime.Object) []string {
 	return nil
 }
 
@@ -120,13 +120,13 @@ type backupBucketStatusStrategy struct {
 // StatusStrategy defines the storage strategy for the status subresource of BackupBuckets.
 var StatusStrategy = backupBucketStatusStrategy{Strategy}
 
-func (backupBucketStatusStrategy) PrepareForUpdate(ctx context.Context, obj, old runtime.Object) {
+func (backupBucketStatusStrategy) PrepareForUpdate(_ context.Context, obj, old runtime.Object) {
 	newBackupBucket := obj.(*core.BackupBucket)
 	oldBackupBucket := old.(*core.BackupBucket)
 	newBackupBucket.Spec = oldBackupBucket.Spec
 }
 
-func (backupBucketStatusStrategy) ValidateUpdate(ctx context.Context, obj, old runtime.Object) field.ErrorList {
+func (backupBucketStatusStrategy) ValidateUpdate(_ context.Context, obj, old runtime.Object) field.ErrorList {
 	return validation.ValidateBackupBucketStatusUpdate(obj.(*core.BackupBucket), old.(*core.BackupBucket))
 }
 

--- a/pkg/registry/core/backupentry/storage/tableconvertor.go
+++ b/pkg/registry/core/backupentry/storage/tableconvertor.go
@@ -47,7 +47,7 @@ func newTableConvertor() rest.TableConvertor {
 }
 
 // ConvertToTable converts the output to a table.
-func (c *convertor) ConvertToTable(ctx context.Context, obj runtime.Object, tableOptions runtime.Object) (*metav1beta1.Table, error) {
+func (c *convertor) ConvertToTable(_ context.Context, obj runtime.Object, _ runtime.Object) (*metav1beta1.Table, error) {
 	var (
 		err   error
 		table = &metav1beta1.Table{

--- a/pkg/registry/core/backupentry/strategy.go
+++ b/pkg/registry/core/backupentry/strategy.go
@@ -52,14 +52,14 @@ func (backupEntryStrategy) NamespaceScoped() bool {
 	return true
 }
 
-func (backupEntryStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object) {
+func (backupEntryStrategy) PrepareForCreate(_ context.Context, obj runtime.Object) {
 	backupEntry := obj.(*core.BackupEntry)
 
 	backupEntry.Generation = 1
 	backupEntry.Status = core.BackupEntryStatus{}
 }
 
-func (backupEntryStrategy) PrepareForUpdate(ctx context.Context, obj, old runtime.Object) {
+func (backupEntryStrategy) PrepareForUpdate(_ context.Context, obj, old runtime.Object) {
 	newBackupEntry := obj.(*core.BackupEntry)
 	oldBackupEntry := old.(*core.BackupEntry)
 	newBackupEntry.Status = oldBackupEntry.Status
@@ -104,19 +104,19 @@ func mustIncreaseGeneration(oldBackupEntry, newBackupEntry *core.BackupEntry) bo
 	return false
 }
 
-func (backupEntryStrategy) Validate(ctx context.Context, obj runtime.Object) field.ErrorList {
+func (backupEntryStrategy) Validate(_ context.Context, obj runtime.Object) field.ErrorList {
 	backupEntry := obj.(*core.BackupEntry)
 	return validation.ValidateBackupEntry(backupEntry)
 }
 
-func (backupEntryStrategy) Canonicalize(obj runtime.Object) {
+func (backupEntryStrategy) Canonicalize(_ runtime.Object) {
 }
 
 func (backupEntryStrategy) AllowCreateOnUpdate() bool {
 	return false
 }
 
-func (backupEntryStrategy) ValidateUpdate(ctx context.Context, newObj, oldObj runtime.Object) field.ErrorList {
+func (backupEntryStrategy) ValidateUpdate(_ context.Context, newObj, oldObj runtime.Object) field.ErrorList {
 	oldBackupEntry, newBackupEntry := oldObj.(*core.BackupEntry), newObj.(*core.BackupEntry)
 	return validation.ValidateBackupEntryUpdate(newBackupEntry, oldBackupEntry)
 }
@@ -126,12 +126,12 @@ func (backupEntryStrategy) AllowUnconditionalUpdate() bool {
 }
 
 // WarningsOnCreate returns warnings to the client performing a create.
-func (backupEntryStrategy) WarningsOnCreate(ctx context.Context, obj runtime.Object) []string {
+func (backupEntryStrategy) WarningsOnCreate(_ context.Context, _ runtime.Object) []string {
 	return nil
 }
 
 // WarningsOnUpdate returns warnings to the client performing the update.
-func (backupEntryStrategy) WarningsOnUpdate(ctx context.Context, obj, old runtime.Object) []string {
+func (backupEntryStrategy) WarningsOnUpdate(_ context.Context, _, _ runtime.Object) []string {
 	return nil
 }
 
@@ -142,13 +142,13 @@ type backupEntryStatusStrategy struct {
 // StatusStrategy defines the storage strategy for the status subresource of BackupEntries.
 var StatusStrategy = backupEntryStatusStrategy{Strategy}
 
-func (backupEntryStatusStrategy) PrepareForUpdate(ctx context.Context, obj, old runtime.Object) {
+func (backupEntryStatusStrategy) PrepareForUpdate(_ context.Context, obj, old runtime.Object) {
 	newBackupEntry := obj.(*core.BackupEntry)
 	oldBackupEntry := old.(*core.BackupEntry)
 	newBackupEntry.Spec = oldBackupEntry.Spec
 }
 
-func (backupEntryStatusStrategy) ValidateUpdate(ctx context.Context, obj, old runtime.Object) field.ErrorList {
+func (backupEntryStatusStrategy) ValidateUpdate(_ context.Context, obj, old runtime.Object) field.ErrorList {
 	return validation.ValidateBackupEntryStatusUpdate(obj.(*core.BackupEntry), old.(*core.BackupEntry))
 }
 

--- a/pkg/registry/core/cloudprofile/storage/tableconvertor.go
+++ b/pkg/registry/core/cloudprofile/storage/tableconvertor.go
@@ -44,7 +44,7 @@ func newTableConvertor() rest.TableConvertor {
 }
 
 // ConvertToTable converts the output to a table.
-func (c *convertor) ConvertToTable(ctx context.Context, obj runtime.Object, tableOptions runtime.Object) (*metav1beta1.Table, error) {
+func (c *convertor) ConvertToTable(_ context.Context, obj runtime.Object, _ runtime.Object) (*metav1beta1.Table, error) {
 	var (
 		err   error
 		table = &metav1beta1.Table{

--- a/pkg/registry/core/cloudprofile/strategy.go
+++ b/pkg/registry/core/cloudprofile/strategy.go
@@ -39,25 +39,25 @@ func (cloudProfileStrategy) NamespaceScoped() bool {
 	return false
 }
 
-func (cloudProfileStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object) {
+func (cloudProfileStrategy) PrepareForCreate(_ context.Context, obj runtime.Object) {
 	cloudprofile := obj.(*core.CloudProfile)
 
 	dropExpiredVersions(cloudprofile)
 }
 
-func (cloudProfileStrategy) Validate(ctx context.Context, obj runtime.Object) field.ErrorList {
+func (cloudProfileStrategy) Validate(_ context.Context, obj runtime.Object) field.ErrorList {
 	cloudprofile := obj.(*core.CloudProfile)
 	return validation.ValidateCloudProfile(cloudprofile)
 }
 
-func (cloudProfileStrategy) Canonicalize(obj runtime.Object) {
+func (cloudProfileStrategy) Canonicalize(_ runtime.Object) {
 }
 
 func (cloudProfileStrategy) AllowCreateOnUpdate() bool {
 	return false
 }
 
-func (cloudProfileStrategy) PrepareForUpdate(ctx context.Context, newObj, oldObj runtime.Object) {
+func (cloudProfileStrategy) PrepareForUpdate(_ context.Context, newObj, oldObj runtime.Object) {
 	_ = oldObj.(*core.CloudProfile)
 	_ = newObj.(*core.CloudProfile)
 }
@@ -66,18 +66,18 @@ func (cloudProfileStrategy) AllowUnconditionalUpdate() bool {
 	return true
 }
 
-func (cloudProfileStrategy) ValidateUpdate(ctx context.Context, newObj, oldObj runtime.Object) field.ErrorList {
+func (cloudProfileStrategy) ValidateUpdate(_ context.Context, newObj, oldObj runtime.Object) field.ErrorList {
 	oldProfile, newProfile := oldObj.(*core.CloudProfile), newObj.(*core.CloudProfile)
 	return validation.ValidateCloudProfileUpdate(newProfile, oldProfile)
 }
 
 // WarningsOnCreate returns warnings to the client performing a create.
-func (cloudProfileStrategy) WarningsOnCreate(ctx context.Context, obj runtime.Object) []string {
+func (cloudProfileStrategy) WarningsOnCreate(_ context.Context, _ runtime.Object) []string {
 	return nil
 }
 
 // WarningsOnUpdate returns warnings to the client performing the update.
-func (cloudProfileStrategy) WarningsOnUpdate(ctx context.Context, obj, old runtime.Object) []string {
+func (cloudProfileStrategy) WarningsOnUpdate(_ context.Context, _, _ runtime.Object) []string {
 	return nil
 }
 

--- a/pkg/registry/core/controllerdeployment/storage/tableconvertor.go
+++ b/pkg/registry/core/controllerdeployment/storage/tableconvertor.go
@@ -43,7 +43,7 @@ func newTableConvertor() rest.TableConvertor {
 }
 
 // ConvertToTable converts the output to a table.
-func (c *convertor) ConvertToTable(ctx context.Context, o runtime.Object, tableOptions runtime.Object) (*metav1beta1.Table, error) {
+func (c *convertor) ConvertToTable(_ context.Context, o runtime.Object, _ runtime.Object) (*metav1beta1.Table, error) {
 	var (
 		err   error
 		table = &metav1beta1.Table{

--- a/pkg/registry/core/controllerdeployment/strategy.go
+++ b/pkg/registry/core/controllerdeployment/strategy.go
@@ -92,11 +92,11 @@ func (controllerDeploymentStrategy) AllowUnconditionalUpdate() bool {
 }
 
 // WarningsOnCreate returns warnings to the client performing a create.
-func (controllerDeploymentStrategy) WarningsOnCreate(ctx context.Context, obj runtime.Object) []string {
+func (controllerDeploymentStrategy) WarningsOnCreate(_ context.Context, _ runtime.Object) []string {
 	return nil
 }
 
 // WarningsOnUpdate returns warnings to the client performing the update.
-func (controllerDeploymentStrategy) WarningsOnUpdate(ctx context.Context, obj, old runtime.Object) []string {
+func (controllerDeploymentStrategy) WarningsOnUpdate(_ context.Context, _, _ runtime.Object) []string {
 	return nil
 }

--- a/pkg/registry/core/controllerinstallation/storage/tableconvertor.go
+++ b/pkg/registry/core/controllerinstallation/storage/tableconvertor.go
@@ -50,7 +50,7 @@ func newTableConvertor() rest.TableConvertor {
 }
 
 // ConvertToTable converts the output to a table.
-func (c *convertor) ConvertToTable(ctx context.Context, o runtime.Object, tableOptions runtime.Object) (*metav1beta1.Table, error) {
+func (c *convertor) ConvertToTable(_ context.Context, o runtime.Object, _ runtime.Object) (*metav1beta1.Table, error) {
 	var (
 		err   error
 		table = &metav1beta1.Table{

--- a/pkg/registry/core/controllerinstallation/strategy.go
+++ b/pkg/registry/core/controllerinstallation/strategy.go
@@ -44,14 +44,14 @@ func (controllerInstallationStrategy) NamespaceScoped() bool {
 	return false
 }
 
-func (controllerInstallationStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object) {
+func (controllerInstallationStrategy) PrepareForCreate(_ context.Context, obj runtime.Object) {
 	controllerInstallation := obj.(*core.ControllerInstallation)
 
 	controllerInstallation.Generation = 1
 	controllerInstallation.Status = core.ControllerInstallationStatus{}
 }
 
-func (controllerInstallationStrategy) PrepareForUpdate(ctx context.Context, obj, old runtime.Object) {
+func (controllerInstallationStrategy) PrepareForUpdate(_ context.Context, obj, old runtime.Object) {
 	newControllerInstallation := obj.(*core.ControllerInstallation)
 	oldControllerInstallation := old.(*core.ControllerInstallation)
 	newControllerInstallation.Status = oldControllerInstallation.Status
@@ -75,19 +75,19 @@ func mustIncreaseGeneration(oldControllerInstallation, newControllerInstallation
 	return false
 }
 
-func (controllerInstallationStrategy) Validate(ctx context.Context, obj runtime.Object) field.ErrorList {
+func (controllerInstallationStrategy) Validate(_ context.Context, obj runtime.Object) field.ErrorList {
 	controllerInstallation := obj.(*core.ControllerInstallation)
 	return validation.ValidateControllerInstallation(controllerInstallation)
 }
 
-func (controllerInstallationStrategy) Canonicalize(obj runtime.Object) {
+func (controllerInstallationStrategy) Canonicalize(_ runtime.Object) {
 }
 
 func (controllerInstallationStrategy) AllowCreateOnUpdate() bool {
 	return false
 }
 
-func (controllerInstallationStrategy) ValidateUpdate(ctx context.Context, newObj, oldObj runtime.Object) field.ErrorList {
+func (controllerInstallationStrategy) ValidateUpdate(_ context.Context, newObj, oldObj runtime.Object) field.ErrorList {
 	newControllerInstallation := newObj.(*core.ControllerInstallation)
 	oldControllerInstallation := oldObj.(*core.ControllerInstallation)
 	return validation.ValidateControllerInstallationUpdate(newControllerInstallation, oldControllerInstallation)
@@ -98,12 +98,12 @@ func (controllerInstallationStrategy) AllowUnconditionalUpdate() bool {
 }
 
 // WarningsOnCreate returns warnings to the client performing a create.
-func (controllerInstallationStrategy) WarningsOnCreate(ctx context.Context, obj runtime.Object) []string {
+func (controllerInstallationStrategy) WarningsOnCreate(_ context.Context, _ runtime.Object) []string {
 	return nil
 }
 
 // WarningsOnUpdate returns warnings to the client performing the update.
-func (controllerInstallationStrategy) WarningsOnUpdate(ctx context.Context, obj, old runtime.Object) []string {
+func (controllerInstallationStrategy) WarningsOnUpdate(_ context.Context, _, _ runtime.Object) []string {
 	return nil
 }
 
@@ -114,13 +114,13 @@ type controllerInstallationStatusStrategy struct {
 // StatusStrategy defines the storage strategy for the status subresource of ControllerInstallations.
 var StatusStrategy = controllerInstallationStatusStrategy{Strategy}
 
-func (controllerInstallationStatusStrategy) PrepareForUpdate(ctx context.Context, obj, old runtime.Object) {
+func (controllerInstallationStatusStrategy) PrepareForUpdate(_ context.Context, obj, old runtime.Object) {
 	newControllerInstallation := obj.(*core.ControllerInstallation)
 	oldControllerInstallation := old.(*core.ControllerInstallation)
 	newControllerInstallation.Spec = oldControllerInstallation.Spec
 }
 
-func (controllerInstallationStatusStrategy) ValidateUpdate(ctx context.Context, obj, old runtime.Object) field.ErrorList {
+func (controllerInstallationStatusStrategy) ValidateUpdate(_ context.Context, obj, old runtime.Object) field.ErrorList {
 	return validation.ValidateControllerInstallationStatusUpdate(obj.(*core.ControllerInstallation).Status, old.(*core.ControllerInstallation).Status)
 }
 

--- a/pkg/registry/core/controllerregistration/storage/tableconvertor.go
+++ b/pkg/registry/core/controllerregistration/storage/tableconvertor.go
@@ -46,7 +46,7 @@ func newTableConvertor() rest.TableConvertor {
 }
 
 // ConvertToTable converts the output to a table.
-func (c *convertor) ConvertToTable(ctx context.Context, o runtime.Object, tableOptions runtime.Object) (*metav1beta1.Table, error) {
+func (c *convertor) ConvertToTable(_ context.Context, o runtime.Object, _ runtime.Object) (*metav1beta1.Table, error) {
 	var (
 		err   error
 		table = &metav1beta1.Table{

--- a/pkg/registry/core/controllerregistration/strategy.go
+++ b/pkg/registry/core/controllerregistration/strategy.go
@@ -39,13 +39,13 @@ func (controllerRegistrationStrategy) NamespaceScoped() bool {
 	return false
 }
 
-func (controllerRegistrationStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object) {
+func (controllerRegistrationStrategy) PrepareForCreate(_ context.Context, obj runtime.Object) {
 	controllerRegistration := obj.(*core.ControllerRegistration)
 
 	controllerRegistration.Generation = 1
 }
 
-func (controllerRegistrationStrategy) PrepareForUpdate(ctx context.Context, obj, old runtime.Object) {
+func (controllerRegistrationStrategy) PrepareForUpdate(_ context.Context, obj, old runtime.Object) {
 	newControllerRegistration := obj.(*core.ControllerRegistration)
 	oldControllerRegistration := old.(*core.ControllerRegistration)
 
@@ -68,19 +68,19 @@ func mustIncreaseGeneration(oldControllerRegistration, newControllerRegistration
 	return false
 }
 
-func (controllerRegistrationStrategy) Validate(ctx context.Context, obj runtime.Object) field.ErrorList {
+func (controllerRegistrationStrategy) Validate(_ context.Context, obj runtime.Object) field.ErrorList {
 	controllerRegistration := obj.(*core.ControllerRegistration)
 	return validation.ValidateControllerRegistration(controllerRegistration)
 }
 
-func (controllerRegistrationStrategy) Canonicalize(obj runtime.Object) {
+func (controllerRegistrationStrategy) Canonicalize(_ runtime.Object) {
 }
 
 func (controllerRegistrationStrategy) AllowCreateOnUpdate() bool {
 	return false
 }
 
-func (controllerRegistrationStrategy) ValidateUpdate(ctx context.Context, newObj, oldObj runtime.Object) field.ErrorList {
+func (controllerRegistrationStrategy) ValidateUpdate(_ context.Context, newObj, oldObj runtime.Object) field.ErrorList {
 	newControllerRegistration := newObj.(*core.ControllerRegistration)
 	oldControllerRegistration := oldObj.(*core.ControllerRegistration)
 	return validation.ValidateControllerRegistrationUpdate(newControllerRegistration, oldControllerRegistration)
@@ -91,11 +91,11 @@ func (controllerRegistrationStrategy) AllowUnconditionalUpdate() bool {
 }
 
 // WarningsOnCreate returns warnings to the client performing a create.
-func (controllerRegistrationStrategy) WarningsOnCreate(ctx context.Context, obj runtime.Object) []string {
+func (controllerRegistrationStrategy) WarningsOnCreate(_ context.Context, _ runtime.Object) []string {
 	return nil
 }
 
 // WarningsOnUpdate returns warnings to the client performing the update.
-func (controllerRegistrationStrategy) WarningsOnUpdate(ctx context.Context, obj, old runtime.Object) []string {
+func (controllerRegistrationStrategy) WarningsOnUpdate(_ context.Context, _, _ runtime.Object) []string {
 	return nil
 }

--- a/pkg/registry/core/exposureclass/storage/tableconvertor.go
+++ b/pkg/registry/core/exposureclass/storage/tableconvertor.go
@@ -44,7 +44,7 @@ func newTableConvertor() rest.TableConvertor {
 }
 
 // ConvertToTable converts the output to a table.
-func (c *convertor) ConvertToTable(ctx context.Context, obj runtime.Object, tableOptions runtime.Object) (*metav1beta1.Table, error) {
+func (c *convertor) ConvertToTable(_ context.Context, obj runtime.Object, _ runtime.Object) (*metav1beta1.Table, error) {
 	var (
 		err   error
 		table = &metav1beta1.Table{

--- a/pkg/registry/core/exposureclass/strategy.go
+++ b/pkg/registry/core/exposureclass/strategy.go
@@ -47,29 +47,29 @@ func (ExposureClassStrategy) NamespaceScoped() bool {
 
 // PrepareForCreate mutates the object before creation.
 // It is called before Validate.
-func (ExposureClassStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object) {
+func (ExposureClassStrategy) PrepareForCreate(_ context.Context, _ runtime.Object) {
 }
 
 // PrepareForUpdate allows to modify an object before it get stored.
 // It is called before ValidateUpdate.
-func (ExposureClassStrategy) PrepareForUpdate(ctx context.Context, obj, old runtime.Object) {
+func (ExposureClassStrategy) PrepareForUpdate(_ context.Context, _, _ runtime.Object) {
 }
 
 // Validate allow to validate the object.
-func (ExposureClassStrategy) Validate(ctx context.Context, obj runtime.Object) field.ErrorList {
+func (ExposureClassStrategy) Validate(_ context.Context, obj runtime.Object) field.ErrorList {
 	exposureClass := obj.(*core.ExposureClass)
 	return validation.ValidateExposureClass(exposureClass)
 }
 
 // ValidateUpdate validates the update on the object.
 // The old and the new version of the object are passed in.
-func (ExposureClassStrategy) ValidateUpdate(ctx context.Context, newObj, oldObj runtime.Object) field.ErrorList {
+func (ExposureClassStrategy) ValidateUpdate(_ context.Context, newObj, oldObj runtime.Object) field.ErrorList {
 	oldExposureClass, newExposureClass := oldObj.(*core.ExposureClass), newObj.(*core.ExposureClass)
 	return validation.ValidateExposureClassUpdate(newExposureClass, oldExposureClass)
 }
 
 // Canonicalize can be used to transfrom the object into its cannoical format.
-func (ExposureClassStrategy) Canonicalize(obj runtime.Object) {
+func (ExposureClassStrategy) Canonicalize(_ runtime.Object) {
 }
 
 // AllowCreateOnUpdate indicates if the object can be created via a PUT operation.
@@ -84,11 +84,11 @@ func (ExposureClassStrategy) AllowUnconditionalUpdate() bool {
 }
 
 // WarningsOnCreate returns warnings to the client performing a create.
-func (ExposureClassStrategy) WarningsOnCreate(ctx context.Context, obj runtime.Object) []string {
+func (ExposureClassStrategy) WarningsOnCreate(_ context.Context, _ runtime.Object) []string {
 	return nil
 }
 
 // WarningsOnUpdate returns warnings to the client performing the update.
-func (ExposureClassStrategy) WarningsOnUpdate(ctx context.Context, obj, old runtime.Object) []string {
+func (ExposureClassStrategy) WarningsOnUpdate(_ context.Context, _, _ runtime.Object) []string {
 	return nil
 }

--- a/pkg/registry/core/internalsecret/storage/tableconvertor.go
+++ b/pkg/registry/core/internalsecret/storage/tableconvertor.go
@@ -45,7 +45,7 @@ func newTableConvertor() rest.TableConvertor {
 }
 
 // ConvertToTable converts the output to a table.
-func (c *convertor) ConvertToTable(ctx context.Context, obj runtime.Object, tableOptions runtime.Object) (*metav1beta1.Table, error) {
+func (c *convertor) ConvertToTable(_ context.Context, obj runtime.Object, _ runtime.Object) (*metav1beta1.Table, error) {
 	var (
 		err   error
 		table = &metav1beta1.Table{

--- a/pkg/registry/core/internalsecret/strategy.go
+++ b/pkg/registry/core/internalsecret/strategy.go
@@ -50,26 +50,24 @@ func (strategy) NamespaceScoped() bool {
 	return true
 }
 
-func (strategy) PrepareForCreate(ctx context.Context, obj runtime.Object) {
-	secret := obj.(*core.InternalSecret)
-	dropDisabledFields(secret, nil)
+func (strategy) PrepareForCreate(_ context.Context, _ runtime.Object) {
 }
 
-func (strategy) Validate(ctx context.Context, obj runtime.Object) field.ErrorList {
+func (strategy) Validate(_ context.Context, obj runtime.Object) field.ErrorList {
 	return validation.ValidateInternalSecret(obj.(*core.InternalSecret))
 }
 
 // WarningsOnCreate returns warnings for the creation of the given object.
-func (strategy) WarningsOnCreate(ctx context.Context, obj runtime.Object) []string { return nil }
+func (strategy) WarningsOnCreate(_ context.Context, _ runtime.Object) []string { return nil }
 
-func (strategy) Canonicalize(obj runtime.Object) {
+func (strategy) Canonicalize(_ runtime.Object) {
 }
 
 func (strategy) AllowCreateOnUpdate() bool {
 	return false
 }
 
-func (strategy) PrepareForUpdate(ctx context.Context, obj, old runtime.Object) {
+func (strategy) PrepareForUpdate(_ context.Context, obj, old runtime.Object) {
 	newInternalSecret := obj.(*core.InternalSecret)
 	oldInternalSecret := old.(*core.InternalSecret)
 
@@ -77,20 +75,15 @@ func (strategy) PrepareForUpdate(ctx context.Context, obj, old runtime.Object) {
 	if len(newInternalSecret.Type) == 0 {
 		newInternalSecret.Type = oldInternalSecret.Type
 	}
-
-	dropDisabledFields(newInternalSecret, oldInternalSecret)
 }
 
-func (strategy) ValidateUpdate(ctx context.Context, obj, old runtime.Object) field.ErrorList {
+func (strategy) ValidateUpdate(_ context.Context, obj, old runtime.Object) field.ErrorList {
 	return validation.ValidateInternalSecretUpdate(obj.(*core.InternalSecret), old.(*core.InternalSecret))
 }
 
 // WarningsOnUpdate returns warnings for the given update.
-func (strategy) WarningsOnUpdate(ctx context.Context, obj, old runtime.Object) []string {
+func (strategy) WarningsOnUpdate(_ context.Context, _, _ runtime.Object) []string {
 	return nil
-}
-
-func dropDisabledFields(secret *core.InternalSecret, oldInternalSecret *core.InternalSecret) {
 }
 
 func (strategy) AllowUnconditionalUpdate() bool {

--- a/pkg/registry/core/project/storage/tableconvertor.go
+++ b/pkg/registry/core/project/storage/tableconvertor.go
@@ -47,7 +47,7 @@ func newTableConvertor() rest.TableConvertor {
 }
 
 // ConvertToTable converts the output to a table.
-func (c *convertor) ConvertToTable(ctx context.Context, obj runtime.Object, tableOptions runtime.Object) (*metav1beta1.Table, error) {
+func (c *convertor) ConvertToTable(_ context.Context, obj runtime.Object, _ runtime.Object) (*metav1beta1.Table, error) {
 	var (
 		err   error
 		table = &metav1beta1.Table{

--- a/pkg/registry/core/project/strategy.go
+++ b/pkg/registry/core/project/strategy.go
@@ -61,12 +61,12 @@ func (projectStrategy) PrepareForUpdate(_ context.Context, obj, old runtime.Obje
 	}
 }
 
-func (projectStrategy) Validate(ctx context.Context, obj runtime.Object) field.ErrorList {
+func (projectStrategy) Validate(_ context.Context, obj runtime.Object) field.ErrorList {
 	project := obj.(*core.Project)
 	return validation.ValidateProject(project)
 }
 
-func (projectStrategy) Canonicalize(obj runtime.Object) {
+func (projectStrategy) Canonicalize(_ runtime.Object) {
 }
 
 func (projectStrategy) AllowCreateOnUpdate() bool {
@@ -77,18 +77,18 @@ func (projectStrategy) AllowUnconditionalUpdate() bool {
 	return true
 }
 
-func (projectStrategy) ValidateUpdate(ctx context.Context, newObj, oldObj runtime.Object) field.ErrorList {
+func (projectStrategy) ValidateUpdate(_ context.Context, newObj, oldObj runtime.Object) field.ErrorList {
 	oldProject, newProject := oldObj.(*core.Project), newObj.(*core.Project)
 	return validation.ValidateProjectUpdate(newProject, oldProject)
 }
 
 // WarningsOnCreate returns warnings to the client performing a create.
-func (projectStrategy) WarningsOnCreate(ctx context.Context, obj runtime.Object) []string {
+func (projectStrategy) WarningsOnCreate(_ context.Context, _ runtime.Object) []string {
 	return nil
 }
 
 // WarningsOnUpdate returns warnings to the client performing the update.
-func (projectStrategy) WarningsOnUpdate(ctx context.Context, obj, old runtime.Object) []string {
+func (projectStrategy) WarningsOnUpdate(_ context.Context, _, _ runtime.Object) []string {
 	return nil
 }
 
@@ -99,13 +99,13 @@ type projectStatusStrategy struct {
 // StatusStrategy defines the storage strategy for the status subresource of Projects.
 var StatusStrategy = projectStatusStrategy{Strategy}
 
-func (projectStatusStrategy) PrepareForUpdate(ctx context.Context, obj, old runtime.Object) {
+func (projectStatusStrategy) PrepareForUpdate(_ context.Context, obj, old runtime.Object) {
 	newProject := obj.(*core.Project)
 	oldProject := old.(*core.Project)
 	newProject.Spec = oldProject.Spec
 }
 
-func (projectStatusStrategy) ValidateUpdate(ctx context.Context, obj, old runtime.Object) field.ErrorList {
+func (projectStatusStrategy) ValidateUpdate(_ context.Context, obj, old runtime.Object) field.ErrorList {
 	return validation.ValidateProjectStatusUpdate(obj.(*core.Project), old.(*core.Project))
 }
 

--- a/pkg/registry/core/quota/storage/tableconvertor.go
+++ b/pkg/registry/core/quota/storage/tableconvertor.go
@@ -46,7 +46,7 @@ func newTableConvertor() rest.TableConvertor {
 }
 
 // ConvertToTable converts the output to a table.
-func (c *convertor) ConvertToTable(ctx context.Context, obj runtime.Object, tableOptions runtime.Object) (*metav1beta1.Table, error) {
+func (c *convertor) ConvertToTable(_ context.Context, obj runtime.Object, _ runtime.Object) (*metav1beta1.Table, error) {
 	var (
 		err   error
 		table = &metav1beta1.Table{

--- a/pkg/registry/core/quota/strategy.go
+++ b/pkg/registry/core/quota/strategy.go
@@ -38,27 +38,27 @@ func (quotaStrategy) NamespaceScoped() bool {
 	return true
 }
 
-func (quotaStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object) {
+func (quotaStrategy) PrepareForCreate(_ context.Context, _ runtime.Object) {
 }
 
-func (quotaStrategy) Validate(ctx context.Context, obj runtime.Object) field.ErrorList {
+func (quotaStrategy) Validate(_ context.Context, obj runtime.Object) field.ErrorList {
 	quota := obj.(*core.Quota)
 	return validation.ValidateQuota(quota)
 }
 
-func (quotaStrategy) Canonicalize(obj runtime.Object) {
+func (quotaStrategy) Canonicalize(_ runtime.Object) {
 }
 
 func (quotaStrategy) AllowCreateOnUpdate() bool {
 	return false
 }
 
-func (quotaStrategy) PrepareForUpdate(ctx context.Context, newObj, oldObj runtime.Object) {
+func (quotaStrategy) PrepareForUpdate(_ context.Context, newObj, oldObj runtime.Object) {
 	_ = oldObj.(*core.Quota)
 	_ = newObj.(*core.Quota)
 }
 
-func (quotaStrategy) ValidateUpdate(ctx context.Context, newObj, oldObj runtime.Object) field.ErrorList {
+func (quotaStrategy) ValidateUpdate(_ context.Context, newObj, oldObj runtime.Object) field.ErrorList {
 	oldQuota, newQuota := oldObj.(*core.Quota), newObj.(*core.Quota)
 	return validation.ValidateQuotaUpdate(newQuota, oldQuota)
 }
@@ -68,11 +68,11 @@ func (quotaStrategy) AllowUnconditionalUpdate() bool {
 }
 
 // WarningsOnCreate returns warnings to the client performing a create.
-func (quotaStrategy) WarningsOnCreate(ctx context.Context, obj runtime.Object) []string {
+func (quotaStrategy) WarningsOnCreate(_ context.Context, _ runtime.Object) []string {
 	return nil
 }
 
 // WarningsOnUpdate returns warnings to the client performing the update.
-func (quotaStrategy) WarningsOnUpdate(ctx context.Context, obj, old runtime.Object) []string {
+func (quotaStrategy) WarningsOnUpdate(_ context.Context, _, _ runtime.Object) []string {
 	return nil
 }

--- a/pkg/registry/core/secretbinding/storage/tableconvertor.go
+++ b/pkg/registry/core/secretbinding/storage/tableconvertor.go
@@ -45,7 +45,7 @@ func newTableConvertor() rest.TableConvertor {
 }
 
 // ConvertToTable converts the output to a table.
-func (c *convertor) ConvertToTable(ctx context.Context, obj runtime.Object, tableOptions runtime.Object) (*metav1beta1.Table, error) {
+func (c *convertor) ConvertToTable(_ context.Context, obj runtime.Object, _ runtime.Object) (*metav1beta1.Table, error) {
 	var (
 		err   error
 		table = &metav1beta1.Table{

--- a/pkg/registry/core/secretbinding/strategy.go
+++ b/pkg/registry/core/secretbinding/strategy.go
@@ -38,10 +38,10 @@ func (secretBindingStrategy) NamespaceScoped() bool {
 	return true
 }
 
-func (secretBindingStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object) {
+func (secretBindingStrategy) PrepareForCreate(_ context.Context, _ runtime.Object) {
 }
 
-func (secretBindingStrategy) Validate(ctx context.Context, obj runtime.Object) field.ErrorList {
+func (secretBindingStrategy) Validate(_ context.Context, obj runtime.Object) field.ErrorList {
 	binding := obj.(*core.SecretBinding)
 	allErrs := field.ErrorList{}
 	allErrs = append(allErrs, validation.ValidateSecretBinding(binding)...)
@@ -49,14 +49,14 @@ func (secretBindingStrategy) Validate(ctx context.Context, obj runtime.Object) f
 	return allErrs
 }
 
-func (secretBindingStrategy) Canonicalize(obj runtime.Object) {
+func (secretBindingStrategy) Canonicalize(_ runtime.Object) {
 }
 
 func (secretBindingStrategy) AllowCreateOnUpdate() bool {
 	return false
 }
 
-func (secretBindingStrategy) PrepareForUpdate(ctx context.Context, newObj, oldObj runtime.Object) {
+func (secretBindingStrategy) PrepareForUpdate(_ context.Context, newObj, oldObj runtime.Object) {
 	_ = oldObj.(*core.SecretBinding)
 	_ = newObj.(*core.SecretBinding)
 }
@@ -65,17 +65,17 @@ func (secretBindingStrategy) AllowUnconditionalUpdate() bool {
 	return true
 }
 
-func (secretBindingStrategy) ValidateUpdate(ctx context.Context, newObj, oldObj runtime.Object) field.ErrorList {
+func (secretBindingStrategy) ValidateUpdate(_ context.Context, newObj, oldObj runtime.Object) field.ErrorList {
 	oldBinding, newBinding := oldObj.(*core.SecretBinding), newObj.(*core.SecretBinding)
 	return validation.ValidateSecretBindingUpdate(newBinding, oldBinding)
 }
 
 // WarningsOnCreate returns warnings to the client performing a create.
-func (secretBindingStrategy) WarningsOnCreate(ctx context.Context, obj runtime.Object) []string {
+func (secretBindingStrategy) WarningsOnCreate(_ context.Context, _ runtime.Object) []string {
 	return nil
 }
 
 // WarningsOnUpdate returns warnings to the client performing the update.
-func (secretBindingStrategy) WarningsOnUpdate(ctx context.Context, obj, old runtime.Object) []string {
+func (secretBindingStrategy) WarningsOnUpdate(_ context.Context, _, _ runtime.Object) []string {
 	return nil
 }

--- a/pkg/registry/core/seed/storage/tableconvertor.go
+++ b/pkg/registry/core/seed/storage/tableconvertor.go
@@ -51,7 +51,7 @@ func newTableConvertor() rest.TableConvertor {
 }
 
 // ConvertToTable converts the output to a table.
-func (c *convertor) ConvertToTable(ctx context.Context, obj runtime.Object, tableOptions runtime.Object) (*metav1beta1.Table, error) {
+func (c *convertor) ConvertToTable(_ context.Context, obj runtime.Object, _ runtime.Object) (*metav1beta1.Table, error) {
 	var (
 		err   error
 		table = &metav1beta1.Table{

--- a/pkg/registry/core/seed/strategy.go
+++ b/pkg/registry/core/seed/strategy.go
@@ -45,7 +45,7 @@ func (Strategy) NamespaceScoped() bool {
 }
 
 // PrepareForCreate mutates some fields in the object before it's created.
-func (s Strategy) PrepareForCreate(ctx context.Context, obj runtime.Object) {
+func (s Strategy) PrepareForCreate(_ context.Context, obj runtime.Object) {
 	seed := obj.(*core.Seed)
 
 	seed.Generation = 1
@@ -57,7 +57,7 @@ func (s Strategy) PrepareForCreate(ctx context.Context, obj runtime.Object) {
 // the object.  For example: remove fields that are not to be persisted,
 // sort order-insensitive list fields, etc.  This should not remove fields
 // whose presence would be considered a validation error.
-func (s Strategy) PrepareForUpdate(ctx context.Context, obj, old runtime.Object) {
+func (s Strategy) PrepareForUpdate(_ context.Context, obj, old runtime.Object) {
 	newSeed := obj.(*core.Seed)
 	oldSeed := old.(*core.Seed)
 	syncDependencyWatchdogSettings(newSeed)
@@ -128,7 +128,7 @@ func syncDependencyWatchdogSettings(seed *core.Seed) {
 }
 
 // Validate validates the given object.
-func (Strategy) Validate(ctx context.Context, obj runtime.Object) field.ErrorList {
+func (Strategy) Validate(_ context.Context, obj runtime.Object) field.ErrorList {
 	seed := obj.(*core.Seed)
 	return validation.ValidateSeed(seed)
 }
@@ -138,7 +138,7 @@ func (Strategy) Validate(ctx context.Context, obj runtime.Object) field.ErrorLis
 // form for things like comparison.  Canonicalize is invoked after
 // validation has succeeded but before the object has been persisted.
 // This method may mutate the object.
-func (Strategy) Canonicalize(obj runtime.Object) {
+func (Strategy) Canonicalize(_ runtime.Object) {
 }
 
 // AllowCreateOnUpdate returns true if the object can be created by a PUT.
@@ -154,18 +154,18 @@ func (Strategy) AllowUnconditionalUpdate() bool {
 }
 
 // ValidateUpdate validates the update on the given old and new object.
-func (Strategy) ValidateUpdate(ctx context.Context, newObj, oldObj runtime.Object) field.ErrorList {
+func (Strategy) ValidateUpdate(_ context.Context, newObj, oldObj runtime.Object) field.ErrorList {
 	oldSeed, newSeed := oldObj.(*core.Seed), newObj.(*core.Seed)
 	return validation.ValidateSeedUpdate(newSeed, oldSeed)
 }
 
 // WarningsOnCreate returns warnings to the client performing a create.
-func (Strategy) WarningsOnCreate(ctx context.Context, obj runtime.Object) []string {
+func (Strategy) WarningsOnCreate(_ context.Context, _ runtime.Object) []string {
 	return nil
 }
 
 // WarningsOnUpdate returns warnings to the client performing the update.
-func (Strategy) WarningsOnUpdate(ctx context.Context, obj, old runtime.Object) []string {
+func (Strategy) WarningsOnUpdate(_ context.Context, _, _ runtime.Object) []string {
 	return nil
 }
 
@@ -183,7 +183,7 @@ func NewStatusStrategy() StatusStrategy {
 // the object.  For example: remove fields that are not to be persisted,
 // sort order-insensitive list fields, etc.  This should not remove fields
 // whose presence would be considered a validation error.
-func (s StatusStrategy) PrepareForUpdate(ctx context.Context, obj, old runtime.Object) {
+func (s StatusStrategy) PrepareForUpdate(_ context.Context, obj, old runtime.Object) {
 	newSeed := obj.(*core.Seed)
 	oldSeed := old.(*core.Seed)
 	newSeed.Spec = oldSeed.Spec
@@ -191,6 +191,6 @@ func (s StatusStrategy) PrepareForUpdate(ctx context.Context, obj, old runtime.O
 }
 
 // ValidateUpdate validates the update on the given old and new object.
-func (StatusStrategy) ValidateUpdate(ctx context.Context, obj, old runtime.Object) field.ErrorList {
+func (StatusStrategy) ValidateUpdate(_ context.Context, obj, old runtime.Object) field.ErrorList {
 	return validation.ValidateSeedStatusUpdate(obj.(*core.Seed), old.(*core.Seed))
 }

--- a/pkg/registry/core/shoot/storage/admin_kubeconfig_test.go
+++ b/pkg/registry/core/shoot/storage/admin_kubeconfig_test.go
@@ -314,7 +314,7 @@ type fakeGetter struct {
 	err error
 }
 
-func (f *fakeGetter) Get(ctx context.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {
+func (f *fakeGetter) Get(_ context.Context, _ string, _ *metav1.GetOptions) (runtime.Object, error) {
 	return f.obj, f.err
 }
 
@@ -328,7 +328,7 @@ func (f fakeSecretLister) Secrets(string) kubecorev1listers.SecretNamespaceListe
 	return f
 }
 
-func (f fakeSecretLister) Get(name string) (*corev1.Secret, error) {
+func (f fakeSecretLister) Get(_ string) (*corev1.Secret, error) {
 	return f.obj, f.err
 }
 
@@ -342,6 +342,6 @@ func (f fakeInternalSecretLister) InternalSecrets(string) gardencorelisters.Inte
 	return f
 }
 
-func (f fakeInternalSecretLister) Get(name string) (*gardencore.InternalSecret, error) {
+func (f fakeInternalSecretLister) Get(_ string) (*gardencore.InternalSecret, error) {
 	return f.obj, f.err
 }

--- a/pkg/registry/core/shoot/storage/tableconvertor.go
+++ b/pkg/registry/core/shoot/storage/tableconvertor.go
@@ -62,7 +62,7 @@ func newTableConvertor() rest.TableConvertor {
 }
 
 // ConvertToTable converts the output to a table.
-func (c *convertor) ConvertToTable(ctx context.Context, obj runtime.Object, tableOptions runtime.Object) (*metav1beta1.Table, error) {
+func (c *convertor) ConvertToTable(_ context.Context, obj runtime.Object, _ runtime.Object) (*metav1beta1.Table, error) {
 	var (
 		err   error
 		table = &metav1beta1.Table{

--- a/pkg/registry/core/shootstate/storage/tableconvertor.go
+++ b/pkg/registry/core/shootstate/storage/tableconvertor.go
@@ -45,7 +45,7 @@ func newTableConvertor() rest.TableConvertor {
 }
 
 // ConvertToTable converts the output to a table.
-func (c *convertor) ConvertToTable(ctx context.Context, o runtime.Object, tableOptions runtime.Object) (*metav1beta1.Table, error) {
+func (c *convertor) ConvertToTable(_ context.Context, o runtime.Object, _ runtime.Object) (*metav1beta1.Table, error) {
 	var (
 		err   error
 		table = &metav1beta1.Table{

--- a/pkg/registry/core/shootstate/strategy.go
+++ b/pkg/registry/core/shootstate/strategy.go
@@ -39,13 +39,13 @@ func (shootStateStrategy) NamespaceScoped() bool {
 	return true
 }
 
-func (shootStateStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object) {
+func (shootStateStrategy) PrepareForCreate(_ context.Context, obj runtime.Object) {
 	shootState := obj.(*core.ShootState)
 
 	shootState.Generation = 1
 }
 
-func (shootStateStrategy) PrepareForUpdate(ctx context.Context, obj, old runtime.Object) {
+func (shootStateStrategy) PrepareForUpdate(_ context.Context, obj, old runtime.Object) {
 	newShootState := obj.(*core.ShootState)
 	oldShootState := old.(*core.ShootState)
 
@@ -68,19 +68,19 @@ func mustIncreaseGeneration(oldShootState, newShootState *core.ShootState) bool 
 	return false
 }
 
-func (shootStateStrategy) Validate(ctx context.Context, obj runtime.Object) field.ErrorList {
+func (shootStateStrategy) Validate(_ context.Context, obj runtime.Object) field.ErrorList {
 	shootState := obj.(*core.ShootState)
 	return validation.ValidateShootState(shootState)
 }
 
-func (shootStateStrategy) Canonicalize(obj runtime.Object) {
+func (shootStateStrategy) Canonicalize(_ runtime.Object) {
 }
 
 func (shootStateStrategy) AllowCreateOnUpdate() bool {
 	return false
 }
 
-func (shootStateStrategy) ValidateUpdate(ctx context.Context, newObj, oldObj runtime.Object) field.ErrorList {
+func (shootStateStrategy) ValidateUpdate(_ context.Context, newObj, oldObj runtime.Object) field.ErrorList {
 	newShootState := newObj.(*core.ShootState)
 	oldShootState := oldObj.(*core.ShootState)
 	return validation.ValidateShootStateUpdate(newShootState, oldShootState)
@@ -91,11 +91,11 @@ func (shootStateStrategy) AllowUnconditionalUpdate() bool {
 }
 
 // WarningsOnCreate returns warnings to the client performing a create.
-func (shootStateStrategy) WarningsOnCreate(ctx context.Context, obj runtime.Object) []string {
+func (shootStateStrategy) WarningsOnCreate(_ context.Context, _ runtime.Object) []string {
 	return nil
 }
 
 // WarningsOnUpdate returns warnings to the client performing the update.
-func (shootStateStrategy) WarningsOnUpdate(ctx context.Context, obj, old runtime.Object) []string {
+func (shootStateStrategy) WarningsOnUpdate(_ context.Context, _, _ runtime.Object) []string {
 	return nil
 }

--- a/pkg/registry/operations/bastion/storage/tableconvertor.go
+++ b/pkg/registry/operations/bastion/storage/tableconvertor.go
@@ -51,7 +51,7 @@ func newTableConvertor() rest.TableConvertor {
 }
 
 // ConvertToTable converts the output to a table.
-func (c *convertor) ConvertToTable(ctx context.Context, obj runtime.Object, tableOptions runtime.Object) (*metav1beta1.Table, error) {
+func (c *convertor) ConvertToTable(_ context.Context, obj runtime.Object, _ runtime.Object) (*metav1beta1.Table, error) {
 	var (
 		err   error
 		table = &metav1beta1.Table{

--- a/pkg/registry/operations/bastion/strategy.go
+++ b/pkg/registry/operations/bastion/strategy.go
@@ -56,7 +56,7 @@ func (bastionStrategy) NamespaceScoped() bool {
 	return true
 }
 
-func (s bastionStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object) {
+func (s bastionStrategy) PrepareForCreate(_ context.Context, obj runtime.Object) {
 	bastion := obj.(*operations.Bastion)
 	bastion.Generation = 1
 
@@ -75,7 +75,7 @@ func (s bastionStrategy) heartbeat(bastion *operations.Bastion) {
 	}
 }
 
-func (s bastionStrategy) PrepareForUpdate(ctx context.Context, obj, old runtime.Object) {
+func (s bastionStrategy) PrepareForUpdate(_ context.Context, obj, old runtime.Object) {
 	newBastion := obj.(*operations.Bastion)
 	oldBastion := old.(*operations.Bastion)
 	newBastion.Status = oldBastion.Status
@@ -107,19 +107,19 @@ func mustIncreaseGeneration(oldBastion, newBastion *operations.Bastion) bool {
 	return false
 }
 
-func (bastionStrategy) Validate(ctx context.Context, obj runtime.Object) field.ErrorList {
+func (bastionStrategy) Validate(_ context.Context, obj runtime.Object) field.ErrorList {
 	bastion := obj.(*operations.Bastion)
 	return operationsvalidation.ValidateBastion(bastion)
 }
 
-func (bastionStrategy) Canonicalize(obj runtime.Object) {
+func (bastionStrategy) Canonicalize(_ runtime.Object) {
 }
 
 func (bastionStrategy) AllowCreateOnUpdate() bool {
 	return false
 }
 
-func (bastionStrategy) ValidateUpdate(ctx context.Context, newObj, oldObj runtime.Object) field.ErrorList {
+func (bastionStrategy) ValidateUpdate(_ context.Context, newObj, oldObj runtime.Object) field.ErrorList {
 	oldBastion, newBastion := oldObj.(*operations.Bastion), newObj.(*operations.Bastion)
 	return operationsvalidation.ValidateBastionUpdate(newBastion, oldBastion)
 }
@@ -129,12 +129,12 @@ func (bastionStrategy) AllowUnconditionalUpdate() bool {
 }
 
 // WarningsOnCreate returns warnings to the client performing a create.
-func (bastionStrategy) WarningsOnCreate(ctx context.Context, obj runtime.Object) []string {
+func (bastionStrategy) WarningsOnCreate(_ context.Context, _ runtime.Object) []string {
 	return nil
 }
 
 // WarningsOnUpdate returns warnings to the client performing the update.
-func (bastionStrategy) WarningsOnUpdate(ctx context.Context, obj, old runtime.Object) []string {
+func (bastionStrategy) WarningsOnUpdate(_ context.Context, _, _ runtime.Object) []string {
 	return nil
 }
 
@@ -145,7 +145,7 @@ type bastionStatusStrategy struct {
 // StatusStrategy defines the storage strategy for the status subresource of Bastions.
 var StatusStrategy = bastionStatusStrategy{Strategy}
 
-func (s bastionStatusStrategy) PrepareForUpdate(ctx context.Context, obj, old runtime.Object) {
+func (s bastionStatusStrategy) PrepareForUpdate(_ context.Context, obj, old runtime.Object) {
 	newBastion := obj.(*operations.Bastion)
 	oldBastion := old.(*operations.Bastion)
 	newBastion.Spec = oldBastion.Spec
@@ -155,7 +155,7 @@ func (s bastionStatusStrategy) PrepareForUpdate(ctx context.Context, obj, old ru
 	newBastion.Status.ExpirationTimestamp = &expires
 }
 
-func (bastionStatusStrategy) ValidateUpdate(ctx context.Context, obj, old runtime.Object) field.ErrorList {
+func (bastionStatusStrategy) ValidateUpdate(_ context.Context, obj, old runtime.Object) field.ErrorList {
 	return operationsvalidation.ValidateBastionStatusUpdate(obj.(*operations.Bastion), old.(*operations.Bastion))
 }
 

--- a/pkg/registry/seedmanagement/managedseed/storage/tableconvertor.go
+++ b/pkg/registry/seedmanagement/managedseed/storage/tableconvertor.go
@@ -49,7 +49,7 @@ func newTableConvertor() rest.TableConvertor {
 }
 
 // ConvertToTable converts the output to a table.
-func (c *convertor) ConvertToTable(ctx context.Context, obj runtime.Object, tableOptions runtime.Object) (*metav1beta1.Table, error) {
+func (c *convertor) ConvertToTable(_ context.Context, obj runtime.Object, _ runtime.Object) (*metav1beta1.Table, error) {
 	var (
 		err   error
 		table = &metav1beta1.Table{

--- a/pkg/registry/seedmanagement/managedseed/strategy.go
+++ b/pkg/registry/seedmanagement/managedseed/strategy.go
@@ -51,7 +51,7 @@ func (Strategy) NamespaceScoped() bool {
 }
 
 // PrepareForCreate mutates some fields in the object before it's created.
-func (s Strategy) PrepareForCreate(ctx context.Context, obj runtime.Object) {
+func (s Strategy) PrepareForCreate(_ context.Context, obj runtime.Object) {
 	managedSeed := obj.(*seedmanagement.ManagedSeed)
 
 	managedSeed.Generation = 1
@@ -62,7 +62,7 @@ func (s Strategy) PrepareForCreate(ctx context.Context, obj runtime.Object) {
 // the object.  For example: remove fields that are not to be persisted,
 // sort order-insensitive list fields, etc.  This should not remove fields
 // whose presence would be considered a validation error.
-func (s Strategy) PrepareForUpdate(ctx context.Context, obj, old runtime.Object) {
+func (s Strategy) PrepareForUpdate(_ context.Context, obj, old runtime.Object) {
 	newManagedSeed := obj.(*seedmanagement.ManagedSeed)
 	oldManagedSeed := old.(*seedmanagement.ManagedSeed)
 	newManagedSeed.Status = oldManagedSeed.Status
@@ -98,7 +98,7 @@ func mustIncreaseGeneration(oldManagedSeed, newManagedSeed *seedmanagement.Manag
 }
 
 // Validate validates the given object.
-func (Strategy) Validate(ctx context.Context, obj runtime.Object) field.ErrorList {
+func (Strategy) Validate(_ context.Context, obj runtime.Object) field.ErrorList {
 	managedSeed := obj.(*seedmanagement.ManagedSeed)
 	return validation.ValidateManagedSeed(managedSeed)
 }
@@ -108,7 +108,7 @@ func (Strategy) Validate(ctx context.Context, obj runtime.Object) field.ErrorLis
 // form for things like comparison.  Canonicalize is invoked after
 // validation has succeeded but before the object has been persisted.
 // This method may mutate the object.
-func (Strategy) Canonicalize(obj runtime.Object) {
+func (Strategy) Canonicalize(_ runtime.Object) {
 }
 
 // AllowCreateOnUpdate returns true if the object can be created by a PUT.
@@ -124,18 +124,18 @@ func (Strategy) AllowUnconditionalUpdate() bool {
 }
 
 // ValidateUpdate validates the update on the given old and new object.
-func (Strategy) ValidateUpdate(ctx context.Context, newObj, oldObj runtime.Object) field.ErrorList {
+func (Strategy) ValidateUpdate(_ context.Context, newObj, oldObj runtime.Object) field.ErrorList {
 	oldManagedSeed, newManagedSeed := oldObj.(*seedmanagement.ManagedSeed), newObj.(*seedmanagement.ManagedSeed)
 	return validation.ValidateManagedSeedUpdate(newManagedSeed, oldManagedSeed)
 }
 
 // WarningsOnCreate returns warnings to the client performing a create.
-func (Strategy) WarningsOnCreate(ctx context.Context, obj runtime.Object) []string {
+func (Strategy) WarningsOnCreate(_ context.Context, _ runtime.Object) []string {
 	return nil
 }
 
 // WarningsOnUpdate returns warnings to the client performing the update.
-func (Strategy) WarningsOnUpdate(ctx context.Context, obj, old runtime.Object) []string {
+func (Strategy) WarningsOnUpdate(_ context.Context, _, _ runtime.Object) []string {
 	return nil
 }
 
@@ -153,14 +153,14 @@ func NewStatusStrategy() StatusStrategy {
 // the object.  For example: remove fields that are not to be persisted,
 // sort order-insensitive list fields, etc.  This should not remove fields
 // whose presence would be considered a validation error.
-func (s StatusStrategy) PrepareForUpdate(ctx context.Context, obj, old runtime.Object) {
+func (s StatusStrategy) PrepareForUpdate(_ context.Context, obj, old runtime.Object) {
 	newManagedSeed := obj.(*seedmanagement.ManagedSeed)
 	oldManagedSeed := old.(*seedmanagement.ManagedSeed)
 	newManagedSeed.Spec = oldManagedSeed.Spec
 }
 
 // ValidateUpdate validates the update on the given old and new object.
-func (StatusStrategy) ValidateUpdate(ctx context.Context, obj, old runtime.Object) field.ErrorList {
+func (StatusStrategy) ValidateUpdate(_ context.Context, obj, old runtime.Object) field.ErrorList {
 	return validation.ValidateManagedSeedStatusUpdate(obj.(*seedmanagement.ManagedSeed), old.(*seedmanagement.ManagedSeed))
 }
 

--- a/pkg/registry/seedmanagement/managedseedset/storage/storage.go
+++ b/pkg/registry/seedmanagement/managedseedset/storage/storage.go
@@ -167,7 +167,7 @@ func (r *ScaleREST) Get(ctx context.Context, name string, options *metav1.GetOpt
 }
 
 // Update alters scale subset of ManagedSeedSet object.
-func (r *ScaleREST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, createValidation rest.ValidateObjectFunc, updateValidation rest.ValidateObjectUpdateFunc, forceAllowCreate bool, options *metav1.UpdateOptions) (runtime.Object, bool, error) {
+func (r *ScaleREST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, createValidation rest.ValidateObjectFunc, updateValidation rest.ValidateObjectUpdateFunc, _ bool, options *metav1.UpdateOptions) (runtime.Object, bool, error) {
 	obj, _, err := r.store.Update(
 		ctx,
 		name,

--- a/pkg/registry/seedmanagement/managedseedset/storage/tableconvertor.go
+++ b/pkg/registry/seedmanagement/managedseedset/storage/tableconvertor.go
@@ -46,7 +46,7 @@ func newTableConvertor() rest.TableConvertor {
 }
 
 // ConvertToTable converts the output to a table.
-func (c *convertor) ConvertToTable(ctx context.Context, obj runtime.Object, tableOptions runtime.Object) (*metav1beta1.Table, error) {
+func (c *convertor) ConvertToTable(_ context.Context, obj runtime.Object, _ runtime.Object) (*metav1beta1.Table, error) {
 	var (
 		err   error
 		table = &metav1beta1.Table{

--- a/pkg/registry/seedmanagement/managedseedset/strategy.go
+++ b/pkg/registry/seedmanagement/managedseedset/strategy.go
@@ -51,7 +51,7 @@ func (Strategy) NamespaceScoped() bool {
 }
 
 // PrepareForCreate mutates some fields in the object before it's created.
-func (s Strategy) PrepareForCreate(ctx context.Context, obj runtime.Object) {
+func (s Strategy) PrepareForCreate(_ context.Context, obj runtime.Object) {
 	managedSeedSet := obj.(*seedmanagement.ManagedSeedSet)
 
 	managedSeedSet.Generation = 1
@@ -62,7 +62,7 @@ func (s Strategy) PrepareForCreate(ctx context.Context, obj runtime.Object) {
 // the object.  For example: remove fields that are not to be persisted,
 // sort order-insensitive list fields, etc.  This should not remove fields
 // whose presence would be considered a validation error.
-func (s Strategy) PrepareForUpdate(ctx context.Context, obj, old runtime.Object) {
+func (s Strategy) PrepareForUpdate(_ context.Context, obj, old runtime.Object) {
 	newManagedSeedSet := obj.(*seedmanagement.ManagedSeedSet)
 	oldManagedSeedSet := old.(*seedmanagement.ManagedSeedSet)
 	newManagedSeedSet.Status = oldManagedSeedSet.Status
@@ -93,7 +93,7 @@ func mustIncreaseGeneration(oldManagedSeedSet, newManagedSeedSet *seedmanagement
 }
 
 // Validate validates the given object.
-func (Strategy) Validate(ctx context.Context, obj runtime.Object) field.ErrorList {
+func (Strategy) Validate(_ context.Context, obj runtime.Object) field.ErrorList {
 	managedSeedSet := obj.(*seedmanagement.ManagedSeedSet)
 	return validation.ValidateManagedSeedSet(managedSeedSet)
 }
@@ -103,7 +103,7 @@ func (Strategy) Validate(ctx context.Context, obj runtime.Object) field.ErrorLis
 // form for things like comparison.  Canonicalize is invoked after
 // validation has succeeded but before the object has been persisted.
 // This method may mutate the object.
-func (Strategy) Canonicalize(obj runtime.Object) {
+func (Strategy) Canonicalize(_ runtime.Object) {
 }
 
 // AllowCreateOnUpdate returns true if the object can be created by a PUT.
@@ -119,18 +119,18 @@ func (Strategy) AllowUnconditionalUpdate() bool {
 }
 
 // ValidateUpdate validates the update on the given old and new object.
-func (Strategy) ValidateUpdate(ctx context.Context, newObj, oldObj runtime.Object) field.ErrorList {
+func (Strategy) ValidateUpdate(_ context.Context, newObj, oldObj runtime.Object) field.ErrorList {
 	oldManagedSeedSet, newManagedSeedSet := oldObj.(*seedmanagement.ManagedSeedSet), newObj.(*seedmanagement.ManagedSeedSet)
 	return validation.ValidateManagedSeedSetUpdate(newManagedSeedSet, oldManagedSeedSet)
 }
 
 // WarningsOnCreate returns warnings to the client performing a create.
-func (Strategy) WarningsOnCreate(ctx context.Context, obj runtime.Object) []string {
+func (Strategy) WarningsOnCreate(_ context.Context, _ runtime.Object) []string {
 	return nil
 }
 
 // WarningsOnUpdate returns warnings to the client performing the update.
-func (Strategy) WarningsOnUpdate(ctx context.Context, obj, old runtime.Object) []string {
+func (Strategy) WarningsOnUpdate(_ context.Context, _, _ runtime.Object) []string {
 	return nil
 }
 
@@ -148,14 +148,14 @@ func NewStatusStrategy() StatusStrategy {
 // the object.  For example: remove fields that are not to be persisted,
 // sort order-insensitive list fields, etc.  This should not remove fields
 // whose presence would be considered a validation error.
-func (s StatusStrategy) PrepareForUpdate(ctx context.Context, obj, old runtime.Object) {
+func (s StatusStrategy) PrepareForUpdate(_ context.Context, obj, old runtime.Object) {
 	newManagedSeedSet := obj.(*seedmanagement.ManagedSeedSet)
 	oldManagedSeedSet := old.(*seedmanagement.ManagedSeedSet)
 	newManagedSeedSet.Spec = oldManagedSeedSet.Spec
 }
 
 // ValidateUpdate validates the update on the given old and new object.
-func (StatusStrategy) ValidateUpdate(ctx context.Context, obj, old runtime.Object) field.ErrorList {
+func (StatusStrategy) ValidateUpdate(_ context.Context, obj, old runtime.Object) field.ErrorList {
 	return validation.ValidateManagedSeedSetStatusUpdate(obj.(*seedmanagement.ManagedSeedSet), old.(*seedmanagement.ManagedSeedSet))
 }
 

--- a/pkg/registry/seedmanagement/managedseedset/strategy_test.go
+++ b/pkg/registry/seedmanagement/managedseedset/strategy_test.go
@@ -77,7 +77,7 @@ var _ = Describe("Strategy", func() {
 
 var _ = Describe("ToSelectableFields", func() {
 	It("should return correct fields", func() {
-		result := ToSelectableFields(newManagedSeedSet("foo"))
+		result := ToSelectableFields(newManagedSeedSet())
 
 		Expect(result).To(HaveLen(2))
 	})
@@ -90,7 +90,7 @@ var _ = Describe("GetAttrs", func() {
 	})
 
 	It("should return correct result", func() {
-		ls, _, err := GetAttrs(newManagedSeedSet("foo"))
+		ls, _, err := GetAttrs(newManagedSeedSet())
 
 		Expect(ls).To(HaveLen(1))
 		Expect(ls.Get("foo")).To(Equal("bar"))
@@ -108,7 +108,7 @@ var _ = Describe("MatchManagedSeedSet", func() {
 	})
 })
 
-func newManagedSeedSet(shootName string) *seedmanagement.ManagedSeedSet {
+func newManagedSeedSet() *seedmanagement.ManagedSeedSet {
 	return &seedmanagement.ManagedSeedSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test",

--- a/pkg/registry/settings/clusteropenidconnectpreset/storage/tableconvertor.go
+++ b/pkg/registry/settings/clusteropenidconnectpreset/storage/tableconvertor.go
@@ -46,7 +46,7 @@ func newTableConvertor() rest.TableConvertor {
 }
 
 // ConvertToTable converts the output to a table.
-func (c *convertor) ConvertToTable(ctx context.Context, o runtime.Object, tableOptions runtime.Object) (*metav1beta1.Table, error) {
+func (c *convertor) ConvertToTable(_ context.Context, o runtime.Object, _ runtime.Object) (*metav1beta1.Table, error) {
 	var (
 		err   error
 		table = &metav1beta1.Table{

--- a/pkg/registry/settings/clusteropenidconnectpreset/strategy.go
+++ b/pkg/registry/settings/clusteropenidconnectpreset/strategy.go
@@ -38,27 +38,27 @@ func (clusterOIDCPresetStrategy) NamespaceScoped() bool {
 	return false
 }
 
-func (clusterOIDCPresetStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object) {
+func (clusterOIDCPresetStrategy) PrepareForCreate(_ context.Context, _ runtime.Object) {
 
 }
 
-func (clusterOIDCPresetStrategy) PrepareForUpdate(ctx context.Context, obj, old runtime.Object) {
+func (clusterOIDCPresetStrategy) PrepareForUpdate(_ context.Context, _, _ runtime.Object) {
 
 }
 
-func (clusterOIDCPresetStrategy) Validate(ctx context.Context, obj runtime.Object) field.ErrorList {
+func (clusterOIDCPresetStrategy) Validate(_ context.Context, obj runtime.Object) field.ErrorList {
 	oidcpreset := obj.(*settings.ClusterOpenIDConnectPreset)
 	return validation.ValidateClusterOpenIDConnectPreset(oidcpreset)
 }
 
-func (clusterOIDCPresetStrategy) Canonicalize(obj runtime.Object) {
+func (clusterOIDCPresetStrategy) Canonicalize(_ runtime.Object) {
 }
 
 func (clusterOIDCPresetStrategy) AllowCreateOnUpdate() bool {
 	return false
 }
 
-func (clusterOIDCPresetStrategy) ValidateUpdate(ctx context.Context, newObj, oldObj runtime.Object) field.ErrorList {
+func (clusterOIDCPresetStrategy) ValidateUpdate(_ context.Context, newObj, oldObj runtime.Object) field.ErrorList {
 	newOIDCPreset := newObj.(*settings.ClusterOpenIDConnectPreset)
 	oldOIDCPreset := oldObj.(*settings.ClusterOpenIDConnectPreset)
 	return validation.ValidateClusterOpenIDConnectPresetUpdate(newOIDCPreset, oldOIDCPreset)
@@ -69,11 +69,11 @@ func (clusterOIDCPresetStrategy) AllowUnconditionalUpdate() bool {
 }
 
 // WarningsOnCreate returns warnings to the client performing a create.
-func (clusterOIDCPresetStrategy) WarningsOnCreate(ctx context.Context, obj runtime.Object) []string {
+func (clusterOIDCPresetStrategy) WarningsOnCreate(_ context.Context, _ runtime.Object) []string {
 	return nil
 }
 
 // WarningsOnUpdate returns warnings to the client performing the update.
-func (clusterOIDCPresetStrategy) WarningsOnUpdate(ctx context.Context, obj, old runtime.Object) []string {
+func (clusterOIDCPresetStrategy) WarningsOnUpdate(_ context.Context, _, _ runtime.Object) []string {
 	return nil
 }

--- a/pkg/registry/settings/openidconnectpreset/storage/tableconvertor.go
+++ b/pkg/registry/settings/openidconnectpreset/storage/tableconvertor.go
@@ -45,7 +45,7 @@ func newTableConvertor() rest.TableConvertor {
 }
 
 // ConvertToTable converts the output to a table.
-func (c *convertor) ConvertToTable(ctx context.Context, o runtime.Object, tableOptions runtime.Object) (*metav1beta1.Table, error) {
+func (c *convertor) ConvertToTable(_ context.Context, o runtime.Object, _ runtime.Object) (*metav1beta1.Table, error) {
 	var (
 		err   error
 		table = &metav1beta1.Table{

--- a/pkg/registry/settings/openidconnectpreset/strategy.go
+++ b/pkg/registry/settings/openidconnectpreset/strategy.go
@@ -38,27 +38,27 @@ func (oidcPresetStrategy) NamespaceScoped() bool {
 	return true
 }
 
-func (oidcPresetStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object) {
+func (oidcPresetStrategy) PrepareForCreate(_ context.Context, _ runtime.Object) {
 
 }
 
-func (oidcPresetStrategy) PrepareForUpdate(ctx context.Context, obj, old runtime.Object) {
+func (oidcPresetStrategy) PrepareForUpdate(_ context.Context, _, _ runtime.Object) {
 
 }
 
-func (oidcPresetStrategy) Validate(ctx context.Context, obj runtime.Object) field.ErrorList {
+func (oidcPresetStrategy) Validate(_ context.Context, obj runtime.Object) field.ErrorList {
 	oidcpreset := obj.(*settings.OpenIDConnectPreset)
 	return validation.ValidateOpenIDConnectPreset(oidcpreset)
 }
 
-func (oidcPresetStrategy) Canonicalize(obj runtime.Object) {
+func (oidcPresetStrategy) Canonicalize(_ runtime.Object) {
 }
 
 func (oidcPresetStrategy) AllowCreateOnUpdate() bool {
 	return false
 }
 
-func (oidcPresetStrategy) ValidateUpdate(ctx context.Context, newObj, oldObj runtime.Object) field.ErrorList {
+func (oidcPresetStrategy) ValidateUpdate(_ context.Context, newObj, oldObj runtime.Object) field.ErrorList {
 	newOIDCPreset := newObj.(*settings.OpenIDConnectPreset)
 	oldOIDCPreset := oldObj.(*settings.OpenIDConnectPreset)
 	return validation.ValidateOpenIDConnectPresetUpdate(newOIDCPreset, oldOIDCPreset)
@@ -69,11 +69,11 @@ func (oidcPresetStrategy) AllowUnconditionalUpdate() bool {
 }
 
 // WarningsOnCreate returns warnings to the client performing a create.
-func (oidcPresetStrategy) WarningsOnCreate(ctx context.Context, obj runtime.Object) []string {
+func (oidcPresetStrategy) WarningsOnCreate(_ context.Context, _ runtime.Object) []string {
 	return nil
 }
 
 // WarningsOnUpdate returns warnings to the client performing the update.
-func (oidcPresetStrategy) WarningsOnUpdate(ctx context.Context, obj, old runtime.Object) []string {
+func (oidcPresetStrategy) WarningsOnUpdate(_ context.Context, _, _ runtime.Object) []string {
 	return nil
 }

--- a/pkg/resourcemanager/webhook/extensionvalidation/handler.go
+++ b/pkg/resourcemanager/webhook/extensionvalidation/handler.go
@@ -42,7 +42,7 @@ type (
 	workerValidator                struct{}
 )
 
-func (backupBucketValidator) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
+func (backupBucketValidator) ValidateCreate(_ context.Context, obj runtime.Object) (admission.Warnings, error) {
 	object := obj.(*extensionsv1alpha1.BackupBucket)
 	if errs := validation.ValidateBackupBucket(object); len(errs) > 0 {
 		return nil, apierrors.NewInvalid(extensionsv1alpha1.Kind(extensionsv1alpha1.BackupBucketResource), object.GetName(), errs)
@@ -50,7 +50,7 @@ func (backupBucketValidator) ValidateCreate(ctx context.Context, obj runtime.Obj
 	return nil, nil
 }
 
-func (backupBucketValidator) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
+func (backupBucketValidator) ValidateUpdate(_ context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
 	object := newObj.(*extensionsv1alpha1.BackupBucket)
 	if errs := validation.ValidateBackupBucketUpdate(object, oldObj.(*extensionsv1alpha1.BackupBucket)); len(errs) > 0 {
 		return nil, apierrors.NewInvalid(extensionsv1alpha1.Kind(extensionsv1alpha1.BackupBucketResource), object.GetName(), errs)
@@ -58,11 +58,11 @@ func (backupBucketValidator) ValidateUpdate(ctx context.Context, oldObj, newObj 
 	return nil, nil
 }
 
-func (backupBucketValidator) ValidateDelete(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
+func (backupBucketValidator) ValidateDelete(_ context.Context, _ runtime.Object) (admission.Warnings, error) {
 	return nil, nil
 }
 
-func (backupEntryValidator) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
+func (backupEntryValidator) ValidateCreate(_ context.Context, obj runtime.Object) (admission.Warnings, error) {
 	object := obj.(*extensionsv1alpha1.BackupEntry)
 	if errs := validation.ValidateBackupEntry(object); len(errs) > 0 {
 		return nil, apierrors.NewInvalid(extensionsv1alpha1.Kind(extensionsv1alpha1.BackupEntryResource), object.GetName(), errs)
@@ -70,7 +70,7 @@ func (backupEntryValidator) ValidateCreate(ctx context.Context, obj runtime.Obje
 	return nil, nil
 }
 
-func (backupEntryValidator) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
+func (backupEntryValidator) ValidateUpdate(_ context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
 	object := newObj.(*extensionsv1alpha1.BackupEntry)
 	if errs := validation.ValidateBackupEntryUpdate(object, oldObj.(*extensionsv1alpha1.BackupEntry)); len(errs) > 0 {
 		return nil, apierrors.NewInvalid(extensionsv1alpha1.Kind(extensionsv1alpha1.BackupEntryResource), object.GetName(), errs)
@@ -78,11 +78,11 @@ func (backupEntryValidator) ValidateUpdate(ctx context.Context, oldObj, newObj r
 	return nil, nil
 }
 
-func (backupEntryValidator) ValidateDelete(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
+func (backupEntryValidator) ValidateDelete(_ context.Context, _ runtime.Object) (admission.Warnings, error) {
 	return nil, nil
 }
 
-func (bastionValidator) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
+func (bastionValidator) ValidateCreate(_ context.Context, obj runtime.Object) (admission.Warnings, error) {
 	object := obj.(*extensionsv1alpha1.Bastion)
 	if errs := validation.ValidateBastion(object); len(errs) > 0 {
 		return nil, apierrors.NewInvalid(extensionsv1alpha1.Kind(extensionsv1alpha1.BastionResource), object.GetName(), errs)
@@ -90,7 +90,7 @@ func (bastionValidator) ValidateCreate(ctx context.Context, obj runtime.Object) 
 	return nil, nil
 }
 
-func (bastionValidator) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
+func (bastionValidator) ValidateUpdate(_ context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
 	object := newObj.(*extensionsv1alpha1.Bastion)
 	if errs := validation.ValidateBastionUpdate(object, oldObj.(*extensionsv1alpha1.Bastion)); len(errs) > 0 {
 		return nil, apierrors.NewInvalid(extensionsv1alpha1.Kind(extensionsv1alpha1.BastionResource), object.GetName(), errs)
@@ -98,11 +98,11 @@ func (bastionValidator) ValidateUpdate(ctx context.Context, oldObj, newObj runti
 	return nil, nil
 }
 
-func (bastionValidator) ValidateDelete(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
+func (bastionValidator) ValidateDelete(_ context.Context, _ runtime.Object) (admission.Warnings, error) {
 	return nil, nil
 }
 
-func (containerRuntimeValidator) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
+func (containerRuntimeValidator) ValidateCreate(_ context.Context, obj runtime.Object) (admission.Warnings, error) {
 	object := obj.(*extensionsv1alpha1.ContainerRuntime)
 	if errs := validation.ValidateContainerRuntime(object); len(errs) > 0 {
 		return nil, apierrors.NewInvalid(extensionsv1alpha1.Kind(extensionsv1alpha1.ContainerRuntimeResource), object.GetName(), errs)
@@ -110,7 +110,7 @@ func (containerRuntimeValidator) ValidateCreate(ctx context.Context, obj runtime
 	return nil, nil
 }
 
-func (containerRuntimeValidator) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
+func (containerRuntimeValidator) ValidateUpdate(_ context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
 	object := newObj.(*extensionsv1alpha1.ContainerRuntime)
 	if errs := validation.ValidateContainerRuntimeUpdate(object, oldObj.(*extensionsv1alpha1.ContainerRuntime)); len(errs) > 0 {
 		return nil, apierrors.NewInvalid(extensionsv1alpha1.Kind(extensionsv1alpha1.ContainerRuntimeResource), object.GetName(), errs)
@@ -118,11 +118,11 @@ func (containerRuntimeValidator) ValidateUpdate(ctx context.Context, oldObj, new
 	return nil, nil
 }
 
-func (containerRuntimeValidator) ValidateDelete(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
+func (containerRuntimeValidator) ValidateDelete(_ context.Context, _ runtime.Object) (admission.Warnings, error) {
 	return nil, nil
 }
 
-func (controlPlaneValidator) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
+func (controlPlaneValidator) ValidateCreate(_ context.Context, obj runtime.Object) (admission.Warnings, error) {
 	object := obj.(*extensionsv1alpha1.ControlPlane)
 	if errs := validation.ValidateControlPlane(object); len(errs) > 0 {
 		return nil, apierrors.NewInvalid(extensionsv1alpha1.Kind(extensionsv1alpha1.ControlPlaneResource), object.GetName(), errs)
@@ -130,7 +130,7 @@ func (controlPlaneValidator) ValidateCreate(ctx context.Context, obj runtime.Obj
 	return nil, nil
 }
 
-func (controlPlaneValidator) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
+func (controlPlaneValidator) ValidateUpdate(_ context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
 	object := newObj.(*extensionsv1alpha1.ControlPlane)
 	if errs := validation.ValidateControlPlaneUpdate(object, oldObj.(*extensionsv1alpha1.ControlPlane)); len(errs) > 0 {
 		return nil, apierrors.NewInvalid(extensionsv1alpha1.Kind(extensionsv1alpha1.ControlPlaneResource), object.GetName(), errs)
@@ -138,11 +138,11 @@ func (controlPlaneValidator) ValidateUpdate(ctx context.Context, oldObj, newObj 
 	return nil, nil
 }
 
-func (controlPlaneValidator) ValidateDelete(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
+func (controlPlaneValidator) ValidateDelete(_ context.Context, _ runtime.Object) (admission.Warnings, error) {
 	return nil, nil
 }
 
-func (dnsRecordValidator) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
+func (dnsRecordValidator) ValidateCreate(_ context.Context, obj runtime.Object) (admission.Warnings, error) {
 	object := obj.(*extensionsv1alpha1.DNSRecord)
 	if errs := validation.ValidateDNSRecord(object); len(errs) > 0 {
 		return nil, apierrors.NewInvalid(extensionsv1alpha1.Kind(extensionsv1alpha1.DNSRecordResource), object.GetName(), errs)
@@ -150,7 +150,7 @@ func (dnsRecordValidator) ValidateCreate(ctx context.Context, obj runtime.Object
 	return nil, nil
 }
 
-func (dnsRecordValidator) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
+func (dnsRecordValidator) ValidateUpdate(_ context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
 	object := newObj.(*extensionsv1alpha1.DNSRecord)
 	if errs := validation.ValidateDNSRecordUpdate(object, oldObj.(*extensionsv1alpha1.DNSRecord)); len(errs) > 0 {
 		return nil, apierrors.NewInvalid(extensionsv1alpha1.Kind(extensionsv1alpha1.DNSRecordResource), object.GetName(), errs)
@@ -158,11 +158,11 @@ func (dnsRecordValidator) ValidateUpdate(ctx context.Context, oldObj, newObj run
 	return nil, nil
 }
 
-func (dnsRecordValidator) ValidateDelete(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
+func (dnsRecordValidator) ValidateDelete(_ context.Context, _ runtime.Object) (admission.Warnings, error) {
 	return nil, nil
 }
 
-func (etcdValidator) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
+func (etcdValidator) ValidateCreate(_ context.Context, obj runtime.Object) (admission.Warnings, error) {
 	object := obj.(*druidv1alpha1.Etcd)
 	if errs := druidvalidation.ValidateEtcd(object); len(errs) > 0 {
 		return nil, apierrors.NewInvalid(object.GroupVersionKind().GroupKind(), object.GetName(), errs)
@@ -170,7 +170,7 @@ func (etcdValidator) ValidateCreate(ctx context.Context, obj runtime.Object) (ad
 	return nil, nil
 }
 
-func (etcdValidator) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
+func (etcdValidator) ValidateUpdate(_ context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
 	object := newObj.(*druidv1alpha1.Etcd)
 	if errs := druidvalidation.ValidateEtcdUpdate(object, oldObj.(*druidv1alpha1.Etcd)); len(errs) > 0 {
 		return nil, apierrors.NewInvalid(object.GroupVersionKind().GroupKind(), object.GetName(), errs)
@@ -178,11 +178,11 @@ func (etcdValidator) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.
 	return nil, nil
 }
 
-func (etcdValidator) ValidateDelete(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
+func (etcdValidator) ValidateDelete(_ context.Context, _ runtime.Object) (admission.Warnings, error) {
 	return nil, nil
 }
 
-func (extensionValidator) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
+func (extensionValidator) ValidateCreate(_ context.Context, obj runtime.Object) (admission.Warnings, error) {
 	object := obj.(*extensionsv1alpha1.Extension)
 	if errs := validation.ValidateExtension(object); len(errs) > 0 {
 		return nil, apierrors.NewInvalid(extensionsv1alpha1.Kind(extensionsv1alpha1.ExtensionResource), object.GetName(), errs)
@@ -190,7 +190,7 @@ func (extensionValidator) ValidateCreate(ctx context.Context, obj runtime.Object
 	return nil, nil
 }
 
-func (extensionValidator) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
+func (extensionValidator) ValidateUpdate(_ context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
 	object := newObj.(*extensionsv1alpha1.Extension)
 	if errs := validation.ValidateExtensionUpdate(object, oldObj.(*extensionsv1alpha1.Extension)); len(errs) > 0 {
 		return nil, apierrors.NewInvalid(extensionsv1alpha1.Kind(extensionsv1alpha1.ExtensionResource), object.GetName(), errs)
@@ -198,11 +198,11 @@ func (extensionValidator) ValidateUpdate(ctx context.Context, oldObj, newObj run
 	return nil, nil
 }
 
-func (extensionValidator) ValidateDelete(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
+func (extensionValidator) ValidateDelete(_ context.Context, _ runtime.Object) (admission.Warnings, error) {
 	return nil, nil
 }
 
-func (infrastructureValidator) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
+func (infrastructureValidator) ValidateCreate(_ context.Context, obj runtime.Object) (admission.Warnings, error) {
 	object := obj.(*extensionsv1alpha1.Infrastructure)
 	if errs := validation.ValidateInfrastructure(object); len(errs) > 0 {
 		return nil, apierrors.NewInvalid(extensionsv1alpha1.Kind(extensionsv1alpha1.InfrastructureResource), object.GetName(), errs)
@@ -210,7 +210,7 @@ func (infrastructureValidator) ValidateCreate(ctx context.Context, obj runtime.O
 	return nil, nil
 }
 
-func (infrastructureValidator) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
+func (infrastructureValidator) ValidateUpdate(_ context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
 	object := newObj.(*extensionsv1alpha1.Infrastructure)
 	if errs := validation.ValidateInfrastructureUpdate(object, oldObj.(*extensionsv1alpha1.Infrastructure)); len(errs) > 0 {
 		return nil, apierrors.NewInvalid(extensionsv1alpha1.Kind(extensionsv1alpha1.InfrastructureResource), object.GetName(), errs)
@@ -218,11 +218,11 @@ func (infrastructureValidator) ValidateUpdate(ctx context.Context, oldObj, newOb
 	return nil, nil
 }
 
-func (infrastructureValidator) ValidateDelete(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
+func (infrastructureValidator) ValidateDelete(_ context.Context, _ runtime.Object) (admission.Warnings, error) {
 	return nil, nil
 }
 
-func (networkValidator) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
+func (networkValidator) ValidateCreate(_ context.Context, obj runtime.Object) (admission.Warnings, error) {
 	object := obj.(*extensionsv1alpha1.Network)
 	if errs := validation.ValidateNetwork(object); len(errs) > 0 {
 		return nil, apierrors.NewInvalid(extensionsv1alpha1.Kind(extensionsv1alpha1.NetworkResource), object.GetName(), errs)
@@ -230,7 +230,7 @@ func (networkValidator) ValidateCreate(ctx context.Context, obj runtime.Object) 
 	return nil, nil
 }
 
-func (networkValidator) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
+func (networkValidator) ValidateUpdate(_ context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
 	object := newObj.(*extensionsv1alpha1.Network)
 	if errs := validation.ValidateNetworkUpdate(object, oldObj.(*extensionsv1alpha1.Network)); len(errs) > 0 {
 		return nil, apierrors.NewInvalid(extensionsv1alpha1.Kind(extensionsv1alpha1.NetworkResource), object.GetName(), errs)
@@ -238,11 +238,11 @@ func (networkValidator) ValidateUpdate(ctx context.Context, oldObj, newObj runti
 	return nil, nil
 }
 
-func (networkValidator) ValidateDelete(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
+func (networkValidator) ValidateDelete(_ context.Context, _ runtime.Object) (admission.Warnings, error) {
 	return nil, nil
 }
 
-func (operatingSystemConfigValidator) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
+func (operatingSystemConfigValidator) ValidateCreate(_ context.Context, obj runtime.Object) (admission.Warnings, error) {
 	object := obj.(*extensionsv1alpha1.OperatingSystemConfig)
 	if errs := validation.ValidateOperatingSystemConfig(object); len(errs) > 0 {
 		return nil, apierrors.NewInvalid(extensionsv1alpha1.Kind(extensionsv1alpha1.OperatingSystemConfigResource), object.GetName(), errs)
@@ -250,7 +250,7 @@ func (operatingSystemConfigValidator) ValidateCreate(ctx context.Context, obj ru
 	return nil, nil
 }
 
-func (operatingSystemConfigValidator) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
+func (operatingSystemConfigValidator) ValidateUpdate(_ context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
 	object := newObj.(*extensionsv1alpha1.OperatingSystemConfig)
 	if errs := validation.ValidateOperatingSystemConfigUpdate(object, oldObj.(*extensionsv1alpha1.OperatingSystemConfig)); len(errs) > 0 {
 		return nil, apierrors.NewInvalid(extensionsv1alpha1.Kind(extensionsv1alpha1.OperatingSystemConfigResource), object.GetName(), errs)
@@ -258,11 +258,11 @@ func (operatingSystemConfigValidator) ValidateUpdate(ctx context.Context, oldObj
 	return nil, nil
 }
 
-func (operatingSystemConfigValidator) ValidateDelete(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
+func (operatingSystemConfigValidator) ValidateDelete(_ context.Context, _ runtime.Object) (admission.Warnings, error) {
 	return nil, nil
 }
 
-func (workerValidator) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
+func (workerValidator) ValidateCreate(_ context.Context, obj runtime.Object) (admission.Warnings, error) {
 	object := obj.(*extensionsv1alpha1.Worker)
 	if errs := validation.ValidateWorker(object); len(errs) > 0 {
 		return nil, apierrors.NewInvalid(extensionsv1alpha1.Kind(extensionsv1alpha1.WorkerResource), object.GetName(), errs)
@@ -270,7 +270,7 @@ func (workerValidator) ValidateCreate(ctx context.Context, obj runtime.Object) (
 	return nil, nil
 }
 
-func (workerValidator) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
+func (workerValidator) ValidateUpdate(_ context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
 	object := newObj.(*extensionsv1alpha1.Worker)
 	if errs := validation.ValidateWorkerUpdate(object, oldObj.(*extensionsv1alpha1.Worker)); len(errs) > 0 {
 		return nil, apierrors.NewInvalid(extensionsv1alpha1.Kind(extensionsv1alpha1.WorkerResource), object.GetName(), errs)
@@ -278,6 +278,6 @@ func (workerValidator) ValidateUpdate(ctx context.Context, oldObj, newObj runtim
 	return nil, nil
 }
 
-func (workerValidator) ValidateDelete(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
+func (workerValidator) ValidateDelete(_ context.Context, _ runtime.Object) (admission.Warnings, error) {
 	return nil, nil
 }

--- a/pkg/utils/kubernetes/client/client.go
+++ b/pkg/utils/kubernetes/client/client.go
@@ -433,7 +433,7 @@ func ApplyToObjectKinds(ctx context.Context, fn func(kind string, objectList cli
 }
 
 // ForceDeleteObjects lists and finalizes all the objects in the passed namespace and deletes them.
-func ForceDeleteObjects(ctx context.Context, c client.Client, kind string, namespace string, objectList client.ObjectList, opts ...client.ListOption) flow.TaskFn {
+func ForceDeleteObjects(c client.Client, namespace string, objectList client.ObjectList, opts ...client.ListOption) flow.TaskFn {
 	return func(ctx context.Context) error {
 		listOpts := &client.ListOptions{Namespace: namespace}
 		listOpts.ApplyOptions(opts)

--- a/pkg/utils/kubernetes/client/client_test.go
+++ b/pkg/utils/kubernetes/client/client_test.go
@@ -706,7 +706,7 @@ var _ = Describe("Cleaner", func() {
 			Expect(fakeClient.List(ctx, secretList)).To(Succeed())
 			Expect(secretList.Items).To(HaveLen(6))
 
-			taskFns := ForceDeleteObjects(ctx, fakeClient, "Secret", "default", &corev1.SecretList{}, client.MatchingLabels{"key": "value"})
+			taskFns := ForceDeleteObjects(fakeClient, "default", &corev1.SecretList{}, client.MatchingLabels{"key": "value"})
 			Expect(flow.Parallel(taskFns)(ctx)).To(Succeed())
 
 			Expect(fakeClient.List(ctx, secretList)).To(Succeed())

--- a/pkg/utils/test/manager.go
+++ b/pkg/utils/test/manager.go
@@ -42,7 +42,7 @@ func (f FakeManager) GetCache() cache.Cache {
 }
 
 // GetEventRecorderFor returns the given eventRecorder.
-func (f FakeManager) GetEventRecorderFor(name string) record.EventRecorder {
+func (f FakeManager) GetEventRecorderFor(_ string) record.EventRecorder {
 	return f.EventRecorder
 }
 

--- a/test/e2e/gardener/shoot/internal/rotation/kubeconfig.go
+++ b/test/e2e/gardener/shoot/internal/rotation/kubeconfig.go
@@ -92,7 +92,7 @@ func (v *KubeconfigVerifier) AfterPrepared(ctx context.Context) {
 }
 
 // ExpectCompletingStatus is called while waiting for the Completing status.
-func (v *KubeconfigVerifier) ExpectCompletingStatus(g Gomega) {
+func (v *KubeconfigVerifier) ExpectCompletingStatus(_ Gomega) {
 	// there is no second phase for the kubeconfig rotation
 }
 

--- a/test/e2e/gardener/shoot/internal/rotation/shoot_access.go
+++ b/test/e2e/gardener/shoot/internal/rotation/shoot_access.go
@@ -91,7 +91,7 @@ func (v *ShootAccessVerifier) Before(ctx context.Context) {
 }
 
 // ExpectPreparingStatus is called while waiting for the Preparing status.
-func (v *ShootAccessVerifier) ExpectPreparingStatus(g Gomega) {}
+func (v *ShootAccessVerifier) ExpectPreparingStatus(_ Gomega) {}
 
 // AfterPrepared is called when the Shoot is in Prepared status.
 func (v *ShootAccessVerifier) AfterPrepared(ctx context.Context) {
@@ -172,7 +172,7 @@ func (v *ShootAccessVerifier) AfterPrepared(ctx context.Context) {
 }
 
 // ExpectCompletingStatus is called while waiting for the Completing status.
-func (v *ShootAccessVerifier) ExpectCompletingStatus(g Gomega) {}
+func (v *ShootAccessVerifier) ExpectCompletingStatus(_ Gomega) {}
 
 // AfterCompleted is called when the Shoot is in Completed status.
 func (v *ShootAccessVerifier) AfterCompleted(ctx context.Context) {

--- a/test/e2e/gardener/shoot/internal/rotation/ssh_keypair.go
+++ b/test/e2e/gardener/shoot/internal/rotation/ssh_keypair.go
@@ -118,10 +118,10 @@ func (v *SSHKeypairVerifier) AfterPrepared(ctx context.Context) {
 // hence, there is nothing to check in the second part of the credentials rotation
 
 // ExpectCompletingStatus is called while waiting for the Completing status.
-func (v *SSHKeypairVerifier) ExpectCompletingStatus(g Gomega) {}
+func (v *SSHKeypairVerifier) ExpectCompletingStatus(_ Gomega) {}
 
 // AfterCompleted is called when the Shoot is in Completed status.
-func (v *SSHKeypairVerifier) AfterCompleted(ctx context.Context) {}
+func (v *SSHKeypairVerifier) AfterCompleted(_ context.Context) {}
 
 // Since we can't (and do not want ;-)) trying to really SSH into the machine pods from our test environment, we can
 // only check whether the `.ssh/authorized_keys` file on the worker nodes has the expected content.

--- a/test/e2e/operator/garden/internal/rotation/certificate_authorities.go
+++ b/test/e2e/operator/garden/internal/rotation/certificate_authorities.go
@@ -35,10 +35,6 @@ type CAVerifier struct {
 	RuntimeClient client.Client
 	Garden        *operatorv1alpha1.Garden
 
-	oldCACert []byte
-	caBundle  []byte
-	newCACert []byte
-
 	secretsBefore    rotation.SecretConfigNamesToSecrets
 	secretsPrepared  rotation.SecretConfigNamesToSecrets
 	secretsCompleted rotation.SecretConfigNamesToSecrets

--- a/test/e2e/operator/garden/internal/rotation/virtual_garden_access.go
+++ b/test/e2e/operator/garden/internal/rotation/virtual_garden_access.go
@@ -66,7 +66,7 @@ func (v *VirtualGardenAccessVerifier) Before(ctx context.Context) {
 }
 
 // ExpectPreparingStatus is called while waiting for the Preparing status.
-func (v *VirtualGardenAccessVerifier) ExpectPreparingStatus(g Gomega) {}
+func (v *VirtualGardenAccessVerifier) ExpectPreparingStatus(_ Gomega) {}
 
 // AfterPrepared is called when the Shoot is in Prepared status.
 func (v *VirtualGardenAccessVerifier) AfterPrepared(ctx context.Context) {
@@ -106,7 +106,7 @@ func (v *VirtualGardenAccessVerifier) AfterPrepared(ctx context.Context) {
 }
 
 // ExpectCompletingStatus is called while waiting for the Completing status.
-func (v *VirtualGardenAccessVerifier) ExpectCompletingStatus(g Gomega) {}
+func (v *VirtualGardenAccessVerifier) ExpectCompletingStatus(_ Gomega) {}
 
 // AfterCompleted is called when the Shoot is in Completed status.
 func (v *VirtualGardenAccessVerifier) AfterCompleted(ctx context.Context) {

--- a/test/framework/framework_test.go
+++ b/test/framework/framework_test.go
@@ -15,7 +15,6 @@
 package framework_test
 
 import (
-	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -57,7 +56,7 @@ var _ = Describe("Framework tests", func() {
 			err := framework.EnsureRepositoryDirectories(helmRepo)
 			Expect(err).NotTo(HaveOccurred())
 
-			err = f.DownloadChartArtifacts(context.TODO(), helmRepo, f.ChartDir, "stable/redis", "10.2.1")
+			err = f.DownloadChartArtifacts(helmRepo, f.ChartDir, "stable/redis", "10.2.1")
 			Expect(err).NotTo(HaveOccurred())
 
 			expectedCachePath := filepath.Join(f.ResourcesDir, "repository", "cache", "stable-index.yaml")

--- a/test/integration/controllermanager/seed/backupbucketscheck/backupbucketscheck_test.go
+++ b/test/integration/controllermanager/seed/backupbucketscheck/backupbucketscheck_test.go
@@ -122,8 +122,8 @@ var _ = Describe("Seed BackupBucketsCheck controller tests", func() {
 	})
 
 	JustBeforeEach(func() {
-		createBackupBucket(bb1, seed)
-		createBackupBucket(bb2, seed)
+		createBackupBucket(bb1)
+		createBackupBucket(bb2)
 
 		By("Wait until BackupBucketsReady condition is set to True")
 		Eventually(func(g Gomega) {
@@ -193,7 +193,7 @@ var _ = Describe("Seed BackupBucketsCheck controller tests", func() {
 	})
 })
 
-func createBackupBucket(backupBucket *gardencorev1beta1.BackupBucket, seed *gardencorev1beta1.Seed) {
+func createBackupBucket(backupBucket *gardencorev1beta1.BackupBucket) {
 	By("Create BackupBucket")
 	Expect(testClient.Create(ctx, backupBucket)).To(Succeed(), backupBucket.Name+" should be created")
 	log.Info("Created BackupBucket for test", "backupBucket", client.ObjectKeyFromObject(backupBucket))

--- a/test/integration/extensions/webhook/cloudprovider/ensurer.go
+++ b/test/integration/extensions/webhook/cloudprovider/ensurer.go
@@ -38,7 +38,7 @@ type ensurer struct {
 // EnsureCloudProviderSecret is implemented on extension side which mutates the cloudprovider secret. contain
 // For testing purpose we are mutating the cloudprovider secret's data to check whether this
 // function is called in webhook.
-func (e *ensurer) EnsureCloudProviderSecret(ctx context.Context, _ extensionscontextwebhook.GardenContext, new, _ *corev1.Secret) error {
+func (e *ensurer) EnsureCloudProviderSecret(_ context.Context, _ extensionscontextwebhook.GardenContext, new, _ *corev1.Secret) error {
 	e.logger.Info("Mutate cloudprovider secret", "namespace", new.Namespace, "name", new.Name)
 	new.Data["clientID"] = []byte(`foo`)
 	new.Data["clientSecret"] = []byte(`bar`)

--- a/test/testmachinery/shoots/logging/seed_logging_stack.go
+++ b/test/testmachinery/shoots/logging/seed_logging_stack.go
@@ -160,7 +160,7 @@ var _ = ginkgo.Describe("Seed logging testing", func() {
 		framework.ExpectNoError(create(ctx, f.ShootClient.Client(), prepareShootLoggingService(shootLoggingService, "logging-shoot", shootValiLabels)))
 		framework.ExpectNoError(create(ctx, f.ShootClient.Client(), shootValiPriorityClass))
 		framework.ExpectNoError(create(ctx, f.ShootClient.Client(), prepareShootValiConfigMap(shootValiConfMap)))
-		framework.ExpectNoError(create(ctx, f.ShootClient.Client(), prepareShootValiStatefulSet(shootValiSts, gardenValiSts, shootValiName, shootValiConfMap.Name, valiPersistentVolumeName, emptyDirSize, shootValiLabels, gardenValiLabels)))
+		framework.ExpectNoError(create(ctx, f.ShootClient.Client(), prepareShootValiStatefulSet(shootValiSts, gardenValiSts, shootValiName, valiPersistentVolumeName, emptyDirSize, shootValiLabels, gardenValiLabels)))
 
 		ginkgo.By("Wait until Vali StatefulSet for Garden namespace is ready")
 		framework.ExpectNoError(f.WaitUntilStatefulSetIsRunning(ctx, gardenValiSts.Name, v1beta1constants.GardenNamespace, f.ShootClient))
@@ -321,7 +321,7 @@ func prepareShootValiConfigMap(confMap *corev1.ConfigMap) *corev1.ConfigMap {
 	return confMap
 }
 
-func prepareShootValiStatefulSet(shootValiSts, gardenValiSts *appsv1.StatefulSet, name, configMapNAme, valiPersistentVolumeName, emptyDirSize string, newLabels, antiAffinityLabels map[string]string) *appsv1.StatefulSet {
+func prepareShootValiStatefulSet(shootValiSts, gardenValiSts *appsv1.StatefulSet, name, valiPersistentVolumeName, emptyDirSize string, newLabels, antiAffinityLabels map[string]string) *appsv1.StatefulSet {
 	// Extract the containers related only to the seed logging stack
 	var containers []corev1.Container
 	for _, gardenCon := range gardenValiSts.Spec.Template.Spec.Containers {

--- a/test/utils/rotation/encrypted_data.go
+++ b/test/utils/rotation/encrypted_data.go
@@ -43,7 +43,7 @@ func (v *EncryptedDataVerifier) Before(ctx context.Context) {
 }
 
 // ExpectPreparingStatus is called while waiting for the Preparing status.
-func (v *EncryptedDataVerifier) ExpectPreparingStatus(g Gomega) {}
+func (v *EncryptedDataVerifier) ExpectPreparingStatus(_ Gomega) {}
 
 // AfterPrepared is called when the Shoot is in Prepared status.
 func (v *EncryptedDataVerifier) AfterPrepared(ctx context.Context) {
@@ -52,7 +52,7 @@ func (v *EncryptedDataVerifier) AfterPrepared(ctx context.Context) {
 }
 
 // ExpectCompletingStatus is called while waiting for the Completing status.
-func (v *EncryptedDataVerifier) ExpectCompletingStatus(g Gomega) {}
+func (v *EncryptedDataVerifier) ExpectCompletingStatus(_ Gomega) {}
 
 // AfterCompleted is called when the Shoot is in Completed status.
 func (v *EncryptedDataVerifier) AfterCompleted(ctx context.Context) {

--- a/test/utils/rotation/observability.go
+++ b/test/utils/rotation/observability.go
@@ -106,10 +106,10 @@ func (v *ObservabilityVerifier) AfterPrepared(ctx context.Context) {
 // hence, there is nothing to check in the second part of the credentials rotation
 
 // ExpectCompletingStatus is called while waiting for the Completing status.
-func (v *ObservabilityVerifier) ExpectCompletingStatus(g Gomega) {}
+func (v *ObservabilityVerifier) ExpectCompletingStatus(_ Gomega) {}
 
 // AfterCompleted is called when the Shoot is in Completed status.
-func (v *ObservabilityVerifier) AfterCompleted(ctx context.Context) {}
+func (v *ObservabilityVerifier) AfterCompleted(_ context.Context) {}
 
 func accessEndpoint(ctx context.Context, url string, username, password []byte) (*http.Response, error) {
 	httpClient := &http.Client{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind cleanup

**What this PR does / why we need it**:
This PR enables the `unused` linter, and the following few rules for the `revive` linter, and fixes the findings:

- `unused-parameter`
- `unreachable-code`
- `context-as-argument`
- `early-return`
- `exported`

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking dependency
The `extensions/pkg/controller.Use{TokenRequestor,ServiceAccountTokenVolumeProjection}` functions have been removed since they always return `true`.
```
