### PR TITLE
Add support for optional `REPO_ROOT` environment var in `vgopath` enabled hack scripts

### DIFF
--- a/hack/check-imports.sh
+++ b/hack/check-imports.sh
@@ -31,26 +31,8 @@ echo "> Check Imports"
 
 this_module=$(go list -m)
 
-SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
-VGOPATH="$VGOPATH"
-
-# Ensure that if GOPATH is set, the GOPATH/{bin,pkg} directory exists. This seems to be not always
-# the case in certain environments like Prow. As we will create a symlink against the bin folder we
-# need to make sure that the bin directory is present in the GOPATH.
-if [ -n "$GOPATH" ] && [ ! -d "$GOPATH/bin" ]; then mkdir -p "$GOPATH/bin"; fi
-if [ -n "$GOPATH" ] && [ ! -d "$GOPATH/pkg" ]; then mkdir -p "$GOPATH/pkg"; fi
-
-VIRTUAL_GOPATH="$(mktemp -d)"
-trap 'rm -rf "$VIRTUAL_GOPATH"' EXIT
-
-# Use REPO_ROOT if set, otherwise default to $SCRIPT_DIR/..
-TARGET_DIR="${REPO_ROOT:-$SCRIPT_DIR/..}"
-
-# Setup virtual GOPATH
-(cd "$TARGET_DIR"; go mod download && "$VGOPATH" -o "$VIRTUAL_GOPATH")
-
-export GOROOT="${GOROOT:-"$(go env GOROOT)"}"
-export GOPATH="$VIRTUAL_GOPATH"
+# setup virtual GOPATH
+source $(dirname $0)/vgopath-setup.sh
 
 # We need to explicitly pass GO111MODULE=off to import-boss as it is significantly slower otherwise,
 # see https://github.com/kubernetes/code-generator/issues/100.

--- a/hack/check-imports.sh
+++ b/hack/check-imports.sh
@@ -43,8 +43,11 @@ if [ -n "$GOPATH" ] && [ ! -d "$GOPATH/pkg" ]; then mkdir -p "$GOPATH/pkg"; fi
 VIRTUAL_GOPATH="$(mktemp -d)"
 trap 'rm -rf "$VIRTUAL_GOPATH"' EXIT
 
-# Setup virtual GOPATH so the codegen tools work as expected.
-(cd "$SCRIPT_DIR/.."; go mod download && "$VGOPATH" -o "$VIRTUAL_GOPATH")
+# Use REPO_ROOT if set, otherwise default to $SCRIPT_DIR/..
+TARGET_DIR="${REPO_ROOT:-$SCRIPT_DIR/..}"
+
+# Setup virtual GOPATH
+(cd "$TARGET_DIR"; go mod download && "$VGOPATH" -o "$VIRTUAL_GOPATH")
 
 export GOROOT="${GOROOT:-"$(go env GOROOT)"}"
 export GOPATH="$VIRTUAL_GOPATH"

--- a/hack/generate-crds.sh
+++ b/hack/generate-crds.sh
@@ -54,8 +54,11 @@ if [ -n "$GOPATH" ] && [ ! -d "$GOPATH/pkg" ]; then mkdir -p "$GOPATH/pkg"; fi
 VIRTUAL_GOPATH="$(mktemp -d)"
 trap 'rm -rf "$VIRTUAL_GOPATH"' EXIT
 
-# Setup virtual GOPATH so the codegen tools work as expected.
-(cd "$SCRIPT_DIR/.."; go mod download && "$VGOPATH" -o "$VIRTUAL_GOPATH")
+# Use REPO_ROOT if set, otherwise default to $SCRIPT_DIR/..
+TARGET_DIR="${REPO_ROOT:-$SCRIPT_DIR/..}"
+
+# Setup virtual GOPATH
+(cd "$TARGET_DIR"; go mod download && "$VGOPATH" -o "$VIRTUAL_GOPATH")
 
 export GOROOT="${GOROOT:-"$(go env GOROOT)"}"
 export GOPATH="$VIRTUAL_GOPATH"

--- a/hack/generate-crds.sh
+++ b/hack/generate-crds.sh
@@ -42,26 +42,9 @@ add_keep_object_annotation=false
 k8s_io_api_approval_reason="unapproved, temporarily squatting"
 crd_options=""
 
-SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
-VGOPATH="$VGOPATH"
+# setup virtual GOPATH
+source $(dirname $0)/vgopath-setup.sh
 
-# Ensure that if GOPATH is set, the GOPATH/{bin,pkg} directory exists. This seems to be not always
-# the case in certain environments like Prow. As we will create a symlink against the bin folder we
-# need to make sure that the bin directory is present in the GOPATH.
-if [ -n "$GOPATH" ] && [ ! -d "$GOPATH/bin" ]; then mkdir -p "$GOPATH/bin"; fi
-if [ -n "$GOPATH" ] && [ ! -d "$GOPATH/pkg" ]; then mkdir -p "$GOPATH/pkg"; fi
-
-VIRTUAL_GOPATH="$(mktemp -d)"
-trap 'rm -rf "$VIRTUAL_GOPATH"' EXIT
-
-# Use REPO_ROOT if set, otherwise default to $SCRIPT_DIR/..
-TARGET_DIR="${REPO_ROOT:-$SCRIPT_DIR/..}"
-
-# Setup virtual GOPATH
-(cd "$TARGET_DIR"; go mod download && "$VGOPATH" -o "$VIRTUAL_GOPATH")
-
-export GOROOT="${GOROOT:-"$(go env GOROOT)"}"
-export GOPATH="$VIRTUAL_GOPATH"
 export GO111MODULE=off
 
 get_group_package () {

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -54,8 +54,11 @@ if [ -n "$GOPATH" ] && [ ! -d "$GOPATH/pkg" ]; then mkdir -p "$GOPATH/pkg"; fi
 VIRTUAL_GOPATH="$(mktemp -d)"
 trap 'rm -rf "$VIRTUAL_GOPATH"' EXIT
 
-# Setup virtual GOPATH so the codegen tools work as expected.
-(cd "$SCRIPT_DIR/.."; go mod download && "$VGOPATH" -o "$VIRTUAL_GOPATH")
+# Use REPO_ROOT if set, otherwise default to $SCRIPT_DIR/..
+TARGET_DIR="${REPO_ROOT:-$SCRIPT_DIR/..}"
+
+# Setup virtual GOPATH
+(cd "$TARGET_DIR"; go mod download && "$VGOPATH" -o "$VIRTUAL_GOPATH")
 
 export GOROOT="${GOROOT:-"$(go env GOROOT)"}"
 export GOPATH="$VIRTUAL_GOPATH"

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -42,26 +42,8 @@ AVAILABLE_CODEGEN_OPTIONS=(
   "nodeagent_groups"
 )
 
-SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
-VGOPATH="$VGOPATH"
-
-# Ensure that if GOPATH is set, the GOPATH/{bin,pkg} directory exists. This seems to be not always
-# the case in certain environments like Prow. As we will create a symlink against the bin folder we
-# need to make sure that the bin directory is present in the GOPATH.
-if [ -n "$GOPATH" ] && [ ! -d "$GOPATH/bin" ]; then mkdir -p "$GOPATH/bin"; fi
-if [ -n "$GOPATH" ] && [ ! -d "$GOPATH/pkg" ]; then mkdir -p "$GOPATH/pkg"; fi
-
-VIRTUAL_GOPATH="$(mktemp -d)"
-trap 'rm -rf "$VIRTUAL_GOPATH"' EXIT
-
-# Use REPO_ROOT if set, otherwise default to $SCRIPT_DIR/..
-TARGET_DIR="${REPO_ROOT:-$SCRIPT_DIR/..}"
-
-# Setup virtual GOPATH
-(cd "$TARGET_DIR"; go mod download && "$VGOPATH" -o "$VIRTUAL_GOPATH")
-
-export GOROOT="${GOROOT:-"$(go env GOROOT)"}"
-export GOPATH="$VIRTUAL_GOPATH"
+# setup virtual GOPATH
+source $(dirname $0)/vgopath-setup.sh
 
 # We need to explicitly pass GO111MODULE=off to k8s.io/code-generator as it is significantly slower otherwise,
 # see https://github.com/kubernetes/code-generator/issues/100.

--- a/hack/update-protobuf.sh
+++ b/hack/update-protobuf.sh
@@ -30,8 +30,11 @@ if [ -n "$GOPATH" ] && [ ! -d "$GOPATH/pkg" ]; then mkdir -p "$GOPATH/pkg"; fi
 VIRTUAL_GOPATH="$(mktemp -d)"
 trap 'rm -rf "$VIRTUAL_GOPATH"' EXIT
 
-# Setup virtual GOPATH so the codegen tools work as expected.
-(cd "$SCRIPT_DIR/.."; go mod download && "$VGOPATH" -o "$VIRTUAL_GOPATH")
+# Use REPO_ROOT if set, otherwise default to $SCRIPT_DIR/..
+TARGET_DIR="${REPO_ROOT:-$SCRIPT_DIR/..}"
+
+# Setup virtual GOPATH
+(cd "$TARGET_DIR"; go mod download && "$VGOPATH" -o "$VIRTUAL_GOPATH")
 
 export GOROOT="${GOROOT:-"$(go env GOROOT)"}"
 export GOPATH="$VIRTUAL_GOPATH"

--- a/hack/update-protobuf.sh
+++ b/hack/update-protobuf.sh
@@ -18,26 +18,8 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
-VGOPATH="$VGOPATH"
-
-# Ensure that if GOPATH is set, the GOPATH/{bin,pkg} directory exists. This seems to be not always
-# the case in certain environments like Prow. As we will create a symlink against the bin folder we
-# need to make sure that the bin directory is present in the GOPATH.
-if [ -n "$GOPATH" ] && [ ! -d "$GOPATH/bin" ]; then mkdir -p "$GOPATH/bin"; fi
-if [ -n "$GOPATH" ] && [ ! -d "$GOPATH/pkg" ]; then mkdir -p "$GOPATH/pkg"; fi
-
-VIRTUAL_GOPATH="$(mktemp -d)"
-trap 'rm -rf "$VIRTUAL_GOPATH"' EXIT
-
-# Use REPO_ROOT if set, otherwise default to $SCRIPT_DIR/..
-TARGET_DIR="${REPO_ROOT:-$SCRIPT_DIR/..}"
-
-# Setup virtual GOPATH
-(cd "$TARGET_DIR"; go mod download && "$VGOPATH" -o "$VIRTUAL_GOPATH")
-
-export GOROOT="${GOROOT:-"$(go env GOROOT)"}"
-export GOPATH="$VIRTUAL_GOPATH"
+# setup virtual GOPATH
+source $(dirname $0)/vgopath-setup.sh
 
 # We need to explicitly pass GO111MODULE=off to k8s.io/code-generator as it is significantly slower otherwise,
 # see https://github.com/kubernetes/code-generator/issues/100.

--- a/hack/vgopath-setup.sh
+++ b/hack/vgopath-setup.sh
@@ -1,3 +1,17 @@
+# Copyright 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 
 # Ensure that if GOPATH is set, the GOPATH/{bin,pkg} directory exists. This seems to be not always

--- a/hack/vgopath-setup.sh
+++ b/hack/vgopath-setup.sh
@@ -1,0 +1,19 @@
+SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+
+# Ensure that if GOPATH is set, the GOPATH/{bin,pkg} directory exists. This seems to be not always
+# the case in certain environments like Prow. As we will create a symlink against the bin folder we
+# need to make sure that the bin directory is present in the GOPATH.
+if [ -n "$GOPATH" ] && [ ! -d "$GOPATH/bin" ]; then mkdir -p "$GOPATH/bin"; fi
+if [ -n "$GOPATH" ] && [ ! -d "$GOPATH/pkg" ]; then mkdir -p "$GOPATH/pkg"; fi
+
+VIRTUAL_GOPATH="$(mktemp -d)"
+trap 'rm -rf "$VIRTUAL_GOPATH"' EXIT
+
+# Use REPO_ROOT if set, otherwise default to $SCRIPT_DIR/..
+TARGET_DIR="${REPO_ROOT:-$SCRIPT_DIR/..}"
+
+# Setup virtual GOPATH
+(cd "$TARGET_DIR"; go mod download && "$VGOPATH" -o "$VIRTUAL_GOPATH")
+
+export GOROOT="${GOROOT:-"$(go env GOROOT)"}"
+export GOPATH="$VIRTUAL_GOPATH"


### PR DESCRIPTION
**How to categorize this PR?**
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
The current virtual gopath enabled generation scripts are making the assumption that they are located inside the `hack` folder of your project. In a vendored setup or where those hack scripts are fetched dynamically into a different location this assumption might not be true anymore and leads to a wrong behaviour in the `vgopath` setup.

This commit introduces the ability to use an optional environment variable, `REPO_ROOT`, in the `vgopath` enabled generation scripts script. When `REPO_ROOT` is set, the script will use this directory instead of the default `$SCRIPT_DIR/..` for setting up the virtual go environment. This enhancement provides flexibility for different runtime environments where the script's working directory might need to be dynamically specified.

Extensions which are dynamically fetching those scripts can run them using the following setup in their `Makefile`:
```
generate-foo:
	@REPO_ROOT=$(CURDIR) /path/to/your/hack/script.sh
```

Additionally the `vgopath` setup has been source out into a sourcable script `vgopath-setup.sh`. This change reduces the duplication of `vgopath` setup code.

/cc @kon-angelo 

**Release note**:
```other developer
Add support for optional `SCRIPT_ROOT` environment var in `vgopath` enabled hack scripts
```
