### PR TITLE
Avoid unnecessary GRM rollouts

### DIFF
--- a/pkg/component/resourcemanager/resource_manager.go
+++ b/pkg/component/resourcemanager/resource_manager.go
@@ -15,9 +15,11 @@
 package resourcemanager
 
 import (
+	"cmp"
 	"context"
 	_ "embed"
 	"fmt"
+	"slices"
 	"time"
 
 	"github.com/Masterminds/semver/v3"
@@ -635,6 +637,11 @@ func (r *resourceManager) ensureConfigMap(ctx context.Context, configMap *corev1
 	}
 
 	if r.values.TargetDiffersFromSourceCluster {
+		// sort system component tolerations for a stable output
+		slices.SortFunc(r.values.SystemComponentTolerations, func(a, b corev1.Toleration) int {
+			return cmp.Compare(a.Key, b.Key)
+		})
+
 		config.Webhooks.SystemComponentsConfig = resourcemanagerv1alpha1.SystemComponentsConfigWebhookConfig{
 			Enabled: true,
 			NodeSelector: map[string]string{

--- a/pkg/component/resourcemanager/resource_manager.go
+++ b/pkg/component/resourcemanager/resource_manager.go
@@ -15,11 +15,9 @@
 package resourcemanager
 
 import (
-	"cmp"
 	"context"
 	_ "embed"
 	"fmt"
-	"slices"
 	"time"
 
 	"github.com/Masterminds/semver/v3"
@@ -637,11 +635,6 @@ func (r *resourceManager) ensureConfigMap(ctx context.Context, configMap *corev1
 	}
 
 	if r.values.TargetDiffersFromSourceCluster {
-		// sort system component tolerations for a stable output
-		slices.SortFunc(r.values.SystemComponentTolerations, func(a, b corev1.Toleration) int {
-			return cmp.Compare(a.Key, b.Key)
-		})
-
 		config.Webhooks.SystemComponentsConfig = resourcemanagerv1alpha1.SystemComponentsConfigWebhookConfig{
 			Enabled: true,
 			NodeSelector: map[string]string{

--- a/pkg/component/resourcemanager/resource_manager_test.go
+++ b/pkg/component/resourcemanager/resource_manager_test.go
@@ -333,9 +333,14 @@ var _ = Describe("ResourceManager", func() {
 			RuntimeKubernetesVersion:                         version,
 			SecretNameServerCA:                               "ca",
 			SyncPeriod:                                       &syncPeriod,
-			TargetDiffersFromSourceCluster:                   true,
-			TargetDisableCache:                               &targetDisableCache,
-			WatchedNamespace:                                 &watchedNamespace,
+			SystemComponentTolerations: []corev1.Toleration{
+				{Key: "b"},
+				{Key: "a"},
+				{Key: "c"},
+			},
+			TargetDiffersFromSourceCluster: true,
+			TargetDisableCache:             &targetDisableCache,
+			WatchedNamespace:               &watchedNamespace,
 			VPA: &VPAConfig{
 				MinAllowed: corev1.ResourceList{
 					corev1.ResourceMemory: resource.MustParse("30Mi"),
@@ -477,6 +482,11 @@ var _ = Describe("ResourceManager", func() {
 					},
 					PodNodeSelector: map[string]string{
 						"worker.gardener.cloud/system-components": "true",
+					},
+					PodTolerations: []corev1.Toleration{
+						{Key: "a"},
+						{Key: "b"},
+						{Key: "c"},
 					},
 				}
 			} else {

--- a/pkg/component/resourcemanager/resource_manager_test.go
+++ b/pkg/component/resourcemanager/resource_manager_test.go
@@ -334,8 +334,8 @@ var _ = Describe("ResourceManager", func() {
 			SecretNameServerCA:                               "ca",
 			SyncPeriod:                                       &syncPeriod,
 			SystemComponentTolerations: []corev1.Toleration{
-				{Key: "b"},
 				{Key: "a"},
+				{Key: "b"},
 				{Key: "c"},
 			},
 			TargetDiffersFromSourceCluster: true,

--- a/pkg/utils/gardener/shoot.go
+++ b/pkg/utils/gardener/shoot.go
@@ -15,8 +15,10 @@
 package gardener
 
 import (
+	"cmp"
 	"context"
 	"fmt"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -494,7 +496,13 @@ func ExtractSystemComponentsTolerations(workers []gardencorev1beta1.Worker) []co
 		}
 	}
 
-	return tolerations.UnsortedList()
+	sortedTolerations := tolerations.UnsortedList()
+
+	// sort system component tolerations for a stable output
+	slices.SortFunc(sortedTolerations, func(a, b corev1.Toleration) int {
+		return cmp.Compare(a.Key, b.Key)
+	})
+	return sortedTolerations
 }
 
 // IncompleteDNSConfigError is a custom error type.

--- a/pkg/utils/gardener/shoot.go
+++ b/pkg/utils/gardener/shoot.go
@@ -24,7 +24,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	utilsets "k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/sets"
 	clientcmdlatest "k8s.io/client-go/tools/clientcmd/api/latest"
 	clientcmdv1 "k8s.io/client-go/tools/clientcmd/api/v1"
 	"k8s.io/component-base/version"
@@ -478,7 +478,7 @@ func GetShootSeedNames(obj client.Object) (*string, *string) {
 // on the given workers. Tolerations are only considered for workers which have `SystemComponents.Allow: true`.
 func ExtractSystemComponentsTolerations(workers []gardencorev1beta1.Worker) []corev1.Toleration {
 	var (
-		tolerations = utilsets.New[corev1.Toleration]()
+		tolerations = sets.New[corev1.Toleration]()
 
 		// We need to use semantically equal tolerations, i.e. equality of underlying values of pointers,
 		// before they are added to the tolerations set.
@@ -587,8 +587,8 @@ func ConstructExternalDomain(ctx context.Context, c client.Reader, shoot *garden
 
 // ComputeRequiredExtensionsForShoot computes the extension kind/type combinations that are required for the
 // shoot reconciliation flow.
-func ComputeRequiredExtensionsForShoot(shoot *gardencorev1beta1.Shoot, seed *gardencorev1beta1.Seed, controllerRegistrationList *gardencorev1beta1.ControllerRegistrationList, internalDomain, externalDomain *Domain) utilsets.Set[string] {
-	requiredExtensions := utilsets.New[string]()
+func ComputeRequiredExtensionsForShoot(shoot *gardencorev1beta1.Shoot, seed *gardencorev1beta1.Seed, controllerRegistrationList *gardencorev1beta1.ControllerRegistrationList, internalDomain, externalDomain *Domain) sets.Set[string] {
+	requiredExtensions := sets.New[string]()
 
 	if seed.Spec.Backup != nil {
 		requiredExtensions.Insert(ExtensionsID(extensionsv1alpha1.BackupBucketResource, seed.Spec.Backup.Provider))
@@ -608,7 +608,7 @@ func ComputeRequiredExtensionsForShoot(shoot *gardencorev1beta1.Shoot, seed *gar
 		}
 	}
 
-	disabledExtensions := utilsets.New[string]()
+	disabledExtensions := sets.New[string]()
 	for _, extension := range shoot.Spec.Extensions {
 		id := ExtensionsID(extensionsv1alpha1.ExtensionResource, extension.Type)
 

--- a/pkg/utils/gardener/shoot_test.go
+++ b/pkg/utils/gardener/shoot_test.go
@@ -712,6 +712,60 @@ var _ = Describe("Shoot", func() {
 			})).To(BeEmpty())
 		})
 
+		It("should return tolerations in order", func() {
+			Expect(ExtractSystemComponentsTolerations([]gardencorev1beta1.Worker{
+				{
+					SystemComponents: &gardencorev1beta1.WorkerSystemComponents{Allow: true},
+					Taints: []corev1.Taint{
+						{
+							Key:    "b",
+							Value:  "someValue",
+							Effect: corev1.TaintEffectNoExecute,
+						},
+					},
+				},
+				{
+					SystemComponents: &gardencorev1beta1.WorkerSystemComponents{Allow: true},
+					Taints: []corev1.Taint{
+						{
+							Key:    "a",
+							Value:  "someValue",
+							Effect: corev1.TaintEffectNoSchedule,
+						},
+					},
+				},
+				{
+					SystemComponents: &gardencorev1beta1.WorkerSystemComponents{Allow: true},
+					Taints: []corev1.Taint{
+						{
+							Key:    "c",
+							Value:  "someValue",
+							Effect: corev1.TaintEffectNoSchedule,
+						},
+					},
+				},
+			})).To(HaveExactElements(
+				corev1.Toleration{
+					Key:      "a",
+					Operator: corev1.TolerationOpEqual,
+					Value:    "someValue",
+					Effect:   corev1.TaintEffectNoSchedule,
+				},
+				corev1.Toleration{
+					Key:      "b",
+					Operator: corev1.TolerationOpEqual,
+					Value:    "someValue",
+					Effect:   corev1.TaintEffectNoExecute,
+				},
+				corev1.Toleration{
+					Key:      "c",
+					Operator: corev1.TolerationOpEqual,
+					Value:    "someValue",
+					Effect:   corev1.TaintEffectNoSchedule,
+				},
+			))
+		})
+
 		It("should return tolerations when taints are defined for system worker group", func() {
 			Expect(ExtractSystemComponentsTolerations([]gardencorev1beta1.Worker{
 				{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement

**What this PR does / why we need it**:
Earlier, GRM was rolled during shoot reconciliation when the order of system component tolerations changed in GRM's config. In rare cases, this even resulted in deployments referring to earlier creates `ConfigMap`s that were garbage collected in the meantime.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The `gardener-resource-manager` deployment procedure was improved. Earlier, GRM was unnecessarily rolled during shoot reconciliation if worker nodes contained custom taints.
```
