### PR TITLE
Change port of ssh reverse tunnel to 443

### DIFF
--- a/example/provider-extensions/seed/configure-seed.sh
+++ b/example/provider-extensions/seed/configure-seed.sh
@@ -211,7 +211,7 @@ fi
 
 echo "Create host and client keys for SSH reverse tunnel"
 "$SCRIPT_DIR"/../ssh-reverse-tunnel/prepare-seed-dir.sh "$seed_name"
-"$SCRIPT_DIR"/../ssh-reverse-tunnel/create-host-keys.sh "$seed_name" "$relay_domain" 6222
+"$SCRIPT_DIR"/../ssh-reverse-tunnel/create-host-keys.sh "$seed_name" "$relay_domain" 443
 "$SCRIPT_DIR"/../ssh-reverse-tunnel/create-client-keys.sh "$seed_name" "$relay_domain"
 
 echo "Deploying kyverno, SSH reverse tunnel and container registry"

--- a/example/provider-extensions/ssh-reverse-tunnel/base/ssh/files/entrypoint.sh
+++ b/example/provider-extensions/ssh-reverse-tunnel/base/ssh/files/entrypoint.sh
@@ -21,4 +21,4 @@ host=$(cat /gardener-apiserver-ssh-keys/host)
 
 # Connect to sshd for gardener-apiserver reverse tunnel
 echo "Connecting to sshd for gardener-apiserver reverse tunnel @ $host"
-exec ssh "root@$host" -R 6443:kubernetes.default.svc.cluster.local:443 -NT -p 6222 -F /gardener_apiserver_ssh/ssh_config
+exec ssh "root@$host" -R 6443:kubernetes.default.svc.cluster.local:443 -NT -p 443 -F /gardener_apiserver_ssh/ssh_config

--- a/example/provider-extensions/ssh-reverse-tunnel/base/ssh/ssh_deployment.yaml
+++ b/example/provider-extensions/ssh-reverse-tunnel/base/ssh/ssh_deployment.yaml
@@ -24,7 +24,7 @@ spec:
             command:
             - sh
             - "-c"
-            - "netstat | grep 6222"
+            - "netstat | 443"
         volumeMounts:
         - name: gardener-apiserver-ssh
           mountPath: /gardener_apiserver_ssh

--- a/example/provider-extensions/ssh-reverse-tunnel/base/ssh/ssh_deployment.yaml
+++ b/example/provider-extensions/ssh-reverse-tunnel/base/ssh/ssh_deployment.yaml
@@ -24,7 +24,7 @@ spec:
             command:
             - sh
             - "-c"
-            - "netstat | 443"
+            - "netstat | grep gardener-apiserver-tunnel-ssh"
         volumeMounts:
         - name: gardener-apiserver-ssh
           mountPath: /gardener_apiserver_ssh

--- a/example/provider-extensions/ssh-reverse-tunnel/base/sshd/files/sshd_config
+++ b/example/provider-extensions/ssh-reverse-tunnel/base/sshd/files/sshd_config
@@ -1,4 +1,4 @@
-Port 6222
+Port 443
 ListenAddress 0.0.0.0
 
 HostKey /gardener-apiserver-ssh-keys/ssh_host_rsa_key

--- a/example/provider-extensions/ssh-reverse-tunnel/base/sshd/sshd_deployment.yaml
+++ b/example/provider-extensions/ssh-reverse-tunnel/base/sshd/sshd_deployment.yaml
@@ -40,7 +40,7 @@ spec:
         - name: https
           containerPort: 6443
         - name: ssh
-          containerPort: 6222
+          containerPort: 433
       volumes:
       - name: gardener-apiserver-sshd
         configMap:

--- a/example/provider-extensions/ssh-reverse-tunnel/load-balancer/load-balancer.yaml
+++ b/example/provider-extensions/ssh-reverse-tunnel/load-balancer/load-balancer.yaml
@@ -11,6 +11,6 @@ spec:
   ports:
   - name: gardener-apiserver-tunnel
     protocol: TCP
-    port: 6222
-    targetPort: 6222
+    port: 443
+    targetPort: 443
   type: LoadBalancer


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
Change the port for ssh tunnel in the development setup for extensions.
Port 6222 might be blocked by some firewalls.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature developer
Change port of ssh reverse tunnel to 443
```
