### PR TITLE
[node-agent] Restrict cache for `Lease`s to `kube-system` namespace

### DIFF
--- a/cmd/gardener-node-agent/app/app.go
+++ b/cmd/gardener-node-agent/app/app.go
@@ -29,6 +29,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
+	coordinationv1 "k8s.io/api/coordination/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -168,8 +169,9 @@ func run(ctx context.Context, cancel context.CancelFunc, log logr.Logger, cfg *c
 		},
 
 		Cache: cache.Options{ByObject: map[client.Object]cache.ByObject{
-			&corev1.Secret{}: {Namespaces: map[string]cache.Config{metav1.NamespaceSystem: {}}},
-			&corev1.Node{}:   {Label: labels.SelectorFromSet(labels.Set{corev1.LabelHostname: hostName})},
+			&corev1.Secret{}:        {Namespaces: map[string]cache.Config{metav1.NamespaceSystem: {}}},
+			&corev1.Node{}:          {Label: labels.SelectorFromSet(labels.Set{corev1.LabelHostname: hostName})},
+			&coordinationv1.Lease{}: {Namespaces: map[string]cache.Config{metav1.NamespaceSystem: {}}},
 		}},
 		LeaderElection: false,
 		Controller: controllerconfig.Controller{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind bug

**What this PR does / why we need it**:
In PR #8767 node-agent has permissions for `Lease`s in `kube-system` namespace only. However, the cache is not restricted to this namespace yet, so node-agent fails watching leases.
```
Dec 01 20:46:19 machine-shoot--local--local-local-bfc8c-c82kf gardener-node-agent[966]: {"level":"error","ts":"2023-12-01T20:46:19.755Z","msg":"k8s.io/client-go@v0.28.3/tools/cache/reflector.go:229: Failed to watch *v1.Lease: failed to list *v1.Lease: leases.coordination.k8s.io is forbidden: User \"system:serviceaccount:kube-system:gardener-node-agent\" cannot list resource \"leases\" in API group \"coordination.k8s.io\" at the cluster scope\n","stacktrace":"k8s.io/client-go/tools/cache.DefaultWatchErrorHandler\n\tk8s.io/client-go@v0.28.3/tools/cache/reflector.go:147\nk8s.io/client-go/tools/cache.(*Reflector).Run.func1\n\tk8s.io/client-go@v0.28.3/tools/cache/reflector.go:292\nk8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1\n\tk8s.io/apimachinery@v0.28.3/pkg/util/wait/backoff.go:226\nk8s.io/apimachinery/pkg/util/wait.BackoffUntil\n\tk8s.io/apimachinery@v0.28.3/pkg/util/wait/backoff.go:227\nk8s.io/client-go/tools/cache.(*Reflector).Run\n\tk8s.io/client-go@v0.28.3/tools/cache/reflector.go:290\nk8s.io/client-go/tools/cache.(*controller).Run.(*Group).StartWithChannel.func2\n\tk8s.io/apimachinery@v0.28.3/pkg/util/wait/wait.go:55\nk8s.io/apimachinery/pkg/util/wait.(*Group).Start.func1\n\tk8s.io/apimachinery@v0.28.3/pkg/util/wait/wait.go:72"}
```

This PR restricts node-agent cache for `Lease`s to `kube-system` namespace to fix this issue.

**Which issue(s) this PR fixes**:
Part of #8023 


**Special notes for your reviewer**:
/cc @rfranzke 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
