### PR TITLE
Allow MCM to delete VolumeAttachments

### DIFF
--- a/pkg/component/machinecontrollermanager/machine_controller_manager.go
+++ b/pkg/component/machinecontrollermanager/machine_controller_manager.go
@@ -386,7 +386,7 @@ func (m *machineControllerManager) computeShootResourcesData(serviceAccountName 
 				{
 					APIGroups: []string{"storage.k8s.io"},
 					Resources: []string{"volumeattachments"},
-					Verbs:     []string{"get", "list", "watch"},
+					Verbs:     []string{"delete", "get", "list", "watch"},
 				},
 			},
 		}

--- a/pkg/component/machinecontrollermanager/machine_controller_manager_test.go
+++ b/pkg/component/machinecontrollermanager/machine_controller_manager_test.go
@@ -402,6 +402,7 @@ rules:
   resources:
   - volumeattachments
   verbs:
+  - delete
   - get
   - list
   - watch


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind bug

**What this PR does / why we need it**:
After https://github.com/gardener/machine-controller-manager/pull/839 MCM provider extensions need to delete VolumeAttachments. See the PR description for more details.

Steps to reproduce:
1. Create a Shoot
2. Create a PVC
3. Delete the Shoot
4. Make sure that MCM provider-aws fails to delete the Node with reason:
```
E1108 13:18:46.014810       1 machine_util.go:1199] (deleteNodeVolAttachments) Error deleting volume attachments for node "ip-10-250-18-49.eu-west-1.compute.internal", machine "shoot--foo--bar-worker-1-z1-dd4b9-rm9zm": volumeattachments.storage.k8s.io "csi-6d9353d0a5734f4c3b1c3643da399da1c91c0a2d6a570e36a88da54be9829b0d" is forbidden: User "system:serviceaccount:kube-system:machine-controller-manager" cannot delete resource "volumeattachments" in API group "storage.k8s.io" at the cluster scope
```

**Which issue(s) this PR fixes**:
See above

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
6. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
machine-controller-manager RBAC in the Shoot cluster does now allow MCM to delete volumeattachments. MCM provider extensions vendoring machine-controller-manager >= v0.50.0 (ref https://github.com/gardener/machine-controller-manager/pull/839) need to delete volumeattachments.
```
