### PR TITLE
Remove Deprecated Check for UpdatedReplicas Field in Etcd Waiter Function

### DIFF
--- a/pkg/component/etcd/waiter.go
+++ b/pkg/component/etcd/waiter.go
@@ -79,10 +79,6 @@ func CheckEtcdObject(obj client.Object) error {
 		return fmt.Errorf("observed generation outdated (%d/%d)", *observedGeneration, generation)
 	}
 
-	if etcd.Status.Replicas != etcd.Status.UpdatedReplicas {
-		return fmt.Errorf("update is being rolled out, only %d/%d replicas are up-to-date", etcd.Status.UpdatedReplicas, etcd.Status.Replicas)
-	}
-
 	if op, ok := etcd.Annotations[v1beta1constants.GardenerOperation]; ok {
 		return fmt.Errorf("gardener operation %q is not yet picked up by etcd-druid", op)
 	}

--- a/pkg/component/etcd/waiter_test.go
+++ b/pkg/component/etcd/waiter_test.go
@@ -246,14 +246,6 @@ var _ = Describe("#CheckEtcdObject", func() {
 		Expect(CheckEtcdObject(obj)).To(MatchError("is not ready yet"))
 	})
 
-	It("should return error if status.replicas != status.updatedReplicas", func() {
-		obj.SetGeneration(1)
-		obj.Status.ObservedGeneration = pointer.Int64(1)
-		obj.Status.Replicas = 3
-		obj.Status.UpdatedReplicas = 2
-		Expect(CheckEtcdObject(obj)).To(MatchError("update is being rolled out, only 2/3 replicas are up-to-date"))
-	})
-
 	It("should not return error if object is ready", func() {
 		obj.SetGeneration(1)
 		obj.Status.ObservedGeneration = pointer.Int64(1)


### PR DESCRIPTION
**How to categorize this PR?**
/area control-plane
/kind cleanup

**What this PR does / why we need it**:
This PR removes the check for the deprecated `UpdatedReplicas` field in the `CheckEtcdObject` function within `etcd/waiter.go`. The logic for checking replicas is now handled by `etcd-druid` [here](https://github.com/gardener/etcd-druid/blob/master/pkg/utils/statefulset.go#L28-L47), making it sufficient to only check [`status.ready`](https://github.com/gardener/etcd-druid/blob/master/controllers/etcd/reconciler.go#L412-L413).
**Release note**:

```other operator
NONE
```
