### PR TITLE
Install gnu bash in local setup

### DIFF
--- a/docs/development/local_setup.md
+++ b/docs/development/local_setup.md
@@ -28,6 +28,14 @@ On macOS run
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 ```
 
+## [macOS only] Installing GNU bash
+
+Built-in apple-darwin bash is missing some features that could cause shell scripts to fail locally.
+
+```bash
+brew install bash
+```
+
 ## Installing git
 
 We use `git` as VCS which you need to install. On macOS run


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
#8766 has changed a bash script to use a feature for capitalizing words which is available in bash >=4.0, however it is failing on MacOS with the apple provided bash like 

```bash
▶ make verify
hack/tools/logcheck
> Check
Executing golangci-lint
Executing gofmt/goimports
All checks successful
> Check Imports
...
> Check hack/tools/logcheck
> Check Helm charts
Checking for chart symlink errors
Checking whether all charts can be rendered
All checks successful
> Checking if license header is present in all required files
All files have license headers, nothing to be done.
hack/check-skaffold-deps.sh: line 21: > ${operation^} Skaffold Dependencies: bad substitution
make: *** [check] Error 1
```

In my case with MacOS Sonoma 14.1.1, the apple provided bash version `GNU bash, version 3.2.57(1)-release (x86_64-apple-darwin23)`, while the bash installed with brew is of version `GNU bash, version 5.2.21(1)-release (x86_64-apple-darwin23.0.0)` and after it is installed, `make verify` no longer fails with the `bad substitution` error. 

/cc @timebertt 


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
