### PR TITLE
Still support extensions with vendor dir

### DIFF
--- a/hack/check-generate.sh
+++ b/hack/check-generate.sh
@@ -106,17 +106,33 @@ if which git &>/dev/null; then
     exit 1
   fi
 
-  echo ">> make tidy"
-  if ! out=$(make -f "$makefile" tidy 2>&1); then
-    echo "Error during calling make tidy: $out"
-    exit 1
-  fi
-  new_status="$(git status -s)"
+  repo_root="$(git rev-parse --show-toplevel)"
+  if [[ -d "$repo_root/vendor" ]]; then
+    echo ">> make revendor"
+    if ! out=$(make -f "$makefile" revendor 2>&1); then
+      echo "Error during calling make revendor: $out"
+      exit 1
+    fi
+    new_status="$(git status -s)"
 
-  if [[ "$old_status" != "$new_status" ]]; then
-    echo "make tidy needs to be run:"
-    echo "$new_status"
-    exit 1
+    if [[ "$old_status" != "$new_status" ]]; then
+      echo "make revendor needs to be run:"
+      echo "$new_status"
+      exit 1
+    fi
+  else
+    echo ">> make tidy"
+    if ! out=$(make -f "$makefile" tidy 2>&1); then
+      echo "Error during calling make tidy: $out"
+      exit 1
+    fi
+    new_status="$(git status -s)"
+
+    if [[ "$old_status" != "$new_status" ]]; then
+      echo "make tidy needs to be run:"
+      echo "$new_status"
+      exit 1
+    fi
   fi
 else
   echo "No git detected, cannot run make check-generate"

--- a/hack/check-skaffold-deps-for-binary.sh
+++ b/hack/check-skaffold-deps-for-binary.sh
@@ -73,6 +73,10 @@ go list -f '{{ join .Deps "\n" }}' "./cmd/$binary_name" |\
 
 # always add VERSION file
 echo "VERSION" >> "$path_actual_dependencies"
+# add vendor if the vendor/ dir exists
+if [[ -d "$repo_root/vendor" ]]; then
+  echo "vendor" >> "$path_actual_dependencies"
+fi
 
 # sort dependencies
 sort -fo "$path_current_skaffold_dependencies"{,}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind bug

**What this PR does / why we need it**:
While vendoring gardener/gardener@v1.84.0 in the registry-cache extension I hit the following issues related to https://github.com/gardener/gardener/issues/8775:
- `hack/check-generate.sh` script requires the target `make tidy` instead of `make revendor`. This PR adapts the logic to check for the vendor dir - if it exists - use `make revendor`, otherwise - `make tidy`
- `hack/check-skaffold-deps-for-binary.sh` script now longer adds the vendor dir and this breaks extensions using this script. See https://github.com/gardener/gardener-extension-shoot-rsyslog-relp/pull/37#discussion_r1401030446. This PR adapts the logic to check for the vendor dir - if it exists add also vendor to the to the list of actual dependencies.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```dependency developer
The `hack/check-skaffold-deps-for-binary.sh` and `hack/check-generate.sh` scripts are adapted to support also extensions that have a vendor dir.
```
