### PR TITLE
Revert "Restrict GRM's token requestor to secrets with `class=shoot`"

### DIFF
--- a/pkg/gardenlet/controller/shoot/shoot/cleaner.go
+++ b/pkg/gardenlet/controller/shoot/shoot/cleaner.go
@@ -184,6 +184,11 @@ func (c *cleaner) finalizeShootManagedResources(ctx context.Context, namespace s
 
 	shootMRList := &resourcesv1alpha1.ManagedResourceList{}
 	for _, mr := range mrList.Items {
+		// TODO(rfranzke): Uncomment the next line after v1.90 has been released
+		// and after handling access Secrets without any class in the runtime cluster.
+		// if pointer.StringDeref(mr.Spec.Class, "") != resourcesv1alpha1.ResourceManagerClassShoot {
+		// 	continue
+		// }
 		if mr.Spec.Class != nil {
 			continue
 		}

--- a/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
@@ -28,7 +28,6 @@ import (
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
-	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap/keys"
 	"github.com/gardener/gardener/pkg/component/kubeapiserver"
 	"github.com/gardener/gardener/pkg/controllerutils"
@@ -326,7 +325,10 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 			Fn: flow.TaskFn(func(ctx context.Context) error {
 				return tokenrequest.RenewAccessSecrets(ctx, o.SeedClientSet.Client(),
 					client.InNamespace(o.Shoot.SeedNamespace),
-					client.MatchingLabels{resourcesv1alpha1.ResourceManagerClass: resourcesv1alpha1.ResourceManagerClassShoot},
+					// TODO(rfranzke): Uncomment the next line after v1.90 has been released
+					//  (together with restricting the garden's/shoot's tokenrequestor to the shoot class)
+					// and after handling access Secrets without any class in the runtime cluster.
+					// client.MatchingLabels{resourcesv1alpha1.ResourceManagerClass: resourcesv1alpha1.ResourceManagerClassShoot},
 				)
 			}).RetryUntilTimeout(defaultInterval, defaultTimeout),
 			SkipIf:       v1beta1helper.GetShootServiceAccountKeyRotationPhase(o.Shoot.GetInfo().Status.Credentials) != gardencorev1beta1.RotationPreparing,

--- a/pkg/operator/controller/garden/garden/reconciler_reconcile.go
+++ b/pkg/operator/controller/garden/garden/reconciler_reconcile.go
@@ -313,7 +313,10 @@ func (r *Reconciler) reconcile(
 			Fn: flow.TaskFn(func(ctx context.Context) error {
 				return tokenrequest.RenewAccessSecrets(ctx, r.RuntimeClientSet.Client(),
 					client.InNamespace(r.GardenNamespace),
-					client.MatchingLabels{resourcesv1alpha1.ResourceManagerClass: resourcesv1alpha1.ResourceManagerClassShoot},
+					// TODO(rfranzke): Uncomment the next line after v1.90 has been released
+					//  (together with restricting the garden's/shoot's tokenrequestor to the shoot class)
+					// and after handling access Secrets without any class in the runtime cluster.
+					// client.MatchingLabels{resourcesv1alpha1.ResourceManagerClass: resourcesv1alpha1.ResourceManagerClassShoot},
 				)
 			}).RetryUntilTimeout(5*time.Second, 30*time.Second),
 			SkipIf:       helper.GetServiceAccountKeyRotationPhase(garden.Status.Credentials) != gardencorev1beta1.RotationPreparing,

--- a/pkg/resourcemanager/controller/add.go
+++ b/pkg/resourcemanager/controller/add.go
@@ -27,7 +27,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
-	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	"github.com/gardener/gardener/pkg/controller/tokenrequestor"
 	"github.com/gardener/gardener/pkg/resourcemanager/apis/config"
 	"github.com/gardener/gardener/pkg/resourcemanager/controller/csrapprover"
@@ -119,7 +118,9 @@ func AddToManager(ctx context.Context, mgr manager.Manager, sourceCluster, targe
 			Clock:           clock.RealClock{},
 			JitterFunc:      wait.Jitter,
 			APIAudiences:    []string{v1beta1constants.GardenerAudience},
-			Class:           pointer.String(resourcesv1alpha1.ResourceManagerClassShoot),
+			// TODO(rfranzke): Uncomment the next line after v1.90 has been released
+			// and after handling access Secrets without any class in the runtime cluster.
+			// Class: pointer.String(resourcesv1alpha1.ResourceManagerClassShoot),
 		}).AddToManager(mgr, sourceCluster, targetCluster); err != nil {
 			return fmt.Errorf("failed adding token requestor controller: %w", err)
 		}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind bug

**What this PR does / why we need it**:
This PR reverts https://github.com/gardener/gardener/pull/8883/commits/ae83aa332ed4855437f74ed834e4a53c0699a695.
In the garden runtime cluster we have access Secrets for gardener-dashboard, terminal-controller-manager and others. These Secrets cannot no longer be renewed because they don't have any class set. https://github.com/gardener/gardener/pull/8883/commits/ae83aa332ed4855437f74ed834e4a53c0699a695 requires every access Secret to have `class=shoot`.

**Which issue(s) this PR fixes**:
See above.

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
