### PR TITLE
Fix Update PR generation for filter extension

### DIFF
--- a/hack/.ci/set_dependency_version
+++ b/hack/.ci/set_dependency_version
@@ -125,7 +125,7 @@ elif name == 'logging':
 elif name == 'etcd-custom-image':
     names = ['etcd']
 elif name == 'egress-filter-refresher':
-    names = ['egress-filter-blackholer', 'egress-filter-firewaller']
+    names = ['egress-filter']
 elif name == 'apiserver-proxy':
     names = ['apiserver-proxy-sidecar']
 else:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/area dev-productivity
/kind bug

**What this PR does / why we need it**:
Fix Update PR generation for filter extension.

With https://github.com/gardener/egress-filter-refresher/pull/12 the implementation of the core part of the filter extension was reworked so that it only needs one container image supporting different filter scenarios. This should be reflected in the `set_dependency_version` script so that automatic update pull requests work again.

**Which issue(s) this PR fixes**:
None.

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
