### PR TITLE
component/kubeapiserver: do not mount host volumes

### DIFF
--- a/pkg/component/kubeapiserver/kube_apiserver_test.go
+++ b/pkg/component/kubeapiserver/kube_apiserver_test.go
@@ -79,7 +79,6 @@ var _ = Describe("KubeAPIServer", func() {
 		namespace         = "some-namespace"
 		vpaUpdateMode     = vpaautoscalingv1.UpdateModeOff
 		controlledValues  = vpaautoscalingv1.ContainerControlledValuesRequestsOnly
-		directoryOrCreate = corev1.HostPathDirectoryOrCreate
 		priorityClassName = "some-priority-class"
 
 		kubernetesInterface kubernetes.Interface
@@ -2479,26 +2478,6 @@ rules:
 							MountPath: "/etc/kubernetes/etcd-encryption-secret",
 							ReadOnly:  true,
 						},
-						corev1.VolumeMount{
-							Name:      "fedora-rhel6-openelec-cabundle",
-							MountPath: "/etc/pki/tls",
-							ReadOnly:  true,
-						},
-						corev1.VolumeMount{
-							Name:      "centos-rhel7-cabundle",
-							MountPath: "/etc/pki/ca-trust/extracted/pem",
-							ReadOnly:  true,
-						},
-						corev1.VolumeMount{
-							Name:      "etc-ssl",
-							MountPath: "/etc/ssl",
-							ReadOnly:  true,
-						},
-						corev1.VolumeMount{
-							Name:      "usr-share-cacerts",
-							MountPath: "/usr/share/ca-certificates",
-							ReadOnly:  true,
-						},
 					))
 					Expect(deployment.Spec.Template.Spec.Volumes).To(ConsistOf(
 						corev1.Volume{
@@ -2614,42 +2593,6 @@ rules:
 							VolumeSource: corev1.VolumeSource{
 								Secret: &corev1.SecretVolumeSource{
 									SecretName: secretNameServer,
-								},
-							},
-						},
-						corev1.Volume{
-							Name: "fedora-rhel6-openelec-cabundle",
-							VolumeSource: corev1.VolumeSource{
-								HostPath: &corev1.HostPathVolumeSource{
-									Path: "/etc/pki/tls",
-									Type: &directoryOrCreate,
-								},
-							},
-						},
-						corev1.Volume{
-							Name: "centos-rhel7-cabundle",
-							VolumeSource: corev1.VolumeSource{
-								HostPath: &corev1.HostPathVolumeSource{
-									Path: "/etc/pki/ca-trust/extracted/pem",
-									Type: &directoryOrCreate,
-								},
-							},
-						},
-						corev1.Volume{
-							Name: "etc-ssl",
-							VolumeSource: corev1.VolumeSource{
-								HostPath: &corev1.HostPathVolumeSource{
-									Path: "/etc/ssl",
-									Type: &directoryOrCreate,
-								},
-							},
-						},
-						corev1.Volume{
-							Name: "usr-share-cacerts",
-							VolumeSource: corev1.VolumeSource{
-								HostPath: &corev1.HostPathVolumeSource{
-									Path: "/usr/share/ca-certificates",
-									Type: &directoryOrCreate,
 								},
 							},
 						},
@@ -3161,81 +3104,6 @@ rules:
 					Expect(deployment.Spec.Template.Spec.Containers[0].Args).NotTo(ContainElements(
 						ContainSubstring("--vmodule=httplog"),
 						ContainSubstring("--v="),
-					))
-				})
-
-				It("should mount the host pki directories", func() {
-					directoryOrCreate := corev1.HostPathDirectoryOrCreate
-
-					kapi = New(kubernetesInterface, namespace, sm, Values{
-						Values: apiserver.Values{
-							RuntimeVersion: runtimeVersion,
-						},
-						Images:  images,
-						Version: version,
-					})
-					deployAndRead()
-
-					Expect(deployment.Spec.Template.Spec.Containers[0].VolumeMounts).To(ContainElements(
-						corev1.VolumeMount{
-							Name:      "fedora-rhel6-openelec-cabundle",
-							MountPath: "/etc/pki/tls",
-							ReadOnly:  true,
-						},
-						corev1.VolumeMount{
-							Name:      "centos-rhel7-cabundle",
-							MountPath: "/etc/pki/ca-trust/extracted/pem",
-							ReadOnly:  true,
-						},
-						corev1.VolumeMount{
-							Name:      "etc-ssl",
-							MountPath: "/etc/ssl",
-							ReadOnly:  true,
-						},
-						corev1.VolumeMount{
-							Name:      "usr-share-cacerts",
-							MountPath: "/usr/share/ca-certificates",
-							ReadOnly:  true,
-						},
-					))
-
-					Expect(deployment.Spec.Template.Spec.Volumes).To(ContainElements(
-						corev1.Volume{
-							Name: "fedora-rhel6-openelec-cabundle",
-							VolumeSource: corev1.VolumeSource{
-								HostPath: &corev1.HostPathVolumeSource{
-									Path: "/etc/pki/tls",
-									Type: &directoryOrCreate,
-								},
-							},
-						},
-						corev1.Volume{
-							Name: "centos-rhel7-cabundle",
-							VolumeSource: corev1.VolumeSource{
-								HostPath: &corev1.HostPathVolumeSource{
-									Path: "/etc/pki/ca-trust/extracted/pem",
-									Type: &directoryOrCreate,
-								},
-							},
-						},
-						corev1.Volume{
-							Name: "etc-ssl",
-							VolumeSource: corev1.VolumeSource{
-								HostPath: &corev1.HostPathVolumeSource{
-									Path: "/etc/ssl",
-									Type: &directoryOrCreate,
-								},
-							},
-						},
-						corev1.Volume{
-							Name: "usr-share-cacerts",
-							VolumeSource: corev1.VolumeSource{
-								HostPath: &corev1.HostPathVolumeSource{
-									Path: "/usr/share/ca-certificates",
-									Type: &directoryOrCreate,
-								},
-							},
-						},
 					))
 				})
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area os security
/kind cleanup enhancement

**What this PR does / why we need it**:
As of v1.19 the `kube-apiserver` images use a `distroless` layer in their containers images which provides root CA bundles. There is no longer the need to mount the `hostPath` volumes since this is covered by the container image. In addition the k8s documentation [advises against using the hostPath volume type](https://kubernetes.io/docs/concepts/storage/volumes/#hostpath). 

https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.19.md#no-really-you-must-read-this-before-you-upgrade

```
dive registry.k8s.io/kube-apiserver:v1.19.0
```
![image](https://github.com/gardener/gardener/assets/28221091/79a6d149-7112-4932-add9-8931e7ee9b47)
 
 
 This is also true for newer versions.
 ```
dive registry.k8s.io/kube-apiserver:v1.28.0
```
![image](https://github.com/gardener/gardener/assets/28221091/d53cc791-2c67-42ff-a2de-f8849cbe2c7e)

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Some relevant issues and PRs:
https://github.com/gardener/gardener/pull/2508
https://github.com/gardener/gardener/pull/2791
https://github.com/gardener/gardener/pull/2842

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy operator
The `kube-apiserver` no longer mounts root CA bundles from the underlying host.
```
