### PR TITLE
Stop patching new secretRefs on MR reconciliaition

### DIFF
--- a/extensions/pkg/controller/controlplane/genericactuator/actuator_test.go
+++ b/extensions/pkg/controller/controlplane/genericactuator/actuator_test.go
@@ -398,8 +398,6 @@ webhooks:
 				c.EXPECT().Delete(ctx, &networkingv1.NetworkPolicy{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "gardener-extension-" + providerName}})
 				c.EXPECT().Delete(ctx, &networkingv1.NetworkPolicy{ObjectMeta: metav1.ObjectMeta{Namespace: webhookServerNamespace, Name: "ingress-from-all-shoots-kube-apiserver"}})
 				c.EXPECT().Create(ctx, createdMRForShootWebhooks).Return(nil)
-				c.EXPECT().Get(ctx, client.ObjectKeyFromObject(createdMRSecretForShootWebhooks), gomock.AssignableToTypeOf(&corev1.Secret{}))
-				c.EXPECT().Patch(ctx, objMatcher{obj: createdMRSecretForShootWebhooks}, gomock.Any())
 			}
 
 			c.EXPECT().Get(ctx, cpSecretKey, &corev1.Secret{}).DoAndReturn(clientGet(cpSecret))
@@ -414,8 +412,6 @@ webhooks:
 			createdMRForCPShootChart.Spec.SecretRefs = []corev1.LocalObjectReference{{Name: createdMRSecretForCPShootChart.Name}}
 			utilruntime.Must(references.InjectAnnotations(createdMRForCPShootChart))
 			c.EXPECT().Create(ctx, createdMRForCPShootChart).Return(nil)
-			c.EXPECT().Get(ctx, client.ObjectKeyFromObject(createdMRSecretForCPShootChart), gomock.AssignableToTypeOf(&corev1.Secret{}))
-			c.EXPECT().Patch(ctx, objMatcher{obj: createdMRSecretForCPShootChart}, gomock.Any())
 
 			if withShootCRDsChart {
 				utilruntime.Must(kubernetesutils.MakeUnique(createdMRSecretForCPShootCRDsChart))
@@ -425,8 +421,6 @@ webhooks:
 				createdMRForCPShootCRDsChart.Spec.SecretRefs = []corev1.LocalObjectReference{{Name: createdMRSecretForCPShootCRDsChart.Name}}
 				utilruntime.Must(references.InjectAnnotations(createdMRForCPShootCRDsChart))
 				c.EXPECT().Create(ctx, createdMRForCPShootCRDsChart).Return(nil)
-				c.EXPECT().Get(ctx, client.ObjectKeyFromObject(createdMRSecretForCPShootCRDsChart), gomock.AssignableToTypeOf(&corev1.Secret{}))
-				c.EXPECT().Patch(ctx, objMatcher{obj: createdMRSecretForCPShootCRDsChart}, gomock.Any())
 			}
 
 			utilruntime.Must(kubernetesutils.MakeUnique(createdMRSecretForStorageClassesChart))
@@ -436,8 +430,6 @@ webhooks:
 			createdMRForStorageClassesChart.Spec.SecretRefs = []corev1.LocalObjectReference{{Name: createdMRSecretForStorageClassesChart.Name}}
 			utilruntime.Must(references.InjectAnnotations(createdMRForStorageClassesChart))
 			c.EXPECT().Create(ctx, createdMRForStorageClassesChart).Return(nil)
-			c.EXPECT().Get(ctx, client.ObjectKeyFromObject(createdMRSecretForStorageClassesChart), gomock.AssignableToTypeOf(&corev1.Secret{}))
-			c.EXPECT().Patch(ctx, objMatcher{obj: createdMRSecretForStorageClassesChart}, gomock.Any())
 
 			// Create mock Gardener clientset and chart applier
 			gardenerClientset := kubernetesmock.NewMockInterface(ctrl)

--- a/extensions/pkg/controller/controlplane/genericactuator/actuator_test.go
+++ b/extensions/pkg/controller/controlplane/genericactuator/actuator_test.go
@@ -17,7 +17,6 @@ package genericactuator
 import (
 	"context"
 	"crypto/rand"
-	"fmt"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -99,29 +98,6 @@ var _ = BeforeSuite(func() {
 		&secretsutils.GenerateKey, secretsutils.FakeGenerateKey,
 	))
 })
-
-type objMatcher struct {
-	obj client.Object
-}
-
-func (o objMatcher) Matches(x interface{}) bool {
-	xx, ok := x.(client.Object)
-	if !ok {
-		return false
-	}
-
-	oKind := o.obj.GetObjectKind()
-	xKind := xx.GetObjectKind()
-	return oKind.GroupVersionKind().Group == xKind.GroupVersionKind().Group &&
-		oKind.GroupVersionKind().Version == xKind.GroupVersionKind().Version &&
-		oKind.GroupVersionKind().Kind == xKind.GroupVersionKind().Kind &&
-		o.obj.GetName() == xx.GetName() &&
-		o.obj.GetNamespace() == xx.GetNamespace()
-}
-
-func (o objMatcher) String() string {
-	return fmt.Sprintf("is the same as %s", client.ObjectKeyFromObject(o.obj).String())
-}
 
 var _ = Describe("Actuator", func() {
 	var (

--- a/pkg/component/etcd/bootstrap_test.go
+++ b/pkg/component/etcd/bootstrap_test.go
@@ -587,8 +587,6 @@ status:
 				c.EXPECT().Get(ctx, kubernetesutils.Key(namespace, managedResourceSecret.Name), gomock.AssignableToTypeOf(&corev1.Secret{})),
 				c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&corev1.Secret{})),
 				c.EXPECT().Get(ctx, kubernetesutils.Key(namespace, managedResourceName), gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})),
-				c.EXPECT().Get(ctx, kubernetesutils.Key(namespace, managedResourceSecret.Name), gomock.AssignableToTypeOf(&corev1.Secret{})),
-				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&corev1.Secret{}), gomock.Any()),
 				c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})).Return(fakeErr),
 			)
 
@@ -603,8 +601,6 @@ status:
 					Expect(obj).To(Equal(managedResourceSecret))
 				}),
 				c.EXPECT().Get(ctx, kubernetesutils.Key(namespace, managedResourceName), gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})),
-				c.EXPECT().Get(ctx, kubernetesutils.Key(namespace, managedResourceSecret.Name), gomock.AssignableToTypeOf(&corev1.Secret{})),
-				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&corev1.Secret{}), gomock.Any()),
 				c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})).Do(func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) {
 					managedResource.Spec.SecretRefs = []corev1.LocalObjectReference{{Name: managedResourceSecret.Name}}
 					utilruntime.Must(references.InjectAnnotations(managedResource))
@@ -628,8 +624,6 @@ status:
 					Expect(obj).To(DeepEqual(managedResourceSecret))
 				}),
 				c.EXPECT().Get(ctx, kubernetesutils.Key(namespace, managedResourceName), gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})),
-				c.EXPECT().Get(ctx, kubernetesutils.Key(namespace, managedResourceSecret.Name), gomock.AssignableToTypeOf(&corev1.Secret{})),
-				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&corev1.Secret{}), gomock.Any()),
 				c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})).Do(func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) {
 					managedResource.Spec.SecretRefs = []corev1.LocalObjectReference{{Name: managedResourceSecret.Name}}
 					utilruntime.Must(references.InjectAnnotations(managedResource))
@@ -653,8 +647,6 @@ status:
 					Expect(obj).To(Equal(managedResourceSecret))
 				}),
 				c.EXPECT().Get(ctx, kubernetesutils.Key(namespace, managedResourceName), gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})),
-				c.EXPECT().Get(ctx, kubernetesutils.Key(namespace, managedResourceSecret.Name), gomock.AssignableToTypeOf(&corev1.Secret{})),
-				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&corev1.Secret{}), gomock.Any()),
 				c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})).Do(func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) {
 					managedResource.Spec.SecretRefs = []corev1.LocalObjectReference{{Name: managedResourceSecret.Name}}
 					utilruntime.Must(references.InjectAnnotations(managedResource))

--- a/pkg/component/logging/vali/vali_test.go
+++ b/pkg/component/logging/vali/vali_test.go
@@ -500,8 +500,6 @@ var _ = Describe("Vali", func() {
 				runtimeClient.EXPECT().Get(ctx, gomock.AssignableToTypeOf(types.NamespacedName{}), objectOfTypeSecret),
 				runtimeClient.EXPECT().Update(ctx, objectOfTypeSecret),
 				runtimeClient.EXPECT().Get(ctx, kubernetesutils.Key(gardenNamespace, managedResourceName), objectOfTypeMR),
-				runtimeClient.EXPECT().Get(ctx, gomock.AssignableToTypeOf(types.NamespacedName{}), objectOfTypeSecret),
-				runtimeClient.EXPECT().Patch(ctx, objectOfTypeSecret, gomock.Any()),
 				runtimeClient.EXPECT().Update(ctx, objectOfTypeMR),
 			)
 			Expect(valiDeployer.Deploy(ctx)).To(Succeed())
@@ -539,8 +537,6 @@ var _ = Describe("Vali", func() {
 				runtimeClient.EXPECT().Get(ctx, gomock.AssignableToTypeOf(types.NamespacedName{}), objectOfTypeSecret),
 				runtimeClient.EXPECT().Update(ctx, objectOfTypeSecret),
 				runtimeClient.EXPECT().Get(ctx, kubernetesutils.Key(gardenNamespace, managedResourceName), objectOfTypeMR),
-				runtimeClient.EXPECT().Get(ctx, gomock.AssignableToTypeOf(types.NamespacedName{}), objectOfTypeSecret),
-				runtimeClient.EXPECT().Patch(ctx, objectOfTypeSecret, gomock.Any()),
 				runtimeClient.EXPECT().Update(ctx, objectOfTypeMR),
 			)
 			Expect(valiDeployer.Deploy(ctx)).To(Succeed())
@@ -567,8 +563,6 @@ var _ = Describe("Vali", func() {
 				runtimeClient.EXPECT().Get(ctx, gomock.AssignableToTypeOf(types.NamespacedName{}), objectOfTypeSecret),
 				runtimeClient.EXPECT().Update(ctx, objectOfTypeSecret),
 				runtimeClient.EXPECT().Get(ctx, kubernetesutils.Key(gardenNamespace, managedResourceName), objectOfTypeMR),
-				runtimeClient.EXPECT().Get(ctx, gomock.AssignableToTypeOf(types.NamespacedName{}), objectOfTypeSecret),
-				runtimeClient.EXPECT().Patch(ctx, objectOfTypeSecret, gomock.Any()),
 				runtimeClient.EXPECT().Update(ctx, objectOfTypeMR),
 			)
 			Expect(valiDeployer.Deploy(ctx)).To(Succeed())
@@ -595,8 +589,6 @@ var _ = Describe("Vali", func() {
 				runtimeClient.EXPECT().Get(ctx, gomock.AssignableToTypeOf(types.NamespacedName{}), objectOfTypeSecret),
 				runtimeClient.EXPECT().Update(ctx, objectOfTypeSecret),
 				runtimeClient.EXPECT().Get(ctx, kubernetesutils.Key(gardenNamespace, managedResourceName), objectOfTypeMR),
-				runtimeClient.EXPECT().Get(ctx, gomock.AssignableToTypeOf(types.NamespacedName{}), objectOfTypeSecret),
-				runtimeClient.EXPECT().Patch(ctx, objectOfTypeSecret, gomock.Any()),
 				runtimeClient.EXPECT().Update(ctx, objectOfTypeMR),
 			)
 			Expect(valiDeployer.Deploy(ctx)).To(Succeed())
@@ -633,8 +625,6 @@ var _ = Describe("Vali", func() {
 				runtimeClient.EXPECT().Get(ctx, gomock.AssignableToTypeOf(types.NamespacedName{}), objectOfTypeSecret),
 				runtimeClient.EXPECT().Update(ctx, objectOfTypeSecret),
 				runtimeClient.EXPECT().Get(ctx, kubernetesutils.Key(gardenNamespace, managedResourceName), objectOfTypeMR),
-				runtimeClient.EXPECT().Get(ctx, gomock.AssignableToTypeOf(types.NamespacedName{}), objectOfTypeSecret),
-				runtimeClient.EXPECT().Patch(ctx, objectOfTypeSecret, gomock.Any()),
 				runtimeClient.EXPECT().Update(ctx, objectOfTypeMR),
 			)
 			Expect(valiDeployer.Deploy(ctx)).To(Succeed())
@@ -672,8 +662,6 @@ var _ = Describe("Vali", func() {
 				runtimeClient.EXPECT().Get(ctx, gomock.AssignableToTypeOf(types.NamespacedName{}), objectOfTypeSecret),
 				runtimeClient.EXPECT().Update(ctx, objectOfTypeSecret),
 				runtimeClient.EXPECT().Get(ctx, kubernetesutils.Key(gardenNamespace, managedResourceName), objectOfTypeMR),
-				runtimeClient.EXPECT().Get(ctx, gomock.AssignableToTypeOf(types.NamespacedName{}), objectOfTypeSecret),
-				runtimeClient.EXPECT().Patch(ctx, objectOfTypeSecret, gomock.Any()),
 				runtimeClient.EXPECT().Update(ctx, objectOfTypeMR),
 			)
 			Expect(valiDeployer.Deploy(ctx)).To(Succeed())
@@ -711,8 +699,6 @@ var _ = Describe("Vali", func() {
 				runtimeClient.EXPECT().Get(ctx, gomock.AssignableToTypeOf(types.NamespacedName{}), objectOfTypeSecret),
 				runtimeClient.EXPECT().Update(ctx, objectOfTypeSecret),
 				runtimeClient.EXPECT().Get(ctx, kubernetesutils.Key(gardenNamespace, managedResourceName), objectOfTypeMR),
-				runtimeClient.EXPECT().Get(ctx, gomock.AssignableToTypeOf(types.NamespacedName{}), objectOfTypeSecret),
-				runtimeClient.EXPECT().Patch(ctx, objectOfTypeSecret, gomock.Any()),
 				runtimeClient.EXPECT().Update(ctx, objectOfTypeMR),
 			)
 			Expect(valiDeployer.Deploy(ctx)).To(Succeed())

--- a/pkg/component/resourcemanager/resource_manager_test.go
+++ b/pkg/component/resourcemanager/resource_manager_test.go
@@ -1925,13 +1925,6 @@ subjects:
 							Expect(obj).To(DeepEqual(managedResourceSecret))
 						}),
 						c.EXPECT().Get(ctx, kubernetesutils.Key(deployNamespace, "shoot-core-gardener-resource-manager"), gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})),
-						c.EXPECT().Get(ctx, kubernetesutils.Key(deployNamespace, managedResourceSecret.Name), gomock.AssignableToTypeOf(&corev1.Secret{})),
-						c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&corev1.Secret{}), gomock.Any()).Do(func(ctx context.Context, obj runtime.Object, _ client.Patch, _ ...client.PatchOption) {
-							expected := &corev1.Secret{
-								ObjectMeta: managedResourceSecret.ObjectMeta,
-							}
-							Expect(obj).To(DeepEqual(expected))
-						}),
 						c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})).Do(func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) {
 							Expect(obj).To(DeepEqual(managedResource))
 						}),
@@ -2009,13 +2002,6 @@ subjects:
 							Expect(obj).To(DeepEqual(managedResourceSecret))
 						}),
 						c.EXPECT().Get(ctx, kubernetesutils.Key(deployNamespace, "shoot-core-gardener-resource-manager"), gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})),
-						c.EXPECT().Get(ctx, kubernetesutils.Key(deployNamespace, managedResourceSecret.Name), gomock.AssignableToTypeOf(&corev1.Secret{})),
-						c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&corev1.Secret{}), gomock.Any()).Do(func(ctx context.Context, obj runtime.Object, _ client.Patch, _ ...client.PatchOption) {
-							expected := &corev1.Secret{
-								ObjectMeta: managedResourceSecret.ObjectMeta,
-							}
-							Expect(obj).To(DeepEqual(expected))
-						}),
 						c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})).Do(func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) {
 							Expect(obj).To(DeepEqual(managedResource))
 						}),
@@ -2101,13 +2087,6 @@ subjects:
 						Expect(obj).To(DeepEqual(managedResourceSecret))
 					}),
 					c.EXPECT().Get(ctx, kubernetesutils.Key(deployNamespace, "shoot-core-gardener-resource-manager"), gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})),
-					c.EXPECT().Get(ctx, kubernetesutils.Key(deployNamespace, managedResourceSecret.Name), gomock.AssignableToTypeOf(&corev1.Secret{})),
-					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&corev1.Secret{}), gomock.Any()).Do(func(ctx context.Context, obj runtime.Object, _ client.Patch, _ ...client.PatchOption) {
-						expected := &corev1.Secret{
-							ObjectMeta: managedResourceSecret.ObjectMeta,
-						}
-						Expect(obj).To(DeepEqual(expected))
-					}),
 					c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})).Do(func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) {
 						Expect(obj).To(DeepEqual(managedResource))
 					}),
@@ -2220,13 +2199,6 @@ subjects:
 						Expect(obj).To(DeepEqual(managedResourceSecret))
 					}),
 					c.EXPECT().Get(ctx, kubernetesutils.Key(deployNamespace, "shoot-core-gardener-resource-manager"), gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})),
-					c.EXPECT().Get(ctx, kubernetesutils.Key(deployNamespace, managedResourceSecret.Name), gomock.AssignableToTypeOf(&corev1.Secret{})),
-					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&corev1.Secret{}), gomock.Any()).Do(func(ctx context.Context, obj runtime.Object, _ client.Patch, _ ...client.PatchOption) {
-						expected := &corev1.Secret{
-							ObjectMeta: managedResourceSecret.ObjectMeta,
-						}
-						Expect(obj).To(DeepEqual(expected))
-					}),
 					c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})).Do(func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) {
 						Expect(obj).To(Equal(managedResource))
 					}),

--- a/pkg/utils/managedresources/builder/resourcemanager_test.go
+++ b/pkg/utils/managedresources/builder/resourcemanager_test.go
@@ -305,19 +305,6 @@ var _ = Describe("Resource Manager", func() {
 
 			Expect(references.InjectAnnotations(expectedMr)).To(Succeed())
 			Expect(mr).To(Equal(expectedMr))
-
-			for _, s := range secrets {
-				secret := &corev1.Secret{}
-				Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(s), secret)).To(Succeed())
-				expected := s.DeepCopy()
-				expected.ObjectMeta.ResourceVersion = "2"
-				expected.Labels["resources.gardener.cloud/garbage-collectable-reference"] = "true"
-				expected.TypeMeta = metav1.TypeMeta{
-					APIVersion: "v1",
-					Kind:       "Secret",
-				}
-				Expect(secret).To(Equal(expected))
-			}
 		})
 
 		It("should label existing managed resource secrets", func() {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind cleanup

**What this PR does / why we need it**:
New managed resource secret references will no longer be ensured to be garbage collectable.

**Which issue(s) this PR fixes**:
Fixes #8549

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking developer
New `Secret`s referenced in `ManagedResource`s will no longer be patched with the label `resources.gardener.cloud/garbage-collectable-reference` when the `ManagedResource` is reconciled. `Secret`s which already exist in the `ManagedResource` specification will still be patched if necessary.
```
