### PR TITLE
Increase RSA key size to 3072 bits

### DIFF
--- a/hack/hook-me.sh
+++ b/hack/hook-me.sh
@@ -257,16 +257,16 @@ extendedKeyUsage = clientAuth
 EOF
 
   # Create a certificate authority
-  openssl genrsa -out ca.key 2048
+  openssl genrsa -out ca.key 3072
   openssl req -x509 -new -nodes -key ca.key -days 100000 -out ca.crt -subj "/CN=quic-tunnel-ca"
 
   # Create a server certiticate
-  openssl genrsa -out tls.key 2048
+  openssl genrsa -out tls.key 3072
   openssl req -new -key tls.key -out server.csr -subj "/CN=quic-tunnel-server" -config server.conf
   openssl x509 -req -in server.csr -CA ca.crt -CAkey ca.key -CAcreateserial -out tls.crt -days 100000 -extensions v3_req -extfile server.conf
 
   # Create a client certiticate
-  openssl genrsa -out client.key 2048
+  openssl genrsa -out client.key 3072
   openssl req -new -key client.key -out client.csr -subj "/CN=quic-tunnel-client" -config client.conf
   openssl x509 -req -in client.csr -CA ca.crt -CAkey ca.key -CAcreateserial -out client.crt -days 100000 -extensions v3_req -extfile client.conf
 

--- a/pkg/utils/secrets/certificate.go
+++ b/pkg/utils/secrets/certificate.go
@@ -59,7 +59,7 @@ const (
 )
 
 // CertificateSecretConfig contains the specification a to-be-generated CA, server, or client certificate.
-// It always contains a 2048-bit RSA private key.
+// It always contains a 3072-bit RSA private key.
 type CertificateSecretConfig struct {
 	Name string
 
@@ -116,7 +116,7 @@ func (s *CertificateSecretConfig) GenerateCertificate() (*Certificate, error) {
 
 	// If no cert type is given then we only return a certificate object that contains the CA.
 	if s.CertType != "" {
-		privateKey, err := GenerateKey(rand.Reader, 2048)
+		privateKey, err := GenerateKey(rand.Reader, 3072)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/utils/secrets/manager/generate_test.go
+++ b/pkg/utils/secrets/manager/generate_test.go
@@ -729,7 +729,7 @@ var _ = Describe("Generate", func() {
 				By("Generate new secret")
 				secret, err := m.Generate(ctx, config)
 				Expect(err).NotTo(HaveOccurred())
-				Expect(secret.Name).To(Equal(name + "-16163da7"))
+				Expect(secret.Name).To(Equal(name + "-c34363f0"))
 				expectSecretWasCreated(ctx, fakeClient, secret)
 
 				By("Find created bundle secret")
@@ -755,7 +755,7 @@ var _ = Describe("Generate", func() {
 				By("Generate new secret")
 				secret, err := m.Generate(ctx, config)
 				Expect(err).NotTo(HaveOccurred())
-				Expect(secret.Name).To(Equal(name + "-fc4f9932"))
+				Expect(secret.Name).To(Equal(name + "-c0d53d4a"))
 				expectSecretWasCreated(ctx, fakeClient, secret)
 
 				By("Verify internal store reflects changes")

--- a/pkg/utils/secrets/manager/generate_test.go
+++ b/pkg/utils/secrets/manager/generate_test.go
@@ -721,7 +721,7 @@ var _ = Describe("Generate", func() {
 			BeforeEach(func() {
 				config = &secretsutils.RSASecretConfig{
 					Name: name,
-					Bits: 2048,
+					Bits: 3072,
 				}
 			})
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security compliance
/kind enhancement

**What this PR does / why we need it**:
This PR increases the RSA key size from 2048 to 3072 bits. 

Currently Gardener uses RSA with 2048 bit keys in order to enforce TLS communication across services. This combination translates to a 112 bit security strength. This is currently acceptable by some agencies like [NIST](https://www.nist.gov/) ([Special Publication 800-57 Part 1 Revision 5](https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-57pt1r5.pdf)), but is also not in line with the recommendations from other agencies like [the German federal office for information security, BSI](https://www.bsi.bund.de/EN/Home/home_node.html). A friendly displayed overview of different recommendations can be found on https://www.keylength.com/en/compare/.

W.r.t keeping the balance between security, performance and compliance requirements the next logical step for an RSA key size would be 3072 bits which will provide 128 bit security strength.

This should be a backwards compatible change.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
As a follow up we can also investigate changing the [DH parameters](https://github.com/gardener/gardener/blob/7c4eff0e34b49082b4e74977f799dc25ce5d01b6/pkg/operation/botanist/vpnseedserver.go#L31) used by openvpn (or removing them by using ECDH). It seems that openvpn has official support for elliptic curve crypto. Some relevant links:
 - https://github.com/OpenVPN/openvpn/blob/master/README.ec
 - https://openvpn.net/community-resources/reference-manual-for-openvpn-2-6/ (see `--dh` and `--ecdh-curve` flags)
 
 cc @gardener/gardener-core-networking-maintainers 
 
**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy user
Gardener now uses 3072 bit RSA keys in order to generate TLS certificates.
```

```noteworthy developer
The `pkg/utils/secrets` package now signs certificates with 3072 bit RSA keys.
```
