### PR TITLE
Use restmapper with `LazyDiscovery`

### DIFF
--- a/extensions/pkg/util/shoot_clients.go
+++ b/extensions/pkg/util/shoot_clients.go
@@ -111,7 +111,7 @@ func NewClientForShoot(ctx context.Context, c client.Client, namespace string, o
 		// TODO(ary1992): The new rest mapper implementation doesn't return a NoKindMatchError but a ErrGroupDiscoveryFailed
 		// when an API GroupVersion is not present in the cluster. Remove the old restmapper usage once the upstream issue
 		// (https://github.com/kubernetes-sigs/controller-runtime/pull/2425) is fixed.
-		mapper, err := thirdpartyapiutil.NewDynamicRESTMapper(shootRESTConfig)
+		mapper, err := thirdpartyapiutil.NewDynamicRESTMapper(shootRESTConfig, thirdpartyapiutil.WithLazyDiscovery)
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to create new DynamicRESTMapper: %w", err)
 		}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug

**What this PR does / why we need it**:
`LazyDiscovery` was removed with https://github.com/gardener/gardener/pull/8245, but without this extension health check fails with the below error -

```
  - lastTransitionTime: "2023-11-08T16:02:25Z"
    lastUpdateTime: "2023-11-08T16:02:25Z"
    message: 'failed to execute 1 health check: failed to create new DynamicRESTMapper:
      Get "https://kube-apiserver.shoot--local--i545932-fd.svc/api?timeout=32s": dial
      tcp 100.109.8.186:443: i/o timeout.'
    reason: ConditionCheckError
    status: Unknown
    type: ControlPlaneHealthy
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @ary1992 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
`NewClientForShoot` creates a client with a rest mapper using `LazyDiscovery`.
```
