### PR TITLE
Fix `provider-extension` script for custom seed name

### DIFF
--- a/example/provider-extensions/seed/create-seed.sh
+++ b/example/provider-extensions/seed/create-seed.sh
@@ -35,12 +35,13 @@ garden_kubeconfig=$1
 seed_kubeconfig=$2
 seed_name=$3
 
-registry_domain=$(cat "$SCRIPT_DIR"/registrydomain)
+registry_domain_file="$SCRIPT_DIR/registrydomain"
 seed_values=values.yaml
 if [[ "$seed_name" != "provider-extensions" ]]; then
-  registry_domain=$(cat "$SCRIPT_DIR"/registrydomain-"$seed_name")
+  registry_domain_file="$SCRIPT_DIR/registrydomain-$seed_name"
   seed_values=values-"$seed_name".yaml
 fi
+registry_domain=$(cat $registry_domain_file)
 
 echo "Skaffolding seed"
 GARDENER_LOCAL_KUBECONFIG=$garden_kubeconfig \

--- a/example/provider-extensions/seed/create-seed.sh
+++ b/example/provider-extensions/seed/create-seed.sh
@@ -41,7 +41,7 @@ if [[ "$seed_name" != "provider-extensions" ]]; then
   registry_domain_file="$SCRIPT_DIR/registrydomain-$seed_name"
   seed_values=values-"$seed_name".yaml
 fi
-registry_domain=$(cat $registry_domain_file)
+registry_domain=$(cat "$registry_domain_file")
 
 echo "Skaffolding seed"
 GARDENER_LOCAL_KUBECONFIG=$garden_kubeconfig \


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind bug

**What this PR does / why we need it**:
When we start the `provider-extension` setup with a custom seed name, It fails with
```
cat: /Users/<user>/go/src/github.com/gardener/gardener/example/provider-extensions/seed/registrydomain: No such file or directory
```
This PR fixes this error by using the correct path for registry domain file.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
