### PR TITLE
Revert "Spread Istio Ingress Gateway pods across hosts if there are multiple nodes per zone."

### DIFF
--- a/charts/gardener/operator/templates/clusterrole.yaml
+++ b/charts/gardener/operator/templates/clusterrole.yaml
@@ -27,7 +27,6 @@ rules:
   - configmaps
   - serviceaccounts
   - pods
-  - nodes
   verbs:
   - get
   - list

--- a/charts/gardener/operator/templates/clusterrole.yaml
+++ b/charts/gardener/operator/templates/clusterrole.yaml
@@ -27,6 +27,7 @@ rules:
   - configmaps
   - serviceaccounts
   - pods
+  - nodes
   verbs:
   - get
   - list

--- a/pkg/component/istio/charts/istio/istio-ingress/templates/deployment.yaml
+++ b/pkg/component/istio/charts/istio/istio-ingress/templates/deployment.yaml
@@ -207,15 +207,10 @@ spec:
       priorityClassName: {{ .Values.priorityClassName }}
       affinity:
         podAntiAffinity:
-          {{- if .Values.ensureHostAntiAffinity }}
-          requiredDuringSchedulingIgnoredDuringExecution:
-            - labelSelector:
-          {{- else }}
           preferredDuringSchedulingIgnoredDuringExecution:
           - weight: 100
             podAffinityTerm:
               labelSelector:
-          {{- end }}
                 matchExpressions:
                 {{- range $key, $value := .Values.labels }}
                 - key: {{ $key }}

--- a/pkg/component/istio/charts/istio/istio-ingress/values.yaml
+++ b/pkg/component/istio/charts/istio/istio-ingress/values.yaml
@@ -25,7 +25,6 @@ ingressVersion: "1.19.3"
 replicas: 2
 minReplicas: 2
 maxReplicas: 5
-ensureHostAntiAffinity: false
 
 # Istio Ingress Configuration Resources
 proxyProtocolEnabled: false

--- a/pkg/component/istio/ingress_gateway.go
+++ b/pkg/component/istio/ingress_gateway.go
@@ -49,7 +49,6 @@ type IngressGatewayValues struct {
 	ProxyProtocolEnabled  bool
 	VPNEnabled            bool
 	Zones                 []string
-	EnsureHostSpreading   bool
 
 	// Ports is a list of all Ports the istio-ingress gateways is listening on.
 	// Port 15021 and 15000 cannot be used.
@@ -77,7 +76,6 @@ func (i *istiod) generateIstioIngressGatewayChart() (*chartrenderer.RenderedChar
 			"vpn": map[string]interface{}{
 				"enabled": istioIngressGateway.VPNEnabled,
 			},
-			"ensureHostAntiAffinity": istioIngressGateway.EnsureHostSpreading,
 		}
 
 		if istioIngressGateway.MinReplicas != nil {

--- a/pkg/gardenlet/controller/seed/seed/components.go
+++ b/pkg/gardenlet/controller/seed/seed/components.go
@@ -72,7 +72,6 @@ import (
 )
 
 func defaultIstio(
-	ctx context.Context,
 	seedClient client.Client,
 	chartRenderer chartrenderer.Interface,
 	seed *seedpkg.Seed,
@@ -88,7 +87,6 @@ func defaultIstio(
 	)
 
 	istioDeployer, err := shared.NewIstio(
-		ctx,
 		seedClient,
 		chartRenderer,
 		"",
@@ -117,8 +115,6 @@ func defaultIstio(
 	if len(seedObj.Spec.Provider.Zones) > 1 {
 		for _, zone := range seedObj.Spec.Provider.Zones {
 			if err := shared.AddIstioIngressGateway(
-				ctx,
-				seedClient,
 				istioDeployer,
 				shared.GetIstioNamespaceForZone(*conf.SNI.Ingress.Namespace, zone),
 				seed.GetZonalLoadBalancerServiceAnnotations(zone),
@@ -135,8 +131,6 @@ func defaultIstio(
 	// Add for each ExposureClass handler in the config an own Ingress Gateway and Proxy Gateway.
 	for _, handler := range conf.ExposureClassHandlers {
 		if err := shared.AddIstioIngressGateway(
-			ctx,
-			seedClient,
 			istioDeployer,
 			*handler.SNI.Ingress.Namespace,
 			// handler.LoadBalancerService.Annotations must put last to override non-exposure class related keys.
@@ -153,8 +147,6 @@ func defaultIstio(
 		if len(seedObj.Spec.Provider.Zones) > 1 {
 			for _, zone := range seedObj.Spec.Provider.Zones {
 				if err := shared.AddIstioIngressGateway(
-					ctx,
-					seedClient,
 					istioDeployer,
 					shared.GetIstioNamespaceForZone(*handler.SNI.Ingress.Namespace, zone),
 					// handler.LoadBalancerService.Annotations must put last to override non-exposure class related keys.

--- a/pkg/gardenlet/controller/seed/seed/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/seed/seed/reconciler_reconcile.go
@@ -376,7 +376,7 @@ func (r *Reconciler) runReconcileSeedFlow(
 	// setup for flow graph
 	var dnsRecord component.DeployMigrateWaiter
 
-	istio, err := defaultIstio(ctx, seedClient, chartRenderer, seed, &r.Config, seedIsGarden)
+	istio, err := defaultIstio(seedClient, chartRenderer, seed, &r.Config, seedIsGarden)
 	if err != nil {
 		return err
 	}

--- a/pkg/operator/controller/garden/garden/components.go
+++ b/pkg/operator/controller/garden/garden/components.go
@@ -162,7 +162,7 @@ func (r *Reconciler) instantiateComponents(
 	if err != nil {
 		return
 	}
-	c.istio, err = r.newIstio(ctx, garden)
+	c.istio, err = r.newIstio(garden)
 	if err != nil {
 		return
 	}
@@ -698,14 +698,13 @@ func (r *Reconciler) newKubeStateMetrics() (component.DeployWaiter, error) {
 	)
 }
 
-func (r *Reconciler) newIstio(ctx context.Context, garden *operatorv1alpha1.Garden) (istio.Interface, error) {
+func (r *Reconciler) newIstio(garden *operatorv1alpha1.Garden) (istio.Interface, error) {
 	var annotations map[string]string
 	if settings := garden.Spec.RuntimeCluster.Settings; settings != nil && settings.LoadBalancerServices != nil {
 		annotations = settings.LoadBalancerServices.Annotations
 	}
 
 	return sharedcomponent.NewIstio(
-		ctx,
 		r.RuntimeClientSet.Client(),
 		r.RuntimeClientSet.ChartRenderer(),
 		namePrefix,


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind cleanup

**What this PR does / why we need it**:
This change reverts pull request #8876.

An unintended side-effect of the #8876 was that seed clusters with two nodes in an availability zone may get stuck during rollout of `istio` if no cluster autoscaling was available or the corresponding node group was maxed out at two nodes. This undesired behaviour should not happen is now prevented by reverting the change.

**Which issue(s) this PR fixes**:
None.

**Special notes for your reviewer**:
We will look into whether replacing the pod anti-affinities with topology spread constraints may resolve this issue.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```

/cc @ialidzhikov 