### PR TITLE
[ResourceManager] Clean up technical debt in defaulting code

### DIFF
--- a/pkg/resourcemanager/apis/config/v1alpha1/defaults.go
+++ b/pkg/resourcemanager/apis/config/v1alpha1/defaults.go
@@ -27,6 +27,9 @@ import (
 
 // SetDefaults_ResourceManagerConfiguration sets defaults for the configuration of the ResourceManagerConfiguration.
 func SetDefaults_ResourceManagerConfiguration(obj *ResourceManagerConfiguration) {
+	if obj.TargetClientConnection == nil {
+		obj.TargetClientConnection = &ClientConnection{}
+	}
 	if len(obj.LogLevel) == 0 {
 		obj.LogLevel = "info"
 	}
@@ -37,8 +40,6 @@ func SetDefaults_ResourceManagerConfiguration(obj *ResourceManagerConfiguration)
 
 // SetDefaults_ClientConnection sets defaults for the client connection.
 func SetDefaults_ClientConnection(obj *ClientConnection) {
-	SetDefaults_ClientConnectionConfiguration(&obj.ClientConnectionConfiguration)
-
 	if obj.CacheResyncPeriod == nil {
 		obj.CacheResyncPeriod = &metav1.Duration{Duration: 24 * time.Hour}
 	}

--- a/pkg/resourcemanager/apis/config/v1alpha1/defaults.go
+++ b/pkg/resourcemanager/apis/config/v1alpha1/defaults.go
@@ -19,16 +19,11 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	componentbaseconfigv1alpha1 "k8s.io/component-base/config/v1alpha1"
 	"k8s.io/utils/pointer"
 
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 )
-
-func addDefaultingFuncs(scheme *runtime.Scheme) error {
-	return RegisterDefaults(scheme)
-}
 
 // SetDefaults_ResourceManagerConfiguration sets defaults for the configuration of the ResourceManagerConfiguration.
 func SetDefaults_ResourceManagerConfiguration(obj *ResourceManagerConfiguration) {

--- a/pkg/resourcemanager/apis/config/v1alpha1/defaults_test.go
+++ b/pkg/resourcemanager/apis/config/v1alpha1/defaults_test.go
@@ -55,10 +55,37 @@ var _ = Describe("ResourceManager defaulting", func() {
 		})
 	})
 
-	Describe("ClientConnection defaulting", func() {
+	Describe("SourceClientConnection defaulting", func() {
 		It("should default the ClientConnection", func() {
-			obj.TargetClientConnection = &ClientConnection{}
+			SetObjectDefaults_ResourceManagerConfiguration(obj)
 
+			Expect(obj.SourceClientConnection.Namespaces).To(BeEmpty())
+			Expect(obj.SourceClientConnection.CacheResyncPeriod).To(PointTo(Equal(metav1.Duration{Duration: 24 * time.Hour})))
+			Expect(obj.SourceClientConnection.QPS).To(Equal(float32(100.0)))
+			Expect(obj.SourceClientConnection.Burst).To(Equal(int32(130)))
+		})
+
+		It("should not overwrite already set values for ClientConnection", func() {
+			obj.SourceClientConnection = ClientConnection{
+				ClientConnectionConfiguration: componentbaseconfigv1alpha1.ClientConnectionConfiguration{
+					QPS:   float32(1.2),
+					Burst: int32(34),
+				},
+				Namespaces:        []string{"foo"},
+				CacheResyncPeriod: &metav1.Duration{Duration: time.Hour},
+			}
+
+			SetObjectDefaults_ResourceManagerConfiguration(obj)
+
+			Expect(obj.SourceClientConnection.Namespaces).To(ConsistOf("foo"))
+			Expect(obj.SourceClientConnection.CacheResyncPeriod).To(PointTo(Equal(metav1.Duration{Duration: time.Hour})))
+			Expect(obj.SourceClientConnection.QPS).To(Equal(float32(1.2)))
+			Expect(obj.SourceClientConnection.Burst).To(Equal(int32(34)))
+		})
+	})
+
+	Describe("TargetClientConnection defaulting", func() {
+		It("should default the ClientConnection", func() {
 			SetObjectDefaults_ResourceManagerConfiguration(obj)
 
 			Expect(obj.TargetClientConnection.Namespaces).To(BeEmpty())

--- a/pkg/resourcemanager/apis/config/v1alpha1/defaults_test.go
+++ b/pkg/resourcemanager/apis/config/v1alpha1/defaults_test.go
@@ -27,24 +27,28 @@ import (
 	. "github.com/gardener/gardener/pkg/resourcemanager/apis/config/v1alpha1"
 )
 
-var _ = Describe("Defaults", func() {
+var _ = Describe("ResourceManager defaulting", func() {
+	var obj *ResourceManagerConfiguration
+
+	BeforeEach(func() {
+		obj = &ResourceManagerConfiguration{}
+	})
+
 	Describe("#SetDefaults_ResourceManagerConfiguration", func() {
 		It("should default the object", func() {
-			obj := &ResourceManagerConfiguration{}
-
-			SetDefaults_ResourceManagerConfiguration(obj)
+			SetObjectDefaults_ResourceManagerConfiguration(obj)
 
 			Expect(obj.LogLevel).To(Equal("info"))
 			Expect(obj.LogFormat).To(Equal("json"))
 		})
 
 		It("should not overwrite existing values", func() {
-			obj := &ResourceManagerConfiguration{
+			obj = &ResourceManagerConfiguration{
 				LogLevel:  "foo",
 				LogFormat: "bar",
 			}
 
-			SetDefaults_ResourceManagerConfiguration(obj)
+			SetObjectDefaults_ResourceManagerConfiguration(obj)
 
 			Expect(obj.LogLevel).To(Equal("foo"))
 			Expect(obj.LogFormat).To(Equal("bar"))
@@ -53,18 +57,18 @@ var _ = Describe("Defaults", func() {
 
 	Describe("#SetDefaults_ClientConnection", func() {
 		It("should default the object", func() {
-			obj := &ClientConnection{}
+			obj.TargetClientConnection = &ClientConnection{}
 
-			SetDefaults_ClientConnection(obj)
+			SetObjectDefaults_ResourceManagerConfiguration(obj)
 
-			Expect(obj.Namespaces).To(BeEmpty())
-			Expect(obj.CacheResyncPeriod).To(PointTo(Equal(metav1.Duration{Duration: 24 * time.Hour})))
-			Expect(obj.QPS).To(Equal(float32(100.0)))
-			Expect(obj.Burst).To(Equal(int32(130)))
+			Expect(obj.TargetClientConnection.Namespaces).To(BeEmpty())
+			Expect(obj.TargetClientConnection.CacheResyncPeriod).To(PointTo(Equal(metav1.Duration{Duration: 24 * time.Hour})))
+			Expect(obj.TargetClientConnection.QPS).To(Equal(float32(100.0)))
+			Expect(obj.TargetClientConnection.Burst).To(Equal(int32(130)))
 		})
 
 		It("should not overwrite existing values", func() {
-			obj := &ClientConnection{
+			obj.TargetClientConnection = &ClientConnection{
 				ClientConnectionConfiguration: componentbaseconfigv1alpha1.ClientConnectionConfiguration{
 					QPS:   float32(1.2),
 					Burst: int32(34),
@@ -73,32 +77,32 @@ var _ = Describe("Defaults", func() {
 				CacheResyncPeriod: &metav1.Duration{Duration: time.Hour},
 			}
 
-			SetDefaults_ClientConnection(obj)
+			SetObjectDefaults_ResourceManagerConfiguration(obj)
 
-			Expect(obj.Namespaces).To(ConsistOf("foo"))
-			Expect(obj.CacheResyncPeriod).To(PointTo(Equal(metav1.Duration{Duration: time.Hour})))
-			Expect(obj.QPS).To(Equal(float32(1.2)))
-			Expect(obj.Burst).To(Equal(int32(34)))
+			Expect(obj.TargetClientConnection.Namespaces).To(ConsistOf("foo"))
+			Expect(obj.TargetClientConnection.CacheResyncPeriod).To(PointTo(Equal(metav1.Duration{Duration: time.Hour})))
+			Expect(obj.TargetClientConnection.QPS).To(Equal(float32(1.2)))
+			Expect(obj.TargetClientConnection.Burst).To(Equal(int32(34)))
 		})
 	})
 
 	Describe("#SetDefaults_LeaderElectionConfiguration", func() {
 		It("should default the object", func() {
-			obj := &componentbaseconfigv1alpha1.LeaderElectionConfiguration{}
+			obj.LeaderElection = componentbaseconfigv1alpha1.LeaderElectionConfiguration{}
 
-			SetDefaults_LeaderElectionConfiguration(obj)
+			SetObjectDefaults_ResourceManagerConfiguration(obj)
 
-			Expect(obj.ResourceLock).To(Equal("leases"))
-			Expect(obj.ResourceName).To(Equal("gardener-resource-manager"))
-			Expect(obj.ResourceNamespace).To(BeEmpty())
-			Expect(obj.LeaseDuration).To(Equal(metav1.Duration{Duration: 15 * time.Second}))
-			Expect(obj.RenewDeadline).To(Equal(metav1.Duration{Duration: 10 * time.Second}))
-			Expect(obj.RetryPeriod).To(Equal(metav1.Duration{Duration: 2 * time.Second}))
-			Expect(obj.LeaderElect).To(PointTo(BeTrue()))
+			Expect(obj.LeaderElection.ResourceLock).To(Equal("leases"))
+			Expect(obj.LeaderElection.ResourceName).To(Equal("gardener-resource-manager"))
+			Expect(obj.LeaderElection.ResourceNamespace).To(BeEmpty())
+			Expect(obj.LeaderElection.LeaseDuration).To(Equal(metav1.Duration{Duration: 15 * time.Second}))
+			Expect(obj.LeaderElection.RenewDeadline).To(Equal(metav1.Duration{Duration: 10 * time.Second}))
+			Expect(obj.LeaderElection.RetryPeriod).To(Equal(metav1.Duration{Duration: 2 * time.Second}))
+			Expect(obj.LeaderElection.LeaderElect).To(PointTo(BeTrue()))
 		})
 
 		It("should not overwrite existing values", func() {
-			obj := &componentbaseconfigv1alpha1.LeaderElectionConfiguration{
+			obj.LeaderElection = componentbaseconfigv1alpha1.LeaderElectionConfiguration{
 				ResourceLock:      "foo",
 				ResourceName:      "bar",
 				ResourceNamespace: "baz",
@@ -108,32 +112,32 @@ var _ = Describe("Defaults", func() {
 				LeaderElect:       pointer.Bool(false),
 			}
 
-			SetDefaults_LeaderElectionConfiguration(obj)
+			SetObjectDefaults_ResourceManagerConfiguration(obj)
 
-			Expect(obj.ResourceLock).To(Equal("foo"))
-			Expect(obj.ResourceName).To(Equal("bar"))
-			Expect(obj.ResourceNamespace).To(Equal("baz"))
-			Expect(obj.LeaseDuration).To(Equal(metav1.Duration{Duration: 1 * time.Second}))
-			Expect(obj.RenewDeadline).To(Equal(metav1.Duration{Duration: 2 * time.Second}))
-			Expect(obj.RetryPeriod).To(Equal(metav1.Duration{Duration: 3 * time.Second}))
-			Expect(obj.LeaderElect).To(PointTo(BeFalse()))
+			Expect(obj.LeaderElection.ResourceLock).To(Equal("foo"))
+			Expect(obj.LeaderElection.ResourceName).To(Equal("bar"))
+			Expect(obj.LeaderElection.ResourceNamespace).To(Equal("baz"))
+			Expect(obj.LeaderElection.LeaseDuration).To(Equal(metav1.Duration{Duration: 1 * time.Second}))
+			Expect(obj.LeaderElection.RenewDeadline).To(Equal(metav1.Duration{Duration: 2 * time.Second}))
+			Expect(obj.LeaderElection.RetryPeriod).To(Equal(metav1.Duration{Duration: 3 * time.Second}))
+			Expect(obj.LeaderElection.LeaderElect).To(PointTo(BeFalse()))
 		})
 	})
 
 	Describe("#SetDefaults_ServerConfiguration", func() {
 		It("should default the object", func() {
-			obj := &ServerConfiguration{}
+			obj.Server = ServerConfiguration{}
 
-			SetDefaults_ServerConfiguration(obj)
+			SetObjectDefaults_ResourceManagerConfiguration(obj)
 
-			Expect(obj.Webhooks.BindAddress).To(BeEmpty())
-			Expect(obj.Webhooks.Port).To(Equal(9449))
-			Expect(obj.HealthProbes.Port).To(Equal(8081))
-			Expect(obj.Metrics.Port).To(Equal(8080))
+			Expect(obj.Server.Webhooks.BindAddress).To(BeEmpty())
+			Expect(obj.Server.Webhooks.Port).To(Equal(9449))
+			Expect(obj.Server.HealthProbes.Port).To(Equal(8081))
+			Expect(obj.Server.Metrics.Port).To(Equal(8080))
 		})
 
 		It("should not overwrite existing values", func() {
-			obj := &ServerConfiguration{
+			obj.Server = ServerConfiguration{
 				Webhooks: HTTPSServer{
 					Server: Server{
 						BindAddress: "foo",
@@ -148,358 +152,358 @@ var _ = Describe("Defaults", func() {
 				},
 			}
 
-			SetDefaults_ServerConfiguration(obj)
+			SetObjectDefaults_ResourceManagerConfiguration(obj)
 
-			Expect(obj.Webhooks.BindAddress).To(Equal("foo"))
-			Expect(obj.Webhooks.Port).To(Equal(1))
-			Expect(obj.HealthProbes.Port).To(Equal(2))
-			Expect(obj.Metrics.Port).To(Equal(3))
+			Expect(obj.Server.Webhooks.BindAddress).To(Equal("foo"))
+			Expect(obj.Server.Webhooks.Port).To(Equal(1))
+			Expect(obj.Server.HealthProbes.Port).To(Equal(2))
+			Expect(obj.Server.Metrics.Port).To(Equal(3))
 		})
 	})
 
 	Describe("#SetDefaults_ResourceManagerControllerConfiguration", func() {
 		It("should default the object", func() {
-			obj := &ResourceManagerControllerConfiguration{}
+			obj.Controllers = ResourceManagerControllerConfiguration{}
 
-			SetDefaults_ResourceManagerControllerConfiguration(obj)
+			SetObjectDefaults_ResourceManagerConfiguration(obj)
 
-			Expect(obj.ClusterID).To(PointTo(Equal("")))
-			Expect(obj.ResourceClass).To(PointTo(Equal("resources")))
+			Expect(obj.Controllers.ClusterID).To(PointTo(Equal("")))
+			Expect(obj.Controllers.ResourceClass).To(PointTo(Equal("resources")))
 		})
 
 		It("should not overwrite existing values", func() {
-			obj := &ResourceManagerControllerConfiguration{
+			obj.Controllers = ResourceManagerControllerConfiguration{
 				ClusterID:     pointer.String("foo"),
 				ResourceClass: pointer.String("bar"),
 			}
 
-			SetDefaults_ResourceManagerControllerConfiguration(obj)
+			SetObjectDefaults_ResourceManagerConfiguration(obj)
 
-			Expect(obj.ClusterID).To(PointTo(Equal("foo")))
-			Expect(obj.ResourceClass).To(PointTo(Equal("bar")))
+			Expect(obj.Controllers.ClusterID).To(PointTo(Equal("foo")))
+			Expect(obj.Controllers.ResourceClass).To(PointTo(Equal("bar")))
 		})
 	})
 
 	Describe("#SetDefaults_KubeletCSRApproverControllerConfig", func() {
 		It("should not default the object because disabled", func() {
-			obj := &KubeletCSRApproverControllerConfig{}
+			obj.Controllers.KubeletCSRApprover = KubeletCSRApproverControllerConfig{}
 
-			SetDefaults_KubeletCSRApproverControllerConfig(obj)
+			SetObjectDefaults_ResourceManagerConfiguration(obj)
 
-			Expect(obj.ConcurrentSyncs).To(BeNil())
+			Expect(obj.Controllers.KubeletCSRApprover.ConcurrentSyncs).To(BeNil())
 		})
 
 		It("should default the object because enabled", func() {
-			obj := &KubeletCSRApproverControllerConfig{
+			obj.Controllers.KubeletCSRApprover = KubeletCSRApproverControllerConfig{
 				Enabled: true,
 			}
 
-			SetDefaults_KubeletCSRApproverControllerConfig(obj)
+			SetObjectDefaults_ResourceManagerConfiguration(obj)
 
-			Expect(obj.ConcurrentSyncs).To(PointTo(Equal(1)))
+			Expect(obj.Controllers.KubeletCSRApprover.ConcurrentSyncs).To(PointTo(Equal(1)))
 		})
 
 		It("should not overwrite existing values", func() {
-			obj := &KubeletCSRApproverControllerConfig{
+			obj.Controllers.KubeletCSRApprover = KubeletCSRApproverControllerConfig{
 				Enabled:         true,
 				ConcurrentSyncs: pointer.Int(2),
 			}
 
-			SetDefaults_KubeletCSRApproverControllerConfig(obj)
+			SetObjectDefaults_ResourceManagerConfiguration(obj)
 
-			Expect(obj.ConcurrentSyncs).To(PointTo(Equal(2)))
+			Expect(obj.Controllers.KubeletCSRApprover.ConcurrentSyncs).To(PointTo(Equal(2)))
 		})
 	})
 
 	Describe("#SetDefaults_GarbageCollectorControllerConfig", func() {
 		It("should not default the object because disabled", func() {
-			obj := &GarbageCollectorControllerConfig{}
+			obj.Controllers.GarbageCollector = GarbageCollectorControllerConfig{}
 
-			SetDefaults_GarbageCollectorControllerConfig(obj)
+			SetObjectDefaults_ResourceManagerConfiguration(obj)
 
-			Expect(obj.SyncPeriod).To(BeNil())
+			Expect(obj.Controllers.GarbageCollector.SyncPeriod).To(BeNil())
 		})
 
 		It("should default the object because enabled", func() {
-			obj := &GarbageCollectorControllerConfig{
+			obj.Controllers.GarbageCollector = GarbageCollectorControllerConfig{
 				Enabled: true,
 			}
 
-			SetDefaults_GarbageCollectorControllerConfig(obj)
+			SetObjectDefaults_ResourceManagerConfiguration(obj)
 
-			Expect(obj.SyncPeriod).To(PointTo(Equal(metav1.Duration{Duration: time.Hour})))
+			Expect(obj.Controllers.GarbageCollector.SyncPeriod).To(PointTo(Equal(metav1.Duration{Duration: time.Hour})))
 		})
 
 		It("should not overwrite existing values", func() {
-			obj := &GarbageCollectorControllerConfig{
+			obj.Controllers.GarbageCollector = GarbageCollectorControllerConfig{
 				Enabled:    true,
 				SyncPeriod: &metav1.Duration{Duration: time.Second},
 			}
 
-			SetDefaults_GarbageCollectorControllerConfig(obj)
+			SetObjectDefaults_ResourceManagerConfiguration(obj)
 
-			Expect(obj.SyncPeriod).To(PointTo(Equal(metav1.Duration{Duration: time.Second})))
+			Expect(obj.Controllers.GarbageCollector.SyncPeriod).To(PointTo(Equal(metav1.Duration{Duration: time.Second})))
 		})
 	})
 
 	Describe("#SetDefaults_NetworkPolicyConfig", func() {
 		It("should not default the object", func() {
-			obj := &NetworkPolicyControllerConfig{}
+			obj.Controllers.NetworkPolicy = NetworkPolicyControllerConfig{}
 
-			SetDefaults_NetworkPolicyControllerConfig(obj)
+			SetObjectDefaults_ResourceManagerConfiguration(obj)
 
-			Expect(obj.ConcurrentSyncs).To(BeNil())
+			Expect(obj.Controllers.NetworkPolicy.ConcurrentSyncs).To(BeNil())
 		})
 
 		It("should default the object", func() {
-			obj := &NetworkPolicyControllerConfig{
+			obj.Controllers.NetworkPolicy = NetworkPolicyControllerConfig{
 				Enabled: true,
 			}
 
-			SetDefaults_NetworkPolicyControllerConfig(obj)
+			SetObjectDefaults_ResourceManagerConfiguration(obj)
 
-			Expect(obj.ConcurrentSyncs).To(PointTo(Equal(5)))
+			Expect(obj.Controllers.NetworkPolicy.ConcurrentSyncs).To(PointTo(Equal(5)))
 		})
 
 		It("should not overwrite existing values", func() {
-			obj := &NetworkPolicyControllerConfig{
+			obj.Controllers.NetworkPolicy = NetworkPolicyControllerConfig{
 				Enabled:         true,
 				ConcurrentSyncs: pointer.Int(6),
 			}
 
-			SetDefaults_NetworkPolicyControllerConfig(obj)
+			SetObjectDefaults_ResourceManagerConfiguration(obj)
 
-			Expect(obj.ConcurrentSyncs).To(PointTo(Equal(6)))
+			Expect(obj.Controllers.NetworkPolicy.ConcurrentSyncs).To(PointTo(Equal(6)))
 		})
 	})
 
 	Describe("#SetDefaults_HealthControllerConfig", func() {
 		It("should not default the object", func() {
-			obj := &HealthControllerConfig{}
+			obj.Controllers.Health = HealthControllerConfig{}
 
-			SetDefaults_HealthControllerConfig(obj)
+			SetObjectDefaults_ResourceManagerConfiguration(obj)
 
-			Expect(obj.ConcurrentSyncs).To(PointTo(Equal(5)))
-			Expect(obj.SyncPeriod).To(PointTo(Equal(metav1.Duration{Duration: time.Minute})))
+			Expect(obj.Controllers.Health.ConcurrentSyncs).To(PointTo(Equal(5)))
+			Expect(obj.Controllers.Health.SyncPeriod).To(PointTo(Equal(metav1.Duration{Duration: time.Minute})))
 		})
 
 		It("should not overwrite existing values", func() {
-			obj := &HealthControllerConfig{
+			obj.Controllers.Health = HealthControllerConfig{
 				ConcurrentSyncs: pointer.Int(1),
 				SyncPeriod:      &metav1.Duration{Duration: time.Second},
 			}
 
-			SetDefaults_HealthControllerConfig(obj)
+			SetObjectDefaults_ResourceManagerConfiguration(obj)
 
-			Expect(obj.ConcurrentSyncs).To(PointTo(Equal(1)))
-			Expect(obj.SyncPeriod).To(PointTo(Equal(metav1.Duration{Duration: time.Second})))
+			Expect(obj.Controllers.Health.ConcurrentSyncs).To(PointTo(Equal(1)))
+			Expect(obj.Controllers.Health.SyncPeriod).To(PointTo(Equal(metav1.Duration{Duration: time.Second})))
 		})
 	})
 
 	Describe("#SetDefaults_ManagedResourceControllerConfig", func() {
 		It("should not default the object", func() {
-			obj := &ManagedResourceControllerConfig{}
+			obj.Controllers.ManagedResource = ManagedResourceControllerConfig{}
 
-			SetDefaults_ManagedResourceControllerConfig(obj)
+			SetObjectDefaults_ResourceManagerConfiguration(obj)
 
-			Expect(obj.ConcurrentSyncs).To(PointTo(Equal(5)))
-			Expect(obj.SyncPeriod).To(PointTo(Equal(metav1.Duration{Duration: time.Minute})))
-			Expect(obj.AlwaysUpdate).To(PointTo(BeFalse()))
-			Expect(obj.ManagedByLabelValue).To(PointTo(Equal("gardener")))
+			Expect(obj.Controllers.ManagedResource.ConcurrentSyncs).To(PointTo(Equal(5)))
+			Expect(obj.Controllers.ManagedResource.SyncPeriod).To(PointTo(Equal(metav1.Duration{Duration: time.Minute})))
+			Expect(obj.Controllers.ManagedResource.AlwaysUpdate).To(PointTo(BeFalse()))
+			Expect(obj.Controllers.ManagedResource.ManagedByLabelValue).To(PointTo(Equal("gardener")))
 		})
 
 		It("should not overwrite existing values", func() {
-			obj := &ManagedResourceControllerConfig{
+			obj.Controllers.ManagedResource = ManagedResourceControllerConfig{
 				ConcurrentSyncs:     pointer.Int(1),
 				SyncPeriod:          &metav1.Duration{Duration: time.Second},
 				AlwaysUpdate:        pointer.Bool(true),
 				ManagedByLabelValue: pointer.String("foo"),
 			}
 
-			SetDefaults_ManagedResourceControllerConfig(obj)
+			SetObjectDefaults_ResourceManagerConfiguration(obj)
 
-			Expect(obj.ConcurrentSyncs).To(PointTo(Equal(1)))
-			Expect(obj.SyncPeriod).To(PointTo(Equal(metav1.Duration{Duration: time.Second})))
-			Expect(obj.AlwaysUpdate).To(PointTo(BeTrue()))
-			Expect(obj.ManagedByLabelValue).To(PointTo(Equal("foo")))
+			Expect(obj.Controllers.ManagedResource.ConcurrentSyncs).To(PointTo(Equal(1)))
+			Expect(obj.Controllers.ManagedResource.SyncPeriod).To(PointTo(Equal(metav1.Duration{Duration: time.Second})))
+			Expect(obj.Controllers.ManagedResource.AlwaysUpdate).To(PointTo(BeTrue()))
+			Expect(obj.Controllers.ManagedResource.ManagedByLabelValue).To(PointTo(Equal("foo")))
 		})
 	})
 
 	Describe("#SetDefaults_SecretControllerConfig", func() {
 		It("should not default the object", func() {
-			obj := &SecretControllerConfig{}
+			obj.Controllers.Secret = SecretControllerConfig{}
 
-			SetDefaults_SecretControllerConfig(obj)
+			SetObjectDefaults_ResourceManagerConfiguration(obj)
 
-			Expect(obj.ConcurrentSyncs).To(PointTo(Equal(5)))
+			Expect(obj.Controllers.Secret.ConcurrentSyncs).To(PointTo(Equal(5)))
 		})
 
 		It("should not overwrite existing values", func() {
-			obj := &SecretControllerConfig{
+			obj.Controllers.Secret = SecretControllerConfig{
 				ConcurrentSyncs: pointer.Int(1),
 			}
 
-			SetDefaults_SecretControllerConfig(obj)
+			SetObjectDefaults_ResourceManagerConfiguration(obj)
 
-			Expect(obj.ConcurrentSyncs).To(PointTo(Equal(1)))
+			Expect(obj.Controllers.Secret.ConcurrentSyncs).To(PointTo(Equal(1)))
 		})
 	})
 
 	Describe("#SetDefaults_TokenInvalidatorControllerConfig", func() {
 		It("should not default the object because disabled", func() {
-			obj := &TokenInvalidatorControllerConfig{}
+			obj.Controllers.TokenInvalidator = TokenInvalidatorControllerConfig{}
 
-			SetDefaults_TokenInvalidatorControllerConfig(obj)
+			SetObjectDefaults_ResourceManagerConfiguration(obj)
 
-			Expect(obj.ConcurrentSyncs).To(BeNil())
+			Expect(obj.Controllers.TokenInvalidator.ConcurrentSyncs).To(BeNil())
 		})
 
 		It("should default the object because enabled", func() {
-			obj := &TokenInvalidatorControllerConfig{
+			obj.Controllers.TokenInvalidator = TokenInvalidatorControllerConfig{
 				Enabled: true,
 			}
 
-			SetDefaults_TokenInvalidatorControllerConfig(obj)
+			SetObjectDefaults_ResourceManagerConfiguration(obj)
 
-			Expect(obj.ConcurrentSyncs).To(PointTo(Equal(5)))
+			Expect(obj.Controllers.TokenInvalidator.ConcurrentSyncs).To(PointTo(Equal(5)))
 		})
 
 		It("should not overwrite existing values", func() {
-			obj := &TokenInvalidatorControllerConfig{
+			obj.Controllers.TokenInvalidator = TokenInvalidatorControllerConfig{
 				Enabled:         true,
 				ConcurrentSyncs: pointer.Int(2),
 			}
 
-			SetDefaults_TokenInvalidatorControllerConfig(obj)
+			SetObjectDefaults_ResourceManagerConfiguration(obj)
 
-			Expect(obj.ConcurrentSyncs).To(PointTo(Equal(2)))
+			Expect(obj.Controllers.TokenInvalidator.ConcurrentSyncs).To(PointTo(Equal(2)))
 		})
 	})
 
 	Describe("#SetDefaults_TokenRequestorControllerConfig", func() {
 		It("should not default the object because disabled", func() {
-			obj := &TokenRequestorControllerConfig{}
+			obj.Controllers.TokenRequestor = TokenRequestorControllerConfig{}
 
-			SetDefaults_TokenRequestorControllerConfig(obj)
+			SetObjectDefaults_ResourceManagerConfiguration(obj)
 
-			Expect(obj.ConcurrentSyncs).To(BeNil())
+			Expect(obj.Controllers.TokenRequestor.ConcurrentSyncs).To(BeNil())
 		})
 
 		It("should default the object because enabled", func() {
-			obj := &TokenRequestorControllerConfig{
+			obj.Controllers.TokenRequestor = TokenRequestorControllerConfig{
 				Enabled: true,
 			}
 
-			SetDefaults_TokenRequestorControllerConfig(obj)
+			SetObjectDefaults_ResourceManagerConfiguration(obj)
 
-			Expect(obj.ConcurrentSyncs).To(PointTo(Equal(5)))
+			Expect(obj.Controllers.TokenRequestor.ConcurrentSyncs).To(PointTo(Equal(5)))
 		})
 
 		It("should not overwrite existing values", func() {
-			obj := &TokenRequestorControllerConfig{
+			obj.Controllers.TokenRequestor = TokenRequestorControllerConfig{
 				Enabled:         true,
 				ConcurrentSyncs: pointer.Int(2),
 			}
 
-			SetDefaults_TokenRequestorControllerConfig(obj)
+			SetObjectDefaults_ResourceManagerConfiguration(obj)
 
-			Expect(obj.ConcurrentSyncs).To(PointTo(Equal(2)))
+			Expect(obj.Controllers.TokenRequestor.ConcurrentSyncs).To(PointTo(Equal(2)))
 		})
 	})
 
 	Describe("#SetDefaults_NodeControllerConfig", func() {
 		It("should not default the object because disabled", func() {
-			obj := &NodeControllerConfig{}
+			obj.Controllers.Node = NodeControllerConfig{}
 
-			SetDefaults_NodeControllerConfig(obj)
+			SetObjectDefaults_ResourceManagerConfiguration(obj)
 
-			Expect(obj.ConcurrentSyncs).To(BeNil())
+			Expect(obj.Controllers.Node.ConcurrentSyncs).To(BeNil())
 		})
 
 		It("should default the object because enabled", func() {
-			obj := &NodeControllerConfig{
+			obj.Controllers.Node = NodeControllerConfig{
 				Enabled: true,
 			}
 
-			SetDefaults_NodeControllerConfig(obj)
+			SetObjectDefaults_ResourceManagerConfiguration(obj)
 
-			Expect(obj.ConcurrentSyncs).To(PointTo(Equal(5)))
-			Expect(obj.Backoff).To(PointTo(Equal(metav1.Duration{Duration: 10 * time.Second})))
+			Expect(obj.Controllers.Node.ConcurrentSyncs).To(PointTo(Equal(5)))
+			Expect(obj.Controllers.Node.Backoff).To(PointTo(Equal(metav1.Duration{Duration: 10 * time.Second})))
 		})
 
 		It("should not overwrite existing values", func() {
-			obj := &NodeControllerConfig{
+			obj.Controllers.Node = NodeControllerConfig{
 				Enabled:         true,
 				ConcurrentSyncs: pointer.Int(2),
 				Backoff:         &metav1.Duration{Duration: time.Minute},
 			}
 
-			SetDefaults_NodeControllerConfig(obj)
+			SetObjectDefaults_ResourceManagerConfiguration(obj)
 
-			Expect(obj.ConcurrentSyncs).To(PointTo(Equal(2)))
-			Expect(obj.Backoff).To(PointTo(Equal(metav1.Duration{Duration: time.Minute})))
+			Expect(obj.Controllers.Node.ConcurrentSyncs).To(PointTo(Equal(2)))
+			Expect(obj.Controllers.Node.Backoff).To(PointTo(Equal(metav1.Duration{Duration: time.Minute})))
 		})
 	})
 
 	Describe("#SetDefaults_PodSchedulerNameWebhookConfig", func() {
 		It("should not default the object because disabled", func() {
-			obj := &PodSchedulerNameWebhookConfig{}
+			obj.Webhooks.PodSchedulerName = PodSchedulerNameWebhookConfig{}
 
-			SetDefaults_PodSchedulerNameWebhookConfig(obj)
+			SetObjectDefaults_ResourceManagerConfiguration(obj)
 
-			Expect(obj.SchedulerName).To(BeNil())
+			Expect(obj.Webhooks.PodSchedulerName.SchedulerName).To(BeNil())
 		})
 
 		It("should default the object because enabled", func() {
-			obj := &PodSchedulerNameWebhookConfig{
+			obj.Webhooks.PodSchedulerName = PodSchedulerNameWebhookConfig{
 				Enabled: true,
 			}
 
-			SetDefaults_PodSchedulerNameWebhookConfig(obj)
+			SetObjectDefaults_ResourceManagerConfiguration(obj)
 
-			Expect(obj.SchedulerName).To(PointTo(Equal("default-scheduler")))
+			Expect(obj.Webhooks.PodSchedulerName.SchedulerName).To(PointTo(Equal("default-scheduler")))
 		})
 
 		It("should not overwrite existing values", func() {
-			obj := &PodSchedulerNameWebhookConfig{
+			obj.Webhooks.PodSchedulerName = PodSchedulerNameWebhookConfig{
 				Enabled:       true,
 				SchedulerName: pointer.String("foo"),
 			}
 
-			SetDefaults_PodSchedulerNameWebhookConfig(obj)
+			SetObjectDefaults_ResourceManagerConfiguration(obj)
 
-			Expect(obj.SchedulerName).To(PointTo(Equal("foo")))
+			Expect(obj.Webhooks.PodSchedulerName.SchedulerName).To(PointTo(Equal("foo")))
 		})
 	})
 
 	Describe("#SetDefaults_ProjectedTokenMountWebhookConfig", func() {
 		It("should not default the object because disabled", func() {
-			obj := &ProjectedTokenMountWebhookConfig{}
+			obj.Webhooks.ProjectedTokenMount = ProjectedTokenMountWebhookConfig{}
 
-			SetDefaults_ProjectedTokenMountWebhookConfig(obj)
+			SetObjectDefaults_ResourceManagerConfiguration(obj)
 
-			Expect(obj.ExpirationSeconds).To(BeNil())
+			Expect(obj.Webhooks.ProjectedTokenMount.ExpirationSeconds).To(BeNil())
 		})
 
 		It("should default the object because enabled", func() {
-			obj := &ProjectedTokenMountWebhookConfig{
+			obj.Webhooks.ProjectedTokenMount = ProjectedTokenMountWebhookConfig{
 				Enabled: true,
 			}
 
-			SetDefaults_ProjectedTokenMountWebhookConfig(obj)
+			SetObjectDefaults_ResourceManagerConfiguration(obj)
 
-			Expect(obj.ExpirationSeconds).To(PointTo(Equal(int64(43200))))
+			Expect(obj.Webhooks.ProjectedTokenMount.ExpirationSeconds).To(PointTo(Equal(int64(43200))))
 		})
 
 		It("should not overwrite existing values", func() {
-			obj := &ProjectedTokenMountWebhookConfig{
+			obj.Webhooks.ProjectedTokenMount = ProjectedTokenMountWebhookConfig{
 				Enabled:           true,
 				ExpirationSeconds: pointer.Int64(1234),
 			}
 
-			SetDefaults_ProjectedTokenMountWebhookConfig(obj)
+			SetObjectDefaults_ResourceManagerConfiguration(obj)
 
-			Expect(obj.ExpirationSeconds).To(PointTo(Equal(int64(1234))))
+			Expect(obj.Webhooks.ProjectedTokenMount.ExpirationSeconds).To(PointTo(Equal(int64(1234))))
 		})
 	})
 })

--- a/pkg/resourcemanager/apis/config/v1alpha1/defaults_test.go
+++ b/pkg/resourcemanager/apis/config/v1alpha1/defaults_test.go
@@ -34,15 +34,15 @@ var _ = Describe("ResourceManager defaulting", func() {
 		obj = &ResourceManagerConfiguration{}
 	})
 
-	Describe("#SetDefaults_ResourceManagerConfiguration", func() {
-		It("should default the object", func() {
+	Describe("ResourceManagerConfiguration defaulting", func() {
+		It("should default the ResourceManagerConfiguration", func() {
 			SetObjectDefaults_ResourceManagerConfiguration(obj)
 
 			Expect(obj.LogLevel).To(Equal("info"))
 			Expect(obj.LogFormat).To(Equal("json"))
 		})
 
-		It("should not overwrite existing values", func() {
+		It("should not overwrite already set values for ResourceManagerConfiguration", func() {
 			obj = &ResourceManagerConfiguration{
 				LogLevel:  "foo",
 				LogFormat: "bar",
@@ -55,8 +55,8 @@ var _ = Describe("ResourceManager defaulting", func() {
 		})
 	})
 
-	Describe("#SetDefaults_ClientConnection", func() {
-		It("should default the object", func() {
+	Describe("ClientConnection defaulting", func() {
+		It("should default the ClientConnection", func() {
 			obj.TargetClientConnection = &ClientConnection{}
 
 			SetObjectDefaults_ResourceManagerConfiguration(obj)
@@ -67,7 +67,7 @@ var _ = Describe("ResourceManager defaulting", func() {
 			Expect(obj.TargetClientConnection.Burst).To(Equal(int32(130)))
 		})
 
-		It("should not overwrite existing values", func() {
+		It("should not overwrite already set values for ClientConnection", func() {
 			obj.TargetClientConnection = &ClientConnection{
 				ClientConnectionConfiguration: componentbaseconfigv1alpha1.ClientConnectionConfiguration{
 					QPS:   float32(1.2),
@@ -86,8 +86,8 @@ var _ = Describe("ResourceManager defaulting", func() {
 		})
 	})
 
-	Describe("#SetDefaults_LeaderElectionConfiguration", func() {
-		It("should default the object", func() {
+	Describe("LeaderElectionConfiguration defaulting", func() {
+		It("should default the LeaderElectionConfiguration", func() {
 			obj.LeaderElection = componentbaseconfigv1alpha1.LeaderElectionConfiguration{}
 
 			SetObjectDefaults_ResourceManagerConfiguration(obj)
@@ -101,7 +101,7 @@ var _ = Describe("ResourceManager defaulting", func() {
 			Expect(obj.LeaderElection.LeaderElect).To(PointTo(BeTrue()))
 		})
 
-		It("should not overwrite existing values", func() {
+		It("should not overwrite already set values for LeaderElectionConfiguration", func() {
 			obj.LeaderElection = componentbaseconfigv1alpha1.LeaderElectionConfiguration{
 				ResourceLock:      "foo",
 				ResourceName:      "bar",
@@ -124,8 +124,8 @@ var _ = Describe("ResourceManager defaulting", func() {
 		})
 	})
 
-	Describe("#SetDefaults_ServerConfiguration", func() {
-		It("should default the object", func() {
+	Describe("ServerConfiguration defaulting", func() {
+		It("should default the ServerConfiguration", func() {
 			obj.Server = ServerConfiguration{}
 
 			SetObjectDefaults_ResourceManagerConfiguration(obj)
@@ -136,7 +136,7 @@ var _ = Describe("ResourceManager defaulting", func() {
 			Expect(obj.Server.Metrics.Port).To(Equal(8080))
 		})
 
-		It("should not overwrite existing values", func() {
+		It("should not overwrite already set values for ServerConfiguration", func() {
 			obj.Server = ServerConfiguration{
 				Webhooks: HTTPSServer{
 					Server: Server{
@@ -161,8 +161,8 @@ var _ = Describe("ResourceManager defaulting", func() {
 		})
 	})
 
-	Describe("#SetDefaults_ResourceManagerControllerConfiguration", func() {
-		It("should default the object", func() {
+	Describe("ResourceManagerControllerConfiguration defaulting", func() {
+		It("should default the ResourceManagerControllerConfiguration", func() {
 			obj.Controllers = ResourceManagerControllerConfiguration{}
 
 			SetObjectDefaults_ResourceManagerConfiguration(obj)
@@ -171,7 +171,7 @@ var _ = Describe("ResourceManager defaulting", func() {
 			Expect(obj.Controllers.ResourceClass).To(PointTo(Equal("resources")))
 		})
 
-		It("should not overwrite existing values", func() {
+		It("should not overwrite already set values for ResourceManagerControllerConfiguration", func() {
 			obj.Controllers = ResourceManagerControllerConfiguration{
 				ClusterID:     pointer.String("foo"),
 				ResourceClass: pointer.String("bar"),
@@ -184,8 +184,8 @@ var _ = Describe("ResourceManager defaulting", func() {
 		})
 	})
 
-	Describe("#SetDefaults_KubeletCSRApproverControllerConfig", func() {
-		It("should not default the object because disabled", func() {
+	Describe("KubeletCSRApproverControllerConfig defaulting", func() {
+		It("should not default the KubeletCSRApproverControllerConfig because it is disabled", func() {
 			obj.Controllers.KubeletCSRApprover = KubeletCSRApproverControllerConfig{}
 
 			SetObjectDefaults_ResourceManagerConfiguration(obj)
@@ -193,7 +193,7 @@ var _ = Describe("ResourceManager defaulting", func() {
 			Expect(obj.Controllers.KubeletCSRApprover.ConcurrentSyncs).To(BeNil())
 		})
 
-		It("should default the object because enabled", func() {
+		It("should default the KubeletCSRApproverControllerConfig because it is enabled", func() {
 			obj.Controllers.KubeletCSRApprover = KubeletCSRApproverControllerConfig{
 				Enabled: true,
 			}
@@ -203,7 +203,7 @@ var _ = Describe("ResourceManager defaulting", func() {
 			Expect(obj.Controllers.KubeletCSRApprover.ConcurrentSyncs).To(PointTo(Equal(1)))
 		})
 
-		It("should not overwrite existing values", func() {
+		It("should not overwrite already set values for KubeletCSRApproverControllerConfig", func() {
 			obj.Controllers.KubeletCSRApprover = KubeletCSRApproverControllerConfig{
 				Enabled:         true,
 				ConcurrentSyncs: pointer.Int(2),
@@ -215,8 +215,8 @@ var _ = Describe("ResourceManager defaulting", func() {
 		})
 	})
 
-	Describe("#SetDefaults_GarbageCollectorControllerConfig", func() {
-		It("should not default the object because disabled", func() {
+	Describe("GarbageCollectorControllerConfig defaulting", func() {
+		It("should not default the GarbageCollectorControllerConfig because it is disabled", func() {
 			obj.Controllers.GarbageCollector = GarbageCollectorControllerConfig{}
 
 			SetObjectDefaults_ResourceManagerConfiguration(obj)
@@ -224,7 +224,7 @@ var _ = Describe("ResourceManager defaulting", func() {
 			Expect(obj.Controllers.GarbageCollector.SyncPeriod).To(BeNil())
 		})
 
-		It("should default the object because enabled", func() {
+		It("should default the GarbageCollectorControllerConfig because it is enabled", func() {
 			obj.Controllers.GarbageCollector = GarbageCollectorControllerConfig{
 				Enabled: true,
 			}
@@ -234,7 +234,7 @@ var _ = Describe("ResourceManager defaulting", func() {
 			Expect(obj.Controllers.GarbageCollector.SyncPeriod).To(PointTo(Equal(metav1.Duration{Duration: time.Hour})))
 		})
 
-		It("should not overwrite existing values", func() {
+		It("should not overwrite already set values for GarbageCollectorControllerConfig", func() {
 			obj.Controllers.GarbageCollector = GarbageCollectorControllerConfig{
 				Enabled:    true,
 				SyncPeriod: &metav1.Duration{Duration: time.Second},
@@ -246,8 +246,8 @@ var _ = Describe("ResourceManager defaulting", func() {
 		})
 	})
 
-	Describe("#SetDefaults_NetworkPolicyConfig", func() {
-		It("should not default the object", func() {
+	Describe("NetworkPolicyConfig defaulting", func() {
+		It("should not default the NetworkPolicyConfig because it is disabled", func() {
 			obj.Controllers.NetworkPolicy = NetworkPolicyControllerConfig{}
 
 			SetObjectDefaults_ResourceManagerConfiguration(obj)
@@ -255,7 +255,7 @@ var _ = Describe("ResourceManager defaulting", func() {
 			Expect(obj.Controllers.NetworkPolicy.ConcurrentSyncs).To(BeNil())
 		})
 
-		It("should default the object", func() {
+		It("should default the NetworkPolicyConfig because it is enabled", func() {
 			obj.Controllers.NetworkPolicy = NetworkPolicyControllerConfig{
 				Enabled: true,
 			}
@@ -265,7 +265,7 @@ var _ = Describe("ResourceManager defaulting", func() {
 			Expect(obj.Controllers.NetworkPolicy.ConcurrentSyncs).To(PointTo(Equal(5)))
 		})
 
-		It("should not overwrite existing values", func() {
+		It("should not overwrite already set values for NetworkPolicyConfig", func() {
 			obj.Controllers.NetworkPolicy = NetworkPolicyControllerConfig{
 				Enabled:         true,
 				ConcurrentSyncs: pointer.Int(6),
@@ -277,8 +277,8 @@ var _ = Describe("ResourceManager defaulting", func() {
 		})
 	})
 
-	Describe("#SetDefaults_HealthControllerConfig", func() {
-		It("should not default the object", func() {
+	Describe("HealthControllerConfig defaulting", func() {
+		It("should default the HealthControllerConfig", func() {
 			obj.Controllers.Health = HealthControllerConfig{}
 
 			SetObjectDefaults_ResourceManagerConfiguration(obj)
@@ -287,7 +287,7 @@ var _ = Describe("ResourceManager defaulting", func() {
 			Expect(obj.Controllers.Health.SyncPeriod).To(PointTo(Equal(metav1.Duration{Duration: time.Minute})))
 		})
 
-		It("should not overwrite existing values", func() {
+		It("should not overwrite already set values for HealthControllerConfig", func() {
 			obj.Controllers.Health = HealthControllerConfig{
 				ConcurrentSyncs: pointer.Int(1),
 				SyncPeriod:      &metav1.Duration{Duration: time.Second},
@@ -300,8 +300,8 @@ var _ = Describe("ResourceManager defaulting", func() {
 		})
 	})
 
-	Describe("#SetDefaults_ManagedResourceControllerConfig", func() {
-		It("should not default the object", func() {
+	Describe("ManagedResourceControllerConfig defaulting", func() {
+		It("should default the ManagedResourceControllerConfig", func() {
 			obj.Controllers.ManagedResource = ManagedResourceControllerConfig{}
 
 			SetObjectDefaults_ResourceManagerConfiguration(obj)
@@ -312,7 +312,7 @@ var _ = Describe("ResourceManager defaulting", func() {
 			Expect(obj.Controllers.ManagedResource.ManagedByLabelValue).To(PointTo(Equal("gardener")))
 		})
 
-		It("should not overwrite existing values", func() {
+		It("should not overwrite already set values for ManagedResourceControllerConfig", func() {
 			obj.Controllers.ManagedResource = ManagedResourceControllerConfig{
 				ConcurrentSyncs:     pointer.Int(1),
 				SyncPeriod:          &metav1.Duration{Duration: time.Second},
@@ -329,8 +329,8 @@ var _ = Describe("ResourceManager defaulting", func() {
 		})
 	})
 
-	Describe("#SetDefaults_SecretControllerConfig", func() {
-		It("should not default the object", func() {
+	Describe("SecretControllerConfig defaulting", func() {
+		It("should default the SecretControllerConfig", func() {
 			obj.Controllers.Secret = SecretControllerConfig{}
 
 			SetObjectDefaults_ResourceManagerConfiguration(obj)
@@ -338,7 +338,7 @@ var _ = Describe("ResourceManager defaulting", func() {
 			Expect(obj.Controllers.Secret.ConcurrentSyncs).To(PointTo(Equal(5)))
 		})
 
-		It("should not overwrite existing values", func() {
+		It("should not overwrite already set values for SecretControllerConfig", func() {
 			obj.Controllers.Secret = SecretControllerConfig{
 				ConcurrentSyncs: pointer.Int(1),
 			}
@@ -349,8 +349,8 @@ var _ = Describe("ResourceManager defaulting", func() {
 		})
 	})
 
-	Describe("#SetDefaults_TokenInvalidatorControllerConfig", func() {
-		It("should not default the object because disabled", func() {
+	Describe("TokenInvalidatorControllerConfig defaulting", func() {
+		It("should not default the TokenInvalidatorControllerConfig because it is disabled", func() {
 			obj.Controllers.TokenInvalidator = TokenInvalidatorControllerConfig{}
 
 			SetObjectDefaults_ResourceManagerConfiguration(obj)
@@ -358,7 +358,7 @@ var _ = Describe("ResourceManager defaulting", func() {
 			Expect(obj.Controllers.TokenInvalidator.ConcurrentSyncs).To(BeNil())
 		})
 
-		It("should default the object because enabled", func() {
+		It("should default the TokenInvalidatorControllerConfig because it is enabled", func() {
 			obj.Controllers.TokenInvalidator = TokenInvalidatorControllerConfig{
 				Enabled: true,
 			}
@@ -368,7 +368,7 @@ var _ = Describe("ResourceManager defaulting", func() {
 			Expect(obj.Controllers.TokenInvalidator.ConcurrentSyncs).To(PointTo(Equal(5)))
 		})
 
-		It("should not overwrite existing values", func() {
+		It("should not overwrite already set values for TokenInvalidatorControllerConfig", func() {
 			obj.Controllers.TokenInvalidator = TokenInvalidatorControllerConfig{
 				Enabled:         true,
 				ConcurrentSyncs: pointer.Int(2),
@@ -380,8 +380,8 @@ var _ = Describe("ResourceManager defaulting", func() {
 		})
 	})
 
-	Describe("#SetDefaults_TokenRequestorControllerConfig", func() {
-		It("should not default the object because disabled", func() {
+	Describe("TokenRequestorControllerConfig defaulting", func() {
+		It("should not default the TokenRequestorControllerConfig because it is disabled", func() {
 			obj.Controllers.TokenRequestor = TokenRequestorControllerConfig{}
 
 			SetObjectDefaults_ResourceManagerConfiguration(obj)
@@ -389,7 +389,7 @@ var _ = Describe("ResourceManager defaulting", func() {
 			Expect(obj.Controllers.TokenRequestor.ConcurrentSyncs).To(BeNil())
 		})
 
-		It("should default the object because enabled", func() {
+		It("should default the TokenRequestorControllerConfig because it is enabled", func() {
 			obj.Controllers.TokenRequestor = TokenRequestorControllerConfig{
 				Enabled: true,
 			}
@@ -399,7 +399,7 @@ var _ = Describe("ResourceManager defaulting", func() {
 			Expect(obj.Controllers.TokenRequestor.ConcurrentSyncs).To(PointTo(Equal(5)))
 		})
 
-		It("should not overwrite existing values", func() {
+		It("should not overwrite already set values for TokenRequestorControllerConfig", func() {
 			obj.Controllers.TokenRequestor = TokenRequestorControllerConfig{
 				Enabled:         true,
 				ConcurrentSyncs: pointer.Int(2),
@@ -411,8 +411,8 @@ var _ = Describe("ResourceManager defaulting", func() {
 		})
 	})
 
-	Describe("#SetDefaults_NodeControllerConfig", func() {
-		It("should not default the object because disabled", func() {
+	Describe("NodeControllerConfig defaulting", func() {
+		It("should not default the NodeControllerConfig because it is disabled", func() {
 			obj.Controllers.Node = NodeControllerConfig{}
 
 			SetObjectDefaults_ResourceManagerConfiguration(obj)
@@ -420,7 +420,7 @@ var _ = Describe("ResourceManager defaulting", func() {
 			Expect(obj.Controllers.Node.ConcurrentSyncs).To(BeNil())
 		})
 
-		It("should default the object because enabled", func() {
+		It("should default the NodeControllerConfig because it is enabled", func() {
 			obj.Controllers.Node = NodeControllerConfig{
 				Enabled: true,
 			}
@@ -431,7 +431,7 @@ var _ = Describe("ResourceManager defaulting", func() {
 			Expect(obj.Controllers.Node.Backoff).To(PointTo(Equal(metav1.Duration{Duration: 10 * time.Second})))
 		})
 
-		It("should not overwrite existing values", func() {
+		It("should not overwrite already set values for NodeControllerConfig", func() {
 			obj.Controllers.Node = NodeControllerConfig{
 				Enabled:         true,
 				ConcurrentSyncs: pointer.Int(2),
@@ -445,8 +445,8 @@ var _ = Describe("ResourceManager defaulting", func() {
 		})
 	})
 
-	Describe("#SetDefaults_PodSchedulerNameWebhookConfig", func() {
-		It("should not default the object because disabled", func() {
+	Describe("PodSchedulerNameWebhookConfig defaulting", func() {
+		It("should not default the PodSchedulerNameWebhookConfig because it is disabled", func() {
 			obj.Webhooks.PodSchedulerName = PodSchedulerNameWebhookConfig{}
 
 			SetObjectDefaults_ResourceManagerConfiguration(obj)
@@ -454,7 +454,7 @@ var _ = Describe("ResourceManager defaulting", func() {
 			Expect(obj.Webhooks.PodSchedulerName.SchedulerName).To(BeNil())
 		})
 
-		It("should default the object because enabled", func() {
+		It("should default the PodSchedulerNameWebhookConfig because it is enabled", func() {
 			obj.Webhooks.PodSchedulerName = PodSchedulerNameWebhookConfig{
 				Enabled: true,
 			}
@@ -464,7 +464,7 @@ var _ = Describe("ResourceManager defaulting", func() {
 			Expect(obj.Webhooks.PodSchedulerName.SchedulerName).To(PointTo(Equal("default-scheduler")))
 		})
 
-		It("should not overwrite existing values", func() {
+		It("should not overwrite already set values for PodSchedulerNameWebhookConfig", func() {
 			obj.Webhooks.PodSchedulerName = PodSchedulerNameWebhookConfig{
 				Enabled:       true,
 				SchedulerName: pointer.String("foo"),
@@ -476,8 +476,8 @@ var _ = Describe("ResourceManager defaulting", func() {
 		})
 	})
 
-	Describe("#SetDefaults_ProjectedTokenMountWebhookConfig", func() {
-		It("should not default the object because disabled", func() {
+	Describe("ProjectedTokenMountWebhookConfig defaulting", func() {
+		It("should not default the ProjectedTokenMountWebhookConfig because it is disabled", func() {
 			obj.Webhooks.ProjectedTokenMount = ProjectedTokenMountWebhookConfig{}
 
 			SetObjectDefaults_ResourceManagerConfiguration(obj)
@@ -485,7 +485,7 @@ var _ = Describe("ResourceManager defaulting", func() {
 			Expect(obj.Webhooks.ProjectedTokenMount.ExpirationSeconds).To(BeNil())
 		})
 
-		It("should default the object because enabled", func() {
+		It("should default the ProjectedTokenMountWebhookConfig because it is enabled", func() {
 			obj.Webhooks.ProjectedTokenMount = ProjectedTokenMountWebhookConfig{
 				Enabled: true,
 			}
@@ -495,7 +495,7 @@ var _ = Describe("ResourceManager defaulting", func() {
 			Expect(obj.Webhooks.ProjectedTokenMount.ExpirationSeconds).To(PointTo(Equal(int64(43200))))
 		})
 
-		It("should not overwrite existing values", func() {
+		It("should not overwrite already set values for ProjectedTokenMountWebhookConfig", func() {
 			obj.Webhooks.ProjectedTokenMount = ProjectedTokenMountWebhookConfig{
 				Enabled:           true,
 				ExpirationSeconds: pointer.Int64(1234),

--- a/pkg/resourcemanager/apis/config/v1alpha1/register.go
+++ b/pkg/resourcemanager/apis/config/v1alpha1/register.go
@@ -52,3 +52,7 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 	)
 	return nil
 }
+
+func addDefaultingFuncs(scheme *runtime.Scheme) error {
+	return RegisterDefaults(scheme)
+}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind technical-debt

**What this PR does / why we need it**:
This PR cleans up technical debt in our API defaulting code according to https://github.com/gardener/gardener/issues/7312.
This PR tackles the following resources in the `resourcemanager.config.gardener.cloud` API group.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/7312

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
