### PR TITLE
Bump observaility components, plutono to 7.5.26, vali and valitail to 2.2.11, kube-rbac-proxy to 0.15.0

### DIFF
--- a/imagevector/images.yaml
+++ b/imagevector/images.yaml
@@ -238,7 +238,7 @@ images:
 - name: plutono
   sourceRepository: github.com/credativ/plutono
   repository: ghcr.io/credativ/plutono
-  tag: "v7.5.25"
+  tag: "v7.5.26"
   labels:
   - name: gardener.cloud/cve-categorisation
     value:
@@ -413,7 +413,7 @@ images:
 - name: vali
   sourceRepository: github.com/credativ/vali
   repository: ghcr.io/credativ/vali
-  tag: "v2.2.9"
+  tag: "v2.2.11"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:
@@ -447,7 +447,7 @@ images:
 - name: kube-rbac-proxy
   sourceRepository: github.com/brancz/kube-rbac-proxy
   repository: quay.io/brancz/kube-rbac-proxy
-  tag: v0.14.2
+  tag: v0.15.0
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:
@@ -465,7 +465,7 @@ images:
 - name: valitail
   sourceRepository: github.com/credativ/vali
   repository: ghcr.io/credativ/valitail
-  tag: "v2.2.9"
+  tag: "v2.2.11"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:


### PR DESCRIPTION
/area logging
/area monitoring

/kind enhancement

This PR brings the latest released versions of the observability componetns.

- Plutono is updated from [v7.5.25 to v7.5.26](https://github.com/credativ/plutono/compare/v7.5.25...v7.5.26)
- Vali (Valitail) are updated from [v2.2.9 to v2.2.11](https://github.com/credativ/vali/compare/v2.2.9...v2.2.11)
- Kube-rbac-proxy is updated from [v0.14.2 to v0.15.0](https://github.com/brancz/kube-rbac-proxy/compare/v0.14.2...v0.15.0)

**Release note**:
```other operator
Plutono is updated to v7.5.26.
Vali is updated to v2.2.11.
Kube-rbac-proxy is updated to v0.15.0.
```
