### PR TITLE
Switch prometheus-config-reloader image to be pulled from quay

### DIFF
--- a/imagevector/images.yaml
+++ b/imagevector/images.yaml
@@ -174,7 +174,7 @@ images:
       teamname: 'gardener/monitoring-maintainers'
 - name: configmap-reloader
   sourceRepository: github.com/prometheus-operator/prometheus-operator
-  repository: ghcr.io/prometheus-operator/prometheus-config-reloader
+  repository: quay.io/prometheus-operator/prometheus-config-reloader
   tag: v0.67.1
   labels:
   - name: gardener.cloud/cve-categorisation


### PR DESCRIPTION

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind enhancement

**What this PR does / why we need it**:
ghcr does not support image pulls over IPv6 - see https://github.com/gardener/ci-infra/pull/982. Fortunately, we the prometheus-config-reloader image is pushed to quay.io as well. Ref https://github.com/prometheus-operator/prometheus-operator/issues/6059#issuecomment-1790707652

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The registry of the prometheus-operator image is switched from ghcr (`ghcr.io/prometheus-operator/prometheus-config-reloader`) to `quay.io` (`quay.io/prometheus-operator/prometheus-config-reloader`) because the ghcr does not support image pulls over IPv6.
```
