### PR TITLE
[provider-extension] Download admission webhook repositories with `curl` instead of `git`

### DIFF
--- a/example/provider-extensions/garden/configure-admission.sh
+++ b/example/provider-extensions/garden/configure-admission.sh
@@ -41,24 +41,25 @@ command=$2
 
 for p in $(yq '. | select(.kind == "ControllerDeployment") | select(.metadata.name == "provider-*") | .metadata.name' "$REPO_ROOT_DIR"/example/provider-extensions/garden/controllerregistrations/* | grep -v -E "^---$"); do
   echo "Found \"$p\" in $REPO_ROOT_DIR/example/provider-extensions/garden/controllerregistrations. Trying to configure its admission controller..."
-  if PROVIDER_RELEASES=$(curl --fail -s -L -H "Accept: application/vnd.github+json" https://api.github.com/repos/gardener/gardener-extension-$p/releases); then
-    LATEST_RELEASE=$(jq -r '.[].tag_name' <<< $PROVIDER_RELEASES | head -n 1)
+  if PROVIDER_RELEASES=$(curl --fail -s -L -H "Accept: application/vnd.github+json" "https://api.github.com/repos/gardener/gardener-extension-$p/releases"); then
+    LATEST_RELEASE=$(jq -r '.[].tag_name' <<< "$PROVIDER_RELEASES" | head -n 1)
     ADMISSION_NAME=${p/provider/admission}
     echo "Identified $LATEST_RELEASE as latest release of $ADMISSION_NAME. Trying to deploy it..."
     ADMISSION_GIT_ROOT=$(mktemp -d)
-    git clone https://github.com/gardener/gardener-extension-$p $ADMISSION_GIT_ROOT
-    git -C $ADMISSION_GIT_ROOT checkout $LATEST_RELEASE
-    CA_BUNDLE=$(yq ".webhooks[0].clientConfig.caBundle" $ADMISSION_GIT_ROOT/example/50-mutatingwebhookconfiguration.yaml | base64 -d)
-    TLS_CRT=$(cat $ADMISSION_GIT_ROOT/example/$ADMISSION_NAME-certs/tls.crt)
-    TLS_KEY=$(cat $ADMISSION_GIT_ROOT/example/$ADMISSION_NAME-certs/tls.key)
+    ADMISSION_FILE=$(mktemp)
+    curl --fail -L -o "$ADMISSION_FILE" "https://github.com/gardener/gardener-extension-$p/archive/refs/tags/$LATEST_RELEASE.tar.gz"
+    tar xfz "$ADMISSION_FILE" -C "$ADMISSION_GIT_ROOT" --strip-components 1
+    CA_BUNDLE=$(yq ".webhooks[0].clientConfig.caBundle" "$ADMISSION_GIT_ROOT/example/50-mutatingwebhookconfiguration.yaml" | base64 -d)
+    TLS_CRT=$(cat "$ADMISSION_GIT_ROOT/example/$ADMISSION_NAME-certs/tls.crt")
+    TLS_KEY=$(cat "$ADMISSION_GIT_ROOT/example/$ADMISSION_NAME-certs/tls.key")
     helm template --namespace garden --set global.image.tag="$LATEST_RELEASE" --set global.webhookConfig.caBundle="$CA_BUNDLE" --set global.webhookConfig.tls.crt="$TLS_CRT" --set global.webhookConfig.tls.key="$TLS_KEY" gardener-extension-"$ADMISSION_NAME" "$ADMISSION_GIT_ROOT"/charts/gardener-extension-"$ADMISSION_NAME"/charts/application > "$ADMISSION_GIT_ROOT"/virtual-resources.yaml
-    helm template --namespace garden --set global.image.tag="$LATEST_RELEASE" --set global.webhookConfig.caBundle="$CA_BUNDLE" --set global.webhookConfig.tls.crt="$TLS_CRT" --set global.webhookConfig.tls.key="$TLS_KEY" --set global.kubeconfig="$(cat $garden_kubeconfig | sed 's/127.0.0.1:.*$/kubernetes.default.svc.cluster.local/g')" --set global.vpa.enabled="false" gardener-extension-"$ADMISSION_NAME" "$ADMISSION_GIT_ROOT"/charts/gardener-extension-"$ADMISSION_NAME"/charts/runtime > "$ADMISSION_GIT_ROOT"/runtime-resources.yaml
-    kubectl --kubeconfig $garden_kubeconfig $command -f $ADMISSION_GIT_ROOT/virtual-resources.yaml
-    kubectl --kubeconfig $garden_kubeconfig $command -f $ADMISSION_GIT_ROOT/runtime-resources.yaml
+    helm template --namespace garden --set global.image.tag="$LATEST_RELEASE" --set global.webhookConfig.caBundle="$CA_BUNDLE" --set global.webhookConfig.tls.crt="$TLS_CRT" --set global.webhookConfig.tls.key="$TLS_KEY" --set global.kubeconfig="$(cat "$garden_kubeconfig" | sed 's/127.0.0.1:.*$/kubernetes.default.svc.cluster.local/g')" --set global.vpa.enabled="false" gardener-extension-"$ADMISSION_NAME" "$ADMISSION_GIT_ROOT"/charts/gardener-extension-"$ADMISSION_NAME"/charts/runtime > "$ADMISSION_GIT_ROOT"/runtime-resources.yaml
+    kubectl --kubeconfig "$garden_kubeconfig" "$command" -f "$ADMISSION_GIT_ROOT/virtual-resources.yaml"
+    kubectl --kubeconfig "$garden_kubeconfig" "$command" -f "$ADMISSION_GIT_ROOT/runtime-resources.yaml"
     if [ "$command" == "apply" ]; then
-      kubectl --kubeconfig $garden_kubeconfig wait --for=condition=available deployment -l app.kubernetes.io/name=gardener-extension-"$ADMISSION_NAME" -n garden --timeout 5m
+      kubectl --kubeconfig "$garden_kubeconfig" wait --for=condition=available deployment -l app.kubernetes.io/name=gardener-extension-"$ADMISSION_NAME" -n garden --timeout 5m
     fi
-    rm -rf $ADMISSION_GIT_ROOT
+    rm -rf "$ADMISSION_FILE" "$ADMISSION_GIT_ROOT"
     echo "Successfully deployed $ADMISSION_NAME:$LATEST_RELEASE."
   else
     echo "Github repository releases of \"$p\" not found."


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
With this PR admission webhook repositories are downloaded as archives using `curl` instead of `git`. This is way faster in most of the cases.
Additionally, some issues discovered by shellcheck have been fixed.  

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
