### PR TITLE
[scheduler] Clean up technical debt in defaulting code

### DIFF
--- a/pkg/scheduler/apis/config/v1alpha1/defaults.go
+++ b/pkg/scheduler/apis/config/v1alpha1/defaults.go
@@ -15,13 +15,8 @@
 package v1alpha1
 
 import (
-	"k8s.io/apimachinery/pkg/runtime"
 	componentbaseconfigv1alpha1 "k8s.io/component-base/config/v1alpha1"
 )
-
-func addDefaultingFuncs(scheme *runtime.Scheme) error {
-	return RegisterDefaults(scheme)
-}
 
 // SetDefaults_SchedulerConfiguration sets defaults for the configuration of the Gardener scheduler.
 func SetDefaults_SchedulerConfiguration(obj *SchedulerConfiguration) {

--- a/pkg/scheduler/apis/config/v1alpha1/defaults.go
+++ b/pkg/scheduler/apis/config/v1alpha1/defaults.go
@@ -28,28 +28,31 @@ func SetDefaults_SchedulerConfiguration(obj *SchedulerConfiguration) {
 		obj.LogFormat = LogFormatJSON
 	}
 
-	if obj.Schedulers.BackupBucket == nil {
-		obj.Schedulers.BackupBucket = &BackupBucketSchedulerConfiguration{
-			ConcurrentSyncs: 2,
-		}
-	}
-
-	if obj.Schedulers.Shoot == nil {
-		obj.Schedulers.Shoot = &ShootSchedulerConfiguration{
-			ConcurrentSyncs: 5,
-			Strategy:        Default,
-		}
-	}
-	if len(obj.Schedulers.Shoot.Strategy) == 0 {
-		obj.Schedulers.Shoot.Strategy = Default
-	}
-
-	if obj.Schedulers.Shoot.ConcurrentSyncs == 0 {
-		obj.Schedulers.Shoot.ConcurrentSyncs = 5
-	}
-
 	if obj.LeaderElection == nil {
 		obj.LeaderElection = &componentbaseconfigv1alpha1.LeaderElectionConfiguration{}
+	}
+}
+
+// SetDefaults_SchedulerControllerConfiguration sets defaults for the configuration of the controllers.
+func SetDefaults_SchedulerControllerConfiguration(obj *SchedulerControllerConfiguration) {
+	if obj.BackupBucket == nil {
+		obj.BackupBucket = &BackupBucketSchedulerConfiguration{}
+	}
+
+	if obj.BackupBucket.ConcurrentSyncs == 0 {
+		obj.BackupBucket.ConcurrentSyncs = 2
+	}
+
+	if obj.Shoot == nil {
+		obj.Shoot = &ShootSchedulerConfiguration{}
+	}
+
+	if len(obj.Shoot.Strategy) == 0 {
+		obj.Shoot.Strategy = Default
+	}
+
+	if obj.Shoot.ConcurrentSyncs == 0 {
+		obj.Shoot.ConcurrentSyncs = 5
 	}
 }
 

--- a/pkg/scheduler/apis/config/v1alpha1/defaults_test.go
+++ b/pkg/scheduler/apis/config/v1alpha1/defaults_test.go
@@ -29,112 +29,160 @@ import (
 )
 
 var _ = Describe("Defaults", func() {
-	Describe("SchedulerConfiguration", func() {
-		var obj *schedulerv1alpha1.SchedulerConfiguration
+	var obj *schedulerv1alpha1.SchedulerConfiguration
 
-		BeforeEach(func() {
-			obj = &schedulerv1alpha1.SchedulerConfiguration{}
+	BeforeEach(func() {
+		obj = &schedulerv1alpha1.SchedulerConfiguration{}
+	})
+
+	Describe("SchedulerConfiguration defaulting", func() {
+		It("should default the admission controller configuration", func() {
+			schedulerv1alpha1.SetObjectDefaults_SchedulerConfiguration(obj)
+
+			Expect(obj.LogLevel).To(Equal(logger.InfoLevel))
+			Expect(obj.LogFormat).To(Equal(logger.FormatJSON))
+			Expect(obj.Schedulers).To(Equal(schedulerv1alpha1.SchedulerControllerConfiguration{
+				BackupBucket: &schedulerv1alpha1.BackupBucketSchedulerConfiguration{
+					ConcurrentSyncs: 2,
+				},
+				Shoot: &schedulerv1alpha1.ShootSchedulerConfiguration{
+					ConcurrentSyncs: 5,
+					Strategy:        schedulerv1alpha1.Default,
+				},
+			}))
+			Expect(obj.LeaderElection).NotTo(BeNil())
 		})
 
-		Context("Empty configuration", func() {
-			It("should correctly default the admission controller configuration", func() {
-				schedulerv1alpha1.SetObjectDefaults_SchedulerConfiguration(obj)
-
-				Expect(obj.LogLevel).To(Equal(logger.InfoLevel))
-				Expect(obj.LogFormat).To(Equal(logger.FormatJSON))
-				Expect(obj.Schedulers).To(Equal(schedulerv1alpha1.SchedulerControllerConfiguration{
+		It("should not overwrite already set values for admission controller configuration", func() {
+			obj = &schedulerv1alpha1.SchedulerConfiguration{
+				LogLevel:  schedulerv1alpha1.LogLevelDebug,
+				LogFormat: schedulerv1alpha1.LogFormatText,
+				Schedulers: schedulerv1alpha1.SchedulerControllerConfiguration{
 					BackupBucket: &schedulerv1alpha1.BackupBucketSchedulerConfiguration{
-						ConcurrentSyncs: 2,
+						ConcurrentSyncs: 3,
 					},
 					Shoot: &schedulerv1alpha1.ShootSchedulerConfiguration{
-						ConcurrentSyncs: 5,
-						Strategy:        schedulerv1alpha1.Default,
+						ConcurrentSyncs: 6,
+						Strategy:        schedulerv1alpha1.MinimalDistance,
 					},
-				}))
-			})
+				},
+			}
+			obj.LeaderElection = &componentbaseconfigv1alpha1.LeaderElectionConfiguration{ResourceLock: "foo"}
+
+			schedulerv1alpha1.SetObjectDefaults_SchedulerConfiguration(obj)
+
+			Expect(obj.LogLevel).To(Equal(logger.DebugLevel))
+			Expect(obj.LogFormat).To(Equal(logger.FormatText))
+			Expect(obj.Schedulers).To(Equal(schedulerv1alpha1.SchedulerControllerConfiguration{
+				BackupBucket: &schedulerv1alpha1.BackupBucketSchedulerConfiguration{
+					ConcurrentSyncs: 3,
+				},
+				Shoot: &schedulerv1alpha1.ShootSchedulerConfiguration{
+					ConcurrentSyncs: 6,
+					Strategy:        schedulerv1alpha1.MinimalDistance,
+				},
+			}))
+			Expect(obj.LeaderElection.ResourceLock).To(Equal("foo"))
+		})
+	})
+
+	Describe("ServerConfiguration defaulting", func() {
+		It("should not overwrite already set values for ServerConfiguration", func() {
+			serverConfiguration := &schedulerv1alpha1.ServerConfiguration{
+				HealthProbes: &schedulerv1alpha1.Server{
+					Port: 1234,
+				},
+				Metrics: &schedulerv1alpha1.Server{
+					Port: 1235,
+				},
+			}
+			obj.Server = *serverConfiguration
+
+			expectedServerConfiguration := serverConfiguration.DeepCopy()
+
+			schedulerv1alpha1.SetObjectDefaults_SchedulerConfiguration(obj)
+			Expect(obj.Server).To(Equal(*expectedServerConfiguration))
 		})
 
-		Describe("ServerConfiguration", func() {
-			It("should not default any values for ServerConfiguration", func() {
-				serverConfiguration := &schedulerv1alpha1.ServerConfiguration{
-					HealthProbes: &schedulerv1alpha1.Server{
-						Port: 1234,
-					},
-					Metrics: &schedulerv1alpha1.Server{
-						Port: 1235,
-					},
-				}
+		It("should default values for ServerConfiguration", func() {
+			obj.Server = schedulerv1alpha1.ServerConfiguration{}
 
-				expectedServerConfiguration := serverConfiguration.DeepCopy()
+			expectedServerConfiguration := schedulerv1alpha1.ServerConfiguration{
+				HealthProbes: &schedulerv1alpha1.Server{
+					Port: 10251,
+				},
+				Metrics: &schedulerv1alpha1.Server{
+					Port: 19251,
+				},
+			}
 
-				schedulerv1alpha1.SetDefaults_ServerConfiguration(serverConfiguration)
-				Expect(serverConfiguration).To(Equal(expectedServerConfiguration))
-			})
+			schedulerv1alpha1.SetObjectDefaults_SchedulerConfiguration(obj)
+			Expect(obj.Server).To(Equal(expectedServerConfiguration))
+		})
+	})
 
-			It("should default values for ServerConfiguration", func() {
-				serverConfiguration := &schedulerv1alpha1.ServerConfiguration{}
+	Describe("ClientConnection defaulting", func() {
+		It("should not default ContentType and AcceptContentTypes", func() {
+			schedulerv1alpha1.SetObjectDefaults_SchedulerConfiguration(obj)
 
-				expectedServerConfiguration := &schedulerv1alpha1.ServerConfiguration{
-					HealthProbes: &schedulerv1alpha1.Server{
-						Port: 10251,
-					},
-					Metrics: &schedulerv1alpha1.Server{
-						Port: 19251,
-					},
-				}
-
-				schedulerv1alpha1.SetDefaults_ServerConfiguration(serverConfiguration)
-				Expect(serverConfiguration).To(Equal(expectedServerConfiguration))
-			})
+			// ContentType fields will be defaulted by client constructors / controller-runtime based on whether a
+			// given APIGroup supports protobuf or not. defaults must not touch these, otherwise the integelligent
+			// logic will be overwritten
+			Expect(obj.ClientConnection.ContentType).To(BeEmpty())
+			Expect(obj.ClientConnection.AcceptContentTypes).To(BeEmpty())
 		})
 
-		Describe("ClientConnection", func() {
-			It("should not default ContentType and AcceptContentTypes", func() {
-				schedulerv1alpha1.SetObjectDefaults_SchedulerConfiguration(obj)
-
-				// ContentType fields will be defaulted by client constructors / controller-runtime based on whether a
-				// given APIGroup supports protobuf or not. defaults must not touch these, otherwise the integelligent
-				// logic will be overwritten
-				Expect(obj.ClientConnection.ContentType).To(BeEmpty())
-				Expect(obj.ClientConnection.AcceptContentTypes).To(BeEmpty())
-			})
-			It("should correctly default ClientConnection", func() {
-				schedulerv1alpha1.SetObjectDefaults_SchedulerConfiguration(obj)
-				Expect(obj.ClientConnection).To(Equal(componentbaseconfigv1alpha1.ClientConnectionConfiguration{
-					QPS:   50.0,
-					Burst: 100,
-				}))
-			})
+		It("should correctly default ClientConnection", func() {
+			schedulerv1alpha1.SetObjectDefaults_SchedulerConfiguration(obj)
+			Expect(obj.ClientConnection).To(Equal(componentbaseconfigv1alpha1.ClientConnectionConfiguration{
+				QPS:   50.0,
+				Burst: 100,
+			}))
 		})
 
-		Describe("leader election settings", func() {
-			It("should correctly default leader election settings", func() {
-				schedulerv1alpha1.SetObjectDefaults_SchedulerConfiguration(obj)
+		It("should not overwrite already set values for ClientConnection", func() {
+			obj.ClientConnection = componentbaseconfigv1alpha1.ClientConnectionConfiguration{
+				QPS:   60.0,
+				Burst: 110,
+			}
 
-				Expect(obj.LeaderElection).NotTo(BeNil())
-				Expect(obj.LeaderElection.LeaderElect).To(PointTo(BeTrue()))
-				Expect(obj.LeaderElection.LeaseDuration).To(Equal(metav1.Duration{Duration: 15 * time.Second}))
-				Expect(obj.LeaderElection.RenewDeadline).To(Equal(metav1.Duration{Duration: 10 * time.Second}))
-				Expect(obj.LeaderElection.RetryPeriod).To(Equal(metav1.Duration{Duration: 2 * time.Second}))
-				Expect(obj.LeaderElection.ResourceLock).To(Equal("leases"))
-				Expect(obj.LeaderElection.ResourceNamespace).To(Equal("garden"))
-				Expect(obj.LeaderElection.ResourceName).To(Equal("gardener-scheduler-leader-election"))
-			})
-			It("should not overwrite custom settings", func() {
-				expectedLeaderElection := &componentbaseconfigv1alpha1.LeaderElectionConfiguration{
-					LeaderElect:       pointer.Bool(true),
-					ResourceLock:      "foo",
-					RetryPeriod:       metav1.Duration{Duration: 40 * time.Second},
-					RenewDeadline:     metav1.Duration{Duration: 41 * time.Second},
-					LeaseDuration:     metav1.Duration{Duration: 42 * time.Second},
-					ResourceNamespace: "other-garden-ns",
-					ResourceName:      "lock-object",
-				}
-				obj.LeaderElection = expectedLeaderElection.DeepCopy()
-				schedulerv1alpha1.SetObjectDefaults_SchedulerConfiguration(obj)
+			schedulerv1alpha1.SetObjectDefaults_SchedulerConfiguration(obj)
 
-				Expect(obj.LeaderElection).To(Equal(expectedLeaderElection))
-			})
+			Expect(obj.ClientConnection).To(Equal(componentbaseconfigv1alpha1.ClientConnectionConfiguration{
+				QPS:   60.0,
+				Burst: 110,
+			}))
+		})
+	})
+
+	Describe("LeaderElection defaulting", func() {
+		It("should default leader election settings", func() {
+			schedulerv1alpha1.SetObjectDefaults_SchedulerConfiguration(obj)
+
+			Expect(obj.LeaderElection).NotTo(BeNil())
+			Expect(obj.LeaderElection.LeaderElect).To(PointTo(BeTrue()))
+			Expect(obj.LeaderElection.LeaseDuration).To(Equal(metav1.Duration{Duration: 15 * time.Second}))
+			Expect(obj.LeaderElection.RenewDeadline).To(Equal(metav1.Duration{Duration: 10 * time.Second}))
+			Expect(obj.LeaderElection.RetryPeriod).To(Equal(metav1.Duration{Duration: 2 * time.Second}))
+			Expect(obj.LeaderElection.ResourceLock).To(Equal("leases"))
+			Expect(obj.LeaderElection.ResourceNamespace).To(Equal("garden"))
+			Expect(obj.LeaderElection.ResourceName).To(Equal("gardener-scheduler-leader-election"))
+		})
+
+		It("should not overwrite already set values for leader election", func() {
+			expectedLeaderElection := &componentbaseconfigv1alpha1.LeaderElectionConfiguration{
+				LeaderElect:       pointer.Bool(true),
+				ResourceLock:      "foo",
+				RetryPeriod:       metav1.Duration{Duration: 40 * time.Second},
+				RenewDeadline:     metav1.Duration{Duration: 41 * time.Second},
+				LeaseDuration:     metav1.Duration{Duration: 42 * time.Second},
+				ResourceNamespace: "other-garden-ns",
+				ResourceName:      "lock-object",
+			}
+			obj.LeaderElection = expectedLeaderElection.DeepCopy()
+			schedulerv1alpha1.SetObjectDefaults_SchedulerConfiguration(obj)
+
+			Expect(obj.LeaderElection).To(Equal(expectedLeaderElection))
 		})
 	})
 })

--- a/pkg/scheduler/apis/config/v1alpha1/defaults_test.go
+++ b/pkg/scheduler/apis/config/v1alpha1/defaults_test.go
@@ -140,7 +140,7 @@ var _ = Describe("Defaults", func() {
 			schedulerv1alpha1.SetObjectDefaults_SchedulerConfiguration(obj)
 
 			// ContentType fields will be defaulted by client constructors / controller-runtime based on whether a
-			// given APIGroup supports protobuf or not. defaults must not touch these, otherwise the integelligent
+			// given APIGroup supports protobuf or not. defaults must not touch these, otherwise the intelligent
 			// logic will be overwritten
 			Expect(obj.ClientConnection.ContentType).To(BeEmpty())
 			Expect(obj.ClientConnection.AcceptContentTypes).To(BeEmpty())

--- a/pkg/scheduler/apis/config/v1alpha1/defaults_test.go
+++ b/pkg/scheduler/apis/config/v1alpha1/defaults_test.go
@@ -36,11 +36,32 @@ var _ = Describe("Defaults", func() {
 	})
 
 	Describe("SchedulerConfiguration defaulting", func() {
-		It("should default the admission controller configuration", func() {
+		It("should default the scheduler configuration", func() {
 			schedulerv1alpha1.SetObjectDefaults_SchedulerConfiguration(obj)
 
 			Expect(obj.LogLevel).To(Equal(logger.InfoLevel))
 			Expect(obj.LogFormat).To(Equal(logger.FormatJSON))
+			Expect(obj.LeaderElection).NotTo(BeNil())
+		})
+
+		It("should not overwrite already set values for scheduler configuration", func() {
+			obj = &schedulerv1alpha1.SchedulerConfiguration{
+				LogLevel:  schedulerv1alpha1.LogLevelDebug,
+				LogFormat: schedulerv1alpha1.LogFormatText,
+			}
+
+			schedulerv1alpha1.SetObjectDefaults_SchedulerConfiguration(obj)
+
+			Expect(obj.LogLevel).To(Equal(logger.DebugLevel))
+			Expect(obj.LogFormat).To(Equal(logger.FormatText))
+			Expect(obj.LeaderElection).NotTo(BeNil())
+		})
+	})
+
+	Describe("SchedulerControllerConfiguration defaulting", func() {
+		It("should default the scheduler controller configuration", func() {
+			schedulerv1alpha1.SetObjectDefaults_SchedulerConfiguration(obj)
+
 			Expect(obj.Schedulers).To(Equal(schedulerv1alpha1.SchedulerControllerConfiguration{
 				BackupBucket: &schedulerv1alpha1.BackupBucketSchedulerConfiguration{
 					ConcurrentSyncs: 2,
@@ -50,13 +71,10 @@ var _ = Describe("Defaults", func() {
 					Strategy:        schedulerv1alpha1.Default,
 				},
 			}))
-			Expect(obj.LeaderElection).NotTo(BeNil())
 		})
 
-		It("should not overwrite already set values for admission controller configuration", func() {
+		It("should not overwrite already set values for scheduler controller configuration", func() {
 			obj = &schedulerv1alpha1.SchedulerConfiguration{
-				LogLevel:  schedulerv1alpha1.LogLevelDebug,
-				LogFormat: schedulerv1alpha1.LogFormatText,
 				Schedulers: schedulerv1alpha1.SchedulerControllerConfiguration{
 					BackupBucket: &schedulerv1alpha1.BackupBucketSchedulerConfiguration{
 						ConcurrentSyncs: 3,
@@ -67,12 +85,9 @@ var _ = Describe("Defaults", func() {
 					},
 				},
 			}
-			obj.LeaderElection = &componentbaseconfigv1alpha1.LeaderElectionConfiguration{ResourceLock: "foo"}
 
 			schedulerv1alpha1.SetObjectDefaults_SchedulerConfiguration(obj)
 
-			Expect(obj.LogLevel).To(Equal(logger.DebugLevel))
-			Expect(obj.LogFormat).To(Equal(logger.FormatText))
 			Expect(obj.Schedulers).To(Equal(schedulerv1alpha1.SchedulerControllerConfiguration{
 				BackupBucket: &schedulerv1alpha1.BackupBucketSchedulerConfiguration{
 					ConcurrentSyncs: 3,
@@ -82,7 +97,6 @@ var _ = Describe("Defaults", func() {
 					Strategy:        schedulerv1alpha1.MinimalDistance,
 				},
 			}))
-			Expect(obj.LeaderElection.ResourceLock).To(Equal("foo"))
 		})
 	})
 

--- a/pkg/scheduler/apis/config/v1alpha1/register.go
+++ b/pkg/scheduler/apis/config/v1alpha1/register.go
@@ -53,3 +53,7 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 	)
 	return nil
 }
+
+func addDefaultingFuncs(scheme *runtime.Scheme) error {
+	return RegisterDefaults(scheme)
+}

--- a/pkg/scheduler/apis/config/v1alpha1/zz_generated.defaults.go
+++ b/pkg/scheduler/apis/config/v1alpha1/zz_generated.defaults.go
@@ -40,4 +40,5 @@ func SetObjectDefaults_SchedulerConfiguration(in *SchedulerConfiguration) {
 		SetDefaults_LeaderElectionConfiguration(in.LeaderElection)
 	}
 	SetDefaults_ServerConfiguration(&in.Server)
+	SetDefaults_SchedulerControllerConfiguration(&in.Schedulers)
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind technical-debt

**What this PR does / why we need it**:
This PR cleans up technical debt in our API defaulting code according to https://github.com/gardener/gardener/issues/7312.
This PR tackles the following resources in the core API group:
- scheduler.config.gardener.cloud

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/7312

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
