### PR TITLE
Run kube-proxy in non-privileged mode for Kubernetes >= 1.29

### DIFF
--- a/pkg/component/kubeproxy/kube_proxy_test.go
+++ b/pkg/component/kubeproxy/kube_proxy_test.go
@@ -849,12 +849,7 @@ status: {}
 						"kubernetes-version": pool.KubernetesVersion.String(),
 					}))
 
-					if versionutils.ConstraintK8sGreaterEqual129.Check(pool.KubernetesVersion) {
-						Expect(string(managedResourceSecret.Data["daemonset__kube-system__"+daemonSetNameFor(pool)+".yaml"])).To(Equal(daemonSetYAMLFor(pool, values.IPVSEnabled, values.VPAEnabled, true)))
-					} else {
-						Expect(string(managedResourceSecret.Data["daemonset__kube-system__"+daemonSetNameFor(pool)+".yaml"])).To(Equal(daemonSetYAMLFor(pool, values.IPVSEnabled, values.VPAEnabled, false)))
-					}
-
+					Expect(string(managedResourceSecret.Data["daemonset__kube-system__"+daemonSetNameFor(pool)+".yaml"])).To(Equal(daemonSetYAMLFor(pool, values.IPVSEnabled, values.VPAEnabled, versionutils.ConstraintK8sGreaterEqual129.Check(pool.KubernetesVersion))))
 					expectedPoolMr.Spec.SecretRefs = []corev1.LocalObjectReference{{Name: managedResourceSecret.Name}}
 					utilruntime.Must(references.InjectAnnotations(expectedPoolMr))
 					Expect(managedResource).To(DeepEqual(expectedPoolMr))
@@ -980,12 +975,7 @@ status: {}
 					"role": "pool",
 				}))
 				Expect(managedResourceSecret.Immutable).To(Equal(pointer.Bool(true)))
-				if versionutils.ConstraintK8sGreaterEqual129.Check(pool.KubernetesVersion) {
-					Expect(string(managedResourceSecret.Data["daemonset__kube-system__"+daemonSetNameFor(pool)+".yaml"])).To(Equal(daemonSetYAMLFor(pool, values.IPVSEnabled, values.VPAEnabled, true)))
-				} else {
-					Expect(string(managedResourceSecret.Data["daemonset__kube-system__"+daemonSetNameFor(pool)+".yaml"])).To(Equal(daemonSetYAMLFor(pool, values.IPVSEnabled, values.VPAEnabled, false)))
-				}
-
+				Expect(string(managedResourceSecret.Data["daemonset__kube-system__"+daemonSetNameFor(pool)+".yaml"])).To(Equal(daemonSetYAMLFor(pool, values.IPVSEnabled, values.VPAEnabled, versionutils.ConstraintK8sGreaterEqual129.Check(pool.KubernetesVersion))))
 				poolExpectedMr.Spec.SecretRefs = []corev1.LocalObjectReference{{Name: managedResourceSecret.Name}}
 				utilruntime.Must(references.InjectAnnotations(poolExpectedMr))
 				Expect(managedResource).To(DeepEqual(poolExpectedMr))
@@ -1021,11 +1011,7 @@ status: {}
 					"pool-name":          pool.Name,
 					"kubernetes-version": pool.KubernetesVersion.String(),
 				}))
-				if versionutils.ConstraintK8sGreaterEqual129.Check(pool.KubernetesVersion) {
-					Expect(string(managedResourceSecret.Data["daemonset__kube-system__"+daemonSetNameFor(pool)+".yaml"])).To(Equal(daemonSetYAMLFor(pool, values.IPVSEnabled, values.VPAEnabled, true)))
-				} else {
-					Expect(string(managedResourceSecret.Data["daemonset__kube-system__"+daemonSetNameFor(pool)+".yaml"])).To(Equal(daemonSetYAMLFor(pool, values.IPVSEnabled, values.VPAEnabled, false)))
-				}
+				Expect(string(managedResourceSecret.Data["daemonset__kube-system__"+daemonSetNameFor(pool)+".yaml"])).To(Equal(daemonSetYAMLFor(pool, values.IPVSEnabled, values.VPAEnabled, versionutils.ConstraintK8sGreaterEqual129.Check(pool.KubernetesVersion))))
 
 				expectedMr := &resourcesv1alpha1.ManagedResource{
 					TypeMeta: metav1.TypeMeta{
@@ -1057,11 +1043,7 @@ status: {}
 				Expect(managedResourceSecret.Immutable).To(Equal(pointer.Bool(true)))
 				Expect(managedResourceSecret.Labels["resources.gardener.cloud/garbage-collectable-reference"]).To(Equal("true"))
 				Expect(managedResourceSecret.Data).To(HaveLen(1))
-				if versionutils.ConstraintK8sGreaterEqual129.Check(pool.KubernetesVersion) {
-					Expect(string(managedResourceSecret.Data["daemonset__kube-system__"+daemonSetNameFor(pool)+".yaml"])).To(Equal(daemonSetYAMLFor(pool, values.IPVSEnabled, values.VPAEnabled, true)))
-				} else {
-					Expect(string(managedResourceSecret.Data["daemonset__kube-system__"+daemonSetNameFor(pool)+".yaml"])).To(Equal(daemonSetYAMLFor(pool, values.IPVSEnabled, values.VPAEnabled, false)))
-				}
+				Expect(string(managedResourceSecret.Data["daemonset__kube-system__"+daemonSetNameFor(pool)+".yaml"])).To(Equal(daemonSetYAMLFor(pool, values.IPVSEnabled, values.VPAEnabled, versionutils.ConstraintK8sGreaterEqual129.Check(pool.KubernetesVersion))))
 
 				// assertions for resources specific to the major/minor parts only of the Kubernetes version
 				managedResourceForMajorMinorVersionOnly := managedResourceForPoolForMajorMinorVersionOnly(pool)

--- a/pkg/component/kubeproxy/kube_proxy_test.go
+++ b/pkg/component/kubeproxy/kube_proxy_test.go
@@ -546,7 +546,8 @@ spec:
 					out += `
           capabilities:
             add:
-            - NET_ADMIN`
+            - NET_ADMIN
+            - SYS_RESOURCE`
 				} else {
 					out += `
           privileged: true`
@@ -628,18 +629,13 @@ spec:
         - --init-only
         image: ` + pool.Image + `
         imagePullPolicy: IfNotPresent
-        name: kube-proxy
-        ports:
-        - containerPort: 10249
-          hostPort: 10249
-          name: metrics
-          protocol: TCP
+        name: kube-proxy-init
         resources:`
 
 					if vpaEnabled {
 						out += `
           limits:
-            memory: 2Gi`
+            memory: 256Mi`
 					}
 
 					out += `

--- a/pkg/component/kubeproxy/kube_proxy_test.go
+++ b/pkg/component/kubeproxy/kube_proxy_test.go
@@ -40,7 +40,7 @@ import (
 	retryfake "github.com/gardener/gardener/pkg/utils/retry/fake"
 	"github.com/gardener/gardener/pkg/utils/test"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
-	"github.com/gardener/gardener/pkg/utils/version"
+	versionutils "github.com/gardener/gardener/pkg/utils/version"
 )
 
 var _ = Describe("KubeProxy", func() {
@@ -131,7 +131,7 @@ var _ = Describe("KubeProxy", func() {
 			VPAEnabled:  false,
 			WorkerPools: []WorkerPool{
 				{Name: "pool1", KubernetesVersion: semver.MustParse("1.24.13"), Image: "some-image:some-tag1"},
-				{Name: "pool2", KubernetesVersion: semver.MustParse("1.25.4"), Image: "some-image:some-tag2"},
+				{Name: "pool2", KubernetesVersion: semver.MustParse("1.29.0"), Image: "some-image:some-tag2"},
 			},
 		}
 		component = New(c, namespace, values)
@@ -459,7 +459,7 @@ subjects:
 			daemonSetNameFor = func(pool WorkerPool) string {
 				return "kube-proxy-" + pool.Name + "-v" + pool.KubernetesVersion.String()
 			}
-			daemonSetYAMLFor = func(pool WorkerPool, ipvsEnabled, vpaEnabled bool) string {
+			daemonSetYAMLFor = func(pool WorkerPool, ipvsEnabled, vpaEnabled, k8sGreaterEqual129 bool) string {
 				referenceAnnotations := func() string {
 					var annotations []string
 
@@ -540,8 +540,19 @@ spec:
           requests:
             cpu: 20m
             memory: 64Mi
-        securityContext:
-          privileged: true
+        securityContext:`
+
+				if k8sGreaterEqual129 {
+					out += `
+          capabilities:
+            add:
+            - NET_ADMIN`
+				} else {
+					out += `
+          privileged: true`
+				}
+
+				out += `
         volumeMounts:
         - mountPath: /var/lib/kube-proxy-kubeconfig
           name: kubeconfig
@@ -587,7 +598,7 @@ spec:
 
 				out += `
         - name: EXECUTE_WORKAROUND_FOR_K8S_ISSUE_109286
-          value: "` + strconv.FormatBool(version.ConstraintK8sLess125.Check(pool.KubernetesVersion)) + `"
+          value: "` + strconv.FormatBool(versionutils.ConstraintK8sLess125.Check(pool.KubernetesVersion)) + `"
         image: ` + pool.Image + `
         imagePullPolicy: IfNotPresent
         name: cleanup
@@ -606,7 +617,52 @@ spec:
         - mountPath: /var/lib/kube-proxy-kubeconfig
           name: kubeconfig
         - mountPath: /var/lib/kube-proxy-config
+          name: kube-proxy-config`
+
+				if k8sGreaterEqual129 {
+					out += `
+      - command:
+        - /usr/local/bin/kube-proxy
+        - --config=/var/lib/kube-proxy-config/config.yaml
+        - --v=2
+        - --init-only
+        image: ` + pool.Image + `
+        imagePullPolicy: IfNotPresent
+        name: kube-proxy
+        ports:
+        - containerPort: 10249
+          hostPort: 10249
+          name: metrics
+          protocol: TCP
+        resources:`
+
+					if vpaEnabled {
+						out += `
+          limits:
+            memory: 2Gi`
+					}
+
+					out += `
+          requests:
+            cpu: 20m
+            memory: 64Mi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /var/lib/kube-proxy-kubeconfig
+          name: kubeconfig
+        - mountPath: /var/lib/kube-proxy-config
           name: kube-proxy-config
+        - mountPath: /etc/ssl/certs
+          name: ssl-certs-hosts
+          readOnly: true
+        - mountPath: /var/run/dbus/system_bus_socket
+          name: systembussocket
+        - mountPath: /lib/modules
+          name: kernel-modules`
+				}
+
+				out += `
       nodeSelector:
         worker.gardener.cloud/kubernetes-version: ` + pool.KubernetesVersion.String() + `
         worker.gardener.cloud/pool: ` + pool.Name + `
@@ -792,7 +848,12 @@ status: {}
 						"pool-name":          pool.Name,
 						"kubernetes-version": pool.KubernetesVersion.String(),
 					}))
-					Expect(string(managedResourceSecret.Data["daemonset__kube-system__"+daemonSetNameFor(pool)+".yaml"])).To(Equal(daemonSetYAMLFor(pool, values.IPVSEnabled, values.VPAEnabled)))
+
+					if versionutils.ConstraintK8sGreaterEqual129.Check(pool.KubernetesVersion) {
+						Expect(string(managedResourceSecret.Data["daemonset__kube-system__"+daemonSetNameFor(pool)+".yaml"])).To(Equal(daemonSetYAMLFor(pool, values.IPVSEnabled, values.VPAEnabled, true)))
+					} else {
+						Expect(string(managedResourceSecret.Data["daemonset__kube-system__"+daemonSetNameFor(pool)+".yaml"])).To(Equal(daemonSetYAMLFor(pool, values.IPVSEnabled, values.VPAEnabled, false)))
+					}
 
 					expectedPoolMr.Spec.SecretRefs = []corev1.LocalObjectReference{{Name: managedResourceSecret.Name}}
 					utilruntime.Must(references.InjectAnnotations(expectedPoolMr))
@@ -919,7 +980,11 @@ status: {}
 					"role": "pool",
 				}))
 				Expect(managedResourceSecret.Immutable).To(Equal(pointer.Bool(true)))
-				Expect(string(managedResourceSecret.Data["daemonset__kube-system__"+daemonSetNameFor(pool)+".yaml"])).To(Equal(daemonSetYAMLFor(pool, values.IPVSEnabled, values.VPAEnabled)))
+				if versionutils.ConstraintK8sGreaterEqual129.Check(pool.KubernetesVersion) {
+					Expect(string(managedResourceSecret.Data["daemonset__kube-system__"+daemonSetNameFor(pool)+".yaml"])).To(Equal(daemonSetYAMLFor(pool, values.IPVSEnabled, values.VPAEnabled, true)))
+				} else {
+					Expect(string(managedResourceSecret.Data["daemonset__kube-system__"+daemonSetNameFor(pool)+".yaml"])).To(Equal(daemonSetYAMLFor(pool, values.IPVSEnabled, values.VPAEnabled, false)))
+				}
 
 				poolExpectedMr.Spec.SecretRefs = []corev1.LocalObjectReference{{Name: managedResourceSecret.Name}}
 				utilruntime.Must(references.InjectAnnotations(poolExpectedMr))
@@ -956,7 +1021,11 @@ status: {}
 					"pool-name":          pool.Name,
 					"kubernetes-version": pool.KubernetesVersion.String(),
 				}))
-				Expect(string(managedResourceSecret.Data["daemonset__kube-system__"+daemonSetNameFor(pool)+".yaml"])).To(Equal(daemonSetYAMLFor(pool, values.IPVSEnabled, values.VPAEnabled)))
+				if versionutils.ConstraintK8sGreaterEqual129.Check(pool.KubernetesVersion) {
+					Expect(string(managedResourceSecret.Data["daemonset__kube-system__"+daemonSetNameFor(pool)+".yaml"])).To(Equal(daemonSetYAMLFor(pool, values.IPVSEnabled, values.VPAEnabled, true)))
+				} else {
+					Expect(string(managedResourceSecret.Data["daemonset__kube-system__"+daemonSetNameFor(pool)+".yaml"])).To(Equal(daemonSetYAMLFor(pool, values.IPVSEnabled, values.VPAEnabled, false)))
+				}
 
 				expectedMr := &resourcesv1alpha1.ManagedResource{
 					TypeMeta: metav1.TypeMeta{
@@ -988,7 +1057,11 @@ status: {}
 				Expect(managedResourceSecret.Immutable).To(Equal(pointer.Bool(true)))
 				Expect(managedResourceSecret.Labels["resources.gardener.cloud/garbage-collectable-reference"]).To(Equal("true"))
 				Expect(managedResourceSecret.Data).To(HaveLen(1))
-				Expect(string(managedResourceSecret.Data["daemonset__kube-system__"+daemonSetNameFor(pool)+".yaml"])).To(Equal(daemonSetYAMLFor(pool, values.IPVSEnabled, values.VPAEnabled)))
+				if versionutils.ConstraintK8sGreaterEqual129.Check(pool.KubernetesVersion) {
+					Expect(string(managedResourceSecret.Data["daemonset__kube-system__"+daemonSetNameFor(pool)+".yaml"])).To(Equal(daemonSetYAMLFor(pool, values.IPVSEnabled, values.VPAEnabled, true)))
+				} else {
+					Expect(string(managedResourceSecret.Data["daemonset__kube-system__"+daemonSetNameFor(pool)+".yaml"])).To(Equal(daemonSetYAMLFor(pool, values.IPVSEnabled, values.VPAEnabled, false)))
+				}
 
 				// assertions for resources specific to the major/minor parts only of the Kubernetes version
 				managedResourceForMajorMinorVersionOnly := managedResourceForPoolForMajorMinorVersionOnly(pool)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind enhancement

**What this PR does / why we need it**:
Run kube-proxy in non-privileged mode for Kubernetes >= 1.29.
This PR follows instructions from https://github.com/kubernetes/contributor-site/blob/master/content/en/blog/2024/kube-proxy-non-privileged.md.

See #8700 for more details.

**Which issue(s) this PR fixes**:
Fixes #8700

**Special notes for your reviewer**:
~Depends on https://github.com/gardener/gardener/pull/8989, since I didn;t want to make changes to the PodSecurityPolicy's as they are anyway getting dropped.
Hence in draft.~
#8989 will be delayed, see https://github.com/gardener/gardener/pull/8989#issuecomment-1882734747

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
kube-proxy is now running in non-privileged mode for K8s >= 1.29 Shoots. The work that needs privileged mode is extracted to an init container. See https://www.kubernetes.dev/blog/2024/01/05/kube-proxy-non-privileged/.
```
