### PR TITLE
Deploy MCM with 0 replicas during cpm `restore` phase

### DIFF
--- a/pkg/operation/botanist/machinecontrollermanager_test.go
+++ b/pkg/operation/botanist/machinecontrollermanager_test.go
@@ -152,6 +152,10 @@ var _ = Describe("MachineControllerManager", func() {
 				shoot.Status.IsHibernated = true
 				botanist.Shoot.SetInfo(shoot)
 			}),
+			Entry("when shoot is in restore phase", 0, func() {
+				shoot.Status.LastOperation = &gardencorev1beta1.LastOperation{Type: gardencorev1beta1.LastOperationTypeRestore}
+				botanist.Shoot.SetInfo(shoot)
+			}),
 		)
 	})
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane-migration
/kind bug

**What this PR does / why we need it**:
1. Ensures that during the `restore` phase of control plane migration MCM is deployed with 0 replicas, if the deployment does not exist yet or it still has 0 replicas.
2. Removes the code in the `Restore` functionality of the worker controller's generic actuator which was responsible for scaling down MCM to 0 at the start of the `Restore` operation. This operation should not be necessary and was slowing down restoration as explained below.

There was an issue when `gardenlet` is responsible for deploying MCM where MCM immediately gets deployed with 1 replica before the `Machine` and `MachineSets` could get restored during the restoration of the worker resource. This could potentially cause MCM to delete the existing nodes in the cluster as it could assume that they have been orphaned (there is no `Machine` object corresponding to a node). 
This behaviour was not present before MCM was managed by `gardenlet` because MCM would not get deployed by the generic actuator as part of the `restore` functionality. More concretely, the following steps took place:
1. Restoration is started in destination seed.
2. There is no MCM deployed yet.
3. MCM gets scaled to 0 [here](https://github.com/gardener/gardener/blob/e361192aeb1b80eaf0ed9f124f94cf26fcd5cac6/extensions/pkg/controller/worker/genericactuator/actuator_restore.go#L73). This is basically a no-op since the deployment doesn’t exist yet.
4. `MachineSets`, `Machine`, `MachineDeployment`, etc. are deployed.
5. MCM gets scaled to 1 [here](https://github.com/gardener/gardener/blob/e361192aeb1b80eaf0ed9f124f94cf26fcd5cac6/extensions/pkg/controller/worker/genericactuator/actuator_restore.go#L98). This is again a no-op since the deployment does not exist yet.
6. MCM finally gets deployed with 1 replica [here](https://github.com/gardener/gardener/blob/e361192aeb1b80eaf0ed9f124f94cf26fcd5cac6/extensions/pkg/controller/worker/genericactuator/actuator_reconcile.go#L83).

When `gardenlet` starts managing the deployment of MCM the following steps can take place:
1. Restoration is started in new seed.
2. There is no MCM deployed yet.
3. MCM gets deployed and scaled to 1 [here](https://github.com/gardener/gardener/blob/e361192aeb1b80eaf0ed9f124f94cf26fcd5cac6/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go#L641-L645).
4. Potential orphan deletion could take place here.
5. MCM gets scaled to 0 [here](https://github.com/gardener/gardener/blob/e361192aeb1b80eaf0ed9f124f94cf26fcd5cac6/extensions/pkg/controller/worker/genericactuator/actuator_restore.go#L73),
6. `MachineSets`, `Machine`, `MachineDeployment`, etc. are deployed.
7. MCM gets scaled to 1 [here](https://github.com/gardener/gardener/blob/e361192aeb1b80eaf0ed9f124f94cf26fcd5cac6/extensions/pkg/controller/worker/genericactuator/actuator_restore.go#L98)

This PR makes it so that in step 3. MCM is deployed with 0 replicas. It also removes the scale down to 0 in step 5. as it is no longer necessary. If restoration is restarted after MCM has been scaled up to 1 in step 7. it it will not be scaled down back to 0. This scaling is not necessary as the relevant machine objects from the `ShootState` have already been created.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
One thing that might need to be addressed in the future is that restoration still relies on the generic actuator to scale up MCM [here](https://github.com/gardener/gardener/blob/e361192aeb1b80eaf0ed9f124f94cf26fcd5cac6/extensions/pkg/controller/worker/genericactuator/actuator_restore.go#L98) rather than having this be entirely managed by `gardenlet`.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
During the `restore` phase of control plane migration, the `machine-controller-manager` is deployed with 0 replicas if it did not exist before or if it existed and was not scaled up yet. This fixes an issue that could cause the `Shoot`'s nodes to get recreated during control plane migration.
```
