### PR TITLE
Fix `gardener-node-agent` image tag defaulting

### DIFF
--- a/pkg/operation/botanist/operatingsystemconfig.go
+++ b/pkg/operation/botanist/operatingsystemconfig.go
@@ -23,6 +23,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/component-base/version"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/gardener/gardener/imagevector"
@@ -50,14 +51,21 @@ const SecretLabelKeyManagedResource = "managed-resource"
 // DefaultOperatingSystemConfig creates the default deployer for the OperatingSystemConfig custom resource.
 func (b *Botanist) DefaultOperatingSystemConfig() (operatingsystemconfig.Interface, error) {
 	images := []string{imagevector.ImageNamePauseContainer, imagevector.ImageNameValitail}
-	if features.DefaultFeatureGate.Enabled(features.UseGardenerNodeAgent) {
-		images = append(images, imagevector.ImageNameGardenerNodeAgent)
-	} else {
+	if !features.DefaultFeatureGate.Enabled(features.UseGardenerNodeAgent) {
 		images = append(images, imagevector.ImageNameHyperkube)
 	}
+
 	oscImages, err := imagevectorutils.FindImages(imagevector.ImageVector(), images, imagevectorutils.RuntimeVersion(b.ShootVersion()), imagevectorutils.TargetVersion(b.ShootVersion()))
 	if err != nil {
 		return nil, err
+	}
+
+	if features.DefaultFeatureGate.Enabled(features.UseGardenerNodeAgent) {
+		oscImages[imagevector.ImageNameGardenerNodeAgent], err = imagevector.ImageVector().FindImage(imagevector.ImageNameGardenerNodeAgent)
+		if err != nil {
+			return nil, fmt.Errorf("failed finding image %q: %w", imagevector.ImageNameGardenerNodeAgent, err)
+		}
+		oscImages[imagevector.ImageNameGardenerNodeAgent].WithOptionalTag(version.Get().GitVersion)
 	}
 
 	clusterDNSAddress := b.Shoot.Networks.CoreDNS.String()


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind bug

**What this PR does / why we need it**:
This PR fixes a bug about the `gardener-node-agent` image which occurs when `gardenlet` does not use an image vector overwrite configuration. In the local scenario, this is always the case, hence we haven't caught it earlier.

When an image without a tag is looked up with runtime/target version find options, then its tag will be defaulted eventually in https://github.com/gardener/gardener/blob/180951eac9b8183175d4dcadc305c7722ce8122d/pkg/utils/imagevector/imagevector.go#L366-L370

This leads to a wrong image tag of GNA in the `init.sh` script of the `gardener-node-init` systemd unit (set to the Kubernetes version instead of the `gardenlet`'s own version):

```
echo "> Pull gardener-node-agent image and mount it to the temporary directory"
ctr images pull  "eu.gcr.io/gardener-project/gardener/node-agent:v1.27.6" --hosts-dir "/etc/containerd/certs.d"
ctr images mount "eu.gcr.io/gardener-project/gardener/node-agent:v1.27.6" "$tmp_dir"
```

**Special notes for your reviewer**:
/cc @plkokanov 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
