### PR TITLE
Enhance `gardener-resource-manager`'s class filter and the corresponding unit tests

### DIFF
--- a/docs/concepts/resource-manager.md
+++ b/docs/concepts/resource-manager.md
@@ -147,8 +147,8 @@ A default class is assumed if no class is specified.
 For instance, the `gardener-resource-manager` which is deployed in the Shoot’s control plane namespace in the Seed does not specify a `.spec.class` and watches only for resources in the control plane namespace by specifying it in the `.sourceClientConnection.namespace`  field.
 
 If the `.spec.class` changes this means that the resources have to be handled by a different Gardener Resource Manager. That is achieved by:
-1. Cleaning all referenced resources by the GRM that was responsible for the old class in its target cluster
-2. Creating all referenced resources by the GRM that is responsible for the new class in its target cluster 
+1. Cleaning all referenced resources by the Gardener Resource Manager that was responsible for the old class in its target cluster.
+2. Creating all referenced resources by the Gardener Resource Manager that is responsible for the new class in its target cluster.
 
 #### [Conditions](../../pkg/resourcemanager/controller/health)
 

--- a/docs/concepts/resource-manager.md
+++ b/docs/concepts/resource-manager.md
@@ -144,8 +144,7 @@ A `ManagedResource` has an optional `.spec.class` field that allows it to indica
 The `.controllers.resourceClass` field in the component configuration restricts the watch to `ManagedResource`s with the given `.spec.class`.
 A default class is assumed if no class is specified.
 
-The seed GRM watches resources with class `seed` in all namespaces.
-THe shoot GRM watches resources with the default class and only in it's designated namespace via `.sourceClientConnection.namespace`
+For instance, the `gardener-resource-manager` which is deployed in the Shoot’s control plane namespace in the Seed does not specify a .spec.class and watches only for resources in the control plane namespace by specifying it in the `.sourceClientConnection.namespace`  field.
 
 If the `.spec.class` changes this means that the resources have to be handled by a different Gardener Resource Manager. That is achieved by:
 1. Cleaning all referenced resources by the GRM that was responsible for the old class in its target cluster

--- a/docs/concepts/resource-manager.md
+++ b/docs/concepts/resource-manager.md
@@ -144,7 +144,7 @@ A `ManagedResource` has an optional `.spec.class` field that allows it to indica
 The `.controllers.resourceClass` field in the component configuration restricts the watch to `ManagedResource`s with the given `.spec.class`.
 A default class is assumed if no class is specified.
 
-For instance, the `gardener-resource-manager` which is deployed in the Shoot’s control plane namespace in the Seed does not specify a .spec.class and watches only for resources in the control plane namespace by specifying it in the `.sourceClientConnection.namespace`  field.
+For instance, the `gardener-resource-manager` which is deployed in the Shoot’s control plane namespace in the Seed does not specify a `.spec.class` and watches only for resources in the control plane namespace by specifying it in the `.sourceClientConnection.namespace`  field.
 
 If the `.spec.class` changes this means that the resources have to be handled by a different Gardener Resource Manager. That is achieved by:
 1. Cleaning all referenced resources by the GRM that was responsible for the old class in its target cluster

--- a/docs/concepts/resource-manager.md
+++ b/docs/concepts/resource-manager.md
@@ -134,7 +134,7 @@ The mode for a resource can be specified with the `resources.gardener.cloud/mode
 
 If a resource in the `ManagedResource` is annotated with `resources.gardener.cloud/skip-health-check=true`, then the resource will be skipped during health checks by the health controller. The `ManagedResource` conditions will not reflect the health condition of this resource anymore. The `ResourcesProgressing` condition will also be set to `False`.
 
-#### Resource Class
+#### Resource Class and Reconcilation Scope
 
 By default, the `gardener-resource-manager` controller watches for `ManagedResource`s in all namespaces.
 The `.sourceClientConnection.namespace` field in the component configuration restricts the watch to `ManagedResource`s in a single namespace only.
@@ -143,6 +143,13 @@ Note that this setting also affects all other controllers and webhooks since it'
 A `ManagedResource` has an optional `.spec.class` field that allows it to indicate that it belongs to a given class of resources.
 The `.controllers.resourceClass` field in the component configuration restricts the watch to `ManagedResource`s with the given `.spec.class`.
 A default class is assumed if no class is specified.
+
+The seed GRM watches resources with class `seed` in all namespaces.
+THe shoot GRM watches resources with the default class and only in it's designated namespace via `.sourceClientConnection.namespace`
+
+If the `.spec.class` changes this means that the resources have to be handled by a different Gardener Resource Manager. That is achieved by:
+1. Cleaning all referenced resources by the GRM that was responsible for the old class in its target cluster
+2. Creating all referenced resources by the GRM that is responsible for the new class in its target cluster 
 
 #### [Conditions](../../pkg/resourcemanager/controller/health)
 

--- a/pkg/resourcemanager/controller/health/health/reconciler.go
+++ b/pkg/resourcemanager/controller/health/health/reconciler.go
@@ -78,7 +78,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	}
 
 	// Check responsibility
-	if _, responsible := r.ClassFilter.Active(mr); !responsible {
+	if responsible := r.ClassFilter.Responsible(mr); !responsible {
 		log.Info("Stopping health checks as the responsibility changed")
 		return reconcile.Result{}, nil
 	}

--- a/pkg/resourcemanager/controller/health/progressing/reconciler.go
+++ b/pkg/resourcemanager/controller/health/progressing/reconciler.go
@@ -71,7 +71,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	}
 
 	// Check responsibility
-	if _, responsible := r.ClassFilter.Active(mr); !responsible {
+	if responsible := r.ClassFilter.Responsible(mr); !responsible {
 		log.Info("Stopping checks as the responsibility changed")
 		return reconcile.Result{}, nil
 	}

--- a/pkg/resourcemanager/controller/managedresource/reconciler.go
+++ b/pkg/resourcemanager/controller/managedresource/reconciler.go
@@ -109,9 +109,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 
 	// If the object should be deleted or the responsibility changed
 	// the actual deployments have to be deleted
-	if noLongerHandledByInstance := r.ClassFilter.NoLongerHandles(mr); mr.DeletionTimestamp != nil || noLongerHandledByInstance {
+	if noLongerHandledByInstance := r.ClassFilter.IsTransferringResponsibility(mr); mr.DeletionTimestamp != nil || noLongerHandledByInstance {
 		if noLongerHandledByInstance {
-			log.Info("Class of ManagedResource changed. This controller stops being the handler")
+			log.Info("Class of ManagedResource changed. Cleaning resources as the responsibility changed")
 		}
 		return r.delete(ctx, log, mr)
 	}
@@ -119,7 +119,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	// If the deletion after a change of responsibility is still
 	// pending, the handling of the object by the responsible controller
 	// must be delayed, until the deletion is finished.
-	if r.ClassFilter.WaitForCleanup(mr) {
+	if r.ClassFilter.IsWaitForCleanupRequired(mr) {
 		log.Info("Waiting for previous handler to clean resources created by ManagedResource")
 		return reconcile.Result{Requeue: true}, nil
 	}

--- a/pkg/resourcemanager/controller/managedresource/reconciler.go
+++ b/pkg/resourcemanager/controller/managedresource/reconciler.go
@@ -109,8 +109,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 
 	// If the object should be deleted or the responsibility changed
 	// the actual deployments have to be deleted
-	if noLongerHandledByInstance := r.ClassFilter.IsTransferringResponsibility(mr); mr.DeletionTimestamp != nil || noLongerHandledByInstance {
-		if noLongerHandledByInstance {
+	if isTransferringResponsibility := r.ClassFilter.IsTransferringResponsibility(mr); mr.DeletionTimestamp != nil || isTransferringResponsibility {
+		if isTransferringResponsibility {
 			log.Info("Class of ManagedResource changed. Cleaning resources as the responsibility changed")
 		}
 		return r.delete(ctx, log, mr)

--- a/pkg/resourcemanager/controller/managedresource/reconciler.go
+++ b/pkg/resourcemanager/controller/managedresource/reconciler.go
@@ -377,7 +377,7 @@ func (r *Reconciler) reconcile(ctx context.Context, log logr.Logger, mr *resourc
 }
 
 func (r *Reconciler) delete(ctx context.Context, log logr.Logger, mr *resourcesv1alpha1.ManagedResource) (reconcile.Result, error) {
-	log.Info("Stared deleting resources created by ManagedResource")
+	log.Info("Started deleting resources created by ManagedResource")
 
 	deleteCtx, cancel := controllerutils.GetMainReconciliationContext(ctx, r.Config.SyncPeriod.Duration)
 	defer cancel()

--- a/pkg/resourcemanager/predicate/class_filter.go
+++ b/pkg/resourcemanager/predicate/class_filter.go
@@ -36,7 +36,7 @@ const (
 // ClassFilter keeps the resource class for the actual controller instance
 // and is used as Filter predicate for events finally passed to the controller.
 // Only objects that have the same class as the controller
-// or their resources deletion is handled by the controller are filtered
+// or their resources deletion is handled by the controller are filtered.
 type ClassFilter struct {
 	resourceClass string
 
@@ -79,12 +79,12 @@ func (f *ClassFilter) Responsible(o runtime.Object) bool {
 	return c == f.resourceClass || (c == "" && f.resourceClass == resourcemanagerv1alpha1.DefaultResourceClass)
 }
 
-// ShouldCleanResources checks if an MR has changed its class and should have its resources cleaned by the given controller instance
-func (f *ClassFilter) ShouldCleanResources(mr *resourcesv1alpha1.ManagedResource) bool {
+// NoLongerHandles checks if an MR has changed its class and should have its resources cleaned by the given controller instance.
+func (f *ClassFilter) NoLongerHandles(mr *resourcesv1alpha1.ManagedResource) bool {
 	return controllerutil.ContainsFinalizer(mr, f.objectFinalizer) && !f.Responsible(mr)
 }
 
-// WaitForCleanup checks if a MR has changed its class and a given controller instance should wait for its resources to be cleaned
+// WaitForCleanup checks if a MR has changed its class and a given controller instance should wait for its resources to be cleaned.
 func (f *ClassFilter) WaitForCleanup(mr *resourcesv1alpha1.ManagedResource) bool {
 	for _, finalizer := range mr.GetFinalizers() {
 		if strings.HasPrefix(finalizer, FinalizerName) {

--- a/pkg/resourcemanager/predicate/class_filter.go
+++ b/pkg/resourcemanager/predicate/class_filter.go
@@ -79,12 +79,12 @@ func (f *ClassFilter) Responsible(o runtime.Object) bool {
 	return c == f.resourceClass || (c == "" && f.resourceClass == resourcemanagerv1alpha1.DefaultResourceClass)
 }
 
-// IsTransferringResponsibility checks if a MR has changed its class and should have its resources cleaned by the given controller instance.
+// IsTransferringResponsibility checks if a Managed Resource has changed its class and should have its resources cleaned by the given controller instance.
 func (f *ClassFilter) IsTransferringResponsibility(mr *resourcesv1alpha1.ManagedResource) bool {
 	return controllerutil.ContainsFinalizer(mr, f.objectFinalizer) && !f.Responsible(mr)
 }
 
-// IsWaitForCleanupRequired checks if a MR has changed its class and a given controller instance should wait for its resources to be cleaned.
+// IsWaitForCleanupRequired checks if a Managed Resource has changed its class and a given controller instance should wait for its resources to be cleaned.
 func (f *ClassFilter) IsWaitForCleanupRequired(mr *resourcesv1alpha1.ManagedResource) bool {
 	for _, finalizer := range mr.GetFinalizers() {
 		if strings.HasPrefix(finalizer, FinalizerName) {

--- a/pkg/resourcemanager/predicate/class_filter.go
+++ b/pkg/resourcemanager/predicate/class_filter.go
@@ -79,13 +79,13 @@ func (f *ClassFilter) Responsible(o runtime.Object) bool {
 	return c == f.resourceClass || (c == "" && f.resourceClass == resourcemanagerv1alpha1.DefaultResourceClass)
 }
 
-// NoLongerHandles checks if an MR has changed its class and should have its resources cleaned by the given controller instance.
-func (f *ClassFilter) NoLongerHandles(mr *resourcesv1alpha1.ManagedResource) bool {
+// IsTransferringResponsibility checks if a MR has changed its class and should have its resources cleaned by the given controller instance.
+func (f *ClassFilter) IsTransferringResponsibility(mr *resourcesv1alpha1.ManagedResource) bool {
 	return controllerutil.ContainsFinalizer(mr, f.objectFinalizer) && !f.Responsible(mr)
 }
 
-// WaitForCleanup checks if a MR has changed its class and a given controller instance should wait for its resources to be cleaned.
-func (f *ClassFilter) WaitForCleanup(mr *resourcesv1alpha1.ManagedResource) bool {
+// IsWaitForCleanupRequired checks if a MR has changed its class and a given controller instance should wait for its resources to be cleaned.
+func (f *ClassFilter) IsWaitForCleanupRequired(mr *resourcesv1alpha1.ManagedResource) bool {
 	for _, finalizer := range mr.GetFinalizers() {
 		if strings.HasPrefix(finalizer, FinalizerName) {
 			// mr has a controller responsible for it's resources deletion

--- a/pkg/resourcemanager/predicate/class_filter_test.go
+++ b/pkg/resourcemanager/predicate/class_filter_test.go
@@ -32,24 +32,24 @@ import (
 
 var _ = Describe("ClassFilter", func() {
 	var (
-		filter = NewClassFilter("")
+		filter *ClassFilter
 
-		differencClass     = "diff"
-		differencFinalizer = fmt.Sprintf("%s-%s", FinalizerName, differencClass)
+		differentClass     = "diff"
+		differentFinalizer = fmt.Sprintf("%s-%s", FinalizerName, differentClass)
 
 		mrWithoutFinalizerDifferentClass = &resourcesv1alpha1.ManagedResource{
 			ObjectMeta: metav1.ObjectMeta{},
 			Spec: resourcesv1alpha1.ManagedResourceSpec{
-				Class: &differencClass,
+				Class: &differentClass,
 			},
 		}
 
 		mrDifferentFinalizerDifferentClass = &resourcesv1alpha1.ManagedResource{
 			ObjectMeta: metav1.ObjectMeta{
-				Finalizers: []string{differencFinalizer},
+				Finalizers: []string{differentFinalizer},
 			},
 			Spec: resourcesv1alpha1.ManagedResourceSpec{
-				Class: &differencClass,
+				Class: &differentClass,
 			},
 		}
 
@@ -58,7 +58,7 @@ var _ = Describe("ClassFilter", func() {
 				Finalizers: []string{FinalizerName},
 			},
 			Spec: resourcesv1alpha1.ManagedResourceSpec{
-				Class: &differencClass,
+				Class: &differentClass,
 			},
 		}
 
@@ -71,7 +71,7 @@ var _ = Describe("ClassFilter", func() {
 
 		mrDifferentFinalizerSameClass = &resourcesv1alpha1.ManagedResource{
 			ObjectMeta: metav1.ObjectMeta{
-				Finalizers: []string{differencFinalizer},
+				Finalizers: []string{differentFinalizer},
 			},
 			Spec: resourcesv1alpha1.ManagedResourceSpec{
 				Class: pointer.String(""),
@@ -88,6 +88,10 @@ var _ = Describe("ClassFilter", func() {
 		}
 	)
 
+	BeforeEach(func() {
+		filter = NewClassFilter("")
+	})
+
 	DescribeTable("Responsible",
 		func(mr *resourcesv1alpha1.ManagedResource, responsible bool) {
 			resp := filter.Responsible(mr)
@@ -101,9 +105,9 @@ var _ = Describe("ClassFilter", func() {
 		Entry("MR with same finalizer and with same class", mrSameFinalizerSameClass, true),
 	)
 
-	DescribeTable("ShouldCleanResources",
+	DescribeTable("NoLongerHandles",
 		func(mr *resourcesv1alpha1.ManagedResource, shouldCleanup bool) {
-			cleanup := filter.ShouldCleanResources(mr)
+			cleanup := filter.NoLongerHandles(mr)
 			Expect(cleanup).To(Equal(shouldCleanup))
 		},
 		Entry("MR without a finalizer and with different class", mrWithoutFinalizerDifferentClass, false),

--- a/pkg/resourcemanager/predicate/class_filter_test.go
+++ b/pkg/resourcemanager/predicate/class_filter_test.go
@@ -23,6 +23,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
@@ -31,111 +32,159 @@ import (
 
 var _ = Describe("ClassFilter", func() {
 	var (
-		classOld     *string = nil
-		finalizerOld         = FinalizerName
+		filter = NewClassFilter("")
 
-		classNew     = "new"
-		finalizerNew = fmt.Sprintf("%s-%s", FinalizerName, classNew)
+		differencClass     = "diff"
+		differencFinalizer = fmt.Sprintf("%s-%s", FinalizerName, differencClass)
 
-		mrOldClass = &resourcesv1alpha1.ManagedResource{
-			ObjectMeta: metav1.ObjectMeta{
-				Finalizers: []string{finalizerOld},
-			},
+		mrWithoutFinalizerDifferentClass = &resourcesv1alpha1.ManagedResource{
+			ObjectMeta: metav1.ObjectMeta{},
 			Spec: resourcesv1alpha1.ManagedResourceSpec{
-				Class: classOld,
+				Class: &differencClass,
 			},
 		}
 
-		mrNewClassOldFinalizer = &resourcesv1alpha1.ManagedResource{
+		mrDifferentFinalizerDifferentClass = &resourcesv1alpha1.ManagedResource{
 			ObjectMeta: metav1.ObjectMeta{
-				Finalizers: []string{finalizerOld},
+				Finalizers: []string{differencFinalizer},
 			},
 			Spec: resourcesv1alpha1.ManagedResourceSpec{
-				Class: &classNew,
+				Class: &differencClass,
 			},
 		}
 
-		mrNewClass = &resourcesv1alpha1.ManagedResource{
+		mrSameFinalizerDifferentClass = &resourcesv1alpha1.ManagedResource{
 			ObjectMeta: metav1.ObjectMeta{
-				Finalizers: []string{finalizerNew},
+				Finalizers: []string{FinalizerName},
 			},
 			Spec: resourcesv1alpha1.ManagedResourceSpec{
-				Class: &classNew,
+				Class: &differencClass,
+			},
+		}
+
+		mrWithoutFinalizerSameClass = &resourcesv1alpha1.ManagedResource{
+			ObjectMeta: metav1.ObjectMeta{},
+			Spec: resourcesv1alpha1.ManagedResourceSpec{
+				Class: pointer.String(""),
+			},
+		}
+
+		mrDifferentFinalizerSameClass = &resourcesv1alpha1.ManagedResource{
+			ObjectMeta: metav1.ObjectMeta{
+				Finalizers: []string{differencFinalizer},
+			},
+			Spec: resourcesv1alpha1.ManagedResourceSpec{
+				Class: pointer.String(""),
+			},
+		}
+
+		mrSameFinalizerSameClass = &resourcesv1alpha1.ManagedResource{
+			ObjectMeta: metav1.ObjectMeta{
+				Finalizers: []string{FinalizerName},
+			},
+			Spec: resourcesv1alpha1.ManagedResourceSpec{
+				Class: pointer.String(""),
 			},
 		}
 	)
 
-	DescribeTable("Active",
-		func(mr *resourcesv1alpha1.ManagedResource, class string, action, responsible bool) {
-			filter := NewClassFilter(class)
-
-			act, resp := filter.Active(mr)
-			Expect(act).To(Equal(action))
+	DescribeTable("Responsible",
+		func(mr *resourcesv1alpha1.ManagedResource, responsible bool) {
+			resp := filter.Responsible(mr)
 			Expect(resp).To(Equal(responsible))
 		},
-		Entry("is responsible and take action", mrOldClass, "", true, true),
-		Entry("is not responsible and take action", mrNewClassOldFinalizer, "", true, false),
-		Entry("is responsible and don't take action", mrNewClassOldFinalizer, classNew, false, true),
-		Entry("is not responsible and don't take action", mrNewClass, "", false, false),
+		Entry("MR without a finalizer and with different class", mrWithoutFinalizerDifferentClass, false),
+		Entry("MR with different finalizer and with different class", mrDifferentFinalizerDifferentClass, false),
+		Entry("MR with same finalizer and with different class", mrSameFinalizerDifferentClass, false),
+		Entry("MR without a finalizer and with same class", mrWithoutFinalizerSameClass, true),
+		Entry("MR with different finalizer and with same class", mrDifferentFinalizerSameClass, true),
+		Entry("MR with same finalizer and with same class", mrSameFinalizerSameClass, true),
 	)
 
-	DescribeTable("Generic",
-		func(mr *resourcesv1alpha1.ManagedResource, class string, expectation bool) {
-			filter := NewClassFilter(class)
-
-			result := filter.Generic(event.GenericEvent{
-				Object: mr,
-			})
-			Expect(result).To(Equal(expectation))
+	DescribeTable("ShouldCleanResources",
+		func(mr *resourcesv1alpha1.ManagedResource, shouldCleanup bool) {
+			cleanup := filter.ShouldCleanResources(mr)
+			Expect(cleanup).To(Equal(shouldCleanup))
 		},
-		Entry("Generic event true", mrOldClass, "", true),
-		Entry("Generic event true", mrNewClassOldFinalizer, "", true),
-		Entry("Generic event true", mrNewClassOldFinalizer, classNew, true),
-		Entry("Generic event false", mrNewClass, "", false),
+		Entry("MR without a finalizer and with different class", mrWithoutFinalizerDifferentClass, false),
+		Entry("MR with different finalizer and with different class", mrDifferentFinalizerDifferentClass, false),
+		Entry("MR with same finalizer and with different class", mrSameFinalizerDifferentClass, true),
+		Entry("MR without a finalizer and with same class", mrWithoutFinalizerSameClass, false),
+		Entry("MR with different finalizer and with same class", mrDifferentFinalizerSameClass, false),
+		Entry("MR with same finalizer and with same class", mrSameFinalizerSameClass, false),
+	)
+
+	DescribeTable("WaitForCleanup",
+		func(mr *resourcesv1alpha1.ManagedResource, shouldWait bool) {
+			wait := filter.WaitForCleanup(mr)
+			Expect(wait).To(Equal(shouldWait))
+		},
+		Entry("MR without a finalizer and with different class", mrWithoutFinalizerDifferentClass, false),
+		Entry("MR with different finalizer and with different class", mrDifferentFinalizerDifferentClass, false),
+		Entry("MR with same finalizer and with different class", mrSameFinalizerDifferentClass, false),
+		Entry("MR without a finalizer and with same class", mrWithoutFinalizerSameClass, false),
+		Entry("MR with different finalizer and with same class", mrDifferentFinalizerSameClass, true),
+		Entry("MR with same finalizer and with same class", mrSameFinalizerSameClass, false),
 	)
 
 	DescribeTable("Create",
-		func(mr *resourcesv1alpha1.ManagedResource, class string, expectation bool) {
-			filter := NewClassFilter(class)
-
-			result := filter.Create(event.CreateEvent{
+		func(mr *resourcesv1alpha1.ManagedResource, expected bool) {
+			got := filter.Create(event.CreateEvent{
 				Object: mr,
 			})
-			Expect(result).To(Equal(expectation))
+			Expect(got).To(Equal(expected))
 		},
-		Entry("Create event true", mrOldClass, "", true),
-		Entry("Create event true", mrNewClassOldFinalizer, "", true),
-		Entry("Create event true", mrNewClassOldFinalizer, classNew, true),
-		Entry("Create event false", mrNewClass, "", false),
+		Entry("MR without a finalizer and with different class", mrWithoutFinalizerDifferentClass, false),
+		Entry("MR with different finalizer and with different class", mrDifferentFinalizerDifferentClass, false),
+		Entry("MR with same finalizer and with different class", mrSameFinalizerDifferentClass, true),
+		Entry("MR without a finalizer and with same class", mrWithoutFinalizerSameClass, true),
+		Entry("MR with different finalizer and with same class", mrDifferentFinalizerSameClass, true),
+		Entry("MR with same finalizer and with same class", mrSameFinalizerSameClass, true),
 	)
 
 	DescribeTable("Delete",
-		func(mr *resourcesv1alpha1.ManagedResource, class string, expectation bool) {
-			filter := NewClassFilter(class)
-
-			result := filter.Delete(event.DeleteEvent{
+		func(mr *resourcesv1alpha1.ManagedResource, expected bool) {
+			got := filter.Delete(event.DeleteEvent{
 				Object: mr,
 			})
-			Expect(result).To(Equal(expectation))
+			Expect(got).To(Equal(expected))
 		},
-		Entry("Delete event true", mrOldClass, "", true),
-		Entry("Delete event true", mrNewClassOldFinalizer, "", true),
-		Entry("Delete event true", mrNewClassOldFinalizer, classNew, true),
-		Entry("Delete event false", mrNewClass, "", false),
+		Entry("MR without a finalizer and with different class", mrWithoutFinalizerDifferentClass, false),
+		Entry("MR with different finalizer and with different class", mrDifferentFinalizerDifferentClass, false),
+		Entry("MR with same finalizer and with different class", mrSameFinalizerDifferentClass, true),
+		Entry("MR without a finalizer and with same class", mrWithoutFinalizerSameClass, true),
+		Entry("MR with different finalizer and with same class", mrDifferentFinalizerSameClass, true),
+		Entry("MR with same finalizer and with same class", mrSameFinalizerSameClass, true),
 	)
 
 	DescribeTable("Update",
-		func(mr *resourcesv1alpha1.ManagedResource, class string, expectation bool) {
-			filter := NewClassFilter(class)
-
-			result := filter.Update(event.UpdateEvent{
+		func(mr *resourcesv1alpha1.ManagedResource, expected bool) {
+			got := filter.Update(event.UpdateEvent{
 				ObjectNew: mr,
 			})
-			Expect(result).To(Equal(expectation))
+			Expect(got).To(Equal(expected))
 		},
-		Entry("Update event true", mrOldClass, "", true),
-		Entry("Update event true", mrNewClassOldFinalizer, "", true),
-		Entry("Update event true", mrNewClassOldFinalizer, classNew, true),
-		Entry("Update event false", mrNewClass, "", false),
+		Entry("MR without a finalizer and with different class", mrWithoutFinalizerDifferentClass, false),
+		Entry("MR with different finalizer and with different class", mrDifferentFinalizerDifferentClass, false),
+		Entry("MR with same finalizer and with different class", mrSameFinalizerDifferentClass, true),
+		Entry("MR without a finalizer and with same class", mrWithoutFinalizerSameClass, true),
+		Entry("MR with different finalizer and with same class", mrDifferentFinalizerSameClass, true),
+		Entry("MR with same finalizer and with same class", mrSameFinalizerSameClass, true),
 	)
+
+	DescribeTable("Generic",
+		func(mr *resourcesv1alpha1.ManagedResource, expected bool) {
+			got := filter.Generic(event.GenericEvent{
+				Object: mr,
+			})
+			Expect(got).To(Equal(expected))
+		},
+		Entry("MR without a finalizer and with different class", mrWithoutFinalizerDifferentClass, false),
+		Entry("MR with different finalizer and with different class", mrDifferentFinalizerDifferentClass, false),
+		Entry("MR with same finalizer and with different class", mrSameFinalizerDifferentClass, true),
+		Entry("MR without a finalizer and with same class", mrWithoutFinalizerSameClass, true),
+		Entry("MR with different finalizer and with same class", mrDifferentFinalizerSameClass, true),
+		Entry("MR with same finalizer and with same class", mrSameFinalizerSameClass, true),
+	)
+
 })

--- a/pkg/resourcemanager/predicate/class_filter_test.go
+++ b/pkg/resourcemanager/predicate/class_filter_test.go
@@ -105,9 +105,9 @@ var _ = Describe("ClassFilter", func() {
 		Entry("MR with same finalizer and with same class", mrSameFinalizerSameClass, true),
 	)
 
-	DescribeTable("NoLongerHandles",
+	DescribeTable("IsTransferringResponsibility",
 		func(mr *resourcesv1alpha1.ManagedResource, shouldCleanup bool) {
-			cleanup := filter.NoLongerHandles(mr)
+			cleanup := filter.IsTransferringResponsibility(mr)
 			Expect(cleanup).To(Equal(shouldCleanup))
 		},
 		Entry("MR without a finalizer and with different class", mrWithoutFinalizerDifferentClass, false),
@@ -118,9 +118,9 @@ var _ = Describe("ClassFilter", func() {
 		Entry("MR with same finalizer and with same class", mrSameFinalizerSameClass, false),
 	)
 
-	DescribeTable("WaitForCleanup",
+	DescribeTable("IsWaitForCleanupRequired",
 		func(mr *resourcesv1alpha1.ManagedResource, shouldWait bool) {
-			wait := filter.WaitForCleanup(mr)
+			wait := filter.IsWaitForCleanupRequired(mr)
 			Expect(wait).To(Equal(shouldWait))
 		},
 		Entry("MR without a finalizer and with different class", mrWithoutFinalizerDifferentClass, false),


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind enhancement

**What this PR does / why we need it**:
1. Covering all test scenarios
2. Encapsulation of `action && !responsible` and `responsible && !action` logic into class filter and having dedicated tests
3. Enhanced documentation

**Special notes for your reviewer**:
The image provides a proof of logical equivalence between the old and new code by examining all possible states of the `active`, `responsible` and `active || responsible` expressions
Here is how the code maps to the image below
`controllerutil.ContainsFinalizer(mr, f.objectFinalizer)` is equivalent to `hasClassFinalizer`
And
```
for _, finalizer := range mr.GetFinalizers() {
	if strings.HasPrefix(finalizer, FinalizerName) {
		// here hasGRMFinalizer is true
	}
}
// here hasGRMFinalizer is false
```

![new](https://github.com/gardener/gardener/assets/14108745/733f5aff-8c9b-4da5-bcb9-0fecfbb057ec)


**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
4. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking developer
The `pkg/resourcemanager/predicate.ClassFilter.Active` function was replaced by `IsTransferringResponsibility` and `IsWaitForCleanupRequired`. 
- `pkg/resourcemanager/predicate.ClassFilter.IsTransferringResponsibility` should be used to check whether the `.spec.class` field of a `ManagedResource` has changed and let the controller which was previously responsible for the `ManagedResource` perform any additional/cleanup tasks.
- `pkg/resourcemanager/predicate.ClassFilter.IsWaitForCleanupRequired` should be used by the controller to which the responsibility was transferred to determine whether it should wait for any tasks/cleanup activities made by the previously responsible controller.
```
