### PR TITLE
[node-agent] Restrict `Lease` cache when `Node` has already been registered

### DIFF
--- a/pkg/nodeagent/controller/lease/lease_suite_test.go
+++ b/pkg/nodeagent/controller/lease/lease_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package lease_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestLease(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "NodeAgent Controller Lease Suite")
+}

--- a/pkg/nodeagent/controller/lease/reconciler.go
+++ b/pkg/nodeagent/controller/lease/reconciler.go
@@ -48,7 +48,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 
 	lease := &coordinationv1.Lease{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "gardener-node-agent-" + node.GetName(),
+			Name:      ObjectName(node.GetName()),
 			Namespace: r.Namespace,
 		},
 	}
@@ -67,4 +67,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	})
 	log.V(1).Info("Heartbeat Lease", "lease", client.ObjectKeyFromObject(lease), "operation", op)
 	return reconcile.Result{RequeueAfter: time.Duration(r.LeaseDurationSeconds) * time.Second / 4}, err
+}
+
+// ObjectName returns the name of the Lease object based on the node name.
+func ObjectName(nodeName string) string {
+	return "gardener-node-agent-" + nodeName
 }

--- a/pkg/nodeagent/controller/lease/reconciler_test.go
+++ b/pkg/nodeagent/controller/lease/reconciler_test.go
@@ -1,0 +1,30 @@
+// Copyright 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package lease_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	. "github.com/gardener/gardener/pkg/nodeagent/controller/lease"
+)
+
+var _ = Describe("Reconciler", func() {
+	Describe("#ObjectName", func() {
+		It("should return the expected name", func() {
+			Expect(ObjectName("foo")).To(Equal("gardener-node-agent-foo"))
+		})
+	})
+})

--- a/pkg/nodeagent/nodeagent_suite_test.go
+++ b/pkg/nodeagent/nodeagent_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nodeagent_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestNodeAgent(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "NodeAgent Suite")
+}

--- a/pkg/nodeagent/nodename.go
+++ b/pkg/nodeagent/nodename.go
@@ -1,0 +1,43 @@
+// Copyright 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nodeagent
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// FetchNodeByHostName tries to fetch the node (metadata-only) object based on the hostname.
+func FetchNodeByHostName(ctx context.Context, c client.Client, hostName string) (*metav1.PartialObjectMetadata, error) {
+	// node name not known yet, try to fetch it via label selector based on hostname
+	nodeList := &metav1.PartialObjectMetadataList{}
+	nodeList.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("NodeList"))
+	if err := c.List(ctx, nodeList, client.MatchingLabels{corev1.LabelHostname: hostName}); err != nil {
+		return nil, fmt.Errorf("unable to list nodes with label selector %s=%s: %w", corev1.LabelHostname, hostName, err)
+	}
+
+	switch len(nodeList.Items) {
+	case 0:
+		return nil, nil
+	case 1:
+		return &nodeList.Items[0], nil
+	default:
+		return nil, fmt.Errorf("found more than one node with label %s=%s", corev1.LabelHostname, hostName)
+	}
+}

--- a/pkg/nodeagent/nodename_test.go
+++ b/pkg/nodeagent/nodename_test.go
@@ -1,0 +1,81 @@
+// Copyright 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nodeagent_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kubernetesscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	. "github.com/gardener/gardener/pkg/nodeagent"
+)
+
+var _ = Describe("NodeName", func() {
+	Describe("#FetchNodeByHostName", func() {
+		var (
+			ctx        = context.Background()
+			fakeClient client.Client
+			hostName   = "foo"
+
+			node *corev1.Node
+		)
+
+		BeforeEach(func() {
+			fakeClient = fakeclient.NewClientBuilder().WithScheme(kubernetesscheme.Scheme).Build()
+
+			node = &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "node-",
+					Labels:       map[string]string{"kubernetes.io/hostname": hostName},
+				},
+			}
+		})
+
+		It("should return nil because no node was found", func() {
+			node, err := FetchNodeByHostName(ctx, fakeClient, hostName)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(node).To(BeNil())
+		})
+
+		It("should return the found node", func() {
+			Expect(fakeClient.Create(ctx, node)).To(Succeed())
+			DeferCleanup(func() { Expect(fakeClient.Delete(ctx, node)).To(Succeed()) })
+
+			node, err := FetchNodeByHostName(ctx, fakeClient, hostName)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(node).To(Equal(node))
+		})
+
+		It("should return an error because multiple nodes were found", func() {
+			node2 := node.DeepCopy()
+
+			Expect(fakeClient.Create(ctx, node)).To(Succeed())
+			DeferCleanup(func() { Expect(fakeClient.Delete(ctx, node)).To(Succeed()) })
+
+			Expect(fakeClient.Create(ctx, node2)).To(Succeed())
+			DeferCleanup(func() { Expect(fakeClient.Delete(ctx, node2)).To(Succeed()) })
+
+			node, err := FetchNodeByHostName(ctx, fakeClient, hostName)
+			Expect(err).To(MatchError(ContainSubstring("found more than one node with label")))
+			Expect(node).To(BeNil())
+		})
+	})
+})

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -1145,6 +1145,7 @@ build:
             - pkg/gardenlet/apis/config/v1alpha1
             - pkg/healthz
             - pkg/logger
+            - pkg/nodeagent
             - pkg/nodeagent/apis/config
             - pkg/nodeagent/apis/config/v1alpha1
             - pkg/nodeagent/apis/config/validation


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area scalability
/kind enhancement

**What this PR does / why we need it**:
This PR restricts the `Lease` cache to the "well-known" object name in case the `Node` has already been registered.

**Which issue(s) this PR fixes**:
Part of #8023
Follow-up of https://github.com/gardener/gardener/pull/8767 and https://github.com/gardener/gardener/pull/8893

**Special notes for your reviewer**:
/cc @timuthy @ScheererJ 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
