### PR TITLE
Return all ControllerRegistration names referring a ControllerDeployment

### DIFF
--- a/docs/api-reference/core.md
+++ b/docs/api-reference/core.md
@@ -3547,7 +3547,7 @@ An empty list means that all seeds are selected.</p>
 </td>
 <td>
 <em>(Optional)</em>
-<p>DeploymentRefs holds references to <code>ControllerDeployments</code>. Only one element is support now.</p>
+<p>DeploymentRefs holds references to <code>ControllerDeployments</code>. Only one element is supported currently.</p>
 </td>
 </tr>
 </tbody>

--- a/pkg/apis/core/types_controllerregistration.go
+++ b/pkg/apis/core/types_controllerregistration.go
@@ -94,7 +94,7 @@ type ControllerRegistrationDeployment struct {
 	// considered for a deployment.
 	// An empty list means that all seeds are selected.
 	SeedSelector *metav1.LabelSelector
-	// DeploymentRefs holds references to `ControllerDeployments`. Only one element is support now.
+	// DeploymentRefs holds references to `ControllerDeployments`. Only one element is supported currently.
 	DeploymentRefs []DeploymentRef
 }
 

--- a/pkg/apis/core/v1beta1/generated.proto
+++ b/pkg/apis/core/v1beta1/generated.proto
@@ -553,7 +553,7 @@ message ControllerRegistrationDeployment {
   // +optional
   optional k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector seedSelector = 4;
 
-  // DeploymentRefs holds references to `ControllerDeployments`. Only one element is support now.
+  // DeploymentRefs holds references to `ControllerDeployments`. Only one element is supported currently.
   // +optional
   repeated DeploymentRef deploymentRefs = 5;
 }

--- a/pkg/apis/core/v1beta1/types_controllerregistration.go
+++ b/pkg/apis/core/v1beta1/types_controllerregistration.go
@@ -104,7 +104,7 @@ type ControllerRegistrationDeployment struct {
 	// An empty list means that all seeds are selected.
 	// +optional
 	SeedSelector *metav1.LabelSelector `json:"seedSelector,omitempty" protobuf:"bytes,4,opt,name=seedSelector"`
-	// DeploymentRefs holds references to `ControllerDeployments`. Only one element is support now.
+	// DeploymentRefs holds references to `ControllerDeployments`. Only one element is supported currently.
 	// +optional
 	DeploymentRefs []DeploymentRef `json:"deploymentRefs,omitempty" protobuf:"bytes,5,opt,name=deploymentRefs"`
 }

--- a/pkg/controllermanager/controller/controllerregistration/controllerregistrationfinalizer/reconciler_test.go
+++ b/pkg/controllermanager/controller/controllerregistration/controllerregistrationfinalizer/reconciler_test.go
@@ -115,11 +115,15 @@ var _ = Describe("ControllerRegistration", func() {
 					},
 				}
 
+				controllerInstallation2 := controllerInstallation.DeepCopy()
+				controllerInstallation2.Name = "controllerInstallation-2"
+
 				Expect(c.Create(ctx, controllerInstallation)).To(Succeed())
+				Expect(c.Create(ctx, controllerInstallation2)).To(Succeed())
 
 				result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: controllerRegistrationName}})
 				Expect(result).To(Equal(reconcile.Result{}))
-				Expect(err).To(MatchError(ContainSubstring("cannot remove finalizer of ControllerRegistration %q because still found ControllerInstallations: [%s]", controllerRegistration.Name, controllerInstallation.Name)))
+				Expect(err).To(MatchError(ContainSubstring("cannot remove finalizer of ControllerRegistration %q because still found ControllerInstallations: [%s %s]", controllerRegistration.Name, controllerInstallation.Name, controllerInstallation2.Name)))
 			})
 
 			It("should remove the finalizer", func() {

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -2223,7 +2223,7 @@ func schema_pkg_apis_core_v1beta1_ControllerRegistrationDeployment(ref common.Re
 					},
 					"deploymentRefs": {
 						SchemaProps: spec.SchemaProps{
-							Description: "DeploymentRefs holds references to `ControllerDeployments`. Only one element is support now.",
+							Description: "DeploymentRefs holds references to `ControllerDeployments`. Only one element is supported currently.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{

--- a/test/framework/k8s_utils.go
+++ b/test/framework/k8s_utils.go
@@ -277,7 +277,7 @@ func DeleteAndWaitForResource(ctx context.Context, k8sClient kubernetes.Interfac
 			}
 			return retry.MinorError(err)
 		}
-		return retry.MinorError(errors.New("Object still exists"))
+		return retry.MinorError(errors.New("object still exists"))
 	})
 }
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind enhancement

**What this PR does / why we need it**:
The controller registration was getting printed wrongly in the error.
Moreover it would be beneficial to print all the controllerRegistration names instead of the first one.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
