### PR TITLE
[node-agent] Use temporary directory in `/var/lib/gardener-node-agent/tmp`

### DIFF
--- a/cmd/gardener-node-agent/app/app.go
+++ b/cmd/gardener-node-agent/app/app.go
@@ -195,6 +195,11 @@ func run(ctx context.Context, cancel context.CancelFunc, log logr.Logger, cfg *c
 		dbus = dbus.New()
 	)
 
+	log.Info("Creating directory for temporary files", "path", nodeagentv1alpha1.TempDir)
+	if err := fs.MkdirAll(nodeagentv1alpha1.TempDir, os.ModeDir); err != nil {
+		return fmt.Errorf("unable to create directory for temporary files %q: %w", nodeagentv1alpha1.TempDir, err)
+	}
+
 	log.Info("Adding runnables to manager")
 	if err := mgr.Add(&controllerutils.ControlledRunner{
 		Manager: mgr,

--- a/pkg/nodeagent/apis/config/v1alpha1/types.go
+++ b/pkg/nodeagent/apis/config/v1alpha1/types.go
@@ -25,6 +25,8 @@ const (
 	BaseDir = "/var/lib/gardener-node-agent"
 	// CredentialsDir is the directory on the worker node that contains credentials for the gardener-node-agent.
 	CredentialsDir = BaseDir + "/credentials"
+	// TempDir is the directory on the worker node that contains temporary directories of files.
+	TempDir = BaseDir + "/tmp"
 	// BinaryDir is the directory on the worker node that contains the binary for the gardener-node-agent.
 	BinaryDir = "/opt/bin"
 

--- a/pkg/nodeagent/bootstrap/kubelet_data_volume.go
+++ b/pkg/nodeagent/bootstrap/kubelet_data_volume.go
@@ -24,6 +24,8 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/spf13/afero"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+
+	nodeagentv1alpha1 "github.com/gardener/gardener/pkg/nodeagent/apis/config/v1alpha1"
 )
 
 var (
@@ -50,7 +52,7 @@ func formatKubeletDataDevice(log logr.Logger, fs afero.Afero, kubeletDataVolumeS
 	}
 
 	log.Info("Creating temporary file")
-	tmpFile, err := fs.TempFile("", "format-kubelet-data-volume-*")
+	tmpFile, err := fs.TempFile(nodeagentv1alpha1.TempDir, "format-kubelet-data-volume-")
 	if err != nil {
 		return fmt.Errorf("unable to create temporary directory: %w", err)
 	}

--- a/pkg/nodeagent/controller/operatingsystemconfig/reconciler.go
+++ b/pkg/nodeagent/controller/operatingsystemconfig/reconciler.go
@@ -205,7 +205,7 @@ var (
 )
 
 func (r *Reconciler) applyChangedFiles(ctx context.Context, log logr.Logger, files []extensionsv1alpha1.File) error {
-	tmpDir, err := r.FS.TempDir("", "gardener-node-agent-*")
+	tmpDir, err := r.FS.TempDir(nodeagentv1alpha1.TempDir, "osc-reconciliation-file-")
 	if err != nil {
 		return fmt.Errorf("unable to create temporary directory: %w", err)
 	}

--- a/pkg/nodeagent/registry/containerd_extractor.go
+++ b/pkg/nodeagent/registry/containerd_extractor.go
@@ -33,6 +33,8 @@ import (
 	"github.com/opencontainers/image-spec/identity"
 	"github.com/spf13/afero"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+
+	nodeagentv1alpha1 "github.com/gardener/gardener/pkg/nodeagent/apis/config/v1alpha1"
 )
 
 type containerdExtractor struct{}
@@ -76,7 +78,7 @@ func (e *containerdExtractor) CopyFromImage(ctx context.Context, imageRef string
 
 	snapshotter := client.SnapshotService(containerd.DefaultSnapshotter)
 
-	imageMountDirectory, err := fs.TempDir("", "node-agent-")
+	imageMountDirectory, err := fs.TempDir(nodeagentv1alpha1.TempDir, "mount-image-")
 	if err != nil {
 		return fmt.Errorf("error creating temp directory: %w", err)
 	}
@@ -157,7 +159,7 @@ func CopyFile(fs afero.Afero, sourceFile, destinationFile string, permissions os
 		return fmt.Errorf("destination directory %q could not be created", path.Dir(destinationFile))
 	}
 
-	tempDir, err := fs.TempDir("", "copy-image-")
+	tempDir, err := fs.TempDir(nodeagentv1alpha1.TempDir, "copy-image-")
 	if err != nil {
 		return fmt.Errorf("error creating temp directory: %w", err)
 	}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind bug

**What this PR does / why we need it**:
Without this, `OperatingSystemConfig` reconciliation might fail with

```
Dec 02 11:41:39 some-node-name gardener-node-agent[18641]: {"level":"info","ts":"2023-12-02T11:41:39.743Z","msg":"Applying new or changed files","controller":"operatingsystemconfig","namespace":"kube-system","name":"gardener-node-agent-worker-zmfgt-8a8eb","reconcileID":"10aa599c-e921-4c34-a22c-f965e4bc6191"}
Dec 02 11:41:39 some-node-name gardener-node-agent[18641]: {"level":"error","ts":"2023-12-02T11:41:39.743Z","msg":"Reconciler error","controller":"operatingsystemconfig","namespace":"kube-system","name":"gardener-node-agent-worker-zmfgt-8a8eb","reconcileID":"10aa599c-e921-4c34-a22c-f965e4bc6191","error":"failed applying changed files: unable to rename temporary file \"/tmp/gardener-node-agent-*635956476/config\" to \"/var/lib/valitail/config/config\": rename /tmp/gardener-node-agent-*635956476/config /var/lib/valitail/config/config: invalid cross-device link","stacktrace":"sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.16.3/pkg/internal/controller/controller.go:329\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.16.3/pkg/internal/contro>
```

This can occur when `/var` and `/tmp` are backed by different file systems or devices (e.g., on `gardenlinux` nodes).

**Which issue(s) this PR fixes**:
Part of #8023

**Special notes for your reviewer**:
/cc @plkokanov 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
`gardener-node-agent` now creates temporary directories and files under `/var/lib/gardener-node-agent/tmp` instead of `/tmp`. This fixes issues during `OperatingSystemConfig` reconciliation which occur when `/var` and `/tmp` are backed by different file systems or devices.
```
