### PR TITLE
[release-v1.79] Do not consider MCM deployment as required

### DIFF
--- a/pkg/gardenlet/controller/shoot/care/health.go
+++ b/pkg/gardenlet/controller/shoot/care/health.go
@@ -781,10 +781,6 @@ func ComputeRequiredControlPlaneDeployments(shoot *gardencorev1beta1.Shoot) (set
 			}
 		}
 
-		if features.DefaultFeatureGate.Enabled(features.MachineControllerManagerDeployment) {
-			requiredControlPlaneDeployments.Insert(v1beta1constants.DeploymentNameMachineControllerManager)
-		}
-
 		// TODO(rfranzke): Uncomment this code once the MachineControllerManagerDeployment feature gate gets removed.
 		// if features.DefaultFeatureGate.Enabled(features.MachineControllerManagerDeployment) {
 		// 	requiredControlPlaneDeployments.Insert(v1beta1constants.DeploymentNameMachineControllerManager)

--- a/pkg/gardenlet/controller/shoot/care/health_test.go
+++ b/pkg/gardenlet/controller/shoot/care/health_test.go
@@ -39,11 +39,9 @@ import (
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	kubernetesfake "github.com/gardener/gardener/pkg/client/kubernetes/fake"
 	"github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/executor"
-	"github.com/gardener/gardener/pkg/features"
 	. "github.com/gardener/gardener/pkg/gardenlet/controller/shoot/care"
 	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
 	shootpkg "github.com/gardener/gardener/pkg/operation/shoot"
-	"github.com/gardener/gardener/pkg/utils/test"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 )
 
@@ -104,19 +102,6 @@ var _ = Describe("health check", func() {
 
 				Expect(err).ToNot(HaveOccurred())
 				Expect(deploymentNames.UnsortedList()).To(ConsistOf(names...))
-			})
-
-			It("should return expected deployments for shoot when MCM management is enabled", func() {
-				defer test.WithFeatureGate(features.DefaultFeatureGate, features.MachineControllerManagerDeployment, true)()
-				expectedDeploymentNames := names
-				if !isWorkerless {
-					expectedDeploymentNames = append(expectedDeploymentNames, "machine-controller-manager")
-				}
-
-				deploymentNames, err := ComputeRequiredControlPlaneDeployments(shoot)
-
-				Expect(err).ToNot(HaveOccurred())
-				Expect(deploymentNames.UnsortedList()).To(ConsistOf(expectedDeploymentNames...))
 			})
 
 			It("should return expected deployments for shoot with Cluster Autoscaler", func() {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind bug

**What this PR does / why we need it**:
Re-apply https://github.com/gardener/gardener/pull/8407 which got reverted with https://github.com/gardener/gardener/pull/8387.

/cc @timuthy

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
An issue has been fixed which was causing a broken `ControlPlaneHealthy` condition report for `Shoot`s when the `MachineControllerManagerDeployment` feature gate gets enabled until their next reconciliation.
```
