### PR TITLE
Extend `ManagedResource` controller to optionally finalize resource deletion after grace period

### DIFF
--- a/docs/concepts/resource-manager.md
+++ b/docs/concepts/resource-manager.md
@@ -200,6 +200,12 @@ In some cases, it is not desirable to update or re-apply some of the cluster com
 For these resources, the annotation "resources.gardener.cloud/ignore" needs to be set to "true" or a truthy value (Truthy values are "1", "t", "T", "true", "TRUE", "True") in the corresponding managed resource secrets.
 This can be done from the components that create the managed resource secrets, for example Gardener extensions or Gardener. Once this is done, the resource will be initially created and later ignored during reconciliation.
 
+#### Finalizing Deletion of Resources After Grace Period
+
+When a `ManagedResource` is deleted, the controller deletes all managed resources from the target cluster.
+In case the resources still have entries in their `.metadata.finalizers[]` list, they will remain stuck in the system until another entity removes the finalizers.
+If you want the controller to forcefully finalize the deletion after some grace period (i.e., setting `.metadata.finalizers=null`), you can annotate the managed resources with `resources.gardener.cloud/finalize-deletion-after=<duration>`, e.g., `resources.gardener.cloud/finalize-deletion-after=1h`.
+
 #### Preserving `replicas` or `resources` in Workload Resources
 
 The objects which are part of the `ManagedResource` can be annotated with:

--- a/pkg/apis/resources/v1alpha1/types.go
+++ b/pkg/apis/resources/v1alpha1/types.go
@@ -52,6 +52,9 @@ const (
 	// It is set by the ManagedResource controller to the key of the owning ManagedResource, optionally prefixed with the
 	// clusterID.
 	OriginAnnotation = "resources.gardener.cloud/origin"
+	// FinalizeDeletionAfter is an annotation on an object part of a ManagedResource that whose value states the
+	// duration after which a deletion should be finalized (i.e., removal of `.metadata.finalizers[]`).
+	FinalizeDeletionAfter = "resources.gardener.cloud/finalize-deletion-after"
 
 	// ManagedBy is a constant for a label on an object managed by a ManagedResource.
 	// It is set by the ManagedResource controller depending on its configuration. By default it is set to "gardener".

--- a/skaffold-operator.yaml
+++ b/skaffold-operator.yaml
@@ -264,9 +264,11 @@ build:
         - pkg/utils/gardener
         - pkg/utils/imagevector
         - pkg/utils/kubernetes
+        - pkg/utils/kubernetes/client
         - pkg/utils/kubernetes/health
         - pkg/utils/retry
         - pkg/utils/secrets
+        - pkg/utils/time
         - pkg/utils/timewindow
         - pkg/utils/validation/cidr
         - pkg/utils/validation/kubernetesversion

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -1077,9 +1077,11 @@ build:
         - pkg/utils/gardener
         - pkg/utils/imagevector
         - pkg/utils/kubernetes
+        - pkg/utils/kubernetes/client
         - pkg/utils/kubernetes/health
         - pkg/utils/retry
         - pkg/utils/secrets
+        - pkg/utils/time
         - pkg/utils/timewindow
         - pkg/utils/validation/cidr
         - pkg/utils/validation/kubernetes/core

--- a/test/integration/resourcemanager/managedresource/resource_test.go
+++ b/test/integration/resourcemanager/managedresource/resource_test.go
@@ -541,6 +541,52 @@ var _ = Describe("ManagedResource controller tests", func() {
 			})
 		})
 
+		Describe("Finalize Deletion", func() {
+			finalizeDeletionAfter := time.Hour
+
+			BeforeEach(func() {
+				configMap.SetAnnotations(map[string]string{resourcesv1alpha1.FinalizeDeletionAfter: finalizeDeletionAfter.String()})
+				configMap.Finalizers = []string{"some.finalizer.to/make-the-deletion-stuck"}
+				secretForManagedResource.Data = secretDataForObject(configMap, dataKey)
+			})
+
+			JustBeforeEach(func() {
+				Eventually(func(g Gomega) []gardencorev1beta1.Condition {
+					g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)).To(Succeed())
+					return managedResource.Status.Conditions
+				}).Should(ContainCondition(
+					OfType(resourcesv1alpha1.ResourcesApplied),
+					WithStatus(gardencorev1beta1.ConditionTrue),
+					WithReason(resourcesv1alpha1.ConditionApplySucceeded),
+				))
+			})
+
+			JustAfterEach(func() {
+				patch := client.MergeFrom(configMap.DeepCopy())
+				configMap.Finalizers = nil
+				Expect(testClient.Patch(ctx, configMap, patch)).To(Or(Succeed(), BeNotFoundError()))
+				Expect(testClient.Delete(ctx, configMap)).To(Or(Succeed(), BeNotFoundError()))
+			})
+
+			It("should forcefully finalize the deletion after the grace period has elapsed", func() {
+				By("Delete ManagedResource")
+				Expect(testClient.Delete(ctx, managedResource)).To(Succeed())
+
+				By("Expect ConfigMap to remain in the system")
+				Consistently(func() error {
+					return testClient.Get(ctx, client.ObjectKeyFromObject(configMap), configMap)
+				}).Should(Succeed())
+
+				By("Stepping fake clock")
+				fakeClock.Step(finalizeDeletionAfter + time.Second)
+
+				By("Expect ConfigMap to disappear from the system")
+				Eventually(func() error {
+					return testClient.Get(ctx, client.ObjectKeyFromObject(configMap), configMap)
+				}).Should(BeNotFoundError())
+			})
+		})
+
 		Describe("Keep garbage-collectable object", func() {
 			var node *corev1.Node
 

--- a/test/integration/resourcemanager/managedresource/resource_test.go
+++ b/test/integration/resourcemanager/managedresource/resource_test.go
@@ -572,13 +572,16 @@ var _ = Describe("ManagedResource controller tests", func() {
 				By("Delete ManagedResource")
 				Expect(testClient.Delete(ctx, managedResource)).To(Succeed())
 
+				By("Stepping fake clock")
+				fakeClock.Step(finalizeDeletionAfter - time.Second)
+
 				By("Expect ConfigMap to remain in the system")
 				Consistently(func() error {
 					return testClient.Get(ctx, client.ObjectKeyFromObject(configMap), configMap)
 				}).Should(Succeed())
 
 				By("Stepping fake clock")
-				fakeClock.Step(finalizeDeletionAfter + time.Second)
+				fakeClock.Step(2 * time.Second)
 
 				By("Expect ConfigMap to disappear from the system")
 				Eventually(func() error {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
With this PR, it is possible to annotate managed resource part of `ManagedResource` with `resources.gardener.cloud/finalize-deletion-after=<duration>`, e.g., `resources.gardener.cloud/finalize-deletion-after=1h`.
After this time, it will forcefully delete the resource by removing their finalizers.

Without this annotation, it would block forever until another entity removes the finalizers from the managed resource (today's behaviour).

This feature can be helpful for extension developers that want `gardener-resource-manager` from forcefully deleting their managed resources after some grace period (e.g., cert-/dns extension which deploy CRDs into the shoot cluster).

**Special notes for your reviewer**:
/cc @ScheererJ 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature developer
It is now possible to annotate managed resources part of `ManagedResource` objects with `resources.gardener.cloud/finalize-deletion-after=<duration>`, e.g., `resources.gardener.cloud/finalize-deletion-after=1h`. After this time, `gardener-resource-manager` will forcefully delete the resource by removing their finalizers.
```
