### PR TITLE
Replace usage of deprecated symbols

### DIFF
--- a/cmd/gardener-apiserver/app/gardener_apiserver.go
+++ b/cmd/gardener-apiserver/app/gardener_apiserver.go
@@ -143,7 +143,7 @@ func NewOptions() *Options {
 		schema.GroupKind{Group: gardencorev1beta1.GroupName},
 	)
 	apiserver.RegisterAllAdmissionPlugins(o.Recommended.Admission.Plugins)
-	o.Recommended.Admission.DefaultOffPlugins = sets.NewString(sets.New[string](plugin.AllPluginNames()...).Difference(plugin.DefaultOnPlugins()).UnsortedList()...)
+	o.Recommended.Admission.DefaultOffPlugins = sets.NewString(sets.List(sets.New(plugin.AllPluginNames()...).Difference(plugin.DefaultOnPlugins()))...)
 	o.Recommended.Admission.RecommendedPluginOrder = plugin.AllPluginNames()
 
 	return o

--- a/cmd/gardener-apiserver/app/gardener_apiserver.go
+++ b/cmd/gardener-apiserver/app/gardener_apiserver.go
@@ -143,7 +143,7 @@ func NewOptions() *Options {
 		schema.GroupKind{Group: gardencorev1beta1.GroupName},
 	)
 	apiserver.RegisterAllAdmissionPlugins(o.Recommended.Admission.Plugins)
-	o.Recommended.Admission.DefaultOffPlugins = sets.NewString(plugin.AllPluginNames()...).Difference(plugin.DefaultOnPlugins())
+	o.Recommended.Admission.DefaultOffPlugins = sets.NewString(sets.New[string](plugin.AllPluginNames()...).Difference(plugin.DefaultOnPlugins()).UnsortedList()...)
 	o.Recommended.Admission.RecommendedPluginOrder = plugin.AllPluginNames()
 
 	return o

--- a/cmd/gardenlet/app/app.go
+++ b/cmd/gardenlet/app/app.go
@@ -506,7 +506,7 @@ func (g *garden) registerSeed(ctx context.Context, gardenClient client.Client) e
 	timeoutCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 
-	return wait.PollUntilWithContext(timeoutCtx, 500*time.Millisecond, func(context.Context) (done bool, err error) {
+	return wait.PollUntilContextCancel(timeoutCtx, 500*time.Millisecond, true, func(context.Context) (done bool, err error) {
 		if err := gardenClient.Get(ctx, kubernetesutils.Key(gardenerutils.ComputeGardenNamespace(g.config.SeedConfig.Name)), &corev1.Namespace{}); err != nil {
 			if apierrors.IsNotFound(err) || apierrors.IsForbidden(err) {
 				return false, nil

--- a/cmd/gardenlet/app/app.go
+++ b/cmd/gardenlet/app/app.go
@@ -506,7 +506,7 @@ func (g *garden) registerSeed(ctx context.Context, gardenClient client.Client) e
 	timeoutCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 
-	return wait.PollUntilContextCancel(timeoutCtx, 500*time.Millisecond, true, func(context.Context) (done bool, err error) {
+	return wait.PollUntilContextCancel(timeoutCtx, 500*time.Millisecond, false, func(context.Context) (done bool, err error) {
 		if err := gardenClient.Get(ctx, kubernetesutils.Key(gardenerutils.ComputeGardenNamespace(g.config.SeedConfig.Name)), &corev1.Namespace{}); err != nil {
 			if apierrors.IsNotFound(err) || apierrors.IsForbidden(err) {
 				return false, nil

--- a/pkg/operation/common/utils.go
+++ b/pkg/operation/common/utils.go
@@ -128,7 +128,7 @@ func waitForLokiPodTermination(ctx context.Context, k8sClient client.Client, nam
 			Namespace: namespace,
 		},
 	}
-	if err := wait.PollUntilWithContext(ctx, 1*time.Second, func(context.Context) (done bool, err error) {
+	if err := wait.PollUntilContextCancel(ctx, 1*time.Second, true, func(context.Context) (done bool, err error) {
 		if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(pod), pod); err != nil {
 			if apierrors.IsNotFound(err) {
 				log.Info("Loki2vali: pod loki-0 not found, continuing with the rename", "lokiNamespace", namespace)
@@ -199,7 +199,7 @@ func deleteLokiPvc(ctx context.Context, k8sClient client.Client, namespace strin
 	defer cancel()
 	deadline, _ := ctx.Deadline()
 
-	if err := wait.PollUntilWithContext(ctx, 1*time.Second, func(context.Context) (done bool, err error) {
+	if err := wait.PollUntilContextCancel(ctx, 1*time.Second, true, func(context.Context) (done bool, err error) {
 		if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(pvc), pvc); err != nil {
 			if apierrors.IsNotFound(err) {
 				log.Info("Loki2vali: Successfully deleted the Loki PVC", "lokiNamespace", namespace)
@@ -298,7 +298,7 @@ func waitForValiPvcToBeBound(ctx context.Context, k8sClient client.Client, names
 	ctx, cancel := context.WithDeadline(ctx, time.Now().Add(1*time.Minute))
 	defer cancel()
 	deadline, _ := ctx.Deadline()
-	if err := wait.PollUntilWithContext(ctx, 1*time.Second, func(context.Context) (done bool, err error) {
+	if err := wait.PollUntilContextCancel(ctx, 1*time.Second, true, func(context.Context) (done bool, err error) {
 		if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(valiPvc), valiPvc); err != nil {
 			if apierrors.IsNotFound(err) {
 				log.Info("Loki2vali: Vali PVC is not yet created", "lokiNamespace", namespace, "lokiError", err)

--- a/pkg/operation/common/utils.go
+++ b/pkg/operation/common/utils.go
@@ -139,7 +139,7 @@ func waitForLokiPodTermination(ctx context.Context, k8sClient client.Client, nam
 		}
 		log.Info("Loki2vali: Waiting for pod loki-0 to terminate", "lokiNamespace", namespace, "timeLeft", time.Until(deadline))
 		return false, nil
-	}); err != nil && err == wait.ErrWaitTimeout {
+	}); wait.Interrupted(err) {
 		err := fmt.Errorf("Loki2vali: %v: Timeout while waiting for the loki-0 pod to terminate", namespace)
 		log.Info("Loki2vali:", "lokiError", err)
 		return err
@@ -210,7 +210,7 @@ func deleteLokiPvc(ctx context.Context, k8sClient client.Client, namespace strin
 		}
 		log.Info("Loki2vali: Wait for Loki PVC deletion to complete", "lokiNamespace", namespace, "timeLeft", time.Until(deadline))
 		return false, nil
-	}); err != nil && err == wait.ErrWaitTimeout {
+	}); wait.Interrupted(err) {
 		err := fmt.Errorf("Loki2vali: %v: Timeout while waiting for the loki-loki-0 PVC to terminate", namespace)
 		log.Info("Loki2vali:", "lokiError", err)
 		return err
@@ -317,7 +317,7 @@ func waitForValiPvcToBeBound(ctx context.Context, k8sClient client.Client, names
 		}
 		log.Info("Loki2vali: Wait for the Vali PVC to be bound", "lokiNamespace", namespace, "timeLeft", time.Until(deadline))
 		return false, nil
-	}); err != nil && err == wait.ErrWaitTimeout {
+	}); wait.Interrupted(err) {
 		err := fmt.Errorf("Loki2vali: %v: Timeout while waiting for the vali PVC to be bound", namespace)
 		log.Info("Loki2vali:", "lokiError", err)
 		return err

--- a/pkg/utils/kubernetes/health/daemonset.go
+++ b/pkg/utils/kubernetes/health/daemonset.go
@@ -31,7 +31,7 @@ func daemonSetMaxUnavailable(daemonSet *appsv1.DaemonSet) int32 {
 		return 0
 	}
 
-	maxUnavailable, err := intstr.GetValueFromIntOrPercent(rollingUpdate.MaxUnavailable, int(daemonSet.Status.DesiredNumberScheduled), false)
+	maxUnavailable, err := intstr.GetScaledValueFromIntOrPercent(rollingUpdate.MaxUnavailable, int(daemonSet.Status.DesiredNumberScheduled), false)
 	if err != nil {
 		return 0
 	}

--- a/pkg/utils/test/matchers/kubernetes_errors_test.go
+++ b/pkg/utils/test/matchers/kubernetes_errors_test.go
@@ -33,7 +33,7 @@ var _ = Describe("BeNotFoundError", func() {
 	})
 
 	It("should be false when error is not k8s not found error", func() {
-		err := apierrors.NewGone("opsie")
+		err := apierrors.NewResourceExpired("opsie")
 		Expect(err).ToNot(BeNotFoundError())
 	})
 
@@ -61,7 +61,7 @@ var _ = Describe("BeAlreadyExistsError", func() {
 	})
 
 	It("should be false when error is not k8s AlreadyExists error", func() {
-		err := apierrors.NewGone("opsie")
+		err := apierrors.NewResourceExpired("opsie")
 		Expect(err).ToNot(BeAlreadyExistsError())
 	})
 
@@ -89,7 +89,7 @@ var _ = Describe("BeForbiddenError", func() {
 	})
 
 	It("should be false when error is not k8s forbidden", func() {
-		err := apierrors.NewGone("opsie")
+		err := apierrors.NewResourceExpired("opsie")
 		Expect(err).ToNot(BeForbiddenError())
 	})
 
@@ -117,7 +117,7 @@ var _ = Describe("BeBadRequestError", func() {
 	})
 
 	It("should be false when error is not k8s bad request", func() {
-		err := apierrors.NewGone("opsie")
+		err := apierrors.NewResourceExpired("opsie")
 		Expect(err).ToNot(BeBadRequestError())
 	})
 
@@ -147,7 +147,7 @@ var _ = Describe("BeNoMatchError", func() {
 	})
 
 	It("should be false when error is not a NoKindMatch", func() {
-		err := apierrors.NewGone("opsie")
+		err := apierrors.NewResourceExpired("opsie")
 		Expect(err).ToNot(BeNoMatchError())
 	})
 

--- a/plugin/pkg/plugins.go
+++ b/plugin/pkg/plugins.go
@@ -111,8 +111,8 @@ func AllPluginNames() []string {
 }
 
 // DefaultOnPlugins is the set of admission plugins that are enabled by default.
-func DefaultOnPlugins() sets.String {
-	return sets.NewString(
+func DefaultOnPlugins() sets.Set[string] {
+	return sets.New[string](
 		lifecycle.PluginName,                      // NamespaceLifecycle
 		PluginNameResourceReferenceManager,        // ResourceReferenceManager
 		PluginNameExtensionValidator,              // ExtensionValidator


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind cleanup

**What this PR does / why we need it**:
Replace usage of deprecated symbols

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
