### PR TITLE
Minor fixes

### DIFF
--- a/docs/api-reference/settings.md
+++ b/docs/api-reference/settings.md
@@ -183,7 +183,7 @@ KubeAPIServerOpenIDConnect
 </td>
 <td>
 <p>Server contains the kube-apiserver&rsquo;s OpenID Connect configuration.
-This configuration is not overwritting any existing OpenID Connect
+This configuration is not overwriting any existing OpenID Connect
 configuration already set on the Shoot object.</p>
 </td>
 </tr>
@@ -200,7 +200,7 @@ OpenIDConnectClientAuthentication
 <em>(Optional)</em>
 <p>Client contains the configuration used for client OIDC authentication
 of Shoot clusters.
-This configuration is not overwritting any existing OpenID Connect
+This configuration is not overwriting any existing OpenID Connect
 client authentication already set on the Shoot object.</p>
 </td>
 </tr>
@@ -497,7 +497,7 @@ KubeAPIServerOpenIDConnect
 </td>
 <td>
 <p>Server contains the kube-apiserver&rsquo;s OpenID Connect configuration.
-This configuration is not overwritting any existing OpenID Connect
+This configuration is not overwriting any existing OpenID Connect
 configuration already set on the Shoot object.</p>
 </td>
 </tr>
@@ -514,7 +514,7 @@ OpenIDConnectClientAuthentication
 <em>(Optional)</em>
 <p>Client contains the configuration used for client OIDC authentication
 of Shoot clusters.
-This configuration is not overwritting any existing OpenID Connect
+This configuration is not overwriting any existing OpenID Connect
 client authentication already set on the Shoot object.</p>
 </td>
 </tr>

--- a/pkg/apis/core/v1beta1/defaults_shoot.go
+++ b/pkg/apis/core/v1beta1/defaults_shoot.go
@@ -32,9 +32,6 @@ func SetDefaults_Shoot(obj *Shoot) {
 	if obj.Spec.Kubernetes.KubeAPIServer == nil {
 		obj.Spec.Kubernetes.KubeAPIServer = &KubeAPIServerConfig{}
 	}
-	if obj.Spec.Kubernetes.KubeControllerManager == nil {
-		obj.Spec.Kubernetes.KubeControllerManager = &KubeControllerManagerConfig{}
-	}
 
 	if obj.Spec.Purpose == nil {
 		p := ShootPurposeEvaluation
@@ -95,6 +92,10 @@ func SetDefaults_Shoot(obj *Shoot) {
 		}
 		if obj.Spec.Kubernetes.KubeAPIServer.DefaultUnreachableTolerationSeconds == nil {
 			obj.Spec.Kubernetes.KubeAPIServer.DefaultUnreachableTolerationSeconds = pointer.Int64(300)
+		}
+
+		if obj.Spec.Kubernetes.KubeControllerManager == nil {
+			obj.Spec.Kubernetes.KubeControllerManager = &KubeControllerManagerConfig{}
 		}
 
 		if obj.Spec.Kubernetes.KubeControllerManager.NodeCIDRMaskSize == nil {

--- a/pkg/apis/core/v1beta1/defaults_shoot_test.go
+++ b/pkg/apis/core/v1beta1/defaults_shoot_test.go
@@ -376,15 +376,17 @@ var _ = Describe("Shoot defaulting", func() {
 	})
 
 	Describe("KubeControllerManager settings defaulting", func() {
-		Describe("NodeCIDRMaskSize", func() {
-			It("should not default nodeCIDRMaskSize field for workerless Shoot", func() {
+		Describe("KubeControllerManager", func() {
+			It("should not default KubeControllerManager field for workerless Shoot", func() {
 				obj.Spec.Provider.Workers = nil
 
 				SetObjectDefaults_Shoot(obj)
 
-				Expect(obj.Spec.Kubernetes.KubeControllerManager.NodeCIDRMaskSize).To(BeNil())
+				Expect(obj.Spec.Kubernetes.KubeControllerManager).To(BeNil())
 			})
+		})
 
+		Describe("NodeCIDRMaskSize", func() {
 			Context("IPv4", func() {
 				It("should make nodeCIDRMaskSize big enough for 2*maxPods", func() {
 					obj.Spec.Provider.Workers = []Worker{{}}

--- a/pkg/apis/settings/types_shared.go
+++ b/pkg/apis/settings/types_shared.go
@@ -23,13 +23,13 @@ import (
 type OpenIDConnectPresetSpec struct {
 
 	// Server contains the kube-apiserver's OpenID Connect configuration.
-	// This configuration is not overwritting any existing OpenID Connect
+	// This configuration is not overwriting any existing OpenID Connect
 	// configuration already set on the Shoot object.
 	Server KubeAPIServerOpenIDConnect
 
 	// Client contains the configuration used for client OIDC authentication
 	// of Shoot clusters.
-	// This configuration is not overwritting any existing OpenID Connect
+	// This configuration is not overwriting any existing OpenID Connect
 	// client authentication already set on the Shoot object.
 	Client *OpenIDConnectClientAuthentication
 

--- a/pkg/apis/settings/v1alpha1/generated.proto
+++ b/pkg/apis/settings/v1alpha1/generated.proto
@@ -139,13 +139,13 @@ message OpenIDConnectPresetList {
 // a specific OpenID Connect configuration is applied.
 message OpenIDConnectPresetSpec {
   // Server contains the kube-apiserver's OpenID Connect configuration.
-  // This configuration is not overwritting any existing OpenID Connect
+  // This configuration is not overwriting any existing OpenID Connect
   // configuration already set on the Shoot object.
   optional KubeAPIServerOpenIDConnect server = 1;
 
   // Client contains the configuration used for client OIDC authentication
   // of Shoot clusters.
-  // This configuration is not overwritting any existing OpenID Connect
+  // This configuration is not overwriting any existing OpenID Connect
   // client authentication already set on the Shoot object.
   // +optional
   optional OpenIDConnectClientAuthentication client = 2;

--- a/pkg/apis/settings/v1alpha1/types_shared.go
+++ b/pkg/apis/settings/v1alpha1/types_shared.go
@@ -30,13 +30,13 @@ const (
 type OpenIDConnectPresetSpec struct {
 
 	// Server contains the kube-apiserver's OpenID Connect configuration.
-	// This configuration is not overwritting any existing OpenID Connect
+	// This configuration is not overwriting any existing OpenID Connect
 	// configuration already set on the Shoot object.
 	Server KubeAPIServerOpenIDConnect `json:"server" protobuf:"bytes,1,opt,name=server"`
 
 	// Client contains the configuration used for client OIDC authentication
 	// of Shoot clusters.
-	// This configuration is not overwritting any existing OpenID Connect
+	// This configuration is not overwriting any existing OpenID Connect
 	// client authentication already set on the Shoot object.
 	// +optional
 	Client *OpenIDConnectClientAuthentication `json:"client,omitempty" protobuf:"bytes,2,opt,name=client"`

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -9821,14 +9821,14 @@ func schema_pkg_apis_settings_v1alpha1_ClusterOpenIDConnectPresetSpec(ref common
 				Properties: map[string]spec.Schema{
 					"server": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Server contains the kube-apiserver's OpenID Connect configuration. This configuration is not overwritting any existing OpenID Connect configuration already set on the Shoot object.",
+							Description: "Server contains the kube-apiserver's OpenID Connect configuration. This configuration is not overwriting any existing OpenID Connect configuration already set on the Shoot object.",
 							Default:     map[string]interface{}{},
 							Ref:         ref("github.com/gardener/gardener/pkg/apis/settings/v1alpha1.KubeAPIServerOpenIDConnect"),
 						},
 					},
 					"client": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Client contains the configuration used for client OIDC authentication of Shoot clusters. This configuration is not overwritting any existing OpenID Connect client authentication already set on the Shoot object.",
+							Description: "Client contains the configuration used for client OIDC authentication of Shoot clusters. This configuration is not overwriting any existing OpenID Connect client authentication already set on the Shoot object.",
 							Ref:         ref("github.com/gardener/gardener/pkg/apis/settings/v1alpha1.OpenIDConnectClientAuthentication"),
 						},
 					},
@@ -10097,14 +10097,14 @@ func schema_pkg_apis_settings_v1alpha1_OpenIDConnectPresetSpec(ref common.Refere
 				Properties: map[string]spec.Schema{
 					"server": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Server contains the kube-apiserver's OpenID Connect configuration. This configuration is not overwritting any existing OpenID Connect configuration already set on the Shoot object.",
+							Description: "Server contains the kube-apiserver's OpenID Connect configuration. This configuration is not overwriting any existing OpenID Connect configuration already set on the Shoot object.",
 							Default:     map[string]interface{}{},
 							Ref:         ref("github.com/gardener/gardener/pkg/apis/settings/v1alpha1.KubeAPIServerOpenIDConnect"),
 						},
 					},
 					"client": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Client contains the configuration used for client OIDC authentication of Shoot clusters. This configuration is not overwritting any existing OpenID Connect client authentication already set on the Shoot object.",
+							Description: "Client contains the configuration used for client OIDC authentication of Shoot clusters. This configuration is not overwriting any existing OpenID Connect client authentication already set on the Shoot object.",
 							Ref:         ref("github.com/gardener/gardener/pkg/apis/settings/v1alpha1.OpenIDConnectClientAuthentication"),
 						},
 					},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind enhancement

**What this PR does / why we need it**:
- For workerless Shoots, `kubeControllerManager` is defaulted but no other field inside is defaulted. This is unnecessary and causes empty struct in the yaml.
```
$ k get shoots -n garden-local local-wl -oyaml
...
  kubernetes:
    enableStaticTokenKubeconfig: true
    kubeAPIServer:
      enableAnonymousAuthentication: false
      eventTTL: 1h0m0s
      logging:
        verbosity: 2
      requests:
        maxMutatingInflight: 200
        maxNonMutatingInflight: 400
    kubeControllerManager: {}
```
- Fix spelling in the doc string inside `OpenIDConnectPresetSpec`

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
