### PR TITLE
Fix: Forbid creation/update of expired k8s/machine image versions 

### DIFF
--- a/docs/usage/shoot_versions.md
+++ b/docs/usage/shoot_versions.md
@@ -123,14 +123,14 @@ Example configuration in the CloudProfile:
 ```yaml
 machineImages:
   - name: gardenlinux
-     autoUpdateStrategy: minor
-     versions:
+    updateStrategy: minor
+    versions:
      - version: 1096.1.0
      - version: 934.8.0
      - version: 934.7.0
   - name: suse-chost
-     autoUpdateStrategy: patch
-     versions:
+    updateStrategy: patch
+    versions:
     - version: 15.3.20220818 
     - version: 15.3.20221118
 ```

--- a/plugin/pkg/shoot/validator/admission.go
+++ b/plugin/pkg/shoot/validator/admission.go
@@ -1512,7 +1512,7 @@ func validateMachineImagesConstraints(a admission.Attributes, constraints []core
 			if machineVersion.ExpirationDate == nil || machineVersion.ExpirationDate.Time.UTC().After(time.Now().UTC()) {
 				activeMachineImageVersions.Insert(machineImageVersion)
 			} else if machineVersion.ExpirationDate != nil && machineVersion.ExpirationDate.Time.UTC().Before(time.Now().UTC()) && a.GetOperation() == admission.Update && !isNewWorkerPool {
-				// An already expired machine image version is a viable machine image version for the worker pool iff.
+				// An already expired machine image version is a viable machine image version for the worker pool if-and-only-if:
 				//  - this is an update call (no new Shoot creation)
 				//  - updates an existing worker pool (not for a new worker pool)
 				//  - the expired version is higher than the old machine's version

--- a/plugin/pkg/shoot/validator/admission.go
+++ b/plugin/pkg/shoot/validator/admission.go
@@ -764,7 +764,7 @@ func (c *validationContext) validateKubernetes(a admission.Attributes) field.Err
 		c.shoot.Spec.Kubernetes.Version = *defaultVersion
 	} else {
 		// We assume that the 'defaultVersion' is already calculated correctly, so only run validation if the version was not defaulted.
-		allErrs = append(allErrs, validateKubernetesVersionConstraints(a, c.cloudProfile.Spec.Kubernetes.Versions, c.shoot.Spec.Kubernetes.Version, c.oldShoot.Spec.Kubernetes.Version, path.Child("version"))...)
+		allErrs = append(allErrs, validateKubernetesVersionConstraints(a, c.cloudProfile.Spec.Kubernetes.Versions, c.shoot.Spec.Kubernetes.Version, c.oldShoot.Spec.Kubernetes.Version, false, path.Child("version"))...)
 	}
 
 	if c.shoot.DeletionTimestamp == nil {
@@ -858,9 +858,11 @@ func (c *validationContext) validateProvider(a admission.Attributes) field.Error
 
 	for i, worker := range c.shoot.Spec.Provider.Workers {
 		var oldWorker = core.Worker{Machine: core.Machine{Image: &core.ShootMachineImage{}}}
+		isNewWorkerPool := true
 		for _, ow := range c.oldShoot.Spec.Provider.Workers {
 			if ow.Name == worker.Name {
 				oldWorker = ow
+				isNewWorkerPool = false
 				break
 			}
 		}
@@ -889,9 +891,9 @@ func (c *validationContext) validateProvider(a admission.Attributes) field.Error
 				allErrs = append(allErrs, field.Invalid(idxPath.Child("machine", "type"), worker.Machine.Type, fmt.Sprintf("%ssupported types are %+v", detail, supportedMachineTypes)))
 			}
 
-			isMachineImagePresentInCloudprofile, architectureSupported, activeMachineImageVersion, validMachineImageversions := validateMachineImagesConstraints(a, c.cloudProfile.Spec.MachineImages, worker.Machine, oldWorker.Machine)
+			isMachineImagePresentInCloudprofile, architectureSupported, activeMachineImageVersion, validMachineImageVersions := validateMachineImagesConstraints(a, c.cloudProfile.Spec.MachineImages, isNewWorkerPool, worker.Machine, oldWorker.Machine)
 			if !isMachineImagePresentInCloudprofile {
-				allErrs = append(allErrs, field.Invalid(idxPath.Child("machine", "image"), worker.Machine.Image, fmt.Sprintf("machine image version is not supported, supported machine image versions are: %+v", validMachineImageversions)))
+				allErrs = append(allErrs, field.Invalid(idxPath.Child("machine", "image"), worker.Machine.Image, fmt.Sprintf("machine image version is not supported, supported machine image versions are: %+v", validMachineImageVersions)))
 			} else if !architectureSupported || !activeMachineImageVersion {
 				detail := fmt.Sprintf("machine image version '%s:%s' ", worker.Machine.Image.Name, worker.Machine.Image.Version)
 				if !architectureSupported {
@@ -900,7 +902,7 @@ func (c *validationContext) validateProvider(a admission.Attributes) field.Error
 				if !activeMachineImageVersion {
 					detail += "is expired, "
 				}
-				allErrs = append(allErrs, field.Invalid(idxPath.Child("machine", "image"), worker.Machine.Image, fmt.Sprintf("%ssupported machine image versions are: %+v", detail, validMachineImageversions)))
+				allErrs = append(allErrs, field.Invalid(idxPath.Child("machine", "image"), worker.Machine.Image, fmt.Sprintf("%ssupported machine image versions are: %+v", detail, validMachineImageVersions)))
 			} else {
 				allErrs = append(allErrs, validateContainerRuntimeConstraints(c.cloudProfile.Spec.MachineImages, worker, oldWorker, idxPath.Child("cri"))...)
 
@@ -952,7 +954,7 @@ func (c *validationContext) validateProvider(a admission.Attributes) field.Error
 					worker.Kubernetes.Version = defaultVersion
 				} else {
 					// We assume that the 'defaultVersion' is already calculated correctly, so only run validation if the version was not defaulted.
-					allErrs = append(allErrs, validateKubernetesVersionConstraints(a, c.cloudProfile.Spec.Kubernetes.Versions, *worker.Kubernetes.Version, oldWorkerKubernetesVersion, idxPath.Child("kubernetes", "version"))...)
+					allErrs = append(allErrs, validateKubernetesVersionConstraints(a, c.cloudProfile.Spec.Kubernetes.Versions, *worker.Kubernetes.Version, oldWorkerKubernetesVersion, isNewWorkerPool, idxPath.Child("kubernetes", "version"))...)
 				}
 			}
 		}
@@ -1204,7 +1206,7 @@ func findLatestVersion(constraints []core.ExpirableVersion, major, minor *uint64
 	return latestVersion
 }
 
-func validateKubernetesVersionConstraints(a admission.Attributes, constraints []core.ExpirableVersion, shootVersion, oldShootVersion string, fldPath *field.Path) field.ErrorList {
+func validateKubernetesVersionConstraints(a admission.Attributes, constraints []core.ExpirableVersion, shootVersion, oldShootVersion string, isNewWorkerPool bool, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	if shootVersion == oldShootVersion {
@@ -1213,7 +1215,9 @@ func validateKubernetesVersionConstraints(a admission.Attributes, constraints []
 
 	var validValues []string
 	for _, versionConstraint := range constraints {
-		if a.GetOperation() == admission.Create {
+		// Disallow usage of an expired Kubernetes version on Shoot creation and new worker pool creation
+		// Updating an existing worker to a higher (ensured by validation) expired Kubernetes version is necessary for consecutive maintenance force updates
+		if a.GetOperation() == admission.Create || isNewWorkerPool {
 			if versionConstraint.ExpirationDate != nil && versionConstraint.ExpirationDate.Time.UTC().Before(time.Now().UTC()) {
 				continue
 			}
@@ -1490,7 +1494,7 @@ func getDefaultMachineImage(machineImages []core.MachineImage, imageName string,
 	return &core.ShootMachineImage{Name: defaultImage.Name, Version: latestMachineImageVersion.Version}, nil
 }
 
-func validateMachineImagesConstraints(a admission.Attributes, constraints []core.MachineImage, machine, oldMachine core.Machine) (bool, bool, bool, []string) {
+func validateMachineImagesConstraints(a admission.Attributes, constraints []core.MachineImage, isNewWorkerPool bool, machine, oldMachine core.Machine) (bool, bool, bool, []string) {
 	if apiequality.Semantic.DeepEqual(machine.Image, oldMachine.Image) && pointer.StringEqual(machine.Architecture, oldMachine.Architecture) {
 		return true, true, true, nil
 	}
@@ -1505,10 +1509,20 @@ func validateMachineImagesConstraints(a admission.Attributes, constraints []core
 		for _, machineVersion := range machineImage.Versions {
 			machineImageVersion := fmt.Sprintf("%s:%s", machineImage.Name, machineVersion.Version)
 
-			// update to an expired version is allowed (required for maintenance force updates)
-			if a.GetOperation() == admission.Update || machineVersion.ExpirationDate == nil || machineVersion.ExpirationDate.Time.UTC().After(time.Now().UTC()) {
+			if machineVersion.ExpirationDate == nil || machineVersion.ExpirationDate.Time.UTC().After(time.Now().UTC()) {
 				activeMachineImageVersions.Insert(machineImageVersion)
+			} else if machineVersion.ExpirationDate != nil && machineVersion.ExpirationDate.Time.UTC().Before(time.Now().UTC()) && a.GetOperation() == admission.Update && !isNewWorkerPool {
+				// An already expired machine image version is a viable machine image version for the worker pool iff.
+				//  - this is an update call (no new Shoot creation)
+				//  - updates an existing worker pool (not for a new worker pool)
+				//  - the expired version is higher than the old machine's version
+				// Reason: updating an existing worker pool to an expired machine image version is required for maintenance force updates
+				downgrade, _ := versionutils.CompareVersions(machineVersion.Version, "<", oldMachine.Image.Version)
+				if !downgrade {
+					activeMachineImageVersions.Insert(machineImageVersion)
+				}
 			}
+
 			if slices.Contains(machineVersion.Architectures, *machine.Architecture) {
 				machineImageVersionsWithSupportedArchitecture.Insert(machineImageVersion)
 			}
@@ -1516,16 +1530,17 @@ func validateMachineImagesConstraints(a admission.Attributes, constraints []core
 		}
 	}
 
-	supportedMachineImageVersions := sets.List(activeMachineImageVersions.Intersection(machineImageVersionsWithSupportedArchitecture))
+	// valid machine image versions are all versions that can be used by this worker pool
+	validMachineImageVersions := sets.List(activeMachineImageVersions.Intersection(machineImageVersionsWithSupportedArchitecture))
 	if machine.Image == nil || len(machine.Image.Version) == 0 {
-		return false, false, false, supportedMachineImageVersions
+		return false, false, false, validMachineImageVersions
 	}
 
 	shootMachineImageVersion := fmt.Sprintf("%s:%s", machine.Image.Name, machine.Image.Version)
 	return machineImageVersionsInCloudProfile.Has(shootMachineImageVersion),
 		machineImageVersionsWithSupportedArchitecture.Has(shootMachineImageVersion),
 		activeMachineImageVersions.Has(shootMachineImageVersion),
-		supportedMachineImageVersions
+		validMachineImageVersions
 }
 
 func validateContainerRuntimeConstraints(constraints []core.MachineImage, worker, oldWorker core.Worker, fldPath *field.Path) field.ErrorList {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity
/kind bug

**What this PR does / why we need it**:

Fixed a bug where a Shoot with an expired machine image or Kubernetes version could be created. 

**For machine images**: only allow updating to a higher expired machine image version for an existing worker pool
**For Kubernetes versions**: do not allow creation of a worker pool with an expired K8s version, but still allow updating an existing worker pool to a higher expired version.

**Background**: Updating to a **higher** expired version is required for consecutive force updates by the maintenance controller. But previously, an update or creation using any expired version was allowed, which makes it difficult to remove expired versions from the cloudprofile (can always revert the force update by the maintenance controller).

**Which issue(s) this PR fixes**:
Fixes #8824

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fixed a bug where a Shoot with an expired machine image or Kubernetes version could be created. 
For machine images: only allow updating to a higher expired machine image version for an existing worker pool
For Kubernetes versions: do not allow creation of a worker pool with an expired K8s version, but still allow updating an existing worker pool to a higher expired version.
```
