### PR TITLE
[node-agent] Do not try fetching node name on start-up

### DIFF
--- a/pkg/nodeagent/controller/add.go
+++ b/pkg/nodeagent/controller/add.go
@@ -27,14 +27,14 @@ import (
 )
 
 // AddToManager adds all controllers to the given manager.
-func AddToManager(cancel context.CancelFunc, mgr manager.Manager, cfg *config.NodeAgentConfiguration, nodeName string) error {
+func AddToManager(cancel context.CancelFunc, mgr manager.Manager, cfg *config.NodeAgentConfiguration, hostName string) error {
 	if err := (&node.Reconciler{}).AddToManager(mgr); err != nil {
 		return fmt.Errorf("failed adding node controller: %w", err)
 	}
 
 	if err := (&operatingsystemconfig.Reconciler{
 		Config:        cfg.Controllers.OperatingSystemConfig,
-		NodeName:      nodeName,
+		HostName:      hostName,
 		CancelContext: cancel,
 	}).AddToManager(mgr); err != nil {
 		return fmt.Errorf("failed adding operating system config controller: %w", err)

--- a/pkg/nodeagent/dbus/dbus.go
+++ b/pkg/nodeagent/dbus/dbus.go
@@ -17,6 +17,7 @@ package dbus
 import (
 	"context"
 	"fmt"
+	"reflect"
 
 	"github.com/coreos/go-systemd/v22/dbus"
 	corev1 "k8s.io/api/core/v1"
@@ -151,7 +152,7 @@ func (_ *db) DaemonReload(ctx context.Context) error {
 }
 
 func recordEvent(recorder record.EventRecorder, node runtime.Object, err error, unitName, reason, operation string) {
-	if recorder != nil && node != nil {
+	if recorder != nil && node != nil && !reflect.ValueOf(node).IsNil() { // nil is not nil :(
 		var (
 			eventType = corev1.EventTypeNormal
 			message   = fmt.Sprintf("processed %s of unit %s", operation, unitName)

--- a/test/integration/nodeagent/operatingsystemconfig/operatingsystemconfig_test.go
+++ b/test/integration/nodeagent/operatingsystemconfig/operatingsystemconfig_test.go
@@ -50,7 +50,8 @@ var _ = Describe("OperatingSystemConfig controller tests", func() {
 		oscSecretName     = testRunID
 		kubernetesVersion = semver.MustParse("1.2.3")
 
-		node *corev1.Node
+		hostName = "test-hostname"
+		node     *corev1.Node
 
 		file1, file2, file3, file4, file5                                          extensionsv1alpha1.File
 		gnaUnit, unit1, unit2, unit3, unit4, unit5, unit5DropInsOnly, unit6, unit7 extensionsv1alpha1.Unit
@@ -86,8 +87,11 @@ var _ = Describe("OperatingSystemConfig controller tests", func() {
 
 		node = &corev1.Node{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:   testRunID,
-				Labels: map[string]string{testID: testRunID},
+				Name: testRunID,
+				Labels: map[string]string{
+					testID:                   testRunID,
+					"kubernetes.io/hostname": hostName,
+				},
 			},
 		}
 
@@ -107,7 +111,7 @@ var _ = Describe("OperatingSystemConfig controller tests", func() {
 			},
 			DBus:          fakeDBus,
 			FS:            fakeFS,
-			NodeName:      node.Name,
+			HostName:      hostName,
 			Extractor:     fakeregistry.NewExtractor(fakeFS, imageMountDirectory),
 			CancelContext: cancelFunc.cancel,
 		}).AddToManager(mgr)).To(Succeed())


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind bug

**What this PR does / why we need it**:
For newly created VMs, the node name is not known yet since the kubelet has to be installed first. Since `gardener-node-agent` is the component that installs the kubelet, it doesn't make sense to try to fetch the node name on start-up.
Instead, the OSC controller tries fetching it as part of its reconciliation flow.

The second commit addresses the fact that in Go, `nil` is not always `nil` - there are many topics and even official FAQ statements on this topic.
In our case, `recordEvent` takes a `runtime.Object` while the https://github.com/gardener/gardener/blob/eba989bc166232707bb1309c7df61cc6fa1ee8ca/pkg/nodeagent/controller/operatingsystemconfig/reconciler.go#L343 takes the `node` argument with type `client.Object`. When the node is not known yet (e.g., newly created VM), the `node !=nil` check in `recordEvent` results to `true` even though the value type is `nil` - but the interface type is not `nil`. This is due to the "conversion" on the way from `*corev1.Node` to `client.Object` and `runtime.Object`, finally.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/8023

**Special notes for your reviewer**:
/cc @oliver-goetz @ScheererJ 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
