### PR TITLE
[Authentication] Technical debt in defaulting code

### DIFF
--- a/pkg/apis/authentication/v1alpha1/defaults_adminkubeconfigrequest.go
+++ b/pkg/apis/authentication/v1alpha1/defaults_adminkubeconfigrequest.go
@@ -18,6 +18,7 @@ package v1alpha1
 
 import (
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/pointer"
 )
 
 func addDefaultingFuncs(scheme *runtime.Scheme) error {
@@ -27,7 +28,6 @@ func addDefaultingFuncs(scheme *runtime.Scheme) error {
 // SetDefaults_AdminKubeconfigRequestSpec sets default values for AdminKubeconfigRequestSpec objects.
 func SetDefaults_AdminKubeconfigRequestSpec(obj *AdminKubeconfigRequestSpec) {
 	if obj.ExpirationSeconds == nil {
-		hour := int64(60 * 60)
-		obj.ExpirationSeconds = &hour
+		obj.ExpirationSeconds = pointer.Int64(60 * 60)
 	}
 }

--- a/pkg/apis/authentication/v1alpha1/defaults_adminkubeconfigrequest.go
+++ b/pkg/apis/authentication/v1alpha1/defaults_adminkubeconfigrequest.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+Copyright 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/apis/authentication/v1alpha1/defaults_adminkubeconfigrequest_test.go
+++ b/pkg/apis/authentication/v1alpha1/defaults_adminkubeconfigrequest_test.go
@@ -24,27 +24,26 @@ import (
 	. "github.com/gardener/gardener/pkg/apis/authentication/v1alpha1"
 )
 
-var _ = Describe("adminKubeconfigRequest defaulting", func() {
+var _ = Describe("AdminKubeconfigRequest defaulting", func() {
 	var obj *AdminKubeconfigRequest
 
 	BeforeEach(func() {
 		obj = &AdminKubeconfigRequest{}
 	})
 
-	Describe("expirationSeconds defaulting", func() {
+	Describe("ExpirationSeconds defaulting", func() {
 		It("should default expirationSeconds field", func() {
 			SetObjectDefaults_AdminKubeconfigRequest(obj)
 
-			Expect(obj.Spec.ExpirationSeconds).To(Equal(pointer.Int64(int64(60 * 60))))
+			Expect(obj.Spec.ExpirationSeconds).To(Equal(pointer.Int64(60 * 60)))
 		})
 
 		It("should not default expirationSeconds field if it is already set", func() {
-			s := int64(10 * 60)
-			obj.Spec.ExpirationSeconds = &s
+			obj.Spec.ExpirationSeconds = pointer.Int64(10 * 60)
 
 			SetObjectDefaults_AdminKubeconfigRequest(obj)
 
-			Expect(obj.Spec.ExpirationSeconds).To(Equal(pointer.Int64(int64(10 * 60))))
+			Expect(obj.Spec.ExpirationSeconds).To(Equal(pointer.Int64(10 * 60)))
 		})
 	})
 })

--- a/pkg/apis/authentication/v1alpha1/defaults_adminkubeconfigrequest_test.go
+++ b/pkg/apis/authentication/v1alpha1/defaults_adminkubeconfigrequest_test.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1_test
+
+import (
+	. "github.com/gardener/gardener/pkg/apis/authentication/v1alpha1"
+	"k8s.io/utils/pointer"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("adminKubeconfigRequest defaulting", func() {
+	var obj *AdminKubeconfigRequest
+
+	BeforeEach(func() {
+		obj = &AdminKubeconfigRequest{}
+	})
+
+	Describe("expirationSeconds defaulting", func() {
+		It("should default expirationSeconds field", func() {
+			SetObjectDefaults_AdminKubeconfigRequest(obj)
+
+			Expect(obj.Spec.ExpirationSeconds).To(Equal(pointer.Int64(int64(60 * 60))))
+		})
+
+		It("should not default expirationSeconds field if it is already set", func() {
+			s := int64(10 * 60)
+			obj.Spec.ExpirationSeconds = &s
+
+			SetObjectDefaults_AdminKubeconfigRequest(obj)
+
+			Expect(obj.Spec.ExpirationSeconds).To(Equal(pointer.Int64(int64(10 * 60))))
+		})
+	})
+})

--- a/pkg/apis/authentication/v1alpha1/defaults_adminkubeconfigrequest_test.go
+++ b/pkg/apis/authentication/v1alpha1/defaults_adminkubeconfigrequest_test.go
@@ -17,11 +17,11 @@ limitations under the License.
 package v1alpha1_test
 
 import (
-	. "github.com/gardener/gardener/pkg/apis/authentication/v1alpha1"
-	"k8s.io/utils/pointer"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"k8s.io/utils/pointer"
+
+	. "github.com/gardener/gardener/pkg/apis/authentication/v1alpha1"
 )
 
 var _ = Describe("adminKubeconfigRequest defaulting", func() {

--- a/pkg/apis/authentication/v1alpha1/v1alpha1_suite_test.go
+++ b/pkg/apis/authentication/v1alpha1/v1alpha1_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1alpha1_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestV1alpha1(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "APIs Authentication V1alpha1 Suite")
+}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind technical-debt

**What this PR does / why we need it**:
This PR cleans up technical debt in our API defaulting code according to https://github.com/gardener/gardener/issues/7312.
This PR tackles the following resources in the API group:
- authentication

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/7312

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
