### PR TITLE
Update apiserver-proxy to v0.15.0 and remove flag `--setup-iptables`

### DIFF
--- a/imagevector/images.yaml
+++ b/imagevector/images.yaml
@@ -664,4 +664,4 @@ images:
     name: apiserver-proxy
   sourceRepository: github.com/gardener/apiserver-proxy
   repository: eu.gcr.io/gardener-project/gardener/apiserver-proxy
-  tag: "v0.14.0"
+  tag: "v0.15.0"

--- a/pkg/component/apiserverproxy/apiserver_proxy.go
+++ b/pkg/component/apiserverproxy/apiserver_proxy.go
@@ -261,7 +261,6 @@ func (a *apiserverProxy) computeResourcesData() (map[string][]byte, error) {
 								ImagePullPolicy: corev1.PullIfNotPresent,
 								Args: []string{
 									fmt.Sprintf("--ip-address=%s", a.values.advertiseIPAddress),
-									"--setup-iptables=false",
 									"--daemon=false",
 									"--interface=lo",
 								},
@@ -290,7 +289,6 @@ func (a *apiserverProxy) computeResourcesData() (map[string][]byte, error) {
 								ImagePullPolicy: corev1.PullIfNotPresent,
 								Args: []string{
 									fmt.Sprintf("--ip-address=%s", a.values.advertiseIPAddress),
-									"--setup-iptables=false",
 									"--interface=lo",
 								},
 								SecurityContext: &corev1.SecurityContext{

--- a/pkg/component/apiserverproxy/apiserver_proxy_test.go
+++ b/pkg/component/apiserverproxy/apiserver_proxy_test.go
@@ -639,7 +639,6 @@ spec:
       containers:
       - args:
         - --ip-address=` + advertiseIPAddress + `
-        - --setup-iptables=false
         - --interface=lo
         image: sidecar-image:some-tag
         imagePullPolicy: IfNotPresent
@@ -705,7 +704,6 @@ spec:
       initContainers:
       - args:
         - --ip-address=` + advertiseIPAddress + `
-        - --setup-iptables=false
         - --daemon=false
         - --interface=lo
         image: sidecar-image:some-tag


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy operator github.com/gardener/apiserver-proxy #70 @axel7born
Remove the optional creation of iptables rules and the flag`--setup-iptables`.
```
