### PR TITLE
[node-agent] Refactor `files` handling in `OperatingSystemConfig` API

### DIFF
--- a/docs/api-reference/extensions.md
+++ b/docs/api-reference/extensions.md
@@ -2951,8 +2951,7 @@ DefaultStatus
 <p>
 (<em>Appears on:</em>
 <a href="#extensions.gardener.cloud/v1alpha1.OperatingSystemConfigSpec">OperatingSystemConfigSpec</a>, 
-<a href="#extensions.gardener.cloud/v1alpha1.OperatingSystemConfigStatus">OperatingSystemConfigStatus</a>, 
-<a href="#extensions.gardener.cloud/v1alpha1.Unit">Unit</a>)
+<a href="#extensions.gardener.cloud/v1alpha1.OperatingSystemConfigStatus">OperatingSystemConfigStatus</a>)
 </p>
 <p>
 <p>File is a file that should get written to the host&rsquo;s file system. The content can either be inlined or
@@ -3808,8 +3807,7 @@ TODO(rfranzke): Deprecate this field once UseGardenerNodeAgent feature gate is p
 <td>
 <em>(Optional)</em>
 <p>Files is a list of file paths that are part of the generated Cloud Config and shall be
-written to the host&rsquo;s file system.
-TODO(rfranzke): Deprecate this field once UseGardenerNodeAgent feature gate is promoted to GA.</p>
+written to the host&rsquo;s file system.</p>
 </td>
 </tr>
 </tbody>
@@ -3916,17 +3914,14 @@ string
 </tr>
 <tr>
 <td>
-<code>files</code></br>
+<code>filePaths</code></br>
 <em>
-<a href="#extensions.gardener.cloud/v1alpha1.File">
-[]File
-</a>
+[]string
 </em>
 </td>
 <td>
-<em>(Optional)</em>
-<p>Files is a list of files the unit depends on that should get written to the host&rsquo;s file system.
-If any file changes a restart of the dependent unit will be triggered.</p>
+<p>FilePaths is a list of files the unit depends on. If any file changes a restart of the dependent unit will be
+triggered. For each FilePath there must exist a File with matching Path in OperatingSystemConfig.Spec.Files.</p>
 </td>
 </tr>
 </tbody>

--- a/docs/api-reference/extensions.md
+++ b/docs/api-reference/extensions.md
@@ -3807,7 +3807,8 @@ TODO(rfranzke): Deprecate this field once UseGardenerNodeAgent feature gate is p
 <td>
 <em>(Optional)</em>
 <p>Files is a list of file paths that are part of the generated Cloud Config and shall be
-written to the host&rsquo;s file system.</p>
+written to the host&rsquo;s file system.
+TODO(rfranzke): Deprecate this field once UseGardenerNodeAgent feature gate is promoted to GA.</p>
 </td>
 </tr>
 </tbody>

--- a/example/seed-crds/10-crd-extensions.gardener.cloud_operatingsystemconfigs.yaml
+++ b/example/seed-crds/10-crd-extensions.gardener.cloud_operatingsystemconfigs.yaml
@@ -200,86 +200,13 @@ spec:
                       description: Enable describes whether the unit is enabled or
                         not.
                       type: boolean
-                    files:
-                      description: Files is a list of files the unit depends on that
-                        should get written to the host's file system. If any file
-                        changes a restart of the dependent unit will be triggered.
+                    filePaths:
+                      description: FilePaths is a list of files the unit depends on.
+                        If any file changes a restart of the dependent unit will be
+                        triggered. For each FilePath there must exist a File with
+                        matching Path in OperatingSystemConfig.Spec.Files.
                       items:
-                        description: File is a file that should get written to the
-                          host's file system. The content can either be inlined or
-                          referenced from a secret in the same namespace.
-                        properties:
-                          content:
-                            description: Content describe the file's content.
-                            properties:
-                              imageRef:
-                                description: ImageRef describes a container image
-                                  which contains a file.
-                                properties:
-                                  filePathInImage:
-                                    description: FilePathInImage contains the path
-                                      in the image to the file that should be extracted.
-                                    type: string
-                                  image:
-                                    description: Image contains the container image
-                                      repository with tag.
-                                    type: string
-                                required:
-                                - filePathInImage
-                                - image
-                                type: object
-                              inline:
-                                description: Inline is a struct that contains information
-                                  about the inlined data.
-                                properties:
-                                  data:
-                                    description: Data is the file's data.
-                                    type: string
-                                  encoding:
-                                    description: Encoding is the file's encoding (e.g.
-                                      base64).
-                                    type: string
-                                required:
-                                - data
-                                - encoding
-                                type: object
-                              secretRef:
-                                description: SecretRef is a struct that contains information
-                                  about the referenced secret.
-                                properties:
-                                  dataKey:
-                                    description: DataKey is the key in the secret's
-                                      `.data` field that should be read.
-                                    type: string
-                                  name:
-                                    description: Name is the name of the secret.
-                                    type: string
-                                required:
-                                - dataKey
-                                - name
-                                type: object
-                              transmitUnencoded:
-                                description: TransmitUnencoded set to true will ensure
-                                  that the os-extension does not encode the file content
-                                  when sent to the node. This for example can be used
-                                  to manipulate the clear-text content before it reaches
-                                  the node.
-                                type: boolean
-                            type: object
-                          path:
-                            description: Path is the path of the file system where
-                              the file should get written to.
-                            type: string
-                          permissions:
-                            description: Permissions describes with which permissions
-                              the file should get written to the file system. Should
-                              be defaulted to octal 0644.
-                            format: int32
-                            type: integer
-                        required:
-                        - content
-                        - path
-                        type: object
+                        type: string
                       type: array
                     name:
                       description: Name is the name of a unit.
@@ -483,86 +410,13 @@ spec:
                       description: Enable describes whether the unit is enabled or
                         not.
                       type: boolean
-                    files:
-                      description: Files is a list of files the unit depends on that
-                        should get written to the host's file system. If any file
-                        changes a restart of the dependent unit will be triggered.
+                    filePaths:
+                      description: FilePaths is a list of files the unit depends on.
+                        If any file changes a restart of the dependent unit will be
+                        triggered. For each FilePath there must exist a File with
+                        matching Path in OperatingSystemConfig.Spec.Files.
                       items:
-                        description: File is a file that should get written to the
-                          host's file system. The content can either be inlined or
-                          referenced from a secret in the same namespace.
-                        properties:
-                          content:
-                            description: Content describe the file's content.
-                            properties:
-                              imageRef:
-                                description: ImageRef describes a container image
-                                  which contains a file.
-                                properties:
-                                  filePathInImage:
-                                    description: FilePathInImage contains the path
-                                      in the image to the file that should be extracted.
-                                    type: string
-                                  image:
-                                    description: Image contains the container image
-                                      repository with tag.
-                                    type: string
-                                required:
-                                - filePathInImage
-                                - image
-                                type: object
-                              inline:
-                                description: Inline is a struct that contains information
-                                  about the inlined data.
-                                properties:
-                                  data:
-                                    description: Data is the file's data.
-                                    type: string
-                                  encoding:
-                                    description: Encoding is the file's encoding (e.g.
-                                      base64).
-                                    type: string
-                                required:
-                                - data
-                                - encoding
-                                type: object
-                              secretRef:
-                                description: SecretRef is a struct that contains information
-                                  about the referenced secret.
-                                properties:
-                                  dataKey:
-                                    description: DataKey is the key in the secret's
-                                      `.data` field that should be read.
-                                    type: string
-                                  name:
-                                    description: Name is the name of the secret.
-                                    type: string
-                                required:
-                                - dataKey
-                                - name
-                                type: object
-                              transmitUnencoded:
-                                description: TransmitUnencoded set to true will ensure
-                                  that the os-extension does not encode the file content
-                                  when sent to the node. This for example can be used
-                                  to manipulate the clear-text content before it reaches
-                                  the node.
-                                type: boolean
-                            type: object
-                          path:
-                            description: Path is the path of the file system where
-                              the file should get written to.
-                            type: string
-                          permissions:
-                            description: Permissions describes with which permissions
-                              the file should get written to the file system. Should
-                              be defaulted to octal 0644.
-                            format: int32
-                            type: integer
-                        required:
-                        - content
-                        - path
-                        type: object
+                        type: string
                       type: array
                     name:
                       description: Name is the name of a unit.
@@ -572,10 +426,8 @@ spec:
                   type: object
                 type: array
               files:
-                description: 'Files is a list of file paths that are part of the generated
-                  Cloud Config and shall be written to the host''s file system. TODO(rfranzke):
-                  Deprecate this field once UseGardenerNodeAgent feature gate is promoted
-                  to GA.'
+                description: Files is a list of file paths that are part of the generated
+                  Cloud Config and shall be written to the host's file system.
                 items:
                   type: string
                 type: array

--- a/example/seed-crds/10-crd-extensions.gardener.cloud_operatingsystemconfigs.yaml
+++ b/example/seed-crds/10-crd-extensions.gardener.cloud_operatingsystemconfigs.yaml
@@ -426,8 +426,10 @@ spec:
                   type: object
                 type: array
               files:
-                description: Files is a list of file paths that are part of the generated
-                  Cloud Config and shall be written to the host's file system.
+                description: 'Files is a list of file paths that are part of the generated
+                  Cloud Config and shall be written to the host''s file system. TODO(rfranzke):
+                  Deprecate this field once UseGardenerNodeAgent feature gate is promoted
+                  to GA.'
                 items:
                   type: string
                 type: array

--- a/extensions/pkg/controller/operatingsystemconfig/bash.go
+++ b/extensions/pkg/controller/operatingsystemconfig/bash.go
@@ -54,7 +54,7 @@ mkdir -p "` + path.Dir(file.Path) + `"
 
 // UnitsToDiskScript is a utility function which generates a bash script for writing the provided units and their
 // drop-ins to the disk.
-func UnitsToDiskScript(ctx context.Context, reader client.Reader, namespace string, units []extensionsv1alpha1.Unit) (string, error) {
+func UnitsToDiskScript(units []extensionsv1alpha1.Unit) (string, error) {
 	var out string
 
 	for _, unit := range units {
@@ -75,12 +75,6 @@ mkdir -p "` + unitDropInsDirectoryPath + `"`
 ` + catDataIntoFile(path.Join(unitDropInsDirectoryPath, dropIn.Name), []byte(dropIn.Content), false)
 			}
 		}
-
-		filesCommands, err := FilesToDiskScript(ctx, reader, namespace, unit.Files)
-		if err != nil {
-			return "", err
-		}
-		out += filesCommands
 	}
 
 	return out, nil

--- a/extensions/pkg/controller/operatingsystemconfig/bash.go
+++ b/extensions/pkg/controller/operatingsystemconfig/bash.go
@@ -54,7 +54,7 @@ mkdir -p "` + path.Dir(file.Path) + `"
 
 // UnitsToDiskScript is a utility function which generates a bash script for writing the provided units and their
 // drop-ins to the disk.
-func UnitsToDiskScript(units []extensionsv1alpha1.Unit) (string, error) {
+func UnitsToDiskScript(units []extensionsv1alpha1.Unit) string {
 	var out string
 
 	for _, unit := range units {
@@ -77,7 +77,7 @@ mkdir -p "` + unitDropInsDirectoryPath + `"`
 		}
 	}
 
-	return out, nil
+	return out
 }
 
 func dataForFileContent(ctx context.Context, c client.Reader, namespace string, content *extensionsv1alpha1.FileContent) ([]byte, error) {

--- a/extensions/pkg/controller/operatingsystemconfig/bash_test.go
+++ b/extensions/pkg/controller/operatingsystemconfig/bash_test.go
@@ -198,8 +198,7 @@ EOF`))
 			)
 
 			By("Ensure the function generated the expected bash script")
-			script, err := UnitsToDiskScript(units)
-			Expect(err).NotTo(HaveOccurred())
+			script := UnitsToDiskScript(units)
 			Expect(script).To(Equal(`
 mkdir -p "/etc/systemd/system/` + unit1 + `.d"
 

--- a/extensions/pkg/controller/operatingsystemconfig/bash_test.go
+++ b/extensions/pkg/controller/operatingsystemconfig/bash_test.go
@@ -193,21 +193,12 @@ EOF`))
 					{
 						Name:    unit2,
 						Content: pointer.String("content2"),
-						Files: []extensionsv1alpha1.File{{
-							Path: file1,
-							Content: extensionsv1alpha1.FileContent{
-								Inline: &extensionsv1alpha1.FileContentInline{
-									Encoding: "",
-									Data:     "plain-text",
-								},
-							},
-						}},
 					},
 				}
 			)
 
 			By("Ensure the function generated the expected bash script")
-			script, err := UnitsToDiskScript(ctx, fakeClient, namespace, units)
+			script, err := UnitsToDiskScript(units)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(script).To(Equal(`
 mkdir -p "/etc/systemd/system/` + unit1 + `.d"
@@ -222,11 +213,6 @@ EOF
 
 cat << EOF | base64 -d > "/etc/systemd/system/` + unit2 + `"
 Y29udGVudDI=
-EOF
-mkdir -p "` + folder1 + `"
-
-cat << EOF | base64 -d > "` + file1 + `"
-cGxhaW4tdGV4dA==
 EOF`))
 
 			By("Ensure that the bash script can be executed and performs the desired operations")
@@ -239,7 +225,6 @@ EOF`))
 
 			runScriptAndCheckFiles(script,
 				tempDir+"/etc/systemd/system/"+unit2,
-				tempDir+file1,
 				tempDir+"/etc/systemd/system/"+unit1+".d/"+unit1DropIn1,
 				tempDir+"/etc/systemd/system/"+unit1+".d/"+unit1DropIn2,
 			)

--- a/extensions/pkg/webhook/controlplane/genericmutator/mutator.go
+++ b/extensions/pkg/webhook/controlplane/genericmutator/mutator.go
@@ -246,12 +246,6 @@ func findFileWithPath(osc *extensionsv1alpha1.OperatingSystemConfig, path string
 		if f := extensionswebhook.FileWithPath(osc.Spec.Files, path); f != nil {
 			return f.Content.Inline
 		}
-
-		for _, unit := range osc.Spec.Units {
-			if f := extensionswebhook.FileWithPath(unit.Files, path); f != nil {
-				return f.Content.Inline
-			}
-		}
 	}
 
 	return nil

--- a/pkg/apis/extensions/v1alpha1/types_operatingsystemconfig.go
+++ b/pkg/apis/extensions/v1alpha1/types_operatingsystemconfig.go
@@ -236,6 +236,7 @@ type OperatingSystemConfigStatus struct {
 	Units []string `json:"units,omitempty"`
 	// Files is a list of file paths that are part of the generated Cloud Config and shall be
 	// written to the host's file system.
+	// TODO(rfranzke): Deprecate this field once UseGardenerNodeAgent feature gate is promoted to GA.
 	// +optional
 	Files []string `json:"files,omitempty"`
 }

--- a/pkg/apis/extensions/v1alpha1/types_operatingsystemconfig.go
+++ b/pkg/apis/extensions/v1alpha1/types_operatingsystemconfig.go
@@ -121,12 +121,9 @@ type Unit struct {
 	// +patchStrategy=merge
 	// +optional
 	DropIns []DropIn `json:"dropIns,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
-	// Files is a list of files the unit depends on that should get written to the host's file system.
-	// If any file changes a restart of the dependent unit will be triggered.
-	// +patchMergeKey=path
-	// +patchStrategy=merge
-	// +optional
-	Files []File `json:"files,omitempty" patchStrategy:"merge" patchMergeKey:"path"`
+	// FilePaths is a list of files the unit depends on. If any file changes a restart of the dependent unit will be
+	// triggered. For each FilePath there must exist a File with matching Path in OperatingSystemConfig.Spec.Files.
+	FilePaths []string `json:"filePaths,omitempty"`
 }
 
 // UnitCommand is a string alias.
@@ -239,7 +236,6 @@ type OperatingSystemConfigStatus struct {
 	Units []string `json:"units,omitempty"`
 	// Files is a list of file paths that are part of the generated Cloud Config and shall be
 	// written to the host's file system.
-	// TODO(rfranzke): Deprecate this field once UseGardenerNodeAgent feature gate is promoted to GA.
 	// +optional
 	Files []string `json:"files,omitempty"`
 }

--- a/pkg/apis/extensions/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/extensions/v1alpha1/zz_generated.deepcopy.go
@@ -1559,12 +1559,10 @@ func (in *Unit) DeepCopyInto(out *Unit) {
 		*out = make([]DropIn, len(*in))
 		copy(*out, *in)
 	}
-	if in.Files != nil {
-		in, out := &in.Files, &out.Files
-		*out = make([]File, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+	if in.FilePaths != nil {
+		in, out := &in.FilePaths, &out.FilePaths
+		*out = make([]string, len(*in))
+		copy(*out, *in)
 	}
 	return
 }

--- a/pkg/component/extensions/crds/assets/crd-extensions.gardener.cloud_operatingsystemconfigs.yaml
+++ b/pkg/component/extensions/crds/assets/crd-extensions.gardener.cloud_operatingsystemconfigs.yaml
@@ -202,86 +202,13 @@ spec:
                       description: Enable describes whether the unit is enabled or
                         not.
                       type: boolean
-                    files:
-                      description: Files is a list of files the unit depends on that
-                        should get written to the host's file system. If any file
-                        changes a restart of the dependent unit will be triggered.
+                    filePaths:
+                      description: FilePaths is a list of files the unit depends on.
+                        If any file changes a restart of the dependent unit will be
+                        triggered. For each FilePath there must exist a File with
+                        matching Path in OperatingSystemConfig.Spec.Files.
                       items:
-                        description: File is a file that should get written to the
-                          host's file system. The content can either be inlined or
-                          referenced from a secret in the same namespace.
-                        properties:
-                          content:
-                            description: Content describe the file's content.
-                            properties:
-                              imageRef:
-                                description: ImageRef describes a container image
-                                  which contains a file.
-                                properties:
-                                  filePathInImage:
-                                    description: FilePathInImage contains the path
-                                      in the image to the file that should be extracted.
-                                    type: string
-                                  image:
-                                    description: Image contains the container image
-                                      repository with tag.
-                                    type: string
-                                required:
-                                - filePathInImage
-                                - image
-                                type: object
-                              inline:
-                                description: Inline is a struct that contains information
-                                  about the inlined data.
-                                properties:
-                                  data:
-                                    description: Data is the file's data.
-                                    type: string
-                                  encoding:
-                                    description: Encoding is the file's encoding (e.g.
-                                      base64).
-                                    type: string
-                                required:
-                                - data
-                                - encoding
-                                type: object
-                              secretRef:
-                                description: SecretRef is a struct that contains information
-                                  about the referenced secret.
-                                properties:
-                                  dataKey:
-                                    description: DataKey is the key in the secret's
-                                      `.data` field that should be read.
-                                    type: string
-                                  name:
-                                    description: Name is the name of the secret.
-                                    type: string
-                                required:
-                                - dataKey
-                                - name
-                                type: object
-                              transmitUnencoded:
-                                description: TransmitUnencoded set to true will ensure
-                                  that the os-extension does not encode the file content
-                                  when sent to the node. This for example can be used
-                                  to manipulate the clear-text content before it reaches
-                                  the node.
-                                type: boolean
-                            type: object
-                          path:
-                            description: Path is the path of the file system where
-                              the file should get written to.
-                            type: string
-                          permissions:
-                            description: Permissions describes with which permissions
-                              the file should get written to the file system. Should
-                              be defaulted to octal 0644.
-                            format: int32
-                            type: integer
-                        required:
-                        - content
-                        - path
-                        type: object
+                        type: string
                       type: array
                     name:
                       description: Name is the name of a unit.
@@ -485,86 +412,13 @@ spec:
                       description: Enable describes whether the unit is enabled or
                         not.
                       type: boolean
-                    files:
-                      description: Files is a list of files the unit depends on that
-                        should get written to the host's file system. If any file
-                        changes a restart of the dependent unit will be triggered.
+                    filePaths:
+                      description: FilePaths is a list of files the unit depends on.
+                        If any file changes a restart of the dependent unit will be
+                        triggered. For each FilePath there must exist a File with
+                        matching Path in OperatingSystemConfig.Spec.Files.
                       items:
-                        description: File is a file that should get written to the
-                          host's file system. The content can either be inlined or
-                          referenced from a secret in the same namespace.
-                        properties:
-                          content:
-                            description: Content describe the file's content.
-                            properties:
-                              imageRef:
-                                description: ImageRef describes a container image
-                                  which contains a file.
-                                properties:
-                                  filePathInImage:
-                                    description: FilePathInImage contains the path
-                                      in the image to the file that should be extracted.
-                                    type: string
-                                  image:
-                                    description: Image contains the container image
-                                      repository with tag.
-                                    type: string
-                                required:
-                                - filePathInImage
-                                - image
-                                type: object
-                              inline:
-                                description: Inline is a struct that contains information
-                                  about the inlined data.
-                                properties:
-                                  data:
-                                    description: Data is the file's data.
-                                    type: string
-                                  encoding:
-                                    description: Encoding is the file's encoding (e.g.
-                                      base64).
-                                    type: string
-                                required:
-                                - data
-                                - encoding
-                                type: object
-                              secretRef:
-                                description: SecretRef is a struct that contains information
-                                  about the referenced secret.
-                                properties:
-                                  dataKey:
-                                    description: DataKey is the key in the secret's
-                                      `.data` field that should be read.
-                                    type: string
-                                  name:
-                                    description: Name is the name of the secret.
-                                    type: string
-                                required:
-                                - dataKey
-                                - name
-                                type: object
-                              transmitUnencoded:
-                                description: TransmitUnencoded set to true will ensure
-                                  that the os-extension does not encode the file content
-                                  when sent to the node. This for example can be used
-                                  to manipulate the clear-text content before it reaches
-                                  the node.
-                                type: boolean
-                            type: object
-                          path:
-                            description: Path is the path of the file system where
-                              the file should get written to.
-                            type: string
-                          permissions:
-                            description: Permissions describes with which permissions
-                              the file should get written to the file system. Should
-                              be defaulted to octal 0644.
-                            format: int32
-                            type: integer
-                        required:
-                        - content
-                        - path
-                        type: object
+                        type: string
                       type: array
                     name:
                       description: Name is the name of a unit.
@@ -574,10 +428,8 @@ spec:
                   type: object
                 type: array
               files:
-                description: 'Files is a list of file paths that are part of the generated
-                  Cloud Config and shall be written to the host''s file system. TODO(rfranzke):
-                  Deprecate this field once UseGardenerNodeAgent feature gate is promoted
-                  to GA.'
+                description: Files is a list of file paths that are part of the generated
+                  Cloud Config and shall be written to the host's file system.
                 items:
                   type: string
                 type: array

--- a/pkg/component/extensions/crds/assets/crd-extensions.gardener.cloud_operatingsystemconfigs.yaml
+++ b/pkg/component/extensions/crds/assets/crd-extensions.gardener.cloud_operatingsystemconfigs.yaml
@@ -428,8 +428,10 @@ spec:
                   type: object
                 type: array
               files:
-                description: Files is a list of file paths that are part of the generated
-                  Cloud Config and shall be written to the host's file system.
+                description: 'Files is a list of file paths that are part of the generated
+                  Cloud Config and shall be written to the host''s file system. TODO(rfranzke):
+                  Deprecate this field once UseGardenerNodeAgent feature gate is promoted
+                  to GA.'
                 items:
                   type: string
                 type: array

--- a/pkg/component/extensions/operatingsystemconfig/nodeinit/nodeinit.go
+++ b/pkg/component/extensions/operatingsystemconfig/nodeinit/nodeinit.go
@@ -69,7 +69,25 @@ EnvironmentFile=/etc/environment
 ExecStart=` + pathInitScript + `
 [Install]
 WantedBy=multi-user.target`),
-			Files: []extensionsv1alpha1.File{{
+			FilePaths: []string{pathInitScript},
+		}}
+
+		nodeInitFiles = []extensionsv1alpha1.File{
+			{
+				Path:        nodeagentv1alpha1.BootstrapTokenFilePath,
+				Permissions: pointer.Int32(0640),
+				Content: extensionsv1alpha1.FileContent{
+					Inline: &extensionsv1alpha1.FileContentInline{
+						// The bootstrap token will be created by the machine-controller-manager when creating an actual
+						// machine, and it will replace this "magic" string with the actual token in the user data. See
+						// https://github.com/gardener/gardener/blob/master/docs/extensions/operatingsystemconfig.md#bootstrap-tokens
+						// for more details.
+						Data: "<<BOOTSTRAP_TOKEN>>",
+					},
+					TransmitUnencoded: pointer.Bool(true),
+				},
+			},
+			{
 				Path:        pathInitScript,
 				Permissions: pointer.Int32(0755),
 				Content: extensionsv1alpha1.FileContent{
@@ -78,23 +96,8 @@ WantedBy=multi-user.target`),
 						Data:     utils.EncodeBase64(initScript),
 					},
 				},
-			}},
-		}}
-
-		nodeInitFiles = []extensionsv1alpha1.File{{
-			Path:        nodeagentv1alpha1.BootstrapTokenFilePath,
-			Permissions: pointer.Int32(0640),
-			Content: extensionsv1alpha1.FileContent{
-				Inline: &extensionsv1alpha1.FileContentInline{
-					// The bootstrap token will be created by the machine-controller-manager when creating an actual
-					// machine, and it will replace this "magic" string with the actual token in the user data. See
-					// https://github.com/gardener/gardener/blob/master/docs/extensions/operatingsystemconfig.md#bootstrap-tokens
-					// for more details.
-					Data: "<<BOOTSTRAP_TOKEN>>",
-				},
-				TransmitUnencoded: pointer.Bool(true),
 			},
-		}}
+		}
 	)
 
 	// The gardener-node-init script above will bootstrap the gardener-node-agent. This means that the unit file for

--- a/pkg/component/extensions/operatingsystemconfig/nodeinit/nodeinit_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/nodeinit/nodeinit_test.go
@@ -206,7 +206,7 @@ server: {}
 
 				writeFilesToDiskScript, err := operatingsystemconfig.FilesToDiskScript(context.Background(), nil, "", files)
 				Expect(err).NotTo(HaveOccurred())
-				writeUnitsToDiskScript, err := operatingsystemconfig.UnitsToDiskScript(context.Background(), nil, "", units)
+				writeUnitsToDiskScript, err := operatingsystemconfig.UnitsToDiskScript(units)
 				Expect(err).NotTo(HaveOccurred())
 
 				// best-effort check: ensure the node init configuration is not exceeding 4KB in size

--- a/pkg/component/extensions/operatingsystemconfig/nodeinit/nodeinit_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/nodeinit/nodeinit_test.go
@@ -207,8 +207,7 @@ server: {}
 
 				writeFilesToDiskScript, err := operatingsystemconfig.FilesToDiskScript(context.Background(), nil, "", files)
 				Expect(err).NotTo(HaveOccurred())
-				writeUnitsToDiskScript, err := operatingsystemconfig.UnitsToDiskScript(units)
-				Expect(err).NotTo(HaveOccurred())
+				writeUnitsToDiskScript := operatingsystemconfig.UnitsToDiskScript(units)
 
 				// best-effort check: ensure the node init configuration is not exceeding 4KB in size
 				Expect(utf8.RuneCountInString(writeFilesToDiskScript + writeUnitsToDiskScript)).To(BeNumerically("<", 4096))

--- a/pkg/component/extensions/operatingsystemconfig/nodeinit/nodeinit_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/nodeinit/nodeinit_test.go
@@ -75,37 +75,7 @@ EnvironmentFile=/etc/environment
 ExecStart=/var/lib/gardener-node-agent/init.sh
 [Install]
 WantedBy=multi-user.target`),
-					Files: []extensionsv1alpha1.File{{
-						Path:        "/var/lib/gardener-node-agent/init.sh",
-						Permissions: pointer.Int32(0755),
-						Content: extensionsv1alpha1.FileContent{
-							Inline: &extensionsv1alpha1.FileContentInline{
-								Encoding: "b64",
-								Data: utils.EncodeBase64([]byte(`#!/usr/bin/env bash
-
-set -o errexit
-set -o nounset
-set -o pipefail
-
-echo "> Prepare temporary directory for image pull and mount"
-tmp_dir="$(mktemp -d)"
-trap 'ctr images unmount "$tmp_dir" && rm -rf "$tmp_dir"' EXIT
-
-echo "> Pull gardener-node-agent image and mount it to the temporary directory"
-ctr images pull  "` + image + `" --hosts-dir "/etc/containerd/certs.d"
-ctr images mount "` + image + `" "$tmp_dir"
-
-echo "> Copy gardener-node-agent binary to host (/opt/bin) and make it executable"
-mkdir -p "/opt/bin"
-cp -f "$tmp_dir/gardener-node-agent" "/opt/bin"
-chmod +x "/opt/bin/gardener-node-agent"
-
-echo "> Bootstrap gardener-node-agent"
-exec "/opt/bin/gardener-node-agent" bootstrap --config="/var/lib/gardener-node-agent/config.yaml"
-`)),
-							},
-						},
-					}},
+					FilePaths: []string{"/var/lib/gardener-node-agent/init.sh"},
 				}))
 				Expect(files).To(ConsistOf(
 					extensionsv1alpha1.File{
@@ -144,6 +114,37 @@ logFormat: ""
 logLevel: ""
 server: {}
 `))}},
+					},
+					extensionsv1alpha1.File{
+						Path:        "/var/lib/gardener-node-agent/init.sh",
+						Permissions: pointer.Int32(0755),
+						Content: extensionsv1alpha1.FileContent{
+							Inline: &extensionsv1alpha1.FileContentInline{
+								Encoding: "b64",
+								Data: utils.EncodeBase64([]byte(`#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+echo "> Prepare temporary directory for image pull and mount"
+tmp_dir="$(mktemp -d)"
+trap 'ctr images unmount "$tmp_dir" && rm -rf "$tmp_dir"' EXIT
+
+echo "> Pull gardener-node-agent image and mount it to the temporary directory"
+ctr images pull  "` + image + `" --hosts-dir "/etc/containerd/certs.d"
+ctr images mount "` + image + `" "$tmp_dir"
+
+echo "> Copy gardener-node-agent binary to host (/opt/bin) and make it executable"
+mkdir -p "/opt/bin"
+cp -f "$tmp_dir/gardener-node-agent" "/opt/bin"
+chmod +x "/opt/bin/gardener-node-agent"
+
+echo "> Bootstrap gardener-node-agent"
+exec "/opt/bin/gardener-node-agent" bootstrap --config="/var/lib/gardener-node-agent/config.yaml"
+`)),
+							},
+						},
 					},
 				))
 			})

--- a/pkg/component/extensions/operatingsystemconfig/original/components/containerd/component.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/containerd/component.go
@@ -111,12 +111,9 @@ ExecStart=` + pathHealthMonitor),
 		},
 	}
 
-	var files []extensionsv1alpha1.File
 	if features.DefaultFeatureGate.Enabled(features.UseGardenerNodeAgent) {
-		monitorUnit.Files = append(monitorUnit.Files, monitorFile)
-	} else {
-		files = append(logRotateFiles, monitorFile)
+		monitorUnit.FilePaths = []string{monitorFile.Path}
 	}
 
-	return append(logRotateUnits, monitorUnit), files, nil
+	return append(logRotateUnits, monitorUnit), append(logRotateFiles, monitorFile), nil
 }

--- a/pkg/component/extensions/operatingsystemconfig/original/components/containerd/component_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/containerd/component_test.go
@@ -107,16 +107,13 @@ WantedBy=multi-user.target`),
 						},
 					}
 
-					var expectedFiles []extensionsv1alpha1.File
 					if useGardenerNodeAgentEnabled {
-						monitorUnit.Files = append(monitorUnit.Files, monitorFile)
-						logrotateUnit.Files = append(logrotateUnit.Files, logrotateConfigFile)
-					} else {
-						expectedFiles = append(expectedFiles, monitorFile, logrotateConfigFile)
+						monitorUnit.FilePaths = []string{"/opt/bin/health-monitor-containerd"}
+						logrotateUnit.FilePaths = []string{"/etc/systemd/containerd.conf"}
 					}
 
 					Expect(units).To(ConsistOf(monitorUnit, logrotateUnit, logrotateTimerUnit))
-					Expect(files).To(ConsistOf(expectedFiles))
+					Expect(files).To(ConsistOf(monitorFile, logrotateConfigFile))
 				})
 			})
 		}

--- a/pkg/component/extensions/operatingsystemconfig/original/components/containerd/logrotate/logrotate.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/containerd/logrotate/logrotate.go
@@ -74,12 +74,9 @@ WantedBy=multi-user.target`),
 		},
 	}
 
-	var files []extensionsv1alpha1.File
 	if features.DefaultFeatureGate.Enabled(features.UseGardenerNodeAgent) {
-		serviceUnit.Files = append(serviceUnit.Files, serviceFile)
-	} else {
-		files = append(files, serviceFile)
+		serviceUnit.FilePaths = []string{serviceFile.Path}
 	}
 
-	return []extensionsv1alpha1.Unit{serviceUnit, timerUnit}, files
+	return []extensionsv1alpha1.Unit{serviceUnit, timerUnit}, []extensionsv1alpha1.File{serviceFile}
 }

--- a/pkg/component/extensions/operatingsystemconfig/original/components/containerd/logrotate/logrotate_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/containerd/logrotate/logrotate_test.go
@@ -94,15 +94,12 @@ WantedBy=multi-user.target`),
 							},
 						}
 
-						var expectedFiles []extensionsv1alpha1.File
 						if useGardenerNodeAgentEnabled {
-							serviceUnit.Files = append(serviceUnit.Files, serviceConfigFile)
-						} else {
-							expectedFiles = append(expectedFiles, serviceConfigFile)
+							serviceUnit.FilePaths = []string{pathConfig}
 						}
 
 						Expect(units).To(ConsistOf(serviceUnit, timerUnit))
-						Expect(files).To(ConsistOf(expectedFiles))
+						Expect(files).To(ConsistOf(serviceConfigFile))
 					})
 				})
 			})

--- a/pkg/component/extensions/operatingsystemconfig/original/components/kernelconfig/component.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/kernelconfig/component.go
@@ -92,14 +92,11 @@ func (component) Config(ctx components.Context) ([]extensionsv1alpha1.Unit, []ex
 		},
 	}
 
-	var files []extensionsv1alpha1.File
 	if features.DefaultFeatureGate.Enabled(features.UseGardenerNodeAgent) {
-		systemdSysctlUnit.Files = append(systemdSysctlUnit.Files, kernelSettingsFile)
-	} else {
-		files = append(files, kernelSettingsFile)
+		systemdSysctlUnit.FilePaths = []string{kernelSettingsFile.Path}
 	}
 
-	return []extensionsv1alpha1.Unit{systemdSysctlUnit}, files, nil
+	return []extensionsv1alpha1.Unit{systemdSysctlUnit}, []extensionsv1alpha1.File{kernelSettingsFile}, nil
 }
 
 // Do not change the encoding here because extensions might modify it!

--- a/pkg/component/extensions/operatingsystemconfig/original/components/kernelconfig/component_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/kernelconfig/component_test.go
@@ -106,15 +106,12 @@ var _ = Describe("Component", func() {
 			},
 		}
 
-		var expectedFiles []extensionsv1alpha1.File
 		if useGardenerNodeAgentEnabled {
-			systemdSysctlUnit.Files = append(systemdSysctlUnit.Files, kernelSettingsFile)
-		} else {
-			expectedFiles = append(expectedFiles, kernelSettingsFile)
+			systemdSysctlUnit.FilePaths = []string{"/etc/sysctl.d/99-k8s-general.conf"}
 		}
 
 		Expect(units).To(ConsistOf(systemdSysctlUnit))
-		Expect(files).To(ConsistOf(expectedFiles))
+		Expect(files).To(ConsistOf(kernelSettingsFile))
 	},
 		Entry("should return the expected units and files", "1.24.0", "", nil, nil, false),
 		Entry("should return the expected units and files when kubelet option protectKernelDefaults is set", "1.24.0", kubeletSysctlConfig, pointer.Bool(true), nil, false),

--- a/pkg/component/extensions/operatingsystemconfig/original/components/kubelet/component.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/kubelet/component.go
@@ -90,9 +90,6 @@ func (component) Name() string {
 
 func (component) Config(ctx components.Context) ([]extensionsv1alpha1.Unit, []extensionsv1alpha1.File, error) {
 	var (
-		units []extensionsv1alpha1.Unit
-		files []extensionsv1alpha1.File
-
 		kubeletStartPre       string
 		healthMonitorStartPre string
 	)
@@ -210,15 +207,16 @@ ExecStart=` + pathHealthMonitor),
 				},
 			},
 		})
-		kubeletUnit.Files = kubeletFiles
-		healthMonitorUnit.Files = healthMonitorFiles
-	} else {
-		files = append(kubeletFiles, healthMonitorFiles...)
+
+		for _, file := range kubeletFiles {
+			kubeletUnit.FilePaths = append(kubeletUnit.FilePaths, file.Path)
+		}
+		for _, file := range healthMonitorFiles {
+			healthMonitorUnit.FilePaths = append(healthMonitorUnit.FilePaths, file.Path)
+		}
 	}
 
-	units = append(units, kubeletUnit, healthMonitorUnit)
-
-	return units, files, nil
+	return []extensionsv1alpha1.Unit{kubeletUnit, healthMonitorUnit}, append(kubeletFiles, healthMonitorFiles...), nil
 }
 
 func getFileContentKubeletConfig(kubernetesVersion *semver.Version, clusterDNSAddress, clusterDomain string, params components.ConfigurableKubeletConfigParameters) (*extensionsv1alpha1.FileContentInline, error) {

--- a/pkg/component/extensions/operatingsystemconfig/original/components/rootcertificates/component.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/rootcertificates/component.go
@@ -123,16 +123,13 @@ WantedBy=multi-user.target`),
 		},
 	}
 
-	var files []extensionsv1alpha1.File
 	if features.DefaultFeatureGate.Enabled(features.UseGardenerNodeAgent) {
-		updateCACertsUnit.Files = updateCACertsFiles
-	} else {
-		files = updateCACertsFiles
+		for _, file := range updateCACertsFiles {
+			updateCACertsUnit.FilePaths = append(updateCACertsUnit.FilePaths, file.Path)
+		}
 	}
 
-	return []extensionsv1alpha1.Unit{updateCACertsUnit},
-		files,
-		nil
+	return []extensionsv1alpha1.Unit{updateCACertsUnit}, updateCACertsFiles, nil
 }
 
 func updateLocalCACertificatesScriptFile() (extensionsv1alpha1.File, error) {

--- a/pkg/component/extensions/operatingsystemconfig/original/components/rootcertificates/component_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/rootcertificates/component_test.go
@@ -135,15 +135,12 @@ fi
 						},
 					}
 
-					var expectedFiles []extensionsv1alpha1.File
 					if useGardenerNodeAgentEnabled {
-						updateCACertsUnit.Files = updateCACertsFiles
-					} else {
-						expectedFiles = updateCACertsFiles
+						updateCACertsUnit.FilePaths = []string{"/var/lib/ssl/update-local-ca-certificates.sh", "/var/lib/ca-certificates-local/ROOTcerts.crt", "/etc/pki/trust/anchors/ROOTcerts.pem"}
 					}
 
 					Expect(units).To(ConsistOf(updateCACertsUnit))
-					Expect(files).To(ConsistOf(expectedFiles))
+					Expect(files).To(ConsistOf(updateCACertsFiles))
 				})
 			})
 		}

--- a/pkg/component/extensions/operatingsystemconfig/original/components/sshdensurer/component.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/sshdensurer/component.go
@@ -109,12 +109,9 @@ WantedBy=multi-user.target`),
 		},
 	}
 
-	var files []extensionsv1alpha1.File
 	if features.DefaultFeatureGate.Enabled(features.UseGardenerNodeAgent) {
-		sshdEnsurerUnit.Files = append(sshdEnsurerUnit.Files, sshdEnsurerFile)
-	} else {
-		files = append(files, sshdEnsurerFile)
+		sshdEnsurerUnit.FilePaths = []string{sshdEnsurerFile.Path}
 	}
 
-	return []extensionsv1alpha1.Unit{sshdEnsurerUnit}, files, nil
+	return []extensionsv1alpha1.Unit{sshdEnsurerUnit}, []extensionsv1alpha1.File{sshdEnsurerFile}, nil
 }

--- a/pkg/component/extensions/operatingsystemconfig/original/components/sshdensurer/component_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/sshdensurer/component_test.go
@@ -77,15 +77,12 @@ WantedBy=multi-user.target`),
 						},
 					}
 
-					var expectedFiles []extensionsv1alpha1.File
 					if useGardenerNodeAgentEnabled {
-						sshdEnsurerUnit.Files = append(sshdEnsurerUnit.Files, sshdEnsurerFile)
-					} else {
-						expectedFiles = append(expectedFiles, sshdEnsurerFile)
+						sshdEnsurerUnit.FilePaths = []string{"/var/lib/sshd-ensurer/run.sh"}
 					}
 
 					Expect(units).To(ConsistOf(sshdEnsurerUnit))
-					Expect(files).To(ConsistOf(expectedFiles))
+					Expect(files).To(ConsistOf(sshdEnsurerFile))
 				})
 
 				It("should return the expected units and files when SSHAccessEnabled is set to false", func() {
@@ -122,15 +119,12 @@ WantedBy=multi-user.target`),
 						},
 					}
 
-					var expectedFiles []extensionsv1alpha1.File
 					if useGardenerNodeAgentEnabled {
-						sshdEnsurerUnit.Files = append(sshdEnsurerUnit.Files, sshdEnsurerFile)
-					} else {
-						expectedFiles = append(expectedFiles, sshdEnsurerFile)
+						sshdEnsurerUnit.FilePaths = []string{"/var/lib/sshd-ensurer/run.sh"}
 					}
 
 					Expect(units).To(ConsistOf(sshdEnsurerUnit))
-					Expect(files).To(ConsistOf(expectedFiles))
+					Expect(files).To(ConsistOf(sshdEnsurerFile))
 				})
 			})
 		}

--- a/pkg/component/extensions/operatingsystemconfig/original/components/valitail/config.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/valitail/config.go
@@ -118,7 +118,7 @@ func getValitailCAFile(ctx components.Context) extensionsv1alpha1.File {
 	}
 }
 
-func getValitailUnit(ctx components.Context) (extensionsv1alpha1.Unit, error) {
+func getValitailUnit(ctx components.Context) extensionsv1alpha1.Unit {
 	var (
 		execStartPre string
 		execStart    = v1beta1constants.OperatingSystemConfigFilePathBinaries + `/valitail -config.file=` + PathConfig
@@ -172,25 +172,10 @@ ExecStart=` + execStart
 	}
 
 	if ctx.ValitailEnabled && features.DefaultFeatureGate.Enabled(features.UseGardenerNodeAgent) {
-		valitailConfigFile, err := getValitailConfigurationFile(ctx)
-		if err != nil {
-			return extensionsv1alpha1.Unit{}, err
-		}
-		unit.Files = append(unit.Files, valitailConfigFile)
-		unit.Files = append(unit.Files, getValitailCAFile(ctx))
-		unit.Files = append(unit.Files, extensionsv1alpha1.File{
-			Path:        v1beta1constants.OperatingSystemConfigFilePathBinaries + "/valitail",
-			Permissions: pointer.Int32(0755),
-			Content: extensionsv1alpha1.FileContent{
-				ImageRef: &extensionsv1alpha1.FileContentImageRef{
-					Image:           ctx.Images[imagevector.ImageNameValitail].String(),
-					FilePathInImage: "/usr/bin/valitail",
-				},
-			},
-		})
+		unit.FilePaths = []string{PathConfig, PathCACert, valitailBinaryPath}
 	}
 
-	return unit, nil
+	return unit
 }
 
 func getFetchTokenScriptFile() (extensionsv1alpha1.File, error) {
@@ -218,7 +203,7 @@ func getFetchTokenScriptFile() (extensionsv1alpha1.File, error) {
 	}, nil
 }
 
-func getFetchTokenScriptUnit(ctx components.Context) (extensionsv1alpha1.Unit, error) {
+func getFetchTokenScriptUnit(ctx components.Context) extensionsv1alpha1.Unit {
 	var (
 		execStartPre string
 		execStart    = PathFetchTokenScript
@@ -257,12 +242,8 @@ ExecStart=` + execStart
 	}
 
 	if ctx.ValitailEnabled && features.DefaultFeatureGate.Enabled(features.UseGardenerNodeAgent) {
-		fetchTokenScriptFile, err := getFetchTokenScriptFile()
-		if err != nil {
-			return extensionsv1alpha1.Unit{}, err
-		}
-		unit.Files = append(unit.Files, fetchTokenScriptFile)
+		unit.FilePaths = []string{PathFetchTokenScript}
 	}
 
-	return unit, nil
+	return unit
 }

--- a/pkg/component/extensions/operatingsystemconfig/original/components/valitail/config_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/valitail/config_test.go
@@ -316,12 +316,15 @@ exit $?
 						},
 					}
 
-					var expectedFiles []extensionsv1alpha1.File
+					expectedFiles := []extensionsv1alpha1.File{valitailConfigFile, valitailFetchTokenScriptFile, caBundleFile}
 					if useGardenerNodeAgentEnabled {
-						valitailDaemonUnit.Files = append(valitailDaemonUnit.Files, valitailConfigFile, caBundleFile, valitailBinaryFile)
-						valitailTokenFetchUnit.Files = append(valitailTokenFetchUnit.Files, valitailFetchTokenScriptFile)
-					} else {
-						expectedFiles = append(expectedFiles, valitailConfigFile, valitailFetchTokenScriptFile, caBundleFile)
+						expectedFiles = append(expectedFiles, valitailBinaryFile)
+						valitailDaemonUnit.FilePaths = []string{
+							"/var/lib/valitail/config/config",
+							"/var/lib/valitail/ca.crt",
+							"/opt/bin/valitail",
+						}
+						valitailTokenFetchUnit.FilePaths = []string{"/var/lib/valitail/scripts/fetch-token.sh"}
 					}
 
 					Expect(units).To(ConsistOf(

--- a/pkg/provider-local/controller/operatingsystemconfig/actuator.go
+++ b/pkg/provider-local/controller/operatingsystemconfig/actuator.go
@@ -108,10 +108,7 @@ func (a *actuator) handleProvisionOSC(ctx context.Context, osc *extensionsv1alph
 	if err != nil {
 		return "", err
 	}
-	writeUnitsToDiskScript, err := operatingsystemconfig.UnitsToDiskScript(osc.Spec.Units)
-	if err != nil {
-		return "", err
-	}
+	writeUnitsToDiskScript := operatingsystemconfig.UnitsToDiskScript(osc.Spec.Units)
 
 	return `#!/bin/bash
 ` + writeFilesToDiskScript + `

--- a/pkg/provider-local/controller/operatingsystemconfig/actuator.go
+++ b/pkg/provider-local/controller/operatingsystemconfig/actuator.go
@@ -108,7 +108,7 @@ func (a *actuator) handleProvisionOSC(ctx context.Context, osc *extensionsv1alph
 	if err != nil {
 		return "", err
 	}
-	writeUnitsToDiskScript, err := operatingsystemconfig.UnitsToDiskScript(ctx, a.client, osc.Namespace, osc.Spec.Units)
+	writeUnitsToDiskScript, err := operatingsystemconfig.UnitsToDiskScript(osc.Spec.Units)
 	if err != nil {
 		return "", err
 	}

--- a/test/integration/nodeagent/operatingsystemconfig/operatingsystemconfig_test.go
+++ b/test/integration/nodeagent/operatingsystemconfig/operatingsystemconfig_test.go
@@ -178,7 +178,7 @@ var _ = Describe("OperatingSystemConfig controller tests", func() {
 				Name:    "drop",
 				Content: "#unit3drop",
 			}},
-			Files: []extensionsv1alpha1.File{file4},
+			FilePaths: []string{file4.Path},
 		}
 		unit4 = extensionsv1alpha1.Unit{
 			Name:    "unit4",
@@ -214,25 +214,25 @@ var _ = Describe("OperatingSystemConfig controller tests", func() {
 			}},
 		}
 		unit6 = extensionsv1alpha1.Unit{
-			Name:    "unit6",
-			Enable:  pointer.Bool(true),
-			Content: pointer.String("#unit6"),
-			Files:   []extensionsv1alpha1.File{file3},
+			Name:      "unit6",
+			Enable:    pointer.Bool(true),
+			Content:   pointer.String("#unit6"),
+			FilePaths: []string{file3.Path},
 		}
 		unit7 = extensionsv1alpha1.Unit{
-			Name:    "unit7",
-			Enable:  pointer.Bool(true),
-			Content: pointer.String("#unit7"),
-			Files:   []extensionsv1alpha1.File{file5},
+			Name:      "unit7",
+			Enable:    pointer.Bool(true),
+			Content:   pointer.String("#unit7"),
+			FilePaths: []string{file5.Path},
 		}
 
 		operatingSystemConfig = &extensionsv1alpha1.OperatingSystemConfig{
 			Spec: extensionsv1alpha1.OperatingSystemConfigSpec{
-				Files: []extensionsv1alpha1.File{file1},
+				Files: []extensionsv1alpha1.File{file1, file3, file5},
 				Units: []extensionsv1alpha1.Unit{unit1, unit2, unit5, unit5DropInsOnly, unit6, unit7},
 			},
 			Status: extensionsv1alpha1.OperatingSystemConfigStatus{
-				ExtensionFiles: []extensionsv1alpha1.File{file2},
+				ExtensionFiles: []extensionsv1alpha1.File{file2, file4},
 				ExtensionUnits: []extensionsv1alpha1.Unit{unit3, unit4},
 			},
 		}
@@ -334,7 +334,7 @@ var _ = Describe("OperatingSystemConfig controller tests", func() {
 		// add drop-in to unit2 and enable+start it
 		// disable unit4 and remove all drop-ins
 		// remove only first drop-in from unit5
-		// move file3 from unit.files to files while keeping it unchanged
+		// remove file3 from unit6.FilePaths while keeping it unchanged
 		// the content of file5 (belonging to unit7) is changed, so unit7 is restarting
 		// file1, unit3, and gardener-node-agent unit are unchanged, so unit3 is not restarting and cancel func is not called
 		unit2.Enable = pointer.Bool(true)
@@ -343,13 +343,12 @@ var _ = Describe("OperatingSystemConfig controller tests", func() {
 		unit4.Enable = pointer.Bool(false)
 		unit4.DropIns = nil
 		unit5.DropIns = unit5.DropIns[1:]
-		unit6.Files = nil
-		unit7.Files[0].Content.Inline.Data = "changeme"
+		unit6.FilePaths = nil
 
 		operatingSystemConfig.Spec.Units = []extensionsv1alpha1.Unit{unit2, unit5, unit6, unit7}
-		operatingSystemConfig.Spec.Files = append(operatingSystemConfig.Spec.Files, file3)
+		operatingSystemConfig.Spec.Files[2].Content.Inline.Data = "changeme"
 		operatingSystemConfig.Status.ExtensionUnits = []extensionsv1alpha1.Unit{unit3, unit4}
-		operatingSystemConfig.Status.ExtensionFiles = nil
+		operatingSystemConfig.Status.ExtensionFiles = []extensionsv1alpha1.File{file4}
 
 		var err error
 		oscRaw, err = runtime.Encode(codec, operatingSystemConfig)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind enhancement

**What this PR does / why we need it**:
This PR refactors the handling of `files` in `OperatingSystemConfig` API. 

PR #8707 added a `files` section to each `unit` in order to identify files which should restart the corresponding unit when they change.
With this PR the `spec.units.files` section is replaced by a `units.filePaths` section. `filePaths` are a slice of strings which point to a `file`. The files are maintained in `spec.files`.
Validation ensures that there is always a `file` whose `path` matches with each `filePath`.

The new approach simplifies the migration from `cloud-config-download` to `node-agent`.
Thanks @timebertt for the idea 😄 

**Which issue(s) this PR fixes**:
Part of #8023

**Special notes for your reviewer**:
/cc @rfranzke 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
