### PR TITLE
Allow reuse of the functionality that checks for skaffold dependencies

### DIFF
--- a/hack/check-skaffold-deps-for-binary.sh
+++ b/hack/check-skaffold-deps-for-binary.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+#
+# Copyright 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+skaffold_file="$1"
+binary_name="$2"
+skaffold_config_name="$3"
+
+parse_flags() {
+  while test $# -gt 0; do
+    case "$1" in
+      --skaffold-file)
+        shift; skaffold_file="$1"
+        ;;
+      --binary)
+        shift; binary_name="$1"
+        ;;
+      --skaffold-config)
+        shift; skaffold_config_name="$1"
+        ;;
+      *)
+        echo "Unknown argument: $1"
+        exit 1
+        ;;
+    esac
+    shift
+  done
+}
+
+parse_flags "$@"
+
+out_dir=$(mktemp -d)
+function cleanup_output {
+  rm -rf "$out_dir"
+}
+trap cleanup_output EXIT
+
+repo_root="$(git rev-parse --show-toplevel)"
+skaffold_yaml="$(cat "$repo_root/$skaffold_file")"
+
+path_current_skaffold_dependencies="${out_dir}/current-$skaffold_file-deps-$binary_name.txt"
+path_actual_dependencies="${out_dir}/actual-$skaffold_file-deps-$binary_name.txt"
+
+echo "$skaffold_yaml" |\
+  yq eval "select(.metadata.name == \"$skaffold_config_name\") | .build.artifacts[] | select(.ko.main == \"./cmd/$binary_name\") | .ko.dependencies.paths[]?" - |\
+  sort |\
+  uniq > "$path_current_skaffold_dependencies"
+
+module_name=$(go list -m)
+module_prefix="$module_name/"
+go list -f '{{ join .Deps "\n" }}' "./cmd/$binary_name" |\
+  grep "$module_prefix" |\
+  sed "s@$module_prefix@@g" |\
+  sort |\
+  uniq > "$path_actual_dependencies"
+
+# always add vendor directory and VERSION file
+echo "vendor" >> "$path_actual_dependencies"
+echo "VERSION" >> "$path_actual_dependencies"
+
+# sort dependencies
+sort -o $path_current_skaffold_dependencies{,}
+sort -o $path_actual_dependencies{,}
+
+echo -n ">> Checking defined dependencies in Skaffold config '$skaffold_config_name' for '$binary_name' in '$skaffold_file'..."
+if ! diff="$(diff "$path_current_skaffold_dependencies" "$path_actual_dependencies")"; then
+  echo
+  echo ">>> The following actual dependencies are missing in $skaffold_file (need to be added):"
+  echo "$diff" | grep '>' | awk '{print $2}'
+  echo
+  echo ">>> The following dependencies defined in $skaffold_file are not needed actually (need to be removed):"
+  echo "$diff" | grep '<' | awk '{print $2}'
+  echo
+
+  exit 1
+else
+  echo " success."
+fi

--- a/hack/check-skaffold-deps-for-binary.sh
+++ b/hack/check-skaffold-deps-for-binary.sh
@@ -16,9 +16,9 @@
 
 set -e
 
-skaffold_file="$1"
-binary_name="$2"
-skaffold_config_name="$3"
+skaffold_file=""
+binary_name=""
+skaffold_config_name=""
 
 parse_flags() {
   while test $# -gt 0; do

--- a/hack/check-skaffold-deps.sh
+++ b/hack/check-skaffold-deps.sh
@@ -18,76 +18,21 @@ set -e
 
 echo "> Check Skaffold Dependencies"
 
-check_successful=true
-
-out_dir=$(mktemp -d)
-function cleanup_output {
-  rm -rf "$out_dir"
-}
-trap cleanup_output EXIT
-
-function check() {
-  skaffold_file="$1"
-  binary_name="$2"
-  skaffold_config_name="$3"
-
-  skaffold_yaml="$(cat "$(dirname "$0")/../$skaffold_file")"
-
-  path_current_skaffold_dependencies="${out_dir}/current-$skaffold_file-deps-$binary_name.txt"
-  path_actual_dependencies="${out_dir}/actual-$skaffold_file-deps-$binary_name.txt"
-
-  echo "$skaffold_yaml" |\
-    yq eval "select(.metadata.name == \"$skaffold_config_name\") | .build.artifacts[] | select(.ko.main == \"./cmd/$binary_name\") | .ko.dependencies.paths[]?" - |\
-    sort |\
-    uniq > "$path_current_skaffold_dependencies"
-
-  go list -f '{{ join .Deps "\n" }}' "./cmd/$binary_name" |\
-    grep "github.com/gardener/gardener/" |\
-    sed 's/github\.com\/gardener\/gardener\///g' |\
-    sort |\
-    uniq > "$path_actual_dependencies"
-
-  # always add vendor directory and VERSION file
-  echo "vendor" >> "$path_actual_dependencies"
-  echo "VERSION" >> "$path_actual_dependencies"
-
-  # sort dependencies
-  sort -o $path_current_skaffold_dependencies{,}
-  sort -o $path_actual_dependencies{,}
-
-  echo -n ">> Checking defined dependencies in Skaffold config '$skaffold_config_name' for '$binary_name' in '$skaffold_file'..."
-  if ! diff="$(diff "$path_current_skaffold_dependencies" "$path_actual_dependencies")"; then
-    check_successful=false
-
-    echo
-    echo ">>> The following actual dependencies are missing in $skaffold_file (need to be added):"
-    echo "$diff" | grep '>' | awk '{print $2}'
-    echo
-    echo ">>> The following dependencies defined in $skaffold_file are not needed actually (need to be removed):"
-    echo "$diff" | grep '<' | awk '{print $2}'
-    echo
-  else
-    echo " success."
-  fi
-}
+REPO_ROOT="$(git rev-parse --show-toplevel)"
 
 # skaffold.yaml
-check "skaffold.yaml" "gardener-admission-controller"      "controlplane"
-check "skaffold.yaml" "gardener-apiserver"                 "controlplane"
-check "skaffold.yaml" "gardener-controller-manager"        "controlplane"
-check "skaffold.yaml" "gardener-extension-provider-local"  "provider-local"
-check "skaffold.yaml" "gardener-resource-manager"          "gardenlet"
-check "skaffold.yaml" "gardener-scheduler"                 "controlplane"
-check "skaffold.yaml" "gardenlet"                          "gardenlet"
+$REPO_ROOT/hack/check-skaffold-deps-for-binary.sh --skaffold-file "skaffold.yaml" --binary "gardener-admission-controller"     --skaffold-config "controlplane"
+$REPO_ROOT/hack/check-skaffold-deps-for-binary.sh --skaffold-file "skaffold.yaml" --binary "gardener-apiserver"                --skaffold-config "controlplane"
+$REPO_ROOT/hack/check-skaffold-deps-for-binary.sh --skaffold-file "skaffold.yaml" --binary "gardener-controller-manager"       --skaffold-config "controlplane"
+$REPO_ROOT/hack/check-skaffold-deps-for-binary.sh --skaffold-file "skaffold.yaml" --binary "gardener-extension-provider-local" --skaffold-config "provider-local"
+$REPO_ROOT/hack/check-skaffold-deps-for-binary.sh --skaffold-file "skaffold.yaml" --binary "gardener-resource-manager"         --skaffold-config "gardenlet"
+$REPO_ROOT/hack/check-skaffold-deps-for-binary.sh --skaffold-file "skaffold.yaml" --binary "gardener-scheduler"                --skaffold-config "controlplane"
+$REPO_ROOT/hack/check-skaffold-deps-for-binary.sh --skaffold-file "skaffold.yaml" --binary "gardenlet"                         --skaffold-config "gardenlet"
 
 # skaffold-operator.yaml
-check "skaffold-operator.yaml" "gardener-operator"             "gardener-operator"
-check "skaffold-operator.yaml" "gardener-resource-manager"     "gardener-operator"
-check "skaffold-operator.yaml" "gardener-admission-controller" "gardener-operator"
-check "skaffold-operator.yaml" "gardener-apiserver"            "gardener-operator"
-check "skaffold-operator.yaml" "gardener-controller-manager"   "gardener-operator"
-check "skaffold-operator.yaml" "gardener-scheduler"            "gardener-operator"
-
-if [ "$check_successful" = false ] ; then
-  exit 1
-fi
+$REPO_ROOT/hack/check-skaffold-deps-for-binary.sh --skaffold-file "skaffold-operator.yaml" --binary "gardener-operator"             --skaffold-config "gardener-operator"
+$REPO_ROOT/hack/check-skaffold-deps-for-binary.sh --skaffold-file "skaffold-operator.yaml" --binary "gardener-resource-manager"     --skaffold-config "gardener-operator"
+$REPO_ROOT/hack/check-skaffold-deps-for-binary.sh --skaffold-file "skaffold-operator.yaml" --binary "gardener-admission-controller" --skaffold-config "gardener-operator"
+$REPO_ROOT/hack/check-skaffold-deps-for-binary.sh --skaffold-file "skaffold-operator.yaml" --binary "gardener-apiserver"            --skaffold-config "gardener-operator"
+$REPO_ROOT/hack/check-skaffold-deps-for-binary.sh --skaffold-file "skaffold-operator.yaml" --binary "gardener-controller-manager"   --skaffold-config "gardener-operator"
+$REPO_ROOT/hack/check-skaffold-deps-for-binary.sh --skaffold-file "skaffold-operator.yaml" --binary "gardener-scheduler"            --skaffold-config "gardener-operator"

--- a/hack/check-skaffold-deps.sh
+++ b/hack/check-skaffold-deps.sh
@@ -18,21 +18,32 @@ set -e
 
 echo "> Check Skaffold Dependencies"
 
-REPO_ROOT="$(git rev-parse --show-toplevel)"
+check_successful=true
+repo_root="$(git rev-parse --show-toplevel)"
+
+function check() {
+  if ! $repo_root/hack/check-skaffold-deps-for-binary.sh --skaffold-file $1 --binary $2 --skaffold-config $3; then
+    check_successful=false
+  fi
+}
 
 # skaffold.yaml
-$REPO_ROOT/hack/check-skaffold-deps-for-binary.sh --skaffold-file "skaffold.yaml" --binary "gardener-admission-controller"     --skaffold-config "controlplane"
-$REPO_ROOT/hack/check-skaffold-deps-for-binary.sh --skaffold-file "skaffold.yaml" --binary "gardener-apiserver"                --skaffold-config "controlplane"
-$REPO_ROOT/hack/check-skaffold-deps-for-binary.sh --skaffold-file "skaffold.yaml" --binary "gardener-controller-manager"       --skaffold-config "controlplane"
-$REPO_ROOT/hack/check-skaffold-deps-for-binary.sh --skaffold-file "skaffold.yaml" --binary "gardener-extension-provider-local" --skaffold-config "provider-local"
-$REPO_ROOT/hack/check-skaffold-deps-for-binary.sh --skaffold-file "skaffold.yaml" --binary "gardener-resource-manager"         --skaffold-config "gardenlet"
-$REPO_ROOT/hack/check-skaffold-deps-for-binary.sh --skaffold-file "skaffold.yaml" --binary "gardener-scheduler"                --skaffold-config "controlplane"
-$REPO_ROOT/hack/check-skaffold-deps-for-binary.sh --skaffold-file "skaffold.yaml" --binary "gardenlet"                         --skaffold-config "gardenlet"
+check "skaffold.yaml" "gardener-admission-controller"      "controlplane"
+check "skaffold.yaml" "gardener-apiserver"                 "controlplane"
+check "skaffold.yaml" "gardener-controller-manager"        "controlplane"
+check "skaffold.yaml" "gardener-extension-provider-local"  "provider-local"
+check "skaffold.yaml" "gardener-resource-manager"          "gardenlet"
+check "skaffold.yaml" "gardener-scheduler"                 "controlplane"
+check "skaffold.yaml" "gardenlet"                          "gardenlet"
 
 # skaffold-operator.yaml
-$REPO_ROOT/hack/check-skaffold-deps-for-binary.sh --skaffold-file "skaffold-operator.yaml" --binary "gardener-operator"             --skaffold-config "gardener-operator"
-$REPO_ROOT/hack/check-skaffold-deps-for-binary.sh --skaffold-file "skaffold-operator.yaml" --binary "gardener-resource-manager"     --skaffold-config "gardener-operator"
-$REPO_ROOT/hack/check-skaffold-deps-for-binary.sh --skaffold-file "skaffold-operator.yaml" --binary "gardener-admission-controller" --skaffold-config "gardener-operator"
-$REPO_ROOT/hack/check-skaffold-deps-for-binary.sh --skaffold-file "skaffold-operator.yaml" --binary "gardener-apiserver"            --skaffold-config "gardener-operator"
-$REPO_ROOT/hack/check-skaffold-deps-for-binary.sh --skaffold-file "skaffold-operator.yaml" --binary "gardener-controller-manager"   --skaffold-config "gardener-operator"
-$REPO_ROOT/hack/check-skaffold-deps-for-binary.sh --skaffold-file "skaffold-operator.yaml" --binary "gardener-scheduler"            --skaffold-config "gardener-operator"
+check "skaffold-operator.yaml" "gardener-operator"             "gardener-operator"
+check "skaffold-operator.yaml" "gardener-resource-manager"     "gardener-operator"
+check "skaffold-operator.yaml" "gardener-admission-controller" "gardener-operator"
+check "skaffold-operator.yaml" "gardener-apiserver"            "gardener-operator"
+check "skaffold-operator.yaml" "gardener-controller-manager"   "gardener-operator"
+check "skaffold-operator.yaml" "gardener-scheduler"            "gardener-operator"
+
+if [ "$check_successful" = false ] ; then
+  exit 1
+fi


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
In the registry-cache extension we also had to specify ko dependencies in the skaffold file to workaround https://github.com/GoogleContainerTools/skaffold/issues/7836. See https://github.com/gardener/gardener-extension-registry-cache/pull/57.
We also forked the `hack/check-skaffold-deps.sh` script and adapted it for us.
This PR makes possible reuse of the core logic so that other extensions using skaffold (such as shoot-rsyslog-relp extension, cc @plkokanov) can easily reuse the logic for checking skaffold deps.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener-extension-registry-cache/issues/3

**Special notes for your reviewer**:
See example usage in https://github.com/ialidzhikov/gardener-extension-registry-cache/commit/7f47b4b822e98da2c4635ba82b1e5a3e896f5e02

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```dependency developer
There is now a new script (`hack/check-skaffold-deps-for-binary.sh`) that can be used by gardener extensions to validate their skaffold ko dependencies.
```
