### PR TITLE
Updated clusterrole for CA

### DIFF
--- a/pkg/component/clusterautoscaler/bootstrap.go
+++ b/pkg/component/clusterautoscaler/bootstrap.go
@@ -61,6 +61,11 @@ func (b *bootstrapper) Deploy(ctx context.Context) error {
 					Resources: []string{"*"},
 					Verbs:     []string{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
 				},
+				{
+					APIGroups: []string{"apps"},
+					Resources: []string{"deployments"},
+					Verbs:     []string{"get", "list", "watch"},
+				},
 			},
 		}
 	)

--- a/pkg/component/clusterautoscaler/bootstrap_test.go
+++ b/pkg/component/clusterautoscaler/bootstrap_test.go
@@ -79,6 +79,14 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - get
+  - list
+  - watch
 `
 
 			expectedSecret = &corev1.Secret{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area auto-scaling
/kind enhancement

**What this PR does / why we need it**:
This PR adds a addition to get/list/watch deployments to cluster role for CA required for this issue: 
https://github.com/gardener/autoscaler/issues/60
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
