### PR TITLE
Slightly improve the "Shoots per Seed" panel of the "Seed Resource Usage" dashboard

### DIFF
--- a/pkg/component/plutono/dashboards/garden/global/seed-resource-usage-dashboard.json
+++ b/pkg/component/plutono/dashboards/garden/global/seed-resource-usage-dashboard.json
@@ -15,8 +15,8 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 1,
-  "id": 3,
-  "iteration": 1602083986345,
+  "id": 5,
+  "iteration": 1696848484420,
   "links": [],
   "panels": [
     {
@@ -41,7 +41,6 @@
           "color": {
             "mode": "thresholds"
           },
-          "custom": {},
           "mappings": [],
           "max": 100,
           "min": 0,
@@ -72,13 +71,16 @@
         "displayMode": "gradient",
         "orientation": "horizontal",
         "reduceOptions": {
-          "calcs": ["last"],
+          "calcs": [
+            "last"
+          ],
           "fields": "",
           "values": false
         },
-        "showUnfilled": true
+        "showUnfilled": true,
+        "text": {}
       },
-      "pluginVersion": "7.0.3",
+      "pluginVersion": "7.5.24",
       "targets": [
         {
           "expr": "count(garden_shoot_info{seed=~\"$seed\"}) by (seed)",
@@ -102,7 +104,7 @@
       "description": "Shows the number of shoots per seed (does not count hibernated shoots).",
       "fieldConfig": {
         "defaults": {
-          "custom": {}
+          "links": []
         },
         "overrides": []
       },
@@ -131,9 +133,10 @@
       "linewidth": 1,
       "nullPointMode": "null",
       "options": {
-        "dataLinks": []
+        "alertThreshold": true
       },
       "percentage": false,
+      "pluginVersion": "7.5.24",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -201,7 +204,7 @@
       "description": "How much of the seed CPU is utilized for control planes.",
       "fieldConfig": {
         "defaults": {
-          "custom": {}
+          "links": []
         },
         "overrides": []
       },
@@ -230,9 +233,10 @@
       "linewidth": 1,
       "nullPointMode": "null",
       "options": {
-        "dataLinks": []
+        "alertThreshold": true
       },
       "percentage": false,
+      "pluginVersion": "7.5.24",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -298,7 +302,7 @@
       "description": "How much of the seed memory is utilized for control planes.",
       "fieldConfig": {
         "defaults": {
-          "custom": {}
+          "links": []
         },
         "overrides": []
       },
@@ -327,9 +331,10 @@
       "linewidth": 1,
       "nullPointMode": "null",
       "options": {
-        "dataLinks": []
+        "alertThreshold": true
       },
       "percentage": false,
+      "pluginVersion": "7.5.24",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -395,7 +400,7 @@
       "description": "How much of the seed CPU is utilized based on requests.",
       "fieldConfig": {
         "defaults": {
-          "custom": {}
+          "links": []
         },
         "overrides": []
       },
@@ -424,9 +429,10 @@
       "linewidth": 1,
       "nullPointMode": "null",
       "options": {
-        "dataLinks": []
+        "alertThreshold": true
       },
       "percentage": false,
+      "pluginVersion": "7.5.24",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -493,7 +499,7 @@
       "description": "How much of the seed memory is utilized based on requests.",
       "fieldConfig": {
         "defaults": {
-          "custom": {}
+          "links": []
         },
         "overrides": []
       },
@@ -522,9 +528,10 @@
       "linewidth": 1,
       "nullPointMode": "null",
       "options": {
-        "dataLinks": []
+        "alertThreshold": true
       },
       "percentage": false,
+      "pluginVersion": "7.5.24",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -605,7 +612,7 @@
       "description": "Shows the total CPU usage of each seed.",
       "fieldConfig": {
         "defaults": {
-          "custom": {}
+          "links": []
         },
         "overrides": []
       },
@@ -635,9 +642,10 @@
       "linewidth": 1,
       "nullPointMode": "null",
       "options": {
-        "dataLinks": []
+        "alertThreshold": true
       },
       "percentage": false,
+      "pluginVersion": "7.5.24",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -703,7 +711,7 @@
       "description": "Shows the total memory usage of each seed.",
       "fieldConfig": {
         "defaults": {
-          "custom": {}
+          "links": []
         },
         "overrides": []
       },
@@ -733,9 +741,10 @@
       "linewidth": 1,
       "nullPointMode": "null",
       "options": {
-        "dataLinks": []
+        "alertThreshold": true
       },
       "percentage": false,
+      "pluginVersion": "7.5.24",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -800,7 +809,6 @@
           "color": {
             "mode": "thresholds"
           },
-          "custom": {},
           "decimals": 0,
           "mappings": [],
           "max": 100,
@@ -832,13 +840,16 @@
         "displayMode": "gradient",
         "orientation": "horizontal",
         "reduceOptions": {
-          "calcs": ["mean"],
+          "calcs": [
+            "mean"
+          ],
           "fields": "",
           "values": false
         },
-        "showUnfilled": true
+        "showUnfilled": true,
+        "text": {}
       },
-      "pluginVersion": "7.0.3",
+      "pluginVersion": "7.5.24",
       "targets": [
         {
           "expr": "sum(shoot:kube_node_info:count{project=\"garden\", shoot_name=~\"$seed\"}) by (shoot_name)",
@@ -862,7 +873,7 @@
       "description": "Shows the total number of nodes for each seed.",
       "fieldConfig": {
         "defaults": {
-          "custom": {}
+          "links": []
         },
         "overrides": []
       },
@@ -891,9 +902,10 @@
       "linewidth": 1,
       "nullPointMode": "null",
       "options": {
-        "dataLinks": []
+        "alertThreshold": true
       },
       "percentage": false,
+      "pluginVersion": "7.5.24",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -960,7 +972,7 @@
       "description": "Shows how many controlplanes are hosted on each node on average.",
       "fieldConfig": {
         "defaults": {
-          "custom": {}
+          "links": []
         },
         "overrides": []
       },
@@ -989,9 +1001,10 @@
       "linewidth": 1,
       "nullPointMode": "null",
       "options": {
-        "dataLinks": []
+        "alertThreshold": true
       },
       "percentage": false,
+      "pluginVersion": "7.5.24",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1567,7 +1580,7 @@
       "description": "Shows how many CPU cores each extension uses.",
       "fieldConfig": {
         "defaults": {
-          "custom": {}
+          "links": []
         },
         "overrides": []
       },
@@ -1595,10 +1608,8 @@
       "lines": true,
       "linewidth": 1,
       "nullPointMode": "null",
-      "options": {
-        "dataLinks": []
-      },
       "percentage": false,
+      "pluginVersion": "7.5.24",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1664,7 +1675,7 @@
       "description": "Shows how much memory each extension is using.",
       "fieldConfig": {
         "defaults": {
-          "custom": {}
+          "links": []
         },
         "overrides": []
       },
@@ -1692,10 +1703,8 @@
       "lines": true,
       "linewidth": 1,
       "nullPointMode": "null",
-      "options": {
-        "dataLinks": []
-      },
       "percentage": false,
+      "pluginVersion": "7.5.24",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1754,27 +1763,39 @@
     }
   ],
   "refresh": false,
-  "schemaVersion": 25,
+  "schemaVersion": 27,
   "style": "dark",
-  "tags": ["seed", "usage"],
+  "tags": [
+    "seed",
+    "usage"
+  ],
   "templating": {
     "list": [
       {
         "allValue": null,
         "current": {
           "selected": true,
-          "text": "All",
-          "value": ["$__all"]
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
         },
         "datasource": "prometheus",
         "definition": "label_values(seed:container_cpu_usage_seconds_total:sum, seed)",
+        "description": null,
+        "error": null,
         "hide": 0,
         "includeAll": true,
         "label": null,
         "multi": true,
         "name": "seed",
         "options": [],
-        "query": "label_values(seed:container_cpu_usage_seconds_total:sum, seed)",
+        "query": {
+          "query": "label_values(seed:container_cpu_usage_seconds_total:sum, seed)",
+          "refId": "prometheus-seed-Variable-Query"
+        },
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,

--- a/pkg/component/plutono/dashboards/garden/global/seed-resource-usage-dashboard.json
+++ b/pkg/component/plutono/dashboards/garden/global/seed-resource-usage-dashboard.json
@@ -78,8 +78,10 @@
       "pluginVersion": "7.5.24",
       "targets": [
         {
-          "expr": "count(garden_shoot_info{seed=~\"$seed\"}) by (seed)",
+          "exemplar": true,
+          "expr": "sort_desc(count(garden_shoot_info{seed=~\"$seed\"}) by (seed))",
           "instant": true,
+          "interval": "",
           "legendFormat": "{{ seed }}",
           "refId": "A"
         }

--- a/pkg/component/plutono/dashboards/garden/global/seed-resource-usage-dashboard.json
+++ b/pkg/component/plutono/dashboards/garden/global/seed-resource-usage-dashboard.json
@@ -42,7 +42,6 @@
             "mode": "thresholds"
           },
           "mappings": [],
-          "max": 100,
           "min": 0,
           "thresholds": {
             "mode": "absolute",

--- a/pkg/component/plutono/dashboards/garden/global/seed-resource-usage-dashboard.json
+++ b/pkg/component/plutono/dashboards/garden/global/seed-resource-usage-dashboard.json
@@ -49,10 +49,6 @@
               {
                 "color": "green",
                 "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
               }
             ]
           }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind enhancement

**What this PR does / why we need it**:

The "Shoots per Seed" panel of the "Seed Resource Usage" dashboard that is deployed to the runtime garden cluster was a bit confusing: seeds with more than 80 shoots were shown in red and the visualisation for seeds with more than 100 shoots was chopped off. With this PR, the bar gauges are always shown in green (the runtime seed capacity should actually be used instead but there is no easy option to achieve that with the current visualisation so this work is postponed for a future PR) and to proper scale, without being chopped off.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

/cc @acumino @ialidzhikov @vlerenc 

Please check the individual commits to filter out the one time noisy and irrelevant changes.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
