### PR TITLE
Spread Istio Ingress Gateway pods across hosts if there are multiple nodes per zone.

### DIFF
--- a/charts/gardener/operator/templates/clusterrole.yaml
+++ b/charts/gardener/operator/templates/clusterrole.yaml
@@ -27,6 +27,7 @@ rules:
   - configmaps
   - serviceaccounts
   - pods
+  - nodes
   verbs:
   - get
   - list

--- a/pkg/component/istio/charts/istio/istio-ingress/templates/deployment.yaml
+++ b/pkg/component/istio/charts/istio/istio-ingress/templates/deployment.yaml
@@ -207,10 +207,15 @@ spec:
       priorityClassName: {{ .Values.priorityClassName }}
       affinity:
         podAntiAffinity:
+          {{- if .Values.ensureHostAntiAffinity }}
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+          {{- else }}
           preferredDuringSchedulingIgnoredDuringExecution:
           - weight: 100
             podAffinityTerm:
               labelSelector:
+          {{- end }}
                 matchExpressions:
                 {{- range $key, $value := .Values.labels }}
                 - key: {{ $key }}

--- a/pkg/component/istio/charts/istio/istio-ingress/values.yaml
+++ b/pkg/component/istio/charts/istio/istio-ingress/values.yaml
@@ -25,6 +25,7 @@ ingressVersion: "1.19.3"
 replicas: 2
 minReplicas: 2
 maxReplicas: 5
+ensureHostAntiAffinity: false
 
 # Istio Ingress Configuration Resources
 proxyProtocolEnabled: false

--- a/pkg/component/istio/ingress_gateway.go
+++ b/pkg/component/istio/ingress_gateway.go
@@ -49,6 +49,7 @@ type IngressGatewayValues struct {
 	ProxyProtocolEnabled  bool
 	VPNEnabled            bool
 	Zones                 []string
+	EnsureHostSpreading   bool
 
 	// Ports is a list of all Ports the istio-ingress gateways is listening on.
 	// Port 15021 and 15000 cannot be used.
@@ -76,6 +77,7 @@ func (i *istiod) generateIstioIngressGatewayChart() (*chartrenderer.RenderedChar
 			"vpn": map[string]interface{}{
 				"enabled": istioIngressGateway.VPNEnabled,
 			},
+			"ensureHostAntiAffinity": istioIngressGateway.EnsureHostSpreading,
 		}
 
 		if istioIngressGateway.MinReplicas != nil {

--- a/pkg/component/shared/istio.go
+++ b/pkg/component/shared/istio.go
@@ -15,10 +15,12 @@
 package shared
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -39,6 +41,7 @@ var ImageVector = imagevector.ImageVector()
 
 // NewIstio returns a deployer for Istio.
 func NewIstio(
+	ctx context.Context,
 	cl client.Client,
 	chartRenderer chartrenderer.Interface,
 	namePrefix string,
@@ -87,6 +90,11 @@ func NewIstio(
 	policyLabels := commonIstioIngressNetworkPolicyLabels(vpnEnabled)
 	policyLabels[toKubeAPIServerPolicyLabel] = v1beta1constants.LabelNetworkPolicyAllowed
 
+	ensureHostSpreading, err := ShouldEnsureHostSpreading(ctx, cl, zones)
+	if err != nil {
+		return nil, err
+	}
+
 	defaultIngressGatewayConfig := istio.IngressGatewayValues{
 		TrustDomain:           gardencorev1beta1.DefaultDomain,
 		Image:                 igwImage.String(),
@@ -103,6 +111,7 @@ func NewIstio(
 		PriorityClassName:     priorityClassName,
 		ProxyProtocolEnabled:  proxyProtocolEnabled,
 		VPNEnabled:            vpnEnabled,
+		EnsureHostSpreading:   ensureHostSpreading,
 	}
 
 	return istio.NewIstio(
@@ -129,6 +138,8 @@ func NewIstio(
 // to fill out common chart values. Hence, it is assumed that at least one Ingress Gateway was added to the given
 // `istioDeployer` before calling this function.
 func AddIstioIngressGateway(
+	ctx context.Context,
+	cl client.Client,
 	istioDeployer istio.Interface,
 	namespace string,
 	annotations map[string]string,
@@ -146,16 +157,24 @@ func AddIstioIngressGateway(
 	templateValues := gatewayValues[0]
 
 	var (
-		zones       []string
-		minReplicas *int
-		maxReplicas *int
+		zones               []string
+		minReplicas         *int
+		maxReplicas         *int
+		ensureHostSpreading bool
+		err                 error
 	)
 
 	if zone == nil {
 		minReplicas = templateValues.MinReplicas
 		maxReplicas = templateValues.MaxReplicas
+		ensureHostSpreading = templateValues.EnsureHostSpreading
 	} else {
 		zones = []string{*zone}
+
+		ensureHostSpreading, err = ShouldEnsureHostSpreading(ctx, cl, []string{*zone})
+		if err != nil {
+			return err
+		}
 	}
 
 	istioDeployer.AddIngressGateway(istio.IngressGatewayValues{
@@ -175,6 +194,7 @@ func AddIstioIngressGateway(
 		TrustDomain:           gardencorev1beta1.DefaultDomain,
 		VPNEnabled:            templateValues.VPNEnabled,
 		Zones:                 zones,
+		EnsureHostSpreading:   ensureHostSpreading,
 	})
 
 	return nil
@@ -237,6 +257,37 @@ func IsZonalIstioExtension(labels map[string]string) (bool, string) {
 		}
 	}
 	return false, ""
+}
+
+// ShouldEnsureHostSpreading checks whether all given zones have at least two nodes so that Istio can be spread across hosts in each zone
+func ShouldEnsureHostSpreading(ctx context.Context, cl client.Client, zones []string) (bool, error) {
+	const targetNodeCount = 2
+	nodeList := &metav1.PartialObjectMetadataList{}
+	nodeList.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("NodeList"))
+	if err := cl.List(ctx, nodeList); err != nil {
+		return false, err
+	}
+	nodesPerZone := make([]int, len(zones))
+	zonesIncomplete := len(zones)
+forNode:
+	for _, node := range nodeList.Items {
+		nodeZone := node.Labels["topology.kubernetes.io/zone"]
+		for i, zone := range zones {
+			if strings.HasSuffix(nodeZone, zone) {
+				if nodesPerZone[i] < targetNodeCount {
+					nodesPerZone[i] = nodesPerZone[i] + 1
+					if nodesPerZone[i] >= targetNodeCount {
+						zonesIncomplete = zonesIncomplete - 1
+						if zonesIncomplete == 0 {
+							break forNode
+						}
+					}
+				}
+				break
+			}
+		}
+	}
+	return zonesIncomplete == 0, nil
 }
 
 func commonIstioIngressNetworkPolicyLabels(vpnEnabled bool) map[string]string {

--- a/pkg/component/shared/istio.go
+++ b/pkg/component/shared/istio.go
@@ -271,7 +271,7 @@ func ShouldEnsureHostSpreading(ctx context.Context, cl client.Client, zones []st
 	zonesIncomplete := len(zones)
 forNode:
 	for _, node := range nodeList.Items {
-		nodeZone := node.Labels["topology.kubernetes.io/zone"]
+		nodeZone := node.Labels[corev1.LabelTopologyZone]
 		for i, zone := range zones {
 			if strings.HasSuffix(nodeZone, zone) {
 				if nodesPerZone[i] < targetNodeCount {

--- a/pkg/component/shared/istio.go
+++ b/pkg/component/shared/istio.go
@@ -287,7 +287,7 @@ forNode:
 			}
 		}
 	}
-	return zonesIncomplete == 0, nil
+	return zonesIncomplete == 0 && len(zones) > 0, nil
 }
 
 func commonIstioIngressNetworkPolicyLabels(vpnEnabled bool) map[string]string {

--- a/pkg/component/shared/istio_test.go
+++ b/pkg/component/shared/istio_test.go
@@ -472,43 +472,43 @@ var _ = Describe("Istio", func() {
 	)
 
 	DescribeTable("#ShouldEnsureHostSpreading",
-		func(nodes []corev1.Node, zones []string, expectedError gomegatypes.GomegaMatcher, expectedHostSpreading bool) {
+		func(nodes []corev1.Node, zones []string, expectedHostSpreading bool) {
 			cl := fakeclient.NewClientBuilder().WithScheme(kubernetes.SeedScheme).Build()
 			for _, n := range nodes {
 				Expect(cl.Create(context.TODO(), &n)).To(Succeed())
 			}
 			hostSpreadingEnabled, err := ShouldEnsureHostSpreading(context.TODO(), cl, zones)
-			Expect(err).To(expectedError)
+			Expect(err).ToNot(HaveOccurred())
 			Expect(hostSpreadingEnabled).To(Equal(expectedHostSpreading))
 		},
 
-		Entry("no nodes", []corev1.Node{}, []string{}, BeNil(), false),
-		Entry("single node", []corev1.Node{{ObjectMeta: metav1.ObjectMeta{Name: "node-0", Labels: map[string]string{"topology.kubernetes.io/zone": "z1"}}}}, []string{"z1"}, BeNil(), false),
+		Entry("no nodes", []corev1.Node{}, []string{}, false),
+		Entry("single node", []corev1.Node{{ObjectMeta: metav1.ObjectMeta{Name: "node-0", Labels: map[string]string{"topology.kubernetes.io/zone": "z1"}}}}, []string{"z1"}, false),
 		Entry("two nodes", []corev1.Node{
 			{ObjectMeta: metav1.ObjectMeta{Name: "node-0", Labels: map[string]string{"topology.kubernetes.io/zone": "z1"}}},
 			{ObjectMeta: metav1.ObjectMeta{Name: "node-1", Labels: map[string]string{"topology.kubernetes.io/zone": "z1"}}},
-		}, []string{"z1"}, BeNil(), true),
+		}, []string{"z1"}, true),
 		Entry("three nodes with different zones targeting one zone", []corev1.Node{
 			{ObjectMeta: metav1.ObjectMeta{Name: "node-0", Labels: map[string]string{"topology.kubernetes.io/zone": "z1"}}},
 			{ObjectMeta: metav1.ObjectMeta{Name: "node-1", Labels: map[string]string{"topology.kubernetes.io/zone": "z1"}}},
 			{ObjectMeta: metav1.ObjectMeta{Name: "node-2", Labels: map[string]string{"topology.kubernetes.io/zone": "z2"}}},
-		}, []string{"z1"}, BeNil(), true),
+		}, []string{"z1"}, true),
 		Entry("three nodes with different zones targeting two zones", []corev1.Node{
 			{ObjectMeta: metav1.ObjectMeta{Name: "node-0", Labels: map[string]string{"topology.kubernetes.io/zone": "z1"}}},
 			{ObjectMeta: metav1.ObjectMeta{Name: "node-1", Labels: map[string]string{"topology.kubernetes.io/zone": "z1"}}},
 			{ObjectMeta: metav1.ObjectMeta{Name: "node-2", Labels: map[string]string{"topology.kubernetes.io/zone": "z2"}}},
-		}, []string{"z1", "z2"}, BeNil(), false),
+		}, []string{"z1", "z2"}, false),
 		Entry("four nodes with different zones targeting two zones", []corev1.Node{
 			{ObjectMeta: metav1.ObjectMeta{Name: "node-0", Labels: map[string]string{"topology.kubernetes.io/zone": "z1"}}},
 			{ObjectMeta: metav1.ObjectMeta{Name: "node-1", Labels: map[string]string{"topology.kubernetes.io/zone": "z1"}}},
 			{ObjectMeta: metav1.ObjectMeta{Name: "node-2", Labels: map[string]string{"topology.kubernetes.io/zone": "z2"}}},
 			{ObjectMeta: metav1.ObjectMeta{Name: "node-3", Labels: map[string]string{"topology.kubernetes.io/zone": "z2"}}},
-		}, []string{"z1", "z2"}, BeNil(), true),
+		}, []string{"z1", "z2"}, true),
 		Entry("four nodes with different zones targeting different zone", []corev1.Node{
 			{ObjectMeta: metav1.ObjectMeta{Name: "node-0", Labels: map[string]string{"topology.kubernetes.io/zone": "z1"}}},
 			{ObjectMeta: metav1.ObjectMeta{Name: "node-1", Labels: map[string]string{"topology.kubernetes.io/zone": "z1"}}},
 			{ObjectMeta: metav1.ObjectMeta{Name: "node-2", Labels: map[string]string{"topology.kubernetes.io/zone": "z2"}}},
 			{ObjectMeta: metav1.ObjectMeta{Name: "node-3", Labels: map[string]string{"topology.kubernetes.io/zone": "z2"}}},
-		}, []string{"z3"}, BeNil(), false),
+		}, []string{"z3"}, false),
 	)
 })

--- a/pkg/component/shared/istio_test.go
+++ b/pkg/component/shared/istio_test.go
@@ -51,6 +51,7 @@ type istioTestValues struct {
 	proxyProtocolEnabled              bool
 	vpnEnabled                        bool
 	zones                             []string
+	ensureHostSpreading               bool
 }
 
 func createIstio(testValues istioTestValues) istio.Interface {
@@ -131,14 +132,15 @@ func checkIstio(istioDeploy istio.Interface, testValues istioTestValues) {
 				PriorityClassName:     testValues.priorityClassName,
 				ProxyProtocolEnabled:  testValues.proxyProtocolEnabled,
 				VPNEnabled:            testValues.vpnEnabled,
-				EnsureHostSpreading:   len(testValues.zones) == 0,
+				EnsureHostSpreading:   testValues.ensureHostSpreading,
 			},
 		},
 		NamePrefix: testValues.prefix,
 	}))
 }
 
-func checkAdditionalIstioGateway(istioDeploy istio.Interface,
+func checkAdditionalIstioGateway(cl client.Client,
+	istioDeploy istio.Interface,
 	namespace string,
 	annotations map[string]string,
 	labels map[string]string,
@@ -146,9 +148,11 @@ func checkAdditionalIstioGateway(istioDeploy istio.Interface,
 	serviceExternalIP *string,
 	zone *string) {
 	var (
-		zones       []string
-		minReplicas *int
-		maxReplicas *int
+		zones               []string
+		minReplicas         *int
+		maxReplicas         *int
+		ensureHostSpreading bool
+		err                 error
 
 		ingressValues = istioDeploy.GetValues().IngressGateway
 	)
@@ -158,6 +162,9 @@ func checkAdditionalIstioGateway(istioDeploy istio.Interface,
 		maxReplicas = ingressValues[0].MaxReplicas
 	} else {
 		zones = []string{*zone}
+
+		ensureHostSpreading, err = ShouldEnsureHostSpreading(context.TODO(), cl, []string{*zone})
+		Expect(err).To(BeNil())
 	}
 
 	Expect(ingressValues[len(ingressValues)-1]).To(Equal(istio.IngressGatewayValues{
@@ -177,7 +184,7 @@ func checkAdditionalIstioGateway(istioDeploy istio.Interface,
 		ProxyProtocolEnabled:  ingressValues[0].ProxyProtocolEnabled,
 		VPNEnabled:            true,
 		Zones:                 zones,
-		EnsureHostSpreading:   zone == nil,
+		EnsureHostSpreading:   ensureHostSpreading,
 	}))
 }
 
@@ -213,6 +220,7 @@ var _ = Describe("Istio", func() {
 			proxyProtocolEnabled:     false,
 			vpnEnabled:               vpnEnabled,
 			zones:                    zones,
+			ensureHostSpreading:      false,
 		}
 
 		istioDeploy = createIstio(testValues)
@@ -243,6 +251,20 @@ var _ = Describe("Istio", func() {
 			It("should successfully create a new Istio deployer", func() {
 				checkIstio(istioDeploy, testValues)
 			})
+
+			Context("with nodes in single zone", func() {
+				JustBeforeEach(func() {
+					testValues.client = fakeclient.NewClientBuilder().WithScheme(kubernetes.SeedScheme).Build()
+					testValues.ensureHostSpreading = true
+					Expect(testValues.client.Create(context.TODO(), &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-0", Labels: map[string]string{"topology.kubernetes.io/zone": "1"}}})).To(Succeed())
+					Expect(testValues.client.Create(context.TODO(), &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-1", Labels: map[string]string{"topology.kubernetes.io/zone": "1"}}})).To(Succeed())
+					istioDeploy = createIstio(testValues)
+				})
+
+				It("should successfully create a new Istio deployer", func() {
+					checkIstio(istioDeploy, testValues)
+				})
+			})
 		})
 
 		Context("with multiple zones", func() {
@@ -252,6 +274,24 @@ var _ = Describe("Istio", func() {
 
 			It("should successfully create a new Istio deployer", func() {
 				checkIstio(istioDeploy, testValues)
+			})
+
+			Context("with nodes in the zones", func() {
+				JustBeforeEach(func() {
+					testValues.client = fakeclient.NewClientBuilder().WithScheme(kubernetes.SeedScheme).Build()
+					testValues.ensureHostSpreading = true
+					Expect(testValues.client.Create(context.TODO(), &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-0", Labels: map[string]string{"topology.kubernetes.io/zone": "1"}}})).To(Succeed())
+					Expect(testValues.client.Create(context.TODO(), &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-1", Labels: map[string]string{"topology.kubernetes.io/zone": "1"}}})).To(Succeed())
+					Expect(testValues.client.Create(context.TODO(), &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-2", Labels: map[string]string{"topology.kubernetes.io/zone": "2"}}})).To(Succeed())
+					Expect(testValues.client.Create(context.TODO(), &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-3", Labels: map[string]string{"topology.kubernetes.io/zone": "2"}}})).To(Succeed())
+					Expect(testValues.client.Create(context.TODO(), &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-4", Labels: map[string]string{"topology.kubernetes.io/zone": "3"}}})).To(Succeed())
+					Expect(testValues.client.Create(context.TODO(), &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-5", Labels: map[string]string{"topology.kubernetes.io/zone": "3"}}})).To(Succeed())
+					istioDeploy = createIstio(testValues)
+				})
+
+				It("should successfully create a new Istio deployer", func() {
+					checkIstio(istioDeploy, testValues)
+				})
 			})
 		})
 	})
@@ -311,6 +351,7 @@ var _ = Describe("Istio", func() {
 					zone)).To(Succeed())
 
 				checkAdditionalIstioGateway(
+					testValues.client,
 					istioDeploy,
 					namespace,
 					annotations,
@@ -340,6 +381,7 @@ var _ = Describe("Istio", func() {
 					zone)).To(Succeed())
 
 				checkAdditionalIstioGateway(
+					testValues.client,
 					istioDeploy,
 					namespace,
 					annotations,
@@ -348,6 +390,41 @@ var _ = Describe("Istio", func() {
 					serviceExternalIP,
 					zone,
 				)
+			})
+
+			Context("with nodes in zone", func() {
+				JustBeforeEach(func() {
+					testValues.client = fakeclient.NewClientBuilder().WithScheme(kubernetes.SeedScheme).Build()
+					testValues.ensureHostSpreading = true
+					Expect(testValues.client.Create(context.TODO(), &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-0", Labels: map[string]string{"topology.kubernetes.io/zone": "1"}}})).To(Succeed())
+					Expect(testValues.client.Create(context.TODO(), &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-1", Labels: map[string]string{"topology.kubernetes.io/zone": "1"}}})).To(Succeed())
+					istioDeploy = createIstio(testValues)
+				})
+
+				It("should successfully create a new Istio deployer", func() {
+					Expect(AddIstioIngressGateway(
+						context.TODO(),
+						testValues.client,
+						istioDeploy,
+						namespace,
+						annotations,
+						labels,
+						&externalTrafficPolicy,
+						serviceExternalIP,
+						zone)).To(Succeed())
+
+					checkAdditionalIstioGateway(
+						testValues.client,
+						istioDeploy,
+						namespace,
+						annotations,
+						labels,
+						&externalTrafficPolicy,
+						serviceExternalIP,
+						zone,
+					)
+				})
+
 			})
 		})
 	})
@@ -405,7 +482,7 @@ var _ = Describe("Istio", func() {
 			Expect(hostSpreadingEnabled).To(Equal(expectedHostSpreading))
 		},
 
-		Entry("no nodes", []corev1.Node{}, []string{}, BeNil(), true),
+		Entry("no nodes", []corev1.Node{}, []string{}, BeNil(), false),
 		Entry("single node", []corev1.Node{{ObjectMeta: metav1.ObjectMeta{Name: "node-0", Labels: map[string]string{"topology.kubernetes.io/zone": "z1"}}}}, []string{"z1"}, BeNil(), false),
 		Entry("two nodes", []corev1.Node{
 			{ObjectMeta: metav1.ObjectMeta{Name: "node-0", Labels: map[string]string{"topology.kubernetes.io/zone": "z1"}}},

--- a/pkg/component/shared/istio_test.go
+++ b/pkg/component/shared/istio_test.go
@@ -15,12 +15,15 @@
 package shared_test
 
 import (
+	"context"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	gomegatypes "github.com/onsi/gomega/types"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/gardener/gardener/pkg/chartrenderer"
 	"github.com/gardener/gardener/pkg/component/istio"
@@ -58,6 +61,7 @@ func createIstio(testValues istioTestValues) istio.Interface {
 	))
 
 	istio, err := NewIstio(
+		context.TODO(),
 		testValues.client,
 		testValues.chartRenderer,
 		testValues.prefix,
@@ -125,6 +129,7 @@ func checkIstio(istioDeploy istio.Interface, testValues istioTestValues) {
 				PriorityClassName:     testValues.priorityClassName,
 				ProxyProtocolEnabled:  testValues.proxyProtocolEnabled,
 				VPNEnabled:            testValues.vpnEnabled,
+				EnsureHostSpreading:   len(testValues.zones) == 0,
 			},
 		},
 		NamePrefix: testValues.prefix,
@@ -170,6 +175,7 @@ func checkAdditionalIstioGateway(istioDeploy istio.Interface,
 		ProxyProtocolEnabled:  ingressValues[0].ProxyProtocolEnabled,
 		VPNEnabled:            true,
 		Zones:                 zones,
+		EnsureHostSpreading:   zone == nil,
 	}))
 }
 
@@ -189,6 +195,7 @@ var _ = Describe("Istio", func() {
 	JustBeforeEach(func() {
 		trafficPolicy := corev1.ServiceExternalTrafficPolicyTypeLocal
 		testValues = istioTestValues{
+			client:                   fakeclient.NewClientBuilder().Build(),
 			istiodImageName:          "istiod",
 			ingressImageName:         "istio-ingress",
 			prefix:                   "shared-istio-test-",
@@ -273,6 +280,8 @@ var _ = Describe("Istio", func() {
 			istioDeploy = istio.NewIstio(nil, nil, istio.Values{})
 
 			Expect(AddIstioIngressGateway(
+				context.TODO(),
+				testValues.client,
 				istioDeploy,
 				namespace,
 				annotations,
@@ -289,6 +298,8 @@ var _ = Describe("Istio", func() {
 
 			It("should successfully add an additional ingress gateway", func() {
 				Expect(AddIstioIngressGateway(
+					context.TODO(),
+					testValues.client,
 					istioDeploy,
 					namespace,
 					annotations,
@@ -316,6 +327,8 @@ var _ = Describe("Istio", func() {
 
 			It("should successfully add an additional ingress gateway", func() {
 				Expect(AddIstioIngressGateway(
+					context.TODO(),
+					testValues.client,
 					istioDeploy,
 					namespace,
 					annotations,

--- a/pkg/component/shared/istio_test.go
+++ b/pkg/component/shared/istio_test.go
@@ -164,7 +164,7 @@ func checkAdditionalIstioGateway(cl client.Client,
 		zones = []string{*zone}
 
 		ensureHostSpreading, err = ShouldEnsureHostSpreading(context.TODO(), cl, []string{*zone})
-		Expect(err).To(BeNil())
+		Expect(err).ToNot(HaveOccurred())
 	}
 
 	Expect(ingressValues[len(ingressValues)-1]).To(Equal(istio.IngressGatewayValues{

--- a/pkg/gardenlet/controller/seed/seed/components.go
+++ b/pkg/gardenlet/controller/seed/seed/components.go
@@ -72,6 +72,7 @@ import (
 )
 
 func defaultIstio(
+	ctx context.Context,
 	seedClient client.Client,
 	chartRenderer chartrenderer.Interface,
 	seed *seedpkg.Seed,
@@ -87,6 +88,7 @@ func defaultIstio(
 	)
 
 	istioDeployer, err := shared.NewIstio(
+		ctx,
 		seedClient,
 		chartRenderer,
 		"",
@@ -115,6 +117,8 @@ func defaultIstio(
 	if len(seedObj.Spec.Provider.Zones) > 1 {
 		for _, zone := range seedObj.Spec.Provider.Zones {
 			if err := shared.AddIstioIngressGateway(
+				ctx,
+				seedClient,
 				istioDeployer,
 				shared.GetIstioNamespaceForZone(*conf.SNI.Ingress.Namespace, zone),
 				seed.GetZonalLoadBalancerServiceAnnotations(zone),
@@ -131,6 +135,8 @@ func defaultIstio(
 	// Add for each ExposureClass handler in the config an own Ingress Gateway and Proxy Gateway.
 	for _, handler := range conf.ExposureClassHandlers {
 		if err := shared.AddIstioIngressGateway(
+			ctx,
+			seedClient,
 			istioDeployer,
 			*handler.SNI.Ingress.Namespace,
 			// handler.LoadBalancerService.Annotations must put last to override non-exposure class related keys.
@@ -147,6 +153,8 @@ func defaultIstio(
 		if len(seedObj.Spec.Provider.Zones) > 1 {
 			for _, zone := range seedObj.Spec.Provider.Zones {
 				if err := shared.AddIstioIngressGateway(
+					ctx,
+					seedClient,
 					istioDeployer,
 					shared.GetIstioNamespaceForZone(*handler.SNI.Ingress.Namespace, zone),
 					// handler.LoadBalancerService.Annotations must put last to override non-exposure class related keys.

--- a/pkg/gardenlet/controller/seed/seed/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/seed/seed/reconciler_reconcile.go
@@ -392,7 +392,7 @@ func (r *Reconciler) runReconcileSeedFlow(
 	// setup for flow graph
 	var dnsRecord component.DeployMigrateWaiter
 
-	istio, err := defaultIstio(seedClient, chartRenderer, seed, &r.Config, seedIsGarden)
+	istio, err := defaultIstio(ctx, seedClient, chartRenderer, seed, &r.Config, seedIsGarden)
 	if err != nil {
 		return err
 	}

--- a/pkg/operator/controller/garden/garden/components.go
+++ b/pkg/operator/controller/garden/garden/components.go
@@ -162,7 +162,7 @@ func (r *Reconciler) instantiateComponents(
 	if err != nil {
 		return
 	}
-	c.istio, err = r.newIstio(garden)
+	c.istio, err = r.newIstio(ctx, garden)
 	if err != nil {
 		return
 	}
@@ -698,13 +698,14 @@ func (r *Reconciler) newKubeStateMetrics() (component.DeployWaiter, error) {
 	)
 }
 
-func (r *Reconciler) newIstio(garden *operatorv1alpha1.Garden) (istio.Interface, error) {
+func (r *Reconciler) newIstio(ctx context.Context, garden *operatorv1alpha1.Garden) (istio.Interface, error) {
 	var annotations map[string]string
 	if settings := garden.Spec.RuntimeCluster.Settings; settings != nil && settings.LoadBalancerServices != nil {
 		annotations = settings.LoadBalancerServices.Annotations
 	}
 
 	return sharedcomponent.NewIstio(
+		ctx,
 		r.RuntimeClientSet.Client(),
 		r.RuntimeClientSet.ChartRenderer(),
 		namePrefix,


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/area high-availability
/area robustness
/kind enhancement

**What this PR does / why we need it**:
Spread Istio Ingress Gateway pods across hosts if there are multiple nodes per zone.

The istio ingress gateway pods are the entry points for all communication to the shoot cluster's control plane. Therefore, ensuring high availability of these pods is crucial. Having multiple replicas is a good step. However, if all replicas are scheduled to the same node a single node failure can lead to some downtime. Therefore, this change tries to enforce spreading of istio pods across multiple nodes if the corresponding availability zone(s) have sufficient nodes available, i.e. if all required zones have more than one node the spreading across hosts is enforced.
While the requirement to spread istio pods seems always relevant it may impact small seeds or development scenarios. Therefore, it is only enforced if sufficient node capacity is available.
Please note that this approach while being automatic and eventually consistent can be slightly outdated as the seed reconciliation flow is executed regularly, but not constantly.

**Which issue(s) this PR fixes**:
None.

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
