### PR TITLE
🧹 Cleanup a few `TODO`s

### DIFF
--- a/charts/gardener/gardenlet/templates/clusterrole-gardenlet.yaml
+++ b/charts/gardener/gardenlet/templates/clusterrole-gardenlet.yaml
@@ -177,13 +177,6 @@ rules:
   - filters.fluentbit.fluent.io
   - outputs.fluentbit.fluent.io
   - parsers.fluentbit.fluent.io
-  # TODO(rfranzke): Remove this code after Gardener v1.83 has been released.
-  - alicloudmachineclasses.machine.sapcloud.io
-  - awsmachineclasses.machine.sapcloud.io
-  - azuremachineclasses.machine.sapcloud.io
-  - gcpmachineclasses.machine.sapcloud.io
-  - openstackmachineclasses.machine.sapcloud.io
-  - packetmachineclasses.machine.sapcloud.io
   verbs:
   - delete
 - apiGroups:

--- a/cmd/gardenlet/app/app.go
+++ b/cmd/gardenlet/app/app.go
@@ -61,7 +61,6 @@ import (
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/apis/operations"
 	operationsv1alpha1 "github.com/gardener/gardener/pkg/apis/operations/v1alpha1"
-	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	clientmapbuilder "github.com/gardener/gardener/pkg/client/kubernetes/clientmap/builder"
 	"github.com/gardener/gardener/pkg/controllerutils"
@@ -377,11 +376,6 @@ func (g *garden) Start(ctx context.Context) error {
 		return err
 	}
 
-	log.Info("Cleaning up legacy 'shoot-node-logging' ManagedResource")
-	if err := cleanupLegacyLoggingManagedResource(ctx, g.mgr.GetClient()); err != nil {
-		return err
-	}
-
 	log.Info("Cleaning up orphaned ServiceAccounts related to garden access secrets for extensions")
 	if err := g.cleanupOrphanedExtensionsServiceAccounts(ctx, gardenCluster.GetClient()); err != nil {
 		return err
@@ -439,30 +433,6 @@ func (g *garden) Start(ctx context.Context) error {
 	}
 
 	return nil
-}
-
-// TODO(rfranzke): Remove this code after v1.83 has been released.
-func cleanupLegacyLoggingManagedResource(ctx context.Context, seedClient client.Client) error {
-	managedResourceList := &metav1.PartialObjectMetadataList{}
-	managedResourceList.SetGroupVersionKind(resourcesv1alpha1.SchemeGroupVersion.WithKind("ManagedResourceList"))
-	if err := seedClient.List(ctx, managedResourceList); err != nil {
-		if meta.IsNoMatchError(err) {
-			return nil
-		}
-		return err
-	}
-
-	var taskFns []flow.TaskFn
-	for _, managedResource := range managedResourceList.Items {
-		if managedResource.GetName() == "shoot-node-logging" {
-			mr := managedResource
-			taskFns = append(taskFns, func(ctx context.Context) error {
-				return seedClient.Delete(ctx, &mr)
-			})
-		}
-	}
-
-	return flow.Parallel(taskFns...)(ctx)
 }
 
 // TODO(rfranzke): Remove this code after v1.86 has been released.

--- a/extensions/pkg/controller/worker/genericactuator/actuator_delete.go
+++ b/extensions/pkg/controller/worker/genericactuator/actuator_delete.go
@@ -53,11 +53,6 @@ func (a *genericActuator) Delete(ctx context.Context, log logr.Logger, worker *e
 		return fmt.Errorf("pre worker deletion hook failed: %w", err)
 	}
 
-	// Cleanup legacy machine-controller-manager resources.
-	if err := a.cleanupLegacyMachineControllerManagerResources(ctx, log, worker); err != nil {
-		return err
-	}
-
 	// Redeploy generated machine classes to update credentials machine-controller-manager used.
 	log.Info("Deploying the machine classes")
 	if err := workerDelegate.DeployMachineClasses(ctx); err != nil {

--- a/extensions/pkg/controller/worker/genericactuator/actuator_migrate.go
+++ b/extensions/pkg/controller/worker/genericactuator/actuator_migrate.go
@@ -24,9 +24,6 @@ import (
 )
 
 // Migrate ensures that the MCM is deleted in case it is managed.
-func (a *genericActuator) Migrate(ctx context.Context, log logr.Logger, worker *extensionsv1alpha1.Worker, _ *controller.Cluster) error {
-	log = log.WithValues("operation", "migrate")
-
-	// Cleanup legacy machine-controller-manager resources.
-	return a.cleanupLegacyMachineControllerManagerResources(ctx, log, worker)
+func (a *genericActuator) Migrate(_ context.Context, _ logr.Logger, _ *extensionsv1alpha1.Worker, _ *controller.Cluster) error {
+	return nil
 }

--- a/extensions/pkg/controller/worker/genericactuator/actuator_reconcile.go
+++ b/extensions/pkg/controller/worker/genericactuator/actuator_reconcile.go
@@ -62,11 +62,6 @@ func (a *genericActuator) Reconcile(ctx context.Context, log logr.Logger, worker
 		return err
 	}
 
-	// Cleanup legacy machine-controller-manager resources.
-	if err := a.cleanupLegacyMachineControllerManagerResources(ctx, log, worker); err != nil {
-		return err
-	}
-
 	// Generate the desired machine deployments.
 	log.Info("Generating machine deployments")
 	wantedMachineDeployments, err := workerDelegate.GenerateMachineDeployments(ctx)

--- a/extensions/pkg/controller/worker/genericactuator/machine_controller_manager.go
+++ b/extensions/pkg/controller/worker/genericactuator/machine_controller_manager.go
@@ -18,25 +18,13 @@ import (
 	"context"
 
 	"github.com/go-logr/logr"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
-	"github.com/gardener/gardener/pkg/utils/managedresources"
 )
-
-// TODO(rfranzke): Remove this function after v1.85 has been released.
-func (a *genericActuator) cleanupLegacyMachineControllerManagerResources(ctx context.Context, logger logr.Logger, workerObj *extensionsv1alpha1.Worker) error {
-	logger.Info("Skip machine-controller-manager deployment since gardenlet manages it - deleting monitoring ConfigMap and extension-worker-mcm-shoot ManagedResource")
-	if err := a.seedClient.Delete(ctx, &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "machine-controller-manager-monitoring-config", Namespace: workerObj.Namespace}}); client.IgnoreNotFound(err) != nil {
-		return err
-	}
-	return managedresources.Delete(ctx, a.seedClient, workerObj.Namespace, "extension-worker-mcm-shoot", false)
-}
 
 func scaleMachineControllerManager(ctx context.Context, logger logr.Logger, cl client.Client, worker *extensionsv1alpha1.Worker, replicas int32) error {
 	logger.Info("Scaling machine-controller-manager", "replicas", replicas)

--- a/pkg/apis/resources/v1alpha1/types.go
+++ b/pkg/apis/resources/v1alpha1/types.go
@@ -179,17 +179,6 @@ const (
 	// NetworkingFromWorldToPorts is a constant for an annotation on a Service which contains a list of ports to which
 	// ingress traffic from everywhere shall be allowed.
 	NetworkingFromWorldToPorts = "networking.resources.gardener.cloud/from-world-to-ports"
-	// NetworkingFromPolicyPodLabelSelector is a constant for an annotation on a Service which contains the label
-	// selector which should be used for pods initiating the communication with this Service. Note that the ports must
-	// be container ports, not service ports.
-	// Deprecated: Use `networking.resources.gardener.cloud/from-<some-alias>-allowed-ports`
-	// (NetworkPolicyFromPolicyAnnotationPrefix and NetworkPolicyFromPolicyAnnotationSuffix) instead.
-	NetworkingFromPolicyPodLabelSelector = "networking.resources.gardener.cloud/from-policy-pod-label-selector"
-	// NetworkingFromPolicyAllowedPorts is a constant for an annotation on a Service which contains a list of ports to
-	// which ingress traffic shall be allowed. Note that the ports must be container ports, not service ports.
-	// Deprecated: Use `networking.resources.gardener.cloud/from-<some-alias>-allowed-ports`
-	// (NetworkPolicyFromPolicyAnnotationPrefix and NetworkPolicyFromPolicyAnnotationSuffix) instead.
-	NetworkingFromPolicyAllowedPorts = "networking.resources.gardener.cloud/from-policy-allowed-ports"
 	// NetworkPolicyFromPolicyAnnotationPrefix is a constant for an annotation key prefix on a Service which contains
 	// the label selector alias which is used by pods initiating the communication to this Service. The annotation key
 	// must be suffixed with NetworkPolicyFromPolicyAnnotationSuffix, and the annotations value must be a list of

--- a/pkg/component/machinecontrollermanager/crd.go
+++ b/pkg/component/machinecontrollermanager/crd.go
@@ -19,14 +19,11 @@ import (
 	_ "embed"
 	"fmt"
 
-	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/component"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
-	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 )
 
 var (
@@ -72,7 +69,7 @@ func (c *crd) Deploy(ctx context.Context) error {
 		}
 	}
 
-	return c.deleteLegacyCRDs(ctx)
+	return nil
 }
 
 func (c *crd) Destroy(ctx context.Context) error {
@@ -89,28 +86,6 @@ func (c *crd) Destroy(ctx context.Context) error {
 		}
 
 		if err := c.applier.DeleteManifest(ctx, reader); client.IgnoreNotFound(err) != nil {
-			return err
-		}
-	}
-
-	return c.deleteLegacyCRDs(ctx)
-}
-
-// TODO(rfranzke): Remove this code after Gardener v1.83 has been released.
-func (c *crd) deleteLegacyCRDs(ctx context.Context) error {
-	for _, name := range []string{
-		"alicloudmachineclasses.machine.sapcloud.io",
-		"awsmachineclasses.machine.sapcloud.io",
-		"azuremachineclasses.machine.sapcloud.io",
-		"gcpmachineclasses.machine.sapcloud.io",
-		"openstackmachineclasses.machine.sapcloud.io",
-		"packetmachineclasses.machine.sapcloud.io",
-	} {
-		obj := &apiextensionsv1.CustomResourceDefinition{ObjectMeta: metav1.ObjectMeta{Name: name}}
-		if err := gardenerutils.ConfirmDeletion(ctx, c.client, obj); client.IgnoreNotFound(err) != nil {
-			return err
-		}
-		if err := kubernetesutils.DeleteObject(ctx, c.client, obj); err != nil {
 			return err
 		}
 	}

--- a/pkg/gardenlet/controller/managedseed/charttest/charttest.go
+++ b/pkg/gardenlet/controller/managedseed/charttest/charttest.go
@@ -279,13 +279,6 @@ func getGardenletClusterRole(labels map[string]string) *rbacv1.ClusterRole {
 					"filters.fluentbit.fluent.io",
 					"outputs.fluentbit.fluent.io",
 					"parsers.fluentbit.fluent.io",
-					// TODO(rfranzke): Remove this code after Gardener v1.83 has been released.
-					"alicloudmachineclasses.machine.sapcloud.io",
-					"awsmachineclasses.machine.sapcloud.io",
-					"azuremachineclasses.machine.sapcloud.io",
-					"gcpmachineclasses.machine.sapcloud.io",
-					"openstackmachineclasses.machine.sapcloud.io",
-					"packetmachineclasses.machine.sapcloud.io",
 				},
 				Verbs: []string{"delete"},
 			},

--- a/pkg/gardenlet/controller/shoot/shoot/cleaner.go
+++ b/pkg/gardenlet/controller/shoot/shoot/cleaner.go
@@ -184,10 +184,6 @@ func (c *cleaner) finalizeShootManagedResources(ctx context.Context, namespace s
 
 	shootMRList := &resourcesv1alpha1.ManagedResourceList{}
 	for _, mr := range mrList.Items {
-		// TODO(rfranzke): Uncomment the next line after v1.85 has been released.
-		// if pointer.StringDeref(mr.Spec.Class, "") != resourcesv1alpha1.ResourceManagerClassShoot {
-		// 	continue
-		// }
 		if mr.Spec.Class != nil {
 			continue
 		}

--- a/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
@@ -28,6 +28,7 @@ import (
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap/keys"
 	"github.com/gardener/gardener/pkg/component/kubeapiserver"
 	"github.com/gardener/gardener/pkg/controllerutils"
@@ -325,9 +326,7 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 			Fn: flow.TaskFn(func(ctx context.Context) error {
 				return tokenrequest.RenewAccessSecrets(ctx, o.SeedClientSet.Client(),
 					client.InNamespace(o.Shoot.SeedNamespace),
-					// TODO(rfranzke): Uncomment the next line after v1.85 has been released
-					//  (together with restricting the garden's/shoot's tokenrequestor to the shoot class).
-					// client.MatchingLabels{resourcesv1alpha1.ResourceManagerClass: resourcesv1alpha1.ResourceManagerClassShoot},
+					client.MatchingLabels{resourcesv1alpha1.ResourceManagerClass: resourcesv1alpha1.ResourceManagerClassShoot},
 				)
 			}).RetryUntilTimeout(defaultInterval, defaultTimeout),
 			SkipIf:       v1beta1helper.GetShootServiceAccountKeyRotationPhase(o.Shoot.GetInfo().Status.Credentials) != gardencorev1beta1.RotationPreparing,

--- a/pkg/operator/controller/garden/garden/reconciler_reconcile.go
+++ b/pkg/operator/controller/garden/garden/reconciler_reconcile.go
@@ -313,9 +313,7 @@ func (r *Reconciler) reconcile(
 			Fn: flow.TaskFn(func(ctx context.Context) error {
 				return tokenrequest.RenewAccessSecrets(ctx, r.RuntimeClientSet.Client(),
 					client.InNamespace(r.GardenNamespace),
-					// TODO(rfranzke): Uncomment the next line after v1.85 has been released
-					//  (together with restricting the garden's/shoot's tokenrequestor to the shoot class).
-					// client.MatchingLabels{resourcesv1alpha1.ResourceManagerClass: resourcesv1alpha1.ResourceManagerClassShoot},
+					client.MatchingLabels{resourcesv1alpha1.ResourceManagerClass: resourcesv1alpha1.ResourceManagerClassShoot},
 				)
 			}).RetryUntilTimeout(5*time.Second, 30*time.Second),
 			SkipIf:       helper.GetServiceAccountKeyRotationPhase(garden.Status.Credentials) != gardencorev1beta1.RotationPreparing,

--- a/pkg/resourcemanager/controller/add.go
+++ b/pkg/resourcemanager/controller/add.go
@@ -27,6 +27,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	"github.com/gardener/gardener/pkg/controller/tokenrequestor"
 	"github.com/gardener/gardener/pkg/resourcemanager/apis/config"
 	"github.com/gardener/gardener/pkg/resourcemanager/controller/csrapprover"
@@ -118,8 +119,7 @@ func AddToManager(ctx context.Context, mgr manager.Manager, sourceCluster, targe
 			Clock:           clock.RealClock{},
 			JitterFunc:      wait.Jitter,
 			APIAudiences:    []string{v1beta1constants.GardenerAudience},
-			// TODO(rfranzke): Uncomment the next line after v1.85 has been released.
-			// Class: pointer.String(resourcesv1alpha1.ResourceManagerClassShoot),
+			Class:           pointer.String(resourcesv1alpha1.ResourceManagerClassShoot),
 		}).AddToManager(mgr, sourceCluster, targetCluster); err != nil {
 			return fmt.Errorf("failed adding token requestor controller: %w", err)
 		}

--- a/pkg/resourcemanager/controller/networkpolicy/add.go
+++ b/pkg/resourcemanager/controller/networkpolicy/add.go
@@ -135,8 +135,6 @@ func (r *Reconciler) ServicePredicate() predicate.Predicate {
 				oldService.Annotations[resourcesv1alpha1.NetworkingPodLabelSelectorNamespaceAlias] != service.Annotations[resourcesv1alpha1.NetworkingPodLabelSelectorNamespaceAlias] ||
 				oldService.Annotations[resourcesv1alpha1.NetworkingNamespaceSelectors] != service.Annotations[resourcesv1alpha1.NetworkingNamespaceSelectors] ||
 				oldService.Annotations[resourcesv1alpha1.NetworkingFromWorldToPorts] != service.Annotations[resourcesv1alpha1.NetworkingFromWorldToPorts] ||
-				oldService.Annotations[resourcesv1alpha1.NetworkingFromPolicyPodLabelSelector] != service.Annotations[resourcesv1alpha1.NetworkingFromPolicyPodLabelSelector] ||
-				oldService.Annotations[resourcesv1alpha1.NetworkingFromPolicyAllowedPorts] != service.Annotations[resourcesv1alpha1.NetworkingFromPolicyAllowedPorts] ||
 				fromPolicyAnnotationsChanged(oldService.Annotations, service.Annotations)
 		},
 	}

--- a/pkg/resourcemanager/controller/networkpolicy/add_test.go
+++ b/pkg/resourcemanager/controller/networkpolicy/add_test.go
@@ -122,20 +122,6 @@ var _ = Describe("Add", func() {
 				Expect(p.Update(event.UpdateEvent{ObjectOld: oldService, ObjectNew: service})).To(BeTrue())
 			})
 
-			It("should return true because the from-policy-pod-label-selector annotation was changed", func() {
-				oldService := service.DeepCopy()
-				service.Annotations = map[string]string{"networking.resources.gardener.cloud/from-policy-pod-label-selector": "foo"}
-
-				Expect(p.Update(event.UpdateEvent{ObjectOld: oldService, ObjectNew: service})).To(BeTrue())
-			})
-
-			It("should return true because the from-policy-allowed-ports annotation was changed", func() {
-				oldService := service.DeepCopy()
-				service.Annotations = map[string]string{"networking.resources.gardener.cloud/from-policy-allowed-ports": "foo"}
-
-				Expect(p.Update(event.UpdateEvent{ObjectOld: oldService, ObjectNew: service})).To(BeTrue())
-			})
-
 			It("should return true because a custom pod label selector was added", func() {
 				oldService := service.DeepCopy()
 				service.Annotations = map[string]string{"networking.resources.gardener.cloud/from-foo-allowed-ports": "foo"}

--- a/pkg/resourcemanager/controller/networkpolicy/reconciler.go
+++ b/pkg/resourcemanager/controller/networkpolicy/reconciler.go
@@ -206,20 +206,6 @@ func (r *Reconciler) reconcileDesiredPolicies(ctx context.Context, service *core
 		addTasksForRelevantNamespacesAndPort(networkingv1.NetworkPolicyPort{Protocol: &port.Protocol, Port: &port.TargetPort}, "")
 	}
 
-	// TODO(rfranzke): The following block is deprecated and should be removed as soon as v1.82 has been released.
-	{
-		if customPodLabelSelector, allowedPorts := service.Annotations[resourcesv1alpha1.NetworkingFromPolicyPodLabelSelector], service.Annotations[resourcesv1alpha1.NetworkingFromPolicyAllowedPorts]; customPodLabelSelector != "" && allowedPorts != "" {
-			var ports []networkingv1.NetworkPolicyPort
-			if err := json.Unmarshal([]byte(allowedPorts), &ports); err != nil {
-				return nil, nil, fmt.Errorf("failed unmarshaling %s: %w", allowedPorts, err)
-			}
-
-			for _, port := range ports {
-				addTasksForRelevantNamespacesAndPort(port, customPodLabelSelector)
-			}
-		}
-	}
-
 	for k, allowedPorts := range service.Annotations {
 		match := fromPolicyRegexp.FindStringSubmatch(k)
 		if len(match) != 2 {

--- a/test/integration/resourcemanager/networkpolicy/networkpolicy_test.go
+++ b/test/integration/resourcemanager/networkpolicy/networkpolicy_test.go
@@ -37,7 +37,6 @@ var _ = Describe("NetworkPolicy Controller tests", func() {
 		service        *corev1.Service
 
 		serviceSelector         = map[string]string{"foo": "bar"}
-		customPodLabelSelector  = "custom-selector"
 		customPodLabelSelector1 = "custom-selector1"
 		customPodLabelSelector2 = "custom-selector2"
 
@@ -133,30 +132,6 @@ var _ = Describe("NetworkPolicy Controller tests", func() {
 		ensureCrossNamespaceNetworkPoliciesGetCreated      = ensureCrossNamespaceNetworkPolicies(EventuallyWithOffset, true)
 		ensureCrossNamespaceNetworkPoliciesGetDeleted      = ensureCrossNamespaceNetworkPolicies(EventuallyWithOffset, false)
 		ensureCrossNamespaceNetworkPoliciesDoNotGetCreated = ensureCrossNamespaceNetworkPolicies(ConsistentlyWithOffset, false)
-
-		ensureNetworkPoliciesWithCustomPodLabelSelector = func(asyncAssertion func(int, interface{}, ...interface{}) AsyncAssertion, should bool) func() {
-			return func() {
-				assertedFunc := func(g Gomega) []networkingv1.NetworkPolicy {
-					networkPolicyList := &networkingv1.NetworkPolicyList{}
-					g.Expect(testClient.List(ctx, networkPolicyList, client.InNamespace(service.Namespace))).To(Succeed())
-					return networkPolicyList.Items
-				}
-				expectation := ContainElements(
-					MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("ingress-to-" + service.Name + port3Suffix + "-via-" + customPodLabelSelector)})}),
-					MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("egress-to-" + service.Name + port3Suffix + "-via-" + customPodLabelSelector)})}),
-					MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("ingress-to-" + service.Name + port4Suffix + "-via-" + customPodLabelSelector)})}),
-					MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("egress-to-" + service.Name + port4Suffix + "-via-" + customPodLabelSelector)})}),
-				)
-
-				if should {
-					asyncAssertion(1, assertedFunc).Should(expectation)
-				} else {
-					asyncAssertion(1, assertedFunc).ShouldNot(expectation)
-				}
-			}
-		}
-		ensureNetworkPoliciesWithCustomPodLabelSelectorGetCreated = ensureNetworkPoliciesWithCustomPodLabelSelector(EventuallyWithOffset, true)
-		ensureNetworkPoliciesWithCustomPodLabelSelectorGetDeleted = ensureNetworkPoliciesWithCustomPodLabelSelector(EventuallyWithOffset, false)
 
 		ensureNetworkPoliciesWithCustomPodLabelSelectors = func(asyncAssertion func(int, interface{}, ...interface{}) AsyncAssertion, should bool) func() {
 			return func() {
@@ -719,154 +694,6 @@ var _ = Describe("NetworkPolicy Controller tests", func() {
 					return networkPolicy.Spec.PodSelector
 				}).Should(Equal(metav1.LabelSelector{MatchLabels: map[string]string{"networking.resources.gardener.cloud/to-" + alias + "-" + service.Name + port2Suffix: "allowed"}}))
 			})
-		})
-	})
-
-	Context("service with custom pod label selector (deprecated)", func() {
-		BeforeEach(func() {
-			metav1.SetMetaDataAnnotation(&service.ObjectMeta, "networking.resources.gardener.cloud/from-policy-pod-label-selector", customPodLabelSelector)
-			metav1.SetMetaDataAnnotation(&service.ObjectMeta, "networking.resources.gardener.cloud/from-policy-allowed-ports", `[{"protocol":"`+string(port3Protocol)+`","port":"`+port3TargetPort.String()+`"},{"protocol":"`+string(port4Protocol)+`","port":`+port4TargetPort.String()+`}]`)
-		})
-
-		It("should create the expected network policies", func() {
-			By("Wait until ingress policy was created for first port")
-			Eventually(func(g Gomega) networkingv1.NetworkPolicySpec {
-				networkPolicy := &networkingv1.NetworkPolicy{ObjectMeta: metav1.ObjectMeta{Name: "ingress-to-" + service.Name + port3Suffix + "-via-" + customPodLabelSelector, Namespace: service.Namespace}}
-				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(networkPolicy), networkPolicy)).To(Succeed())
-				return networkPolicy.Spec
-			}).Should(Equal(networkingv1.NetworkPolicySpec{
-				PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
-				PodSelector: metav1.LabelSelector{MatchLabels: serviceSelector},
-				Ingress: []networkingv1.NetworkPolicyIngressRule{{
-					From:  []networkingv1.NetworkPolicyPeer{{PodSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"networking.resources.gardener.cloud/to-" + customPodLabelSelector: "allowed"}}}},
-					Ports: []networkingv1.NetworkPolicyPort{{Protocol: &port3Protocol, Port: &port3TargetPort}},
-				}},
-			}))
-
-			By("Wait until egress policy was created for first port")
-			Eventually(func(g Gomega) networkingv1.NetworkPolicySpec {
-				networkPolicy := &networkingv1.NetworkPolicy{ObjectMeta: metav1.ObjectMeta{Name: "egress-to-" + service.Name + port3Suffix + "-via-" + customPodLabelSelector, Namespace: service.Namespace}}
-				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(networkPolicy), networkPolicy)).To(Succeed())
-				return networkPolicy.Spec
-			}).Should(Equal(networkingv1.NetworkPolicySpec{
-				PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeEgress},
-				PodSelector: metav1.LabelSelector{MatchLabels: map[string]string{"networking.resources.gardener.cloud/to-" + customPodLabelSelector: "allowed"}},
-				Egress: []networkingv1.NetworkPolicyEgressRule{{
-					To:    []networkingv1.NetworkPolicyPeer{{PodSelector: &metav1.LabelSelector{MatchLabels: serviceSelector}}},
-					Ports: []networkingv1.NetworkPolicyPort{{Protocol: &port3Protocol, Port: &port3TargetPort}},
-				}},
-			}))
-
-			By("Wait until ingress policy was created for second port")
-			Eventually(func(g Gomega) networkingv1.NetworkPolicySpec {
-				networkPolicy := &networkingv1.NetworkPolicy{ObjectMeta: metav1.ObjectMeta{Name: "ingress-to-" + service.Name + port4Suffix + "-via-" + customPodLabelSelector, Namespace: service.Namespace}}
-				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(networkPolicy), networkPolicy)).To(Succeed())
-				return networkPolicy.Spec
-			}).Should(Equal(networkingv1.NetworkPolicySpec{
-				PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
-				PodSelector: metav1.LabelSelector{MatchLabels: serviceSelector},
-				Ingress: []networkingv1.NetworkPolicyIngressRule{{
-					From:  []networkingv1.NetworkPolicyPeer{{PodSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"networking.resources.gardener.cloud/to-" + customPodLabelSelector: "allowed"}}}},
-					Ports: []networkingv1.NetworkPolicyPort{{Protocol: &port4Protocol, Port: &port4TargetPort}},
-				}},
-			}))
-
-			By("Wait until egress policy was created for second port")
-			Eventually(func(g Gomega) networkingv1.NetworkPolicySpec {
-				networkPolicy := &networkingv1.NetworkPolicy{ObjectMeta: metav1.ObjectMeta{Name: "egress-to-" + service.Name + port4Suffix + "-via-" + customPodLabelSelector, Namespace: service.Namespace}}
-				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(networkPolicy), networkPolicy)).To(Succeed())
-				return networkPolicy.Spec
-			}).Should(Equal(networkingv1.NetworkPolicySpec{
-				PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeEgress},
-				PodSelector: metav1.LabelSelector{MatchLabels: map[string]string{"networking.resources.gardener.cloud/to-" + customPodLabelSelector: "allowed"}},
-				Egress: []networkingv1.NetworkPolicyEgressRule{{
-					To:    []networkingv1.NetworkPolicyPeer{{PodSelector: &metav1.LabelSelector{MatchLabels: serviceSelector}}},
-					Ports: []networkingv1.NetworkPolicyPort{{Protocol: &port4Protocol, Port: &port4TargetPort}},
-				}},
-			}))
-		})
-
-		It("should reconcile the policies when the allowed ports are changed", func() {
-			By("Wait until all policies are created")
-			ensureNetworkPoliciesWithCustomPodLabelSelectorGetCreated()
-
-			By("Patch Service")
-			patch := client.MergeFrom(service.DeepCopy())
-			metav1.SetMetaDataAnnotation(&service.ObjectMeta, "networking.resources.gardener.cloud/from-policy-allowed-ports", `[{"protocol":"`+string(port4Protocol)+`","port":`+port4TargetPort.String()+`},{"protocol":"`+string(corev1.ProtocolUDP)+`","port":2468}]`)
-			Expect(testClient.Patch(ctx, service, patch)).To(Succeed())
-
-			By("Wait until all policies were reconciled")
-			Eventually(func(g Gomega) []networkingv1.NetworkPolicy {
-				networkPolicyList := &networkingv1.NetworkPolicyList{}
-				g.Expect(testClient.List(ctx, networkPolicyList, client.InNamespace(service.Namespace))).To(Succeed())
-				return networkPolicyList.Items
-			}).Should(And(
-				Not(ContainElements(
-					MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("ingress-to-" + service.Name + port3Suffix + "-via-" + customPodLabelSelector)})}),
-					MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("egress-to-" + service.Name + port3Suffix + "-via-" + customPodLabelSelector)})}),
-				)),
-				ContainElements(
-					MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("ingress-to-" + service.Name + port4Suffix + "-via-" + customPodLabelSelector)})}),
-					MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("egress-to-" + service.Name + port4Suffix + "-via-" + customPodLabelSelector)})}),
-					MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("ingress-to-" + service.Name + "-udp-2468-via-" + customPodLabelSelector)})}),
-					MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("egress-to-" + service.Name + "-udp-2468-via-" + customPodLabelSelector)})}),
-				),
-			))
-		})
-
-		It("should not create any cross-namespace policies or ingress-from-world policy", func() {
-			ensureCrossNamespaceNetworkPoliciesDoNotGetCreated()
-			ensureIngressFromWorldNetworkPolicyDoesNotGetCreated()
-		})
-
-		It("should delete the policies when the custom pod label selector in service annotations is removed", func() {
-			By("Wait until all policies are created")
-			ensureNetworkPoliciesWithCustomPodLabelSelectorGetCreated()
-
-			By("Patch Service")
-			patch := client.MergeFrom(service.DeepCopy())
-			delete(service.Annotations, "networking.resources.gardener.cloud/from-policy-pod-label-selector")
-			Expect(testClient.Patch(ctx, service, patch)).To(Succeed())
-
-			By("Wait until all policies are deleted")
-			ensureNetworkPoliciesWithCustomPodLabelSelectorGetDeleted()
-		})
-
-		It("should delete the policies when the allowed ports in service annotations are removed", func() {
-			By("Wait until all policies are created")
-			ensureNetworkPoliciesWithCustomPodLabelSelectorGetCreated()
-
-			By("Patch Service")
-			patch := client.MergeFrom(service.DeepCopy())
-			delete(service.Annotations, "networking.resources.gardener.cloud/from-policy-allowed-ports")
-			Expect(testClient.Patch(ctx, service, patch)).To(Succeed())
-
-			By("Wait until all policies are deleted")
-			ensureNetworkPoliciesWithCustomPodLabelSelectorGetDeleted()
-		})
-
-		It("should delete the policies when the service gets deleted", func() {
-			By("Wait until all policies are created")
-			ensureNetworkPoliciesWithCustomPodLabelSelectorGetCreated()
-
-			By("Delete Service")
-			Expect(testClient.Delete(ctx, service)).To(Succeed())
-
-			By("Wait until all policies are deleted")
-			ensureNetworkPoliciesWithCustomPodLabelSelectorGetDeleted()
-		})
-
-		It("should delete the policies when the namespace is no longer handled", func() {
-			By("Wait until all policies are created")
-			ensureNetworkPoliciesWithCustomPodLabelSelectorGetCreated()
-
-			By("Patch Namespace and remove label")
-			patch := client.MergeFrom(namespace.DeepCopy())
-			namespace.Labels[testID] = "foo"
-			Expect(testClient.Patch(ctx, namespace, patch)).To(Succeed())
-
-			By("Wait until all policies are deleted")
-			ensureNetworkPoliciesWithCustomPodLabelSelectorGetDeleted()
 		})
 	})
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
- Remove MCM legacy CRD deletion, follow-up of #8559, released with `v1.82.0`
- Remove legacy `shoot-node-logging` MR cleanup, follow-up of #8501, released with `v1.80.0`
- Remove MCM legacy resources cleanup in generic `Worker` actuator, follow-up of #8596, released with `v1.82.0`
- Restrict GRM's token requestor to secrets with `class=shoot`, follow-up of #8152, released with `v1.74.0`
- Remove support for deprecated `NetworkPolicy` annotations, follow-up of #7907, released with `v1.71.0`

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking developer
Support for the deprecated `NetworkPolicy` annotations `networking.resources.gardener.cloud/from-policy-allowed-ports` and `networking.resources.gardener.cloud/from-policy-pod-label-selector` has been removed. Use `networking.resources.gardener.cloud/from-<some-alias>-allowed-ports` instead ([documentation](https://github.com/gardener/gardener/blob/master/docs/concepts/resource-manager.md#networkpolicy-controller)).
```

```breaking operator
All virtual garden access Secrets have to be labeled with with `resources.gardener.cloud/class=shoot`. Otherwise the virtual-GRM won't consider the Secrets and won't renew them.
```
