### PR TITLE
Fix unrecoverable issues with `etcd` during credentials rotation

### DIFF
--- a/pkg/component/etcd/etcd.go
+++ b/pkg/component/etcd/etcd.go
@@ -693,12 +693,6 @@ func (e *etcd) RolloutPeerCA(ctx context.Context) error {
 	}
 
 	_, err := controllerutils.GetAndCreateOrMergePatch(ctx, e.client, e.etcd, func() error {
-		// Exit early if etcd object has already the expected CA reference.
-		if peerTLS := e.etcd.Spec.Etcd.PeerUrlTLS; peerTLS != nil &&
-			peerTLS.TLSCASecretRef.Name == etcdPeerCASecret.Name {
-			return nil
-		}
-
 		e.etcd.Annotations = map[string]string{
 			v1beta1constants.GardenerOperation: v1beta1constants.GardenerOperationReconcile,
 			v1beta1constants.GardenerTimestamp: TimeNow().UTC().Format(time.RFC3339Nano),

--- a/pkg/component/etcd/etcd.go
+++ b/pkg/component/etcd/etcd.go
@@ -692,7 +692,7 @@ func (e *etcd) RolloutPeerCA(ctx context.Context) error {
 		return fmt.Errorf("secret %q not found", v1beta1constants.SecretNameCAETCDPeer)
 	}
 
-	_, err := controllerutils.GetAndCreateOrMergePatch(ctx, e.client, e.etcd, func() error {
+	if _, err := controllerutils.GetAndCreateOrMergePatch(ctx, e.client, e.etcd, func() error {
 		e.etcd.Annotations = map[string]string{
 			v1beta1constants.GardenerOperation: v1beta1constants.GardenerOperationReconcile,
 			v1beta1constants.GardenerTimestamp: TimeNow().UTC().Format(time.RFC3339Nano),
@@ -715,8 +715,11 @@ func (e *etcd) RolloutPeerCA(ctx context.Context) error {
 			DataKey: dataKey,
 		}
 		return nil
-	})
-	return err
+	}); err != nil {
+		return err
+	}
+
+	return e.Wait(ctx)
 }
 
 func (e *etcd) GetValues() Values { return e.values }

--- a/pkg/component/etcd/etcd_test.go
+++ b/pkg/component/etcd/etcd_test.go
@@ -1804,7 +1804,7 @@ var _ = Describe("Etcd", func() {
 				Expect(etcd.RolloutPeerCA(ctx)).To(Succeed())
 			})
 
-			It("should not patch anything because the expected CA ref is already configured", func() {
+			It("should only patch reconcile annotation data because the expected CA ref is already configured", func() {
 				peerCAName := "ca-etcd-peer"
 
 				Expect(fakeClient.Create(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: peerCAName, Namespace: testNamespace}})).To(Succeed())
@@ -1818,7 +1818,7 @@ var _ = Describe("Etcd", func() {
 					func(_ context.Context, obj *druidv1alpha1.Etcd, patch client.Patch, _ ...client.PatchOption) error {
 						data, err := patch.Data(obj)
 						Expect(err).ToNot(HaveOccurred())
-						Expect(data).To(MatchJSON("{}"))
+						Expect(data).To(MatchJSON("{\"metadata\":{\"annotations\":{\"gardener.cloud/operation\":\"reconcile\",\"gardener.cloud/timestamp\":\"0001-01-01T00:00:00Z\"}}}"))
 						return nil
 					})
 

--- a/pkg/operation/botanist/etcd.go
+++ b/pkg/operation/botanist/etcd.go
@@ -133,10 +133,6 @@ func (b *Botanist) DeployEtcd(ctx context.Context) error {
 		)(ctx); err != nil {
 			return err
 		}
-
-		if err := b.WaitUntilEtcdsReady(ctx); err != nil {
-			return err
-		}
 	}
 
 	return flow.Parallel(

--- a/pkg/operator/controller/garden/garden/reconciler_reconcile.go
+++ b/pkg/operator/controller/garden/garden/reconciler_reconcile.go
@@ -465,9 +465,9 @@ func (r *Reconciler) deployEtcdsFunc(garden *operatorv1alpha1.Garden, etcdMain, 
 		// This is required because peer certificates which are used for client and server authentication at the same time,
 		// are re-created with the new CA in the `Deploy` step.
 		if helper.GetCARotationPhase(garden.Status.Credentials) == gardencorev1beta1.RotationPreparing {
-			if err := flow.Sequential(
-				flow.Parallel(etcdMain.RolloutPeerCA, etcdEvents.RolloutPeerCA),
-				flow.Parallel(etcdMain.Wait, etcdEvents.Wait),
+			if err := flow.Parallel(
+				etcdMain.RolloutPeerCA,
+				etcdEvents.RolloutPeerCA,
 			)(ctx); err != nil {
 				return err
 			}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind bug

**What this PR does / why we need it**:
Shoot clusters can run into unrecoverable issues (for users) while the credentials rotation is in `preparing` phase. Gardenlet waits for `etcd` to get ready during the Peer-CA rollout but for unknown reasons, Druid occasionally swallows the reconcile annotation which will result in a `Generation != ObservedGeneration` error.
In the next `shoot` reconcile loop, Gardenlet runs into an early exit und just waits again for the `etcd` resource to get ready (w/o adding `gardener.cloud/operation: reconcile`).

This PR removes the mentioned early and improves handling for non-HA shoots (see commits).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The credentials (CA) rotation has been made more robust. In some cases, the `Shoot` reconciliation stuck at `Deploying main and events etcd` when the rotation was in `Preparing` phase.
```
