### PR TITLE
Clean-up old unsupported ClusterRoleBinding for MCM before deploying new one

### DIFF
--- a/pkg/component/machinecontrollermanager/bootstrap.go
+++ b/pkg/component/machinecontrollermanager/bootstrap.go
@@ -33,6 +33,7 @@ import (
 const (
 	managedResourceControlName = "machine-controller-manager"
 	clusterRoleName            = "system:machine-controller-manager-runtime"
+	// TODO(himanshu-kun): remove after g/g v1.88 has been released
 	unsupportedClusterRoleName = "system:machine-controller-manager-seed"
 )
 

--- a/pkg/component/machinecontrollermanager/bootstrap.go
+++ b/pkg/component/machinecontrollermanager/bootstrap.go
@@ -33,6 +33,7 @@ import (
 const (
 	managedResourceControlName = "machine-controller-manager"
 	clusterRoleName            = "system:machine-controller-manager-runtime"
+	unsupportedClusterRoleName = "system:machine-controller-manager-seed"
 )
 
 // NewBootstrapper creates a new instance of DeployWaiter for the machine-controller-manager bootstrapper.

--- a/pkg/component/machinecontrollermanager/machine_controller_manager.go
+++ b/pkg/component/machinecontrollermanager/machine_controller_manager.go
@@ -513,8 +513,5 @@ func (m *machineControllerManager) checkUnsupportedClusterRoleBindingSeed(ctx co
 		return false, err
 	}
 
-	if crb.RoleRef.Name == unsupportedClusterRoleName {
-		return true, nil
-	}
-	return false, nil
+	return crb.RoleRef.Name == unsupportedClusterRoleName, nil
 }

--- a/pkg/component/machinecontrollermanager/machine_controller_manager.go
+++ b/pkg/component/machinecontrollermanager/machine_controller_manager.go
@@ -129,6 +129,14 @@ func (m *machineControllerManager) Deploy(ctx context.Context) error {
 		return err
 	}
 
+	if exists, err := m.checkUnsupportedClusterRoleBindingSeed(ctx); err != nil {
+		return err
+	} else if exists {
+		if err = kubernetesutils.DeleteObject(ctx, m.client, m.emptyClusterRoleBindingSeed()); err != nil {
+			return err
+		}
+	}
+
 	if _, err := controllerutils.GetAndCreateOrStrategicMergePatch(ctx, m.client, clusterRoleBinding, func() error {
 		clusterRoleBinding.OwnerReferences = []metav1.OwnerReference{{
 			APIVersion:         "v1",
@@ -452,6 +460,10 @@ func (m *machineControllerManager) emptyServiceAccount() *corev1.ServiceAccount 
 	return &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "machine-controller-manager", Namespace: m.namespace}}
 }
 
+func (m *machineControllerManager) emptyClusterRoleBindingSeed() *rbacv1.ClusterRoleBinding {
+	return &rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: "machine-controller-manager-" + m.namespace}}
+}
+
 func (m *machineControllerManager) emptyClusterRoleBindingRuntime() *rbacv1.ClusterRoleBinding {
 	return &rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: "machine-controller-manager-" + m.namespace}}
 }
@@ -490,4 +502,19 @@ func getLabels() map[string]string {
 		v1beta1constants.LabelApp:  v1beta1constants.LabelKubernetes,
 		v1beta1constants.LabelRole: "machine-controller-manager",
 	}
+}
+
+func (m *machineControllerManager) checkUnsupportedClusterRoleBindingSeed(ctx context.Context) (bool, error) {
+	crb := &rbacv1.ClusterRoleBinding{}
+	if err := m.client.Get(ctx, client.ObjectKeyFromObject(m.emptyClusterRoleBindingSeed()), crb); err != nil {
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, err
+	}
+
+	if crb.RoleRef.Name == unsupportedClusterRoleName {
+		return true, nil
+	}
+	return false, nil
 }

--- a/pkg/component/machinecontrollermanager/machine_controller_manager.go
+++ b/pkg/component/machinecontrollermanager/machine_controller_manager.go
@@ -504,6 +504,7 @@ func getLabels() map[string]string {
 	}
 }
 
+// TODO(himanshu-kun): remove after g/g v1.88 has been released
 func (m *machineControllerManager) checkUnsupportedClusterRoleBindingSeed(ctx context.Context) (bool, error) {
 	crb := &rbacv1.ClusterRoleBinding{}
 	if err := m.client.Get(ctx, client.ObjectKeyFromObject(m.emptyClusterRoleBindingSeed()), crb); err != nil {

--- a/pkg/component/machinecontrollermanager/machine_controller_manager_test.go
+++ b/pkg/component/machinecontrollermanager/machine_controller_manager_test.go
@@ -577,6 +577,7 @@ subjects:
 			managedResourceSecret.ResourceVersion = "1"
 			Expect(actualManagedResourceSecret).To(Equal(managedResourceSecret))
 		})
+
 		It("should successfully delete unsupported clusterrolebinding and create new one", func() {
 			Expect(fakeClient.Create(ctx, unsupportedClusterRoleBindingSeed)).To(Succeed())
 			Expect(mcm.Deploy(ctx)).To(Succeed())

--- a/pkg/component/machinecontrollermanager/machine_controller_manager_test.go
+++ b/pkg/component/machinecontrollermanager/machine_controller_manager_test.go
@@ -587,6 +587,16 @@ subjects:
 			clusterRoleBinding.ResourceVersion = "1"
 			Expect(actualClusterRoleBinding).To(Equal(clusterRoleBinding))
 		})
+
+		It("should not delete supported clusterrolebinding, if already present", func() {
+			Expect(fakeClient.Create(ctx, clusterRoleBinding)).To(Succeed())
+			Expect(mcm.Deploy(ctx)).To(Succeed())
+
+			actualClusterRoleBinding := &rbacv1.ClusterRoleBinding{}
+			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(clusterRoleBinding), actualClusterRoleBinding)).To(Succeed())
+			clusterRoleBinding.ResourceVersion = "2"
+			Expect(actualClusterRoleBinding).To(Equal(clusterRoleBinding))
+		})
 	})
 
 	Describe("#Destroy", func() {

--- a/pkg/component/machinecontrollermanager/machine_controller_manager_test.go
+++ b/pkg/component/machinecontrollermanager/machine_controller_manager_test.go
@@ -63,15 +63,16 @@ var _ = Describe("MachineControllerManager", func() {
 		values     Values
 		mcm        Interface
 
-		serviceAccount        *corev1.ServiceAccount
-		clusterRoleBinding    *rbacv1.ClusterRoleBinding
-		service               *corev1.Service
-		shootAccessSecret     *corev1.Secret
-		deployment            *appsv1.Deployment
-		podDisruptionBudget   *policyv1.PodDisruptionBudget
-		vpa                   *vpaautoscalingv1.VerticalPodAutoscaler
-		managedResourceSecret *corev1.Secret
-		managedResource       *resourcesv1alpha1.ManagedResource
+		serviceAccount                    *corev1.ServiceAccount
+		unsupportedClusterRoleBindingSeed *rbacv1.ClusterRoleBinding
+		clusterRoleBinding                *rbacv1.ClusterRoleBinding
+		service                           *corev1.Service
+		shootAccessSecret                 *corev1.Secret
+		deployment                        *appsv1.Deployment
+		podDisruptionBudget               *policyv1.PodDisruptionBudget
+		vpa                               *vpaautoscalingv1.VerticalPodAutoscaler
+		managedResourceSecret             *corev1.Secret
+		managedResource                   *resourcesv1alpha1.ManagedResource
 	)
 
 	BeforeEach(func() {
@@ -98,6 +99,34 @@ var _ = Describe("MachineControllerManager", func() {
 				Namespace: namespace,
 			},
 			AutomountServiceAccountToken: pointer.Bool(false),
+		}
+
+		unsupportedClusterRoleBindingSeed = &rbacv1.ClusterRoleBinding{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "rbac.authorization.k8s.io/v1",
+				Kind:       "ClusterRoleBinding",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "machine-controller-manager-" + namespace,
+				OwnerReferences: []metav1.OwnerReference{{
+					APIVersion:         "v1",
+					Kind:               "Namespace",
+					Name:               namespace,
+					UID:                namespaceUID,
+					Controller:         pointer.Bool(true),
+					BlockOwnerDeletion: pointer.Bool(true),
+				}},
+			},
+			RoleRef: rbacv1.RoleRef{
+				APIGroup: "rbac.authorization.k8s.io",
+				Kind:     "ClusterRole",
+				Name:     "system:machine-controller-manager-seed",
+			},
+			Subjects: []rbacv1.Subject{{
+				Kind:      "ServiceAccount",
+				Name:      "machine-controller-manager",
+				Namespace: namespace,
+			}},
 		}
 
 		clusterRoleBinding = &rbacv1.ClusterRoleBinding{
@@ -547,6 +576,15 @@ subjects:
 			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(managedResourceSecret), actualManagedResourceSecret)).To(Succeed())
 			managedResourceSecret.ResourceVersion = "1"
 			Expect(actualManagedResourceSecret).To(Equal(managedResourceSecret))
+		})
+		It("should successfully delete unsupported clusterrolebinding and create new one", func() {
+			Expect(fakeClient.Create(ctx, unsupportedClusterRoleBindingSeed)).To(Succeed())
+			Expect(mcm.Deploy(ctx)).To(Succeed())
+
+			actualClusterRoleBinding := &rbacv1.ClusterRoleBinding{}
+			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(clusterRoleBinding), actualClusterRoleBinding)).To(Succeed())
+			clusterRoleBinding.ResourceVersion = "1"
+			Expect(actualClusterRoleBinding).To(Equal(clusterRoleBinding))
 		})
 	})
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind bug

**What this PR does / why we need it**:
This PR introduces fix for the case when a clusterrolebinding with a roleRef to `system:machine-controller-manager-seed` clusterrole already exists, and gardenlet fails to deploy new clusterrolebinding with the same name but different roleRef `system:machine-controller-manager-runtime`.

For more details refer : Live issue # 3887

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
A bug has been fixed which prevented shoot reconciliations in case the old `system:machine-controller-manager-seed` `ClusterRole` was still referenced in the `RoleBinding` for `machine-controller-manager`.
```
