### PR TITLE
Add container registry for `europe-docker.pkg.dev` to local-setup

### DIFF
--- a/example/gardener-local/registry-prow/kustomization.yaml
+++ b/example/gardener-local/registry-prow/kustomization.yaml
@@ -45,3 +45,11 @@ patches:
       group: apps
       kind: Deployment
       name: registry-quay
+  - patch: |
+      - op: replace
+        path: /spec/template/spec/containers/0/env/0/value
+        value: http://registry-europe-docker-pkg-dev.kube-system.svc.cluster.local:5000
+    target:
+      group: apps
+      kind: Deployment
+      name: registry-europe-docker-pkg-dev

--- a/example/gardener-local/registry/europe-docker-pkg-dev/kustomization.yaml
+++ b/example/gardener-local/registry/europe-docker-pkg-dev/kustomization.yaml
@@ -1,0 +1,33 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+
+resources:
+  - ../base
+
+patches:
+  - patch: |
+      - op: replace
+        path: /metadata/name
+        value: registry-europe-docker-pkg-dev
+      - op: replace
+        path: /spec/template/spec/containers/0/env
+        value:
+          - name: REGISTRY_PROXY_REMOTEURL
+            value: https://europe-docker.pkg.dev
+          - name: REGISTRY_HTTP_ADDR
+            value: :5008
+      - op: replace
+        path: /spec/template/spec/containers/0/ports/0/containerPort
+        value: 5008
+      - op: replace
+        path: /spec/template/spec/volumes/0/hostPath/path
+        value: /etc/gardener/local-registry/europe-docker-pkg-dev
+    target:
+      group: apps
+      kind: Deployment
+      name: registry
+labels:
+  - includeSelectors: true
+    pairs:
+      upstream: europe-docker-pkg-dev

--- a/example/gardener-local/registry/kustomization.yaml
+++ b/example/gardener-local/registry/kustomization.yaml
@@ -12,6 +12,7 @@ resources:
 - k8s
 - localhost
 - quay
+- europe-docker-pkg-dev
 labels:
 - includeSelectors: true
   pairs:

--- a/hack/kind-up.sh
+++ b/hack/kind-up.sh
@@ -129,6 +129,7 @@ setup_containerd_registry_mirrors() {
     setup_containerd_registry_mirror $NODE "ghcr.io" "https://ghcr.io" "http://${REGISTRY_HOSTNAME}:5005"
     setup_containerd_registry_mirror $NODE "registry.k8s.io" "https://registry.k8s.io" "http://${REGISTRY_HOSTNAME}:5006"
     setup_containerd_registry_mirror $NODE "quay.io" "https://quay.io" "http://${REGISTRY_HOSTNAME}:5007"
+    setup_containerd_registry_mirror $NODE "europe-docker.pkg.dev" "https://europe-docker.pkg.dev" "http://${REGISTRY_HOSTNAME}:5008"
   done
 }
 

--- a/pkg/provider-local/webhook/controlplane/ensurer.go
+++ b/pkg/provider-local/webhook/controlplane/ensurer.go
@@ -118,6 +118,7 @@ func ensureRegistryMirrorConfig(new *[]extensionsv1alpha1.File) {
 		{UpstreamHost: "ghcr.io", UpstreamServer: "https://ghcr.io", MirrorHost: "http://garden.local.gardener.cloud:5005"},
 		{UpstreamHost: "registry.k8s.io", UpstreamServer: "https://registry.k8s.io", MirrorHost: "http://garden.local.gardener.cloud:5006"},
 		{UpstreamHost: "quay.io", UpstreamServer: "https://quay.io", MirrorHost: "http://garden.local.gardener.cloud:5007"},
+		{UpstreamHost: "europe-docker.pkg.dev", UpstreamServer: "https://europe-docker.pkg.dev", MirrorHost: "http://garden.local.gardener.cloud:5008"},
 	}
 
 	for _, mirror := range mirrors {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
This PR adds a container registry for `europe-docker.pkg.dev` to local-setup.
Sooner or later more and more Gardener related images will move to `europe-docker.pkg.dev` and we could support that right from the beginning.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
