### PR TITLE
Refactor `gardenertools` image to `golang-test`

### DIFF
--- a/hack/tools/image/Dockerfile
+++ b/hack/tools/image/Dockerfile
@@ -1,18 +1,20 @@
-# builder
+# base
 ARG image
-FROM ${image} AS builder
-RUN set -eux; \
-	apt-get update; \
-	apt-get install -y --no-install-recommends \
-		unzip \
-		jq \
-		parallel \
-	; \
-	rm -rf /var/lib/apt/lists/*
+FROM ${image} AS base
+RUN echo "Installing Packages ..." \
+		&& apt-get update \
+		&& apt-get install -y --no-install-recommends \
+			unzip \
+			jq \
+			parallel \
+		&& rm -rf /var/lib/apt/lists/*
+
+# builder
+FROM base as builder
 WORKDIR /go/src/github.com/gardener/gardener
 COPY . .
 RUN make create-tools-bin
 
-# gardenertools
-FROM scratch AS gardenertools
+# golang-test
+FROM base AS golang-test
 COPY --from=builder /go/src/github.com/gardener/gardener/hack/tools/bin /gardenertools

--- a/hack/tools/image/README.md
+++ b/hack/tools/image/README.md
@@ -1,18 +1,15 @@
-# `gardenertools` image
+# `golang-test` image
 
 ## Motivation
 
-There are lots flakes in our tests because the download of binaries like `yq` from github.com fails. Thus, we created the `gardenertools` image which contains the content of `./hack/tools/bin` directory. These are downloaded binaries like `yq`, `skaffold`, `helm` and Go binaries. This will also speed up the tests a bit, because the binaries does not have to be downloaded anymore and the Go based test tools does not have to be compiled on every test run.
+There are lots flakes in our tests because the download of binaries like `yq` from github.com fails. Thus, we created the `golang-test` image which contains the content of `./hack/tools/bin` directory. These are downloaded binaries like `yq`, `skaffold`, `helm` and Go binaries. This will also speed up the tests a bit, because the binaries does not have to be downloaded anymore and the Go based test tools does not have to be compiled on every test run.
 
 ## Usage
 
-`gardenertools` does not have an entrypoint. It is intended to be a base image for test-images only.
+`golang-test` installs a couple of debian tools and binaries of the `gardener/gardener` toolchain.
 
 Before running tests, binaries could be imported by `make import-tools-bin`. If the source directory is not available, the step will be skipped. The default source directory is `/gardenertools` and can be changed by setting the `TOOLS_BIN_SOURCE_DIR` variable accordingly. 
 
-The scenario runs like this:
-- `gardenertools` image will be [built by prow](https://github.com/gardener/ci-infra/blob/bdf1542fb74296b005a69b395779bb89dbdbe703/config/jobs/gardener/gardener-build-dev-images.yaml#L56-L100) every time the content of `./hack/tools.mk` or `./hack/tools/image` changes.
-- When prow notices a new `gardenertools` image it build a new version of [golang-test](https://github.com/gardener/ci-infra/tree/master/images/golang-test) and [krte](https://github.com/gardener/ci-infra/tree/master/images/krte) images which include these binaries.
-- `import-tools-bin` make target is added as first target to each prow job.
+In case some binaries are updated and not part of the `golang-test` image yet, the tests can still succeed. Each binary has a `.version_...` file in `./hack/tools/bin` directory. If the version file is outdated or does not exist yet, the respective binary is downloaded anyway while the test is executed.
 
-In case some binaries are updated and not part of the `gardenertools` image yet, the tests can still succeed. Each binary has a `.version_...` file in `./hack/tools/bin` directory. If the version file is outdated or does not exist yet, the respective binary is downloaded anyway while the test is executed.
+`golang-test` image is used to run our unit and integration tests. Additionally, it is the base image of our [krte](https://github.com/gardener/ci-infra/tree/master/images/krte) image, we use to run our e2e tests. When a new `golang-test` image was built, prow automatically builds the corresponding `krte` image.

--- a/hack/tools/image/variants.yaml
+++ b/hack/tools/image/variants.yaml
@@ -1,8 +1,9 @@
-# Debian versions of golang images must be in sync with these images to avoid problems with different `glibc` versions:
-# - https://github.com/gardener/ci-infra/blob/master/images/golang-test/variants.yaml
-# - https://github.com/gardener/ci-infra/blob/master/images/krte/Dockerfile
+# Debian versions of golang images should be `bookworm`.
+# The Kubernetes upstream `krte` images uses the same version and we should keep this in sync.
+# - https://github.com/kubernetes/test-infra/blob/master/images/krte/Dockerfile
+# - https://github.com/gardener/ci-infra/blob/master/images/krte
 variants:
   "1.20":
-    image: golang:1.20.8-bookworm
+    image: golang:1.20.9-bookworm
   "1.21":
-    image: golang:1.21.1-bookworm
+    image: golang:1.21.2-bookworm


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing robustness
/kind enhancement

**What this PR does / why we need it**:
Currently there are `golang-test`, `krte` and `gardenertools` images where the Debian and Go versions have to be in sync. 
Thus, updating these versions without breaking the tests is a manual effort.

This PR simplifies the setup. It deprecates `gardenertools` image and builds its content directly into `golang-test` image. This is very easy because we had to create an image which is similar to `golang-test` image to build `gardenertools` anyway.

`golang-test` image is still used for our unit and integration tests. Additionally, it becomes the base image of our [krte](https://github.com/gardener/ci-infra/blob/master/images/krte) image. By doing so we ensure that Debian and Go versions of the prebuilt artifacts of the Gardener toolchain are always in sync.

`golang-test` image will now be maintained in `gardener/gardener` repository, because only a new build can be triggered when a part of the Gardener toolchain is changing. `krte` remains in `gardener/ci-infra` repository. New builds are triggered automatically by prow. The only place to update Go versions for test images will be the [hack/tools/images/variants.yaml](https://github.com/gardener/gardener/blob/master/hack/tools/image/variants.yaml) file.

Additionally, Go versions are updated to the latest patch release.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/hold 
Merge https://github.com/gardener/ci-infra/pull/936 shortly before.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
