### PR TITLE
Make machine state computation backwards-compatible

### DIFF
--- a/pkg/utils/gardener/shootstate/machines.go
+++ b/pkg/utils/gardener/shootstate/machines.go
@@ -27,6 +27,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 )
 
@@ -43,12 +44,32 @@ type MachineState struct {
 	MachineDeployments map[string]*MachineDeploymentState `json:"machineDeployments,omitempty"`
 }
 
-func computeMachineState(ctx context.Context, seedClient client.Client, namespace string) (*MachineState, error) {
+func computeMachineState(ctx context.Context, seedClient client.Client, namespace, shootName string) (*MachineState, error) {
 	state := &MachineState{MachineDeployments: make(map[string]*MachineDeploymentState)}
 
 	machineDeployments := &machinev1alpha1.MachineDeploymentList{}
 	if err := seedClient.List(ctx, machineDeployments, client.InNamespace(namespace)); err != nil {
 		return nil, err
+	}
+
+	// If a provider extensions uses a version < v1.82 of the extensions library, then the Worker controller will have
+	// persisted the machine state to the `Worker`'s `.status.state` field and already shallow-deleted all machine
+	// objects before below code gets executed (i.e., before gardenlet can compute the machine state itself).
+	// In this case, let's get the data from the `Worker`'s `.status.state` field instead of trying to (re-)compute it
+	// (which will fail anyways).
+	// TODO(rfranzke): Remove this block after Gardener v1.86 has been released.
+	if len(machineDeployments.Items) == 0 {
+		worker := &extensionsv1alpha1.Worker{ObjectMeta: metav1.ObjectMeta{Name: shootName, Namespace: namespace}}
+		if err := seedClient.Get(ctx, client.ObjectKeyFromObject(worker), worker); client.IgnoreNotFound(err) != nil {
+			return nil, fmt.Errorf("failed reading Worker object %s: %w", client.ObjectKeyFromObject(worker), err)
+		}
+
+		if worker.Status.State != nil && len(worker.Status.State.Raw) > 0 {
+			if err := json.Unmarshal(worker.Status.State.Raw, &state); err != nil {
+				return nil, fmt.Errorf("failed unmarshaling machine state from Worker's '.status.state' field: %w", err)
+			}
+			return state, nil
+		}
 	}
 
 	machineDeploymentToMachineSets, err := getMachineDeploymentToMachineSetsMap(ctx, seedClient, namespace)

--- a/pkg/utils/gardener/shootstate/shootstate.go
+++ b/pkg/utils/gardener/shootstate/shootstate.go
@@ -50,7 +50,7 @@ func Deploy(ctx context.Context, clock clock.Clock, gardenClient, seedClient cli
 		},
 	}
 
-	spec, err := computeSpec(ctx, seedClient, shoot.Status.TechnicalID)
+	spec, err := computeSpec(ctx, seedClient, shoot.Status.TechnicalID, shoot.Name)
 	if err != nil {
 		return fmt.Errorf("failed computing spec of ShootState for shoot %s: %w", client.ObjectKeyFromObject(shoot), err)
 	}
@@ -108,8 +108,8 @@ func Delete(ctx context.Context, gardenClient client.Client, shoot *gardencorev1
 	return client.IgnoreNotFound(gardenClient.Delete(ctx, shootState))
 }
 
-func computeSpec(ctx context.Context, seedClient client.Client, seedNamespace string) (*gardencorev1beta1.ShootStateSpec, error) {
-	gardener, err := computeGardenerData(ctx, seedClient, seedNamespace)
+func computeSpec(ctx context.Context, seedClient client.Client, seedNamespace, shootName string) (*gardencorev1beta1.ShootStateSpec, error) {
+	gardener, err := computeGardenerData(ctx, seedClient, seedNamespace, shootName)
 	if err != nil {
 		return nil, fmt.Errorf("failed computing Gardener data: %w", err)
 	}
@@ -130,6 +130,7 @@ func computeGardenerData(
 	ctx context.Context,
 	seedClient client.Client,
 	seedNamespace string,
+	shootName string,
 ) (
 	[]gardencorev1beta1.GardenerResourceData,
 	error,
@@ -139,7 +140,7 @@ func computeGardenerData(
 		return nil, err
 	}
 
-	machineState, err := computeMachineState(ctx, seedClient, seedNamespace)
+	machineState, err := computeMachineState(ctx, seedClient, seedNamespace, shootName)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind regression

**What this PR does / why we need it**:
If a provider extensions uses a version < v1.82 of the extensions library, then the Worker controller will have persisted the machine state to the `Worker`'s `.status.state` field and already shallow-deleted all machine objects before below code gets executed (i.e., before gardenlet can compute the machine state itself).
In this case, let's get the data from the `Worker`'s `.status.state` field instead of trying to (re-)compute it (which will fail anyways).

**Which issue(s) this PR fixes**:
Follow-up of #8559 

**Special notes for your reviewer**:
/cc @timuthy
/hold - needs verification

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
