### PR TITLE
use artifact registry for IPv6 support

### DIFF
--- a/imagevector/images.yaml
+++ b/imagevector/images.yaml
@@ -237,7 +237,7 @@ images:
       teamname: 'gardener/monitoring-maintainers'
 - name: plutono
   sourceRepository: github.com/credativ/plutono
-  repository: ghcr.io/credativ/plutono
+  repository: europe-docker.pkg.dev/gardener-project/releases/3rd/credativ/plutono
   tag: "v7.5.28"
   labels:
   - name: gardener.cloud/cve-categorisation
@@ -416,7 +416,7 @@ images:
       teamname: 'gardener/logging-maintainers'
 - name: vali
   sourceRepository: github.com/credativ/vali
-  repository: ghcr.io/credativ/vali
+  repository: europe-docker.pkg.dev/gardener-project/releases/3rd/credativ/vali
   tag: "v2.2.13"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
@@ -468,7 +468,7 @@ images:
       teamname: 'gardener/logging-maintainers'
 - name: valitail
   sourceRepository: github.com/credativ/vali
-  repository: ghcr.io/credativ/valitail
+  repository: europe-docker.pkg.dev/gardener-project/releases/3rd/credativ/valitail
   tag: "v2.2.13"
   labels:
   - name: 'gardener.cloud/cve-categorisation'


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement

**What this PR does / why we need it**:
Images are copied in https://github.com/gardener/ci-infra/pull/982 from ghcr to artifact registry for IPv6 support. The PR makes use of  the copied images.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Depends on https://github.com/gardener/ci-infra/pull/982.
**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
