### PR TITLE
[admissioncontroller] Clean up technical debt in defaulting code 

### DIFF
--- a/pkg/admissioncontroller/apis/config/v1alpha1/defaults.go
+++ b/pkg/admissioncontroller/apis/config/v1alpha1/defaults.go
@@ -16,13 +16,8 @@ package v1alpha1
 
 import (
 	rbacv1 "k8s.io/api/rbac/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	componentbaseconfigv1alpha1 "k8s.io/component-base/config/v1alpha1"
 )
-
-func addDefaultingFuncs(scheme *runtime.Scheme) error {
-	return RegisterDefaults(scheme)
-}
 
 // SetDefaults_AdmissionControllerConfiguration sets defaults for the configuration of the Gardener admission controller.
 func SetDefaults_AdmissionControllerConfiguration(obj *AdmissionControllerConfiguration) {
@@ -32,32 +27,35 @@ func SetDefaults_AdmissionControllerConfiguration(obj *AdmissionControllerConfig
 	if len(obj.LogFormat) == 0 {
 		obj.LogFormat = "json"
 	}
-	if obj.Server.Webhooks.Port == 0 {
-		obj.Server.Webhooks.Port = 2721
+}
+
+// SetDefaults_ServerConfiguration sets defaults for the configuration of the server
+func SetDefaults_ServerConfiguration(obj *ServerConfiguration) {
+	if obj.Webhooks.Port == 0 {
+		obj.Webhooks.Port = 2721
 	}
 
-	if obj.Server.ResourceAdmissionConfiguration == nil {
-		obj.Server.ResourceAdmissionConfiguration = &ResourceAdmissionConfiguration{}
+	if obj.ResourceAdmissionConfiguration == nil {
+		obj.ResourceAdmissionConfiguration = &ResourceAdmissionConfiguration{}
 	}
 
-	if obj.Server.HealthProbes == nil {
-		obj.Server.HealthProbes = &Server{}
+	if obj.HealthProbes == nil {
+		obj.HealthProbes = &Server{}
 	}
-	if obj.Server.HealthProbes.Port == 0 {
-		obj.Server.HealthProbes.Port = 2722
-	}
-
-	if obj.Server.Metrics == nil {
-		obj.Server.Metrics = &Server{}
-	}
-	if obj.Server.Metrics.Port == 0 {
-		obj.Server.Metrics.Port = 2723
+	if obj.HealthProbes.Port == 0 {
+		obj.HealthProbes.Port = 2722
 	}
 
-	resourceAdmission := obj.Server.ResourceAdmissionConfiguration
-	for i, subject := range resourceAdmission.UnrestrictedSubjects {
+	if obj.Metrics == nil {
+		obj.Metrics = &Server{}
+	}
+	if obj.Metrics.Port == 0 {
+		obj.Metrics.Port = 2723
+	}
+
+	for i, subject := range obj.ResourceAdmissionConfiguration.UnrestrictedSubjects {
 		if (subject.Kind == rbacv1.UserKind || subject.Kind == rbacv1.GroupKind) && subject.APIGroup == "" {
-			resourceAdmission.UnrestrictedSubjects[i].APIGroup = rbacv1.GroupName
+			obj.ResourceAdmissionConfiguration.UnrestrictedSubjects[i].APIGroup = rbacv1.GroupName
 		}
 	}
 }

--- a/pkg/admissioncontroller/apis/config/v1alpha1/defaults.go
+++ b/pkg/admissioncontroller/apis/config/v1alpha1/defaults.go
@@ -52,10 +52,13 @@ func SetDefaults_ServerConfiguration(obj *ServerConfiguration) {
 	if obj.Metrics.Port == 0 {
 		obj.Metrics.Port = 2723
 	}
+}
 
-	for i, subject := range obj.ResourceAdmissionConfiguration.UnrestrictedSubjects {
+// SetDefaults_ResourceAdmissionConfiguration sets defaults for the resource admission configuration.
+func SetDefaults_ResourceAdmissionConfiguration(obj *ResourceAdmissionConfiguration) {
+	for i, subject := range obj.UnrestrictedSubjects {
 		if (subject.Kind == rbacv1.UserKind || subject.Kind == rbacv1.GroupKind) && subject.APIGroup == "" {
-			obj.ResourceAdmissionConfiguration.UnrestrictedSubjects[i].APIGroup = rbacv1.GroupName
+			obj.UnrestrictedSubjects[i].APIGroup = rbacv1.GroupName
 		}
 	}
 }

--- a/pkg/admissioncontroller/apis/config/v1alpha1/defaults_test.go
+++ b/pkg/admissioncontroller/apis/config/v1alpha1/defaults_test.go
@@ -24,9 +24,14 @@ import (
 )
 
 var _ = Describe("Defaults", func() {
+	var obj *AdmissionControllerConfiguration
+
+	BeforeEach(func() {
+		obj = &AdmissionControllerConfiguration{}
+	})
+
 	Describe("AdmissionControllerConfiguration defaulting", func() {
-		It("should default AdmissionControllerConfiguration correctly", func() {
-			obj := &AdmissionControllerConfiguration{}
+		It("should correctly default the AdmissionControllerConfiguration", func() {
 			SetObjectDefaults_AdmissionControllerConfiguration(obj)
 			// ContentType fields will be defaulted by client constructors / controller-runtime based on whether a
 			// given APIGroup supports protobuf or not. defaults must not touch these, otherwise the integelligent
@@ -42,8 +47,8 @@ var _ = Describe("Defaults", func() {
 
 		})
 
-		It("should not default other fields that are set", func() {
-			obj := &AdmissionControllerConfiguration{
+		It("should not overwrite already set values", func() {
+			obj = &AdmissionControllerConfiguration{
 				LogLevel:  "warning",
 				LogFormat: "md",
 			}
@@ -59,8 +64,7 @@ var _ = Describe("Defaults", func() {
 	})
 
 	Describe("ServerConfiguration defaulting", func() {
-		It("should default ServerConfiguration correctly", func() {
-			obj := &AdmissionControllerConfiguration{}
+		It("should correctly default the ServerConfiguration", func() {
 			expected := &ServerConfiguration{
 				Webhooks: HTTPSServer{
 					Server: Server{
@@ -84,7 +88,7 @@ var _ = Describe("Defaults", func() {
 		})
 
 		It("should correctly default the resource admission configuration if given", func() {
-			obj := &AdmissionControllerConfiguration{
+			obj = &AdmissionControllerConfiguration{
 				Server: ServerConfiguration{
 					ResourceAdmissionConfiguration: &ResourceAdmissionConfiguration{
 						UnrestrictedSubjects: []rbacv1.Subject{
@@ -107,8 +111,8 @@ var _ = Describe("Defaults", func() {
 			Expect(obj.Server.ResourceAdmissionConfiguration).To(Equal(expected))
 		})
 
-		It("should not default other fields that are set", func() {
-			obj := &AdmissionControllerConfiguration{
+		It("should not overwrite already set values", func() {
+			obj = &AdmissionControllerConfiguration{
 				Server: ServerConfiguration{
 					Webhooks: HTTPSServer{
 						Server: Server{

--- a/pkg/admissioncontroller/apis/config/v1alpha1/defaults_test.go
+++ b/pkg/admissioncontroller/apis/config/v1alpha1/defaults_test.go
@@ -159,5 +159,23 @@ var _ = Describe("Defaults", func() {
 
 			Expect(obj.Server.ResourceAdmissionConfiguration).To(Equal(expected))
 		})
+
+		It("should not overwrite already set values", func() {
+			obj = &AdmissionControllerConfiguration{
+				Server: ServerConfiguration{
+					ResourceAdmissionConfiguration: &ResourceAdmissionConfiguration{
+						UnrestrictedSubjects: []rbacv1.Subject{
+							{Kind: rbacv1.UserKind, Name: "foo", APIGroup: "fooGroup"},
+							{Kind: rbacv1.GroupKind, Name: "bar", APIGroup: "barGroup"},
+							{Kind: rbacv1.ServiceAccountKind, Name: "foobar", Namespace: "default", APIGroup: "foobarGroup"},
+						},
+					},
+				},
+			}
+			expected := obj.Server.ResourceAdmissionConfiguration.DeepCopy()
+			SetObjectDefaults_AdmissionControllerConfiguration(obj)
+
+			Expect(obj.Server.ResourceAdmissionConfiguration).To(Equal(expected))
+		})
 	})
 })

--- a/pkg/admissioncontroller/apis/config/v1alpha1/defaults_test.go
+++ b/pkg/admissioncontroller/apis/config/v1alpha1/defaults_test.go
@@ -61,15 +61,26 @@ var _ = Describe("Defaults", func() {
 	Describe("ServerConfiguration defaulting", func() {
 		It("should default ServerConfiguration correctly", func() {
 			obj := &AdmissionControllerConfiguration{}
+			expected := &ServerConfiguration{
+				Webhooks: HTTPSServer{
+					Server: Server{
+						BindAddress: "",
+						Port:        2721,
+					},
+				},
+				ResourceAdmissionConfiguration: &ResourceAdmissionConfiguration{},
+				HealthProbes: &Server{
+					BindAddress: "",
+					Port:        2722,
+				},
+				Metrics: &Server{
+					BindAddress: "",
+					Port:        2723,
+				},
+			}
 			SetObjectDefaults_AdmissionControllerConfiguration(obj)
 
-			Expect(obj.Server.Webhooks.BindAddress).To(BeEmpty())
-			Expect(obj.Server.Webhooks.Port).To(Equal(2721))
-			Expect(obj.Server.ResourceAdmissionConfiguration).To(Equal(&ResourceAdmissionConfiguration{}))
-			Expect(obj.Server.HealthProbes.BindAddress).To(BeEmpty())
-			Expect(obj.Server.HealthProbes.Port).To(Equal(2722))
-			Expect(obj.Server.Metrics.BindAddress).To(BeEmpty())
-			Expect(obj.Server.Metrics.Port).To(Equal(2723))
+			Expect(&obj.Server).To(Equal(expected))
 		})
 
 		It("should correctly default the resource admission configuration if given", func() {
@@ -84,11 +95,16 @@ var _ = Describe("Defaults", func() {
 					},
 				},
 			}
+			expected := &ResourceAdmissionConfiguration{
+				UnrestrictedSubjects: []rbacv1.Subject{
+					{Kind: rbacv1.UserKind, Name: "foo", APIGroup: rbacv1.GroupName},
+					{Kind: rbacv1.GroupKind, Name: "bar", APIGroup: rbacv1.GroupName},
+					{Kind: rbacv1.ServiceAccountKind, Name: "foobar", Namespace: "default", APIGroup: ""},
+				},
+			}
 			SetObjectDefaults_AdmissionControllerConfiguration(obj)
 
-			Expect(obj.Server.ResourceAdmissionConfiguration.UnrestrictedSubjects[0].APIGroup).To(Equal(rbacv1.GroupName))
-			Expect(obj.Server.ResourceAdmissionConfiguration.UnrestrictedSubjects[1].APIGroup).To(Equal(rbacv1.GroupName))
-			Expect(obj.Server.ResourceAdmissionConfiguration.UnrestrictedSubjects[2].APIGroup).To(Equal(""))
+			Expect(obj.Server.ResourceAdmissionConfiguration).To(Equal(expected))
 		})
 
 		It("should not default other fields that are set", func() {

--- a/pkg/admissioncontroller/apis/config/v1alpha1/register.go
+++ b/pkg/admissioncontroller/apis/config/v1alpha1/register.go
@@ -52,3 +52,7 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 	)
 	return nil
 }
+
+func addDefaultingFuncs(scheme *runtime.Scheme) error {
+	return RegisterDefaults(scheme)
+}

--- a/pkg/admissioncontroller/apis/config/v1alpha1/zz_generated.defaults.go
+++ b/pkg/admissioncontroller/apis/config/v1alpha1/zz_generated.defaults.go
@@ -38,4 +38,5 @@ func RegisterDefaults(scheme *runtime.Scheme) error {
 func SetObjectDefaults_AdmissionControllerConfiguration(in *AdmissionControllerConfiguration) {
 	SetDefaults_AdmissionControllerConfiguration(in)
 	SetDefaults_ClientConnectionConfiguration(&in.GardenClientConnection)
+	SetDefaults_ServerConfiguration(&in.Server)
 }

--- a/pkg/admissioncontroller/apis/config/v1alpha1/zz_generated.defaults.go
+++ b/pkg/admissioncontroller/apis/config/v1alpha1/zz_generated.defaults.go
@@ -39,4 +39,7 @@ func SetObjectDefaults_AdmissionControllerConfiguration(in *AdmissionControllerC
 	SetDefaults_AdmissionControllerConfiguration(in)
 	SetDefaults_ClientConnectionConfiguration(&in.GardenClientConnection)
 	SetDefaults_ServerConfiguration(&in.Server)
+	if in.Server.ResourceAdmissionConfiguration != nil {
+		SetDefaults_ResourceAdmissionConfiguration(in.Server.ResourceAdmissionConfiguration)
+	}
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area dev-productivity
  /area technical-debt
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind technical-debt

**What this PR does / why we need it**:
This PR cleans up technical debt in our API defaulting code according to https://github.com/gardener/gardener/issues/7312.
This PR tackles the following resources in the core API group:

- admissioncontroller.config.gardener.cloud

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/7312

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
NONE
```
