### PR TITLE
Enable UseEtcdWrapper feature gate in example gardenlet values

### DIFF
--- a/example/gardener-local/gardenlet/values.yaml
+++ b/example/gardener-local/gardenlet/values.yaml
@@ -51,7 +51,7 @@ config:
     ContainerdRegistryHostsDir: true
   etcdConfig:
     featureGates:
-      UseEtcdWrapper: false
+      UseEtcdWrapper: true
   logging:
     enabled: true
     vali:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane

**What this PR does / why we need it**:
This PR enables the `UseEtcdWrapper` feature gate for `etcd-druid`, so that the local setup uses the `etcd-wrapper` setup by default.
This is so that `etcd-wrapper` can be used and validated more widely


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
This feature gate is already enabled in our dev landscape and is operating without any reported issue

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
