### PR TITLE
Read `ImageNameGardenerNodeAgent` image only if `UseGardenerNodeAgent` feature gate is enabled

### DIFF
--- a/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig.go
+++ b/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig.go
@@ -633,15 +633,21 @@ func (d *deployer) deploy(ctx context.Context, operation string) (extensionsv1al
 	var (
 		units []extensionsv1alpha1.Unit
 		files []extensionsv1alpha1.File
+
+		initUnits []extensionsv1alpha1.Unit
+		initFiles []extensionsv1alpha1.File
+		err       error
 	)
 
-	initUnits, initFiles, err := InitConfigFn(
-		d.worker,
-		d.images[imagevector.ImageNameGardenerNodeAgent].String(),
-		nodeagent.ComponentConfig(d.key, d.kubernetesVersion, d.apiServerURL, d.clusterCABundle, d.oscSyncJitterPeriod, nil),
-	)
-	if err != nil {
-		return nil, err
+	if features.DefaultFeatureGate.Enabled(features.UseGardenerNodeAgent) {
+		initUnits, initFiles, err = InitConfigFn(
+			d.worker,
+			d.images[imagevector.ImageNameGardenerNodeAgent].String(),
+			nodeagent.ComponentConfig(d.key, d.kubernetesVersion, d.apiServerURL, d.clusterCABundle, d.oscSyncJitterPeriod, nil),
+		)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	// The cloud-config-downloader unit is added regardless of the purpose of the OperatingSystemConfig:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area os
/kind bug

**What this PR does / why we need it**:
The PR fixes a nil pointer exception by reading `ImageNameGardenerNodeAgent` image only if `UseGardenerNodeAgent` feature gate is enabled. This image is not populated in case the featuregate is off, see https://github.com/gardener/gardener/blob/3d3887c4ea7877d5f7661ce186be8ac3a2781456/pkg/operation/botanist/operatingsystemconfig.go#L52-L61.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Introduced with https://github.com/gardener/gardener/pull/8847

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
