### PR TITLE
[node-agent] Add logging configuration for `gardener-node-agent` unit

### DIFF
--- a/hack/ci-common.sh
+++ b/hack/ci-common.sh
@@ -38,8 +38,8 @@ export_artifacts() {
       kubectl -n "$namespace" exec "$node" -- crictl images >"$node_dir/images.log" || true
       kubectl -n "$namespace" get pod "$node" --show-managed-fields -oyaml >"$node_dir/pod.yaml" || true
 
-      # systemd units
-      for unit in cloud-config-downloader kubelet containerd containerd-configuration-local-setup; do
+      # relevant systemd units
+      for unit in cloud-config-downloader gardener-node-agent kubelet containerd containerd-configuration-local-setup; do
         kubectl -n "$namespace" exec "$node" -- journalctl --no-pager -u $unit.service >"$node_dir/$unit.log" || true
       done
       kubectl -n "$namespace" exec "$node" -- journalctl --no-pager >"$node_dir/journal.log" || true

--- a/pkg/component/extensions/operatingsystemconfig/original/components/nodeagent/logging.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/nodeagent/logging.go
@@ -1,0 +1,73 @@
+// Copyright 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nodeagent
+
+import (
+	fluentbitv1alpha2 "github.com/fluent/fluent-operator/v2/apis/fluentbit/v1alpha2"
+	fluentbitv1alpha2filter "github.com/fluent/fluent-operator/v2/apis/fluentbit/v1alpha2/plugins/filter"
+	fluentbitv1alpha2input "github.com/fluent/fluent-operator/v2/apis/fluentbit/v1alpha2/plugins/input"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	comp "github.com/gardener/gardener/pkg/component"
+)
+
+var (
+	journaldServiceName = "journald-gardener-node-agent"
+)
+
+// CentralLoggingConfiguration returns a fluent-bit parser and filter for the gardener-node-agent logs.
+func CentralLoggingConfiguration() (comp.CentralLoggingConfig, error) {
+	return comp.CentralLoggingConfig{Inputs: generateClusterInputs(), Filters: generateClusterFilters()}, nil
+}
+
+func generateClusterInputs() []*fluentbitv1alpha2.ClusterInput {
+	return []*fluentbitv1alpha2.ClusterInput{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   journaldServiceName,
+				Labels: map[string]string{v1beta1constants.LabelKeyCustomLoggingResource: v1beta1constants.LabelValueCustomLoggingResource},
+			},
+			Spec: fluentbitv1alpha2.InputSpec{
+				Systemd: &fluentbitv1alpha2input.Systemd{
+					Tag:           "journald.gardener-node-agent",
+					ReadFromTail:  "on",
+					SystemdFilter: []string{"_SYSTEMD_UNIT=gardener-node-agent.service"},
+				},
+			},
+		},
+	}
+}
+
+func generateClusterFilters() []*fluentbitv1alpha2.ClusterFilter {
+	return []*fluentbitv1alpha2.ClusterFilter{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   journaldServiceName,
+				Labels: map[string]string{v1beta1constants.LabelKeyCustomLoggingResource: v1beta1constants.LabelValueCustomLoggingResource},
+			},
+			Spec: fluentbitv1alpha2.FilterSpec{
+				Match: "journald.gardener-node-agent*",
+				FilterItems: []fluentbitv1alpha2.FilterItem{
+					{
+						RecordModifier: &fluentbitv1alpha2filter.RecordModifier{
+							Records: []string{"hostname ${NODE_NAME}", "unit gardener-node-agent"},
+						},
+					},
+				},
+			},
+		},
+	}
+}

--- a/pkg/component/extensions/operatingsystemconfig/original/components/nodeagent/logging_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/nodeagent/logging_test.go
@@ -1,0 +1,67 @@
+// Copyright 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nodeagent_test
+
+import (
+	fluentbitv1alpha2 "github.com/fluent/fluent-operator/v2/apis/fluentbit/v1alpha2"
+	fluentbitv1alpha2filter "github.com/fluent/fluent-operator/v2/apis/fluentbit/v1alpha2/plugins/filter"
+	fluentbitv1alpha2input "github.com/fluent/fluent-operator/v2/apis/fluentbit/v1alpha2/plugins/input"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	. "github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/original/components/nodeagent"
+)
+
+var _ = Describe("Logging", func() {
+	Describe("#CentralLoggingConfiguration", func() {
+		It("should return the expected logging inputs and filters", func() {
+			loggingConfig, err := CentralLoggingConfiguration()
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(loggingConfig.Inputs).To(ConsistOf(&fluentbitv1alpha2.ClusterInput{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "journald-gardener-node-agent",
+					Labels: map[string]string{"fluentbit.gardener/type": "seed"},
+				},
+				Spec: fluentbitv1alpha2.InputSpec{
+					Systemd: &fluentbitv1alpha2input.Systemd{
+						Tag:           "journald.gardener-node-agent",
+						ReadFromTail:  "on",
+						SystemdFilter: []string{"_SYSTEMD_UNIT=gardener-node-agent.service"},
+					},
+				},
+			}))
+
+			Expect(loggingConfig.Filters).To(ConsistOf(&fluentbitv1alpha2.ClusterFilter{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "journald-gardener-node-agent",
+					Labels: map[string]string{"fluentbit.gardener/type": "seed"},
+				},
+				Spec: fluentbitv1alpha2.FilterSpec{
+					Match: "journald.gardener-node-agent*",
+					FilterItems: []fluentbitv1alpha2.FilterItem{
+						{
+							RecordModifier: &fluentbitv1alpha2filter.RecordModifier{
+								Records: []string{"hostname ${NODE_NAME}", "unit gardener-node-agent"},
+							},
+						},
+					},
+				},
+			}))
+			Expect(loggingConfig.Parsers).To(BeNil())
+		})
+	})
+})

--- a/pkg/gardenlet/controller/seed/seed/components.go
+++ b/pkg/gardenlet/controller/seed/seed/components.go
@@ -41,6 +41,7 @@ import (
 	"github.com/gardener/gardener/pkg/component/etcd"
 	"github.com/gardener/gardener/pkg/component/extensions"
 	"github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/downloader"
+	"github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/original/components/nodeagent"
 	"github.com/gardener/gardener/pkg/component/kubeapiserver"
 	kubeapiserverconstants "github.com/gardener/gardener/pkg/component/kubeapiserver/constants"
 	"github.com/gardener/gardener/pkg/component/kubeproxy"
@@ -474,6 +475,7 @@ func getFluentOperatorCustomResources(
 		machinecontrollermanager.CentralLoggingConfiguration,
 		// shoot worker components
 		downloader.CentralLoggingConfiguration,
+		nodeagent.CentralLoggingConfiguration,
 		// shoot system components
 		nodeexporter.CentralLoggingConfiguration,
 		nodeproblemdetector.CentralLoggingConfiguration,

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -844,6 +844,7 @@ build:
             - pkg/component/extensions/operatingsystemconfig/original/components/journald
             - pkg/component/extensions/operatingsystemconfig/original/components/kernelconfig
             - pkg/component/extensions/operatingsystemconfig/original/components/kubelet
+            - pkg/component/extensions/operatingsystemconfig/original/components/nodeagent
             - pkg/component/extensions/operatingsystemconfig/original/components/rootcertificates
             - pkg/component/extensions/operatingsystemconfig/original/components/sshdensurer
             - pkg/component/extensions/operatingsystemconfig/original/components/valitail


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area logging
/kind enhancement

**What this PR does / why we need it**:
This PR adds the logging configuration for `gardener-node-agent`, similar to the [configuration for `cloud-config-downloader`](https://github.com/gardener/gardener/blob/master/pkg/component/extensions/operatingsystemconfig/downloader/logging.go).

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/8023

**Special notes for your reviewer**:
/cc @oliver-goetz 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
