### PR TITLE
Don't set `EveryNodeReady` condition for workerless shoots

### DIFF
--- a/pkg/controllermanager/controller/seed/lifecycle/reconciler.go
+++ b/pkg/controllermanager/controller/seed/lifecycle/reconciler.go
@@ -181,7 +181,7 @@ func setShootStatusToUnknown(ctx context.Context, clock clock.Clock, c client.St
 		}
 	)
 
-	for _, conditionType := range gardenerutils.GetShootConditionTypes(false) {
+	for _, conditionType := range gardenerutils.GetShootConditionTypes(v1beta1helper.IsWorkerless(shoot)) {
 		c := v1beta1helper.GetOrInitConditionWithClock(clock, shoot.Status.Conditions, conditionType)
 		c = v1beta1helper.UpdatedConditionWithClock(clock, c, gardencorev1beta1.ConditionUnknown, reason, msg)
 		conditions[conditionType] = c

--- a/test/integration/controllermanager/seed/lifecycle/lifecycle_test.go
+++ b/test/integration/controllermanager/seed/lifecycle/lifecycle_test.go
@@ -66,7 +66,7 @@ var _ = Describe("Seed Lifecycle controller tests", func() {
 		}
 	})
 
-	BeforeEach(func() {
+	JustBeforeEach(func() {
 		seed = &gardencorev1beta1.Seed{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:   lease.Name,
@@ -157,7 +157,7 @@ var _ = Describe("Seed Lifecycle controller tests", func() {
 			},
 		}
 
-		shootConditions = 4
+		shootConditions = 5
 	})
 
 	Context("when there is no GardenletReady condition", func() {
@@ -287,7 +287,6 @@ var _ = Describe("Seed Lifecycle controller tests", func() {
 					}
 
 					if !workerless {
-						shootConditions = 5
 						shoot.Status.Conditions = append(shoot.Status.Conditions, gardencorev1beta1.Condition{Type: gardencorev1beta1.ShootEveryNodeReady, Status: gardencorev1beta1.ConditionTrue})
 					}
 
@@ -347,6 +346,8 @@ var _ = Describe("Seed Lifecycle controller tests", func() {
 					shoot.Spec.Networking = nil
 					shoot.Spec.Provider.Workers = nil
 					shoot.Spec.SecretBindingName = nil
+
+					shootConditions = 4
 				})
 
 				test(true)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug

**What this PR does / why we need it**:
Previously, `EveryNodeReady` condition was wrongly set for workerless shoot by the `seed-lifecycle` controller, in case of `gardenlet` becomes unhealthy 
```yaml
    - type: EveryNodeReady
      status: Progressing
      lastTransitionTime: '2023-11-15T14:26:43Z'
      lastUpdateTime: '2023-11-26T21:22:09Z'
      reason: StatusUnknown
      message: Gardenlet stopped sending heartbeats.
```

This PR fixes it so only required conditions are added.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
A bug causing `EveryNodeReady` condition to be added in workerless shoot status if gardenlet of the given shoot's seed becomes unhealthy is fixed.
```
