### PR TITLE
Fix CPM for hibernated Shoots

### DIFF
--- a/extensions/pkg/controller/worker/genericactuator/actuator_restore.go
+++ b/extensions/pkg/controller/worker/genericactuator/actuator_restore.go
@@ -143,6 +143,11 @@ func addStateToMachineDeployment(
 		state = worker.Status.State.Raw
 	}
 
+	if len(state) == 0 {
+		log.Info("Machine state is empty, no state to add")
+		return nil
+	}
+
 	// Parse the worker state to MachineDeploymentStates
 	machineState := &shootstate.MachineState{MachineDeployments: make(map[string]*shootstate.MachineDeploymentState)}
 	if err := json.Unmarshal(state, &machineState); err != nil {

--- a/extensions/pkg/controller/worker/genericactuator/actuator_restore_test.go
+++ b/extensions/pkg/controller/worker/genericactuator/actuator_restore_test.go
@@ -102,6 +102,24 @@ var _ = Describe("ActuatorRestore", func() {
 			Expect(wantedMachineDeployments[2].State).To(BeNil())
 		})
 
+		It("should do nothing because machine state data in ShootState is null", func() {
+			patch := client.MergeFrom(shootState.DeepCopy())
+			shootState.Spec = gardencorev1beta1.ShootStateSpec{
+				Gardener: []gardencorev1beta1.GardenerResourceData{{
+					Name: "machine-state",
+					Type: "machine-state",
+					Data: runtime.RawExtension{Raw: []byte("null")},
+				}},
+			}
+			Expect(fakeGardenClient.Patch(ctx, shootState, patch)).To(Succeed())
+
+			Expect(addStateToMachineDeployment(ctx, log, fakeGardenClient, shoot, worker, wantedMachineDeployments)).To(Succeed())
+
+			Expect(wantedMachineDeployments[0].State).To(BeNil())
+			Expect(wantedMachineDeployments[1].State).To(BeNil())
+			Expect(wantedMachineDeployments[2].State).To(BeNil())
+		})
+
 		It("should fetch the machine state from the ShootState", func() {
 			patch := client.MergeFrom(shootState.DeepCopy())
 			shootState.Spec = gardencorev1beta1.ShootStateSpec{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane-migration
/kind regression

**What this PR does / why we need it**:
https://github.com/gardener/gardener/pull/8559 introduces the following issue.
1. machine-state in the ShootState for hibernated Shoots is stored as follows:
```yaml
spec:
  gardener:
  # ...
  - data: null
    name: machine-state
    type: machine-state
```
2. The above machine-state causes the `addStateToMachineDeployment` to fail with `unexpected end of JSON input`.


In https://github.com/gardener/gardener/blob/c39c665948d6c12d150fefa8d5f429a4a1d6e8a9/extensions/pkg/controller/worker/genericactuator/actuator_restore.go#L153-L155 the state `var` is nil because of https://github.com/gardener/gardener/blob/c39c665948d6c12d150fefa8d5f429a4a1d6e8a9/extensions/pkg/controller/worker/genericactuator/actuator_restore.go#L131 and https://github.com/gardener/gardener/blob/694b88c048001eee0572f310001b8ebf82a0436d/pkg/utils/gardener/shootstate/machines.go#L205-L207.

**Which issue(s) this PR fixes**:
See above.

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix dependency
extension library: An issue causing the Worker restore operation to fail for hibernated Shoots is now fixed.
```
