### PR TITLE
Scrape kubelet volume metrics

### DIFF
--- a/pkg/component/monitoring/charts/seed-monitoring/charts/core/charts/prometheus/templates/config.yaml
+++ b/pkg/component/monitoring/charts/seed-monitoring/charts/core/charts/prometheus/templates/config.yaml
@@ -277,8 +277,12 @@ data:
       # get system services
       metric_relabel_configs:
       - source_labels: [ __name__ ]
-        regex: ^(kubelet_running_pods|process_max_fds|process_open_fds)$
+        regex: ^(kubelet_running_pods|process_max_fds|process_open_fds|kubelet_volume_stats_available_bytes|kubelet_volume_stats_capacity_bytes|kubelet_volume_stats_used_bytes)$
         action: keep
+      - source_labels: [ namespace ]
+        action: keep
+        # Not all kubelet metrics have a namespace label. That's why we also need to match empty namespace (^$).
+        regex: (^$|^kube-system$)
 {{- end }}
 
 {{- if .Values.additionalScrapeConfigs }}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind enhancement

**What this PR does / why we need it**:
This PR adapts Shoot control plane prometheus config to start scraping the metrics `kubelet_volume_stats_available_bytes`, `kubelet_volume_stats_capacity_bytes` and `kubelet_volume_stats_used_bytes`. These metrics are about to be used by the registry cache extensions for alerting (alerts for the registry cache PVC size - `RegistryCachePersistentVolumeUsageCritical` and `RegistryCachePersistentVolumeFullInFourDays` and plutono/grafana dashboard panels.
The corresponding kubelet metrics are fetched only from volumes with the `namespace="kube-system"` label.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener-extension-registry-cache/issues/3

**Special notes for your reviewer**:
Corresponding PR on registry-cache side - ref https://github.com/gardener/gardener-extension-registry-cache/pull/96.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Shoot control plane prometheus is now scraping kubelet volume metrics (`kubelet_volume_stats_available_bytes`, `kubelet_volume_stats_capacity_bytes` and `kubelet_volume_stats_used_bytes`) from the kube-system namespace. This allows Gardener extensions deploying PVCs to the Shoot's kube-system namespace (such as the registry-cache extension) to build alerting and plutono dashboard panels using these kubelet volume metrics.
```
