### PR TITLE
Do not persist extensions with empty state in `ShootState`

### DIFF
--- a/pkg/utils/gardener/shootstate/shootstate.go
+++ b/pkg/utils/gardener/shootstate/shootstate.go
@@ -197,7 +197,8 @@ func computeExtensionsDataAndResources(
 				return fmt.Errorf("failed accessing extension object: %w", err)
 			}
 
-			if extensionObj.GetDeletionTimestamp() != nil {
+			if extensionObj.GetDeletionTimestamp() != nil ||
+				(extensionObj.GetExtensionStatus().GetState() == nil && len(extensionObj.GetExtensionStatus().GetResources()) == 0) {
 				return nil
 			}
 

--- a/pkg/utils/gardener/shootstate/shootstate_test.go
+++ b/pkg/utils/gardener/shootstate/shootstate_test.go
@@ -114,8 +114,9 @@ var _ = Describe("ShootState", func() {
 				createExtensionObject(ctx, fakeSeedClient, "infrastructure", seedNamespace, &extensionsv1alpha1.Infrastructure{}, &runtime.RawExtension{Raw: []byte(`{"name":"infrastructure"}`)})
 				createExtensionObject(ctx, fakeSeedClient, "network", seedNamespace, &extensionsv1alpha1.Network{}, &runtime.RawExtension{Raw: []byte(`{"name":"network"}`)})
 				createExtensionObject(ctx, fakeSeedClient, "osc", seedNamespace, &extensionsv1alpha1.OperatingSystemConfig{}, &runtime.RawExtension{Raw: []byte(`{"name":"osc"}`)})
-				createExtensionObject(ctx, fakeSeedClient, "osc2", seedNamespace, &extensionsv1alpha1.OperatingSystemConfig{}, nil)
 				createExtensionObject(ctx, fakeSeedClient, "worker", seedNamespace, &extensionsv1alpha1.Worker{}, &runtime.RawExtension{Raw: []byte(`{"name":"worker"}`)})
+				// this extension object has no state, hence it should not be persisted in the ShootState
+				createExtensionObject(ctx, fakeSeedClient, "osc2", seedNamespace, &extensionsv1alpha1.OperatingSystemConfig{}, nil)
 
 				expectedSpec = gardencorev1beta1.ShootStateSpec{
 					Gardener: []gardencorev1beta1.GardenerResourceData{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area scalability
/kind enhancement

**What this PR does / why we need it**:
Before:

```yaml
apiVersion: core.gardener.cloud/v1beta1
kind: ShootState
metadata:
  name: local
  namespace: garden-local
spec:
  extensions:
  - kind: ControlPlane
    name: local
    purpose: normal
  - kind: DNSRecord
    name: local-external
  - kind: DNSRecord
    name: local-internal
  - kind: DNSRecord
    name: plutono-5ef32b8d
  - kind: DNSRecord
    name: vali-b2d94c12
  - kind: DNSRecord
    name: prometheus-e81fd523
  - kind: Infrastructure
    name: local
  - kind: Network
    name: local
  - kind: OperatingSystemConfig
    name: cloud-config-local-f76b6-local-downloader
    purpose: provision
  - kind: OperatingSystemConfig
    name: cloud-config-local-f76b6-local-original
    purpose: reconcile
  - kind: Worker
    name: local
    state:
      machineDeployments:
        shoot--local--local-local:
          machineSets:
          - apiVersion: machine.sapcloud.io/v1alpha1
...
```

After:

```yaml
apiVersion: core.gardener.cloud/v1beta1
kind: ShootState
metadata:
  name: local
  namespace: garden-local
spec:
  extensions:
  - kind: Worker
    name: local
    state:
      machineDeployments:
        shoot--local--local-local:
          machineSets:
          - apiVersion: machine.sapcloud.io/v1alpha1
```

Triggered by #8488

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
