### PR TITLE
Prepare migration from GCR -> Artifact Registry

### DIFF
--- a/hack/.ci/component_descriptor
+++ b/hack/.ci/component_descriptor
@@ -4,7 +4,7 @@
 #
 # COMPONENT_PREFIXES: Set the image prefix that should be used to
 #                     determine if an image is defined by another component.
-#                     Defaults to "eu.gcr.io/gardener-project/gardener"
+#                     Defaults to "eu.gcr.io/gardener-project/gardener,europe-docker.pkg.dev/gardener-project"
 #
 # GENERIC_DEPENDENCIES: Set images that are generic dependencies with no specific tag.
 #                       Defaults to "hyperkube,kube-apiserver,kube-controller-manager,kube-scheduler,kube-proxy"
@@ -58,7 +58,7 @@ fi
 if [[ ! -z "$image_vector_path" ]]; then
   # default environment variables
   if [[ -z "${COMPONENT_PREFIXES}" ]]; then
-    COMPONENT_PREFIXES="eu.gcr.io/gardener-project/gardener"
+    COMPONENT_PREFIXES="eu.gcr.io/gardener-project/gardener,europe-docker.pkg.dev/gardener-project"
   fi
   if [[ -z "${GENERIC_DEPENDENCIES}" ]]; then
     GENERIC_DEPENDENCIES="hyperkube,kube-apiserver,kube-controller-manager,kube-scheduler,kube-proxy"

--- a/hack/.ci/component_descriptor
+++ b/hack/.ci/component_descriptor
@@ -6,9 +6,6 @@
 #                     determine if an image is defined by another component.
 #                     Defaults to "eu.gcr.io/gardener-project/gardener,europe-docker.pkg.dev/gardener-project"
 #
-# GENERIC_DEPENDENCIES: Set images that are generic dependencies with no specific tag.
-#                       Defaults to "hyperkube,kube-apiserver,kube-controller-manager,kube-scheduler,kube-proxy"
-#
 # COMPONENT_CLI_ARGS: Set all component-cli arguments.
 #                     This should be used with care as all defaults are overwritten.
 #
@@ -60,16 +57,12 @@ if [[ ! -z "$image_vector_path" ]]; then
   if [[ -z "${COMPONENT_PREFIXES}" ]]; then
     COMPONENT_PREFIXES="eu.gcr.io/gardener-project/gardener,europe-docker.pkg.dev/gardener-project"
   fi
-  if [[ -z "${GENERIC_DEPENDENCIES}" ]]; then
-    GENERIC_DEPENDENCIES="hyperkube,kube-apiserver,kube-controller-manager,kube-scheduler,kube-proxy"
-  fi
 
   if [[ -z "${COMPONENT_CLI_ARGS}" ]]; then
     COMPONENT_CLI_ARGS="
     --comp-desc ${BASE_DEFINITION_PATH} \
     --image-vector "$image_vector_path" \
     --component-prefixes "${COMPONENT_PREFIXES}" \
-    --generic-dependencies "${GENERIC_DEPENDENCIES}" \
     "
   fi
 
@@ -97,13 +90,7 @@ if [[ -d "$repo_root_dir/charts/" ]]; then
       TAG=${imageAndTag[1]}
 
       gardener="eu.gcr.io/gardener-project/gardener"
-      if [[ "$NAME" == "hyperkube" ]]; then
-        ${ADD_DEPENDENCIES_CMD} --generic-dependencies "{\"name\": \"$NAME\", \"version\": \"$TAG\"}"
-      elif [[ $REPOSITORY =~ "eu.gcr.io/gardener-project/gardener"* ]]; then
-        ${ADD_DEPENDENCIES_CMD} --generic-dependencies "{\"name\": \"$NAME\", \"version\": \"$TAG\"}"
-      else
-        ${ADD_DEPENDENCIES_CMD} --container-image-dependencies "{\"name\": \"${NAME}\", \"image_reference\": \"${REPOSITORY}:${TAG}\", \"version\": \"$TAG\"}"
-      fi
+      ${ADD_DEPENDENCIES_CMD} --container-image-dependencies "{\"name\": \"${NAME}\", \"image_reference\": \"${REPOSITORY}:${TAG}\", \"version\": \"$TAG\"}"
     done < <(echo "$outputFile")
   done
 fi

--- a/hack/.ci/component_descriptor
+++ b/hack/.ci/component_descriptor
@@ -89,7 +89,6 @@ if [[ -d "$repo_root_dir/charts/" ]]; then
       REPOSITORY=${imageAndTag[0]}
       TAG=${imageAndTag[1]}
 
-      gardener="eu.gcr.io/gardener-project/gardener"
       ${ADD_DEPENDENCIES_CMD} --container-image-dependencies "{\"name\": \"${NAME}\", \"image_reference\": \"${REPOSITORY}:${TAG}\", \"version\": \"$TAG\"}"
     done < <(echo "$outputFile")
   done


### PR DESCRIPTION
**How to categorize this PR?**

/area delivery
/kind technical-debt

**What this PR does / why we need it**

As [GCR was deprecated](https://cloud.google.com/artifact-registry/docs/transition/transition-from-gcr), Gardener-Project needs to migrate from GCR (`eu.gcr.io/gardener-project`) to Artifact Registry (`europe-docker.pkg.dev/gardener-project`). This will result in different URLs (Registry + Repository, as called in OCI's terms) for Container Images built by Gardener-Project, which will require some build-scripts to be adjusted.

This specific Pull-Request will "register" the new Artifact-Registry as another "well-known" OCI Image Registry hosting images built by Gardener-Project.

In addition, it removes some "cruft" that seems has no longer been in use for quite some time by now.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```other operator
Prepare shared `component_descriptor` script for migration from GCR to Artifact Registry.
```
