### PR TITLE
Drop graduated `MachineControllerManagerDeployment` feature gate

### DIFF
--- a/docs/deployment/feature_gates.md
+++ b/docs/deployment/feature_gates.md
@@ -28,9 +28,6 @@ The following tables are a summary of the feature gates that you can set on diff
 | MutableShootSpecNetworkingNodes     | `false` | `Alpha` | `1.64` |        |
 | WorkerlessShoots                    | `false` | `Alpha` | `1.70` | `1.78` |
 | WorkerlessShoots                    | `false` | `Beta`  | `1.79` |        |
-| MachineControllerManagerDeployment  | `false` | `Alpha` | `1.73` |        |
-| MachineControllerManagerDeployment  | `true`  | `Beta`  | `1.81` | `1.81` |
-| MachineControllerManagerDeployment  | `true`  | `GA`    | `1.82` |        |
 | ContainerdRegistryHostsDir          | `false` | `Alpha` | `1.77` |        |
 | ShootForceDeletion                  | `false` | `Alpha` | `1.81` |        |
 | APIServerFastRollout                | `true`  | `Beta`  | `1.82` |        |
@@ -138,6 +135,10 @@ The following tables are a summary of the feature gates that you can set on diff
 | DisableScalingClassesForShoots               | `true`  | `Beta`       | `1.79` | `1.80` |
 | DisableScalingClassesForShoots               | `true`  | `GA`         | `1.81` | `1.81` |
 | DisableScalingClassesForShoots               | `true`  | `Removed`    | `1.82` |        |
+| MachineControllerManagerDeployment           | `false` | `Alpha`      | `1.73` |        |
+| MachineControllerManagerDeployment           | `true`  | `Beta`       | `1.81` | `1.81` |
+| MachineControllerManagerDeployment           | `true`  | `GA`         | `1.82` | `1.82` |
+| MachineControllerManagerDeployment           | `true`  | `Removed`    | `1.83` |        |
 
 ## Using a Feature
 
@@ -184,7 +185,6 @@ A *General Availability* (GA) feature is also referred to as a *stable* feature.
 | IPv6SingleStack                    | `gardener-apiserver`, `gardenlet` | Allows creating seed and shoot clusters with [IPv6 single-stack networking](../usage/ipv6.md) enabled in their spec ([GEP-21](../proposals/21-ipv6-singlestack-local.md)). If enabled in gardenlet, the default behavior is unchanged, but setting `ipFamilies=[IPv6]` in the `seedConfig` is allowed. Only if the `ipFamilies` setting is changed, gardenlet behaves differently. |
 | MutableShootSpecNetworkingNodes    | `gardener-apiserver`              | Allows updating the field `spec.networking.nodes`. The validity of the values has to be checked in the provider extensions. Only enable this feature gate when your system runs provider extensions which have implemented the validation.                                                                                                                                         |
 | WorkerlessShoots                   | `gardener-apiserver`              | WorkerlessShoots allows creation of Shoot clusters with no worker pools.                                                                                                                                                                                                                                                                                                           |
-| MachineControllerManagerDeployment | `gardenlet`                       | Enables Gardener to take over the deployment of the machine-controller-manager. If enabled, all registered provider extensions must support injecting the provider-specific MCM sidecar container into the deployment via the `controlplane` webhook.                                                                                                                              |
 | ContainerdRegistryHostsDir         | `gardenlet`                       | Enables registry configuration in containerd based on the hosts directory pattern. The hosts directory pattern is the new way of configuring registries/mirrors in containerd. Ref https://github.com/containerd/containerd/blob/main/docs/hosts.md.                                                                                                                               |
 | ShootForceDeletion                 | `gardener-apiserver`              | Allows forceful deletion of Shoots by annotating them with the `confirmation.gardener.cloud/force-deletion` annotation.                                                                                                                                                                                                                                                            |
 | APIServerFastRollout               | `gardenlet`                       | Enables fast rollouts for Shoot kube-apiservers on the given Seed. When enabled, `maxSurge` for Shoot kube-apiserver deployments is set to 100%.                                                                                                                                                                                                                                                                  |

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -70,15 +70,6 @@ const (
 	// alpha: v1.81.0
 	ShootForceDeletion featuregate.Feature = "ShootForceDeletion"
 
-	// MachineControllerManagerDeployment enables Gardener to take over the deployment of the
-	// machine-controller-manager. If enabled, all registered provider extensions must support injecting the
-	// provider-specific MCM provider sidecar container into the deployment via the `controlplane` webhook.
-	// owner: @rfranzke @JensAc @mreiger
-	// alpha: v1.73.0
-	// beta: v1.81.0
-	// GA: v1.82.0
-	MachineControllerManagerDeployment featuregate.Feature = "MachineControllerManagerDeployment"
-
 	// ContainerdRegistryHostsDir enables registry configuration in containerd based on the hosts directory pattern.
 	// The hosts directory pattern is the new way of configuring registries/mirrors in containerd.
 	// Ref https://github.com/containerd/containerd/blob/main/docs/hosts.md.
@@ -132,18 +123,17 @@ var DefaultFeatureGate = utilfeature.DefaultMutableFeatureGate
 
 // AllFeatureGates is the list of all feature gates.
 var AllFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
-	HVPA:                               {Default: false, PreRelease: featuregate.Alpha},
-	HVPAForShootedSeed:                 {Default: false, PreRelease: featuregate.Alpha},
-	DefaultSeccompProfile:              {Default: false, PreRelease: featuregate.Alpha},
-	CoreDNSQueryRewriting:              {Default: false, PreRelease: featuregate.Alpha},
-	IPv6SingleStack:                    {Default: false, PreRelease: featuregate.Alpha},
-	MutableShootSpecNetworkingNodes:    {Default: false, PreRelease: featuregate.Alpha},
-	WorkerlessShoots:                   {Default: true, PreRelease: featuregate.Beta},
-	ShootForceDeletion:                 {Default: false, PreRelease: featuregate.Alpha},
-	MachineControllerManagerDeployment: {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
-	ContainerdRegistryHostsDir:         {Default: false, PreRelease: featuregate.Alpha},
-	APIServerFastRollout:               {Default: true, PreRelease: featuregate.Beta},
-	UseGardenerNodeAgent:               {Default: false, PreRelease: featuregate.Alpha},
+	HVPA:                            {Default: false, PreRelease: featuregate.Alpha},
+	HVPAForShootedSeed:              {Default: false, PreRelease: featuregate.Alpha},
+	DefaultSeccompProfile:           {Default: false, PreRelease: featuregate.Alpha},
+	CoreDNSQueryRewriting:           {Default: false, PreRelease: featuregate.Alpha},
+	IPv6SingleStack:                 {Default: false, PreRelease: featuregate.Alpha},
+	MutableShootSpecNetworkingNodes: {Default: false, PreRelease: featuregate.Alpha},
+	WorkerlessShoots:                {Default: true, PreRelease: featuregate.Beta},
+	ShootForceDeletion:              {Default: false, PreRelease: featuregate.Alpha},
+	ContainerdRegistryHostsDir:      {Default: false, PreRelease: featuregate.Alpha},
+	APIServerFastRollout:            {Default: true, PreRelease: featuregate.Beta},
+	UseGardenerNodeAgent:            {Default: false, PreRelease: featuregate.Alpha},
 }
 
 // GetFeatures returns a feature gate map with the respective specifications. Non-existing feature gates are ignored.

--- a/pkg/gardenlet/features/features.go
+++ b/pkg/gardenlet/features/features.go
@@ -34,7 +34,6 @@ func GetFeatures() []featuregate.Feature {
 		features.DefaultSeccompProfile,
 		features.CoreDNSQueryRewriting,
 		features.IPv6SingleStack,
-		features.MachineControllerManagerDeployment,
 		features.ContainerdRegistryHostsDir,
 		features.APIServerFastRollout,
 	}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area open-source
/kind cleanup

**What this PR does / why we need it**:
Drop graduated `MachineControllerManagerDeployment` feature gate.

**Which issue(s) this PR fixes**:
Follow-up of https://github.com/gardener/gardener/pull/8596
Related to https://github.com/gardener/gardener/issues/7594

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy operator
NONE
```
