### PR TITLE
Original `OperatingSystemConfig` components always specify `filePaths` in their units

### DIFF
--- a/pkg/apis/extensions/v1alpha1/helper/helper.go
+++ b/pkg/apis/extensions/v1alpha1/helper/helper.go
@@ -57,3 +57,14 @@ func DeterminePrimaryIPFamily(ipFamilies []extensionsv1alpha1.IPFamily) extensio
 	}
 	return ipFamilies[0]
 }
+
+// FilePathsFrom returns the paths for all the given files.
+func FilePathsFrom(files []extensionsv1alpha1.File) []string {
+	var out []string
+
+	for _, file := range files {
+		out = append(out, file.Path)
+	}
+
+	return out
+}

--- a/pkg/apis/extensions/v1alpha1/helper/helper_test.go
+++ b/pkg/apis/extensions/v1alpha1/helper/helper_test.go
@@ -75,6 +75,15 @@ var _ = Describe("helper", func() {
 			Expect(DeterminePrimaryIPFamily([]extensionsv1alpha1.IPFamily{extensionsv1alpha1.IPFamilyIPv6, extensionsv1alpha1.IPFamilyIPv4})).To(Equal(extensionsv1alpha1.IPFamilyIPv6))
 		})
 	})
+
+	Describe("#FilePathsFrom", func() {
+		It("should return the expected list", func() {
+			file1 := extensionsv1alpha1.File{Path: "foo"}
+			file2 := extensionsv1alpha1.File{Path: "bar"}
+
+			Expect(FilePathsFrom([]extensionsv1alpha1.File{file1, file2})).To(ConsistOf("foo", "bar"))
+		})
+	})
 })
 
 var _ = Describe("filecodec", func() {

--- a/pkg/component/extensions/operatingsystemconfig/original/components/kubelet/component_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/kubelet/component_test.go
@@ -428,10 +428,11 @@ EnvironmentFile=/etc/environment
 EnvironmentFile=-/var/lib/kubelet/extra_args` + kubeletStartPre + `
 ExecStart=/opt/bin/kubelet \
     ` + utils.Indent(strings.Join(cliFlags, " \\\n"), 4) + ` $KUBELET_EXTRA_ARGS`),
+		FilePaths: []string{"/var/lib/kubelet/ca.crt", "/var/lib/kubelet/config/kubelet"},
 	}
 
 	if useGardenerNodeAgentEnabled {
-		unit.FilePaths = []string{"/var/lib/kubelet/ca.crt", "/var/lib/kubelet/config/kubelet", "/opt/bin/kubelet"}
+		unit.FilePaths = append(unit.FilePaths, "/opt/bin/kubelet")
 	}
 
 	return unit
@@ -497,10 +498,11 @@ WantedBy=multi-user.target
 Restart=always
 EnvironmentFile=/etc/environment` + healthMonitorStartPre + `
 ExecStart=/opt/bin/health-monitor-kubelet`),
+		FilePaths: []string{"/opt/bin/health-monitor-kubelet"},
 	}
 
 	if useGardenerNodeAgentEnabled {
-		unit.FilePaths = []string{"/opt/bin/health-monitor-kubelet", "/opt/bin/kubectl"}
+		unit.FilePaths = append(unit.FilePaths, "/opt/bin/kubectl")
 	}
 
 	return unit

--- a/pkg/component/extensions/operatingsystemconfig/original/components/nodeagent/component.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/nodeagent/component.go
@@ -29,6 +29,7 @@ import (
 	"github.com/gardener/gardener/imagevector"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	extensionsv1alpha1helper "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1/helper"
 	"github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/original/components"
 	nodeagentv1alpha1 "github.com/gardener/gardener/pkg/nodeagent/apis/config/v1alpha1"
 	"github.com/gardener/gardener/pkg/utils"
@@ -81,16 +82,14 @@ func (component) Config(ctx components.Context) ([]extensionsv1alpha1.Unit, []ex
 		},
 	})
 
-	nodeAgentUnit := extensionsv1alpha1.Unit{
-		Name:    nodeagentv1alpha1.UnitName,
-		Enable:  pointer.Bool(true),
-		Content: pointer.String(UnitContent()),
-	}
-	for _, file := range files {
-		nodeAgentUnit.FilePaths = append(nodeAgentUnit.FilePaths, file.Path)
-	}
+	units := []extensionsv1alpha1.Unit{{
+		Name:      nodeagentv1alpha1.UnitName,
+		Enable:    pointer.Bool(true),
+		Content:   pointer.String(UnitContent()),
+		FilePaths: extensionsv1alpha1helper.FilePathsFrom(files),
+	}}
 
-	return []extensionsv1alpha1.Unit{nodeAgentUnit}, files, nil
+	return units, files, nil
 }
 
 // UnitContent returns the systemd unit content for the gardener-node-agent unit.

--- a/pkg/component/extensions/operatingsystemconfig/original/components/valitail/config.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/valitail/config.go
@@ -32,6 +32,7 @@ import (
 	"github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/original/components"
 	"github.com/gardener/gardener/pkg/component/logging/vali"
 	"github.com/gardener/gardener/pkg/features"
+	nodeagentv1alpha1 "github.com/gardener/gardener/pkg/nodeagent/apis/config/v1alpha1"
 	"github.com/gardener/gardener/pkg/utils"
 )
 
@@ -183,15 +184,23 @@ ExecStart=` + execStart
 }
 
 func getFetchTokenScriptFile() (extensionsv1alpha1.File, error) {
+	values := map[string]interface{}{
+		"pathAuthToken": PathAuthToken,
+		"dataKeyToken":  resourcesv1alpha1.DataKeyToken,
+		"secretName":    vali.ValitailTokenSecretName,
+	}
+
+	if features.DefaultFeatureGate.Enabled(features.UseGardenerNodeAgent) {
+		values["pathCredentialsToken"] = nodeagentv1alpha1.TokenFilePath
+		values["pathNodeAgentConfig"] = nodeagentv1alpha1.ConfigFilePath
+	} else {
+		values["pathCredentialsToken"] = downloader.PathCredentialsToken
+		values["pathCredentialsServer"] = downloader.PathCredentialsServer
+		values["pathCredentialsCACert"] = downloader.PathCredentialsCACert
+	}
+
 	var script bytes.Buffer
-	if err := tplFetchToken.Execute(&script, map[string]interface{}{
-		"pathCredentialsToken":  downloader.PathCredentialsToken,
-		"pathCredentialsServer": downloader.PathCredentialsServer,
-		"pathCredentialsCACert": downloader.PathCredentialsCACert,
-		"pathAuthToken":         PathAuthToken,
-		"dataKeyToken":          resourcesv1alpha1.DataKeyToken,
-		"secretName":            vali.ValitailTokenSecretName,
-	}); err != nil {
+	if err := tplFetchToken.Execute(&script, values); err != nil {
 		return extensionsv1alpha1.File{}, err
 	}
 

--- a/pkg/component/extensions/operatingsystemconfig/original/components/valitail/config.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/valitail/config.go
@@ -171,8 +171,12 @@ ExecStart=` + execStart
 		Content: &unitContent,
 	}
 
-	if ctx.ValitailEnabled && features.DefaultFeatureGate.Enabled(features.UseGardenerNodeAgent) {
-		unit.FilePaths = []string{PathConfig, PathCACert, valitailBinaryPath}
+	if ctx.ValitailEnabled {
+		unit.FilePaths = []string{PathConfig, PathCACert}
+
+		if features.DefaultFeatureGate.Enabled(features.UseGardenerNodeAgent) {
+			unit.FilePaths = append(unit.FilePaths, valitailBinaryPath)
+		}
 	}
 
 	return unit
@@ -241,7 +245,7 @@ ExecStart=` + execStart
 		Content: &unitContent,
 	}
 
-	if ctx.ValitailEnabled && features.DefaultFeatureGate.Enabled(features.UseGardenerNodeAgent) {
+	if ctx.ValitailEnabled {
 		unit.FilePaths = []string{PathFetchTokenScript}
 	}
 

--- a/pkg/component/extensions/operatingsystemconfig/original/components/valitail/config.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/valitail/config.go
@@ -218,9 +218,14 @@ func getFetchTokenScriptUnit(ctx components.Context) extensionsv1alpha1.Unit {
 		execStart = fmt.Sprintf(`/bin/sh -c "rm -f `+PathAuthToken+`; echo service %s is removed!; while true; do sleep 86400; done"`, unitNameFetchToken)
 	}
 
+	afterUnit := downloader.UnitName
+	if features.DefaultFeatureGate.Enabled(features.UseGardenerNodeAgent) {
+		afterUnit = nodeagentv1alpha1.UnitName
+	}
+
 	unitContent := `[Unit]
 Description=valitail token fetcher
-After=` + downloader.UnitName + `
+After=` + afterUnit + `
 [Install]
 WantedBy=multi-user.target
 [Service]

--- a/pkg/component/extensions/operatingsystemconfig/original/components/valitail/config_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/valitail/config_test.go
@@ -113,6 +113,7 @@ RuntimeMaxSec=120
 EnvironmentFile=/etc/environment
 ExecStartPre=/bin/sh -c "systemctl stop promtail-fetch-token.service || true"
 ExecStart=/var/lib/valitail/scripts/fetch-token.sh`),
+						FilePaths: []string{"/var/lib/valitail/scripts/fetch-token.sh"},
 					}
 
 					valitailConfigFile := extensionsv1alpha1.File{
@@ -317,21 +318,19 @@ exit $?
 					}
 
 					expectedFiles := []extensionsv1alpha1.File{valitailConfigFile, valitailFetchTokenScriptFile, caBundleFile}
+
+					valitailDaemonUnit.FilePaths = []string{
+						"/var/lib/valitail/config/config",
+						"/var/lib/valitail/ca.crt",
+					}
+					valitailTokenFetchUnit.FilePaths = []string{"/var/lib/valitail/scripts/fetch-token.sh"}
+
 					if useGardenerNodeAgentEnabled {
 						expectedFiles = append(expectedFiles, valitailBinaryFile)
-						valitailDaemonUnit.FilePaths = []string{
-							"/var/lib/valitail/config/config",
-							"/var/lib/valitail/ca.crt",
-							"/opt/bin/valitail",
-						}
-						valitailTokenFetchUnit.FilePaths = []string{"/var/lib/valitail/scripts/fetch-token.sh"}
+						valitailDaemonUnit.FilePaths = append(valitailDaemonUnit.FilePaths, "/opt/bin/valitail")
 					}
 
-					Expect(units).To(ConsistOf(
-						valitailDaemonUnit,
-						valitailTokenFetchUnit,
-					))
-
+					Expect(units).To(ConsistOf(valitailDaemonUnit, valitailTokenFetchUnit))
 					Expect(files).To(ConsistOf(expectedFiles))
 				})
 

--- a/pkg/component/extensions/operatingsystemconfig/original/components/valitail/templates/scripts/fetch-token.tpl.sh
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/valitail/templates/scripts/fetch-token.tpl.sh
@@ -5,12 +5,22 @@ set -o nounset
 set -o pipefail
 
 {
+{{- if .pathNodeAgentConfig }}
+server="$(cat "{{ .pathNodeAgentConfig }}" | sed -rn "s/  server: (.*)/\1/p")"
+ca_bundle="$(mktemp)"
+trap 'rm -f "$ca_bundle"' EXIT
+cat "{{ .pathNodeAgentConfig }}" | sed -rn "s/  caBundle: (.*)/\1/p" | base64 -d > "$ca_bundle"
+{{- else }}
+server="$(cat "{{ .pathCredentialsServer }}")"
+ca_bundle="{{ .pathCredentialsCACert }}"
+{{- end }}
+
 if ! SECRET="$(wget \
   -qO- \
   --header         "Accept: application/yaml" \
   --header         "Authorization: Bearer $(cat "{{ .pathCredentialsToken }}")" \
-  --ca-certificate "{{ .pathCredentialsCACert }}" \
-  "$(cat "{{ .pathCredentialsServer }}")/api/v1/namespaces/kube-system/secrets/{{ .secretName }}")"; then
+  --ca-certificate "$ca_bundle" \
+  "$server/api/v1/namespaces/kube-system/secrets/{{ .secretName }}")"; then
 
   echo "Could not retrieve the valitail token secret"
   exit 1

--- a/pkg/component/extensions/operatingsystemconfig/original/components/valitail/templates/valitail-config.tpl.yaml
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/valitail/templates/valitail-config.tpl.yaml
@@ -30,7 +30,7 @@ scrape_configs:
     source_labels: ['__journal__systemd_unit']
     target_label: '__journal_syslog_identifier'
   - action: keep
-    regex: ^kernel|kubelet\.service|docker\.service|containerd\.service$
+    regex: ^kernel|kubelet\.service|docker\.service|containerd\.service|gardener-node-agent\.service$
     source_labels: ['__journal_syslog_identifier']
   - source_labels: ['__journal_syslog_identifier']
     target_label: unit
@@ -53,7 +53,7 @@ scrape_configs:
     source_labels: ['__journal__systemd_unit']
     target_label: '__journal_syslog_identifier'
   - action: drop
-    regex: ^kernel|kubelet\.service|docker\.service|containerd\.service$
+    regex: ^kernel|kubelet\.service|docker\.service|containerd\.service|gardener-node-agent\.service$
     source_labels: ['__journal_syslog_identifier']
   - source_labels: ['__journal_syslog_identifier']
     target_label: unit

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -928,6 +928,8 @@ build:
             - pkg/gardenlet/features
             - pkg/healthz
             - pkg/logger
+            - pkg/nodeagent/apis/config
+            - pkg/nodeagent/apis/config/v1alpha1
             - pkg/operation
             - pkg/operation/botanist
             - pkg/operation/botanist/matchers


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
#8814 introduced the new `.spec.units[].filePaths[]` field in the `extensions.gardener.cloud/v1alpha1.OperatingSystemConfig` API. To simplify the code complexity, we can always use it even when the `UseGardenerNodeAgent` feature gate is not enabled, since neither `cloud-config-downloader` nor the OS extensions know this field, hence it doesn't provide any harm.

In addition to this change, the `valitail` component was adapted to

- fetch logs of `gardener-node-agent.service` unit if it exists.
- fetch its access token with the credentials of `gardener-node-agent` in case the `UseGardenerNodeAgent` feature gate is enabled.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/8023

**Special notes for your reviewer**:
/cc @oliver-goetz 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
