### PR TITLE
[node-agent] Make hostname lower case

### DIFF
--- a/cmd/gardener-node-agent/app/app.go
+++ b/cmd/gardener-node-agent/app/app.go
@@ -24,6 +24,7 @@ import (
 	"path/filepath"
 	goruntime "runtime"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -156,6 +157,7 @@ func run(ctx context.Context, cancel context.CancelFunc, log logr.Logger, cfg *c
 	if err != nil {
 		return fmt.Errorf("failed fetching hostname: %w", err)
 	}
+	hostName = strings.ToLower(hostName)
 
 	log.Info("Setting up manager")
 	mgr, err := manager.New(restConfig, manager.Options{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind bug

**What this PR does / why we need it**:
For some providers, the hostname contains upper-case letters. However, the `kubelet` seems to always lower them when maintaining the `kubernetes.io/hostname` label:

```
root@privileged-pod:/# cat /etc/hostname
iZgw833e4trj6kafv0zpxxZ
```

vs.

```
$ k get no -L kubernetes.io/hostname
NAME                      STATUS   ROLES    AGE   VERSION   HOSTNAME
izgw833e4trj6kafv0zpxxz   Ready    <none>   27m   v1.27.7   izgw833e4trj6kafv0zpxxz
```

**Which issue(s) this PR fixes**:
Part of #8023

**Special notes for your reviewer**:
/cc @timuthy 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
`gardener-node-agent` now converts the hostname to lower case to match `kubelet` behaviour when it maintains the `kubernetes.io/hostname` label on `Node`s.
```
