### PR TITLE
Introduce Configurable `DeltaSnapshotRetentionPeriod ` in GardenletConfiguration

### DIFF
--- a/example/20-componentconfig-gardenlet.yaml
+++ b/example/20-componentconfig-gardenlet.yaml
@@ -176,6 +176,7 @@ etcdConfig:
     eventsThreshold: 1000000
     activeDeadlineDuration: "3h"
     metricsScrapeWaitDuration: "60s"
+  deltaSnapshotRetentionPeriod: 48h
 # backupLeaderElection:
 #   reelectionPeriod: 5s
 #   etcdConnectionTimeout: 5s

--- a/pkg/component/etcd/etcd.go
+++ b/pkg/component/etcd/etcd.go
@@ -837,7 +837,7 @@ type BackupConfig struct {
 	// FullSnapshotSchedule is a cron schedule that declares how frequent full snapshots shall be taken.
 	FullSnapshotSchedule string
 	// LeaderElection contains configuration for the leader election for the etcd backup-restore sidecar.
-	LeaderElection               *gardenletconfig.ETCDBackupLeaderElection
+	LeaderElection *gardenletconfig.ETCDBackupLeaderElection
 	// DeltaSnapshotRetentionPeriod defines the duration for which delta snapshots will be retained, excluding the latest snapshot set.
 	DeltaSnapshotRetentionPeriod *metav1.Duration
 }

--- a/pkg/component/etcd/etcd.go
+++ b/pkg/component/etcd/etcd.go
@@ -838,6 +838,7 @@ type BackupConfig struct {
 	FullSnapshotSchedule string
 	// LeaderElection contains configuration for the leader election for the etcd backup-restore sidecar.
 	LeaderElection               *gardenletconfig.ETCDBackupLeaderElection
+	// DeltaSnapshotRetentionPeriod defines the duration for which delta snapshots will be retained, excluding the latest snapshot set.
 	DeltaSnapshotRetentionPeriod *metav1.Duration
 }
 

--- a/pkg/component/etcd/etcd.go
+++ b/pkg/component/etcd/etcd.go
@@ -388,6 +388,7 @@ func (e *etcd) Deploy(ctx context.Context) error {
 			e.etcd.Spec.Backup.FullSnapshotSchedule = e.computeFullSnapshotSchedule(existingEtcd)
 			e.etcd.Spec.Backup.DeltaSnapshotPeriod = &deltaSnapshotPeriod
 			e.etcd.Spec.Backup.DeltaSnapshotMemoryLimit = utils.QuantityPtr(resource.MustParse("100Mi"))
+			e.etcd.Spec.Backup.DeltaSnapshotRetentionPeriod = e.values.BackupConfig.DeltaSnapshotRetentionPeriod
 
 			if e.values.BackupConfig.LeaderElection != nil {
 				e.etcd.Spec.Backup.LeaderElection = &druidv1alpha1.LeaderElectionSpec{
@@ -836,7 +837,8 @@ type BackupConfig struct {
 	// FullSnapshotSchedule is a cron schedule that declares how frequent full snapshots shall be taken.
 	FullSnapshotSchedule string
 	// LeaderElection contains configuration for the leader election for the etcd backup-restore sidecar.
-	LeaderElection *gardenletconfig.ETCDBackupLeaderElection
+	LeaderElection               *gardenletconfig.ETCDBackupLeaderElection
+	DeltaSnapshotRetentionPeriod *metav1.Duration
 }
 
 // HVPAConfig contains information for configuring the HVPA object for the etcd.

--- a/pkg/component/etcd/etcd_test.go
+++ b/pkg/component/etcd/etcd_test.go
@@ -322,6 +322,7 @@ var _ = Describe("Etcd", func() {
 				}
 				obj.Spec.Backup.FullSnapshotSchedule = &fullSnapshotSchedule
 				obj.Spec.Backup.DeltaSnapshotPeriod = &deltaSnapshotPeriod
+				obj.Spec.Backup.DeltaSnapshotRetentionPeriod = &metav1.Duration{Duration: 15 * 24 * time.Hour}
 				obj.Spec.Backup.DeltaSnapshotMemoryLimit = &deltaSnapshotMemoryLimit
 
 				if backupConfig.LeaderElection != nil {
@@ -1030,11 +1031,12 @@ var _ = Describe("Etcd", func() {
 
 		Context("with backup", func() {
 			var backupConfig = &BackupConfig{
-				Provider:             "prov",
-				SecretRefName:        "secret-key",
-				Prefix:               "prefix",
-				Container:            "bucket",
-				FullSnapshotSchedule: "1234",
+				Provider:                     "prov",
+				SecretRefName:                "secret-key",
+				Prefix:                       "prefix",
+				Container:                    "bucket",
+				FullSnapshotSchedule:         "1234",
+				DeltaSnapshotRetentionPeriod: &metav1.Duration{Duration: 15 * 24 * time.Hour},
 			}
 
 			BeforeEach(func() {

--- a/pkg/gardenlet/apis/config/types.go
+++ b/pkg/gardenlet/apis/config/types.go
@@ -461,6 +461,8 @@ type ETCDConfig struct {
 	// "github.com/gardener/etcd-druid/pkg/features/features.go".
 	// Default: nil
 	FeatureGates map[string]bool
+	// DeltaSnapshotRetentionPeriod defines the duration for which delta snapshots will be retained, excluding the latest snapshot set.
+	DeltaSnapshotRetentionPeriod *metav1.Duration
 }
 
 // ETCDController contains config specific to ETCD controller

--- a/pkg/gardenlet/apis/config/v1alpha1/types.go
+++ b/pkg/gardenlet/apis/config/v1alpha1/types.go
@@ -560,6 +560,9 @@ type ETCDConfig struct {
 	// Default: nil
 	// +optional
 	FeatureGates map[string]bool `json:"featureGates,omitempty"`
+	// DeltaSnapshotRetentionPeriod defines the duration for which delta snapshots will be retained, excluding the latest snapshot set.
+	// +optional
+	DeltaSnapshotRetentionPeriod *metav1.Duration `json:"deltaSnapshotRetentionPeriod,omitempty"`
 }
 
 // ETCDController contains config specific to ETCD controller

--- a/pkg/gardenlet/apis/config/v1alpha1/zz_generated.conversion.go
+++ b/pkg/gardenlet/apis/config/v1alpha1/zz_generated.conversion.go
@@ -720,6 +720,7 @@ func autoConvert_v1alpha1_ETCDConfig_To_config_ETCDConfig(in *ETCDConfig, out *c
 	out.BackupCompactionController = (*config.BackupCompactionController)(unsafe.Pointer(in.BackupCompactionController))
 	out.BackupLeaderElection = (*config.ETCDBackupLeaderElection)(unsafe.Pointer(in.BackupLeaderElection))
 	out.FeatureGates = *(*map[string]bool)(unsafe.Pointer(&in.FeatureGates))
+	out.DeltaSnapshotRetentionPeriod = (*v1.Duration)(unsafe.Pointer(in.DeltaSnapshotRetentionPeriod))
 	return nil
 }
 
@@ -734,6 +735,7 @@ func autoConvert_config_ETCDConfig_To_v1alpha1_ETCDConfig(in *config.ETCDConfig,
 	out.BackupCompactionController = (*BackupCompactionController)(unsafe.Pointer(in.BackupCompactionController))
 	out.BackupLeaderElection = (*ETCDBackupLeaderElection)(unsafe.Pointer(in.BackupLeaderElection))
 	out.FeatureGates = *(*map[string]bool)(unsafe.Pointer(&in.FeatureGates))
+	out.DeltaSnapshotRetentionPeriod = (*v1.Duration)(unsafe.Pointer(in.DeltaSnapshotRetentionPeriod))
 	return nil
 }
 

--- a/pkg/gardenlet/apis/config/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/gardenlet/apis/config/v1alpha1/zz_generated.deepcopy.go
@@ -305,6 +305,11 @@ func (in *ETCDConfig) DeepCopyInto(out *ETCDConfig) {
 			(*out)[key] = val
 		}
 	}
+	if in.DeltaSnapshotRetentionPeriod != nil {
+		in, out := &in.DeltaSnapshotRetentionPeriod, &out.DeltaSnapshotRetentionPeriod
+		*out = new(v1.Duration)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/gardenlet/apis/config/zz_generated.deepcopy.go
+++ b/pkg/gardenlet/apis/config/zz_generated.deepcopy.go
@@ -305,6 +305,11 @@ func (in *ETCDConfig) DeepCopyInto(out *ETCDConfig) {
 			(*out)[key] = val
 		}
 	}
+	if in.DeltaSnapshotRetentionPeriod != nil {
+		in, out := &in.DeltaSnapshotRetentionPeriod, &out.DeltaSnapshotRetentionPeriod
+		*out = new(v1.Duration)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/operation/botanist/etcd.go
+++ b/pkg/operation/botanist/etcd.go
@@ -109,17 +109,20 @@ func (b *Botanist) DeployEtcd(ctx context.Context) error {
 		}
 
 		var backupLeaderElection *config.ETCDBackupLeaderElection
+		var deltaSnapshotRetentionPeriod *metav1.Duration
 		if b.Config != nil && b.Config.ETCDConfig != nil {
 			backupLeaderElection = b.Config.ETCDConfig.BackupLeaderElection
+			deltaSnapshotRetentionPeriod = b.Config.ETCDConfig.DeltaSnapshotRetentionPeriod
 		}
 
 		b.Shoot.Components.ControlPlane.EtcdMain.SetBackupConfig(&etcd.BackupConfig{
-			Provider:             b.Seed.GetInfo().Spec.Backup.Provider,
-			SecretRefName:        v1beta1constants.BackupSecretName,
-			Prefix:               b.Shoot.BackupEntryName,
-			Container:            string(secret.Data[v1beta1constants.DataKeyBackupBucketName]),
-			FullSnapshotSchedule: snapshotSchedule,
-			LeaderElection:       backupLeaderElection,
+			Provider:                     b.Seed.GetInfo().Spec.Backup.Provider,
+			SecretRefName:                v1beta1constants.BackupSecretName,
+			Prefix:                       b.Shoot.BackupEntryName,
+			Container:                    string(secret.Data[v1beta1constants.DataKeyBackupBucketName]),
+			FullSnapshotSchedule:         snapshotSchedule,
+			LeaderElection:               backupLeaderElection,
+			DeltaSnapshotRetentionPeriod: deltaSnapshotRetentionPeriod,
 		})
 	}
 

--- a/pkg/operation/botanist/etcd.go
+++ b/pkg/operation/botanist/etcd.go
@@ -109,7 +109,7 @@ func (b *Botanist) DeployEtcd(ctx context.Context) error {
 		}
 
 		var (
-	        	backupLeaderElection *config.ETCDBackupLeaderElection
+			backupLeaderElection         *config.ETCDBackupLeaderElection
 			deltaSnapshotRetentionPeriod *metav1.Duration
 		)
 		if b.Config != nil && b.Config.ETCDConfig != nil {

--- a/pkg/operation/botanist/etcd.go
+++ b/pkg/operation/botanist/etcd.go
@@ -108,8 +108,10 @@ func (b *Botanist) DeployEtcd(ctx context.Context) error {
 			return err
 		}
 
-		var backupLeaderElection *config.ETCDBackupLeaderElection
-		var deltaSnapshotRetentionPeriod *metav1.Duration
+		var (
+	        	backupLeaderElection *config.ETCDBackupLeaderElection
+			deltaSnapshotRetentionPeriod *metav1.Duration
+		)
 		if b.Config != nil && b.Config.ETCDConfig != nil {
 			backupLeaderElection = b.Config.ETCDConfig.BackupLeaderElection
 			deltaSnapshotRetentionPeriod = b.Config.ETCDConfig.DeltaSnapshotRetentionPeriod


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area backup
/kind enhancement

**What this PR does / why we need it**:
This PR introduces the ability to configure the retention period for delta snapshots in the Gardener ETCD component. The `deltaSnapshotRetentionPeriod` value can now be set under the `etcdConfig` section in the gardenlet configuration. This enhancement facilitates better debugging experiences by ensuring delta snapshots are retained for a configurable duration, providing a valuable window for reviewing changes in case of any issues.


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
The `deltaSnapshotRetentionPeriod` parameter has been introduced in the `etcdConfig` section of the `GardenletConfiguration`. This new feature allows users to configure the retention period for delta snapshots in the ETCD component. By making the delta snapshot retention period configurable, we provide a more flexible debugging experience. Delta snapshots can now be retained for a user-defined duration, offering a valuable window for reviewing changes in case of any issues. 
```
