### PR TITLE
Bump up upstream observability components: plutono to v7.5.25, vali to v2.2.9

### DIFF
--- a/imagevector/images.yaml
+++ b/imagevector/images.yaml
@@ -233,7 +233,7 @@ images:
 - name: plutono
   sourceRepository: github.com/credativ/plutono
   repository: ghcr.io/credativ/plutono
-  tag: "v7.5.24"
+  tag: "v7.5.25"
   labels:
   - name: gardener.cloud/cve-categorisation
     value:
@@ -408,7 +408,7 @@ images:
 - name: vali
   sourceRepository: github.com/credativ/vali
   repository: ghcr.io/credativ/vali
-  tag: "v2.2.8"
+  tag: "v2.2.9"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:
@@ -460,7 +460,7 @@ images:
 - name: valitail
   sourceRepository: github.com/credativ/vali
   repository: ghcr.io/credativ/valitail
-  tag: "v2.2.8"
+  tag: "v2.2.9"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:


### PR DESCRIPTION
/area logging
/area monitoring
/kind enhancement

This pr brings the lateset updates of the upstream observability components to gardener.

- Plutono is now upgraded from [v7.5.24 to v7.5.25](https://github.com/credativ/plutono/compare/v7.5.24...v7.5.25)
- Vali and valitail are now upgraded from [v2.2.8 to v2.2.9](https://github.com/credativ/vali/compare/v2.2.8...v2.2.9)

```other operator
With this release the obervability compoents are updated to the latest release versions. Plutono is now at v2.5.25 and Vali is now at v2.2.9
```
