### PR TITLE
Deprecated OS common package ignores files with image ref

### DIFF
--- a/extensions/pkg/controller/operatingsystemconfig/oscommon/actuator/actuator_util.go
+++ b/extensions/pkg/controller/operatingsystemconfig/oscommon/actuator/actuator_util.go
@@ -42,6 +42,10 @@ func CloudConfigFromOperatingSystemConfig(
 ) {
 	files := make([]*commonosgenerator.File, 0, len(config.Spec.Files))
 	for _, file := range config.Spec.Files {
+		if file.Content.ImageRef != nil {
+			continue
+		}
+
 		data, err := DataForFileContent(ctx, c, config.Namespace, &file.Content)
 		if err != nil {
 			return nil, nil, err


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind enhancement

**What this PR does / why we need it**:
When the `UseGardenerNodeAgent` feature gate is activated, OS extensions must execute both their old reconciliation logic (generating a bash script for `cloud-config-{downloader,executor}`) and their new logic (only providing additional units and files via `.status.extension{Units,Files}`).
However, with the activated feature gate, `gardenlet` adds files to the `.spec.files` of the `OperatingSystemConfig` which have `.content.imageRef != null`. The `DataForFileContent` file used by the deprecated OS common package does not work well for such files and panics: https://github.com/gardener/gardener/blob/eba989bc166232707bb1309c7df61cc6fa1ee8ca/extensions/pkg/controller/operatingsystemconfig/oscommon/actuator/actuator_util.go#L77-L89

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/8023

**Special notes for your reviewer**:
/cc @oliver-goetz 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
NONE
```
