### PR TITLE
vpnseedserver supports now IPv4 seeds with IPv6 shoots

### DIFF
--- a/pkg/component/vpnseedserver/vpn_seed_server_test.go
+++ b/pkg/component/vpnseedserver/vpn_seed_server_test.go
@@ -93,9 +93,10 @@ var _ = Describe("VpnSeedServer", func() {
 		}
 
 		listenAddress   = "0.0.0.0"
-		dnsLookUpFamily = "V4_ONLY"
+		listenAddressV6 = "::"
+		dnsLookUpFamily = "V4_PREFERRED"
 
-		configMap = seedConfigMap(listenAddress, dnsLookUpFamily, namespace)
+		configMap = seedConfigMap(listenAddress, listenAddressV6, dnsLookUpFamily, namespace)
 		secretDH  = &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{Name: "vpn-seed-server-dh", Namespace: namespace},
 			Type:       corev1.SecretTypeOpaque,
@@ -659,9 +660,10 @@ var _ = Describe("VpnSeedServer", func() {
 
 		Context("IPv6", func() {
 			BeforeEach(func() {
-				listenAddress = "::"
-				dnsLookUpFamily = "V6_ONLY"
-				configMap = seedConfigMap(listenAddress, dnsLookUpFamily, namespace)
+				listenAddress = "0.0.0.0"
+				listenAddressV6 = "::"
+				dnsLookUpFamily = "V4_PREFERRED"
+				configMap = seedConfigMap(listenAddress, listenAddressV6, dnsLookUpFamily, namespace)
 				networkConfig := NetworkValues{
 					PodCIDR:     "2001:db8:1::/48",
 					ServiceCIDR: "2001:db8:3::/48",
@@ -1179,7 +1181,7 @@ var _ = Describe("VpnSeedServer", func() {
 	})
 })
 
-func seedConfigMap(listenAddress string, dnsLookUpFamily string, namespace string) *corev1.ConfigMap {
+func seedConfigMap(listenAddress, listenAddressV6 string, dnsLookUpFamily string, namespace string) *corev1.ConfigMap {
 	configMap := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "vpn-seed-server-envoy-config",
@@ -1194,6 +1196,11 @@ func seedConfigMap(listenAddress string, dnsLookUpFamily string, namespace strin
         protocol: TCP
         address: "` + listenAddress + `"
         port_value: 9443
+    additional_addresses:
+    - address:
+        socket_address:
+          address: "` + listenAddressV6 + `"
+          port_value: 9443
     listener_filters:
     - name: "envoy.filters.listener.tls_inspector"
       typed_config:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement

**What this PR does / why we need it**:
With the current vpnseedserver configuration it is only possible to run IPv4 seeds with IPv4 shoots and IPv6 seeds with IPv6 Shoots. As a first step towards a pure IPv6 setup it might be desirable to run IPv4 seeds with IPv4 shoots and IPv6 shoots. This PR gives more flexibility in regards to which seed shoot setup should be run.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
The `vpn-seed-server` component now supports IPv4 seed clusters hosting IPv6 shoot clusters. 
```
