### PR TITLE
Document the Shoot status error classification (user error or not)

### DIFF
--- a/docs/usage/shoot_status.md
+++ b/docs/usage/shoot_status.md
@@ -121,19 +121,23 @@ The Shoot status also contains information about the last occurred error(s) (if 
 
 ### Error Codes
 
-Known error codes are:
+Known error codes and their classification are:
 
-- `ERR_INFRA_UNAUTHENTICATED` - Indicates that the last error occurred due to the client request not being completed because it lacks valid authentication credentials for the requested resource. It is classified as a non-retryable error code.
-- `ERR_INFRA_UNAUTHORIZED` - Indicates that the last error occurred due to the server understanding the request but refusing to authorize it. It is classified as a non-retryable error code.
-- `ERR_INFRA_QUOTA_EXCEEDED` - Indicates that the last error occurred due to infrastructure quota limits. It is classified as a non-retryable error code.
-- `ERR_INFRA_RATE_LIMITS_EXCEEDED` - Indicates that the last error occurred due to exceeded infrastructure request rate limits.
-- `ERR_INFRA_DEPENDENCIES` - Indicates that the last error occurred due to dependent objects on the infrastructure level. It is classified as a non-retryable error code.
-- `ERR_RETRYABLE_INFRA_DEPENDENCIES` - Indicates that the last error occurred due to dependent objects on the infrastructure level, but the operation should be retried.
-- `ERR_INFRA_RESOURCES_DEPLETED` - Indicates that the last error occurred due to depleted resource in the infrastructure.
-- `ERR_CLEANUP_CLUSTER_RESOURCES` - Indicates that the last error occurred due to resources in the cluster that are stuck in deletion.
-- `ERR_CONFIGURATION_PROBLEM` - Indicates that the last error occurred due to a configuration problem. It is classified as a non-retryable error code.
-- `ERR_RETRYABLE_CONFIGURATION_PROBLEM` - Indicates that the last error occurred due to a retryable configuration problem. "Retryable" means that the occurred error is likely to be resolved in a ungraceful manner after given period of time.
-- `ERR_PROBLEMATIC_WEBHOOK` - Indicates that the last error occurred due to a webhook not following the [Kubernetes best practices](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#best-practices-and-warnings).
+| Error code                            | User error | Description                                                                                         |
+| ------------------------------------- | :--------: | --------------------------------------------------------------------------------------------------- |
+| `ERR_INFRA_UNAUTHENTICATED`           | true       | Indicates that the last error occurred due to the client request not being completed because it lacks valid authentication credentials for the requested resource. It is classified as a non-retryable error code. |
+| `ERR_INFRA_UNAUTHORIZED`              | true       | Indicates that the last error occurred due to the server understanding the request but refusing to authorize it. It is classified as a non-retryable error code. |
+| `ERR_INFRA_QUOTA_EXCEEDED`            | true       | Indicates that the last error occurred due to infrastructure quota limits. It is classified as a non-retryable error code. |
+| `ERR_INFRA_RATE_LIMITS_EXCEEDED`      | false      | Indicates that the last error occurred due to exceeded infrastructure request rate limits. |
+| `ERR_INFRA_DEPENDENCIES`              | true       | Indicates that the last error occurred due to dependent objects on the infrastructure level. It is classified as a non-retryable error code. |
+| `ERR_RETRYABLE_INFRA_DEPENDENCIES`    | false      | Indicates that the last error occurred due to dependent objects on the infrastructure level, but the operation should be retried. |
+| `ERR_INFRA_RESOURCES_DEPLETED`        | true       | Indicates that the last error occurred due to depleted resource in the infrastructure. |
+| `ERR_CLEANUP_CLUSTER_RESOURCES`       | true       | Indicates that the last error occurred due to resources in the cluster that are stuck in deletion. |
+| `ERR_CONFIGURATION_PROBLEM`           | true       | Indicates that the last error occurred due to a configuration problem. It is classified as a non-retryable error code. |
+| `ERR_RETRYABLE_CONFIGURATION_PROBLEM` | true       | Indicates that the last error occurred due to a retryable configuration problem. "Retryable" means that the occurred error is likely to be resolved in a ungraceful manner after given period of time. |
+| `ERR_PROBLEMATIC_WEBHOOK`             | true       | Indicates that the last error occurred due to a webhook not following the [Kubernetes best practices](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#best-practices-and-warnings). |
+
+**Please note:** Errors classified as `User error: true` do not require a Gardener operator to resolve but can be remediated by the user (e.g. by refreshing expired infrastructure credentials).
 
 ### Status Label
 

--- a/docs/usage/shoot_status.md
+++ b/docs/usage/shoot_status.md
@@ -138,6 +138,7 @@ Known error codes and their classification are:
 | `ERR_PROBLEMATIC_WEBHOOK`             | true       | Indicates that the last error occurred due to a webhook not following the [Kubernetes best practices](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#best-practices-and-warnings). |
 
 **Please note:** Errors classified as `User error: true` do not require a Gardener operator to resolve but can be remediated by the user (e.g. by refreshing expired infrastructure credentials).
+Even though `ERR_INFRA_RATE_LIMITS_EXCEEDED` and `ERR_RETRYABLE_INFRA_DEPENDENCIES` is mentioned as User error: false` operator can't provide any resolution because it is related to cloud provider issue.
 
 ### Status Label
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area documentation
/kind enhancement

**What this PR does / why we need it**:
While the Gardener dashboard provides a classification for errors to hint whether a user can fix an issue or needs help by an operator, the same information seems to be missing form the Gardener documentation.

See https://github.com/gardener/dashboard/blob/5698c5d7df85ed95626a07f7027029ef5361eb70/frontend/src/utils/errorCodes.js#L38-L113.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

/invite @n-boshnakov 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```doc user
Document whether is an error in the `shoot.status` is a user error or not.
```
