### PR TITLE
Add `node-local-dns` enablement to rolling update trigger docs

### DIFF
--- a/docs/usage/node-local-dns.md
+++ b/docs/usage/node-local-dns.md
@@ -45,6 +45,7 @@ It is worth noting that:
 - During the reconfiguration of the node-local-dns there might be a short disruption in terms of domain name resolution depending on the setup. Usually, DNS requests are repeated for some time as UDP is an unreliable protocol, but that strictly depends on the application/way the domain name resolution happens. It is recommended to let the shoot be reconciled during the next maintenance period. 
 - If a short DNS outage is not a big issue, you can [trigger reconciliation](./shoot_operations.md#immediate-reconciliation) directly after setting the annotation.
 - Switching node-local-dns off by removing the annotation can be a rather destructive operation that will result in pods without a working DNS configuration.
+- Enabling or disabling node-local-dns triggers a rollout of all shoot worker nodes, see also [this document](shoot_updates.md#rolling-update-triggers).
 
 For more information about `node-local-dns`, please refer to the [KEP](https://github.com/kubernetes/enhancements/blob/master/keps/sig-network/1024-nodelocal-cache-dns/README.md) or to the [usage documentation](https://kubernetes.io/docs/tasks/administer-cluster/nodelocaldns/). 
 

--- a/docs/usage/node-local-dns.md
+++ b/docs/usage/node-local-dns.md
@@ -39,12 +39,9 @@ spec:
 
 It is worth noting that: 
 
-- When migrating from IPVS to IPTables, existing pods will continue to leverage the node-local-dns cache. 
+- When migrating from IPVS to IPTables, existing pods will continue to leverage the node-local-dns cache.
 - When migrating from IPtables to IPVS, only newer pods will be switched to the node-local-dns cache.
-- The annotation will take effect during the next shoot reconciliation. This happens automatically once per day in the maintenance period (unless you have disabled it). 
-- During the reconfiguration of the node-local-dns there might be a short disruption in terms of domain name resolution depending on the setup. Usually, DNS requests are repeated for some time as UDP is an unreliable protocol, but that strictly depends on the application/way the domain name resolution happens. It is recommended to let the shoot be reconciled during the next maintenance period. 
-- If a short DNS outage is not a big issue, you can [trigger reconciliation](./shoot_operations.md#immediate-reconciliation) directly after setting the annotation.
-- Switching node-local-dns off by removing the annotation can be a rather destructive operation that will result in pods without a working DNS configuration.
+- During the reconfiguration of the node-local-dns there might be a short disruption in terms of domain name resolution depending on the setup. Usually, DNS requests are repeated for some time as UDP is an unreliable protocol, but that strictly depends on the application/way the domain name resolution happens. It is recommended to let the shoot be reconciled during the next maintenance period.
 - Enabling or disabling node-local-dns triggers a rollout of all shoot worker nodes, see also [this document](shoot_updates.md#rolling-update-triggers).
 
 For more information about `node-local-dns`, please refer to the [KEP](https://github.com/kubernetes/enhancements/blob/master/keps/sig-network/1024-nodelocal-cache-dns/README.md) or to the [usage documentation](https://kubernetes.io/docs/tasks/administer-cluster/nodelocaldns/). 

--- a/docs/usage/shoot_updates.md
+++ b/docs/usage/shoot_updates.md
@@ -85,6 +85,7 @@ The complete list of fields that trigger a rolling update:
 * `.spec.provider.workers[].providerConfig`
 * `.spec.provider.workers[].cri.name`
 * `.spec.provider.workers[].kubernetes.version` (except for patch version changes)
+* `.spec.systemComponents.nodeLocalDNS.enabled`
 * `.status.credentials.rotation.certificateAuthorities.lastInitiationTime` (changed by Gardener when a shoot CA rotation is initiated)
 * `.status.credentials.rotation.serviceAccountKey.lastInitiationTime` (changed by Gardener when a shoot service account signing key rotation is initiated)
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area documentation
/kind enhancement

**What this PR does / why we need it**:
Add `node-local-dns` enablement to rolling update trigger docs

**Special notes for your reviewer**:
/cc @ScheererJ 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
