### PR TITLE
Prepare for removal of `.spec.secretRef` field in the Seed

### DIFF
--- a/docs/concepts/gardenlet.md
+++ b/docs/concepts/gardenlet.md
@@ -149,15 +149,11 @@ seedConfig:
     provider:
       type: aws
     # ...
-    secretRef:
-      name: my-seed-secret
-      namespace: garden
+    settings:
+      scheduling:
+        visible: true
 ```
 (see [this yaml file](../../example/20-componentconfig-gardenlet.yaml) for a more complete example)
-
-When using `make start-gardenlet`, the corresponding script will automatically
-fetch the seed cluster's `kubeconfig` based on the `seedConfig.spec.secretRef`
-and set the environment accordingly.
 
 On startup, gardenlet registers a `Seed` resource using the given template
 in the `seedConfig` if it's not present already.

--- a/example/gardener-local/gardenlet/values-kind-ha-multi-zone.yaml
+++ b/example/gardener-local/gardenlet/values-kind-ha-multi-zone.yaml
@@ -11,8 +11,6 @@ config:
         - "2"
       ingress:
         domain: ingress.local-ha-multi-zone.seed.local.gardener.cloud
-      secretRef:
-        name: seed-local-ha-multi-zone
       settings:
         topologyAwareRouting:
           enabled: true

--- a/example/gardener-local/gardenlet/values-kind-ha-single-zone.yaml
+++ b/example/gardener-local/gardenlet/values-kind-ha-single-zone.yaml
@@ -9,9 +9,6 @@ config:
         - "0"
       ingress:
         domain: ingress.local-ha-single-zone.seed.local.gardener.cloud
-      secretRef:
-        name: seed-local-ha-single-zone
 nodeToleration:
   defaultNotReadyTolerationSeconds: 60
   defaultUnreachableTolerationSeconds: 60
-

--- a/example/gardener-local/gardenlet/values-kind2-ha-single-zone.yaml
+++ b/example/gardener-local/gardenlet/values-kind2-ha-single-zone.yaml
@@ -27,5 +27,3 @@ config:
     spec:
       ingress:
         domain: ingress.local2-ha-single-zone.seed.local.gardener.cloud
-      secretRef:
-        name: seed-local2-ha-single-zone

--- a/example/gardener-local/gardenlet/values-kind2.yaml
+++ b/example/gardener-local/gardenlet/values-kind2.yaml
@@ -31,5 +31,3 @@ config:
     spec:
       ingress:
         domain: ingress.local2.seed.local.gardener.cloud
-      secretRef:
-        name: seed-local2

--- a/example/gardener-local/gardenlet/values.yaml
+++ b/example/gardener-local/gardenlet/values.yaml
@@ -91,9 +91,6 @@ config:
         domain: ingress.local.seed.local.gardener.cloud
         controller:
           kind: nginx
-      secretRef:
-        name: seed-local
-        namespace: garden
       networks:
         nodes: 172.18.0.0/16
         # Those CIDRs must match those specified in the kind Cluster configuration.

--- a/example/provider-extensions/gardenlet/values.yaml.tmpl
+++ b/example/provider-extensions/gardenlet/values.yaml.tmpl
@@ -7,7 +7,6 @@ config:
       name: ""
     spec:
       backup: null
-      secretRef: null
       dns:
         provider:
           secretRef:

--- a/pkg/admissioncontroller/webhook/admission/seedrestriction/handler.go
+++ b/pkg/admissioncontroller/webhook/admission/seedrestriction/handler.go
@@ -389,12 +389,6 @@ func (h *Handler) admitSecret(ctx context.Context, seedName string, request admi
 			return admission.Errored(http.StatusInternalServerError, err)
 		}
 
-		if seedTemplate.Spec.SecretRef != nil &&
-			seedTemplate.Spec.SecretRef.Namespace == request.Namespace &&
-			seedTemplate.Spec.SecretRef.Name == request.Name {
-			return admission.Allowed("")
-		}
-
 		if seedTemplate.Spec.Backup != nil &&
 			seedTemplate.Spec.Backup.SecretRef.Namespace == request.Namespace &&
 			seedTemplate.Spec.Backup.SecretRef.Name == request.Name {

--- a/pkg/admissioncontroller/webhook/admission/seedrestriction/handler_test.go
+++ b/pkg/admissioncontroller/webhook/admission/seedrestriction/handler_test.go
@@ -1484,43 +1484,6 @@ var _ = Describe("handler", func() {
 
 						It("should forbid because the secret is referenced in a managedseed's gardenlet config but belongs to another seed", func() {
 							var (
-								secretName      = "secret-foo"
-								secretNamespace = "secret-bar"
-							)
-
-							request.Namespace = secretNamespace
-							request.Name = secretName
-							seedConfig1.Spec.SecretRef = &corev1.SecretReference{
-								Name:      secretName,
-								Namespace: secretNamespace,
-							}
-
-							mockCache.EXPECT().List(ctx, gomock.AssignableToTypeOf(&seedmanagementv1alpha1.ManagedSeedList{})).DoAndReturn(func(ctx context.Context, list *seedmanagementv1alpha1.ManagedSeedList, opts ...client.ListOption) error {
-								(&seedmanagementv1alpha1.ManagedSeedList{Items: managedSeeds}).DeepCopyInto(list)
-								return nil
-							})
-							mockCache.EXPECT().Get(ctx, kubernetesutils.Key(managedSeed1Namespace, shoot1.Name), gomock.AssignableToTypeOf(&gardencorev1beta1.Shoot{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.Shoot, _ ...client.GetOption) error {
-								shoot1.DeepCopyInto(obj)
-								return nil
-							})
-							mockCache.EXPECT().Get(ctx, kubernetesutils.Key(managedSeed1Namespace, shoot2.Name), gomock.AssignableToTypeOf(&gardencorev1beta1.Shoot{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.Shoot, _ ...client.GetOption) error {
-								shoot2.DeepCopyInto(obj)
-								return nil
-							})
-
-							Expect(handler.Handle(ctx, request)).To(Equal(admission.Response{
-								AdmissionResponse: admissionv1.AdmissionResponse{
-									Allowed: false,
-									Result: &metav1.Status{
-										Code:    int32(http.StatusForbidden),
-										Message: fmt.Sprintf("object does not belong to seed %q", seedName),
-									},
-								},
-							}))
-						})
-
-						It("should forbid because the secret is referenced in a managedseed's gardenlet config but belongs to another seed", func() {
-							var (
 								secretName      = "secret-bar"
 								secretNamespace = "secret-foo"
 							)
@@ -1556,35 +1519,6 @@ var _ = Describe("handler", func() {
 									},
 								},
 							}))
-						})
-
-						It("should allow because the secret is referenced in a managedseed's gardenlet config", func() {
-							var (
-								secretName      = "secret-foo"
-								secretNamespace = "secret-bar"
-							)
-
-							request.Namespace = secretNamespace
-							request.Name = secretName
-							seedConfig2.Spec.SecretRef = &corev1.SecretReference{
-								Name:      secretName,
-								Namespace: secretNamespace,
-							}
-
-							mockCache.EXPECT().List(ctx, gomock.AssignableToTypeOf(&seedmanagementv1alpha1.ManagedSeedList{})).DoAndReturn(func(ctx context.Context, list *seedmanagementv1alpha1.ManagedSeedList, opts ...client.ListOption) error {
-								(&seedmanagementv1alpha1.ManagedSeedList{Items: managedSeeds}).DeepCopyInto(list)
-								return nil
-							})
-							mockCache.EXPECT().Get(ctx, kubernetesutils.Key(managedSeed1Namespace, shoot1.Name), gomock.AssignableToTypeOf(&gardencorev1beta1.Shoot{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.Shoot, _ ...client.GetOption) error {
-								shoot1.DeepCopyInto(obj)
-								return nil
-							})
-							mockCache.EXPECT().Get(ctx, kubernetesutils.Key(managedSeed1Namespace, shoot2.Name), gomock.AssignableToTypeOf(&gardencorev1beta1.Shoot{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.Shoot, _ ...client.GetOption) error {
-								shoot2.DeepCopyInto(obj)
-								return nil
-							})
-
-							Expect(handler.Handle(ctx, request)).To(Equal(responseAllowed))
 						})
 
 						It("should allow because the secret is referenced in a managedseed's gardenlet config", func() {

--- a/pkg/admissioncontroller/webhook/auth/seed/graph/eventhandler_managedseed.go
+++ b/pkg/admissioncontroller/webhook/auth/seed/graph/eventhandler_managedseed.go
@@ -95,11 +95,6 @@ func (g *graph) handleManagedSeedCreateOrUpdate(ctx context.Context, managedSeed
 			secretVertex := g.getOrCreateVertex(VertexTypeSecret, seedTemplate.Spec.Backup.SecretRef.Namespace, seedTemplate.Spec.Backup.SecretRef.Name)
 			g.addEdge(secretVertex, managedSeedVertex)
 		}
-
-		if seedTemplate.Spec.SecretRef != nil {
-			secretVertex := g.getOrCreateVertex(VertexTypeSecret, seedTemplate.Spec.SecretRef.Namespace, seedTemplate.Spec.SecretRef.Name)
-			g.addEdge(secretVertex, managedSeedVertex)
-		}
 	}
 
 	if metav1.HasAnnotation(managedSeed.ObjectMeta, seedmanagementv1alpha1constants.AnnotationSeedSecretName) &&

--- a/pkg/admissioncontroller/webhook/auth/seed/graph/eventhandler_managedseed.go
+++ b/pkg/admissioncontroller/webhook/auth/seed/graph/eventhandler_managedseed.go
@@ -27,7 +27,6 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
-	seedmanagementv1alpha1constants "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1/constants"
 	seedmanagementv1alpha1helper "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1/helper"
 	gardenletbootstraputil "github.com/gardener/gardener/pkg/gardenlet/bootstrap/util"
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
@@ -95,12 +94,6 @@ func (g *graph) handleManagedSeedCreateOrUpdate(ctx context.Context, managedSeed
 			secretVertex := g.getOrCreateVertex(VertexTypeSecret, seedTemplate.Spec.Backup.SecretRef.Namespace, seedTemplate.Spec.Backup.SecretRef.Name)
 			g.addEdge(secretVertex, managedSeedVertex)
 		}
-	}
-
-	if metav1.HasAnnotation(managedSeed.ObjectMeta, seedmanagementv1alpha1constants.AnnotationSeedSecretName) &&
-		metav1.HasAnnotation(managedSeed.ObjectMeta, seedmanagementv1alpha1constants.AnnotationSeedSecretNamespace) {
-		secretVertex := g.getOrCreateVertex(VertexTypeSecret, managedSeed.GetAnnotations()[seedmanagementv1alpha1constants.AnnotationSeedSecretNamespace], managedSeed.GetAnnotations()[seedmanagementv1alpha1constants.AnnotationSeedSecretName])
-		g.addEdge(secretVertex, managedSeedVertex)
 	}
 
 	if gardenletConfig == nil || managedSeed.Spec.Gardenlet.Bootstrap == nil {

--- a/pkg/admissioncontroller/webhook/auth/seed/graph/eventhandler_seed.go
+++ b/pkg/admissioncontroller/webhook/auth/seed/graph/eventhandler_seed.go
@@ -52,8 +52,7 @@ func (g *graph) setupSeedWatch(ctx context.Context, informer cache.Informer) err
 				return
 			}
 
-			if !apiequality.Semantic.DeepEqual(oldSeed.Spec.SecretRef, newSeed.Spec.SecretRef) ||
-				!v1beta1helper.SeedBackupSecretRefEqual(oldSeed.Spec.Backup, newSeed.Spec.Backup) ||
+			if !v1beta1helper.SeedBackupSecretRefEqual(oldSeed.Spec.Backup, newSeed.Spec.Backup) ||
 				!seedDNSProviderSecretRefEqual(oldSeed.Spec.DNS.Provider, newSeed.Spec.DNS.Provider) {
 				g.handleSeedCreateOrUpdate(newSeed)
 			}
@@ -106,11 +105,6 @@ func (g *graph) handleSeedCreateOrUpdate(seed *gardencorev1beta1.Seed) {
 
 	leaseVertex := g.getOrCreateVertex(VertexTypeLease, gardencorev1beta1.GardenerSeedLeaseNamespace, seed.Name)
 	g.addEdge(leaseVertex, seedVertex)
-
-	if seed.Spec.SecretRef != nil {
-		secretVertex := g.getOrCreateVertex(VertexTypeSecret, seed.Spec.SecretRef.Namespace, seed.Spec.SecretRef.Name)
-		g.addEdge(secretVertex, seedVertex)
-	}
 
 	if seed.Spec.Backup != nil {
 		secretVertex := g.getOrCreateVertex(VertexTypeSecret, seed.Spec.Backup.SecretRef.Namespace, seed.Spec.Backup.SecretRef.Name)

--- a/pkg/apis/core/validation/seed.go
+++ b/pkg/apis/core/validation/seed.go
@@ -111,10 +111,6 @@ func ValidateSeedSpec(seedSpec *core.SeedSpec, fldPath *field.Path, inTemplate b
 		zones.Insert(zone)
 	}
 
-	if seedSpec.SecretRef != nil {
-		allErrs = append(allErrs, validateSecretReference(*seedSpec.SecretRef, fldPath.Child("secretRef"))...)
-	}
-
 	allErrs = append(allErrs, validateSeedNetworks(seedSpec.Networks, fldPath.Child("networks"), inTemplate)...)
 
 	if seedSpec.Backup != nil {

--- a/pkg/apis/core/validation/seed_test.go
+++ b/pkg/apis/core/validation/seed_test.go
@@ -71,10 +71,6 @@ var _ = Describe("Seed Validation Tests", func() {
 						Kind: "nginx",
 					},
 				},
-				SecretRef: &corev1.SecretReference{
-					Name:      "seed-foo",
-					Namespace: "garden",
-				},
 				Taints: []core.SeedTaint{
 					{Key: "foo"},
 				},
@@ -224,7 +220,6 @@ var _ = Describe("Seed Validation Tests", func() {
 			seed.Spec.Provider = core.SeedProvider{
 				Zones: []string{"a", "a"},
 			}
-			seed.Spec.SecretRef = &corev1.SecretReference{}
 			seed.Spec.Networks = core.SeedNetworks{
 				Nodes:    &invalidCIDR,
 				Pods:     "300.300.300.300/300",
@@ -289,14 +284,6 @@ var _ = Describe("Seed Validation Tests", func() {
 				PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":  Equal(field.ErrorTypeDuplicate),
 					"Field": Equal("spec.provider.zones[1]"),
-				})),
-				PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":  Equal(field.ErrorTypeRequired),
-					"Field": Equal("spec.secretRef.name"),
-				})),
-				PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":  Equal(field.ErrorTypeRequired),
-					"Field": Equal("spec.secretRef.namespace"),
 				})),
 				PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":  Equal(field.ErrorTypeDuplicate),

--- a/pkg/apis/seedmanagement/v1alpha1/constants/types_constants.go
+++ b/pkg/apis/seedmanagement/v1alpha1/constants/types_constants.go
@@ -18,9 +18,4 @@ const (
 	// AnnotationProtectFromDeletion is a constant for an annotation on a replica of a ManagedSeedSet
 	//(either ManagedSeed or Shoot) to protect it from deletion..
 	AnnotationProtectFromDeletion = "seedmanagement.gardener.cloud/protect-from-deletion"
-
-	// AnnotationSeedSecretName is the name of the secret which is referred in the Seed spec of a ManagedSeed.
-	AnnotationSeedSecretName = "seedmanagement.gardener.cloud/seed-secret-name"
-	// AnnotationSeedSecretNamespace is the namespace of the secret which is referred in the Seed spec of a ManagedSeed.
-	AnnotationSeedSecretNamespace = "seedmanagement.gardener.cloud/seed-secret-namespace"
 )

--- a/pkg/apis/seedmanagement/v1alpha1/defaults_managedseed.go
+++ b/pkg/apis/seedmanagement/v1alpha1/defaults_managedseed.go
@@ -134,7 +134,7 @@ func setDefaultsGardenletConfiguration(obj *gardenletv1alpha1.GardenletConfigura
 	}
 
 	// Set seed spec defaults
-	setDefaultsSeedSpec(&obj.SeedConfig.SeedTemplate.Spec, name, namespace, false)
+	setDefaultsSeedSpec(&obj.SeedConfig.SeedTemplate.Spec, name, namespace)
 }
 
 func setDefaultsResources(obj *gardenletv1alpha1.ResourcesConfiguration) {
@@ -146,13 +146,7 @@ func setDefaultsResources(obj *gardenletv1alpha1.ResourcesConfiguration) {
 	}
 }
 
-func setDefaultsSeedSpec(spec *gardencorev1beta1.SeedSpec, name, namespace string, withSecretRef bool) {
-	if spec.SecretRef == nil && withSecretRef {
-		spec.SecretRef = &corev1.SecretReference{
-			Name:      fmt.Sprintf("seed-%s", name),
-			Namespace: namespace,
-		}
-	}
+func setDefaultsSeedSpec(spec *gardencorev1beta1.SeedSpec, name, namespace string) {
 	if spec.Backup != nil && spec.Backup.SecretRef == (corev1.SecretReference{}) {
 		spec.Backup.SecretRef = corev1.SecretReference{
 			Name:      fmt.Sprintf("backup-%s", name),

--- a/pkg/apis/seedmanagement/validation/managedseed_test.go
+++ b/pkg/apis/seedmanagement/validation/managedseed_test.go
@@ -83,10 +83,6 @@ var _ = Describe("ManagedSeed Validation Tests", func() {
 					Type:   "foo",
 					Region: "some-region",
 				},
-				SecretRef: &corev1.SecretReference{
-					Name:      "seed-test",
-					Namespace: "garden",
-				},
 				Taints: []core.SeedTaint{
 					{Key: "foo"},
 				},

--- a/pkg/gardenlet/controller/managedseed/actuator.go
+++ b/pkg/gardenlet/controller/managedseed/actuator.go
@@ -30,14 +30,12 @@ import (
 	"k8s.io/utils/clock"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	"github.com/gardener/gardener/charts"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
-	seedmanagementv1alpha1constants "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1/constants"
 	"github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1/helper"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap"
@@ -165,7 +163,7 @@ func (a *actuator) Reconcile(
 	// Create or update seed secrets
 	log.Info("Reconciling seed secrets")
 	a.recorder.Event(ms, corev1.EventTypeNormal, gardencorev1beta1.EventReconciling, "Reconciling seed secrets")
-	if err := a.reconcileSeedSecrets(ctx, log, &seedTemplate.Spec, ms, shoot); err != nil {
+	if err := a.reconcileSeedSecrets(ctx, &seedTemplate.Spec, ms, shoot); err != nil {
 		return status, false, fmt.Errorf("could not reconcile seed %s secrets: %w", ms.Name, err)
 	}
 
@@ -281,13 +279,13 @@ func (a *actuator) Delete(
 	}
 
 	// Delete seed secrets if any of them still exists and is not already deleting
-	secret, backupSecret, err := a.getSeedSecrets(ctx, &seedTemplate.Spec, ms)
+	backupSecret, err := a.getSeedSecrets(ctx, &seedTemplate.Spec, ms)
 	if err != nil {
 		return status, false, false, fmt.Errorf("could not get seed %s secrets: %w", ms.Name, err)
 	}
 
-	if secret != nil || backupSecret != nil {
-		if (secret != nil && secret.DeletionTimestamp == nil) || (backupSecret != nil && backupSecret.DeletionTimestamp == nil) {
+	if backupSecret != nil {
+		if backupSecret.DeletionTimestamp == nil {
 			log.Info("Deleting seed secrets")
 			a.recorder.Event(ms, corev1.EventTypeNormal, gardencorev1beta1.EventDeleting, "Deleting seed secrets")
 			if err := a.deleteSeedSecrets(ctx, &seedTemplate.Spec, ms); err != nil {
@@ -479,7 +477,7 @@ func (a *actuator) checkSeedSpec(ctx context.Context, spec *gardencorev1beta1.Se
 	return nil
 }
 
-func (a *actuator) reconcileSeedSecrets(ctx context.Context, log logr.Logger, spec *gardencorev1beta1.SeedSpec, managedSeed *seedmanagementv1alpha1.ManagedSeed, shoot *gardencorev1beta1.Shoot) error {
+func (a *actuator) reconcileSeedSecrets(ctx context.Context, spec *gardencorev1beta1.SeedSpec, managedSeed *seedmanagementv1alpha1.ManagedSeed, shoot *gardencorev1beta1.Shoot) error {
 	// Get shoot secret
 	shootSecret, err := a.getShootSecret(ctx, shoot)
 	if err != nil {
@@ -523,70 +521,6 @@ func (a *actuator) reconcileSeedSecrets(ctx context.Context, log logr.Logger, sp
 		})
 	}
 
-	// If secret reference is specified and the static token kubeconfig is enabled,
-	// create or update the corresponding secret with the kubeconfig from the static token kubeconfig secret.
-	if spec.SecretRef != nil && pointer.BoolDeref(shoot.Spec.Kubernetes.EnableStaticTokenKubeconfig, false) {
-		// Get shoot kubeconfig secret
-		shootKubeconfigSecret, err := a.getShootKubeconfigSecret(ctx, shoot)
-		if err != nil {
-			return err
-		}
-
-		// Create or update seed secret
-		secret := &corev1.Secret{
-			ObjectMeta: kubernetesutils.ObjectMeta(spec.SecretRef.Namespace, spec.SecretRef.Name),
-		}
-		if _, err := controllerutils.CreateOrGetAndStrategicMergePatch(ctx, a.gardenClient, secret, func() error {
-			secret.OwnerReferences = []metav1.OwnerReference{
-				*metav1.NewControllerRef(managedSeed, seedmanagementv1alpha1.SchemeGroupVersion.WithKind("ManagedSeed")),
-			}
-			secret.Type = corev1.SecretTypeOpaque
-			secret.Data = map[string][]byte{
-				kubernetes.KubeConfig: shootKubeconfigSecret.Data[kubernetes.KubeConfig],
-			}
-			return nil
-		}); err != nil {
-			return err
-		}
-	}
-
-	// When the secretRef is unset, cleanup the secret if the reference annotations are present in the managedseed.
-	if spec.SecretRef == nil &&
-		metav1.HasAnnotation(managedSeed.ObjectMeta, seedmanagementv1alpha1constants.AnnotationSeedSecretName) &&
-		metav1.HasAnnotation(managedSeed.ObjectMeta, seedmanagementv1alpha1constants.AnnotationSeedSecretNamespace) {
-		secret, err := kubernetesutils.GetSecretByReference(ctx,
-			a.gardenClient,
-			&corev1.SecretReference{
-				Name:      managedSeed.Annotations[seedmanagementv1alpha1constants.AnnotationSeedSecretName],
-				Namespace: managedSeed.Annotations[seedmanagementv1alpha1constants.AnnotationSeedSecretNamespace],
-			},
-		)
-		if client.IgnoreNotFound(err) != nil {
-			return fmt.Errorf("failed getting secret in the managedseed annotations: %w", err)
-		}
-
-		if err == nil && metav1.IsControlledBy(secret, managedSeed) {
-			// This finalizer is added by the seed controller, but it cannot remove it when the secretRef is unset.
-			if controllerutil.ContainsFinalizer(secret, gardencorev1beta1.ExternalGardenerName) {
-				if err := controllerutils.RemoveFinalizers(ctx, a.gardenClient, secret, gardencorev1beta1.ExternalGardenerName); err != nil {
-					return fmt.Errorf("failed to remove finalizer from secret referred by managedseed: %w", err)
-				}
-			}
-
-			if err := a.gardenClient.Delete(ctx, secret); client.IgnoreNotFound(err) != nil {
-				return fmt.Errorf("error deleting seed secret referred by managedseed: %w", err)
-			}
-			log.Info("Deleted seed secret referred by managedseed", "secretName", secret.Name, "secretNamespace", secret.Namespace)
-		}
-
-		patch := client.MergeFrom(managedSeed.DeepCopy())
-		delete(managedSeed.Annotations, seedmanagementv1alpha1constants.AnnotationSeedSecretName)
-		delete(managedSeed.Annotations, seedmanagementv1alpha1constants.AnnotationSeedSecretNamespace)
-		if err := a.gardenClient.Patch(ctx, managedSeed, patch); err != nil {
-			return fmt.Errorf("error removing seed secret reference annotations: %w", err)
-		}
-	}
-
 	return nil
 }
 
@@ -604,40 +538,25 @@ func (a *actuator) deleteSeedSecrets(ctx context.Context, spec *gardencorev1beta
 		}
 	}
 
-	// If secret reference is specified, delete the corresponding secret
-	if spec.SecretRef != nil {
-		if err := kubernetesutils.DeleteSecretByReference(ctx, a.gardenClient, spec.SecretRef); err != nil {
-			return err
-		}
-	}
-
 	return nil
 }
 
-func (a *actuator) getSeedSecrets(ctx context.Context, spec *gardencorev1beta1.SeedSpec, managedSeed *seedmanagementv1alpha1.ManagedSeed) (*corev1.Secret, *corev1.Secret, error) {
-	var secret, backupSecret *corev1.Secret
+func (a *actuator) getSeedSecrets(ctx context.Context, spec *gardencorev1beta1.SeedSpec, managedSeed *seedmanagementv1alpha1.ManagedSeed) (*corev1.Secret, error) {
+	var backupSecret *corev1.Secret
 	var err error
 
 	// If backup is specified, get the backup secret if it exists and is owned by the managed seed
 	if spec.Backup != nil {
 		backupSecret, err = kubernetesutils.GetSecretByReference(ctx, a.gardenClient, &spec.Backup.SecretRef)
 		if client.IgnoreNotFound(err) != nil {
-			return nil, nil, err
+			return nil, err
 		}
 		if backupSecret != nil && !metav1.IsControlledBy(backupSecret, managedSeed) {
 			backupSecret = nil
 		}
 	}
 
-	// If secret reference is specified, get the corresponding secret if it exists
-	if spec.SecretRef != nil {
-		secret, err = kubernetesutils.GetSecretByReference(ctx, a.gardenClient, spec.SecretRef)
-		if client.IgnoreNotFound(err) != nil {
-			return nil, nil, err
-		}
-	}
-
-	return secret, backupSecret, nil
+	return backupSecret, nil
 }
 
 func (a *actuator) getShootSecret(ctx context.Context, shoot *gardencorev1beta1.Shoot) (*corev1.Secret, error) {
@@ -649,14 +568,6 @@ func (a *actuator) getShootSecret(ctx context.Context, shoot *gardencorev1beta1.
 		return nil, err
 	}
 	return kubernetesutils.GetSecretByReference(ctx, a.gardenClient, &shootSecretBinding.SecretRef)
-}
-
-func (a *actuator) getShootKubeconfigSecret(ctx context.Context, shoot *gardencorev1beta1.Shoot) (*corev1.Secret, error) {
-	shootKubeconfigSecret := &corev1.Secret{}
-	if err := a.gardenClient.Get(ctx, kubernetesutils.Key(shoot.Namespace, gardenerutils.ComputeShootProjectSecretName(shoot.Name, gardenerutils.ShootProjectSecretSuffixKubeconfig)), shootKubeconfigSecret); err != nil {
-		return nil, err
-	}
-	return shootKubeconfigSecret, nil
 }
 
 func (a *actuator) seedVPADeploymentExists(ctx context.Context, seedClient client.Client, shoot *gardencorev1beta1.Shoot) (bool, error) {

--- a/pkg/gardenlet/controller/seed/seed/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/seed/seed/reconciler_reconcile.go
@@ -89,22 +89,6 @@ func (r *Reconciler) reconcile(
 		}
 	}
 
-	// Add the Gardener finalizer to the referenced Seed secret to protect it from deletion as long as the Seed resource
-	// does exist.
-	if seed.Spec.SecretRef != nil {
-		secret, err := kubernetesutils.GetSecretByReference(ctx, r.GardenClient, seed.Spec.SecretRef)
-		if err != nil {
-			return reconcile.Result{}, err
-		}
-
-		if !controllerutil.ContainsFinalizer(secret, gardencorev1beta1.ExternalGardenerName) {
-			log.Info("Adding finalizer to referenced secret", "secret", client.ObjectKeyFromObject(secret))
-			if err := controllerutils.AddFinalizers(ctx, r.GardenClient, secret, gardencorev1beta1.ExternalGardenerName); err != nil {
-				return reconcile.Result{}, err
-			}
-		}
-	}
-
 	// Check whether the Kubernetes version of the Seed cluster fulfills the minimal requirements.
 	if err := r.checkMinimumK8SVersion(r.SeedClientSet.Version()); err != nil {
 		return reconcile.Result{}, err

--- a/plugin/pkg/global/resourcereferencemanager/admission.go
+++ b/plugin/pkg/global/resourcereferencemanager/admission.go
@@ -261,16 +261,6 @@ func (r *ReferenceManager) Admit(ctx context.Context, a admission.Attributes, _ 
 		}
 		err = r.ensureSecretBindingReferences(ctx, a, binding)
 
-	case core.Kind("Seed"):
-		seed, ok := a.GetObject().(*core.Seed)
-		if !ok {
-			return apierrors.NewBadRequest("could not convert resource into Seed object")
-		}
-		if utils.SkipVerification(operation, seed.ObjectMeta) {
-			return nil
-		}
-		err = r.ensureSeedReferences(ctx, seed)
-
 	case core.Kind("Shoot"):
 		var (
 			oldShoot, shoot *core.Shoot
@@ -616,13 +606,6 @@ func (r *ReferenceManager) ensureSecretBindingReferences(ctx context.Context, at
 	}
 
 	return nil
-}
-
-func (r *ReferenceManager) ensureSeedReferences(ctx context.Context, seed *core.Seed) error {
-	if seed.Spec.SecretRef == nil {
-		return nil
-	}
-	return r.lookupSecret(ctx, seed.Spec.SecretRef.Namespace, seed.Spec.SecretRef.Name)
 }
 
 func (r *ReferenceManager) ensureShootReferences(ctx context.Context, attributes admission.Attributes, oldShoot, shoot *core.Shoot) error {

--- a/plugin/pkg/global/resourcereferencemanager/admission_test.go
+++ b/plugin/pkg/global/resourcereferencemanager/admission_test.go
@@ -137,7 +137,6 @@ var _ = Describe("resourcereferencemanager", func() {
 					Name:       seedName,
 					Finalizers: finalizers,
 				},
-				Spec: core.SeedSpec{},
 			}
 			quota = core.Quota{
 				ObjectMeta: metav1.ObjectMeta{

--- a/plugin/pkg/managedseed/validator/admission_test.go
+++ b/plugin/pkg/managedseed/validator/admission_test.go
@@ -157,10 +157,6 @@ var _ = Describe("ManagedSeed", func() {
 							Enabled: false,
 						},
 					},
-					SecretRef: &corev1.SecretReference{
-						Name:      "seed-secret",
-						Namespace: "garden",
-					},
 					Ingress: &core.Ingress{
 						Domain: "ingress." + domain,
 					},
@@ -336,10 +332,6 @@ var _ = Describe("ManagedSeed", func() {
 							SeedTemplate: gardencorev1beta1.SeedTemplate{
 								Spec: gardencorev1beta1.SeedSpec{
 									Backup: &gardencorev1beta1.SeedBackup{},
-									SecretRef: &corev1.SecretReference{
-										Name:      "seed-secret",
-										Namespace: "garden",
-									},
 								},
 							},
 						},
@@ -370,33 +362,6 @@ var _ = Describe("ManagedSeed", func() {
 						},
 					},
 				}))
-			})
-
-			It("should forbid setting seed secretRef if static token kubeconfig is disabled in the shoot", func() {
-				shoot.Spec.Kubernetes.EnableStaticTokenKubeconfig = pointer.Bool(false)
-				Expect(kubeInformerFactory.Core().V1().Secrets().Informer().GetStore().Add(secret)).To(Succeed())
-
-				err := admissionHandler.Admit(context.TODO(), getManagedSeedAttributes(managedSeed), nil)
-				Expect(err).To(BeInvalidError())
-				Expect(getErrorList(err)).To(ConsistOf(
-					PointTo(MatchFields(IgnoreExtras, Fields{
-						"Type":   Equal(field.ErrorTypeInvalid),
-						"Field":  Equal("spec.gardenlet.config.seedConfig.spec.secretRef"),
-						"Detail": ContainSubstring("seed secretRef cannot be specified when the shoot static token kubeconfig is disabled"),
-					})),
-				))
-			})
-
-			It("should add the secret reference annotations to the managedseed if spec.secretRef is present in the seed template", func() {
-				Expect(kubeInformerFactory.Core().V1().Secrets().Informer().GetStore().Add(secret)).To(Succeed())
-
-				err := admissionHandler.Admit(context.TODO(), getManagedSeedAttributes(managedSeed), nil)
-				Expect(err).NotTo(HaveOccurred())
-
-				Expect(managedSeed.Annotations).To(And(
-					HaveKeyWithValue("seedmanagement.gardener.cloud/seed-secret-name", "seed-secret"),
-					HaveKeyWithValue("seedmanagement.gardener.cloud/seed-secret-namespace", "garden"),
-				))
 			})
 
 			It("should fail if config could not be converted to GardenletConfiguration", func() {
@@ -430,10 +395,6 @@ var _ = Describe("ManagedSeed", func() {
 						Type:   "bar-provider",
 						Region: "bar-region",
 						Zones:  []string{"foo", "bar"},
-					},
-					SecretRef: &corev1.SecretReference{
-						Name:      name,
-						Namespace: namespace,
 					},
 					Settings: &gardencorev1beta1.SeedSettings{
 						VerticalPodAutoscaler: &gardencorev1beta1.SeedSettingVerticalPodAutoscaler{
@@ -620,10 +581,6 @@ var _ = Describe("ManagedSeed", func() {
 						SeedConfig: &gardenletv1alpha1.SeedConfig{
 							SeedTemplate: gardencorev1beta1.SeedTemplate{
 								Spec: gardencorev1beta1.SeedSpec{
-									SecretRef: &corev1.SecretReference{
-										Name:      "seed-secret",
-										Namespace: "garden",
-									},
 									Ingress: seedx.Spec.Ingress,
 									Provider: gardencorev1beta1.SeedProvider{
 										Zones: []string{zone1, zone2},
@@ -636,45 +593,6 @@ var _ = Describe("ManagedSeed", func() {
 					newManagedSeed = managedSeed.DeepCopy()
 
 					Expect(kubeInformerFactory.Core().V1().Secrets().Informer().GetStore().Add(secret)).To(Succeed())
-				})
-
-				It("should not remove the secret reference annotations if spec.secretRef is unset in the new managedseed", func() {
-					Expect(kubeInformerFactory.Core().V1().Secrets().Informer().GetStore().Add(secret)).To(Succeed())
-
-					err := admissionHandler.Admit(context.TODO(), getManagedSeedAttributes(managedSeed), nil)
-					Expect(err).NotTo(HaveOccurred())
-
-					Expect(managedSeed.Annotations).To(And(
-						HaveKeyWithValue("seedmanagement.gardener.cloud/seed-secret-name", "seed-secret"),
-						HaveKeyWithValue("seedmanagement.gardener.cloud/seed-secret-namespace", "garden"),
-					))
-
-					gardenletConfig := &gardenletv1alpha1.GardenletConfiguration{
-						TypeMeta: metav1.TypeMeta{
-							APIVersion: gardenletv1alpha1.SchemeGroupVersion.String(),
-							Kind:       "GardenletConfiguration",
-						},
-						SeedConfig: &gardenletv1alpha1.SeedConfig{
-							SeedTemplate: gardencorev1beta1.SeedTemplate{
-								Spec: gardencorev1beta1.SeedSpec{
-									SecretRef: nil,
-									Ingress:   seedx.Spec.Ingress,
-									Provider: gardencorev1beta1.SeedProvider{
-										Zones: []string{zone1, zone2},
-									},
-								},
-							},
-						},
-					}
-					newManagedSeed = managedSeed.DeepCopy()
-					newManagedSeed.Spec.Gardenlet = &seedmanagement.Gardenlet{Config: gardenletConfig}
-
-					Expect(admissionHandler.Admit(ctx, getManagedSeedUpdateAttributes(managedSeed, newManagedSeed), nil)).To(Succeed())
-
-					Expect(newManagedSeed.Annotations).To(And(
-						HaveKeyWithValue("seedmanagement.gardener.cloud/seed-secret-name", "seed-secret"),
-						HaveKeyWithValue("seedmanagement.gardener.cloud/seed-secret-namespace", "garden"),
-					))
 				})
 
 				It("should allow zone removal when there are no shoots running on seed", func() {

--- a/plugin/pkg/shoot/managedseed/admission.go
+++ b/plugin/pkg/shoot/managedseed/admission.go
@@ -25,7 +25,6 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/apiserver/pkg/admission"
-	"k8s.io/utils/pointer"
 
 	"github.com/gardener/gardener/pkg/apis/core"
 	gardencorehelper "github.com/gardener/gardener/pkg/apis/core/helper"
@@ -171,10 +170,6 @@ func (v *ManagedSeed) validateUpdate(ctx context.Context, a admission.Attributes
 	seedTemplate, _, err := seedmanagementv1alpha1helper.ExtractSeedTemplateAndGardenletConfig(managedSeed)
 	if err != nil {
 		return apierrors.NewInternalError(fmt.Errorf("cannot extract the seed template: %w", err))
-	}
-
-	if seedTemplate.Spec.SecretRef != nil && !pointer.BoolDeref(shoot.Spec.Kubernetes.EnableStaticTokenKubeconfig, false) {
-		allErrs = append(allErrs, field.Invalid(field.NewPath("spec", "kubernetes", "enableStaticTokenKubeconfig"), shoot.Spec.Kubernetes.EnableStaticTokenKubeconfig, "shoot static token kubeconfig cannot be disabled when the seed secretRef is set"))
 	}
 
 	zoneValidationErrs, err := v.validateZoneRemovalFromShoot(field.NewPath("spec", "providers", "workers"), oldShoot, shoot, seedTemplate)

--- a/plugin/pkg/shoot/managedseed/admission_test.go
+++ b/plugin/pkg/shoot/managedseed/admission_test.go
@@ -20,7 +20,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -217,37 +216,6 @@ var _ = Describe("ManagedSeed", func() {
 				Expect(err).To(HaveOccurred())
 				Expect(err).To(BeInternalServerError())
 				Expect(err).To(MatchError(ContainSubstring("cannot extract the seed template")))
-			})
-
-			It("should forbid Shoot update if shoot static token kubeconfig gets disabled and seed secretRef is set", func() {
-				seedConfig := &gardenletv1alpha1.SeedConfig{
-					SeedTemplate: gardencorev1beta1.SeedTemplate{
-						Spec: gardencorev1beta1.SeedSpec{
-							SecretRef: &corev1.SecretReference{
-								Name:      "foo",
-								Namespace: "garden",
-							},
-						},
-					},
-				}
-				managedSeed.Spec.Gardenlet = &seedmanagementv1alpha1.Gardenlet{
-					Config: runtime.RawExtension{
-						Object: &gardenletv1alpha1.GardenletConfiguration{
-							SeedConfig: seedConfig,
-						},
-					},
-				}
-				seedManagementClient.AddReactor("list", "managedseeds", func(action testing.Action) (bool, runtime.Object, error) {
-					return true, &seedmanagementv1alpha1.ManagedSeedList{Items: []seedmanagementv1alpha1.ManagedSeed{*managedSeed}}, nil
-				})
-				shoot.Spec.Kubernetes.EnableStaticTokenKubeconfig = pointer.Bool(true)
-				oldShoot := shoot.DeepCopy()
-				shoot.Spec.Kubernetes.EnableStaticTokenKubeconfig = pointer.Bool(false)
-				attrs := getShootAttributes(shoot, oldShoot, admission.Update, &metav1.UpdateOptions{})
-				err := admissionHandler.Validate(context.TODO(), attrs, nil)
-				Expect(err).To(HaveOccurred())
-				Expect(err).To(BeInvalidError())
-				Expect(err).To(MatchError(ContainSubstring("shoot static token kubeconfig cannot be disabled when the seed secretRef is set")))
 			})
 
 			It("should forbid Shoot update when zones have changed but still configured in ManagedSeed", func() {

--- a/plugin/pkg/shoot/validator/admission_test.go
+++ b/plugin/pkg/shoot/validator/admission_test.go
@@ -40,7 +40,6 @@ import (
 	"github.com/gardener/gardener/pkg/apis/core"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	gardencoreinformers "github.com/gardener/gardener/pkg/client/core/informers/internalversion"
-	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/controllerutils"
 	mockauthorizer "github.com/gardener/gardener/pkg/mock/apiserver/authorization/authorizer"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
@@ -105,17 +104,6 @@ var _ = Describe("validator", func() {
 			seedPodsCIDR     = "10.241.128.0/17"
 			seedServicesCIDR = "10.241.0.0/17"
 			seedNodesCIDR    = "10.240.0.0/16"
-			seedSecret       = corev1.Secret{
-				TypeMeta: metav1.TypeMeta{},
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      seedName,
-					Namespace: "garden",
-				},
-				Data: map[string][]byte{
-					kubernetes.KubeConfig: []byte(""),
-				},
-				Type: corev1.SecretTypeOpaque,
-			}
 
 			projectBase = core.Project{
 				ObjectMeta: metav1.ObjectMeta{
@@ -214,10 +202,6 @@ var _ = Describe("validator", func() {
 						Services:   seedServicesCIDR,
 						Nodes:      &seedNodesCIDR,
 						IPFamilies: []core.IPFamily{core.IPFamilyIPv4},
-					},
-					SecretRef: &corev1.SecretReference{
-						Name:      seedSecret.Name,
-						Namespace: seedSecret.Namespace,
 					},
 				},
 			}

--- a/skaffold-operator.yaml
+++ b/skaffold-operator.yaml
@@ -314,7 +314,6 @@ build:
             - pkg/apis/seedmanagement/helper
             - pkg/apis/seedmanagement/install
             - pkg/apis/seedmanagement/v1alpha1
-            - pkg/apis/seedmanagement/v1alpha1/constants
             - pkg/apis/seedmanagement/v1alpha1/helper
             - pkg/apis/seedmanagement/validation
             - pkg/apis/settings
@@ -677,7 +676,6 @@ build:
             - pkg/apis/seedmanagement/encoding
             - pkg/apis/seedmanagement/install
             - pkg/apis/seedmanagement/v1alpha1
-            - pkg/apis/seedmanagement/v1alpha1/constants
             - pkg/apis/seedmanagement/v1alpha1/helper
             - pkg/apis/settings
             - pkg/apis/settings/install

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -54,7 +54,6 @@ build:
             - pkg/apis/seedmanagement/helper
             - pkg/apis/seedmanagement/install
             - pkg/apis/seedmanagement/v1alpha1
-            - pkg/apis/seedmanagement/v1alpha1/constants
             - pkg/apis/seedmanagement/v1alpha1/helper
             - pkg/apis/seedmanagement/validation
             - pkg/apis/settings
@@ -417,7 +416,6 @@ build:
             - pkg/apis/seedmanagement/encoding
             - pkg/apis/seedmanagement/install
             - pkg/apis/seedmanagement/v1alpha1
-            - pkg/apis/seedmanagement/v1alpha1/constants
             - pkg/apis/seedmanagement/v1alpha1/helper
             - pkg/apis/settings
             - pkg/apis/settings/install
@@ -805,7 +803,6 @@ build:
             - pkg/apis/seedmanagement/encoding
             - pkg/apis/seedmanagement/install
             - pkg/apis/seedmanagement/v1alpha1
-            - pkg/apis/seedmanagement/v1alpha1/constants
             - pkg/apis/seedmanagement/v1alpha1/helper
             - pkg/apis/settings
             - pkg/apis/settings/install

--- a/test/framework/gardener_utils.go
+++ b/test/framework/gardener_utils.go
@@ -60,7 +60,7 @@ func (f *GardenerFramework) GetSeed(ctx context.Context, seedName string) (*gard
 		if apierrors.IsNotFound(err) {
 			f.Logger.Info("Seed is not a ManagedSeed, checking seed secret")
 
-			// here we expect seed kubeconfig secret is created in Garden for testing
+			// For tests, we expect the seed kubeconfig secret to be present in the garden namespace
 			seedSecret := &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "seed-" + seedName,
@@ -69,7 +69,7 @@ func (f *GardenerFramework) GetSeed(ctx context.Context, seedName string) (*gard
 			}
 
 			if err := f.GardenClient.Client().Get(ctx, client.ObjectKeyFromObject(seedSecret), seedSecret); err != nil {
-				return seed, nil, fmt.Errorf("seed is not a ManagedSeed also seed kubeconfig secret is not present in Garden, %s: %w", client.ObjectKeyFromObject(seed), err)
+				return seed, nil, fmt.Errorf("seed is not a ManagedSeed also no seed kubeconfig secret present in the garden namespace, %s: %w", client.ObjectKeyFromObject(seed), err)
 			}
 
 			seedClient, err := kubernetes.NewClientFromSecret(ctx, f.GardenClient.Client(), seedSecret.Namespace, seedSecret.Name,

--- a/test/framework/gardener_utils.go
+++ b/test/framework/gardener_utils.go
@@ -58,7 +58,29 @@ func (f *GardenerFramework) GetSeed(ctx context.Context, seedName string) (*gard
 	managedSeed := &seedmanagementv1alpha1.ManagedSeed{}
 	if err := f.GardenClient.Client().Get(ctx, kubernetesutils.Key(v1beta1constants.GardenNamespace, seed.Name), managedSeed); err != nil {
 		if apierrors.IsNotFound(err) {
-			return seed, nil, fmt.Errorf("Seed is not a ManagedSeed, %s: %w", client.ObjectKeyFromObject(seed), err)
+			f.Logger.Info("Seed is not a ManagedSeed, checking seed secret")
+
+			// here we expect seed kubeconfig secret is created in Garden for testing
+			seedSecret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "seed-" + seedName,
+					Namespace: "garden",
+				},
+			}
+
+			if err := f.GardenClient.Client().Get(ctx, client.ObjectKeyFromObject(seedSecret), seedSecret); err != nil {
+				return seed, nil, fmt.Errorf("seed is not a ManagedSeed also seed kubeconfig secret is not present in Garden, %s: %w", client.ObjectKeyFromObject(seed), err)
+			}
+
+			seedClient, err := kubernetes.NewClientFromSecret(ctx, f.GardenClient.Client(), seedSecret.Namespace, seedSecret.Name,
+				kubernetes.WithClientOptions(client.Options{Scheme: kubernetes.SeedScheme}),
+				kubernetes.WithDisabledCachedClient(),
+			)
+			if err != nil {
+				return nil, nil, fmt.Errorf("could not construct Seed client: %w", err)
+			}
+
+			return seed, seedClient, nil
 		}
 
 		return seed, nil, fmt.Errorf("failed to get ManagedSeed for Seed, %s: %w", client.ObjectKeyFromObject(seed), err)

--- a/test/framework/gardener_utils.go
+++ b/test/framework/gardener_utils.go
@@ -58,23 +58,9 @@ func (f *GardenerFramework) GetSeed(ctx context.Context, seedName string) (*gard
 	managedSeed := &seedmanagementv1alpha1.ManagedSeed{}
 	if err := f.GardenClient.Client().Get(ctx, kubernetesutils.Key(v1beta1constants.GardenNamespace, seed.Name), managedSeed); err != nil {
 		if apierrors.IsNotFound(err) {
-			f.Logger.Info("Seed is not a ManagedSeed, checking seed.spec.secretRef")
-
-			seedSecretRef := seed.Spec.SecretRef
-			if seedSecretRef == nil {
-				f.Logger.Info("Seed does not have secretRef set, skip constructing seed client")
-				return seed, nil, nil
-			}
-
-			seedClient, err := kubernetes.NewClientFromSecret(ctx, f.GardenClient.Client(), seedSecretRef.Namespace, seedSecretRef.Name,
-				kubernetes.WithClientOptions(client.Options{Scheme: kubernetes.SeedScheme}),
-				kubernetes.WithDisabledCachedClient(),
-			)
-			if err != nil {
-				return nil, nil, fmt.Errorf("could not construct Seed client: %w", err)
-			}
-			return seed, seedClient, nil
+			return seed, nil, fmt.Errorf("Seed is not a ManagedSeed, %s: %w", client.ObjectKeyFromObject(seed), err)
 		}
+
 		return seed, nil, fmt.Errorf("failed to get ManagedSeed for Seed, %s: %w", client.ObjectKeyFromObject(seed), err)
 	}
 

--- a/test/framework/shootcreationframework.go
+++ b/test/framework/shootcreationframework.go
@@ -434,16 +434,6 @@ func (f *ShootCreationFramework) CreateShootAndWaitForCreation(ctx context.Conte
 		}
 	}
 
-	if f.Config.seedKubeconfigPath == "" {
-		f.Logger.Info("Seed kubeconfig path is not specified, skipping downloading the static token kubeconfig for the Seed")
-	} else if seedSecretRef := shootFramework.Seed.Spec.SecretRef; seedSecretRef == nil {
-		f.Logger.Info("Seed does not have secretRef set, skipping constructing seed client")
-	} else {
-		if err := DownloadKubeconfig(ctx, shootFramework.GardenClient, shootFramework.Seed.Spec.SecretRef.Namespace, shootFramework.Seed.Spec.SecretRef.Name, f.Config.seedKubeconfigPath); err != nil {
-			return fmt.Errorf("failed downloading seed kubeconfig: %w", err)
-		}
-	}
-
 	log.Info("Finished creating shoot")
 	return nil
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind api-change
/kind cleanup

**What this PR does / why we need it**:
https://github.com/gardener/gardener/pull/8064 deprecated field `seed.spec.secretRef`, as a subsequent step this PR drops the usage of `secretRef` and in the subsequent release, the field will be dropped from the API.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/7597

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
All the functionality related to the deprecated field `seed.spec.secretRef` has been removed and subsequently `seed.spec.secretRef` will be dropped from the Seed API in a later release of Gardener. Please check your `Seed`s and remove any usage before upgrading to this Gardener version.
```
