### PR TITLE
Reduce the number of parallel running e2e tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ SEED_NAME                                  := provider-extensions
 SEED_KUBECONFIG                            := $(REPO_ROOT)/example/provider-extensions/seed/kubeconfig
 DEV_SETUP_WITH_WEBHOOKS                    := false
 IPFAMILY                                   := ipv4
-PARALLEL_E2E_TESTS                         := 15
+PARALLEL_E2E_TESTS                         := 5
 GARDENER_RELEASE_DOWNLOAD_PATH             := $(REPO_ROOT)/dev
 PRINT_HELP ?=
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind flake

**What this PR does / why we need it**:
We run lots of e2e tests in parallel. Thus, many kubelets, pods etc. using use the same cgroup filesystem which could lead to very high loads (~750). 
This could cause inaccessible nodes in our prow cluster and flaking tests.

This PR reduces the number of parallel running e2e tests to reduce the load on the prow nodes.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
I'm not sure about the best value for the number of parallel tests yet, so I'm planning to test it with this PR.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
