### PR TITLE
Explicitly disable `UseGardenerNodeAgent` feature gate in local extensions setup

### DIFF
--- a/example/gardener-local/gardenlet/values-provider-extensions.yaml
+++ b/example/gardener-local/gardenlet/values-provider-extensions.yaml
@@ -19,3 +19,6 @@ config:
         - name: gardenlet-bootstrap
           user:
             token: 07401d.f395accd246ae52d
+  featureGates:
+    # TODO(oliver-goetz): Remove this as soon as the local provider extensions setup supports this feature gate.
+    UseGardenerNodeAgent: false

--- a/example/provider-extensions/seed/create-seed.sh
+++ b/example/provider-extensions/seed/create-seed.sh
@@ -46,7 +46,6 @@ registry_domain=$(cat "$registry_domain_file")
 echo "Skaffolding seed"
 GARDENER_LOCAL_KUBECONFIG=$garden_kubeconfig \
   SKAFFOLD_DEFAULT_REPO=$registry_domain \
-  REGISTRY_DOMAIN=$registry_domain \
   SEED_NAME=$seed_name \
   SEED_VALUES=$seed_values \
   SKAFFOLD_PUSH=true \


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
Explicitly disable `UseGardenerNodeAgent` feature gate in local extensions setup since it is not ready for it (the `gardener-node-agent` image is pushed to the registry in the seed cluster, however the shoot worker VMs do not have credentials to pull it from this registry, hence the nodes don't join the cluster).

**Which issue(s) this PR fixes**:
Related to https://github.com/gardener/gardener/issues/8023

**Special notes for your reviewer**:
/cc @timuthy 
FYI @JensAc @oliver-goetz 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
