### PR TITLE
Remove the secretRef annotation from the ManagedSeed if the secret is already gone

### DIFF
--- a/test/integration/gardenlet/managedseed/managedseed_test.go
+++ b/test/integration/gardenlet/managedseed/managedseed_test.go
@@ -384,6 +384,42 @@ var _ = Describe("ManagedSeed controller test", func() {
 				))
 			}).Should(Succeed())
 		})
+
+		It("should not error and continue to remove the annotations if .spec.secretRef is unset but the seed secret is already deleted ", func() {
+			Eventually(func(g Gomega) {
+				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(managedSeed), managedSeed)).To(Succeed())
+				condition := v1beta1helper.GetCondition(managedSeed.Status.Conditions, seedmanagementv1alpha1.ManagedSeedShootReconciled)
+				g.Expect(condition).NotTo(BeNil())
+				g.Expect(condition.Status).To(Equal(gardencorev1beta1.ConditionTrue))
+				g.Expect(condition.Reason).To(Equal(gardencorev1beta1.EventReconciled))
+			}).Should(Succeed())
+
+			checkIfSeedSecretsCreated()
+			checkIfGardenletWasDeployed()
+
+			Expect(testClient.Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: seedSecretName, Namespace: gardenNamespaceGarden.Name}})).Should(Succeed())
+
+			patch := client.MergeFrom(managedSeed.DeepCopy())
+			gardenletConfig, err := encoding.DecodeGardenletConfiguration(&managedSeed.Spec.Gardenlet.Config, false)
+			Expect(err).NotTo(HaveOccurred())
+			gardenletConfig.SeedConfig.Spec.SecretRef = nil
+			gardenletConfigRaw, err := encoding.EncodeGardenletConfiguration(gardenletConfig)
+			Expect(err).NotTo(HaveOccurred())
+			managedSeed.Spec.Gardenlet.Config = *gardenletConfigRaw
+			// This should be ideally done by the ManagedSeed admission plugin, but it's disabled in the test
+			metav1.SetMetaDataAnnotation(&managedSeed.ObjectMeta, "seedmanagement.gardener.cloud/seed-secret-name", seedSecretName)
+			metav1.SetMetaDataAnnotation(&managedSeed.ObjectMeta, "seedmanagement.gardener.cloud/seed-secret-namespace", gardenNamespaceGarden.Name)
+			Expect(testClient.Patch(ctx, managedSeed, patch)).To(Succeed())
+
+			Eventually(func(g Gomega) {
+				g.Expect(testClient.Get(ctx, client.ObjectKey{Name: seedSecretName, Namespace: gardenNamespaceGarden.Name}, &corev1.Secret{})).Should(BeNotFoundError())
+				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(managedSeed), managedSeed)).To(Succeed())
+				g.Expect(managedSeed.Annotations).NotTo(And(
+					HaveKey("seedmanagement.gardener.cloud/seed-secret-name"),
+					HaveKey("seedmanagement.gardener.cloud/seed-secret-namespace"),
+				))
+			}).Should(Succeed())
+		})
 	})
 
 	Context("deletion", func() {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug

**What this PR does / why we need it**:
With https://github.com/gardener/gardener/pull/8039, we cleanup the seed secret for the managedseed when the `spec.secretRef` is set to nil and then remove the reference annotations from the managedseed.
There is a slight chance, if the controller restarts right after deleting the secret but before removing the annotation, then in the next try it could error when the secret is not found.
```
{"level":"error","ts":"2023-10-26T17:34:13.733Z","msg":"Reconciler error","controller":"managedseed","namespace":"garden","name":"managedseed","reconcileID":"4362718b-9fbc-416c-bcf0-fe1d630d53fb","error":"could not reconcile ManagedSeed garden/managedseed creation or update: could not reconcile seed managedseed secrets: failed getting secret in the managedseed annotations: secrets \"seed-secret\" not found","stacktrace":"sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\tsigs.k8s.io/controller-runtime@v0.16.3/pkg/internal/controller/controller.go:329\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\tsigs.k8s.io/controller-runtime@v0.16.3/pkg/internal/controller/controller.go:266\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2\n\tsigs.k8s.io/controller-runtime@v0.16.3/pkg/internal/controller/controller.go:227"}
```
This PR ignores this `NotFound` error and continues to remove the secretRef annotation from the ManagedSeed if the secret is already gone.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @ialidzhikov @dimitar-kostadinov as reviewers of the original PR

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
A bug causing the managedseed controller to error if the controller restarts and the seed secret is already deleted is now fixed.
```
