### PR TITLE
Promote `WorkerlessShoots` to `GA`

### DIFF
--- a/docs/deployment/feature_gates.md
+++ b/docs/deployment/feature_gates.md
@@ -27,7 +27,8 @@ The following tables are a summary of the feature gates that you can set on diff
 | IPv6SingleStack                     | `false` | `Alpha` | `1.63` |        |
 | MutableShootSpecNetworkingNodes     | `false` | `Alpha` | `1.64` |        |
 | WorkerlessShoots                    | `false` | `Alpha` | `1.70` | `1.78` |
-| WorkerlessShoots                    | `false` | `Beta`  | `1.79` |        |
+| WorkerlessShoots                    | `false` | `Beta`  | `1.79` | `1.85` |
+| WorkerlessShoots                    | `true`  | `GA`    | `1.86` |        |
 | MachineControllerManagerDeployment  | `false` | `Alpha` | `1.73` |        |
 | MachineControllerManagerDeployment  | `true`  | `Beta`  | `1.81` | `1.81` |
 | MachineControllerManagerDeployment  | `true`  | `GA`    | `1.82` |        |

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -62,6 +62,7 @@ const (
 	// owner: @acumino @ary1992 @shafeeqes
 	// alpha: v1.70.0
 	// beta: v1.79.0
+	// GA: v1.86.0
 	WorkerlessShoots featuregate.Feature = "WorkerlessShoots"
 
 	// ShootForceDeletion allows force deletion of Shoots.
@@ -141,7 +142,7 @@ var AllFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	CoreDNSQueryRewriting:              {Default: false, PreRelease: featuregate.Alpha},
 	IPv6SingleStack:                    {Default: false, PreRelease: featuregate.Alpha},
 	MutableShootSpecNetworkingNodes:    {Default: false, PreRelease: featuregate.Alpha},
-	WorkerlessShoots:                   {Default: true, PreRelease: featuregate.Beta},
+	WorkerlessShoots:                   {Default: true, PreRelease: featuregate.Beta, LockToDefault: true},
 	ShootForceDeletion:                 {Default: false, PreRelease: featuregate.Alpha},
 	MachineControllerManagerDeployment: {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
 	ContainerdRegistryHostsDir:         {Default: true, PreRelease: featuregate.Beta},

--- a/pkg/registry/core/shoot/strategy.go
+++ b/pkg/registry/core/shoot/strategy.go
@@ -29,7 +29,6 @@ import (
 	"k8s.io/apiserver/pkg/registry/rest"
 	"k8s.io/apiserver/pkg/storage"
 	"k8s.io/apiserver/pkg/storage/names"
-	utilfeature "k8s.io/apiserver/pkg/util/feature"
 
 	"github.com/gardener/gardener/pkg/api"
 	"github.com/gardener/gardener/pkg/api/core/shoot"
@@ -37,7 +36,6 @@ import (
 	gardencorehelper "github.com/gardener/gardener/pkg/apis/core/helper"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/apis/core/validation"
-	"github.com/gardener/gardener/pkg/features"
 	admissionpluginsvalidation "github.com/gardener/gardener/pkg/utils/validation/admissionplugins"
 )
 
@@ -164,11 +162,7 @@ func (shootStrategy) Validate(_ context.Context, obj runtime.Object) field.Error
 		allErrs = append(allErrs, err)
 	}
 	allErrs = append(allErrs, validation.ValidateFinalizersOnCreation(shoot.Finalizers, field.NewPath("metadata", "finalizers"))...)
-	if gardencorehelper.IsWorkerless(shoot) {
-		if !utilfeature.DefaultFeatureGate.Enabled(features.WorkerlessShoots) {
-			allErrs = append(allErrs, field.Forbidden(field.NewPath("spec", "provider", "workers"), "must provide at least one worker pool when WorkerlessShoots feature gate is disabled"))
-		}
-	} else if shoot.Spec.Networking != nil {
+	if !gardencorehelper.IsWorkerless(shoot) && shoot.Spec.Networking != nil {
 		allErrs = append(allErrs, validation.ValidateTotalNodeCountWithPodCIDR(shoot)...)
 	}
 	return allErrs

--- a/pkg/registry/core/shoot/strategy_test.go
+++ b/pkg/registry/core/shoot/strategy_test.go
@@ -19,19 +19,15 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	. "github.com/onsi/gomega/gstruct"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/utils/pointer"
 
 	"github.com/gardener/gardener/pkg/apis/core"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
-	"github.com/gardener/gardener/pkg/features"
 	shootregistry "github.com/gardener/gardener/pkg/registry/core/shoot"
-	"github.com/gardener/gardener/pkg/utils/test"
 )
 
 var _ = Describe("Strategy", func() {
@@ -58,18 +54,6 @@ var _ = Describe("Strategy", func() {
 					},
 				},
 			}
-		})
-
-		It("should forbid an empty worker list if WorkerlessShoots featuregate is disabled", func() {
-			DeferCleanup(test.WithFeatureGate(features.DefaultFeatureGate, features.WorkerlessShoots, false))
-
-			errorList := shootregistry.NewStrategy(0).Validate(context.TODO(), shoot)
-
-			Expect(errorList).To(ContainElement(PointTo(MatchFields(IgnoreExtras, Fields{
-				"Type":   Equal(field.ErrorTypeForbidden),
-				"Field":  Equal("spec.provider.workers"),
-				"Detail": ContainSubstring("must provide at least one worker pool when WorkerlessShoots feature gate is disabled"),
-			}))))
 		})
 
 		It("should allow an empty worker list if WorkerlessShoots featuregate is enabled", func() {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area open-source
/kind enhancement

**What this PR does / why we need it**:
This PR promotes `WorkerlessShoots` feature gate to `GA`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy operator
The `WorkerlessShoots` has been promoted to GA and is now locked to "enabled by default".
```
