### PR TITLE
enable annotation snippets in nginx ingress controller

### DIFF
--- a/pkg/gardenlet/controller/seed/seed/nginxingress.go
+++ b/pkg/gardenlet/controller/seed/seed/nginxingress.go
@@ -70,6 +70,7 @@ func getConfig(seed *gardencorev1beta1.Seed) (map[string]string, error) {
 			"server-name-hash-bucket-size": "256",
 			"use-proxy-protocol":           "false",
 			"worker-processes":             "2",
+			"allow-snippet-annotations":    "true",
 		}
 		providerConfig = map[string]interface{}{}
 	)


### PR DESCRIPTION
/area monitoring
/area logging
/kind regression

**What this PR does / why we need it**:

- This PR restores the support for annotation snippets in ingress annotations. It has been disabled with the release of nginx controller above [v1.9.0](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/#configuration-snippet). This PR restores regression brought by #8558. The [CVE-2021-25742](https://nvd.nist.gov/vuln/detail/CVE-2021-25742) expressed in the nginx release v1.9.0 is not of a concern for the gardener use case.

Fixes an issue where control plane logs cannot be accessed by Plutono.

cc @timuthy Please cherry pick for 1.81 release.

```other operator
The regression is now fixed and the control plane logs shall be visible in the Plutono dashboards.
```
