### PR TITLE
Promote `ContainerdRegistryHostsDir` feature gate to GA

### DIFF
--- a/docs/deployment/feature_gates.md
+++ b/docs/deployment/feature_gates.md
@@ -27,13 +27,14 @@ The following tables are a summary of the feature gates that you can set on diff
 | IPv6SingleStack                     | `false` | `Alpha` | `1.63` |        |
 | MutableShootSpecNetworkingNodes     | `false` | `Alpha` | `1.64` |        |
 | WorkerlessShoots                    | `false` | `Alpha` | `1.70` | `1.78` |
-| WorkerlessShoots                    | `false` | `Beta`  | `1.79` | `1.85` |
+| WorkerlessShoots                    | `true`  | `Beta`  | `1.79` | `1.85` |
 | WorkerlessShoots                    | `true`  | `GA`    | `1.86` |        |
 | MachineControllerManagerDeployment  | `false` | `Alpha` | `1.73` |        |
 | MachineControllerManagerDeployment  | `true`  | `Beta`  | `1.81` | `1.81` |
 | MachineControllerManagerDeployment  | `true`  | `GA`    | `1.82` |        |
 | ContainerdRegistryHostsDir          | `false` | `Alpha` | `1.77` | `1.85` |
-| ContainerdRegistryHostsDir          | `false` | `Beta`  | `1.86` |        |
+| ContainerdRegistryHostsDir          | `true`  | `Beta`  | `1.86` | `1.86` |
+| ContainerdRegistryHostsDir          | `true`  | `GA`    | `1.87` |        |
 | ShootForceDeletion                  | `false` | `Alpha` | `1.81` |        |
 | APIServerFastRollout                | `true`  | `Beta`  | `1.82` |        |
 | UseGardenerNodeAgent                | `false` | `Alpha` | `1.82` |        |

--- a/docs/usage/containerd-registry-configuration.md
+++ b/docs/usage/containerd-registry-configuration.md
@@ -60,8 +60,6 @@ server = "https://registry-1.docker.io"
 
 ### Configuring `containerd` Registries for a Shoot
 
-> Note: The below-described functionality is provided by the `ContainerdRegistryHostsDir` feature gate in gardenlet.
-
 Gardener supports configuring `containerd` registries on a Shoot using the new [hosts directory pattern](https://github.com/containerd/containerd/blob/main/docs/hosts.md). For each Shoot Node, Gardener creates the `/etc/containerd/certs.d` directory and adds the following section to the containerd's `/etc/containerd/config.toml` file:
 
 ```toml
@@ -73,36 +71,4 @@ This allows Shoot owners to use the [hosts directory pattern](https://github.com
 
 ### The registry-cache Extension
 
-[Configuring `containerd` registries for a Shoot](#configuring-containerd-registries-for-a-shoot) won't be the recommended approach for configuring a pull through cache for a Shoot in near future. There is a Gardener-native extension named [registry-cache](https://github.com/gardener/gardener-extension-registry-cache) that manages a pull through cache for a Shoot using the upstream [distribution/distribution](https://github.com/distribution/distribution) project.
-
-> Note: The [registry-cache](https://github.com/gardener/gardener-extension-registry-cache) extension is currently under active development and not recommended for productive usage.
-
-### Migration
-
-This section describe the migration process from the old and deprecated pattern to the hosts directory pattern for a Shoot cluster.
-
-Let's assume that the following `containerd` registries configuration using the old and deprecated pattern is being configured (for example via DaemonSet) for a Shoot:
-
-```toml
-version = 2
-
-[plugins."io.containerd.grpc.v1.cri".registry]
-  [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
-    [plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]
-      endpoint = ["https://public-mirror.example.com"]
-```
-
-The migration steps are as follows:
-1. The `containerd` registries configuration has to be adapted to the hosts directory pattern.
-
-   1.1 The `/etc/containerd/config.toml` file needs to be adapted as follows:
-   ```toml
-   version = 2
-   
-   [plugins."io.containerd.grpc.v1.cri".registry]
-      config_path = "/etc/containerd/certs.d"
-   ```
-
-   1.2 The appropriate directory structure and `hosts.toml` file has to be created as described in the [hosts directory pattern section](#hosts-directory-pattern).
-
-2. When the `ContainerdRegistryHostsDir` feature gate is GA, then the machinery that performs step 1.1 can be removed. A Shoot cluster can rely that the `config_path` will be always set by gardenlet.
+[Configuring `containerd` registries for a Shoot](#configuring-containerd-registries-for-a-shoot) is not the recommended approach for configuring a pull through cache for a Shoot. There is a Gardener-native extension named [registry-cache](https://github.com/gardener/gardener-extension-registry-cache) that manages a pull through cache for a Shoot using the upstream [distribution/distribution](https://github.com/distribution/distribution) project.

--- a/example/gardener-local/gardenlet/values.yaml
+++ b/example/gardener-local/gardenlet/values.yaml
@@ -44,11 +44,6 @@ config:
     # This feature gate doesn't change gardenlet's default behavior, it only allows setting `ipFamilies=[IPv6]` in the
     # Seed config. Only when this is set, gardenlet's behavior changes.
     IPv6SingleStack: true
-    # Enable ContainerdRegistryHostsDir as provider-local requires the feature gate to be enabled 
-    # in order to have the registry cache working for a Shoot cluster in local setup.
-    # If disabled, a Shoot cluster in local setup won't be able to use the registry cache
-    # (it will be still able to pull images but registry cache won't be used).
-    ContainerdRegistryHostsDir: true
     UseGardenerNodeAgent: true
   etcdConfig:
     featureGates:

--- a/extensions/pkg/webhook/controlplane/genericmutator/.import-restrictions
+++ b/extensions/pkg/webhook/controlplane/genericmutator/.import-restrictions
@@ -16,7 +16,8 @@ rules:
   allowedPrefixes:
   - github.com/gardener/gardener/pkg/component
 # allow the transitive import of github.com/gardener/gardener/pkg/features
-# which is imported by github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/original/components/containerd
+# which is imported by github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/original/components/kubelet
+# TODO(ialidzhikov): Remove the below rule when the UseGardenerNodeAgent feature gate is promoted to GA.
 - selectorRegexp: github[.]com/gardener/gardener/pkg/features
   allowedPrefixes:
   - github.com/gardener/gardener/pkg/features

--- a/pkg/component/extensions/operatingsystemconfig/original/components/containerd/containerd_suite_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/containerd/containerd_suite_test.go
@@ -19,12 +19,9 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-
-	"github.com/gardener/gardener/pkg/gardenlet/features"
 )
 
 func TestContainerD(t *testing.T) {
-	features.RegisterFeatureGates()
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Component Extensions OperatingSystemConfig Original Components ContainerD Suite")
 }

--- a/pkg/component/extensions/operatingsystemconfig/original/components/containerd/initializer.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/containerd/initializer.go
@@ -26,7 +26,6 @@ import (
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/original/components"
-	"github.com/gardener/gardener/pkg/features"
 	"github.com/gardener/gardener/pkg/utils"
 )
 
@@ -67,9 +66,8 @@ func (initializer) Config(ctx components.Context) ([]extensionsv1alpha1.Unit, []
 
 	var script bytes.Buffer
 	if err := tplInitializer.Execute(&script, map[string]interface{}{
-		"binaryPath":                        extensionsv1alpha1.ContainerDRuntimeContainersBinFolder,
-		"pauseContainerImage":               ctx.Images[imagevector.ImageNamePauseContainer],
-		"containerdRegistryHostsDirEnabled": features.DefaultFeatureGate.Enabled(features.ContainerdRegistryHostsDir),
+		"binaryPath":          extensionsv1alpha1.ContainerDRuntimeContainersBinFolder,
+		"pauseContainerImage": ctx.Images[imagevector.ImageNamePauseContainer],
 	}); err != nil {
 		return nil, nil, err
 	}

--- a/pkg/component/extensions/operatingsystemconfig/original/components/containerd/initializer_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/containerd/initializer_test.go
@@ -22,10 +22,8 @@ import (
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/original/components"
 	. "github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/original/components/containerd"
-	"github.com/gardener/gardener/pkg/features"
 	"github.com/gardener/gardener/pkg/utils"
 	"github.com/gardener/gardener/pkg/utils/imagevector"
-	"github.com/gardener/gardener/pkg/utils/test"
 )
 
 var _ = Describe("Initializer", func() {
@@ -48,19 +46,16 @@ var _ = Describe("Initializer", func() {
 			ctx.Images = images
 		})
 
-		DescribeTable("should return the expected units and files",
-			func(containerdRegistryHostsDirEnabled bool) {
-				defer test.WithFeatureGate(features.DefaultFeatureGate, features.ContainerdRegistryHostsDir, containerdRegistryHostsDirEnabled)()
+		It("should return the expected units and files", func() {
+			units, files, err := component.Config(ctx)
 
-				units, files, err := component.Config(ctx)
-
-				Expect(err).NotTo(HaveOccurred())
-				Expect(units).To(ConsistOf(
-					extensionsv1alpha1.Unit{
-						Name:    "containerd-initializer.service",
-						Command: extensionsv1alpha1.UnitCommandPtr(extensionsv1alpha1.CommandStart),
-						Enable:  pointer.Bool(true),
-						Content: pointer.String(`[Unit]
+			Expect(err).NotTo(HaveOccurred())
+			Expect(units).To(ConsistOf(
+				extensionsv1alpha1.Unit{
+					Name:    "containerd-initializer.service",
+					Command: extensionsv1alpha1.UnitCommandPtr(extensionsv1alpha1.CommandStart),
+					Enable:  pointer.Bool(true),
+					Content: pointer.String(`[Unit]
 Description=Containerd initializer
 [Install]
 WantedBy=multi-user.target
@@ -68,76 +63,39 @@ WantedBy=multi-user.target
 Type=oneshot
 RemainAfterExit=yes
 ExecStart=/opt/bin/init-containerd`),
-					},
-				))
-				Expect(files).To(ConsistOf(
-					extensionsv1alpha1.File{
-						Path:        "/opt/bin/init-containerd",
-						Permissions: pointer.Int32(744),
-						Content: extensionsv1alpha1.FileContent{
-							Inline: &extensionsv1alpha1.FileContentInline{
-								Encoding: "b64",
-								Data:     utils.EncodeBase64([]byte(initScriptFor(containerdRegistryHostsDirEnabled))),
-							},
+				},
+			))
+			Expect(files).To(ConsistOf(
+				extensionsv1alpha1.File{
+					Path:        "/opt/bin/init-containerd",
+					Permissions: pointer.Int32(744),
+					Content: extensionsv1alpha1.FileContent{
+						Inline: &extensionsv1alpha1.FileContentInline{
+							Encoding: "b64",
+							Data:     utils.EncodeBase64([]byte(initScript)),
 						},
 					},
-					extensionsv1alpha1.File{
-						Path:        "/etc/systemd/system/containerd.service.d/10-require-containerd-initializer.conf",
-						Permissions: pointer.Int32(0644),
-						Content: extensionsv1alpha1.FileContent{
-							Inline: &extensionsv1alpha1.FileContentInline{
-								Data: `[Unit]
+				},
+				extensionsv1alpha1.File{
+					Path:        "/etc/systemd/system/containerd.service.d/10-require-containerd-initializer.conf",
+					Permissions: pointer.Int32(0644),
+					Content: extensionsv1alpha1.FileContent{
+						Inline: &extensionsv1alpha1.FileContentInline{
+							Data: `[Unit]
 After=containerd-initializer.service
 Requires=containerd-initializer.service`,
-							},
 						},
 					},
-				))
-			},
-
-			Entry("when ContainerdRegistryHostsDir feature gate is disabled", false),
-			Entry("when ContainerdRegistryHostsDir feature gate is enabled", true),
-		)
+				},
+			))
+		})
 	})
 })
 
 const (
 	pauseContainerImageRepo = "foo.io"
 	pauseContainerImageTag  = "v1.2.3"
-)
-
-func initScriptFor(containerdRegistryHostsDirEnabled bool) string {
-	var registryHostsDirPart string
-	if containerdRegistryHostsDirEnabled {
-		registryHostsDirPart = `CONFIG_PATH=/etc/containerd/certs.d
-mkdir -p "$CONFIG_PATH"
-if ! grep --quiet --fixed-strings '[plugins."io.containerd.grpc.v1.cri".registry]' "$FILE"; then
-  echo "CRI registry section not found. Adding CRI registry section with config_path = \"$CONFIG_PATH\" in $FILE."
-  # TODO(ialidzhikov): Drop the "# gardener-managed" comment when removing the ContainerdRegistryHostsDir feature gate.
-  # Currently we need such comment to distinguish whether the config is added by this script or externally by the Shoot owner.
-  # When the feature gate is disabled, the config section is being removed only when it was added by this script.
-  cat <<EOF >> $FILE
-[plugins."io.containerd.grpc.v1.cri".registry] # gardener-managed
-  config_path = "/etc/containerd/certs.d"
-EOF
-else
-  if grep --quiet --fixed-strings '[plugins."io.containerd.grpc.v1.cri".registry] # gardener-managed' "$FILE"; then
-    echo "CRI registry section is already gardener managed. Nothing to do."
-  else
-    echo "CRI registry section is not gardener managed. Setting config_path = \"$CONFIG_PATH\" in $FILE."
-    sed --null-data --in-place 's/\(\[plugins\."io\.containerd\.grpc\.v1\.cri"\.registry\]\)\n\(\s*config_path\s*=\s*\)""\n/\1 \# gardener-managed\n\2"\/etc\/containerd\/certs.d"\n/' "$FILE"
-  fi
-fi`
-	} else {
-		registryHostsDirPart = `if grep --quiet --fixed-strings '[plugins."io.containerd.grpc.v1.cri".registry] # gardener-managed' "$FILE"; then
-  echo "CRI registry section is gardener managed. Removing CRI registry section from $FILE."
-  sed --null-data --in-place 's/\[plugins\."io\.containerd\.grpc\.v1\.cri"\.registry\]\ #\ gardener-managed\n\s*config_path.*\n//' "$FILE"
-else
-  echo "A gardener managed CRI section is not found. Nothing to do."
-fi`
-	}
-
-	return `#!/bin/bash
+	initScript              = `#!/bin/bash
 
 FILE=/etc/containerd/config.toml
 if [ ! -s "$FILE" ]; then
@@ -151,8 +109,22 @@ pause_image=` + pauseContainerImageRepo + `:` + pauseContainerImageTag + `
 sed -i  "s|$sandbox_image_line|sandbox_image = \"$pause_image\"|g" $FILE
 
 # create and configure registry hosts directory
-# or remove registry hosts directory configuration
-` + registryHostsDirPart + `
+CONFIG_PATH=/etc/containerd/certs.d
+mkdir -p "$CONFIG_PATH"
+if ! grep --quiet --fixed-strings '[plugins."io.containerd.grpc.v1.cri".registry]' "$FILE"; then
+  echo "CRI registry section not found. Adding CRI registry section with config_path = \"$CONFIG_PATH\" in $FILE."
+  cat <<EOF >> $FILE
+[plugins."io.containerd.grpc.v1.cri".registry] # gardener-managed
+  config_path = "/etc/containerd/certs.d"
+EOF
+else
+  if grep --quiet --fixed-strings '[plugins."io.containerd.grpc.v1.cri".registry] # gardener-managed' "$FILE"; then
+    echo "CRI registry section is already gardener managed. Nothing to do."
+  else
+    echo "CRI registry section is not gardener managed. Setting config_path = \"$CONFIG_PATH\" in $FILE."
+    sed --null-data --in-place 's/\(\[plugins\."io\.containerd\.grpc\.v1\.cri"\.registry\]\)\n\(\s*config_path\s*=\s*\)""\n/\1 \# gardener-managed\n\2"\/etc\/containerd\/certs.d"\n/' "$FILE"
+  fi
+fi
 
 # allow to import custom configuration files
 CUSTOM_CONFIG_DIR=/etc/containerd/conf.d
@@ -184,4 +156,4 @@ EOF
   systemctl daemon-reload
 fi
 `
-}
+)

--- a/pkg/component/extensions/operatingsystemconfig/original/components/containerd/templates/scripts/init.tpl.sh
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/containerd/templates/scripts/init.tpl.sh
@@ -12,15 +12,10 @@ pause_image={{ .pauseContainerImage }}
 sed -i  "s|$sandbox_image_line|sandbox_image = \"$pause_image\"|g" $FILE
 
 # create and configure registry hosts directory
-# or remove registry hosts directory configuration
-{{- if .containerdRegistryHostsDirEnabled }}
 CONFIG_PATH=/etc/containerd/certs.d
 mkdir -p "$CONFIG_PATH"
 if ! grep --quiet --fixed-strings '[plugins."io.containerd.grpc.v1.cri".registry]' "$FILE"; then
   echo "CRI registry section not found. Adding CRI registry section with config_path = \"$CONFIG_PATH\" in $FILE."
-  # TODO(ialidzhikov): Drop the "# gardener-managed" comment when removing the ContainerdRegistryHostsDir feature gate.
-  # Currently we need such comment to distinguish whether the config is added by this script or externally by the Shoot owner.
-  # When the feature gate is disabled, the config section is being removed only when it was added by this script.
   cat <<EOF >> $FILE
 [plugins."io.containerd.grpc.v1.cri".registry] # gardener-managed
   config_path = "/etc/containerd/certs.d"
@@ -33,14 +28,6 @@ else
     sed --null-data --in-place 's/\(\[plugins\."io\.containerd\.grpc\.v1\.cri"\.registry\]\)\n\(\s*config_path\s*=\s*\)""\n/\1 \# gardener-managed\n\2"\/etc\/containerd\/certs.d"\n/' "$FILE"
   fi
 fi
-{{- else }}
-if grep --quiet --fixed-strings '[plugins."io.containerd.grpc.v1.cri".registry] # gardener-managed' "$FILE"; then
-  echo "CRI registry section is gardener managed. Removing CRI registry section from $FILE."
-  sed --null-data --in-place 's/\[plugins\."io\.containerd\.grpc\.v1\.cri"\.registry\]\ #\ gardener-managed\n\s*config_path.*\n//' "$FILE"
-else
-  echo "A gardener managed CRI section is not found. Nothing to do."
-fi
-{{- end }}
 
 # allow to import custom configuration files
 CUSTOM_CONFIG_DIR=/etc/containerd/conf.d

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -96,6 +96,7 @@ const (
 	// owner: @ialidzhikov, @dimitar-kostadinov
 	// alpha: v1.77.0
 	// beta: v1.86.0
+	// GA: v1.87.0
 	ContainerdRegistryHostsDir featuregate.Feature = "ContainerdRegistryHostsDir"
 
 	// APIServerFastRollout enables fast rollouts for Shoot kube-apiservers on the given Seed.
@@ -145,7 +146,7 @@ var AllFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	WorkerlessShoots:                   {Default: true, PreRelease: featuregate.Beta, LockToDefault: true},
 	ShootForceDeletion:                 {Default: false, PreRelease: featuregate.Alpha},
 	MachineControllerManagerDeployment: {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
-	ContainerdRegistryHostsDir:         {Default: true, PreRelease: featuregate.Beta},
+	ContainerdRegistryHostsDir:         {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
 	APIServerFastRollout:               {Default: true, PreRelease: featuregate.Beta},
 	UseGardenerNodeAgent:               {Default: false, PreRelease: featuregate.Alpha},
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind enhancement

**What this PR does / why we need it**:
Promote `ContainerdRegistryHostsDir` feature gate to GA and lock it to its default (`true`).

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener-extension-registry-cache/issues/3

**Special notes for your reviewer**:
I decided to drop the TODO in https://github.com/gardener/gardener/blob/92940f4b542207fe1ccf323f1385ce70c21ac592/pkg/component/extensions/operatingsystemconfig/original/components/containerd/templates/scripts/init.tpl.sh#L21-L23 as I prefer the current approach of not doing anything if we already added/updated the config (comment is present) over every time updating (with the sed) the config (no matter there is need for update or not).

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy operator
The `ContainerdRegistryHostsDir` feature gate has been promoted to GA and is now locked to "enabled by default".
```

