### PR TITLE
[node-agent] Refactor `{kubelet,containerd}-monitor` health check bash scripts to Golang

### DIFF
--- a/pkg/component/extensions/operatingsystemconfig/original/components/nodeagent/rbac.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/nodeagent/rbac.go
@@ -39,7 +39,7 @@ func RBACResourcesData(secretNames []string) (map[string][]byte, error) {
 			Rules: []rbacv1.PolicyRule{
 				{
 					APIGroups: []string{""},
-					Resources: []string{"nodes"},
+					Resources: []string{"nodes", "nodes/status"},
 					Verbs:     []string{"get", "list", "watch", "patch", "update"},
 				},
 				{

--- a/pkg/component/extensions/operatingsystemconfig/original/components/nodeagent/rbac_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/nodeagent/rbac_test.go
@@ -44,6 +44,7 @@ rules:
   - ""
   resources:
   - nodes
+  - nodes/status
   verbs:
   - get
   - list

--- a/pkg/nodeagent/controller/add.go
+++ b/pkg/nodeagent/controller/add.go
@@ -24,6 +24,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	"github.com/gardener/gardener/pkg/nodeagent/apis/config"
+	"github.com/gardener/gardener/pkg/nodeagent/controller/healthcheck"
 	"github.com/gardener/gardener/pkg/nodeagent/controller/lease"
 	"github.com/gardener/gardener/pkg/nodeagent/controller/node"
 	"github.com/gardener/gardener/pkg/nodeagent/controller/operatingsystemconfig"
@@ -57,6 +58,10 @@ func AddToManager(ctx context.Context, cancel context.CancelFunc, mgr manager.Ma
 
 	if err := (&lease.Reconciler{}).AddToManager(mgr, nodePredicate); err != nil {
 		return fmt.Errorf("failed adding lease controller: %w", err)
+	}
+
+	if err := (&healthcheck.Reconciler{}).AddToManager(mgr, nodePredicate); err != nil {
+		return fmt.Errorf("failed adding healthcheck controller: %w", err)
 	}
 
 	return nil

--- a/pkg/nodeagent/controller/healthcheck/add.go
+++ b/pkg/nodeagent/controller/healthcheck/add.go
@@ -1,0 +1,93 @@
+// Copyright 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package healthcheck
+
+import (
+	"fmt"
+	"net"
+	"os"
+
+	"github.com/containerd/containerd"
+	"github.com/containerd/containerd/defaults"
+	"github.com/containerd/containerd/namespaces"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/clock"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	"github.com/gardener/gardener/pkg/nodeagent/dbus"
+)
+
+// ControllerName is the name of this controller.
+const ControllerName = "healthcheck"
+
+const defaultIntervalSeconds = 30
+
+// AddToManager adds Reconciler to the given manager.
+func (r *Reconciler) AddToManager(mgr manager.Manager, nodePredicate predicate.Predicate) error {
+	if r.Client == nil {
+		r.Client = mgr.GetClient()
+	}
+	if r.Recorder == nil {
+		r.Recorder = mgr.GetEventRecorderFor(ControllerName)
+	}
+	if r.DBus == nil {
+		r.DBus = dbus.New(mgr.GetLogger().WithValues("controller", ControllerName))
+	}
+	if len(r.HealthCheckers) == 0 {
+		err := r.setDefaultHealthChecks()
+		if err != nil {
+			return err
+		}
+	}
+	if r.HealthCheckIntervalSeconds == 0 {
+		r.HealthCheckIntervalSeconds = defaultIntervalSeconds
+	}
+
+	node := &metav1.PartialObjectMetadata{}
+	node.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("Node"))
+
+	return builder.
+		ControllerManagedBy(mgr).
+		Named(ControllerName).
+		For(node, builder.WithPredicates(nodePredicate)).
+		WithOptions(controller.Options{MaxConcurrentReconciles: 1}).
+		Complete(r)
+}
+
+func (r *Reconciler) setDefaultHealthChecks() error {
+	clock := clock.RealClock{}
+
+	address := os.Getenv("CONTAINERD_ADDRESS")
+	if address == "" {
+		address = defaults.DefaultAddress
+	}
+	namespace := os.Getenv(namespaces.NamespaceEnvVar)
+	if namespace == "" {
+		namespace = namespaces.Default
+	}
+	client, err := containerd.New(address, containerd.WithDefaultNamespace(namespace))
+	if err != nil {
+		return fmt.Errorf("error creating containerd client: %w", err)
+	}
+	containerdHealthChecker := NewContainerdHealthChecker(r.Client, client, clock, r.DBus, r.Recorder)
+
+	kubeletHealthChecker := NewKubeletHealthChecker(r.Client, clock, r.DBus, r.Recorder, net.InterfaceAddrs)
+	r.HealthCheckers = []HealthChecker{containerdHealthChecker, kubeletHealthChecker}
+	return nil
+}

--- a/pkg/nodeagent/controller/healthcheck/add.go
+++ b/pkg/nodeagent/controller/healthcheck/add.go
@@ -50,8 +50,7 @@ func (r *Reconciler) AddToManager(mgr manager.Manager, nodePredicate predicate.P
 		r.DBus = dbus.New(mgr.GetLogger().WithValues("controller", ControllerName))
 	}
 	if len(r.HealthCheckers) == 0 {
-		err := r.setDefaultHealthChecks()
-		if err != nil {
+		if err := r.setDefaultHealthChecks(); err != nil {
 			return err
 		}
 	}

--- a/pkg/nodeagent/controller/healthcheck/containerd.go
+++ b/pkg/nodeagent/controller/healthcheck/containerd.go
@@ -78,7 +78,8 @@ func (c *containerdHealthChecker) Check(ctx context.Context, node *corev1.Node) 
 			return nil
 		}
 
-		log.Error(err, "Unable to get containerd version, restarting containerd")
+		log.Error(err, "Unable to get containerd version, restarting it", "failureDuration", maxFailureDuration)
+		c.recorder.Eventf(node, corev1.EventTypeWarning, "containerd", "Containerd is unhealthy for more than %s, restarting it: %s", maxFailureDuration, err.Error())
 		if err := c.dbus.Restart(ctx, c.recorder, node, v1beta1constants.OperatingSystemConfigUnitNameContainerDService); err != nil {
 			return fmt.Errorf("failed restarting containerd: %w", err)
 		}

--- a/pkg/nodeagent/controller/healthcheck/containerd.go
+++ b/pkg/nodeagent/controller/healthcheck/containerd.go
@@ -1,0 +1,97 @@
+// Copyright 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package healthcheck
+
+import (
+	"context"
+	"time"
+
+	"github.com/containerd/containerd"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/utils/clock"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/gardener/gardener/pkg/nodeagent/dbus"
+)
+
+// containerdServiceName is the systemd service name of the containerd.
+const containerdServiceName = "containerd.service"
+
+// ContainerdClient defines the containerd client Interface exported for testing.
+type ContainerdClient interface {
+	Version(context.Context) (containerd.Version, error)
+}
+
+type containerdHealthChecker struct {
+	kclient client.Client
+
+	client       ContainerdClient
+	firstFailure *time.Time
+	clock        clock.Clock
+	dbus         dbus.DBus
+	recorder     record.EventRecorder
+}
+
+// NewContainerdHealthChecker creates a new instance of a containerd healthcheck.
+func NewContainerdHealthChecker(kclient client.Client, cclient ContainerdClient, clock clock.Clock, dbus dbus.DBus, recorder record.EventRecorder) HealthChecker {
+	return &containerdHealthChecker{
+		kclient:  kclient,
+		client:   cclient,
+		clock:    clock,
+		dbus:     dbus,
+		recorder: recorder,
+	}
+}
+
+// Name returns the name of this healthcheck.
+func (*containerdHealthChecker) Name() string {
+	return "containerd"
+}
+
+// Check performs the actual health check for containerd.
+func (c *containerdHealthChecker) Check(ctx context.Context, node *corev1.Node) error {
+	log := logf.FromContext(ctx).WithName("containerd")
+
+	_, err := c.client.Version(ctx)
+	if err == nil {
+		if c.firstFailure != nil {
+			log.Info("Containerd is healthy again")
+			c.recorder.Event(node, corev1.EventTypeNormal, "containerd", "healthy")
+			c.firstFailure = nil
+		}
+		return nil
+	}
+
+	if c.firstFailure == nil {
+		now := c.clock.Now()
+		c.firstFailure = &now
+		log.Error(err, "Unable to get containerd version, considered unhealthy")
+		c.recorder.Eventf(node, corev1.EventTypeWarning, "containerd", "unhealthy: %s", err.Error())
+	}
+
+	if time.Since(*c.firstFailure).Abs() < maxFailureDuration {
+		return nil
+	}
+
+	log.Error(err, "Unable to get containerd version, restarting containerd")
+
+	err = c.dbus.Restart(ctx, c.recorder, node, containerdServiceName)
+	if err == nil {
+		c.firstFailure = nil
+	}
+	return err
+}

--- a/pkg/nodeagent/controller/healthcheck/containerd.go
+++ b/pkg/nodeagent/controller/healthcheck/containerd.go
@@ -63,7 +63,7 @@ func (*containerdHealthChecker) Name() string {
 
 // Check performs the actual health check for containerd.
 func (c *containerdHealthChecker) Check(ctx context.Context, node *corev1.Node) error {
-	log := logf.FromContext(ctx).WithName("containerd")
+	log := logf.FromContext(ctx).WithName(c.Name())
 
 	_, err := c.containerdClient.Version(ctx)
 	if err != nil {

--- a/pkg/nodeagent/controller/healthcheck/healthcheck.go
+++ b/pkg/nodeagent/controller/healthcheck/healthcheck.go
@@ -1,0 +1,33 @@
+// Copyright 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package healthcheck
+
+import (
+	"context"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+const maxFailureDuration = 60 * time.Second
+
+// HealthChecker can be implemented to run a healthcheck against a node component
+// and repair if possible, otherwise fail and report bach.
+type HealthChecker interface {
+	// Name returns the name of the healthchecker.
+	Name() string
+	// Check executes the healthcheck.
+	Check(ctx context.Context, node *corev1.Node) error
+}

--- a/pkg/nodeagent/controller/healthcheck/healthcheck.go
+++ b/pkg/nodeagent/controller/healthcheck/healthcheck.go
@@ -21,13 +21,13 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-const maxFailureDuration = 60 * time.Second
+const maxFailureDuration = time.Minute
 
-// HealthChecker can be implemented to run a healthcheck against a node component
-// and repair if possible, otherwise fail and report bach.
+// HealthChecker can be implemented to run a health check against a node component
+// and fix it if possible.
 type HealthChecker interface {
 	// Name returns the name of the healthchecker.
 	Name() string
-	// Check executes the healthcheck.
+	// Check executes the health check.
 	Check(ctx context.Context, node *corev1.Node) error
 }

--- a/pkg/nodeagent/controller/healthcheck/healthcheck_suite_test.go
+++ b/pkg/nodeagent/controller/healthcheck/healthcheck_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package healthcheck_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestNode(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "NodeAgent Controller Healthcheck Suite")
+}

--- a/pkg/nodeagent/controller/healthcheck/healthcheck_suite_test.go
+++ b/pkg/nodeagent/controller/healthcheck/healthcheck_suite_test.go
@@ -21,7 +21,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestNode(t *testing.T) {
+func TestHealthCheck(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "NodeAgent Controller Healthcheck Suite")
+	RunSpecs(t, "NodeAgent Controller HealthCheck Suite")
 }

--- a/pkg/nodeagent/controller/healthcheck/kubelet.go
+++ b/pkg/nodeagent/controller/healthcheck/kubelet.go
@@ -1,0 +1,262 @@
+// Copyright 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package healthcheck
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"net/netip"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/utils/clock"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/gardener/gardener/pkg/nodeagent/dbus"
+)
+
+const (
+	// kubeletServiceName is the systemd service name of the kubelet
+	kubeletServiceName = "kubelet.service"
+	// defaultKubeletHealthEndpoint is the health endpoint of the kubelet
+	defaultKubeletHealthEndpoint = "http://127.0.0.1:10248/healthz"
+	// maxToggles defines how often the kubelet can chang the readiness during toggleTimeSpan until the node will be hard rebooted
+	maxToggles = 5
+	// toggleTimeSpan is a floating time window where the kubelet readiness toggles are considered harmful
+	toggleTimeSpan = 10 * time.Minute
+)
+
+// KubeletHealthChecker configures the kubelet healthcheck
+type KubeletHealthChecker struct {
+	// Clock exported for testing
+	Clock clock.Clock
+	// KubeletReadynessToggles contains a entry for every toggle between kubelet Ready->NotReady or NotReady->Ready state
+	KubeletReadynessToggles []time.Time
+
+	client client.Client
+	// firstFailure stores the time of the first failed kubelet health check
+	firstFailure *time.Time
+	dbus         dbus.DBus
+	recorder     record.EventRecorder
+	// lastInternalIP stores the node internalIP
+	lastInternalIP netip.Addr
+	// getAddresses is a func which returns a slice of ip addresses on this node
+	getAddresses          func() ([]net.Addr, error)
+	nodeReady             bool
+	kubeletHealthEndpoint string
+}
+
+// NewKubeletHealthChecker create a instance of a kubelet healthcheck
+func NewKubeletHealthChecker(client client.Client, clock clock.Clock, dbus dbus.DBus, recorder record.EventRecorder, getAddresses func() ([]net.Addr, error)) *KubeletHealthChecker {
+	return &KubeletHealthChecker{
+		client:                  client,
+		dbus:                    dbus,
+		Clock:                   clock,
+		recorder:                recorder,
+		getAddresses:            getAddresses,
+		KubeletReadynessToggles: []time.Time{},
+		kubeletHealthEndpoint:   defaultKubeletHealthEndpoint,
+	}
+}
+
+// Name returns the name of this healthcheck.
+func (*KubeletHealthChecker) Name() string {
+	return "kubelet"
+}
+
+// HasLastInternalIP returns true if the node.InternalIP was stored
+// exported for testing
+func (k *KubeletHealthChecker) HasLastInternalIP() bool {
+	return k.lastInternalIP.IsValid()
+}
+
+// SetKubeletHealthEndpoint set the kubeletHealthEndpoint
+// exported for testing
+func (k *KubeletHealthChecker) SetKubeletHealthEndpoint(kubeletHealthEndpoint string) {
+	k.kubeletHealthEndpoint = kubeletHealthEndpoint
+}
+
+// Check performs the actual health check for the kubelet.
+func (k *KubeletHealthChecker) Check(ctx context.Context, node *corev1.Node) error {
+	log := logf.FromContext(ctx).WithName("kubelet")
+
+	// This mimics the old behavior of the kubelet-health-monitor which checks for
+	// to many Ready->NoReady toggles in a certain time and reboots the node in such a case.
+	if k.nodeReady != isNodeReady(node) {
+		needsReboot := k.ToggleKubeletState()
+		if needsReboot {
+			log.Info("Kubelet toggled between Ready and NotReady too often, reboot the node now")
+			k.recorder.Eventf(node, corev1.EventTypeWarning, "kubelet", "toggled between Ready and NotReady more than %d times in a %s time window, reboot the node now to resolve this", maxToggles, toggleTimeSpan)
+			err := k.dbus.Reboot()
+			if err != nil {
+				return fmt.Errorf("unable to reboot node %w", err)
+			}
+		}
+	}
+	k.nodeReady = isNodeReady(node)
+
+	err := k.ensureNodeInternalIP(ctx, node)
+	if err != nil {
+		return err
+	}
+
+	client := &http.Client{
+		Timeout: 10 * time.Second,
+	}
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, k.kubeletHealthEndpoint, nil)
+	if err != nil {
+		log.Error(err, "Unable to fetch kubelet health")
+		return err
+	}
+	response, err := client.Do(request)
+	if err != nil {
+		log.Error(err, "Unable to fetch kubelet health with http get request")
+	}
+	if err == nil && response.StatusCode == http.StatusOK {
+		if k.firstFailure != nil {
+			log.Info("Kubelet is healthy again", "statusCode", response.StatusCode)
+			k.recorder.Event(node, corev1.EventTypeNormal, "kubelet", "healthy")
+			k.firstFailure = nil
+		}
+		return nil
+	}
+	if k.firstFailure == nil {
+		now := k.Clock.Now()
+		k.firstFailure = &now
+		log.Error(err, "Kubelet is not healthy")
+		k.recorder.Event(node, corev1.EventTypeWarning, "kubelet", "unhealthy")
+	}
+
+	if time.Since(*k.firstFailure).Abs() < maxFailureDuration {
+		return nil
+	}
+
+	log.Error(err, "Kubelet is not healthy, restarting")
+	err = k.dbus.Restart(ctx, k.recorder, node, kubeletServiceName)
+	if err == nil {
+		k.firstFailure = nil
+	}
+	return err
+}
+
+// ensureNodeInternalIP mimics the old weird logic which restores the internalIP of the node
+// if this was lost for some reason.
+func (k *KubeletHealthChecker) ensureNodeInternalIP(ctx context.Context, node *corev1.Node) error {
+	log := logf.FromContext(ctx).WithName("kubelet")
+	var (
+		externalIP string
+		internalIP string
+	)
+	for _, addr := range node.Status.Addresses {
+		switch addr.Type {
+		case corev1.NodeExternalIP:
+			externalIP = addr.Address
+		case corev1.NodeInternalIP:
+			internalIP = addr.Address
+		default:
+			// ignore
+		}
+	}
+
+	if externalIP == "" && internalIP == "" {
+		if k.lastInternalIP.IsValid() {
+			k.recorder.Eventf(node, corev1.EventTypeWarning, "kubelet", "node status does neither have an internal nor an external IP, try to recover from last known internal IP:%s", k.lastInternalIP)
+		} else {
+			k.recorder.Event(node, corev1.EventTypeWarning, "kubelet", "node status does neither have an internal nor an external IP")
+		}
+		addresses, err := k.getAddresses()
+		if err != nil {
+			return fmt.Errorf("unable to list all network interface IP addresses")
+		}
+
+		for _, addr := range addresses {
+			parsed, err := netip.ParsePrefix(addr.String())
+			parsedIP := parsed.Addr()
+			if err != nil {
+				return fmt.Errorf("unable to parse IP address %w", err)
+			}
+			if parsedIP.Compare(k.lastInternalIP) != 0 {
+				continue
+			}
+
+			// One of the ip addresses on the node matches the previous set internalIP of the node which is now gone, set it again.
+			node.Status.Addresses = []corev1.NodeAddress{
+				{
+					Type:    corev1.NodeInternalIP,
+					Address: k.lastInternalIP.String(),
+				},
+			}
+
+			err = k.client.Status().Update(ctx, node)
+			if err != nil {
+				if !apierrors.IsConflict(err) {
+					log.Error(err, "Unable to update node with internal IP")
+					k.recorder.Eventf(node, corev1.EventTypeWarning, "kubelet", "unable to update node with internal IP: %s", err.Error())
+					return k.dbus.Restart(ctx, k.recorder, node, kubeletServiceName)
+				}
+				return err
+			}
+			log.Info("Updated internal IP address of node", "ip", k.lastInternalIP.String())
+			k.recorder.Eventf(node, corev1.EventTypeNormal, "kubelet", "updated the lost internal IP address of node to the previous known: %s ", k.lastInternalIP.String())
+		}
+	} else {
+		var err error
+		k.lastInternalIP, err = netip.ParseAddr(internalIP)
+		if err != nil {
+			return fmt.Errorf("unable to parse internal IP address %w", err)
+		}
+	}
+
+	return nil
+}
+
+// ToggleKubeletState should be triggered if the state of the kubelet changed from Ready -> NotReady or vise versa.
+// It returns true if a reboot of the node should be triggered.
+func (k *KubeletHealthChecker) ToggleKubeletState() bool {
+	k.KubeletReadynessToggles = append(k.KubeletReadynessToggles, time.Now())
+	if len(k.KubeletReadynessToggles) < maxToggles {
+		return false
+	}
+
+	// We have more than maxToggles reached but in a too long period.
+	if k.Clock.Since(k.KubeletReadynessToggles[0]).Abs() > toggleTimeSpan.Abs() {
+		k.KubeletReadynessToggles = k.KubeletReadynessToggles[:len(k.KubeletReadynessToggles)-1]
+		return false
+	}
+
+	// If the oldest entry is older than allowed, trim the slices.
+	if len(k.KubeletReadynessToggles) > maxToggles {
+		k.KubeletReadynessToggles = k.KubeletReadynessToggles[:len(k.KubeletReadynessToggles)-1]
+	}
+
+	// Reaching this point means we need to reboot.
+	clear(k.KubeletReadynessToggles)
+	return true
+}
+
+// isNodeReady returns true if a node is ready; false otherwise.
+func isNodeReady(node *corev1.Node) bool {
+	for _, c := range node.Status.Conditions {
+		if c.Type == corev1.NodeReady {
+			return c.Status == corev1.ConditionTrue
+		}
+	}
+	return false
+}

--- a/pkg/nodeagent/controller/healthcheck/kubelet_test.go
+++ b/pkg/nodeagent/controller/healthcheck/kubelet_test.go
@@ -1,0 +1,64 @@
+// Copyright 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package healthcheck_test
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/utils/clock/testing"
+
+	. "github.com/gardener/gardener/pkg/nodeagent/controller/healthcheck"
+)
+
+var _ = Describe("Kubelet", func() {
+	Describe("#KubeletToggleStats", func() {
+		var (
+			khc   KubeletHealthChecker
+			clock *testing.FakeClock
+		)
+		BeforeEach(func() {
+			clock = testing.NewFakeClock(time.Now())
+			khc = KubeletHealthChecker{
+				KubeletReadynessToggles: []time.Time{},
+				Clock:                   clock,
+			}
+		})
+		It("toggle the first time should not harm", func() {
+			Expect(khc.ToggleKubeletState()).To(BeFalse())
+		})
+
+		It("toggle five times must trigger reboot", func() {
+			Expect(khc.ToggleKubeletState()).To(BeFalse())
+			Expect(khc.ToggleKubeletState()).To(BeFalse())
+			Expect(khc.ToggleKubeletState()).To(BeFalse())
+			Expect(khc.ToggleKubeletState()).To(BeFalse())
+			Expect(khc.ToggleKubeletState()).To(BeTrue())
+		})
+
+		It("toggle five times within a too long timespan must not trigger reboot", func() {
+			Expect(khc.ToggleKubeletState()).To(BeFalse())
+			Expect(khc.ToggleKubeletState()).To(BeFalse())
+			Expect(khc.ToggleKubeletState()).To(BeFalse())
+			Expect(khc.ToggleKubeletState()).To(BeFalse())
+
+			clock.Step(11 * time.Minute)
+
+			Expect(khc.ToggleKubeletState()).To(BeFalse())
+		})
+
+	})
+})

--- a/pkg/nodeagent/controller/healthcheck/kubelet_test.go
+++ b/pkg/nodeagent/controller/healthcheck/kubelet_test.go
@@ -55,13 +55,21 @@ var _ = Describe("Kubelet", func() {
 			Expect(khc.ToggleKubeletState()).To(BeFalse())
 			Expect(khc.ToggleKubeletState()).To(BeFalse())
 			Expect(khc.ToggleKubeletState()).To(BeFalse())
+
+			clock.Step(3 * time.Minute)
+
 			Expect(khc.ToggleKubeletState()).To(BeFalse())
+
+			clock.Step(8 * time.Minute)
+
+			Expect(khc.ToggleKubeletState()).To(BeFalse())
+			Expect(khc.ToggleKubeletState()).To(BeFalse())
+			Expect(khc.KubeletReadinessToggles).To(HaveLen(3))
 
 			clock.Step(11 * time.Minute)
 
 			Expect(khc.ToggleKubeletState()).To(BeFalse())
-			Expect(khc.ToggleKubeletState()).To(BeFalse())
-			Expect(khc.KubeletReadinessToggles).To(HaveLen(2))
+			Expect(khc.KubeletReadinessToggles).To(HaveLen(1))
 		})
 	})
 

--- a/pkg/nodeagent/controller/healthcheck/reconciler.go
+++ b/pkg/nodeagent/controller/healthcheck/reconciler.go
@@ -53,7 +53,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		taskFns = append(taskFns, func(ctx context.Context) error { return f.Check(ctx, node.DeepCopy()) })
 	}
 
-	err := flow.Parallel(taskFns...)(ctx)
+	if err := flow.Parallel(taskFns...)(ctx); err != nil {
+		return reconcile.Result{}, err
+	}
 
-	return reconcile.Result{RequeueAfter: time.Duration(r.HealthCheckIntervalSeconds) * time.Second}, err
+	return reconcile.Result{RequeueAfter: time.Duration(r.HealthCheckIntervalSeconds) * time.Second}, nil
 }

--- a/pkg/nodeagent/controller/healthcheck/reconciler.go
+++ b/pkg/nodeagent/controller/healthcheck/reconciler.go
@@ -1,0 +1,59 @@
+// Copyright 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package healthcheck
+
+import (
+	"context"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/gardener/gardener/pkg/nodeagent/dbus"
+	"github.com/gardener/gardener/pkg/utils/flow"
+)
+
+// Reconciler checks for containerd and kubelet health and restarts them if required.
+type Reconciler struct {
+	Client                     client.Client
+	Recorder                   record.EventRecorder
+	DBus                       dbus.DBus
+	HealthCheckers             []HealthChecker
+	HealthCheckIntervalSeconds int32
+}
+
+// Reconcile executes all defined healtchecks
+func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
+	log := logf.FromContext(ctx)
+	log.Info("Reconcile Healthchecks")
+
+	node := &corev1.Node{}
+	if err := r.Client.Get(ctx, request.NamespacedName, node); err != nil {
+		return reconcile.Result{}, err
+	}
+
+	var taskFns []flow.TaskFn
+	for _, healthChecker := range r.HealthCheckers {
+		f := healthChecker
+		taskFns = append(taskFns, func(ctx context.Context) error { return f.Check(ctx, node.DeepCopy()) })
+	}
+
+	err := flow.Parallel(taskFns...)(ctx)
+
+	return reconcile.Result{RequeueAfter: time.Duration(r.HealthCheckIntervalSeconds) * time.Second}, err
+}

--- a/pkg/nodeagent/dbus/dbus.go
+++ b/pkg/nodeagent/dbus/dbus.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/coreos/go-systemd/v22/dbus"
+	"github.com/coreos/go-systemd/v22/login1"
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -41,6 +42,8 @@ type DBus interface {
 	Stop(ctx context.Context, recorder record.EventRecorder, node runtime.Object, unitName string) error
 	// Restart the given unit and record an event to the node object, same as executing "systemctl restart unit".
 	Restart(ctx context.Context, recorder record.EventRecorder, node runtime.Object, unitName string) error
+	// Reboot this machines, is the same as executing "systemctl reboot".
+	Reboot() error
 }
 
 type db struct {
@@ -50,6 +53,16 @@ type db struct {
 // New returns a new working DBus
 func New(log logr.Logger) DBus {
 	return &db{log: log.WithName("dbus")}
+}
+func (_ *db) Reboot() error {
+	login, err := login1.New()
+	if err != nil {
+		return fmt.Errorf("unable to connect to dbus: %w", err)
+	}
+	defer login.Close()
+
+	login.Reboot(false)
+	return nil
 }
 
 func (_ *db) Enable(ctx context.Context, unitNames ...string) error {

--- a/pkg/nodeagent/dbus/fake/fake_dbus.go
+++ b/pkg/nodeagent/dbus/fake/fake_dbus.go
@@ -40,6 +40,8 @@ const (
 	ActionStart
 	// ActionStop is constant for the 'Stop' action.
 	ActionStop
+	// ActionReboot is constant for the 'Reboot' action.
+	ActionReboot
 )
 
 // SystemdAction is used for the implementation of the fake dbus.
@@ -106,6 +108,18 @@ func (d *DBus) Restart(_ context.Context, _ record.EventRecorder, _ runtime.Obje
 	d.Actions = append(d.Actions, SystemdAction{
 		Action:    ActionRestart,
 		UnitNames: []string{unitName},
+	})
+	return nil
+}
+
+// Reboot implements dbus.DBus.
+func (d *DBus) Reboot() error {
+	d.mutex.Lock()
+	defer d.mutex.Unlock()
+
+	d.Actions = append(d.Actions, SystemdAction{
+		Action:    ActionReboot,
+		UnitNames: []string{"reboot"},
 	})
 	return nil
 }

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -1149,6 +1149,7 @@ build:
             - pkg/nodeagent/apis/config/validation
             - pkg/nodeagent/bootstrap
             - pkg/nodeagent/controller
+            - pkg/nodeagent/controller/healthcheck
             - pkg/nodeagent/controller/lease
             - pkg/nodeagent/controller/node
             - pkg/nodeagent/controller/operatingsystemconfig

--- a/test/integration/nodeagent/healthcheck/healthcheck_suite_test.go
+++ b/test/integration/nodeagent/healthcheck/healthcheck_suite_test.go
@@ -1,0 +1,71 @@
+// Copyright 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package healthcheck_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	"github.com/gardener/gardener/pkg/logger"
+)
+
+func TestHealthcheck(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Test Integration NodeAgent Healthcheck Suite")
+}
+
+const testID = "healthcheck-controller-test"
+
+var (
+	ctx = context.Background()
+	log logr.Logger
+
+	restConfig *rest.Config
+	testEnv    *envtest.Environment
+	testClient client.Client
+
+	testRunID string
+)
+
+var _ = BeforeSuite(func() {
+	logf.SetLogger(logger.MustNewZapLogger(logger.DebugLevel, logger.FormatJSON, zap.WriteTo(GinkgoWriter)))
+	log = logf.Log.WithName(testID)
+
+	By("Start test environment")
+	testEnv = &envtest.Environment{}
+
+	var err error
+	restConfig, err = testEnv.Start()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(restConfig).NotTo(BeNil())
+
+	DeferCleanup(func() {
+		By("Stop test environment")
+		Expect(testEnv.Stop()).To(Succeed())
+	})
+
+	By("Create test client")
+	testClient, err = client.New(restConfig, client.Options{})
+	Expect(err).NotTo(HaveOccurred())
+})

--- a/test/integration/nodeagent/healthcheck/healthcheck_test.go
+++ b/test/integration/nodeagent/healthcheck/healthcheck_test.go
@@ -1,0 +1,301 @@
+// Copyright 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package healthcheck_test
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"time"
+
+	"github.com/containerd/containerd"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/uuid"
+	"k8s.io/utils/clock/testing"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	"github.com/gardener/gardener/pkg/nodeagent/controller/healthcheck"
+	fakedbus "github.com/gardener/gardener/pkg/nodeagent/dbus/fake"
+	gardenerutils "github.com/gardener/gardener/pkg/utils"
+)
+
+var _ = Describe("Healthcheck controller tests", func() {
+	var (
+		clock              *testing.FakeClock
+		nodeName           string
+		node               *corev1.Node
+		fakeDBus           *fakedbus.DBus
+		interfaceAddresses []string
+		containerdClient   *fakeContainerdClient
+		kubeletHealthcheck *healthcheck.KubeletHealthChecker
+	)
+
+	BeforeEach(func() {
+		By("Setup manager")
+		mgr, err := manager.New(restConfig, manager.Options{
+			Metrics: metricsserver.Options{BindAddress: "0"},
+			// Cache:   cache.Options{
+			// DefaultLabelSelector: labels.SelectorFromSet(labels.Set{testID: testRunID}),
+			// },
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		clock = testing.NewFakeClock(time.Now())
+		fakeDBus = fakedbus.New()
+		getAddresses := func() ([]net.Addr, error) {
+			var result []net.Addr
+			for _, addr := range interfaceAddresses {
+				_, ip, err := net.ParseCIDR(addr)
+				Expect(err).NotTo(HaveOccurred())
+				result = append(result, ip)
+			}
+			return result, nil
+		}
+		containerdClient = &fakeContainerdClient{
+			returnError: false,
+		}
+		testRunID = "test-" + gardenerutils.ComputeSHA256Hex([]byte(uuid.NewUUID()))[:8]
+		nodeName = testRunID
+
+		kubeletHealthcheck = healthcheck.NewKubeletHealthChecker(
+			mgr.GetClient(), clock, fakeDBus, mgr.GetEventRecorderFor(healthcheck.ControllerName), getAddresses,
+		)
+
+		containerdHealthcheck := healthcheck.NewContainerdHealthChecker(
+			mgr.GetClient(), containerdClient, clock, fakeDBus, mgr.GetEventRecorderFor(healthcheck.ControllerName),
+		)
+
+		By("Register controller")
+		Expect((&healthcheck.Reconciler{
+			HealthCheckIntervalSeconds: 1,
+			HealthCheckers:             []healthcheck.HealthChecker{containerdHealthcheck, kubeletHealthcheck},
+		}).AddToManager(mgr, predicate.NewPredicateFuncs(func(obj client.Object) bool { return obj.GetName() == nodeName }))).To(Succeed())
+
+		By("Start manager")
+		mgrContext, mgrCancel := context.WithCancel(ctx)
+
+		go func() {
+			defer GinkgoRecover()
+			Expect(mgr.Start(mgrContext)).To(Succeed())
+		}()
+
+		DeferCleanup(func() {
+			By("Stop manager")
+			mgrCancel()
+		})
+
+		node = &corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   nodeName,
+				Labels: map[string]string{testID: testRunID},
+			},
+		}
+
+		By("Create Node")
+		Expect(testClient.Create(ctx, node)).To(Succeed())
+		DeferCleanup(func() {
+			By("Delete Node")
+			Expect(testClient.Delete(ctx, node)).To(Succeed())
+			By("Cleanup fakeDBUS")
+		})
+	})
+
+	It("Containerd health should be true", func() {
+		By("Start fake kubelet healthz endpoint")
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			fmt.Fprintln(w, "OK")
+		}))
+		kubeletHealthcheck.SetKubeletHealthEndpoint(ts.URL)
+
+		Consistently(func() []fakedbus.SystemdAction {
+			return fakeDBus.Actions
+		}).Should(BeEmpty())
+	})
+
+	It("Containerd health should be false", func() {
+		By("Start fake kubelet healthz endpoint")
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			fmt.Fprintln(w, "OK")
+		}))
+		kubeletHealthcheck.SetKubeletHealthEndpoint(ts.URL)
+		containerdClient.returnError = true
+		clock.Step(80 * time.Second)
+		Eventually(func() []fakedbus.SystemdAction {
+			return fakeDBus.Actions
+		}).Should(
+			ConsistOf(fakedbus.SystemdAction{Action: fakedbus.ActionRestart, UnitNames: []string{"containerd.service"}}),
+		)
+	})
+
+	It("Kubelet health should be false", func() {
+		clock.Step(80 * time.Second)
+		Eventually(func() []fakedbus.SystemdAction {
+			return fakeDBus.Actions
+		}).Should(
+			ConsistOf(fakedbus.SystemdAction{Action: fakedbus.ActionRestart, UnitNames: []string{"kubelet.service"}}),
+		)
+	})
+
+	It("Kubelet health should be true", func() {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			fmt.Fprintln(w, "OK")
+		}))
+
+		kubeletHealthcheck.SetKubeletHealthEndpoint(ts.URL)
+		clock.Step(80 * time.Second)
+		Eventually(func() []fakedbus.SystemdAction {
+			return fakeDBus.Actions
+		}).Should(BeEmpty())
+	})
+
+	It("Node InternalIP went away and came back", func() {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			fmt.Fprintln(w, "OK")
+		}))
+
+		kubeletHealthcheck.SetKubeletHealthEndpoint(ts.URL)
+
+		interfaceAddresses = []string{"1.2.3.4/32"}
+		By("Patch Node Status add NodeAddress")
+		node.Status.Addresses = []corev1.NodeAddress{
+			{
+				Type:    corev1.NodeInternalIP,
+				Address: "1.2.3.4",
+			},
+		}
+		Expect(testClient.Status().Update(ctx, node)).To(Succeed())
+
+		Eventually(func() []corev1.NodeAddress {
+			Expect(testClient.Get(ctx, types.NamespacedName{Name: nodeName}, node)).To(Succeed())
+			return node.Status.Addresses
+		}).Should(ConsistOf(corev1.NodeAddress{Type: corev1.NodeInternalIP, Address: "1.2.3.4"}))
+
+		Eventually(func() bool {
+			return kubeletHealthcheck.HasLastInternalIP()
+		}).Should(BeTrue())
+
+		By("Update Node Status, remove NodeAddresses")
+		node.Status.Addresses = []corev1.NodeAddress{}
+		Expect(testClient.Status().Update(ctx, node)).To(Succeed())
+		Eventually(func() []corev1.NodeAddress {
+			Expect(testClient.Get(ctx, types.NamespacedName{Name: nodeName}, node)).To(Succeed())
+			return node.Status.Addresses
+		}).Should(BeEmpty())
+
+		By("Wait for reappearing NodeAddress")
+		Eventually(func() []corev1.NodeAddress {
+			Expect(testClient.Get(ctx, types.NamespacedName{Name: nodeName}, node)).To(Succeed())
+			return node.Status.Addresses
+		}).Should(ConsistOf(corev1.NodeAddress{Type: corev1.NodeInternalIP, Address: "1.2.3.4"}))
+	})
+
+	It("Kubelet toggles between Ready and NotReady to fast and triggers a reboot", func() {
+		By("Start fake kubelet healthz endpoint")
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			fmt.Fprintln(w, "OK")
+		}))
+
+		kubeletHealthcheck.SetKubeletHealthEndpoint(ts.URL)
+
+		By("Patch Node Status add NodeAddress")
+		node.Status.Addresses = []corev1.NodeAddress{
+			{
+				Type:    corev1.NodeInternalIP,
+				Address: "1.2.3.4",
+			},
+		}
+		Expect(testClient.Status().Update(ctx, node)).To(Succeed())
+		Eventually(func() bool {
+			return kubeletHealthcheck.HasLastInternalIP()
+		}).Should(BeTrue())
+
+		By("Patch Node Status to Ready")
+		setNodeCondition(ctx, node, corev1.ConditionTrue)
+		Eventually(func() int {
+			return len(kubeletHealthcheck.KubeletReadynessToggles)
+		}).Should(Equal(1))
+
+		clock.Step(2 * time.Second)
+		By("Patch Node Status to NotReady")
+		setNodeCondition(ctx, node, corev1.ConditionFalse)
+		Eventually(func() int {
+			return len(kubeletHealthcheck.KubeletReadynessToggles)
+		}).Should(Equal(2))
+
+		clock.Step(2 * time.Second)
+		By("Patch Node Status to Ready")
+		setNodeCondition(ctx, node, corev1.ConditionTrue)
+		Eventually(func() int {
+			return len(kubeletHealthcheck.KubeletReadynessToggles)
+		}).Should(Equal(3))
+
+		clock.Step(2 * time.Second)
+		By("Patch Node Status to NotReady")
+		setNodeCondition(ctx, node, corev1.ConditionFalse)
+		Eventually(func() int {
+			return len(kubeletHealthcheck.KubeletReadynessToggles)
+		}).Should(Equal(4))
+
+		clock.Step(2 * time.Second)
+		By("Patch Node Status to Ready")
+		setNodeCondition(ctx, node, corev1.ConditionTrue)
+		Eventually(func() int {
+			return len(kubeletHealthcheck.KubeletReadynessToggles)
+		}).Should(Equal(5))
+
+		clock.Step(2 * time.Second)
+		By("Patch Node Status to NotReady")
+		setNodeCondition(ctx, node, corev1.ConditionFalse)
+
+		clock.Step(80 * time.Second)
+		Eventually(func() []fakedbus.SystemdAction {
+			return fakeDBus.Actions
+		}).Should(
+			ConsistOf(fakedbus.SystemdAction{Action: fakedbus.ActionReboot, UnitNames: []string{"reboot"}}),
+		)
+
+	})
+
+})
+
+type fakeContainerdClient struct {
+	returnError bool
+}
+
+func (f *fakeContainerdClient) Version(_ context.Context) (containerd.Version, error) {
+	if f.returnError {
+		return containerd.Version{}, fmt.Errorf("calling fake containerd socket error")
+	}
+	return containerd.Version{Version: "fake version"}, nil
+}
+
+func setNodeCondition(ctx context.Context, node *corev1.Node, condition corev1.ConditionStatus) {
+	node.Status.Conditions = []corev1.NodeCondition{
+		{
+			Type:   corev1.NodeReady,
+			Status: condition,
+		},
+	}
+	Expect(testClient.Status().Update(ctx, node)).To(Succeed())
+}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:

Refactor the existing health checks for the kubelet and the containerd from bash to a pure go implementation. These healthchecks run in a healthcheck controller in the gardener-node-agent.
The docker healthcheck is not refactored.

**Which issue(s) this PR fixes**:
Part of #8023

**Special notes for your reviewer**:

/cc @rfranzke 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
`node-agent` checks health of `containerd` and `kubelet` now. This replaces the previous bash implementation of these health checks.
```
