### PR TITLE
Fast fail e2e test

### DIFF
--- a/hack/test-e2e-local.sh
+++ b/hack/test-e2e-local.sh
@@ -30,7 +30,7 @@ if [ -n "${CI:-}" -a -n "${ARTIFACTS:-}" ]; then
   mkdir -p "$ARTIFACTS"
   ginkgo_flags="--output-dir=$ARTIFACTS --junit-report=junit.xml"
   if [ "${JOB_TYPE:-}" != "periodic" ]; then
-    ginkgo_flags+=" --failFast"
+    ginkgo_flags+=" --fail-fast"
   fi
 fi
 

--- a/hack/test-e2e-local.sh
+++ b/hack/test-e2e-local.sh
@@ -28,10 +28,9 @@ ginkgo_flags=
 # This will add a JUnit view above the build log that shows an overview over successful and failed test cases.
 if [ -n "${CI:-}" -a -n "${ARTIFACTS:-}" ]; then
   mkdir -p "$ARTIFACTS"
+  ginkgo_flags="--output-dir=$ARTIFACTS --junit-report=junit.xml"
   if [ "${JOB_TYPE:-}" != "periodic" ]; then
-    ginkgo_flags="--failFast --output-dir=$ARTIFACTS --junit-report=junit.xml"
-  else
-    ginkgo_flags="--output-dir=$ARTIFACTS --junit-report=junit.xml"
+    ginkgo_flags+=" --failFast"
   fi
 fi
 

--- a/hack/test-e2e-local.sh
+++ b/hack/test-e2e-local.sh
@@ -28,7 +28,11 @@ ginkgo_flags=
 # This will add a JUnit view above the build log that shows an overview over successful and failed test cases.
 if [ -n "${CI:-}" -a -n "${ARTIFACTS:-}" ]; then
   mkdir -p "$ARTIFACTS"
-  ginkgo_flags="--output-dir=$ARTIFACTS --junit-report=junit.xml"
+  if [ "${JOB_TYPE:-}" != "periodic" ]; then
+    ginkgo_flags="--failFast --output-dir=$ARTIFACTS --junit-report=junit.xml"
+  else
+    ginkgo_flags="--output-dir=$ARTIFACTS --junit-report=junit.xml"
+  fi
 fi
 
 # If we are not running the gardener-operator tests then we have to make the shoot domains accessible.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind enhancement

**What this PR does / why we need it**:
As a developer, I would like to have our ginkgo e2e tests fail fast so I can get a quicker signal back instead of having to wait up to an hour.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
