### PR TITLE
Prevent reading encrypted resources with `shoots/viewerkubeconfig` subresource

### DIFF
--- a/docs/usage/shoot_access.md
+++ b/docs/usage/shoot_access.md
@@ -86,7 +86,7 @@ v1 = client.CoreV1Api(shoot_api_client)
 ## `shoots/viewerkubeconfig` Subresource
 
 The `shoots/viewerkubeconfig` subresource works similar to the [`shoots/adminkubeconfig`](#shootsadminkubeconfig-subresource).
-The difference is that it returns a kubeconfig with read-only access for all APIs except the `core/v1.Secret` API.
+The difference is that it returns a kubeconfig with read-only access for all APIs except the `core/v1.Secret` API and the resources which are specified in the `spec.kubernetes.kubeAPIServer.encryptionConfig` field in the Shoot (See [this document](./etcd_encryption_config.md)).
 
 In order to request such a `kubeconfig`, you can run follow almost the same code as above - the only difference is that you need to use the `viewerkubeconfig` subresource.
 For example, in bash this looks like this:
@@ -144,11 +144,13 @@ spec:
 ```
 
 It is **not** the recommended method to access the shoot cluster, as the static token `kubeconfig` has some security flaws associated with it:
+
 - The static token in the `kubeconfig` doesn't have any expiration date. Read [this document](shoot_credentials_rotation.md#kubeconfig) to learn how to rotate the static token.
 - The static token doesn't have any user identity associated with it. The user in that token will always be `system:cluster-admin`, irrespective of the person accessing the cluster. Hence, it is impossible to audit the events in cluster.
 
 When `enableStaticTokenKubeconfig` field is not explicitly set in the Shoot spec:
+
 - for Shoot clusters using Kubernetes version < 1.26 the field is defaulted to `true`.
 - for Shoot clusters using Kubernetes version >= 1.26 the field is defaulted to `false`.
 
-> **Note:** Starting with Kubernetes 1.27, the `enableStaticTokenKubeconfig` field will be locked to `false`. 
+> **Note:** Starting with Kubernetes 1.27, the `enableStaticTokenKubeconfig` field will be locked to `false`.

--- a/docs/usage/shoot_access.md
+++ b/docs/usage/shoot_access.md
@@ -86,7 +86,7 @@ v1 = client.CoreV1Api(shoot_api_client)
 ## `shoots/viewerkubeconfig` Subresource
 
 The `shoots/viewerkubeconfig` subresource works similar to the [`shoots/adminkubeconfig`](#shootsadminkubeconfig-subresource).
-The difference is that it returns a kubeconfig with read-only access for all APIs except the `core/v1.Secret` API and the resources which are specified in the `spec.kubernetes.kubeAPIServer.encryptionConfig` field in the Shoot (See [this document](./etcd_encryption_config.md)).
+The difference is that it returns a kubeconfig with read-only access for all APIs except the `core/v1.Secret` API and the resources which are specified in the `spec.kubernetes.kubeAPIServer.encryptionConfig` field in the Shoot (see [this document](./etcd_encryption_config.md)).
 
 In order to request such a `kubeconfig`, you can run follow almost the same code as above - the only difference is that you need to use the `viewerkubeconfig` subresource.
 For example, in bash this looks like this:

--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -1088,9 +1088,8 @@ func validateEncryptionConfig(encryptionConfig *core.EncryptionConfig, version s
 			allErrs = append(allErrs, field.Duplicate(idxPath, resource))
 		}
 
-		if defaultEncryptedResources.Has(resource) ||
-			// core resources can be mentioned with empty group (eg: secrets.)
-			defaultEncryptedResources.Has(strings.TrimSuffix(resource, ".")) {
+		// core resources can be mentioned with empty group (eg: secrets.)
+		if defaultEncryptedResources.Has(strings.TrimSuffix(resource, ".")) {
 			allErrs = append(allErrs, field.Forbidden(idxPath, fmt.Sprintf("%q are always encrypted", resource)))
 		}
 

--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -1083,7 +1083,8 @@ func validateEncryptionConfig(encryptionConfig *core.EncryptionConfig, version s
 	seenResources := sets.New[string]()
 	for i, resource := range encryptionConfig.Resources {
 		idxPath := fldPath.Child("encryptionConfig", "resources").Index(i)
-		if seenResources.Has(resource) {
+		// core resources can be mentioned with empty group (eg: secrets.)
+		if seenResources.Has(resource) || seenResources.Has(strings.TrimSuffix(resource, ".")) {
 			allErrs = append(allErrs, field.Duplicate(idxPath, resource))
 		}
 

--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -1809,13 +1809,17 @@ var _ = Describe("Shoot Validation Tests", func() {
 
 				It("should deny specifying duplicated resources", func() {
 					shoot.Spec.Kubernetes.KubeAPIServer.EncryptionConfig = &core.EncryptionConfig{
-						Resources: []string{"configmaps", "configmaps"},
+						Resources: []string{"configmaps", "configmaps", "services", "services."},
 					}
 
 					Expect(ValidateShoot(shoot)).To(ConsistOf(
 						PointTo(MatchFields(IgnoreExtras, Fields{
 							"Type":  Equal(field.ErrorTypeDuplicate),
 							"Field": Equal("spec.kubernetes.kubeAPIServer.encryptionConfig.resources[1]"),
+						})),
+						PointTo(MatchFields(IgnoreExtras, Fields{
+							"Type":  Equal(field.ErrorTypeDuplicate),
+							"Field": Equal("spec.kubernetes.kubeAPIServer.encryptionConfig.resources[3]"),
 						})),
 					))
 				})
@@ -1841,7 +1845,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 
 				It("should deny specifying 'secrets' resource in resources", func() {
 					shoot.Spec.Kubernetes.KubeAPIServer.EncryptionConfig = &core.EncryptionConfig{
-						Resources: []string{"configmaps", "secrets", "secrets."},
+						Resources: []string{"configmaps", "secrets"},
 					}
 
 					Expect(ValidateShoot(shoot)).To(ConsistOf(
@@ -1850,9 +1854,18 @@ var _ = Describe("Shoot Validation Tests", func() {
 							"Field":  Equal("spec.kubernetes.kubeAPIServer.encryptionConfig.resources[1]"),
 							"Detail": Equal("\"secrets\" are always encrypted"),
 						})),
+					))
+				})
+
+				It("should deny specifying 'secrets.' resource in resources", func() {
+					shoot.Spec.Kubernetes.KubeAPIServer.EncryptionConfig = &core.EncryptionConfig{
+						Resources: []string{"configmaps", "secrets."},
+					}
+
+					Expect(ValidateShoot(shoot)).To(ConsistOf(
 						PointTo(MatchFields(IgnoreExtras, Fields{
 							"Type":   Equal(field.ErrorTypeForbidden),
-							"Field":  Equal("spec.kubernetes.kubeAPIServer.encryptionConfig.resources[2]"),
+							"Field":  Equal("spec.kubernetes.kubeAPIServer.encryptionConfig.resources[1]"),
 							"Detail": Equal("\"secrets.\" are always encrypted"),
 						})),
 					))

--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -1824,6 +1824,19 @@ var _ = Describe("Shoot Validation Tests", func() {
 					))
 				})
 
+				It("should deny specifying duplicated resources", func() {
+					shoot.Spec.Kubernetes.KubeAPIServer.EncryptionConfig = &core.EncryptionConfig{
+						Resources: []string{"services.", "services."},
+					}
+
+					Expect(ValidateShoot(shoot)).To(ConsistOf(
+						PointTo(MatchFields(IgnoreExtras, Fields{
+							"Type":  Equal(field.ErrorTypeDuplicate),
+							"Field": Equal("spec.kubernetes.kubeAPIServer.encryptionConfig.resources[1]"),
+						})),
+					))
+				})
+
 				It("should deny specifying wildcard resources", func() {
 					shoot.Spec.Kubernetes.KubeAPIServer.EncryptionConfig = &core.EncryptionConfig{
 						Resources: []string{"*.apps", "*.*"},

--- a/pkg/component/shared/apiserver.go
+++ b/pkg/component/shared/apiserver.go
@@ -17,6 +17,7 @@ package shared
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -222,4 +223,16 @@ func GetResourcesForEncryptionFromConfig(encryptionConfig *gardencorev1beta1.Enc
 	}
 
 	return sets.List(sets.New(encryptionConfig.Resources...))
+}
+
+// NormalizeResources returns the list of resources after trimming the suffix '.' if present.
+// This is needed for core resources which can be specified as '<resource>.' as well.
+func NormalizeResources(resources []string) []string {
+	var out []string
+
+	for _, resource := range resources {
+		out = append(out, strings.TrimSuffix(resource, "."))
+	}
+
+	return out
 }

--- a/pkg/component/shared/apiserver_test.go
+++ b/pkg/component/shared/apiserver_test.go
@@ -42,4 +42,21 @@ var _ = Describe("APIServer", func() {
 		})
 	})
 
+	Describe("#NormalizeResources", func() {
+		It("should return nil when encryptionConfig is nil", func() {
+			Expect(NormalizeResources(nil)).To(BeNil())
+		})
+
+		It("should return the correct list of resources when encryptionConfig is not nil", func() {
+			resources := []string{"deployments.apps", "fancyresource.customoperator.io", "endpoints.", "configmaps", "services."}
+
+			Expect(NormalizeResources(resources)).To(ConsistOf(
+				"deployments.apps",
+				"fancyresource.customoperator.io",
+				"configmaps",
+				"services",
+				"endpoints",
+			))
+		})
+	})
 })

--- a/pkg/component/shootsystem/shootsystem.go
+++ b/pkg/component/shootsystem/shootsystem.go
@@ -482,12 +482,11 @@ func (s *shootSystem) readOnlyRBACResources() []client.Object {
 }
 
 func (s *shootSystem) isEncryptedResource(resource, group string) bool {
+	resourceName := fmt.Sprintf("%s.%s", resource, group)
+
 	if group == corev1.SchemeGroupVersion.Group {
-		// cores resource can also be present as '<resource>.' For example, 'configmaps' as 'configmaps.'
-		coreResourceName := fmt.Sprintf("%s.", resource)
-		return slices.Contains(s.values.EncryptedResources, resource) || slices.Contains(s.values.EncryptedResources, coreResourceName)
+		resourceName = resource
 	}
 
-	resourceName := fmt.Sprintf("%s.%s", resource, group)
 	return slices.Contains(s.values.EncryptedResources, resourceName)
 }

--- a/pkg/component/shootsystem/shootsystem_test.go
+++ b/pkg/component/shootsystem/shootsystem_test.go
@@ -486,7 +486,7 @@ spec:
 
 					values.EncryptedResources = []string{
 						"secrets",
-						"services.",
+						"services",
 						"statefulsets.apps",
 						"fancyresource1.fancyoperator.io",
 						"dash.foo",

--- a/pkg/component/shootsystem/shootsystem_test.go
+++ b/pkg/component/shootsystem/shootsystem_test.go
@@ -450,6 +450,7 @@ spec:
 							APIResources: []metav1.APIResource{
 								{Name: "bar", Verbs: metav1.Verbs{"create", "delete"}},
 								{Name: "baz", Verbs: metav1.Verbs{"get", "list", "watch"}},
+								{Name: "dash", Verbs: metav1.Verbs{"get", "list", "watch"}},
 							},
 						},
 						{
@@ -457,6 +458,7 @@ spec:
 							APIResources: []metav1.APIResource{
 								{Name: "secrets", Verbs: metav1.Verbs{"get", "list", "watch"}},
 								{Name: "configmaps", Verbs: metav1.Verbs{"get", "list", "watch"}},
+								{Name: "services", Verbs: metav1.Verbs{"get", "list", "watch"}},
 							},
 						},
 						{
@@ -466,11 +468,33 @@ spec:
 								{Name: "baz", Verbs: metav1.Verbs{"get", "list", "watch"}},
 							},
 						},
+						{
+							GroupVersion: "fancyoperator.io/v1alpha1",
+							APIResources: []metav1.APIResource{
+								{Name: "fancyresource1", Verbs: metav1.Verbs{"get", "list", "watch"}},
+								{Name: "fancyresource2", Verbs: metav1.Verbs{"get", "list", "watch"}},
+							},
+						},
+						{
+							GroupVersion: "apps/v1",
+							APIResources: []metav1.APIResource{
+								{Name: "deployments", Verbs: metav1.Verbs{"get", "list", "watch"}},
+								{Name: "statefulsets", Verbs: metav1.Verbs{"get", "list", "watch"}},
+							},
+						},
+					}
+
+					values.EncryptedResources = []string{
+						"secrets",
+						"services.",
+						"statefulsets.apps",
+						"fancyresource1.fancyoperator.io",
+						"dash.foo",
 					}
 				})
 
 				It("should successfully deploy the related RBAC resources", func() {
-					Expect(managedResourceSecret.Data["clusterrole____gardener.cloud_system_read-only.yaml"]).To(Equal([]byte(`apiVersion: rbac.authorization.k8s.io/v1
+					Expect(string(managedResourceSecret.Data["clusterrole____gardener.cloud_system_read-only.yaml"])).To(Equal(`apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   creationTimestamp: null
@@ -485,10 +509,26 @@ rules:
   - list
   - watch
 - apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - bar
   resources:
   - foo
   - baz
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - fancyoperator.io
+  resources:
+  - fancyresource2
   verbs:
   - get
   - list
@@ -501,8 +541,8 @@ rules:
   - get
   - list
   - watch
-`)))
-					Expect(managedResourceSecret.Data["clusterrolebinding____gardener.cloud_system_read-only.yaml"]).To(Equal([]byte(`apiVersion: rbac.authorization.k8s.io/v1
+`))
+					Expect(string(managedResourceSecret.Data["clusterrolebinding____gardener.cloud_system_read-only.yaml"])).To(Equal(`apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   annotations:
@@ -516,7 +556,7 @@ roleRef:
 subjects:
 - kind: Group
   name: gardener.cloud:system:viewers
-`)))
+`))
 				})
 			})
 		})

--- a/pkg/operation/botanist/kubeapiserver.go
+++ b/pkg/operation/botanist/kubeapiserver.go
@@ -246,7 +246,7 @@ func (b *Botanist) DeployKubeAPIServer(ctx context.Context) error {
 		b.Shoot.ComputeOutOfClusterAPIServerAddress(true),
 		externalServer,
 		b.Shoot.ResourcesToEncrypt,
-		b.Shoot.GetInfo().Status.EncryptedResources,
+		b.Shoot.EncryptedResources,
 		v1beta1helper.GetShootETCDEncryptionKeyRotationPhase(b.Shoot.GetInfo().Status.Credentials),
 		v1beta1helper.GetShootServiceAccountKeyRotationPhase(b.Shoot.GetInfo().Status.Credentials),
 		b.Shoot.HibernationEnabled,

--- a/pkg/operation/botanist/shootsystem.go
+++ b/pkg/operation/botanist/shootsystem.go
@@ -19,7 +19,10 @@ import (
 	"fmt"
 	"slices"
 
+	"k8s.io/apimachinery/pkg/util/sets"
+
 	"github.com/gardener/gardener/pkg/component/shootsystem"
+	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 )
 
 // DefaultShootSystem returns a deployer for the shoot system resources.
@@ -39,6 +42,7 @@ func (b *Botanist) DefaultShootSystem() shootsystem.Interface {
 		PodNetworkCIDR:        b.Shoot.Networks.Pods.String(),
 		ServiceNetworkCIDR:    b.Shoot.Networks.Services.String(),
 		ProjectName:           b.Garden.Project.Name,
+		EncryptedResources:    append(sets.List(gardenerutils.DefaultResourcesForEncryption()), b.Shoot.ResourcesToEncrypt...),
 	}
 
 	return shootsystem.New(b.SeedClientSet.Client(), b.Shoot.SeedNamespace, values)

--- a/pkg/operation/shoot/shoot.go
+++ b/pkg/operation/shoot/shoot.go
@@ -246,7 +246,10 @@ func (b *Builder) Build(ctx context.Context, c client.Reader) (*Shoot, error) {
 	shoot.PSPDisabled = v1beta1helper.IsPSPDisabled(shoot.GetInfo())
 
 	if shoot.GetInfo().Spec.Kubernetes.KubeAPIServer != nil {
-		shoot.ResourcesToEncrypt = sharedcomponent.GetResourcesForEncryptionFromConfig(shoot.GetInfo().Spec.Kubernetes.KubeAPIServer.EncryptionConfig)
+		shoot.ResourcesToEncrypt = sharedcomponent.NormalizeResources(sharedcomponent.GetResourcesForEncryptionFromConfig(shoot.GetInfo().Spec.Kubernetes.KubeAPIServer.EncryptionConfig))
+	}
+	if len(shoot.GetInfo().Status.EncryptedResources) > 0 {
+		shoot.EncryptedResources = sharedcomponent.NormalizeResources(shoot.GetInfo().Status.EncryptedResources)
 	}
 
 	if b.seed == nil {

--- a/pkg/operation/shoot/types.go
+++ b/pkg/operation/shoot/types.go
@@ -111,6 +111,7 @@ type Shoot struct {
 	// TODO(rfranzke): Remove this field when UseGardenerNodeAgent feature gate gets removed.
 	CloudConfigExecutionMaxDelaySeconds int
 	ResourcesToEncrypt                  []string
+	EncryptedResources                  []string
 
 	Components *Components
 }

--- a/test/e2e/gardener/common.go
+++ b/test/e2e/gardener/common.go
@@ -130,6 +130,7 @@ func DefaultWorkerlessShoot(name string) *gardencorev1beta1.Shoot {
 			Kubernetes: gardencorev1beta1.Kubernetes{
 				Version:                     "1.28.2",
 				EnableStaticTokenKubeconfig: pointer.Bool(false),
+				KubeAPIServer:               &gardencorev1beta1.KubeAPIServerConfig{},
 			},
 			Provider: gardencorev1beta1.Provider{
 				Type: "local",


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind enhancement

**What this PR does / why we need it**:
The PR adapts the RBAC for the `viewerkubeconfig` to not include viewing permissions for resources which are encrypted in the Shoot spec.

Followup after https://github.com/gardener/gardener/pull/8842 and https://github.com/gardener/gardener/pull/8870

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener/pull/8870#pullrequestreview-1752054482 comment

**Special notes for your reviewer**:
/cc @timuthy 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
The `shoots/viewerkubeconfig` subresource now also restricts viewer access to resources which are specified in the `spec.kubernetes.kubeAPIServer.encryptionConfig` in the Shoot in addition to `Secrets`.
```
