### PR TITLE
Run Control Plane components as `nonroot` user `65532`

### DIFF
--- a/pkg/component/kubeapiserver/deployment.go
+++ b/pkg/component/kubeapiserver/deployment.go
@@ -834,6 +834,8 @@ func (k *kubeAPIServer) vpnSeedClientContainer(index int) *corev1.Container {
 			},
 		},
 		SecurityContext: &corev1.SecurityContext{
+			RunAsNonRoot: pointer.Bool(false),
+			RunAsUser:    pointer.Int64(0),
 			Capabilities: &corev1.Capabilities{
 				Add: []corev1.Capability{"NET_ADMIN"},
 			},
@@ -892,6 +894,8 @@ func (k *kubeAPIServer) vpnSeedPathControllerContainer() *corev1.Container {
 			},
 		},
 		SecurityContext: &corev1.SecurityContext{
+			RunAsNonRoot: pointer.Bool(false),
+			RunAsUser:    pointer.Int64(0),
 			Capabilities: &corev1.Capabilities{
 				Add: []corev1.Capability{"NET_ADMIN"},
 			},

--- a/pkg/component/kubeapiserver/deployment.go
+++ b/pkg/component/kubeapiserver/deployment.go
@@ -225,6 +225,12 @@ func (k *kubeAPIServer) reconcileDeployment(
 					RestartPolicy:                 corev1.RestartPolicyAlways,
 					SchedulerName:                 corev1.DefaultSchedulerName,
 					TerminationGracePeriodSeconds: pointer.Int64(30),
+					SecurityContext: &corev1.PodSecurityContext{
+						RunAsNonRoot: pointer.Bool(true),
+						RunAsUser:    pointer.Int64(65532),
+						RunAsGroup:   pointer.Int64(65532),
+						FSGroup:      pointer.Int64(65532),
+					},
 					Containers: []corev1.Container{{
 						Name:                     ContainerNameKubeAPIServer,
 						Image:                    k.values.Images.KubeAPIServer,
@@ -233,10 +239,6 @@ func (k *kubeAPIServer) reconcileDeployment(
 						Args:                     k.computeKubeAPIServerArgs(),
 						TerminationMessagePath:   corev1.TerminationMessagePathDefault,
 						TerminationMessagePolicy: corev1.TerminationMessageReadFile,
-						SecurityContext: &corev1.SecurityContext{
-							RunAsNonRoot: pointer.Bool(true),
-							RunAsUser:    pointer.Int64(65532),
-						},
 						Ports: []corev1.ContainerPort{{
 							Name:          "https",
 							ContainerPort: kubeapiserverconstants.Port,

--- a/pkg/component/kubeapiserver/deployment.go
+++ b/pkg/component/kubeapiserver/deployment.go
@@ -233,6 +233,10 @@ func (k *kubeAPIServer) reconcileDeployment(
 						Args:                     k.computeKubeAPIServerArgs(),
 						TerminationMessagePath:   corev1.TerminationMessagePathDefault,
 						TerminationMessagePolicy: corev1.TerminationMessageReadFile,
+						SecurityContext: &corev1.SecurityContext{
+							RunAsNonRoot: pointer.Bool(true),
+							RunAsUser:    pointer.Int64(65532),
+						},
 						Ports: []corev1.ContainerPort{{
 							Name:          "https",
 							ContainerPort: kubeapiserverconstants.Port,

--- a/pkg/component/kubeapiserver/deployment.go
+++ b/pkg/component/kubeapiserver/deployment.go
@@ -226,6 +226,8 @@ func (k *kubeAPIServer) reconcileDeployment(
 					SchedulerName:                 corev1.DefaultSchedulerName,
 					TerminationGracePeriodSeconds: pointer.Int64(30),
 					SecurityContext: &corev1.PodSecurityContext{
+						// use the nonroot user from a distroless container
+						// https://github.com/GoogleContainerTools/distroless/blob/1a8918fcaa7313fd02ae08089a57a701faea999c/base/base.bzl#L8
 						RunAsNonRoot: pointer.Bool(true),
 						RunAsUser:    pointer.Int64(65532),
 						RunAsGroup:   pointer.Int64(65532),

--- a/pkg/component/kubeapiserver/kube_apiserver_test.go
+++ b/pkg/component/kubeapiserver/kube_apiserver_test.go
@@ -1985,6 +1985,10 @@ rules:
 				Expect(deployment.Spec.Template.Spec.RestartPolicy).To(Equal(corev1.RestartPolicyAlways))
 				Expect(deployment.Spec.Template.Spec.SchedulerName).To(Equal("default-scheduler"))
 				Expect(deployment.Spec.Template.Spec.TerminationGracePeriodSeconds).To(PointTo(Equal(int64(30))))
+				Expect(deployment.Spec.Template.Spec.SecurityContext.RunAsNonRoot).To(Equal(pointer.Bool(true)))
+				Expect(deployment.Spec.Template.Spec.SecurityContext.RunAsUser).To(Equal(pointer.Int64(65532)))
+				Expect(deployment.Spec.Template.Spec.SecurityContext.RunAsGroup).To(Equal(pointer.Int64(65532)))
+				Expect(deployment.Spec.Template.Spec.SecurityContext.FSGroup).To(Equal(pointer.Int64(65532)))
 			})
 
 			It("should have no init containers", func() {
@@ -2436,8 +2440,6 @@ rules:
 					Expect(issuerIdx).To(BeNumerically(">=", 0))
 					Expect(issuerIdx).To(BeNumerically("<", issuerIdx1))
 					Expect(issuerIdx).To(BeNumerically("<", issuerIdx2))
-					Expect(deployment.Spec.Template.Spec.Containers[0].SecurityContext.RunAsNonRoot).To(Equal(pointer.Bool(true)))
-					Expect(deployment.Spec.Template.Spec.Containers[0].SecurityContext.RunAsUser).To(Equal(pointer.Int64(65532)))
 					Expect(deployment.Spec.Template.Spec.Containers[0].TerminationMessagePath).To(Equal("/dev/termination-log"))
 					Expect(deployment.Spec.Template.Spec.Containers[0].TerminationMessagePolicy).To(Equal(corev1.TerminationMessageReadFile))
 					Expect(deployment.Spec.Template.Spec.Containers[0].Ports).To(ConsistOf(corev1.ContainerPort{

--- a/pkg/component/kubeapiserver/kube_apiserver_test.go
+++ b/pkg/component/kubeapiserver/kube_apiserver_test.go
@@ -2436,6 +2436,8 @@ rules:
 					Expect(issuerIdx).To(BeNumerically(">=", 0))
 					Expect(issuerIdx).To(BeNumerically("<", issuerIdx1))
 					Expect(issuerIdx).To(BeNumerically("<", issuerIdx2))
+					Expect(deployment.Spec.Template.Spec.Containers[0].SecurityContext.RunAsNonRoot).To(Equal(pointer.Bool(true)))
+					Expect(deployment.Spec.Template.Spec.Containers[0].SecurityContext.RunAsUser).To(Equal(pointer.Int64(65532)))
 					Expect(deployment.Spec.Template.Spec.Containers[0].TerminationMessagePath).To(Equal("/dev/termination-log"))
 					Expect(deployment.Spec.Template.Spec.Containers[0].TerminationMessagePolicy).To(Equal(corev1.TerminationMessageReadFile))
 					Expect(deployment.Spec.Template.Spec.Containers[0].Ports).To(ConsistOf(corev1.ContainerPort{

--- a/pkg/component/kubeapiserver/kube_apiserver_test.go
+++ b/pkg/component/kubeapiserver/kube_apiserver_test.go
@@ -2077,6 +2077,8 @@ rules:
 							},
 						},
 						SecurityContext: &corev1.SecurityContext{
+							RunAsNonRoot: pointer.Bool(false),
+							RunAsUser:    pointer.Int64(0),
 							Capabilities: &corev1.Capabilities{
 								Add: []corev1.Capability{"NET_ADMIN"},
 							},
@@ -2174,6 +2176,8 @@ rules:
 						},
 					},
 					SecurityContext: &corev1.SecurityContext{
+						RunAsNonRoot: pointer.Bool(false),
+						RunAsUser:    pointer.Int64(0),
 						Capabilities: &corev1.Capabilities{
 							Add: []corev1.Capability{"NET_ADMIN"},
 						},

--- a/pkg/component/kubecontrollermanager/kube_controller_manager.go
+++ b/pkg/component/kubecontrollermanager/kube_controller_manager.go
@@ -340,6 +340,10 @@ func (k *kubeControllerManager) Deploy(ctx context.Context) error {
 						Image:           k.values.Image,
 						ImagePullPolicy: corev1.PullIfNotPresent,
 						Command:         command,
+						SecurityContext: &corev1.SecurityContext{
+							RunAsNonRoot: pointer.Bool(true),
+							RunAsUser:    pointer.Int64(65532),
+						},
 						LivenessProbe: &corev1.Probe{
 							ProbeHandler: corev1.ProbeHandler{
 								HTTPGet: &corev1.HTTPGetAction{

--- a/pkg/component/kubecontrollermanager/kube_controller_manager.go
+++ b/pkg/component/kubecontrollermanager/kube_controller_manager.go
@@ -335,6 +335,8 @@ func (k *kubeControllerManager) Deploy(ctx context.Context) error {
 				AutomountServiceAccountToken: pointer.Bool(false),
 				PriorityClassName:            k.values.PriorityClassName,
 				SecurityContext: &corev1.PodSecurityContext{
+					// use the nonroot user from a distroless container
+					// https://github.com/GoogleContainerTools/distroless/blob/1a8918fcaa7313fd02ae08089a57a701faea999c/base/base.bzl#L8
 					RunAsNonRoot: pointer.Bool(true),
 					RunAsUser:    pointer.Int64(65532),
 					RunAsGroup:   pointer.Int64(65532),

--- a/pkg/component/kubecontrollermanager/kube_controller_manager.go
+++ b/pkg/component/kubecontrollermanager/kube_controller_manager.go
@@ -334,16 +334,18 @@ func (k *kubeControllerManager) Deploy(ctx context.Context) error {
 			Spec: corev1.PodSpec{
 				AutomountServiceAccountToken: pointer.Bool(false),
 				PriorityClassName:            k.values.PriorityClassName,
+				SecurityContext: &corev1.PodSecurityContext{
+					RunAsNonRoot: pointer.Bool(true),
+					RunAsUser:    pointer.Int64(65532),
+					RunAsGroup:   pointer.Int64(65532),
+					FSGroup:      pointer.Int64(65532),
+				},
 				Containers: []corev1.Container{
 					{
 						Name:            containerName,
 						Image:           k.values.Image,
 						ImagePullPolicy: corev1.PullIfNotPresent,
 						Command:         command,
-						SecurityContext: &corev1.SecurityContext{
-							RunAsNonRoot: pointer.Bool(true),
-							RunAsUser:    pointer.Int64(65532),
-						},
 						LivenessProbe: &corev1.Probe{
 							ProbeHandler: corev1.ProbeHandler{
 								HTTPGet: &corev1.HTTPGetAction{

--- a/pkg/component/kubecontrollermanager/kube_controller_manager_test.go
+++ b/pkg/component/kubecontrollermanager/kube_controller_manager_test.go
@@ -391,16 +391,18 @@ var _ = Describe("KubeControllerManager", func() {
 						Spec: corev1.PodSpec{
 							AutomountServiceAccountToken: pointer.Bool(false),
 							PriorityClassName:            priorityClassName,
+							SecurityContext: &corev1.PodSecurityContext{
+								RunAsNonRoot: pointer.Bool(true),
+								RunAsUser:    pointer.Int64(65532),
+								RunAsGroup:   pointer.Int64(65532),
+								FSGroup:      pointer.Int64(65532),
+							},
 							Containers: []corev1.Container{
 								{
 									Name:            "kube-controller-manager",
 									Image:           image,
 									ImagePullPolicy: corev1.PullIfNotPresent,
 									Command:         commandForKubernetesVersion(version, 10257, config.NodeCIDRMaskSize, config.PodEvictionTimeout, config.NodeMonitorGracePeriod, namespace, isWorkerless, serviceCIDR, podCIDR, getHorizontalPodAutoscalerConfig(config.HorizontalPodAutoscalerConfig), kubernetesutils.FeatureGatesToCommandLineParameter(config.FeatureGates), clusterSigningDuration, controllerWorkers, controllerSyncPeriods),
-									SecurityContext: &corev1.SecurityContext{
-										RunAsNonRoot: pointer.Bool(true),
-										RunAsUser:    pointer.Int64(65532),
-									},
 									LivenessProbe: &corev1.Probe{
 										ProbeHandler: corev1.ProbeHandler{
 											HTTPGet: &corev1.HTTPGetAction{

--- a/pkg/component/kubecontrollermanager/kube_controller_manager_test.go
+++ b/pkg/component/kubecontrollermanager/kube_controller_manager_test.go
@@ -397,6 +397,10 @@ var _ = Describe("KubeControllerManager", func() {
 									Image:           image,
 									ImagePullPolicy: corev1.PullIfNotPresent,
 									Command:         commandForKubernetesVersion(version, 10257, config.NodeCIDRMaskSize, config.PodEvictionTimeout, config.NodeMonitorGracePeriod, namespace, isWorkerless, serviceCIDR, podCIDR, getHorizontalPodAutoscalerConfig(config.HorizontalPodAutoscalerConfig), kubernetesutils.FeatureGatesToCommandLineParameter(config.FeatureGates), clusterSigningDuration, controllerWorkers, controllerSyncPeriods),
+									SecurityContext: &corev1.SecurityContext{
+										RunAsNonRoot: pointer.Bool(true),
+										RunAsUser:    pointer.Int64(65532),
+									},
 									LivenessProbe: &corev1.Probe{
 										ProbeHandler: corev1.ProbeHandler{
 											HTTPGet: &corev1.HTTPGetAction{

--- a/pkg/component/kubescheduler/kube_scheduler.go
+++ b/pkg/component/kubescheduler/kube_scheduler.go
@@ -250,6 +250,8 @@ func (k *kubeScheduler) Deploy(ctx context.Context) error {
 			Spec: corev1.PodSpec{
 				AutomountServiceAccountToken: pointer.Bool(false),
 				SecurityContext: &corev1.PodSecurityContext{
+					// use the nonroot user from a distroless container
+					// https://github.com/GoogleContainerTools/distroless/blob/1a8918fcaa7313fd02ae08089a57a701faea999c/base/base.bzl#L8
 					RunAsNonRoot: pointer.Bool(true),
 					RunAsUser:    pointer.Int64(65532),
 					RunAsGroup:   pointer.Int64(65532),

--- a/pkg/component/kubescheduler/kube_scheduler.go
+++ b/pkg/component/kubescheduler/kube_scheduler.go
@@ -249,16 +249,18 @@ func (k *kubeScheduler) Deploy(ctx context.Context) error {
 			},
 			Spec: corev1.PodSpec{
 				AutomountServiceAccountToken: pointer.Bool(false),
+				SecurityContext: &corev1.PodSecurityContext{
+					RunAsNonRoot: pointer.Bool(true),
+					RunAsUser:    pointer.Int64(65532),
+					RunAsGroup:   pointer.Int64(65532),
+					FSGroup:      pointer.Int64(65532),
+				},
 				Containers: []corev1.Container{
 					{
 						Name:            containerName,
 						Image:           k.image,
 						ImagePullPolicy: corev1.PullIfNotPresent,
 						Command:         command,
-						SecurityContext: &corev1.SecurityContext{
-							RunAsNonRoot: pointer.Bool(true),
-							RunAsUser:    pointer.Int64(65532),
-						},
 						LivenessProbe: &corev1.Probe{
 							ProbeHandler: corev1.ProbeHandler{
 								HTTPGet: &corev1.HTTPGetAction{

--- a/pkg/component/kubescheduler/kube_scheduler.go
+++ b/pkg/component/kubescheduler/kube_scheduler.go
@@ -255,6 +255,10 @@ func (k *kubeScheduler) Deploy(ctx context.Context) error {
 						Image:           k.image,
 						ImagePullPolicy: corev1.PullIfNotPresent,
 						Command:         command,
+						SecurityContext: &corev1.SecurityContext{
+							RunAsNonRoot: pointer.Bool(true),
+							RunAsUser:    pointer.Int64(65532),
+						},
 						LivenessProbe: &corev1.Probe{
 							ProbeHandler: corev1.ProbeHandler{
 								HTTPGet: &corev1.HTTPGetAction{

--- a/pkg/component/kubescheduler/kube_scheduler_test.go
+++ b/pkg/component/kubescheduler/kube_scheduler_test.go
@@ -261,6 +261,10 @@ var _ = Describe("KubeScheduler", func() {
 									Image:           image,
 									ImagePullPolicy: corev1.PullIfNotPresent,
 									Command:         commandForKubernetesVersion(10259, featureGateFlags(config)...),
+									SecurityContext: &corev1.SecurityContext{
+										RunAsNonRoot: pointer.Bool(true),
+										RunAsUser:    pointer.Int64(65532),
+									},
 									LivenessProbe: &corev1.Probe{
 										ProbeHandler: corev1.ProbeHandler{
 											HTTPGet: &corev1.HTTPGetAction{

--- a/pkg/component/kubescheduler/kube_scheduler_test.go
+++ b/pkg/component/kubescheduler/kube_scheduler_test.go
@@ -255,16 +255,18 @@ var _ = Describe("KubeScheduler", func() {
 						},
 						Spec: corev1.PodSpec{
 							AutomountServiceAccountToken: pointer.Bool(false),
+							SecurityContext: &corev1.PodSecurityContext{
+								RunAsNonRoot: pointer.Bool(true),
+								RunAsUser:    pointer.Int64(65532),
+								RunAsGroup:   pointer.Int64(65532),
+								FSGroup:      pointer.Int64(65532),
+							},
 							Containers: []corev1.Container{
 								{
 									Name:            "kube-scheduler",
 									Image:           image,
 									ImagePullPolicy: corev1.PullIfNotPresent,
 									Command:         commandForKubernetesVersion(10259, featureGateFlags(config)...),
-									SecurityContext: &corev1.SecurityContext{
-										RunAsNonRoot: pointer.Bool(true),
-										RunAsUser:    pointer.Int64(65532),
-									},
 									LivenessProbe: &corev1.Probe{
 										ProbeHandler: corev1.ProbeHandler{
 											HTTPGet: &corev1.HTTPGetAction{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security quality
/kind enhancement

**What this PR does / why we need it**:
This PR modifies Control Plane components `kube-apiserver`, `kube-controller-manager` and `kube-scheduler` to run as `nonroot` user `65532` (id of `nonroot` user in `distroless` images [ref](https://github.com/GoogleContainerTools/distroless/blob/main/base/base.bzl#L8)). The aim of this PR is to adhere to the principles of least privilege and reduce potential attack surface.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Control plane components `kube-apiserver`, `kube-controller-manager` and `kube-scheduler` now run as `nonroot` user and group `65532`.
```
