### PR TITLE
[node-agent] Introduce token `Secret` controller

### DIFF
--- a/docs/concepts/node-agent.md
+++ b/docs/concepts/node-agent.md
@@ -24,6 +24,17 @@ Along with the init script, a configuration for the `gardener-node-agent` is car
 
 In a bootstrapping phase, the `gardener-node-agent` sets itself up as a systemd service. It also executes tasks that need to be executed before any other components are installed, e.g. formatting the data device for the `kubelet`.
 
+## Controllers
+
+This section describes the controllers in more details.
+
+### [Token Controller](../../pkg/nodeagent/controller/token)
+
+This controller watches the access token `Secret` in the `kube-system` namespace whose name is provided via the `gardener-node-agent`'s component configuration (`.accessTokenSecret` field).
+Whenever the `.data.token` field changes, it writes the new content to the `/var/lib/gardener-node-agent/credentials/token` file on the host file system.
+Since the underlying client is based on `k8s.io/client-go` and the kubeconfig points to this token file, it is dynamically reloaded without further doing.
+This procedure ensures that the most up-to-date token is always present on the host and used by the `gardener-node-agent`.
+
 ## Reasoning
 
 The `gardener-node-agent` is a replacement for what was called the `cloud-config-downloader` and the `cloud-config-executor`, both written in `bash`. The `gardener-node-agent` implements this functionality as a regular controller and feels more uniform in terms of maintenance.

--- a/docs/concepts/node-agent.md
+++ b/docs/concepts/node-agent.md
@@ -32,7 +32,7 @@ This section describes the controllers in more details.
 
 This controller watches the access token `Secret` in the `kube-system` namespace whose name is provided via the `gardener-node-agent`'s component configuration (`.accessTokenSecret` field).
 Whenever the `.data.token` field changes, it writes the new content to the `/var/lib/gardener-node-agent/credentials/token` file on the host file system.
-Since the underlying client is based on `k8s.io/client-go` and the kubeconfig points to this token file, it is dynamically reloaded without further doing.
+Since the underlying client is based on `k8s.io/client-go` and the kubeconfig points to this token file, it is dynamically reloaded without the necessity of explicit configuration or code changes.
 This procedure ensures that the most up-to-date token is always present on the host and used by the `gardener-node-agent`.
 
 ## Reasoning

--- a/pkg/nodeagent/controller/token/add.go
+++ b/pkg/nodeagent/controller/token/add.go
@@ -1,0 +1,77 @@
+// Copyright 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package token
+
+import (
+	"github.com/spf13/afero"
+	corev1 "k8s.io/api/core/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
+)
+
+// ControllerName is the name of this controller.
+const ControllerName = "token"
+
+// AddToManager adds Reconciler to the given manager.
+func (r *Reconciler) AddToManager(mgr manager.Manager) error {
+	if r.Client == nil {
+		r.Client = mgr.GetClient()
+	}
+	if r.FS == nil {
+		r.FS = afero.NewOsFs()
+	}
+
+	return builder.
+		ControllerManagedBy(mgr).
+		Named(ControllerName).
+		For(&corev1.Secret{}, builder.WithPredicates(
+			predicate.NewPredicateFuncs(func(obj client.Object) bool {
+				return obj.GetNamespace() == metav1.NamespaceSystem && obj.GetName() == r.AccessTokenSecretName
+			}),
+			r.SecretPredicate(),
+		)).
+		WithOptions(controller.Options{MaxConcurrentReconciles: 1}).
+		Complete(r)
+}
+
+// SecretPredicate returns the predicate for Secret events.
+func (r *Reconciler) SecretPredicate() predicate.Predicate {
+	return predicate.Funcs{
+		CreateFunc: func(_ event.CreateEvent) bool { return true },
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			oldSecret, ok := e.ObjectOld.(*corev1.Secret)
+			if !ok {
+				return false
+			}
+
+			newSecret, ok := e.ObjectNew.(*corev1.Secret)
+			if !ok {
+				return false
+			}
+
+			return !apiequality.Semantic.DeepEqual(oldSecret.Data[resourcesv1alpha1.DataKeyToken], newSecret.Data[resourcesv1alpha1.DataKeyToken])
+		},
+		DeleteFunc:  func(_ event.DeleteEvent) bool { return false },
+		GenericFunc: func(_ event.GenericEvent) bool { return false },
+	}
+}

--- a/pkg/nodeagent/controller/token/add_test.go
+++ b/pkg/nodeagent/controller/token/add_test.go
@@ -1,0 +1,77 @@
+// Copyright 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package token_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	. "github.com/gardener/gardener/pkg/nodeagent/controller/token"
+)
+
+var _ = Describe("Add", func() {
+	Describe("#SecretPredicate", func() {
+		var (
+			p      predicate.Predicate
+			secret *corev1.Secret
+		)
+
+		BeforeEach(func() {
+			p = (&Reconciler{}).SecretPredicate()
+			secret = &corev1.Secret{}
+		})
+
+		Describe("#Create", func() {
+			It("should return true", func() {
+				Expect(p.Create(event.CreateEvent{})).To(BeTrue())
+			})
+		})
+
+		Describe("#Update", func() {
+			It("should return false because old object is not a secret", func() {
+				Expect(p.Update(event.UpdateEvent{})).To(BeFalse())
+			})
+
+			It("should return false because new object is not a secret", func() {
+				Expect(p.Update(event.UpdateEvent{ObjectOld: secret})).To(BeFalse())
+			})
+
+			It("should return false because token data does not change", func() {
+				Expect(p.Update(event.UpdateEvent{ObjectOld: secret, ObjectNew: secret})).To(BeFalse())
+			})
+
+			It("should return true because token data changes", func() {
+				oldSecret := secret.DeepCopy()
+				secret.Data = map[string][]byte{"token": []byte("foo")}
+				Expect(p.Update(event.UpdateEvent{ObjectOld: oldSecret, ObjectNew: secret})).To(BeTrue())
+			})
+		})
+
+		Describe("#Delete", func() {
+			It("should return false", func() {
+				Expect(p.Delete(event.DeleteEvent{})).To(BeFalse())
+			})
+		})
+
+		Describe("#Generic", func() {
+			It("should return false", func() {
+				Expect(p.Generic(event.GenericEvent{})).To(BeFalse())
+			})
+		})
+	})
+})

--- a/pkg/nodeagent/controller/token/reconciler.go
+++ b/pkg/nodeagent/controller/token/reconciler.go
@@ -1,0 +1,77 @@
+// Copyright 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package token
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/spf13/afero"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
+	"github.com/gardener/gardener/pkg/controllerutils"
+	nodeagentv1alpha1 "github.com/gardener/gardener/pkg/nodeagent/apis/config/v1alpha1"
+)
+
+// Reconciler fetches the shoot access token for gardener-node-agent and writes it to disk.
+type Reconciler struct {
+	Client                client.Client
+	FS                    afero.Fs
+	AccessTokenSecretName string
+}
+
+// Reconcile fetches the shoot access token for gardener-node-agent and writes it to disk.
+func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
+	log := logf.FromContext(ctx)
+
+	ctx, cancel := controllerutils.GetMainReconciliationContext(ctx, controllerutils.DefaultReconciliationTimeout)
+	defer cancel()
+
+	secret := &corev1.Secret{}
+	if err := r.Client.Get(ctx, request.NamespacedName, secret); err != nil {
+		if apierrors.IsNotFound(err) {
+			log.V(1).Info("Object is gone, stop reconciling")
+			return reconcile.Result{}, nil
+		}
+		return reconcile.Result{}, fmt.Errorf("error retrieving object from store: %w", err)
+	}
+
+	token := secret.Data[resourcesv1alpha1.DataKeyToken]
+	if len(token) == 0 {
+		return reconcile.Result{}, fmt.Errorf("secret key %q does not exist or empty", resourcesv1alpha1.DataKeyToken)
+	}
+
+	currentToken, err := afero.ReadFile(r.FS, nodeagentv1alpha1.TokenFilePath)
+	if err != nil && !errors.Is(err, afero.ErrFileNotFound) {
+		return reconcile.Result{}, fmt.Errorf("failed reading token file %s: %w", nodeagentv1alpha1.TokenFilePath, err)
+	}
+
+	if !bytes.Equal(currentToken, token) {
+		log.Info("Access token differs from the one currently stored on the disk, updating it", "path", nodeagentv1alpha1.TokenFilePath)
+		if err := afero.WriteFile(r.FS, nodeagentv1alpha1.TokenFilePath, token, 0600); err != nil {
+			return reconcile.Result{}, fmt.Errorf("unable to write access token to %s: %w", nodeagentv1alpha1.TokenFilePath, err)
+		}
+		log.Info("Updated token written to disk")
+	}
+
+	return reconcile.Result{}, nil
+}

--- a/pkg/nodeagent/controller/token/reconciler.go
+++ b/pkg/nodeagent/controller/token/reconciler.go
@@ -57,7 +57,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 
 	token := secret.Data[resourcesv1alpha1.DataKeyToken]
 	if len(token) == 0 {
-		return reconcile.Result{}, fmt.Errorf("secret key %q does not exist or empty", resourcesv1alpha1.DataKeyToken)
+		return reconcile.Result{}, fmt.Errorf("secret key %q does not exist or is empty", resourcesv1alpha1.DataKeyToken)
 	}
 
 	currentToken, err := afero.ReadFile(r.FS, nodeagentv1alpha1.TokenFilePath)

--- a/pkg/nodeagent/controller/token/token_suite_test.go
+++ b/pkg/nodeagent/controller/token/token_suite_test.go
@@ -12,24 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package controller
+package token_test
 
 import (
-	"fmt"
+	"testing"
 
-	"sigs.k8s.io/controller-runtime/pkg/manager"
-
-	"github.com/gardener/gardener/pkg/nodeagent/apis/config"
-	"github.com/gardener/gardener/pkg/nodeagent/controller/token"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 )
 
-// AddToManager adds all controllers to the given manager.
-func AddToManager(mgr manager.Manager, cfg *config.NodeAgentConfiguration) error {
-	if err := (&token.Reconciler{
-		AccessTokenSecretName: cfg.AccessTokenSecretName,
-	}).AddToManager(mgr); err != nil {
-		return fmt.Errorf("failed adding token controller: %w", err)
-	}
-
-	return nil
+func TestToken(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "NodeAgent Controller Token Suite")
 }

--- a/test/integration/nodeagent/token/token_suite_test.go
+++ b/test/integration/nodeagent/token/token_suite_test.go
@@ -1,0 +1,73 @@
+// Copyright 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package token_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/util/uuid"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	"github.com/gardener/gardener/pkg/logger"
+	gardenerutils "github.com/gardener/gardener/pkg/utils"
+)
+
+func TestToken(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Test Integration NodeAgent Token Suite")
+}
+
+const testID = "token-controller-test"
+
+var (
+	ctx = context.Background()
+	log logr.Logger
+
+	restConfig *rest.Config
+	testEnv    *envtest.Environment
+	testClient client.Client
+
+	testRunID = "test-" + gardenerutils.ComputeSHA256Hex([]byte(uuid.NewUUID()))
+)
+
+var _ = BeforeSuite(func() {
+	logf.SetLogger(logger.MustNewZapLogger(logger.DebugLevel, logger.FormatJSON, zap.WriteTo(GinkgoWriter)))
+	log = logf.Log.WithName(testID)
+
+	By("Start test environment")
+	testEnv = &envtest.Environment{}
+
+	var err error
+	restConfig, err = testEnv.Start()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(restConfig).NotTo(BeNil())
+
+	DeferCleanup(func() {
+		By("Stop test environment")
+		Expect(testEnv.Stop()).To(Succeed())
+	})
+
+	By("Create test client")
+	testClient, err = client.New(restConfig, client.Options{})
+	Expect(err).NotTo(HaveOccurred())
+})

--- a/test/integration/nodeagent/token/token_test.go
+++ b/test/integration/nodeagent/token/token_test.go
@@ -1,0 +1,135 @@
+// Copyright 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package token_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/spf13/afero"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+
+	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
+	nodeagentv1alpha1 "github.com/gardener/gardener/pkg/nodeagent/apis/config/v1alpha1"
+	"github.com/gardener/gardener/pkg/nodeagent/controller/token"
+)
+
+var _ = Describe("Token controller tests", func() {
+	var (
+		testFS afero.Fs
+
+		accessToken = []byte("access-token")
+		secret      *corev1.Secret
+	)
+
+	BeforeEach(func() {
+		By("Setup manager")
+		mgr, err := manager.New(restConfig, manager.Options{
+			Metrics: metricsserver.Options{BindAddress: "0"},
+			Cache: cache.Options{
+				DefaultNamespaces: map[string]cache.Config{metav1.NamespaceSystem: {}},
+			},
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Register controller")
+		testFS = afero.NewMemMapFs()
+		Expect((&token.Reconciler{
+			FS:                    testFS,
+			AccessTokenSecretName: testRunID,
+		}).AddToManager(mgr)).To(Succeed())
+
+		By("Start manager")
+		mgrContext, mgrCancel := context.WithCancel(ctx)
+
+		go func() {
+			defer GinkgoRecover()
+			Expect(mgr.Start(mgrContext)).To(Succeed())
+		}()
+
+		DeferCleanup(func() {
+			By("Stop manager")
+			mgrCancel()
+		})
+
+		secret = &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      testRunID,
+				Namespace: metav1.NamespaceSystem,
+			},
+			Data: map[string][]byte{resourcesv1alpha1.DataKeyToken: accessToken},
+		}
+	})
+
+	JustBeforeEach(func() {
+		By("Create access token secret")
+		Expect(testClient.Create(ctx, secret)).To(Succeed())
+		DeferCleanup(func() {
+			Expect(testClient.Delete(ctx, secret)).To(Succeed())
+		})
+
+		tokenOnDisk, err := afero.ReadFile(testFS, nodeagentv1alpha1.TokenFilePath)
+		Expect(err).To(MatchError(ContainSubstring("file does not exist")))
+		Expect(tokenOnDisk).To(BeEmpty())
+	})
+
+	It("should write the token to the local file system", func() {
+		Eventually(func(g Gomega) []byte {
+			tokenOnDisk, err := afero.ReadFile(testFS, nodeagentv1alpha1.TokenFilePath)
+			g.Expect(err).NotTo(HaveOccurred())
+			return tokenOnDisk
+		}).Should(Equal(accessToken))
+	})
+
+	It("should update the token on the local file system when it changes", func() {
+		Eventually(func(g Gomega) []byte {
+			tokenOnDisk, err := afero.ReadFile(testFS, nodeagentv1alpha1.TokenFilePath)
+			g.Expect(err).NotTo(HaveOccurred())
+			return tokenOnDisk
+		}).Should(Equal(accessToken))
+
+		By("Update token in secret data")
+		newToken := []byte("new-token")
+		patch := client.MergeFrom(secret.DeepCopy())
+		secret.Data[resourcesv1alpha1.DataKeyToken] = newToken
+		Expect(testClient.Patch(ctx, secret, patch)).To(Succeed())
+
+		Eventually(func(g Gomega) []byte {
+			tokenOnDisk, err := afero.ReadFile(testFS, nodeagentv1alpha1.TokenFilePath)
+			g.Expect(err).NotTo(HaveOccurred())
+			return tokenOnDisk
+		}).Should(Equal(newToken))
+	})
+
+	Context("unrelated secret", func() {
+		BeforeEach(func() {
+			secret.Name = "some-other-secret"
+		})
+
+		It("should do nothing because the secret is unrelated", func() {
+			Consistently(func(g Gomega) error {
+				tokenOnDisk, err := afero.ReadFile(testFS, nodeagentv1alpha1.TokenFilePath)
+				g.Expect(tokenOnDisk).To(BeEmpty())
+				return err
+			}).Should(MatchError(ContainSubstring("file does not exist")))
+		})
+	})
+})

--- a/test/integration/nodeagent/token/token_test.go
+++ b/test/integration/nodeagent/token/token_test.go
@@ -85,10 +85,6 @@ var _ = Describe("Token controller tests", func() {
 		DeferCleanup(func() {
 			Expect(testClient.Delete(ctx, secret)).To(Succeed())
 		})
-
-		tokenOnDisk, err := afero.ReadFile(testFS, nodeagentv1alpha1.TokenFilePath)
-		Expect(err).To(MatchError(ContainSubstring("file does not exist")))
-		Expect(tokenOnDisk).To(BeEmpty())
 	})
 
 	It("should write the token to the local file system", func() {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind enhancement

**What this PR does / why we need it**:
This PR introduces the token controller in `gardener-node-agent` whose main purpose is watching the access token `Secret` in the (shoot) cluster's `kube-system` namespace. Whenever it changes, it writes the new token to the disk. The kubeconfig points to the same file ([ref](https://github.com/gardener/gardener/pull/8627/files#diff-55fb15b9da09f83f4983b2003c189b5e2ad4d71afb010bbf61f97dfe1a0b8fcfR210)).

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/8023

**Special notes for your reviewer**:
- [x] This PR depends on #8627 which needs to be merged, hence it remains in draft state until then. Relevant commits start after the "empty separator commit".

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
