### PR TITLE
Use managed resource for shoot cluster's envoy filter resource.

### DIFF
--- a/pkg/component/kubeapiserverexposure/kube_apiserver_sni.go
+++ b/pkg/component/kubeapiserverexposure/kube_apiserver_sni.go
@@ -42,8 +42,7 @@ import (
 	netutils "github.com/gardener/gardener/pkg/utils/net"
 )
 
-// ManagedResourceName is the name of the managed resource for the envoy filter.
-const ManagedResourceName = "kube-apiserver-sni"
+const managedResourceName = "kube-apiserver-sni"
 
 var (
 	//go:embed templates/envoyfilter.yaml
@@ -146,10 +145,10 @@ func (s *sni) Deploy(ctx context.Context) error {
 			return err
 		}
 
-		filename := fmt.Sprintf("envoyfilter__%s__%s.yaml", envoyFilter.Namespace, s.namespace)
+		filename := fmt.Sprintf("envoyfilter__%s__%s.yaml", envoyFilter.Namespace, envoyFilter.Name)
 		registry := managedresources.NewRegistry(kubernetes.SeedScheme, kubernetes.SeedCodec, kubernetes.SeedSerializer)
 		registry.AddSerialized(filename, envoyFilterSpec.Bytes())
-		if err := managedresources.CreateForSeed(ctx, s.client, s.namespace, ManagedResourceName, false, registry.SerializedObjects()); err != nil {
+		if err := managedresources.CreateForSeed(ctx, s.client, s.namespace, managedResourceName, false, registry.SerializedObjects()); err != nil {
 			return err
 		}
 	}
@@ -238,7 +237,7 @@ func (s *sni) Deploy(ctx context.Context) error {
 }
 
 func (s *sni) Destroy(ctx context.Context) error {
-	if err := managedresources.DeleteForSeed(ctx, s.client, s.namespace, ManagedResourceName); err != nil {
+	if err := managedresources.DeleteForSeed(ctx, s.client, s.namespace, managedResourceName); err != nil {
 		return err
 	}
 

--- a/pkg/component/kubeapiserverexposure/kube_apiserver_sni_test.go
+++ b/pkg/component/kubeapiserverexposure/kube_apiserver_sni_test.go
@@ -201,7 +201,7 @@ var _ = Describe("#SNI", func() {
 				Kind:       "ManagedResource",
 			},
 			ObjectMeta: metav1.ObjectMeta{
-				Name:            ManagedResourceName,
+				Name:            "kube-apiserver-sni",
 				Namespace:       namespace,
 				ResourceVersion: "1",
 				Labels:          map[string]string{"gardener.cloud/role": "seed-system-component"},
@@ -259,6 +259,7 @@ var _ = Describe("#SNI", func() {
 
 				managedResourceEnvoyFilter, _, err := kubernetes.ShootCodec.UniversalDecoder().Decode(managedResourceSecret.Data["envoyfilter__istio-foo__test-namespace.yaml"], nil, &istionetworkingv1alpha3.EnvoyFilter{})
 				Expect(err).ToNot(HaveOccurred())
+				Expect(managedResourceEnvoyFilter.GetObjectKind()).To(Equal(&metav1.TypeMeta{Kind: "EnvoyFilter", APIVersion: "networking.istio.io/v1alpha3"}))
 				actualEnvoyFilter := managedResourceEnvoyFilter.(*istionetworkingv1alpha3.EnvoyFilter)
 				// cannot validate the Spec as there is no meaningful way to unmarshal the data into the Golang structure
 				Expect(actualEnvoyFilter.ObjectMeta).To(DeepEqual(expectedEnvoyFilterObjectMeta))

--- a/pkg/component/kubeapiserverexposure/kube_apiserver_sni_test.go
+++ b/pkg/component/kubeapiserverexposure/kube_apiserver_sni_test.go
@@ -24,31 +24,30 @@ import (
 	istioapinetworkingv1beta1 "istio.io/api/networking/v1beta1"
 	istionetworkingv1alpha3 "istio.io/client-go/pkg/apis/networking/v1alpha3"
 	istionetworkingv1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/version"
-	fakediscovery "k8s.io/client-go/discovery/fake"
-	"k8s.io/client-go/testing"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
-	"github.com/gardener/gardener/pkg/client/kubernetes/test"
 	"github.com/gardener/gardener/pkg/component"
 	. "github.com/gardener/gardener/pkg/component/kubeapiserverexposure"
 	comptest "github.com/gardener/gardener/pkg/component/test"
+	"github.com/gardener/gardener/pkg/resourcemanager/controller/garbagecollector/references"
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 )
 
 var _ = Describe("#SNI", func() {
 	var (
-		ctx     context.Context
-		c       client.Client
-		applier kubernetes.Applier
+		ctx context.Context
+		c   client.Client
 
 		defaultDepWaiter component.DeployWaiter
 		namespace        = "test-namespace"
@@ -64,12 +63,15 @@ var _ = Describe("#SNI", func() {
 		expectedGateway               *istionetworkingv1beta1.Gateway
 		expectedVirtualService        *istionetworkingv1beta1.VirtualService
 		expectedEnvoyFilterObjectMeta metav1.ObjectMeta
+		expectedManagedResource       *resourcesv1alpha1.ManagedResource
 	)
 
 	BeforeEach(func() {
 		ctx = context.TODO()
 
 		s := runtime.NewScheme()
+		Expect(corev1.AddToScheme(s)).To(Succeed())
+		Expect(resourcesv1alpha1.AddToScheme(s)).To(Succeed())
 		Expect(istionetworkingv1beta1.AddToScheme(s)).To(Succeed())
 		Expect(istionetworkingv1alpha3.AddToScheme(s)).To(Succeed())
 		c = fake.NewClientBuilder().WithScheme(s).Build()
@@ -77,13 +79,6 @@ var _ = Describe("#SNI", func() {
 			APIServerClusterIP: "1.1.1.1",
 			NamespaceUID:       namespaceUID,
 		}
-
-		var err error
-		applier, err = test.NewTestApplier(c, &fakediscovery.FakeDiscovery{
-			Fake:               &testing.Fake{},
-			FakedServerVersion: &version.Info{GitVersion: "v1.25.0"},
-		})
-		Expect(err).NotTo(HaveOccurred())
 
 		expectedDestinationRule = &istionetworkingv1beta1.DestinationRule{
 			TypeMeta: metav1.TypeMeta{
@@ -138,7 +133,6 @@ var _ = Describe("#SNI", func() {
 				BlockOwnerDeletion: pointer.Bool(false),
 				Controller:         pointer.Bool(false),
 			}},
-			ResourceVersion: "1",
 		}
 		expectedGateway = &istionetworkingv1beta1.Gateway{
 			TypeMeta: metav1.TypeMeta{
@@ -201,10 +195,26 @@ var _ = Describe("#SNI", func() {
 				}},
 			},
 		}
+		expectedManagedResource = &resourcesv1alpha1.ManagedResource{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: resourcesv1alpha1.SchemeGroupVersion.String(),
+				Kind:       "ManagedResource",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            ManagedResourceName,
+				Namespace:       namespace,
+				ResourceVersion: "1",
+				Labels:          map[string]string{"gardener.cloud/role": "seed-system-component"},
+			},
+			Spec: resourcesv1alpha1.ManagedResourceSpec{
+				Class:       pointer.String("seed"),
+				KeepObjects: pointer.Bool(false),
+			},
+		}
 	})
 
 	JustBeforeEach(func() {
-		defaultDepWaiter = NewSNI(c, applier, v1beta1constants.DeploymentNameKubeAPIServer, namespace, func() *SNIValues {
+		defaultDepWaiter = NewSNI(c, v1beta1constants.DeploymentNameKubeAPIServer, namespace, func() *SNIValues {
 			val := &SNIValues{
 				Hosts:          hosts,
 				APIServerProxy: apiServerProxyValues,
@@ -234,8 +244,22 @@ var _ = Describe("#SNI", func() {
 			Expect(actualVirtualService).To(BeComparableTo(expectedVirtualService, comptest.CmpOptsForVirtualService()))
 
 			if apiServerProxyValues != nil {
-				actualEnvoyFilter := &istionetworkingv1alpha3.EnvoyFilter{}
-				Expect(c.Get(ctx, kubernetesutils.Key(expectedEnvoyFilterObjectMeta.Namespace, expectedEnvoyFilterObjectMeta.Name), actualEnvoyFilter)).To(Succeed())
+				managedResource := &resourcesv1alpha1.ManagedResource{}
+				Expect(c.Get(ctx, kubernetesutils.Key(expectedManagedResource.Namespace, expectedManagedResource.Name), managedResource)).To(Succeed())
+				expectedManagedResource.Spec.SecretRefs = []corev1.LocalObjectReference{{Name: managedResource.Spec.SecretRefs[0].Name}}
+				utilruntime.Must(references.InjectAnnotations(expectedManagedResource))
+				Expect(managedResource).To(DeepEqual(expectedManagedResource))
+
+				managedResourceSecret := &corev1.Secret{}
+				Expect(c.Get(ctx, kubernetesutils.Key(expectedManagedResource.Namespace, expectedManagedResource.Spec.SecretRefs[0].Name), managedResourceSecret)).To(Succeed())
+				Expect(managedResourceSecret.Type).To(Equal(corev1.SecretTypeOpaque))
+				Expect(managedResourceSecret.Data).To(HaveLen(1))
+				Expect(managedResourceSecret.Immutable).To(Equal(pointer.Bool(true)))
+				Expect(managedResourceSecret.Labels["resources.gardener.cloud/garbage-collectable-reference"]).To(Equal("true"))
+
+				managedResourceEnvoyFilter, _, err := kubernetes.ShootCodec.UniversalDecoder().Decode(managedResourceSecret.Data["envoyfilter__istio-foo__test-namespace.yaml"], nil, &istionetworkingv1alpha3.EnvoyFilter{})
+				Expect(err).ToNot(HaveOccurred())
+				actualEnvoyFilter := managedResourceEnvoyFilter.(*istionetworkingv1alpha3.EnvoyFilter)
 				// cannot validate the Spec as there is no meaningful way to unmarshal the data into the Golang structure
 				Expect(actualEnvoyFilter.ObjectMeta).To(DeepEqual(expectedEnvoyFilterObjectMeta))
 			}
@@ -264,14 +288,18 @@ var _ = Describe("#SNI", func() {
 		Expect(c.Get(ctx, kubernetesutils.Key(expectedDestinationRule.Namespace, expectedDestinationRule.Name), &istionetworkingv1beta1.DestinationRule{})).To(Succeed())
 		Expect(c.Get(ctx, kubernetesutils.Key(expectedGateway.Namespace, expectedGateway.Name), &istionetworkingv1beta1.Gateway{})).To(Succeed())
 		Expect(c.Get(ctx, kubernetesutils.Key(expectedVirtualService.Namespace, expectedVirtualService.Name), &istionetworkingv1beta1.VirtualService{})).To(Succeed())
-		Expect(c.Get(ctx, kubernetesutils.Key(expectedEnvoyFilterObjectMeta.Namespace, expectedEnvoyFilterObjectMeta.Name), &istionetworkingv1alpha3.EnvoyFilter{})).To(Succeed())
+		managedResource := &resourcesv1alpha1.ManagedResource{}
+		Expect(c.Get(ctx, kubernetesutils.Key(expectedManagedResource.Namespace, expectedManagedResource.Name), managedResource)).To(Succeed())
+		managedResourceSecretName := managedResource.Spec.SecretRefs[0].Name
+		Expect(c.Get(ctx, kubernetesutils.Key(expectedManagedResource.Namespace, managedResourceSecretName), &corev1.Secret{})).To(Succeed())
 
 		Expect(defaultDepWaiter.Destroy(ctx)).To(Succeed())
 
 		Expect(c.Get(ctx, kubernetesutils.Key(expectedDestinationRule.Namespace, expectedDestinationRule.Name), &istionetworkingv1beta1.DestinationRule{})).To(BeNotFoundError())
 		Expect(c.Get(ctx, kubernetesutils.Key(expectedGateway.Namespace, expectedGateway.Name), &istionetworkingv1beta1.Gateway{})).To(BeNotFoundError())
 		Expect(c.Get(ctx, kubernetesutils.Key(expectedVirtualService.Namespace, expectedVirtualService.Name), &istionetworkingv1beta1.VirtualService{})).To(BeNotFoundError())
-		Expect(c.Get(ctx, kubernetesutils.Key(expectedEnvoyFilterObjectMeta.Namespace, expectedEnvoyFilterObjectMeta.Name), &istionetworkingv1alpha3.EnvoyFilter{})).To(BeNotFoundError())
+		Expect(c.Get(ctx, kubernetesutils.Key(expectedManagedResource.Namespace, expectedManagedResource.Name), managedResource)).To(BeNotFoundError())
+		Expect(c.Get(ctx, kubernetesutils.Key(expectedManagedResource.Namespace, managedResourceSecretName), &corev1.Secret{})).To(BeNotFoundError())
 	})
 
 	Describe("#Wait", func() {

--- a/pkg/operation/botanist/kubeapiserverexposure.go
+++ b/pkg/operation/botanist/kubeapiserverexposure.go
@@ -59,7 +59,6 @@ func (b *Botanist) ShootUsesDNS() bool {
 func (b *Botanist) DefaultKubeAPIServerSNI() component.DeployWaiter {
 	return component.OpDestroyWithoutWait(kubeapiserverexposure.NewSNI(
 		b.SeedClientSet.Client(),
-		b.SeedClientSet.Applier(),
 		v1beta1constants.DeploymentNameKubeAPIServer,
 		b.Shoot.SeedNamespace,
 		func() *kubeapiserverexposure.SNIValues {
@@ -82,7 +81,6 @@ func (b *Botanist) setAPIServerServiceClusterIP(clusterIP string) {
 	b.APIServerClusterIP = clusterIP
 	b.Shoot.Components.ControlPlane.KubeAPIServerSNI = kubeapiserverexposure.NewSNI(
 		b.SeedClientSet.Client(),
-		b.SeedClientSet.Applier(),
 		v1beta1constants.DeploymentNameKubeAPIServer,
 		b.Shoot.SeedNamespace,
 		func() *kubeapiserverexposure.SNIValues {

--- a/pkg/operator/controller/garden/garden/components.go
+++ b/pkg/operator/controller/garden/garden/components.go
@@ -733,7 +733,6 @@ func (r *Reconciler) newSNI(garden *operatorv1alpha1.Garden, ingressGatewayValue
 
 	return kubeapiserverexposure.NewSNI(
 		r.RuntimeClientSet.Client(),
-		r.RuntimeClientSet.Applier(),
 		namePrefix+v1beta1constants.DeploymentNameKubeAPIServer,
 		r.GardenNamespace,
 		func() *kubeapiserverexposure.SNIValues {

--- a/test/utils/shoots/update/highavailability/upgrade.go
+++ b/test/utils/shoots/update/highavailability/upgrade.go
@@ -178,17 +178,18 @@ func DeployZeroDownTimeValidatorJob(ctx context.Context, c client.Client, testNa
 }
 
 func verifyEnvoyFilterInIstioNamespace(ctx context.Context, seedClient kubernetes.Interface, shootName string) {
-	filteredList := []*istionetworkingv1alpha3.EnvoyFilter{}
+	var filteredList []*istionetworkingv1alpha3.EnvoyFilter
 	CEventually(ctx, func(g Gomega) {
 		envoyFilters := &istionetworkingv1alpha3.EnvoyFilterList{}
-		Expect(seedClient.Client().List(ctx, envoyFilters)).To(Succeed(), "trying to list envoy filters, but did not succeed.")
+		g.Expect(seedClient.Client().List(ctx, envoyFilters)).To(Succeed(), "trying to list envoy filters, but did not succeed.")
+		filteredList = []*istionetworkingv1alpha3.EnvoyFilter{}
 		for _, filter := range envoyFilters.Items {
 			if filter.Name != shootName {
 				continue
 			}
 			filteredList = append(filteredList, filter)
 		}
-		Expect(filteredList).To(HaveLen(1))
+		g.Expect(filteredList).To(HaveLen(1))
 	}).Should(Succeed())
 	Expect(filteredList[0].Namespace).To(HavePrefix("istio-ingress"))
 }

--- a/test/utils/shoots/update/highavailability/upgrade.go
+++ b/test/utils/shoots/update/highavailability/upgrade.go
@@ -187,6 +187,10 @@ func verifyEnvoyFilterInIstioNamespace(ctx context.Context, seedClient kubernete
 			if filter.Name != shootName {
 				continue
 			}
+			// Old Gardener releases do not manage the envoy filter and hence we may end up with one managed and one unmanaged filter
+			if filter.Labels["resources.gardener.cloud/managed-by"] != "gardener" {
+				continue
+			}
 			filteredList = append(filteredList, filter)
 		}
 		g.Expect(filteredList).To(HaveLen(1))

--- a/test/utils/shoots/update/highavailability/upgrade.go
+++ b/test/utils/shoots/update/highavailability/upgrade.go
@@ -40,7 +40,7 @@ import (
 
 // UpgradeAndVerify runs the HA control-plane upgrade tests for an existing shoot cluster.
 func UpgradeAndVerify(ctx context.Context, f *framework.ShootFramework, failureToleranceType gardencorev1beta1.FailureToleranceType) {
-	verifyEnvoyFilterInIstioNamespace(ctx, f.SeedClient, f.ShootSeedNamespace(), false)
+	verifyEnvoyFilterInIstioNamespace(ctx, f.SeedClient, f.ShootSeedNamespace())
 	By("Update Shoot control plane to HA with failure tolerance type " + string(failureToleranceType))
 	Expect(f.UpdateShoot(ctx, func(shoot *gardencorev1beta1.Shoot) error {
 		shoot.Spec.ControlPlane = &gardencorev1beta1.ControlPlane{
@@ -56,7 +56,7 @@ func UpgradeAndVerify(ctx context.Context, f *framework.ShootFramework, failureT
 	By("Verify Shoot's control plane components")
 	verifyTopologySpreadConstraint(ctx, f.SeedClient, f.Shoot, f.ShootSeedNamespace())
 	verifyEtcdAffinity(ctx, f.SeedClient, f.Shoot, f.ShootSeedNamespace())
-	verifyEnvoyFilterInIstioNamespace(ctx, f.SeedClient, f.ShootSeedNamespace(), failureToleranceType == gardencorev1beta1.FailureToleranceTypeZone)
+	verifyEnvoyFilterInIstioNamespace(ctx, f.SeedClient, f.ShootSeedNamespace())
 }
 
 func verifyTopologySpreadConstraint(ctx context.Context, seedClient kubernetes.Interface, shoot *gardencorev1beta1.Shoot, namespace string) {
@@ -176,21 +176,18 @@ func DeployZeroDownTimeValidatorJob(ctx context.Context, c client.Client, testNa
 	return &job, c.Create(ctx, &job)
 }
 
-func verifyEnvoyFilterInIstioNamespace(ctx context.Context, seedClient kubernetes.Interface, shootName string, multiZone bool) {
-	envoyFilters := &istionetworkingv1alpha3.EnvoyFilterList{}
-	Expect(seedClient.Client().List(ctx, envoyFilters)).To(Succeed(), "trying to list envoy filters, but did not succeed.")
+func verifyEnvoyFilterInIstioNamespace(ctx context.Context, seedClient kubernetes.Interface, shootName string) {
 	filteredList := []*istionetworkingv1alpha3.EnvoyFilter{}
-	for _, filter := range envoyFilters.Items {
-		if filter.Name != shootName {
-			continue
+	Eventually(func(g Gomega) {
+		envoyFilters := &istionetworkingv1alpha3.EnvoyFilterList{}
+		Expect(seedClient.Client().List(ctx, envoyFilters)).To(Succeed(), "trying to list envoy filters, but did not succeed.")
+		for _, filter := range envoyFilters.Items {
+			if filter.Name != shootName {
+				continue
+			}
+			filteredList = append(filteredList, filter)
 		}
-		filteredList = append(filteredList, filter)
-	}
-	Expect(filteredList).To(HaveLen(1))
-	if multiZone {
-		Expect(filteredList[0].Namespace).To(Equal("istio-ingress"))
-	} else {
-		// zonal istio ingress gateway namespaces are called istio-ingress--<zone>
-		Expect(filteredList[0].Namespace).To(HavePrefix("istio-ingress--"))
-	}
+		Expect(filteredList).To(HaveLen(1))
+	}).Should(Succeed())
+	Expect(filteredList[0].Namespace).To(HavePrefix("istio-ingress"))
 }

--- a/test/utils/shoots/update/highavailability/upgrade.go
+++ b/test/utils/shoots/update/highavailability/upgrade.go
@@ -35,6 +35,7 @@ import (
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	kubeapiserverconstants "github.com/gardener/gardener/pkg/component/kubeapiserver/constants"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
+	. "github.com/gardener/gardener/pkg/utils/test"
 	"github.com/gardener/gardener/test/framework"
 )
 
@@ -178,7 +179,7 @@ func DeployZeroDownTimeValidatorJob(ctx context.Context, c client.Client, testNa
 
 func verifyEnvoyFilterInIstioNamespace(ctx context.Context, seedClient kubernetes.Interface, shootName string) {
 	filteredList := []*istionetworkingv1alpha3.EnvoyFilter{}
-	Eventually(func(g Gomega) {
+	CEventually(ctx, func(g Gomega) {
 		envoyFilters := &istionetworkingv1alpha3.EnvoyFilterList{}
 		Expect(seedClient.Client().List(ctx, envoyFilters)).To(Succeed(), "trying to list envoy filters, but did not succeed.")
 		for _, filter := range envoyFilters.Items {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/area high-availability
/area ops-productivity
/kind cleanup

**What this PR does / why we need it**:
Use managed resource for shoot cluster's envoy filter resource.

To implement `kubernetes.default.svc.cluster.local` the SNI approach uses `apiserver-proxy` component in the shoot cluster and an envoy filter on the seed. Unfortunately, istio requires the envoy filter to be deployed in the istio ingress gateway namespace even though it semantically belongs to the shoot cluster control plane.
With the high-availability support in Gardener, the istio ingress gateway responsible for shoot cluster control plane may change when it is upgraded to be multi-zonal. Previously, the necessary envoy filter was created in the new target namespace, but the old one was left as is. (It would be deleted eventually when the shoot cluster would be deleted due to an owner reference.)
This could be confusing. Therefore, this change moves the envoy filter into a managed resource thereby ensuring that a move will automatically delete the old resource. The result will be that only the current version will be there for new clusters.
(This change does not handle existing envoy filters that could be deleted. Operators are expected to delete them eventually or wait for the shoot clusters to be deleted, which also cleans up the envoy filters.)

**Which issue(s) this PR fixes**:
Fixes #8982 

**Special notes for your reviewer**:
This change does not handle existing envoy filters that could be deleted. Operators are expected to delete them eventually or wait for the shoot clusters to be deleted, which also cleans up the envoy filters.

Feel free to comment if you think this is not sufficient.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
When upgrading a shoot control plane to multi-zonal high-availability there will no longer be an envoy filter left in the old istio ingress namespace
```
