### PR TITLE
Set logger in e2e test

### DIFF
--- a/test/e2e/gardener/shoot/common.go
+++ b/test/e2e/gardener/shoot/common.go
@@ -18,17 +18,21 @@ import (
 	"context"
 
 	. "github.com/onsi/ginkgo/v2"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
+	"github.com/gardener/gardener/pkg/logger"
 	e2e "github.com/gardener/gardener/test/e2e/gardener"
 	"github.com/gardener/gardener/test/framework"
 )
 
-var (
-	parentCtx context.Context
-)
+const testID = "shoot-test"
+
+var parentCtx context.Context
 
 var _ = BeforeEach(func() {
 	parentCtx = context.Background()
+	logf.SetLogger(logger.MustNewZapLogger(logger.InfoLevel, logger.FormatJSON, zap.WriteTo(GinkgoWriter)).WithName(testID))
 })
 
 func defaultShootCreationFramework() *framework.ShootCreationFramework {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind bug

**What this PR does / why we need it**:
Prevent logger warning in shoot e2e test ref - https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/8839/pull-gardener-e2e-kind/1726876627314413568#1:build-log.txt%3A312-339

Similar to https://github.com/gardener/gardener/pull/8514

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
