### PR TITLE
Fix PodStuckInPending rule to match description

### DIFF
--- a/pkg/component/monitoring/charts/bootstrap/aggregate-prometheus-rules/seed.rules.yaml
+++ b/pkg/component/monitoring/charts/bootstrap/aggregate-prometheus-rules/seed.rules.yaml
@@ -3,7 +3,7 @@ groups:
   rules:
   - alert: PodStuckInPending
     expr: |
-      sum_over_time(kube_pod_status_phase{phase="Pending"}[5m]) > 0
+      sum_over_time(kube_pod_status_phase{phase="Pending"}[10m]) > 0
     for: 10m
     labels:
       severity: warning


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind bug

**What this PR does / why we need it**:
It corrects the time mentioned in the prometheus rule, to match the description that a pod is stuck in pending for more than 10 mins.
 
**Which issue(s) this PR fixes**:
-

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
