### PR TITLE
[node-agent] Stop waiting for systemd command results after `10s`

### DIFF
--- a/cmd/gardener-node-agent/app/app.go
+++ b/cmd/gardener-node-agent/app/app.go
@@ -101,7 +101,7 @@ func getBootstrapCommand(opts *options) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			return bootstrap.Bootstrap(cmd.Context(), log, afero.Afero{Fs: afero.NewOsFs()}, dbus.New(), opts.config.Bootstrap)
+			return bootstrap.Bootstrap(cmd.Context(), log, afero.Afero{Fs: afero.NewOsFs()}, dbus.New(log), opts.config.Bootstrap)
 		},
 	}
 
@@ -210,7 +210,7 @@ func run(ctx context.Context, cancel context.CancelFunc, log logr.Logger, cfg *c
 
 	var (
 		fs   = afero.Afero{Fs: afero.NewOsFs()}
-		dbus = dbus.New()
+		dbus = dbus.New(log)
 	)
 
 	log.Info("Creating directory for temporary files", "path", nodeagentv1alpha1.TempDir)

--- a/pkg/nodeagent/controller/node/add.go
+++ b/pkg/nodeagent/controller/node/add.go
@@ -38,7 +38,7 @@ func (r *Reconciler) AddToManager(mgr manager.Manager, nodePredicate predicate.P
 		r.Recorder = mgr.GetEventRecorderFor(ControllerName)
 	}
 	if r.DBus == nil {
-		r.DBus = dbus.New(mgr.GetLogger().WithValues("controller", ControllerName).WithName("dbus"))
+		r.DBus = dbus.New(mgr.GetLogger().WithValues("controller", ControllerName))
 	}
 
 	node := &metav1.PartialObjectMetadata{}

--- a/pkg/nodeagent/controller/node/add.go
+++ b/pkg/nodeagent/controller/node/add.go
@@ -38,7 +38,7 @@ func (r *Reconciler) AddToManager(mgr manager.Manager, nodePredicate predicate.P
 		r.Recorder = mgr.GetEventRecorderFor(ControllerName)
 	}
 	if r.DBus == nil {
-		r.DBus = dbus.New()
+		r.DBus = dbus.New(mgr.GetLogger().WithValues("controller", ControllerName).WithName("dbus"))
 	}
 
 	node := &metav1.PartialObjectMetadata{}

--- a/pkg/nodeagent/controller/operatingsystemconfig/add.go
+++ b/pkg/nodeagent/controller/operatingsystemconfig/add.go
@@ -55,7 +55,7 @@ func (r *Reconciler) AddToManager(ctx context.Context, mgr manager.Manager) erro
 		r.Recorder = mgr.GetEventRecorderFor(ControllerName)
 	}
 	if r.DBus == nil {
-		r.DBus = dbus.New()
+		r.DBus = dbus.New(mgr.GetLogger().WithValues("controller", ControllerName).WithName("dbus"))
 	}
 	if r.FS.Fs == nil {
 		r.FS = afero.Afero{Fs: afero.NewOsFs()}

--- a/pkg/nodeagent/controller/operatingsystemconfig/add.go
+++ b/pkg/nodeagent/controller/operatingsystemconfig/add.go
@@ -55,7 +55,7 @@ func (r *Reconciler) AddToManager(ctx context.Context, mgr manager.Manager) erro
 		r.Recorder = mgr.GetEventRecorderFor(ControllerName)
 	}
 	if r.DBus == nil {
-		r.DBus = dbus.New(mgr.GetLogger().WithValues("controller", ControllerName).WithName("dbus"))
+		r.DBus = dbus.New(mgr.GetLogger().WithValues("controller", ControllerName))
 	}
 	if r.FS.Fs == nil {
 		r.FS = afero.Afero{Fs: afero.NewOsFs()}

--- a/pkg/nodeagent/dbus/dbus.go
+++ b/pkg/nodeagent/dbus/dbus.go
@@ -49,7 +49,7 @@ type db struct {
 
 // New returns a new working DBus
 func New(log logr.Logger) DBus {
-	return &db{log: log}
+	return &db{log: log.WithName("dbus")}
 }
 
 func (_ *db) Enable(ctx context.Context, unitNames ...string) error {

--- a/pkg/nodeagent/dbus/dbus.go
+++ b/pkg/nodeagent/dbus/dbus.go
@@ -127,11 +127,11 @@ func runCommand(
 	operation string,
 ) error {
 	var (
-		jobCh = make(chan string)
-		err   error
+		resultCh = make(chan string)
+		err      error
 	)
 
-	if _, err := f(ctx, unitName, "replace", jobCh); err != nil {
+	if _, err := f(ctx, unitName, "replace", resultCh); err != nil {
 		return fmt.Errorf("unable to %s unit %s: %w", operation, unitName, err)
 	}
 
@@ -139,7 +139,7 @@ func runCommand(
 	case <-ctx.Done(): // context is cancelled
 		return ctx.Err()
 
-	case result := <-jobCh: // job channel reported back
+	case result := <-resultCh: // job channel reported back
 		if result != "done" {
 			err = fmt.Errorf("%s failed for %s, due %s", operation, unitName, result)
 		}

--- a/pkg/nodeagent/dbus/dbus.go
+++ b/pkg/nodeagent/dbus/dbus.go
@@ -20,6 +20,7 @@ import (
 	"reflect"
 
 	"github.com/coreos/go-systemd/v22/dbus"
+	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
@@ -41,11 +42,13 @@ type DBus interface {
 	Restart(ctx context.Context, recorder record.EventRecorder, node runtime.Object, unitName string) error
 }
 
-type db struct{}
+type db struct {
+	log logr.Logger
+}
 
 // New returns a new working DBus
-func New() DBus {
-	return &db{}
+func New(log logr.Logger) DBus {
+	return &db{log: log}
 }
 
 func (_ *db) Enable(ctx context.Context, unitNames ...string) error {

--- a/pkg/nodeagent/dbus/dbus.go
+++ b/pkg/nodeagent/dbus/dbus.go
@@ -138,7 +138,7 @@ func (d *db) runCommand(
 
 	select {
 	case <-ctx.Done(): // context is cancelled
-		return ctx.Err()
+		err = ctx.Err()
 
 	case result := <-resultCh: // job channel reported back
 		if result != "done" {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind enhancement

**What this PR does / why we need it**:

Sometimes, systemd commands take longer than this, and we don't want to wait forever (or until the context expires) because this just fails the entire reconciliation eventually.
Previously (with cloud-config-downloader), we were always executing the commands as "non-blocking" as well: https://github.com/gardener/gardener/blob/fc80be941edf1381b7c792b27883614c47580c45/pkg/component/extensions/operatingsystemconfig/executor/templates/scripts/execute-cloud-config.tpl.sh#L257

**Which issue(s) this PR fixes**:
Part of #8023

**Special notes for your reviewer**:
/cc @timuthy @majst01 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
`gardener-node-agent` now stops waiting for `systemd` command results if they don't respond back after `10s`.
```
