### PR TITLE
Add e2e test for cpm of hibernated shoot

### DIFF
--- a/docs/deployment/content/remote-local-setup.yaml
+++ b/docs/deployment/content/remote-local-setup.yaml
@@ -33,7 +33,7 @@ spec:
           echo kubectl           && curl -sL  "https://dl.k8s.io/release/$(curl -sL https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" -o /usr/local/bin/kubectl && chmod +x /usr/local/bin/kubectl
           echo tmux-completion   && curl -sL  "https://raw.githubusercontent.com/imomaliev/tmux-bash-completion/master/completions/tmux" -o /usr/share/bash-completion/completions/tmux
           echo docker-completion && curl -sL  "https://raw.githubusercontent.com/docker/docker-ce/master/components/cli/contrib/completion/bash/docker" -o /usr/share/bash-completion/completions/docker
-          bash -c "echo api.{e2e-managedseed.garden,{local,e2e-{managedseed,hib,hib-wl,unpriv,wake-up,wake-up-wl,migrate,migrate-wl,rotate,rotate-wl,default,default-wl,upd-node,upd-node-wl,upgrade,upgrade-wl,upg-hib,upg-hib-wl}}.local}.{internal,external}.local.gardener.cloud \
+          bash -c "echo api.{e2e-managedseed.garden,{local,e2e-{managedseed,hib,hib-wl,unpriv,wake-up,wake-up-wl,migrate,migrate-wl,mgr-hib,rotate,rotate-wl,default,default-wl,upd-node,upd-node-wl,upgrade,upgrade-wl,upg-hib,upg-hib-wl}}.local}.{internal,external}.local.gardener.cloud \
                    | sed 's/ /\n/g' | sed 's/^/127.0.0.1 /' | sort >> /etc/hosts"
           echo 'source ~/.bashrc' > ~/.bash_profile
           cat > ~/.bashrc <<"EOF"

--- a/docs/deployment/getting_started_locally.md
+++ b/docs/deployment/getting_started_locally.md
@@ -226,6 +226,8 @@ cat <<EOF | sudo tee -a /etc/hosts
 127.0.0.1 api.e2e-migrate.local.internal.local.gardener.cloud
 127.0.0.1 api.e2e-migrate-wl.local.external.local.gardener.cloud
 127.0.0.1 api.e2e-migrate-wl.local.internal.local.gardener.cloud
+127.0.0.1 api.e2e-mgr-hib.local.external.local.gardener.cloud
+127.0.0.1 api.e2e-mgr-hib.local.internal.local.gardener.cloud
 127.0.0.1 api.e2e-rotate.local.external.local.gardener.cloud
 127.0.0.1 api.e2e-rotate.local.internal.local.gardener.cloud
 127.0.0.1 api.e2e-rotate-wl.local.external.local.gardener.cloud

--- a/hack/test-e2e-local.sh
+++ b/hack/test-e2e-local.sh
@@ -52,6 +52,7 @@ if [[ "$1" != "operator" ]]; then
     e2e-wake-up-wl.local
     e2e-migrate.local
     e2e-migrate-wl.local
+    e2e-mgr-hib.local
     e2e-rotate.local
     e2e-rotate-wl.local
     e2e-default.local

--- a/test/e2e/gardener/shoot/create_migrate_delete.go
+++ b/test/e2e/gardener/shoot/create_migrate_delete.go
@@ -65,6 +65,14 @@ var _ = Describe("Shoot Tests", Label("Shoot", "control-plane-migration"), func(
 	Context("Workerless Shoot", Label("workerless"), func() {
 		test(e2e.DefaultWorkerlessShoot("e2e-migrate"))
 	})
+
+	Context("Hibernated Shoot", Label("hibernated"), func() {
+		shoot := e2e.DefaultShoot("e2e-mgr-hib")
+		shoot.Spec.Hibernation = &gardencorev1beta1.Hibernation{
+			Enabled: pointer.Bool(true),
+		}
+		test(shoot)
+	})
 })
 
 func newDefaultShootMigrationTest(ctx context.Context, shoot *gardencorev1beta1.Shoot, gardenerFramework *GardenerFramework) (*ShootMigrationTest, error) {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane-migration
/kind test

**What this PR does / why we need it**:
This PR adds an e2e test for performing control plane migration of hibernated shoots. With this we should avoid future regressions as the one fixed in #8943 

/cc @ialidzhikov 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
