### PR TITLE
Decrease log verbosity of MCM

### DIFF
--- a/pkg/component/machinecontrollermanager/machine_controller_manager.go
+++ b/pkg/component/machinecontrollermanager/machine_controller_manager.go
@@ -213,7 +213,7 @@ func (m *machineControllerManager) Deploy(ctx context.Context) error {
 						"--safety-up=2",
 						"--safety-down=1",
 						"--target-kubeconfig=" + gardenerutils.PathGenericKubeconfig,
-						"--v=4",
+						"--v=3",
 					},
 					LivenessProbe: &corev1.Probe{
 						ProbeHandler: corev1.ProbeHandler{

--- a/pkg/component/machinecontrollermanager/machine_controller_manager_test.go
+++ b/pkg/component/machinecontrollermanager/machine_controller_manager_test.go
@@ -229,7 +229,7 @@ var _ = Describe("MachineControllerManager", func() {
 								"--safety-up=2",
 								"--safety-down=1",
 								"--target-kubeconfig=/var/run/secrets/gardener.cloud/shoot/generic-kubeconfig/kubeconfig",
-								"--v=4",
+								"--v=3",
 							},
 							LivenessProbe: &corev1.Probe{
 								ProbeHandler: corev1.ProbeHandler{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity quality
/kind enhancement

**What this PR does / why we need it**:
When multiple pods run for MCM then logs of pods which is not a leader is polluted by the leader-election logs as below -
```
I1003 08:23:13.051130       1 leaderelection.go:352] lock is held by machine-controller-manager-9f54c64d4-szkrb and has not yet expired
I1003 08:23:13.051146       1 leaderelection.go:253] failed to acquire lease shoot--dev--local/machine-controller-manager
I1003 08:23:15.330279       1 leaderelection.go:352] lock is held by machine-controller-manager-9f54c64d4-szkrb and has not yet expired
I1003 08:23:15.330294       1 leaderelection.go:253] failed to acquire lease shoot--dev--local/machine-controller-manager
I1003 08:23:17.518888       1 leaderelection.go:352] lock is held by machine-controller-manager-9f54c64d4-szkrb and has not yet expired
I1003 08:23:17.518903       1 leaderelection.go:253] failed to acquire lease shoot--dev--local/machine-controller-manager
I1003 08:23:20.934809       1 leaderelection.go:352] lock is held by machine-controller-manager-9f54c64d4-szkrb and has not yet expired
I1003 08:23:20.934824       1 leaderelection.go:253] failed to acquire lease shoot--dev--local/machine-controller-manager
I1003 08:23:23.850938       1 leaderelection.go:352] lock is held by machine-controller-manager-9f54c64d4-szkrb and has not yet expired
I1003 08:23:23.850954       1 leaderelection.go:253] failed to acquire lease shoot--dev--local/machine-controller-manager
I1003 08:23:27.604540       1 leaderelection.go:352] lock is held by machine-controller-manager-9f54c64d4-szkrb and has not yet expired
I1003 08:23:27.604554       1 leaderelection.go:253] failed to acquire lease shoot--dev--local/machine-controller-manager
I1003 08:23:31.365744       1 leaderelection.go:352] lock is held by machine-controller-manager-9f54c64d4-szkrb and has not yet expired
I1003 08:23:31.365759       1 leaderelection.go:253] failed to acquire lease shoot--dev--local/machine-controller-manager
I1003 08:23:35.071822       1 leaderelection.go:352] lock is held by machine-controller-manager-9f54c64d4-szkrb and has not yet expired
```

Similarly for pods which is leader these kind (ex - informer) of logs is logged 
```
I0928 04:13:51.605324       1 reflector.go:559] github.com/gardener/machine-controller-manager/pkg/client/informers/externalversions/factory.go:132: Watch close - *v1alpha1.MachineSet total 1 items received
```
 
These are irrelevant and should not stored.

/cc @himanshu-kun 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
