### PR TITLE
[node-agent] controlplane mutator webhook also searches for files in units.files of OSC

### DIFF
--- a/extensions/pkg/webhook/controlplane/genericmutator/mutator.go
+++ b/extensions/pkg/webhook/controlplane/genericmutator/mutator.go
@@ -246,6 +246,12 @@ func findFileWithPath(osc *extensionsv1alpha1.OperatingSystemConfig, path string
 		if f := extensionswebhook.FileWithPath(osc.Spec.Files, path); f != nil {
 			return f.Content.Inline
 		}
+
+		for _, unit := range osc.Spec.Units {
+			if f := extensionswebhook.FileWithPath(unit.Files, path); f != nil {
+				return f.Content.Inline
+			}
+		}
 	}
 
 	return nil

--- a/extensions/pkg/webhook/controlplane/genericmutator/mutator_test.go
+++ b/extensions/pkg/webhook/controlplane/genericmutator/mutator_test.go
@@ -407,11 +407,8 @@ var _ = Describe("Mutator", func() {
 				c.EXPECT().Get(context.TODO(), clusterKey, &extensionsv1alpha1.Cluster{}).DoAndReturn(clientGet(clusterObject(cluster)))
 			})
 
-			It("should invoke appropriate ensurer methods with OperatingSystemConfig", func() {
-				oldOSC := newOSC.DeepCopy()
-				oldOSC.Spec.Units[0].Content = pointer.String(oldServiceContent)
-				oldOSC.Spec.Files[0].Content.Inline.Data = oldKubeletConfigData
-				oldOSC.Spec.Files[1].Content.Inline.Data = oldKubernetesGeneralConfigData
+			DescribeTable("should invoke appropriate ensurer methods with OperatingSystemConfig", func(mutateOSC func() *extensionsv1alpha1.OperatingSystemConfig) {
+				oldOSC := mutateOSC()
 
 				// Create mock ensurer
 				ensurer.EXPECT().EnsureKubeletServiceUnitOptions(context.TODO(), gomock.Any(), kubernetesVersionSemver, newUnitOptions, oldUnitOptions).Return(mutatedUnitOptions, nil)
@@ -464,6 +461,40 @@ var _ = Describe("Mutator", func() {
 				Expect(err).To(Not(HaveOccurred()))
 				checkOperatingSystemConfig(newOSC)
 			},
+				Entry(
+					"OSC has spec.files",
+					func() *extensionsv1alpha1.OperatingSystemConfig {
+						oldOSC := newOSC.DeepCopy()
+						oldOSC.Spec.Units[0].Content = pointer.String(oldServiceContent)
+						oldOSC.Spec.Files[0].Content.Inline.Data = oldKubeletConfigData
+						oldOSC.Spec.Files[1].Content.Inline.Data = oldKubernetesGeneralConfigData
+						return oldOSC
+					},
+				),
+				Entry(
+					"OSC has spec.units.files",
+					func() *extensionsv1alpha1.OperatingSystemConfig {
+						newOSC.Spec.Units[0].Files = newOSC.Spec.Files
+						newOSC.Spec.Files = nil
+						oldOSC := newOSC.DeepCopy()
+						oldOSC.Spec.Units[0].Content = pointer.String(oldServiceContent)
+						oldOSC.Spec.Units[0].Files[0].Content.Inline.Data = oldKubeletConfigData
+						oldOSC.Spec.Units[0].Files[1].Content.Inline.Data = oldKubernetesGeneralConfigData
+						return oldOSC
+					},
+				),
+				Entry(
+					"OSC has mixed spec.files and spec.units.files",
+					func() *extensionsv1alpha1.OperatingSystemConfig {
+						newOSC.Spec.Units[0].Files = append(newOSC.Spec.Units[0].Files, newOSC.Spec.Files[0])
+						newOSC.Spec.Files = newOSC.Spec.Files[1:]
+						oldOSC := newOSC.DeepCopy()
+						oldOSC.Spec.Units[0].Content = pointer.String(oldServiceContent)
+						oldOSC.Spec.Units[0].Files[0].Content.Inline.Data = oldKubeletConfigData
+						oldOSC.Spec.Files[0].Content.Inline.Data = oldKubernetesGeneralConfigData
+						return oldOSC
+					},
+				),
 			)
 
 			It("should not add invalid file content to OSC", func() {
@@ -538,18 +569,18 @@ func checkOperatingSystemConfig(osc *extensionsv1alpha1.OperatingSystemConfig) {
 	customMTU := extensionswebhook.UnitWithName(osc.Spec.Units, "custom-mtu.service")
 	Expect(customMTU).To(Not(BeNil()))
 
-	customFile := extensionswebhook.FileWithPath(osc.Spec.Files, "/test/path")
+	customFile := collectFile(osc, "/test/path")
 	Expect(customFile).To(Not(BeNil()))
 
-	kubeletFile := extensionswebhook.FileWithPath(osc.Spec.Files, v1beta1constants.OperatingSystemConfigFilePathKubeletConfig)
+	kubeletFile := collectFile(osc, v1beta1constants.OperatingSystemConfigFilePathKubeletConfig)
 	Expect(kubeletFile).To(Not(BeNil()))
 	Expect(kubeletFile.Content.Inline).To(Equal(&extensionsv1alpha1.FileContentInline{Data: mutatedKubeletConfigData}))
 
-	general := extensionswebhook.FileWithPath(osc.Spec.Files, v1beta1constants.OperatingSystemConfigFilePathKernelSettings)
+	general := collectFile(osc, v1beta1constants.OperatingSystemConfigFilePathKernelSettings)
 	Expect(general).To(Not(BeNil()))
 	Expect(general.Content.Inline).To(Equal(&extensionsv1alpha1.FileContentInline{Data: mutatedKubernetesGeneralConfigData}))
 
-	cloudProvider := extensionswebhook.FileWithPath(osc.Spec.Files, genericmutator.CloudProviderConfigPath)
+	cloudProvider := collectFile(osc, genericmutator.CloudProviderConfigPath)
 	Expect(cloudProvider).To(Not(BeNil()))
 	Expect(cloudProvider.Path).To(Equal(genericmutator.CloudProviderConfigPath))
 	Expect(cloudProvider.Permissions).To(Equal(pointer.Int32(0644)))
@@ -585,4 +616,12 @@ func clusterObject(cluster *extensionscontroller.Cluster) *extensionsv1alpha1.Cl
 func encode(obj runtime.Object) []byte {
 	data, _ := json.Marshal(obj)
 	return data
+}
+
+func collectFile(osc *extensionsv1alpha1.OperatingSystemConfig, path string) *extensionsv1alpha1.File {
+	files := osc.Spec.Files
+	for _, unit := range osc.Spec.Units {
+		files = append(files, unit.Files...)
+	}
+	return extensionswebhook.FileWithPath(files, path)
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind bug

**What this PR does / why we need it**:
This PR adds a missing piece of the OSC API change introduced in PR #8707.
With this change controlplane mutator webhook also searches for files in the new `spec.units.files` section of `OperatingSystemConfig`.

**Which issue(s) this PR fixes**:
Part of #8023

**Special notes for your reviewer**:
/cc @rfranzke 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
