### PR TITLE
Fix flaking seed e2e test

### DIFF
--- a/example/gardener-local/gardenlet/values-kind2-ha-single-zone.yaml
+++ b/example/gardener-local/gardenlet/values-kind2-ha-single-zone.yaml
@@ -22,6 +22,8 @@ config:
   seedConfig:
     metadata:
       name: local2-ha-single-zone
+      labels:
+        base: kind2
     spec:
       ingress:
         domain: ingress.local2-ha-single-zone.seed.local.gardener.cloud

--- a/example/gardener-local/gardenlet/values-kind2.yaml
+++ b/example/gardener-local/gardenlet/values-kind2.yaml
@@ -26,6 +26,8 @@ config:
   seedConfig:
     metadata:
       name: local2
+      labels:
+        base: kind2
     spec:
       ingress:
         domain: ingress.local2.seed.local.gardener.cloud

--- a/example/gardener-local/gardenlet/values.yaml
+++ b/example/gardener-local/gardenlet/values.yaml
@@ -67,6 +67,8 @@ config:
     kind: Seed
     metadata:
       name: local
+      labels:
+        base: kind
     spec:
       backup:
         provider: local

--- a/test/e2e/gardener/seed/renew_garden_access_secrets.go
+++ b/test/e2e/gardener/seed/renew_garden_access_secrets.go
@@ -44,9 +44,9 @@ var _ = Describe("Seed Tests", Label("Seed", "default"), func() {
 		)
 
 		BeforeEach(func() {
-			// find the first seed (seed name differs between test scenarios, e.g., non-ha/ha)
+			// find seed for kind cluster based on label (seed name differs between test scenarios, e.g., non-ha/ha)
 			seedList := &gardencorev1beta1.SeedList{}
-			Expect(testClient.List(ctx, seedList, client.Limit(1))).To(Succeed())
+			Expect(testClient.List(ctx, seedList, client.MatchingLabels{"base": "kind"}, client.Limit(1))).To(Succeed())
 			seed = seedList.Items[0].DeepCopy()
 
 			seedNamespace = gardenerutils.ComputeGardenNamespace(seed.Name)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind flake

**What this PR does / why we need it**:
This PR fixes a flake in the e2e seed test, see for example:

- https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/8726/pull-gardener-e2e-kind/1718731959233941504#1:build-log.txt%3A1568
- https://prow.gardener.cloud/view/gs/gardener-prow/logs/ci-gardener-e2e-kind/1718471943717392384#1:build-log.txt%3A669
- https://prow.gardener.cloud/view/gs/gardener-prow/logs/ci-gardener-e2e-kind/1717384769391562752#1:build-log.txt%3A679

The error message says

> "serviceaccounts \"test-85c52e64\" is forbidden: User \"system:serviceaccount:seed-local:test-85c52e64\" cannot get resource \"serviceaccounts\" in API group \"\" in the namespace \"seed-e2e-managedseed\"",

The `ServiceAccount` in namespace `seed-local` may not read `ServiceAccount`s in the `e2e-managedseed` namespace. This is correct - the test is buggy.

The [garden access secret](https://github.com/gardener/gardener/blob/master/test/e2e/gardener/seed/renew_garden_access_secrets.go#L56-L68) will always be created in the base cluster, i.e., in the kind cluster created via `make kind-up`. However, the `Seed` retrieved via https://github.com/gardener/gardener/blob/93e7b0936cab2a78242d98a5bb9d1564e871fa0a/test/e2e/gardener/seed/renew_garden_access_secrets.go#L47-L50 may not necessarily be the correct `Seed` for this kind cluster - when the `ManagedSeed` e2e runs, this could also return the name of the `Seed` related to the `ManagedSeed`.

**Special notes for your reviewer**:
/cc @timuthy 
Thanks again for the collaboration :)

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
