### PR TITLE
Prevent false positive PrometheusCantScrape alerts for the etcd-druid job

### DIFF
--- a/pkg/component/monitoring/charts/seed-monitoring/charts/core/charts/prometheus/rules/prometheus.rules.yaml
+++ b/pkg/component/monitoring/charts/seed-monitoring/charts/core/charts/prometheus/rules/prometheus.rules.yaml
@@ -3,7 +3,7 @@ groups:
   rules:
   - alert: PrometheusCantScrape
     # Alert only if there are jobs but no samples scraped.
-    expr: scrape_samples_scraped == 0 and on(job) up == 1
+    expr: scrape_samples_scraped == 0 and on(job) up{job!="etcd-druid"} == 1
     for: 1h
     labels:
       service: prometheus


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind bug

**What this PR does / why we need it**:

Prevent false positive PrometheusCantScrape alerts for the etcd-druid job

The etcd-druid scrape job in the control plane Prometheus is federating metrics from the "cache" Prometheus in the garden namespace, which scrapes the shared etcd-druid component.

If the --enable-backup-compaction flag is not turned on for etcd-druid, then etcd-druid does not expose any relevant (allow listed) metrics and the generic PrometheusCantScrape alert fires for all the shoots.

To prevent that, with this commit, the etcd-druid job is removed from the scope of the generic PrometheusCantScrape alert.

This commit can be reverted if the etcd-druid job will expose at least some metrics with any valid configuration.

**Which issue(s) this PR fixes**:

Fixes #8831

**Special notes for your reviewer**:

cc @abdasgupta @ishan16696 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
False positive `PrometheusCantScrape` alerts for the etcd-druid job in the shoot control plane are no longer firing, even if the `--enable-backup-compaction` feature of `etcd-druid` is not turned on.
```
