### PR TITLE
[controllermanager] Clean up technical debt in defaulting code

### DIFF
--- a/pkg/controllermanager/apis/config/v1alpha1/defaults.go
+++ b/pkg/controllermanager/apis/config/v1alpha1/defaults.go
@@ -18,211 +18,21 @@ import (
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	componentbaseconfigv1alpha1 "k8s.io/component-base/config/v1alpha1"
 	"k8s.io/utils/pointer"
 )
 
-func addDefaultingFuncs(scheme *runtime.Scheme) error {
-	return RegisterDefaults(scheme)
-}
-
 // SetDefaults_ControllerManagerConfiguration sets defaults for the configuration of the Gardener controller manager.
 func SetDefaults_ControllerManagerConfiguration(obj *ControllerManagerConfiguration) {
-	if obj.Controllers.Bastion == nil {
-		obj.Controllers.Bastion = &BastionControllerConfiguration{}
-	}
-	if obj.Controllers.Bastion.ConcurrentSyncs == nil {
-		v := DefaultControllerConcurrentSyncs
-		obj.Controllers.Bastion.ConcurrentSyncs = &v
-	}
-	if obj.Controllers.Bastion.MaxLifetime == nil {
-		obj.Controllers.Bastion.MaxLifetime = &metav1.Duration{Duration: 24 * time.Hour}
-	}
-
-	if obj.Controllers.CertificateSigningRequest == nil {
-		obj.Controllers.CertificateSigningRequest = &CertificateSigningRequestControllerConfiguration{}
-	}
-
-	if obj.Controllers.CloudProfile == nil {
-		obj.Controllers.CloudProfile = &CloudProfileControllerConfiguration{}
-	}
-	if obj.Controllers.CloudProfile.ConcurrentSyncs == nil {
-		v := DefaultControllerConcurrentSyncs
-		obj.Controllers.CloudProfile.ConcurrentSyncs = &v
-	}
-
-	if obj.Controllers.ControllerDeployment == nil {
-		obj.Controllers.ControllerDeployment = &ControllerDeploymentControllerConfiguration{}
-	}
-	if obj.Controllers.ControllerDeployment.ConcurrentSyncs == nil {
-		v := DefaultControllerConcurrentSyncs
-		obj.Controllers.ControllerDeployment.ConcurrentSyncs = &v
-	}
-
-	if obj.Controllers.ControllerRegistration == nil {
-		obj.Controllers.ControllerRegistration = &ControllerRegistrationControllerConfiguration{}
-	}
-	if obj.Controllers.ControllerRegistration.ConcurrentSyncs == nil {
-		v := DefaultControllerConcurrentSyncs
-		obj.Controllers.ControllerRegistration.ConcurrentSyncs = &v
-	}
-
-	if obj.Controllers.ExposureClass == nil {
-		obj.Controllers.ExposureClass = &ExposureClassControllerConfiguration{}
-	}
-	if obj.Controllers.ExposureClass.ConcurrentSyncs == nil {
-		v := DefaultControllerConcurrentSyncs
-		obj.Controllers.ExposureClass.ConcurrentSyncs = &v
-	}
-
-	if obj.Controllers.Project == nil {
-		obj.Controllers.Project = &ProjectControllerConfiguration{}
-	}
-	if obj.Controllers.Project.ConcurrentSyncs == nil {
-		v := DefaultControllerConcurrentSyncs
-		obj.Controllers.Project.ConcurrentSyncs = &v
-	}
-	if obj.Controllers.Project.MinimumLifetimeDays == nil {
-		v := 30
-		obj.Controllers.Project.MinimumLifetimeDays = &v
-	}
-	if obj.Controllers.Project.StaleGracePeriodDays == nil {
-		v := 14
-		obj.Controllers.Project.StaleGracePeriodDays = &v
-	}
-	if obj.Controllers.Project.StaleExpirationTimeDays == nil {
-		v := 90
-		obj.Controllers.Project.StaleExpirationTimeDays = &v
-	}
-	if obj.Controllers.Project.StaleSyncPeriod == nil {
-		obj.Controllers.Project.StaleSyncPeriod = &metav1.Duration{
-			Duration: 12 * time.Hour,
-		}
-	}
-	for i, quota := range obj.Controllers.Project.Quotas {
-		if quota.ProjectSelector == nil {
-			obj.Controllers.Project.Quotas[i].ProjectSelector = &metav1.LabelSelector{}
-		}
-	}
-
-	if obj.Controllers.Quota == nil {
-		obj.Controllers.Quota = &QuotaControllerConfiguration{}
-	}
-	if obj.Controllers.Quota.ConcurrentSyncs == nil {
-		v := DefaultControllerConcurrentSyncs
-		obj.Controllers.Quota.ConcurrentSyncs = &v
-	}
-
-	if obj.Controllers.SecretBinding == nil {
-		obj.Controllers.SecretBinding = &SecretBindingControllerConfiguration{}
-	}
-	if obj.Controllers.SecretBinding.ConcurrentSyncs == nil {
-		v := DefaultControllerConcurrentSyncs
-		obj.Controllers.SecretBinding.ConcurrentSyncs = &v
-	}
-
-	if obj.Controllers.Seed == nil {
-		obj.Controllers.Seed = &SeedControllerConfiguration{}
-	}
-
-	if obj.Controllers.SeedExtensionsCheck == nil {
-		obj.Controllers.SeedExtensionsCheck = &SeedExtensionsCheckControllerConfiguration{}
-	}
-
-	if obj.Controllers.SeedBackupBucketsCheck == nil {
-		obj.Controllers.SeedBackupBucketsCheck = &SeedBackupBucketsCheckControllerConfiguration{}
-	}
-
-	if obj.Controllers.ShootMaintenance.ConcurrentSyncs == nil {
-		v := DefaultControllerConcurrentSyncs
-		obj.Controllers.ShootMaintenance.ConcurrentSyncs = &v
-	}
-	if obj.Controllers.ShootMaintenance.EnableShootControlPlaneRestarter == nil {
-		obj.Controllers.ShootMaintenance.EnableShootControlPlaneRestarter = pointer.Bool(true)
-	}
-
-	if obj.Controllers.ShootQuota == nil {
-		obj.Controllers.ShootQuota = &ShootQuotaControllerConfiguration{}
-	}
-	if obj.Controllers.ShootQuota.ConcurrentSyncs == nil {
-		v := DefaultControllerConcurrentSyncs
-		obj.Controllers.ShootQuota.ConcurrentSyncs = &v
-	}
-	if obj.Controllers.ShootQuota.SyncPeriod == nil {
-		obj.Controllers.ShootQuota.SyncPeriod = &metav1.Duration{
-			Duration: 60 * time.Minute,
-		}
-	}
-
-	if obj.Controllers.ShootReference == nil {
-		obj.Controllers.ShootReference = &ShootReferenceControllerConfiguration{}
-	}
-	if obj.Controllers.ShootReference.ConcurrentSyncs == nil {
-		v := DefaultControllerConcurrentSyncs
-		obj.Controllers.ShootReference.ConcurrentSyncs = &v
-	}
-
-	if obj.Controllers.ShootRetry == nil {
-		obj.Controllers.ShootRetry = &ShootRetryControllerConfiguration{}
-	}
-	if obj.Controllers.ShootRetry.ConcurrentSyncs == nil {
-		v := DefaultControllerConcurrentSyncs
-		obj.Controllers.ShootRetry.ConcurrentSyncs = &v
-	}
-
-	if obj.Controllers.ShootConditions == nil {
-		obj.Controllers.ShootConditions = &ShootConditionsControllerConfiguration{}
-	}
-	if obj.Controllers.ShootConditions.ConcurrentSyncs == nil {
-		v := DefaultControllerConcurrentSyncs
-		obj.Controllers.ShootConditions.ConcurrentSyncs = &v
-	}
-
-	if obj.Controllers.ShootStatusLabel == nil {
-		obj.Controllers.ShootStatusLabel = &ShootStatusLabelControllerConfiguration{}
-	}
-	if obj.Controllers.ShootStatusLabel.ConcurrentSyncs == nil {
-		v := DefaultControllerConcurrentSyncs
-		obj.Controllers.ShootStatusLabel.ConcurrentSyncs = &v
-	}
-
-	if obj.Controllers.ManagedSeedSet == nil {
-		obj.Controllers.ManagedSeedSet = &ManagedSeedSetControllerConfiguration{
-			SyncPeriod: metav1.Duration{
-				Duration: 30 * time.Minute,
-			},
-		}
-	}
-	if obj.Controllers.ManagedSeedSet.ConcurrentSyncs == nil {
-		v := DefaultControllerConcurrentSyncs
-		obj.Controllers.ManagedSeedSet.ConcurrentSyncs = &v
-	}
-
 	if obj.LogLevel == "" {
 		obj.LogLevel = LogLevelInfo
 	}
-
 	if obj.LogFormat == "" {
 		obj.LogFormat = LogFormatJSON
 	}
 
 	if obj.LeaderElection == nil {
 		obj.LeaderElection = &componentbaseconfigv1alpha1.LeaderElectionConfiguration{}
-	}
-
-	if obj.Server.HealthProbes == nil {
-		obj.Server.HealthProbes = &Server{}
-	}
-	if obj.Server.HealthProbes.Port == 0 {
-		obj.Server.HealthProbes.Port = 2718
-	}
-
-	if obj.Server.Metrics == nil {
-		obj.Server.Metrics = &Server{}
-	}
-	if obj.Server.Metrics.Port == 0 {
-		obj.Server.Metrics.Port = 2719
 	}
 }
 
@@ -254,19 +64,11 @@ func SetDefaults_LeaderElectionConfiguration(obj *componentbaseconfigv1alpha1.Le
 	}
 }
 
-// SetDefaults_EventControllerConfiguration sets defaults for the EventControllerConfiguration.
-func SetDefaults_EventControllerConfiguration(obj *EventControllerConfiguration) {
-	if obj.ConcurrentSyncs == nil {
-		v := DefaultControllerConcurrentSyncs
-		obj.ConcurrentSyncs = &v
-	}
-	if obj.TTLNonShootEvents == nil {
-		obj.TTLNonShootEvents = &metav1.Duration{Duration: 1 * time.Hour}
-	}
-}
-
 // SetDefaults_ShootRetryControllerConfiguration sets defaults for the ShootRetryControllerConfiguration.
 func SetDefaults_ShootRetryControllerConfiguration(obj *ShootRetryControllerConfiguration) {
+	if obj.ConcurrentSyncs == nil {
+		obj.ConcurrentSyncs = pointer.Int(DefaultControllerConcurrentSyncs)
+	}
 	if obj.RetryPeriod == nil {
 		obj.RetryPeriod = &metav1.Duration{Duration: 10 * time.Minute}
 	}
@@ -275,74 +77,256 @@ func SetDefaults_ShootRetryControllerConfiguration(obj *ShootRetryControllerConf
 	}
 }
 
-// SetDefaults_ManagedSeedSetControllerConfiguration sets defaults for the given ManagedSeedSetControllerConfiguration.
-func SetDefaults_ManagedSeedSetControllerConfiguration(obj *ManagedSeedSetControllerConfiguration) {
-	if obj.MaxShootRetries == nil {
-		v := 3
-		obj.MaxShootRetries = &v
+// SetDefaults_SeedControllerConfiguration sets defaults for the given SeedControllerConfiguration.
+func SetDefaults_SeedControllerConfiguration(obj *SeedControllerConfiguration) {
+	if obj.SyncPeriod == nil {
+		obj.SyncPeriod = &metav1.Duration{Duration: 10 * time.Second}
 	}
-}
-
-// SetDefaults_ShootHibernationControllerConfiguration sets defaults for the given ShootHibernationControllerConfiguration.
-func SetDefaults_ShootHibernationControllerConfiguration(obj *ShootHibernationControllerConfiguration) {
 	if obj.ConcurrentSyncs == nil {
-		v := DefaultControllerConcurrentSyncs
-		obj.ConcurrentSyncs = &v
+		obj.ConcurrentSyncs = pointer.Int(DefaultControllerConcurrentSyncs)
 	}
-	if obj.TriggerDeadlineDuration == nil {
-		obj.TriggerDeadlineDuration = &metav1.Duration{Duration: 2 * time.Hour}
+	if obj.MonitorPeriod == nil {
+		obj.MonitorPeriod = &metav1.Duration{Duration: 40 * time.Second}
+	}
+	if obj.ShootMonitorPeriod == nil {
+		obj.ShootMonitorPeriod = &metav1.Duration{Duration: 5 * obj.MonitorPeriod.Duration}
 	}
 }
 
-// SetDefaults_SeedExtensionsCheckControllerConfiguration sets defaults for the given SeedExtensionsCheckControllerConfiguration.
+func SetDefaults_ProjectControllerConfiguration(obj *ProjectControllerConfiguration) {
+	if obj.ConcurrentSyncs == nil {
+		obj.ConcurrentSyncs = pointer.Int(DefaultControllerConcurrentSyncs)
+	}
+	if obj.MinimumLifetimeDays == nil {
+		obj.MinimumLifetimeDays = pointer.Int(30)
+	}
+	if obj.StaleGracePeriodDays == nil {
+		obj.StaleGracePeriodDays = pointer.Int(14)
+	}
+	if obj.StaleExpirationTimeDays == nil {
+		obj.StaleExpirationTimeDays = pointer.Int(90)
+	}
+	if obj.StaleSyncPeriod == nil {
+		obj.StaleSyncPeriod = &metav1.Duration{
+			Duration: 12 * time.Hour,
+		}
+	}
+	for i, quota := range obj.Quotas {
+		if quota.ProjectSelector == nil {
+			obj.Quotas[i].ProjectSelector = &metav1.LabelSelector{}
+		}
+	}
+}
+
+func SetDefaults_ServerConfiguration(obj *ServerConfiguration) {
+	if obj.HealthProbes == nil {
+		obj.HealthProbes = &Server{}
+	}
+	if obj.HealthProbes.Port == 0 {
+		obj.HealthProbes.Port = 2718
+	}
+
+	if obj.Metrics == nil {
+		obj.Metrics = &Server{}
+	}
+	if obj.Metrics.Port == 0 {
+		obj.Metrics.Port = 2719
+	}
+}
+
+func SetDefaults_BastionControllerConfiguration(obj *BastionControllerConfiguration) {
+	if obj.ConcurrentSyncs == nil {
+		obj.ConcurrentSyncs = pointer.Int(DefaultControllerConcurrentSyncs)
+	}
+	if obj.MaxLifetime == nil {
+		obj.MaxLifetime = &metav1.Duration{Duration: 24 * time.Hour}
+	}
+}
+
+func SetDefaults_CertificateSigningRequestControllerConfiguration(obj *CertificateSigningRequestControllerConfiguration) {
+	if obj.ConcurrentSyncs == nil {
+		obj.ConcurrentSyncs = pointer.Int(DefaultControllerConcurrentSyncs)
+	}
+}
+
+func SetDefaults_CloudProfileControllerConfiguration(obj *CloudProfileControllerConfiguration) {
+	if obj.ConcurrentSyncs == nil {
+		obj.ConcurrentSyncs = pointer.Int(DefaultControllerConcurrentSyncs)
+	}
+}
+
+func SetDefaults_ControllerDeploymentControllerConfiguration(obj *ControllerDeploymentControllerConfiguration) {
+	if obj.ConcurrentSyncs == nil {
+		obj.ConcurrentSyncs = pointer.Int(DefaultControllerConcurrentSyncs)
+	}
+}
+
+func SetDefaults_ControllerRegistrationControllerConfiguration(obj *ControllerRegistrationControllerConfiguration) {
+	if obj.ConcurrentSyncs == nil {
+		obj.ConcurrentSyncs = pointer.Int(DefaultControllerConcurrentSyncs)
+	}
+}
+
+func SetDefaults_ExposureClassControllerConfiguration(obj *ExposureClassControllerConfiguration) {
+	if obj.ConcurrentSyncs == nil {
+		obj.ConcurrentSyncs = pointer.Int(DefaultControllerConcurrentSyncs)
+	}
+}
+
+func SetDefaults_QuotaControllerConfiguration(obj *QuotaControllerConfiguration) {
+	if obj.ConcurrentSyncs == nil {
+		obj.ConcurrentSyncs = pointer.Int(DefaultControllerConcurrentSyncs)
+	}
+}
+
+func SetDefaults_SecretBindingControllerConfiguration(obj *SecretBindingControllerConfiguration) {
+	if obj.ConcurrentSyncs == nil {
+		obj.ConcurrentSyncs = pointer.Int(DefaultControllerConcurrentSyncs)
+	}
+}
+
 func SetDefaults_SeedExtensionsCheckControllerConfiguration(obj *SeedExtensionsCheckControllerConfiguration) {
 	if obj.ConcurrentSyncs == nil {
-		v := DefaultControllerConcurrentSyncs
-		obj.ConcurrentSyncs = &v
-	}
-	if obj.SyncPeriod == nil {
-		v := metav1.Duration{Duration: 30 * time.Second}
-		obj.SyncPeriod = &v
-	}
-}
-
-// SetDefaults_SeedBackupBucketsCheckControllerConfiguration sets defaults for the given SeedBackupBucketsCheckControllerConfiguration.
-func SetDefaults_SeedBackupBucketsCheckControllerConfiguration(obj *SeedBackupBucketsCheckControllerConfiguration) {
-	if obj.ConcurrentSyncs == nil {
-		v := DefaultControllerConcurrentSyncs
-		obj.ConcurrentSyncs = &v
+		obj.ConcurrentSyncs = pointer.Int(DefaultControllerConcurrentSyncs)
 	}
 	if obj.SyncPeriod == nil {
 		obj.SyncPeriod = &metav1.Duration{Duration: 30 * time.Second}
 	}
 }
 
-// SetDefaults_CertificateSigningRequestControllerConfiguration sets defaults for the given CertificateSigningRequestControllerConfiguration.
-func SetDefaults_CertificateSigningRequestControllerConfiguration(obj *CertificateSigningRequestControllerConfiguration) {
+func SetDefaults_SeedBackupBucketsCheckControllerConfiguration(obj *SeedBackupBucketsCheckControllerConfiguration) {
 	if obj.ConcurrentSyncs == nil {
-		v := DefaultControllerConcurrentSyncs
-		obj.ConcurrentSyncs = &v
+		obj.ConcurrentSyncs = pointer.Int(DefaultControllerConcurrentSyncs)
+	}
+	if obj.SyncPeriod == nil {
+		obj.SyncPeriod = &metav1.Duration{Duration: 30 * time.Second}
 	}
 }
 
-// SetDefaults_SeedControllerConfiguration sets defaults for the given SeedControllerConfiguration.
-func SetDefaults_SeedControllerConfiguration(obj *SeedControllerConfiguration) {
-	if obj.SyncPeriod == nil {
-		obj.SyncPeriod = &metav1.Duration{Duration: 10 * time.Second}
-	}
-
+func SetDefaults_ShootHibernationControllerConfiguration(obj *ShootHibernationControllerConfiguration) {
 	if obj.ConcurrentSyncs == nil {
-		v := DefaultControllerConcurrentSyncs
-		obj.ConcurrentSyncs = &v
+		obj.ConcurrentSyncs = pointer.Int(DefaultControllerConcurrentSyncs)
+	}
+	if obj.TriggerDeadlineDuration == nil {
+		obj.TriggerDeadlineDuration = &metav1.Duration{Duration: 2 * time.Hour}
+	}
+}
+
+func SetDefaults_ShootMaintenanceControllerConfiguration(obj *ShootMaintenanceControllerConfiguration) {
+	if obj.ConcurrentSyncs == nil {
+		obj.ConcurrentSyncs = pointer.Int(DefaultControllerConcurrentSyncs)
+	}
+	if obj.EnableShootControlPlaneRestarter == nil {
+		obj.EnableShootControlPlaneRestarter = pointer.Bool(true)
+	}
+}
+
+func SetDefaults_ShootQuotaControllerConfiguration(obj *ShootQuotaControllerConfiguration) {
+	if obj.ConcurrentSyncs == nil {
+		obj.ConcurrentSyncs = pointer.Int(DefaultControllerConcurrentSyncs)
+	}
+	if obj.SyncPeriod == nil {
+		obj.SyncPeriod = &metav1.Duration{
+			Duration: 60 * time.Minute,
+		}
+	}
+}
+
+func SetDefaults_ShootReferenceControllerConfiguration(obj *ShootReferenceControllerConfiguration) {
+	if obj.ConcurrentSyncs == nil {
+		obj.ConcurrentSyncs = pointer.Int(DefaultControllerConcurrentSyncs)
+	}
+}
+
+func SetDefaults_ShootConditionsControllerConfiguration(obj *ShootConditionsControllerConfiguration) {
+	if obj.ConcurrentSyncs == nil {
+		obj.ConcurrentSyncs = pointer.Int(DefaultControllerConcurrentSyncs)
+	}
+}
+
+func SetDefaults_EventControllerConfiguration(obj *EventControllerConfiguration) {
+	if obj.ConcurrentSyncs == nil {
+		obj.ConcurrentSyncs = pointer.Int(DefaultControllerConcurrentSyncs)
+	}
+	if obj.TTLNonShootEvents == nil {
+		obj.TTLNonShootEvents = &metav1.Duration{Duration: 1 * time.Hour}
+	}
+}
+
+func SetDefaults_ShootStatusLabelControllerConfiguration(obj *ShootStatusLabelControllerConfiguration) {
+	if obj.ConcurrentSyncs == nil {
+		obj.ConcurrentSyncs = pointer.Int(DefaultControllerConcurrentSyncs)
+	}
+}
+
+func SetDefaults_ManagedSeedSetControllerConfiguration(obj *ManagedSeedSetControllerConfiguration) {
+	if obj.ConcurrentSyncs == nil {
+		obj.ConcurrentSyncs = pointer.Int(DefaultControllerConcurrentSyncs)
+	}
+	if obj.MaxShootRetries == nil {
+		obj.MaxShootRetries = pointer.Int(3)
+	}
+}
+
+func SetDefaults_ControllerManagerControllerConfiguration(obj *ControllerManagerControllerConfiguration) {
+	if obj.Bastion == nil {
+		obj.Bastion = &BastionControllerConfiguration{}
+	}
+	if obj.CertificateSigningRequest == nil {
+		obj.CertificateSigningRequest = &CertificateSigningRequestControllerConfiguration{}
+	}
+	if obj.CloudProfile == nil {
+		obj.CloudProfile = &CloudProfileControllerConfiguration{}
+	}
+	if obj.ControllerDeployment == nil {
+		obj.ControllerDeployment = &ControllerDeploymentControllerConfiguration{}
+	}
+	if obj.ControllerRegistration == nil {
+		obj.ControllerRegistration = &ControllerRegistrationControllerConfiguration{}
+	}
+	if obj.ExposureClass == nil {
+		obj.ExposureClass = &ExposureClassControllerConfiguration{}
+	}
+	if obj.Project == nil {
+		obj.Project = &ProjectControllerConfiguration{}
+	}
+	if obj.Quota == nil {
+		obj.Quota = &QuotaControllerConfiguration{}
+	}
+	if obj.SecretBinding == nil {
+		obj.SecretBinding = &SecretBindingControllerConfiguration{}
+	}
+	if obj.Seed == nil {
+		obj.Seed = &SeedControllerConfiguration{}
+	}
+	if obj.SeedExtensionsCheck == nil {
+		obj.SeedExtensionsCheck = &SeedExtensionsCheckControllerConfiguration{}
+	}
+	if obj.SeedBackupBucketsCheck == nil {
+		obj.SeedBackupBucketsCheck = &SeedBackupBucketsCheckControllerConfiguration{}
+	}
+	if obj.ShootQuota == nil {
+		obj.ShootQuota = &ShootQuotaControllerConfiguration{}
+	}
+	if obj.ShootReference == nil {
+		obj.ShootReference = &ShootReferenceControllerConfiguration{}
+	}
+	if obj.ShootRetry == nil {
+		obj.ShootRetry = &ShootRetryControllerConfiguration{}
+	}
+	if obj.ShootConditions == nil {
+		obj.ShootConditions = &ShootConditionsControllerConfiguration{}
+	}
+	if obj.ShootStatusLabel == nil {
+		obj.ShootStatusLabel = &ShootStatusLabelControllerConfiguration{}
 	}
 
-	if obj.MonitorPeriod == nil {
-		v := metav1.Duration{Duration: 40 * time.Second}
-		obj.MonitorPeriod = &v
+	if obj.ManagedSeedSet == nil {
+		obj.ManagedSeedSet = &ManagedSeedSetControllerConfiguration{
+			SyncPeriod: metav1.Duration{
+				Duration: 30 * time.Minute,
+			},
+		}
 	}
 
-	if obj.ShootMonitorPeriod == nil {
-		v := metav1.Duration{Duration: 5 * obj.MonitorPeriod.Duration}
-		obj.ShootMonitorPeriod = &v
-	}
 }

--- a/pkg/controllermanager/apis/config/v1alpha1/defaults.go
+++ b/pkg/controllermanager/apis/config/v1alpha1/defaults.go
@@ -93,6 +93,7 @@ func SetDefaults_SeedControllerConfiguration(obj *SeedControllerConfiguration) {
 	}
 }
 
+// SetDefaults_ProjectControllerConfiguration sets defaults for the ProjectControllerConfiguration.
 func SetDefaults_ProjectControllerConfiguration(obj *ProjectControllerConfiguration) {
 	if obj.ConcurrentSyncs == nil {
 		obj.ConcurrentSyncs = pointer.Int(DefaultControllerConcurrentSyncs)
@@ -118,6 +119,7 @@ func SetDefaults_ProjectControllerConfiguration(obj *ProjectControllerConfigurat
 	}
 }
 
+// SetDefaults_ServerConfiguration sets defaults for the ServerConfiguration.
 func SetDefaults_ServerConfiguration(obj *ServerConfiguration) {
 	if obj.HealthProbes == nil {
 		obj.HealthProbes = &Server{}
@@ -134,6 +136,7 @@ func SetDefaults_ServerConfiguration(obj *ServerConfiguration) {
 	}
 }
 
+// SetDefaults_BastionControllerConfiguration sets defaults for the BastionControllerConfiguration.
 func SetDefaults_BastionControllerConfiguration(obj *BastionControllerConfiguration) {
 	if obj.ConcurrentSyncs == nil {
 		obj.ConcurrentSyncs = pointer.Int(DefaultControllerConcurrentSyncs)
@@ -143,48 +146,56 @@ func SetDefaults_BastionControllerConfiguration(obj *BastionControllerConfigurat
 	}
 }
 
+// SetDefaults_CertificateSigningRequestControllerConfiguration sets defaults for the CertificateSigningRequestControllerConfiguration.
 func SetDefaults_CertificateSigningRequestControllerConfiguration(obj *CertificateSigningRequestControllerConfiguration) {
 	if obj.ConcurrentSyncs == nil {
 		obj.ConcurrentSyncs = pointer.Int(DefaultControllerConcurrentSyncs)
 	}
 }
 
+// SetDefaults_CloudProfileControllerConfiguration sets defaults for the CloudProfileControllerConfiguration.
 func SetDefaults_CloudProfileControllerConfiguration(obj *CloudProfileControllerConfiguration) {
 	if obj.ConcurrentSyncs == nil {
 		obj.ConcurrentSyncs = pointer.Int(DefaultControllerConcurrentSyncs)
 	}
 }
 
+// SetDefaults_ControllerDeploymentControllerConfiguration sets defaults for the ControllerDeploymentControllerConfiguration.
 func SetDefaults_ControllerDeploymentControllerConfiguration(obj *ControllerDeploymentControllerConfiguration) {
 	if obj.ConcurrentSyncs == nil {
 		obj.ConcurrentSyncs = pointer.Int(DefaultControllerConcurrentSyncs)
 	}
 }
 
+// SetDefaults_ControllerRegistrationControllerConfiguration sets defaults for the ControllerRegistrationControllerConfiguration.
 func SetDefaults_ControllerRegistrationControllerConfiguration(obj *ControllerRegistrationControllerConfiguration) {
 	if obj.ConcurrentSyncs == nil {
 		obj.ConcurrentSyncs = pointer.Int(DefaultControllerConcurrentSyncs)
 	}
 }
 
+// SetDefaults_ExposureClassControllerConfiguration sets defaults for the ExposureClassControllerConfiguration.
 func SetDefaults_ExposureClassControllerConfiguration(obj *ExposureClassControllerConfiguration) {
 	if obj.ConcurrentSyncs == nil {
 		obj.ConcurrentSyncs = pointer.Int(DefaultControllerConcurrentSyncs)
 	}
 }
 
+// SetDefaults_QuotaControllerConfiguration sets defaults for the QuotaControllerConfiguration.
 func SetDefaults_QuotaControllerConfiguration(obj *QuotaControllerConfiguration) {
 	if obj.ConcurrentSyncs == nil {
 		obj.ConcurrentSyncs = pointer.Int(DefaultControllerConcurrentSyncs)
 	}
 }
 
+// SetDefaults_SecretBindingControllerConfiguration sets defaults for the SecretBindingControllerConfiguration.
 func SetDefaults_SecretBindingControllerConfiguration(obj *SecretBindingControllerConfiguration) {
 	if obj.ConcurrentSyncs == nil {
 		obj.ConcurrentSyncs = pointer.Int(DefaultControllerConcurrentSyncs)
 	}
 }
 
+// SetDefaults_SeedExtensionsCheckControllerConfiguration sets defaults for the SeedExtensionsCheckControllerConfiguration.
 func SetDefaults_SeedExtensionsCheckControllerConfiguration(obj *SeedExtensionsCheckControllerConfiguration) {
 	if obj.ConcurrentSyncs == nil {
 		obj.ConcurrentSyncs = pointer.Int(DefaultControllerConcurrentSyncs)
@@ -194,6 +205,7 @@ func SetDefaults_SeedExtensionsCheckControllerConfiguration(obj *SeedExtensionsC
 	}
 }
 
+// SetDefaults_SeedBackupBucketsCheckControllerConfiguration sets defaults for the SeedBackupBucketsCheckControllerConfiguration.
 func SetDefaults_SeedBackupBucketsCheckControllerConfiguration(obj *SeedBackupBucketsCheckControllerConfiguration) {
 	if obj.ConcurrentSyncs == nil {
 		obj.ConcurrentSyncs = pointer.Int(DefaultControllerConcurrentSyncs)
@@ -203,6 +215,7 @@ func SetDefaults_SeedBackupBucketsCheckControllerConfiguration(obj *SeedBackupBu
 	}
 }
 
+// SetDefaults_ShootHibernationControllerConfiguration sets defaults for the ShootHibernationControllerConfiguration.
 func SetDefaults_ShootHibernationControllerConfiguration(obj *ShootHibernationControllerConfiguration) {
 	if obj.ConcurrentSyncs == nil {
 		obj.ConcurrentSyncs = pointer.Int(DefaultControllerConcurrentSyncs)
@@ -212,6 +225,7 @@ func SetDefaults_ShootHibernationControllerConfiguration(obj *ShootHibernationCo
 	}
 }
 
+// SetDefaults_ShootMaintenanceControllerConfiguration sets defaults for the ShootMaintenanceControllerConfiguration.
 func SetDefaults_ShootMaintenanceControllerConfiguration(obj *ShootMaintenanceControllerConfiguration) {
 	if obj.ConcurrentSyncs == nil {
 		obj.ConcurrentSyncs = pointer.Int(DefaultControllerConcurrentSyncs)
@@ -221,6 +235,7 @@ func SetDefaults_ShootMaintenanceControllerConfiguration(obj *ShootMaintenanceCo
 	}
 }
 
+// SetDefaults_ShootQuotaControllerConfiguration sets defaults for the ShootQuotaControllerConfiguration.
 func SetDefaults_ShootQuotaControllerConfiguration(obj *ShootQuotaControllerConfiguration) {
 	if obj.ConcurrentSyncs == nil {
 		obj.ConcurrentSyncs = pointer.Int(DefaultControllerConcurrentSyncs)
@@ -232,18 +247,21 @@ func SetDefaults_ShootQuotaControllerConfiguration(obj *ShootQuotaControllerConf
 	}
 }
 
+// SetDefaults_ShootReferenceControllerConfiguration sets defaults for the ShootReferenceControllerConfiguration.
 func SetDefaults_ShootReferenceControllerConfiguration(obj *ShootReferenceControllerConfiguration) {
 	if obj.ConcurrentSyncs == nil {
 		obj.ConcurrentSyncs = pointer.Int(DefaultControllerConcurrentSyncs)
 	}
 }
 
+// SetDefaults_ShootConditionsControllerConfiguration sets defaults for the ShootConditionsControllerConfiguration.
 func SetDefaults_ShootConditionsControllerConfiguration(obj *ShootConditionsControllerConfiguration) {
 	if obj.ConcurrentSyncs == nil {
 		obj.ConcurrentSyncs = pointer.Int(DefaultControllerConcurrentSyncs)
 	}
 }
 
+// SetDefaults_EventControllerConfiguration sets defaults for the EventControllerConfiguration.
 func SetDefaults_EventControllerConfiguration(obj *EventControllerConfiguration) {
 	if obj.ConcurrentSyncs == nil {
 		obj.ConcurrentSyncs = pointer.Int(DefaultControllerConcurrentSyncs)
@@ -253,12 +271,14 @@ func SetDefaults_EventControllerConfiguration(obj *EventControllerConfiguration)
 	}
 }
 
+// SetDefaults_ShootStatusLabelControllerConfiguration sets defaults for the ShootStatusLabelControllerConfiguration.
 func SetDefaults_ShootStatusLabelControllerConfiguration(obj *ShootStatusLabelControllerConfiguration) {
 	if obj.ConcurrentSyncs == nil {
 		obj.ConcurrentSyncs = pointer.Int(DefaultControllerConcurrentSyncs)
 	}
 }
 
+// SetDefaults_ManagedSeedSetControllerConfiguration sets defaults for the ManagedSeedSetControllerConfiguration.
 func SetDefaults_ManagedSeedSetControllerConfiguration(obj *ManagedSeedSetControllerConfiguration) {
 	if obj.ConcurrentSyncs == nil {
 		obj.ConcurrentSyncs = pointer.Int(DefaultControllerConcurrentSyncs)
@@ -268,6 +288,7 @@ func SetDefaults_ManagedSeedSetControllerConfiguration(obj *ManagedSeedSetContro
 	}
 }
 
+// SetDefaults_ControllerManagerControllerConfiguration sets defaults for the ControllerManagerControllerConfiguration.
 func SetDefaults_ControllerManagerControllerConfiguration(obj *ControllerManagerControllerConfiguration) {
 	if obj.Bastion == nil {
 		obj.Bastion = &BastionControllerConfiguration{}

--- a/pkg/controllermanager/apis/config/v1alpha1/defaults.go
+++ b/pkg/controllermanager/apis/config/v1alpha1/defaults.go
@@ -349,5 +349,4 @@ func SetDefaults_ControllerManagerControllerConfiguration(obj *ControllerManager
 			},
 		}
 	}
-
 }

--- a/pkg/controllermanager/apis/config/v1alpha1/defaults_test.go
+++ b/pkg/controllermanager/apis/config/v1alpha1/defaults_test.go
@@ -43,7 +43,7 @@ var _ = Describe("Defaults", func() {
 		})
 
 		It("should not default fields that are set", func() {
-			obj := &ControllerManagerConfiguration{
+			obj = &ControllerManagerConfiguration{
 				LogLevel:  "warning",
 				LogFormat: "md",
 			}
@@ -75,7 +75,7 @@ var _ = Describe("Defaults", func() {
 		})
 
 		It("should not default fields that are set", func() {
-			obj := &ControllerManagerConfiguration{
+			obj = &ControllerManagerConfiguration{
 				GardenClientConnection: componentbaseconfigv1alpha1.ClientConnectionConfiguration{
 					QPS:   60.0,
 					Burst: 120,
@@ -105,7 +105,7 @@ var _ = Describe("Defaults", func() {
 		})
 
 		It("should not default fields that are set", func() {
-			obj := &ControllerManagerConfiguration{
+			obj = &ControllerManagerConfiguration{
 				LeaderElection: &componentbaseconfigv1alpha1.LeaderElectionConfiguration{
 					LeaderElect:       pointer.Bool(true),
 					ResourceLock:      "foo",
@@ -136,7 +136,7 @@ var _ = Describe("Defaults", func() {
 		})
 
 		It("should not default fields that are set", func() {
-			obj := &ControllerManagerConfiguration{
+			obj = &ControllerManagerConfiguration{
 				Controllers: ControllerManagerControllerConfiguration{
 					ShootRetry: &ShootRetryControllerConfiguration{
 						ConcurrentSyncs:   pointer.Int(10),
@@ -166,7 +166,7 @@ var _ = Describe("Defaults", func() {
 		})
 
 		It("should not default fields that are set", func() {
-			obj := &ControllerManagerConfiguration{
+			obj = &ControllerManagerConfiguration{
 				Controllers: ControllerManagerControllerConfiguration{
 					Seed: &SeedControllerConfiguration{
 						ConcurrentSyncs:    pointer.Int(10),
@@ -200,7 +200,7 @@ var _ = Describe("Defaults", func() {
 		})
 
 		It("should default ProjectControllerConfiguration unset QuotaConfiguration correctly", func() {
-			obj := &ControllerManagerConfiguration{
+			obj = &ControllerManagerConfiguration{
 				Controllers: ControllerManagerControllerConfiguration{
 					Project: &ProjectControllerConfiguration{
 						Quotas: []QuotaConfiguration{
@@ -224,7 +224,7 @@ var _ = Describe("Defaults", func() {
 		})
 
 		It("should not default fields that are set", func() {
-			obj := &ControllerManagerConfiguration{
+			obj = &ControllerManagerConfiguration{
 				Controllers: ControllerManagerControllerConfiguration{
 					Project: &ProjectControllerConfiguration{
 						ConcurrentSyncs:         pointer.Int(20),
@@ -260,7 +260,7 @@ var _ = Describe("Defaults", func() {
 		})
 
 		It("should not default fields that are set", func() {
-			obj := &ControllerManagerConfiguration{
+			obj = &ControllerManagerConfiguration{
 				Server: ServerConfiguration{
 					HealthProbes: &Server{
 						Port: 3000,
@@ -289,7 +289,7 @@ var _ = Describe("Defaults", func() {
 		})
 
 		It("should not default fields that are set", func() {
-			obj := &ControllerManagerConfiguration{
+			obj = &ControllerManagerConfiguration{
 				Controllers: ControllerManagerControllerConfiguration{
 					Bastion: &BastionControllerConfiguration{
 						ConcurrentSyncs: pointer.Int(10),
@@ -315,7 +315,7 @@ var _ = Describe("Defaults", func() {
 		})
 
 		It("should not default fields that are set", func() {
-			obj := &ControllerManagerConfiguration{
+			obj = &ControllerManagerConfiguration{
 				Controllers: ControllerManagerControllerConfiguration{
 					CertificateSigningRequest: &CertificateSigningRequestControllerConfiguration{
 						ConcurrentSyncs: pointer.Int(10),
@@ -340,7 +340,7 @@ var _ = Describe("Defaults", func() {
 		})
 
 		It("should not default fields that are set", func() {
-			obj := &ControllerManagerConfiguration{
+			obj = &ControllerManagerConfiguration{
 				Controllers: ControllerManagerControllerConfiguration{
 					CloudProfile: &CloudProfileControllerConfiguration{
 						ConcurrentSyncs: pointer.Int(10),
@@ -365,7 +365,7 @@ var _ = Describe("Defaults", func() {
 		})
 
 		It("should not default fields that are set", func() {
-			obj := &ControllerManagerConfiguration{
+			obj = &ControllerManagerConfiguration{
 				Controllers: ControllerManagerControllerConfiguration{
 					ControllerDeployment: &ControllerDeploymentControllerConfiguration{
 						ConcurrentSyncs: pointer.Int(10),
@@ -390,7 +390,7 @@ var _ = Describe("Defaults", func() {
 		})
 
 		It("should not default fields that are set", func() {
-			obj := &ControllerManagerConfiguration{
+			obj = &ControllerManagerConfiguration{
 				Controllers: ControllerManagerControllerConfiguration{
 					ControllerRegistration: &ControllerRegistrationControllerConfiguration{
 						ConcurrentSyncs: pointer.Int(10),
@@ -415,7 +415,7 @@ var _ = Describe("Defaults", func() {
 		})
 
 		It("should not default fields that are set", func() {
-			obj := &ControllerManagerConfiguration{
+			obj = &ControllerManagerConfiguration{
 				Controllers: ControllerManagerControllerConfiguration{
 					ExposureClass: &ExposureClassControllerConfiguration{
 						ConcurrentSyncs: pointer.Int(10),
@@ -440,7 +440,7 @@ var _ = Describe("Defaults", func() {
 		})
 
 		It("should not default fields that are set", func() {
-			obj := &ControllerManagerConfiguration{
+			obj = &ControllerManagerConfiguration{
 				Controllers: ControllerManagerControllerConfiguration{
 					Quota: &QuotaControllerConfiguration{
 						ConcurrentSyncs: pointer.Int(10),
@@ -465,7 +465,7 @@ var _ = Describe("Defaults", func() {
 		})
 
 		It("should not default fields that are set", func() {
-			obj := &ControllerManagerConfiguration{
+			obj = &ControllerManagerConfiguration{
 				Controllers: ControllerManagerControllerConfiguration{
 					SecretBinding: &SecretBindingControllerConfiguration{
 						ConcurrentSyncs: pointer.Int(10),
@@ -491,7 +491,7 @@ var _ = Describe("Defaults", func() {
 		})
 
 		It("should not default fields that are set", func() {
-			obj := &ControllerManagerConfiguration{
+			obj = &ControllerManagerConfiguration{
 				Controllers: ControllerManagerControllerConfiguration{
 					SeedExtensionsCheck: &SeedExtensionsCheckControllerConfiguration{
 						ConcurrentSyncs: pointer.Int(10),
@@ -518,7 +518,7 @@ var _ = Describe("Defaults", func() {
 		})
 
 		It("should not default fields that are set", func() {
-			obj := &ControllerManagerConfiguration{
+			obj = &ControllerManagerConfiguration{
 				Controllers: ControllerManagerControllerConfiguration{
 					SeedBackupBucketsCheck: &SeedBackupBucketsCheckControllerConfiguration{
 						ConcurrentSyncs: pointer.Int(10),
@@ -545,7 +545,7 @@ var _ = Describe("Defaults", func() {
 		})
 
 		It("should not default fields that are set", func() {
-			obj := &ControllerManagerConfiguration{
+			obj = &ControllerManagerConfiguration{
 				Controllers: ControllerManagerControllerConfiguration{
 					ShootHibernation: ShootHibernationControllerConfiguration{
 						ConcurrentSyncs:         pointer.Int(10),
@@ -572,7 +572,7 @@ var _ = Describe("Defaults", func() {
 		})
 
 		It("should not default fields that are set", func() {
-			obj := &ControllerManagerConfiguration{
+			obj = &ControllerManagerConfiguration{
 				Controllers: ControllerManagerControllerConfiguration{
 					ShootMaintenance: ShootMaintenanceControllerConfiguration{
 						ConcurrentSyncs:                  pointer.Int(10),
@@ -601,7 +601,7 @@ var _ = Describe("Defaults", func() {
 		})
 
 		It("should not default fields that are set", func() {
-			obj := &ControllerManagerConfiguration{
+			obj = &ControllerManagerConfiguration{
 				Controllers: ControllerManagerControllerConfiguration{
 					ShootQuota: &ShootQuotaControllerConfiguration{
 						ConcurrentSyncs: pointer.Int(10),
@@ -629,7 +629,7 @@ var _ = Describe("Defaults", func() {
 		})
 
 		It("should not default fields that are set", func() {
-			obj := &ControllerManagerConfiguration{
+			obj = &ControllerManagerConfiguration{
 				Controllers: ControllerManagerControllerConfiguration{
 					ShootReference: &ShootReferenceControllerConfiguration{
 						ConcurrentSyncs: pointer.Int(10),
@@ -654,7 +654,7 @@ var _ = Describe("Defaults", func() {
 		})
 
 		It("should not default fields that are set", func() {
-			obj := &ControllerManagerConfiguration{
+			obj = &ControllerManagerConfiguration{
 				Controllers: ControllerManagerControllerConfiguration{
 					ShootConditions: &ShootConditionsControllerConfiguration{
 						ConcurrentSyncs: pointer.Int(10),
@@ -670,7 +670,7 @@ var _ = Describe("Defaults", func() {
 
 	Describe("EventControllerConfiguration defaulting", func() {
 		It("should default EventControllerConfiguration correctly if set", func() {
-			obj := &ControllerManagerConfiguration{
+			obj = &ControllerManagerConfiguration{
 				Controllers: ControllerManagerControllerConfiguration{
 					Event: &EventControllerConfiguration{},
 				},
@@ -692,7 +692,7 @@ var _ = Describe("Defaults", func() {
 		})
 
 		It("should not default fields that are set", func() {
-			obj := &ControllerManagerConfiguration{
+			obj = &ControllerManagerConfiguration{
 				Controllers: ControllerManagerControllerConfiguration{
 					Event: &EventControllerConfiguration{
 						ConcurrentSyncs:   pointer.Int(10),
@@ -718,7 +718,7 @@ var _ = Describe("Defaults", func() {
 		})
 
 		It("should not default fields that are set", func() {
-			obj := &ControllerManagerConfiguration{
+			obj = &ControllerManagerConfiguration{
 				Controllers: ControllerManagerControllerConfiguration{
 					ShootStatusLabel: &ShootStatusLabelControllerConfiguration{
 						ConcurrentSyncs: pointer.Int(10),
@@ -747,7 +747,7 @@ var _ = Describe("Defaults", func() {
 		})
 
 		It("should default ManagedSeedSetControllerConfiguration correctly if not nil", func() {
-			obj := &ControllerManagerConfiguration{
+			obj = &ControllerManagerConfiguration{
 				Controllers: ControllerManagerControllerConfiguration{
 					ManagedSeedSet: &ManagedSeedSetControllerConfiguration{},
 				},
@@ -762,7 +762,7 @@ var _ = Describe("Defaults", func() {
 		})
 
 		It("should not default fields that are set", func() {
-			obj := &ControllerManagerConfiguration{
+			obj = &ControllerManagerConfiguration{
 				Controllers: ControllerManagerControllerConfiguration{
 					ManagedSeedSet: &ManagedSeedSetControllerConfiguration{
 						ConcurrentSyncs: pointer.Int(10),

--- a/pkg/controllermanager/apis/config/v1alpha1/defaults_test.go
+++ b/pkg/controllermanager/apis/config/v1alpha1/defaults_test.go
@@ -68,7 +68,7 @@ var _ = Describe("Defaults", func() {
 		It("should not default ContentType and AcceptContentTypes", func() {
 			SetObjectDefaults_ControllerManagerConfiguration(obj)
 			// ContentType fields will be defaulted by client constructors / controller-runtime based on whether a
-			// given APIGroup supports protobuf or not. defaults must not touch these, otherwise the integelligent
+			// given APIGroup supports protobuf or not. defaults must not touch these, otherwise the intelligent
 			// logic will be overwritten
 			Expect(obj.GardenClientConnection.ContentType).To(BeEmpty())
 			Expect(obj.GardenClientConnection.AcceptContentTypes).To(BeEmpty())
@@ -749,12 +749,19 @@ var _ = Describe("Defaults", func() {
 		It("should default ManagedSeedSetControllerConfiguration correctly if not nil", func() {
 			obj = &ControllerManagerConfiguration{
 				Controllers: ControllerManagerControllerConfiguration{
-					ManagedSeedSet: &ManagedSeedSetControllerConfiguration{},
+					ManagedSeedSet: &ManagedSeedSetControllerConfiguration{
+						SyncPeriod: metav1.Duration{
+							Duration: 20 * time.Minute,
+						},
+					},
 				},
 			}
 			expected := &ManagedSeedSetControllerConfiguration{
 				ConcurrentSyncs: pointer.Int(DefaultControllerConcurrentSyncs),
 				MaxShootRetries: pointer.Int(3),
+				SyncPeriod: metav1.Duration{
+					Duration: 20 * time.Minute,
+				},
 			}
 			SetObjectDefaults_ControllerManagerConfiguration(obj)
 
@@ -767,6 +774,9 @@ var _ = Describe("Defaults", func() {
 					ManagedSeedSet: &ManagedSeedSetControllerConfiguration{
 						ConcurrentSyncs: pointer.Int(10),
 						MaxShootRetries: pointer.Int(5),
+						SyncPeriod: metav1.Duration{
+							Duration: 10 * time.Minute,
+						},
 					},
 				},
 			}

--- a/pkg/controllermanager/apis/config/v1alpha1/defaults_test.go
+++ b/pkg/controllermanager/apis/config/v1alpha1/defaults_test.go
@@ -19,7 +19,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	. "github.com/onsi/gomega/gstruct"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	componentbaseconfigv1alpha1 "k8s.io/component-base/config/v1alpha1"
 	"k8s.io/utils/pointer"
@@ -29,149 +28,81 @@ import (
 )
 
 var _ = Describe("Defaults", func() {
-	Describe("ControllerManagerConfiguration", func() {
-		var obj *ControllerManagerConfiguration
 
-		BeforeEach(func() {
-			obj = &ControllerManagerConfiguration{}
-		})
-
-		It("should correctly default the controller manager configuration", func() {
+	Describe("ControllerManagerConfiguration defaulting", func() {
+		It("should default ControllerManagerConfiguration correctly", func() {
+			obj := &ControllerManagerConfiguration{}
 			SetObjectDefaults_ControllerManagerConfiguration(obj)
-
-			Expect(obj.Controllers.Bastion).NotTo(BeNil())
-			Expect(obj.Controllers.Bastion.ConcurrentSyncs).NotTo(BeNil())
-			Expect(obj.Controllers.Bastion.ConcurrentSyncs).To(PointTo(Equal(5)))
-			Expect(obj.Controllers.Bastion.MaxLifetime).To(PointTo(Equal(metav1.Duration{Duration: 24 * time.Hour})))
-
-			Expect(obj.Controllers.CertificateSigningRequest).NotTo(BeNil())
-
-			Expect(obj.Controllers.CloudProfile).NotTo(BeNil())
-			Expect(obj.Controllers.CloudProfile.ConcurrentSyncs).NotTo(BeNil())
-			Expect(obj.Controllers.CloudProfile.ConcurrentSyncs).To(PointTo(Equal(5)))
-
-			Expect(obj.Controllers.ControllerDeployment).NotTo(BeNil())
-			Expect(obj.Controllers.ControllerDeployment.ConcurrentSyncs).NotTo(BeNil())
-			Expect(obj.Controllers.ControllerDeployment.ConcurrentSyncs).To(PointTo(Equal(5)))
-
-			Expect(obj.Controllers.ControllerRegistration).NotTo(BeNil())
-			Expect(obj.Controllers.ControllerRegistration.ConcurrentSyncs).NotTo(BeNil())
-			Expect(obj.Controllers.ControllerRegistration.ConcurrentSyncs).To(PointTo(Equal(5)))
-
-			Expect(obj.Controllers.ExposureClass).NotTo(BeNil())
-			Expect(obj.Controllers.ExposureClass.ConcurrentSyncs).NotTo(BeNil())
-			Expect(obj.Controllers.ExposureClass.ConcurrentSyncs).To(PointTo(Equal(5)))
-
-			Expect(obj.Controllers.Project).NotTo(BeNil())
-			Expect(obj.Controllers.Project.ConcurrentSyncs).NotTo(BeNil())
-			Expect(obj.Controllers.Project.ConcurrentSyncs).To(PointTo(Equal(5)))
-			Expect(obj.Controllers.Project.MinimumLifetimeDays).To(PointTo(Equal(30)))
-			Expect(obj.Controllers.Project.StaleGracePeriodDays).To(PointTo(Equal(14)))
-			Expect(obj.Controllers.Project.StaleExpirationTimeDays).To(PointTo(Equal(90)))
-			Expect(obj.Controllers.Project.StaleSyncPeriod).To(PointTo(Equal(metav1.Duration{Duration: 12 * time.Hour})))
-			Expect(obj.Controllers.Project.Quotas).To(BeNil())
-
-			Expect(obj.Controllers.Quota).NotTo(BeNil())
-			Expect(obj.Controllers.Quota.ConcurrentSyncs).NotTo(BeNil())
-			Expect(obj.Controllers.Quota.ConcurrentSyncs).To(PointTo(Equal(5)))
-
-			Expect(obj.Controllers.SecretBinding).NotTo(BeNil())
-			Expect(obj.Controllers.SecretBinding.ConcurrentSyncs).NotTo(BeNil())
-			Expect(obj.Controllers.SecretBinding.ConcurrentSyncs).To(PointTo(Equal(5)))
-
-			Expect(obj.Controllers.Seed).NotTo(BeNil())
-			Expect(obj.Controllers.SeedExtensionsCheck).NotTo(BeNil())
-			Expect(obj.Controllers.SeedBackupBucketsCheck).NotTo(BeNil())
-
-			Expect(obj.Controllers.ShootMaintenance.ConcurrentSyncs).NotTo(BeNil())
-			Expect(obj.Controllers.ShootMaintenance.ConcurrentSyncs).To(PointTo(Equal(5)))
-			Expect(obj.Controllers.ShootMaintenance.EnableShootControlPlaneRestarter).NotTo(BeNil())
-			Expect(obj.Controllers.ShootMaintenance.EnableShootControlPlaneRestarter).To(PointTo(Equal(true)))
-
-			Expect(obj.Controllers.ShootQuota).NotTo(BeNil())
-			Expect(obj.Controllers.ShootQuota.ConcurrentSyncs).NotTo(BeNil())
-			Expect(obj.Controllers.ShootQuota.ConcurrentSyncs).To(PointTo(Equal(5)))
-			Expect(obj.Controllers.ShootQuota.SyncPeriod).NotTo(BeNil())
-			Expect(obj.Controllers.ShootQuota.SyncPeriod).To(PointTo(Equal(metav1.Duration{Duration: 60 * time.Minute})))
-
-			Expect(obj.Controllers.ShootReference).NotTo(BeNil())
-			Expect(obj.Controllers.ShootReference.ConcurrentSyncs).NotTo(BeNil())
-			Expect(obj.Controllers.ShootReference.ConcurrentSyncs).To(PointTo(Equal(5)))
-
-			Expect(obj.Controllers.ShootRetry).NotTo(BeNil())
-			Expect(obj.Controllers.ShootRetry.ConcurrentSyncs).NotTo(BeNil())
-			Expect(obj.Controllers.ShootRetry.ConcurrentSyncs).To(PointTo(Equal(5)))
-
-			Expect(obj.Controllers.ShootConditions).NotTo(BeNil())
-			Expect(obj.Controllers.ShootConditions.ConcurrentSyncs).NotTo(BeNil())
-			Expect(obj.Controllers.ShootConditions.ConcurrentSyncs).To(PointTo(Equal(5)))
-
-			Expect(obj.Controllers.ShootStatusLabel).NotTo(BeNil())
-			Expect(obj.Controllers.ShootStatusLabel.ConcurrentSyncs).NotTo(BeNil())
-			Expect(obj.Controllers.ShootStatusLabel.ConcurrentSyncs).To(PointTo(Equal(5)))
 
 			Expect(obj.LogLevel).To(Equal(logger.InfoLevel))
 			Expect(obj.LogFormat).To(Equal(logger.FormatJSON))
-
-			Expect(obj.Server.HealthProbes.BindAddress).To(BeEmpty())
-			Expect(obj.Server.HealthProbes.Port).To(Equal(2718))
-			Expect(obj.Server.Metrics.BindAddress).To(BeEmpty())
-			Expect(obj.Server.Metrics.Port).To(Equal(2719))
 		})
 
-		It("should correctly default the project quota configuration", func() {
-			fooSelector, _ := metav1.ParseToLabelSelector("role = foo")
-
-			obj.Controllers = ControllerManagerControllerConfiguration{
-				Project: &ProjectControllerConfiguration{
-					Quotas: []QuotaConfiguration{
-						{
-							ProjectSelector: fooSelector,
-						},
-						{},
-					},
-				},
+		It("should not default fields that are set", func() {
+			obj := &ControllerManagerConfiguration{
+				LogLevel:  "warning",
+				LogFormat: "md",
 			}
 			SetObjectDefaults_ControllerManagerConfiguration(obj)
 
-			Expect(obj.Controllers.Project.Quotas[0].ProjectSelector).To(Equal(fooSelector))
-			Expect(obj.Controllers.Project.Quotas[1].ProjectSelector).To(Equal(&metav1.LabelSelector{}))
+			Expect(obj.LogLevel).To(Equal("warning"))
+			Expect(obj.LogFormat).To(Equal("md"))
 		})
 
-		Describe("GardenClientConnection", func() {
-			It("should not default ContentType and AcceptContentTypes", func() {
-				SetObjectDefaults_ControllerManagerConfiguration(obj)
+	})
 
-				// ContentType fields will be defaulted by client constructors / controller-runtime based on whether a
-				// given APIGroup supports protobuf or not. defaults must not touch these, otherwise the integelligent
-				// logic will be overwritten
-				Expect(obj.GardenClientConnection.ContentType).To(BeEmpty())
-				Expect(obj.GardenClientConnection.AcceptContentTypes).To(BeEmpty())
-			})
-			It("should correctly default GardenClientConnection", func() {
-				SetObjectDefaults_ControllerManagerConfiguration(obj)
-				Expect(obj.GardenClientConnection).To(Equal(componentbaseconfigv1alpha1.ClientConnectionConfiguration{
-					QPS:   50.0,
-					Burst: 100,
-				}))
-			})
+	Describe("ClientConnectionConfiguration defaulting", func() {
+		It("should default ClientConnectionConfiguration correctly", func() {
+			obj := &ControllerManagerConfiguration{}
+			expected := &componentbaseconfigv1alpha1.ClientConnectionConfiguration{
+				QPS:   50.0,
+				Burst: 100,
+			}
+			SetObjectDefaults_ControllerManagerConfiguration(obj)
+			Expect(&obj.GardenClientConnection).To(Equal(expected))
+		})
+		It("should not default ContentType and AcceptContentTypes", func() {
+			obj := &ControllerManagerConfiguration{}
+			SetObjectDefaults_ControllerManagerConfiguration(obj)
+			// ContentType fields will be defaulted by client constructors / controller-runtime based on whether a
+			// given APIGroup supports protobuf or not. defaults must not touch these, otherwise the integelligent
+			// logic will be overwritten
+			Expect(obj.GardenClientConnection.ContentType).To(BeEmpty())
+			Expect(obj.GardenClientConnection.AcceptContentTypes).To(BeEmpty())
 		})
 
-		Describe("leader election settings", func() {
-			It("should correctly default leader election settings", func() {
-				SetObjectDefaults_ControllerManagerConfiguration(obj)
+		It("should not default fields that are set", func() {
+			obj := &ControllerManagerConfiguration{
+				GardenClientConnection: componentbaseconfigv1alpha1.ClientConnectionConfiguration{
+					QPS:   60.0,
+					Burst: 120,
+				},
+			}
+			expected := obj.GardenClientConnection.DeepCopy()
+			SetObjectDefaults_ControllerManagerConfiguration(obj)
+			Expect(&obj.GardenClientConnection).To(Equal(expected))
+		})
+	})
 
-				Expect(obj.LeaderElection).NotTo(BeNil())
-				Expect(obj.LeaderElection.LeaderElect).To(PointTo(BeTrue()))
-				Expect(obj.LeaderElection.LeaseDuration).To(Equal(metav1.Duration{Duration: 15 * time.Second}))
-				Expect(obj.LeaderElection.RenewDeadline).To(Equal(metav1.Duration{Duration: 10 * time.Second}))
-				Expect(obj.LeaderElection.RetryPeriod).To(Equal(metav1.Duration{Duration: 2 * time.Second}))
-				Expect(obj.LeaderElection.ResourceLock).To(Equal("leases"))
-				Expect(obj.LeaderElection.ResourceNamespace).To(Equal("garden"))
-				Expect(obj.LeaderElection.ResourceName).To(Equal("gardener-controller-manager-leader-election"))
-			})
-			It("should not overwrite custom settings", func() {
-				expectedLeaderElection := &componentbaseconfigv1alpha1.LeaderElectionConfiguration{
+	Describe("LeaderElectionConfiguration defaulting", func() {
+		It("should default LeaderElectionConfiguration correctly", func() {
+			obj := &ControllerManagerConfiguration{}
+			expected := &componentbaseconfigv1alpha1.LeaderElectionConfiguration{
+				LeaderElect:       pointer.Bool(true),
+				ResourceLock:      "leases",
+				RetryPeriod:       metav1.Duration{Duration: 2 * time.Second},
+				RenewDeadline:     metav1.Duration{Duration: 10 * time.Second},
+				LeaseDuration:     metav1.Duration{Duration: 15 * time.Second},
+				ResourceNamespace: "garden",
+				ResourceName:      "gardener-controller-manager-leader-election",
+			}
+			SetObjectDefaults_ControllerManagerConfiguration(obj)
+
+			Expect(obj.LeaderElection).To(Equal(expected))
+		})
+		It("should not default fields that are set", func() {
+			obj := &ControllerManagerConfiguration{
+				LeaderElection: &componentbaseconfigv1alpha1.LeaderElectionConfiguration{
 					LeaderElect:       pointer.Bool(true),
 					ResourceLock:      "foo",
 					RetryPeriod:       metav1.Duration{Duration: 40 * time.Second},
@@ -179,95 +110,672 @@ var _ = Describe("Defaults", func() {
 					LeaseDuration:     metav1.Duration{Duration: 42 * time.Second},
 					ResourceNamespace: "other-garden-ns",
 					ResourceName:      "lock-object",
-				}
-				obj.LeaderElection = expectedLeaderElection.DeepCopy()
-				SetObjectDefaults_ControllerManagerConfiguration(obj)
+				},
+			}
+			expected := obj.LeaderElection.DeepCopy()
+			SetObjectDefaults_ControllerManagerConfiguration(obj)
 
-				Expect(obj.LeaderElection).To(Equal(expectedLeaderElection))
-			})
+			Expect(obj.LeaderElection).To(Equal(expected))
 		})
 	})
 
-	Describe("#SetDefaults_EventControllerConfiguration", func() {
-		It("should correctly default the Event Controller configuration", func() {
-			obj := &EventControllerConfiguration{}
+	Describe("ShootRetryControllerConfiguration defaulting", func() {
+		It("should default ShootRetryControllerConfiguration correctly", func() {
+			obj := &ControllerManagerConfiguration{}
+			expected := &ShootRetryControllerConfiguration{
+				ConcurrentSyncs:   pointer.Int(DefaultControllerConcurrentSyncs),
+				RetryPeriod:       &metav1.Duration{Duration: 10 * time.Minute},
+				RetryJitterPeriod: &metav1.Duration{Duration: 5 * time.Minute},
+			}
+			SetObjectDefaults_ControllerManagerConfiguration(obj)
 
-			SetDefaults_EventControllerConfiguration(obj)
-			Expect(obj.ConcurrentSyncs).NotTo(BeNil())
-			Expect(obj.ConcurrentSyncs).To(PointTo(Equal(5)))
-			Expect(obj.TTLNonShootEvents).To(PointTo(Equal(metav1.Duration{Duration: time.Hour})))
+			Expect(obj.Controllers.ShootRetry).To(Equal(expected))
+		})
+
+		It("should not default fields that are set", func() {
+			obj := &ControllerManagerConfiguration{
+				Controllers: ControllerManagerControllerConfiguration{
+					ShootRetry: &ShootRetryControllerConfiguration{
+						ConcurrentSyncs:   pointer.Int(10),
+						RetryPeriod:       &metav1.Duration{Duration: 12 * time.Minute},
+						RetryJitterPeriod: &metav1.Duration{Duration: 8 * time.Minute},
+					},
+				},
+			}
+			expected := obj.Controllers.ShootRetry.DeepCopy()
+			SetObjectDefaults_ControllerManagerConfiguration(obj)
+
+			Expect(obj.Controllers.ShootRetry).To(Equal(expected))
 		})
 	})
 
-	Describe("#SetDefaults_ShootRetryControllerConfiguration", func() {
-		It("should correctly default the ShootRetry Controller configuration", func() {
-			obj := &ShootRetryControllerConfiguration{}
+	Describe("SeedControllerConfiguration defaulting", func() {
+		It("should default SeedControllerConfiguration correctly", func() {
+			obj := &ControllerManagerConfiguration{}
+			expected := &SeedControllerConfiguration{
+				ConcurrentSyncs:    pointer.Int(DefaultControllerConcurrentSyncs),
+				SyncPeriod:         &metav1.Duration{Duration: 10 * time.Second},
+				MonitorPeriod:      &metav1.Duration{Duration: 40 * time.Second},
+				ShootMonitorPeriod: &metav1.Duration{Duration: 5 * 40 * time.Second},
+			}
+			SetObjectDefaults_ControllerManagerConfiguration(obj)
 
-			SetDefaults_ShootRetryControllerConfiguration(obj)
-			Expect(obj.RetryPeriod).To(PointTo(Equal(metav1.Duration{Duration: 10 * time.Minute})))
-			Expect(obj.RetryJitterPeriod).To(PointTo(Equal(metav1.Duration{Duration: 5 * time.Minute})))
+			Expect(obj.Controllers.Seed).To(Equal(expected))
+		})
+
+		It("should not default fields that are set", func() {
+			obj := &ControllerManagerConfiguration{
+				Controllers: ControllerManagerControllerConfiguration{
+					Seed: &SeedControllerConfiguration{
+						ConcurrentSyncs:    pointer.Int(10),
+						SyncPeriod:         &metav1.Duration{Duration: 12 * time.Second},
+						MonitorPeriod:      &metav1.Duration{Duration: 42 * time.Second},
+						ShootMonitorPeriod: &metav1.Duration{Duration: 6 * 42 * time.Second},
+					},
+				},
+			}
+			expected := obj.Controllers.Seed.DeepCopy()
+			SetObjectDefaults_ControllerManagerConfiguration(obj)
+
+			Expect(obj.Controllers.Seed).To(Equal(expected))
 		})
 	})
 
-	Describe("#SetDefaults_ManagedSeedSetControllerConfiguration", func() {
-		It("should correctly default the ManagedSeedSet Controller configuration", func() {
-			obj := &ManagedSeedSetControllerConfiguration{}
+	Describe("ProjectControllerConfiguration defaulting", func() {
+		It("should default ProjectControllerConfiguration correctly", func() {
+			obj := &ControllerManagerConfiguration{}
+			expected := &ProjectControllerConfiguration{
+				ConcurrentSyncs:         pointer.Int(DefaultControllerConcurrentSyncs),
+				MinimumLifetimeDays:     pointer.Int(30),
+				StaleGracePeriodDays:    pointer.Int(14),
+				StaleExpirationTimeDays: pointer.Int(90),
+				StaleSyncPeriod: &metav1.Duration{
+					Duration: 12 * time.Hour,
+				},
+			}
+			SetObjectDefaults_ControllerManagerConfiguration(obj)
 
-			SetDefaults_ManagedSeedSetControllerConfiguration(obj)
-			Expect(obj.MaxShootRetries).To(PointTo(Equal(3)))
+			Expect(obj.Controllers.Project).To(Equal(expected))
+		})
+
+		It("should default ProjectControllerConfiguration unset QuotaConfiguration correctly", func() {
+			obj := &ControllerManagerConfiguration{
+				Controllers: ControllerManagerControllerConfiguration{
+					Project: &ProjectControllerConfiguration{
+						Quotas: []QuotaConfiguration{
+							{},
+							{ProjectSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"foo": "bar"}}},
+							{},
+						},
+					},
+				},
+			}
+			expected := &ProjectControllerConfiguration{
+				Quotas: []QuotaConfiguration{
+					{ProjectSelector: &metav1.LabelSelector{}},
+					{ProjectSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"foo": "bar"}}},
+					{ProjectSelector: &metav1.LabelSelector{}},
+				},
+			}
+			SetObjectDefaults_ControllerManagerConfiguration(obj)
+
+			Expect(obj.Controllers.Project.Quotas).To(Equal(expected.Quotas))
+		})
+
+		It("should not default fields that are set", func() {
+			obj := &ControllerManagerConfiguration{
+				Controllers: ControllerManagerControllerConfiguration{
+					Project: &ProjectControllerConfiguration{
+						ConcurrentSyncs:         pointer.Int(20),
+						MinimumLifetimeDays:     pointer.Int(40),
+						StaleGracePeriodDays:    pointer.Int(24),
+						StaleExpirationTimeDays: pointer.Int(100),
+						StaleSyncPeriod: &metav1.Duration{
+							Duration: 12 * time.Hour,
+						},
+					},
+				},
+			}
+			expected := obj.Controllers.Project.DeepCopy()
+			SetObjectDefaults_ControllerManagerConfiguration(obj)
+
+			Expect(obj.Controllers.Project).To(Equal(expected))
 		})
 	})
 
-	Describe("#SetDefaults_ShootHibernationControllerConfiguration", func() {
-		It("should correctly default the ShootHibernation Controller configuration", func() {
-			obj := &ShootHibernationControllerConfiguration{}
+	Describe("ServerConfiguration defaulting", func() {
+		It("should default ServerConfiguration correctly", func() {
+			obj := &ControllerManagerConfiguration{}
+			expected := &ServerConfiguration{
+				HealthProbes: &Server{
+					Port: 2718,
+				},
+				Metrics: &Server{
+					Port: 2719,
+				},
+			}
+			SetObjectDefaults_ControllerManagerConfiguration(obj)
 
-			SetDefaults_ShootHibernationControllerConfiguration(obj)
-			Expect(obj.ConcurrentSyncs).To(PointTo(Equal(5)))
-			Expect(obj.TriggerDeadlineDuration).To(PointTo(Equal(metav1.Duration{Duration: 2 * time.Hour})))
+			Expect(&obj.Server).To(Equal(expected))
+		})
+
+		It("should not default fields that are set", func() {
+			obj := &ControllerManagerConfiguration{
+				Server: ServerConfiguration{
+					HealthProbes: &Server{
+						Port: 3000,
+					},
+					Metrics: &Server{
+						Port: 4000,
+					},
+				},
+			}
+			expected := obj.Server.DeepCopy()
+			SetObjectDefaults_ControllerManagerConfiguration(obj)
+
+			Expect(&obj.Server).To(Equal(expected))
 		})
 	})
 
-	Describe("#SetDefaults_SeedExtensionsCheckControllerConfiguration", func() {
-		It("should correctly default the SeedExtensionsCheck Controller configuration", func() {
-			obj := &SeedExtensionsCheckControllerConfiguration{}
+	Describe("BastionControllerConfiguration defaulting", func() {
+		It("should default BastionControllerConfiguration correctly", func() {
+			obj := &ControllerManagerConfiguration{}
+			expected := &BastionControllerConfiguration{
+				ConcurrentSyncs: pointer.Int(DefaultControllerConcurrentSyncs),
+				MaxLifetime:     &metav1.Duration{Duration: 24 * time.Hour},
+			}
+			SetObjectDefaults_ControllerManagerConfiguration(obj)
 
-			SetDefaults_SeedExtensionsCheckControllerConfiguration(obj)
-			Expect(obj.ConcurrentSyncs).To(PointTo(Equal(5)))
-			Expect(obj.SyncPeriod).To(PointTo(Equal(metav1.Duration{Duration: 30 * time.Second})))
+			Expect(obj.Controllers.Bastion).To(Equal(expected))
+		})
+
+		It("should not default fields that are set", func() {
+			obj := &ControllerManagerConfiguration{
+				Controllers: ControllerManagerControllerConfiguration{
+					Bastion: &BastionControllerConfiguration{
+						ConcurrentSyncs: pointer.Int(10),
+						MaxLifetime:     &metav1.Duration{Duration: 48 * time.Hour},
+					},
+				},
+			}
+			expected := obj.Controllers.Bastion.DeepCopy()
+			SetObjectDefaults_ControllerManagerConfiguration(obj)
+
+			Expect(obj.Controllers.Bastion).To(Equal(expected))
 		})
 	})
 
-	Describe("#SetDefaults_SeedBackupBucketsCheckControllerConfiguration", func() {
-		It("should correctly default the SeedBackupBucketsCheck Controller configuration", func() {
-			obj := &SeedBackupBucketsCheckControllerConfiguration{}
+	Describe("CertificateSigningRequestControllerConfiguration defaulting", func() {
+		It("should default CertificateSigningRequestControllerConfiguration correctly", func() {
+			obj := &ControllerManagerConfiguration{}
+			expected := &CertificateSigningRequestControllerConfiguration{
+				ConcurrentSyncs: pointer.Int(DefaultControllerConcurrentSyncs),
+			}
+			SetObjectDefaults_ControllerManagerConfiguration(obj)
 
-			SetDefaults_SeedBackupBucketsCheckControllerConfiguration(obj)
-			Expect(obj.ConcurrentSyncs).To(PointTo(Equal(5)))
-			Expect(obj.SyncPeriod).To(PointTo(Equal(metav1.Duration{Duration: 30 * time.Second})))
+			Expect(obj.Controllers.CertificateSigningRequest).To(Equal(expected))
+		})
+
+		It("should not default fields that are set", func() {
+			obj := &ControllerManagerConfiguration{
+				Controllers: ControllerManagerControllerConfiguration{
+					CertificateSigningRequest: &CertificateSigningRequestControllerConfiguration{
+						ConcurrentSyncs: pointer.Int(10),
+					},
+				},
+			}
+			expected := obj.Controllers.CertificateSigningRequest.DeepCopy()
+			SetObjectDefaults_ControllerManagerConfiguration(obj)
+
+			Expect(obj.Controllers.CertificateSigningRequest).To(Equal(expected))
 		})
 	})
 
-	Describe("#SetDefaults_CertificateSigningRequestControllerConfiguration", func() {
-		It("should correctly default the CertificateSigningRequest Controller configuration", func() {
-			obj := &CertificateSigningRequestControllerConfiguration{}
+	Describe("CloudProfileControllerConfiguration defaulting", func() {
+		It("should default CloudProfileControllerConfiguration correctly", func() {
+			obj := &ControllerManagerConfiguration{}
+			expected := &CloudProfileControllerConfiguration{
+				ConcurrentSyncs: pointer.Int(DefaultControllerConcurrentSyncs),
+			}
+			SetObjectDefaults_ControllerManagerConfiguration(obj)
 
-			SetDefaults_CertificateSigningRequestControllerConfiguration(obj)
-			Expect(obj.ConcurrentSyncs).To(PointTo(Equal(5)))
+			Expect(obj.Controllers.CloudProfile).To(Equal(expected))
+		})
+
+		It("should not default fields that are set", func() {
+			obj := &ControllerManagerConfiguration{
+				Controllers: ControllerManagerControllerConfiguration{
+					CloudProfile: &CloudProfileControllerConfiguration{
+						ConcurrentSyncs: pointer.Int(10),
+					},
+				},
+			}
+			expected := obj.Controllers.CloudProfile.DeepCopy()
+			SetObjectDefaults_ControllerManagerConfiguration(obj)
+
+			Expect(obj.Controllers.CloudProfile).To(Equal(expected))
 		})
 	})
 
-	Describe("#SetDefaults_SeedControllerConfiguration", func() {
-		It("should correctly default the Seed Controller configuration", func() {
-			obj := &SeedControllerConfiguration{}
+	Describe("ControllerDeploymentControllerConfiguration defaulting", func() {
+		It("should default ControllerDeploymentControllerConfiguration correctly", func() {
+			obj := &ControllerManagerConfiguration{}
+			expected := &ControllerDeploymentControllerConfiguration{
+				ConcurrentSyncs: pointer.Int(DefaultControllerConcurrentSyncs),
+			}
+			SetObjectDefaults_ControllerManagerConfiguration(obj)
 
-			SetDefaults_SeedControllerConfiguration(obj)
-			Expect(obj.ConcurrentSyncs).To(PointTo(Equal(5)))
-			Expect(obj.SyncPeriod).To(PointTo(Equal(metav1.Duration{Duration: 10 * time.Second})))
-			Expect(obj.MonitorPeriod).To(PointTo(Equal(metav1.Duration{Duration: 40 * time.Second})))
-			Expect(obj.ShootMonitorPeriod).To(PointTo(Equal(metav1.Duration{Duration: 200 * time.Second})))
+			Expect(obj.Controllers.ControllerDeployment).To(Equal(expected))
+		})
+
+		It("should not default fields that are set", func() {
+			obj := &ControllerManagerConfiguration{
+				Controllers: ControllerManagerControllerConfiguration{
+					ControllerDeployment: &ControllerDeploymentControllerConfiguration{
+						ConcurrentSyncs: pointer.Int(10),
+					},
+				},
+			}
+			expected := obj.Controllers.ControllerDeployment.DeepCopy()
+			SetObjectDefaults_ControllerManagerConfiguration(obj)
+
+			Expect(obj.Controllers.ControllerDeployment).To(Equal(expected))
 		})
 	})
+
+	Describe("ControllerRegistrationControllerConfiguration defaulting", func() {
+		It("should default ControllerRegistrationControllerConfiguration correctly", func() {
+			obj := &ControllerManagerConfiguration{}
+			expected := &ControllerRegistrationControllerConfiguration{
+				ConcurrentSyncs: pointer.Int(DefaultControllerConcurrentSyncs),
+			}
+			SetObjectDefaults_ControllerManagerConfiguration(obj)
+
+			Expect(obj.Controllers.ControllerRegistration).To(Equal(expected))
+		})
+
+		It("should not default fields that are set", func() {
+			obj := &ControllerManagerConfiguration{
+				Controllers: ControllerManagerControllerConfiguration{
+					ControllerRegistration: &ControllerRegistrationControllerConfiguration{
+						ConcurrentSyncs: pointer.Int(10),
+					},
+				},
+			}
+			expected := obj.Controllers.ControllerRegistration.DeepCopy()
+			SetObjectDefaults_ControllerManagerConfiguration(obj)
+
+			Expect(obj.Controllers.ControllerRegistration).To(Equal(expected))
+		})
+	})
+
+	Describe("ExposureClassControllerConfiguration defaulting", func() {
+		It("should default ExposureClassControllerConfiguration correctly", func() {
+			obj := &ControllerManagerConfiguration{}
+			expected := &ExposureClassControllerConfiguration{
+				ConcurrentSyncs: pointer.Int(DefaultControllerConcurrentSyncs),
+			}
+			SetObjectDefaults_ControllerManagerConfiguration(obj)
+
+			Expect(obj.Controllers.ExposureClass).To(Equal(expected))
+		})
+
+		It("should not default fields that are set", func() {
+			obj := &ControllerManagerConfiguration{
+				Controllers: ControllerManagerControllerConfiguration{
+					ExposureClass: &ExposureClassControllerConfiguration{
+						ConcurrentSyncs: pointer.Int(10),
+					},
+				},
+			}
+			expected := obj.Controllers.ExposureClass.DeepCopy()
+			SetObjectDefaults_ControllerManagerConfiguration(obj)
+
+			Expect(obj.Controllers.ExposureClass).To(Equal(expected))
+		})
+	})
+
+	Describe("QuotaControllerConfiguration defaulting", func() {
+		It("should default QuotaControllerConfiguration correctly", func() {
+			obj := &ControllerManagerConfiguration{}
+			expected := &QuotaControllerConfiguration{
+				ConcurrentSyncs: pointer.Int(DefaultControllerConcurrentSyncs),
+			}
+			SetObjectDefaults_ControllerManagerConfiguration(obj)
+
+			Expect(obj.Controllers.Quota).To(Equal(expected))
+		})
+
+		It("should not default fields that are set", func() {
+			obj := &ControllerManagerConfiguration{
+				Controllers: ControllerManagerControllerConfiguration{
+					Quota: &QuotaControllerConfiguration{
+						ConcurrentSyncs: pointer.Int(10),
+					},
+				},
+			}
+			expected := obj.Controllers.Quota.DeepCopy()
+			SetObjectDefaults_ControllerManagerConfiguration(obj)
+
+			Expect(obj.Controllers.Quota).To(Equal(expected))
+		})
+	})
+
+	Describe("SecretBindingControllerConfiguration defaulting", func() {
+		It("should default SecretBindingControllerConfiguration correctly", func() {
+			obj := &ControllerManagerConfiguration{}
+			expected := &SecretBindingControllerConfiguration{
+				ConcurrentSyncs: pointer.Int(DefaultControllerConcurrentSyncs),
+			}
+			SetObjectDefaults_ControllerManagerConfiguration(obj)
+			Expect(obj.Controllers.SecretBinding).To(Equal(expected))
+		})
+		It("should not default fields that are set", func() {
+			obj := &ControllerManagerConfiguration{
+				Controllers: ControllerManagerControllerConfiguration{
+					SecretBinding: &SecretBindingControllerConfiguration{
+						ConcurrentSyncs: pointer.Int(10),
+					},
+				},
+			}
+			expected := obj.Controllers.SecretBinding.DeepCopy()
+			SetObjectDefaults_ControllerManagerConfiguration(obj)
+			Expect(obj.Controllers.SecretBinding).To(Equal(expected))
+		})
+	})
+	Describe("SeedExtensionsCheckControllerConfiguration defaulting", func() {
+		It("should default SeedExtensionsCheckControllerConfiguration correctly", func() {
+			obj := &ControllerManagerConfiguration{}
+			expected := &SeedExtensionsCheckControllerConfiguration{
+				ConcurrentSyncs: pointer.Int(DefaultControllerConcurrentSyncs),
+				SyncPeriod:      &metav1.Duration{Duration: 30 * time.Second},
+			}
+			SetObjectDefaults_ControllerManagerConfiguration(obj)
+			Expect(obj.Controllers.SeedExtensionsCheck).To(Equal(expected))
+		})
+		It("should not default fields that are set", func() {
+			obj := &ControllerManagerConfiguration{
+				Controllers: ControllerManagerControllerConfiguration{
+					SeedExtensionsCheck: &SeedExtensionsCheckControllerConfiguration{
+						ConcurrentSyncs: pointer.Int(10),
+						SyncPeriod:      &metav1.Duration{Duration: 60 * time.Second},
+					},
+				},
+			}
+			expected := obj.Controllers.SeedExtensionsCheck.DeepCopy()
+			SetObjectDefaults_ControllerManagerConfiguration(obj)
+			Expect(obj.Controllers.SeedExtensionsCheck).To(Equal(expected))
+		})
+	})
+	Describe("SeedBackupBucketsCheckControllerConfiguration defaulting", func() {
+		It("should default SeedBackupBucketsCheckControllerConfiguration correctly", func() {
+			obj := &ControllerManagerConfiguration{}
+			expected := &SeedBackupBucketsCheckControllerConfiguration{
+				ConcurrentSyncs: pointer.Int(DefaultControllerConcurrentSyncs),
+				SyncPeriod:      &metav1.Duration{Duration: 30 * time.Second},
+			}
+			SetObjectDefaults_ControllerManagerConfiguration(obj)
+			Expect(obj.Controllers.SeedBackupBucketsCheck).To(Equal(expected))
+		})
+		It("should not default fields that are set", func() {
+			obj := &ControllerManagerConfiguration{
+				Controllers: ControllerManagerControllerConfiguration{
+					SeedBackupBucketsCheck: &SeedBackupBucketsCheckControllerConfiguration{
+						ConcurrentSyncs: pointer.Int(10),
+						SyncPeriod:      &metav1.Duration{Duration: 60 * time.Second},
+					},
+				},
+			}
+			expected := obj.Controllers.SeedBackupBucketsCheck.DeepCopy()
+			SetObjectDefaults_ControllerManagerConfiguration(obj)
+			Expect(obj.Controllers.SeedBackupBucketsCheck).To(Equal(expected))
+		})
+	})
+	Describe("ShootHibernationControllerConfiguration defaulting", func() {
+		It("should default ShootHibernationControllerConfiguration correctly", func() {
+			obj := &ControllerManagerConfiguration{}
+			expected := &ShootHibernationControllerConfiguration{
+				ConcurrentSyncs:         pointer.Int(DefaultControllerConcurrentSyncs),
+				TriggerDeadlineDuration: &metav1.Duration{Duration: 2 * time.Hour},
+			}
+			SetObjectDefaults_ControllerManagerConfiguration(obj)
+			Expect(&obj.Controllers.ShootHibernation).To(Equal(expected))
+		})
+		It("should not default fields that are set", func() {
+			obj := &ControllerManagerConfiguration{
+				Controllers: ControllerManagerControllerConfiguration{
+					ShootHibernation: ShootHibernationControllerConfiguration{
+						ConcurrentSyncs:         pointer.Int(10),
+						TriggerDeadlineDuration: &metav1.Duration{Duration: 3 * time.Hour},
+					},
+				},
+			}
+			expected := obj.Controllers.ShootHibernation.DeepCopy()
+			SetObjectDefaults_ControllerManagerConfiguration(obj)
+			Expect(&obj.Controllers.ShootHibernation).To(Equal(expected))
+		})
+	})
+	Describe("ShootMaintenanceControllerConfiguration defaulting", func() {
+		It("should default ShootMaintenanceControllerConfiguration correctly", func() {
+			obj := &ControllerManagerConfiguration{}
+			expected := &ShootMaintenanceControllerConfiguration{
+				ConcurrentSyncs:                  pointer.Int(DefaultControllerConcurrentSyncs),
+				EnableShootControlPlaneRestarter: pointer.Bool(true),
+			}
+			SetObjectDefaults_ControllerManagerConfiguration(obj)
+			Expect(&obj.Controllers.ShootMaintenance).To(Equal(expected))
+		})
+		It("should not default fields that are set", func() {
+			obj := &ControllerManagerConfiguration{
+				Controllers: ControllerManagerControllerConfiguration{
+					ShootMaintenance: ShootMaintenanceControllerConfiguration{
+						ConcurrentSyncs:                  pointer.Int(10),
+						EnableShootControlPlaneRestarter: pointer.Bool(false),
+					},
+				},
+			}
+			expected := obj.Controllers.ShootMaintenance.DeepCopy()
+			SetObjectDefaults_ControllerManagerConfiguration(obj)
+			Expect(&obj.Controllers.ShootMaintenance).To(Equal(expected))
+		})
+	})
+
+	Describe("ShootQuotaControllerConfiguration defaulting", func() {
+		It("should default ShootQuotaControllerConfiguration correctly", func() {
+			obj := &ControllerManagerConfiguration{}
+			expected := &ShootQuotaControllerConfiguration{
+				ConcurrentSyncs: pointer.Int(DefaultControllerConcurrentSyncs),
+				SyncPeriod: &metav1.Duration{
+					Duration: 60 * time.Minute,
+				},
+			}
+			SetObjectDefaults_ControllerManagerConfiguration(obj)
+
+			Expect(obj.Controllers.ShootQuota).To(Equal(expected))
+		})
+
+		It("should not default fields that are set", func() {
+			obj := &ControllerManagerConfiguration{
+				Controllers: ControllerManagerControllerConfiguration{
+					ShootQuota: &ShootQuotaControllerConfiguration{
+						ConcurrentSyncs: pointer.Int(10),
+						SyncPeriod: &metav1.Duration{
+							Duration: 120 * time.Minute,
+						},
+					},
+				},
+			}
+			expected := obj.Controllers.ShootQuota.DeepCopy()
+			SetObjectDefaults_ControllerManagerConfiguration(obj)
+
+			Expect(obj.Controllers.ShootQuota).To(Equal(expected))
+		})
+	})
+
+	Describe("ShootReferenceControllerConfiguration defaulting", func() {
+		It("should default ShootReferenceControllerConfiguration correctly", func() {
+			obj := &ControllerManagerConfiguration{}
+			expected := &ShootReferenceControllerConfiguration{
+				ConcurrentSyncs: pointer.Int(DefaultControllerConcurrentSyncs),
+			}
+			SetObjectDefaults_ControllerManagerConfiguration(obj)
+
+			Expect(obj.Controllers.ShootReference).To(Equal(expected))
+		})
+
+		It("should not default fields that are set", func() {
+			obj := &ControllerManagerConfiguration{
+				Controllers: ControllerManagerControllerConfiguration{
+					ShootReference: &ShootReferenceControllerConfiguration{
+						ConcurrentSyncs: pointer.Int(10),
+					},
+				},
+			}
+			expected := obj.Controllers.ShootReference.DeepCopy()
+			SetObjectDefaults_ControllerManagerConfiguration(obj)
+
+			Expect(obj.Controllers.ShootReference).To(Equal(expected))
+		})
+	})
+
+	Describe("ShootConditionsControllerConfiguration defaulting", func() {
+		It("should default ShootConditionsControllerConfiguration correctly", func() {
+			obj := &ControllerManagerConfiguration{}
+			expected := &ShootConditionsControllerConfiguration{
+				ConcurrentSyncs: pointer.Int(DefaultControllerConcurrentSyncs),
+			}
+			SetObjectDefaults_ControllerManagerConfiguration(obj)
+
+			Expect(obj.Controllers.ShootConditions).To(Equal(expected))
+		})
+
+		It("should not default fields that are set", func() {
+			obj := &ControllerManagerConfiguration{
+				Controllers: ControllerManagerControllerConfiguration{
+					ShootConditions: &ShootConditionsControllerConfiguration{
+						ConcurrentSyncs: pointer.Int(10),
+					},
+				},
+			}
+			expected := obj.Controllers.ShootConditions.DeepCopy()
+			SetObjectDefaults_ControllerManagerConfiguration(obj)
+
+			Expect(obj.Controllers.ShootConditions).To(Equal(expected))
+		})
+	})
+
+	Describe("EventControllerConfiguration defaulting", func() {
+		It("should default EventControllerConfiguration correctly if set", func() {
+			obj := &ControllerManagerConfiguration{
+				Controllers: ControllerManagerControllerConfiguration{
+					Event: &EventControllerConfiguration{},
+				},
+			}
+			expected := &EventControllerConfiguration{
+				ConcurrentSyncs:   pointer.Int(DefaultControllerConcurrentSyncs),
+				TTLNonShootEvents: &metav1.Duration{Duration: 1 * time.Hour},
+			}
+			SetObjectDefaults_ControllerManagerConfiguration(obj)
+
+			Expect(obj.Controllers.Event).To(Equal(expected))
+		})
+
+		It("should not default EventControllerConfiguration if not set", func() {
+			obj := &ControllerManagerConfiguration{}
+			var expected *EventControllerConfiguration
+			SetObjectDefaults_ControllerManagerConfiguration(obj)
+
+			Expect(obj.Controllers.Event).To(Equal(expected))
+		})
+
+		It("should not default fields that are set", func() {
+			obj := &ControllerManagerConfiguration{
+				Controllers: ControllerManagerControllerConfiguration{
+					Event: &EventControllerConfiguration{
+						ConcurrentSyncs:   pointer.Int(10),
+						TTLNonShootEvents: &metav1.Duration{Duration: 2 * time.Hour},
+					},
+				},
+			}
+			expected := obj.Controllers.Event.DeepCopy()
+			SetObjectDefaults_ControllerManagerConfiguration(obj)
+
+			Expect(obj.Controllers.Event).To(Equal(expected))
+		})
+	})
+
+	Describe("ShootStatusLabelControllerConfiguration defaulting", func() {
+		It("should default ShootStatusLabelControllerConfiguration correctly", func() {
+			obj := &ControllerManagerConfiguration{}
+			expected := &ShootStatusLabelControllerConfiguration{
+				ConcurrentSyncs: pointer.Int(DefaultControllerConcurrentSyncs),
+			}
+			SetObjectDefaults_ControllerManagerConfiguration(obj)
+
+			Expect(obj.Controllers.ShootStatusLabel).To(Equal(expected))
+		})
+
+		It("should not default fields that are set", func() {
+			obj := &ControllerManagerConfiguration{
+				Controllers: ControllerManagerControllerConfiguration{
+					ShootStatusLabel: &ShootStatusLabelControllerConfiguration{
+						ConcurrentSyncs: pointer.Int(10),
+					},
+				},
+			}
+			expected := obj.Controllers.ShootStatusLabel.DeepCopy()
+			SetObjectDefaults_ControllerManagerConfiguration(obj)
+
+			Expect(obj.Controllers.ShootStatusLabel).To(Equal(expected))
+		})
+	})
+
+	Describe("ManagedSeedSetControllerConfiguration defaulting", func() {
+		It("should default ManagedSeedSetControllerConfiguration correctly if nil", func() {
+			obj := &ControllerManagerConfiguration{}
+			expected := &ManagedSeedSetControllerConfiguration{
+				ConcurrentSyncs: pointer.Int(DefaultControllerConcurrentSyncs),
+				MaxShootRetries: pointer.Int(3),
+				SyncPeriod: metav1.Duration{
+					Duration: 30 * time.Minute,
+				},
+			}
+			SetObjectDefaults_ControllerManagerConfiguration(obj)
+
+			Expect(obj.Controllers.ManagedSeedSet).To(Equal(expected))
+		})
+
+		It("should default ManagedSeedSetControllerConfiguration correctly if not nil", func() {
+			obj := &ControllerManagerConfiguration{
+				Controllers: ControllerManagerControllerConfiguration{
+					ManagedSeedSet: &ManagedSeedSetControllerConfiguration{},
+				},
+			}
+			expected := &ManagedSeedSetControllerConfiguration{
+				ConcurrentSyncs: pointer.Int(DefaultControllerConcurrentSyncs),
+				MaxShootRetries: pointer.Int(3),
+			}
+			SetObjectDefaults_ControllerManagerConfiguration(obj)
+
+			Expect(obj.Controllers.ManagedSeedSet).To(Equal(expected))
+		})
+
+		It("should not default fields that are set", func() {
+			obj := &ControllerManagerConfiguration{
+				Controllers: ControllerManagerControllerConfiguration{
+					ManagedSeedSet: &ManagedSeedSetControllerConfiguration{
+						ConcurrentSyncs: pointer.Int(10),
+						MaxShootRetries: pointer.Int(5),
+					},
+				},
+			}
+			expected := obj.Controllers.ManagedSeedSet.DeepCopy()
+			SetObjectDefaults_ControllerManagerConfiguration(obj)
+
+			Expect(obj.Controllers.ManagedSeedSet).To(Equal(expected))
+		})
+	})
+
 })
 
 var _ = Describe("Constants", func() {

--- a/pkg/controllermanager/apis/config/v1alpha1/defaults_test.go
+++ b/pkg/controllermanager/apis/config/v1alpha1/defaults_test.go
@@ -61,6 +61,7 @@ var _ = Describe("Defaults", func() {
 			SetObjectDefaults_ControllerManagerConfiguration(obj)
 			Expect(&obj.GardenClientConnection).To(Equal(expected))
 		})
+
 		It("should not default ContentType and AcceptContentTypes", func() {
 			obj := &ControllerManagerConfiguration{}
 			SetObjectDefaults_ControllerManagerConfiguration(obj)
@@ -100,6 +101,7 @@ var _ = Describe("Defaults", func() {
 
 			Expect(obj.LeaderElection).To(Equal(expected))
 		})
+
 		It("should not default fields that are set", func() {
 			obj := &ControllerManagerConfiguration{
 				LeaderElection: &componentbaseconfigv1alpha1.LeaderElectionConfiguration{
@@ -470,6 +472,7 @@ var _ = Describe("Defaults", func() {
 			SetObjectDefaults_ControllerManagerConfiguration(obj)
 			Expect(obj.Controllers.SecretBinding).To(Equal(expected))
 		})
+
 		It("should not default fields that are set", func() {
 			obj := &ControllerManagerConfiguration{
 				Controllers: ControllerManagerControllerConfiguration{
@@ -483,6 +486,7 @@ var _ = Describe("Defaults", func() {
 			Expect(obj.Controllers.SecretBinding).To(Equal(expected))
 		})
 	})
+
 	Describe("SeedExtensionsCheckControllerConfiguration defaulting", func() {
 		It("should default SeedExtensionsCheckControllerConfiguration correctly", func() {
 			obj := &ControllerManagerConfiguration{}
@@ -493,6 +497,7 @@ var _ = Describe("Defaults", func() {
 			SetObjectDefaults_ControllerManagerConfiguration(obj)
 			Expect(obj.Controllers.SeedExtensionsCheck).To(Equal(expected))
 		})
+
 		It("should not default fields that are set", func() {
 			obj := &ControllerManagerConfiguration{
 				Controllers: ControllerManagerControllerConfiguration{
@@ -507,6 +512,7 @@ var _ = Describe("Defaults", func() {
 			Expect(obj.Controllers.SeedExtensionsCheck).To(Equal(expected))
 		})
 	})
+
 	Describe("SeedBackupBucketsCheckControllerConfiguration defaulting", func() {
 		It("should default SeedBackupBucketsCheckControllerConfiguration correctly", func() {
 			obj := &ControllerManagerConfiguration{}
@@ -517,6 +523,7 @@ var _ = Describe("Defaults", func() {
 			SetObjectDefaults_ControllerManagerConfiguration(obj)
 			Expect(obj.Controllers.SeedBackupBucketsCheck).To(Equal(expected))
 		})
+
 		It("should not default fields that are set", func() {
 			obj := &ControllerManagerConfiguration{
 				Controllers: ControllerManagerControllerConfiguration{
@@ -531,6 +538,7 @@ var _ = Describe("Defaults", func() {
 			Expect(obj.Controllers.SeedBackupBucketsCheck).To(Equal(expected))
 		})
 	})
+
 	Describe("ShootHibernationControllerConfiguration defaulting", func() {
 		It("should default ShootHibernationControllerConfiguration correctly", func() {
 			obj := &ControllerManagerConfiguration{}
@@ -541,6 +549,7 @@ var _ = Describe("Defaults", func() {
 			SetObjectDefaults_ControllerManagerConfiguration(obj)
 			Expect(&obj.Controllers.ShootHibernation).To(Equal(expected))
 		})
+
 		It("should not default fields that are set", func() {
 			obj := &ControllerManagerConfiguration{
 				Controllers: ControllerManagerControllerConfiguration{
@@ -555,6 +564,7 @@ var _ = Describe("Defaults", func() {
 			Expect(&obj.Controllers.ShootHibernation).To(Equal(expected))
 		})
 	})
+
 	Describe("ShootMaintenanceControllerConfiguration defaulting", func() {
 		It("should default ShootMaintenanceControllerConfiguration correctly", func() {
 			obj := &ControllerManagerConfiguration{}
@@ -565,6 +575,7 @@ var _ = Describe("Defaults", func() {
 			SetObjectDefaults_ControllerManagerConfiguration(obj)
 			Expect(&obj.Controllers.ShootMaintenance).To(Equal(expected))
 		})
+
 		It("should not default fields that are set", func() {
 			obj := &ControllerManagerConfiguration{
 				Controllers: ControllerManagerControllerConfiguration{

--- a/pkg/controllermanager/apis/config/v1alpha1/defaults_test.go
+++ b/pkg/controllermanager/apis/config/v1alpha1/defaults_test.go
@@ -28,10 +28,14 @@ import (
 )
 
 var _ = Describe("Defaults", func() {
+	var obj *ControllerManagerConfiguration
+
+	BeforeEach(func() {
+		obj = &ControllerManagerConfiguration{}
+	})
 
 	Describe("ControllerManagerConfiguration defaulting", func() {
 		It("should default ControllerManagerConfiguration correctly", func() {
-			obj := &ControllerManagerConfiguration{}
 			SetObjectDefaults_ControllerManagerConfiguration(obj)
 
 			Expect(obj.LogLevel).To(Equal(logger.InfoLevel))
@@ -48,22 +52,20 @@ var _ = Describe("Defaults", func() {
 			Expect(obj.LogLevel).To(Equal("warning"))
 			Expect(obj.LogFormat).To(Equal("md"))
 		})
-
 	})
 
 	Describe("ClientConnectionConfiguration defaulting", func() {
 		It("should default ClientConnectionConfiguration correctly", func() {
-			obj := &ControllerManagerConfiguration{}
 			expected := &componentbaseconfigv1alpha1.ClientConnectionConfiguration{
 				QPS:   50.0,
 				Burst: 100,
 			}
 			SetObjectDefaults_ControllerManagerConfiguration(obj)
+
 			Expect(&obj.GardenClientConnection).To(Equal(expected))
 		})
 
 		It("should not default ContentType and AcceptContentTypes", func() {
-			obj := &ControllerManagerConfiguration{}
 			SetObjectDefaults_ControllerManagerConfiguration(obj)
 			// ContentType fields will be defaulted by client constructors / controller-runtime based on whether a
 			// given APIGroup supports protobuf or not. defaults must not touch these, otherwise the integelligent
@@ -81,13 +83,13 @@ var _ = Describe("Defaults", func() {
 			}
 			expected := obj.GardenClientConnection.DeepCopy()
 			SetObjectDefaults_ControllerManagerConfiguration(obj)
+
 			Expect(&obj.GardenClientConnection).To(Equal(expected))
 		})
 	})
 
 	Describe("LeaderElectionConfiguration defaulting", func() {
 		It("should default LeaderElectionConfiguration correctly", func() {
-			obj := &ControllerManagerConfiguration{}
 			expected := &componentbaseconfigv1alpha1.LeaderElectionConfiguration{
 				LeaderElect:       pointer.Bool(true),
 				ResourceLock:      "leases",
@@ -123,7 +125,6 @@ var _ = Describe("Defaults", func() {
 
 	Describe("ShootRetryControllerConfiguration defaulting", func() {
 		It("should default ShootRetryControllerConfiguration correctly", func() {
-			obj := &ControllerManagerConfiguration{}
 			expected := &ShootRetryControllerConfiguration{
 				ConcurrentSyncs:   pointer.Int(DefaultControllerConcurrentSyncs),
 				RetryPeriod:       &metav1.Duration{Duration: 10 * time.Minute},
@@ -153,7 +154,6 @@ var _ = Describe("Defaults", func() {
 
 	Describe("SeedControllerConfiguration defaulting", func() {
 		It("should default SeedControllerConfiguration correctly", func() {
-			obj := &ControllerManagerConfiguration{}
 			expected := &SeedControllerConfiguration{
 				ConcurrentSyncs:    pointer.Int(DefaultControllerConcurrentSyncs),
 				SyncPeriod:         &metav1.Duration{Duration: 10 * time.Second},
@@ -185,7 +185,6 @@ var _ = Describe("Defaults", func() {
 
 	Describe("ProjectControllerConfiguration defaulting", func() {
 		It("should default ProjectControllerConfiguration correctly", func() {
-			obj := &ControllerManagerConfiguration{}
 			expected := &ProjectControllerConfiguration{
 				ConcurrentSyncs:         pointer.Int(DefaultControllerConcurrentSyncs),
 				MinimumLifetimeDays:     pointer.Int(30),
@@ -247,7 +246,6 @@ var _ = Describe("Defaults", func() {
 
 	Describe("ServerConfiguration defaulting", func() {
 		It("should default ServerConfiguration correctly", func() {
-			obj := &ControllerManagerConfiguration{}
 			expected := &ServerConfiguration{
 				HealthProbes: &Server{
 					Port: 2718,
@@ -281,7 +279,6 @@ var _ = Describe("Defaults", func() {
 
 	Describe("BastionControllerConfiguration defaulting", func() {
 		It("should default BastionControllerConfiguration correctly", func() {
-			obj := &ControllerManagerConfiguration{}
 			expected := &BastionControllerConfiguration{
 				ConcurrentSyncs: pointer.Int(DefaultControllerConcurrentSyncs),
 				MaxLifetime:     &metav1.Duration{Duration: 24 * time.Hour},
@@ -309,7 +306,6 @@ var _ = Describe("Defaults", func() {
 
 	Describe("CertificateSigningRequestControllerConfiguration defaulting", func() {
 		It("should default CertificateSigningRequestControllerConfiguration correctly", func() {
-			obj := &ControllerManagerConfiguration{}
 			expected := &CertificateSigningRequestControllerConfiguration{
 				ConcurrentSyncs: pointer.Int(DefaultControllerConcurrentSyncs),
 			}
@@ -335,7 +331,6 @@ var _ = Describe("Defaults", func() {
 
 	Describe("CloudProfileControllerConfiguration defaulting", func() {
 		It("should default CloudProfileControllerConfiguration correctly", func() {
-			obj := &ControllerManagerConfiguration{}
 			expected := &CloudProfileControllerConfiguration{
 				ConcurrentSyncs: pointer.Int(DefaultControllerConcurrentSyncs),
 			}
@@ -361,7 +356,6 @@ var _ = Describe("Defaults", func() {
 
 	Describe("ControllerDeploymentControllerConfiguration defaulting", func() {
 		It("should default ControllerDeploymentControllerConfiguration correctly", func() {
-			obj := &ControllerManagerConfiguration{}
 			expected := &ControllerDeploymentControllerConfiguration{
 				ConcurrentSyncs: pointer.Int(DefaultControllerConcurrentSyncs),
 			}
@@ -387,7 +381,6 @@ var _ = Describe("Defaults", func() {
 
 	Describe("ControllerRegistrationControllerConfiguration defaulting", func() {
 		It("should default ControllerRegistrationControllerConfiguration correctly", func() {
-			obj := &ControllerManagerConfiguration{}
 			expected := &ControllerRegistrationControllerConfiguration{
 				ConcurrentSyncs: pointer.Int(DefaultControllerConcurrentSyncs),
 			}
@@ -413,7 +406,6 @@ var _ = Describe("Defaults", func() {
 
 	Describe("ExposureClassControllerConfiguration defaulting", func() {
 		It("should default ExposureClassControllerConfiguration correctly", func() {
-			obj := &ControllerManagerConfiguration{}
 			expected := &ExposureClassControllerConfiguration{
 				ConcurrentSyncs: pointer.Int(DefaultControllerConcurrentSyncs),
 			}
@@ -439,7 +431,6 @@ var _ = Describe("Defaults", func() {
 
 	Describe("QuotaControllerConfiguration defaulting", func() {
 		It("should default QuotaControllerConfiguration correctly", func() {
-			obj := &ControllerManagerConfiguration{}
 			expected := &QuotaControllerConfiguration{
 				ConcurrentSyncs: pointer.Int(DefaultControllerConcurrentSyncs),
 			}
@@ -465,11 +456,11 @@ var _ = Describe("Defaults", func() {
 
 	Describe("SecretBindingControllerConfiguration defaulting", func() {
 		It("should default SecretBindingControllerConfiguration correctly", func() {
-			obj := &ControllerManagerConfiguration{}
 			expected := &SecretBindingControllerConfiguration{
 				ConcurrentSyncs: pointer.Int(DefaultControllerConcurrentSyncs),
 			}
 			SetObjectDefaults_ControllerManagerConfiguration(obj)
+
 			Expect(obj.Controllers.SecretBinding).To(Equal(expected))
 		})
 
@@ -483,18 +474,19 @@ var _ = Describe("Defaults", func() {
 			}
 			expected := obj.Controllers.SecretBinding.DeepCopy()
 			SetObjectDefaults_ControllerManagerConfiguration(obj)
+
 			Expect(obj.Controllers.SecretBinding).To(Equal(expected))
 		})
 	})
 
 	Describe("SeedExtensionsCheckControllerConfiguration defaulting", func() {
 		It("should default SeedExtensionsCheckControllerConfiguration correctly", func() {
-			obj := &ControllerManagerConfiguration{}
 			expected := &SeedExtensionsCheckControllerConfiguration{
 				ConcurrentSyncs: pointer.Int(DefaultControllerConcurrentSyncs),
 				SyncPeriod:      &metav1.Duration{Duration: 30 * time.Second},
 			}
 			SetObjectDefaults_ControllerManagerConfiguration(obj)
+
 			Expect(obj.Controllers.SeedExtensionsCheck).To(Equal(expected))
 		})
 
@@ -509,18 +501,19 @@ var _ = Describe("Defaults", func() {
 			}
 			expected := obj.Controllers.SeedExtensionsCheck.DeepCopy()
 			SetObjectDefaults_ControllerManagerConfiguration(obj)
+
 			Expect(obj.Controllers.SeedExtensionsCheck).To(Equal(expected))
 		})
 	})
 
 	Describe("SeedBackupBucketsCheckControllerConfiguration defaulting", func() {
 		It("should default SeedBackupBucketsCheckControllerConfiguration correctly", func() {
-			obj := &ControllerManagerConfiguration{}
 			expected := &SeedBackupBucketsCheckControllerConfiguration{
 				ConcurrentSyncs: pointer.Int(DefaultControllerConcurrentSyncs),
 				SyncPeriod:      &metav1.Duration{Duration: 30 * time.Second},
 			}
 			SetObjectDefaults_ControllerManagerConfiguration(obj)
+
 			Expect(obj.Controllers.SeedBackupBucketsCheck).To(Equal(expected))
 		})
 
@@ -535,18 +528,19 @@ var _ = Describe("Defaults", func() {
 			}
 			expected := obj.Controllers.SeedBackupBucketsCheck.DeepCopy()
 			SetObjectDefaults_ControllerManagerConfiguration(obj)
+
 			Expect(obj.Controllers.SeedBackupBucketsCheck).To(Equal(expected))
 		})
 	})
 
 	Describe("ShootHibernationControllerConfiguration defaulting", func() {
 		It("should default ShootHibernationControllerConfiguration correctly", func() {
-			obj := &ControllerManagerConfiguration{}
 			expected := &ShootHibernationControllerConfiguration{
 				ConcurrentSyncs:         pointer.Int(DefaultControllerConcurrentSyncs),
 				TriggerDeadlineDuration: &metav1.Duration{Duration: 2 * time.Hour},
 			}
 			SetObjectDefaults_ControllerManagerConfiguration(obj)
+
 			Expect(&obj.Controllers.ShootHibernation).To(Equal(expected))
 		})
 
@@ -561,18 +555,19 @@ var _ = Describe("Defaults", func() {
 			}
 			expected := obj.Controllers.ShootHibernation.DeepCopy()
 			SetObjectDefaults_ControllerManagerConfiguration(obj)
+
 			Expect(&obj.Controllers.ShootHibernation).To(Equal(expected))
 		})
 	})
 
 	Describe("ShootMaintenanceControllerConfiguration defaulting", func() {
 		It("should default ShootMaintenanceControllerConfiguration correctly", func() {
-			obj := &ControllerManagerConfiguration{}
 			expected := &ShootMaintenanceControllerConfiguration{
 				ConcurrentSyncs:                  pointer.Int(DefaultControllerConcurrentSyncs),
 				EnableShootControlPlaneRestarter: pointer.Bool(true),
 			}
 			SetObjectDefaults_ControllerManagerConfiguration(obj)
+
 			Expect(&obj.Controllers.ShootMaintenance).To(Equal(expected))
 		})
 
@@ -587,13 +582,13 @@ var _ = Describe("Defaults", func() {
 			}
 			expected := obj.Controllers.ShootMaintenance.DeepCopy()
 			SetObjectDefaults_ControllerManagerConfiguration(obj)
+
 			Expect(&obj.Controllers.ShootMaintenance).To(Equal(expected))
 		})
 	})
 
 	Describe("ShootQuotaControllerConfiguration defaulting", func() {
 		It("should default ShootQuotaControllerConfiguration correctly", func() {
-			obj := &ControllerManagerConfiguration{}
 			expected := &ShootQuotaControllerConfiguration{
 				ConcurrentSyncs: pointer.Int(DefaultControllerConcurrentSyncs),
 				SyncPeriod: &metav1.Duration{
@@ -625,7 +620,6 @@ var _ = Describe("Defaults", func() {
 
 	Describe("ShootReferenceControllerConfiguration defaulting", func() {
 		It("should default ShootReferenceControllerConfiguration correctly", func() {
-			obj := &ControllerManagerConfiguration{}
 			expected := &ShootReferenceControllerConfiguration{
 				ConcurrentSyncs: pointer.Int(DefaultControllerConcurrentSyncs),
 			}
@@ -651,7 +645,6 @@ var _ = Describe("Defaults", func() {
 
 	Describe("ShootConditionsControllerConfiguration defaulting", func() {
 		It("should default ShootConditionsControllerConfiguration correctly", func() {
-			obj := &ControllerManagerConfiguration{}
 			expected := &ShootConditionsControllerConfiguration{
 				ConcurrentSyncs: pointer.Int(DefaultControllerConcurrentSyncs),
 			}
@@ -692,7 +685,6 @@ var _ = Describe("Defaults", func() {
 		})
 
 		It("should not default EventControllerConfiguration if not set", func() {
-			obj := &ControllerManagerConfiguration{}
 			var expected *EventControllerConfiguration
 			SetObjectDefaults_ControllerManagerConfiguration(obj)
 
@@ -717,7 +709,6 @@ var _ = Describe("Defaults", func() {
 
 	Describe("ShootStatusLabelControllerConfiguration defaulting", func() {
 		It("should default ShootStatusLabelControllerConfiguration correctly", func() {
-			obj := &ControllerManagerConfiguration{}
 			expected := &ShootStatusLabelControllerConfiguration{
 				ConcurrentSyncs: pointer.Int(DefaultControllerConcurrentSyncs),
 			}
@@ -743,7 +734,6 @@ var _ = Describe("Defaults", func() {
 
 	Describe("ManagedSeedSetControllerConfiguration defaulting", func() {
 		It("should default ManagedSeedSetControllerConfiguration correctly if nil", func() {
-			obj := &ControllerManagerConfiguration{}
 			expected := &ManagedSeedSetControllerConfiguration{
 				ConcurrentSyncs: pointer.Int(DefaultControllerConcurrentSyncs),
 				MaxShootRetries: pointer.Int(3),

--- a/pkg/controllermanager/apis/config/v1alpha1/register.go
+++ b/pkg/controllermanager/apis/config/v1alpha1/register.go
@@ -52,3 +52,7 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 	)
 	return nil
 }
+
+func addDefaultingFuncs(scheme *runtime.Scheme) error {
+	return RegisterDefaults(scheme)
+}

--- a/pkg/controllermanager/apis/config/v1alpha1/zz_generated.defaults.go
+++ b/pkg/controllermanager/apis/config/v1alpha1/zz_generated.defaults.go
@@ -38,11 +38,36 @@ func RegisterDefaults(scheme *runtime.Scheme) error {
 func SetObjectDefaults_ControllerManagerConfiguration(in *ControllerManagerConfiguration) {
 	SetDefaults_ControllerManagerConfiguration(in)
 	SetDefaults_ClientConnectionConfiguration(&in.GardenClientConnection)
+	SetDefaults_ControllerManagerControllerConfiguration(&in.Controllers)
+	if in.Controllers.Bastion != nil {
+		SetDefaults_BastionControllerConfiguration(in.Controllers.Bastion)
+	}
 	if in.Controllers.CertificateSigningRequest != nil {
 		SetDefaults_CertificateSigningRequestControllerConfiguration(in.Controllers.CertificateSigningRequest)
 	}
+	if in.Controllers.CloudProfile != nil {
+		SetDefaults_CloudProfileControllerConfiguration(in.Controllers.CloudProfile)
+	}
+	if in.Controllers.ControllerDeployment != nil {
+		SetDefaults_ControllerDeploymentControllerConfiguration(in.Controllers.ControllerDeployment)
+	}
+	if in.Controllers.ControllerRegistration != nil {
+		SetDefaults_ControllerRegistrationControllerConfiguration(in.Controllers.ControllerRegistration)
+	}
 	if in.Controllers.Event != nil {
 		SetDefaults_EventControllerConfiguration(in.Controllers.Event)
+	}
+	if in.Controllers.ExposureClass != nil {
+		SetDefaults_ExposureClassControllerConfiguration(in.Controllers.ExposureClass)
+	}
+	if in.Controllers.Project != nil {
+		SetDefaults_ProjectControllerConfiguration(in.Controllers.Project)
+	}
+	if in.Controllers.Quota != nil {
+		SetDefaults_QuotaControllerConfiguration(in.Controllers.Quota)
+	}
+	if in.Controllers.SecretBinding != nil {
+		SetDefaults_SecretBindingControllerConfiguration(in.Controllers.SecretBinding)
 	}
 	if in.Controllers.Seed != nil {
 		SetDefaults_SeedControllerConfiguration(in.Controllers.Seed)
@@ -53,9 +78,22 @@ func SetObjectDefaults_ControllerManagerConfiguration(in *ControllerManagerConfi
 	if in.Controllers.SeedBackupBucketsCheck != nil {
 		SetDefaults_SeedBackupBucketsCheckControllerConfiguration(in.Controllers.SeedBackupBucketsCheck)
 	}
+	SetDefaults_ShootMaintenanceControllerConfiguration(&in.Controllers.ShootMaintenance)
+	if in.Controllers.ShootQuota != nil {
+		SetDefaults_ShootQuotaControllerConfiguration(in.Controllers.ShootQuota)
+	}
 	SetDefaults_ShootHibernationControllerConfiguration(&in.Controllers.ShootHibernation)
+	if in.Controllers.ShootReference != nil {
+		SetDefaults_ShootReferenceControllerConfiguration(in.Controllers.ShootReference)
+	}
 	if in.Controllers.ShootRetry != nil {
 		SetDefaults_ShootRetryControllerConfiguration(in.Controllers.ShootRetry)
+	}
+	if in.Controllers.ShootConditions != nil {
+		SetDefaults_ShootConditionsControllerConfiguration(in.Controllers.ShootConditions)
+	}
+	if in.Controllers.ShootStatusLabel != nil {
+		SetDefaults_ShootStatusLabelControllerConfiguration(in.Controllers.ShootStatusLabel)
 	}
 	if in.Controllers.ManagedSeedSet != nil {
 		SetDefaults_ManagedSeedSetControllerConfiguration(in.Controllers.ManagedSeedSet)
@@ -63,4 +101,5 @@ func SetObjectDefaults_ControllerManagerConfiguration(in *ControllerManagerConfi
 	if in.LeaderElection != nil {
 		SetDefaults_LeaderElectionConfiguration(in.LeaderElection)
 	}
+	SetDefaults_ServerConfiguration(&in.Server)
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind technical-debt

**What this PR does / why we need it**:
This PR cleans up technical debt in our API defaulting code according to https://github.com/gardener/gardener/issues/7312.
This PR tackles the following resources in the core API group:

- controllermanager.config.gardener.cloud

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/7312

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
NONE
```
