### PR TITLE
Only set external traffic policy to local in local setup for multi-zone kind clusters.

### DIFF
--- a/pkg/controller/service/reconciler.go
+++ b/pkg/controller/service/reconciler.go
@@ -50,6 +50,7 @@ type MultiZone interface {
 	HasNodesInMultipleZones(_ context.Context, _ client.Client) (bool, error)
 }
 
+// StaticMultiZone returns an object implementing the MultiZone interface always returning a static value.
 func StaticMultiZone(multiZone bool) MultiZone {
 	return &staticMultiZone{multiZone: multiZone}
 }

--- a/pkg/operator/controller/add.go
+++ b/pkg/operator/controller/add.go
@@ -62,7 +62,7 @@ func AddToManager(ctx context.Context, mgr manager.Manager, cfg *config.Operator
 			return err
 		}
 
-		if err := (&service.Reconciler{MultiZone: service.StaticMultiZone(true)}).AddToManager(mgr, predicate.Or(virtualGardenIstioIngressPredicate, nginxIngressPredicate)); err != nil {
+		if err := (&service.Reconciler{IsMultiZone: true}).AddToManager(mgr, predicate.Or(virtualGardenIstioIngressPredicate, nginxIngressPredicate)); err != nil {
 			return fmt.Errorf("failed adding Service controller: %w", err)
 		}
 	}

--- a/pkg/operator/controller/add.go
+++ b/pkg/operator/controller/add.go
@@ -62,7 +62,7 @@ func AddToManager(ctx context.Context, mgr manager.Manager, cfg *config.Operator
 			return err
 		}
 
-		if err := (&service.Reconciler{}).AddToManager(mgr, predicate.Or(virtualGardenIstioIngressPredicate, nginxIngressPredicate)); err != nil {
+		if err := (&service.Reconciler{MultiZone: service.StaticMultiZone(true)}).AddToManager(mgr, predicate.Or(virtualGardenIstioIngressPredicate, nginxIngressPredicate)); err != nil {
 			return fmt.Errorf("failed adding Service controller: %w", err)
 		}
 	}

--- a/pkg/provider-local/controller/service/add.go
+++ b/pkg/provider-local/controller/service/add.go
@@ -112,6 +112,7 @@ func matchExpressionsIstioIngressGateway(zone *string) []metav1.LabelSelectorReq
 	}
 }
 
+// HasNodesInMultipleZones indicates whether there are nodes in multiple availability zones or not.
 func HasNodesInMultipleZones(ctx context.Context, c client.Reader) (bool, error) {
 	nodes := &metav1.PartialObjectMetadataList{}
 	nodes.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("NodeList"))

--- a/pkg/provider-local/controller/service/add.go
+++ b/pkg/provider-local/controller/service/add.go
@@ -17,8 +17,10 @@ package service
 import (
 	"context"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
@@ -48,7 +50,7 @@ type AddOptions struct {
 
 // AddToManagerWithOptions adds a controller with the given Options to the given manager.
 // The opts.Reconciler is being set with a newly instantiated actuator.
-func AddToManagerWithOptions(mgr manager.Manager, opts AddOptions) error {
+func AddToManagerWithOptions(ctx context.Context, mgr manager.Manager, opts AddOptions) error {
 	var istioIngressGatewayPredicates []predicate.Predicate
 	for _, zone := range []*string{
 		nil,
@@ -72,16 +74,17 @@ func AddToManagerWithOptions(mgr manager.Manager, opts AddOptions) error {
 	}
 
 	return (&service.Reconciler{
-		HostIP:  opts.HostIP,
-		Zone0IP: opts.Zone0IP,
-		Zone1IP: opts.Zone1IP,
-		Zone2IP: opts.Zone2IP,
+		HostIP:    opts.HostIP,
+		Zone0IP:   opts.Zone0IP,
+		Zone1IP:   opts.Zone1IP,
+		Zone2IP:   opts.Zone2IP,
+		MultiZone: &nodeZoneInitializer{},
 	}).AddToManager(mgr, predicate.Or(nginxIngressPredicate, predicate.Or(istioIngressGatewayPredicates...)))
 }
 
 // AddToManager adds a controller with the default Options.
-func AddToManager(_ context.Context, mgr manager.Manager) error {
-	return AddToManagerWithOptions(mgr, DefaultAddOptions)
+func AddToManager(ctx context.Context, mgr manager.Manager) error {
+	return AddToManagerWithOptions(ctx, mgr, DefaultAddOptions)
 }
 
 func matchExpressionsIstioIngressGateway(zone *string) []metav1.LabelSelectorRequirement {
@@ -102,4 +105,38 @@ func matchExpressionsIstioIngressGateway(zone *string) []metav1.LabelSelectorReq
 			Values:   []string{istioLabelValue},
 		},
 	}
+}
+
+type nodeZoneInitializer struct {
+	multiZone *bool
+}
+
+func (nzi *nodeZoneInitializer) HasNodesInMultipleZones(ctx context.Context, c client.Client) (bool, error) {
+	if nzi.multiZone == nil {
+		multiZone, err := hasNodesInMultipleZones(ctx, c)
+		if err != nil {
+			// Propagate the error, but retry on next call
+			return false, err
+		}
+		nzi.multiZone = &multiZone
+	}
+	return *nzi.multiZone, nil
+}
+
+func hasNodesInMultipleZones(ctx context.Context, c client.Client) (bool, error) {
+	nodes := &metav1.PartialObjectMetadataList{}
+	nodes.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("NodeList"))
+	if err := c.List(ctx, nodes); err != nil {
+		return false, err
+	}
+
+	var firstZone *string
+	for _, node := range nodes.Items {
+		if zone := node.Labels[corev1.LabelTopologyZone]; firstZone == nil {
+			firstZone = &zone
+		} else if *firstZone != zone {
+			return true, nil
+		}
+	}
+	return false, nil
 }

--- a/pkg/provider-local/controller/service/add_test.go
+++ b/pkg/provider-local/controller/service/add_test.go
@@ -1,0 +1,100 @@
+// Copyright 2024 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package service_test
+
+import (
+	"context"
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	. "github.com/gardener/gardener/pkg/provider-local/controller/service"
+)
+
+var _ = Describe("Add", func() {
+	DescribeTable("NodeZoneInitializer#HasNodesInMultipleZones",
+		func(nodes []string, zones []string, funcs *interceptor.Funcs, expectedResult []bool, expectedError []error) {
+			c := fakeclient.NewClientBuilder().WithScheme(scheme.Scheme).Build()
+			Expect(nodes).To(HaveLen(len(zones)))
+			for i := range nodes {
+				Expect(c.Create(context.TODO(), &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: nodes[i], Labels: map[string]string{"topology.kubernetes.io/zone": zones[i]}}})).To(Succeed(), fmt.Sprintf("creation of %d. node failed", i))
+			}
+
+			nzi := &NodeZoneInitializer{}
+			Expect(expectedResult).To(HaveLen(len(expectedError)))
+			for i := range expectedResult {
+				cl := c
+				if funcs != nil {
+					cl = interceptor.NewClient(c, *funcs)
+				}
+				result, err := nzi.HasNodesInMultipleZones(context.TODO(), cl)
+				Expect(result).To(Equal(expectedResult[i]), fmt.Sprintf("failure on %d. iteration: expected=%t, got=%t", i, expectedResult[i], result))
+				if expectedError[i] == nil {
+					Expect(err).To(Succeed(), fmt.Sprintf("failure on %d. iteration: expected=%s, got=%s", i, expectedError[i], err))
+				} else {
+					Expect(err).To(Equal(expectedError[i]), fmt.Sprintf("failure on %d. iteration: expected=%s, got=%s", i, expectedError[i], err))
+				}
+			}
+		},
+
+		Entry("No nodes/zones", []string{}, []string{}, nil, []bool{false, false}, []error{nil, nil}),
+		Entry("1 node/zone", []string{"node-0"}, []string{"0"}, nil, []bool{false, false}, []error{nil, nil}),
+		Entry("2 nodes, 1 zone", []string{"node-0", "node-1"}, []string{"0", "0"}, nil, []bool{false, false}, []error{nil, nil}),
+		Entry("2 nodes/zones", []string{"node-0", "node-1"}, []string{"0", "1"}, nil, []bool{true, true}, []error{nil, nil}),
+		Entry("3 nodes, 1 zones", []string{"node-0", "node-1", "node-2"}, []string{"0", "0", "0"}, nil, []bool{false, false}, []error{nil, nil}),
+		Entry("3 nodes, 2 zones", []string{"node-0", "node-1", "node-2"}, []string{"0", "1", "1"}, nil, []bool{true, true}, []error{nil, nil}),
+		Entry("3 nodes/zones", []string{"node-0", "node-1", "node-2"}, []string{"0", "1", "2"}, nil, []bool{true, true}, []error{nil, nil}),
+		Entry("No nodes/zones with errors", []string{}, []string{}, createAlwaysErrorClientInterceptor(), []bool{false, false, false}, []error{errInterceptor, errInterceptor, errInterceptor}),
+		Entry("1 node/zone with errors", []string{"node-0"}, []string{"0"}, createAlwaysErrorClientInterceptor(), []bool{false, false, false}, []error{errInterceptor, errInterceptor, errInterceptor}),
+		Entry("2 nodes, 1 zone with errors", []string{"node-0", "node-1"}, []string{"0", "0"}, createAlwaysErrorClientInterceptor(), []bool{false, false, false}, []error{errInterceptor, errInterceptor, errInterceptor}),
+		Entry("2 nodes/zones with errors", []string{"node-0", "node-1"}, []string{"0", "1"}, createAlwaysErrorClientInterceptor(), []bool{false, false, false}, []error{errInterceptor, errInterceptor, errInterceptor}),
+		Entry("3 nodes, 1 zones with errors", []string{"node-0", "node-1", "node-2"}, []string{"0", "0", "0"}, createAlwaysErrorClientInterceptor(), []bool{false, false, false}, []error{errInterceptor, errInterceptor, errInterceptor}),
+		Entry("3 nodes, 2 zones with errors", []string{"node-0", "node-1", "node-2"}, []string{"0", "1", "1"}, createAlwaysErrorClientInterceptor(), []bool{false, false, false}, []error{errInterceptor, errInterceptor, errInterceptor}),
+		Entry("3 nodes/zones with errors", []string{"node-0", "node-1", "node-2"}, []string{"0", "1", "2"}, createAlwaysErrorClientInterceptor(), []bool{false, false, false}, []error{errInterceptor, errInterceptor, errInterceptor}),
+		Entry("No nodes/zones with one error", []string{}, []string{}, createOnceErrorClientInterceptor(), []bool{false, false, false}, []error{errInterceptor, nil, nil}),
+		Entry("1 node/zone with one error", []string{"node-0"}, []string{"0"}, createOnceErrorClientInterceptor(), []bool{false, false, false}, []error{errInterceptor, nil, nil}),
+		Entry("2 nodes, 1 zone with one error", []string{"node-0", "node-1"}, []string{"0", "0"}, createOnceErrorClientInterceptor(), []bool{false, false, false}, []error{errInterceptor, nil, nil}),
+		Entry("2 nodes/zones with one error", []string{"node-0", "node-1"}, []string{"0", "1"}, createOnceErrorClientInterceptor(), []bool{false, true, true}, []error{errInterceptor, nil, nil}),
+		Entry("3 nodes, 1 zones with one error", []string{"node-0", "node-1", "node-2"}, []string{"0", "0", "0"}, createOnceErrorClientInterceptor(), []bool{false, false, false}, []error{errInterceptor, nil, nil}),
+		Entry("3 nodes, 2 zones with one error", []string{"node-0", "node-1", "node-2"}, []string{"0", "1", "1"}, createOnceErrorClientInterceptor(), []bool{false, true, true}, []error{errInterceptor, nil, nil}),
+		Entry("3 nodes/zones with one error", []string{"node-0", "node-1", "node-2"}, []string{"0", "1", "2"}, createOnceErrorClientInterceptor(), []bool{false, true, true}, []error{errInterceptor, nil, nil}),
+	)
+})
+
+var errInterceptor = fmt.Errorf("temporary test error")
+
+func createAlwaysErrorClientInterceptor() *interceptor.Funcs {
+	return &interceptor.Funcs{
+		List: func(_ context.Context, _ client.WithWatch, _ client.ObjectList, _ ...client.ListOption) error {
+			return errInterceptor
+		},
+	}
+}
+
+func createOnceErrorClientInterceptor() *interceptor.Funcs {
+	result := &interceptor.Funcs{}
+	result.List = func(ctx context.Context, client client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+		result.List = nil
+		return errInterceptor
+	}
+	return result
+}

--- a/pkg/provider-local/controller/service/add_test.go
+++ b/pkg/provider-local/controller/service/add_test.go
@@ -31,70 +31,45 @@ import (
 )
 
 var _ = Describe("Add", func() {
-	DescribeTable("NodeZoneInitializer#HasNodesInMultipleZones",
-		func(nodes []string, zones []string, funcs *interceptor.Funcs, expectedResult []bool, expectedError []error) {
+	DescribeTable("#HasNodesInMultipleZones",
+		func(nodes []string, zones []string, funcs *interceptor.Funcs, expectedResult bool, expectedError error) {
 			c := fakeclient.NewClientBuilder().WithScheme(scheme.Scheme).Build()
 			Expect(nodes).To(HaveLen(len(zones)))
 			for i := range nodes {
 				Expect(c.Create(context.TODO(), &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: nodes[i], Labels: map[string]string{"topology.kubernetes.io/zone": zones[i]}}})).To(Succeed(), fmt.Sprintf("creation of %d. node failed", i))
 			}
 
-			nzi := &NodeZoneInitializer{}
-			Expect(expectedResult).To(HaveLen(len(expectedError)))
-			for i := range expectedResult {
-				cl := c
-				if funcs != nil {
-					cl = interceptor.NewClient(c, *funcs)
-				}
-				result, err := nzi.HasNodesInMultipleZones(context.TODO(), cl)
-				Expect(result).To(Equal(expectedResult[i]), fmt.Sprintf("failure on %d. iteration: expected=%t, got=%t", i, expectedResult[i], result))
-				if expectedError[i] == nil {
-					Expect(err).To(Succeed(), fmt.Sprintf("failure on %d. iteration: expected=%s, got=%s", i, expectedError[i], err))
-				} else {
-					Expect(err).To(Equal(expectedError[i]), fmt.Sprintf("failure on %d. iteration: expected=%s, got=%s", i, expectedError[i], err))
-				}
+			cl := c
+			if funcs != nil {
+				cl = interceptor.NewClient(c, *funcs)
+			}
+			result, err := HasNodesInMultipleZones(context.TODO(), cl)
+			Expect(result).To(Equal(expectedResult))
+			if expectedError == nil {
+				Expect(err).To(Succeed())
+			} else {
+				Expect(err).To(Equal(expectedError))
 			}
 		},
 
-		Entry("No nodes/zones", []string{}, []string{}, nil, []bool{false, false}, []error{nil, nil}),
-		Entry("1 node/zone", []string{"node-0"}, []string{"0"}, nil, []bool{false, false}, []error{nil, nil}),
-		Entry("2 nodes, 1 zone", []string{"node-0", "node-1"}, []string{"0", "0"}, nil, []bool{false, false}, []error{nil, nil}),
-		Entry("2 nodes/zones", []string{"node-0", "node-1"}, []string{"0", "1"}, nil, []bool{true, true}, []error{nil, nil}),
-		Entry("3 nodes, 1 zones", []string{"node-0", "node-1", "node-2"}, []string{"0", "0", "0"}, nil, []bool{false, false}, []error{nil, nil}),
-		Entry("3 nodes, 2 zones", []string{"node-0", "node-1", "node-2"}, []string{"0", "1", "1"}, nil, []bool{true, true}, []error{nil, nil}),
-		Entry("3 nodes/zones", []string{"node-0", "node-1", "node-2"}, []string{"0", "1", "2"}, nil, []bool{true, true}, []error{nil, nil}),
-		Entry("No nodes/zones with errors", []string{}, []string{}, createAlwaysErrorClientInterceptor(), []bool{false, false, false}, []error{errInterceptor, errInterceptor, errInterceptor}),
-		Entry("1 node/zone with errors", []string{"node-0"}, []string{"0"}, createAlwaysErrorClientInterceptor(), []bool{false, false, false}, []error{errInterceptor, errInterceptor, errInterceptor}),
-		Entry("2 nodes, 1 zone with errors", []string{"node-0", "node-1"}, []string{"0", "0"}, createAlwaysErrorClientInterceptor(), []bool{false, false, false}, []error{errInterceptor, errInterceptor, errInterceptor}),
-		Entry("2 nodes/zones with errors", []string{"node-0", "node-1"}, []string{"0", "1"}, createAlwaysErrorClientInterceptor(), []bool{false, false, false}, []error{errInterceptor, errInterceptor, errInterceptor}),
-		Entry("3 nodes, 1 zones with errors", []string{"node-0", "node-1", "node-2"}, []string{"0", "0", "0"}, createAlwaysErrorClientInterceptor(), []bool{false, false, false}, []error{errInterceptor, errInterceptor, errInterceptor}),
-		Entry("3 nodes, 2 zones with errors", []string{"node-0", "node-1", "node-2"}, []string{"0", "1", "1"}, createAlwaysErrorClientInterceptor(), []bool{false, false, false}, []error{errInterceptor, errInterceptor, errInterceptor}),
-		Entry("3 nodes/zones with errors", []string{"node-0", "node-1", "node-2"}, []string{"0", "1", "2"}, createAlwaysErrorClientInterceptor(), []bool{false, false, false}, []error{errInterceptor, errInterceptor, errInterceptor}),
-		Entry("No nodes/zones with one error", []string{}, []string{}, createOnceErrorClientInterceptor(), []bool{false, false, false}, []error{errInterceptor, nil, nil}),
-		Entry("1 node/zone with one error", []string{"node-0"}, []string{"0"}, createOnceErrorClientInterceptor(), []bool{false, false, false}, []error{errInterceptor, nil, nil}),
-		Entry("2 nodes, 1 zone with one error", []string{"node-0", "node-1"}, []string{"0", "0"}, createOnceErrorClientInterceptor(), []bool{false, false, false}, []error{errInterceptor, nil, nil}),
-		Entry("2 nodes/zones with one error", []string{"node-0", "node-1"}, []string{"0", "1"}, createOnceErrorClientInterceptor(), []bool{false, true, true}, []error{errInterceptor, nil, nil}),
-		Entry("3 nodes, 1 zones with one error", []string{"node-0", "node-1", "node-2"}, []string{"0", "0", "0"}, createOnceErrorClientInterceptor(), []bool{false, false, false}, []error{errInterceptor, nil, nil}),
-		Entry("3 nodes, 2 zones with one error", []string{"node-0", "node-1", "node-2"}, []string{"0", "1", "1"}, createOnceErrorClientInterceptor(), []bool{false, true, true}, []error{errInterceptor, nil, nil}),
-		Entry("3 nodes/zones with one error", []string{"node-0", "node-1", "node-2"}, []string{"0", "1", "2"}, createOnceErrorClientInterceptor(), []bool{false, true, true}, []error{errInterceptor, nil, nil}),
+		Entry("No nodes/zones", []string{}, []string{}, nil, false, nil),
+		Entry("1 node/zone", []string{"node-0"}, []string{"0"}, nil, false, nil),
+		Entry("2 nodes, 1 zone", []string{"node-0", "node-1"}, []string{"0", "0"}, nil, false, nil),
+		Entry("2 nodes/zones", []string{"node-0", "node-1"}, []string{"0", "1"}, nil, true, nil),
+		Entry("3 nodes, 1 zones", []string{"node-0", "node-1", "node-2"}, []string{"0", "0", "0"}, nil, false, nil),
+		Entry("3 nodes, 2 zones", []string{"node-0", "node-1", "node-2"}, []string{"0", "1", "1"}, nil, true, nil),
+		Entry("3 nodes/zones", []string{"node-0", "node-1", "node-2"}, []string{"0", "1", "2"}, nil, true, nil),
+		Entry("No nodes/zones with errors", []string{}, []string{}, createErrorClientInterceptor(), false, errInterceptor),
+		Entry("3 nodes/zones with errors", []string{"node-0", "node-1", "node-2"}, []string{"0", "1", "2"}, createErrorClientInterceptor(), false, errInterceptor),
 	)
 })
 
 var errInterceptor = fmt.Errorf("temporary test error")
 
-func createAlwaysErrorClientInterceptor() *interceptor.Funcs {
+func createErrorClientInterceptor() *interceptor.Funcs {
 	return &interceptor.Funcs{
 		List: func(_ context.Context, _ client.WithWatch, _ client.ObjectList, _ ...client.ListOption) error {
 			return errInterceptor
 		},
 	}
-}
-
-func createOnceErrorClientInterceptor() *interceptor.Funcs {
-	result := &interceptor.Funcs{}
-	result.List = func(ctx context.Context, client client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
-		result.List = nil
-		return errInterceptor
-	}
-	return result
 }

--- a/pkg/provider-local/controller/service/service_suite_test.go
+++ b/pkg/provider-local/controller/service/service_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright 2024 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package service_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestReference(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Provider-Local Controller Service Suite")
+}

--- a/pkg/provider-local/controller/service/service_suite_test.go
+++ b/pkg/provider-local/controller/service/service_suite_test.go
@@ -21,7 +21,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestReference(t *testing.T) {
+func TestService(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Provider-Local Controller Service Suite")
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/area dev-productivity
/kind flake
/kind regression

**What this PR does / why we need it**:
Only set external traffic policy to local in local setup for multi-zone kind clusters.

The mitigation for docker desktop issues on mac (see https://github.com/gardener/gardener/pull/8972) caused single-zone tests to fail when the istio ingress gateway pods were not scheduled on the `gardener-local-ha-single-zone-control-plane` node. Now, the external traffic policy is only set in scenarios when there should be istio ingress gateway pods in all zones, i.e. in the operator setup and in the gardener multi-zone setup.

**Which issue(s) this PR fixes**:
Fixes #8993 

**Special notes for your reviewer**:
#8972 did not take into consideration that the single-zone HA development setup also uses multiple nodes, but does not enforce istio ingress gateway pods on all nodes. Therefore, the ingress from outside of the kind cluster to the shoot control planes could be broken if the istio ingress gateway pods were only scheduled to the worker nodes.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix developer
Local single-zone gardener development setups should now work as expected again even if the istio ingress pods are not scheduled on the control plane node.
```
