### PR TITLE
Improve `generic-token-kubeconfig` handling

### DIFF
--- a/docs/concepts/operator.md
+++ b/docs/concepts/operator.md
@@ -100,6 +100,7 @@ Most prominently, **the `serviceaccount-token` controller is unconditionally dis
 Hence, the usage of static `ServiceAccount` secrets is not supported generally.
 Instead, the [`TokenRequest` API](https://kubernetes.io/docs/reference/kubernetes-api/authentication-resources/token-request-v1/) should be used.
 Third-party components that need to communicate with the virtual cluster can leverage the [`gardener-resource-manager`'s `TokenRequestor` controller](resource-manager.md#tokenrequestor-controller) and the generic kubeconfig, just like it works for `Shoot`s.
+Please note, that this functionality is restricted to the `garden` namespace. The current `Secret` name of the generic kubeconfig can be found in the annotations (key: `generic-token-kubeconfig.secret.gardener.cloud/name`) of the `garden` resource.
 
 For the virtual cluster, it is essential to provide a DNS domain via `.spec.virtualCluster.dns.domain`.
 **The respective DNS record is not managed by `gardener-operator` and should be manually created and pointed to the load balancer IP of the `virtual-garden-kube-apiserver` `Service`.**

--- a/docs/concepts/operator.md
+++ b/docs/concepts/operator.md
@@ -100,7 +100,7 @@ Most prominently, **the `serviceaccount-token` controller is unconditionally dis
 Hence, the usage of static `ServiceAccount` secrets is not supported generally.
 Instead, the [`TokenRequest` API](https://kubernetes.io/docs/reference/kubernetes-api/authentication-resources/token-request-v1/) should be used.
 Third-party components that need to communicate with the virtual cluster can leverage the [`gardener-resource-manager`'s `TokenRequestor` controller](resource-manager.md#tokenrequestor-controller) and the generic kubeconfig, just like it works for `Shoot`s.
-Please note, that this functionality is restricted to the `garden` namespace. The current `Secret` name of the generic kubeconfig can be found in the annotations (key: `generic-token-kubeconfig.secret.gardener.cloud/name`) of the `garden` resource.
+Please note, that this functionality is restricted to the `garden` namespace. The current `Secret` name of the generic kubeconfig can be found in the annotations (key: `generic-token-kubeconfig.secret.gardener.cloud/name`) of the `Garden` resource.
 
 For the virtual cluster, it is essential to provide a DNS domain via `.spec.virtualCluster.dns.domain`.
 **The respective DNS record is not managed by `gardener-operator` and should be manually created and pointed to the load balancer IP of the `virtual-garden-kube-apiserver` `Service`.**

--- a/pkg/operator/controller/garden/garden/reconciler_reconcile.go
+++ b/pkg/operator/controller/garden/garden/reconciler_reconcile.go
@@ -128,7 +128,7 @@ func (r *Reconciler) reconcile(
 		generateGenericTokenKubeconfig = g.Add(flow.Task{
 			Name: "Generating generic token kubeconfig",
 			Fn: func(ctx context.Context) error {
-				return r.generateGenericTokenKubeconfig(ctx, secretsManager)
+				return r.generateGenericTokenKubeconfig(ctx, garden, secretsManager)
 			},
 		})
 		deployEtcdCRD = g.Add(flow.Task{

--- a/pkg/utils/gardener/tokenrequest/secrets_test.go
+++ b/pkg/utils/gardener/tokenrequest/secrets_test.go
@@ -60,7 +60,7 @@ var _ = Describe("Secrets", func() {
 			Expect(c.Get(ctx, client.ObjectKeyFromObject(secret), secret)).To(Succeed())
 		})
 
-		It("should generate a new the generic token kubeconfig while keeping the old one", func() {
+		It("should generate a new generic token kubeconfig while keeping the old one", func() {
 			By("create kubeconfig with existing CA")
 			secretBefore, err := GenerateGenericTokenKubeconfig(ctx, fakeSecretsManager, namespace, "kube-apiserver")
 			Expect(err).ShouldNot(HaveOccurred())

--- a/test/integration/operator/garden/garden/garden_test.go
+++ b/test/integration/operator/garden/garden/garden_test.go
@@ -344,6 +344,12 @@ var _ = Describe("Garden controller tests", func() {
 			g.Expect(testNamespace.Annotations).To(HaveKeyWithValue("high-availability-config.resources.gardener.cloud/zones", "a,b,c"))
 		}).Should(Succeed())
 
+		By("Verify that garden has generic token kubeconfig annotation")
+		Eventually(func(g Gomega) map[string]string {
+			g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(garden), garden)).To(Succeed())
+			return garden.Annotations
+		}).Should(HaveKey("generic-token-kubeconfig.secret.gardener.cloud/name"))
+
 		// The garden controller waits for the gardener-resource-manager Deployment to be healthy, so let's fake this here.
 		By("Patch gardener-resource-manager deployment to report healthiness")
 		Eventually(func(g Gomega) {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind enhancement

**What this PR does / why we need it**:
This PR enhances the creation for `generic-token-kubeconfig` secrets. Whenever a new kubeconfig `Secret` is created (e.g. due to CA rotation), the old secret is kept in the cluster. In addition, the `Secret` name of the most recent `generic-token-kubeconfig` is written to the `garden` resource in `.metadata.annotations[generic-token-kubeconfig.secret.gardener.cloud/name]` (similar to how it is done by `gardenlet` for the `cluster` resource).

The change is necessary to give third-party components the chance to adapt to newly generated kubeconfig `Secret`s. Earlier, the old `Secret` was immediately removed during rotation and left those components in a broken state because they typically refer to them in projected volumes.

**Special notes for your reviewer**:
/cc @rfranzke @dguendisch

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
`gardener-operator` maintains the two most recent `generic-token-kubeconfig` secrets in the runtime-cluster. In addition the latest secret name is published to the `garden` resource in `.metadata.annotations[generic-token-kubeconfig.secret.gardener.cloud/name]`. Third-party components referring to this secret should check this annotation value after a credentials or CA rotation for the virtual-garden cluster took place.
```
