### PR TITLE
Add flow.ParallelN

### DIFF
--- a/pkg/utils/flow/taskfn.go
+++ b/pkg/utils/flow/taskfn.go
@@ -97,6 +97,53 @@ func Sequential(fns ...TaskFn) TaskFn {
 	}
 }
 
+// ParallelN returns a function that runs the given TaskFns in parallel by spawning N workers,
+// collecting their errors in a multierror. If N <= 0, then N will be defaulted to len(fns).
+func ParallelN(n int, fns ...TaskFn) TaskFn {
+	workers := n
+	if n <= 0 {
+		workers = len(fns)
+	}
+	return func(ctx context.Context) error {
+		var (
+			wg     sync.WaitGroup
+			fnsCh  = make(chan TaskFn)
+			errCh  = make(chan error)
+			result error
+		)
+
+		for i := 0; i < workers; i++ {
+			wg.Add(1)
+			go func() {
+				for fn := range fnsCh {
+					fn := fn
+					errCh <- fn(ctx)
+				}
+				wg.Done()
+			}()
+		}
+
+		go func() {
+			for _, f := range fns {
+				fnsCh <- f
+			}
+			close(fnsCh)
+		}()
+
+		go func() {
+			defer close(errCh)
+			wg.Wait()
+		}()
+
+		for err := range errCh {
+			if err != nil {
+				result = multierror.Append(result, err)
+			}
+		}
+		return result
+	}
+}
+
 // Parallel runs the given TaskFns in parallel, collecting their errors in a multierror.
 func Parallel(fns ...TaskFn) TaskFn {
 	return func(ctx context.Context) error {

--- a/pkg/utils/flow/taskfn_test.go
+++ b/pkg/utils/flow/taskfn_test.go
@@ -182,7 +182,7 @@ var _ = Describe("task functions", func() {
 			}()
 			Expect(flow.ParallelN(n, tasks...)(ctx)).To(Succeed())
 			Expect(m).To(HaveLen(len(tasks)))
-			Expect(tasksAsserted.Load()).To(Equal(true))
+			Expect(tasksAsserted.Load()).To(BeTrue())
 		})
 
 		It("should collect the errors", func() {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
In https://github.com/gardener/gardener/pull/8812 we discussed that there is no straightforward way to limit the number of workers when calling `flow.Parallel` so lets add this helper func.

cc @rfranzke 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
