### PR TITLE
Read `ExposureClass` object for the handler name

### DIFF
--- a/pkg/operation/istio_config.go
+++ b/pkg/operation/istio_config.go
@@ -61,9 +61,9 @@ func (o *Operation) IstioLabels() map[string]string {
 }
 
 func (o *Operation) exposureClassHandler() *gardenletconfig.ExposureClassHandler {
-	if exposureClassName := o.Shoot.GetInfo().Spec.ExposureClassName; exposureClassName != nil {
+	if exposureClass := o.Shoot.ExposureClass; exposureClass != nil {
 		for _, handler := range o.Config.ExposureClassHandlers {
-			if *exposureClassName == handler.Name {
+			if exposureClass.Handler == handler.Name {
 				return &handler
 			}
 		}

--- a/pkg/operation/shoot/shoot.go
+++ b/pkg/operation/shoot/shoot.go
@@ -107,6 +107,12 @@ func (b *Builder) WithSeedObject(seed *gardencorev1beta1.Seed) *Builder {
 	return b
 }
 
+// WithExposureClassObject sets the exposureClass attribute at the Builder.
+func (b *Builder) WithExposureClassObject(exposureClass *gardencorev1beta1.ExposureClass) *Builder {
+	b.exposureClass = exposureClass
+	return b
+}
+
 // WithShootSecret sets the shootSecretFunc attribute at the Builder.
 func (b *Builder) WithShootSecret(secret *corev1.Secret) *Builder {
 	b.shootSecretFunc = func(context.Context, string, string) (*corev1.Secret, error) { return secret, nil }
@@ -164,6 +170,7 @@ func (b *Builder) Build(ctx context.Context, c client.Reader) (*Shoot, error) {
 		return nil, err
 	}
 	shoot.CloudProfile = cloudProfile
+	shoot.ExposureClass = b.exposureClass
 
 	if shootObject.Spec.SecretBindingName != nil {
 		secret, err := b.shootSecretFunc(ctx, shootObject.Namespace, *shootObject.Spec.SecretBindingName)

--- a/pkg/operation/shoot/types.go
+++ b/pkg/operation/shoot/types.go
@@ -67,6 +67,7 @@ type Builder struct {
 	cloudProfileFunc func(context.Context, string) (*gardencorev1beta1.CloudProfile, error)
 	shootSecretFunc  func(context.Context, string, string) (*corev1.Secret, error)
 	seed             *gardencorev1beta1.Seed
+	exposureClass    *gardencorev1beta1.ExposureClass
 	projectName      string
 	internalDomain   *gardenerutils.Domain
 	defaultDomains   []*gardenerutils.Domain
@@ -79,8 +80,9 @@ type Shoot struct {
 
 	shootState atomic.Value
 
-	Secret       *corev1.Secret
-	CloudProfile *gardencorev1beta1.CloudProfile
+	Secret        *corev1.Secret
+	CloudProfile  *gardencorev1beta1.CloudProfile
+	ExposureClass *gardencorev1beta1.ExposureClass
 
 	SeedNamespace     string
 	KubernetesVersion *semver.Version


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind bug

**What this PR does / why we need it**:
For detailed issue description, see https://github.com/gardener/gardener/issues/8794
The PR fixes this issue by fetching the exposureclass object using the `GardenClient` and reads it's handler name.

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener/issues/8794

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
A bug causing the Shoot to use the wrong istio load balancer if the `ExposureClass` name and the exposureclass handler name are not the same is now fixed. 
```
