### PR TITLE
add Python example for creation of AdminKubeconfigRequest

### DIFF
--- a/docs/usage/shoot_access.md
+++ b/docs/usage/shoot_access.md
@@ -20,6 +20,7 @@ kubectl create \
     base64 -d
 ```
 
+
 You also can use controller-runtime `client` (>= v0.14.3) to create such a kubeconfig from your go code like so:
 
 ```go
@@ -78,6 +79,7 @@ print(decoded_kubeconfig)
 shoot_api_client = config.new_client_from_config_dict(yaml.safe_load(decoded_kubeconfig))
 v1 = client.CoreV1Api(shoot_api_client)
 ```
+
 > **Note:** The [`gardenctl-v2`](https://github.com/gardener/gardenctl-v2) tool simplifies targeting shoot clusters. It automatically downloads a kubeconfig that uses the [gardenlogin](https://github.com/gardener/gardenlogin) kubectl auth plugin. This transparently manages authentication and certificate renewal without containing any credentials.
 
 ## OpenID Connect

--- a/docs/usage/shoot_access.md
+++ b/docs/usage/shoot_access.md
@@ -11,7 +11,7 @@ The username associated with such `kubeconfig` will be the same which is used fo
 In order to request such a `kubeconfig`, you can run the following commands:
 
 ```bash
-export NAMESPACE=my-namespace
+export NAMESPACE=garden-my-namespace
 export SHOOT_NAME=my-shoot
 kubectl create \
     -f <(printf '{"spec":{"expirationSeconds":600}}') \
@@ -51,7 +51,7 @@ import yaml
 
 # Set configuration options
 shoot_name="my-shoot" # Name of the shoot
-project_namespace="my-namespace" # Namespace of the project
+project_namespace="garden-my-namespace" # Namespace of the project
 
 # Load kubeconfig from default ~/.kube/config
 config.load_kube_config()
@@ -61,7 +61,9 @@ api = client.ApiClient()
 kubeconfig_request = {
     'apiVersion': 'authentication.gardener.cloud/v1alpha1',
     'kind': 'AdminKubeconfigRequest',
-    'spec': {'expirationSeconds': 600}
+    'spec': {
+      'expirationSeconds': 600
+    }
 }
 
 response = api.call_api(resource_path=f'/apis/core.gardener.cloud/v1beta1/namespaces/{project_namespace}/shoots/{shoot_name}/adminkubeconfig',


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area documentation
/kind enhancement

**What this PR does / why we need it**:
This PR adds a basic example how one can perform a `AdminKubeconfigRequest` via the Python Kubernetes client.
Endusers might use several different progamming clients to interact with Gardener and this example gives the Python users a small script, which they can adopt for their own automation.

**Which issue(s) this PR fixes**:
n/a

**Special notes for your reviewer**:
n/a

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```doc user
Added an example for `AdminKubeconfigRequest` via the Python Kubernetes client.
```
