### PR TITLE
Use registry-cache extension when running e2e tests in prow

### DIFF
--- a/example/gardener-local/registry-prow/kustomization.yaml
+++ b/example/gardener-local/registry-prow/kustomization.yaml
@@ -7,60 +7,40 @@ resources:
 patches:
   - patch: |
       - op: replace
-        path: /spec/template/spec/containers/0/env
-        value:
-          - name: REGISTRY_PROXY_REMOTEURL
-            value: http://registry-gcr-io.kube-system.svc.cluster.local:5000
-          - name: REGISTRY_HTTP_ADDR
-            value: :5003
+        path: /spec/template/spec/containers/0/env/0/value
+        value: http://registry-gcr-io.kube-system.svc.cluster.local:5000
     target:
       group: apps
       kind: Deployment
       name: registry-gcr
   - patch: |
       - op: replace
-        path: /spec/template/spec/containers/0/env
-        value:
-          - name: REGISTRY_PROXY_REMOTEURL
-            value: http://registry-eu-gcr-io.kube-system.svc.cluster.local:5000
-          - name: REGISTRY_HTTP_ADDR
-            value: :5004
+        path: /spec/template/spec/containers/0/env/0/value
+        value: http://registry-eu-gcr-io.kube-system.svc.cluster.local:5000
     target:
       group: apps
       kind: Deployment
       name: registry-gcr-eu
   - patch: |
       - op: replace
-        path: /spec/template/spec/containers/0/env
-        value:
-          - name: REGISTRY_PROXY_REMOTEURL
-            value: http://registry-ghcr-io.kube-system.svc.cluster.local:5000
-          - name: REGISTRY_HTTP_ADDR
-            value: :5005
+        path: /spec/template/spec/containers/0/env/0/value
+        value: http://registry-ghcr-io.kube-system.svc.cluster.local:5000
     target:
       group: apps
       kind: Deployment
       name: registry-ghcr
   - patch: |
       - op: replace
-        path: /spec/template/spec/containers/0/env
-        value:
-          - name: REGISTRY_PROXY_REMOTEURL
-            value: http://registry-registry-k8s-io.kube-system.svc.cluster.local:5000
-          - name: REGISTRY_HTTP_ADDR
-            value: :5006
+        path: /spec/template/spec/containers/0/env/0/value
+        value: http://registry-registry-k8s-io.kube-system.svc.cluster.local:5000
     target:
       group: apps
       kind: Deployment
       name: registry-k8s
   - patch: |
       - op: replace
-        path: /spec/template/spec/containers/0/env
-        value:
-          - name: REGISTRY_PROXY_REMOTEURL
-            value: http://registry-quay-io.kube-system.svc.cluster.local:5000
-          - name: REGISTRY_HTTP_ADDR
-            value: :5007
+        path: /spec/template/spec/containers/0/env/0/value
+        value: http://registry-quay-io.kube-system.svc.cluster.local:5000
     target:
       group: apps
       kind: Deployment

--- a/example/gardener-local/registry-prow/kustomization.yaml
+++ b/example/gardener-local/registry-prow/kustomization.yaml
@@ -1,0 +1,67 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../registry
+
+patches:
+  - patch: |
+      - op: replace
+        path: /spec/template/spec/containers/0/env
+        value:
+          - name: REGISTRY_PROXY_REMOTEURL
+            value: http://registry-gcr-io.kube-system.svc.cluster.local:5000
+          - name: REGISTRY_HTTP_ADDR
+            value: :5003
+    target:
+      group: apps
+      kind: Deployment
+      name: registry-gcr
+  - patch: |
+      - op: replace
+        path: /spec/template/spec/containers/0/env
+        value:
+          - name: REGISTRY_PROXY_REMOTEURL
+            value: http://registry-eu-gcr-io.kube-system.svc.cluster.local:5000
+          - name: REGISTRY_HTTP_ADDR
+            value: :5004
+    target:
+      group: apps
+      kind: Deployment
+      name: registry-gcr-eu
+  - patch: |
+      - op: replace
+        path: /spec/template/spec/containers/0/env
+        value:
+          - name: REGISTRY_PROXY_REMOTEURL
+            value: http://registry-ghcr-io.kube-system.svc.cluster.local:5000
+          - name: REGISTRY_HTTP_ADDR
+            value: :5005
+    target:
+      group: apps
+      kind: Deployment
+      name: registry-ghcr
+  - patch: |
+      - op: replace
+        path: /spec/template/spec/containers/0/env
+        value:
+          - name: REGISTRY_PROXY_REMOTEURL
+            value: http://registry-registry-k8s-io.kube-system.svc.cluster.local:5000
+          - name: REGISTRY_HTTP_ADDR
+            value: :5006
+    target:
+      group: apps
+      kind: Deployment
+      name: registry-k8s
+  - patch: |
+      - op: replace
+        path: /spec/template/spec/containers/0/env
+        value:
+          - name: REGISTRY_PROXY_REMOTEURL
+            value: http://registry-quay-io.kube-system.svc.cluster.local:5000
+          - name: REGISTRY_HTTP_ADDR
+            value: :5007
+    target:
+      group: apps
+      kind: Deployment
+      name: registry-quay


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing cost
/kind enhancement

**What this PR does / why we need it**:
Our prow build cluster has the [registry-cache extension](https://github.com/gardener/gardener-extension-registry-cache) enabled now.
It already caches the test-images. However, we could save more network traffic by using it for caching the images used in our e2e tests.
The kind setup already runs local registries to cache images. This PR adapts their configuration to pull images from the registry-cache registries of the prow cluster instead of the upstream registries. Registry-cache mode is only enabled if environment variable `CI=true` which is the case in prow. Local development is not affected (unless some sets the env 😄 ). When the registry-cache mode is enabled, but the registry-cache services are not deployed, it becomes automatically disabled.  

I reconfigured the local registries instead of disabling them and reconfigure containerd in the local setup to keep the footprint of this change smaller.
Additionally, this setup creates less load on the registry-cache instances of the prow cluster.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy developer
The local Gardener environments for e2e tests running in Prow are now backed by the [`registry-cache`](https://github.com/gardener/gardener-extension-registry-cache/) extensions enabled in the Prow cluster. This should have a positive impact on the network I/O for image pulls and resulting costs.
```
