### PR TITLE
Clean up orphaned `ServiceAccount`s related to garden access secrets for extensions

### DIFF
--- a/cmd/gardenlet/app/app.go
+++ b/cmd/gardenlet/app/app.go
@@ -484,17 +484,15 @@ func cleanupLegacyLoggingManagedResource(ctx context.Context, seedClient client.
 
 // TODO(rfranzke): Remove this code after v1.86 has been released.
 func (g *garden) cleanupOrphanedExtensionsServiceAccounts(ctx context.Context, gardenClient client.Client) error {
-	serviceAccountList := &metav1.PartialObjectMetadataList{}
-	serviceAccountList.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("ServiceAccountList"))
+	serviceAccountList := &corev1.ServiceAccountList{}
 	if err := gardenClient.List(ctx, serviceAccountList, client.InNamespace(gardenerutils.ComputeGardenNamespace(g.config.SeedConfig.Name))); err != nil {
 		return err
 	}
 
 	var taskFns []flow.TaskFn
 	for _, serviceAccount := range serviceAccountList.Items {
-		controllerInstallation := &metav1.PartialObjectMetadata{}
-		controllerInstallation.SetGroupVersionKind(gardencorev1beta1.SchemeGroupVersion.WithKind("ControllerInstallation"))
-		if err := gardenClient.Get(ctx, client.ObjectKey{Name: strings.TrimPrefix(serviceAccount.Name, v1beta1constants.ExtensionGardenServiceAccountPrefix)}, controllerInstallation); err != nil {
+		controllerInstallation := &gardencorev1beta1.ControllerInstallation{ObjectMeta: metav1.ObjectMeta{Name: strings.TrimPrefix(serviceAccount.Name, v1beta1constants.ExtensionGardenServiceAccountPrefix)}}
+		if err := gardenClient.Get(ctx, client.ObjectKeyFromObject(controllerInstallation), controllerInstallation); err != nil {
 			if !apierrors.IsNotFound(err) {
 				return err
 			}

--- a/pkg/gardenlet/controller/controllerinstallation/controllerinstallation/reconciler.go
+++ b/pkg/gardenlet/controller/controllerinstallation/controllerinstallation/reconciler.go
@@ -359,7 +359,7 @@ func (r *Reconciler) delete(
 
 	gardenClusterServiceAccount := &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{
 		Name:      v1beta1constants.ExtensionGardenServiceAccountPrefix + controllerInstallation.Name,
-		Namespace: gardenerutils.ComputeGardenNamespace(r.Config.SeedConfig.Name),
+		Namespace: gardenerutils.ComputeGardenNamespace(seed.Name),
 	}}
 	if err := r.GardenClient.Delete(gardenCtx, gardenClusterServiceAccount); client.IgnoreNotFound(err) != nil {
 		conditionInstalled = v1beta1helper.UpdatedConditionWithClock(r.Clock, conditionInstalled, gardencorev1beta1.ConditionFalse, "DeletionFailed", fmt.Sprintf("Deletion of ServiceAccount %q in garden cluster failed: %+v", client.ObjectKeyFromObject(gardenClusterServiceAccount), err))

--- a/pkg/gardenlet/controller/controllerinstallation/controllerinstallation/reconciler.go
+++ b/pkg/gardenlet/controller/controllerinstallation/controllerinstallation/reconciler.go
@@ -357,6 +357,15 @@ func (r *Reconciler) delete(
 
 	conditionInstalled = v1beta1helper.UpdatedConditionWithClock(r.Clock, conditionInstalled, gardencorev1beta1.ConditionFalse, "DeletionSuccessful", "Deletion of old resources succeeded.")
 
+	gardenClusterServiceAccount := &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{
+		Name:      v1beta1constants.ExtensionGardenServiceAccountPrefix + controllerInstallation.Name,
+		Namespace: gardenerutils.ComputeGardenNamespace(r.Config.SeedConfig.Name),
+	}}
+	if err := r.GardenClient.Delete(gardenCtx, gardenClusterServiceAccount); client.IgnoreNotFound(err) != nil {
+		conditionInstalled = v1beta1helper.UpdatedConditionWithClock(r.Clock, conditionInstalled, gardencorev1beta1.ConditionFalse, "DeletionFailed", fmt.Sprintf("Deletion of ServiceAccount %q in garden cluster failed: %+v", client.ObjectKeyFromObject(gardenClusterServiceAccount), err))
+		return reconcile.Result{}, err
+	}
+
 	if controllerutil.ContainsFinalizer(controllerInstallation, finalizerName) {
 		log.Info("Removing finalizer")
 		if err := controllerutils.RemoveFinalizers(gardenCtx, r.GardenClient, controllerInstallation, finalizerName); err != nil {

--- a/test/integration/gardenlet/controllerinstallation/controllerinstallation/controllerinstallation_suite_test.go
+++ b/test/integration/gardenlet/controllerinstallation/controllerinstallation/controllerinstallation_suite_test.go
@@ -247,13 +247,6 @@ var _ = BeforeSuite(func() {
 					ConcurrentSyncs: pointer.Int(5),
 				},
 			},
-			SeedConfig: &config.SeedConfig{
-				SeedTemplate: gardencore.SeedTemplate{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: seed.Name,
-					},
-				},
-			},
 		},
 		Identity:              identity,
 		GardenClusterIdentity: gardenClusterIdentity,

--- a/test/integration/gardenlet/controllerinstallation/controllerinstallation/controllerinstallation_suite_test.go
+++ b/test/integration/gardenlet/controllerinstallation/controllerinstallation/controllerinstallation_suite_test.go
@@ -247,6 +247,13 @@ var _ = BeforeSuite(func() {
 					ConcurrentSyncs: pointer.Int(5),
 				},
 			},
+			SeedConfig: &config.SeedConfig{
+				SeedTemplate: gardencore.SeedTemplate{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: seed.Name,
+					},
+				},
+			},
 		},
 		Identity:              identity,
 		GardenClusterIdentity: gardenClusterIdentity,

--- a/test/integration/gardenlet/controllerinstallation/controllerinstallation/controllerinstallation_suite_test.go
+++ b/test/integration/gardenlet/controllerinstallation/controllerinstallation/controllerinstallation_suite_test.go
@@ -78,6 +78,7 @@ var (
 	mgrClient     client.Client
 
 	seed                  *gardencorev1beta1.Seed
+	seedNamespace         *corev1.Namespace
 	gardenNamespace       *corev1.Namespace
 	identity              = &gardencorev1beta1.Gardener{Version: "1.2.3"}
 	gardenClusterIdentity = "test-garden"
@@ -169,6 +170,20 @@ var _ = BeforeSuite(func() {
 		Expect(testClient.Delete(ctx, seed)).To(Or(Succeed(), BeNotFoundError()))
 	})
 
+	By("Create seed namespace")
+	seedNamespace = &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "seed-" + seed.Name,
+		},
+	}
+	Expect(testClient.Create(ctx, seedNamespace)).To(Succeed())
+	log.Info("Created seed namespace for test", "namespaceName", seedNamespace)
+
+	DeferCleanup(func() {
+		By("Delete seed namespace")
+		Expect(testClient.Delete(ctx, seedNamespace)).To(Or(Succeed(), BeNotFoundError()))
+	})
+
 	By("Create garden namespace")
 	gardenNamespace = &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
@@ -176,7 +191,7 @@ var _ = BeforeSuite(func() {
 		},
 	}
 	Expect(testClient.Create(ctx, gardenNamespace)).To(Succeed())
-	log.Info("Created namespace for test", "namespaceName", gardenNamespace)
+	log.Info("Created garden namespace for test", "namespaceName", gardenNamespace)
 
 	By("Setup manager")
 	mgr, err := manager.New(restConfig, manager.Options{

--- a/test/integration/gardenlet/controllerinstallation/controllerinstallation/controllerinstallation_test.go
+++ b/test/integration/gardenlet/controllerinstallation/controllerinstallation/controllerinstallation_test.go
@@ -332,6 +332,15 @@ var _ = Describe("ControllerInstallation controller tests", func() {
 				g.Expect(testClient.Get(ctx, client.ObjectKey{Namespace: managedResource.Namespace, Name: managedResource.Spec.SecretRefs[0].Name}, secret)).To(Succeed())
 			}).Should(Succeed())
 
+			By("Create ServiceAccount for garden access secret")
+			// This ServiceAccount is typically created by the token-requestor controller which does not run in this
+			// integration test, so let's fake it here.
+			gardenClusterServiceAccount := &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{
+				Name:      "extension-" + controllerInstallation.Name,
+				Namespace: seedNamespace.Name,
+			}}
+			Expect(testClient.Create(ctx, gardenClusterServiceAccount)).To(Succeed())
+
 			By("Delete ControllerInstallation")
 			Expect(testClient.Delete(ctx, controllerInstallation)).To(Succeed())
 
@@ -344,6 +353,7 @@ var _ = Describe("ControllerInstallation controller tests", func() {
 			Expect(testClient.Get(ctx, client.ObjectKeyFromObject(namespace), namespace)).To(BeNotFoundError())
 			Expect(testClient.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)).To(BeNotFoundError())
 			Expect(testClient.Get(ctx, client.ObjectKeyFromObject(secret), secret)).To(BeNotFoundError())
+			Expect(testClient.Get(ctx, client.ObjectKeyFromObject(gardenClusterServiceAccount), gardenClusterServiceAccount)).To(BeNotFoundError())
 		})
 
 		It("should not overwrite the Installed condition when it is not 'Unknown'", func() {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind bug

**What this PR does / why we need it**:
Since #8204, `gardenlet` creates garden access secrets for each extension. The `token-requestor` controller will reconcile them and create a `ServiceAccount` for the extension in the seed namespace in the garden cluster.
However, when an extension gets uninstalled, the `ServiceAccount` in the garden cluster gets orphaned and remains in the system - it will never be deleted.

Note that the `token-requestor` controller doesn't handle deletion of access secrets for various reasons, see #4931 (https://github.com/gardener/gardener/pull/4931/commits/4c1178d91f06063967276575fc729d542212b3ea) for details if interested. Hence, `gardenlet`'s `ControllerInstallation` controller now takes care to cleanup before releasing a `ControllerInstallation` in deletion.

In addition, some cleanup code has been added to the gardenlet startup procedure to make sure existing systems are getting cleaned.

/cc @timebertt 

**Which issue(s) this PR fixes**:
Follow-up of #8204
Related to #8001

**Special notes for your reviewer**:
Reproduce the issue (e.g., in a local setup) by running `make kind-up gardener-up` and applying the following `Controller{Deployment,Registration}` (or any other if you like):

```yaml
---
apiVersion: core.gardener.cloud/v1beta1
kind: ControllerDeployment
metadata:
  name: networking-calico
type: helm
providerConfig:
  chart: H4sIAAAAAAAAA+0ca3PbNrKf+StwzHnyaEjq4Uequ+bq2m7qqWN7LDedTh8ZiIQk1hTBI0g5ujT322/xIAU+ZIm2z2laYjwyCWIXi8cuFrsLTHDskZDEFnmXkJD5NLRCklzT+MoPJ5aLA9+lzmd3Sx1Iezs74j+k8n/x3O1vd3s7vd1dnt/d3dvrfoZ27ljvRillCY4R+iymNLmp3Lrvn2iabDL+9pQEM38S0pjcpg4+wLvb2yvHH4a9OP69bheyUOe+G1uX/uLj/wid4yQhcchQQpEcY3Q9JSEapX7gwSRAEXav8IQw23iELqc+QyyNIhon8ADzIkCTgI7QDCfuFEo/RzEJcOLPCcAlUy0fhx4gCMkEvtIQPYliMvbfEQ9d+1Dub09tdBYGC0RDAclJQhGJUeCHxDbsw+HbYQK0AYoDOpsBgjcHQ+T5MTPsiZ844leSb9ij/8SO+M0yphOH/2SvbB46S0QjaF8aobEfEGY8s9l1BL8jfAW/yQye/wtF3+DYpylDx4dHUGEU09+Imxi27xHsyHKQZdhz5lKPOMbHHtXN00b8fzDFcWIv8Cy4VR3r+L/X3yvxf2ev12n5/yESjvw3JObjPkDzroGjKH81u3bHNDzC3NiPEpG1j76FlQC5fD6gMY1RMiXolZpC6EDMFnQq5w86ymaUEeIZGaBNppoxz2rv2FD9J8RIn2jaiP896toTeus61vB/r7Nd4f/OXsv/D5IcB5bBaAEr5TRBT9ynqNfpfoGG++doeISAwXEoXvAYlkcfJwS5dBbhcGGjfVj6BRiDJZ+ReE48W+oHfCVF8B/mDkwpWOHT0CNSVuyDMgH/hnScXGPQNE5kkedobqMeIu9cEiUIMxTSBOAogMTXPgNsoQA/OT44OgXCeA2G48BfhqGmkhy3kmioZ3fQE17AVJ/Mp//gKBY0BT1lwStFKVSW5I1QBEHtvNnQAaFLpL6SLCuwOY4fFQ46SjAUxwAQwdtYL4hwoogWaZok0cBxrq+vbSwotmk8cVSnMUe11QKqFdT3IWgovLf/nfoxtHi0QCCvAQCPgNYAX4sBm8QEvnFlLkTXMShFXPliqsM5Gs9nSeyP0qTQaRmN0HS9AHQbTAFzf4iOhyb6en94PHzOkfxwfPnt2feX6If9i4v908vjoyE6u0AHZ6eHx5fHZ6fw9g3aP/0RfXd8evgcEZ+PJHQnKH3QAiDT590JM4bjGhJSICFbWFhEXH/su9C0cJKCCoomFNaHUCilJJ75jA8rE5oloAn8mZ8I5ZJV22UbUGRCBxMu7Pg8ZlNkuci0bQf+5iT0aOyACjlNRzaMtZPJxeXDFNREJwO3XBomMQ0CkJwxmfAOEzXbgLYiP5GN/v7ExQmSlb05uhhCFz1Vr+Qdhr4gziqMXO3K1tSBRGjyxoDiLvRytRqTkM8ChgptlIq66FCVyfuOd4tL4xhUWLSsFRVqNSIde7sO/1nTRut/QmCGwoRit7MENbb/gP6/u9fafx4iNRz/t7DjB9HL7CTafC+4Rv/r7u6U7T/9fq/b6n8Pkd6/t5BHxn4IWhHfppnI+vDB2GirxkFh3RQAho4nwCMSMFBqIvuKLCRG8ZKOYPUmMI9snzq8tgKOFSjmOEgVWe/fg1LjBqmXE2sjBXgDIVXYMoEcywCtKKHqFzVVW+GHMH9AKxTg9gUJCAZl4xSIu5EyV5iezkbcjHSiUVnfTRvunbmVFhQQRyzZG8LcuUV5k/wZqAuyFQjxL/4YTTE7F2Y+ZLIp7u3sDqAj3/AOhap4eTvBE5RDRLEfJmNkbrGvtli5ZEwiyvyExoubUEBPkjqEg1sjhMZq7S4PpEeigC5mJEyU5SIfR+bMu6snQEQ9ULPjVBhWRqk3IUUEEYXhWZRR3D//N5T/wB4sITFsjuCXWQGdTKDcGtPgWvt/t1eS/7v97b1W/j9E0u1/Y+CBMBn5iS2fuDSYd3EQAesaMB+8ATqQ4/+NGH9jRhLs4QQPgFekxORPSEOU756SRQQSxWSwNzVXlLHdgKZeuaSUf3IiWiH1iMG3hbweNQn5I3A6jhmJZfUIgVQ/FXAwQVWWKqBjsmSeKqCMGIe8PSiJUwL5wnsxQJqAfKbBF54/0S3S7fhfdty98f9elf93t1v+f4h0O/4/l4yj83+FT5fc9f8RDZkYiMmEvJPIE39GviOLgXjIc76hMfAxwG39aG3NrC0PbX072Ho92BraWyeyRokDPf71yb/+yUFe/uy93/5gwW9P/f7MPv/pV/TLs6fw8PNPUIwRWK/9ZPHy52vI/EXkRb4HkJ/zV/Y5L0PT2CUvf/p1AIADmQcs89J+9vTxH0ReNOV/Go79yQxHllCV5qC+0tjiVjluaiT1gmAd/2/v9ov83+90d1r7/4MkpagXFOA3YlTPskGVG5+Cm1AJAzEZXuOoRhDUb9XqZ40CYhGu23WIbKmPZ4KkulPj6H+HTJjLCdrmpTNyRI3sbXGKDtDvHMmNrS6i0/T/jz1k95puy/9NogHW+v8q9r/+bqeN/3mQdF+MnU+M/yszy1pyFuZLt2VZ4r/eEDlt7eVEtvPZzWyFo6RaKD2nK3DlvaBcI7I/UukaMUoiU+FzAx/IhZIhyBHubRSNBJJL+dkWBbvctcjrgM+XoNgw0Vu5c89cg9+uIuC+uwzeXEdfHbwiWfRzltuQKg2yGTk6YE7Hv6OmvQIQzerlAHl9ozRmScMaBUyzOiVIcVWpn1VjgpM0Jq+48M3I1PME+yT0R+4jvAk0Z6fdUrUN5f/S3NVgAVgj/3e7/bL83+70+638f4iki83MaCnF32E+1BuvAneS/XUm8fI6IMIm/MnUwnPsAxI/gB2YWnvsmMj9FqvfNi493drWce7zpn/rM24GPuEBBAPUEV9EXIWUPhljqcwDmoaJpIZB87jWKIW6sBadbLas7UoEGWcpBFo/izUiDKmKaMiyctP6Oo09K+5OiXvF0pm2dVMMXq+MF8b2iTCgo7/bl4pO+2sYzXMe2GtutBc0n4pGS+M/UKFTpkmhG4i9Ud+4BbEbkaX1L4xJ7LvMlvEVQzcGjgknOkAUUyg0JanmrzFrfCfmCgjGcXIYbnRcVYjHcSi0JcJEhIeOvdKvuv2FJ00vKnMKtWKY3P6MWNBMYQ+NQS4EAb0m3mbwHszVHGINE7zIaMwYUrbbp9ywchBgxk6L3i+2YMAx1hedjirMSfRdsu+6nClPN/eVLfUc7IfKiizUSdTA4ZZ1iJj/RaGovGG2PlFE3nkaBOfCuVOQLdLzFOUfC1wBkhGDSM4zLOQ0os8CLRmmoseLB1IHsTJpaQXUvfpSo0QWPFLlcql6AsV0ojjOGX7HGdFN4xiGE1DyFx5Gr+Nbyl17WXa4CF1WRjclOEimQgY0Rq3BblBNnIxAO7LyxerLVWsVWgEJyMm1BeIG5h8OLMbJ826gTYLZAuxYQQ0lUKUWeUrBohGRGw5ruQysqEBCnGUA+3n5ctOlFLR4bOOXDklcp166KmnpaNutApp88imXpU5WLhHUN50EEs71SSw57eRo//Do4u3RydEBjxx8e7r/+mh4vn9wlJdESPjgvwGBONAyuQeIBN4FGRdzVT4X/IN8SbXzsb7tQprRe/x6/9XRGyD27OLt2Zujix8uji8rtA6Q9MJrhien1hJVJ7VLhOV6jU5Nnlm3A1hC/I5CJWu7nZLmn9NLg3RGXnP5yaqjI6eA1rwZLyj7dv0MumtfrzIX1hFT6W+tXAwyjZ8uyh17lT7X+6KyGJQa42bmEX3ebWwdyZJHxjgNktfUA7jtXraiNeqpzfqpOb3r+v0G2v+MRtI/cWq4/68JW1lvCFjv/ynH/+3s7bTxHw+S9P2/Lgxuik+ygb+ljeCceod5qa9FqT+OsSDbVIAq+X2oDAYBVNW9+8b9Y4/a/aWG/B+PsNv4IOga/u9v73VL/A+78pb/HyRx94kuA8QA4zSZwh78P/IoyNULJiNBijEgFzQgTZj9tmwcpwHXyCzu4XkV0zRSEV+aS6dohTAK2jEvqqKWGLyAEBupXC6s+P/AZ/LhmouBO1WkWIcVXhyYYUm6WeUylC17SiPoW1KlyKU09vxQH54qLUKWlmp1QREWipysGC1rRnetJcsXwrvQG0tBUjZCyJ6oSqB8w4zqO21Vv6yyAFfJnuEQNFwvz10zOFq/eUC8emwyZKYp/nETu3gY5RArOU4CeOqYW+F0ll4g8rUJumqY8pVW1g66Pez2xCMj0Dj1nG9TVKnQi6ifFVy6firvDoPxJQqdMMgx/QVL6xzTeTGmAalkjIDvYbbI/GWJyqff6Eg+gJayfHBksCcMbpqIg27XZDSl9MrVvbeqTqiSzrI+EjHZfvZVmwfmM9O4m4D8WpJdIyc3NODptts7HQ7gCG5zQKC+4psPCfABU2aZjA1u6Dgjd7hrC0ujbmKpWEHEKiFRDQt24aadvole+rEX7ntKDfU/xdHNVMB18T+9znbl/Fe3Pf/1IKk2/kdxz/1v5SoOTc2VtNJ9O47pzMIBt7ITz5LeMgsGDVZpZilPkyUuJBqgxz+9N/mjOVjtKXtuRjFNqEsDc2BeHpybH355vDExeTutbAupatX2kFC5WRSXBSs01CqRmh+a1AxLnCVWg7zmpf8CusHnzuqlJiDPZumGROEjuCjbkldWJ8vnXsmSqfQRujw7PBvI+x4EVXyRiCkGTZLfIECimLiYXyCAASikKKDhhMTQUFhtvew6h3HKI1RsdEFmdC7uAJjxyx8Y5bcOsFxa586ur+Zde2+HnypDI0JCftUUn2We3WwuybNVVrVDheOybprdCv/9Tc0moXKZ1UMGPagl9fi8YPPYLDZB0q3UqzgpuCtLdIv+yUiHWXFwLnJk752vA/7YMvCvnG63/iuNfkM1YJ39lx/2LsV/7bbnfx4m3bT+Z9rzH8aiC7sHKlx+RQIv6RXhx5dwwEgrTJqlhvw/j3DzewDXx/+X/T+97X5r/32QVHI38/GVkW5e+diPybmPG3q4ApSbPEwlMqBY4sPHc+rtq3K1BwRXOJyh3g2lR6bf1BCeaWV6BFUxT2468qgvkeln/n5r+UEGkj1+9rjeKV+tzJ754b7U95be+WXe0vE+A1U3XqwIMb8Rry1B6yPNN4LMCavEPWzQPvyu2r48b9k+N0obNC5HYAPc5i0rgmlxI417d4mpae9WIOt7t/Ai9eE8YKku9prnV+Kvl/EaGxqwpBVan/MyRwZsmJxDzT/tkbY2NUgbrf9zyQa3vQB43frf3+5X7v/eac//PUiSoctiocxuwxkgktoTN+YLfD491JXXy+sQl6Ymp04CJXgyQEJn5OIr0oKej8enNDnnt22AZDOWfir0/oNhgKTlxCgVJA/XK6/ij0qr66OC9O/2Xrz2jfoVSqxP20Zxueh2XhmAoy7Wjh8z5Nhl8KasKYu6i3DK5E2QQmlQVEhKL7Tu1K6VXJoF9cdRQEfODHNLjSOuXXcEaueQulfish2icOuDlI0QpZOAvF1GsktYC8+83W0FJgbD7PPrnGVGfsty1+527Xefdqu6lVaZL7/kLevJD7ZtG8YyWlqdI9UjxAdox+DesTyEPNcTa0tJ3/QAKQNqNaR7gPod/nVlXHa2WTWKwfYDbarzePtB5l431HEXY9V50rrTpOpuWF7I+Y0Jb3vpZGdtCXHmsqtOWKgDkd0+fy0cPOTsKi3BpzQ8j/05jOeEePIO8FOhZ6g2ZiJjYOhDZALHPUKMJNxTy8QVpcou+BwRe2Ijlh21GS2QMMkuD8QYquRSVGTncnKJIS2WLzov2jvE29SmNrWpTW1qU5va1KY2talNbWpTm9r0F07/A7v9Tl4AeAAA
  values:
    image:
      tag: v1.36.0
---
apiVersion: core.gardener.cloud/v1beta1
kind: ControllerRegistration
metadata:
  name: networking-calico
spec:
  deployment:
    deploymentRefs:
    - name: networking-calico
    policy: Always
```

After deletion of this `Controller{Deployment,Registration}`, see the `ServiceAccount` in the `seed-local` namespace named `extension-networking-calico-****` to still appear. You can repeat this a couple of times and see `ServiceAccount`s piling up.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
A bug has been fixed which caused `ServiceAccount`s related to garden access secrets for extensions to leak in the seed namespace in the garden cluster after uninstallation of said extensions.
```
