### PR TITLE
[node-agent] Integrate `gardener-node-agent` into `gardenlet`'s `Shoot` controller

### DIFF
--- a/cmd/gardener-node-agent/app/bootstrappers/bootstrappers_suite_test.go
+++ b/cmd/gardener-node-agent/app/bootstrappers/bootstrappers_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bootstrappers_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestBootstrappers(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Command NodeAgent App Bootstrappers Suite")
+}

--- a/cmd/gardener-node-agent/app/bootstrappers/cloud_config_downloader_cleaner.go
+++ b/cmd/gardener-node-agent/app/bootstrappers/cloud_config_downloader_cleaner.go
@@ -1,0 +1,66 @@
+// Copyright 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bootstrappers
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path"
+
+	"github.com/go-logr/logr"
+	"github.com/spf13/afero"
+
+	"github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/downloader"
+	"github.com/gardener/gardener/pkg/nodeagent/dbus"
+)
+
+// CloudConfigDownloaderCleaner is a runnable for cleaning up the legacy cloud-config-downloader resources.
+// TODO(rfranzke): Remove this bootstrapper when the UseGardenerNodeAgent feature gate gets removed.
+type CloudConfigDownloaderCleaner struct {
+	Log  logr.Logger
+	FS   afero.Afero
+	DBus dbus.DBus
+}
+
+// Start performs the cleanup logic. Note that this function does only delete the following directories/files:
+//   - /var/lib/cloud-config-downloader
+//   - /etc/systemd/system/multi-user.target.wants/cloud-config-downloader.service (typically symlinks to
+//     /etc/systemd/system/cloud-config-downloader.service
+//
+// The /etc/systemd/system/cloud-config-downloader.service file already gets removed by cloud-config-downloader itself
+// when migrating to gardener-node-agent because it is no longer part of the original OperatingSystemConfig. Hence,
+// cloud-config-downloader considers it as stale and cleans it up.
+// All this still leaves some artefacts on the nodes (e.g., `systemctl status cloud-config-downloader` and
+// `journalctl -u cloud-config-downloader` still works), however, maybe that's even a benefit in case of operations/
+// debugging activities. All nodes get rolled/replaced eventually (latest with the next OS/Kubernetes version update),
+// so we leave the final cleanup for then (new nodes will have no traces of cloud-config-downloader whatsoever).
+func (c *CloudConfigDownloaderCleaner) Start(ctx context.Context) error {
+	c.Log.Info("Removing legacy directory if it exists", "path", downloader.PathCCDDirectory)
+	if err := c.FS.RemoveAll(downloader.PathCCDDirectory); err != nil {
+		return fmt.Errorf("failed to remove legacy directory %q: %w", downloader.PathCCDDirectory, err)
+	}
+
+	unitFilePath := path.Join("/", "etc", "systemd", "system", "multi-user.target.wants", downloader.UnitName)
+	c.Log.Info("Removing legacy unit file if it exists", "path", unitFilePath)
+	if err := c.FS.Remove(unitFilePath); err != nil {
+		if !errors.Is(err, afero.ErrFileNotFound) {
+			return fmt.Errorf("failed removing legacy unit file file %q: %w", unitFilePath, err)
+		}
+		return nil
+	}
+
+	return c.DBus.DaemonReload(ctx)
+}

--- a/cmd/gardener-node-agent/app/bootstrappers/cloud_config_downloader_cleaner_test.go
+++ b/cmd/gardener-node-agent/app/bootstrappers/cloud_config_downloader_cleaner_test.go
@@ -1,0 +1,84 @@
+// Copyright 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bootstrappers
+
+import (
+	"context"
+	"io/fs"
+	"path/filepath"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/spf13/afero"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	fakedbus "github.com/gardener/gardener/pkg/nodeagent/dbus/fake"
+	"github.com/gardener/gardener/pkg/utils/test"
+)
+
+var _ = Describe("CloudConfigDownloaderCleaner", func() {
+	var (
+		ctx = context.TODO()
+		log = logr.Discard()
+
+		fakeFS   afero.Afero
+		fakeDBus *fakedbus.DBus
+		runnable manager.Runnable
+	)
+
+	BeforeEach(func() {
+		fakeFS = afero.Afero{Fs: afero.NewMemMapFs()}
+		fakeDBus = fakedbus.New()
+		runnable = &CloudConfigDownloaderCleaner{
+			Log:  log,
+			FS:   fakeFS,
+			DBus: fakeDBus,
+		}
+	})
+
+	Describe("#Start", func() {
+		var (
+			pathDirectory              = filepath.Join("/", "var", "lib", "cloud-config-downloader")
+			pathSystemdUnitFileSymlink = filepath.Join("/", "etc", "systemd", "system", "multi-user.target.wants", "cloud-config-downloader.service")
+		)
+
+		It("should remove the directories and files, and reload systemd daemon", func() {
+			Expect(fakeFS.MkdirAll(pathDirectory, fs.ModeDir)).To(Succeed())
+			_, err := fakeFS.Create(pathSystemdUnitFileSymlink)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(runnable.Start(ctx)).To(Succeed())
+
+			test.AssertNoDirectoryOnDisk(fakeFS, pathDirectory)
+			test.AssertNoFileOnDisk(fakeFS, pathSystemdUnitFileSymlink)
+			Expect(fakeDBus.Actions).To(ConsistOf(fakedbus.SystemdAction{Action: fakedbus.ActionDaemonReload}))
+		})
+
+		It("should not restart when the systemd unit file does not exist anymore", func() {
+			Expect(fakeFS.MkdirAll(pathDirectory, fs.ModeDir)).To(Succeed())
+
+			Expect(runnable.Start(ctx)).To(Succeed())
+
+			Expect(fakeDBus.Actions).To(BeEmpty())
+		})
+
+		It("should not fail when there is nothing to cleanup", func() {
+			Expect(runnable.Start(ctx)).To(Succeed())
+
+			Expect(fakeDBus.Actions).To(BeEmpty())
+		})
+	})
+})

--- a/cmd/gardener-node-agent/app/bootstrappers/kubelet_bootstrap_kubeconfig.go
+++ b/cmd/gardener-node-agent/app/bootstrappers/kubelet_bootstrap_kubeconfig.go
@@ -1,0 +1,88 @@
+// Copyright 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bootstrappers
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/go-logr/logr"
+	"github.com/spf13/afero"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientcmdlatest "k8s.io/client-go/tools/clientcmd/api/latest"
+	clientcmdv1 "k8s.io/client-go/tools/clientcmd/api/v1"
+
+	"github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/original/components/kubelet"
+	"github.com/gardener/gardener/pkg/nodeagent/apis/config"
+	nodeagentv1alpha1 "github.com/gardener/gardener/pkg/nodeagent/apis/config/v1alpha1"
+	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
+)
+
+// KubeletBootstrapKubeconfig is a runnable for creating a bootstrap kubeconfig for kubelet.
+type KubeletBootstrapKubeconfig struct {
+	Log             logr.Logger
+	FS              afero.Afero
+	APIServerConfig config.APIServer
+}
+
+// Start performs creation of the bootstrap kubeconfig.
+func (k *KubeletBootstrapKubeconfig) Start(_ context.Context) error {
+	k.Log.Info("Checking whether kubelet bootstrap kubeconfig needs to be created")
+
+	bootstrapToken, err := k.FS.ReadFile(nodeagentv1alpha1.BootstrapTokenFilePath)
+	if err != nil {
+		if !errors.Is(err, afero.ErrFileNotFound) {
+			return fmt.Errorf("failed checking whether bootstrap token file %q already exists: %w", nodeagentv1alpha1.BootstrapTokenFilePath, err)
+		}
+		k.Log.Info("Bootstrap token file does not exist, nothing to be done", "path", nodeagentv1alpha1.BootstrapTokenFilePath)
+		return nil
+	}
+
+	if _, err := k.FS.Stat(kubelet.PathKubeconfigReal); err != nil && !errors.Is(err, afero.ErrFileNotFound) {
+		return fmt.Errorf("failed checking whether kubelet kubeconfig file %q already exists: %w", kubelet.PathKubeconfigReal, err)
+	} else if err == nil {
+		k.Log.Info("Kubelet kubeconfig with client certificates already exists, nothing to be done", "path", kubelet.PathKubeconfigReal)
+		return nil
+	}
+
+	kubeletClientCertificatePath := filepath.Join(kubelet.PathKubeletDirectory, "pki", "kubelet-client-current.pem")
+	if _, err := k.FS.Stat(kubeletClientCertificatePath); err != nil && !errors.Is(err, afero.ErrFileNotFound) {
+		return fmt.Errorf("failed checking whether kubelet client certificate file %q already exists: %w", kubeletClientCertificatePath, err)
+	} else if err == nil {
+		k.Log.Info("Kubelet client certificates file already exists, nothing to be done", "path", kubeletClientCertificatePath)
+		return nil
+	}
+
+	k.Log.Info("Creating kubelet directory", "path", kubelet.PathKubeletDirectory)
+	if err := k.FS.MkdirAll(kubelet.PathKubeletDirectory, os.ModeDir); err != nil {
+		return fmt.Errorf("unable to create kubelet directory %q: %w", kubelet.PathKubeletDirectory, err)
+	}
+
+	kubeconfig, err := runtime.Encode(clientcmdlatest.Codec, kubernetesutils.NewKubeconfig(
+		"kubelet-bootstrap",
+		clientcmdv1.Cluster{Server: k.APIServerConfig.Server, CertificateAuthorityData: k.APIServerConfig.CABundle},
+		clientcmdv1.AuthInfo{Token: strings.TrimSpace(string(bootstrapToken))},
+	))
+	if err != nil {
+		return fmt.Errorf("unable to encode kubeconfig: %w", err)
+	}
+
+	k.Log.Info("Writing kubelet bootstrap kubeconfig file", "path", kubelet.PathKubeconfigBootstrap)
+	return k.FS.WriteFile(kubelet.PathKubeconfigBootstrap, kubeconfig, 0600)
+}

--- a/cmd/gardener-node-agent/app/bootstrappers/kubelet_bootstrap_kubeconfig_test.go
+++ b/cmd/gardener-node-agent/app/bootstrappers/kubelet_bootstrap_kubeconfig_test.go
@@ -1,0 +1,126 @@
+// Copyright 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bootstrappers
+
+import (
+	"context"
+	"path/filepath"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/spf13/afero"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	"github.com/gardener/gardener/pkg/nodeagent/apis/config"
+	"github.com/gardener/gardener/pkg/utils"
+	"github.com/gardener/gardener/pkg/utils/test"
+)
+
+var _ = Describe("KubeletBootstrapKubeconfig", func() {
+	var (
+		ctx = context.TODO()
+		log = logr.Discard()
+
+		fakeFS          afero.Afero
+		apiServerConfig = config.APIServer{
+			Server:   "server",
+			CABundle: []byte("ca-bundle"),
+		}
+		bootstrapToken = "bootstrap-token"
+		runnable       manager.Runnable
+	)
+
+	BeforeEach(func() {
+		fakeFS = afero.Afero{Fs: afero.NewMemMapFs()}
+		runnable = &KubeletBootstrapKubeconfig{
+			Log:             log,
+			FS:              fakeFS,
+			APIServerConfig: apiServerConfig,
+		}
+	})
+
+	Describe("#Start", func() {
+		var (
+			pathBootstrapTokenFile              = filepath.Join("/", "var", "lib", "gardener-node-agent", "credentials", "bootstrap-token")
+			pathKubeletDirectory                = filepath.Join("/", "var", "lib", "kubelet")
+			pathKubeletBootstrapKubeconfigFile  = filepath.Join(pathKubeletDirectory, "kubeconfig-bootstrap")
+			pathKubeletClientCertKubeconfigFile = filepath.Join(pathKubeletDirectory, "kubeconfig-real")
+			pathKubeletClientCertFile           = filepath.Join(pathKubeletDirectory, "pki", "kubelet-client-current.pem")
+		)
+
+		When("bootstrap token file does not exist", func() {
+			It("should do nothing when bootstrap token file does not exist", func() {
+				Expect(runnable.Start(ctx)).To(Succeed())
+
+				test.AssertNoDirectoryOnDisk(fakeFS, pathKubeletDirectory)
+				test.AssertNoFileOnDisk(fakeFS, pathKubeletBootstrapKubeconfigFile)
+			})
+		})
+
+		When("bootstrap token file exists", func() {
+			BeforeEach(func() {
+				Expect(fakeFS.WriteFile(pathBootstrapTokenFile, []byte(bootstrapToken), 0600)).To(Succeed())
+			})
+
+			It("should do nothing when kubelet kubeconfig with client certificate already exists", func() {
+				_, err := fakeFS.Create(pathKubeletClientCertKubeconfigFile)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(runnable.Start(ctx)).To(Succeed())
+
+				test.AssertDirectoryOnDisk(fakeFS, pathKubeletDirectory)
+				test.AssertNoFileOnDisk(fakeFS, pathKubeletBootstrapKubeconfigFile)
+			})
+
+			It("should do nothing when kubelet client certificate file already exists", func() {
+				_, err := fakeFS.Create(pathKubeletClientCertFile)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(runnable.Start(ctx)).To(Succeed())
+
+				test.AssertDirectoryOnDisk(fakeFS, pathKubeletDirectory)
+				test.AssertNoFileOnDisk(fakeFS, pathKubeletBootstrapKubeconfigFile)
+			})
+
+			It("should create the bootstrap kubeconfig file", func() {
+				expectedBootstrapKubeconfig := `apiVersion: v1
+clusters:
+- cluster:
+    certificate-authority-data: ` + utils.EncodeBase64(apiServerConfig.CABundle) + `
+    server: https://` + apiServerConfig.Server + `
+  name: kubelet-bootstrap
+contexts:
+- context:
+    cluster: kubelet-bootstrap
+    user: kubelet-bootstrap
+  name: kubelet-bootstrap
+current-context: kubelet-bootstrap
+kind: Config
+preferences: {}
+users:
+- name: kubelet-bootstrap
+  user:
+    token: ` + bootstrapToken + `
+`
+
+				Expect(runnable.Start(ctx)).To(Succeed())
+
+				test.AssertDirectoryOnDisk(fakeFS, pathKubeletDirectory)
+				test.AssertFileOnDisk(fakeFS, pathKubeletBootstrapKubeconfigFile, expectedBootstrapKubeconfig, 0600)
+			})
+		})
+	})
+})

--- a/cmd/gardener-node-agent/app/bootstrappers/kubelet_bootstrap_kubeconfig_test.go
+++ b/cmd/gardener-node-agent/app/bootstrappers/kubelet_bootstrap_kubeconfig_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package bootstrappers
+package bootstrappers_test
 
 import (
 	"context"
@@ -24,6 +24,7 @@ import (
 	"github.com/spf13/afero"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
+	. "github.com/gardener/gardener/cmd/gardener-node-agent/app/bootstrappers"
 	"github.com/gardener/gardener/pkg/nodeagent/apis/config"
 	"github.com/gardener/gardener/pkg/utils"
 	"github.com/gardener/gardener/pkg/utils/test"

--- a/example/gardener-local/gardenlet/values.yaml
+++ b/example/gardener-local/gardenlet/values.yaml
@@ -49,6 +49,7 @@ config:
     # If disabled, a Shoot cluster in local setup won't be able to use the registry cache
     # (it will be still able to pull images but registry cache won't be used).
     ContainerdRegistryHostsDir: true
+    UseGardenerNodeAgent: true
   etcdConfig:
     featureGates:
       UseEtcdWrapper: true

--- a/hack/check-skaffold-deps.sh
+++ b/hack/check-skaffold-deps.sh
@@ -35,6 +35,7 @@ run "skaffold.yaml" "gardener-apiserver"                 "controlplane"
 run "skaffold.yaml" "gardener-controller-manager"        "controlplane"
 run "skaffold.yaml" "gardener-extension-provider-local"  "provider-local"
 run "skaffold.yaml" "gardener-resource-manager"          "gardenlet"
+run "skaffold.yaml" "gardener-node-agent"                "gardenlet"
 run "skaffold.yaml" "gardener-scheduler"                 "controlplane"
 run "skaffold.yaml" "gardenlet"                          "gardenlet"
 

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -603,10 +603,10 @@ const (
 	AnnotationShootInfrastructureCleanupWaitPeriodSeconds = "shoot.gardener.cloud/infrastructure-cleanup-wait-period-seconds"
 	// AnnotationShootCloudConfigExecutionMaxDelaySeconds is a key for an annotation on a Shoot resource that declares
 	// the maximum delay in seconds when potentially updated cloud-config user data is executed on the worker nodes.
-	// Concretely, the cloud-config-downloader systemd service running on all worker nodes will wait for a random
-	// duration based on the configured value before executing the user data (default value is 300) plus an additional
-	// offset of 30s. If set to 0 then no random delay will be applied and the minimum delay (30s) applies. Any value
-	// above 1800 is ignored (in this case the default value is used).
+	// Concretely, the cloud-config-downloader/gardener-node-agent systemd service running on all worker nodes will wait
+	// for a random duration based on the configured value before executing the user data (default value is 300) plus an
+	// additional offset of 30s. If set to 0 then no random delay will be applied and the minimum delay (30s) applies.
+	// Any value above 1800 is ignored (in this case the default value is used).
 	// Note that changing this value only applies to new nodes. Existing nodes which already computed their individual
 	// delays will not recompute it.
 	AnnotationShootCloudConfigExecutionMaxDelaySeconds = "shoot.gardener.cloud/cloud-config-execution-max-delay-seconds"

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -267,6 +267,8 @@ const (
 	GardenRoleOptionalAddon = "optional-addon"
 	// GardenRoleCloudConfig is the value of the GardenRole key indicating type 'cloud-config'.
 	GardenRoleCloudConfig = "cloud-config"
+	// GardenRoleOperatingSystemConfig is the value of the GardenRole key indicating type 'operating-system-config'.
+	GardenRoleOperatingSystemConfig = "operating-system-config"
 	// GardenRoleKubeconfig is the value of the GardenRole key indicating type 'kubeconfig'.
 	GardenRoleKubeconfig = "kubeconfig"
 	// GardenRoleCACluster is the value of the GardenRole key indicating type 'ca-cluster'.

--- a/pkg/component/extensions/operatingsystemconfig/downloader/downloader.go
+++ b/pkg/component/extensions/operatingsystemconfig/downloader/downloader.go
@@ -33,6 +33,7 @@ import (
 	"github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/original/components/docker"
 	"github.com/gardener/gardener/pkg/component/logging/vali"
 	"github.com/gardener/gardener/pkg/features"
+	nodeagentv1alpha1 "github.com/gardener/gardener/pkg/nodeagent/apis/config/v1alpha1"
 	"github.com/gardener/gardener/pkg/utils"
 	"github.com/gardener/gardener/pkg/utils/managedresources"
 	"github.com/gardener/gardener/pkg/utils/secrets"
@@ -71,7 +72,7 @@ const (
 	DataKeyScript = "script"
 	// AnnotationKeyChecksum is the key of an annotation on a Secret object whose value is the checksum of the cloud
 	// config user data stored in the data map of this Secret.
-	AnnotationKeyChecksum = "checksum/data-script"
+	AnnotationKeyChecksum = nodeagentv1alpha1.AnnotationKeyChecksumDownloadedOperatingSystemConfig
 
 	// PathCCDDirectory is a constant for the path of the cloud-config-downloader unit.
 	PathCCDDirectory = "/var/lib/" + Name

--- a/pkg/component/extensions/operatingsystemconfig/downloader/downloader.go
+++ b/pkg/component/extensions/operatingsystemconfig/downloader/downloader.go
@@ -32,6 +32,7 @@ import (
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/original/components/docker"
 	"github.com/gardener/gardener/pkg/component/logging/vali"
+	"github.com/gardener/gardener/pkg/features"
 	"github.com/gardener/gardener/pkg/utils"
 	"github.com/gardener/gardener/pkg/utils/managedresources"
 	"github.com/gardener/gardener/pkg/utils/secrets"
@@ -221,10 +222,14 @@ func GenerateRBACResourcesData(secretNames []string) (map[string][]byte, error) 
 			},
 			Rules: []rbacv1.PolicyRule{
 				{
-					APIGroups:     []string{""},
-					Resources:     []string{"secrets"},
-					ResourceNames: append(secretNames, Name, vali.ValitailTokenSecretName),
-					Verbs:         []string{"get"},
+					APIGroups: []string{""},
+					Resources: []string{"secrets"},
+					ResourceNames: append(secretNames, Name, vali.ValitailTokenSecretName,
+						// This is needed for migration from cloud-config-downloader to gardener-node-agent: The CCD
+						// token will be used to fetch the GNA token, hence it needs permissions to read the secret.
+						"gardener-node-agent",
+					),
+					Verbs: []string{"get"},
 				},
 			},
 		}
@@ -300,6 +305,14 @@ func GenerateRBACResourcesData(secretNames []string) (map[string][]byte, error) 
 			}},
 		}
 	)
+
+	if features.DefaultFeatureGate.Enabled(features.UseGardenerNodeAgent) {
+		// The following resources will be managed by the gardener-node-agent when the feature gate is turned on. 'role'
+		// and 'roleBinding' are kept for the migration scenario.
+		metav1.SetMetaDataAnnotation(&clusterRoleBindingNodeBootstrapper.ObjectMeta, resourcesv1alpha1.Mode, resourcesv1alpha1.ModeIgnore)
+		metav1.SetMetaDataAnnotation(&clusterRoleBindingNodeClient.ObjectMeta, resourcesv1alpha1.Mode, resourcesv1alpha1.ModeIgnore)
+		metav1.SetMetaDataAnnotation(&clusterRoleBindingSelfNodeClient.ObjectMeta, resourcesv1alpha1.Mode, resourcesv1alpha1.ModeIgnore)
+	}
 
 	return managedresources.
 		NewRegistry(kubernetes.ShootScheme, kubernetes.ShootCodec, kubernetes.ShootSerializer).

--- a/pkg/component/extensions/operatingsystemconfig/downloader/downloader_suite_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/downloader/downloader_suite_test.go
@@ -19,9 +19,12 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	"github.com/gardener/gardener/pkg/gardenlet/features"
 )
 
 func TestDownloader(t *testing.T) {
+	features.RegisterFeatureGates()
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Component Extensions OperatingSystemConfig Downloader Suite")
 }

--- a/pkg/component/extensions/operatingsystemconfig/executor/executor.go
+++ b/pkg/component/extensions/operatingsystemconfig/executor/executor.go
@@ -32,6 +32,7 @@ import (
 	"github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/original/components/docker"
 	"github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/original/components/kubelet"
 	"github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/original/components/varlibmount"
+	nodeagentv1alpha1 "github.com/gardener/gardener/pkg/nodeagent/apis/config/v1alpha1"
 	"github.com/gardener/gardener/pkg/utils"
 	"github.com/gardener/gardener/pkg/utils/imagevector"
 )
@@ -70,7 +71,7 @@ func init() {
 const (
 	// AnnotationKeyChecksum is the key of an annotation on a shoot Node object whose value is the checksum
 	// of the last applied cloud config user data.
-	AnnotationKeyChecksum = "checksum/cloud-config-data"
+	AnnotationKeyChecksum = nodeagentv1alpha1.AnnotationKeyChecksumAppliedOperatingSystemConfig
 	// PathExecutionDelaySeconds is the path on the shoot worker nodes at which the randomly computed delay for the
 	// execution will be persisted.
 	PathExecutionDelaySeconds = downloader.PathCCDDirectory + "/execution_delay_seconds"

--- a/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig.go
+++ b/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig.go
@@ -191,6 +191,8 @@ type OperatingSystemConfigs struct {
 
 // Data contains the actual content, a command to load it and all units that shall be considered for restart on change.
 type Data struct {
+	// Object is the plain OperatingSystemConfig object.
+	Object *extensionsv1alpha1.OperatingSystemConfig
 	// Content is the actual cloud-config user data.
 	Content string
 	// Command is the command for reloading the cloud-config (in case a new version was downloaded).
@@ -273,6 +275,7 @@ func (o *operatingSystemConfig) Wait(ctx context.Context) error {
 				}
 
 				data := Data{
+					Object:  osc,
 					Content: string(secret.Data[extensionsv1alpha1.OperatingSystemConfigSecretDataKey]),
 					Command: osc.Status.Command,
 					Units:   osc.Status.Units,

--- a/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig.go
+++ b/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig.go
@@ -127,6 +127,8 @@ type OriginalValues struct {
 	ValiIngressHostName string
 	// NodeLocalDNSEnabled indicates whether node local dns is enabled or not.
 	NodeLocalDNSEnabled bool
+	// SyncJitterPeriod is the duration of how the operating system config sync will be jittered on updates.
+	SyncJitterPeriod *metav1.Duration
 }
 
 // New creates a new instance of Interface.
@@ -519,6 +521,7 @@ func (o *operatingSystemConfig) newDeployer(osc *extensionsv1alpha1.OperatingSys
 		valiIngressHostName:     o.values.ValiIngressHostName,
 		valitailEnabled:         o.values.ValitailEnabled,
 		nodeLocalDNSEnabled:     o.values.NodeLocalDNSEnabled,
+		oscSyncJitterPeriod:     o.values.SyncJitterPeriod,
 	}, nil
 }
 
@@ -580,6 +583,7 @@ type deployer struct {
 	valiIngressHostName     string
 	valitailEnabled         bool
 	nodeLocalDNSEnabled     bool
+	oscSyncJitterPeriod     *metav1.Duration
 }
 
 // exposed for testing
@@ -632,6 +636,7 @@ func (d *deployer) deploy(ctx context.Context, operation string) (extensionsv1al
 			ValiIngress:             d.valiIngressHostName,
 			APIServerURL:            d.apiServerURL,
 			Sysctls:                 d.worker.Sysctls,
+			OSCSyncJitterPeriod:     d.oscSyncJitterPeriod,
 		})
 		if err != nil {
 			return nil, err

--- a/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig_suite_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig_suite_test.go
@@ -19,9 +19,12 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	"github.com/gardener/gardener/pkg/gardenlet/features"
 )
 
 func TestOperatingSystemConfig(t *testing.T) {
+	features.RegisterFeatureGates()
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Component Extensions OperatingSystemConfig Suite")
 }

--- a/pkg/component/extensions/operatingsystemconfig/original/components/nodeagent/component.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/nodeagent/component.go
@@ -45,9 +45,10 @@ var codec runtime.Codec
 func init() {
 	scheme := runtime.NewScheme()
 	utilruntime.Must(nodeagentv1alpha1.AddToScheme(scheme))
+	utilruntime.Must(extensionsv1alpha1.AddToScheme(scheme))
 
 	ser := json.NewSerializerWithOptions(json.DefaultMetaFactory, scheme, scheme, json.SerializerOptions{Yaml: true, Pretty: false, Strict: false})
-	versions := schema.GroupVersions([]schema.GroupVersion{nodeagentv1alpha1.SchemeGroupVersion})
+	versions := schema.GroupVersions([]schema.GroupVersion{nodeagentv1alpha1.SchemeGroupVersion, extensionsv1alpha1.SchemeGroupVersion})
 	codec = serializer.NewCodecFactory(scheme).CodecForVersions(ser, ser, versions, versions)
 }
 

--- a/pkg/component/extensions/operatingsystemconfig/original/components/nodeagent/rbac.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/nodeagent/rbac.go
@@ -1,0 +1,162 @@
+// Copyright 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nodeagent
+
+import (
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apiserver/pkg/authentication/user"
+	bootstraptokenapi "k8s.io/cluster-bootstrap/token/api"
+
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	nodeagentv1alpha1 "github.com/gardener/gardener/pkg/nodeagent/apis/config/v1alpha1"
+	"github.com/gardener/gardener/pkg/utils/managedresources"
+)
+
+// RBACResourcesData returns a map of serialized Kubernetes resources that allow the gardener-node-agent to
+// access the list of given secrets. Additionally, serialized resources providing permissions to allow initiating the
+// Kubernetes TLS bootstrapping process will be returned.
+func RBACResourcesData(_ []string) (map[string][]byte, error) {
+	var (
+		clusterRole = &rbacv1.ClusterRole{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "gardener-node-agent",
+			},
+			Rules: []rbacv1.PolicyRule{
+				{
+					APIGroups: []string{""},
+					Resources: []string{"nodes"},
+					Verbs:     []string{"get", "list", "watch", "patch", "update"},
+				},
+				{
+					APIGroups: []string{""},
+					Resources: []string{"events"},
+					Verbs:     []string{"get", "list", "watch", "create", "patch", "update"},
+				},
+			},
+		}
+
+		clusterRoleBinding = &rbacv1.ClusterRoleBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "gardener-node-agent",
+			},
+			RoleRef: rbacv1.RoleRef{
+				APIGroup: rbacv1.SchemeGroupVersion.Group,
+				Kind:     "ClusterRole",
+				Name:     clusterRole.Name,
+			},
+			Subjects: []rbacv1.Subject{{
+				Kind:      rbacv1.ServiceAccountKind,
+				Name:      nodeagentv1alpha1.AccessSecretName,
+				Namespace: metav1.NamespaceSystem,
+			}},
+		}
+
+		role = &rbacv1.Role{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "gardener-node-agent",
+				Namespace: metav1.NamespaceSystem,
+			},
+			Rules: []rbacv1.PolicyRule{{
+				APIGroups: []string{""},
+				Resources: []string{"secrets"},
+				Verbs:     []string{"get", "list", "watch"},
+			}},
+		}
+
+		roleBinding = &rbacv1.RoleBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "gardener-node-agent",
+				Namespace: metav1.NamespaceSystem,
+			},
+			RoleRef: rbacv1.RoleRef{
+				APIGroup: rbacv1.SchemeGroupVersion.Group,
+				Kind:     "Role",
+				Name:     role.Name,
+			},
+			Subjects: []rbacv1.Subject{
+				{
+					Kind: rbacv1.GroupKind,
+					Name: bootstraptokenapi.BootstrapDefaultGroup,
+				},
+				{
+					Kind:      rbacv1.ServiceAccountKind,
+					Name:      nodeagentv1alpha1.AccessSecretName,
+					Namespace: metav1.NamespaceSystem,
+				},
+			},
+		}
+
+		clusterRoleBindingNodeBootstrapper = &rbacv1.ClusterRoleBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "system:node-bootstrapper",
+			},
+			RoleRef: rbacv1.RoleRef{
+				APIGroup: rbacv1.SchemeGroupVersion.Group,
+				Kind:     "ClusterRole",
+				Name:     "system:node-bootstrapper",
+			},
+			Subjects: []rbacv1.Subject{{
+				APIGroup: rbacv1.SchemeGroupVersion.Group,
+				Kind:     rbacv1.GroupKind,
+				Name:     bootstraptokenapi.BootstrapDefaultGroup,
+			}},
+		}
+
+		clusterRoleBindingNodeClient = &rbacv1.ClusterRoleBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "system:certificates.k8s.io:certificatesigningrequests:nodeclient",
+			},
+			RoleRef: rbacv1.RoleRef{
+				APIGroup: rbacv1.SchemeGroupVersion.Group,
+				Kind:     "ClusterRole",
+				Name:     "system:certificates.k8s.io:certificatesigningrequests:nodeclient",
+			},
+			Subjects: []rbacv1.Subject{{
+				APIGroup: rbacv1.SchemeGroupVersion.Group,
+				Kind:     rbacv1.GroupKind,
+				Name:     bootstraptokenapi.BootstrapDefaultGroup,
+			}},
+		}
+
+		clusterRoleBindingSelfNodeClient = &rbacv1.ClusterRoleBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "system:certificates.k8s.io:certificatesigningrequests:selfnodeclient",
+			},
+			RoleRef: rbacv1.RoleRef{
+				APIGroup: rbacv1.SchemeGroupVersion.Group,
+				Kind:     "ClusterRole",
+				Name:     "system:certificates.k8s.io:certificatesigningrequests:selfnodeclient",
+			},
+			Subjects: []rbacv1.Subject{{
+				APIGroup: rbacv1.SchemeGroupVersion.Group,
+				Kind:     rbacv1.GroupKind,
+				Name:     user.NodesGroup,
+			}},
+		}
+	)
+
+	return managedresources.
+		NewRegistry(kubernetes.ShootScheme, kubernetes.ShootCodec, kubernetes.ShootSerializer).
+		AddAllAndSerialize(
+			clusterRole,
+			clusterRoleBinding,
+			role,
+			roleBinding,
+			clusterRoleBindingNodeBootstrapper,
+			clusterRoleBindingNodeClient,
+			clusterRoleBindingSelfNodeClient,
+		)
+}

--- a/pkg/component/extensions/operatingsystemconfig/original/components/nodeagent/rbac_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/nodeagent/rbac_test.go
@@ -1,0 +1,174 @@
+// Copyright 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nodeagent_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	. "github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/original/components/nodeagent"
+)
+
+var _ = Describe("RBAC", func() {
+	Describe("#RBACResourcesData", func() {
+		var (
+			clusterRoleYAML                        string
+			clusterRoleBindingYAML                 string
+			roleYAML                               string
+			roleBindingYAML                        string
+			clusterRoleBindingNodeBootstrapperYAML string
+			clusterRoleBindingNodeClientYAML       string
+			clusterRoleBindingSelfNodeClientYAML   string
+		)
+
+		BeforeEach(func() {
+			clusterRoleYAML = `apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: gardener-node-agent
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - patch
+  - update
+`
+
+			clusterRoleBindingYAML = `apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  creationTimestamp: null
+  name: gardener-node-agent
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: gardener-node-agent
+subjects:
+- kind: ServiceAccount
+  name: gardener-node-agent
+  namespace: kube-system
+`
+
+			roleYAML = `apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  name: gardener-node-agent
+  namespace: kube-system
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+`
+
+			roleBindingYAML = `apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  creationTimestamp: null
+  name: gardener-node-agent
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: gardener-node-agent
+subjects:
+- kind: Group
+  name: system:bootstrappers
+- kind: ServiceAccount
+  name: gardener-node-agent
+  namespace: kube-system
+`
+
+			clusterRoleBindingNodeBootstrapperYAML = `apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  creationTimestamp: null
+  name: system:node-bootstrapper
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:node-bootstrapper
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:bootstrappers
+`
+
+			clusterRoleBindingNodeClientYAML = `apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  creationTimestamp: null
+  name: system:certificates.k8s.io:certificatesigningrequests:nodeclient
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:certificates.k8s.io:certificatesigningrequests:nodeclient
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:bootstrappers
+`
+			clusterRoleBindingSelfNodeClientYAML = `apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  creationTimestamp: null
+  name: system:certificates.k8s.io:certificatesigningrequests:selfnodeclient
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:certificates.k8s.io:certificatesigningrequests:selfnodeclient
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:nodes
+`
+		})
+
+		It("should generate the expected RBAC resources", func() {
+			data, err := RBACResourcesData(nil)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(data).To(HaveLen(7))
+			Expect(string(data["clusterrole____gardener-node-agent.yaml"])).To(Equal(clusterRoleYAML))
+			Expect(string(data["clusterrolebinding____gardener-node-agent.yaml"])).To(Equal(clusterRoleBindingYAML))
+			Expect(string(data["role__kube-system__gardener-node-agent.yaml"])).To(Equal(roleYAML))
+			Expect(string(data["rolebinding__kube-system__gardener-node-agent.yaml"])).To(Equal(roleBindingYAML))
+			Expect(string(data["clusterrolebinding____system_node-bootstrapper.yaml"])).To(Equal(clusterRoleBindingNodeBootstrapperYAML))
+			Expect(string(data["clusterrolebinding____system_certificates.k8s.io_certificatesigningrequests_nodeclient.yaml"])).To(Equal(clusterRoleBindingNodeClientYAML))
+			Expect(string(data["clusterrolebinding____system_certificates.k8s.io_certificatesigningrequests_selfnodeclient.yaml"])).To(Equal(clusterRoleBindingSelfNodeClientYAML))
+		})
+	})
+})

--- a/pkg/component/extensions/operatingsystemconfig/original/components/nodeagent/secrets.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/nodeagent/secrets.go
@@ -1,0 +1,93 @@
+// Copyright 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nodeagent
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	nodeagentv1alpha1 "github.com/gardener/gardener/pkg/nodeagent/apis/config/v1alpha1"
+	"github.com/gardener/gardener/pkg/utils"
+)
+
+// OperatingSystemConfigSecret returns a Kubernetes secret object containing the OperatingSystemConfig that
+// gardener-node-agent will read and reconcile on the worker machines.
+func OperatingSystemConfigSecret(
+	ctx context.Context,
+	seedClient client.Client,
+	osc *extensionsv1alpha1.OperatingSystemConfig,
+	secretName string,
+	workerPoolName string,
+) (
+	*corev1.Secret,
+	error,
+) {
+	operatingSystemConfig := &extensionsv1alpha1.OperatingSystemConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        osc.Name,
+			Labels:      osc.Labels,
+			Annotations: osc.Annotations,
+		},
+		Spec:   osc.Spec,
+		Status: osc.Status,
+	}
+
+	// The OperatingSystemConfig will be deployed to the shoot to get processed by gardener-node-agent. It doesn't
+	// have access to the referenced secrets (stored in the shoot namespace in the seed), hence we have to translate
+	// all references into inline content.
+	for i, file := range operatingSystemConfig.Spec.Files {
+		if file.Content.SecretRef == nil {
+			continue
+		}
+
+		secret := &corev1.Secret{}
+		if err := seedClient.Get(ctx, client.ObjectKey{Name: file.Content.SecretRef.Name, Namespace: osc.Namespace}, secret); err != nil {
+			return nil, fmt.Errorf("cannot resolve secret ref from osc: %w", err)
+		}
+
+		operatingSystemConfig.Spec.Files[i].Content.SecretRef = nil
+		operatingSystemConfig.Spec.Files[i].Content.Inline = &extensionsv1alpha1.FileContentInline{
+			Encoding: "b64",
+			Data:     utils.EncodeBase64(secret.Data[file.Content.SecretRef.DataKey]),
+		}
+	}
+
+	operatingSystemConfigRaw, err := runtime.Encode(codec, operatingSystemConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed encoding OperatingSystemConfig: %w", err)
+	}
+
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      secretName,
+			Namespace: metav1.NamespaceSystem,
+			Annotations: map[string]string{
+				nodeagentv1alpha1.AnnotationKeyChecksumDownloadedOperatingSystemConfig: utils.ComputeSHA256Hex(operatingSystemConfigRaw),
+			},
+			Labels: map[string]string{
+				v1beta1constants.GardenRole:      v1beta1constants.GardenRoleOperatingSystemConfig,
+				v1beta1constants.LabelWorkerPool: workerPoolName,
+			},
+		},
+		Data: map[string][]byte{nodeagentv1alpha1.DataKeyOperatingSystemConfig: operatingSystemConfigRaw},
+	}, nil
+}

--- a/pkg/component/extensions/operatingsystemconfig/original/components/nodeagent/secrets_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/nodeagent/secrets_test.go
@@ -1,0 +1,154 @@
+// Copyright 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nodeagent_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	. "github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/original/components/nodeagent"
+	"github.com/gardener/gardener/pkg/utils"
+)
+
+var _ = Describe("Secrets", func() {
+	Describe("#OperatingSystemConfigSecret", func() {
+		var (
+			ctx            = context.TODO()
+			fakeClient     client.Client
+			secretName     = "secret-name"
+			workerPoolName = "worker-pool-name"
+
+			namespace         = "namespace"
+			fileSecret        *corev1.Secret
+			fileSecretDataKey = "foo"
+			fileSecretContent = []byte("bar")
+			osc               *extensionsv1alpha1.OperatingSystemConfig
+		)
+
+		BeforeEach(func() {
+			fakeClient = fakeclient.NewClientBuilder().WithScheme(kubernetes.SeedScheme).Build()
+
+			fileSecret = &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "file-secret",
+					Namespace: namespace,
+				},
+				Data: map[string][]byte{fileSecretDataKey: fileSecretContent},
+			}
+
+			Expect(fakeClient.Create(ctx, fileSecret)).To(Succeed())
+			DeferCleanup(func() {
+				Expect(fakeClient.Delete(ctx, fileSecret)).To(Succeed())
+			})
+
+			osc = &extensionsv1alpha1.OperatingSystemConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "osc-name",
+					Namespace:       namespace,
+					ResourceVersion: "1",
+					UID:             "foo",
+					OwnerReferences: []metav1.OwnerReference{{}},
+					Labels:          map[string]string{"foo": "bar"},
+					Annotations:     map[string]string{"bar": "foo"},
+				},
+				Spec: extensionsv1alpha1.OperatingSystemConfigSpec{
+					Units: []extensionsv1alpha1.Unit{{
+						Name: "some-unit.service",
+					}},
+					Files: []extensionsv1alpha1.File{{
+						Path: "/some/path",
+						Content: extensionsv1alpha1.FileContent{
+							SecretRef: &extensionsv1alpha1.FileContentSecretRef{
+								Name:    fileSecret.Name,
+								DataKey: fileSecretDataKey,
+							},
+						},
+					}},
+				},
+				Status: extensionsv1alpha1.OperatingSystemConfigStatus{
+					ExtensionUnits: []extensionsv1alpha1.Unit{{
+						Name: "some-other-unit.service",
+					}},
+				},
+			}
+		})
+
+		It("should generate the expected secret", func() {
+			secret, err := OperatingSystemConfigSecret(ctx, fakeClient, osc, secretName, workerPoolName)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(secret).To(Equal(&corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      secretName,
+					Namespace: "kube-system",
+					Annotations: map[string]string{
+						"checksum/data-script": "b0a0d190d45f0d67d97bf30d7e45d9cbbaa86bbe99f34bc095a6fd172d1a18a2",
+					},
+					Labels: map[string]string{
+						"gardener.cloud/role":        "operating-system-config",
+						"worker.gardener.cloud/pool": workerPoolName,
+					},
+				},
+				Data: map[string][]byte{"osc.yaml": []byte(`apiVersion: extensions.gardener.cloud/v1alpha1
+kind: OperatingSystemConfig
+metadata:
+  annotations:
+    bar: foo
+  creationTimestamp: null
+  labels:
+    foo: bar
+  name: osc-name
+spec:
+  files:
+  - content:
+      inline:
+        data: ` + utils.EncodeBase64(fileSecretContent) + `
+        encoding: b64
+    path: /some/path
+  purpose: ""
+  type: ""
+  units:
+  - name: some-unit.service
+status:
+  extensionUnits:
+  - name: some-other-unit.service
+`)},
+			}))
+		})
+
+		It("should return an error because a referenced secret cannot be found", func() {
+			osc.Spec.Files = append(osc.Spec.Files, extensionsv1alpha1.File{
+				Path: "/non/existing/path",
+				Content: extensionsv1alpha1.FileContent{
+					SecretRef: &extensionsv1alpha1.FileContentSecretRef{
+						Name:    "non-existing",
+						DataKey: "foo",
+					},
+				},
+			})
+
+			secret, err := OperatingSystemConfigSecret(ctx, fakeClient, osc, secretName, workerPoolName)
+			Expect(err).To(MatchError(ContainSubstring(`cannot resolve secret ref from osc: secrets "non-existing" not found`)))
+			Expect(secret).To(BeNil())
+		})
+	})
+})

--- a/pkg/component/extensions/operatingsystemconfig/original/original.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/original.go
@@ -23,10 +23,12 @@ import (
 	"github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/original/components/journald"
 	"github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/original/components/kernelconfig"
 	"github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/original/components/kubelet"
+	"github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/original/components/nodeagent"
 	"github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/original/components/rootcertificates"
 	"github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/original/components/sshdensurer"
 	"github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/original/components/valitail"
 	"github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/original/components/varlibmount"
+	"github.com/gardener/gardener/pkg/features"
 )
 
 // ComponentsFn is a function that returns the list of original operating system config components.
@@ -72,6 +74,10 @@ func Components(criName extensionsv1alpha1.CRIName, sshAccessEnabled bool) []com
 
 	if criName == extensionsv1alpha1.CRINameContainerD {
 		components = append(components, containerd.NewInitializer())
+	}
+
+	if features.DefaultFeatureGate.Enabled(features.UseGardenerNodeAgent) {
+		components = append(components, nodeagent.New())
 	}
 
 	return components

--- a/pkg/component/extensions/operatingsystemconfig/original/original_suite_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/original_suite_test.go
@@ -19,9 +19,12 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	"github.com/gardener/gardener/pkg/gardenlet/features"
 )
 
 func TestOriginal(t *testing.T) {
+	features.RegisterFeatureGates()
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Component Extensions OperatingSystemConfig Original Suite")
 }

--- a/pkg/component/extensions/operatingsystemconfig/original/original_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/original_test.go
@@ -25,7 +25,9 @@ import (
 	. "github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/original"
 	"github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/original/components"
 	mockcomponents "github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/original/components/mock"
+	"github.com/gardener/gardener/pkg/features"
 	"github.com/gardener/gardener/pkg/utils/imagevector"
+	"github.com/gardener/gardener/pkg/utils/test"
 )
 
 var _ = Describe("Original", func() {
@@ -106,7 +108,6 @@ var _ = Describe("Original", func() {
 	})
 
 	Describe("#Components", func() {
-
 		It("should compute the units and files w/ docker", func() {
 			var order []string
 			for _, component := range Components(extensionsv1alpha1.CRINameDocker, true) {
@@ -162,6 +163,29 @@ var _ = Describe("Original", func() {
 				"kubelet",
 				"sshd-ensurer",
 				"containerd-initializer",
+			}))
+		})
+
+		It("should compute the units and files when UseGardenerNodeAgent is enabled", func() {
+			DeferCleanup(test.WithFeatureGate(features.DefaultFeatureGate, features.UseGardenerNodeAgent, true))
+
+			var order []string
+			for _, component := range Components(extensionsv1alpha1.CRINameContainerD, true) {
+				order = append(order, component.Name())
+			}
+
+			Expect(order).To(Equal([]string{
+				"valitail",
+				"var-lib-mount",
+				"root-certificates",
+				"containerd",
+				"journald",
+				"kernel-config",
+				"kubelet",
+				"sshd-ensurer",
+				"gardener-user",
+				"containerd-initializer",
+				"gardener-node-agent",
 			}))
 		})
 	})

--- a/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
@@ -766,8 +766,8 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 			Dependencies: flow.NewTaskIDs(syncPointAllSystemComponentsDeployed, waitUntilNetworkIsReady, waitUntilWorkerReady),
 		})
 		_ = g.Add(flow.Task{
-			Name:         "Waiting until all shoot worker nodes have updated the cloud config user data",
-			Fn:           botanist.WaitUntilCloudConfigUpdatedForAllWorkerPools,
+			Name:         "Waiting until all shoot worker nodes have updated the operating system config",
+			Fn:           botanist.WaitUntilOperatingSystemConfigUpdatedForAllWorkerPools,
 			SkipIf:       o.Shoot.IsWorkerless || o.Shoot.HibernationEnabled,
 			Dependencies: flow.NewTaskIDs(waitUntilWorkerReady, waitUntilTunnelConnectionExists),
 		})

--- a/pkg/nodeagent/apis/config/v1alpha1/types.go
+++ b/pkg/nodeagent/apis/config/v1alpha1/types.go
@@ -41,6 +41,10 @@ const (
 	UnitName = "gardener-node-agent.service"
 	// InitUnitName is the name of the gardener-node-agent systemd service.
 	InitUnitName = "gardener-node-init.service"
+
+	// DataKeyOperatingSystemConfig is the constant for a key in the data map of an OSC secret which contains the
+	// encoded operating system config.
+	DataKeyOperatingSystemConfig = "osc.yaml"
 	// AnnotationKeyChecksumDownloadedOperatingSystemConfig is a constant for an annotation key on a Secret describing
 	// the checksum of the operating system configuration in the data map.
 	AnnotationKeyChecksumDownloadedOperatingSystemConfig = "checksum/data-script"

--- a/pkg/nodeagent/apis/config/v1alpha1/types.go
+++ b/pkg/nodeagent/apis/config/v1alpha1/types.go
@@ -41,6 +41,12 @@ const (
 	UnitName = "gardener-node-agent.service"
 	// InitUnitName is the name of the gardener-node-agent systemd service.
 	InitUnitName = "gardener-node-init.service"
+	// AnnotationKeyChecksumDownloadedOperatingSystemConfig is a constant for an annotation key on a Secret describing
+	// the checksum of the operating system configuration in the data map.
+	AnnotationKeyChecksumDownloadedOperatingSystemConfig = "checksum/data-script"
+	// AnnotationKeyChecksumAppliedOperatingSystemConfig is a constant for an annotation key on a Node describing the
+	// checksum of the last applied operating system configuration.
+	AnnotationKeyChecksumAppliedOperatingSystemConfig = "checksum/cloud-config-data"
 )
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/nodeagent/controller/operatingsystemconfig/add.go
+++ b/pkg/nodeagent/controller/operatingsystemconfig/add.go
@@ -35,6 +35,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	predicateutils "github.com/gardener/gardener/pkg/controllerutils/predicate"
+	nodeagentv1alpha1 "github.com/gardener/gardener/pkg/nodeagent/apis/config/v1alpha1"
 	"github.com/gardener/gardener/pkg/nodeagent/dbus"
 	"github.com/gardener/gardener/pkg/nodeagent/registry"
 	"github.com/gardener/gardener/pkg/utils"
@@ -94,7 +95,7 @@ func (r *Reconciler) SecretPredicate() predicate.Predicate {
 				return false
 			}
 
-			return !bytes.Equal(oldSecret.Data[dataKeyOperatingSystemConfig], newSecret.Data[dataKeyOperatingSystemConfig])
+			return !bytes.Equal(oldSecret.Data[nodeagentv1alpha1.DataKeyOperatingSystemConfig], newSecret.Data[nodeagentv1alpha1.DataKeyOperatingSystemConfig])
 		},
 		DeleteFunc:  func(_ event.DeleteEvent) bool { return false },
 		GenericFunc: func(_ event.GenericEvent) bool { return false },
@@ -132,7 +133,7 @@ func (r *Reconciler) EnqueueWithJitterDelay(log logr.Logger) handler.EventHandle
 				return
 			}
 
-			if !bytes.Equal(oldSecret.Data[dataKeyOperatingSystemConfig], newSecret.Data[dataKeyOperatingSystemConfig]) {
+			if !bytes.Equal(oldSecret.Data[nodeagentv1alpha1.DataKeyOperatingSystemConfig], newSecret.Data[nodeagentv1alpha1.DataKeyOperatingSystemConfig]) {
 				duration := RandomDurationWithMetaDuration(r.Config.SyncJitterPeriod)
 				log.Info("Enqueued secret with operating system config with a jitter period", "duration", duration)
 				q.AddAfter(reconcileRequest(evt.ObjectNew), duration)

--- a/pkg/nodeagent/controller/operatingsystemconfig/changes.go
+++ b/pkg/nodeagent/controller/operatingsystemconfig/changes.go
@@ -40,14 +40,14 @@ func init() {
 }
 
 func extractOSCFromSecret(secret *corev1.Secret) (*extensionsv1alpha1.OperatingSystemConfig, []byte, string, error) {
-	oscRaw, ok := secret.Data[dataKeyOperatingSystemConfig]
+	oscRaw, ok := secret.Data[nodeagentv1alpha1.DataKeyOperatingSystemConfig]
 	if !ok {
-		return nil, nil, "", fmt.Errorf("no %s key found in OSC secret", dataKeyOperatingSystemConfig)
+		return nil, nil, "", fmt.Errorf("no %s key found in OSC secret", nodeagentv1alpha1.DataKeyOperatingSystemConfig)
 	}
 
 	osc := &extensionsv1alpha1.OperatingSystemConfig{}
 	if err := runtime.DecodeInto(decoder, oscRaw, osc); err != nil {
-		return nil, nil, "", fmt.Errorf("unable to decode OSC from secret data key %s: %w", dataKeyOperatingSystemConfig, err)
+		return nil, nil, "", fmt.Errorf("unable to decode OSC from secret data key %s: %w", nodeagentv1alpha1.DataKeyOperatingSystemConfig, err)
 	}
 
 	return osc, oscRaw, secret.Annotations[nodeagentv1alpha1.AnnotationKeyChecksumDownloadedOperatingSystemConfig], nil

--- a/pkg/nodeagent/controller/operatingsystemconfig/changes.go
+++ b/pkg/nodeagent/controller/operatingsystemconfig/changes.go
@@ -28,7 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
-	"github.com/gardener/gardener/pkg/utils"
+	nodeagentv1alpha1 "github.com/gardener/gardener/pkg/nodeagent/apis/config/v1alpha1"
 )
 
 var decoder runtime.Decoder
@@ -50,7 +50,7 @@ func extractOSCFromSecret(secret *corev1.Secret) (*extensionsv1alpha1.OperatingS
 		return nil, nil, "", fmt.Errorf("unable to decode OSC from secret data key %s: %w", dataKeyOperatingSystemConfig, err)
 	}
 
-	return osc, oscRaw, utils.ComputeSHA256Hex(oscRaw), nil
+	return osc, oscRaw, secret.Annotations[nodeagentv1alpha1.AnnotationKeyChecksumDownloadedOperatingSystemConfig], nil
 }
 
 type operatingSystemConfigChanges struct {

--- a/pkg/nodeagent/controller/operatingsystemconfig/reconciler.go
+++ b/pkg/nodeagent/controller/operatingsystemconfig/reconciler.go
@@ -40,7 +40,6 @@ import (
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	extensionsv1alpha1helper "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1/helper"
-	"github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/executor"
 	"github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/original/components/kubelet"
 	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/nodeagent/apis/config"
@@ -101,7 +100,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		return reconcile.Result{}, fmt.Errorf("failed calculating the OSC changes: %w", err)
 	}
 
-	if node != nil && node.Annotations[executor.AnnotationKeyChecksum] == oscChecksum {
+	if node != nil && node.Annotations[nodeagentv1alpha1.AnnotationKeyChecksumAppliedOperatingSystemConfig] == oscChecksum {
 		log.Info("Configuration on this node is up to date, nothing to be done")
 		return reconcile.Result{}, nil
 	}
@@ -171,7 +170,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	r.Recorder.Event(node, corev1.EventTypeNormal, "OSCApplied", "Operating system config has been applied successfully")
 	patch := client.MergeFrom(node.DeepCopy())
 	metav1.SetMetaDataAnnotation(&node.ObjectMeta, v1beta1constants.LabelWorkerKubernetesVersion, r.Config.KubernetesVersion.String())
-	metav1.SetMetaDataAnnotation(&node.ObjectMeta, executor.AnnotationKeyChecksum, oscChecksum)
+	metav1.SetMetaDataAnnotation(&node.ObjectMeta, nodeagentv1alpha1.AnnotationKeyChecksumAppliedOperatingSystemConfig, oscChecksum)
 	return reconcile.Result{RequeueAfter: r.Config.SyncPeriod.Duration}, r.Client.Patch(ctx, node, patch)
 }
 

--- a/pkg/nodeagent/controller/operatingsystemconfig/reconciler.go
+++ b/pkg/nodeagent/controller/operatingsystemconfig/reconciler.go
@@ -49,10 +49,7 @@ import (
 	"github.com/gardener/gardener/pkg/utils/flow"
 )
 
-const (
-	dataKeyOperatingSystemConfig             = "osc.yaml"
-	lastAppliedOperatingSystemConfigFilePath = nodeagentv1alpha1.BaseDir + "/last-applied-osc.yaml"
-)
+const lastAppliedOperatingSystemConfigFilePath = nodeagentv1alpha1.BaseDir + "/last-applied-osc.yaml"
 
 // Reconciler decodes the OperatingSystemConfig resources from secrets and applies the systemd units and files to the
 // node.

--- a/pkg/operation/botanist/operatingsystemconfig.go
+++ b/pkg/operation/botanist/operatingsystemconfig.go
@@ -47,7 +47,7 @@ const SecretLabelKeyManagedResource = "managed-resource"
 
 // DefaultOperatingSystemConfig creates the default deployer for the OperatingSystemConfig custom resource.
 func (b *Botanist) DefaultOperatingSystemConfig() (operatingsystemconfig.Interface, error) {
-	oscImages, err := imagevectorutils.FindImages(imagevector.ImageVector(), []string{imagevector.ImageNameHyperkube, imagevector.ImageNamePauseContainer, imagevector.ImageNameValitail}, imagevectorutils.RuntimeVersion(b.ShootVersion()), imagevectorutils.TargetVersion(b.ShootVersion()))
+	oscImages, err := imagevectorutils.FindImages(imagevector.ImageVector(), []string{imagevector.ImageNameHyperkube, imagevector.ImageNamePauseContainer, imagevector.ImageNameValitail, imagevector.ImageNameGardenerNodeAgent}, imagevectorutils.RuntimeVersion(b.ShootVersion()), imagevectorutils.TargetVersion(b.ShootVersion()))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/operation/botanist/operatingsystemconfig.go
+++ b/pkg/operation/botanist/operatingsystemconfig.go
@@ -34,6 +34,7 @@ import (
 	"github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/downloader"
 	"github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/executor"
 	nodelocaldnsconstants "github.com/gardener/gardener/pkg/component/nodelocaldns/constants"
+	"github.com/gardener/gardener/pkg/features"
 	"github.com/gardener/gardener/pkg/utils/flow"
 	imagevectorutils "github.com/gardener/gardener/pkg/utils/imagevector"
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
@@ -47,7 +48,13 @@ const SecretLabelKeyManagedResource = "managed-resource"
 
 // DefaultOperatingSystemConfig creates the default deployer for the OperatingSystemConfig custom resource.
 func (b *Botanist) DefaultOperatingSystemConfig() (operatingsystemconfig.Interface, error) {
-	oscImages, err := imagevectorutils.FindImages(imagevector.ImageVector(), []string{imagevector.ImageNameHyperkube, imagevector.ImageNamePauseContainer, imagevector.ImageNameValitail, imagevector.ImageNameGardenerNodeAgent}, imagevectorutils.RuntimeVersion(b.ShootVersion()), imagevectorutils.TargetVersion(b.ShootVersion()))
+	images := []string{imagevector.ImageNamePauseContainer, imagevector.ImageNameValitail}
+	if features.DefaultFeatureGate.Enabled(features.UseGardenerNodeAgent) {
+		images = append(images, imagevector.ImageNameGardenerNodeAgent)
+	} else {
+		images = append(images, imagevector.ImageNameHyperkube)
+	}
+	oscImages, err := imagevectorutils.FindImages(imagevector.ImageVector(), images, imagevectorutils.RuntimeVersion(b.ShootVersion()), imagevectorutils.TargetVersion(b.ShootVersion()))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/operation/botanist/operatingsystemconfig.go
+++ b/pkg/operation/botanist/operatingsystemconfig.go
@@ -83,6 +83,7 @@ func (b *Botanist) DefaultOperatingSystemConfig() (operatingsystemconfig.Interfa
 				ValitailEnabled:     valitailEnabled,
 				ValiIngressHostName: valiIngressHost,
 				NodeLocalDNSEnabled: v1beta1helper.IsNodeLocalDNSEnabled(b.Shoot.GetInfo().Spec.SystemComponents),
+				SyncJitterPeriod:    b.Shoot.OSCSyncJitterPeriod,
 			},
 		},
 		operatingsystemconfig.DefaultInterval,

--- a/pkg/operation/botanist/operatingsystemconfig_test.go
+++ b/pkg/operation/botanist/operatingsystemconfig_test.go
@@ -210,7 +210,7 @@ var _ = Describe("operatingsystemconfig", func() {
 			worker1OriginalCommand = "/foo"
 			worker1OriginalUnits   = []string{"w1u1", "w1u2"}
 			worker1OriginalFiles   = []string{"w1f1", "w1f2"}
-			worker1Key             = operatingsystemconfig.Key(worker1Name, semver.MustParse(kubernetesVersion), nil)
+			worker1Key             string
 
 			worker2Name                  = "worker2"
 			worker2OriginalContent       = "w2content"
@@ -218,7 +218,7 @@ var _ = Describe("operatingsystemconfig", func() {
 			worker2OriginalUnits         = []string{"w2u2", "w2u2", "w2u3"}
 			worker2OriginalFiles         = []string{"w2f2", "w2f2", "w2f3"}
 			worker2KubernetesVersion     = "4.5.6"
-			worker2Key                   = operatingsystemconfig.Key(worker2Name, semver.MustParse(worker2KubernetesVersion), nil)
+			worker2Key                   string
 			worker2KubeletDataVolumeName = "vol"
 
 			workerNameToOperatingSystemConfigMaps = map[string]*operatingsystemconfig.OperatingSystemConfigs{
@@ -243,6 +243,11 @@ var _ = Describe("operatingsystemconfig", func() {
 			oldSecret1Name = "old-secret-1"
 			oldSecret2Name = "old-secret-2"
 		)
+
+		JustBeforeEach(func() {
+			worker1Key = operatingsystemconfig.Key(worker1Name, semver.MustParse(kubernetesVersion), nil)
+			worker2Key = operatingsystemconfig.Key(worker2Name, semver.MustParse(worker2KubernetesVersion), nil)
+		})
 
 		BeforeEach(func() {
 			kubernetesInterfaceSeed = kubernetesmock.NewMockInterface(ctrl)

--- a/pkg/operation/botanist/worker_test.go
+++ b/pkg/operation/botanist/worker_test.go
@@ -546,6 +546,19 @@ var _ = Describe("Worker", func() {
 					}).AnyTimes(),
 				)
 
+				if expectedCloudConfigDownloaderCleanup {
+					gomock.InOrder(
+						seedInterface.EXPECT().Client().Return(seedClient),
+						seedClient.EXPECT().Delete(gomock.Any(), &resourcesv1alpha1.ManagedResource{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace}}),
+						seedInterface.EXPECT().Client().Return(seedClient),
+						seedClient.EXPECT().Delete(gomock.Any(), &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "shoot-access-cloud-config-downloader", Namespace: namespace}}),
+						seedInterface.EXPECT().Client().Return(seedClient),
+						seedClient.EXPECT().DeleteAllOf(gomock.Any(), &corev1.Secret{}, client.InNamespace(namespace), client.MatchingLabels{"managed-resource": name}),
+						shootInterface.EXPECT().Client().Return(shootClient),
+						shootClient.EXPECT().Delete(gomock.Any(), &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "cloud-config-downloader", Namespace: "kube-system"}}),
+					)
+				}
+
 				Expect(botanist.WaitUntilOperatingSystemConfigUpdatedForAllWorkerPools(ctx)).To(Succeed())
 			})
 		}

--- a/pkg/operation/shoot/shoot.go
+++ b/pkg/operation/shoot/shoot.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"net"
 	"strconv"
+	"time"
 
 	"github.com/Masterminds/semver/v3"
 	corev1 "k8s.io/api/core/v1"
@@ -258,6 +259,7 @@ func (b *Builder) Build(ctx context.Context, c client.Reader) (*Shoot, error) {
 			shoot.CloudConfigExecutionMaxDelaySeconds = seconds
 		}
 	}
+	shoot.OSCSyncJitterPeriod = &metav1.Duration{Duration: time.Duration(shoot.CloudConfigExecutionMaxDelaySeconds) * time.Second}
 
 	if lastOperation := shootObject.Status.LastOperation; lastOperation != nil &&
 		lastOperation.Type == gardencorev1beta1.LastOperationTypeRestore &&

--- a/pkg/operation/shoot/types.go
+++ b/pkg/operation/shoot/types.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/Masterminds/semver/v3"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	"github.com/gardener/gardener/pkg/component"
@@ -103,7 +104,9 @@ type Shoot struct {
 	TopologyAwareRoutingEnabled             bool
 	Networks                                *Networks
 	BackupEntryName                         string
-	CloudConfigExecutionMaxDelaySeconds     int
+	OSCSyncJitterPeriod                     *metav1.Duration
+	// TODO(rfranzke): Remove this field when UseGardenerNodeAgent feature gate gets removed.
+	CloudConfigExecutionMaxDelaySeconds int
 
 	Components *Components
 }

--- a/pkg/utils/test/afero.go
+++ b/pkg/utils/test/afero.go
@@ -1,0 +1,55 @@
+// Copyright 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package test
+
+import (
+	"io/fs"
+
+	. "github.com/onsi/gomega"
+	"github.com/spf13/afero"
+)
+
+// AssertFileOnDisk asserts that a given file exists and has the expected content and mode.
+func AssertFileOnDisk(fakeFS afero.Afero, path, expectedContent string, fileMode uint32) {
+	description := "file path " + path
+
+	content, err := fakeFS.ReadFile(path)
+	ExpectWithOffset(1, err).NotTo(HaveOccurred(), description)
+	ExpectWithOffset(1, string(content)).To(Equal(expectedContent), description)
+
+	fileInfo, err := fakeFS.Stat(path)
+	ExpectWithOffset(1, err).NotTo(HaveOccurred(), description)
+	ExpectWithOffset(1, fileInfo.Mode()).To(Equal(fs.FileMode(fileMode)), description)
+}
+
+// AssertNoFileOnDisk asserts that a given file does not exist.
+func AssertNoFileOnDisk(fakeFS afero.Afero, path string) {
+	_, err := fakeFS.ReadFile(path)
+	ExpectWithOffset(1, err).To(MatchError(afero.ErrFileNotFound), "file path "+path)
+}
+
+// AssertDirectoryOnDisk asserts that a given directory exists.
+func AssertDirectoryOnDisk(fakeFS afero.Afero, path string) {
+	exists, err := fakeFS.DirExists(path)
+	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "directory path "+path)
+	ExpectWithOffset(1, exists).To(BeTrue(), "directory path "+path)
+}
+
+// AssertNoDirectoryOnDisk asserts that a given directory does not exist.
+func AssertNoDirectoryOnDisk(fakeFS afero.Afero, path string) {
+	exists, err := fakeFS.DirExists(path)
+	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "directory path "+path)
+	ExpectWithOffset(1, exists).To(BeFalse(), "directory path "+path)
+}

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -1135,7 +1135,6 @@ build:
             - pkg/client/kubernetes/cache
             - pkg/component
             - pkg/component/extensions/operatingsystemconfig/downloader
-            - pkg/component/extensions/operatingsystemconfig/executor
             - pkg/component/extensions/operatingsystemconfig/original/components
             - pkg/component/extensions/operatingsystemconfig/original/components/containerd
             - pkg/component/extensions/operatingsystemconfig/original/components/containerd/logrotate
@@ -1144,7 +1143,6 @@ build:
             - pkg/component/extensions/operatingsystemconfig/original/components/kubelet
             - pkg/component/extensions/operatingsystemconfig/original/components/nodeagent
             - pkg/component/extensions/operatingsystemconfig/original/components/valitail
-            - pkg/component/extensions/operatingsystemconfig/original/components/varlibmount
             - pkg/component/extensions/operatingsystemconfig/utils
             - pkg/component/kubeapiserver/constants
             - pkg/component/logging/vali

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -1098,6 +1098,98 @@ build:
         ldflags:
           - '{{.LD_FLAGS}}'
         main: ./cmd/gardener-resource-manager
+    - image: eu.gcr.io/gardener-project/gardener/node-agent
+      ko:
+        dependencies:
+          paths:
+            - cmd/gardener-node-agent/app
+            - cmd/gardener-node-agent/app/bootstrappers
+            - cmd/utils
+            - imagevector
+            - pkg/api/extensions
+            - pkg/apis/core
+            - pkg/apis/core/install
+            - pkg/apis/core/v1beta1
+            - pkg/apis/core/v1beta1/constants
+            - pkg/apis/core/v1beta1/helper
+            - pkg/apis/extensions
+            - pkg/apis/extensions/v1alpha1
+            - pkg/apis/extensions/v1alpha1/helper
+            - pkg/apis/operations
+            - pkg/apis/operations/install
+            - pkg/apis/operations/v1alpha1
+            - pkg/apis/operator
+            - pkg/apis/operator/v1alpha1
+            - pkg/apis/resources
+            - pkg/apis/resources/v1alpha1
+            - pkg/apis/seedmanagement
+            - pkg/apis/seedmanagement/encoding
+            - pkg/apis/seedmanagement/install
+            - pkg/apis/seedmanagement/v1alpha1
+            - pkg/apis/settings
+            - pkg/apis/settings/install
+            - pkg/apis/settings/v1alpha1
+            - pkg/chartrenderer
+            - pkg/client/kubernetes
+            - pkg/client/kubernetes/cache
+            - pkg/component
+            - pkg/component/extensions/operatingsystemconfig/downloader
+            - pkg/component/extensions/operatingsystemconfig/executor
+            - pkg/component/extensions/operatingsystemconfig/original/components
+            - pkg/component/extensions/operatingsystemconfig/original/components/containerd
+            - pkg/component/extensions/operatingsystemconfig/original/components/containerd/logrotate
+            - pkg/component/extensions/operatingsystemconfig/original/components/docker
+            - pkg/component/extensions/operatingsystemconfig/original/components/docker/logrotate
+            - pkg/component/extensions/operatingsystemconfig/original/components/kubelet
+            - pkg/component/extensions/operatingsystemconfig/original/components/nodeagent
+            - pkg/component/extensions/operatingsystemconfig/original/components/valitail
+            - pkg/component/extensions/operatingsystemconfig/original/components/varlibmount
+            - pkg/component/extensions/operatingsystemconfig/utils
+            - pkg/component/kubeapiserver/constants
+            - pkg/component/logging/vali
+            - pkg/controllerutils
+            - pkg/controllerutils/predicate
+            - pkg/controllerutils/routes
+            - pkg/features
+            - pkg/gardenlet/apis/config
+            - pkg/gardenlet/apis/config/v1alpha1
+            - pkg/healthz
+            - pkg/logger
+            - pkg/nodeagent/apis/config
+            - pkg/nodeagent/apis/config/v1alpha1
+            - pkg/nodeagent/apis/config/validation
+            - pkg/nodeagent/bootstrap
+            - pkg/nodeagent/controller
+            - pkg/nodeagent/controller/node
+            - pkg/nodeagent/controller/operatingsystemconfig
+            - pkg/nodeagent/controller/token
+            - pkg/nodeagent/dbus
+            - pkg/nodeagent/features
+            - pkg/nodeagent/registry
+            - pkg/resourcemanager/controller/garbagecollector/references
+            - pkg/utils
+            - pkg/utils/chart
+            - pkg/utils/context
+            - pkg/utils/errors
+            - pkg/utils/flow
+            - pkg/utils/gardener
+            - pkg/utils/imagevector
+            - pkg/utils/kubernetes
+            - pkg/utils/kubernetes/health
+            - pkg/utils/managedresources
+            - pkg/utils/managedresources/builder
+            - pkg/utils/retry
+            - pkg/utils/secrets
+            - pkg/utils/secrets/manager
+            - pkg/utils/timewindow
+            - pkg/utils/validation/kubernetesversion
+            - pkg/utils/version
+            - third_party/controller-runtime/pkg/apiutil
+            - third_party/gopkg.in/yaml.v2
+            - VERSION
+        ldflags:
+          - '{{.LD_FLAGS}}'
+        main: ./cmd/gardener-node-agent
 deploy:
   helm:
     releases:
@@ -1120,6 +1212,9 @@ deploy:
             - name: gardener-resource-manager
               repository: '{{.IMAGE_REPO_eu_gcr_io_gardener_project_gardener_resource_manager}}'
               tag: '{{.IMAGE_TAG_eu_gcr_io_gardener_project_gardener_resource_manager}}@{{.IMAGE_DIGEST_eu_gcr_io_gardener_project_gardener_resource_manager}}'
+            - name: gardener-node-agent
+              repository: '{{.IMAGE_REPO_eu_gcr_io_gardener_project_gardener_node_agent}}'
+              tag: '{{.IMAGE_TAG_eu_gcr_io_gardener_project_gardener_node_agent}}@{{.IMAGE_DIGEST_eu_gcr_io_gardener_project_gardener_node_agent}}'
         createNamespace: true
         wait: true
     hooks:

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -842,6 +842,7 @@ build:
             - pkg/component/extensions/operatingsystemconfig
             - pkg/component/extensions/operatingsystemconfig/downloader
             - pkg/component/extensions/operatingsystemconfig/executor
+            - pkg/component/extensions/operatingsystemconfig/nodeinit
             - pkg/component/extensions/operatingsystemconfig/original
             - pkg/component/extensions/operatingsystemconfig/original/components
             - pkg/component/extensions/operatingsystemconfig/original/components/containerd

--- a/test/integration/nodeagent/operatingsystemconfig/operatingsystemconfig_test.go
+++ b/test/integration/nodeagent/operatingsystemconfig/operatingsystemconfig_test.go
@@ -274,9 +274,10 @@ var _ = Describe("OperatingSystemConfig controller tests", func() {
 
 		oscSecret = &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      oscSecretName,
-				Namespace: metav1.NamespaceSystem,
-				Labels:    map[string]string{testID: testRunID},
+				Name:        oscSecretName,
+				Namespace:   metav1.NamespaceSystem,
+				Labels:      map[string]string{testID: testRunID},
+				Annotations: map[string]string{"checksum/data-script": utils.ComputeSHA256Hex(oscRaw)},
 			},
 			Data: map[string][]byte{"osc.yaml": oscRaw},
 		}
@@ -417,6 +418,7 @@ var _ = Describe("OperatingSystemConfig controller tests", func() {
 
 		By("Update Secret containing the operating system config")
 		patch := client.MergeFrom(oscSecret.DeepCopy())
+		oscSecret.Annotations["checksum/data-script"] = utils.ComputeSHA256Hex(oscRaw)
 		oscSecret.Data["osc.yaml"] = oscRaw
 		Expect(testClient.Patch(ctx, oscSecret, patch)).To(Succeed())
 
@@ -496,6 +498,7 @@ var _ = Describe("OperatingSystemConfig controller tests", func() {
 
 		By("Update Secret containing the operating system config")
 		patch := client.MergeFrom(oscSecret.DeepCopy())
+		oscSecret.Annotations["checksum/data-script"] = utils.ComputeSHA256Hex(oscRaw)
 		oscSecret.Data["osc.yaml"] = oscRaw
 		Expect(testClient.Patch(ctx, oscSecret, patch)).To(Succeed())
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity dev-productivity
/kind enhancement

**What this PR does / why we need it**:
This PR integrates `gardener-node-agent` into `gardenlet`'s `Shoot` controller. Health checks in its `shoot-care` reconciler are adapted as well.

The overall flow is similar to before with `cloud-config-downloader`: `gardenlet` generates a `ManagedResource` which has multiple `Secret` references:
- one for the RBAC resources needed for `gardener-node-agent`
- one for each worker pool containing the `OperatingSystemConfig` secret that is later reconciled by `gardener-node-agent`

When `gardener-node-agent` was successfully rolled out, all leftover files of `cloud-config-downloader` are cleaned up. For existing nodes, `cloud-config-downloader` fetches the updated `OperatingSystemConfig` (which now contains `gardener-node-init` and `gardener-node-agent` units), and it deletes its own `systemd` unit file (`gardener-node-agent` must just clean a few leftovers):

```
Nov 21 17:11:15 machine-shoot--local--local-local-bfc8c-bsxtt systemd[1]: cloud-config-downloader.service: Scheduled restart job, restart counter is at 14.
Nov 21 17:11:15 machine-shoot--local--local-local-bfc8c-bsxtt systemd[1]: Stopped Downloads the actual cloud config from the Shoot API server and executes it.
Nov 21 17:11:15 machine-shoot--local--local-local-bfc8c-bsxtt systemd[1]: Started Downloads the actual cloud config from the Shoot API server and executes it.
Nov 21 17:11:15 machine-shoot--local--local-local-bfc8c-bsxtt download-cloud-config.sh[21731]: Checksum of cloud config script has changed compared to what I had downloaded earlier (new: 4285af521e03bfc8b60ffcc2a0d90a7fb09c61f0ef2da0c11a33bf4faea6c994, old: 50a08949422791d415d6d655534ee622840b9d3344bb7dedf722c49a3dae53e5). Fetching new script...
Nov 21 17:11:15 machine-shoot--local--local-local-bfc8c-bsxtt download-cloud-config.sh[21767]: Checking whether we need to preload a new hyperkube image...
Nov 21 17:11:15 machine-shoot--local--local-local-bfc8c-bsxtt download-cloud-config.sh[21767]: No need to preload new hyperkube image because binaries for eu.gcr.io/gardener-project/hyperkube:v1.28.2 were found in /var/lib/cloud-config-downloader/downloads/hyperkube
Nov 21 17:11:15 machine-shoot--local--local-local-bfc8c-bsxtt download-cloud-config.sh[21767]: Seen newer cloud config or cloud config downloader version or hyperkube image
[...]
Nov 21 17:11:18 machine-shoot--local--local-local-bfc8c-bsxtt download-cloud-config.sh[22302]: Created symlink /etc/systemd/system/multi-user.target.wants/gardener-node-agent.service → /etc/systemd/system/gardener-node-agent.service.
Nov 21 17:11:18 machine-shoot--local--local-local-bfc8c-bsxtt download-cloud-config.sh[22331]: Created symlink /etc/systemd/system/multi-user.target.wants/gardener-node-init.service → /etc/systemd/system/gardener-node-init.service.
Nov 21 17:11:19 machine-shoot--local--local-local-bfc8c-bsxtt download-cloud-config.sh[21767]: Successfully restarted all units referenced in the cloud config.
Nov 21 17:11:19 machine-shoot--local--local-local-bfc8c-bsxtt download-cloud-config.sh[22601]: removed '/etc/systemd/system/cloud-config-downloader.service'
Nov 21 17:11:19 machine-shoot--local--local-local-bfc8c-bsxtt download-cloud-config.sh[22607]: removed '/var/lib/cloud-config-downloader/credentials/ca.crt'
Nov 21 17:11:19 machine-shoot--local--local-local-bfc8c-bsxtt download-cloud-config.sh[22608]: removed '/var/lib/cloud-config-downloader/credentials/server'
Nov 21 17:11:19 machine-shoot--local--local-local-bfc8c-bsxtt download-cloud-config.sh[22609]: removed '/var/lib/cloud-config-downloader/download-cloud-config.sh'
Nov 21 17:11:19 machine-shoot--local--local-local-bfc8c-bsxtt download-cloud-config.sh[22610]: removed '/var/lib/valitail/scripts/fetch-token.sh'
Nov 21 17:11:19 machine-shoot--local--local-local-bfc8c-bsxtt download-cloud-config.sh[21767]: Cloud config is up to date.
Nov 21 17:11:19 machine-shoot--local--local-local-bfc8c-bsxtt download-cloud-config.sh[22613]: node/machine-shoot--local--local-local-bfc8c-bsxtt not labeled
Nov 21 17:11:19 machine-shoot--local--local-local-bfc8c-bsxtt download-cloud-config.sh[22651]: node/machine-shoot--local--local-local-bfc8c-bsxtt annotated
Nov 21 17:11:19 machine-shoot--local--local-local-bfc8c-bsxtt systemd[1]: cloud-config-downloader.service: Succeeded.
Nov 21 17:11:20 machine-shoot--local--local-local-bfc8c-bsxtt systemd[1]: cloud-config-downloader.service: Failed to schedule restart job: Unit cloud-config-downloader.service not found.
Nov 21 17:11:20 machine-shoot--local--local-local-bfc8c-bsxtt systemd[1]: cloud-config-downloader.service: Failed with result 'resources'.
```

The PR also adds handling for the `kubelet`'s bootstrap kubeconfig generation/cleanup into `gardener-node-agent`.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/8023

**Special notes for your reviewer**:
/cc @oliver-goetz @ScheererJ 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy developer
The `UseGardenerNodeAgent` feature gate is now enabled for the local development scenario. You can read more about `gardener-node-agent` [here](https://github.com/gardener/gardener/blob/master/docs/concepts/node-agent.md).
```
