### PR TITLE
Introduce csinode-webhook

### DIFF
--- a/extensions/pkg/webhook/csinode/csinode.go
+++ b/extensions/pkg/webhook/csinode/csinode.go
@@ -17,7 +17,6 @@ import (
 	"golang.org/x/exp/maps"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	storagev1 "k8s.io/api/storage/v1"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
@@ -28,8 +27,6 @@ const (
 	WebhookName = "csinode"
 )
 
-var logger = log.Log.WithName("csinode-webhook")
-
 // Args are the requirements to create a csinode webhook.
 type Args struct {
 	// Drivers is a list that maps a csidriver to the mutating function. CSIDrivers without an entry in this map will be ignored by the webhook.
@@ -38,10 +35,11 @@ type Args struct {
 }
 
 // New creates a new cloudprovider webhook.
-func New(mgr manager.Manager, args Args) (*extensionswebhook.Webhook, error) {
-	logger := logger.WithValues("csi-drivers", maps.Keys(args.Drivers))
+func New(mgr manager.Manager, args *Args) (*extensionswebhook.Webhook, error) {
+	logger := mgr.GetLogger().WithName("csinode-webhook")
 
 	logger.Info("Adding webhook to manager")
+	logger.Info("Monitoring CSI Drivers to mutate", "driver-names", maps.Keys(args.Drivers))
 	types := []extensionswebhook.Type{extensionswebhook.Type{
 		Obj: &storagev1.CSINode{},
 	}}

--- a/extensions/pkg/webhook/csinode/csinode.go
+++ b/extensions/pkg/webhook/csinode/csinode.go
@@ -1,0 +1,68 @@
+// Copyright (c) 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package csinode
+
+import (
+	"golang.org/x/exp/maps"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
+)
+
+const (
+	// WebhookName is the name of the webhook.
+	WebhookName = "csinode"
+)
+
+var logger = log.Log.WithName("csinode-webhook")
+
+// Args are the requirements to create a csinode webhook.
+type Args struct {
+	// Drivers is a list that maps a csidriver to the mutating function. CSIDrivers without an entry in this map will be ignored by the webhook.
+	Drivers  map[string]CSINodeMutateFunc
+	Provider string
+}
+
+// New creates a new cloudprovider webhook.
+func New(mgr manager.Manager, args Args) (*extensionswebhook.Webhook, error) {
+	logger := logger.WithValues("csi-drivers", maps.Keys(args.Drivers))
+
+	logger.Info("Adding webhook to manager")
+	types := []extensionswebhook.Type{extensionswebhook.Type{
+		Obj: &storagev1.CSINode{},
+	}}
+
+	handler, err := extensionswebhook.NewHandlerWithShootClient(mgr, types, NewMutator(mgr, logger, args), logger)
+	if err != nil {
+		return nil, err
+	}
+
+	wh := &extensionswebhook.Webhook{
+		Name:          WebhookName,
+		Path:          WebhookName,
+		Target:        extensionswebhook.TargetShoot,
+		Types:         types,
+		Handler:       handler,
+		FailurePolicy: toPtr(admissionregistrationv1.Fail),
+	}
+
+	return wh, nil
+}
+
+func toPtr[T any](t T) *T {
+	return &t
+}

--- a/extensions/pkg/webhook/csinode/mutator.go
+++ b/extensions/pkg/webhook/csinode/mutator.go
@@ -1,0 +1,140 @@
+//  Copyright (c) 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package csinode
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	"github.com/gardener/gardener/extensions/pkg/webhook"
+	"github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	"github.com/gardener/gardener/pkg/extensions"
+)
+
+const (
+	errMsg = "failed to mutate CSINode %s: %v"
+)
+
+// NewMutator creates a new accelerated network mutator.
+func NewMutator(mgr manager.Manager, logger logr.Logger, args Args) webhook.MutatorWithShootClient {
+	return &mutator{
+		client:   mgr.GetClient(),
+		logger:   logger,
+		drivers:  args.Drivers,
+		provider: args.Provider,
+	}
+}
+
+// CSINodeMutateFunc mutates the given CSINodeDriver in-place
+type CSINodeMutateFunc func(logr.Logger, *storagev1.CSINodeDriver, *extensionsv1alpha1.WorkerPool, *extensions.Cluster) error
+
+type mutator struct {
+	client   client.Client
+	logger   logr.Logger
+	drivers  map[string]CSINodeMutateFunc
+	provider string
+}
+
+// Mutate validates and if needed mutates the given object.
+func (m *mutator) Mutate(ctx context.Context, new, old client.Object, sc client.Client, cluster *extensions.Cluster) error {
+	var (
+		cnNew, cnOld *storagev1.CSINode
+		ok           bool
+	)
+
+	if m.provider != cluster.Shoot.GetProviderType() {
+		return nil
+	}
+
+	cnNew, ok = new.(*storagev1.CSINode)
+	if !ok {
+		return fmt.Errorf("could not mutate: new object is not of kind %q", "CSINode")
+	}
+	if old != nil {
+		cnOld, ok = old.(*storagev1.CSINode)
+		if !ok {
+			return fmt.Errorf("could not mutate: new object is not of kind %q", "CSINode")
+		}
+	}
+
+Outer:
+	for idx, driver := range cnNew.Spec.Drivers {
+		// skip drivers that we do not care to mutate.
+		if _, ok := m.drivers[driver.Name]; !ok {
+			continue
+		}
+
+		if cnOld != nil {
+			for _, oldDriver := range cnOld.Spec.Drivers {
+				// skip CSI Drivers that we have already adapted
+				if oldDriver.Name == driver.Name {
+					m.logger.Info("Tried to update CSINode, but the driver is already there... skipping")
+					continue Outer
+				}
+			}
+		}
+
+		nodeName := new.GetName()
+		node := &corev1.Node{}
+		err := sc.Get(ctx, client.ObjectKey{Name: nodeName}, node)
+		if err != nil {
+			return err
+		}
+
+		var poolName string
+		if poolName, ok = node.GetLabels()[constants.LabelWorkerPool]; !ok {
+			return fmt.Errorf(errMsg, nodeName, "can't find worker pool label on the node object")
+		}
+
+		worker := &extensionsv1alpha1.Worker{}
+		err = m.client.Get(ctx, client.ObjectKey{
+			Namespace: cluster.ObjectMeta.Name,
+			Name:      cluster.Shoot.GetName(),
+		}, worker)
+		if err != nil {
+			return err
+		}
+
+		for _, pool := range worker.Spec.Pools {
+			if pool.Name != poolName {
+				continue
+			}
+			m.logger.Info("Driver", "name", &cnNew.Spec.Drivers[idx], "pool", pool.Name)
+			err := m.drivers[driver.Name](m.logger, &cnNew.Spec.Drivers[idx], &pool, cluster)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// GenericCSINodeMutate is a generic way to implement the csi node
+func GenericCSINodeMutate(log logr.Logger, driver *storagev1.CSINodeDriver, pool *extensionsv1alpha1.WorkerPool, _ *extensions.Cluster) error {
+	if pool.DataVolumes != nil {
+		if driver.Allocatable != nil && driver.Allocatable.Count != nil {
+			driver.Allocatable.Count = toPtr(*driver.Allocatable.Count - int32(len(pool.DataVolumes)))
+			log.Info("Set allocatable field for csi driver", "driver", driver.Name, "value", *driver.Allocatable.Count)
+		}
+	}
+
+	return nil
+}

--- a/extensions/pkg/webhook/csinode/mutator_test.go
+++ b/extensions/pkg/webhook/csinode/mutator_test.go
@@ -1,0 +1,224 @@
+// Copyright 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package csinode_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"go.uber.org/mock/gomock"
+	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/gardener/gardener/extensions/pkg/webhook"
+	"github.com/gardener/gardener/extensions/pkg/webhook/csinode"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	"github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	"github.com/gardener/gardener/pkg/extensions"
+	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
+	mockmanager "github.com/gardener/gardener/pkg/mock/controller-runtime/manager"
+)
+
+func TestCSINode(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Extensions Webhook CloudProvider Suite")
+}
+
+const (
+	nodeFoo       = "shoot--foo"
+	providerFoo   = "provider-foo"
+	providerBar   = "provider-bar"
+	driverFoo     = "foo.csi"
+	driverBar     = "bar.csi"
+	driverBaz     = "baz.csi"
+	fooWorkerPool = "worker-foo"
+)
+
+var _ = Describe("Mutator", func() {
+	var (
+		mgr                        *mockmanager.MockManager
+		ctrl                       *gomock.Controller
+		cSeed                      *mockclient.MockClient
+		cShoot                     *mockclient.MockClient
+		logger                     logr.Logger
+		args                       *csinode.Args
+		mutFunc                    csinode.CSINodeMutateFunc
+		worker                     *extensionsv1alpha1.Worker
+		node                       *corev1.Node
+		mutator                    webhook.MutatorWithShootClient
+		csiNew, csiNewCopy, csiOld *storagev1.CSINode
+		cluster                    *extensions.Cluster
+		ctx                        context.Context
+		allocatableCount           *int32
+	)
+
+	BeforeEach(func() {
+		allocatableCount = pointer.Int32(10)
+		ctrl = gomock.NewController(GinkgoT())
+		cSeed = mockclient.NewMockClient(ctrl)
+		cShoot = mockclient.NewMockClient(ctrl)
+
+		logger = log.Log.WithName("test")
+		ctx = context.Background()
+
+		// Create fake manager
+		mgr = mockmanager.NewMockManager(ctrl)
+		mgr.EXPECT().GetClient().Return(cSeed)
+		mutFunc = csinode.GenericCSINodeMutate
+
+		args = &csinode.Args{
+			Provider: providerFoo,
+			Drivers: map[string]csinode.CSINodeMutateFunc{
+				driverFoo: mutFunc,
+			},
+		}
+
+		mutator = csinode.NewMutator(mgr, logger, args)
+		csiNew = &storagev1.CSINode{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: nodeFoo,
+			},
+			Spec: storagev1.CSINodeSpec{
+				Drivers: []storagev1.CSINodeDriver{
+					{
+						Name: driverFoo,
+						Allocatable: &storagev1.VolumeNodeResources{
+							Count: allocatableCount,
+						},
+					},
+					{
+						Name: driverBaz,
+					},
+				},
+			},
+		}
+		csiNewCopy = csiNew.DeepCopy()
+
+		csiOld = &storagev1.CSINode{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: nodeFoo,
+			},
+			Spec: storagev1.CSINodeSpec{
+				Drivers: []storagev1.CSINodeDriver{},
+			},
+		}
+
+		cluster = &extensions.Cluster{
+			Shoot: &gardencorev1beta1.Shoot{
+				Spec: gardencorev1beta1.ShootSpec{
+					Provider: gardencorev1beta1.Provider{
+						Type: providerFoo,
+					},
+				},
+			},
+		}
+		worker = &extensionsv1alpha1.Worker{
+			Spec: extensionsv1alpha1.WorkerSpec{
+				Pools: []extensionsv1alpha1.WorkerPool{
+					extensionsv1alpha1.WorkerPool{
+						Name: fooWorkerPool,
+						DataVolumes: []extensionsv1alpha1.DataVolume{
+							{
+								Name: "foo1",
+							},
+							{
+								Name: "foo2",
+							},
+						},
+					},
+				},
+			},
+		}
+		node = &corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: nodeFoo,
+				Labels: map[string]string{
+					constants.LabelWorkerPool: fooWorkerPool,
+				},
+			},
+		}
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
+	})
+
+	It("Should ignore shoots of other provider-types", func() {
+		cluster.Shoot.Spec.Provider.Type = providerBar
+		Expect(mutator.Mutate(ctx, csiNew, csiOld, cShoot, cluster)).To(Succeed())
+		Expect(csiNew).To(Equal(csiNewCopy))
+	})
+
+	It("Should ignore drivers not registered with the args", func() {
+		csiNew.Spec.Drivers[0].Name = driverBar
+		csiNewCopy = csiNew.DeepCopy()
+
+		Expect(mutator.Mutate(ctx, csiNew, csiOld, cShoot, cluster)).To(Succeed())
+		Expect(csiNew).To(Equal(csiNewCopy))
+	})
+	It("Should not mutate if driver is already present", func() {
+		csiOld = csiNew
+		Expect(mutator.Mutate(ctx, csiNew, csiOld, cShoot, cluster)).To(Succeed())
+		Expect(csiNew).To(Equal(csiNewCopy))
+	})
+	It("Should return an error if worker pool is not found", func() {
+		node.Labels = map[string]string{}
+		cShoot.EXPECT().Get(ctx, k8sclient.ObjectKey{
+			Name: node.Name,
+		}, gomock.AssignableToTypeOf(&corev1.Node{})).DoAndReturn(getter(node))
+		Expect(mutator.Mutate(ctx, csiNew, csiOld, cShoot, cluster)).NotTo(Succeed())
+
+	})
+	It("Should mutate correctly", func() {
+		cShoot.EXPECT().Get(ctx, k8sclient.ObjectKey{
+			Name: node.Name,
+		}, gomock.AssignableToTypeOf(&corev1.Node{})).DoAndReturn(getter(node))
+		cSeed.EXPECT().Get(ctx, k8sclient.ObjectKey{
+			Namespace: cluster.ObjectMeta.Name,
+			Name:      cluster.Shoot.Name,
+		}, gomock.AssignableToTypeOf(&extensionsv1alpha1.Worker{})).DoAndReturn(getter(worker))
+
+		Expect(mutator.Mutate(ctx, csiNew, csiOld, cShoot, cluster)).To(Succeed())
+		Expect(*csiNew.Spec.Drivers[0].Allocatable.Count).To(BeEquivalentTo(8))
+	})
+	It("Should skip registering the driver if node reached max attachments", func() {
+		csiNew.Spec.Drivers[0].Allocatable.Count = pointer.Int32(2)
+		cShoot.EXPECT().Get(ctx, k8sclient.ObjectKey{
+			Name: node.Name,
+		}, gomock.AssignableToTypeOf(&corev1.Node{})).DoAndReturn(getter(node))
+		cSeed.EXPECT().Get(ctx, k8sclient.ObjectKey{
+			Namespace: cluster.ObjectMeta.Name,
+			Name:      cluster.Shoot.Name,
+		}, gomock.AssignableToTypeOf(&extensionsv1alpha1.Worker{})).DoAndReturn(getter(worker))
+
+		Expect(mutator.Mutate(ctx, csiNew, csiOld, cShoot, cluster)).To(Succeed())
+		Expect(*csiNew.Spec.Drivers[0].Allocatable.Count).To(BeEquivalentTo(1))
+	})
+})
+
+func getter[T any](t *T) func(context.Context, k8sclient.ObjectKey, *T, ...k8sclient.GetOption) error {
+	return func(_ context.Context, _ k8sclient.ObjectKey, tIn *T, _ ...k8sclient.GetOption) error {
+		*tIn = *t
+		return nil
+	}
+}

--- a/extensions/pkg/webhook/handler_shootclient.go
+++ b/extensions/pkg/webhook/handler_shootclient.go
@@ -32,6 +32,7 @@ import (
 	extensionsconfig "github.com/gardener/gardener/extensions/pkg/apis/config"
 	"github.com/gardener/gardener/extensions/pkg/util"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	"github.com/gardener/gardener/pkg/extensions"
 )
 
 // NewHandlerWithShootClient creates a new handler for the given types, using the given mutator, and logger.
@@ -113,7 +114,11 @@ func (h *handlerShootClient) Handle(ctx context.Context, req admission.Request) 
 			return fmt.Errorf("could not create shoot client: %w", err)
 		}
 
-		return h.mutator.Mutate(ctx, new, old, shootClient)
+		cluster, err := extensions.GetCluster(ctx, h.client, shootNamespace)
+		if err != nil {
+			return fmt.Errorf("could not get cluster object for %s", shootNamespace)
+		}
+		return h.mutator.Mutate(ctx, new, old, shootClient, cluster)
 	}
 
 	// Decode object

--- a/extensions/pkg/webhook/mutator.go
+++ b/extensions/pkg/webhook/mutator.go
@@ -18,6 +18,8 @@ import (
 	"context"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/gardener/gardener/pkg/extensions"
 )
 
 // Mutator validates and if needed mutates objects.
@@ -31,7 +33,7 @@ type Mutator interface {
 type MutatorWithShootClient interface {
 	// Mutate validates and if needed mutates the given object.
 	// "old" is optional and it must always be checked for nil.
-	Mutate(ctx context.Context, new, old client.Object, shootClient client.Client) error
+	Mutate(ctx context.Context, new, old client.Object, shootClient client.Client, cluster *extensions.Cluster) error
 }
 
 type mutationWrapper struct {

--- a/go.mod
+++ b/go.mod
@@ -73,6 +73,8 @@ require (
 	sigs.k8s.io/yaml v1.3.0
 )
 
+require golang.org/x/exp v0.0.0-20230321023759-10a507213a29
+
 require (
 	github.com/BurntSushi/toml v1.2.1 // indirect
 	github.com/Masterminds/goutils v1.1.1 // indirect
@@ -177,7 +179,6 @@ require (
 	go.opentelemetry.io/otel/trace v1.10.0 // indirect
 	go.opentelemetry.io/proto/otlp v0.19.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
-	golang.org/x/exp v0.0.0-20230321023759-10a507213a29 // indirect
 	golang.org/x/mod v0.12.0 // indirect
 	golang.org/x/net v0.17.0 // indirect
 	golang.org/x/oauth2 v0.8.0 // indirect


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement

**What this PR does / why we need it**:

Main goal of the PR is to fix an issue with gardener's data volumes relative to the CSIDriver implementations. 

Background:
1. Typically there is a limit to how many volumes can be attached to a node. In most cases this is a property of the VM type used.
2. K8s scheduler/autoscaler need to know how many volumes can be attached to a VM so that they can correctly calculate where pods can fit.
3. Most CSI Drivers calculate that from a static list:
      - Azure maintains a list per VM type
      - GCP has 2 static variations big (128 volumes) and small (16 volumes)
      - Openstack is either provided as an argument to CSI driver or defaulted to 256.
      - AWS is the only exception and is utilising metadata magic to calculate a more accurate limit but this may go away with the next EBS driver release.
4. The problem with the static list is that it doesn't take into account data volumes (or volumes that come to the node outside the realm of Kubernetes).

This PR is an attempt to fix this issue generically for gardener. The main assumption applicable to Gardener, is that any non-k8s volumes that are attached to the node, would be done so via the worker pool specification and hence are known to the extensions on node creation.

This webhook runs in the extension and will mutate CSINode objects on the time where the CSIDriver is first registered to the node. The allocatable field is anyway immutable and so any mutation to it, can only be applied then.

A sample branch to showcase the change in the provider is in https://github.com/kon-angelo/gardener-extension-provider-azure/tree/csinode-webhook2

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

In addition to the main change of introducing the csinode-webhook, we needed to change the interface of `MutatorWithShootClient` to also provide the cluster object. This is mainly needed because we need to be able to retrieve the worker resource from a kubernetes node.

**** Important note ****
If you notice in the comments, I refer to a very specific edge case: when the amount of dta volumes == max # of attachable disks.

This is a particularly tricky case because the number 0 is interpreted as infinite and thus imposes no limits to the attachable volumes on the node.

In this PR, the current workaround is to set it to 1 instead of 0 and there is a PR linked in the comments as this is the same workaround done by AWS guys in EBS recently. Of course, this creates a problem that a stateful pod will not be able to start if the node fulfils the above criterion. 
A possible workaround would be to not register the CSIDriver on the CSINode object, however that creates a conflict currently with as the node would be marked not ready due to the critical-pods-started check. Unfortunately, this creates an impasse at the moment, as we need to start the CSI driver pod on that node to get the initial `allocatable` estimation so the pod needs to be deployed and only later can we really find out if the CSI Driver is needed. Hence, for now we use the workaround of setting the number to 1 if it would be set to `<=0`
 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Introduce the csinode webhook for provider extensions
```
