### PR TITLE
Use annotation for old secret name instead of label

### DIFF
--- a/cmd/gardenlet/app/app_test.go
+++ b/cmd/gardenlet/app/app_test.go
@@ -90,7 +90,9 @@ var _ = Describe("Recreate Managed Resource Secrets", func() {
 				Labels: map[string]string{
 					"resources.gardener.cloud/garbage-collectable-reference": "true",
 					"resources.gardener.cloud/temp-secret":                   "true",
-					"resources.gardener.cloud/temp-secret-old-name":          "secret3",
+				},
+				Annotations: map[string]string{
+					"resources.gardener.cloud/temp-secret-old-name": "secret3",
 				},
 			},
 			Immutable: pointer.Bool(true),
@@ -121,7 +123,9 @@ var _ = Describe("Recreate Managed Resource Secrets", func() {
 				Labels: map[string]string{
 					"resources.gardener.cloud/garbage-collectable-reference": "true",
 					"resources.gardener.cloud/temp-secret":                   "true",
-					"resources.gardener.cloud/temp-secret-old-name":          "secret4",
+				},
+				Annotations: map[string]string{
+					"resources.gardener.cloud/temp-secret-old-name": "secret4",
 				},
 			},
 			Immutable: pointer.Bool(true),


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind bug cleanup

**What this PR does / why we need it**:

```
panic: 6 errors occurred:
	* failed to create a temporary secret Secret "tmp-managedresource-shoot-core-kube-proxy-worker-remote-v1.24-e3b0c442" is invalid: metadata.labels: Invalid value: "managedresource-shoot-core-kube-proxy-worker-remote-v1.24-e3b0c442": must be no more than 63 characters
	* failed to create a temporary secret Secret "tmp-managedresource-shoot-core-kube-proxy-worker-f8blv-v1.27-5f0350de" is invalid: metadata.labels: Invalid value: "managedresource-shoot-core-kube-proxy-worker-f8blv-v1.27-5f0350de": must be no more than 63 characters
	* failed to create a temporary secret Secret "tmp-managedresource-shoot-core-kube-proxy-worker-hb2ub-v1.26.5-28fc7969" is invalid: metadata.labels: Invalid value: "managedresource-shoot-core-kube-proxy-worker-hb2ub-v1.26.5-28fc7969": must be no more than 63 characters
	* failed to create a temporary secret Secret "tmp-managedresource-shoot-core-kube-proxy-worker-hb2ub-v1.26-479c5685" is invalid: metadata.labels: Invalid value: "managedresource-shoot-core-kube-proxy-worker-hb2ub-v1.26-479c5685": must be no more than 63 characters
	* failed to create a temporary secret Secret "tmp-managedresource-shoot-core-kube-proxy-worker-fqi0o-v1.24-e3b0c442" is invalid: metadata.labels: Invalid value: "managedresource-shoot-core-kube-proxy-worker-fqi0o-v1.24-e3b0c442": must be no more than 63 characters
...
```

**Which issue(s) this PR fixes**:
Follow-up of https://github.com/gardener/gardener/pull/8812

**Special notes for your reviewer**:
FYI @dimityrmirchev 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
