### PR TITLE
[release-v1.80] Automated cherry pick of #8639: Bump golang from 1.21.2 to 1.21.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # builder
-FROM golang:1.21.1 AS builder
+FROM golang:1.21.3 AS builder
 WORKDIR /go/src/github.com/gardener/gardener
 COPY . .
 ARG EFFECTIVE_VERSION


### PR DESCRIPTION
/kind enhancement

Cherry pick of #8639 on release-v1.80.

#8639: Bump golang from 1.21.2 to 1.21.3

**Release Notes:**