### PR TITLE
Drop unwanted annotations from referenced resources

### DIFF
--- a/pkg/operation/botanist/resources.go
+++ b/pkg/operation/botanist/resources.go
@@ -51,6 +51,15 @@ func (b *Botanist) DeployReferencedResources(ctx context.Context) error {
 		unstructuredObj := &unstructured.Unstructured{Object: obj}
 		unstructuredObj.SetNamespace(b.Shoot.SeedNamespace)
 		unstructuredObj.SetName(v1beta1constants.ReferencedResourcesPrefix + unstructuredObj.GetName())
+
+		// Drop unwanted annotations before copying the resource to the seed.
+		// All annotations contained in the ManagedResource secret will end up in `ManagedResource.status.resources[].annotations`.
+		// We don't want this to happen for the last applied annotation of secrets, which includes the secret data in plain
+		// text. This would put sensitive secret data into the ManagedResource object which is probably unencrypted in etcd.
+		annotations := unstructuredObj.GetAnnotations()
+		delete(annotations, "kubectl.kubernetes.io/last-applied-configuration")
+		unstructuredObj.SetAnnotations(annotations)
+
 		unstructuredObjs = append(unstructuredObjs, unstructuredObj)
 	}
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind bug

**What this PR does / why we need it**:

This PR ensures we don't blindly copy kubectl's last applied annotation of referenced resources to the seed, where it might put sensitive data in the ManagedResource status, which is probably not encrypted in etcd.

**Which issue(s) this PR fixes**:
n/a

**Special notes for your reviewer**:

Steps to reproduce:

1. Create the following secret with `kubectl apply`:
```bash
k apply -f - <<EOF
apiVersion: v1
kind: Secret
metadata:
  name: test-secret
  namespace: garden-local
stringData:
  mySecret: value
EOF
```
2. Create a shoot referencing this secret:
```yaml
apiVersion: core.gardener.cloud/v1beta1
kind: Shoot
metadata:
  name: local-wl
  namespace: garden-local
spec:
  cloudProfileName: local
  region: local
  provider:
    type: local
  resources:
  - name: test-secret
    resourceRef:
      apiVersion: v1
      kind: Secret
      name: test-secret
```
3. Observe that the secret data is visible in the `MangedResource` status in the seed:
```bash
$ k -n shoot--local--local-wl get mr referenced-resources -oyaml | yq '.status.resources[0].annotations'
kubectl.kubernetes.io/last-applied-configuration: |
  {"apiVersion":"v1","kind":"Secret","metadata":{"annotations":{},"name":"test-secret","namespace":"garden-local"},"stringData":{"mySecret":"value"}}
```

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
5. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
