### PR TITLE
Local-Setup: add node internal IP addresses to istio-ingressgateway LB service

### DIFF
--- a/charts/gardener/operator/templates/clusterrole.yaml
+++ b/charts/gardener/operator/templates/clusterrole.yaml
@@ -27,6 +27,7 @@ rules:
   - configmaps
   - serviceaccounts
   - pods
+  - nodes
   verbs:
   - get
   - list

--- a/pkg/controller/service/reconciler.go
+++ b/pkg/controller/service/reconciler.go
@@ -107,20 +107,26 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	}
 
 	patch = client.MergeFrom(service.DeepCopy())
-	service.Status.LoadBalancer.Ingress = []corev1.LoadBalancerIngress{{IP: ip}}
+	service.Status.LoadBalancer.Ingress = []corev1.LoadBalancerIngress{}
 
-	nodes := &corev1.NodeList{}
-	if err := r.Client.List(ctx, nodes); err != nil {
-		return reconcile.Result{}, err
-	}
+	if key != keyNginxIngress {
+		nodes := &corev1.NodeList{}
+		if err := r.Client.List(ctx, nodes); err != nil {
+			return reconcile.Result{}, err
+		}
 
-	for _, node := range nodes.Items {
-		for _, address := range node.Status.Addresses {
-			if address.Type == corev1.NodeInternalIP {
-				service.Status.LoadBalancer.Ingress = append(service.Status.LoadBalancer.Ingress, corev1.LoadBalancerIngress{IP: address.Address})
+		for _, node := range nodes.Items {
+			for _, address := range node.Status.Addresses {
+				if address.Type == corev1.NodeInternalIP {
+					service.Status.LoadBalancer.Ingress = append(service.Status.LoadBalancer.Ingress, corev1.LoadBalancerIngress{IP: address.Address})
+				}
 			}
 		}
 	}
+
+	// We append this IP behind the nodeIPs because the gardenlet puts the last ingress IP into the DNSRecords
+	// and we need a change in the DNSRecords if the control-plane moved from one zone to another to update the coredns-custom configMap.
+	service.Status.LoadBalancer.Ingress = append(service.Status.LoadBalancer.Ingress, corev1.LoadBalancerIngress{IP: ip})
 
 	return reconcile.Result{}, r.Client.Status().Patch(ctx, service, patch)
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

Co-authored-by @ScheererJ 

**What this PR does / why we need it**:
When communicating between local kind clusters for control-plane migration it helps to have the loadbalancers bound to the kind clusters node IPs to be able to directly communicate using the default loadbalancer ports.
Previously you were required to use the service node ports instead.  

**Special notes for your reviewer**:
This is only relevant for kind local & operator setups because `pkg/controller/service/reconciler.go` isn't used for other things.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
NONE
```
