### PR TITLE
Add feature gate `UnauthenticatedHTTP2DOSMitigation`

### DIFF
--- a/pkg/utils/validation/features/featuregates.go
+++ b/pkg/utils/validation/features/featuregates.go
@@ -227,6 +227,7 @@ var featureGateVersionRanges = map[string]*FeatureGateVersionRange{
 	"TopologyManagerPolicyAlphaOptions":              {AddedInVersion: "1.26"},
 	"TopologyManagerPolicyBetaOptions":               {AddedInVersion: "1.26"},
 	"TopologyManagerPolicyOptions":                   {AddedInVersion: "1.26"},
+	"UnauthenticatedHTTP2DOSMitigation:":             {AddedInVersion: "1.25"},
 	"UnknownVersionInteroperabilityProxy":            {AddedInVersion: "1.28"},
 	"UserNamespacesStatelessPodsSupport":             {AddedInVersion: "1.25", RemovedInVersion: "1.28"},
 	"UserNamespacesSupport":                          {AddedInVersion: "1.28"},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area open-source
/kind enhancement

**What this PR does / why we need it**:
The feature gate was added retrospectively to versions `1.25`, `1.26`, `1.27` and `1.28`, see https://github.com/kubernetes/kubernetes/pull/121224.

**Special notes for your reviewer**:
Thanks @vpnachev.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Kubernetes feature gate `UnauthenticatedHTTP2DOSMitigation` is considered valid for versions >= `1.25`.
```
