### PR TITLE
Use debian 12 (bookworm) distroless image as base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ARG EFFECTIVE_VERSION
 RUN make install EFFECTIVE_VERSION=$EFFECTIVE_VERSION
 
 # distroless-static
-FROM gcr.io/distroless/static-debian11:nonroot as distroless-static
+FROM gcr.io/distroless/static-debian12:nonroot as distroless-static
 
 # apiserver
 FROM distroless-static AS apiserver


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area open-source
/kind enhancement

**What this PR does / why we need it**:
There is a [debian 12 (bookworm) distroless](https://github.com/GoogleContainerTools/distroless#debian-12) image available. [Go 1.21.x](https://hub.docker.com/layers/library/golang/1.21.2/images/sha256-e63f8cf91f5b59ce217f2804936132b2964b04bb5b06c0a79b9e37990a6ab148?context=explore) images are based on debian bookworm too.
Thus, this PR updates base images of Gardener.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
Gardener base image is updated to `gcr.io/distroless/static-debian12:nonroot`.
```
