### PR TITLE
Improved kube-state-metrics Configuration

### DIFF
--- a/pkg/component/shared/kube_state_metrics.go
+++ b/pkg/component/shared/kube_state_metrics.go
@@ -43,6 +43,6 @@ func NewKubeStateMetrics(
 		ClusterType:       component.ClusterTypeSeed,
 		Image:             image.String(),
 		PriorityClassName: priorityClassName,
-		Replicas:          1,
+		Replicas:          2,
 	}), nil
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/area monitoring
/area robustness
/kind enhancement

**What this PR does / why we need it**:
This PR improves the kube-state-metrics configuration to enhance its reliability for the cluster type `Seed`.

- A Pod Disruption Budget has been added with `MaxUnavailable` set to 1, and the replica count has been increased to 2. These changes aim to minimize periods of unavailability for Prometheus metric collection, such as when the VPA scales kube-state-metrics
- The `--metric-allowlist` flag has been set to limit the served metrics to those that are scraped by Prometheus to reduce unnecessary network traffic

The following metrics are not served anymore:
```
kube_deployment_annotations
kube_deployment_created
kube_deployment_labels
kube_deployment_spec_paused
kube_deployment_spec_strategy_rollingupdate_max_surge
kube_deployment_spec_strategy_rollingupdate_max_unavailable
kube_deployment_status_condition
kube_horizontalpodautoscaler_annotations
kube_horizontalpodautoscaler_info
kube_horizontalpodautoscaler_labels
kube_horizontalpodautoscaler_metadata_generation
kube_horizontalpodautoscaler_spec_target_metric
kube_horizontalpodautoscaler_status_target_metric
kube_namespace_created
kube_namespace_labels
kube_namespace_status_condition
kube_namespace_status_phase
kube_node_annotations
kube_node_created
kube_node_deletion_timestamp
kube_node_role
kube_persistentvolumeclaim_access_mode
kube_persistentvolumeclaim_annotations
kube_persistentvolumeclaim_created
kube_persistentvolumeclaim_info
kube_persistentvolumeclaim_labels
kube_persistentvolumeclaim_status_condition
kube_persistentvolumeclaim_status_phase
kube_pod_annotations
kube_pod_completion_time
kube_pod_container_state_started
kube_pod_container_status_last_terminated_exitcode
kube_pod_container_status_last_terminated_reason
kube_pod_container_status_ready
kube_pod_container_status_running
kube_pod_container_status_terminated
kube_pod_container_status_terminated_reason
kube_pod_container_status_waiting
kube_pod_container_status_waiting_reason
kube_pod_created
kube_pod_deletion_timestamp
kube_pod_init_container_info
kube_pod_init_container_resource_limits
kube_pod_init_container_resource_requests
kube_pod_init_container_status_last_terminated_reason
kube_pod_init_container_status_ready
kube_pod_init_container_status_restarts_total
kube_pod_init_container_status_running
kube_pod_init_container_status_terminated
kube_pod_init_container_status_terminated_reason
kube_pod_init_container_status_waiting
kube_pod_init_container_status_waiting_reason
kube_pod_ips
kube_pod_overhead_cpu_cores
kube_pod_overhead_memory_bytes
kube_pod_restart_policy
kube_pod_runtimeclass_name_info
kube_pod_spec_volumes_persistentvolumeclaims_readonly
kube_pod_start_time
kube_pod_status_container_ready_time
kube_pod_status_qos_class
kube_pod_status_reason
kube_pod_status_scheduled
kube_pod_status_scheduled_time
kube_pod_status_unschedulable
kube_pod_tolerations
kube_replicaset_annotations
kube_replicaset_created
kube_replicaset_labels
kube_replicaset_metadata_generation
kube_replicaset_spec_replicas
kube_replicaset_status_fully_labeled_replicas
kube_replicaset_status_observed_generation
kube_replicaset_status_ready_replicas
kube_replicaset_status_replicas
kube_statefulset_annotations
kube_statefulset_created
kube_statefulset_labels
kube_statefulset_persistentvolumeclaim_retention_policy
kube_statefulset_status_current_revision
kube_statefulset_status_update_revision
kube_verticalpodautoscaler_annotations
kube_verticalpodautoscaler_labels
kube_verticalpodautoscaler_status_recommendation_containerrecommendations_uncappedtarget
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The reliability of `kube-state-metrics` in the `garden` namespace of the `Seed` cluster has been improved to minimize periods of unavailability for Prometheus metric collection
```
