### PR TITLE
[Flaky Test] Run difference after eventually assert

### DIFF
--- a/pkg/utils/flow/taskfn_test.go
+++ b/pkg/utils/flow/taskfn_test.go
@@ -163,8 +163,9 @@ var _ = Describe("task functions", func() {
 						return nil
 					}
 				}
-				taskIds = sets.New("1", "2", "3", "4", "5")
-				tasks   = []flow.TaskFn{fn("1"), fn("2"), fn("3"), fn("4"), fn("5")}
+				taskIds    = sets.New("1", "2", "3", "4", "5")
+				tasks      = []flow.TaskFn{fn("1"), fn("2"), fn("3"), fn("4"), fn("5")}
+				tasksFound sets.Set[string]
 			)
 
 			go func() {
@@ -175,19 +176,19 @@ var _ = Describe("task functions", func() {
 			By("Checking active tasks after initial ParallelN call")
 			Eventually(func() int {
 				// find two of the active tasks and remove them from the ids
-				tasksFound := findTasks(taskIds, activeTasks)
-				taskIds = taskIds.Difference(tasksFound)
+				tasksFound = findTasks(taskIds, activeTasks)
 				return tasksFound.Len()
 			}).Should(Equal(n))
+			taskIds = taskIds.Difference(tasksFound)
 
 			By("Unblocking single task")
 			blockCh <- struct{}{}
 			Eventually(func() int {
 				// find the newest active task and remove it from the ids
-				tasksFound := findTasks(taskIds, activeTasks)
-				taskIds = taskIds.Difference(tasksFound)
+				tasksFound = findTasks(taskIds, activeTasks)
 				return tasksFound.Len()
 			}).Should(Equal(1))
+			taskIds = taskIds.Difference(tasksFound)
 
 			Eventually(func(g Gomega) {
 				doneTasks.Range(func(key, value any) bool {
@@ -201,10 +202,10 @@ var _ = Describe("task functions", func() {
 			blockCh <- struct{}{}
 			Eventually(func() int {
 				// find the remaining 2 active tasks and remove them from the ids
-				tasksFound := findTasks(taskIds, activeTasks)
-				taskIds = taskIds.Difference(tasksFound)
+				tasksFound = findTasks(taskIds, activeTasks)
 				return tasksFound.Len()
 			}).Should(Equal(2))
+			taskIds = taskIds.Difference(tasksFound)
 
 			Eventually(func(g Gomega) {
 				doneTasks.Range(func(key, value any) bool {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind flake

**What this PR does / why we need it**:
The removal of task ids should happen after the assertion passes. Before this PR on occasions task ids were removed one by one and the assertion never passes because it was expecting a different number of active tasks.

After the change:

```
stress -p 6 ./pkg/utils/flow/flow.test -ginkgo.focus "should run the tasks"
5s: 529 runs so far, 0 failures
10s: 1107 runs so far, 0 failures
```

**Which issue(s) this PR fixes**:
Fixes #9002 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
