### PR TITLE
Duplicate the `GetResourceByName` helper func to internal API helper pkg

### DIFF
--- a/pkg/apis/core/helper/helpers.go
+++ b/pkg/apis/core/helper/helpers.go
@@ -365,6 +365,16 @@ func SystemComponentsAllowed(worker *core.Worker) bool {
 	return worker.SystemComponents == nil || worker.SystemComponents.Allow
 }
 
+// GetResourceByName returns the NamedResourceReference with the given name in the given slice, or nil if not found.
+func GetResourceByName(resources []core.NamedResourceReference, name string) *core.NamedResourceReference {
+	for _, resource := range resources {
+		if resource.Name == name {
+			return &resource
+		}
+	}
+	return nil
+}
+
 // KubernetesDashboardEnabled returns true if the kubernetes-dashboard addon is enabled in the Shoot manifest.
 func KubernetesDashboardEnabled(addons *core.Addons) bool {
 	return addons != nil && addons.KubernetesDashboard != nil && addons.KubernetesDashboard.Enabled

--- a/pkg/apis/core/v1beta1/helper/helper.go
+++ b/pkg/apis/core/v1beta1/helper/helper.go
@@ -928,7 +928,7 @@ func FilterDeprecatedVersion() func(expirableVersion gardencorev1beta1.Expirable
 	}
 }
 
-// GetResourceByName returns the first NamedResourceReference with the given name in the given slice, or nil if not found.
+// GetResourceByName returns the NamedResourceReference with the given name in the given slice, or nil if not found.
 func GetResourceByName(resources []gardencorev1beta1.NamedResourceReference, name string) *gardencorev1beta1.NamedResourceReference {
 	for _, resource := range resources {
 		if resource.Name == name {

--- a/pkg/apis/core/v1beta1/helper/helper_test.go
+++ b/pkg/apis/core/v1beta1/helper/helper_test.go
@@ -2118,6 +2118,32 @@ var _ = Describe("Helper", func() {
 			)
 		})
 
+		DescribeTable("#GetResourceByName",
+			func(resources []gardencorev1beta1.NamedResourceReference, name string, expected *gardencorev1beta1.NamedResourceReference) {
+				actual := GetResourceByName(resources, name)
+				Expect(actual).To(Equal(expected))
+			},
+
+			Entry("resources is nil", nil, "foo", nil),
+			Entry("resources doesn't contain a resource with the given name",
+				[]gardencorev1beta1.NamedResourceReference{
+					{Name: "bar", ResourceRef: autoscalingv1.CrossVersionObjectReference{Kind: "Secret", Name: "bar"}},
+					{Name: "baz", ResourceRef: autoscalingv1.CrossVersionObjectReference{Kind: "ConfigMap", Name: "baz"}},
+				},
+				"foo",
+				nil,
+			),
+			Entry("resources contains a resource with the given name",
+				[]gardencorev1beta1.NamedResourceReference{
+					{Name: "bar", ResourceRef: autoscalingv1.CrossVersionObjectReference{Kind: "Secret", Name: "bar"}},
+					{Name: "baz", ResourceRef: autoscalingv1.CrossVersionObjectReference{Kind: "ConfigMap", Name: "baz"}},
+					{Name: "foo", ResourceRef: autoscalingv1.CrossVersionObjectReference{Kind: "Secret", Name: "foo"}},
+				},
+				"foo",
+				&gardencorev1beta1.NamedResourceReference{Name: "foo", ResourceRef: autoscalingv1.CrossVersionObjectReference{Kind: "Secret", Name: "foo"}},
+			),
+		)
+
 		DescribeTable("#UpsertLastError",
 			func(lastErrors []gardencorev1beta1.LastError, lastError gardencorev1beta1.LastError, expected []gardencorev1beta1.LastError) {
 				Expect(UpsertLastError(lastErrors, lastError)).To(Equal(expected))


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind enhancement

**What this PR does / why we need it**:
Right now there is a `GetResourceByName` func in the v1beta1 helpers:
https://github.com/gardener/gardener/blob/7b0520866bc18af83af5e58f11922863451e4991/pkg/apis/core/v1beta1/helper/helper.go#L931-L939

This PR duplicates the same func for the internal API helper pkg.
In https://github.com/gardener/gardener-extension-registry-cache/pull/94 we would like to use this helper func - we have admission component and there we work with the internal types (`core.Shoot`), hence we need this helper func for the internal types. I think this func can be used by all of admission components validating referenced resources such as registry-cache, shoot-rsyslog-relp, etc.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
