### PR TITLE
Enable accidentally (and forgotten) skipped integration test case for `NetworkPolicy` controller

### DIFF
--- a/test/integration/gardenlet/networkpolicy/networkpolicy_test.go
+++ b/test/integration/gardenlet/networkpolicy/networkpolicy_test.go
@@ -204,9 +204,9 @@ var _ = Describe("NetworkPolicy controller tests", func() {
 		})
 	})
 
-	PContext("garden namespace", func() {
+	Context("garden namespace", func() {
 		It("should have the expected network policies", func() {
-			By("Verify that all expected NetworkPolicys get created")
+			By("Verify that all expected NetworkPolicies get created")
 			Eventually(func(g Gomega) []networkingv1.NetworkPolicy {
 				networkPolicyList := &networkingv1.NetworkPolicyList{}
 				g.Expect(testClient.List(ctx, networkPolicyList, client.InNamespace(gardenNamespace.Name))).To(Succeed())
@@ -217,18 +217,17 @@ var _ = Describe("NetworkPolicy controller tests", func() {
 				MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("allow-to-private-networks")})}),
 				MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("allow-to-blocked-cidrs")})}),
 				MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("allow-to-dns")})}),
+				MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("deny-all")})}),
 			))
 
-			By("Verify that no unexpected NetworkPolicys get created")
+			By("Verify that no unexpected NetworkPolicies get created")
 			Consistently(func(g Gomega) []networkingv1.NetworkPolicy {
 				networkPolicyList := &networkingv1.NetworkPolicyList{}
 				g.Expect(testClient.List(ctx, networkPolicyList, client.InNamespace(gardenNamespace.Name))).To(Succeed())
 				return networkPolicyList.Items
-			}).Should(ConsistOf(
-				MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("deny-all")})}),
+			}).ShouldNot(ConsistOf(
 				MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("allow-to-shoot-networks")})}),
 			))
-
 		})
 	})
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind test

**What this PR does / why we need it**:
Enable accidentally (and forgotten) skipped integration test case for `NetworkPolicy` controller

**Special notes for your reviewer**:
/cc @timuthy

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
