### PR TITLE
Shoot care controller garbage-collects orphaned `Lease` objects related to no longer existing `Node`s

### DIFF
--- a/pkg/gardenlet/controller/shoot/care/garbage_collection.go
+++ b/pkg/gardenlet/controller/shoot/care/garbage_collection.go
@@ -16,19 +16,23 @@ package care
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/hashicorp/go-multierror"
+	coordinationv1 "k8s.io/api/coordination/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/operation"
 	"github.com/gardener/gardener/pkg/operation/shoot"
+	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 )
 
 // GarbageCollection contains required information for shoot and seed garbage collection.
@@ -90,12 +94,47 @@ func (g *GarbageCollection) performGarbageCollectionSeed(ctx context.Context) er
 // PerformGarbageCollectionShoot performs garbage collection in the kube-system namespace in the Shoot
 // cluster, i.e., it deletes evicted pods (mitigation for https://github.com/kubernetes/kubernetes/issues/55051).
 func (g *GarbageCollection) performGarbageCollectionShoot(ctx context.Context, shootClient client.Client) error {
+	if err := g.deleteOrphanedNodeLeases(ctx, shootClient); err != nil {
+		return fmt.Errorf("failed deleting orphaned node lease objects: %w", err)
+	}
+
 	namespace := metav1.NamespaceSystem
 	if g.shoot.GetInfo().DeletionTimestamp != nil {
 		namespace = metav1.NamespaceAll
 	}
 
 	return g.deleteStalePods(ctx, shootClient, namespace)
+}
+
+// See https://github.com/gardener/gardener/issues/8749 and https://github.com/kubernetes/kubernetes/issues/109777.
+// kubelet sometimes created Lease objects without owner reference. When the respective node gets deleted eventually,
+// the Lease object remains in the system and no Kubernetes controller will ever clean it up. Hence, this function takes
+// over this task.
+func (g *GarbageCollection) deleteOrphanedNodeLeases(ctx context.Context, c client.Client) error {
+	leaseList := &coordinationv1.LeaseList{}
+	if err := c.List(ctx, leaseList, client.InNamespace(corev1.NamespaceNodeLease)); err != nil {
+		return err
+	}
+
+	var orphanedLeases []client.Object
+
+	for _, l := range leaseList.Items {
+		if len(l.OwnerReferences) > 0 {
+			continue
+		}
+		lease := l.DeepCopy()
+
+		if err := c.Get(ctx, client.ObjectKey{Name: lease.Name}, &metav1.PartialObjectMetadata{TypeMeta: metav1.TypeMeta{APIVersion: corev1.SchemeGroupVersion.String(), Kind: "Node"}}); err != nil {
+			if !apierrors.IsNotFound(err) {
+				return fmt.Errorf("failed getting node %s when checking for potential orphaned Lease %s: %w", lease.Name, client.ObjectKeyFromObject(lease), err)
+			}
+
+			g.log.Info("Detected orphaned Lease object, cleaning it up", "nodeName", lease.Name, "lease", client.ObjectKeyFromObject(lease))
+			orphanedLeases = append(orphanedLeases, lease.DeepCopy())
+		}
+	}
+
+	return kubernetesutils.DeleteObjects(ctx, c, orphanedLeases...)
 }
 
 // GardenerDeletionGracePeriod is the default grace period for Gardener's force deletion methods.

--- a/pkg/gardenlet/controller/shoot/care/garbage_collection.go
+++ b/pkg/gardenlet/controller/shoot/care/garbage_collection.go
@@ -110,6 +110,7 @@ func (g *GarbageCollection) performGarbageCollectionShoot(ctx context.Context, s
 // kubelet sometimes created Lease objects without owner reference. When the respective node gets deleted eventually,
 // the Lease object remains in the system and no Kubernetes controller will ever clean it up. Hence, this function takes
 // over this task.
+// TODO: Remove this function when support for Kubernetes 1.28 is dropped.
 func (g *GarbageCollection) deleteOrphanedNodeLeases(ctx context.Context, c client.Client) error {
 	leaseList := &coordinationv1.LeaseList{}
 	if err := c.List(ctx, leaseList, client.InNamespace(corev1.NamespaceNodeLease)); err != nil {

--- a/pkg/gardenlet/controller/shoot/care/garbage_collection.go
+++ b/pkg/gardenlet/controller/shoot/care/garbage_collection.go
@@ -131,7 +131,7 @@ func (g *GarbageCollection) deleteOrphanedNodeLeases(ctx context.Context, c clie
 			}
 
 			g.log.Info("Detected orphaned Lease object, cleaning it up", "nodeName", lease.Name, "lease", client.ObjectKeyFromObject(lease))
-			orphanedLeases = append(orphanedLeases, lease.DeepCopy())
+			orphanedLeases = append(orphanedLeases, lease)
 		}
 	}
 

--- a/pkg/gardenlet/controller/shoot/care/garbage_collection_test.go
+++ b/pkg/gardenlet/controller/shoot/care/garbage_collection_test.go
@@ -1,0 +1,121 @@
+// Copyright 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package care_test
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	coordinationv1 "k8s.io/api/coordination/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	kubernetesfake "github.com/gardener/gardener/pkg/client/kubernetes/fake"
+	. "github.com/gardener/gardener/pkg/gardenlet/controller/shoot/care"
+	"github.com/gardener/gardener/pkg/operation"
+	"github.com/gardener/gardener/pkg/operation/shoot"
+	. "github.com/gardener/gardener/pkg/utils/test/matchers"
+)
+
+var _ = Describe("GarbageCollection", func() {
+	var (
+		ctx                          = context.Background()
+		fakeSeedClient               client.Client
+		fakeShootClient              client.Client
+		fakeSeedKubernetesInterface  kubernetes.Interface
+		fakeShootKubernetesInterface kubernetes.Interface
+
+		op *operation.Operation
+		gc *GarbageCollection
+	)
+
+	BeforeEach(func() {
+		fakeSeedClient = fakeclient.NewClientBuilder().WithScheme(kubernetes.SeedScheme).Build()
+		fakeShootClient = fakeclient.NewClientBuilder().WithScheme(kubernetes.ShootScheme).Build()
+		fakeSeedKubernetesInterface = kubernetesfake.NewClientSetBuilder().WithClient(fakeSeedClient).Build()
+		fakeShootKubernetesInterface = kubernetesfake.NewClientSetBuilder().WithClient(fakeShootClient).Build()
+
+		op = &operation.Operation{
+			Logger:        logr.Discard(),
+			SeedClientSet: fakeSeedKubernetesInterface,
+			Shoot:         &shoot.Shoot{SeedNamespace: "some-namespace"},
+		}
+		op.Shoot.SetInfo(&gardencorev1beta1.Shoot{})
+
+		gc = NewGarbageCollection(op, func() (kubernetes.Interface, bool, error) { return fakeShootKubernetesInterface, true, nil })
+	})
+
+	Describe("#Collect", func() {
+		Context("shoot cluster", func() {
+			Context("orphaned node leases", func() {
+				var (
+					node1, node2   *corev1.Node
+					lease1, lease2 *coordinationv1.Lease
+				)
+
+				BeforeEach(func() {
+					node1 = &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node1"}}
+					node2 = &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node2"}}
+					lease1 = &coordinationv1.Lease{ObjectMeta: metav1.ObjectMeta{Name: node1.Name, Namespace: "kube-node-lease"}}
+					lease2 = &coordinationv1.Lease{ObjectMeta: metav1.ObjectMeta{Name: node2.Name, Namespace: "kube-node-lease"}}
+
+					// only lease1 gets a proper owner ref to a node
+					Expect(controllerutil.SetControllerReference(node1, lease1, kubernetes.ShootScheme)).To(Succeed())
+				})
+
+				It("should do nothing because there are no orphaned objects", func() {
+					Expect(fakeShootClient.Create(ctx, node1)).To(Succeed())
+					Expect(fakeShootClient.Create(ctx, lease1)).To(Succeed())
+
+					gc.Collect(ctx)
+
+					Expect(fakeShootClient.Get(ctx, client.ObjectKeyFromObject(lease1), lease1)).To(Succeed())
+				})
+
+				It("should do nothing because node still exists despite missing owner reference", func() {
+					Expect(fakeShootClient.Create(ctx, node1)).To(Succeed())
+					Expect(fakeShootClient.Create(ctx, lease1)).To(Succeed())
+
+					Expect(fakeShootClient.Create(ctx, node2)).To(Succeed())
+					Expect(fakeShootClient.Create(ctx, lease2)).To(Succeed())
+
+					gc.Collect(ctx)
+
+					Expect(fakeShootClient.Get(ctx, client.ObjectKeyFromObject(lease1), lease1)).To(Succeed())
+					Expect(fakeShootClient.Get(ctx, client.ObjectKeyFromObject(lease2), lease2)).To(Succeed())
+				})
+
+				It("should clean up orphaned node Lease objects", func() {
+					Expect(fakeShootClient.Create(ctx, node1)).To(Succeed())
+					Expect(fakeShootClient.Create(ctx, lease1)).To(Succeed())
+
+					Expect(fakeShootClient.Create(ctx, lease2)).To(Succeed())
+
+					gc.Collect(ctx)
+
+					Expect(fakeShootClient.Get(ctx, client.ObjectKeyFromObject(lease1), lease1)).To(Succeed())
+					Expect(fakeShootClient.Get(ctx, client.ObjectKeyFromObject(lease2), lease2)).To(BeNotFoundError())
+				})
+			})
+		})
+	})
+})


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area scalability
/kind enhancement

**What this PR does / why we need it**:
Shoot care controller garbage-collects orphaned `Lease` objects related to no longer existing `Node`s, see https://github.com/kubernetes/kubernetes/issues/119660.

**Which issue(s) this PR fixes**:
Fixes #8749

**Special notes for your reviewer**:
/cc @timuthy 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
`gardenlet'`s `Shoot` care controller now garbage-collects orphaned `Lease` objects related to no longer existing `Node`s - see [this upstream issue](https://github.com/kubernetes/kubernetes/issues/119660) for more details.
```
