### PR TITLE
Federate non-namespaced metrics

### DIFF
--- a/pkg/component/monitoring/charts/bootstrap/templates/aggregate-prometheus/config.yaml
+++ b/pkg/component/monitoring/charts/bootstrap/templates/aggregate-prometheus/config.yaml
@@ -67,6 +67,7 @@ data:
         - '{__name__=~"metering:.+", __name__!~"metering:.+(over_time|_seconds|:this_month)"}'
         - '{__name__=~"seed:(.+):(.+)"}'
         - '{job="kube-state-metrics",namespace=~"garden|extension-.+"}'
+        - '{job="kube-state-metrics",namespace=""}'
         - '{job="cadvisor",namespace=~"garden|extension-.+"}'
       kubernetes_sd_configs:
       - role: service


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind enhancement

**What this PR does / why we need it**:
This PR enables the federation of non-namespaced metrics to the aggregate-prometheus. Metrics that would be added are:

```
kube_node_info
kube_node_labels
kube_node_spec_taint
kube_node_spec_unschedulable
kube_node_status_allocatable
kube_node_status_capacity
kube_node_status_condition
scrape_duration_seconds
scrape_samples_post_metric_relabeling
scrape_samples_scraped
scrape_series_added
up
```

**Which issue(s) this PR fixes**:
The interest of this PR is to have more node specific metrics available at the aggregate level.

**Special notes for your reviewer**:
Discussed this approach with @istvanballok and @rickardsjp . 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Federate non-namespaced metrics, e.g. kube_node_spec_taint, kube_node_spec_unschedulable. 
```
