### PR TITLE
Add `etcd-backup` secret BackupEntry name annotation

### DIFF
--- a/extensions/pkg/controller/backupentry/genericactuator/actuator_test.go
+++ b/extensions/pkg/controller/backupentry/genericactuator/actuator_test.go
@@ -22,7 +22,6 @@ import (
 	. "github.com/onsi/gomega"
 	"go.uber.org/mock/gomock"
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -35,6 +34,7 @@ import (
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	mockmanager "github.com/gardener/gardener/pkg/mock/controller-runtime/manager"
+	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 )
 
 const (
@@ -133,7 +133,7 @@ var _ = Describe("Actuator", func() {
 
 		It("shouldn't delete secret if has annotation with different BE name", func() {
 			etcdBackupSecret.Annotations = map[string]string{
-				genericactuator.BackupentryName: "foo",
+				genericactuator.AnnotationKeyCreatedByBackupEntry: "foo",
 			}
 			// Create mock values provider
 			client = fakeclient.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(seedNamespace, beSecret, etcdBackupSecret).Build()
@@ -156,7 +156,7 @@ var _ = Describe("Actuator", func() {
 
 		It("should delete secret if it has anntation whith same BE name", func() {
 			etcdBackupSecret.Annotations = map[string]string{
-				genericactuator.BackupentryName: be.Name,
+				genericactuator.AnnotationKeyCreatedByBackupEntry: be.Name,
 			}
 			// Create mock values provider
 			client = fakeclient.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(seedNamespace, beSecret, etcdBackupSecret).Build()
@@ -174,8 +174,7 @@ var _ = Describe("Actuator", func() {
 
 			deployedSecret := &corev1.Secret{}
 			err = client.Get(context.TODO(), etcdBackupSecretKey, deployedSecret)
-			Expect(err).To(HaveOccurred())
-			Expect(apierrors.IsNotFound(err)).To(Equal(true))
+			Expect(err).To(BeNotFoundError())
 		})
 
 		It("should delete secret if it has no annotations", func() {
@@ -195,8 +194,7 @@ var _ = Describe("Actuator", func() {
 
 			deployedSecret := &corev1.Secret{}
 			err = client.Get(context.TODO(), etcdBackupSecretKey, deployedSecret)
-			Expect(err).To(HaveOccurred())
-			Expect(apierrors.IsNotFound(err)).To(Equal(true))
+			Expect(err).To(BeNotFoundError())
 		})
 	})
 
@@ -222,7 +220,7 @@ var _ = Describe("Actuator", func() {
 				err = client.Get(context.TODO(), etcdBackupSecretKey, deployedSecret)
 				Expect(err).NotTo(HaveOccurred())
 				etcdBackupSecret.Annotations = map[string]string{
-					genericactuator.BackupentryName: be.Name,
+					genericactuator.AnnotationKeyCreatedByBackupEntry: be.Name,
 				}
 				Expect(deployedSecret).To(Equal(etcdBackupSecret))
 			})
@@ -245,7 +243,7 @@ var _ = Describe("Actuator", func() {
 
 				deployedSecret := &corev1.Secret{}
 				err = client.Get(context.TODO(), etcdBackupSecretKey, deployedSecret)
-				Expect(apierrors.IsNotFound(err)).To(Equal(true))
+				Expect(err).To(BeNotFoundError())
 			})
 		})
 	})


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area quality
  /area bug
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
  /area quality
  /area bug

**What this PR does / why we need it**:
1. When `extensions.gardener.cloud/v1alpha1.BackupEntry` gets reconciled it adds `backup.gardener.cloud/created-by` annotation to `etcd-backup` secret that links the secret to the corresponding BackupEntry
2. When `extensions.gardener.cloud/v1alpha1.BackupEntry` gets deleted it only deletes `backup.gardener.cloud/created-by` secret if any of the following is true
    - it is not annotated with `backup.gardener.cloud/created-by`
    - it is annotated with `backup.gardener.cloud/created-by` with value matching the name of the BackupEntry being deleted

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener/issues/8675

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
An issue causing the `etcd-backup` Secret to be wrongly deleted for a Shoot cluster due to stale BackupEntry deletion from a previous Shoot creation with the same name is now fixed.
```
