### PR TITLE
Forbid changes to primary DNS provider

### DIFF
--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -588,9 +588,7 @@ func validateDNSUpdate(new, old *core.DNS, seedGotAssigned bool, fldPath *field.
 			allErrs = append(allErrs, apivalidation.ValidateImmutableField(new.Domain, old.Domain, fldPath.Child("domain"))...)
 		}
 
-		// allow to finalize DNS configuration during seed assignment. this is required because
-		// some decisions about the DNS setup can only be taken once the target seed is clarified.
-		if !seedGotAssigned {
+		if seedGotAssigned {
 			var (
 				primaryOld = helper.FindPrimaryDNSProvider(old.Providers)
 				primaryNew = helper.FindPrimaryDNSProvider(new.Providers)

--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -1507,9 +1507,8 @@ var _ = Describe("Shoot Validation Tests", func() {
 				}))))
 			})
 
-			It("should allow updating the dns providers if seed is assigned", func() {
+			It("should forbid updating the dns providers", func() {
 				oldShoot := shoot.DeepCopy()
-				oldShoot.Spec.SeedName = nil
 				oldShoot.Spec.DNS.Providers[0].Type = pointer.String("some-dns-provider")
 
 				newShoot := prepareShootForUpdate(oldShoot)
@@ -1517,15 +1516,6 @@ var _ = Describe("Shoot Validation Tests", func() {
 				newShoot.Spec.DNS.Providers = nil
 
 				errorList := ValidateShootUpdate(newShoot, oldShoot)
-
-				Expect(errorList).To(BeEmpty())
-			})
-
-			It("should forbid updating the primary dns provider type", func() {
-				newShoot := prepareShootForUpdate(shoot)
-				shoot.Spec.DNS.Providers[0].Type = pointer.String("some-other-provider")
-
-				errorList := ValidateShootUpdate(newShoot, shoot)
 
 				Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":  Equal(field.ErrorTypeForbidden),
@@ -1535,6 +1525,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 
 			It("should forbid to unset the primary DNS provider type", func() {
 				newShoot := prepareShootForUpdate(shoot)
+				newShoot.Spec.SeedName = pointer.String("seed")
 				newShoot.Spec.DNS.Providers[0].Type = nil
 
 				errorList := ValidateShootUpdate(newShoot, shoot)
@@ -1547,6 +1538,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 
 			It("should forbid to remove the primary DNS provider", func() {
 				newShoot := prepareShootForUpdate(shoot)
+				newShoot.Spec.SeedName = pointer.String("seed")
 				newShoot.Spec.DNS.Providers[0].Primary = pointer.Bool(false)
 
 				errorList := ValidateShootUpdate(newShoot, shoot)
@@ -1559,6 +1551,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 
 			It("should forbid adding another primary provider", func() {
 				newShoot := prepareShootForUpdate(shoot)
+				newShoot.Spec.SeedName = pointer.String("seed")
 				newShoot.Spec.DNS.Providers = append(newShoot.Spec.DNS.Providers, core.DNSProvider{
 					Primary: pointer.Bool(true),
 				})
@@ -1571,7 +1564,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 				}))))
 			})
 
-			It("should having the a provider with invalid secretName", func() {
+			It("should forbid having a provider with invalid secretName", func() {
 				invalidSecretName := "foo/bar"
 
 				shoot.Spec.DNS.Providers = []core.DNSProvider{
@@ -1593,7 +1586,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 				}))))
 			})
 
-			It("should having the same provider multiple times", func() {
+			It("should forbid having the same provider multiple times", func() {
 				shoot.Spec.DNS.Providers = []core.DNSProvider{
 					{
 						SecretName: &secretName,


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind api-change

**What this PR does / why we need it**:
This PR forbids changes to the primary DNS provider when a seed is assigned to the shoot.

The change was introduced with https://github.com/gardener/gardener/pull/1756:
> We have seen users that still were creating shoots with .spec.dns.domain=<default-domain> and .spec.dns.provider=<some-provider> (with old garden.sapcloud.io/v1beta1 API). In v0.33, the DNS admission plugin tries to remove .spec.dns.providers when it assigns a default domain, and this failed because our validation prevented it.

The removal code does not exist anymore and the current validation can cause issues for the user, see linked issue.

**Which issue(s) this PR fixes**:
Fixes #8744

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking user
A validation rule was added that forbids changing the primary DNS provider in `.spec.dns.providers` as soon as the shoot was scheduled.
```
