### PR TITLE
Handle force delete for bastion resource

### DIFF
--- a/extensions/pkg/controller/bastion/reconciler.go
+++ b/extensions/pkg/controller/bastion/reconciler.go
@@ -29,11 +29,13 @@ import (
 
 	extensionscontroller "github.com/gardener/gardener/extensions/pkg/controller"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/controllerutils"
 	reconcilerutils "github.com/gardener/gardener/pkg/controllerutils/reconciler"
 	"github.com/gardener/gardener/pkg/extensions"
+	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 )
 
 type reconciler struct {
@@ -148,7 +150,7 @@ func (r *reconciler) delete(
 
 	log.Info("Starting the deletion of Bastion")
 	var err error
-	if cluster != nil && v1beta1helper.ShootNeedsForceDeletion(cluster.Shoot) {
+	if kubernetesutils.HasMetaDataAnnotation(&bastion.ObjectMeta, v1beta1constants.AnnotationConfirmationForceDeletion, "true") {
 		err = r.actuator.ForceDelete(ctx, log, bastion, cluster)
 	} else {
 		err = r.actuator.Delete(ctx, log, bastion, cluster)

--- a/extensions/pkg/controller/containerruntime/actuator.go
+++ b/extensions/pkg/controller/containerruntime/actuator.go
@@ -29,6 +29,8 @@ type Actuator interface {
 	Reconcile(context.Context, logr.Logger, *extensionsv1alpha1.ContainerRuntime, *extensionscontroller.Cluster) error
 	// Delete the ContainerRuntime resource.
 	Delete(context.Context, logr.Logger, *extensionsv1alpha1.ContainerRuntime, *extensionscontroller.Cluster) error
+	// ForceDelete forcefully deletes the ContainerRuntime.
+	ForceDelete(context.Context, logr.Logger, *extensionsv1alpha1.ContainerRuntime, *extensionscontroller.Cluster) error
 	// Restore the ContainerRuntime resource.
 	Restore(context.Context, logr.Logger, *extensionsv1alpha1.ContainerRuntime, *extensionscontroller.Cluster) error
 	// Migrate the ContainerRuntime resource.

--- a/extensions/pkg/controller/containerruntime/reconciler.go
+++ b/extensions/pkg/controller/containerruntime/reconciler.go
@@ -185,7 +185,13 @@ func (r *reconciler) delete(
 		return reconcile.Result{}, err
 	}
 
-	if err := r.actuator.Delete(ctx, log, cr, cluster); err != nil {
+	var err error
+	if cluster != nil && v1beta1helper.ShootNeedsForceDeletion(cluster.Shoot) {
+		err = r.actuator.ForceDelete(ctx, log, cr, cluster)
+	} else {
+		err = r.actuator.Delete(ctx, log, cr, cluster)
+	}
+	if err != nil {
 		_ = r.statusUpdater.Error(ctx, log, cr, reconcilerutils.ReconcileErrCauseOrErr(err), gardencorev1beta1.LastOperationTypeDelete, "Error deleting ContainerRuntime")
 		return reconcilerutils.ReconcileErr(err)
 	}

--- a/pkg/gardenlet/controller/shoot/shoot/cleaner.go
+++ b/pkg/gardenlet/controller/shoot/shoot/cleaner.go
@@ -43,7 +43,6 @@ var (
 
 var (
 	extensionKindToObjectList = map[string]client.ObjectList{
-		extensionsv1alpha1.BastionResource:               &extensionsv1alpha1.BastionList{},
 		extensionsv1alpha1.ContainerRuntimeResource:      &extensionsv1alpha1.ContainerRuntimeList{},
 		extensionsv1alpha1.ControlPlaneResource:          &extensionsv1alpha1.ControlPlaneList{},
 		extensionsv1alpha1.DNSRecordResource:             &extensionsv1alpha1.DNSRecordList{},

--- a/pkg/registry/operations/bastion/strategy.go
+++ b/pkg/registry/operations/bastion/strategy.go
@@ -104,6 +104,11 @@ func mustIncreaseGeneration(oldBastion, newBastion *operations.Bastion) bool {
 		return true
 	}
 
+	if kubernetesutils.HasMetaDataAnnotation(&newBastion.ObjectMeta, v1beta1constants.AnnotationConfirmationForceDeletion, "true") &&
+		!kubernetesutils.HasMetaDataAnnotation(&oldBastion.ObjectMeta, v1beta1constants.AnnotationConfirmationForceDeletion, "true") {
+		return true
+	}
+
 	return false
 }
 

--- a/test/integration/gardenlet/bastion/bastion_test.go
+++ b/test/integration/gardenlet/bastion/bastion_test.go
@@ -41,28 +41,28 @@ var _ = Describe("Bastion controller tests", func() {
 		seed              *gardencorev1beta1.Seed
 		shoot             *gardencorev1beta1.Shoot
 		operationsBastion *operationsv1alpha1.Bastion
-		extensionsBastion *extensionsv1alpha1.Bastion
+		extensionBastion  *extensionsv1alpha1.Bastion
 		cluster           *extensionsv1alpha1.Cluster
 		seedNamespace     *corev1.Namespace
 
-		reconcileExtensionsBastion = func() {
+		reconcileExtensionBastion = func() {
 			EventuallyWithOffset(1, func(g Gomega) {
 				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(operationsBastion), operationsBastion)).To(Succeed())
-				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(extensionsBastion), extensionsBastion)).To(Succeed())
-				g.Expect(extensionsBastion.Spec.Type).To(Equal(*operationsBastion.Spec.ProviderType))
-				g.Expect(extensionsBastion.Spec.UserData).To(Equal(createUserData(operationsBastion)))
-				g.Expect(extensionsBastion.Annotations).To(HaveKeyWithValue(v1beta1constants.GardenerOperation, v1beta1constants.GardenerOperationReconcile))
+				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(extensionBastion), extensionBastion)).To(Succeed())
+				g.Expect(extensionBastion.Spec.Type).To(Equal(*operationsBastion.Spec.ProviderType))
+				g.Expect(extensionBastion.Spec.UserData).To(Equal(createUserData(operationsBastion)))
+				g.Expect(extensionBastion.Annotations).To(HaveKeyWithValue(v1beta1constants.GardenerOperation, v1beta1constants.GardenerOperationReconcile))
 			}).Should(Succeed())
 
 			By("Patch the extension Bastion to satisfy the condition for readiness as there is no extension controller running in test")
-			patch := client.MergeFrom(extensionsBastion.DeepCopy())
-			delete(extensionsBastion.Annotations, v1beta1constants.GardenerOperation)
-			ExpectWithOffset(1, testClient.Patch(ctx, extensionsBastion, patch)).To(Succeed())
+			patch := client.MergeFrom(extensionBastion.DeepCopy())
+			delete(extensionBastion.Annotations, v1beta1constants.GardenerOperation)
+			ExpectWithOffset(1, testClient.Patch(ctx, extensionBastion, patch)).To(Succeed())
 
-			patch = client.MergeFrom(extensionsBastion.DeepCopy())
-			extensionsBastion.Status = extensionsv1alpha1.BastionStatus{
+			patch = client.MergeFrom(extensionBastion.DeepCopy())
+			extensionBastion.Status = extensionsv1alpha1.BastionStatus{
 				DefaultStatus: extensionsv1alpha1.DefaultStatus{
-					ObservedGeneration: extensionsBastion.Generation,
+					ObservedGeneration: extensionBastion.Generation,
 					LastOperation: &gardencorev1beta1.LastOperation{
 						LastUpdateTime: metav1.NewTime(fakeClock.Now()),
 						State:          gardencorev1beta1.LastOperationStateSucceeded,
@@ -70,7 +70,7 @@ var _ = Describe("Bastion controller tests", func() {
 				},
 				Ingress: &corev1.LoadBalancerIngress{},
 			}
-			ExpectWithOffset(1, testClient.Status().Patch(ctx, extensionsBastion, patch)).To(Succeed())
+			ExpectWithOffset(1, testClient.Status().Patch(ctx, extensionBastion, patch)).To(Succeed())
 		}
 	)
 
@@ -252,7 +252,7 @@ var _ = Describe("Bastion controller tests", func() {
 		Expect(testClient.Create(ctx, operationsBastion)).To(Succeed())
 		log.Info("Created Bastion for test", "bastion", client.ObjectKeyFromObject(operationsBastion))
 
-		extensionsBastion = &extensionsv1alpha1.Bastion{
+		extensionBastion = &extensionsv1alpha1.Bastion{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      operationsBastion.Name,
 				Namespace: seedNamespace.Name,
@@ -279,22 +279,22 @@ var _ = Describe("Bastion controller tests", func() {
 	Context("reconciliation", func() {
 		It("should create or patch the Bastion in the Seed cluster", func() {
 			Eventually(func(g Gomega) {
-				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(extensionsBastion), extensionsBastion)).To(Succeed())
-				g.Expect(extensionsBastion.GetAnnotations()).To(And(
+				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(extensionBastion), extensionBastion)).To(Succeed())
+				g.Expect(extensionBastion.GetAnnotations()).To(And(
 					HaveKeyWithValue(v1beta1constants.GardenerOperation, v1beta1constants.GardenerOperationReconcile),
 					HaveKey(v1beta1constants.GardenerTimestamp),
 				))
-				g.Expect(extensionsBastion.Spec.Type).To(Equal(*operationsBastion.Spec.ProviderType))
-				g.Expect(extensionsBastion.Spec.UserData).To(Equal(createUserData(operationsBastion)))
+				g.Expect(extensionBastion.Spec.Type).To(Equal(*operationsBastion.Spec.ProviderType))
+				g.Expect(extensionBastion.Spec.UserData).To(Equal(createUserData(operationsBastion)))
 			}).Should(Succeed())
 		})
 
 		It("should set BastionReady to True once extension Bastion is ready", func() {
-			reconcileExtensionsBastion()
+			reconcileExtensionBastion()
 
 			Eventually(func(g Gomega) {
-				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(extensionsBastion), extensionsBastion)).To(Succeed())
-				g.Expect(extensionsBastion.Status.ObservedGeneration).To(Equal((extensionsBastion.Generation)))
+				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(extensionBastion), extensionBastion)).To(Succeed())
+				g.Expect(extensionBastion.Status.ObservedGeneration).To(Equal((extensionBastion.Generation)))
 				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(operationsBastion), operationsBastion)).To(Succeed())
 				g.Expect(operationsBastion.Status.Conditions).To(ContainElement(MatchFields(IgnoreExtras, Fields{
 					"Type":    Equal(operationsv1alpha1.BastionReady),
@@ -308,17 +308,59 @@ var _ = Describe("Bastion controller tests", func() {
 	})
 
 	Context("deletion", func() {
-		It("should delete the extensions Bastions and the operations Bastion resource", func() {
+		It("should delete the extension Bastion and the operations Bastion resource", func() {
+			reconcileExtensionBastion()
+
 			Eventually(func(g Gomega) {
 				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(operationsBastion), operationsBastion)).To(Succeed())
-				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(extensionsBastion), extensionsBastion)).To(Succeed())
+				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(extensionBastion), extensionBastion)).To(Succeed())
 			}).Should(Succeed())
 
 			By("Mark Bastion for deletion")
 			Expect(testClient.Delete(ctx, operationsBastion)).To(Succeed())
 
 			Eventually(func() error {
-				return testClient.Get(ctx, client.ObjectKeyFromObject(extensionsBastion), extensionsBastion)
+				return testClient.Get(ctx, client.ObjectKeyFromObject(extensionBastion), extensionBastion)
+			}).Should(BeNotFoundError())
+
+			Eventually(func() error {
+				return testClient.Get(ctx, client.ObjectKeyFromObject(operationsBastion), operationsBastion)
+			}).Should(BeNotFoundError())
+		})
+
+		It("should add the force delete annotation to the extension Bastion if the operation's Bastion has it", func() {
+			reconcileExtensionBastion()
+
+			Eventually(func(g Gomega) {
+				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(operationsBastion), operationsBastion)).To(Succeed())
+				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(extensionBastion), extensionBastion)).To(Succeed())
+			}).Should(Succeed())
+
+			By("Patching extension bastion with some finalizer")
+			patch := client.MergeFrom(extensionBastion.DeepCopy())
+			extensionBastion.Finalizers = append(extensionBastion.Finalizers, "random")
+			Expect(testClient.Patch(ctx, extensionBastion, patch)).To(Succeed())
+
+			By("Delete Bastion")
+			Expect(testClient.Delete(ctx, operationsBastion)).To(Succeed())
+
+			By("Patching Bastion with ForceDeletion annotation")
+			patch = client.MergeFrom(operationsBastion.DeepCopy())
+			metav1.SetMetaDataAnnotation(&operationsBastion.ObjectMeta, v1beta1constants.AnnotationConfirmationForceDeletion, "true")
+			Expect(testClient.Patch(ctx, operationsBastion, patch)).To(Succeed())
+
+			Eventually(func(g Gomega) map[string]string {
+				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(extensionBastion), extensionBastion)).To(Succeed())
+				return extensionBastion.Annotations
+			}).Should(HaveKeyWithValue(v1beta1constants.AnnotationConfirmationForceDeletion, "true"))
+
+			By("Removing finalizer from extension bastion")
+			patch = client.MergeFrom(extensionBastion.DeepCopy())
+			extensionBastion.Finalizers = nil
+			Expect(testClient.Patch(ctx, extensionBastion, patch)).To(Succeed())
+
+			Eventually(func() error {
+				return testClient.Get(ctx, client.ObjectKeyFromObject(extensionBastion), extensionBastion)
 			}).Should(BeNotFoundError())
 
 			Eventually(func() error {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area delivery ops-productivity
/kind enhancement

**What this PR does / why we need it**:
Previously delete flow would not have been executed in case of remaining bastion related to shoot.  This PR enhances the force deletion of bastion resources to cover this scenario by adding force delete annotation to remaining operation bastion resource that would propagate to the extension bastion and it will get forcefully deleted.

It also adds ForceDelete option for containerruntime.


**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/3110

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
