### PR TITLE
egress cidrs

### DIFF
--- a/docs/api-reference/extensions.md
+++ b/docs/api-reference/extensions.md
@@ -3333,6 +3333,19 @@ This might be needed in environments in which the CIDR for the network for the s
 be statically defined in the Shoot resource but must be computed dynamically.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>egressCIDRs</code></br>
+<em>
+[]string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>EgressCIDRs is a list of CIDRs used by the shoot as the source IP for egress traffic. For certain environments the egress
+IPs may not be stable in which case the extension controller may opt to not populate this field.</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="extensions.gardener.cloud/v1alpha1.MachineDeployment">MachineDeployment

--- a/example/seed-crds/10-crd-extensions.gardener.cloud_infrastructures.yaml
+++ b/example/seed-crds/10-crd-extensions.gardener.cloud_infrastructures.yaml
@@ -138,6 +138,14 @@ spec:
                   - type
                   type: object
                 type: array
+              egressCIDRs:
+                description: EgressCIDRs is a list of CIDRs used by the shoot as the
+                  source IP for egress traffic. For certain environments the egress
+                  IPs may not be stable in which case the extension controller may
+                  opt to not populate this field.
+                items:
+                  type: string
+                type: array
               lastError:
                 description: LastError holds information about the last occurred error
                   during an operation.

--- a/pkg/apis/extensions/v1alpha1/types_infrastructure.go
+++ b/pkg/apis/extensions/v1alpha1/types_infrastructure.go
@@ -89,4 +89,8 @@ type InfrastructureStatus struct {
 	// be statically defined in the Shoot resource but must be computed dynamically.
 	// +optional
 	NodesCIDR *string `json:"nodesCIDR,omitempty"`
+	// EgressCIDRs is a list of CIDRs used by the shoot as the source IP for egress traffic. For certain environments the egress
+	// IPs may not be stable in which case the extension controller may opt to not populate this field.
+	// +optional
+	EgressCIDRs []string `json:"egressCIDRs,omitempty"`
 }

--- a/pkg/apis/extensions/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/extensions/v1alpha1/zz_generated.deepcopy.go
@@ -1215,6 +1215,11 @@ func (in *InfrastructureStatus) DeepCopyInto(out *InfrastructureStatus) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.EgressCIDRs != nil {
+		in, out := &in.EgressCIDRs, &out.EgressCIDRs
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/component/extensions/crds/assets/crd-extensions.gardener.cloud_infrastructures.yaml
+++ b/pkg/component/extensions/crds/assets/crd-extensions.gardener.cloud_infrastructures.yaml
@@ -140,6 +140,14 @@ spec:
                   - type
                   type: object
                 type: array
+              egressCIDRs:
+                description: EgressCIDRs is a list of CIDRs used by the shoot as the
+                  source IP for egress traffic. For certain environments the egress
+                  IPs may not be stable in which case the extension controller may
+                  opt to not populate this field.
+                items:
+                  type: string
+                type: array
               lastError:
                 description: LastError holds information about the last occurred error
                   during an operation.

--- a/pkg/component/extensions/infrastructure/infrastructure.go
+++ b/pkg/component/extensions/infrastructure/infrastructure.go
@@ -56,6 +56,8 @@ type Interface interface {
 	ProviderStatus() *runtime.RawExtension
 	// NodesCIDR returns the generated nodes CIDR of the provider.
 	NodesCIDR() *string
+	// EgressCIDRs returns a list of CIDRs used as source IP by any traffic originating from the shoot's worker nodes.
+	EgressCIDRs() []string
 }
 
 // Values contains the values used to create an Infrastructure resources.
@@ -116,6 +118,7 @@ type infrastructure struct {
 	infrastructure *extensionsv1alpha1.Infrastructure
 	providerStatus *runtime.RawExtension
 	nodesCIDR      *string
+	egressCIDRs    []string
 }
 
 // Deploy uses the seed client to create or update the Infrastructure resource.
@@ -254,9 +257,15 @@ func (i *infrastructure) NodesCIDR() *string {
 	return i.nodesCIDR
 }
 
+// EgressCIDRs returns a list of CIDRs used as source IP by any traffic originating from the shoot's worker nodes.
+func (i *infrastructure) EgressCIDRs() []string {
+	return i.egressCIDRs
+}
+
 func (i *infrastructure) extractStatus(status extensionsv1alpha1.InfrastructureStatus) {
 	i.providerStatus = status.ProviderStatus
 	i.nodesCIDR = status.NodesCIDR
+	i.egressCIDRs = status.DeepCopy().EgressCIDRs
 }
 
 func (i *infrastructure) lastOperationNotSuccessful() bool {

--- a/pkg/component/extensions/infrastructure/infrastructure.go
+++ b/pkg/component/extensions/infrastructure/infrastructure.go
@@ -265,7 +265,8 @@ func (i *infrastructure) EgressCIDRs() []string {
 func (i *infrastructure) extractStatus(status extensionsv1alpha1.InfrastructureStatus) {
 	i.providerStatus = status.ProviderStatus
 	i.nodesCIDR = status.NodesCIDR
-	i.egressCIDRs = status.DeepCopy().EgressCIDRs
+	i.egressCIDRs = make([]string, len(status.EgressCIDRs))
+	copy(i.egressCIDRs, status.EgressCIDRs)
 }
 
 func (i *infrastructure) lastOperationNotSuccessful() bool {

--- a/pkg/component/extensions/infrastructure/infrastructure_test.go
+++ b/pkg/component/extensions/infrastructure/infrastructure_test.go
@@ -69,6 +69,7 @@ var _ = Describe("#Interface", func() {
 		providerConfig *runtime.RawExtension
 		providerStatus *runtime.RawExtension
 		nodesCIDR      *string
+		egressCIDRs    []string
 
 		empty, expected *extensionsv1alpha1.Infrastructure
 		values          *infrastructure.Values
@@ -95,6 +96,7 @@ var _ = Describe("#Interface", func() {
 		providerConfig = &runtime.RawExtension{Raw: []byte(`{"very":"provider-specific"}`)}
 		providerStatus = &runtime.RawExtension{Raw: []byte(`{"very":"provider-specific-status"}`)}
 		nodesCIDR = pointer.String("1.2.3.4/5")
+		egressCIDRs = []string{"1.2.3.4/5", "5.6.7.8/9"}
 
 		values = &infrastructure.Values{
 			Namespace:      namespace,
@@ -332,6 +334,7 @@ var _ = Describe("#Interface", func() {
 			}
 			expected.Status.NodesCIDR = nodesCIDR
 			expected.Status.ProviderStatus = providerStatus
+			expected.Status.EgressCIDRs = egressCIDRs
 			Expect(c.Patch(ctx, expected, patch)).To(Succeed(), "patching infrastructure succeeds")
 
 			By("Wait")
@@ -340,6 +343,7 @@ var _ = Describe("#Interface", func() {
 			By("Verify status")
 			Expect(deployWaiter.ProviderStatus()).To(Equal(providerStatus))
 			Expect(deployWaiter.NodesCIDR()).To(Equal(nodesCIDR))
+			Expect(deployWaiter.EgressCIDRs()).To(Equal(egressCIDRs))
 		})
 
 		It("should return no error when is ready (AnnotateOperation == false)", func() {
@@ -350,11 +354,13 @@ var _ = Describe("#Interface", func() {
 			}
 			expected.Status.NodesCIDR = nodesCIDR
 			expected.Status.ProviderStatus = providerStatus
+			expected.Status.EgressCIDRs = egressCIDRs
 
 			Expect(c.Create(ctx, expected)).To(Succeed(), "creating infrastructure succeeds")
 			Expect(deployWaiter.Wait(ctx)).To(Succeed())
 			Expect(deployWaiter.ProviderStatus()).To(Equal(providerStatus))
 			Expect(deployWaiter.NodesCIDR()).To(Equal(nodesCIDR))
+			Expect(deployWaiter.EgressCIDRs()).To(Equal(egressCIDRs))
 		})
 	})
 
@@ -542,6 +548,7 @@ var _ = Describe("#Interface", func() {
 			infra := empty.DeepCopy()
 			infra.Status.ProviderStatus = providerStatus
 			infra.Status.NodesCIDR = nodesCIDR
+			infra.Status.EgressCIDRs = egressCIDRs
 			Expect(c.Create(ctx, infra)).To(Succeed())
 
 			expected = infra.DeepCopy()
@@ -552,6 +559,7 @@ var _ = Describe("#Interface", func() {
 
 			Expect(deployWaiter.ProviderStatus()).To(Equal(providerStatus))
 			Expect(deployWaiter.NodesCIDR()).To(Equal(nodesCIDR))
+			Expect(deployWaiter.EgressCIDRs()).To(Equal(egressCIDRs))
 		})
 	})
 })

--- a/pkg/component/extensions/infrastructure/mock/mocks.go
+++ b/pkg/component/extensions/infrastructure/mock/mocks.go
@@ -65,6 +65,20 @@ func (mr *MockInterfaceMockRecorder) Destroy(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Destroy", reflect.TypeOf((*MockInterface)(nil).Destroy), arg0)
 }
 
+// EgressCIDRs mocks base method.
+func (m *MockInterface) EgressCIDRs() []string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "EgressCIDRs")
+	ret0, _ := ret[0].([]string)
+	return ret0
+}
+
+// EgressCIDRs indicates an expected call of EgressCIDRs.
+func (mr *MockInterfaceMockRecorder) EgressCIDRs() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EgressCIDRs", reflect.TypeOf((*MockInterface)(nil).EgressCIDRs))
+}
+
 // Get mocks base method.
 func (m *MockInterface) Get(arg0 context.Context) (*v1alpha1.Infrastructure, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement

**What this PR does / why we need it**:
Adds an additional field in the infrastructure status, that will allow the provider extensions to expose a list of CIDRs used as the source IP of egress traffic by worker nodes.

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener/issues/8837

**Special notes for your reviewer**:
Sample implementation for AWS in https://github.com/kon-angelo/gardener-extension-provider-aws/tree/hackathon-acl

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Add `egressCIDRs` field to the infrastructureStatus resource. This allows provider-extensions to specify a list of stable CIDRs used as source IP for traffic generated by the shoot's worker nodes.
```
