### PR TITLE
Delete MCM before deleting the MCM resources in the Shoot force deletion flow

### DIFF
--- a/pkg/gardenlet/controller/shoot/shoot/cleaner.go
+++ b/pkg/gardenlet/controller/shoot/shoot/cleaner.go
@@ -56,8 +56,8 @@ var (
 	machineKindToObjectList = map[string]client.ObjectList{
 		"MachineDeployment": &machinev1alpha1.MachineDeploymentList{},
 		"MachineSet":        &machinev1alpha1.MachineSetList{},
-		"MachineClass":      &machinev1alpha1.MachineClassList{},
 		"Machine":           &machinev1alpha1.MachineList{},
+		"MachineClass":      &machinev1alpha1.MachineClassList{},
 	}
 
 	kubernetesKindToObjectList = map[string]client.ObjectList{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind bug

**What this PR does / why we need it**:
This PR eletes MCM before deleting the MCM resources in the Shoot force deletion flow.
In this way we prevent cases where Machines are force deleted first and then machine-controller-manager Pod creates a new Machine as replacement. For more datails, see https://github.com/gardener/gardener/issues/8861.

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener/issues/8861

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
