### PR TITLE
Configure `0640` permissions to mounted `key` files on Control plane components

### DIFF
--- a/pkg/component/apiserver/deployment.go
+++ b/pkg/component/apiserver/deployment.go
@@ -20,6 +20,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/pointer"
 
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	etcdconstants "github.com/gardener/gardener/pkg/component/etcd/constants"
@@ -128,7 +129,8 @@ func InjectDefaultSettings(
 			Name: volumeNameEtcdClient,
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
-					SecretName: secretETCDClient.Name,
+					SecretName:  secretETCDClient.Name,
+					DefaultMode: pointer.Int32(416),
 				},
 			},
 		},
@@ -136,7 +138,8 @@ func InjectDefaultSettings(
 			Name: volumeNameServer,
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
-					SecretName: secretServer.Name,
+					SecretName:  secretServer.Name,
+					DefaultMode: pointer.Int32(416),
 				},
 			},
 		},

--- a/pkg/component/apiserver/deployment.go
+++ b/pkg/component/apiserver/deployment.go
@@ -130,7 +130,7 @@ func InjectDefaultSettings(
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
 					SecretName:  secretETCDClient.Name,
-					DefaultMode: pointer.Int32(416),
+					DefaultMode: pointer.Int32(0640),
 				},
 			},
 		},
@@ -139,7 +139,7 @@ func InjectDefaultSettings(
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
 					SecretName:  secretServer.Name,
-					DefaultMode: pointer.Int32(416),
+					DefaultMode: pointer.Int32(0640),
 				},
 			},
 		},

--- a/pkg/component/apiserver/deployment_test.go
+++ b/pkg/component/apiserver/deployment_test.go
@@ -112,7 +112,8 @@ var _ = Describe("Deployment", func() {
 									Name: "etcd-client",
 									VolumeSource: corev1.VolumeSource{
 										Secret: &corev1.SecretVolumeSource{
-											SecretName: secretETCDClient.Name,
+											SecretName:  secretETCDClient.Name,
+											DefaultMode: pointer.Int32(416),
 										},
 									},
 								},
@@ -120,7 +121,8 @@ var _ = Describe("Deployment", func() {
 									Name: "server",
 									VolumeSource: corev1.VolumeSource{
 										Secret: &corev1.SecretVolumeSource{
-											SecretName: secretServer.Name,
+											SecretName:  secretServer.Name,
+											DefaultMode: pointer.Int32(416),
 										},
 									},
 								},

--- a/pkg/component/apiserver/deployment_test.go
+++ b/pkg/component/apiserver/deployment_test.go
@@ -113,7 +113,7 @@ var _ = Describe("Deployment", func() {
 									VolumeSource: corev1.VolumeSource{
 										Secret: &corev1.SecretVolumeSource{
 											SecretName:  secretETCDClient.Name,
-											DefaultMode: pointer.Int32(416),
+											DefaultMode: pointer.Int32(0640),
 										},
 									},
 								},
@@ -122,7 +122,7 @@ var _ = Describe("Deployment", func() {
 									VolumeSource: corev1.VolumeSource{
 										Secret: &corev1.SecretVolumeSource{
 											SecretName:  secretServer.Name,
-											DefaultMode: pointer.Int32(416),
+											DefaultMode: pointer.Int32(0640),
 										},
 									},
 								},

--- a/pkg/component/apiserver/encryptionconfiguration.go
+++ b/pkg/component/apiserver/encryptionconfiguration.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/serializer/json"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	apiserverconfigv1 "k8s.io/apiserver/pkg/apis/config/v1"
+	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
@@ -169,7 +170,8 @@ func InjectEncryptionSettings(deployment *appsv1.Deployment, secretETCDEncryptio
 		Name: volumeNameEtcdEncryptionConfig,
 		VolumeSource: corev1.VolumeSource{
 			Secret: &corev1.SecretVolumeSource{
-				SecretName: secretETCDEncryptionConfiguration.Name,
+				SecretName:  secretETCDEncryptionConfiguration.Name,
+				DefaultMode: pointer.Int32(416),
 			},
 		},
 	})

--- a/pkg/component/apiserver/encryptionconfiguration.go
+++ b/pkg/component/apiserver/encryptionconfiguration.go
@@ -171,7 +171,7 @@ func InjectEncryptionSettings(deployment *appsv1.Deployment, secretETCDEncryptio
 		VolumeSource: corev1.VolumeSource{
 			Secret: &corev1.SecretVolumeSource{
 				SecretName:  secretETCDEncryptionConfiguration.Name,
-				DefaultMode: pointer.Int32(416),
+				DefaultMode: pointer.Int32(0640),
 			},
 		},
 	})

--- a/pkg/component/apiserver/encryptionconfiguration_test.go
+++ b/pkg/component/apiserver/encryptionconfiguration_test.go
@@ -228,7 +228,8 @@ resources:
 								Name: "etcd-encryption-secret",
 								VolumeSource: corev1.VolumeSource{
 									Secret: &corev1.SecretVolumeSource{
-										SecretName: secretETCDEncryptionConfiguration.Name,
+										SecretName:  secretETCDEncryptionConfiguration.Name,
+										DefaultMode: pointer.Int32(416),
 									},
 								},
 							}},

--- a/pkg/component/apiserver/encryptionconfiguration_test.go
+++ b/pkg/component/apiserver/encryptionconfiguration_test.go
@@ -229,7 +229,7 @@ resources:
 								VolumeSource: corev1.VolumeSource{
 									Secret: &corev1.SecretVolumeSource{
 										SecretName:  secretETCDEncryptionConfiguration.Name,
-										DefaultMode: pointer.Int32(416),
+										DefaultMode: pointer.Int32(0640),
 									},
 								},
 							}},

--- a/pkg/component/gardeneradmissioncontroller/deployment.go
+++ b/pkg/component/gardeneradmissioncontroller/deployment.go
@@ -66,6 +66,14 @@ func (a *gardenerAdmissionController) deployment(secretServerCert, secretGeneric
 				Spec: corev1.PodSpec{
 					PriorityClassName:            v1beta1constants.PriorityClassNameGardenSystem400,
 					AutomountServiceAccountToken: pointer.Bool(false),
+					SecurityContext: &corev1.PodSecurityContext{
+						// use the nonroot user from a distroless container
+						// https://github.com/GoogleContainerTools/distroless/blob/1a8918fcaa7313fd02ae08089a57a701faea999c/base/base.bzl#L8
+						RunAsNonRoot: pointer.Bool(true),
+						RunAsUser:    pointer.Int64(65532),
+						RunAsGroup:   pointer.Int64(65532),
+						FSGroup:      pointer.Int64(65532),
+					},
 					Containers: []corev1.Container{
 						{
 							Name:            DeploymentName,

--- a/pkg/component/gardeneradmissioncontroller/deployment.go
+++ b/pkg/component/gardeneradmissioncontroller/deployment.go
@@ -127,7 +127,10 @@ func (a *gardenerAdmissionController) deployment(secretServerCert, secretGeneric
 						{
 							Name: volumeNameCerts,
 							VolumeSource: corev1.VolumeSource{
-								Secret: &corev1.SecretVolumeSource{SecretName: secretServerCert},
+								Secret: &corev1.SecretVolumeSource{
+									SecretName:  secretServerCert,
+									DefaultMode: pointer.Int32(416),
+								},
 							},
 						},
 						{

--- a/pkg/component/gardeneradmissioncontroller/deployment.go
+++ b/pkg/component/gardeneradmissioncontroller/deployment.go
@@ -129,7 +129,7 @@ func (a *gardenerAdmissionController) deployment(secretServerCert, secretGeneric
 							VolumeSource: corev1.VolumeSource{
 								Secret: &corev1.SecretVolumeSource{
 									SecretName:  secretServerCert,
-									DefaultMode: pointer.Int32(416),
+									DefaultMode: pointer.Int32(0640),
 								},
 							},
 						},

--- a/pkg/component/gardeneradmissioncontroller/gardener_admission_controller_test.go
+++ b/pkg/component/gardeneradmissioncontroller/gardener_admission_controller_test.go
@@ -567,6 +567,12 @@ func deployment(namespace, configSecretName, serverCertSecretName string, testVa
 				Spec: corev1.PodSpec{
 					PriorityClassName:            "gardener-garden-system-400",
 					AutomountServiceAccountToken: pointer.Bool(false),
+					SecurityContext: &corev1.PodSecurityContext{
+						RunAsNonRoot: pointer.Bool(true),
+						RunAsUser:    pointer.Int64(65532),
+						RunAsGroup:   pointer.Int64(65532),
+						FSGroup:      pointer.Int64(65532),
+					},
 					Containers: []corev1.Container{
 						{
 							Name:            "gardener-admission-controller",

--- a/pkg/component/gardeneradmissioncontroller/gardener_admission_controller_test.go
+++ b/pkg/component/gardeneradmissioncontroller/gardener_admission_controller_test.go
@@ -633,7 +633,7 @@ func deployment(namespace, configSecretName, serverCertSecretName string, testVa
 							VolumeSource: corev1.VolumeSource{
 								Secret: &corev1.SecretVolumeSource{
 									SecretName:  serverCertSecretName,
-									DefaultMode: pointer.Int32(416),
+									DefaultMode: pointer.Int32(0640),
 								},
 							},
 						},

--- a/pkg/component/gardeneradmissioncontroller/gardener_admission_controller_test.go
+++ b/pkg/component/gardeneradmissioncontroller/gardener_admission_controller_test.go
@@ -631,7 +631,10 @@ func deployment(namespace, configSecretName, serverCertSecretName string, testVa
 						{
 							Name: "gardener-admission-controller-cert",
 							VolumeSource: corev1.VolumeSource{
-								Secret: &corev1.SecretVolumeSource{SecretName: serverCertSecretName},
+								Secret: &corev1.SecretVolumeSource{
+									SecretName:  serverCertSecretName,
+									DefaultMode: pointer.Int32(416),
+								},
 							},
 						},
 						{

--- a/pkg/component/gardenerapiserver/deployment.go
+++ b/pkg/component/gardenerapiserver/deployment.go
@@ -87,6 +87,14 @@ func (g *gardenerAPIServer) deployment(
 				Spec: corev1.PodSpec{
 					AutomountServiceAccountToken: pointer.Bool(false),
 					PriorityClassName:            v1beta1constants.PriorityClassNameGardenSystem500,
+					SecurityContext: &corev1.PodSecurityContext{
+						// use the nonroot user from a distroless container
+						// https://github.com/GoogleContainerTools/distroless/blob/1a8918fcaa7313fd02ae08089a57a701faea999c/base/base.bzl#L8
+						RunAsNonRoot: pointer.Bool(true),
+						RunAsUser:    pointer.Int64(65532),
+						RunAsGroup:   pointer.Int64(65532),
+						FSGroup:      pointer.Int64(65532),
+					},
 					Containers: []corev1.Container{{
 						Name:            containerName,
 						Image:           g.values.Image,

--- a/pkg/component/gardenerapiserver/gardener_apiserver_test.go
+++ b/pkg/component/gardenerapiserver/gardener_apiserver_test.go
@@ -560,7 +560,7 @@ var _ = Describe("GardenerAPIServer", func() {
 								VolumeSource: corev1.VolumeSource{
 									Secret: &corev1.SecretVolumeSource{
 										SecretName:  "etcd-client",
-										DefaultMode: pointer.Int32(416),
+										DefaultMode: pointer.Int32(0640),
 									},
 								},
 							},
@@ -569,7 +569,7 @@ var _ = Describe("GardenerAPIServer", func() {
 								VolumeSource: corev1.VolumeSource{
 									Secret: &corev1.SecretVolumeSource{
 										SecretName:  "gardener-apiserver",
-										DefaultMode: pointer.Int32(416),
+										DefaultMode: pointer.Int32(0640),
 									},
 								},
 							},
@@ -606,7 +606,7 @@ var _ = Describe("GardenerAPIServer", func() {
 								VolumeSource: corev1.VolumeSource{
 									Secret: &corev1.SecretVolumeSource{
 										SecretName:  "gardener-apiserver-etcd-encryption-configuration-944a649a",
-										DefaultMode: pointer.Int32(416),
+										DefaultMode: pointer.Int32(0640),
 									},
 								},
 							},

--- a/pkg/component/gardenerapiserver/gardener_apiserver_test.go
+++ b/pkg/component/gardenerapiserver/gardener_apiserver_test.go
@@ -553,7 +553,8 @@ var _ = Describe("GardenerAPIServer", func() {
 								Name: "etcd-client",
 								VolumeSource: corev1.VolumeSource{
 									Secret: &corev1.SecretVolumeSource{
-										SecretName: "etcd-client",
+										SecretName:  "etcd-client",
+										DefaultMode: pointer.Int32(416),
 									},
 								},
 							},
@@ -561,7 +562,8 @@ var _ = Describe("GardenerAPIServer", func() {
 								Name: "server",
 								VolumeSource: corev1.VolumeSource{
 									Secret: &corev1.SecretVolumeSource{
-										SecretName: "gardener-apiserver",
+										SecretName:  "gardener-apiserver",
+										DefaultMode: pointer.Int32(416),
 									},
 								},
 							},
@@ -597,7 +599,8 @@ var _ = Describe("GardenerAPIServer", func() {
 								Name: "etcd-encryption-secret",
 								VolumeSource: corev1.VolumeSource{
 									Secret: &corev1.SecretVolumeSource{
-										SecretName: "gardener-apiserver-etcd-encryption-configuration-944a649a",
+										SecretName:  "gardener-apiserver-etcd-encryption-configuration-944a649a",
+										DefaultMode: pointer.Int32(416),
 									},
 								},
 							},

--- a/pkg/component/gardenerapiserver/gardener_apiserver_test.go
+++ b/pkg/component/gardenerapiserver/gardener_apiserver_test.go
@@ -443,6 +443,12 @@ var _ = Describe("GardenerAPIServer", func() {
 					Spec: corev1.PodSpec{
 						AutomountServiceAccountToken: pointer.Bool(false),
 						PriorityClassName:            "gardener-garden-system-500",
+						SecurityContext: &corev1.PodSecurityContext{
+							RunAsNonRoot: pointer.Bool(true),
+							RunAsUser:    pointer.Int64(65532),
+							RunAsGroup:   pointer.Int64(65532),
+							FSGroup:      pointer.Int64(65532),
+						},
 						Containers: []corev1.Container{{
 							Name:            "gardener-apiserver",
 							Image:           image,

--- a/pkg/component/gardenercontrollermanager/deployment.go
+++ b/pkg/component/gardenercontrollermanager/deployment.go
@@ -63,6 +63,14 @@ func (g *gardenerControllerManager) deployment(secretGenericTokenKubeconfig, sec
 				Spec: corev1.PodSpec{
 					PriorityClassName:            v1beta1constants.PriorityClassNameGardenSystem200,
 					AutomountServiceAccountToken: pointer.Bool(false),
+					SecurityContext: &corev1.PodSecurityContext{
+						// use the nonroot user from a distroless container
+						// https://github.com/GoogleContainerTools/distroless/blob/1a8918fcaa7313fd02ae08089a57a701faea999c/base/base.bzl#L8
+						RunAsNonRoot: pointer.Bool(true),
+						RunAsUser:    pointer.Int64(65532),
+						RunAsGroup:   pointer.Int64(65532),
+						FSGroup:      pointer.Int64(65532),
+					},
 					Containers: []corev1.Container{
 						{
 							Name:            DeploymentName,

--- a/pkg/component/gardenercontrollermanager/gardener_controller_manager_test.go
+++ b/pkg/component/gardenercontrollermanager/gardener_controller_manager_test.go
@@ -776,6 +776,12 @@ func deployment(namespace, configSecretName string, testValues Values) string {
 				Spec: corev1.PodSpec{
 					PriorityClassName:            "gardener-garden-system-200",
 					AutomountServiceAccountToken: pointer.Bool(false),
+					SecurityContext: &corev1.PodSecurityContext{
+						RunAsNonRoot: pointer.Bool(true),
+						RunAsUser:    pointer.Int64(65532),
+						RunAsGroup:   pointer.Int64(65532),
+						FSGroup:      pointer.Int64(65532),
+					},
 					Containers: []corev1.Container{
 						{
 							Name:            "gardener-controller-manager",

--- a/pkg/component/gardenerscheduler/deployment.go
+++ b/pkg/component/gardenerscheduler/deployment.go
@@ -63,6 +63,12 @@ func (g *gardenerScheduler) deployment(secretGenericTokenKubeconfig, secretVirtu
 				Spec: corev1.PodSpec{
 					PriorityClassName:            v1beta1constants.PriorityClassNameGardenSystem200,
 					AutomountServiceAccountToken: pointer.Bool(false),
+					SecurityContext: &corev1.PodSecurityContext{
+						RunAsNonRoot: pointer.Bool(true),
+						RunAsUser:    pointer.Int64(65532),
+						RunAsGroup:   pointer.Int64(65532),
+						FSGroup:      pointer.Int64(65532),
+					},
 					Containers: []corev1.Container{
 						{
 							Name:            DeploymentName,

--- a/pkg/component/gardenerscheduler/gardener_scheduler_test.go
+++ b/pkg/component/gardenerscheduler/gardener_scheduler_test.go
@@ -790,6 +790,12 @@ func deployment(namespace, configSecretName string, testValues Values) string {
 				Spec: corev1.PodSpec{
 					PriorityClassName:            "gardener-garden-system-200",
 					AutomountServiceAccountToken: pointer.Bool(false),
+					SecurityContext: &corev1.PodSecurityContext{
+						RunAsNonRoot: pointer.Bool(true),
+						RunAsUser:    pointer.Int64(65532),
+						RunAsGroup:   pointer.Int64(65532),
+						FSGroup:      pointer.Int64(65532),
+					},
 					Containers: []corev1.Container{
 						{
 							Name:            "gardener-scheduler",

--- a/pkg/component/kubeapiserver/deployment.go
+++ b/pkg/component/kubeapiserver/deployment.go
@@ -344,7 +344,7 @@ func (k *kubeAPIServer) reconcileDeployment(
 							VolumeSource: corev1.VolumeSource{
 								Secret: &corev1.SecretVolumeSource{
 									SecretName:  secretServiceAccountKey.Name,
-									DefaultMode: pointer.Int32(416),
+									DefaultMode: pointer.Int32(0640),
 								},
 							},
 						},
@@ -353,7 +353,7 @@ func (k *kubeAPIServer) reconcileDeployment(
 							VolumeSource: corev1.VolumeSource{
 								Secret: &corev1.SecretVolumeSource{
 									SecretName:  secretServiceAccountKeyBundle.Name,
-									DefaultMode: pointer.Int32(416),
+									DefaultMode: pointer.Int32(0640),
 								},
 							},
 						},
@@ -370,7 +370,7 @@ func (k *kubeAPIServer) reconcileDeployment(
 							VolumeSource: corev1.VolumeSource{
 								Secret: &corev1.SecretVolumeSource{
 									SecretName:  secretKubeAggregator.Name,
-									DefaultMode: pointer.Int32(416),
+									DefaultMode: pointer.Int32(0640),
 								},
 							},
 						},
@@ -532,7 +532,7 @@ func (k *kubeAPIServer) handleTLSSNISettings(deployment *appsv1.Deployment, tlsS
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
 					SecretName:  sni.secretName,
-					DefaultMode: pointer.Int32(416),
+					DefaultMode: pointer.Int32(0640),
 				},
 			},
 		})
@@ -616,7 +616,7 @@ func (k *kubeAPIServer) handleVPNSettingsNonHA(
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
 					SecretName:  secretHTTPProxy.Name,
-					DefaultMode: pointer.Int32(416),
+					DefaultMode: pointer.Int32(0640),
 				},
 			},
 		},
@@ -1017,7 +1017,7 @@ func (k *kubeAPIServer) handleKubeletSettings(deployment *appsv1.Deployment, sec
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
 					SecretName:  secretKubeletClient.Name,
-					DefaultMode: pointer.Int32(416),
+					DefaultMode: pointer.Int32(0640),
 				},
 			},
 		},

--- a/pkg/component/kubeapiserver/deployment.go
+++ b/pkg/component/kubeapiserver/deployment.go
@@ -343,7 +343,8 @@ func (k *kubeAPIServer) reconcileDeployment(
 							Name: volumeNameServiceAccountKey,
 							VolumeSource: corev1.VolumeSource{
 								Secret: &corev1.SecretVolumeSource{
-									SecretName: secretServiceAccountKey.Name,
+									SecretName:  secretServiceAccountKey.Name,
+									DefaultMode: pointer.Int32(416),
 								},
 							},
 						},
@@ -351,7 +352,8 @@ func (k *kubeAPIServer) reconcileDeployment(
 							Name: volumeNameServiceAccountKeyBundle,
 							VolumeSource: corev1.VolumeSource{
 								Secret: &corev1.SecretVolumeSource{
-									SecretName: secretServiceAccountKeyBundle.Name,
+									SecretName:  secretServiceAccountKeyBundle.Name,
+									DefaultMode: pointer.Int32(416),
 								},
 							},
 						},
@@ -367,7 +369,8 @@ func (k *kubeAPIServer) reconcileDeployment(
 							Name: volumeNameKubeAggregator,
 							VolumeSource: corev1.VolumeSource{
 								Secret: &corev1.SecretVolumeSource{
-									SecretName: secretKubeAggregator.Name,
+									SecretName:  secretKubeAggregator.Name,
+									DefaultMode: pointer.Int32(416),
 								},
 							},
 						},
@@ -528,7 +531,8 @@ func (k *kubeAPIServer) handleTLSSNISettings(deployment *appsv1.Deployment, tlsS
 			Name: volumeName,
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
-					SecretName: sni.secretName,
+					SecretName:  sni.secretName,
+					DefaultMode: pointer.Int32(416),
 				},
 			},
 		})
@@ -611,7 +615,8 @@ func (k *kubeAPIServer) handleVPNSettingsNonHA(
 			Name: volumeNameHTTPProxy,
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
-					SecretName: secretHTTPProxy.Name,
+					SecretName:  secretHTTPProxy.Name,
+					DefaultMode: pointer.Int32(416),
 				},
 			},
 		},
@@ -1011,7 +1016,8 @@ func (k *kubeAPIServer) handleKubeletSettings(deployment *appsv1.Deployment, sec
 			Name: volumeNameKubeAPIServerToKubelet,
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
-					SecretName: secretKubeletClient.Name,
+					SecretName:  secretKubeletClient.Name,
+					DefaultMode: pointer.Int32(416),
 				},
 			},
 		},

--- a/pkg/component/kubeapiserver/kube_apiserver_test.go
+++ b/pkg/component/kubeapiserver/kube_apiserver_test.go
@@ -2576,7 +2576,8 @@ rules:
 							Name: "etcd-client",
 							VolumeSource: corev1.VolumeSource{
 								Secret: &corev1.SecretVolumeSource{
-									SecretName: secretNameEtcd,
+									SecretName:  secretNameEtcd,
+									DefaultMode: pointer.Int32(416),
 								},
 							},
 						},
@@ -2584,7 +2585,8 @@ rules:
 							Name: "service-account-key",
 							VolumeSource: corev1.VolumeSource{
 								Secret: &corev1.SecretVolumeSource{
-									SecretName: secretNameServiceAccountKey,
+									SecretName:  secretNameServiceAccountKey,
+									DefaultMode: pointer.Int32(416),
 								},
 							},
 						},
@@ -2592,7 +2594,8 @@ rules:
 							Name: "service-account-key-bundle",
 							VolumeSource: corev1.VolumeSource{
 								Secret: &corev1.SecretVolumeSource{
-									SecretName: secretNameServiceAccountKeyBundle,
+									SecretName:  secretNameServiceAccountKeyBundle,
+									DefaultMode: pointer.Int32(416),
 								},
 							},
 						},
@@ -2608,7 +2611,8 @@ rules:
 							Name: "kube-aggregator",
 							VolumeSource: corev1.VolumeSource{
 								Secret: &corev1.SecretVolumeSource{
-									SecretName: secretNameKubeAggregator,
+									SecretName:  secretNameKubeAggregator,
+									DefaultMode: pointer.Int32(416),
 								},
 							},
 						},
@@ -2616,7 +2620,8 @@ rules:
 							Name: "etcd-encryption-secret",
 							VolumeSource: corev1.VolumeSource{
 								Secret: &corev1.SecretVolumeSource{
-									SecretName: secretNameETCDEncryptionConfig,
+									SecretName:  secretNameETCDEncryptionConfig,
+									DefaultMode: pointer.Int32(416),
 								},
 							},
 						},
@@ -2624,7 +2629,8 @@ rules:
 							Name: "server",
 							VolumeSource: corev1.VolumeSource{
 								Secret: &corev1.SecretVolumeSource{
-									SecretName: secretNameServer,
+									SecretName:  secretNameServer,
+									DefaultMode: pointer.Int32(416),
 								},
 							},
 						},
@@ -2670,7 +2676,8 @@ rules:
 							Name: "kubelet-client",
 							VolumeSource: corev1.VolumeSource{
 								Secret: &corev1.SecretVolumeSource{
-									SecretName: secretNameKubeAPIServerToKubelet,
+									SecretName:  secretNameKubeAPIServerToKubelet,
+									DefaultMode: pointer.Int32(416),
 								},
 							},
 						},
@@ -3182,7 +3189,8 @@ rules:
 							Name: "http-proxy",
 							VolumeSource: corev1.VolumeSource{
 								Secret: &corev1.SecretVolumeSource{
-									SecretName: secretNameHTTPProxy,
+									SecretName:  secretNameHTTPProxy,
+									DefaultMode: pointer.Int32(416),
 								},
 							},
 						},
@@ -3294,7 +3302,8 @@ rules:
 							Name: "tls-sni-0",
 							VolumeSource: corev1.VolumeSource{
 								Secret: &corev1.SecretVolumeSource{
-									SecretName: "existing-secret",
+									SecretName:  "existing-secret",
+									DefaultMode: pointer.Int32(416),
 								},
 							},
 						},
@@ -3302,7 +3311,8 @@ rules:
 							Name: "tls-sni-1",
 							VolumeSource: corev1.VolumeSource{
 								Secret: &corev1.SecretVolumeSource{
-									SecretName: "kube-apiserver-tls-sni-1-ec321de5",
+									SecretName:  "kube-apiserver-tls-sni-1-ec321de5",
+									DefaultMode: pointer.Int32(416),
 								},
 							},
 						},

--- a/pkg/component/kubeapiserver/kube_apiserver_test.go
+++ b/pkg/component/kubeapiserver/kube_apiserver_test.go
@@ -2577,7 +2577,7 @@ rules:
 							VolumeSource: corev1.VolumeSource{
 								Secret: &corev1.SecretVolumeSource{
 									SecretName:  secretNameEtcd,
-									DefaultMode: pointer.Int32(416),
+									DefaultMode: pointer.Int32(0640),
 								},
 							},
 						},
@@ -2586,7 +2586,7 @@ rules:
 							VolumeSource: corev1.VolumeSource{
 								Secret: &corev1.SecretVolumeSource{
 									SecretName:  secretNameServiceAccountKey,
-									DefaultMode: pointer.Int32(416),
+									DefaultMode: pointer.Int32(0640),
 								},
 							},
 						},
@@ -2595,7 +2595,7 @@ rules:
 							VolumeSource: corev1.VolumeSource{
 								Secret: &corev1.SecretVolumeSource{
 									SecretName:  secretNameServiceAccountKeyBundle,
-									DefaultMode: pointer.Int32(416),
+									DefaultMode: pointer.Int32(0640),
 								},
 							},
 						},
@@ -2612,7 +2612,7 @@ rules:
 							VolumeSource: corev1.VolumeSource{
 								Secret: &corev1.SecretVolumeSource{
 									SecretName:  secretNameKubeAggregator,
-									DefaultMode: pointer.Int32(416),
+									DefaultMode: pointer.Int32(0640),
 								},
 							},
 						},
@@ -2621,7 +2621,7 @@ rules:
 							VolumeSource: corev1.VolumeSource{
 								Secret: &corev1.SecretVolumeSource{
 									SecretName:  secretNameETCDEncryptionConfig,
-									DefaultMode: pointer.Int32(416),
+									DefaultMode: pointer.Int32(0640),
 								},
 							},
 						},
@@ -2630,7 +2630,7 @@ rules:
 							VolumeSource: corev1.VolumeSource{
 								Secret: &corev1.SecretVolumeSource{
 									SecretName:  secretNameServer,
-									DefaultMode: pointer.Int32(416),
+									DefaultMode: pointer.Int32(0640),
 								},
 							},
 						},
@@ -2677,7 +2677,7 @@ rules:
 							VolumeSource: corev1.VolumeSource{
 								Secret: &corev1.SecretVolumeSource{
 									SecretName:  secretNameKubeAPIServerToKubelet,
-									DefaultMode: pointer.Int32(416),
+									DefaultMode: pointer.Int32(0640),
 								},
 							},
 						},
@@ -3190,7 +3190,7 @@ rules:
 							VolumeSource: corev1.VolumeSource{
 								Secret: &corev1.SecretVolumeSource{
 									SecretName:  secretNameHTTPProxy,
-									DefaultMode: pointer.Int32(416),
+									DefaultMode: pointer.Int32(0640),
 								},
 							},
 						},
@@ -3303,7 +3303,7 @@ rules:
 							VolumeSource: corev1.VolumeSource{
 								Secret: &corev1.SecretVolumeSource{
 									SecretName:  "existing-secret",
-									DefaultMode: pointer.Int32(416),
+									DefaultMode: pointer.Int32(0640),
 								},
 							},
 						},
@@ -3312,7 +3312,7 @@ rules:
 							VolumeSource: corev1.VolumeSource{
 								Secret: &corev1.SecretVolumeSource{
 									SecretName:  "kube-apiserver-tls-sni-1-ec321de5",
-									DefaultMode: pointer.Int32(416),
+									DefaultMode: pointer.Int32(0640),
 								},
 							},
 						},

--- a/pkg/component/kubecontrollermanager/kube_controller_manager.go
+++ b/pkg/component/kubecontrollermanager/kube_controller_manager.go
@@ -404,7 +404,7 @@ func (k *kubeControllerManager) Deploy(ctx context.Context) error {
 						VolumeSource: corev1.VolumeSource{
 							Secret: &corev1.SecretVolumeSource{
 								SecretName:  secretCAClient.Name,
-								DefaultMode: pointer.Int32(416),
+								DefaultMode: pointer.Int32(0640),
 							},
 						},
 					},
@@ -413,7 +413,7 @@ func (k *kubeControllerManager) Deploy(ctx context.Context) error {
 						VolumeSource: corev1.VolumeSource{
 							Secret: &corev1.SecretVolumeSource{
 								SecretName:  serviceAccountKeySecret.Name,
-								DefaultMode: pointer.Int32(416),
+								DefaultMode: pointer.Int32(0640),
 							},
 						},
 					},
@@ -422,7 +422,7 @@ func (k *kubeControllerManager) Deploy(ctx context.Context) error {
 						VolumeSource: corev1.VolumeSource{
 							Secret: &corev1.SecretVolumeSource{
 								SecretName:  serverSecret.Name,
-								DefaultMode: pointer.Int32(416),
+								DefaultMode: pointer.Int32(0640),
 							},
 						},
 					},
@@ -441,7 +441,7 @@ func (k *kubeControllerManager) Deploy(ctx context.Context) error {
 				VolumeSource: corev1.VolumeSource{
 					Secret: &corev1.SecretVolumeSource{
 						SecretName:  secretCAKubelet.Name,
-						DefaultMode: pointer.Int32(416),
+						DefaultMode: pointer.Int32(0640),
 					},
 				},
 			})

--- a/pkg/component/kubecontrollermanager/kube_controller_manager.go
+++ b/pkg/component/kubecontrollermanager/kube_controller_manager.go
@@ -403,7 +403,8 @@ func (k *kubeControllerManager) Deploy(ctx context.Context) error {
 						Name: volumeNameCAClient,
 						VolumeSource: corev1.VolumeSource{
 							Secret: &corev1.SecretVolumeSource{
-								SecretName: secretCAClient.Name,
+								SecretName:  secretCAClient.Name,
+								DefaultMode: pointer.Int32(416),
 							},
 						},
 					},
@@ -411,7 +412,8 @@ func (k *kubeControllerManager) Deploy(ctx context.Context) error {
 						Name: volumeNameServiceAccountKey,
 						VolumeSource: corev1.VolumeSource{
 							Secret: &corev1.SecretVolumeSource{
-								SecretName: serviceAccountKeySecret.Name,
+								SecretName:  serviceAccountKeySecret.Name,
+								DefaultMode: pointer.Int32(416),
 							},
 						},
 					},
@@ -419,7 +421,8 @@ func (k *kubeControllerManager) Deploy(ctx context.Context) error {
 						Name: volumeNameServer,
 						VolumeSource: corev1.VolumeSource{
 							Secret: &corev1.SecretVolumeSource{
-								SecretName: serverSecret.Name,
+								SecretName:  serverSecret.Name,
+								DefaultMode: pointer.Int32(416),
 							},
 						},
 					},
@@ -437,7 +440,8 @@ func (k *kubeControllerManager) Deploy(ctx context.Context) error {
 				Name: volumeNameCAKubelet,
 				VolumeSource: corev1.VolumeSource{
 					Secret: &corev1.SecretVolumeSource{
-						SecretName: secretCAKubelet.Name,
+						SecretName:  secretCAKubelet.Name,
+						DefaultMode: pointer.Int32(416),
 					},
 				},
 			})

--- a/pkg/component/kubecontrollermanager/kube_controller_manager_test.go
+++ b/pkg/component/kubecontrollermanager/kube_controller_manager_test.go
@@ -464,7 +464,7 @@ var _ = Describe("KubeControllerManager", func() {
 									VolumeSource: corev1.VolumeSource{
 										Secret: &corev1.SecretVolumeSource{
 											SecretName:  "ca-client-current",
-											DefaultMode: pointer.Int32(416),
+											DefaultMode: pointer.Int32(0640),
 										},
 									},
 								},
@@ -473,7 +473,7 @@ var _ = Describe("KubeControllerManager", func() {
 									VolumeSource: corev1.VolumeSource{
 										Secret: &corev1.SecretVolumeSource{
 											SecretName:  "service-account-key-current",
-											DefaultMode: pointer.Int32(416),
+											DefaultMode: pointer.Int32(0640),
 										},
 									},
 								},
@@ -482,7 +482,7 @@ var _ = Describe("KubeControllerManager", func() {
 									VolumeSource: corev1.VolumeSource{
 										Secret: &corev1.SecretVolumeSource{
 											SecretName:  "kube-controller-manager-server",
-											DefaultMode: pointer.Int32(416),
+											DefaultMode: pointer.Int32(0640),
 										},
 									},
 								},
@@ -503,7 +503,7 @@ var _ = Describe("KubeControllerManager", func() {
 					VolumeSource: corev1.VolumeSource{
 						Secret: &corev1.SecretVolumeSource{
 							SecretName:  "ca-kubelet-current",
-							DefaultMode: pointer.Int32(416),
+							DefaultMode: pointer.Int32(0640),
 						},
 					},
 				})

--- a/pkg/component/kubecontrollermanager/kube_controller_manager_test.go
+++ b/pkg/component/kubecontrollermanager/kube_controller_manager_test.go
@@ -463,7 +463,8 @@ var _ = Describe("KubeControllerManager", func() {
 									Name: "ca-client",
 									VolumeSource: corev1.VolumeSource{
 										Secret: &corev1.SecretVolumeSource{
-											SecretName: "ca-client-current",
+											SecretName:  "ca-client-current",
+											DefaultMode: pointer.Int32(416),
 										},
 									},
 								},
@@ -471,7 +472,8 @@ var _ = Describe("KubeControllerManager", func() {
 									Name: "service-account-key",
 									VolumeSource: corev1.VolumeSource{
 										Secret: &corev1.SecretVolumeSource{
-											SecretName: "service-account-key-current",
+											SecretName:  "service-account-key-current",
+											DefaultMode: pointer.Int32(416),
 										},
 									},
 								},
@@ -479,7 +481,8 @@ var _ = Describe("KubeControllerManager", func() {
 									Name: "server",
 									VolumeSource: corev1.VolumeSource{
 										Secret: &corev1.SecretVolumeSource{
-											SecretName: "kube-controller-manager-server",
+											SecretName:  "kube-controller-manager-server",
+											DefaultMode: pointer.Int32(416),
 										},
 									},
 								},
@@ -499,7 +502,8 @@ var _ = Describe("KubeControllerManager", func() {
 					Name: "ca-kubelet",
 					VolumeSource: corev1.VolumeSource{
 						Secret: &corev1.SecretVolumeSource{
-							SecretName: "ca-kubelet-current",
+							SecretName:  "ca-kubelet-current",
+							DefaultMode: pointer.Int32(416),
 						},
 					},
 				})

--- a/pkg/component/kubescheduler/kube_scheduler.go
+++ b/pkg/component/kubescheduler/kube_scheduler.go
@@ -335,7 +335,7 @@ func (k *kubeScheduler) Deploy(ctx context.Context) error {
 						VolumeSource: corev1.VolumeSource{
 							Secret: &corev1.SecretVolumeSource{
 								SecretName:  serverSecret.Name,
-								DefaultMode: pointer.Int32(416),
+								DefaultMode: pointer.Int32(0640),
 							},
 						},
 					},

--- a/pkg/component/kubescheduler/kube_scheduler.go
+++ b/pkg/component/kubescheduler/kube_scheduler.go
@@ -334,7 +334,8 @@ func (k *kubeScheduler) Deploy(ctx context.Context) error {
 						Name: volumeNameServer,
 						VolumeSource: corev1.VolumeSource{
 							Secret: &corev1.SecretVolumeSource{
-								SecretName: serverSecret.Name,
+								SecretName:  serverSecret.Name,
+								DefaultMode: pointer.Int32(416),
 							},
 						},
 					},

--- a/pkg/component/kubescheduler/kube_scheduler_test.go
+++ b/pkg/component/kubescheduler/kube_scheduler_test.go
@@ -338,7 +338,8 @@ var _ = Describe("KubeScheduler", func() {
 									Name: "kube-scheduler-server",
 									VolumeSource: corev1.VolumeSource{
 										Secret: &corev1.SecretVolumeSource{
-											SecretName: secretNameServer,
+											SecretName:  secretNameServer,
+											DefaultMode: pointer.Int32(416),
 										},
 									},
 								},

--- a/pkg/component/kubescheduler/kube_scheduler_test.go
+++ b/pkg/component/kubescheduler/kube_scheduler_test.go
@@ -339,7 +339,7 @@ var _ = Describe("KubeScheduler", func() {
 									VolumeSource: corev1.VolumeSource{
 										Secret: &corev1.SecretVolumeSource{
 											SecretName:  secretNameServer,
-											DefaultMode: pointer.Int32(416),
+											DefaultMode: pointer.Int32(0640),
 										},
 									},
 								},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/area compliance
/kind enhancement

**What this PR does / why we need it**:
This PR enhances security by revoking `other` groups access to mounted `key` files on Control plane components by configuring `0640` permissions. `0640` are the minimal possible permissions for `key` files given that Control plane components run as `65532` user/group and mounted files are with owner user `root` (cannot be changed easily [ref](https://github.com/kubernetes/kubernetes/issues/81089)) and group `65532` ( set by `fsGroup`).

This PR is in sync with Kubernetes' STIG.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Control plane components `kube-apiserver`, `kube-controller-manager` and `kube-scheduler` now mount `key` files with `DefaultMode` set to `416`(`0640` permissions).
```
```other operator
`gardener-apiserver` and `gardener-admission-controller` now mount `key` files with `DefaultMode` set to `416`(`0640` permissions).
```

