### PR TITLE
[Gardenlet] Clean up technical debt in defaulting code

### DIFF
--- a/pkg/gardenlet/apis/config/v1alpha1/defaults.go
+++ b/pkg/gardenlet/apis/config/v1alpha1/defaults.go
@@ -60,20 +60,6 @@ func SetDefaults_GardenletConfiguration(obj *GardenletConfiguration) {
 		obj.LogFormat = LogFormatJSON
 	}
 
-	if obj.Server.HealthProbes == nil {
-		obj.Server.HealthProbes = &Server{}
-	}
-	if obj.Server.HealthProbes.Port == 0 {
-		obj.Server.HealthProbes.Port = 2728
-	}
-
-	if obj.Server.Metrics == nil {
-		obj.Server.Metrics = &Server{}
-	}
-	if obj.Server.Metrics.Port == 0 {
-		obj.Server.Metrics.Port = 2729
-	}
-
 	if obj.Logging == nil {
 		obj.Logging = &Logging{}
 	}
@@ -92,23 +78,45 @@ func SetDefaults_GardenletConfiguration(obj *GardenletConfiguration) {
 		obj.ETCDConfig = &ETCDConfig{}
 	}
 
+	SetDefaults_ExposureClassHandler(obj.ExposureClassHandlers)
+}
+
+// SetDefaults_ServerConfiguration sets defaults for the configuration of the HTTP server.
+func SetDefaults_ServerConfiguration(obj *ServerConfiguration) {
+	if obj.HealthProbes == nil {
+		obj.HealthProbes = &Server{}
+	}
+	if obj.HealthProbes.Port == 0 {
+		obj.HealthProbes.Port = 2728
+	}
+
+	if obj.Metrics == nil {
+		obj.Metrics = &Server{}
+	}
+	if obj.Metrics.Port == 0 {
+		obj.Metrics.Port = 2729
+	}
+}
+
+// SetDefaults_ExposureClassHandler sets defaults for the configuration for an exposure class handler.
+func SetDefaults_ExposureClassHandler(obj []ExposureClassHandler) {
 	var defaultSVCName = v1beta1constants.DefaultSNIIngressServiceName
-	for i, handler := range obj.ExposureClassHandlers {
-		if obj.ExposureClassHandlers[i].SNI == nil {
-			obj.ExposureClassHandlers[i].SNI = &SNI{Ingress: &SNIIngress{}}
+	for i, handler := range obj {
+		if obj[i].SNI == nil {
+			obj[i].SNI = &SNI{Ingress: &SNIIngress{}}
 		}
-		if obj.ExposureClassHandlers[i].SNI.Ingress == nil {
-			obj.ExposureClassHandlers[i].SNI.Ingress = &SNIIngress{}
+		if obj[i].SNI.Ingress == nil {
+			obj[i].SNI.Ingress = &SNIIngress{}
 		}
-		if obj.ExposureClassHandlers[i].SNI.Ingress.Namespace == nil {
+		if obj[i].SNI.Ingress.Namespace == nil {
 			namespaceName := fmt.Sprintf("istio-ingress-handler-%s", handler.Name)
-			obj.ExposureClassHandlers[i].SNI.Ingress.Namespace = &namespaceName
+			obj[i].SNI.Ingress.Namespace = &namespaceName
 		}
-		if obj.ExposureClassHandlers[i].SNI.Ingress.ServiceName == nil {
-			obj.ExposureClassHandlers[i].SNI.Ingress.ServiceName = &defaultSVCName
+		if obj[i].SNI.Ingress.ServiceName == nil {
+			obj[i].SNI.Ingress.ServiceName = &defaultSVCName
 		}
-		if len(obj.ExposureClassHandlers[i].SNI.Ingress.Labels) == 0 {
-			obj.ExposureClassHandlers[i].SNI.Ingress.Labels = map[string]string{
+		if len(obj[i].SNI.Ingress.Labels) == 0 {
+			obj[i].SNI.Ingress.Labels = map[string]string{
 				v1beta1constants.LabelApp:   v1beta1constants.DefaultIngressGatewayAppLabelValue,
 				v1beta1constants.GardenRole: v1beta1constants.GardenRoleExposureClassHandler,
 			}
@@ -476,28 +484,40 @@ func SetDefaults_ETCDConfig(obj *ETCDConfig) {
 	if obj.ETCDController == nil {
 		obj.ETCDController = &ETCDController{}
 	}
-	if obj.ETCDController.Workers == nil {
-		obj.ETCDController.Workers = pointer.Int64(50)
-	}
 	if obj.CustodianController == nil {
 		obj.CustodianController = &CustodianController{}
-	}
-	if obj.CustodianController.Workers == nil {
-		obj.CustodianController.Workers = pointer.Int64(10)
 	}
 	if obj.BackupCompactionController == nil {
 		obj.BackupCompactionController = &BackupCompactionController{}
 	}
-	if obj.BackupCompactionController.Workers == nil {
-		obj.BackupCompactionController.Workers = pointer.Int64(3)
+}
+
+// SetDefaults_ETCDController sets defaults for the ETCD controller.
+func SetDefaults_ETCDController(obj *ETCDController) {
+	if obj.Workers == nil {
+		obj.Workers = pointer.Int64(50)
 	}
-	if obj.BackupCompactionController.EnableBackupCompaction == nil {
-		obj.BackupCompactionController.EnableBackupCompaction = pointer.Bool(false)
+}
+
+// SetDefaults_CustodianController sets defaults for the ETCD custodian controller.
+func SetDefaults_CustodianController(obj *CustodianController) {
+	if obj.Workers == nil {
+		obj.Workers = pointer.Int64(10)
 	}
-	if obj.BackupCompactionController.EventsThreshold == nil {
-		obj.BackupCompactionController.EventsThreshold = pointer.Int64(1000000)
+}
+
+// SetDefaults_BackupCompactionController sets defaults for the backup compaction controller.
+func SetDefaults_BackupCompactionController(obj *BackupCompactionController) {
+	if obj.Workers == nil {
+		obj.Workers = pointer.Int64(3)
 	}
-	if obj.BackupCompactionController.MetricsScrapeWaitDuration == nil {
-		obj.BackupCompactionController.MetricsScrapeWaitDuration = &metav1.Duration{Duration: 60 * time.Second}
+	if obj.EnableBackupCompaction == nil {
+		obj.EnableBackupCompaction = pointer.Bool(false)
+	}
+	if obj.EventsThreshold == nil {
+		obj.EventsThreshold = pointer.Int64(1000000)
+	}
+	if obj.MetricsScrapeWaitDuration == nil {
+		obj.MetricsScrapeWaitDuration = &metav1.Duration{Duration: 60 * time.Second}
 	}
 }

--- a/pkg/gardenlet/apis/config/v1alpha1/defaults.go
+++ b/pkg/gardenlet/apis/config/v1alpha1/defaults.go
@@ -19,16 +19,11 @@ import (
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	componentbaseconfigv1alpha1 "k8s.io/component-base/config/v1alpha1"
 	"k8s.io/utils/pointer"
 
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 )
-
-func addDefaultingFuncs(scheme *runtime.Scheme) error {
-	return RegisterDefaults(scheme)
-}
 
 // SetDefaults_GardenletConfiguration sets defaults for the configuration of the Gardenlet.
 func SetDefaults_GardenletConfiguration(obj *GardenletConfiguration) {
@@ -251,7 +246,7 @@ func SetDefaults_ShootMonitoringConfig(obj *ShootMonitoringConfig) {
 	}
 }
 
-// SetDefaults_BastionControllerConfiguration sets defaults for the backup bucket controller.
+// SetDefaults_BastionControllerConfiguration sets defaults for the bastion controller.
 func SetDefaults_BastionControllerConfiguration(obj *BastionControllerConfiguration) {
 	if obj.ConcurrentSyncs == nil {
 		v := DefaultControllerConcurrentSyncs
@@ -372,7 +367,7 @@ func SetDefaults_StaleExtensionHealthChecks(obj *StaleExtensionHealthChecks) {
 	}
 }
 
-// SetDefaults_ShootStateControllerConfiguration sets defaults for the shoot secret controller.
+// SetDefaults_ShootStateControllerConfiguration sets defaults for the shoot state controller.
 func SetDefaults_ShootStateControllerConfiguration(obj *ShootStateControllerConfiguration) {
 	if obj.ConcurrentSyncs == nil {
 		obj.ConcurrentSyncs = pointer.Int(5)
@@ -506,7 +501,7 @@ func SetDefaults_CustodianController(obj *CustodianController) {
 	}
 }
 
-// SetDefaults_BackupCompactionController sets defaults for the backup compaction controller.
+// SetDefaults_BackupCompactionController sets defaults for the ETCD backup compaction controller.
 func SetDefaults_BackupCompactionController(obj *BackupCompactionController) {
 	if obj.Workers == nil {
 		obj.Workers = pointer.Int64(3)

--- a/pkg/gardenlet/apis/config/v1alpha1/defaults_test.go
+++ b/pkg/gardenlet/apis/config/v1alpha1/defaults_test.go
@@ -38,7 +38,7 @@ var _ = Describe("Defaults", func() {
 		obj = &GardenletConfiguration{}
 	})
 
-	Describe("GardenletConfiguration", func() {
+	Describe("GardenletConfiguration defaulting", func() {
 		It("should default the gardenlet configuration", func() {
 			SetObjectDefaults_GardenletConfiguration(obj)
 
@@ -60,13 +60,579 @@ var _ = Describe("Defaults", func() {
 			Expect(obj.LeaderElection).NotTo(BeNil())
 			Expect(obj.LogLevel).To(Equal(logger.InfoLevel))
 			Expect(obj.LogFormat).To(Equal(logger.FormatJSON))
+			Expect(obj.SNI).NotTo(BeNil())
+			Expect(obj.Monitoring).NotTo(BeNil())
+			Expect(obj.ETCDConfig).NotTo(BeNil())
+		})
+
+		It("should not overwrite already set values for the gardenlet configuration", func() {
+			obj.LogLevel = LogLevelDebug
+			obj.LogFormat = LogFormatText
+			SetObjectDefaults_GardenletConfiguration(obj)
+
+			Expect(obj.LogLevel).To(Equal(logger.DebugLevel))
+			Expect(obj.LogFormat).To(Equal(logger.FormatText))
+		})
+	})
+
+	Describe("GardenClientConnection defaulting", func() {
+		It("should default the garden client connection", func() {
+			SetObjectDefaults_GardenletConfiguration(obj)
+
+			// ContentType fields will be defaulted by client constructors / controller-runtime based on whether a
+			// given APIGroup supports protobuf or not. defaults must not touch these, otherwise the integelligent
+			// logic will be overwritten
+			Expect(obj.GardenClientConnection.ContentType).To(BeEmpty())
+			Expect(obj.GardenClientConnection.AcceptContentTypes).To(BeEmpty())
+			Expect(obj.GardenClientConnection.KubeconfigValidity).NotTo(BeNil())
+			Expect(obj.GardenClientConnection.ClientConnectionConfiguration.QPS).To(Equal(float32(50.0)))
+			Expect(obj.GardenClientConnection.ClientConnectionConfiguration.Burst).To(Equal(int32(100)))
+		})
+
+		It("should not overwrite already set values for the garden client connection", func() {
+			obj.GardenClientConnection = &GardenClientConnection{
+				ClientConnectionConfiguration: componentbaseconfigv1alpha1.ClientConnectionConfiguration{
+					QPS:   60.0,
+					Burst: 90,
+				},
+			}
+			SetObjectDefaults_GardenletConfiguration(obj)
+
+			Expect(obj.GardenClientConnection.ClientConnectionConfiguration.QPS).To(Equal(float32(60.0)))
+			Expect(obj.GardenClientConnection.ClientConnectionConfiguration.Burst).To(Equal(int32(90)))
+		})
+	})
+
+	Describe("KubeconfigValidity defaulting", func() {
+		It("should default the kubeconfig validity", func() {
+			SetObjectDefaults_GardenletConfiguration(obj)
+
+			Expect(obj.GardenClientConnection.KubeconfigValidity).To(Equal(&KubeconfigValidity{
+				AutoRotationJitterPercentageMin: pointer.Int32(70),
+				AutoRotationJitterPercentageMax: pointer.Int32(90),
+			}))
+		})
+
+		It("should not overwrite already set values for the kubeconfig validity", func() {
+			v := metav1.Duration{Duration: 2 * time.Minute}
+			obj.GardenClientConnection = &GardenClientConnection{
+				KubeconfigValidity: &KubeconfigValidity{
+					Validity:                        &v,
+					AutoRotationJitterPercentageMin: pointer.Int32(10),
+					AutoRotationJitterPercentageMax: pointer.Int32(50),
+				},
+			}
+			SetObjectDefaults_GardenletConfiguration(obj)
+
+			Expect(obj.GardenClientConnection.KubeconfigValidity.Validity).To(PointTo(Equal(v)))
+			Expect(obj.GardenClientConnection.KubeconfigValidity.AutoRotationJitterPercentageMin).To(PointTo(Equal(int32(10))))
+			Expect(obj.GardenClientConnection.KubeconfigValidity.AutoRotationJitterPercentageMax).To(PointTo(Equal(int32(50))))
+		})
+	})
+
+	Describe("SeedClientConnection defaulting", func() {
+		It("should default the seed client connection", func() {
+			SetObjectDefaults_GardenletConfiguration(obj)
+
+			// ContentType fields will be defaulted by client constructors / controller-runtime based on whether a
+			// given APIGroup supports protobuf or not. defaults must not touch these, otherwise the integelligent
+			// logic will be overwritten
+			Expect(obj.SeedClientConnection.ContentType).To(BeEmpty())
+			Expect(obj.SeedClientConnection.AcceptContentTypes).To(BeEmpty())
+			Expect(obj.SeedClientConnection.ClientConnectionConfiguration.QPS).To(Equal(float32(50.0)))
+			Expect(obj.SeedClientConnection.ClientConnectionConfiguration.Burst).To(Equal(int32(100)))
+		})
+
+		It("should not overwrite already set values for the seed client connection", func() {
+			obj.SeedClientConnection = &SeedClientConnection{
+				ClientConnectionConfiguration: componentbaseconfigv1alpha1.ClientConnectionConfiguration{
+					QPS:   60.0,
+					Burst: 90,
+				},
+			}
+			SetObjectDefaults_GardenletConfiguration(obj)
+
+			Expect(obj.SeedClientConnection.ClientConnectionConfiguration.QPS).To(Equal(float32(60.0)))
+			Expect(obj.SeedClientConnection.ClientConnectionConfiguration.Burst).To(Equal(int32(90)))
+		})
+	})
+
+	Describe("ShootClientConnection defaulting", func() {
+		It("should default the shoot client connection", func() {
+			SetObjectDefaults_GardenletConfiguration(obj)
+
+			// ContentType fields will be defaulted by client constructors / controller-runtime based on whether a
+			// given APIGroup supports protobuf or not. defaults must not touch these, otherwise the integelligent
+			// logic will be overwritten
+			Expect(obj.ShootClientConnection.ContentType).To(BeEmpty())
+			Expect(obj.ShootClientConnection.AcceptContentTypes).To(BeEmpty())
+			Expect(obj.ShootClientConnection.ClientConnectionConfiguration.QPS).To(Equal(float32(50.0)))
+			Expect(obj.ShootClientConnection.ClientConnectionConfiguration.Burst).To(Equal(int32(100)))
+		})
+
+		It("should not overwrite already set values for the shoot client connection", func() {
+			obj.ShootClientConnection = &ShootClientConnection{
+				ClientConnectionConfiguration: componentbaseconfigv1alpha1.ClientConnectionConfiguration{
+					QPS:   60.0,
+					Burst: 90,
+				},
+			}
+			SetObjectDefaults_GardenletConfiguration(obj)
+
+			Expect(obj.ShootClientConnection.ClientConnectionConfiguration.QPS).To(Equal(float32(60.0)))
+			Expect(obj.ShootClientConnection.ClientConnectionConfiguration.Burst).To(Equal(int32(90)))
+		})
+	})
+
+	Describe("BackupBucketControllerConfiguration defaulting", func() {
+		It("should default the backup bucket controller configuration", func() {
+			SetObjectDefaults_GardenletConfiguration(obj)
+
+			Expect(obj.Controllers.BackupBucket.ConcurrentSyncs).To(PointTo(Equal(20)))
+		})
+
+		It("should not overwrite already set values for the backup bucket controller configuration", func() {
+			obj.Controllers = &GardenletControllerConfiguration{
+				BackupBucket: &BackupBucketControllerConfiguration{ConcurrentSyncs: pointer.Int(10)},
+			}
+			SetObjectDefaults_GardenletConfiguration(obj)
+
+			Expect(obj.Controllers.BackupBucket.ConcurrentSyncs).To(PointTo(Equal(10)))
+		})
+	})
+
+	Describe("BackupEntryControllerConfiguration defaulting", func() {
+		It("should default the backup entry controller configuration", func() {
+			SetObjectDefaults_GardenletConfiguration(obj)
+
+			Expect(obj.Controllers.BackupEntry.ConcurrentSyncs).To(PointTo(Equal(20)))
+			Expect(obj.Controllers.BackupEntry.DeletionGracePeriodHours).To(PointTo(Equal(0)))
+			Expect(obj.Controllers.BackupEntry.DeletionGracePeriodShootPurposes).To(BeEmpty())
+		})
+
+		It("should not overwrite already set values for the backup entry controller configuration", func() {
+			deletionGracePeriodShootPurposes := []gardencorev1beta1.ShootPurpose{gardencorev1beta1.ShootPurposeEvaluation}
+			obj.Controllers = &GardenletControllerConfiguration{
+				BackupEntry: &BackupEntryControllerConfiguration{
+					ConcurrentSyncs:                  pointer.Int(10),
+					DeletionGracePeriodHours:         pointer.Int(1),
+					DeletionGracePeriodShootPurposes: deletionGracePeriodShootPurposes,
+				},
+			}
+			SetObjectDefaults_GardenletConfiguration(obj)
+
+			Expect(obj.Controllers.BackupEntry.ConcurrentSyncs).To(PointTo(Equal(10)))
+			Expect(obj.Controllers.BackupEntry.DeletionGracePeriodHours).To(PointTo(Equal(1)))
+			Expect(obj.Controllers.BackupEntry.DeletionGracePeriodShootPurposes).To(Equal(deletionGracePeriodShootPurposes))
+		})
+	})
+
+	Describe("BastionControllerConfiguration defaulting", func() {
+		It("should default the bastion controller configuration", func() {
+			SetObjectDefaults_GardenletConfiguration(obj)
+
+			Expect(obj.Controllers.Bastion.ConcurrentSyncs).To(PointTo(Equal(20)))
+		})
+
+		It("should not overwrite already set values for the bastion controller configuration", func() {
+			obj.Controllers = &GardenletControllerConfiguration{
+				Bastion: &BastionControllerConfiguration{ConcurrentSyncs: pointer.Int(10)},
+			}
+			SetObjectDefaults_GardenletConfiguration(obj)
+
+			Expect(obj.Controllers.Bastion.ConcurrentSyncs).To(PointTo(Equal(10)))
+		})
+	})
+
+	Describe("ControllerInstallationControllerConfiguration defaulting", func() {
+		It("should default the controller installation controller configuration", func() {
+			SetObjectDefaults_GardenletConfiguration(obj)
+
+			Expect(obj.Controllers.ControllerInstallation.ConcurrentSyncs).To(PointTo(Equal(20)))
+		})
+
+		It("should not overwrite already set values for the controller installation controller configuration", func() {
+			obj.Controllers = &GardenletControllerConfiguration{
+				ControllerInstallation: &ControllerInstallationControllerConfiguration{ConcurrentSyncs: pointer.Int(10)},
+			}
+			SetObjectDefaults_GardenletConfiguration(obj)
+
+			Expect(obj.Controllers.ControllerInstallation.ConcurrentSyncs).To(PointTo(Equal(10)))
+		})
+	})
+
+	Describe("ControllerInstallationCareControllerConfiguration defaulting", func() {
+		It("should default the controller installation care controller configuration", func() {
+			v := metav1.Duration{Duration: 30 * time.Second}
+			SetObjectDefaults_GardenletConfiguration(obj)
+
+			Expect(obj.Controllers.ControllerInstallationCare.ConcurrentSyncs).To(PointTo(Equal(20)))
+			Expect(obj.Controllers.ControllerInstallationCare.SyncPeriod).To(PointTo(Equal(v)))
+		})
+
+		It("should not overwrite already set values for the controller installation care controller configuration", func() {
+			v := metav1.Duration{Duration: 2 * time.Minute}
+			obj.Controllers = &GardenletControllerConfiguration{
+				ControllerInstallationCare: &ControllerInstallationCareControllerConfiguration{
+					ConcurrentSyncs: pointer.Int(10),
+					SyncPeriod:      &v,
+				},
+			}
+			SetObjectDefaults_GardenletConfiguration(obj)
+
+			Expect(obj.Controllers.ControllerInstallationCare.ConcurrentSyncs).To(PointTo(Equal(10)))
+			Expect(obj.Controllers.ControllerInstallationCare.SyncPeriod).To(PointTo(Equal(v)))
+		})
+	})
+
+	Describe("ControllerInstallationRequiredControllerConfiguration defaulting", func() {
+		It("should default the controller installation required controller configuration", func() {
+			SetObjectDefaults_GardenletConfiguration(obj)
+
+			Expect(obj.Controllers.ControllerInstallationRequired.ConcurrentSyncs).To(PointTo(Equal(1)))
+		})
+
+		It("should not overwrite already set values for the controller installation required controller configuration", func() {
+			obj.Controllers = &GardenletControllerConfiguration{
+				ControllerInstallationRequired: &ControllerInstallationRequiredControllerConfiguration{ConcurrentSyncs: pointer.Int(10)},
+			}
+			SetObjectDefaults_GardenletConfiguration(obj)
+
+			Expect(obj.Controllers.ControllerInstallationRequired.ConcurrentSyncs).To(PointTo(Equal(10)))
+		})
+	})
+
+	Describe("SeedControllerConfiguration defaulting", func() {
+		It("should default the seed controller configuration", func() {
+			SetObjectDefaults_GardenletConfiguration(obj)
+
+			Expect(obj.Controllers.Seed.SyncPeriod).To(PointTo(Equal(DefaultControllerSyncPeriod)))
+			Expect(obj.Controllers.Seed.LeaseResyncSeconds).To(PointTo(Equal(int32(2))))
+			Expect(obj.Controllers.Seed.LeaseResyncMissThreshold).To(PointTo(Equal(int32(10))))
+		})
+
+		It("should not overwrite already set values for the seed controller configuration", func() {
+			syncPeriod := metav1.Duration{Duration: 2 * time.Minute}
+			obj.Controllers = &GardenletControllerConfiguration{
+				Seed: &SeedControllerConfiguration{
+					SyncPeriod:               &syncPeriod,
+					LeaseResyncSeconds:       pointer.Int32(1),
+					LeaseResyncMissThreshold: pointer.Int32(5),
+				},
+			}
+			SetObjectDefaults_GardenletConfiguration(obj)
+
+			Expect(obj.Controllers.Seed.SyncPeriod).To(PointTo(Equal(syncPeriod)))
+			Expect(obj.Controllers.Seed.LeaseResyncSeconds).To(PointTo(Equal(int32(1))))
+			Expect(obj.Controllers.Seed.LeaseResyncMissThreshold).To(PointTo(Equal(int32(5))))
+		})
+	})
+
+	Describe("SeedCareControllerConfiguration defaulting", func() {
+		It("should default the seed care controller configuration", func() {
+			SetObjectDefaults_GardenletConfiguration(obj)
+
+			Expect(obj.Controllers.SeedCare.SyncPeriod).To(PointTo(Equal(metav1.Duration{Duration: 30 * time.Second})))
+		})
+
+		It("should not overwrite already set values for the seed care controller configuration", func() {
+			syncPeriod := metav1.Duration{Duration: 2 * time.Minute}
+			obj.Controllers = &GardenletControllerConfiguration{
+				SeedCare: &SeedCareControllerConfiguration{SyncPeriod: &syncPeriod},
+			}
+			SetObjectDefaults_GardenletConfiguration(obj)
+
+			Expect(obj.Controllers.SeedCare.SyncPeriod).To(PointTo(Equal(syncPeriod)))
+		})
+	})
+
+	Describe("ShootControllerConfiguration defaulting", func() {
+		It("should default the shoot controller configuration", func() {
+			SetObjectDefaults_GardenletConfiguration(obj)
+
+			Expect(obj.Controllers.Shoot.ConcurrentSyncs).To(PointTo(Equal(20)))
+			Expect(obj.Controllers.Shoot.SyncPeriod).To(PointTo(Equal(metav1.Duration{Duration: time.Hour})))
+			Expect(obj.Controllers.Shoot.RespectSyncPeriodOverwrite).To(PointTo(Equal(false)))
+			Expect(obj.Controllers.Shoot.ReconcileInMaintenanceOnly).To(PointTo(Equal(false)))
+			Expect(obj.Controllers.Shoot.RetryDuration).To(PointTo(Equal(metav1.Duration{Duration: 12 * time.Hour})))
+			Expect(obj.Controllers.Shoot.DNSEntryTTLSeconds).To(PointTo(Equal(int64(120))))
+		})
+
+		It("should not overwrite already set values for the shoot controller configuration", func() {
+			v := metav1.Duration{Duration: 2 * time.Hour}
+			obj.Controllers = &GardenletControllerConfiguration{
+				Shoot: &ShootControllerConfiguration{
+					ConcurrentSyncs:            pointer.Int(10),
+					SyncPeriod:                 &v,
+					RespectSyncPeriodOverwrite: pointer.Bool(true),
+					ReconcileInMaintenanceOnly: pointer.Bool(true),
+					RetryDuration:              &v,
+					DNSEntryTTLSeconds:         pointer.Int64(60),
+				},
+			}
+			SetObjectDefaults_GardenletConfiguration(obj)
+
+			Expect(obj.Controllers.Shoot.ConcurrentSyncs).To(PointTo(Equal(10)))
+			Expect(obj.Controllers.Shoot.SyncPeriod).To(PointTo(Equal(metav1.Duration{Duration: 2 * time.Hour})))
+			Expect(obj.Controllers.Shoot.RespectSyncPeriodOverwrite).To(PointTo(Equal(true)))
+			Expect(obj.Controllers.Shoot.ReconcileInMaintenanceOnly).To(PointTo(Equal(true)))
+			Expect(obj.Controllers.Shoot.RetryDuration).To(PointTo(Equal(metav1.Duration{Duration: 2 * time.Hour})))
+			Expect(obj.Controllers.Shoot.DNSEntryTTLSeconds).To(PointTo(Equal(int64(60))))
+		})
+	})
+
+	Describe("ShootCareControllerConfiguration defaulting", func() {
+		It("should default the shoot care controller configuration", func() {
+			SetObjectDefaults_GardenletConfiguration(obj)
+
+			Expect(obj.Controllers.ShootCare.SyncPeriod).To(PointTo(Equal(metav1.Duration{Duration: time.Minute})))
+			Expect(obj.Controllers.ShootCare.ConcurrentSyncs).To(PointTo(Equal(20)))
+			Expect(obj.Controllers.ShootCare.StaleExtensionHealthChecks.Enabled).To(BeTrue())
+			Expect(obj.Controllers.ShootCare.StaleExtensionHealthChecks.Threshold).To(PointTo(Equal(metav1.Duration{Duration: 5 * time.Minute})))
+		})
+
+		It("should not overwrite already set values for the shoot care controller configuration", func() {
+			syncPeriod := metav1.Duration{Duration: 2 * time.Minute}
+			obj.Controllers = &GardenletControllerConfiguration{
+				ShootCare: &ShootCareControllerConfiguration{
+					SyncPeriod:                 &syncPeriod,
+					ConcurrentSyncs:            pointer.Int(10),
+					StaleExtensionHealthChecks: &StaleExtensionHealthChecks{Enabled: false},
+				},
+			}
+			SetObjectDefaults_GardenletConfiguration(obj)
+
+			Expect(obj.Controllers.ShootCare.SyncPeriod).To(PointTo(Equal(syncPeriod)))
+			Expect(obj.Controllers.ShootCare.ConcurrentSyncs).To(PointTo(Equal(10)))
+			Expect(obj.Controllers.ShootCare.StaleExtensionHealthChecks.Enabled).To(BeFalse())
+		})
+	})
+
+	Describe("StaleExtensionHealthChecks defaulting", func() {
+		It("should default the stale extension health checks", func() {
+			SetObjectDefaults_GardenletConfiguration(obj)
+
+			Expect(obj.Controllers.ShootCare.StaleExtensionHealthChecks.Threshold).To(PointTo(Equal(metav1.Duration{Duration: 5 * time.Minute})))
+		})
+
+		It("should not overwrite already set values for the stale extension health checks", func() {
+			threshold := metav1.Duration{Duration: 2 * time.Minute}
+			obj.Controllers = &GardenletControllerConfiguration{
+				ShootCare: &ShootCareControllerConfiguration{
+					StaleExtensionHealthChecks: &StaleExtensionHealthChecks{Threshold: &threshold},
+				},
+			}
+
+			SetObjectDefaults_GardenletConfiguration(obj)
+
+			Expect(obj.Controllers.ShootCare.StaleExtensionHealthChecks.Threshold).To(PointTo(Equal(threshold)))
+		})
+	})
+
+	Describe("ShootStateControllerConfiguration defaulting", func() {
+		It("should default the shoot state controller configuration", func() {
+			SetObjectDefaults_GardenletConfiguration(obj)
+
+			Expect(obj.Controllers.ShootState.ConcurrentSyncs).To(PointTo(Equal(5)))
+			Expect(obj.Controllers.ShootState.SyncPeriod).To(PointTo(Equal(metav1.Duration{Duration: 6 * time.Hour})))
+		})
+
+		It("should not overwrite already set values for the shoot state controller configuration", func() {
+			syncPeriod := metav1.Duration{Duration: 2 * time.Hour}
+			obj.Controllers = &GardenletControllerConfiguration{
+				ShootState: &ShootStateControllerConfiguration{
+					SyncPeriod:      &syncPeriod,
+					ConcurrentSyncs: pointer.Int(10),
+				},
+			}
+
+			SetObjectDefaults_GardenletConfiguration(obj)
+
+			Expect(obj.Controllers.ShootState.ConcurrentSyncs).To(PointTo(Equal(10)))
+			Expect(obj.Controllers.ShootState.SyncPeriod).To(PointTo(Equal(syncPeriod)))
+		})
+	})
+
+	Describe("NetworkPolicyControllerConfiguration defaulting", func() {
+		It("should default the network policy controller configuration", func() {
+			SetObjectDefaults_GardenletConfiguration(obj)
+
+			Expect(obj.Controllers.NetworkPolicy.ConcurrentSyncs).To(PointTo(Equal(5)))
+		})
+
+		It("should not overwrite already set values for the network policy controller configuration", func() {
+			obj.Controllers = &GardenletControllerConfiguration{
+				NetworkPolicy: &NetworkPolicyControllerConfiguration{ConcurrentSyncs: pointer.Int(10)},
+			}
+			SetObjectDefaults_GardenletConfiguration(obj)
+
+			Expect(obj.Controllers.NetworkPolicy.ConcurrentSyncs).To(PointTo(Equal(10)))
+		})
+	})
+
+	Describe("ManagedSeedControllerConfiguration defaulting", func() {
+		It("should default the managed seed controller configuration", func() {
+			SetObjectDefaults_GardenletConfiguration(obj)
+
+			Expect(obj.Controllers.ManagedSeed.ConcurrentSyncs).To(PointTo(Equal(DefaultControllerConcurrentSyncs)))
+			Expect(obj.Controllers.ManagedSeed.SyncPeriod).To(PointTo(Equal(metav1.Duration{Duration: 1 * time.Hour})))
+			Expect(obj.Controllers.ManagedSeed.WaitSyncPeriod).To(PointTo(Equal(metav1.Duration{Duration: 15 * time.Second})))
+			Expect(obj.Controllers.ManagedSeed.SyncJitterPeriod).To(PointTo(Equal(metav1.Duration{Duration: 5 * time.Minute})))
+			Expect(obj.Controllers.ManagedSeed.JitterUpdates).To(PointTo(BeFalse()))
+		})
+
+		It("should not overwrite already set values for the managed seed controller configuration", func() {
+			v := metav1.Duration{Duration: 2 * time.Minute}
+			obj.Controllers = &GardenletControllerConfiguration{
+				ManagedSeed: &ManagedSeedControllerConfiguration{
+					ConcurrentSyncs:  pointer.Int(10),
+					SyncPeriod:       &v,
+					WaitSyncPeriod:   &v,
+					SyncJitterPeriod: &v,
+					JitterUpdates:    pointer.Bool(true),
+				},
+			}
+			SetObjectDefaults_GardenletConfiguration(obj)
+
+			Expect(obj.Controllers.ManagedSeed.ConcurrentSyncs).To(PointTo(Equal(10)))
+			Expect(obj.Controllers.ManagedSeed.SyncPeriod).To(PointTo(Equal(v)))
+			Expect(obj.Controllers.ManagedSeed.WaitSyncPeriod).To(PointTo(Equal(v)))
+			Expect(obj.Controllers.ManagedSeed.SyncJitterPeriod).To(PointTo(Equal(v)))
+			Expect(obj.Controllers.ManagedSeed.JitterUpdates).To(PointTo(BeTrue()))
+		})
+	})
+
+	Describe("TokenRequestorControllerConfiguration defaulting", func() {
+		It("should default the token requestor controller configuration", func() {
+			SetObjectDefaults_GardenletConfiguration(obj)
+
+			Expect(obj.Controllers.TokenRequestor.ConcurrentSyncs).To(PointTo(Equal(5)))
+		})
+
+		It("should not overwrite already set values for the token requestor controller configuration", func() {
+			obj.Controllers = &GardenletControllerConfiguration{
+				TokenRequestor: &TokenRequestorControllerConfiguration{ConcurrentSyncs: pointer.Int(10)},
+			}
+			SetObjectDefaults_GardenletConfiguration(obj)
+
+			Expect(obj.Controllers.TokenRequestor.ConcurrentSyncs).To(PointTo(Equal(10)))
+		})
+	})
+
+	Describe("LeaderElectionConfiguration defaulting", func() {
+		It("should correctly default the leader election configuration", func() {
+			SetObjectDefaults_GardenletConfiguration(obj)
+
+			Expect(obj.LeaderElection).NotTo(BeNil())
+			Expect(obj.LeaderElection.LeaderElect).To(PointTo(BeTrue()))
+			Expect(obj.LeaderElection.LeaseDuration).To(Equal(metav1.Duration{Duration: 15 * time.Second}))
+			Expect(obj.LeaderElection.RenewDeadline).To(Equal(metav1.Duration{Duration: 10 * time.Second}))
+			Expect(obj.LeaderElection.RetryPeriod).To(Equal(metav1.Duration{Duration: 2 * time.Second}))
+			Expect(obj.LeaderElection.ResourceLock).To(Equal("leases"))
+			Expect(obj.LeaderElection.ResourceNamespace).To(Equal("garden"))
+			Expect(obj.LeaderElection.ResourceName).To(Equal("gardenlet-leader-election"))
+		})
+
+		It("should not overwrite already set values for the leader election configuration", func() {
+			expectedLeaderElection := &componentbaseconfigv1alpha1.LeaderElectionConfiguration{
+				LeaderElect:       pointer.Bool(true),
+				ResourceLock:      "foo",
+				RetryPeriod:       metav1.Duration{Duration: 40 * time.Second},
+				RenewDeadline:     metav1.Duration{Duration: 41 * time.Second},
+				LeaseDuration:     metav1.Duration{Duration: 42 * time.Second},
+				ResourceName:      "lock-object",
+				ResourceNamespace: "other-garden-ns",
+			}
+			obj.LeaderElection = expectedLeaderElection.DeepCopy()
+			SetObjectDefaults_GardenletConfiguration(obj)
+
+			Expect(obj.LeaderElection).To(Equal(expectedLeaderElection))
+		})
+	})
+
+	Describe("ServerConfiguration defaulting", func() {
+		It("should default the HTTP server configuration", func() {
+			SetObjectDefaults_GardenletConfiguration(obj)
+
 			Expect(obj.Server.HealthProbes.BindAddress).To(BeEmpty())
 			Expect(obj.Server.HealthProbes.Port).To(Equal(2728))
 			Expect(obj.Server.Metrics.BindAddress).To(BeEmpty())
 			Expect(obj.Server.Metrics.Port).To(Equal(2729))
-			Expect(obj.SNI).ToNot(BeNil())
-			Expect(obj.Monitoring).ToNot(BeNil())
-			Expect(obj.SNI.Ingress).ToNot(BeNil())
+		})
+
+		It("should not overwrite already set values for the HTTP server configuration", func() {
+			obj.Server = ServerConfiguration{
+				HealthProbes: &Server{
+					BindAddress: "127.0.0.0",
+					Port:        1010,
+				},
+				Metrics: &Server{
+					BindAddress: "127.0.0.1",
+					Port:        1011,
+				},
+			}
+			SetObjectDefaults_GardenletConfiguration(obj)
+
+			Expect(obj.Server.HealthProbes.BindAddress).To(Equal("127.0.0.0"))
+			Expect(obj.Server.HealthProbes.Port).To(Equal(1010))
+			Expect(obj.Server.Metrics.BindAddress).To(Equal("127.0.0.1"))
+			Expect(obj.Server.Metrics.Port).To(Equal(1011))
+		})
+	})
+
+	Describe("Logging defaulting", func() {
+		It("should default the logging configuration", func() {
+			SetObjectDefaults_GardenletConfiguration(obj)
+			Expect(obj.Logging).NotTo(BeNil())
+			Expect(obj.Logging.Enabled).To(PointTo(Equal(false)))
+			Expect(obj.Logging.Vali).NotTo(BeNil())
+			Expect(obj.Logging.Vali.Enabled).To(PointTo(Equal(false)))
+			Expect(obj.Logging.Vali.Garden).NotTo(BeNil())
+			Expect(obj.Logging.Vali.Garden.Storage).To(PointTo(Equal(resource.MustParse("100Gi"))))
+			Expect(obj.Logging.ShootEventLogging).NotTo(BeNil())
+			Expect(obj.Logging.ShootEventLogging.Enabled).To(PointTo(Equal(false)))
+		})
+
+		It("should not overwrite already set values for the logging configuration", func() {
+			gardenValiStorage := resource.MustParse("10Gi")
+			expectedLogging := &Logging{
+				Enabled: pointer.Bool(true),
+				Vali: &Vali{
+					Enabled: pointer.Bool(false),
+					Garden: &GardenVali{
+						Storage: &gardenValiStorage,
+					},
+				},
+				ShootNodeLogging: &ShootNodeLogging{
+					ShootPurposes: []gardencorev1beta1.ShootPurpose{
+						"development",
+						"evaluation",
+					},
+				},
+				ShootEventLogging: &ShootEventLogging{
+					Enabled: pointer.Bool(false),
+				},
+			}
+
+			obj.Logging = expectedLogging.DeepCopy()
+			SetObjectDefaults_GardenletConfiguration(obj)
+
+			Expect(obj.Logging).To(Equal(expectedLogging))
+		})
+	})
+
+	Describe("SNI defaulting", func() {
+		It("should default the SNI", func() {
+			SetObjectDefaults_GardenletConfiguration(obj)
+
+			Expect(obj.SNI.Ingress).NotTo(BeNil())
+		})
+	})
+
+	Describe("SNIIngress defaulting", func() {
+		It("should default the SNI ingressgateway", func() {
+			SetObjectDefaults_GardenletConfiguration(obj)
+
 			Expect(obj.SNI.Ingress.Namespace).To(PointTo(Equal("istio-ingress")))
 			Expect(obj.SNI.Ingress.ServiceName).To(PointTo(Equal("istio-ingressgateway")))
 			Expect(obj.SNI.Ingress.Labels).To(Equal(map[string]string{
@@ -75,6 +641,96 @@ var _ = Describe("Defaults", func() {
 			}))
 		})
 
+		It("should not overwrite already set values for the SNI ingressgateway", func() {
+			obj.SNI = &SNI{
+				Ingress: &SNIIngress{
+					Namespace:   pointer.String("namespace"),
+					ServiceName: pointer.String("svc"),
+					Labels:      map[string]string{"label1": "value1"},
+				},
+			}
+			SetObjectDefaults_GardenletConfiguration(obj)
+
+			Expect(obj.SNI.Ingress.Namespace).To(PointTo(Equal("namespace")))
+			Expect(obj.SNI.Ingress.ServiceName).To(PointTo(Equal("svc")))
+			Expect(obj.SNI.Ingress.Labels).To(Equal(map[string]string{"label1": "value1"}))
+		})
+	})
+
+	Describe("ETCDConfig defaulting", func() {
+		It("should correctly default ETCD configuration", func() {
+			SetObjectDefaults_GardenletConfiguration(obj)
+
+			Expect(obj.ETCDConfig).NotTo(BeNil())
+			Expect(obj.ETCDConfig.ETCDController).NotTo(BeNil())
+			Expect(obj.ETCDConfig.CustodianController).NotTo(BeNil())
+			Expect(obj.ETCDConfig.BackupCompactionController).NotTo(BeNil())
+		})
+	})
+
+	Describe("ETCDController defaulting", func() {
+		It("should default the ETCD controller", func() {
+			SetObjectDefaults_GardenletConfiguration(obj)
+
+			Expect(obj.ETCDConfig.ETCDController.Workers).To(PointTo(Equal(int64(50))))
+		})
+
+		It("should not overwrite already set values for the ETCD controller", func() {
+			obj.ETCDConfig = &ETCDConfig{
+				ETCDController: &ETCDController{Workers: pointer.Int64(5)},
+			}
+			SetObjectDefaults_GardenletConfiguration(obj)
+
+			Expect(obj.ETCDConfig.ETCDController.Workers).To(PointTo(Equal(int64(5))))
+		})
+	})
+
+	Describe("CustodianController defaulting", func() {
+		It("should default the ETCD custodian controller", func() {
+			SetObjectDefaults_GardenletConfiguration(obj)
+
+			Expect(obj.ETCDConfig.CustodianController.Workers).To(PointTo(Equal(int64(10))))
+		})
+
+		It("should not overwrite already set values for the ETCD custodian controller", func() {
+			obj.ETCDConfig = &ETCDConfig{
+				CustodianController: &CustodianController{Workers: pointer.Int64(5)},
+			}
+			SetObjectDefaults_GardenletConfiguration(obj)
+
+			Expect(obj.ETCDConfig.CustodianController.Workers).To(PointTo(Equal(int64(5))))
+		})
+	})
+
+	Describe("BackupCompactionController defaulting", func() {
+		It("should default the ETCD backup compaction controller", func() {
+			SetObjectDefaults_GardenletConfiguration(obj)
+
+			Expect(obj.ETCDConfig.BackupCompactionController.Workers).To(PointTo(Equal(int64(3))))
+			Expect(obj.ETCDConfig.BackupCompactionController.EnableBackupCompaction).To(PointTo(Equal(false)))
+			Expect(obj.ETCDConfig.BackupCompactionController.EventsThreshold).To(PointTo(Equal(int64(1000000))))
+			Expect(obj.ETCDConfig.BackupCompactionController.MetricsScrapeWaitDuration).To(PointTo(Equal(metav1.Duration{Duration: 60 * time.Second})))
+		})
+
+		It("should not overwrite already set values for the ETCD backup compaction controller", func() {
+			v := metav1.Duration{Duration: 30 * time.Second}
+			obj.ETCDConfig = &ETCDConfig{
+				BackupCompactionController: &BackupCompactionController{
+					Workers:                   pointer.Int64(4),
+					EnableBackupCompaction:    pointer.Bool(true),
+					EventsThreshold:           pointer.Int64(900000),
+					MetricsScrapeWaitDuration: &v,
+				}}
+			SetObjectDefaults_GardenletConfiguration(obj)
+
+			Expect(obj.ETCDConfig.BackupCompactionController.Workers).To(PointTo(Equal(int64(4))))
+			Expect(obj.ETCDConfig.BackupCompactionController.EnableBackupCompaction).To(PointTo(Equal(true)))
+			Expect(obj.ETCDConfig.BackupCompactionController.EventsThreshold).To(PointTo(Equal(int64(900000))))
+			Expect(obj.ETCDConfig.BackupCompactionController.MetricsScrapeWaitDuration).To(PointTo(Equal(v)))
+		})
+	})
+
+	Describe("ExposureClassHandler defaulting", func() {
 		It("should default the gardenlets exposure class handlers sni config", func() {
 			obj.ExposureClassHandlers = []ExposureClassHandler{
 				{Name: "test1"},
@@ -103,249 +759,63 @@ var _ = Describe("Defaults", func() {
 			}))
 		})
 
-		Describe("ClientConnection settings", func() {
-			It("should not default ContentType and AcceptContentTypes", func() {
-				SetObjectDefaults_GardenletConfiguration(obj)
-
-				// ContentType fields will be defaulted by client constructors / controller-runtime based on whether a
-				// given APIGroup supports protobuf or not. defaults must not touch these, otherwise the integelligent
-				// logic will be overwritten
-				Expect(obj.GardenClientConnection.ContentType).To(BeEmpty())
-				Expect(obj.GardenClientConnection.AcceptContentTypes).To(BeEmpty())
-				Expect(obj.SeedClientConnection.ContentType).To(BeEmpty())
-				Expect(obj.SeedClientConnection.AcceptContentTypes).To(BeEmpty())
-				Expect(obj.ShootClientConnection.ContentType).To(BeEmpty())
-				Expect(obj.ShootClientConnection.AcceptContentTypes).To(BeEmpty())
-			})
-
-			It("should correctly default GardenClientConnection", func() {
-				SetObjectDefaults_GardenletConfiguration(obj)
-				Expect(obj.GardenClientConnection).To(Equal(&GardenClientConnection{
-					ClientConnectionConfiguration: componentbaseconfigv1alpha1.ClientConnectionConfiguration{
-						QPS:   50.0,
-						Burst: 100,
+		It("should not overwrite already set values for the gardenlets exposure class handlers sni config", func() {
+			obj.ExposureClassHandlers = []ExposureClassHandler{
+				{Name: "test1"},
+				{Name: "test2", SNI: &SNI{
+					Ingress: &SNIIngress{
+						Namespace:   pointer.String("namespace"),
+						ServiceName: pointer.String("svc"),
+						Labels:      map[string]string{"label1": "value1"},
 					},
-					KubeconfigValidity: &KubeconfigValidity{
-						AutoRotationJitterPercentageMin: pointer.Int32(70),
-						AutoRotationJitterPercentageMax: pointer.Int32(90),
-					},
-				}))
-				Expect(obj.SeedClientConnection).To(Equal(&SeedClientConnection{
-					ClientConnectionConfiguration: componentbaseconfigv1alpha1.ClientConnectionConfiguration{
-						QPS:   50.0,
-						Burst: 100,
-					},
-				}))
-				Expect(obj.ShootClientConnection).To(Equal(&ShootClientConnection{
-					ClientConnectionConfiguration: componentbaseconfigv1alpha1.ClientConnectionConfiguration{
-						QPS:   50.0,
-						Burst: 100,
-					},
-				}))
-			})
-		})
+				}},
+			}
 
-		Describe("leader election settings", func() {
-			It("should correctly default leader election settings", func() {
-				SetObjectDefaults_GardenletConfiguration(obj)
-
-				Expect(obj.LeaderElection).NotTo(BeNil())
-				Expect(obj.LeaderElection.LeaderElect).To(PointTo(BeTrue()))
-				Expect(obj.LeaderElection.LeaseDuration).To(Equal(metav1.Duration{Duration: 15 * time.Second}))
-				Expect(obj.LeaderElection.RenewDeadline).To(Equal(metav1.Duration{Duration: 10 * time.Second}))
-				Expect(obj.LeaderElection.RetryPeriod).To(Equal(metav1.Duration{Duration: 2 * time.Second}))
-				Expect(obj.LeaderElection.ResourceLock).To(Equal("leases"))
-				Expect(obj.LeaderElection.ResourceNamespace).To(Equal("garden"))
-				Expect(obj.LeaderElection.ResourceName).To(Equal("gardenlet-leader-election"))
-			})
-			It("should not overwrite custom settings", func() {
-				expectedLeaderElection := &componentbaseconfigv1alpha1.LeaderElectionConfiguration{
-					LeaderElect:       pointer.Bool(true),
-					ResourceLock:      "foo",
-					RetryPeriod:       metav1.Duration{Duration: 40 * time.Second},
-					RenewDeadline:     metav1.Duration{Duration: 41 * time.Second},
-					LeaseDuration:     metav1.Duration{Duration: 42 * time.Second},
-					ResourceName:      "lock-object",
-					ResourceNamespace: "other-garden-ns",
-				}
-				obj.LeaderElection = expectedLeaderElection.DeepCopy()
-				SetObjectDefaults_GardenletConfiguration(obj)
-
-				Expect(obj.LeaderElection).To(Equal(expectedLeaderElection))
-			})
-		})
-
-		Describe("Logging settings", func() {
-			It("should correctly default Logging configuration", func() {
-				SetObjectDefaults_GardenletConfiguration(obj)
-				Expect(obj.Logging).NotTo(BeNil())
-				Expect(obj.Logging.Enabled).To(PointTo(Equal(false)))
-				Expect(obj.Logging.Vali).NotTo(BeNil())
-				Expect(obj.Logging.Vali.Enabled).To(PointTo(Equal(false)))
-				Expect(obj.Logging.Vali.Garden).NotTo(BeNil())
-				Expect(obj.Logging.Vali.Garden.Storage).To(PointTo(Equal(resource.MustParse("100Gi"))))
-				Expect(obj.Logging.ShootEventLogging).NotTo(BeNil())
-				Expect(obj.Logging.ShootEventLogging.Enabled).To(PointTo(Equal(false)))
-			})
-
-			It("should not overwrite custom settings", func() {
-				gardenValiStorage := resource.MustParse("10Gi")
-				expectedLogging := &Logging{
-					Enabled: pointer.Bool(true),
-					Vali: &Vali{
-						Enabled: pointer.Bool(false),
-						Garden: &GardenVali{
-							Storage: &gardenValiStorage,
-						},
-					},
-					ShootNodeLogging: &ShootNodeLogging{
-						ShootPurposes: []gardencorev1beta1.ShootPurpose{
-							"development",
-							"evaluation",
-						},
-					},
-					ShootEventLogging: &ShootEventLogging{
-						Enabled: pointer.Bool(false),
-					},
-				}
-
-				obj.Logging = expectedLogging.DeepCopy()
-				SetObjectDefaults_GardenletConfiguration(obj)
-
-				Expect(obj.Logging).To(Equal(expectedLogging))
-			})
-		})
-
-		Describe("#SetDefaults_ETCDConfig", func() {
-			It("should correctly default ETCDConfig configuration", func() {
-				SetObjectDefaults_GardenletConfiguration(obj)
-				Expect(obj.ETCDConfig).NotTo(BeNil())
-				Expect(obj.ETCDConfig.ETCDController).NotTo(BeNil())
-				Expect(obj.ETCDConfig.ETCDController.Workers).To(PointTo(Equal(int64(50))))
-				Expect(obj.ETCDConfig.CustodianController).NotTo(BeNil())
-				Expect(obj.ETCDConfig.CustodianController.Workers).To(PointTo(Equal(int64(10))))
-				Expect(obj.ETCDConfig.BackupCompactionController).NotTo(BeNil())
-				Expect(obj.ETCDConfig.BackupCompactionController.Workers).To(PointTo(Equal(int64(3))))
-				Expect(obj.ETCDConfig.BackupCompactionController.EnableBackupCompaction).To(PointTo(Equal(false)))
-				Expect(obj.ETCDConfig.BackupCompactionController.EventsThreshold).To(PointTo(Equal(int64(1000000))))
-				Expect(obj.ETCDConfig.BackupCompactionController.MetricsScrapeWaitDuration).To(PointTo(Equal(metav1.Duration{Duration: 60 * time.Second})))
-			})
-		})
-	})
-
-	Describe("#SetDefaults_GardenClientConnection", func() {
-		It("should default the configuration", func() {
 			SetObjectDefaults_GardenletConfiguration(obj)
 
-			Expect(obj.GardenClientConnection.KubeconfigValidity).NotTo(BeNil())
+			Expect(obj.ExposureClassHandlers[0].SNI).ToNot(BeNil())
+			Expect(obj.ExposureClassHandlers[0].SNI.Ingress).ToNot(BeNil())
+			Expect(obj.ExposureClassHandlers[0].SNI.Ingress.Namespace).ToNot(BeNil())
+			Expect(*obj.ExposureClassHandlers[0].SNI.Ingress.Namespace).To(Equal(fmt.Sprintf("istio-ingress-handler-%s", obj.ExposureClassHandlers[0].Name)))
+			Expect(*obj.ExposureClassHandlers[0].SNI.Ingress.ServiceName).To(Equal("istio-ingressgateway"))
+			Expect(obj.ExposureClassHandlers[0].SNI.Ingress.Labels).To(Equal(map[string]string{
+				"app":                 "istio-ingressgateway",
+				"gardener.cloud/role": "exposureclass-handler",
+			}))
+
+			Expect(obj.ExposureClassHandlers[1].SNI.Ingress).ToNot(BeNil())
+			Expect(obj.ExposureClassHandlers[1].SNI.Ingress.Namespace).ToNot(BeNil())
+			Expect(*obj.ExposureClassHandlers[1].SNI.Ingress.Namespace).To(Equal("namespace"))
+			Expect(*obj.ExposureClassHandlers[1].SNI.Ingress.ServiceName).To(Equal("svc"))
+			Expect(obj.ExposureClassHandlers[1].SNI.Ingress.Labels).To(Equal(map[string]string{"label1": "value1"}))
 		})
 	})
 
-	Describe("#SetDefaults_KubeconfigValidity", func() {
-		It("should default the configuration", func() {
-			SetObjectDefaults_GardenletConfiguration(obj)
-
-			Expect(obj.GardenClientConnection.KubeconfigValidity.Validity).To(BeNil())
-			Expect(obj.GardenClientConnection.KubeconfigValidity.AutoRotationJitterPercentageMin).To(PointTo(Equal(int32(70))))
-			Expect(obj.GardenClientConnection.KubeconfigValidity.AutoRotationJitterPercentageMax).To(PointTo(Equal(int32(90))))
-		})
-	})
-
-	Describe("#SetDefaults_ManagedSeedControllerConfiguration", func() {
-		It("should default the configuration", func() {
-			SetObjectDefaults_GardenletConfiguration(obj)
-
-			Expect(obj.Controllers.ManagedSeed.ConcurrentSyncs).To(PointTo(Equal(DefaultControllerConcurrentSyncs)))
-			Expect(obj.Controllers.ManagedSeed.SyncPeriod).To(PointTo(Equal(metav1.Duration{Duration: 1 * time.Hour})))
-			Expect(obj.Controllers.ManagedSeed.WaitSyncPeriod).To(PointTo(Equal(metav1.Duration{Duration: 15 * time.Second})))
-			Expect(obj.Controllers.ManagedSeed.SyncJitterPeriod).To(PointTo(Equal(metav1.Duration{Duration: 5 * time.Minute})))
-			Expect(obj.Controllers.ManagedSeed.JitterUpdates).To(PointTo(BeFalse()))
-		})
-	})
-
-	Describe("#SetDefaults_SeedControllerConfiguration", func() {
-		It("should default the configuration", func() {
-			SetObjectDefaults_GardenletConfiguration(obj)
-
-			Expect(obj.Controllers.Seed.SyncPeriod).To(PointTo(Equal(DefaultControllerSyncPeriod)))
-			Expect(obj.Controllers.Seed.LeaseResyncSeconds).To(PointTo(Equal(int32(2))))
-			Expect(obj.Controllers.Seed.LeaseResyncMissThreshold).To(PointTo(Equal(int32(10))))
-		})
-	})
-
-	Describe("#SetDefaults_SeedCareControllerConfiguration", func() {
-		It("should default the configuration", func() {
-			SetObjectDefaults_GardenletConfiguration(obj)
-
-			Expect(obj.Controllers.SeedCare.SyncPeriod).To(PointTo(Equal(metav1.Duration{Duration: 30 * time.Second})))
-		})
-	})
-
-	Describe("#SetDefaults_ShootControllerConfiguration", func() {
-		It("should default the configuration", func() {
-			SetObjectDefaults_GardenletConfiguration(obj)
-
-			Expect(obj.Controllers.Shoot.ConcurrentSyncs).To(PointTo(Equal(20)))
-			Expect(obj.Controllers.Shoot.SyncPeriod).To(PointTo(Equal(metav1.Duration{Duration: time.Hour})))
-			Expect(obj.Controllers.Shoot.RespectSyncPeriodOverwrite).To(PointTo(Equal(false)))
-			Expect(obj.Controllers.Shoot.ReconcileInMaintenanceOnly).To(PointTo(Equal(false)))
-			Expect(obj.Controllers.Shoot.RetryDuration).To(PointTo(Equal(metav1.Duration{Duration: 12 * time.Hour})))
-			Expect(obj.Controllers.Shoot.DNSEntryTTLSeconds).To(PointTo(Equal(int64(120))))
-		})
-	})
-
-	Describe("#SetDefaults_ShootCareControllerConfiguration", func() {
-		It("should default the configuration", func() {
-			SetObjectDefaults_GardenletConfiguration(obj)
-
-			Expect(obj.Controllers.ShootCare.SyncPeriod).To(PointTo(Equal(DefaultControllerSyncPeriod)))
-			Expect(obj.Controllers.ShootCare.ConcurrentSyncs).To(PointTo(Equal(DefaultControllerConcurrentSyncs)))
-			Expect(obj.Controllers.ShootCare.StaleExtensionHealthChecks.Enabled).To(BeTrue())
-			Expect(obj.Controllers.ShootCare.StaleExtensionHealthChecks.Threshold).To(PointTo(Equal(metav1.Duration{Duration: 5 * time.Minute})))
-		})
-	})
-
-	Describe("#SetDefaults_ShootStateControllerConfiguration", func() {
-		It("should default the configuration", func() {
-			SetObjectDefaults_GardenletConfiguration(obj)
-
-			Expect(obj.Controllers.ShootState.ConcurrentSyncs).To(PointTo(Equal(5)))
-			Expect(obj.Controllers.ShootState.SyncPeriod).To(PointTo(Equal(metav1.Duration{Duration: 6 * time.Hour})))
-		})
-	})
-
-	Describe("#SetDefaults_BackupEntryControllerConfiguration", func() {
-		It("should default the configuration", func() {
-			SetObjectDefaults_GardenletConfiguration(obj)
-
-			Expect(obj.Controllers.BackupEntry.ConcurrentSyncs).To(PointTo(Equal(20)))
-			Expect(obj.Controllers.BackupEntry.DeletionGracePeriodHours).To(PointTo(Equal(0)))
-			Expect(obj.Controllers.BackupEntry.DeletionGracePeriodShootPurposes).To(BeEmpty())
-		})
-	})
-
-	Describe("#SetDefaults_BastionControllerConfiguration", func() {
-		It("should default the configuration", func() {
-			SetObjectDefaults_GardenletConfiguration(obj)
-
-			Expect(obj.Controllers.Bastion.ConcurrentSyncs).To(PointTo(Equal(20)))
-		})
-	})
-
-	Describe("#SetDefaults_MonitoringConfig", func() {
-		It("should default to the configuration", func() {
+	Describe("MonitoringConfig defaulting", func() {
+		It("should default the monitoring configuration", func() {
 			SetObjectDefaults_GardenletConfiguration(obj)
 
 			Expect(obj.Monitoring.Shoot).ToNot(BeNil())
 		})
 	})
 
-	Describe("#SetDefaults_ShootMonitoringConfig", func() {
-		It("should default to the configuration", func() {
+	Describe("ShootMonitoringConfig defaulting", func() {
+		It("should default the shoot monitoring configuration", func() {
 			SetObjectDefaults_GardenletConfiguration(obj)
 
 			Expect(obj.Monitoring.Shoot).ToNot(BeNil())
 			Expect(*obj.Monitoring.Shoot.Enabled).To(BeTrue())
+		})
+
+		It("should not overwrite already set values for the shoot monitoring configuration", func() {
+			obj.Monitoring = &MonitoringConfig{
+				&ShootMonitoringConfig{
+					Enabled: pointer.Bool(false),
+				}}
+			SetObjectDefaults_GardenletConfiguration(obj)
+
+			Expect(obj.Monitoring.Shoot).ToNot(BeNil())
+			Expect(*obj.Monitoring.Shoot.Enabled).To(BeFalse())
 		})
 	})
 })

--- a/pkg/gardenlet/apis/config/v1alpha1/defaults_test.go
+++ b/pkg/gardenlet/apis/config/v1alpha1/defaults_test.go
@@ -32,13 +32,13 @@ import (
 )
 
 var _ = Describe("Defaults", func() {
+	var obj *GardenletConfiguration
+
+	BeforeEach(func() {
+		obj = &GardenletConfiguration{}
+	})
+
 	Describe("GardenletConfiguration", func() {
-		var obj *GardenletConfiguration
-
-		BeforeEach(func() {
-			obj = &GardenletConfiguration{}
-		})
-
 		It("should default the gardenlet configuration", func() {
 			SetObjectDefaults_GardenletConfiguration(obj)
 
@@ -234,189 +234,118 @@ var _ = Describe("Defaults", func() {
 	})
 
 	Describe("#SetDefaults_GardenClientConnection", func() {
-		var obj *GardenClientConnection
-
-		BeforeEach(func() {
-			obj = &GardenClientConnection{}
-		})
-
 		It("should default the configuration", func() {
-			SetDefaults_GardenClientConnection(obj)
+			SetObjectDefaults_GardenletConfiguration(obj)
 
-			Expect(obj.KubeconfigValidity).NotTo(BeNil())
+			Expect(obj.GardenClientConnection.KubeconfigValidity).NotTo(BeNil())
 		})
 	})
 
 	Describe("#SetDefaults_KubeconfigValidity", func() {
-		var obj *KubeconfigValidity
-
-		BeforeEach(func() {
-			obj = &KubeconfigValidity{}
-		})
-
 		It("should default the configuration", func() {
-			SetDefaults_KubeconfigValidity(obj)
+			SetObjectDefaults_GardenletConfiguration(obj)
 
-			Expect(obj.Validity).To(BeNil())
-			Expect(obj.AutoRotationJitterPercentageMin).To(PointTo(Equal(int32(70))))
-			Expect(obj.AutoRotationJitterPercentageMax).To(PointTo(Equal(int32(90))))
+			Expect(obj.GardenClientConnection.KubeconfigValidity.Validity).To(BeNil())
+			Expect(obj.GardenClientConnection.KubeconfigValidity.AutoRotationJitterPercentageMin).To(PointTo(Equal(int32(70))))
+			Expect(obj.GardenClientConnection.KubeconfigValidity.AutoRotationJitterPercentageMax).To(PointTo(Equal(int32(90))))
 		})
 	})
 
 	Describe("#SetDefaults_ManagedSeedControllerConfiguration", func() {
-		var obj *ManagedSeedControllerConfiguration
-
-		BeforeEach(func() {
-			obj = &ManagedSeedControllerConfiguration{}
-		})
-
 		It("should default the configuration", func() {
-			SetDefaults_ManagedSeedControllerConfiguration(obj)
+			SetObjectDefaults_GardenletConfiguration(obj)
 
-			Expect(obj.ConcurrentSyncs).To(PointTo(Equal(DefaultControllerConcurrentSyncs)))
-			Expect(obj.SyncPeriod).To(PointTo(Equal(metav1.Duration{Duration: 1 * time.Hour})))
-			Expect(obj.WaitSyncPeriod).To(PointTo(Equal(metav1.Duration{Duration: 15 * time.Second})))
-			Expect(obj.SyncJitterPeriod).To(PointTo(Equal(metav1.Duration{Duration: 5 * time.Minute})))
-			Expect(obj.JitterUpdates).To(PointTo(BeFalse()))
+			Expect(obj.Controllers.ManagedSeed.ConcurrentSyncs).To(PointTo(Equal(DefaultControllerConcurrentSyncs)))
+			Expect(obj.Controllers.ManagedSeed.SyncPeriod).To(PointTo(Equal(metav1.Duration{Duration: 1 * time.Hour})))
+			Expect(obj.Controllers.ManagedSeed.WaitSyncPeriod).To(PointTo(Equal(metav1.Duration{Duration: 15 * time.Second})))
+			Expect(obj.Controllers.ManagedSeed.SyncJitterPeriod).To(PointTo(Equal(metav1.Duration{Duration: 5 * time.Minute})))
+			Expect(obj.Controllers.ManagedSeed.JitterUpdates).To(PointTo(BeFalse()))
 		})
 	})
 
 	Describe("#SetDefaults_SeedControllerConfiguration", func() {
-		var obj *SeedControllerConfiguration
-
-		BeforeEach(func() {
-			obj = &SeedControllerConfiguration{}
-		})
-
 		It("should default the configuration", func() {
-			SetDefaults_SeedControllerConfiguration(obj)
+			SetObjectDefaults_GardenletConfiguration(obj)
 
-			Expect(obj.SyncPeriod).To(PointTo(Equal(DefaultControllerSyncPeriod)))
-			Expect(obj.LeaseResyncSeconds).To(PointTo(Equal(int32(2))))
-			Expect(obj.LeaseResyncMissThreshold).To(PointTo(Equal(int32(10))))
+			Expect(obj.Controllers.Seed.SyncPeriod).To(PointTo(Equal(DefaultControllerSyncPeriod)))
+			Expect(obj.Controllers.Seed.LeaseResyncSeconds).To(PointTo(Equal(int32(2))))
+			Expect(obj.Controllers.Seed.LeaseResyncMissThreshold).To(PointTo(Equal(int32(10))))
 		})
 	})
 
 	Describe("#SetDefaults_SeedCareControllerConfiguration", func() {
-		var obj *SeedCareControllerConfiguration
-
-		BeforeEach(func() {
-			obj = &SeedCareControllerConfiguration{}
-		})
-
 		It("should default the configuration", func() {
-			SetDefaults_SeedCareControllerConfiguration(obj)
+			SetObjectDefaults_GardenletConfiguration(obj)
 
-			Expect(obj.SyncPeriod).To(PointTo(Equal(metav1.Duration{Duration: 30 * time.Second})))
+			Expect(obj.Controllers.SeedCare.SyncPeriod).To(PointTo(Equal(metav1.Duration{Duration: 30 * time.Second})))
 		})
 	})
 
 	Describe("#SetDefaults_ShootControllerConfiguration", func() {
-		var obj *ShootControllerConfiguration
-
-		BeforeEach(func() {
-			obj = &ShootControllerConfiguration{}
-		})
-
 		It("should default the configuration", func() {
-			SetDefaults_ShootControllerConfiguration(obj)
+			SetObjectDefaults_GardenletConfiguration(obj)
 
-			Expect(obj.ConcurrentSyncs).To(PointTo(Equal(20)))
-			Expect(obj.SyncPeriod).To(PointTo(Equal(metav1.Duration{Duration: time.Hour})))
-			Expect(obj.RespectSyncPeriodOverwrite).To(PointTo(Equal(false)))
-			Expect(obj.ReconcileInMaintenanceOnly).To(PointTo(Equal(false)))
-			Expect(obj.RetryDuration).To(PointTo(Equal(metav1.Duration{Duration: 12 * time.Hour})))
-			Expect(obj.DNSEntryTTLSeconds).To(PointTo(Equal(int64(120))))
+			Expect(obj.Controllers.Shoot.ConcurrentSyncs).To(PointTo(Equal(20)))
+			Expect(obj.Controllers.Shoot.SyncPeriod).To(PointTo(Equal(metav1.Duration{Duration: time.Hour})))
+			Expect(obj.Controllers.Shoot.RespectSyncPeriodOverwrite).To(PointTo(Equal(false)))
+			Expect(obj.Controllers.Shoot.ReconcileInMaintenanceOnly).To(PointTo(Equal(false)))
+			Expect(obj.Controllers.Shoot.RetryDuration).To(PointTo(Equal(metav1.Duration{Duration: 12 * time.Hour})))
+			Expect(obj.Controllers.Shoot.DNSEntryTTLSeconds).To(PointTo(Equal(int64(120))))
 		})
 	})
 
 	Describe("#SetDefaults_ShootCareControllerConfiguration", func() {
-		var obj *ShootCareControllerConfiguration
-
-		BeforeEach(func() {
-			obj = &ShootCareControllerConfiguration{}
-		})
-
 		It("should default the configuration", func() {
-			SetDefaults_ShootCareControllerConfiguration(obj)
+			SetObjectDefaults_GardenletConfiguration(obj)
 
-			Expect(obj.SyncPeriod).To(PointTo(Equal(DefaultControllerSyncPeriod)))
-			Expect(obj.ConcurrentSyncs).To(PointTo(Equal(DefaultControllerConcurrentSyncs)))
-			Expect(obj.StaleExtensionHealthChecks).To(PointTo(Equal(StaleExtensionHealthChecks{Enabled: true})))
+			Expect(obj.Controllers.ShootCare.SyncPeriod).To(PointTo(Equal(DefaultControllerSyncPeriod)))
+			Expect(obj.Controllers.ShootCare.ConcurrentSyncs).To(PointTo(Equal(DefaultControllerConcurrentSyncs)))
+			Expect(obj.Controllers.ShootCare.StaleExtensionHealthChecks.Enabled).To(BeTrue())
+			Expect(obj.Controllers.ShootCare.StaleExtensionHealthChecks.Threshold).To(PointTo(Equal(metav1.Duration{Duration: 5 * time.Minute})))
 		})
 	})
 
 	Describe("#SetDefaults_ShootStateControllerConfiguration", func() {
-		var obj *ShootStateControllerConfiguration
-
-		BeforeEach(func() {
-			obj = &ShootStateControllerConfiguration{}
-		})
-
 		It("should default the configuration", func() {
-			SetDefaults_ShootStateControllerConfiguration(obj)
+			SetObjectDefaults_GardenletConfiguration(obj)
 
-			Expect(obj.ConcurrentSyncs).To(PointTo(Equal(5)))
-			Expect(obj.SyncPeriod).To(PointTo(Equal(metav1.Duration{Duration: 6 * time.Hour})))
+			Expect(obj.Controllers.ShootState.ConcurrentSyncs).To(PointTo(Equal(5)))
+			Expect(obj.Controllers.ShootState.SyncPeriod).To(PointTo(Equal(metav1.Duration{Duration: 6 * time.Hour})))
 		})
 	})
 
 	Describe("#SetDefaults_BackupEntryControllerConfiguration", func() {
-		var obj *BackupEntryControllerConfiguration
-
-		BeforeEach(func() {
-			obj = &BackupEntryControllerConfiguration{}
-		})
-
 		It("should default the configuration", func() {
-			SetDefaults_BackupEntryControllerConfiguration(obj)
+			SetObjectDefaults_GardenletConfiguration(obj)
 
-			Expect(obj.ConcurrentSyncs).To(PointTo(Equal(20)))
-			Expect(obj.DeletionGracePeriodHours).To(PointTo(Equal(0)))
-			Expect(obj.DeletionGracePeriodShootPurposes).To(BeEmpty())
+			Expect(obj.Controllers.BackupEntry.ConcurrentSyncs).To(PointTo(Equal(20)))
+			Expect(obj.Controllers.BackupEntry.DeletionGracePeriodHours).To(PointTo(Equal(0)))
+			Expect(obj.Controllers.BackupEntry.DeletionGracePeriodShootPurposes).To(BeEmpty())
 		})
 	})
 
 	Describe("#SetDefaults_BastionControllerConfiguration", func() {
-		var obj *BastionControllerConfiguration
-
-		BeforeEach(func() {
-			obj = &BastionControllerConfiguration{}
-		})
-
 		It("should default the configuration", func() {
-			SetDefaults_BastionControllerConfiguration(obj)
+			SetObjectDefaults_GardenletConfiguration(obj)
 
-			Expect(obj.ConcurrentSyncs).To(PointTo(Equal(20)))
+			Expect(obj.Controllers.Bastion.ConcurrentSyncs).To(PointTo(Equal(20)))
 		})
 	})
 
 	Describe("#SetDefaults_MonitoringConfig", func() {
-		var obj *MonitoringConfig
-
-		BeforeEach(func() {
-			obj = &MonitoringConfig{}
-		})
-
 		It("should default to the configuration", func() {
-			SetDefaults_MonitoringConfig(obj)
+			SetObjectDefaults_GardenletConfiguration(obj)
 
-			Expect(obj.Shoot).ToNot(BeNil())
+			Expect(obj.Monitoring.Shoot).ToNot(BeNil())
 		})
 	})
 
 	Describe("#SetDefaults_ShootMonitoringConfig", func() {
-		var obj *ShootMonitoringConfig
-
-		BeforeEach(func() {
-			obj = &ShootMonitoringConfig{}
-		})
-
 		It("should default to the configuration", func() {
-			SetDefaults_ShootMonitoringConfig(obj)
+			SetObjectDefaults_GardenletConfiguration(obj)
 
-			Expect(obj).ToNot(BeNil())
-			Expect(*obj.Enabled).To(BeTrue())
+			Expect(obj.Monitoring.Shoot).ToNot(BeNil())
+			Expect(*obj.Monitoring.Shoot.Enabled).To(BeTrue())
 		})
 	})
 })

--- a/pkg/gardenlet/apis/config/v1alpha1/defaults_test.go
+++ b/pkg/gardenlet/apis/config/v1alpha1/defaults_test.go
@@ -80,7 +80,7 @@ var _ = Describe("Defaults", func() {
 			SetObjectDefaults_GardenletConfiguration(obj)
 
 			// ContentType fields will be defaulted by client constructors / controller-runtime based on whether a
-			// given APIGroup supports protobuf or not. defaults must not touch these, otherwise the integelligent
+			// given APIGroup supports protobuf or not. defaults must not touch these, otherwise the intelligent
 			// logic will be overwritten
 			Expect(obj.GardenClientConnection.ContentType).To(BeEmpty())
 			Expect(obj.GardenClientConnection.AcceptContentTypes).To(BeEmpty())
@@ -135,7 +135,7 @@ var _ = Describe("Defaults", func() {
 			SetObjectDefaults_GardenletConfiguration(obj)
 
 			// ContentType fields will be defaulted by client constructors / controller-runtime based on whether a
-			// given APIGroup supports protobuf or not. defaults must not touch these, otherwise the integelligent
+			// given APIGroup supports protobuf or not. defaults must not touch these, otherwise the intelligent
 			// logic will be overwritten
 			Expect(obj.SeedClientConnection.ContentType).To(BeEmpty())
 			Expect(obj.SeedClientConnection.AcceptContentTypes).To(BeEmpty())
@@ -162,7 +162,7 @@ var _ = Describe("Defaults", func() {
 			SetObjectDefaults_GardenletConfiguration(obj)
 
 			// ContentType fields will be defaulted by client constructors / controller-runtime based on whether a
-			// given APIGroup supports protobuf or not. defaults must not touch these, otherwise the integelligent
+			// given APIGroup supports protobuf or not. defaults must not touch these, otherwise the intelligent
 			// logic will be overwritten
 			Expect(obj.ShootClientConnection.ContentType).To(BeEmpty())
 			Expect(obj.ShootClientConnection.AcceptContentTypes).To(BeEmpty())

--- a/pkg/gardenlet/apis/config/v1alpha1/register.go
+++ b/pkg/gardenlet/apis/config/v1alpha1/register.go
@@ -52,3 +52,7 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 	)
 	return nil
 }
+
+func addDefaultingFuncs(scheme *runtime.Scheme) error {
+	return RegisterDefaults(scheme)
+}

--- a/pkg/gardenlet/apis/config/v1alpha1/zz_generated.defaults.go
+++ b/pkg/gardenlet/apis/config/v1alpha1/zz_generated.defaults.go
@@ -99,6 +99,7 @@ func SetObjectDefaults_GardenletConfiguration(in *GardenletConfiguration) {
 	if in.LeaderElection != nil {
 		SetDefaults_LeaderElectionConfiguration(in.LeaderElection)
 	}
+	SetDefaults_ServerConfiguration(&in.Server)
 	if in.Logging != nil {
 		SetDefaults_Logging(in.Logging)
 	}
@@ -110,6 +111,15 @@ func SetObjectDefaults_GardenletConfiguration(in *GardenletConfiguration) {
 	}
 	if in.ETCDConfig != nil {
 		SetDefaults_ETCDConfig(in.ETCDConfig)
+		if in.ETCDConfig.ETCDController != nil {
+			SetDefaults_ETCDController(in.ETCDConfig.ETCDController)
+		}
+		if in.ETCDConfig.CustodianController != nil {
+			SetDefaults_CustodianController(in.ETCDConfig.CustodianController)
+		}
+		if in.ETCDConfig.BackupCompactionController != nil {
+			SetDefaults_BackupCompactionController(in.ETCDConfig.BackupCompactionController)
+		}
 	}
 	for i := range in.ExposureClassHandlers {
 		a := &in.ExposureClassHandlers[i]

--- a/pkg/operator/apis/config/v1alpha1/defaults.go
+++ b/pkg/operator/apis/config/v1alpha1/defaults.go
@@ -42,6 +42,9 @@ func SetDefaults_OperatorConfiguration(obj *OperatorConfiguration) {
 	if obj.Controllers.Garden.ETCDConfig == nil {
 		obj.Controllers.Garden.ETCDConfig = &gardenletv1alpha1.ETCDConfig{}
 		gardenletv1alpha1.SetDefaults_ETCDConfig(obj.Controllers.Garden.ETCDConfig)
+		gardenletv1alpha1.SetDefaults_ETCDController(obj.Controllers.Garden.ETCDConfig.ETCDController)
+		gardenletv1alpha1.SetDefaults_CustodianController(obj.Controllers.Garden.ETCDConfig.CustodianController)
+		gardenletv1alpha1.SetDefaults_BackupCompactionController(obj.Controllers.Garden.ETCDConfig.BackupCompactionController)
 	}
 }
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind technical-debt

**What this PR does / why we need it**:
This PR cleans up technical debt in our API defaulting code according to https://github.com/gardener/gardener/issues/7312.
This PR tackles the following resources in the `gardenlet.config.gardener.cloud` API group.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/7312

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->

```other operator
NONE
```
