### PR TITLE
Fix `generate-crds.sh` script

### DIFF
--- a/hack/generate-crds.sh
+++ b/hack/generate-crds.sh
@@ -105,7 +105,7 @@ generate_group () {
     # etcd-druid, due to adverse interaction with VPA.
     # See https://github.com/gardener/gardener/pull/6850 and https://github.com/gardener/gardener/pull/8560#discussion_r1347470394
     # TODO(shreyas-s-rao): Remove this workaround as soon as the scale subresource is supported properly.
-    etcd_api_types_file="$(dirname "$0")/../vendor/github.com/gardener/etcd-druid/api/v1alpha1/types_etcd.go"
+    etcd_api_types_file="${package_path%;}/types_etcd.go"
     sed -i '/\/\/ +kubebuilder:subresource:scale:specpath=.spec.replicas,statuspath=.status.replicas,selectorpath=.status.labelSelector/d' "$etcd_api_types_file"
     $generate
     git checkout "$etcd_api_types_file"


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind bug

**What this PR does / why we need it**:
Fix crd generation script.
The script works fine for `gardener/gardener` but for extensions vendoring it, it fails with
```
Generating CRDs for druid.gardener.cloud group
sed: can't read ../vendor/github.com/gardener/gardener/hack/../vendor/github.com/gardener/etcd-druid/api/v1alpha1/types_etcd.go: No such file or directory
example/doc.go:15: running "../vendor/github.com/gardener/gardener/hack/generate-crds.sh": exit status 2
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Introduced with https://github.com/gardener/gardener/pull/8560

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix developer
A bug causing the crd generation for `druid.gardener.cloud` group to fail in extensions is now fixed.
```
