### PR TITLE
Compress machine state in `ShootState` resource

### DIFF
--- a/extensions/pkg/controller/worker/genericactuator/actuator_restore.go
+++ b/extensions/pkg/controller/worker/genericactuator/actuator_restore.go
@@ -138,7 +138,11 @@ func addStateToMachineDeployment(
 	gardenerData := v1beta1helper.GardenerResourceDataList(shootState.Spec.Gardener)
 	if machineState := gardenerData.Get(v1beta1constants.DataTypeMachineState); machineState != nil && machineState.Type == v1beta1constants.DataTypeMachineState {
 		log.Info("Fetching machine state from ShootState succeeded", "shootState", client.ObjectKeyFromObject(shootState))
-		state = machineState.Data.Raw
+		var err error
+		state, err = shootstate.DecompressMachineState(machineState.Data.Raw)
+		if err != nil {
+			return err
+		}
 	} else {
 		// TODO(rfranzke): Drop this code after Gardener v1.86 has been released.
 		log.Info("Fetching machine state from ShootState not possible since the machine state was not found, falling back to Worker's .status.state field", "shootState", client.ObjectKeyFromObject(shootState))

--- a/pkg/component/extensions/worker/worker_test.go
+++ b/pkg/component/extensions/worker/worker_test.go
@@ -667,20 +667,17 @@ var _ = Describe("Worker", func() {
 	})
 
 	Describe("#Restore", func() {
-		var (
-			state      = runtime.RawExtension{Raw: []byte(`{"dummy":"state"}`)}
-			shootState = &gardencorev1beta1.ShootState{
-				Spec: gardencorev1beta1.ShootStateSpec{
-					Gardener: []gardencorev1beta1.GardenerResourceData{
-						{
-							Name: "machine-state",
-							Type: "machine-state",
-							Data: state,
-						},
+		shootState := &gardencorev1beta1.ShootState{
+			Spec: gardencorev1beta1.ShootStateSpec{
+				Gardener: []gardencorev1beta1.GardenerResourceData{
+					{
+						Name: "machine-state",
+						Type: "machine-state",
+						Data: runtime.RawExtension{Raw: []byte(`{"state":"H4sIAAAAAAAAA6tWKs7PTVWyUiouSSxJVaoFACDAdOAQAAAA"}`)},
 					},
 				},
-			}
-		)
+			},
+		}
 
 		It("should properly restore the worker state if it exists", func() {
 			defer test.WithVars(
@@ -711,7 +708,7 @@ var _ = Describe("Worker", func() {
 
 			// restore state
 			expectedWithState := obj.DeepCopy()
-			expectedWithState.Status.State = &state
+			expectedWithState.Status.State = &runtime.RawExtension{Raw: []byte(`{"some":"state"}`)}
 			test.EXPECTStatusPatch(ctx, mockStatusWriter, expectedWithState, obj, types.MergePatchType)
 
 			// annotate with restore annotation

--- a/pkg/utils/gardener/shootstate/machines.go
+++ b/pkg/utils/gardener/shootstate/machines.go
@@ -15,8 +15,12 @@
 package shootstate
 
 import (
+	"bytes"
 	"cmp"
+	"compress/gzip"
 	"context"
+	"encoding/json"
+	"fmt"
 	"slices"
 
 	machinev1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
@@ -143,4 +147,58 @@ func getMachineSetToMachinesMap(ctx context.Context, seedClient client.Client, n
 	})
 
 	return gardenerutils.BuildOwnerToMachinesMap(filteredMachines), nil
+}
+
+type compressedMachineState struct {
+	State []byte `json:"state"`
+}
+
+func compressMachineState(state []byte) ([]byte, error) {
+	if len(state) == 0 || string(state) == "{}" {
+		return nil, nil
+	}
+
+	var stateCompressed bytes.Buffer
+	gzipWriter, err := gzip.NewWriterLevel(&stateCompressed, gzip.BestCompression)
+	if err != nil {
+		return nil, fmt.Errorf("failed creating gzip writer for compressing machine state data: %w", err)
+	}
+
+	if _, err := gzipWriter.Write(state); err != nil {
+		return nil, fmt.Errorf("failed writing machine state data for compression: %w", err)
+	}
+
+	if err := gzipWriter.Close(); err != nil {
+		return nil, fmt.Errorf("failed closing the gzip writer after compressing the machine state data: %w", err)
+	}
+
+	return json.Marshal(&compressedMachineState{State: stateCompressed.Bytes()})
+}
+
+// DecompressMachineState decompresses the machine state data.
+func DecompressMachineState(stateCompressed []byte) ([]byte, error) {
+	if len(stateCompressed) == 0 {
+		return nil, nil
+	}
+
+	var machineState compressedMachineState
+	if err := json.Unmarshal(stateCompressed, &machineState); err != nil {
+		return nil, fmt.Errorf("failed unmarshalling JSON to compressed machine state structure: %w", err)
+	}
+
+	gzipReader, err := gzip.NewReader(bytes.NewReader(machineState.State))
+	if err != nil {
+		return nil, fmt.Errorf("failed creating gzip reader for decompressing machine state data: %w", err)
+	}
+
+	var state bytes.Buffer
+	if _, err := state.ReadFrom(gzipReader); err != nil {
+		return nil, fmt.Errorf("failed reading machine state data for decompression: %w", err)
+	}
+
+	if err := gzipReader.Close(); err != nil {
+		return nil, fmt.Errorf("failed closing the gzip reader after decompressing the machine state data: %w", err)
+	}
+
+	return state.Bytes(), nil
 }

--- a/pkg/utils/gardener/shootstate/machines_test.go
+++ b/pkg/utils/gardener/shootstate/machines_test.go
@@ -1,0 +1,50 @@
+// Copyright 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package shootstate_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	. "github.com/gardener/gardener/pkg/utils/gardener/shootstate"
+)
+
+var _ = Describe("Machines", func() {
+	Describe("#DecompressMachineState", func() {
+		It("should do nothing because state is empty", func() {
+			state, err := DecompressMachineState(nil)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(state).To(BeNil())
+		})
+
+		It("should fail because the state cannot be unmarshalled", func() {
+			state, err := DecompressMachineState([]byte("{foo"))
+			Expect(err).To(MatchError(ContainSubstring("failed unmarshalling JSON to compressed machine state structure")))
+			Expect(state).To(BeNil())
+		})
+
+		It("should fail because the gzip reader cannot be created", func() {
+			state, err := DecompressMachineState([]byte(`{"state":"eW91LXNob3VsZC1ub3QtaGF2ZS1yZWFkLXRoaXM="}`))
+			Expect(err).To(MatchError(ContainSubstring("failed creating gzip reader for decompressing machine state data")))
+			Expect(state).To(BeNil())
+		})
+
+		It("should successfully decompress the data", func() {
+			state, err := DecompressMachineState([]byte(`{"state":"H4sIAAAAAAAAAyvJyCzWLc/MydHNSCxL1U3OzytOLSxNzUtOLQYA3w65lxsAAAA="}`))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(state).To(Equal([]byte("this-will-have-consequences")))
+		})
+	})
+})

--- a/pkg/utils/gardener/shootstate/shootstate.go
+++ b/pkg/utils/gardener/shootstate/shootstate.go
@@ -149,10 +149,15 @@ func computeGardenerData(
 		return nil, fmt.Errorf("failed marshalling machine state to JSON: %w", err)
 	}
 
+	machineStateJSONCompressed, err := compressMachineState(machineStateJSON)
+	if err != nil {
+		return nil, fmt.Errorf("failed compressing machine state data: %w", err)
+	}
+
 	return append(secretsToPersist, gardencorev1beta1.GardenerResourceData{
 		Name: v1beta1constants.DataTypeMachineState,
 		Type: v1beta1constants.DataTypeMachineState,
-		Data: runtime.RawExtension{Raw: machineStateJSON},
+		Data: runtime.RawExtension{Raw: machineStateJSONCompressed},
 	}), nil
 }
 

--- a/pkg/utils/gardener/shootstate/shootstate_test.go
+++ b/pkg/utils/gardener/shootstate/shootstate_test.go
@@ -79,7 +79,7 @@ var _ = Describe("ShootState", func() {
 			Expect(Deploy(ctx, fakeClock, fakeGardenClient, fakeSeedClient, shoot, true)).To(Succeed())
 			Expect(fakeGardenClient.Get(ctx, client.ObjectKeyFromObject(shootState), shootState)).To(Succeed())
 			Expect(shootState.Spec).To(Equal(gardencorev1beta1.ShootStateSpec{
-				Gardener: []gardencorev1beta1.GardenerResourceData{{Name: "machine-state", Type: "machine-state", Data: runtime.RawExtension{Raw: []byte("{}")}}},
+				Gardener: []gardencorev1beta1.GardenerResourceData{{Name: "machine-state", Type: "machine-state"}},
 			}))
 			Expect(shootState.Annotations).To(HaveKeyWithValue("gardener.cloud/timestamp", fakeClock.Now().UTC().Format(time.RFC3339)))
 		})
@@ -143,7 +143,7 @@ var _ = Describe("ShootState", func() {
 						{
 							Name: "machine-state",
 							Type: "machine-state",
-							Data: runtime.RawExtension{Raw: []byte(`{"machineDeployments":{"deploy1":{"machineSets":[{"metadata":{"annotations":{"some":"annotation"},"creationTimestamp":null,"name":"deploy1-set1","namespace":"shoot--my-project--my-shoot"},"spec":{"machineClass":{},"template":{"metadata":{"creationTimestamp":null},"spec":{"class":{},"nodeTemplate":{"metadata":{"creationTimestamp":null},"spec":{}}}}},"status":{"lastOperation":{"lastUpdateTime":null}}},{"metadata":{"annotations":{"some":"annotation"},"creationTimestamp":null,"labels":{"name":"deploy1"},"name":"deploy1-set2","namespace":"shoot--my-project--my-shoot"},"spec":{"machineClass":{},"template":{"metadata":{"creationTimestamp":null},"spec":{"class":{},"nodeTemplate":{"metadata":{"creationTimestamp":null},"spec":{}}}}},"status":{"lastOperation":{"lastUpdateTime":null}}}],"machines":[{"metadata":{"annotations":{"some":"annotation"},"creationTimestamp":null,"labels":{"node":"nodename"},"name":"deploy1-set1-machine1","namespace":"shoot--my-project--my-shoot"},"spec":{"class":{},"nodeTemplate":{"metadata":{"creationTimestamp":null},"spec":{}}},"status":{"currentStatus":{"lastUpdateTime":null},"lastOperation":{"lastUpdateTime":null}}},{"metadata":{"annotations":{"some":"annotation"},"creationTimestamp":null,"labels":{"name":"deploy1"},"name":"deploy1-set2-machine2","namespace":"shoot--my-project--my-shoot"},"spec":{"class":{},"nodeTemplate":{"metadata":{"creationTimestamp":null},"spec":{}},"providerID":"provider-id"},"status":{"currentStatus":{"lastUpdateTime":null},"lastOperation":{"lastUpdateTime":null}}},{"metadata":{"annotations":{"some":"annotation"},"creationTimestamp":null,"labels":{"name":"deploy1"},"name":"deploy1-set2-machine2","namespace":"shoot--my-project--my-shoot"},"spec":{"class":{},"nodeTemplate":{"metadata":{"creationTimestamp":null},"spec":{}},"providerID":"provider-id"},"status":{"currentStatus":{"lastUpdateTime":null},"lastOperation":{"lastUpdateTime":null}}}],"replicas":3}}}`)},
+							Data: runtime.RawExtension{Raw: []byte(`{"state":"H4sIAAAAAAAC/+yUPU8DMQyG/4vnZChst9KFiaFlQgwmsdSgfCl2kaoq/x0lvX4gVEGrG5DoLZfYb177nli3hYBm5SLNKfu0CRSFYdiC7dtZWxbK3hlkGO7VXr2gJnvZQiBBi4JNGDEQDPujmklmoHqUM5qW4lVKonXY6FzSO5ndukdBgSmE4lJcukAsGDIMce29AowxSU/13jj1Osco1KqAM5mWHTt88MhNXRUIhexRqGdP+j1T78TLHE1isrS81qi2RwELyrp/gkeWp0xl1/4YeM4WhZrJeL5W9RPhu2kIe3wjz99LQP3P9F8P8/6rYdejeDb5nSTbfNqrl730UiYEeTlGBWZdCkVZfDl41bDvCf+1qT8BnEv6cJbK4xyGw0Y7Czf2N/ZnfjO11s8AAAD//7Qj9vuIBwAA"}`)},
 						},
 					},
 					Extensions: []gardencorev1beta1.ExtensionResourceState{

--- a/test/integration/gardenlet/shoot/state/state_test.go
+++ b/test/integration/gardenlet/shoot/state/state_test.go
@@ -21,7 +21,6 @@ import (
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -41,7 +40,7 @@ var _ = Describe("Shoot State controller tests", func() {
 
 		lastOperation *gardencorev1beta1.LastOperation
 
-		emptyMachineState = gardencorev1beta1.GardenerResourceData{Name: "machine-state", Type: "machine-state", Data: runtime.RawExtension{Raw: []byte("{}")}}
+		emptyMachineState = gardencorev1beta1.GardenerResourceData{Name: "machine-state", Type: "machine-state"}
 	)
 
 	BeforeEach(func() {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area scalability
/kind enhancement

**What this PR does / why we need it**:
With this PR, the machine state in the `ShootState` resource is compressed using GZIP to make sure we save space when persisting the data. This was also discussed in the original [GEP-22](https://github.com/gardener/gardener/blob/master/docs/proposals/22-improved-usage-of-shootstate-api.md#compressing-the-shootstate-data) as potential future improvement.

In the unit test part of this PR, the size of the machine state data was reduced by 77%.
I also tried it for one larger cluster (147 `MachineDeployment`s, 147 `MachineSet`s, 147 `MachineClass`es, 269 `Machine`s) for which compressing the machine state data led to a space reduction of 95,8%.

/cc @timuthy @plkokanov 

**Which issue(s) this PR fixes**:
Follow-up of #8073 
Related to #8488
Follow-up of #8559

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
