### PR TITLE
Use adminkubeconfig of the `Shoot`s of `ManagedSeed`s to create seed client in TM tests

### DIFF
--- a/test/framework/gardener_utils.go
+++ b/test/framework/gardener_utils.go
@@ -75,9 +75,8 @@ func (f *GardenerFramework) GetSeed(ctx context.Context, seedName string) (*gard
 				return nil, nil, fmt.Errorf("could not construct Seed client: %w", err)
 			}
 			return seed, seedClient, nil
-		} else {
-			return seed, nil, fmt.Errorf("failed to get ManagedSeed for Seed, %s: %w", client.ObjectKeyFromObject(seed), err)
 		}
+		return seed, nil, fmt.Errorf("failed to get ManagedSeed for Seed, %s: %w", client.ObjectKeyFromObject(seed), err)
 	}
 
 	if managedSeed.Spec.Shoot == nil {

--- a/test/framework/gardener_utils.go
+++ b/test/framework/gardener_utils.go
@@ -22,16 +22,19 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
+	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/kubernetes/health"
 	"github.com/gardener/gardener/pkg/utils/retry"
+	"github.com/gardener/gardener/test/utils/access"
 )
 
 // GetSeeds returns all registered seeds
@@ -53,13 +56,46 @@ func (f *GardenerFramework) GetSeed(ctx context.Context, seedName string) (*gard
 		return nil, nil, fmt.Errorf("could not get Seed from Shoot in Garden cluster: %w", err)
 	}
 
-	seedSecretRef := seed.Spec.SecretRef
-	if seedSecretRef == nil {
-		f.Logger.Info("Seed does not have secretRef set, skip constructing seed client")
-		return seed, nil, nil
+	managedSeed := &seedmanagementv1alpha1.ManagedSeed{}
+	if err := f.GardenClient.Client().Get(ctx, kubernetesutils.Key(v1beta1constants.GardenNamespace, seed.Name), managedSeed); err != nil {
+		if apierrors.IsNotFound(err) {
+			f.Logger.Info("Seed is not a ManagedSeed, checking seed.spec.secretRef")
+
+			seedSecretRef := seed.Spec.SecretRef
+			if seedSecretRef == nil {
+				f.Logger.Info("Seed does not have secretRef set, skip constructing seed client")
+				return seed, nil, nil
+			}
+
+			seedClient, err := kubernetes.NewClientFromSecret(ctx, f.GardenClient.Client(), seedSecretRef.Namespace, seedSecretRef.Name,
+				kubernetes.WithClientOptions(client.Options{Scheme: kubernetes.SeedScheme}),
+				kubernetes.WithDisabledCachedClient(),
+			)
+			if err != nil {
+				return nil, nil, fmt.Errorf("could not construct Seed client: %w", err)
+			}
+			return seed, seedClient, nil
+		} else {
+			return seed, nil, fmt.Errorf("failed to get ManagedSeed for Seed, %s: %w", client.ObjectKeyFromObject(seed), err)
+		}
 	}
 
-	seedClient, err := kubernetes.NewClientFromSecret(ctx, f.GardenClient.Client(), seedSecretRef.Namespace, seedSecretRef.Name,
+	if managedSeed.Spec.Shoot == nil {
+		return seed, nil, fmt.Errorf("shoot for ManagedSeed, %s is nil", client.ObjectKeyFromObject(managedSeed))
+	}
+
+	shoot := &gardencorev1beta1.Shoot{}
+	if err := f.GardenClient.Client().Get(ctx, kubernetesutils.Key(v1beta1constants.GardenNamespace, managedSeed.Spec.Shoot.Name), shoot); err != nil {
+		return seed, nil, fmt.Errorf("failed to get Shoot %s for ManagedSeed, %s: %w", managedSeed.Spec.Shoot.Name, client.ObjectKeyFromObject(managedSeed), err)
+	}
+
+	const expirationSeconds = 6 * 3600 // 6h
+	kubeconfig, err := access.RequestAdminKubeconfigForShoot(ctx, f.GardenClient, shoot, pointer.Int64(expirationSeconds))
+	if err != nil {
+		return seed, nil, fmt.Errorf("failed to request AdminKubeConfig for Shoot %s: %w", client.ObjectKeyFromObject(shoot), err)
+	}
+
+	seedClient, err := kubernetes.NewClientFromBytes(kubeconfig,
 		kubernetes.WithClientOptions(client.Options{Scheme: kubernetes.SeedScheme}),
 		kubernetes.WithDisabledCachedClient(),
 	)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind enhancement

**What this PR does / why we need it**:
When `spec.secretRef` is nil in the seed, we skip creating seed client, this can cause panic later when some tests try to access the seedClient. For ManagedSeeds >= k8s 1.27, enabling this is not possible.
This PR uses adminkubeconfig of the Shoots of the ManagedSeeds to create seedClient in TM tests.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @adenitiu 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The testmachinery tests now use `AdminKubeconfig` of the `Shoot`s of `ManagedSeed`s to create seed client.
```
