### PR TITLE
Allow shoot clusters without connectivity to alpine repositories to work as expected

### DIFF
--- a/imagevector/images.go
+++ b/imagevector/images.go
@@ -23,6 +23,8 @@ const (
 	ImageNameAlertmanager = "alertmanager"
 	// ImageNameAlpine is a constant for an image in the image vector with name 'alpine'.
 	ImageNameAlpine = "alpine"
+	// ImageNameAlpineConntrack is a constant for an image in the image vector with name 'alpine-conntrack'.
+	ImageNameAlpineConntrack = "alpine-conntrack"
 	// ImageNameApiserverProxy is a constant for an image in the image vector with name 'apiserver-proxy'.
 	ImageNameApiserverProxy = "apiserver-proxy"
 	// ImageNameApiserverProxySidecar is a constant for an image in the image vector with name 'apiserver-proxy-sidecar'.

--- a/imagevector/images.yaml
+++ b/imagevector/images.yaml
@@ -354,6 +354,9 @@ images:
 - name: alpine
   repository: europe-docker.pkg.dev/gardener-project/releases/3rd/alpine
   tag: "3.18.4"
+- name: alpine-conntrack
+  repository: europe-docker.pkg.dev/gardener-project/releases/gardener/alpine-conntrack
+  tag: "3.18.4"
 
 # Logging
 - name: fluent-operator

--- a/imagevector/images.yaml
+++ b/imagevector/images.yaml
@@ -355,6 +355,7 @@ images:
   repository: europe-docker.pkg.dev/gardener-project/releases/3rd/alpine
   tag: "3.18.4"
 - name: alpine-conntrack
+  sourceRepository: github.com/gardener/alpine-conntrack
   repository: europe-docker.pkg.dev/gardener-project/releases/gardener/alpine-conntrack
   tag: "3.18.4"
 

--- a/pkg/component/kubeproxy/kube_proxy_test.go
+++ b/pkg/component/kubeproxy/kube_proxy_test.go
@@ -307,7 +307,7 @@ metadata:
 				return out
 			}
 
-			configMapConntrackFixScriptName = "kube-proxy-conntrack-fix-script-ebff3d39" //40092541"
+			configMapConntrackFixScriptName = "kube-proxy-conntrack-fix-script-ebff3d39"
 			configMapConntrackFixScriptYAML = `apiVersion: v1
 data:
   conntrack_fix.sh: |

--- a/pkg/component/kubeproxy/kube_proxy_test.go
+++ b/pkg/component/kubeproxy/kube_proxy_test.go
@@ -313,7 +313,6 @@ data:
   conntrack_fix.sh: |
     #!/bin/sh -e
     trap "kill -s INT 1" TERM
-    apk add conntrack-tools
     sleep 120 & wait
     date
     # conntrack example:

--- a/pkg/component/kubeproxy/kube_proxy_test.go
+++ b/pkg/component/kubeproxy/kube_proxy_test.go
@@ -307,7 +307,7 @@ metadata:
 				return out
 			}
 
-			configMapConntrackFixScriptName = "kube-proxy-conntrack-fix-script-40092541"
+			configMapConntrackFixScriptName = "kube-proxy-conntrack-fix-script-ebff3d39" //40092541"
 			configMapConntrackFixScriptYAML = `apiVersion: v1
 data:
   conntrack_fix.sh: |
@@ -465,16 +465,16 @@ subjects:
 
 					if ipvsEnabled {
 						annotations = []string{
-							references.AnnotationKey(references.KindConfigMap, configMapConntrackFixScriptName) + `: ` + configMapConntrackFixScriptName,
 							references.AnnotationKey(references.KindConfigMap, configMapCleanupScriptName) + `: ` + configMapCleanupScriptName,
 							references.AnnotationKey(references.KindConfigMap, configMapNameFor(ipvsEnabled)) + `: ` + configMapNameFor(ipvsEnabled),
+							references.AnnotationKey(references.KindConfigMap, configMapConntrackFixScriptName) + `: ` + configMapConntrackFixScriptName,
 							references.AnnotationKey(references.KindSecret, secretName) + `: ` + secretName,
 						}
 					} else {
 						annotations = []string{
-							references.AnnotationKey(references.KindConfigMap, configMapConntrackFixScriptName) + `: ` + configMapConntrackFixScriptName,
 							references.AnnotationKey(references.KindConfigMap, configMapCleanupScriptName) + `: ` + configMapCleanupScriptName,
 							references.AnnotationKey(references.KindConfigMap, configMapNameFor(ipvsEnabled)) + `: ` + configMapNameFor(ipvsEnabled),
+							references.AnnotationKey(references.KindConfigMap, configMapConntrackFixScriptName) + `: ` + configMapConntrackFixScriptName,
 							references.AnnotationKey(references.KindSecret, secretName) + `: ` + secretName,
 						}
 					}

--- a/pkg/component/kubeproxy/resources/conntrack-fix.sh
+++ b/pkg/component/kubeproxy/resources/conntrack-fix.sh
@@ -1,6 +1,5 @@
 #!/bin/sh -e
 trap "kill -s INT 1" TERM
-apk add conntrack-tools
 sleep 120 & wait
 date
 # conntrack example:

--- a/pkg/operation/botanist/kubeproxy.go
+++ b/pkg/operation/botanist/kubeproxy.go
@@ -36,7 +36,7 @@ import (
 
 // DefaultKubeProxy returns a deployer for the kube-proxy.
 func (b *Botanist) DefaultKubeProxy() (kubeproxy.Interface, error) {
-	imageAlpine, err := imagevector.ImageVector().FindImage(imagevector.ImageNameAlpine, imagevectorutils.RuntimeVersion(b.ShootVersion()), imagevectorutils.TargetVersion(b.ShootVersion()))
+	imageAlpine, err := imagevector.ImageVector().FindImage(imagevector.ImageNameAlpineConntrack, imagevectorutils.RuntimeVersion(b.ShootVersion()), imagevectorutils.TargetVersion(b.ShootVersion()))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/area compliance
/area cost
/area security
/kind enhancement

**What this PR does / why we need it**:
Allow shoot clusters without connectivity to alpine repositories to work as expected.

Previously, the conntrack side car container of kube-proxy installed the conntrack tools during its runtime dynamically. This is bad for various reasons, e.g. compliance, immutability or traffic costs.
Now, we use a pre-built container images already including the conntrack tools.

**Which issue(s) this PR fixes**:
None.

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
kube-proxy's sidecar container no longer installs its tools at runtime, but comes with its toolset pre-installed.
```
