### PR TITLE
[provider-local] Adapt to changes needed for `gardener-node-agent`

### DIFF
--- a/cmd/gardener-extension-provider-local/app/app.go
+++ b/cmd/gardener-extension-provider-local/app/app.go
@@ -62,6 +62,7 @@ import (
 	localservice "github.com/gardener/gardener/pkg/provider-local/controller/service"
 	localworker "github.com/gardener/gardener/pkg/provider-local/controller/worker"
 	"github.com/gardener/gardener/pkg/provider-local/local"
+	controlplanewebhook "github.com/gardener/gardener/pkg/provider-local/webhook/controlplane"
 	"github.com/gardener/gardener/pkg/utils/retry"
 )
 
@@ -267,6 +268,7 @@ func NewControllerManagerCommand(ctx context.Context) *cobra.Command {
 			// TODO(rfranzke): Remove the UseGardenerNodeAgent fields as soon as the general options no longer support
 			//  the GardenletUsesGardenerNodeAgent field.
 			localoperatingsystemconfig.DefaultAddOptions.UseGardenerNodeAgent = generalOpts.Completed().GardenletUsesGardenerNodeAgent
+			controlplanewebhook.UseGardenerNodeAgent = generalOpts.Completed().GardenletUsesGardenerNodeAgent
 
 			if err := mgr.AddReadyzCheck("informer-sync", gardenerhealthz.NewCacheSyncHealthz(mgr.GetCache())); err != nil {
 				return fmt.Errorf("could not add readycheck for informers: %w", err)

--- a/cmd/gardener-extension-provider-local/app/options.go
+++ b/cmd/gardener-extension-provider-local/app/options.go
@@ -44,6 +44,7 @@ import (
 	"github.com/gardener/gardener/pkg/provider-local/webhook/machinecontrollermanager"
 	networkpolicywebhook "github.com/gardener/gardener/pkg/provider-local/webhook/networkpolicy"
 	nodewebhook "github.com/gardener/gardener/pkg/provider-local/webhook/node"
+	"github.com/gardener/gardener/pkg/provider-local/webhook/nodeagentosc"
 	shootwebhook "github.com/gardener/gardener/pkg/provider-local/webhook/shoot"
 )
 
@@ -77,5 +78,6 @@ func WebhookSwitchOptions() *extensionscmdwebhook.SwitchOptions {
 		extensionscmdwebhook.Switch(nodewebhook.WebhookName, nodewebhook.AddToManager),
 		extensionscmdwebhook.Switch(nodewebhook.WebhookNameShoot, nodewebhook.AddShootWebhookToManager),
 		extensionscmdwebhook.Switch(machinecontrollermanager.WebhookName, machinecontrollermanager.AddToManager),
+		extensionscmdwebhook.Switch(nodeagentosc.WebhookName, nodeagentosc.AddToManager),
 	)
 }

--- a/extensions/pkg/webhook/controlplane/genericmutator/mock/mocks.go
+++ b/extensions/pkg/webhook/controlplane/genericmutator/mock/mocks.go
@@ -57,6 +57,34 @@ func (mr *MockEnsurerMockRecorder) EnsureAdditionalFiles(arg0, arg1, arg2, arg3 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureAdditionalFiles", reflect.TypeOf((*MockEnsurer)(nil).EnsureAdditionalFiles), arg0, arg1, arg2, arg3)
 }
 
+// EnsureAdditionalProvisionFiles mocks base method.
+func (m *MockEnsurer) EnsureAdditionalProvisionFiles(arg0 context.Context, arg1 context0.GardenContext, arg2, arg3 *[]v1alpha10.File) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "EnsureAdditionalProvisionFiles", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// EnsureAdditionalProvisionFiles indicates an expected call of EnsureAdditionalProvisionFiles.
+func (mr *MockEnsurerMockRecorder) EnsureAdditionalProvisionFiles(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureAdditionalProvisionFiles", reflect.TypeOf((*MockEnsurer)(nil).EnsureAdditionalProvisionFiles), arg0, arg1, arg2, arg3)
+}
+
+// EnsureAdditionalProvisionUnits mocks base method.
+func (m *MockEnsurer) EnsureAdditionalProvisionUnits(arg0 context.Context, arg1 context0.GardenContext, arg2, arg3 *[]v1alpha10.Unit) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "EnsureAdditionalProvisionUnits", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// EnsureAdditionalProvisionUnits indicates an expected call of EnsureAdditionalProvisionUnits.
+func (mr *MockEnsurerMockRecorder) EnsureAdditionalProvisionUnits(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureAdditionalProvisionUnits", reflect.TypeOf((*MockEnsurer)(nil).EnsureAdditionalProvisionUnits), arg0, arg1, arg2, arg3)
+}
+
 // EnsureAdditionalUnits mocks base method.
 func (m *MockEnsurer) EnsureAdditionalUnits(arg0 context.Context, arg1 context0.GardenContext, arg2, arg3 *[]v1alpha10.Unit) error {
 	m.ctrl.T.Helper()

--- a/extensions/pkg/webhook/controlplane/genericmutator/mutator_test.go
+++ b/extensions/pkg/webhook/controlplane/genericmutator/mutator_test.go
@@ -323,208 +323,247 @@ var _ = Describe("Mutator", func() {
 		)
 
 		Context("OperatingSystemConfig mutation", func() {
-			var (
-				newOSC               *extensionsv1alpha1.OperatingSystemConfig
-				oldUnitOptions       []*unit.UnitOption
-				newUnitOptions       []*unit.UnitOption
-				mutatedUnitOptions   []*unit.UnitOption
-				oldKubeletConfig     *kubeletconfigv1beta1.KubeletConfiguration
-				newKubeletConfig     *kubeletconfigv1beta1.KubeletConfiguration
-				mutatedKubeletConfig *kubeletconfigv1beta1.KubeletConfiguration
-				additionalUnit       = extensionsv1alpha1.Unit{Name: "custom-mtu.service"}
-				additionalFile       = extensionsv1alpha1.File{Path: "/test/path"}
-			)
+			var newOSC *extensionsv1alpha1.OperatingSystemConfig
 
-			BeforeEach(func() {
-				newOSC = &extensionsv1alpha1.OperatingSystemConfig{
-					ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "test"},
-					Spec: extensionsv1alpha1.OperatingSystemConfigSpec{
-						Purpose: extensionsv1alpha1.OperatingSystemConfigPurposeReconcile,
-						Units: []extensionsv1alpha1.Unit{
-							{
-								Name:    v1beta1constants.OperatingSystemConfigUnitNameKubeletService,
-								Content: pointer.String(newServiceContent),
-							},
-						},
-						Files: []extensionsv1alpha1.File{
-							{
-								Path: v1beta1constants.OperatingSystemConfigFilePathKubeletConfig,
-								Content: extensionsv1alpha1.FileContent{
-									Inline: &extensionsv1alpha1.FileContentInline{
-										Data: newKubeletConfigData,
-									},
-								},
-							},
-							{
-								Path: v1beta1constants.OperatingSystemConfigFilePathKernelSettings,
-								Content: extensionsv1alpha1.FileContent{
-									Inline: &extensionsv1alpha1.FileContentInline{
-										Data: newKubernetesGeneralConfigData,
-									},
-								},
-							},
-						},
-					},
-				}
-				oldUnitOptions = []*unit.UnitOption{
-					{
-						Section: "Service",
-						Name:    "Foo",
-						Value:   "old",
-					},
-				}
-				newUnitOptions = []*unit.UnitOption{
-					{
-						Section: "Service",
-						Name:    "Foo",
-						Value:   "bar",
-					},
-				}
-				mutatedUnitOptions = []*unit.UnitOption{
-					{
-						Section: "Service",
-						Name:    "Foo",
-						Value:   "baz",
-					},
-				}
-				oldKubeletConfig = &kubeletconfigv1beta1.KubeletConfiguration{
-					FeatureGates: map[string]bool{
-						"Old": true,
-					},
-				}
-				newKubeletConfig = &kubeletconfigv1beta1.KubeletConfiguration{
-					FeatureGates: map[string]bool{
-						"Foo": true,
-						"Bar": true,
-					},
-				}
-				mutatedKubeletConfig = &kubeletconfigv1beta1.KubeletConfiguration{
-					FeatureGates: map[string]bool{
-						"Foo": true,
-					},
-				}
+			Context("provision purpose", func() {
+				var (
+					additionalUnit = extensionsv1alpha1.Unit{Name: "custom-provision-unit.service"}
+					additionalFile = extensionsv1alpha1.File{Path: "/test/provision"}
+				)
 
-				c.EXPECT().Get(context.TODO(), clusterKey, &extensionsv1alpha1.Cluster{}).DoAndReturn(clientGet(clusterObject(cluster)))
+				BeforeEach(func() {
+					newOSC = &extensionsv1alpha1.OperatingSystemConfig{
+						ObjectMeta: metav1.ObjectMeta{Name: "test-provision", Namespace: "test"},
+						Spec: extensionsv1alpha1.OperatingSystemConfigSpec{
+							Purpose: extensionsv1alpha1.OperatingSystemConfigPurposeProvision,
+						},
+					}
+				})
+
+				It("should invoke appropriate ensurer methods with OperatingSystemConfig", func() {
+					oldProvisionOSC := newOSC.DeepCopy()
+
+					// Create mock ensurer
+					ensurer.EXPECT().EnsureAdditionalProvisionUnits(context.TODO(), gomock.Any(), &newOSC.Spec.Units, &oldProvisionOSC.Spec.Units).DoAndReturn(
+						func(ctx context.Context, gctx extensionscontextwebhook.GardenContext, oscUnits, oldOSCUnits *[]extensionsv1alpha1.Unit) error {
+							*oscUnits = append(*oscUnits, additionalUnit)
+							return nil
+						})
+					ensurer.EXPECT().EnsureAdditionalProvisionFiles(context.TODO(), gomock.Any(), &newOSC.Spec.Files, &oldProvisionOSC.Spec.Files).DoAndReturn(
+						func(ctx context.Context, gctx extensionscontextwebhook.GardenContext, oscFiles, oldOSCFiles *[]extensionsv1alpha1.File) error {
+							*oscFiles = append(*oscFiles, additionalFile)
+							return nil
+						})
+
+					// Call Mutate method and check the result
+					err := mutator.Mutate(context.TODO(), newOSC, oldProvisionOSC)
+					Expect(err).To(Not(HaveOccurred()))
+					checkProvisionOperatingSystemConfig(newOSC)
+				})
 			})
 
-			It("should invoke appropriate ensurer methods with OperatingSystemConfig", func() {
-				oldOSC := newOSC.DeepCopy()
-				oldOSC.Spec.Units[0].Content = pointer.String(oldServiceContent)
-				oldOSC.Spec.Files[0].Content.Inline.Data = oldKubeletConfigData
-				oldOSC.Spec.Files[1].Content.Inline.Data = oldKubernetesGeneralConfigData
-
-				// Create mock ensurer
-				ensurer.EXPECT().EnsureKubeletServiceUnitOptions(context.TODO(), gomock.Any(), kubernetesVersionSemver, newUnitOptions, oldUnitOptions).Return(mutatedUnitOptions, nil)
-				ensurer.EXPECT().EnsureKubeletConfiguration(context.TODO(), gomock.Any(), kubernetesVersionSemver, newKubeletConfig, oldKubeletConfig).DoAndReturn(
-					func(ctx context.Context, gctx extensionscontextwebhook.GardenContext, kubeletVersion *semver.Version, kubeletConfig, newKubeletConfig *kubeletconfigv1beta1.KubeletConfiguration) error {
-						*kubeletConfig = *mutatedKubeletConfig
-						return nil
-					},
-				)
-				ensurer.EXPECT().EnsureKubernetesGeneralConfiguration(context.TODO(), gomock.Any(), pointer.String(newKubernetesGeneralConfigData), pointer.String(oldKubernetesGeneralConfigData)).DoAndReturn(
-					func(ctx context.Context, gctx extensionscontextwebhook.GardenContext, newData, data *string) error {
-						*newData = mutatedKubernetesGeneralConfigData
-						return nil
-					},
-				)
-				ensurer.EXPECT().EnsureAdditionalUnits(context.TODO(), gomock.Any(), &newOSC.Spec.Units, &oldOSC.Spec.Units).DoAndReturn(
-					func(ctx context.Context, gctx extensionscontextwebhook.GardenContext, oscUnits, oldOSCUnits *[]extensionsv1alpha1.Unit) error {
-						*oscUnits = append(*oscUnits, additionalUnit)
-						return nil
-					})
-				ensurer.EXPECT().EnsureAdditionalFiles(context.TODO(), gomock.Any(), &newOSC.Spec.Files, &oldOSC.Spec.Files).DoAndReturn(
-					func(ctx context.Context, gctx extensionscontextwebhook.GardenContext, oscFiles, oldOSCFiles *[]extensionsv1alpha1.File) error {
-						*oscFiles = append(*oscFiles, additionalFile)
-						return nil
-					})
-
-				ensurer.EXPECT().ShouldProvisionKubeletCloudProviderConfig(context.TODO(), gomock.Any(), kubernetesVersionSemver).Return(true)
-				ensurer.EXPECT().EnsureKubeletCloudProviderConfig(context.TODO(), gomock.Any(), kubernetesVersionSemver, gomock.Any(), newOSC.Namespace).DoAndReturn(
-					func(ctx context.Context, gctx extensionscontextwebhook.GardenContext, kubeletVersion *semver.Version, data *string, _ string) error {
-						*data = cloudproviderconf
-						return nil
-					},
+			Context("reconcile purpose", func() {
+				var (
+					oldUnitOptions       []*unit.UnitOption
+					newUnitOptions       []*unit.UnitOption
+					mutatedUnitOptions   []*unit.UnitOption
+					oldKubeletConfig     *kubeletconfigv1beta1.KubeletConfiguration
+					newKubeletConfig     *kubeletconfigv1beta1.KubeletConfiguration
+					mutatedKubeletConfig *kubeletconfigv1beta1.KubeletConfiguration
+					additionalUnit       = extensionsv1alpha1.Unit{Name: "custom-mtu.service"}
+					additionalFile       = extensionsv1alpha1.File{Path: "/test/path"}
 				)
 
-				us.EXPECT().Deserialize(newServiceContent).Return(newUnitOptions, nil)
-				us.EXPECT().Deserialize(oldServiceContent).Return(oldUnitOptions, nil)
-				us.EXPECT().Serialize(mutatedUnitOptions).Return(mutatedServiceContent, nil)
+				BeforeEach(func() {
+					newOSC = &extensionsv1alpha1.OperatingSystemConfig{
+						ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "test"},
+						Spec: extensionsv1alpha1.OperatingSystemConfigSpec{
+							Purpose: extensionsv1alpha1.OperatingSystemConfigPurposeReconcile,
+							Units: []extensionsv1alpha1.Unit{
+								{
+									Name:    v1beta1constants.OperatingSystemConfigUnitNameKubeletService,
+									Content: pointer.String(newServiceContent),
+								},
+							},
+							Files: []extensionsv1alpha1.File{
+								{
+									Path: v1beta1constants.OperatingSystemConfigFilePathKubeletConfig,
+									Content: extensionsv1alpha1.FileContent{
+										Inline: &extensionsv1alpha1.FileContentInline{
+											Data: newKubeletConfigData,
+										},
+									},
+								},
+								{
+									Path: v1beta1constants.OperatingSystemConfigFilePathKernelSettings,
+									Content: extensionsv1alpha1.FileContent{
+										Inline: &extensionsv1alpha1.FileContentInline{
+											Data: newKubernetesGeneralConfigData,
+										},
+									},
+								},
+							},
+						},
+					}
+					oldUnitOptions = []*unit.UnitOption{
+						{
+							Section: "Service",
+							Name:    "Foo",
+							Value:   "old",
+						},
+					}
+					newUnitOptions = []*unit.UnitOption{
+						{
+							Section: "Service",
+							Name:    "Foo",
+							Value:   "bar",
+						},
+					}
+					mutatedUnitOptions = []*unit.UnitOption{
+						{
+							Section: "Service",
+							Name:    "Foo",
+							Value:   "baz",
+						},
+					}
+					oldKubeletConfig = &kubeletconfigv1beta1.KubeletConfiguration{
+						FeatureGates: map[string]bool{
+							"Old": true,
+						},
+					}
+					newKubeletConfig = &kubeletconfigv1beta1.KubeletConfiguration{
+						FeatureGates: map[string]bool{
+							"Foo": true,
+							"Bar": true,
+						},
+					}
+					mutatedKubeletConfig = &kubeletconfigv1beta1.KubeletConfiguration{
+						FeatureGates: map[string]bool{
+							"Foo": true,
+						},
+					}
 
-				kcc.EXPECT().Decode(&extensionsv1alpha1.FileContentInline{Data: newKubeletConfigData}).Return(newKubeletConfig, nil)
-				kcc.EXPECT().Decode(&extensionsv1alpha1.FileContentInline{Data: oldKubeletConfigData}).Return(oldKubeletConfig, nil)
-				kcc.EXPECT().Encode(mutatedKubeletConfig, "").Return(&extensionsv1alpha1.FileContentInline{Data: mutatedKubeletConfigData}, nil)
+					c.EXPECT().Get(context.TODO(), clusterKey, &extensionsv1alpha1.Cluster{}).DoAndReturn(clientGet(clusterObject(cluster)))
+				})
 
-				fcic.EXPECT().Decode(&extensionsv1alpha1.FileContentInline{Data: newKubernetesGeneralConfigData}).Return([]byte(newKubernetesGeneralConfigData), nil)
-				fcic.EXPECT().Decode(&extensionsv1alpha1.FileContentInline{Data: oldKubernetesGeneralConfigData}).Return([]byte(oldKubernetesGeneralConfigData), nil)
-				fcic.EXPECT().Encode([]byte(mutatedKubernetesGeneralConfigData), "").Return(&extensionsv1alpha1.FileContentInline{Data: mutatedKubernetesGeneralConfigData}, nil)
-				fcic.EXPECT().Encode([]byte(cloudproviderconf), encoding).Return(&extensionsv1alpha1.FileContentInline{Data: cloudproviderconfEncoded, Encoding: encoding}, nil)
+				It("should invoke appropriate ensurer methods with OperatingSystemConfig", func() {
+					oldOSC := newOSC.DeepCopy()
+					oldOSC.Spec.Units[0].Content = pointer.String(oldServiceContent)
+					oldOSC.Spec.Files[0].Content.Inline.Data = oldKubeletConfigData
+					oldOSC.Spec.Files[1].Content.Inline.Data = oldKubernetesGeneralConfigData
 
-				// Call Mutate method and check the result
-				err := mutator.Mutate(context.TODO(), newOSC, oldOSC)
-				Expect(err).To(Not(HaveOccurred()))
-				checkOperatingSystemConfig(newOSC)
-			},
-			)
+					// Create mock ensurer
+					ensurer.EXPECT().EnsureKubeletServiceUnitOptions(context.TODO(), gomock.Any(), kubernetesVersionSemver, newUnitOptions, oldUnitOptions).Return(mutatedUnitOptions, nil)
+					ensurer.EXPECT().EnsureKubeletConfiguration(context.TODO(), gomock.Any(), kubernetesVersionSemver, newKubeletConfig, oldKubeletConfig).DoAndReturn(
+						func(ctx context.Context, gctx extensionscontextwebhook.GardenContext, kubeletVersion *semver.Version, kubeletConfig, newKubeletConfig *kubeletconfigv1beta1.KubeletConfiguration) error {
+							*kubeletConfig = *mutatedKubeletConfig
+							return nil
+						},
+					)
+					ensurer.EXPECT().EnsureKubernetesGeneralConfiguration(context.TODO(), gomock.Any(), pointer.String(newKubernetesGeneralConfigData), pointer.String(oldKubernetesGeneralConfigData)).DoAndReturn(
+						func(ctx context.Context, gctx extensionscontextwebhook.GardenContext, newData, data *string) error {
+							*newData = mutatedKubernetesGeneralConfigData
+							return nil
+						},
+					)
+					ensurer.EXPECT().EnsureAdditionalUnits(context.TODO(), gomock.Any(), &newOSC.Spec.Units, &oldOSC.Spec.Units).DoAndReturn(
+						func(ctx context.Context, gctx extensionscontextwebhook.GardenContext, oscUnits, oldOSCUnits *[]extensionsv1alpha1.Unit) error {
+							*oscUnits = append(*oscUnits, additionalUnit)
+							return nil
+						})
+					ensurer.EXPECT().EnsureAdditionalFiles(context.TODO(), gomock.Any(), &newOSC.Spec.Files, &oldOSC.Spec.Files).DoAndReturn(
+						func(ctx context.Context, gctx extensionscontextwebhook.GardenContext, oscFiles, oldOSCFiles *[]extensionsv1alpha1.File) error {
+							*oscFiles = append(*oscFiles, additionalFile)
+							return nil
+						})
 
-			It("should not add invalid file content to OSC", func() {
-				oldOSC := newOSC.DeepCopy()
-				oldOSC.Spec.Units[0].Content = pointer.String(oldServiceContent)
-				oldOSC.Spec.Files[0].Content.Inline.Data = oldKubeletConfigData
-				oldOSC.Spec.Files[1].Content.Inline.Data = oldKubernetesGeneralConfigData
+					ensurer.EXPECT().ShouldProvisionKubeletCloudProviderConfig(context.TODO(), gomock.Any(), kubernetesVersionSemver).Return(true)
+					ensurer.EXPECT().EnsureKubeletCloudProviderConfig(context.TODO(), gomock.Any(), kubernetesVersionSemver, gomock.Any(), newOSC.Namespace).DoAndReturn(
+						func(ctx context.Context, gctx extensionscontextwebhook.GardenContext, kubeletVersion *semver.Version, data *string, _ string) error {
+							*data = cloudproviderconf
+							return nil
+						},
+					)
 
-				// Create mock ensurer
-				ensurer.EXPECT().EnsureKubeletServiceUnitOptions(context.TODO(), gomock.Any(), kubernetesVersionSemver, newUnitOptions, oldUnitOptions).Return(mutatedUnitOptions, nil)
-				ensurer.EXPECT().EnsureKubeletConfiguration(context.TODO(), gomock.Any(), kubernetesVersionSemver, newKubeletConfig, oldKubeletConfig).DoAndReturn(
-					func(ctx context.Context, gctx extensionscontextwebhook.GardenContext, kubeletVersion *semver.Version, kubeletConfig, newKubeletConfig *kubeletconfigv1beta1.KubeletConfiguration) error {
-						*kubeletConfig = *mutatedKubeletConfig
-						return nil
-					},
-				)
-				ensurer.EXPECT().EnsureKubernetesGeneralConfiguration(context.TODO(), gomock.Any(), pointer.String(newKubernetesGeneralConfigData), pointer.String(oldKubernetesGeneralConfigData)).DoAndReturn(
-					func(ctx context.Context, gctx extensionscontextwebhook.GardenContext, newData, data *string) error {
-						*newData = ""
-						return nil
-					},
-				)
-				ensurer.EXPECT().EnsureAdditionalUnits(context.TODO(), gomock.Any(), &newOSC.Spec.Units, &oldOSC.Spec.Units).DoAndReturn(
-					func(ctx context.Context, gctx extensionscontextwebhook.GardenContext, oscUnits, oldOSCUnits *[]extensionsv1alpha1.Unit) error {
-						*oscUnits = append(*oscUnits, additionalUnit)
-						return nil
-					})
-				ensurer.EXPECT().EnsureAdditionalFiles(context.TODO(), gomock.Any(), &newOSC.Spec.Files, &oldOSC.Spec.Files).DoAndReturn(
-					func(ctx context.Context, gctx extensionscontextwebhook.GardenContext, oscFiles, oldOSCFiles *[]extensionsv1alpha1.File) error {
-						*oscFiles = append(*oscFiles, additionalFile)
-						return nil
-					})
+					us.EXPECT().Deserialize(newServiceContent).Return(newUnitOptions, nil)
+					us.EXPECT().Deserialize(oldServiceContent).Return(oldUnitOptions, nil)
+					us.EXPECT().Serialize(mutatedUnitOptions).Return(mutatedServiceContent, nil)
 
-				ensurer.EXPECT().ShouldProvisionKubeletCloudProviderConfig(context.TODO(), gomock.Any(), kubernetesVersionSemver).Return(true)
-				ensurer.EXPECT().EnsureKubeletCloudProviderConfig(context.TODO(), gomock.Any(), kubernetesVersionSemver, gomock.Any(), newOSC.Namespace).DoAndReturn(
-					func(ctx context.Context, gctx extensionscontextwebhook.GardenContext, kubeletVersion *semver.Version, data *string, _ string) error {
-						*data = ""
-						return nil
-					},
-				)
+					kcc.EXPECT().Decode(&extensionsv1alpha1.FileContentInline{Data: newKubeletConfigData}).Return(newKubeletConfig, nil)
+					kcc.EXPECT().Decode(&extensionsv1alpha1.FileContentInline{Data: oldKubeletConfigData}).Return(oldKubeletConfig, nil)
+					kcc.EXPECT().Encode(mutatedKubeletConfig, "").Return(&extensionsv1alpha1.FileContentInline{Data: mutatedKubeletConfigData}, nil)
 
-				us.EXPECT().Deserialize(newServiceContent).Return(newUnitOptions, nil)
-				us.EXPECT().Deserialize(oldServiceContent).Return(oldUnitOptions, nil)
-				us.EXPECT().Serialize(mutatedUnitOptions).Return(mutatedServiceContent, nil)
+					fcic.EXPECT().Decode(&extensionsv1alpha1.FileContentInline{Data: newKubernetesGeneralConfigData}).Return([]byte(newKubernetesGeneralConfigData), nil)
+					fcic.EXPECT().Decode(&extensionsv1alpha1.FileContentInline{Data: oldKubernetesGeneralConfigData}).Return([]byte(oldKubernetesGeneralConfigData), nil)
+					fcic.EXPECT().Encode([]byte(mutatedKubernetesGeneralConfigData), "").Return(&extensionsv1alpha1.FileContentInline{Data: mutatedKubernetesGeneralConfigData}, nil)
+					fcic.EXPECT().Encode([]byte(cloudproviderconf), encoding).Return(&extensionsv1alpha1.FileContentInline{Data: cloudproviderconfEncoded, Encoding: encoding}, nil)
 
-				kcc.EXPECT().Decode(&extensionsv1alpha1.FileContentInline{Data: newKubeletConfigData}).Return(newKubeletConfig, nil)
-				kcc.EXPECT().Decode(&extensionsv1alpha1.FileContentInline{Data: oldKubeletConfigData}).Return(oldKubeletConfig, nil)
-				kcc.EXPECT().Encode(mutatedKubeletConfig, "").Return(&extensionsv1alpha1.FileContentInline{Data: mutatedKubeletConfigData}, nil)
+					// Call Mutate method and check the result
+					err := mutator.Mutate(context.TODO(), newOSC, oldOSC)
+					Expect(err).To(Not(HaveOccurred()))
+					checkOperatingSystemConfig(newOSC)
+				})
 
-				fcic.EXPECT().Decode(&extensionsv1alpha1.FileContentInline{Data: newKubernetesGeneralConfigData}).Return([]byte(newKubernetesGeneralConfigData), nil)
-				fcic.EXPECT().Decode(&extensionsv1alpha1.FileContentInline{Data: oldKubernetesGeneralConfigData}).Return([]byte(oldKubernetesGeneralConfigData), nil)
+				It("should not add invalid file content to OSC", func() {
+					oldOSC := newOSC.DeepCopy()
+					oldOSC.Spec.Units[0].Content = pointer.String(oldServiceContent)
+					oldOSC.Spec.Files[0].Content.Inline.Data = oldKubeletConfigData
+					oldOSC.Spec.Files[1].Content.Inline.Data = oldKubernetesGeneralConfigData
 
-				// Call Mutate method and check the result
-				err := mutator.Mutate(context.TODO(), newOSC, oldOSC)
-				Expect(err).To(Not(HaveOccurred()))
+					// Create mock ensurer
+					ensurer.EXPECT().EnsureKubeletServiceUnitOptions(context.TODO(), gomock.Any(), kubernetesVersionSemver, newUnitOptions, oldUnitOptions).Return(mutatedUnitOptions, nil)
+					ensurer.EXPECT().EnsureKubeletConfiguration(context.TODO(), gomock.Any(), kubernetesVersionSemver, newKubeletConfig, oldKubeletConfig).DoAndReturn(
+						func(ctx context.Context, gctx extensionscontextwebhook.GardenContext, kubeletVersion *semver.Version, kubeletConfig, newKubeletConfig *kubeletconfigv1beta1.KubeletConfiguration) error {
+							*kubeletConfig = *mutatedKubeletConfig
+							return nil
+						},
+					)
+					ensurer.EXPECT().EnsureKubernetesGeneralConfiguration(context.TODO(), gomock.Any(), pointer.String(newKubernetesGeneralConfigData), pointer.String(oldKubernetesGeneralConfigData)).DoAndReturn(
+						func(ctx context.Context, gctx extensionscontextwebhook.GardenContext, newData, data *string) error {
+							*newData = ""
+							return nil
+						},
+					)
+					ensurer.EXPECT().EnsureAdditionalUnits(context.TODO(), gomock.Any(), &newOSC.Spec.Units, &oldOSC.Spec.Units).DoAndReturn(
+						func(ctx context.Context, gctx extensionscontextwebhook.GardenContext, oscUnits, oldOSCUnits *[]extensionsv1alpha1.Unit) error {
+							*oscUnits = append(*oscUnits, additionalUnit)
+							return nil
+						})
+					ensurer.EXPECT().EnsureAdditionalFiles(context.TODO(), gomock.Any(), &newOSC.Spec.Files, &oldOSC.Spec.Files).DoAndReturn(
+						func(ctx context.Context, gctx extensionscontextwebhook.GardenContext, oscFiles, oldOSCFiles *[]extensionsv1alpha1.File) error {
+							*oscFiles = append(*oscFiles, additionalFile)
+							return nil
+						})
 
-				general := extensionswebhook.FileWithPath(newOSC.Spec.Files, v1beta1constants.OperatingSystemConfigFilePathKernelSettings)
-				Expect(general).To(Not(BeNil()))
-				Expect(general.Content.Inline).To(Equal(&extensionsv1alpha1.FileContentInline{Data: newKubernetesGeneralConfigData}))
-				cloudProvider := extensionswebhook.FileWithPath(newOSC.Spec.Files, genericmutator.CloudProviderConfigPath)
-				Expect(cloudProvider).To(BeNil())
+					ensurer.EXPECT().ShouldProvisionKubeletCloudProviderConfig(context.TODO(), gomock.Any(), kubernetesVersionSemver).Return(true)
+					ensurer.EXPECT().EnsureKubeletCloudProviderConfig(context.TODO(), gomock.Any(), kubernetesVersionSemver, gomock.Any(), newOSC.Namespace).DoAndReturn(
+						func(ctx context.Context, gctx extensionscontextwebhook.GardenContext, kubeletVersion *semver.Version, data *string, _ string) error {
+							*data = ""
+							return nil
+						},
+					)
+
+					us.EXPECT().Deserialize(newServiceContent).Return(newUnitOptions, nil)
+					us.EXPECT().Deserialize(oldServiceContent).Return(oldUnitOptions, nil)
+					us.EXPECT().Serialize(mutatedUnitOptions).Return(mutatedServiceContent, nil)
+
+					kcc.EXPECT().Decode(&extensionsv1alpha1.FileContentInline{Data: newKubeletConfigData}).Return(newKubeletConfig, nil)
+					kcc.EXPECT().Decode(&extensionsv1alpha1.FileContentInline{Data: oldKubeletConfigData}).Return(oldKubeletConfig, nil)
+					kcc.EXPECT().Encode(mutatedKubeletConfig, "").Return(&extensionsv1alpha1.FileContentInline{Data: mutatedKubeletConfigData}, nil)
+
+					fcic.EXPECT().Decode(&extensionsv1alpha1.FileContentInline{Data: newKubernetesGeneralConfigData}).Return([]byte(newKubernetesGeneralConfigData), nil)
+					fcic.EXPECT().Decode(&extensionsv1alpha1.FileContentInline{Data: oldKubernetesGeneralConfigData}).Return([]byte(oldKubernetesGeneralConfigData), nil)
+
+					// Call Mutate method and check the result
+					err := mutator.Mutate(context.TODO(), newOSC, oldOSC)
+					Expect(err).To(Not(HaveOccurred()))
+
+					general := extensionswebhook.FileWithPath(newOSC.Spec.Files, v1beta1constants.OperatingSystemConfigFilePathKernelSettings)
+					Expect(general).To(Not(BeNil()))
+					Expect(general.Content.Inline).To(Equal(&extensionsv1alpha1.FileContentInline{Data: newKubernetesGeneralConfigData}))
+					cloudProvider := extensionswebhook.FileWithPath(newOSC.Spec.Files, genericmutator.CloudProviderConfigPath)
+					Expect(cloudProvider).To(BeNil())
+				})
 			})
 		})
 	})
@@ -532,28 +571,36 @@ var _ = Describe("Mutator", func() {
 
 func checkOperatingSystemConfig(osc *extensionsv1alpha1.OperatingSystemConfig) {
 	kubeletUnit := extensionswebhook.UnitWithName(osc.Spec.Units, v1beta1constants.OperatingSystemConfigUnitNameKubeletService)
-	Expect(kubeletUnit).To(Not(BeNil()))
-	Expect(kubeletUnit.Content).To(Equal(pointer.String(mutatedServiceContent)))
+	ExpectWithOffset(1, kubeletUnit).To(Not(BeNil()))
+	ExpectWithOffset(1, kubeletUnit.Content).To(Equal(pointer.String(mutatedServiceContent)))
 
 	customMTU := extensionswebhook.UnitWithName(osc.Spec.Units, "custom-mtu.service")
-	Expect(customMTU).To(Not(BeNil()))
+	ExpectWithOffset(1, customMTU).To(Not(BeNil()))
 
 	customFile := extensionswebhook.FileWithPath(osc.Spec.Files, "/test/path")
-	Expect(customFile).To(Not(BeNil()))
+	ExpectWithOffset(1, customFile).To(Not(BeNil()))
 
 	kubeletFile := extensionswebhook.FileWithPath(osc.Spec.Files, v1beta1constants.OperatingSystemConfigFilePathKubeletConfig)
-	Expect(kubeletFile).To(Not(BeNil()))
-	Expect(kubeletFile.Content.Inline).To(Equal(&extensionsv1alpha1.FileContentInline{Data: mutatedKubeletConfigData}))
+	ExpectWithOffset(1, kubeletFile).To(Not(BeNil()))
+	ExpectWithOffset(1, kubeletFile.Content.Inline).To(Equal(&extensionsv1alpha1.FileContentInline{Data: mutatedKubeletConfigData}))
 
 	general := extensionswebhook.FileWithPath(osc.Spec.Files, v1beta1constants.OperatingSystemConfigFilePathKernelSettings)
-	Expect(general).To(Not(BeNil()))
-	Expect(general.Content.Inline).To(Equal(&extensionsv1alpha1.FileContentInline{Data: mutatedKubernetesGeneralConfigData}))
+	ExpectWithOffset(1, general).To(Not(BeNil()))
+	ExpectWithOffset(1, general.Content.Inline).To(Equal(&extensionsv1alpha1.FileContentInline{Data: mutatedKubernetesGeneralConfigData}))
 
 	cloudProvider := extensionswebhook.FileWithPath(osc.Spec.Files, genericmutator.CloudProviderConfigPath)
-	Expect(cloudProvider).To(Not(BeNil()))
-	Expect(cloudProvider.Path).To(Equal(genericmutator.CloudProviderConfigPath))
-	Expect(cloudProvider.Permissions).To(Equal(pointer.Int32(0644)))
-	Expect(cloudProvider.Content.Inline).To(Equal(&extensionsv1alpha1.FileContentInline{Data: cloudproviderconfEncoded, Encoding: encoding}))
+	ExpectWithOffset(1, cloudProvider).To(Not(BeNil()))
+	ExpectWithOffset(1, cloudProvider.Path).To(Equal(genericmutator.CloudProviderConfigPath))
+	ExpectWithOffset(1, cloudProvider.Permissions).To(Equal(pointer.Int32(0644)))
+	ExpectWithOffset(1, cloudProvider.Content.Inline).To(Equal(&extensionsv1alpha1.FileContentInline{Data: cloudproviderconfEncoded, Encoding: encoding}))
+}
+
+func checkProvisionOperatingSystemConfig(osc *extensionsv1alpha1.OperatingSystemConfig) {
+	customUnit := extensionswebhook.UnitWithName(osc.Spec.Units, "custom-provision-unit.service")
+	ExpectWithOffset(1, customUnit).To(Not(BeNil()))
+
+	customFile := extensionswebhook.FileWithPath(osc.Spec.Files, "/test/provision")
+	ExpectWithOffset(1, customFile).To(Not(BeNil()))
 }
 
 func clientGet(result client.Object) interface{} {

--- a/extensions/pkg/webhook/controlplane/genericmutator/noopensurer.go
+++ b/extensions/pkg/webhook/controlplane/genericmutator/noopensurer.go
@@ -113,3 +113,13 @@ func (e *NoopEnsurer) EnsureAdditionalUnits(_ context.Context, _ extensionsconte
 func (e *NoopEnsurer) EnsureAdditionalFiles(_ context.Context, _ extensionscontextwebhook.GardenContext, _, _ *[]extensionsv1alpha1.File) error {
 	return nil
 }
+
+// EnsureAdditionalProvisionUnits ensures that additional required system units are added.
+func (e *NoopEnsurer) EnsureAdditionalProvisionUnits(_ context.Context, _ extensionscontextwebhook.GardenContext, _, _ *[]extensionsv1alpha1.Unit) error {
+	return nil
+}
+
+// EnsureAdditionalProvisionFiles ensures that additional required system files are added.
+func (e *NoopEnsurer) EnsureAdditionalProvisionFiles(_ context.Context, _ extensionscontextwebhook.GardenContext, _, _ *[]extensionsv1alpha1.File) error {
+	return nil
+}

--- a/pkg/component/extensions/operatingsystemconfig/nodeinit/nodeinit.go
+++ b/pkg/component/extensions/operatingsystemconfig/nodeinit/nodeinit.go
@@ -29,7 +29,8 @@ import (
 	"github.com/gardener/gardener/pkg/utils"
 )
 
-const pathInitScript = nodeagentv1alpha1.BaseDir + "/init.sh"
+// PathInitScript is the path to the init script.
+const PathInitScript = nodeagentv1alpha1.BaseDir + "/init.sh"
 
 // Config returns the init units and the files for the OperatingSystemConfig for bootstrapping the gardener-node-agent.
 // ### !CAUTION! ###
@@ -66,10 +67,10 @@ Restart=on-failure
 RestartSec=5
 StartLimitBurst=0
 EnvironmentFile=/etc/environment
-ExecStart=` + pathInitScript + `
+ExecStart=` + PathInitScript + `
 [Install]
 WantedBy=multi-user.target`),
-			FilePaths: []string{pathInitScript},
+			FilePaths: []string{PathInitScript},
 		}}
 
 		nodeInitFiles = []extensionsv1alpha1.File{
@@ -88,7 +89,7 @@ WantedBy=multi-user.target`),
 				},
 			},
 			{
-				Path:        pathInitScript,
+				Path:        PathInitScript,
 				Permissions: pointer.Int32(0755),
 				Content: extensionsv1alpha1.FileContent{
 					Inline: &extensionsv1alpha1.FileContentInline{

--- a/pkg/component/extensions/operatingsystemconfig/original/components/nodeagent/component.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/nodeagent/component.go
@@ -35,8 +35,12 @@ import (
 	"github.com/gardener/gardener/pkg/utils"
 )
 
-// AccessSecretName is a constant for the secret name for the gardener-node-agent's shoot access secret.
-const AccessSecretName = "gardener-node-agent"
+const (
+	// AccessSecretName is a constant for the secret name for the gardener-node-agent's shoot access secret.
+	AccessSecretName = "gardener-node-agent"
+	// PathBinary is a constant for the path to the gardener-node-agent binary file on the VMs.
+	PathBinary = v1beta1constants.OperatingSystemConfigFilePathBinaries + "/gardener-node-agent"
+)
 
 var codec runtime.Codec
 
@@ -72,7 +76,7 @@ func (component) Config(ctx components.Context) ([]extensionsv1alpha1.Unit, []ex
 	}
 
 	files = append(files, extensionsv1alpha1.File{
-		Path:        v1beta1constants.OperatingSystemConfigFilePathBinaries + "/gardener-node-agent",
+		Path:        PathBinary,
 		Permissions: pointer.Int32(0755),
 		Content: extensionsv1alpha1.FileContent{
 			ImageRef: &extensionsv1alpha1.FileContentImageRef{

--- a/pkg/provider-local/webhook/controlplane/add.go
+++ b/pkg/provider-local/webhook/controlplane/add.go
@@ -29,7 +29,11 @@ import (
 	"github.com/gardener/gardener/pkg/provider-local/local"
 )
 
-var logger = log.Log.WithName("local-controlplane-webhook")
+var (
+	logger = log.Log.WithName("local-controlplane-webhook")
+	// UseGardenerNodeAgent controls whether the UseGardenerNodeAgent feature gate of gardenlet is enabled.
+	UseGardenerNodeAgent bool
+)
 
 // AddToManager creates a webhook and adds it to the manager.
 func AddToManager(mgr manager.Manager) (*extensionswebhook.Webhook, error) {
@@ -45,6 +49,6 @@ func AddToManager(mgr manager.Manager) (*extensionswebhook.Webhook, error) {
 			{Obj: &vpaautoscalingv1.VerticalPodAutoscaler{}},
 			{Obj: &extensionsv1alpha1.OperatingSystemConfig{}},
 		},
-		Mutator: genericmutator.NewMutator(mgr, NewEnsurer(logger), oscutils.NewUnitSerializer(), kubelet.NewConfigCodec(fciCodec), fciCodec, logger),
+		Mutator: genericmutator.NewMutator(mgr, NewEnsurer(logger, UseGardenerNodeAgent), oscutils.NewUnitSerializer(), kubelet.NewConfigCodec(fciCodec), fciCodec, logger),
 	})
 }

--- a/pkg/provider-local/webhook/nodeagentosc/add.go
+++ b/pkg/provider-local/webhook/nodeagentosc/add.go
@@ -1,0 +1,97 @@
+// Copyright 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nodeagentosc
+
+import (
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	"github.com/gardener/gardener/pkg/provider-local/local"
+)
+
+const (
+	// WebhookName is the name of the webhook for mutating the gardener-node-agent files in OperatingSystemConfigs.
+	WebhookName = "operatingsystemconfig-gardener-node-agent"
+)
+
+var (
+	logger = log.Log.WithName("local-operatingsystemconfig-gardener-node-agent-webhook")
+
+	// DefaultAddOptions are the default AddOptions for AddToManager.
+	DefaultAddOptions = AddOptions{}
+)
+
+// AddOptions are options to apply when adding the webhook to the manager.
+type AddOptions struct{}
+
+// AddToManagerWithOptions creates a webhook with the given options and adds it to the manager.
+func AddToManagerWithOptions(
+	mgr manager.Manager,
+	_ AddOptions,
+	name string,
+	target string,
+	failurePolicy admissionregistrationv1.FailurePolicyType,
+) (
+	*extensionswebhook.Webhook,
+	error,
+) {
+	logger.Info("Adding webhook to manager")
+
+	var (
+		provider = local.Type
+		types    = []extensionswebhook.Type{{Obj: &extensionsv1alpha1.OperatingSystemConfig{}}}
+	)
+
+	logger = logger.WithValues("provider", provider)
+
+	handler, err := extensionswebhook.NewBuilder(mgr, logger).WithMutator(&mutator{}, types...).Build()
+	if err != nil {
+		return nil, err
+	}
+
+	logger.Info("Creating webhook", "name", name)
+
+	return &extensionswebhook.Webhook{
+		Name:           name,
+		Provider:       provider,
+		Types:          types,
+		Target:         target,
+		Path:           name,
+		Webhook:        &admission.Webhook{Handler: handler, RecoverPanic: true},
+		FailurePolicy:  &failurePolicy,
+		TimeoutSeconds: pointer.Int32(5),
+		Selector: &metav1.LabelSelector{MatchExpressions: []metav1.LabelSelectorRequirement{
+			{Key: v1beta1constants.LabelShootProvider, Operator: metav1.LabelSelectorOpIn, Values: []string{provider}},
+		}},
+	}, nil
+}
+
+// AddToManager creates a webhook with the default options and adds it to the manager.
+func AddToManager(mgr manager.Manager) (*extensionswebhook.Webhook, error) {
+	return AddToManagerWithOptions(
+		mgr,
+		DefaultAddOptions,
+		WebhookName,
+		extensionswebhook.TargetSeed,
+		admissionregistrationv1.Fail,
+	)
+}

--- a/pkg/provider-local/webhook/nodeagentosc/mutator.go
+++ b/pkg/provider-local/webhook/nodeagentosc/mutator.go
@@ -1,0 +1,76 @@
+// Copyright 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nodeagentosc
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	"github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/nodeinit"
+	"github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/original/components/nodeagent"
+	oscutils "github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/utils"
+)
+
+const gnaBinaryPathBuiltViaKo = "/ko-app/gardener-node-agent"
+
+type mutator struct{}
+
+func (m *mutator) Mutate(_ context.Context, newObj, _ client.Object) error {
+	operatingSystemConfig, ok := newObj.(*extensionsv1alpha1.OperatingSystemConfig)
+	if !ok {
+		return fmt.Errorf("unexpected object, got %T wanted *extensionsv1alpha1.OperatingSystemConfig", newObj)
+	}
+
+	if err := modifyFile(operatingSystemConfig.Spec.Files, nodeinit.PathInitScript, func(oldContent string) string {
+		return strings.ReplaceAll(oldContent,
+			`cp -f "$tmp_dir/gardener-node-agent"`,
+			`cp -f "$tmp_dir`+gnaBinaryPathBuiltViaKo+`"`,
+		)
+	}); err != nil {
+		return fmt.Errorf("failed modifying file %q: %w", nodeinit.PathInitScript, err)
+	}
+
+	if file := extensionswebhook.FileWithPath(operatingSystemConfig.Spec.Files, nodeagent.PathBinary); file != nil && file.Content.ImageRef != nil {
+		file.Content.ImageRef.FilePathInImage = gnaBinaryPathBuiltViaKo
+	}
+
+	return nil
+}
+
+var fciCodec = oscutils.NewFileContentInlineCodec()
+
+func modifyFile(files []extensionsv1alpha1.File, path string, mutateFunc func(string) string) error {
+	if file := extensionswebhook.FileWithPath(files, path); file != nil {
+		oldContent, err := fciCodec.Decode(file.Content.Inline)
+		if err != nil {
+			return fmt.Errorf("failed to decode file %q: %w", path, err)
+		}
+
+		newContent := mutateFunc(string(oldContent))
+
+		var newFileContent *extensionsv1alpha1.FileContentInline
+		if newFileContent, err = fciCodec.Encode([]byte(newContent), file.Content.Inline.Encoding); err != nil {
+			return fmt.Errorf("could not encode file: %q: %w", path, err)
+		}
+		*file.Content.Inline = *newFileContent
+	}
+
+	return nil
+}

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -603,12 +603,14 @@ build:
             - pkg/client/kubernetes
             - pkg/client/kubernetes/cache
             - pkg/component
+            - pkg/component/extensions/operatingsystemconfig/nodeinit
             - pkg/component/extensions/operatingsystemconfig/original/components
             - pkg/component/extensions/operatingsystemconfig/original/components/containerd
             - pkg/component/extensions/operatingsystemconfig/original/components/containerd/logrotate
             - pkg/component/extensions/operatingsystemconfig/original/components/docker
             - pkg/component/extensions/operatingsystemconfig/original/components/docker/logrotate
             - pkg/component/extensions/operatingsystemconfig/original/components/kubelet
+            - pkg/component/extensions/operatingsystemconfig/original/components/nodeagent
             - pkg/component/extensions/operatingsystemconfig/utils
             - pkg/component/kubeapiserver/constants
             - pkg/component/kubeproxy
@@ -624,6 +626,8 @@ build:
             - pkg/gardenlet/apis/config/v1alpha1
             - pkg/healthz
             - pkg/logger
+            - pkg/nodeagent/apis/config
+            - pkg/nodeagent/apis/config/v1alpha1
             - pkg/provider-local/apis/local
             - pkg/provider-local/apis/local/helper
             - pkg/provider-local/apis/local/install
@@ -650,6 +654,7 @@ build:
             - pkg/provider-local/webhook/machinecontrollermanager
             - pkg/provider-local/webhook/networkpolicy
             - pkg/provider-local/webhook/node
+            - pkg/provider-local/webhook/nodeagentosc
             - pkg/provider-local/webhook/shoot
             - pkg/resourcemanager/controller/garbagecollector/references
             - pkg/utils


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability dev-productivity
/kind enhancement

**What this PR does / why we need it**:
This PR contains three enhancements:

- [Always perform legacy 'provision' OSC reconciliation](https://github.com/gardener/gardener/commit/46b3f3c1f72634053d6fd26df90d5ee67f2c2eb9) 
  Even when `UseGardenerNodeAgent` feature gate is enabled, the legacy OSC reconciliation logic must be performed. This is to make the migration scenario work where `cloud-config-downloader` is still running on a node. Without this, its execution script would not be updated with the new `gardener-node-agent` unit, i.e., CCD would never install `gardener-node-agent`. This would effectively break migration.
- [Inject registry cache hosts into both OSCs](https://github.com/gardener/gardener/commit/a83f88dbcab7b0fec17876cc75e0fc7d2f85aaa6) 
   Without this, the `gardener-node-init` script will fail to extract the GNA binary from its image since this is loaded into the local registry (`localhost:5001/eu_gcr_io/...`).
   When the `UseGardenerNodeAgent` feature gate gets promoted to GA (and with this locked to "always" enabled), we no longer need to inject the hosts into both OSCs. This is just needed temporary to make both scenarios work (`cloud-config-downloader` / `gardener-node-agent`).
- [Prefix GNA binary path with /ko-app via webhook](https://github.com/gardener/gardener/commit/a36d171ade0ddf07ad71fa00695fc9e122b7875f) 
   In the local scenario, the Gardener binaries are built with `ko`, and `ko` puts the binaries into the `/ko-app` folder in the image. This is not configurable/changeable.
   Hence, provider-local must mutate the `OperatingSystemConfig`s and add the `/ko-app` prefix to the locations where the GNA binary is referenced:
   - `gardener-node-init` bash script in 'provision' OSC
   - `gardener-node-agent` image ref file in the 'reconcile' OSC

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/8023

**Special notes for your reviewer**:
/cc @oliver-goetz 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
