### PR TITLE
Add new recording rule for kube apiserver latency

### DIFF
--- a/pkg/component/kubeapiserver/monitoring.go
+++ b/pkg/component/kubeapiserver/monitoring.go
@@ -40,6 +40,7 @@ const (
 	monitoringMetricApiserverAuditEventTotal                             = "apiserver_audit_event_total"
 	monitoringMetricApiserverAuditErrorTotal                             = "apiserver_audit_error_total"
 	monitoringMetricApiserverAuditRequestsRejectedTotal                  = "apiserver_audit_requests_rejected_total"
+	monitoringMetricApiserverLatency                                     = "apiserver_latency"
 	monitoringMetricApiserverLatencySeconds                              = "apiserver_latency_seconds"
 	monitoringMetricApiserverCRDWebhookConversionDurationSeconds         = "apiserver_crd_webhook_conversion_duration_seconds_.+"
 	monitoringMetricApiserverCurrentInflightRequests                     = "apiserver_current_inflight_requests"
@@ -49,6 +50,7 @@ const (
 	monitoringMetricApiserverRegisteredWatchers                          = "apiserver_registered_watchers"
 	monitoringMetricApiserverRequestDurationSeconds                      = "apiserver_request_duration_seconds_.+"
 	monitoringMetricApiserverRequestDurationSecondsBucket                = "apiserver_request_duration_seconds_bucket"
+	monitoringMetricApiserverRequestDurationSecondsCount                 = "apiserver_request_duration_seconds_count"
 	monitoringMetricApiserverRequestTerminationsTotal                    = "apiserver_request_terminations_total"
 	monitoringMetricApiserverRequestTotal                                = "apiserver_request_total"
 	monitoringMetricApiserverRequestCount                                = "apiserver_request_count"
@@ -188,6 +190,9 @@ const (
     expr: histogram_quantile(0.5, sum without (instance, pod) (rate(` + monitoringMetricApiserverRequestDurationSecondsBucket + `[5m])))
     labels:
       quantile: "0.5"
+  ### API server request duration greater than 1s percentage
+  - record: shoot:` + monitoringMetricApiserverLatency + `:percentage
+    expr: 1 - sum(rate(` + monitoringMetricApiserverRequestDurationSecondsBucket + `{le="1",subresource!~"log|portforward|exec|proxy|attach",verb!~"CONNECT|LIST|WATCH"}[1h])) / sum(rate(` + monitoringMetricApiserverRequestDurationSecondsCount + `{subresource!~"log|portforward|exec|proxy|attach",verb!~"CONNECT|LIST|WATCH"}[1h]))
 
   - record: shoot:kube_apiserver:sum_by_pod
     expr: sum(up{job="` + monitoringPrometheusJobName + `"}) by (pod)

--- a/pkg/component/kubeapiserver/monitoring_test.go
+++ b/pkg/component/kubeapiserver/monitoring_test.go
@@ -188,6 +188,9 @@ metric_relabel_configs:
     expr: histogram_quantile(0.5, sum without (instance, pod) (rate(apiserver_request_duration_seconds_bucket[5m])))
     labels:
       quantile: "0.5"
+  ### API server request duration greater than 1s percentage
+  - record: shoot:apiserver_latency:percentage
+    expr: 1 - sum(rate(apiserver_request_duration_seconds_bucket{le="1",subresource!~"log|portforward|exec|proxy|attach",verb!~"CONNECT|LIST|WATCH"}[1h])) / sum(rate(apiserver_request_duration_seconds_count{subresource!~"log|portforward|exec|proxy|attach",verb!~"CONNECT|LIST|WATCH"}[1h]))
 
   - record: shoot:kube_apiserver:sum_by_pod
     expr: sum(up{job="kube-apiserver"}) by (pod)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind enhancement

**What this PR does / why we need it**:
Add a new recording rule to get the percentage of kube apiserver requests which are greater than 1 s, and federate this latency metrics to garden-prometheus.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
The same changes as [PR](https://github.com/gardener/gardener/pull/8897) which has been closed. 
**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
