### PR TITLE
[Operator] Clean up technical debt in defaulting code

### DIFF
--- a/pkg/operator/apis/config/v1alpha1/defaults.go
+++ b/pkg/operator/apis/config/v1alpha1/defaults.go
@@ -18,17 +18,12 @@ import (
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	componentbaseconfigv1alpha1 "k8s.io/component-base/config/v1alpha1"
 	"k8s.io/utils/pointer"
 
 	gardenletv1alpha1 "github.com/gardener/gardener/pkg/gardenlet/apis/config/v1alpha1"
 	"github.com/gardener/gardener/pkg/logger"
 )
-
-func addDefaultingFuncs(scheme *runtime.Scheme) error {
-	return RegisterDefaults(scheme)
-}
 
 // SetDefaults_OperatorConfiguration sets defaults for the configuration of the Gardener operator.
 func SetDefaults_OperatorConfiguration(obj *OperatorConfiguration) {
@@ -37,14 +32,6 @@ func SetDefaults_OperatorConfiguration(obj *OperatorConfiguration) {
 	}
 	if obj.LogFormat == "" {
 		obj.LogFormat = logger.FormatJSON
-	}
-
-	if obj.Controllers.Garden.ETCDConfig == nil {
-		obj.Controllers.Garden.ETCDConfig = &gardenletv1alpha1.ETCDConfig{}
-		gardenletv1alpha1.SetDefaults_ETCDConfig(obj.Controllers.Garden.ETCDConfig)
-		gardenletv1alpha1.SetDefaults_ETCDController(obj.Controllers.Garden.ETCDConfig.ETCDController)
-		gardenletv1alpha1.SetDefaults_CustodianController(obj.Controllers.Garden.ETCDConfig.CustodianController)
-		gardenletv1alpha1.SetDefaults_BackupCompactionController(obj.Controllers.Garden.ETCDConfig.BackupCompactionController)
 	}
 }
 
@@ -105,6 +92,13 @@ func SetDefaults_GardenControllerConfig(obj *GardenControllerConfig) {
 	if obj.SyncPeriod == nil {
 		obj.SyncPeriod = &metav1.Duration{Duration: time.Hour}
 	}
+	if obj.ETCDConfig == nil {
+		obj.ETCDConfig = &gardenletv1alpha1.ETCDConfig{}
+	}
+	gardenletv1alpha1.SetDefaults_ETCDConfig(obj.ETCDConfig)
+	gardenletv1alpha1.SetDefaults_ETCDController(obj.ETCDConfig.ETCDController)
+	gardenletv1alpha1.SetDefaults_CustodianController(obj.ETCDConfig.CustodianController)
+	gardenletv1alpha1.SetDefaults_BackupCompactionController(obj.ETCDConfig.BackupCompactionController)
 }
 
 // SetDefaults_GardenCareControllerConfiguration sets defaults for the GardenCareControllerConfiguration object.

--- a/pkg/operator/apis/config/v1alpha1/defaults_test.go
+++ b/pkg/operator/apis/config/v1alpha1/defaults_test.go
@@ -114,6 +114,55 @@ var _ = Describe("Defaults", func() {
 				Burst: 130,
 			}))
 		})
+
+		It("should not overwrite already set values for RuntimeClientConnection", func() {
+			obj.RuntimeClientConnection = componentbaseconfigv1alpha1.ClientConnectionConfiguration{
+				QPS:   60.0,
+				Burst: 90,
+			}
+
+			SetObjectDefaults_OperatorConfiguration(obj)
+
+			Expect(obj.RuntimeClientConnection).To(Equal(componentbaseconfigv1alpha1.ClientConnectionConfiguration{
+				QPS:   60.0,
+				Burst: 90,
+			}))
+		})
+	})
+
+	Describe("VirtualClientConnection defaulting", func() {
+		It("should not default ContentType and AcceptContentTypes", func() {
+			SetObjectDefaults_OperatorConfiguration(obj)
+
+			// ContentType fields will be defaulted by client constructors / controller-runtime based on whether a
+			// given APIGroup supports protobuf or not. defaults must not touch these, otherwise the integelligent
+			// logic will be overwritten
+			Expect(obj.VirtualClientConnection.ContentType).To(BeEmpty())
+			Expect(obj.VirtualClientConnection.AcceptContentTypes).To(BeEmpty())
+		})
+
+		It("should correctly default VirtualClientConnection", func() {
+			SetObjectDefaults_OperatorConfiguration(obj)
+
+			Expect(obj.VirtualClientConnection).To(Equal(componentbaseconfigv1alpha1.ClientConnectionConfiguration{
+				QPS:   100.0,
+				Burst: 130,
+			}))
+		})
+
+		It("should not overwrite already set values for VirtualClientConnection", func() {
+			obj.VirtualClientConnection = componentbaseconfigv1alpha1.ClientConnectionConfiguration{
+				QPS:   60.0,
+				Burst: 90,
+			}
+
+			SetObjectDefaults_OperatorConfiguration(obj)
+
+			Expect(obj.VirtualClientConnection).To(Equal(componentbaseconfigv1alpha1.ClientConnectionConfiguration{
+				QPS:   60.0,
+				Burst: 90,
+			}))
+		})
 	})
 
 	Describe("LeaderElection defaulting", func() {
@@ -167,7 +216,6 @@ var _ = Describe("Defaults", func() {
 			})
 
 			It("should not overwrite already set values for Garden controller config", func() {
-				v := metav1.Duration{Duration: 30 * time.Second}
 				obj = &OperatorConfiguration{
 					Controllers: ControllerConfiguration{
 						Garden: GardenControllerConfig{
@@ -180,7 +228,7 @@ var _ = Describe("Defaults", func() {
 									Workers:                   pointer.Int64(4),
 									EnableBackupCompaction:    pointer.Bool(true),
 									EventsThreshold:           pointer.Int64(900000),
-									MetricsScrapeWaitDuration: &v,
+									MetricsScrapeWaitDuration: &metav1.Duration{Duration: 30 * time.Second},
 								},
 							},
 						},
@@ -196,7 +244,7 @@ var _ = Describe("Defaults", func() {
 				Expect(obj.Controllers.Garden.ETCDConfig.BackupCompactionController.Workers).To(PointTo(Equal(int64(4))))
 				Expect(obj.Controllers.Garden.ETCDConfig.BackupCompactionController.EnableBackupCompaction).To(PointTo(Equal(true)))
 				Expect(obj.Controllers.Garden.ETCDConfig.BackupCompactionController.EventsThreshold).To(PointTo(Equal(int64(900000))))
-				Expect(obj.Controllers.Garden.ETCDConfig.BackupCompactionController.MetricsScrapeWaitDuration).To(PointTo(Equal(v)))
+				Expect(obj.Controllers.Garden.ETCDConfig.BackupCompactionController.MetricsScrapeWaitDuration).To(PointTo(Equal(metav1.Duration{Duration: 30 * time.Second})))
 			})
 		})
 

--- a/pkg/operator/apis/config/v1alpha1/defaults_test.go
+++ b/pkg/operator/apis/config/v1alpha1/defaults_test.go
@@ -136,28 +136,31 @@ var _ = Describe("Defaults", func() {
 		Describe("Controller configuration", func() {
 			Describe("Garden controller", func() {
 				It("should default the object", func() {
-					obj := &GardenControllerConfig{}
+					SetObjectDefaults_OperatorConfiguration(obj)
 
-					SetDefaults_GardenControllerConfig(obj)
-
-					Expect(obj.ConcurrentSyncs).To(PointTo(Equal(1)))
-					Expect(obj.SyncPeriod).To(PointTo(Equal(metav1.Duration{Duration: time.Hour})))
+					Expect(obj.Controllers.Garden.ConcurrentSyncs).To(PointTo(Equal(1)))
+					Expect(obj.Controllers.Garden.SyncPeriod).To(PointTo(Equal(metav1.Duration{Duration: time.Hour})))
 				})
 
 				It("should not overwrite existing values", func() {
-					obj := &GardenControllerConfig{
-						ConcurrentSyncs: pointer.Int(5),
-						SyncPeriod:      &metav1.Duration{Duration: time.Second},
+					obj = &OperatorConfiguration{
+						Controllers: ControllerConfiguration{
+							Garden: GardenControllerConfig{
+								ConcurrentSyncs: pointer.Int(5),
+								SyncPeriod:      &metav1.Duration{Duration: time.Second},
+							},
+						},
 					}
 
-					SetDefaults_GardenControllerConfig(obj)
+					SetObjectDefaults_OperatorConfiguration(obj)
 
-					Expect(obj.ConcurrentSyncs).To(PointTo(Equal(5)))
-					Expect(obj.SyncPeriod).To(PointTo(Equal(metav1.Duration{Duration: time.Second})))
+					Expect(obj.Controllers.Garden.ConcurrentSyncs).To(PointTo(Equal(5)))
+					Expect(obj.Controllers.Garden.SyncPeriod).To(PointTo(Equal(metav1.Duration{Duration: time.Second})))
 				})
 
 				It("should correctly default ETCDConfig configuration", func() {
-					SetDefaults_OperatorConfiguration(obj)
+					SetObjectDefaults_OperatorConfiguration(obj)
+
 					Expect(obj.Controllers.Garden.ETCDConfig).NotTo(BeNil())
 					Expect(obj.Controllers.Garden.ETCDConfig.ETCDController).NotTo(BeNil())
 					Expect(obj.Controllers.Garden.ETCDConfig.ETCDController.Workers).To(PointTo(Equal(int64(50))))
@@ -172,21 +175,23 @@ var _ = Describe("Defaults", func() {
 
 			Describe("GardenCare controller", func() {
 				It("should default the object", func() {
-					obj := &GardenCareControllerConfiguration{}
+					SetObjectDefaults_OperatorConfiguration(obj)
 
-					SetDefaults_GardenCareControllerConfiguration(obj)
-
-					Expect(obj.SyncPeriod).To(PointTo(Equal(metav1.Duration{Duration: time.Minute})))
+					Expect(obj.Controllers.GardenCare.SyncPeriod).To(PointTo(Equal(metav1.Duration{Duration: time.Minute})))
 				})
 
 				It("should not overwrite existing values", func() {
-					obj := &GardenCareControllerConfiguration{
-						SyncPeriod: &metav1.Duration{Duration: time.Second},
+					obj = &OperatorConfiguration{
+						Controllers: ControllerConfiguration{
+							GardenCare: GardenCareControllerConfiguration{
+								SyncPeriod: &metav1.Duration{Duration: time.Second},
+							},
+						},
 					}
 
-					SetDefaults_GardenCareControllerConfiguration(obj)
+					SetObjectDefaults_OperatorConfiguration(obj)
 
-					Expect(obj.SyncPeriod).To(PointTo(Equal(metav1.Duration{Duration: time.Second})))
+					Expect(obj.Controllers.GardenCare.SyncPeriod).To(PointTo(Equal(metav1.Duration{Duration: time.Second})))
 				})
 			})
 		})

--- a/pkg/operator/apis/config/v1alpha1/defaults_test.go
+++ b/pkg/operator/apis/config/v1alpha1/defaults_test.go
@@ -100,7 +100,7 @@ var _ = Describe("Defaults", func() {
 			SetObjectDefaults_OperatorConfiguration(obj)
 
 			// ContentType fields will be defaulted by client constructors / controller-runtime based on whether a
-			// given APIGroup supports protobuf or not. defaults must not touch these, otherwise the integelligent
+			// given APIGroup supports protobuf or not. defaults must not touch these, otherwise the intelligent
 			// logic will be overwritten
 			Expect(obj.RuntimeClientConnection.ContentType).To(BeEmpty())
 			Expect(obj.RuntimeClientConnection.AcceptContentTypes).To(BeEmpty())
@@ -135,7 +135,7 @@ var _ = Describe("Defaults", func() {
 			SetObjectDefaults_OperatorConfiguration(obj)
 
 			// ContentType fields will be defaulted by client constructors / controller-runtime based on whether a
-			// given APIGroup supports protobuf or not. defaults must not touch these, otherwise the integelligent
+			// given APIGroup supports protobuf or not. defaults must not touch these, otherwise the intelligent
 			// logic will be overwritten
 			Expect(obj.VirtualClientConnection.ContentType).To(BeEmpty())
 			Expect(obj.VirtualClientConnection.AcceptContentTypes).To(BeEmpty())
@@ -213,6 +213,7 @@ var _ = Describe("Defaults", func() {
 				Expect(obj.Controllers.Garden.ETCDConfig.BackupCompactionController.Workers).To(PointTo(Equal(int64(3))))
 				Expect(obj.Controllers.Garden.ETCDConfig.BackupCompactionController.EnableBackupCompaction).To(PointTo(Equal(false)))
 				Expect(obj.Controllers.Garden.ETCDConfig.BackupCompactionController.EventsThreshold).To(PointTo(Equal(int64(1000000))))
+				Expect(obj.Controllers.Garden.ETCDConfig.BackupCompactionController.MetricsScrapeWaitDuration).To(PointTo(Equal(metav1.Duration{Duration: 60 * time.Second})))
 			})
 
 			It("should not overwrite already set values for Garden controller config", func() {

--- a/pkg/operator/apis/config/v1alpha1/defaults_test.go
+++ b/pkg/operator/apis/config/v1alpha1/defaults_test.go
@@ -24,23 +24,45 @@ import (
 	componentbaseconfigv1alpha1 "k8s.io/component-base/config/v1alpha1"
 	"k8s.io/utils/pointer"
 
+	"github.com/gardener/gardener/pkg/gardenlet/apis/config/v1alpha1"
 	"github.com/gardener/gardener/pkg/logger"
 	. "github.com/gardener/gardener/pkg/operator/apis/config/v1alpha1"
 )
 
 var _ = Describe("Defaults", func() {
-	Describe("OperatorConfiguration", func() {
-		var obj *OperatorConfiguration
+	var obj *OperatorConfiguration
 
-		BeforeEach(func() {
-			obj = &OperatorConfiguration{}
-		})
+	BeforeEach(func() {
+		obj = &OperatorConfiguration{}
+	})
 
+	Describe("OperatorConfiguration defaulting", func() {
 		It("should correctly default the configuration", func() {
 			SetObjectDefaults_OperatorConfiguration(obj)
 
 			Expect(obj.LogLevel).To(Equal(logger.InfoLevel))
 			Expect(obj.LogFormat).To(Equal(logger.FormatJSON))
+		})
+
+		It("should not overwrite already set values for OperatorConfiguration", func() {
+			var (
+				expectedLogLevel  = "foo"
+				expectedLogFormat = "bar"
+			)
+
+			obj.LogLevel = expectedLogLevel
+			obj.LogFormat = expectedLogFormat
+
+			SetObjectDefaults_OperatorConfiguration(obj)
+
+			Expect(obj.LogLevel).To(Equal(expectedLogLevel))
+			Expect(obj.LogFormat).To(Equal(expectedLogFormat))
+		})
+	})
+
+	Describe("ServerConfiguration defaulting", func() {
+		It("should correctly default the Server configuration", func() {
+			SetObjectDefaults_OperatorConfiguration(obj)
 
 			Expect(obj.Server.Webhooks.BindAddress).To(BeEmpty())
 			Expect(obj.Server.Webhooks.Port).To(Equal(2750))
@@ -50,149 +72,153 @@ var _ = Describe("Defaults", func() {
 			Expect(obj.Server.Metrics.Port).To(Equal(2752))
 		})
 
-		It("should not overwrite custom settings", func() {
-			var (
-				expectedLogLevel  = "foo"
-				expectedLogFormat = "bar"
-				expectedServer    = ServerConfiguration{
-					Webhooks: Server{
-						BindAddress: "bay",
-						Port:        3,
-					},
-					HealthProbes: &Server{
-						BindAddress: "baz",
-						Port:        1,
-					},
-					Metrics: &Server{
-						BindAddress: "bax",
-						Port:        2,
-					},
-				}
-			)
-
-			obj.LogLevel = expectedLogLevel
-			obj.LogFormat = expectedLogFormat
+		It("should not overwrite already set values for Server configuration", func() {
+			expectedServer := ServerConfiguration{
+				Webhooks: Server{
+					BindAddress: "bay",
+					Port:        3,
+				},
+				HealthProbes: &Server{
+					BindAddress: "baz",
+					Port:        1,
+				},
+				Metrics: &Server{
+					BindAddress: "bax",
+					Port:        2,
+				},
+			}
 			obj.Server = expectedServer
 
 			SetObjectDefaults_OperatorConfiguration(obj)
 
-			Expect(obj.LogLevel).To(Equal(expectedLogLevel))
-			Expect(obj.LogFormat).To(Equal(expectedLogFormat))
 			Expect(obj.Server).To(Equal(expectedServer))
 		})
+	})
 
-		Describe("RuntimeClientConnection", func() {
-			It("should not default ContentType and AcceptContentTypes", func() {
-				SetObjectDefaults_OperatorConfiguration(obj)
+	Describe("RuntimeClientConnection defaulting", func() {
+		It("should not default ContentType and AcceptContentTypes", func() {
+			SetObjectDefaults_OperatorConfiguration(obj)
 
-				// ContentType fields will be defaulted by client constructors / controller-runtime based on whether a
-				// given APIGroup supports protobuf or not. defaults must not touch these, otherwise the integelligent
-				// logic will be overwritten
-				Expect(obj.RuntimeClientConnection.ContentType).To(BeEmpty())
-				Expect(obj.RuntimeClientConnection.AcceptContentTypes).To(BeEmpty())
-			})
-
-			It("should correctly default RuntimeClientConnection", func() {
-				SetObjectDefaults_OperatorConfiguration(obj)
-
-				Expect(obj.RuntimeClientConnection).To(Equal(componentbaseconfigv1alpha1.ClientConnectionConfiguration{
-					QPS:   100.0,
-					Burst: 130,
-				}))
-			})
+			// ContentType fields will be defaulted by client constructors / controller-runtime based on whether a
+			// given APIGroup supports protobuf or not. defaults must not touch these, otherwise the integelligent
+			// logic will be overwritten
+			Expect(obj.RuntimeClientConnection.ContentType).To(BeEmpty())
+			Expect(obj.RuntimeClientConnection.AcceptContentTypes).To(BeEmpty())
 		})
 
-		Describe("leader election settings", func() {
-			It("should correctly default leader election settings", func() {
+		It("should correctly default RuntimeClientConnection", func() {
+			SetObjectDefaults_OperatorConfiguration(obj)
+
+			Expect(obj.RuntimeClientConnection).To(Equal(componentbaseconfigv1alpha1.ClientConnectionConfiguration{
+				QPS:   100.0,
+				Burst: 130,
+			}))
+		})
+	})
+
+	Describe("LeaderElection defaulting", func() {
+		It("should correctly default leader election settings", func() {
+			SetObjectDefaults_OperatorConfiguration(obj)
+
+			Expect(obj.LeaderElection).NotTo(BeNil())
+			Expect(obj.LeaderElection.LeaderElect).To(PointTo(BeTrue()))
+			Expect(obj.LeaderElection.LeaseDuration).To(Equal(metav1.Duration{Duration: 15 * time.Second}))
+			Expect(obj.LeaderElection.RenewDeadline).To(Equal(metav1.Duration{Duration: 10 * time.Second}))
+			Expect(obj.LeaderElection.RetryPeriod).To(Equal(metav1.Duration{Duration: 2 * time.Second}))
+			Expect(obj.LeaderElection.ResourceLock).To(Equal("leases"))
+			Expect(obj.LeaderElection.ResourceNamespace).To(Equal("garden"))
+			Expect(obj.LeaderElection.ResourceName).To(Equal("gardener-operator-leader-election"))
+		})
+
+		It("should not overwrite already set values for leader election settings", func() {
+			expectedLeaderElection := componentbaseconfigv1alpha1.LeaderElectionConfiguration{
+				LeaderElect:       pointer.Bool(true),
+				ResourceLock:      "foo",
+				RetryPeriod:       metav1.Duration{Duration: 40 * time.Second},
+				RenewDeadline:     metav1.Duration{Duration: 41 * time.Second},
+				LeaseDuration:     metav1.Duration{Duration: 42 * time.Second},
+				ResourceNamespace: "other-garden-ns",
+				ResourceName:      "lock-object",
+			}
+			obj.LeaderElection = expectedLeaderElection
+
+			SetObjectDefaults_OperatorConfiguration(obj)
+
+			Expect(obj.LeaderElection).To(Equal(expectedLeaderElection))
+		})
+	})
+
+	Describe("Controller configuration defaulting", func() {
+		Describe("Garden controller defaulting", func() {
+			It("should default the Garden controller config", func() {
 				SetObjectDefaults_OperatorConfiguration(obj)
 
-				Expect(obj.LeaderElection).NotTo(BeNil())
-				Expect(obj.LeaderElection.LeaderElect).To(PointTo(BeTrue()))
-				Expect(obj.LeaderElection.LeaseDuration).To(Equal(metav1.Duration{Duration: 15 * time.Second}))
-				Expect(obj.LeaderElection.RenewDeadline).To(Equal(metav1.Duration{Duration: 10 * time.Second}))
-				Expect(obj.LeaderElection.RetryPeriod).To(Equal(metav1.Duration{Duration: 2 * time.Second}))
-				Expect(obj.LeaderElection.ResourceLock).To(Equal("leases"))
-				Expect(obj.LeaderElection.ResourceNamespace).To(Equal("garden"))
-				Expect(obj.LeaderElection.ResourceName).To(Equal("gardener-operator-leader-election"))
+				Expect(obj.Controllers.Garden.ConcurrentSyncs).To(PointTo(Equal(1)))
+				Expect(obj.Controllers.Garden.SyncPeriod).To(PointTo(Equal(metav1.Duration{Duration: time.Hour})))
+				Expect(obj.Controllers.Garden.ETCDConfig).NotTo(BeNil())
+				Expect(obj.Controllers.Garden.ETCDConfig.ETCDController).NotTo(BeNil())
+				Expect(obj.Controllers.Garden.ETCDConfig.ETCDController.Workers).To(PointTo(Equal(int64(50))))
+				Expect(obj.Controllers.Garden.ETCDConfig.CustodianController).NotTo(BeNil())
+				Expect(obj.Controllers.Garden.ETCDConfig.CustodianController.Workers).To(PointTo(Equal(int64(10))))
+				Expect(obj.Controllers.Garden.ETCDConfig.BackupCompactionController).NotTo(BeNil())
+				Expect(obj.Controllers.Garden.ETCDConfig.BackupCompactionController.Workers).To(PointTo(Equal(int64(3))))
+				Expect(obj.Controllers.Garden.ETCDConfig.BackupCompactionController.EnableBackupCompaction).To(PointTo(Equal(false)))
+				Expect(obj.Controllers.Garden.ETCDConfig.BackupCompactionController.EventsThreshold).To(PointTo(Equal(int64(1000000))))
 			})
 
-			It("should not overwrite custom settings", func() {
-				expectedLeaderElection := componentbaseconfigv1alpha1.LeaderElectionConfiguration{
-					LeaderElect:       pointer.Bool(true),
-					ResourceLock:      "foo",
-					RetryPeriod:       metav1.Duration{Duration: 40 * time.Second},
-					RenewDeadline:     metav1.Duration{Duration: 41 * time.Second},
-					LeaseDuration:     metav1.Duration{Duration: 42 * time.Second},
-					ResourceNamespace: "other-garden-ns",
-					ResourceName:      "lock-object",
+			It("should not overwrite already set values for Garden controller config", func() {
+				v := metav1.Duration{Duration: 30 * time.Second}
+				obj = &OperatorConfiguration{
+					Controllers: ControllerConfiguration{
+						Garden: GardenControllerConfig{
+							ConcurrentSyncs: pointer.Int(5),
+							SyncPeriod:      &metav1.Duration{Duration: time.Second},
+							ETCDConfig: &v1alpha1.ETCDConfig{
+								ETCDController:      &v1alpha1.ETCDController{Workers: pointer.Int64(5)},
+								CustodianController: &v1alpha1.CustodianController{Workers: pointer.Int64(5)},
+								BackupCompactionController: &v1alpha1.BackupCompactionController{
+									Workers:                   pointer.Int64(4),
+									EnableBackupCompaction:    pointer.Bool(true),
+									EventsThreshold:           pointer.Int64(900000),
+									MetricsScrapeWaitDuration: &v,
+								},
+							},
+						},
+					},
 				}
-				obj.LeaderElection = expectedLeaderElection
+
 				SetObjectDefaults_OperatorConfiguration(obj)
 
-				Expect(obj.LeaderElection).To(Equal(expectedLeaderElection))
+				Expect(obj.Controllers.Garden.ConcurrentSyncs).To(PointTo(Equal(5)))
+				Expect(obj.Controllers.Garden.SyncPeriod).To(PointTo(Equal(metav1.Duration{Duration: time.Second})))
+				Expect(obj.Controllers.Garden.ETCDConfig.ETCDController.Workers).To(PointTo(Equal(int64(5))))
+				Expect(obj.Controllers.Garden.ETCDConfig.CustodianController.Workers).To(PointTo(Equal(int64(5))))
+				Expect(obj.Controllers.Garden.ETCDConfig.BackupCompactionController.Workers).To(PointTo(Equal(int64(4))))
+				Expect(obj.Controllers.Garden.ETCDConfig.BackupCompactionController.EnableBackupCompaction).To(PointTo(Equal(true)))
+				Expect(obj.Controllers.Garden.ETCDConfig.BackupCompactionController.EventsThreshold).To(PointTo(Equal(int64(900000))))
+				Expect(obj.Controllers.Garden.ETCDConfig.BackupCompactionController.MetricsScrapeWaitDuration).To(PointTo(Equal(v)))
 			})
 		})
 
-		Describe("Controller configuration", func() {
-			Describe("Garden controller", func() {
-				It("should default the object", func() {
-					SetObjectDefaults_OperatorConfiguration(obj)
+		Describe("GardenCare controller defaulting", func() {
+			It("should default the GardenCare controller config", func() {
+				SetObjectDefaults_OperatorConfiguration(obj)
 
-					Expect(obj.Controllers.Garden.ConcurrentSyncs).To(PointTo(Equal(1)))
-					Expect(obj.Controllers.Garden.SyncPeriod).To(PointTo(Equal(metav1.Duration{Duration: time.Hour})))
-				})
-
-				It("should not overwrite existing values", func() {
-					obj = &OperatorConfiguration{
-						Controllers: ControllerConfiguration{
-							Garden: GardenControllerConfig{
-								ConcurrentSyncs: pointer.Int(5),
-								SyncPeriod:      &metav1.Duration{Duration: time.Second},
-							},
-						},
-					}
-
-					SetObjectDefaults_OperatorConfiguration(obj)
-
-					Expect(obj.Controllers.Garden.ConcurrentSyncs).To(PointTo(Equal(5)))
-					Expect(obj.Controllers.Garden.SyncPeriod).To(PointTo(Equal(metav1.Duration{Duration: time.Second})))
-				})
-
-				It("should correctly default ETCDConfig configuration", func() {
-					SetObjectDefaults_OperatorConfiguration(obj)
-
-					Expect(obj.Controllers.Garden.ETCDConfig).NotTo(BeNil())
-					Expect(obj.Controllers.Garden.ETCDConfig.ETCDController).NotTo(BeNil())
-					Expect(obj.Controllers.Garden.ETCDConfig.ETCDController.Workers).To(PointTo(Equal(int64(50))))
-					Expect(obj.Controllers.Garden.ETCDConfig.CustodianController).NotTo(BeNil())
-					Expect(obj.Controllers.Garden.ETCDConfig.CustodianController.Workers).To(PointTo(Equal(int64(10))))
-					Expect(obj.Controllers.Garden.ETCDConfig.BackupCompactionController).NotTo(BeNil())
-					Expect(obj.Controllers.Garden.ETCDConfig.BackupCompactionController.Workers).To(PointTo(Equal(int64(3))))
-					Expect(obj.Controllers.Garden.ETCDConfig.BackupCompactionController.EnableBackupCompaction).To(PointTo(Equal(false)))
-					Expect(obj.Controllers.Garden.ETCDConfig.BackupCompactionController.EventsThreshold).To(PointTo(Equal(int64(1000000))))
-				})
+				Expect(obj.Controllers.GardenCare.SyncPeriod).To(PointTo(Equal(metav1.Duration{Duration: time.Minute})))
 			})
 
-			Describe("GardenCare controller", func() {
-				It("should default the object", func() {
-					SetObjectDefaults_OperatorConfiguration(obj)
-
-					Expect(obj.Controllers.GardenCare.SyncPeriod).To(PointTo(Equal(metav1.Duration{Duration: time.Minute})))
-				})
-
-				It("should not overwrite existing values", func() {
-					obj = &OperatorConfiguration{
-						Controllers: ControllerConfiguration{
-							GardenCare: GardenCareControllerConfiguration{
-								SyncPeriod: &metav1.Duration{Duration: time.Second},
-							},
+			It("should not overwrite already set values for GardenCare controller config", func() {
+				obj = &OperatorConfiguration{
+					Controllers: ControllerConfiguration{
+						GardenCare: GardenCareControllerConfiguration{
+							SyncPeriod: &metav1.Duration{Duration: time.Second},
 						},
-					}
+					},
+				}
 
-					SetObjectDefaults_OperatorConfiguration(obj)
+				SetObjectDefaults_OperatorConfiguration(obj)
 
-					Expect(obj.Controllers.GardenCare.SyncPeriod).To(PointTo(Equal(metav1.Duration{Duration: time.Second})))
-				})
+				Expect(obj.Controllers.GardenCare.SyncPeriod).To(PointTo(Equal(metav1.Duration{Duration: time.Second})))
 			})
 		})
 	})

--- a/pkg/operator/apis/config/v1alpha1/register.go
+++ b/pkg/operator/apis/config/v1alpha1/register.go
@@ -52,3 +52,7 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 	)
 	return nil
 }
+
+func addDefaultingFuncs(scheme *runtime.Scheme) error {
+	return RegisterDefaults(scheme)
+}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind technical-debt

**What this PR does / why we need it**:
This PR cleans up technical debt in our API defaulting code according to https://github.com/gardener/gardener/issues/7312.
This PR tackles the following resources in the `operator.config.gardener.cloud` API group.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/7312

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->

```other operator
NONE
```
