### PR TITLE
Improve condition handling for `ManagedSeed`s

### DIFF
--- a/hack/tools/image/README.md
+++ b/hack/tools/image/README.md
@@ -2,7 +2,9 @@
 
 ## Motivation
 
-There are lots flakes in our tests because the download of binaries like `yq` from github.com fails. Thus, we created the `golang-test` image which contains the content of `./hack/tools/bin` directory. These are downloaded binaries like `yq`, `skaffold`, `helm` and Go binaries. This will also speed up the tests a bit, because the binaries does not have to be downloaded anymore and the Go based test tools does not have to be compiled on every test run.
+There were many flakes in our tests when downloads of binaries like `yq` failed from https://github.com.
+Thus, we created the `golang-test` image which contains the content of `./hack/tools/bin` directory. It already contains tools like `yq`, `skaffold`, `helm` and Go binaries.
+This slightly speeds up the tests, because required binaries do not have to be downloaded and a compilation of Go based test tools is not required anymore on every test run.
 
 ## Usage
 
@@ -12,4 +14,4 @@ Before running tests, binaries could be imported by `make import-tools-bin`. If 
 
 In case some binaries are updated and not part of the `golang-test` image yet, the tests can still succeed. Each binary has a `.version_...` file in `./hack/tools/bin` directory. If the version file is outdated or does not exist yet, the respective binary is downloaded anyway while the test is executed.
 
-`golang-test` image is used to run our unit and integration tests. Additionally, it is the base image of our [krte](https://github.com/gardener/ci-infra/tree/master/images/krte) image, we use to run our e2e tests. When a new `golang-test` image was built, prow automatically builds the corresponding `krte` image.
+`golang-test` image is used to run our unit and integration tests. Additionally, it is the base image of our [krte](https://github.com/gardener/ci-infra/tree/master/images/krte) image, we use to run e2e tests with. When a new `golang-test` image was built, prow automatically builds the corresponding `krte` image.

--- a/pkg/apis/core/v1beta1/helper/condition.go
+++ b/pkg/apis/core/v1beta1/helper/condition.go
@@ -21,6 +21,7 @@ import (
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/utils/clock"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
@@ -174,6 +175,20 @@ func RemoveConditions(conditions []gardencorev1beta1.Condition, conditionTypes .
 	var newConditions []gardencorev1beta1.Condition
 	for _, condition := range conditions {
 		if _, ok := conditionTypesMap[condition.Type]; !ok {
+			newConditions = append(newConditions, condition)
+		}
+	}
+
+	return newConditions
+}
+
+// RetainConditions retains all given conditionsTypes from the given conditions slice.
+func RetainConditions(conditions []gardencorev1beta1.Condition, conditionTypes ...gardencorev1beta1.ConditionType) []gardencorev1beta1.Condition {
+	wantedConditionsTypes := sets.New(conditionTypes...)
+
+	var newConditions []gardencorev1beta1.Condition
+	for _, condition := range conditions {
+		if wantedConditionsTypes.Has(condition.Type) {
 			newConditions = append(newConditions, condition)
 		}
 	}

--- a/pkg/apis/core/v1beta1/helper/condition.go
+++ b/pkg/apis/core/v1beta1/helper/condition.go
@@ -167,14 +167,11 @@ func MergeConditions(oldConditions []gardencorev1beta1.Condition, newConditions 
 
 // RemoveConditions removes the conditions with the given types from the given conditions slice.
 func RemoveConditions(conditions []gardencorev1beta1.Condition, conditionTypes ...gardencorev1beta1.ConditionType) []gardencorev1beta1.Condition {
-	conditionTypesMap := make(map[gardencorev1beta1.ConditionType]struct{}, len(conditionTypes))
-	for _, conditionType := range conditionTypes {
-		conditionTypesMap[conditionType] = struct{}{}
-	}
+	unwantedConditionTypes := sets.New(conditionTypes...)
 
 	var newConditions []gardencorev1beta1.Condition
 	for _, condition := range conditions {
-		if _, ok := conditionTypesMap[condition.Type]; !ok {
+		if !unwantedConditionTypes.Has(condition.Type) {
 			newConditions = append(newConditions, condition)
 		}
 	}

--- a/pkg/apis/core/v1beta1/helper/condition_test.go
+++ b/pkg/apis/core/v1beta1/helper/condition_test.go
@@ -457,6 +457,21 @@ var _ = Describe("Condition", func() {
 		Entry("remove from an empty slice", nil, []gardencorev1beta1.ConditionType{"foo"}, nil),
 	)
 
+	DescribeTable("#RetainConditions",
+		func(conditions []gardencorev1beta1.Condition, conditionTypes []gardencorev1beta1.ConditionType, expectedResult []gardencorev1beta1.Condition) {
+			Expect(RetainConditions(conditions, conditionTypes...)).To(Equal(expectedResult))
+		},
+		Entry("remove foo", []gardencorev1beta1.Condition{{Type: "foo"}, {Type: "bar"}}, []gardencorev1beta1.ConditionType{"bar"},
+			[]gardencorev1beta1.Condition{{Type: "bar"}}),
+		Entry("remove bar", []gardencorev1beta1.Condition{{Type: "foo"}, {Type: "bar"}}, []gardencorev1beta1.ConditionType{"foo"},
+			[]gardencorev1beta1.Condition{{Type: "foo"}}),
+		Entry("remove anything", []gardencorev1beta1.Condition{{Type: "foo"}, {Type: "bar"}}, nil,
+			nil),
+		Entry("don't remove anything", []gardencorev1beta1.Condition{{Type: "foo"}, {Type: "bar"}}, []gardencorev1beta1.ConditionType{"foo", "bar"},
+			[]gardencorev1beta1.Condition{{Type: "foo"}, {Type: "bar"}}),
+		Entry("remove from an empty slice", nil, []gardencorev1beta1.ConditionType{"foo"}, nil),
+	)
+
 	Describe("#NewConditionOrError", func() {
 		It("should return the condition", func() {
 			condition := gardencorev1beta1.Condition{Type: "foo"}

--- a/pkg/controllermanager/controller/seed/lifecycle/reconciler.go
+++ b/pkg/controllermanager/controller/seed/lifecycle/reconciler.go
@@ -33,6 +33,7 @@ import (
 	"github.com/gardener/gardener/pkg/controllermanager/apis/config"
 	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/utils/flow"
+	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 )
 
@@ -173,21 +174,14 @@ func setShootStatusToUnknown(ctx context.Context, clock clock.Clock, c client.St
 		reason = "StatusUnknown"
 		msg    = "Gardenlet stopped sending heartbeats."
 
-		conditions = map[gardencorev1beta1.ConditionType]gardencorev1beta1.Condition{
-			gardencorev1beta1.ShootAPIServerAvailable:             {},
-			gardencorev1beta1.ShootControlPlaneHealthy:            {},
-			gardencorev1beta1.ShootObservabilityComponentsHealthy: {},
-			gardencorev1beta1.ShootEveryNodeReady:                 {},
-			gardencorev1beta1.ShootSystemComponentsHealthy:        {},
-		}
-
+		conditions  = make(map[gardencorev1beta1.ConditionType]gardencorev1beta1.Condition)
 		constraints = map[gardencorev1beta1.ConditionType]gardencorev1beta1.Condition{
 			gardencorev1beta1.ShootHibernationPossible:               {},
 			gardencorev1beta1.ShootMaintenancePreconditionsSatisfied: {},
 		}
 	)
 
-	for conditionType := range conditions {
+	for _, conditionType := range gardenerutils.GetShootConditionTypes(false) {
 		c := v1beta1helper.GetOrInitConditionWithClock(clock, shoot.Status.Conditions, conditionType)
 		c = v1beta1helper.UpdatedConditionWithClock(clock, c, gardencorev1beta1.ConditionUnknown, reason, msg)
 		conditions[conditionType] = c

--- a/pkg/controllermanager/controller/shoot/conditions/reconciler.go
+++ b/pkg/controllermanager/controller/shoot/conditions/reconciler.go
@@ -27,6 +27,7 @@ import (
 	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	"github.com/gardener/gardener/pkg/controllermanager/apis/config"
 	"github.com/gardener/gardener/pkg/controllerutils"
+	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 )
 
@@ -62,13 +63,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	// First remove all existing seed conditions and then add the current seed conditions if the shoot is still registered as seed.
 	// The list of shoot conditions is well known (see contract https://github.com/gardener/gardener/blob/master/docs/extensions/shoot-health-status-conditions.md)
 	// as opposed to seed conditions. Thus, subtract all shoot conditions to filter out the seed conditions.
-	shootConditions := []gardencorev1beta1.ConditionType{
-		gardencorev1beta1.ShootAPIServerAvailable,
-		gardencorev1beta1.ShootControlPlaneHealthy,
-		gardencorev1beta1.ShootObservabilityComponentsHealthy,
-		gardencorev1beta1.ShootSystemComponentsHealthy,
-		gardencorev1beta1.ShootEveryNodeReady,
-	}
+	shootConditions := gardenerutils.GetShootConditionTypes(false)
 
 	conditions := v1beta1helper.RetainConditions(shoot.Status.Conditions, shootConditions...)
 	if seed != nil {

--- a/pkg/controllermanager/controller/shoot/conditions/reconciler.go
+++ b/pkg/controllermanager/controller/shoot/conditions/reconciler.go
@@ -59,15 +59,18 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	}
 
 	// Build new shoot conditions
-	// First remove all existing seed conditions and then add the current seed conditions
-	// if the shoot is still registered as seed
-	seedConditionTypes := []gardencorev1beta1.ConditionType{
-		gardencorev1beta1.SeedBackupBucketsReady,
-		gardencorev1beta1.SeedExtensionsReady,
-		gardencorev1beta1.SeedGardenletReady,
-		gardencorev1beta1.SeedSystemComponentsHealthy,
+	// First remove all existing seed conditions and then add the current seed conditions if the shoot is still registered as seed.
+	// The list of shoot conditions is well known (see contract https://github.com/gardener/gardener/blob/master/docs/extensions/shoot-health-status-conditions.md)
+	// as opposed to seed conditions. Thus, subtract all shoot conditions to filter out the seed conditions.
+	shootConditions := []gardencorev1beta1.ConditionType{
+		gardencorev1beta1.ShootAPIServerAvailable,
+		gardencorev1beta1.ShootControlPlaneHealthy,
+		gardencorev1beta1.ShootObservabilityComponentsHealthy,
+		gardencorev1beta1.ShootSystemComponentsHealthy,
+		gardencorev1beta1.ShootEveryNodeReady,
 	}
-	conditions := v1beta1helper.RemoveConditions(shoot.Status.Conditions, seedConditionTypes...)
+
+	conditions := v1beta1helper.RetainConditions(shoot.Status.Conditions, shootConditions...)
 	if seed != nil {
 		conditions = v1beta1helper.MergeConditions(conditions, seed.Status.Conditions...)
 	}

--- a/pkg/utils/gardener/shoot.go
+++ b/pkg/utils/gardener/shoot.go
@@ -688,12 +688,11 @@ func GetShootConditionTypes(workerless bool) []gardencorev1beta1.ConditionType {
 		gardencorev1beta1.ShootAPIServerAvailable,
 		gardencorev1beta1.ShootControlPlaneHealthy,
 		gardencorev1beta1.ShootObservabilityComponentsHealthy,
-		gardencorev1beta1.ShootSystemComponentsHealthy,
 	}
 
 	if !workerless {
 		shootConditionTypes = append(shootConditionTypes, gardencorev1beta1.ShootEveryNodeReady)
 	}
 
-	return shootConditionTypes
+	return append(shootConditionTypes, gardencorev1beta1.ShootSystemComponentsHealthy)
 }

--- a/pkg/utils/gardener/shoot.go
+++ b/pkg/utils/gardener/shoot.go
@@ -681,3 +681,19 @@ func ComputeTechnicalID(projectName string, shoot *gardencorev1beta1.Shoot) stri
 	// New clusters shall be created with the new technical id (double hyphens).
 	return fmt.Sprintf("%s-%s--%s", v1beta1constants.TechnicalIDPrefix, projectName, shoot.Name)
 }
+
+// GetShootConditionTypes returns all known shoot condition types.
+func GetShootConditionTypes(workerless bool) []gardencorev1beta1.ConditionType {
+	shootConditionTypes := []gardencorev1beta1.ConditionType{
+		gardencorev1beta1.ShootAPIServerAvailable,
+		gardencorev1beta1.ShootControlPlaneHealthy,
+		gardencorev1beta1.ShootObservabilityComponentsHealthy,
+		gardencorev1beta1.ShootSystemComponentsHealthy,
+	}
+
+	if !workerless {
+		shootConditionTypes = append(shootConditionTypes, gardencorev1beta1.ShootEveryNodeReady)
+	}
+
+	return shootConditionTypes
+}

--- a/pkg/utils/gardener/shoot_test.go
+++ b/pkg/utils/gardener/shoot_test.go
@@ -1234,17 +1234,17 @@ var _ = Describe("Shoot", func() {
 
 	Describe("#GetShootConditionTypes", func() {
 		It("should return all shoot condition types", func() {
-			Expect(GetShootConditionTypes(false)).To(ConsistOf(
+			Expect(GetShootConditionTypes(false)).To(HaveExactElements(
 				gardencorev1beta1.ConditionType("APIServerAvailable"),
 				gardencorev1beta1.ConditionType("ControlPlaneHealthy"),
 				gardencorev1beta1.ConditionType("ObservabilityComponentsHealthy"),
-				gardencorev1beta1.ConditionType("SystemComponentsHealthy"),
 				gardencorev1beta1.ConditionType("EveryNodeReady"),
+				gardencorev1beta1.ConditionType("SystemComponentsHealthy"),
 			))
 		})
 
 		It("should return all shoot condition types for workerless shoot", func() {
-			Expect(GetShootConditionTypes(true)).To(ConsistOf(
+			Expect(GetShootConditionTypes(true)).To(HaveExactElements(
 				gardencorev1beta1.ConditionType("APIServerAvailable"),
 				gardencorev1beta1.ConditionType("ControlPlaneHealthy"),
 				gardencorev1beta1.ConditionType("ObservabilityComponentsHealthy"),

--- a/pkg/utils/gardener/shoot_test.go
+++ b/pkg/utils/gardener/shoot_test.go
@@ -1231,4 +1231,25 @@ var _ = Describe("Shoot", func() {
 			Expect(ComputeTechnicalID(projectName, shoot)).To(Equal(fmt.Sprintf("shoot--%s--%s", projectName, shoot.Name)))
 		})
 	})
+
+	Describe("#GetShootConditionTypes", func() {
+		It("should return all shoot condition types", func() {
+			Expect(GetShootConditionTypes(false)).To(ConsistOf(
+				gardencorev1beta1.ConditionType("APIServerAvailable"),
+				gardencorev1beta1.ConditionType("ControlPlaneHealthy"),
+				gardencorev1beta1.ConditionType("ObservabilityComponentsHealthy"),
+				gardencorev1beta1.ConditionType("SystemComponentsHealthy"),
+				gardencorev1beta1.ConditionType("EveryNodeReady"),
+			))
+		})
+
+		It("should return all shoot condition types for workerless shoot", func() {
+			Expect(GetShootConditionTypes(true)).To(ConsistOf(
+				gardencorev1beta1.ConditionType("APIServerAvailable"),
+				gardencorev1beta1.ConditionType("ControlPlaneHealthy"),
+				gardencorev1beta1.ConditionType("ObservabilityComponentsHealthy"),
+				gardencorev1beta1.ConditionType("SystemComponentsHealthy"),
+			))
+		})
+	})
 })

--- a/test/framework/k8s_utils.go
+++ b/test/framework/k8s_utils.go
@@ -39,6 +39,7 @@ import (
 	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/utils"
+	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/kubernetes/health"
 	"github.com/gardener/gardener/pkg/utils/retry"
@@ -348,18 +349,8 @@ func ShootReconciliationSuccessful(shoot *gardencorev1beta1.Shoot) (bool, string
 		return false, "no conditions and last operation present yet"
 	}
 
-	shootConditions := sets.New(
-		gardencorev1beta1.ShootAPIServerAvailable,
-		gardencorev1beta1.ShootControlPlaneHealthy,
-		gardencorev1beta1.ShootObservabilityComponentsHealthy,
-		gardencorev1beta1.ShootSystemComponentsHealthy,
-	)
-
-	if !v1beta1helper.IsWorkerless(shoot) {
-		shootConditions.Insert(
-			gardencorev1beta1.ShootEveryNodeReady,
-		)
-	}
+	workerlessShoot := v1beta1helper.IsWorkerless(shoot)
+	shootConditions := sets.New(gardenerutils.GetShootConditionTypes(workerlessShoot)...)
 
 	for _, condition := range shoot.Status.Conditions {
 		if condition.Status != gardencorev1beta1.ConditionTrue {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind bug

**What this PR does / why we need it**:
This PR fixes the logic which merges conditions from seeds to shoots if a `ManagedSeed` is involved. Earlier, when unknown conditions were removed from seeds (e.g. maintained by third-party components), the affected condition was still present in the shoot'a conditions.

**Special notes for your reviewer**:
/cc @vpnachev

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Condition handling was improved for `Shoot`s of `ManagedSeed`s. Earlier, when unknown conditions were removed from seeds (e.g. maintained by third-party components), the affected condition was still present in the shoot's conditions.
```
