### PR TITLE
Set a timeout for the `WaitUntilMachineResourcesDeleted` step in the Shoot force deletion flow

### DIFF
--- a/pkg/gardenlet/controller/shoot/shoot/reconciler_force_delete.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler_force_delete.go
@@ -100,7 +100,7 @@ func (r *Reconciler) runForceDeleteShootFlow(ctx context.Context, log logr.Logge
 		})
 		waitUntilMachineResourcesDeleted = g.Add(flow.Task{
 			Name:         "Waiting until machine resources have been deleted",
-			Fn:           cleaner.WaitUntilMachineResourcesDeleted,
+			Fn:           flow.TaskFn(cleaner.WaitUntilMachineResourcesDeleted).Timeout(defaultTimeout),
 			Dependencies: flow.NewTaskIDs(deleteMachineResources),
 		})
 		deleteCluster = g.Add(flow.Task{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind bug

**What this PR does / why we need it**:
As described in https://github.com/gardener/gardener/issues/8861, the corresponding step is without any timeout. In my local setup the step hangs for 27+ mins and it is still counting. Maybe we have some context timeout from the reconciler context.
This PR sets the timeout to `30s`. The previous step should take care to finalize MCM resources (see  https://github.com/gardener/gardener/issues/8861 that it occasionally leak some), so `30s` should be fine.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/8861

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
