### PR TITLE
tests: Drop no longer used repositories.yaml file

### DIFF
--- a/docs/development/testmachinery_tests.md
+++ b/docs/development/testmachinery_tests.md
@@ -27,14 +27,17 @@ The `test` directory is structured as follows:
 ```console
 test
 ├── e2e           # end-to-end tests (using provider-local)
-│  └── shoot
+│  ├── gardener
+│  │  ├── seed
+│  │  ├── shoot
+|  |  └── ...
+|  └──operator
 ├── framework     # helper code shared across integration, e2e and testmachinery tests
 ├── integration   # integration tests (envtests)
 │  ├── controllermanager
 │  ├── envtest
 │  ├── resourcemanager
 │  ├── scheduler
-│  ├── shootmaintenance
 │  └── ...
 └── testmachinery # test machinery tests
    ├── gardener   # actual test cases imported by suites/gardener
@@ -216,22 +219,14 @@ An example document for one test case would look like the following document:
 
 **Resources**
 
-The resources directory contains all the templates, helm config files (e.g., repositories.yaml, charts, and cache index which are downloaded upon the start of the test), shoot configs, etc.
+The resources directory contains templates used by the tests.
 
 ```console
 resources
-├── charts
-├── repository
-│   └── repositories.yaml
 └── templates
     ├── guestbook-app.yaml.tpl
     └── logger-app.yaml.tpl
 ```
-
-There are two special directories that are dynamically filled with the correct test files:
-
-- **charts** - the charts will be downloaded and saved in this directory
-- **repository** - contains the `repository.yaml` file that the target helm repos will be read from and the cache where the `stable-index.yaml` file will be created
 
 ### System Tests
 

--- a/test/framework/resources/repository/repositories.yaml
+++ b/test/framework/resources/repository/repositories.yaml
@@ -1,9 +1,0 @@
-apiVersion: v1
-repositories:
-  - caFile: ""
-    certFile: ""
-    keyFile: ""
-    name: stable
-    password: ""
-    url: https://storage.googleapis.com/gardener-public/integrationtests-charts
-    username: ""


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind cleanup

**What this PR does / why we need it**:
https://github.com/gardener/gardener/pull/8540/commits/48970c6aca3be95b5c725d9c71b43da3a266862c adapts the guestbook test to do not download the redis chart from `https://storage.googleapis.com/gardener-public/integrationtests-charts` but copies the redis chart locally under `test/framework/applications/charts/redis`.
Hence, the `test/framework/resources/repository/repositories.yaml` config is no longer used anywhere.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
