### PR TITLE
Recreate managed resource secrets that have deletion timestamp

### DIFF
--- a/cmd/gardenlet/app/app.go
+++ b/cmd/gardenlet/app/app.go
@@ -620,7 +620,7 @@ func getSecretsToRecreate(ctx context.Context, c client.Client) ([]corev1.Secret
 		return nil, err
 	}
 	secretsToRecreate := slices.DeleteFunc(secretList.Items, func(s corev1.Secret) bool {
-		return !slices.Contains(s.Finalizers, grmFinalizer)
+		return !slices.Contains(s.Finalizers, grmFinalizer) || s.DeletionTimestamp == nil
 	})
 	return secretsToRecreate, nil
 }

--- a/cmd/gardenlet/app/app.go
+++ b/cmd/gardenlet/app/app.go
@@ -512,6 +512,8 @@ func recreateDeletedManagedResourceSecrets(ctx context.Context, c client.Client)
 			if apierrors.IsNotFound(err) {
 				// original secret is not found so we recreate it
 				original := temp.DeepCopy()
+				delete(original.Labels, tempSecretLabel)
+				delete(original.Labels, tempSecretOldNameLabel)
 				original.ResourceVersion = ""
 				original.Name = originalName
 

--- a/cmd/gardenlet/app/app.go
+++ b/cmd/gardenlet/app/app.go
@@ -597,10 +597,9 @@ func removeFinalizersAndWait(ctx context.Context, c client.Client, secret *corev
 		return fmt.Errorf("failed to patch the original secret %w", err)
 	}
 
-	goneSecret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: secret.Name, Namespace: secret.Namespace}}
 	cancelCtx, cancel := context.WithTimeout(ctx, time.Second*10)
 	defer cancel()
-	return kubernetesutils.WaitUntilResourceDeleted(cancelCtx, c, goneSecret, 1*time.Second)
+	return kubernetesutils.WaitUntilResourceDeleted(cancelCtx, c, secret, 1*time.Second)
 }
 
 // TODO(dimityrmirchev): Remove this code after v1.87 has been released.
@@ -610,7 +609,7 @@ func getSecretsToRecreate(ctx context.Context, c client.Client) ([]corev1.Secret
 	if err != nil {
 		return nil, err
 	}
-	notTemp, err := labels.NewRequirement(tempSecretLabel, selection.DoesNotExist, []string{})
+	notTemp, err := labels.NewRequirement(tempSecretLabel, selection.DoesNotExist, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/gardenlet/app/app_test.go
+++ b/cmd/gardenlet/app/app_test.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/gardener/gardener/pkg/client/kubernetes"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
@@ -26,6 +25,8 @@ import (
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/gardener/gardener/pkg/client/kubernetes"
 )
 
 func TestApp(t *testing.T) {

--- a/cmd/gardenlet/app/app_test.go
+++ b/cmd/gardenlet/app/app_test.go
@@ -1,0 +1,234 @@
+// Copyright 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package app
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestApp(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Gardenlet App Test Suite")
+}
+
+var _ = Describe("Recreate Managed Resource Secrets", func() {
+	var (
+		ctx        = context.TODO()
+		fakeClient client.Client
+
+		secret1         *corev1.Secret
+		secret2         *corev1.Secret
+		expectedSecret1 *corev1.Secret
+		expectedSecret2 *corev1.Secret
+		tempSecret3     *corev1.Secret
+		expectedSecret3 *corev1.Secret
+		secret4         *corev1.Secret
+		tempSecret4     *corev1.Secret
+		expectedSecret4 *corev1.Secret
+	)
+
+	BeforeEach(func() {
+		fakeClient = fakeclient.NewClientBuilder().WithScheme(kubernetes.SeedScheme).Build()
+		secret1 = &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "secret1",
+				Namespace: "shoot-ns",
+				Labels: map[string]string{
+					"resources.gardener.cloud/garbage-collectable-reference": "true",
+				},
+				Finalizers: []string{"resources.gardener.cloud/gardener-resource-manager"},
+			},
+			Immutable: pointer.Bool(true),
+			Data: map[string][]byte{
+				"test": []byte("foo"),
+			},
+		}
+		secret2 = &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "secret2",
+				Namespace: "garden",
+				Labels: map[string]string{
+					"resources.gardener.cloud/garbage-collectable-reference": "true",
+				},
+				Finalizers: []string{"resources.gardener.cloud/gardener-resource-manager"},
+			},
+			Immutable: pointer.Bool(true),
+			Data: map[string][]byte{
+				"test": []byte("bar"),
+			},
+		}
+
+		tempSecret3 = &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "secret3-temp",
+				Namespace: "garden",
+				Labels: map[string]string{
+					"resources.gardener.cloud/garbage-collectable-reference": "true",
+					"resources.gardener.cloud/temp-secret":                   "true",
+					"resources.gardener.cloud/temp-secret-old-name":          "secret3",
+				},
+			},
+			Immutable: pointer.Bool(true),
+			Data: map[string][]byte{
+				"test": []byte("bar1"),
+			},
+		}
+
+		secret4 = &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "secret4",
+				Namespace: "garden",
+				Labels: map[string]string{
+					"resources.gardener.cloud/garbage-collectable-reference": "true",
+				},
+				Finalizers: []string{"resources.gardener.cloud/gardener-resource-manager"},
+			},
+			Immutable: pointer.Bool(true),
+			Data: map[string][]byte{
+				"test": []byte("bar1"),
+			},
+		}
+
+		tempSecret4 = &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "secret4-temp",
+				Namespace: "garden",
+				Labels: map[string]string{
+					"resources.gardener.cloud/garbage-collectable-reference": "true",
+					"resources.gardener.cloud/temp-secret":                   "true",
+					"resources.gardener.cloud/temp-secret-old-name":          "secret4",
+				},
+			},
+			Immutable: pointer.Bool(true),
+			Data: map[string][]byte{
+				"test": []byte("bar1"),
+			},
+		}
+
+		expectedSecret1 = &corev1.Secret{
+			TypeMeta: metav1.TypeMeta{Kind: "Secret", APIVersion: "v1"},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "secret1",
+				Namespace: "shoot-ns",
+				Labels: map[string]string{
+					"resources.gardener.cloud/garbage-collectable-reference": "true",
+				},
+				ResourceVersion: "1",
+			},
+			Immutable: pointer.Bool(true),
+			Data: map[string][]byte{
+				"test": []byte("foo"),
+			},
+		}
+
+		expectedSecret2 = &corev1.Secret{
+			TypeMeta: metav1.TypeMeta{Kind: "Secret", APIVersion: "v1"},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "secret2",
+				Namespace: "garden",
+				Labels: map[string]string{
+					"resources.gardener.cloud/garbage-collectable-reference": "true",
+				},
+				ResourceVersion: "1",
+			},
+			Immutable: pointer.Bool(true),
+			Data: map[string][]byte{
+				"test": []byte("bar"),
+			},
+		}
+
+		expectedSecret3 = &corev1.Secret{
+			TypeMeta: metav1.TypeMeta{Kind: "Secret", APIVersion: "v1"},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "secret3",
+				Namespace: "garden",
+				Labels: map[string]string{
+					"resources.gardener.cloud/garbage-collectable-reference": "true",
+				},
+				ResourceVersion: "1",
+			},
+			Immutable: pointer.Bool(true),
+			Data: map[string][]byte{
+				"test": []byte("bar1"),
+			},
+		}
+
+		expectedSecret4 = &corev1.Secret{
+			TypeMeta: metav1.TypeMeta{Kind: "Secret", APIVersion: "v1"},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "secret4",
+				Namespace: "garden",
+				Labels: map[string]string{
+					"resources.gardener.cloud/garbage-collectable-reference": "true",
+				},
+				ResourceVersion: "1",
+			},
+			Immutable: pointer.Bool(true),
+			Data: map[string][]byte{
+				"test": []byte("bar1"),
+			},
+		}
+	})
+
+	It("should recreate the managed resource secrets", func() {
+		Expect(fakeClient.Create(ctx, secret1)).To(Succeed())
+		Expect(fakeClient.Create(ctx, secret2)).To(Succeed())
+		Expect(fakeClient.Create(ctx, tempSecret3)).To(Succeed())
+		Expect(fakeClient.Create(ctx, secret4)).To(Succeed())
+		Expect(fakeClient.Create(ctx, tempSecret4)).To(Succeed())
+
+		Expect(fakeClient.Delete(ctx, secret1)).To(Succeed())
+		Expect(fakeClient.Delete(ctx, secret2)).To(Succeed())
+		Expect(fakeClient.Delete(ctx, secret4)).To(Succeed())
+
+		s1 := &corev1.Secret{}
+		s2 := &corev1.Secret{}
+		s3 := &corev1.Secret{}
+		s4 := &corev1.Secret{}
+		Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(secret1), s1)).To(Succeed())
+		Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(secret2), s2)).To(Succeed())
+		Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(secret2), s4)).To(Succeed())
+
+		Expect(s1.DeletionTimestamp).ToNot(BeNil())
+		Expect(s2.DeletionTimestamp).ToNot(BeNil())
+		Expect(s4.DeletionTimestamp).ToNot(BeNil())
+
+		Expect(recreateDeletedManagedResourceSecrets(ctx, fakeClient)).To(Succeed())
+
+		Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(expectedSecret1), s1)).To(Succeed())
+		Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(expectedSecret2), s2)).To(Succeed())
+		Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(expectedSecret3), s3)).To(Succeed())
+		Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(expectedSecret4), s4)).To(Succeed())
+
+		Expect(s1).To(Equal(expectedSecret1))
+		Expect(s2).To(Equal(expectedSecret2))
+		Expect(s3).To(Equal(expectedSecret3))
+		Expect(s4).To(Equal(expectedSecret4))
+
+		secretList := &corev1.SecretList{}
+		Expect(fakeClient.List(ctx, secretList)).To(Succeed())
+		Expect(secretList.Items).To(HaveLen(4))
+	})
+})


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind cleanup

**What this PR does / why we need it**:
In https://github.com/gardener/gardener/pull/8398 a fix for unwanted garbage collection of MR secrets was provided, but in some systems there are still such secrets that have deletion timestamp. After https://github.com/gardener/gardener/pull/8745 the finalizer that protects them will be gone. This PR introduces a recreation step so gardenlet can recreate these secrets on startup.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/invite @rfranzke 

Thanks for reporting!

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
