### PR TITLE
Remove MR secret GRM finaliser

### DIFF
--- a/pkg/resourcemanager/controller/secret/reconciler.go
+++ b/pkg/resourcemanager/controller/secret/reconciler.go
@@ -39,7 +39,7 @@ type Reconciler struct {
 
 // Reconcile implements reconcile.Reconciler.
 func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
-	// TODO(Kostov6): Drop secret reconciler after gardener v1.85
+	// TODO(Kostov6): Drop secret reconciler after v1.86 has been released.
 	log := logf.FromContext(ctx)
 
 	ctx, cancel := controllerutils.GetMainReconciliationContext(ctx, controllerutils.DefaultReconciliationTimeout)

--- a/pkg/resourcemanager/controller/secret/reconciler.go
+++ b/pkg/resourcemanager/controller/secret/reconciler.go
@@ -37,9 +37,9 @@ type Reconciler struct {
 	ClassFilter  *predicate.ClassFilter
 }
 
-// TODO(Kostov6): Drop secret reconciler after gardener v1.85
 // Reconcile implements reconcile.Reconciler.
 func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
+	// TODO(Kostov6): Drop secret reconciler after gardener v1.85
 	log := logf.FromContext(ctx)
 
 	ctx, cancel := controllerutils.GetMainReconciliationContext(ctx, controllerutils.DefaultReconciliationTimeout)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind cleanup

**What this PR does / why we need it**:
Part of https://github.com/gardener/gardener/issues/8190
For the secret reconciler to be dropped we have first to remove present GRM finaliser that MR secrets have. That is achieved by changing the MR secret reconciler to remove GMR finaliser if it is present

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy developer
The `Secret` reconciler in `gardener-resource-manager` will now always remove its finalizer (if present).
```
