### PR TITLE
Enables `node-exporter`'s `textfile` collector

### DIFF
--- a/docs/development/monitoring-stack.md
+++ b/docs/development/monitoring-stack.md
@@ -30,6 +30,8 @@ The alerts for all Shoot clusters hosted on a Seed are routed to a central Alert
 
 The Alertmanager in the Shoot namespace on the Seed is only responsible for forwarding alerts from its Shoot cluster to a cluster owner/cluster alert receiver via email. The Alertmanager is optional and the conditions for a deployment are already described in [Alerting](../monitoring/alerting.md).
 
+The node-exporter's [textfile collector](https://github.com/prometheus/node_exporter#textfile-collector) is enabled and configured to parse all `*.prom` files in the `/var/lib/node-exporter/textfile-collector` directory on each Shoot node. Scripts and programs which run on Shoot nodes and cannot expose an endpoint to be scraped by prometheus can use this directory to export metrics in files that match the glob `*.prom` using the [text format](https://prometheus.io/docs/instrumenting/exposition_formats/).
+
 ## Adding New Monitoring Targets
 
 After exploring the metrics which your component provides or adding new metrics, you should be aware which metrics are required to write the needed alerts and dashboards.

--- a/pkg/component/nodeexporter/nodeexporter.go
+++ b/pkg/component/nodeexporter/nodeexporter.go
@@ -54,6 +54,10 @@ const (
 	portMetrics         = int32(16909)
 	volumeNameHost      = "host"
 	volumeMountPathHost = "/host"
+
+	volumeNameTextFileCollector      = "textfile"
+	volumeMountPathTextFileCollector = "/textfile-collector"
+	hostPathTextFileCollector        = "/var/lib/node-exporter/textfile-collector"
 )
 
 // Interface contains functions for a node-exporter deployer.
@@ -226,6 +230,8 @@ func (n *nodeExporter) computeResourcesData() (map[string][]byte, error) {
 									"--collector.uname",
 									"--collector.stat",
 									"--collector.pressure",
+									"--collector.textfile",
+									fmt.Sprintf("--collector.textfile.directory=%s", volumeMountPathTextFileCollector),
 								},
 								Ports: []corev1.ContainerPort{
 									{
@@ -270,6 +276,11 @@ func (n *nodeExporter) computeResourcesData() (map[string][]byte, error) {
 										ReadOnly:  true,
 										MountPath: volumeMountPathHost,
 									},
+									{
+										Name:      volumeNameTextFileCollector,
+										ReadOnly:  true,
+										MountPath: volumeMountPathTextFileCollector,
+									},
 								},
 							},
 						},
@@ -279,6 +290,14 @@ func (n *nodeExporter) computeResourcesData() (map[string][]byte, error) {
 								VolumeSource: corev1.VolumeSource{
 									HostPath: &corev1.HostPathVolumeSource{
 										Path: "/",
+									},
+								},
+							},
+							{
+								Name: volumeNameTextFileCollector,
+								VolumeSource: corev1.VolumeSource{
+									HostPath: &corev1.HostPathVolumeSource{
+										Path: hostPathTextFileCollector,
 									},
 								},
 							},

--- a/pkg/component/nodeexporter/nodeexporter_test.go
+++ b/pkg/component/nodeexporter/nodeexporter_test.go
@@ -155,6 +155,8 @@ spec:
         - --collector.uname
         - --collector.stat
         - --collector.pressure
+        - --collector.textfile
+        - --collector.textfile.directory=/textfile-collector
         image: some-image:some-tag
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -185,6 +187,9 @@ spec:
         - mountPath: /host
           name: host
           readOnly: true
+        - mountPath: /textfile-collector
+          name: textfile
+          readOnly: true
       hostNetwork: true
       hostPID: true
       priorityClassName: system-cluster-critical
@@ -203,6 +208,9 @@ spec:
       - hostPath:
           path: /
         name: host
+      - hostPath:
+          path: /var/lib/node-exporter/textfile-collector
+        name: textfile
   updateStrategy:
     type: RollingUpdate
 status:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind enhancement

**What this PR does / why we need it**:
This PR enables the `node-exporter`'s [textfile collector](https://github.com/prometheus/node_exporter#textfile-collector) and configures it so that it will parse files that match the `*.prom` glob from the `/var/lib/node-exporter/textfile-collector` directory on shoot nodes.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
I decided to add a volume mount for the `/var/lib/node-exporter/textfile-collector` directory because this will automatically create it. The `node-exporter` currently does not create the directory specified in the `--collector.textfile.directory` flag.
A different option would be to use an init container to create the directory passed to `--collector.textfile.directory`

/cc @rickardsjp @istvanballok 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Enabled the `node-exporter`'s  [textfile collector](https://github.com/prometheus/node_exporter#textfile-collector). It will parse files matching the `*.prom` glob in the `/var/lib/node-exporter/textfile-collector` directory and load metrics from them so that they can be scraped by prometheus.
```
