### PR TITLE
Log node before printing containerd mirror logs in local setup

### DIFF
--- a/hack/kind-up.sh
+++ b/hack/kind-up.sh
@@ -123,7 +123,6 @@ setup_containerd_registry_mirrors() {
   REGISTRY_HOSTNAME="garden.local.gardener.cloud"
 
   for NODE in $(kind get nodes --name="$CLUSTER_NAME"); do
-    echo "Setting up containerd registry mirrors on node ${NODE}.";
     setup_containerd_registry_mirror $NODE "localhost:5001" "http://localhost:5001" "http://${REGISTRY_HOSTNAME}:5001"
     setup_containerd_registry_mirror $NODE "gcr.io" "https://gcr.io" "http://${REGISTRY_HOSTNAME}:5003"
     setup_containerd_registry_mirror $NODE "eu.gcr.io" "https://eu.gcr.io" "http://${REGISTRY_HOSTNAME}:5004"
@@ -141,7 +140,7 @@ setup_containerd_registry_mirror() {
   UPSTREAM_SERVER=$3
   MIRROR_HOST=$4
 
-  echo "Setting up containerd registry mirror for host ${UPSTREAM_HOST}.";
+  echo "[${NODE}] Setting up containerd registry mirror for host ${UPSTREAM_HOST}.";
   REGISTRY_DIR="/etc/containerd/certs.d/${UPSTREAM_HOST}"
   docker exec "${NODE}" mkdir -p "${REGISTRY_DIR}"
   cat <<EOF | docker exec -i "${NODE}" cp /dev/stdin "${REGISTRY_DIR}/hosts.toml"

--- a/hack/kind-up.sh
+++ b/hack/kind-up.sh
@@ -123,6 +123,7 @@ setup_containerd_registry_mirrors() {
   REGISTRY_HOSTNAME="garden.local.gardener.cloud"
 
   for NODE in $(kind get nodes --name="$CLUSTER_NAME"); do
+    echo "Setting up containerd registry mirrors on node ${NODE}.";
     setup_containerd_registry_mirror $NODE "localhost:5001" "http://localhost:5001" "http://${REGISTRY_HOSTNAME}:5001"
     setup_containerd_registry_mirror $NODE "gcr.io" "https://gcr.io" "http://${REGISTRY_HOSTNAME}:5003"
     setup_containerd_registry_mirror $NODE "eu.gcr.io" "https://eu.gcr.io" "http://${REGISTRY_HOSTNAME}:5004"


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
Log node before printing containerd mirror logs in local setup.

In multi-node local development setups, e.g. `ha-multi-zone`, the container registry mirror logs are printed multiple times, i.e. once per node. This leads to slightly confusing output like the following:

```
Setting up containerd registry mirror for host localhost:5001.
Setting up containerd registry mirror for host gcr.io.
Setting up containerd registry mirror for host eu.gcr.io.
Setting up containerd registry mirror for host ghcr.io.
Setting up containerd registry mirror for host registry.k8s.io.
Setting up containerd registry mirror for host quay.io.
Setting up containerd registry mirror for host europe-docker.pkg.dev.
Setting up containerd registry mirror for host localhost:5001.
Setting up containerd registry mirror for host gcr.io.
Setting up containerd registry mirror for host eu.gcr.io.
Setting up containerd registry mirror for host ghcr.io.
Setting up containerd registry mirror for host registry.k8s.io.
Setting up containerd registry mirror for host quay.io.
Setting up containerd registry mirror for host europe-docker.pkg.dev.
Setting up containerd registry mirror for host localhost:5001.
Setting up containerd registry mirror for host gcr.io.
Setting up containerd registry mirror for host eu.gcr.io.
Setting up containerd registry mirror for host ghcr.io.
Setting up containerd registry mirror for host registry.k8s.io.
Setting up containerd registry mirror for host quay.io.
Setting up containerd registry mirror for host europe-docker.pkg.dev.
```

This changes add another log line before the existing messages so that it is clear to which node they belong.

**Which issue(s) this PR fixes**:
None.

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
