### PR TITLE
[node-agent] `dbus` interface should not block and wait for result channel forever

### DIFF
--- a/pkg/nodeagent/dbus/dbus.go
+++ b/pkg/nodeagent/dbus/dbus.go
@@ -77,7 +77,7 @@ func (d *db) Stop(ctx context.Context, recorder record.EventRecorder, node runti
 	}
 	defer dbc.Close()
 
-	return d.runCommand(ctx, recorder, node, unitName, dbc.StopUnitContext, "SystemDUnitStop", "stop")
+	return runCommand(ctx, recorder, node, unitName, dbc.StopUnitContext, "SystemDUnitStop", "stop")
 }
 
 func (d *db) Start(ctx context.Context, recorder record.EventRecorder, node runtime.Object, unitName string) error {
@@ -87,7 +87,7 @@ func (d *db) Start(ctx context.Context, recorder record.EventRecorder, node runt
 	}
 	defer dbc.Close()
 
-	return d.runCommand(ctx, recorder, node, unitName, dbc.StartUnitContext, "SystemDUnitStart", "start")
+	return runCommand(ctx, recorder, node, unitName, dbc.StartUnitContext, "SystemDUnitStart", "start")
 }
 
 func (d *db) Restart(ctx context.Context, recorder record.EventRecorder, node runtime.Object, unitName string) error {
@@ -97,7 +97,7 @@ func (d *db) Restart(ctx context.Context, recorder record.EventRecorder, node ru
 	}
 	defer dbc.Close()
 
-	return d.runCommand(ctx, recorder, node, unitName, dbc.RestartUnitContext, "SystemDUnitRestart", "restart")
+	return runCommand(ctx, recorder, node, unitName, dbc.RestartUnitContext, "SystemDUnitRestart", "restart")
 }
 
 func (_ *db) DaemonReload(ctx context.Context) error {
@@ -114,7 +114,7 @@ func (_ *db) DaemonReload(ctx context.Context) error {
 	return nil
 }
 
-func (_ *db) runCommand(
+func runCommand(
 	ctx context.Context,
 	recorder record.EventRecorder,
 	node runtime.Object,

--- a/pkg/nodeagent/dbus/dbus.go
+++ b/pkg/nodeagent/dbus/dbus.go
@@ -72,69 +72,34 @@ func (_ *db) Disable(ctx context.Context, unitNames ...string) error {
 	return err
 }
 
-func (_ *db) Stop(ctx context.Context, recorder record.EventRecorder, node runtime.Object, unitName string) error {
+func (d *db) Stop(ctx context.Context, recorder record.EventRecorder, node runtime.Object, unitName string) error {
 	dbc, err := dbus.NewWithContext(ctx)
 	if err != nil {
 		return fmt.Errorf("unable to connect to dbus: %w", err)
 	}
 	defer dbc.Close()
 
-	jobCh := make(chan string)
-
-	if _, err := dbc.StopUnitContext(ctx, unitName, "replace", jobCh); err != nil {
-		return fmt.Errorf("unable to stop unit %s: %w", unitName, err)
-	}
-
-	if completion := <-jobCh; completion != done {
-		err = fmt.Errorf("stop failed for %s, due %s", unitName, completion)
-	}
-
-	recordEvent(recorder, node, err, unitName, "SystemDUnitStop", "stop")
-	return err
+	return d.runCommand(ctx, recorder, node, unitName, dbc.StopUnitContext, "SystemDUnitStop", "stop")
 }
 
-func (_ *db) Start(ctx context.Context, recorder record.EventRecorder, node runtime.Object, unitName string) error {
+func (d *db) Start(ctx context.Context, recorder record.EventRecorder, node runtime.Object, unitName string) error {
 	dbc, err := dbus.NewWithContext(ctx)
 	if err != nil {
 		return fmt.Errorf("unable to connect to dbus: %w", err)
 	}
 	defer dbc.Close()
 
-	jobCh := make(chan string)
-
-	if _, err := dbc.StartUnitContext(ctx, unitName, "replace", jobCh); err != nil {
-		return fmt.Errorf("unable to start unit %s: %w", unitName, err)
-	}
-
-	completion := <-jobCh
-	if completion != done {
-		err = fmt.Errorf("start failed for %s, due %s", unitName, completion)
-	}
-
-	recordEvent(recorder, node, err, unitName, "SystemDUnitStart", "start")
-	return err
+	return d.runCommand(ctx, recorder, node, unitName, dbc.StartUnitContext, "SystemDUnitStart", "start")
 }
 
-func (_ *db) Restart(ctx context.Context, recorder record.EventRecorder, node runtime.Object, unitName string) error {
+func (d *db) Restart(ctx context.Context, recorder record.EventRecorder, node runtime.Object, unitName string) error {
 	dbc, err := dbus.NewWithContext(ctx)
 	if err != nil {
 		return fmt.Errorf("unable to connect to dbus: %w", err)
 	}
 	defer dbc.Close()
 
-	jobCh := make(chan string)
-
-	if _, err := dbc.RestartUnitContext(ctx, unitName, "replace", jobCh); err != nil {
-		return fmt.Errorf("unable to restart unit %s: %w", unitName, err)
-	}
-
-	completion := <-jobCh
-	if completion != done {
-		err = fmt.Errorf("restart failed for %s, due %s", unitName, completion)
-	}
-
-	recordEvent(recorder, node, err, unitName, "SystemDUnitRestart", "restart")
-	return nil
+	return d.runCommand(ctx, recorder, node, unitName, dbc.RestartUnitContext, "SystemDUnitRestart", "restart")
 }
 
 func (_ *db) DaemonReload(ctx context.Context) error {
@@ -149,6 +114,32 @@ func (_ *db) DaemonReload(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+func (_ *db) runCommand(
+	ctx context.Context,
+	recorder record.EventRecorder,
+	node runtime.Object,
+	unitName string,
+	f func(context.Context, string, string, chan<- string) (int, error),
+	eventReason string,
+	operation string,
+) error {
+	var (
+		jobCh = make(chan string)
+		err   error
+	)
+
+	if _, err := f(ctx, unitName, "replace", jobCh); err != nil {
+		return fmt.Errorf("unable to %s unit %s: %w", operation, unitName, err)
+	}
+
+	if completion := <-jobCh; completion != done {
+		err = fmt.Errorf("%s failed for %s, due %s", operation, unitName, completion)
+	}
+
+	recordEvent(recorder, node, err, unitName, eventReason, operation)
+	return err
 }
 
 func recordEvent(recorder record.EventRecorder, node runtime.Object, err error, unitName, reason, operation string) {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind bug

**What this PR does / why we need it**:
Earlier, the `dbus` methods were waiting for a result sent via the `jobCh` forever. We have seen cases where no result was sent (reason unclear and yet to understand), which blocked the GNA's `OperatingSystemConfig` reconciler indefinitely. Our code should at least respect the reconciliation timeout part of the passed `context.Context`.

**Which issue(s) this PR fixes**:
Part of #8023

**Special notes for your reviewer**:
/cc @ScheererJ 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
`gardener-node-agent`'s `OperatingSystemConfig` controller now respects the reconciliation timeout and aborts the reconciliation if it takes too long.
```
