### PR TITLE
Add VPA memory and cpu limits to seed and shoot Prometheus instances

### DIFF
--- a/pkg/component/monitoring/charts/bootstrap/charts/monitoring/templates/prometheus-vpa.yaml
+++ b/pkg/component/monitoring/charts/bootstrap/charts/monitoring/templates/prometheus-vpa.yaml
@@ -10,6 +10,10 @@ spec:
     - containerName: '*'
       minAllowed:
         memory: 400Mi
+    - containerName: prometheus
+      maxAllowed:
+        cpu: "4"
+        memory: 28G
   targetRef:
     apiVersion: apps/v1
     kind: StatefulSet

--- a/pkg/component/monitoring/charts/bootstrap/templates/aggregate-prometheus/hvpa.yaml
+++ b/pkg/component/monitoring/charts/bootstrap/templates/aggregate-prometheus/hvpa.yaml
@@ -68,6 +68,9 @@ spec:
             - containerName: prometheus
               minAllowed:
                 memory: {{ .Values.aggregatePrometheus.hvpa.minAllowed.memory }}
+              maxAllowed:
+                memory: {{ .Values.aggregatePrometheus.hvpa.maxAllowed.memory }}
+                cpu: {{ .Values.aggregatePrometheus.hvpa.maxAllowed.cpu }}
             - containerName: prometheus-config-reloader
               mode: "Off"
   weightBasedScalingIntervals:

--- a/pkg/component/monitoring/charts/bootstrap/templates/aggregate-prometheus/vpa.yaml
+++ b/pkg/component/monitoring/charts/bootstrap/templates/aggregate-prometheus/vpa.yaml
@@ -11,4 +11,10 @@ spec:
     name: aggregate-prometheus
   updatePolicy:
     updateMode: "Auto"
+  resourcePolicy:
+    containerPolicies:
+    - containerName: prometheus
+      maxAllowed:
+        cpu: "4"
+        memory: 28G
 {{ end }}

--- a/pkg/component/monitoring/charts/bootstrap/templates/prometheus/hvpa.yaml
+++ b/pkg/component/monitoring/charts/bootstrap/templates/prometheus/hvpa.yaml
@@ -68,6 +68,9 @@ spec:
             - containerName: prometheus
               minAllowed:
                 memory: {{ .Values.prometheus.hvpa.minAllowed.memory }}
+              maxAllowed:
+                memory: {{ .Values.prometheus.hvpa.maxAllowed.memory }}
+                cpu: {{ .Values.prometheus.hvpa.maxAllowed.cpu }}
             - containerName: prometheus-config-reloader
               mode: "Off"
   weightBasedScalingIntervals:

--- a/pkg/component/monitoring/charts/bootstrap/templates/prometheus/prometheus-vpa.yaml
+++ b/pkg/component/monitoring/charts/bootstrap/templates/prometheus/prometheus-vpa.yaml
@@ -11,4 +11,10 @@ spec:
     name: prometheus
   updatePolicy:
     updateMode: "Auto"
+  resourcePolicy:
+    containerPolicies:
+    - containerName: prometheus
+      maxAllowed:
+        cpu: "4"
+        memory: 28G
 {{ end }}

--- a/pkg/component/monitoring/charts/bootstrap/values.yaml
+++ b/pkg/component/monitoring/charts/bootstrap/values.yaml
@@ -20,6 +20,9 @@ prometheus:
     enabled: false
     minAllowed:
       memory: 1000M
+    maxAllowed:
+      cpu: "4"
+      memory: 28G
     targetAverageUtilizationCpu: 80
     targetAverageUtilizationMemory: 80
     scaleUpStabilization:
@@ -72,6 +75,9 @@ aggregatePrometheus:
     enabled: false
     minAllowed:
       memory: 1000M
+    maxAllowed:
+      cpu: "4"
+      memory: 28G
     targetAverageUtilizationCpu: 80
     targetAverageUtilizationMemory: 80
     scaleUpStabilization:

--- a/pkg/component/monitoring/charts/seed-monitoring/charts/core/charts/prometheus/templates/prometheus-vpa.yaml
+++ b/pkg/component/monitoring/charts/seed-monitoring/charts/core/charts/prometheus/templates/prometheus-vpa.yaml
@@ -12,6 +12,10 @@ spec:
     updateMode: "Auto"
   resourcePolicy:
     containerPolicies:
+    - containerName: prometheus
+      maxAllowed:
+        cpu: "4"
+        memory: 28G
     # Due to CVE-2019-5736 runC is initially loaded into memory when the container starts.
     # After some time VPA recommends less memory (2,3Mb) than the size of runC binary (about 10Mb).
     # This results in an error when trying to start the container:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind enhancement

**What this PR does / why we need it**:
In the past, we've encountered situations where Prometheus experienced sudden spikes in memory usage. This led the Vertical Pod Autoscaler (VPA) or Horizontal VPA (HVPA) to set the memory request for Prometheus at a level exceeding the node's limits, rendering the pod unschedulable. To avoid this issue, this commit adds the `maxAllowed` field to the (H)VPAs with a value lower than the upper limit that Prometheus should reach during normal operations, yet equal to or less than the available memory on smaller nodes.

**Special notes for your reviewer**:
/cc @istvanballok 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Add memory and cpu limits (maxAllowed) to Prometheus (H)VPAs.
```
