### PR TITLE
Fix `Seed` care controller checks when `vali` is disabled

### DIFF
--- a/pkg/gardenlet/controller/seed/add.go
+++ b/pkg/gardenlet/controller/seed/add.go
@@ -60,6 +60,7 @@ func AddToManager(
 		Config:         *cfg.Controllers.SeedCare,
 		SeedName:       cfg.SeedConfig.Name,
 		LoggingEnabled: gardenlethelper.IsLoggingEnabled(&cfg),
+		ValiEnabled:    gardenlethelper.IsValiEnabled(&cfg),
 	}).AddToManager(ctx, mgr, gardenCluster, seedCluster); err != nil {
 		return fmt.Errorf("failed adding care reconciler: %w", err)
 	}

--- a/pkg/gardenlet/controller/seed/care/health.go
+++ b/pkg/gardenlet/controller/seed/care/health.go
@@ -62,6 +62,7 @@ type health struct {
 	namespace           *string
 	seedIsGarden        bool
 	loggingEnabled      bool
+	valiEnabled         bool
 	conditionThresholds map[gardencorev1beta1.ConditionType]time.Duration
 	healthChecker       *healthchecker.HealthChecker
 }
@@ -74,6 +75,7 @@ func NewHealth(
 	namespace *string,
 	seedIsGarden bool,
 	loggingEnabled bool,
+	valiEnabled bool,
 	conditionThresholds map[gardencorev1beta1.ConditionType]time.Duration,
 ) HealthCheck {
 	return &health{
@@ -83,6 +85,7 @@ func NewHealth(
 		namespace:           namespace,
 		seedIsGarden:        seedIsGarden,
 		loggingEnabled:      loggingEnabled,
+		valiEnabled:         valiEnabled,
 		conditionThresholds: conditionThresholds,
 		healthChecker:       healthchecker.NewHealthChecker(seedClient, clock, conditionThresholds, seed.Status.LastOperation),
 	}
@@ -128,6 +131,8 @@ func (h *health) checkSystemComponents(
 		managedResources = append(managedResources, fluentoperator.OperatorManagedResourceName)
 		managedResources = append(managedResources, fluentoperator.CustomResourcesManagedResourceName)
 		managedResources = append(managedResources, fluentoperator.FluentBitManagedResourceName)
+	}
+	if h.valiEnabled {
 		managedResources = append(managedResources, vali.ManagedResourceNameRuntime)
 	}
 

--- a/pkg/gardenlet/controller/seed/care/health_test.go
+++ b/pkg/gardenlet/controller/seed/care/health_test.go
@@ -129,7 +129,7 @@ var _ = Describe("Seed health", func() {
 			})
 
 			It("should set SeedSystemComponentsHealthy condition to true", func() {
-				healthCheck := NewHealth(seed, c, fakeClock, nil, false, true, nil)
+				healthCheck := NewHealth(seed, c, fakeClock, nil, false, true, true, nil)
 				conditions := NewSeedConditions(fakeClock, gardencorev1beta1.SeedStatus{
 					Conditions: []gardencorev1beta1.Condition{seedSystemComponentsHealthyCondition},
 				})
@@ -152,7 +152,7 @@ var _ = Describe("Seed health", func() {
 			})
 
 			It("should set SeedSystemComponentsHealthy condition to true", func() {
-				healthCheck := NewHealth(seed, c, fakeClock, nil, true, false, nil)
+				healthCheck := NewHealth(seed, c, fakeClock, nil, true, false, false, nil)
 				conditions := NewSeedConditions(fakeClock, gardencorev1beta1.SeedStatus{
 					Conditions: []gardencorev1beta1.Condition{seedSystemComponentsHealthyCondition},
 				})
@@ -167,7 +167,7 @@ var _ = Describe("Seed health", func() {
 			var (
 				tests = func(reason, message string) {
 					It("should set SeedSystemComponentsHealthy condition to False if there is no Progressing threshold duration mapping", func() {
-						healthCheck := NewHealth(seed, c, fakeClock, nil, false, false, nil)
+						healthCheck := NewHealth(seed, c, fakeClock, nil, false, false, false, nil)
 						conditions := NewSeedConditions(fakeClock, gardencorev1beta1.SeedStatus{
 							Conditions: []gardencorev1beta1.Condition{seedSystemComponentsHealthyCondition},
 						})
@@ -182,7 +182,7 @@ var _ = Describe("Seed health", func() {
 						seedSystemComponentsHealthyCondition.Status = gardencorev1beta1.ConditionFalse
 						fakeClock.Step(30 * time.Second)
 
-						healthCheck := NewHealth(seed, c, fakeClock, nil, false, false, map[gardencorev1beta1.ConditionType]time.Duration{gardencorev1beta1.SeedSystemComponentsHealthy: time.Minute})
+						healthCheck := NewHealth(seed, c, fakeClock, nil, false, false, false, map[gardencorev1beta1.ConditionType]time.Duration{gardencorev1beta1.SeedSystemComponentsHealthy: time.Minute})
 						conditions := NewSeedConditions(fakeClock, gardencorev1beta1.SeedStatus{
 							Conditions: []gardencorev1beta1.Condition{seedSystemComponentsHealthyCondition},
 						})
@@ -197,7 +197,7 @@ var _ = Describe("Seed health", func() {
 						seedSystemComponentsHealthyCondition.Status = gardencorev1beta1.ConditionTrue
 						fakeClock.Step(30 * time.Second)
 
-						healthCheck := NewHealth(seed, c, fakeClock, nil, false, false, map[gardencorev1beta1.ConditionType]time.Duration{gardencorev1beta1.SeedSystemComponentsHealthy: time.Minute})
+						healthCheck := NewHealth(seed, c, fakeClock, nil, false, false, false, map[gardencorev1beta1.ConditionType]time.Duration{gardencorev1beta1.SeedSystemComponentsHealthy: time.Minute})
 						conditions := NewSeedConditions(fakeClock, gardencorev1beta1.SeedStatus{
 							Conditions: []gardencorev1beta1.Condition{seedSystemComponentsHealthyCondition},
 						})
@@ -212,7 +212,7 @@ var _ = Describe("Seed health", func() {
 						seedSystemComponentsHealthyCondition.Status = gardencorev1beta1.ConditionProgressing
 						fakeClock.Step(30 * time.Second)
 
-						healthCheck := NewHealth(seed, c, fakeClock, nil, false, false, map[gardencorev1beta1.ConditionType]time.Duration{gardencorev1beta1.SeedSystemComponentsHealthy: time.Minute})
+						healthCheck := NewHealth(seed, c, fakeClock, nil, false, false, false, map[gardencorev1beta1.ConditionType]time.Duration{gardencorev1beta1.SeedSystemComponentsHealthy: time.Minute})
 						conditions := NewSeedConditions(fakeClock, gardencorev1beta1.SeedStatus{
 							Conditions: []gardencorev1beta1.Condition{seedSystemComponentsHealthyCondition},
 						})
@@ -227,7 +227,7 @@ var _ = Describe("Seed health", func() {
 						seedSystemComponentsHealthyCondition.Status = gardencorev1beta1.ConditionProgressing
 						fakeClock.Step(90 * time.Second)
 
-						healthCheck := NewHealth(seed, c, fakeClock, nil, false, false, map[gardencorev1beta1.ConditionType]time.Duration{gardencorev1beta1.SeedSystemComponentsHealthy: time.Minute})
+						healthCheck := NewHealth(seed, c, fakeClock, nil, false, false, false, map[gardencorev1beta1.ConditionType]time.Duration{gardencorev1beta1.SeedSystemComponentsHealthy: time.Minute})
 						conditions := NewSeedConditions(fakeClock, gardencorev1beta1.SeedStatus{
 							Conditions: []gardencorev1beta1.Condition{seedSystemComponentsHealthyCondition},
 						})

--- a/pkg/gardenlet/controller/seed/care/reconciler.go
+++ b/pkg/gardenlet/controller/seed/care/reconciler.go
@@ -48,6 +48,7 @@ type Reconciler struct {
 	Namespace      *string
 	SeedName       string
 	LoggingEnabled bool
+	ValiEnabled    bool
 }
 
 // Reconcile reconciles Seed resources and executes health check operations.
@@ -89,6 +90,7 @@ func (r *Reconciler) Reconcile(reconcileCtx context.Context, req reconcile.Reque
 		r.Namespace,
 		seedIsGarden,
 		r.LoggingEnabled,
+		r.ValiEnabled,
 		r.conditionThresholdsToProgressingMapping(),
 	).Check(
 		ctx,

--- a/pkg/gardenlet/controller/seed/care/reconciler_test.go
+++ b/pkg/gardenlet/controller/seed/care/reconciler_test.go
@@ -205,7 +205,7 @@ func (c resultingConditionFunc) Check(_ context.Context, conditions SeedConditio
 }
 
 func healthCheckFunc(fn resultingConditionFunc) NewHealthCheckFunc {
-	return func(*gardencorev1beta1.Seed, client.Client, clock.Clock, *string, bool, bool, map[gardencorev1beta1.ConditionType]time.Duration) HealthCheck {
+	return func(*gardencorev1beta1.Seed, client.Client, clock.Clock, *string, bool, bool, bool, map[gardencorev1beta1.ConditionType]time.Duration) HealthCheck {
 		return fn
 	}
 }

--- a/pkg/gardenlet/controller/seed/care/types.go
+++ b/pkg/gardenlet/controller/seed/care/types.go
@@ -30,11 +30,11 @@ var defaultNewSeedObjectFunc = func(ctx context.Context, seed *gardencorev1beta1
 }
 
 // NewHealthCheckFunc is a function used to create a new instance for performing health checks.
-type NewHealthCheckFunc func(*gardencorev1beta1.Seed, client.Client, clock.Clock, *string, bool, bool, map[gardencorev1beta1.ConditionType]time.Duration) HealthCheck
+type NewHealthCheckFunc func(*gardencorev1beta1.Seed, client.Client, clock.Clock, *string, bool, bool, bool, map[gardencorev1beta1.ConditionType]time.Duration) HealthCheck
 
 // defaultNewHealthCheck is the default function to create a new instance for performing health checks.
-var defaultNewHealthCheck NewHealthCheckFunc = func(seed *gardencorev1beta1.Seed, client client.Client, clock clock.Clock, namespace *string, seedIsGarden bool, loggingEnabled bool, conditionThresholds map[gardencorev1beta1.ConditionType]time.Duration) HealthCheck {
-	return NewHealth(seed, client, clock, namespace, seedIsGarden, loggingEnabled, conditionThresholds)
+var defaultNewHealthCheck NewHealthCheckFunc = func(seed *gardencorev1beta1.Seed, client client.Client, clock clock.Clock, namespace *string, seedIsGarden bool, loggingEnabled, valiEnabled bool, conditionThresholds map[gardencorev1beta1.ConditionType]time.Duration) HealthCheck {
+	return NewHealth(seed, client, clock, namespace, seedIsGarden, loggingEnabled, valiEnabled, conditionThresholds)
 }
 
 // HealthCheck is an interface used to perform health checks.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity
/kind bug

**What this PR does / why we need it**:
When `vali` is disabled in `gardenlet`'s component configuration (`.logging.vali.enabled=false`) while logging was enabled (`.logging.enabled=true`), then the `Seed` conditions will show the following error:

```yaml
conditions:
- lastTransitionTime: "2023-11-18T18:23:54Z"
  lastUpdateTime: "2023-11-18T18:22:36Z"
  message: ManagedResource.resources.gardener.cloud "vali" not found
  reason: ResourceNotFound
  status: "False"
  type: SeedSystemComponentsHealthy
```

Hence, the `Seed` will remain in `NotReady` state forever.

This PR addresses this issue and only adds the `vali` `ManagedResource` to the list of required `ManagedResource`s when it is enabled.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
A bug in the `Seed` care controller has been fixed which caused the `Seed` to remain in `NotReady` state when `vali` was disabled in `gardenlet`'s component config (via `.logging.vali.enabled=false`) while logging was enabled (`.logging.enabled=true`).
```
