### PR TITLE
Bump gardener-metrics-exporter version to v0.28.0

### DIFF
--- a/imagevector/images.yaml
+++ b/imagevector/images.yaml
@@ -214,7 +214,7 @@ images:
 - name: gardener-metrics-exporter
   sourceRepository: github.com/gardener/gardener-metrics-exporter
   repository: eu.gcr.io/gardener-project/gardener/metrics-exporter
-  tag: "0.27.0"
+  tag: "0.28.0"
   resourceId:
     name: metrics-exporter
 - name: node-exporter


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind enhancement

**What this PR does / why we need it**:
Updates gardener-metrics-exporter to v0.28.0

**Which issue(s) this PR fixes**:
Fixes an issue where the minimum and maximum shoot node count metrics were reversed.
Enables metrics for pending shoots.

**Special notes for your reviewer**:
/cc @istvanballok

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Bump gardener-metrics-exporter to v0.28.0
```
