### PR TITLE
Clear GRM secret finalizer from hibernated or broken clusters

### DIFF
--- a/cmd/gardenlet/app/app.go
+++ b/cmd/gardenlet/app/app.go
@@ -385,7 +385,7 @@ func (g *garden) Start(ctx context.Context) error {
 	}
 
 	log.Info("Cleaning up GRM secret finalizers")
-	if err := g.cleanupGRMSecretFinalizers(ctx, g.mgr.GetClient(), log); err != nil {
+	if err := g.cleanupGRMSecretFinalizers(ctx, g.mgr.GetClient()); err != nil {
 		return err
 	}
 
@@ -469,7 +469,7 @@ func (g *garden) cleanupOrphanedExtensionsServiceAccounts(ctx context.Context, g
 }
 
 // TODO(Kostov6): Remove this code after v1.91 has been released.
-func (g *garden) cleanupGRMSecretFinalizers(ctx context.Context, seedClient client.Client, log logr.Logger) error {
+func (g *garden) cleanupGRMSecretFinalizers(ctx context.Context, seedClient client.Client) error {
 	mrs := &resourcesv1alpha1.ManagedResourceList{}
 	if err := seedClient.List(ctx, mrs); err != nil {
 		if meta.IsNoMatchError(err) {

--- a/cmd/gardenlet/app/app.go
+++ b/cmd/gardenlet/app/app.go
@@ -61,6 +61,7 @@ import (
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/apis/operations"
 	operationsv1alpha1 "github.com/gardener/gardener/pkg/apis/operations/v1alpha1"
+	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	clientmapbuilder "github.com/gardener/gardener/pkg/client/kubernetes/clientmap/builder"
 	"github.com/gardener/gardener/pkg/controllerutils"
@@ -73,6 +74,7 @@ import (
 	"github.com/gardener/gardener/pkg/gardenlet/controller"
 	gardenerhealthz "github.com/gardener/gardener/pkg/healthz"
 	"github.com/gardener/gardener/pkg/resourcemanager/controller/garbagecollector/references"
+	"github.com/gardener/gardener/pkg/resourcemanager/predicate"
 	"github.com/gardener/gardener/pkg/utils"
 	"github.com/gardener/gardener/pkg/utils/flow"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
@@ -381,6 +383,11 @@ func (g *garden) Start(ctx context.Context) error {
 		return err
 	}
 
+	log.Info("Cleaning up GRM secret finalizers")
+	if err := g.cleanupGRMSecretFinalizers(ctx, g.mgr.GetClient(), log); err != nil {
+		return err
+	}
+
 	log.Info("Recreating wrongly deleted managed resource secrets")
 	if err := recreateDeletedManagedResourceSecrets(ctx, g.mgr.GetClient()); err != nil {
 		return err
@@ -458,6 +465,30 @@ func (g *garden) cleanupOrphanedExtensionsServiceAccounts(ctx context.Context, g
 	}
 
 	return flow.Parallel(taskFns...)(ctx)
+}
+
+// TODO(Kostov6): Remove this code after v1.89 has been released.
+func (g *garden) cleanupGRMSecretFinalizers(ctx context.Context, seedClient client.Client, log logr.Logger) error {
+	mrs := &resourcesv1alpha1.ManagedResourceList{}
+	if err := seedClient.List(ctx, mrs); err != nil {
+		log.Error(err, "Failed to list ManagedResources while cleaing up GRM finalizers")
+	}
+	secret := &corev1.Secret{}
+	for _, mr := range mrs.Items {
+		for _, ref := range mr.Spec.SecretRefs {
+			if err := g.mgr.GetClient().Get(ctx, client.ObjectKey{Namespace: mr.Namespace, Name: ref.Name}, secret); err != nil {
+				log.Error(err, "Failed to get secret while cleaing up GRM finalizers")
+			}
+			for _, finalizer := range secret.Finalizers {
+				if strings.HasPrefix(finalizer, predicate.FinalizerName) {
+					if err := controllerutils.RemoveFinalizers(ctx, seedClient, secret, finalizer); err != nil {
+						log.Error(err, "Failed to remove finalizer while cleaing up GRM finalizers")
+					}
+				}
+			}
+		}
+	}
+	return nil
 }
 
 const (

--- a/cmd/gardenlet/app/app.go
+++ b/cmd/gardenlet/app/app.go
@@ -472,7 +472,7 @@ func cleanupGRMSecretFinalizers(ctx context.Context, seedClient client.Client, l
 	mrs := &resourcesv1alpha1.ManagedResourceList{}
 	if err := seedClient.List(ctx, mrs); err != nil {
 		if meta.IsNoMatchError(err) {
-			log.Info("Received a 'no match error' while trying to list managed resources. Will assume that the managed resources CRD is not yet installed (for example new Seed creation) and will skip cleaning up GRM finalizers.")
+			log.Info("Received a 'no match error' while trying to list managed resources. Will assume that the managed resources CRD is not yet installed (for example new Seed creation) and will skip cleaning up GRM finalizers")
 			return nil
 		}
 		return fmt.Errorf("failed to list managed resources: %w", err)

--- a/pkg/resourcemanager/controller/secret/reconciler.go
+++ b/pkg/resourcemanager/controller/secret/reconciler.go
@@ -39,7 +39,7 @@ type Reconciler struct {
 
 // Reconcile implements reconcile.Reconciler.
 func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
-	// TODO(Kostov6): Drop secret reconciler after v1.86 has been released.
+	// TODO(Kostov6): Drop secret reconciler after v1.89 has been released.
 	log := logf.FromContext(ctx)
 
 	ctx, cancel := controllerutils.GetMainReconciliationContext(ctx, controllerutils.DefaultReconciliationTimeout)

--- a/pkg/resourcemanager/controller/secret/reconciler.go
+++ b/pkg/resourcemanager/controller/secret/reconciler.go
@@ -39,7 +39,7 @@ type Reconciler struct {
 
 // Reconcile implements reconcile.Reconciler.
 func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
-	// TODO(Kostov6): Drop secret reconciler after v1.89 has been released.
+	// TODO(Kostov6): Drop secret reconciler after v1.91 has been released.
 	log := logf.FromContext(ctx)
 
 	ctx, cancel := controllerutils.GetMainReconciliationContext(ctx, controllerutils.DefaultReconciliationTimeout)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind cleanup

**What this PR does / why we need it**:
GRM secret reconciler was unable to clean up secret finalizers when a cluster was hibernated or broken
This PR makes gardenlet responsible to remove GRM secret finalizer on all managed resources.

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener/issues/8882

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
On startup, `gardenlet` now removes the `resources.gardener.cloud/gardener-resource-manager` finalizer from `Secret`s related to `ManagedResource`s.
```
