### PR TITLE
[node-agent] Use linear mapping to distribute `OperatingSystemConfig` reconciliation delays evenly

### DIFF
--- a/cmd/gardener-node-agent/app/app.go
+++ b/cmd/gardener-node-agent/app/app.go
@@ -229,7 +229,7 @@ func run(ctx context.Context, cancel context.CancelFunc, log logr.Logger, cfg *c
 			&bootstrappers.KubeletBootstrapKubeconfig{Log: log.WithName("kubelet-bootstrap-kubeconfig-creator"), FS: fs, APIServerConfig: cfg.APIServer},
 		},
 		ActualRunnables: []manager.Runnable{
-			manager.RunnableFunc(func(_ context.Context) error { return controller.AddToManager(cancel, mgr, cfg, hostName) }),
+			manager.RunnableFunc(func(ctx context.Context) error { return controller.AddToManager(ctx, cancel, mgr, cfg, hostName) }),
 			&bootstrappers.CloudConfigDownloaderCleaner{Log: log.WithName("legacy-cloud-config-downloader-cleaner"), FS: fs, DBus: dbus},
 		},
 	}); err != nil {

--- a/cmd/gardener-node-agent/app/app.go
+++ b/cmd/gardener-node-agent/app/app.go
@@ -34,7 +34,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/rest"
 	"k8s.io/component-base/version/verflag"
 	"k8s.io/utils/pointer"
@@ -189,9 +188,6 @@ func run(ctx context.Context, cancel context.CancelFunc, log logr.Logger, cfg *c
 			&corev1.Secret{}: {
 				Namespaces: map[string]cache.Config{metav1.NamespaceSystem: {}},
 				Field:      fields.SelectorFromSet(fields.Set{metav1.ObjectNameField: cfg.Controllers.OperatingSystemConfig.SecretName}),
-			},
-			&corev1.Node{}: {
-				Label: labels.SelectorFromSet(labels.Set{corev1.LabelHostname: hostName}),
 			},
 			&coordinationv1.Lease{}: leaseCacheOptions,
 		}},

--- a/pkg/nodeagent/controller/add.go
+++ b/pkg/nodeagent/controller/add.go
@@ -18,7 +18,10 @@ import (
 	"context"
 	"fmt"
 
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	"github.com/gardener/gardener/pkg/nodeagent/apis/config"
 	"github.com/gardener/gardener/pkg/nodeagent/controller/lease"
@@ -29,7 +32,12 @@ import (
 
 // AddToManager adds all controllers to the given manager.
 func AddToManager(ctx context.Context, cancel context.CancelFunc, mgr manager.Manager, cfg *config.NodeAgentConfiguration, hostName string) error {
-	if err := (&node.Reconciler{}).AddToManager(mgr); err != nil {
+	nodePredicate, err := predicate.LabelSelectorPredicate(metav1.LabelSelector{MatchLabels: map[string]string{corev1.LabelHostname: hostName}})
+	if err != nil {
+		return fmt.Errorf("failed computing label selector predicate for node: %w", err)
+	}
+
+	if err := (&node.Reconciler{}).AddToManager(mgr, nodePredicate); err != nil {
 		return fmt.Errorf("failed adding node controller: %w", err)
 	}
 
@@ -47,7 +55,7 @@ func AddToManager(ctx context.Context, cancel context.CancelFunc, mgr manager.Ma
 		return fmt.Errorf("failed adding token controller: %w", err)
 	}
 
-	if err := (&lease.Reconciler{}).AddToManager(mgr); err != nil {
+	if err := (&lease.Reconciler{}).AddToManager(mgr, nodePredicate); err != nil {
 		return fmt.Errorf("failed adding lease controller: %w", err)
 	}
 

--- a/pkg/nodeagent/controller/add.go
+++ b/pkg/nodeagent/controller/add.go
@@ -28,7 +28,7 @@ import (
 )
 
 // AddToManager adds all controllers to the given manager.
-func AddToManager(cancel context.CancelFunc, mgr manager.Manager, cfg *config.NodeAgentConfiguration, hostName string) error {
+func AddToManager(ctx context.Context, cancel context.CancelFunc, mgr manager.Manager, cfg *config.NodeAgentConfiguration, hostName string) error {
 	if err := (&node.Reconciler{}).AddToManager(mgr); err != nil {
 		return fmt.Errorf("failed adding node controller: %w", err)
 	}
@@ -37,7 +37,7 @@ func AddToManager(cancel context.CancelFunc, mgr manager.Manager, cfg *config.No
 		Config:        cfg.Controllers.OperatingSystemConfig,
 		HostName:      hostName,
 		CancelContext: cancel,
-	}).AddToManager(mgr); err != nil {
+	}).AddToManager(ctx, mgr); err != nil {
 		return fmt.Errorf("failed adding operating system config controller: %w", err)
 	}
 

--- a/pkg/nodeagent/controller/lease/add.go
+++ b/pkg/nodeagent/controller/lease/add.go
@@ -21,6 +21,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	predicateutils "github.com/gardener/gardener/pkg/controllerutils/predicate"
 )
@@ -29,7 +30,7 @@ import (
 const ControllerName = "lease"
 
 // AddToManager adds the lease controller with the default Options to the manager.
-func (r *Reconciler) AddToManager(mgr manager.Manager) error {
+func (r *Reconciler) AddToManager(mgr manager.Manager, nodePredicate predicate.Predicate) error {
 	if r.Client == nil {
 		r.Client = mgr.GetClient()
 	}
@@ -49,7 +50,7 @@ func (r *Reconciler) AddToManager(mgr manager.Manager) error {
 	return builder.
 		ControllerManagedBy(mgr).
 		Named(ControllerName).
-		For(node, builder.WithPredicates(predicateutils.ForEventTypes(predicateutils.Create))).
+		For(node, builder.WithPredicates(nodePredicate, predicateutils.ForEventTypes(predicateutils.Create))).
 		WithOptions(controller.Options{MaxConcurrentReconciles: 1}).
 		Complete(r)
 }

--- a/pkg/nodeagent/controller/node/add.go
+++ b/pkg/nodeagent/controller/node/add.go
@@ -30,7 +30,7 @@ import (
 const ControllerName = "node"
 
 // AddToManager adds Reconciler to the given manager.
-func (r *Reconciler) AddToManager(mgr manager.Manager) error {
+func (r *Reconciler) AddToManager(mgr manager.Manager, nodePredicate predicate.Predicate) error {
 	if r.Client == nil {
 		r.Client = mgr.GetClient()
 	}
@@ -47,7 +47,7 @@ func (r *Reconciler) AddToManager(mgr manager.Manager) error {
 	return builder.
 		ControllerManagedBy(mgr).
 		Named(ControllerName).
-		For(node, builder.WithPredicates(r.NodePredicate())).
+		For(node, builder.WithPredicates(r.NodePredicate(), nodePredicate)).
 		WithOptions(controller.Options{MaxConcurrentReconciles: 1}).
 		Complete(r)
 }

--- a/pkg/nodeagent/controller/operatingsystemconfig/add.go
+++ b/pkg/nodeagent/controller/operatingsystemconfig/add.go
@@ -17,10 +17,13 @@ package operatingsystemconfig
 import (
 	"bytes"
 	"context"
+	"slices"
+	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/spf13/afero"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/workqueue"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -38,13 +41,14 @@ import (
 	"github.com/gardener/gardener/pkg/nodeagent/dbus"
 	"github.com/gardener/gardener/pkg/nodeagent/registry"
 	"github.com/gardener/gardener/pkg/utils"
+	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 )
 
 // ControllerName is the name of this controller.
 const ControllerName = "operatingsystemconfig"
 
 // AddToManager adds Reconciler to the given manager.
-func (r *Reconciler) AddToManager(mgr manager.Manager) error {
+func (r *Reconciler) AddToManager(ctx context.Context, mgr manager.Manager) error {
 	if r.Client == nil {
 		r.Client = mgr.GetClient()
 	}
@@ -66,7 +70,7 @@ func (r *Reconciler) AddToManager(mgr manager.Manager) error {
 		Named(ControllerName).
 		WatchesRawSource(
 			source.Kind(mgr.GetCache(), &corev1.Secret{}),
-			r.EnqueueWithJitterDelay(mgr.GetLogger().WithValues("controller", ControllerName).WithName("jitterEventHandler")),
+			r.EnqueueWithJitterDelay(ctx, mgr.GetLogger().WithValues("controller", ControllerName).WithName("reconciliation-delayer")),
 			builder.WithPredicates(
 				r.SecretPredicate(),
 				predicateutils.ForEventTypes(predicateutils.Create, predicateutils.Update),
@@ -110,7 +114,14 @@ var RandomDurationWithMetaDuration = utils.RandomDurationWithMetaDuration
 
 // EnqueueWithJitterDelay returns handler.Funcs which enqueues the object with a random jitter duration for 'update'
 // events. 'Create' events are enqueued immediately.
-func (r *Reconciler) EnqueueWithJitterDelay(log logr.Logger) handler.EventHandler {
+func (r *Reconciler) EnqueueWithJitterDelay(ctx context.Context, log logr.Logger) handler.EventHandler {
+	delay := delayer{
+		log:             log,
+		client:          r.Client,
+		minDelaySeconds: 0,
+		maxDelaySeconds: int(r.Config.SyncJitterPeriod.Duration.Seconds()),
+	}
+
 	return &handler.Funcs{
 		CreateFunc: func(_ context.Context, evt event.CreateEvent, q workqueue.RateLimitingInterface) {
 			if evt.Object == nil {
@@ -130,10 +141,55 @@ func (r *Reconciler) EnqueueWithJitterDelay(log logr.Logger) handler.EventHandle
 			}
 
 			if !bytes.Equal(oldSecret.Data[nodeagentv1alpha1.DataKeyOperatingSystemConfig], newSecret.Data[nodeagentv1alpha1.DataKeyOperatingSystemConfig]) {
-				duration := RandomDurationWithMetaDuration(r.Config.SyncJitterPeriod)
+				duration := delay.compute(ctx, r.NodeName)
 				log.Info("Enqueued secret with operating system config with a jitter period", "duration", duration)
 				q.AddAfter(reconcileRequest(evt.ObjectNew), duration)
 			}
 		},
 	}
+}
+
+type delayer struct {
+	log    logr.Logger
+	client client.Client
+
+	minDelaySeconds int
+	maxDelaySeconds int
+
+	nodeList *metav1.PartialObjectMetadataList
+}
+
+// compute computes a time.Duration that can be used to delay reconciliations by using a simple linear mapping approach
+// based on the index of the node this instance of gardener-node-agent is responsible for in the list of all nodes in
+// the cluster. This way, the delays of all instances of gardener-node-agent are distributed evenly.
+// This works well as long as the number of nodes in the cluster is not higher than the configured maximum delay in
+// seconds. In this case, a random duration in [0, maxDelaySeconds] is computed (which obviously leads to an uneven
+// distribution).
+func (d *delayer) compute(ctx context.Context, nodeName string) time.Duration {
+	if nodeName == "" {
+		return 0
+	}
+
+	nodeList := &metav1.PartialObjectMetadataList{}
+	nodeList.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("NodeList"))
+	if err := d.client.List(ctx, nodeList); err != nil {
+		d.log.Error(err, "Failed to list nodes when computing reconciliation delay", "nodeName", nodeName)
+		// fall back to previously computed list of nodes
+	} else {
+		kubernetesutils.ByName().Sort(nodeList)
+		d.nodeList = nodeList
+	}
+
+	if numberOfNodes := len(d.nodeList.Items); numberOfNodes > d.maxDelaySeconds {
+		d.log.Info("Number of nodes is higher than maximum delay in seconds, falling back to random duration", "numberOfNodes", numberOfNodes, "maxDelaySeconds", d.maxDelaySeconds)
+		return RandomDurationWithMetaDuration(&metav1.Duration{Duration: time.Duration(d.maxDelaySeconds) * time.Second})
+	}
+
+	index := slices.IndexFunc(d.nodeList.Items, func(node metav1.PartialObjectMetadata) bool {
+		return node.GetName() == nodeName
+	})
+
+	rangeSize := (d.maxDelaySeconds - d.minDelaySeconds) / len(d.nodeList.Items)
+	delaySeconds := d.minDelaySeconds + index*rangeSize
+	return time.Duration(delaySeconds) * time.Second
 }

--- a/pkg/nodeagent/controller/operatingsystemconfig/add.go
+++ b/pkg/nodeagent/controller/operatingsystemconfig/add.go
@@ -158,9 +158,6 @@ type delayer struct {
 // compute computes a time.Duration that can be used to delay reconciliations by using a simple linear mapping approach
 // based on the index of the node this instance of gardener-node-agent is responsible for in the list of all nodes in
 // the cluster. This way, the delays of all instances of gardener-node-agent are distributed evenly.
-// This works well as long as the number of nodes in the cluster is not higher than the configured maximum delay in
-// seconds. In this case, a random duration in [0, maxDelaySeconds] is computed (which obviously leads to an uneven
-// distribution).
 func (d *delayer) compute(ctx context.Context, nodeName string) time.Duration {
 	if nodeName == "" {
 		return 0

--- a/pkg/nodeagent/controller/operatingsystemconfig/reconciler.go
+++ b/pkg/nodeagent/controller/operatingsystemconfig/reconciler.go
@@ -63,7 +63,7 @@ type Reconciler struct {
 	Extractor     registry.Extractor
 	CancelContext context.CancelFunc
 	HostName      string
-	nodeName      string
+	NodeName      string
 }
 
 // Reconcile decodes the OperatingSystemConfig resources from secrets and applies the systemd units and files to the
@@ -173,11 +173,11 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 }
 
 func (r *Reconciler) getNode(ctx context.Context) (*metav1.PartialObjectMetadata, error) {
-	if r.nodeName != "" {
-		node := &metav1.PartialObjectMetadata{ObjectMeta: metav1.ObjectMeta{Name: r.nodeName}}
+	if r.NodeName != "" {
+		node := &metav1.PartialObjectMetadata{ObjectMeta: metav1.ObjectMeta{Name: r.NodeName}}
 		node.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("Node"))
 		if err := r.Client.Get(ctx, client.ObjectKeyFromObject(node), node); err != nil {
-			return nil, fmt.Errorf("unable to fetch node %q: %w", r.nodeName, err)
+			return nil, fmt.Errorf("unable to fetch node %q: %w", r.NodeName, err)
 		}
 		return node, nil
 	}
@@ -188,7 +188,7 @@ func (r *Reconciler) getNode(ctx context.Context) (*metav1.PartialObjectMetadata
 	}
 
 	if node != nil {
-		r.nodeName = node.Name
+		r.NodeName = node.Name
 	}
 
 	return node, nil

--- a/test/integration/nodeagent/lease/lease_suite_test.go
+++ b/test/integration/nodeagent/lease/lease_suite_test.go
@@ -34,6 +34,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	"github.com/gardener/gardener/pkg/logger"
 	leasecontroller "github.com/gardener/gardener/pkg/nodeagent/controller/lease"
@@ -118,7 +119,7 @@ var _ = BeforeSuite(func() {
 		Namespace:            testNamespace.Name,
 		LeaseDurationSeconds: leaseDurationSeconds,
 	}
-	Expect(leaseReconciler.AddToManager(mgr)).To(Succeed())
+	Expect(leaseReconciler.AddToManager(mgr, predicate.NewPredicateFuncs(func(client.Object) bool { return true }))).To(Succeed())
 
 	By("Start manager")
 	mgrContext, mgrCancel := context.WithCancel(ctx)

--- a/test/integration/nodeagent/node/node_test.go
+++ b/test/integration/nodeagent/node/node_test.go
@@ -26,6 +26,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	nodecontroller "github.com/gardener/gardener/pkg/nodeagent/controller/node"
 	"github.com/gardener/gardener/pkg/nodeagent/dbus/fake"
@@ -52,7 +53,7 @@ var _ = Describe("Node controller tests", func() {
 		fakeDBus = fake.New()
 		Expect((&nodecontroller.Reconciler{
 			DBus: fakeDBus,
-		}).AddToManager(mgr)).To(Succeed())
+		}).AddToManager(mgr, predicate.NewPredicateFuncs(func(client.Object) bool { return true }))).To(Succeed())
 
 		By("Start manager")
 		mgrContext, mgrCancel := context.WithCancel(ctx)

--- a/test/integration/nodeagent/operatingsystemconfig/operatingsystemconfig_test.go
+++ b/test/integration/nodeagent/operatingsystemconfig/operatingsystemconfig_test.go
@@ -111,13 +111,14 @@ var _ = Describe("OperatingSystemConfig controller tests", func() {
 				SyncPeriod:        &metav1.Duration{Duration: time.Hour},
 				SecretName:        oscSecretName,
 				KubernetesVersion: kubernetesVersion,
+				SyncJitterPeriod:  &metav1.Duration{Duration: 0},
 			},
 			DBus:          fakeDBus,
 			FS:            fakeFS,
 			HostName:      hostName,
 			Extractor:     fakeregistry.NewExtractor(fakeFS, imageMountDirectory),
 			CancelContext: cancelFunc.cancel,
-		}).AddToManager(mgr)).To(Succeed())
+		}).AddToManager(ctx, mgr)).To(Succeed())
 
 		By("Start manager")
 		mgrContext, mgrCancel := context.WithCancel(ctx)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area scalability
/kind enhancement

**What this PR does / why we need it**:
As discussed in https://github.com/gardener-community/hackathon/blob/main/2023-11_Schelklingen/discussions/gardener_node_agent_rolling_update.md, this PR improves the reconciliation delay computation for the `OperatingSystemConfig` controller.

Earlier, the delay was completely random which can potentially lead to too many concurrent `kubelet` restarts (in case it must be restarted).

Now, we compute a the delay by using a simple linear mapping approach based on the index of the node the respective instance of `gardener-node-agent` is responsible for in the list of all nodes in the shoot cluster. This way, the delays of all instances of `gardener-node-agent` are distributed evenly.
This works well as long as the number of nodes in the cluster is not higher than the configured maximum delay in seconds. In this case, a random duration in `[0, maxDelaySeconds]` is computed (which obviously leads to an uneven distribution).

As a result, we cannot restrict the `corev1.Node` cache anymore since the `OperatingSystemConfig` controller needs to list all nodes now to compute the reconciliation delay. However, given that all controllers working with nodes use metadata-only requests, the impact should be negligible.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/8023

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
