### PR TITLE
Remove ExpandDNSConfig from local kind cluster

### DIFF
--- a/example/gardener-local/kind/cluster/templates/cluster.yaml
+++ b/example/gardener-local/kind/cluster/templates/cluster.yaml
@@ -1,10 +1,5 @@
 apiVersion: kind.x-k8s.io/v1alpha4
 kind: Cluster
-featureGates:
-# Introduced due to the issue outlined in the following link: https://github.com/gardener/gardener/issues/7297#issuecomment-1377515385."
-# Feature gate 'ExpandedDNSConfig' will be true by default from k8s version 1.26.
-# Remove this once kind cluster version is upgraded to 1.26
-  ExpandedDNSConfig: true
 nodes:
 - role: control-plane
   image: {{ .Values.image }}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind cleanup

**What this PR does / why we need it**:
https://github.com/gardener/gardener/pull/8533 has upgraded the kind clusters to 1.28, so `ExpandDNSConfig` is set to `true` by default and does not need to be explicitly done. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
