### PR TITLE
Properly handle error in `ControllerInstallation` controller

### DIFF
--- a/pkg/gardenlet/controller/controllerinstallation/controllerinstallation/reconciler.go
+++ b/pkg/gardenlet/controller/controllerinstallation/controllerinstallation/reconciler.go
@@ -504,6 +504,12 @@ func mutateObjects(secretData map[string][]byte, mutate func(obj *unstructured.U
 			if err == io.EOF {
 				break
 			}
+			if err != nil {
+				return err
+			}
+			if obj == nil {
+				continue
+			}
 
 			if err := mutate(obj); err != nil {
 				return err


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind bug

**What this PR does / why we need it**:

Properly handle errors and nil objects returned from `UnstructuredReader` in `ControllerInstallation` controller.
This is similar to the `Applier` code: https://github.com/gardener/gardener/blob/5abed1bfedd6f2188e5dcec9af161d1b5c286236/pkg/client/kubernetes/applier.go#L316-L326

**Which issue(s) this PR fixes**:

Without this change, the `ControllerInstallation` controller can panic if the YAML decoder fails to read the document, e.g., due to wrong indentation:

```
Observed a panic: "invalid memory address or nil pointer dereference" (runtime error: invalid memory address or nil pointer dereference)
goroutine 452 [running]:
k8s.io/apimachinery/pkg/util/runtime.logPanic({0x26a6ca0, 0x4303cf0})
    /home/git/gardener/gardener/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:75 +0xdc
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile.func1()
    /home/git/gardener/gardener/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:108 +0x118
panic({0x26a6ca0?, 0x4303cf0?})
    /home/sdk/go1.21.3/src/runtime/panic.go:920 +0x254
k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.(*Unstructured).GetAPIVersion(0x0)
    /home/git/gardener/gardener/vendor/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/unstructured.go:223 +0x64
k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.(*Unstructured).GroupVersionKind(0x0)
    /home/git/gardener/gardener/vendor/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/unstructured.go:431 +0x38
github.com/gardener/gardener/pkg/gardenlet/controller/controllerinstallation/controllerinstallation.injectGardenAccessSecrets.func1(0x0)
    /home/git/gardener/gardener/pkg/gardenlet/controller/controllerinstallation/controllerinstallation/reconciler.go:457 +0x88
github.com/gardener/gardener/pkg/gardenlet/controller/controllerinstallation/controllerinstallation.mutateObjects(0x4001ce2600, 0x4001204530)
    /home/git/gardener/gardener/pkg/gardenlet/controller/controllerinstallation/controllerinstallation/reconciler.go:508 +0x264
github.com/gardener/gardener/pkg/gardenlet/controller/controllerinstallation/controllerinstallation.injectGardenAccessSecrets(0x4001ce2600, {0x4001a68810, 0x13}, {0x4001e9cc60, 0x22}, {0x40016b65e8, 0x17}, {0x4001381ad0, 0x5})
    /home/git/gardener/gardener/pkg/gardenlet/controller/controllerinstallation/controllerinstallation/reconciler.go:455 +0x124
github.com/gardener/gardener/pkg/gardenlet/controller/controllerinstallation/controllerinstallation.(*Reconciler).reconcile(0x4000e9b680, {0x30c1ce8, 0x4002678af0}, {0x30c1ce8, 0x4002678b60}, {{0x30c5f18, 0x400263dfb0}, 0x0}, 0x4001b9e240)
    /home/git/gardener/gardener/pkg/gardenlet/controller/controllerinstallation/controllerinstallation/reconciler.go:262 +0x276c
github.com/gardener/gardener/pkg/gardenlet/controller/controllerinstallation/controllerinstallation.(*Reconciler).Reconcile(0x4000e9b680, {0x30c1c40, 0x400263df80}, {{{0x0, 0x0}, {0x4001028060, 0x9}}})
    /home/git/gardener/gardener/pkg/gardenlet/controller/controllerinstallation/controllerinstallation/reconciler.go:103 +0x46c
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile(0x40001357c0, {0x30c1c40, 0x400263df80}, {{{0x0, 0x0}, {0x4001028060, 0x9}}})
    /home/git/gardener/gardener/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:119 +0xec
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler(0x40001357c0, {0x30c1c40, 0x400263df80}, {0x279e5e0, 0x40029b3440})
    /home/git/gardener/gardener/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:316 +0x36c
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem(0x40001357c0, {0x30c1c78, 0x4000339400})
    /home/git/gardener/gardener/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:266 +0x2cc
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2()
    /home/git/gardener/gardener/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:227 +0xa8
created by sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2 in goroutine 429
    /home/git/gardener/gardener/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:223 +0x794
```

**Special notes for your reviewer**:

Thanks @dergeberl for reporting!

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
