### PR TITLE
Adjust default values for `cluster-autoscaler` in shoot example

### DIFF
--- a/example/90-shoot.yaml
+++ b/example/90-shoot.yaml
@@ -283,17 +283,17 @@ spec:
   # clusterAutoscaler:
   #   expander: "priority,least-waste" # see: https://github.com/gardener/autoscaler/blob/machine-controller-manager-provider/cluster-autoscaler/FAQ.md#what-are-expanders
   #   maxGracefulTerminationSeconds: 600
-  #   maxNodeProvisionTime: 20m
+  #   maxNodeProvisionTime: 15m
   #   scaleDownUtilizationThreshold: 0.5
-  #   scaleDownUnneededTime: 30m
-  #   scaleDownDelayAfterAdd: 1h
+  #   scaleDownUnneededTime: 10m
+  #   scaleDownDelayAfterAdd: 10m
   #   scaleDownDelayAfterFailure: 3m
   #   scaleDownDelayAfterDelete: 0s
   #   scanInterval: 10s
   #   ignoreTaints: 
   #     - "node.kubernetes.io/memory-pressure"
   #     - "node.kubernetes.io/disk-pressure"
-  #   newPodScaleUpDelay: 10s
+  #   newPodScaleUpDelay: 0s
   #   maxEmptyBulkDelete: 10
   # verticalPodAutoscaler:
   #   enabled: true


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area documentation open-source

**What this PR does / why we need it**:
This PR adjusts the values for `cluster-autoscaler` in the shoot example
These new values are taken from default values defined in the `autoscaler` repo

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
None
```
