### PR TITLE
Add logs in e2e seed test

### DIFF
--- a/test/e2e/gardener/seed/renew_garden_access_secrets.go
+++ b/test/e2e/gardener/seed/renew_garden_access_secrets.go
@@ -48,6 +48,7 @@ var _ = Describe("Seed Tests", Label("Seed", "default"), func() {
 			seedList := &gardencorev1beta1.SeedList{}
 			Expect(testClient.List(ctx, seedList, client.MatchingLabels{"base": "kind"}, client.Limit(1))).To(Succeed())
 			seed = seedList.Items[0].DeepCopy()
+			log.Info("Renewing garden cluster access", "seedName", seed.Name)
 
 			seedNamespace = gardenerutils.ComputeGardenNamespace(seed.Name)
 

--- a/test/e2e/gardener/seed/renew_gardenlet_kubeconfig.go
+++ b/test/e2e/gardener/seed/renew_gardenlet_kubeconfig.go
@@ -34,6 +34,7 @@ var _ = Describe("Seed Tests", Label("Seed", "default"), func() {
 			seedList := &gardencorev1beta1.SeedList{}
 			Expect(testClient.List(ctx, seedList, client.Limit(1))).To(Succeed())
 			seed = seedList.Items[0].DeepCopy()
+			log.Info("Renewing gardenlet kubeconfig", "seedName", seed.Name)
 		})
 
 		It("should renew the gardenlet garden kubeconfig when triggered by annotation", func() {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind enhancement

**What this PR does / why we need it**:
`Renew gardenlet kubeconfig [It] should renew the gardenlet garden kubeconfig when triggered by annotation` test flake very often, one example - https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/8725/pull-gardener-e2e-kind/1729072121931370496

I tried to reproduce it locally for `local` seed, but was not able to reproduce it. This PR adds log to print seed name that get selected for above test, to figure out if the test fails when some specific seed is selected.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @oliver-goetz 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
