### PR TITLE
Enhance `Ensure_` functions from `extensions/pkg/webhook` package

### DIFF
--- a/extensions/pkg/webhook/controlplane/test/matchers.go
+++ b/extensions/pkg/webhook/controlplane/test/matchers.go
@@ -18,6 +18,8 @@ import (
 	"fmt"
 	"strings"
 
+	"slices"
+
 	"github.com/onsi/gomega/types"
 
 	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
@@ -48,7 +50,9 @@ func (m *containElementWithPrefixContainingMatcher) Match(actual interface{}) (s
 		return false, nil
 	}
 	values := strings.Split(strings.TrimPrefix(items[i], m.prefix), m.sep)
-	j := extensionswebhook.StringIndex(values, m.value)
+	j := slices.IndexFunc(values, func(s string) bool {
+		return s == m.value
+	})
 	return j >= 0, nil
 }
 

--- a/extensions/pkg/webhook/controlplane/test/matchers.go
+++ b/extensions/pkg/webhook/controlplane/test/matchers.go
@@ -16,9 +16,8 @@ package test
 
 import (
 	"fmt"
-	"strings"
-
 	"slices"
+	"strings"
 
 	"github.com/onsi/gomega/types"
 

--- a/extensions/pkg/webhook/controlplane/test/matchers.go
+++ b/extensions/pkg/webhook/controlplane/test/matchers.go
@@ -50,10 +50,7 @@ func (m *containElementWithPrefixContainingMatcher) Match(actual interface{}) (s
 		return false, nil
 	}
 	values := strings.Split(strings.TrimPrefix(items[i], m.prefix), m.sep)
-	j := slices.IndexFunc(values, func(s string) bool {
-		return s == m.value
-	})
-	return j >= 0, nil
+	return slices.Index(values, m.value) >= 0, nil
 }
 
 func (m *containElementWithPrefixContainingMatcher) FailureMessage(actual interface{}) (message string) {

--- a/extensions/pkg/webhook/utils.go
+++ b/extensions/pkg/webhook/utils.go
@@ -19,6 +19,8 @@ import (
 	"regexp"
 	"strings"
 
+	"slices"
+
 	"github.com/coreos/go-systemd/v22/unit"
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
@@ -65,70 +67,91 @@ func SerializeCommandLine(command []string, n int, sep string) string {
 
 // ContainerWithName returns the container with the given name if it exists in the given slice, nil otherwise.
 func ContainerWithName(containers []corev1.Container, name string) *corev1.Container {
-	if i := containerWithNameIndex(containers, name); i >= 0 {
-		return &containers[i]
+	for _, container := range containers {
+		if container.Name == name {
+			return &container
+		}
 	}
 	return nil
 }
 
 // PVCWithName returns the PersistentVolumeClaim with the given name if it exists in the given slice, nil otherwise.
 func PVCWithName(pvcs []corev1.PersistentVolumeClaim, name string) *corev1.PersistentVolumeClaim {
-	if i := pvcWithNameIndex(pvcs, name); i >= 0 {
-		return &pvcs[i]
+	for _, pvc := range pvcs {
+		if pvc.Name == name {
+			return &pvc
+		}
 	}
 	return nil
 }
 
 // UnitWithName returns the unit with the given name if it exists in the given slice, nil otherwise.
 func UnitWithName(units []extensionsv1alpha1.Unit, name string) *extensionsv1alpha1.Unit {
-	if i := unitWithNameIndex(units, name); i >= 0 {
-		return &units[i]
+	for _, unit := range units {
+		if unit.Name == name {
+			return &unit
+		}
 	}
 	return nil
 }
 
 // FileWithPath returns the file with the given path if it exists in the given slice, nil otherwise.
 func FileWithPath(files []extensionsv1alpha1.File, path string) *extensionsv1alpha1.File {
-	if i := fileWithPathIndex(files, path); i >= 0 {
-		return &files[i]
+	for _, file := range files {
+		if file.Path == path {
+			return &file
+		}
 	}
 	return nil
 }
 
 // UnitOptionWithSectionAndName returns the unit option with the given section and name if it exists in the given slice, nil otherwise.
 func UnitOptionWithSectionAndName(opts []*unit.UnitOption, section, name string) *unit.UnitOption {
-	if i := unitOptionWithSectionAndNameIndex(opts, section, name); i >= 0 {
-		return opts[i]
+	for _, opt := range opts {
+		if opt.Section == section && opt.Name == name {
+			return opt
+		}
 	}
+
 	return nil
 }
 
 // EnsureStringWithPrefix ensures that a string having the given prefix exists in the given slice
-// with a value equal to prefix + value.
+// and all matches are with a value equal to prefix + value.
 func EnsureStringWithPrefix(items []string, prefix, value string) []string {
-	item := prefix + value
 	if i := StringWithPrefixIndex(items, prefix); i < 0 {
-		items = append(items, item)
-	} else if items[i] != item {
-		items = append(append(items[:i], item), items[i+1:]...)
+		return append(items, prefix+value)
+	}
+
+	for i, item := range items {
+		if !strings.HasPrefix(item, prefix) {
+			continue
+		}
+		if item != prefix+value {
+			items = append(append(items[:i], prefix+value), items[i+1:]...)
+		}
 	}
 	return items
 }
 
 // EnsureNoStringWithPrefix ensures that a string having the given prefix does not exist in the given slice.
 func EnsureNoStringWithPrefix(items []string, prefix string) []string {
-	if i := StringWithPrefixIndex(items, prefix); i >= 0 {
-		items = append(items[:i], items[i+1:]...)
-	}
-	return items
+	return slices.DeleteFunc(items, func(s string) bool {
+		return strings.HasPrefix(s, prefix)
+	})
 }
 
 // EnsureStringWithPrefixContains ensures that a string having the given prefix exists in the given slice
-// and contains the given value in a list separated by sep.
+// and all matches contain the given value in a list separated by sep.
 func EnsureStringWithPrefixContains(items []string, prefix, value, sep string) []string {
 	if i := StringWithPrefixIndex(items, prefix); i < 0 {
-		items = append(items, prefix+value)
-	} else {
+		return append(items, prefix+value)
+	}
+
+	for i, item := range items {
+		if !strings.HasPrefix(item, prefix) {
+			continue
+		}
 		valuesList := strings.TrimPrefix(items[i], prefix)
 		var values []string
 		if valuesList != "" {
@@ -156,115 +179,119 @@ func EnsureNoStringWithPrefixContains(items []string, prefix, value, sep string)
 }
 
 // EnsureEnvVarWithName ensures that a EnvVar with a name equal to the name of the given EnvVar exists
-// in the given slice and is equal to the given EnvVar.
+// in the given slice and the first item in the list would be equal to the given EnvVar.
 func EnsureEnvVarWithName(items []corev1.EnvVar, item corev1.EnvVar) []corev1.EnvVar {
-	if i := envVarWithNameIndex(items, item.Name); i < 0 {
-		items = append(items, item)
-	} else if !reflect.DeepEqual(items[i], item) {
-		items = append(append(items[:i], item), items[i+1:]...)
+	i := slices.IndexFunc(items, func(ev corev1.EnvVar) bool {
+		return ev.Name == item.Name
+	})
+	if i < 0 {
+		return append(items, item)
 	}
-	return items
+	return append(append(items[:i], item), items[i+1:]...)
 }
 
 // EnsureNoEnvVarWithName ensures that a EnvVar with the given name does not exist in the given slice.
 func EnsureNoEnvVarWithName(items []corev1.EnvVar, name string) []corev1.EnvVar {
-	if i := envVarWithNameIndex(items, name); i >= 0 {
-		items = append(items[:i], items[i+1:]...)
-	}
-	return items
+	return slices.DeleteFunc(items, func(ev corev1.EnvVar) bool {
+		return ev.Name == name
+	})
 }
 
 // EnsureVolumeMountWithName ensures that a VolumeMount with a name equal to the name of the given VolumeMount exists
-// in the given slice and is equal to the given VolumeMount.
+// in the given slice and the first item in the list would be equal to the given VolumeMount.
 func EnsureVolumeMountWithName(items []corev1.VolumeMount, item corev1.VolumeMount) []corev1.VolumeMount {
-	if i := volumeMountWithNameIndex(items, item.Name); i < 0 {
-		items = append(items, item)
-	} else if !reflect.DeepEqual(items[i], item) {
-		items = append(append(items[:i], item), items[i+1:]...)
+	i := slices.IndexFunc(items, func(vm corev1.VolumeMount) bool {
+		return vm.Name == item.Name
+	})
+	if i < 0 {
+		return append(items, item)
 	}
-	return items
+	return append(append(items[:i], item), items[i+1:]...)
 }
 
 // EnsureNoVolumeMountWithName ensures that a VolumeMount with the given name does not exist in the given slice.
 func EnsureNoVolumeMountWithName(items []corev1.VolumeMount, name string) []corev1.VolumeMount {
-	if i := volumeMountWithNameIndex(items, name); i >= 0 {
-		items = append(items[:i], items[i+1:]...)
-	}
-	return items
+	return slices.DeleteFunc(items, func(vm corev1.VolumeMount) bool {
+		return vm.Name == name
+	})
 }
 
 // EnsureVolumeWithName ensures that a Volume with a name equal to the name of the given Volume exists
-// in the given slice and is equal to the given Volume.
+// in the given slice and the first item in the list would be equal to the given Volume.
 func EnsureVolumeWithName(items []corev1.Volume, item corev1.Volume) []corev1.Volume {
-	if i := volumeWithNameIndex(items, item.Name); i < 0 {
-		items = append(items, item)
-	} else if !reflect.DeepEqual(items[i], item) {
-		items = append(append(items[:i], item), items[i+1:]...)
+	i := slices.IndexFunc(items, func(v corev1.Volume) bool {
+		return v.Name == item.Name
+	})
+	if i < 0 {
+		return append(items, item)
 	}
-	return items
+	return append(append(items[:i], item), items[i+1:]...)
 }
 
 // EnsureNoVolumeWithName ensures that a Volume with the given name does not exist in the given slice.
 func EnsureNoVolumeWithName(items []corev1.Volume, name string) []corev1.Volume {
-	if i := volumeWithNameIndex(items, name); i >= 0 {
-		items = append(items[:i], items[i+1:]...)
-	}
-	return items
+	return slices.DeleteFunc(items, func(v corev1.Volume) bool {
+		return v.Name == name
+	})
 }
 
 // EnsureContainerWithName ensures that a Container with a name equal to the name of the given Container exists
-// in the given slice and is equal to the given Container.
+// in the given slice and the first item in the list would be equal to the given Container.
 func EnsureContainerWithName(items []corev1.Container, item corev1.Container) []corev1.Container {
-	if i := containerWithNameIndex(items, item.Name); i < 0 {
-		items = append(items, item)
-	} else if !reflect.DeepEqual(items[i], item) {
-		items = append(append(items[:i], item), items[i+1:]...)
+	i := slices.IndexFunc(items, func(c corev1.Container) bool {
+		return c.Name == item.Name
+	})
+	if i < 0 {
+		return append(items, item)
 	}
-	return items
+	return append(append(items[:i], item), items[i+1:]...)
 }
 
 // EnsureNoContainerWithName ensures that a Container with the given name does not exist in the given slice.
 func EnsureNoContainerWithName(items []corev1.Container, name string) []corev1.Container {
-	if i := containerWithNameIndex(items, name); i >= 0 {
-		items = append(items[:i], items[i+1:]...)
-	}
-	return items
+	return slices.DeleteFunc(items, func(c corev1.Container) bool {
+		return c.Name == name
+	})
 }
 
 // EnsureVPAContainerResourcePolicyWithName ensures that a container policy with a name equal to the name of the given
-// container policy exists in the given slice and is equal to the given container policy.
+// container policy exists in the given slice and the first item in the list would be equal to the given container policy.
 func EnsureVPAContainerResourcePolicyWithName(items []vpaautoscalingv1.ContainerResourcePolicy, item vpaautoscalingv1.ContainerResourcePolicy) []vpaautoscalingv1.ContainerResourcePolicy {
-	if i := vpaContainerResourcePolicyWithNameIndex(items, item.ContainerName); i < 0 {
-		items = append(items, item)
-	} else if !reflect.DeepEqual(items[i], item) {
-		items = append(append(items[:i], item), items[i+1:]...)
+	i := slices.IndexFunc(items, func(crp vpaautoscalingv1.ContainerResourcePolicy) bool {
+		return crp.ContainerName == item.ContainerName
+	})
+	if i < 0 {
+		return append(items, item)
 	}
-	return items
+	return append(append(items[:i], item), items[i+1:]...)
 }
 
 // EnsurePVCWithName ensures that a PVC with a name equal to the name of the given PVC exists
-// in the given slice and is equal to the given PVC.
+// in the given slice and the first item in the list would be equal to the given PVC.
 func EnsurePVCWithName(items []corev1.PersistentVolumeClaim, item corev1.PersistentVolumeClaim) []corev1.PersistentVolumeClaim {
-	if i := pvcWithNameIndex(items, item.Name); i < 0 {
-		items = append(items, item)
-	} else if !reflect.DeepEqual(items[i], item) {
-		items = append(append(items[:i], item), items[i+1:]...)
+	i := slices.IndexFunc(items, func(pvc corev1.PersistentVolumeClaim) bool {
+		return pvc.Name == item.Name
+	})
+	if i < 0 {
+		return append(items, item)
 	}
-	return items
+	return append(append(items[:i], item), items[i+1:]...)
 }
 
 // EnsureNoPVCWithName ensures that a PVC with the given name does not exist in the given slice.
 func EnsureNoPVCWithName(items []corev1.PersistentVolumeClaim, name string) []corev1.PersistentVolumeClaim {
-	if i := pvcWithNameIndex(items, name); i >= 0 {
-		items = append(items[:i], items[i+1:]...)
-	}
-	return items
+	return slices.DeleteFunc(items, func(pvc corev1.PersistentVolumeClaim) bool {
+		return pvc.Name == name
+	})
 }
 
 // EnsureUnitOption ensures the given unit option exist in the given slice.
 func EnsureUnitOption(items []*unit.UnitOption, item *unit.UnitOption) []*unit.UnitOption {
-	if i := unitOptionIndex(items, item); i < 0 {
-		items = append(items, item)
+	i := slices.IndexFunc(items, func(uo *unit.UnitOption) bool {
+		return reflect.DeepEqual(uo, item)
+	})
+	if i < 0 {
+		return append(items, item)
 	}
 	return items
 }
@@ -288,7 +315,7 @@ func EnsureUnitWithName(items []extensionsv1alpha1.Unit, item extensionsv1alpha1
 	} else if !reflect.DeepEqual(items[i], item) {
 		items[i] = item
 	}
-	return items
+	return append(append(items[:i], item), items[i+1:]...)
 }
 
 // EnsureAnnotationOrLabel ensures the given key/value exists in the annotationOrLabelMap map.
@@ -302,110 +329,14 @@ func EnsureAnnotationOrLabel(annotationOrLabelMap map[string]string, key, value 
 
 // StringIndex returns the index of the first occurrence of the given string in the given slice, or -1 if not found.
 func StringIndex(items []string, value string) int {
-	for i, item := range items {
-		if item == value {
-			return i
-		}
-	}
-	return -1
+	return slices.IndexFunc(items, func(s string) bool {
+		return s == value
+	})
 }
 
 // StringWithPrefixIndex returns the index of the first occurrence of a string having the given prefix in the given slice, or -1 if not found.
 func StringWithPrefixIndex(items []string, prefix string) int {
-	for i, item := range items {
-		if strings.HasPrefix(item, prefix) {
-			return i
-		}
-	}
-	return -1
-}
-
-func containerWithNameIndex(items []corev1.Container, name string) int {
-	for i, item := range items {
-		if item.Name == name {
-			return i
-		}
-	}
-	return -1
-}
-
-func vpaContainerResourcePolicyWithNameIndex(items []vpaautoscalingv1.ContainerResourcePolicy, name string) int {
-	for i, item := range items {
-		if item.ContainerName == name {
-			return i
-		}
-	}
-	return -1
-}
-
-func unitWithNameIndex(items []extensionsv1alpha1.Unit, name string) int {
-	for i, item := range items {
-		if item.Name == name {
-			return i
-		}
-	}
-	return -1
-}
-
-func fileWithPathIndex(items []extensionsv1alpha1.File, path string) int {
-	for i, item := range items {
-		if item.Path == path {
-			return i
-		}
-	}
-	return -1
-}
-
-func unitOptionWithSectionAndNameIndex(items []*unit.UnitOption, section, name string) int {
-	for i, item := range items {
-		if item.Section == section && item.Name == name {
-			return i
-		}
-	}
-	return -1
-}
-
-func unitOptionIndex(items []*unit.UnitOption, item *unit.UnitOption) int {
-	for i := range items {
-		if reflect.DeepEqual(items[i], item) {
-			return i
-		}
-	}
-	return -1
-}
-
-func envVarWithNameIndex(items []corev1.EnvVar, name string) int {
-	for i, item := range items {
-		if item.Name == name {
-			return i
-		}
-	}
-	return -1
-}
-
-func volumeMountWithNameIndex(items []corev1.VolumeMount, name string) int {
-	for i, item := range items {
-		if item.Name == name {
-			return i
-		}
-	}
-	return -1
-}
-
-func volumeWithNameIndex(items []corev1.Volume, name string) int {
-	for i, item := range items {
-		if item.Name == name {
-			return i
-		}
-	}
-	return -1
-}
-
-func pvcWithNameIndex(items []corev1.PersistentVolumeClaim, name string) int {
-	for i, item := range items {
-		if item.Name == name {
-			return i
-		}
-	}
-	return -1
+	return slices.IndexFunc(items, func(s string) bool {
+		return strings.HasPrefix(s, prefix)
+	})
 }

--- a/extensions/pkg/webhook/utils.go
+++ b/extensions/pkg/webhook/utils.go
@@ -157,7 +157,10 @@ func EnsureStringWithPrefixContains(items []string, prefix, value, sep string) [
 		if valuesList != "" {
 			values = strings.Split(valuesList, sep)
 		}
-		if j := StringIndex(values, value); j < 0 {
+		j := slices.IndexFunc(values, func(s string) bool {
+			return s == value
+		})
+		if j < 0 {
 			values = append(values, value)
 			items = append(append(items[:i], prefix+strings.Join(values, sep)), items[i+1:]...)
 		}
@@ -170,7 +173,10 @@ func EnsureStringWithPrefixContains(items []string, prefix, value, sep string) [
 func EnsureNoStringWithPrefixContains(items []string, prefix, value, sep string) []string {
 	if i := StringWithPrefixIndex(items, prefix); i >= 0 {
 		values := strings.Split(strings.TrimPrefix(items[i], prefix), sep)
-		if j := StringIndex(values, value); j >= 0 {
+		j := slices.IndexFunc(values, func(s string) bool {
+			return s == value
+		})
+		if j >= 0 {
 			values = append(values[:j], values[j+1:]...)
 			items = append(append(items[:i], prefix+strings.Join(values, sep)), items[i+1:]...)
 		}
@@ -325,13 +331,6 @@ func EnsureAnnotationOrLabel(annotationOrLabelMap map[string]string, key, value 
 	}
 	annotationOrLabelMap[key] = value
 	return annotationOrLabelMap
-}
-
-// StringIndex returns the index of the first occurrence of the given string in the given slice, or -1 if not found.
-func StringIndex(items []string, value string) int {
-	return slices.IndexFunc(items, func(s string) bool {
-		return s == value
-	})
 }
 
 // StringWithPrefixIndex returns the index of the first occurrence of a string having the given prefix in the given slice, or -1 if not found.

--- a/extensions/pkg/webhook/utils.go
+++ b/extensions/pkg/webhook/utils.go
@@ -112,7 +112,6 @@ func UnitOptionWithSectionAndName(opts []*unit.UnitOption, section, name string)
 			return opts[i]
 		}
 	}
-
 	return nil
 }
 
@@ -127,9 +126,7 @@ func EnsureStringWithPrefix(items []string, prefix, value string) []string {
 		if !strings.HasPrefix(item, prefix) {
 			continue
 		}
-		if item != prefix+value {
-			items = append(append(items[:i], prefix+value), items[i+1:]...)
-		}
+		items[i] = prefix + value
 	}
 	return items
 }
@@ -157,12 +154,9 @@ func EnsureStringWithPrefixContains(items []string, prefix, value, sep string) [
 		if valuesList != "" {
 			values = strings.Split(valuesList, sep)
 		}
-		j := slices.IndexFunc(values, func(s string) bool {
-			return s == value
-		})
-		if j < 0 {
+		if j := slices.Index(values, value); j < 0 {
 			values = append(values, value)
-			items = append(append(items[:i], prefix+strings.Join(values, sep)), items[i+1:]...)
+			items[i] = prefix + strings.Join(values, sep)
 		}
 	}
 	return items
@@ -171,15 +165,14 @@ func EnsureStringWithPrefixContains(items []string, prefix, value, sep string) [
 // EnsureNoStringWithPrefixContains ensures that either a string having the given prefix does not exist in the given slice,
 // or it doesn't contain the given value in a list separated by sep.
 func EnsureNoStringWithPrefixContains(items []string, prefix, value, sep string) []string {
-	if i := StringWithPrefixIndex(items, prefix); i >= 0 {
-		values := strings.Split(strings.TrimPrefix(items[i], prefix), sep)
-		j := slices.IndexFunc(values, func(s string) bool {
-			return s == value
-		})
-		if j >= 0 {
-			values = append(values[:j], values[j+1:]...)
-			items = append(append(items[:i], prefix+strings.Join(values, sep)), items[i+1:]...)
-		}
+	i := StringWithPrefixIndex(items, prefix)
+	if i < 0 {
+		return items
+	}
+	values := strings.Split(strings.TrimPrefix(items[i], prefix), sep)
+	if j := slices.Index(values, value); j >= 0 {
+		values = append(values[:j], values[j+1:]...)
+		items[i] = prefix + strings.Join(values, sep)
 	}
 	return items
 }
@@ -193,7 +186,8 @@ func EnsureEnvVarWithName(items []corev1.EnvVar, item corev1.EnvVar) []corev1.En
 	if i < 0 {
 		return append(items, item)
 	}
-	return append(append(items[:i], item), items[i+1:]...)
+	items[i] = item
+	return items
 }
 
 // EnsureNoEnvVarWithName ensures that a EnvVar with the given name does not exist in the given slice.
@@ -212,7 +206,8 @@ func EnsureVolumeMountWithName(items []corev1.VolumeMount, item corev1.VolumeMou
 	if i < 0 {
 		return append(items, item)
 	}
-	return append(append(items[:i], item), items[i+1:]...)
+	items[i] = item
+	return items
 }
 
 // EnsureNoVolumeMountWithName ensures that a VolumeMount with the given name does not exist in the given slice.
@@ -231,7 +226,8 @@ func EnsureVolumeWithName(items []corev1.Volume, item corev1.Volume) []corev1.Vo
 	if i < 0 {
 		return append(items, item)
 	}
-	return append(append(items[:i], item), items[i+1:]...)
+	items[i] = item
+	return items
 }
 
 // EnsureNoVolumeWithName ensures that a Volume with the given name does not exist in the given slice.
@@ -250,7 +246,8 @@ func EnsureContainerWithName(items []corev1.Container, item corev1.Container) []
 	if i < 0 {
 		return append(items, item)
 	}
-	return append(append(items[:i], item), items[i+1:]...)
+	items[i] = item
+	return items
 }
 
 // EnsureNoContainerWithName ensures that a Container with the given name does not exist in the given slice.
@@ -269,7 +266,8 @@ func EnsureVPAContainerResourcePolicyWithName(items []vpaautoscalingv1.Container
 	if i < 0 {
 		return append(items, item)
 	}
-	return append(append(items[:i], item), items[i+1:]...)
+	items[i] = item
+	return items
 }
 
 // EnsurePVCWithName ensures that a PVC with a name equal to the name of the given PVC exists
@@ -281,7 +279,8 @@ func EnsurePVCWithName(items []corev1.PersistentVolumeClaim, item corev1.Persist
 	if i < 0 {
 		return append(items, item)
 	}
-	return append(append(items[:i], item), items[i+1:]...)
+	items[i] = item
+	return items
 }
 
 // EnsureNoPVCWithName ensures that a PVC with the given name does not exist in the given slice.
@@ -321,7 +320,8 @@ func EnsureUnitWithName(items []extensionsv1alpha1.Unit, item extensionsv1alpha1
 	} else if !reflect.DeepEqual(items[i], item) {
 		items[i] = item
 	}
-	return append(append(items[:i], item), items[i+1:]...)
+	items[i] = item
+	return items
 }
 
 // EnsureAnnotationOrLabel ensures the given key/value exists in the annotationOrLabelMap map.

--- a/extensions/pkg/webhook/utils.go
+++ b/extensions/pkg/webhook/utils.go
@@ -64,7 +64,7 @@ func SerializeCommandLine(command []string, n int, sep string) string {
 	return strings.Join(command[0:n], " ") + " " + strings.Join(command[n:], sep)
 }
 
-// ContainerWithName returns the first occurrence of a container with the given name if it exists in the given slice, nil otherwise.
+// ContainerWithName returns the first container with the specified name from the slice, or nil if not found.
 func ContainerWithName(containers []corev1.Container, name string) *corev1.Container {
 	for i, container := range containers {
 		if container.Name == name {
@@ -74,7 +74,7 @@ func ContainerWithName(containers []corev1.Container, name string) *corev1.Conta
 	return nil
 }
 
-// PVCWithName returns the first occurrence of a PersistentVolumeClaim with the given name if it exists in the given slice, nil otherwise.
+// PVCWithName returns the first PersistentVolumeClaim with the specified name from the slice, or nil if not found.
 func PVCWithName(pvcs []corev1.PersistentVolumeClaim, name string) *corev1.PersistentVolumeClaim {
 	for i, pvc := range pvcs {
 		if pvc.Name == name {
@@ -84,7 +84,7 @@ func PVCWithName(pvcs []corev1.PersistentVolumeClaim, name string) *corev1.Persi
 	return nil
 }
 
-// UnitWithName returns the first occurrence of a unit with the given name if it exists in the given slice, nil otherwise.
+// UnitWithName returns the first unit with the specified name from the slice, or nil if not found.
 func UnitWithName(units []extensionsv1alpha1.Unit, name string) *extensionsv1alpha1.Unit {
 	for i, unit := range units {
 		if unit.Name == name {
@@ -94,7 +94,7 @@ func UnitWithName(units []extensionsv1alpha1.Unit, name string) *extensionsv1alp
 	return nil
 }
 
-// FileWithPath returns the first occurrence of a file with the given path if it exists in the given slice, nil otherwise.
+// FileWithPath returns the first file with the specified path from the slice, or nil if not found.
 func FileWithPath(files []extensionsv1alpha1.File, path string) *extensionsv1alpha1.File {
 	for i, file := range files {
 		if file.Path == path {
@@ -104,7 +104,7 @@ func FileWithPath(files []extensionsv1alpha1.File, path string) *extensionsv1alp
 	return nil
 }
 
-// UnitOptionWithSectionAndName returns the first occurrence of a unit option with the given section and name if it exists in the given slice, nil otherwise.
+// UnitOptionWithSectionAndName returns the first unit option with the specified section and name from the slice, or nil if not found.
 func UnitOptionWithSectionAndName(opts []*unit.UnitOption, section, name string) *unit.UnitOption {
 	for i, opt := range opts {
 		if opt.Section == section && opt.Name == name {
@@ -159,7 +159,6 @@ func EnsureStringWithPrefixContains(items []string, prefix, value, sep string) [
 // EnsureNoStringWithPrefixContains ensures that either a string having the given prefix does not exist in the given slice,
 // or it doesn't contain the given value in a list separated by sep.
 func EnsureNoStringWithPrefixContains(items []string, prefix, value, sep string) []string {
-
 	for i, item := range items {
 		if !strings.HasPrefix(item, prefix) {
 			continue

--- a/extensions/pkg/webhook/utils.go
+++ b/extensions/pkg/webhook/utils.go
@@ -1,4 +1,4 @@
-// Copyright 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+// Copyright 2024 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,9 +17,8 @@ package webhook
 import (
 	"reflect"
 	"regexp"
-	"strings"
-
 	"slices"
+	"strings"
 
 	"github.com/coreos/go-systemd/v22/unit"
 	"github.com/go-logr/logr"
@@ -160,14 +159,16 @@ func EnsureStringWithPrefixContains(items []string, prefix, value, sep string) [
 // EnsureNoStringWithPrefixContains ensures that either a string having the given prefix does not exist in the given slice,
 // or it doesn't contain the given value in a list separated by sep.
 func EnsureNoStringWithPrefixContains(items []string, prefix, value, sep string) []string {
-	i := StringWithPrefixIndex(items, prefix)
-	if i < 0 {
-		return items
-	}
-	values := strings.Split(strings.TrimPrefix(items[i], prefix), sep)
-	if j := slices.Index(values, value); j >= 0 {
-		values = append(values[:j], values[j+1:]...)
-		items[i] = prefix + strings.Join(values, sep)
+
+	for i, item := range items {
+		if !strings.HasPrefix(item, prefix) {
+			continue
+		}
+		values := strings.Split(strings.TrimPrefix(items[i], prefix), sep)
+		if j := slices.Index(values, value); j >= 0 {
+			values = append(values[:j], values[j+1:]...)
+			items[i] = prefix + strings.Join(values, sep)
+		}
 	}
 	return items
 }

--- a/extensions/pkg/webhook/utils.go
+++ b/extensions/pkg/webhook/utils.go
@@ -299,21 +299,24 @@ func EnsureUnitOption(items []*unit.UnitOption, item *unit.UnitOption) []*unit.U
 // EnsureFileWithPath ensures that a file with a path equal to the path of the given file exists in the given slice
 // and is equal to the given file.
 func EnsureFileWithPath(items []extensionsv1alpha1.File, item extensionsv1alpha1.File) []extensionsv1alpha1.File {
-	if i := fileWithPathIndex(items, item.Path); i < 0 {
-		items = append(items, item)
-	} else if !reflect.DeepEqual(items[i], item) {
-		items[i] = item
+	i := slices.IndexFunc(items, func(f extensionsv1alpha1.File) bool {
+		return f.Path == item.Path
+	})
+	if i < 0 {
+		return append(items, item)
 	}
+	items[i] = item
 	return items
 }
 
 // EnsureUnitWithName ensures that an unit with a name equal to the name of the given unit exists in the given slice
 // and is equal to the given unit.
 func EnsureUnitWithName(items []extensionsv1alpha1.Unit, item extensionsv1alpha1.Unit) []extensionsv1alpha1.Unit {
-	if i := unitWithNameIndex(items, item.Name); i < 0 {
-		items = append(items, item)
-	} else if !reflect.DeepEqual(items[i], item) {
-		items[i] = item
+	i := slices.IndexFunc(items, func(u extensionsv1alpha1.Unit) bool {
+		return u.Name == item.Name
+	})
+	if i < 0 {
+		return append(items, item)
 	}
 	items[i] = item
 	return items

--- a/extensions/pkg/webhook/utils.go
+++ b/extensions/pkg/webhook/utils.go
@@ -65,51 +65,51 @@ func SerializeCommandLine(command []string, n int, sep string) string {
 	return strings.Join(command[0:n], " ") + " " + strings.Join(command[n:], sep)
 }
 
-// ContainerWithName returns the container with the given name if it exists in the given slice, nil otherwise.
+// ContainerWithName returns the first occurrence of a container with the given name if it exists in the given slice, nil otherwise.
 func ContainerWithName(containers []corev1.Container, name string) *corev1.Container {
-	for _, container := range containers {
+	for i, container := range containers {
 		if container.Name == name {
-			return &container
+			return &containers[i]
 		}
 	}
 	return nil
 }
 
-// PVCWithName returns the PersistentVolumeClaim with the given name if it exists in the given slice, nil otherwise.
+// PVCWithName returns the first occurrence of a PersistentVolumeClaim with the given name if it exists in the given slice, nil otherwise.
 func PVCWithName(pvcs []corev1.PersistentVolumeClaim, name string) *corev1.PersistentVolumeClaim {
-	for _, pvc := range pvcs {
+	for i, pvc := range pvcs {
 		if pvc.Name == name {
-			return &pvc
+			return &pvcs[i]
 		}
 	}
 	return nil
 }
 
-// UnitWithName returns the unit with the given name if it exists in the given slice, nil otherwise.
+// UnitWithName returns the first occurrence of a unit with the given name if it exists in the given slice, nil otherwise.
 func UnitWithName(units []extensionsv1alpha1.Unit, name string) *extensionsv1alpha1.Unit {
-	for _, unit := range units {
+	for i, unit := range units {
 		if unit.Name == name {
-			return &unit
+			return &units[i]
 		}
 	}
 	return nil
 }
 
-// FileWithPath returns the file with the given path if it exists in the given slice, nil otherwise.
+// FileWithPath returns the first occurrence of a file with the given path if it exists in the given slice, nil otherwise.
 func FileWithPath(files []extensionsv1alpha1.File, path string) *extensionsv1alpha1.File {
-	for _, file := range files {
+	for i, file := range files {
 		if file.Path == path {
-			return &file
+			return &files[i]
 		}
 	}
 	return nil
 }
 
-// UnitOptionWithSectionAndName returns the unit option with the given section and name if it exists in the given slice, nil otherwise.
+// UnitOptionWithSectionAndName returns the first occurrence of a unit option with the given section and name if it exists in the given slice, nil otherwise.
 func UnitOptionWithSectionAndName(opts []*unit.UnitOption, section, name string) *unit.UnitOption {
-	for _, opt := range opts {
+	for i, opt := range opts {
 		if opt.Section == section && opt.Name == name {
-			return opt
+			return opts[i]
 		}
 	}
 

--- a/extensions/pkg/webhook/utils.go
+++ b/extensions/pkg/webhook/utils.go
@@ -118,15 +118,14 @@ func UnitOptionWithSectionAndName(opts []*unit.UnitOption, section, name string)
 // EnsureStringWithPrefix ensures that a string having the given prefix exists in the given slice
 // and all matches are with a value equal to prefix + value.
 func EnsureStringWithPrefix(items []string, prefix, value string) []string {
-	if i := StringWithPrefixIndex(items, prefix); i < 0 {
+	if StringWithPrefixIndex(items, prefix) < 0 {
 		return append(items, prefix+value)
 	}
 
 	for i, item := range items {
-		if !strings.HasPrefix(item, prefix) {
-			continue
+		if strings.HasPrefix(item, prefix) {
+			items[i] = prefix + value
 		}
-		items[i] = prefix + value
 	}
 	return items
 }
@@ -141,7 +140,7 @@ func EnsureNoStringWithPrefix(items []string, prefix string) []string {
 // EnsureStringWithPrefixContains ensures that a string having the given prefix exists in the given slice
 // and all matches contain the given value in a list separated by sep.
 func EnsureStringWithPrefixContains(items []string, prefix, value, sep string) []string {
-	if i := StringWithPrefixIndex(items, prefix); i < 0 {
+	if StringWithPrefixIndex(items, prefix) < 0 {
 		return append(items, prefix+value)
 	}
 
@@ -149,12 +148,8 @@ func EnsureStringWithPrefixContains(items []string, prefix, value, sep string) [
 		if !strings.HasPrefix(item, prefix) {
 			continue
 		}
-		valuesList := strings.TrimPrefix(items[i], prefix)
-		var values []string
-		if valuesList != "" {
-			values = strings.Split(valuesList, sep)
-		}
-		if j := slices.Index(values, value); j < 0 {
+		values := strings.Split(strings.TrimPrefix(items[i], prefix), sep)
+		if slices.Index(values, value) < 0 {
 			values = append(values, value)
 			items[i] = prefix + strings.Join(values, sep)
 		}

--- a/extensions/pkg/webhook/utils_test.go
+++ b/extensions/pkg/webhook/utils_test.go
@@ -22,7 +22,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	vpaautoscalingv1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
-	"k8s.io/utils/pointer"
 	"k8s.io/utils/ptr"
 
 	"github.com/gardener/gardener/extensions/pkg/webhook"
@@ -737,11 +736,11 @@ var _ = Describe("Utils", func() {
 					files = []extensionsv1alpha1.File{
 						{
 							Path:        "path1",
-							Permissions: pointer.Int32(0644),
+							Permissions: ptr.To(int32(0644)),
 						},
 						{
 							Path:        "path2",
-							Permissions: pointer.Int32(0644),
+							Permissions: ptr.To(int32(0644)),
 						},
 					}
 				})
@@ -749,7 +748,7 @@ var _ = Describe("Utils", func() {
 				It("should add a new File if not present", func() {
 					newFile := extensionsv1alpha1.File{
 						Path:        "path3",
-						Permissions: pointer.Int32(0644),
+						Permissions: ptr.To(int32(0644)),
 					}
 					result := webhook.EnsureFileWithPath(files, newFile)
 					Expect(result).To(Equal(append(files, newFile)))
@@ -758,17 +757,17 @@ var _ = Describe("Utils", func() {
 				It("should replace the existing File if it's not identical", func() {
 					existingFile := extensionsv1alpha1.File{
 						Path:        "path1",
-						Permissions: pointer.Int32(0400),
+						Permissions: ptr.To(int32(0400)),
 					}
 					result := webhook.EnsureFileWithPath(files, existingFile)
 					Expect(result).To(Equal([]extensionsv1alpha1.File{
 						{
 							Path:        "path1",
-							Permissions: pointer.Int32(0400),
+							Permissions: ptr.To(int32(0400)),
 						},
 						{
 							Path:        "path2",
-							Permissions: pointer.Int32(0644),
+							Permissions: ptr.To(int32(0644)),
 						},
 					}))
 				})

--- a/extensions/pkg/webhook/utils_test.go
+++ b/extensions/pkg/webhook/utils_test.go
@@ -15,17 +15,178 @@
 package webhook_test
 
 import (
+	"github.com/coreos/go-systemd/v22/unit"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"k8s.io/utils/ptr"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	vpaautoscalingv1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
+	"k8s.io/utils/pointer"
 
 	"github.com/gardener/gardener/extensions/pkg/webhook"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 )
 
 var _ = Describe("Utils", func() {
-	Describe("Ensure_", func() {
-		Describe("EnsureVolumeWithName", func() {
+	Describe("#Ensure*", func() {
+		Describe("#EnsureStringWithPrefix", func() {
+			var flags []string
+
+			BeforeEach(func() {
+				flags = []string{
+					"--flag1=key2=value2,key3=value3",
+					"--flag2=value1",
+					"--flag3=value3,value1",
+					"--flag1=value4",
+				}
+			})
+
+			It("should replace all strings with a given prefix with prefix+value", func() {
+				result := webhook.EnsureStringWithPrefix(flags, "--flag1=", "key1=value1")
+				Expect(result).To(Equal([]string{
+					"--flag1=key1=value1",
+					"--flag2=value1",
+					"--flag3=value3,value1",
+					"--flag1=key1=value1",
+				}))
+			})
+
+			It("should add prefix+value if there is no string with a given prefix", func() {
+				result := webhook.EnsureStringWithPrefix(flags, "--flag4=", "key1=value1")
+				Expect(result).To(Equal(append(flags, "--flag4=key1=value1")))
+			})
+		})
+
+		Describe("#EnsureStringWithPrefixContains", func() {
+			var flags []string
+
+			BeforeEach(func() {
+				flags = []string{
+					"--flag1=key1=value1,key2=value2",
+					"--flag2=value1",
+					"--flag3=value3,value1",
+					"--flag1=key1=value1",
+				}
+			})
+
+			It("should ensure the specified value is in all strings with a given prefix", func() {
+				result := webhook.EnsureStringWithPrefixContains(flags, "--flag1=", "key2=value2", ",")
+				Expect(result).To(Equal([]string{
+					"--flag1=key1=value1,key2=value2",
+					"--flag2=value1",
+					"--flag3=value3,value1",
+					"--flag1=key1=value1,key2=value2",
+				}))
+			})
+
+			It("should add prefix+value if there is no string with a given prefix", func() {
+				result := webhook.EnsureStringWithPrefixContains(flags, "--flag4=", "value4", ",")
+				Expect(result).To(Equal(append(flags, "--flag4=value4")))
+			})
+		})
+
+		Describe("#EnsureEnvVarWithName", func() {
+			var envVars []corev1.EnvVar
+
+			BeforeEach(func() {
+				envVars = []corev1.EnvVar{
+					{
+						Name:  "envVar1",
+						Value: "value1",
+					},
+					{
+						Name:  "envVar2",
+						Value: "value2",
+					},
+				}
+			})
+
+			It("should add a new EnvVar if not present", func() {
+				newEnvVar := corev1.EnvVar{
+					Name:  "envVar3",
+					Value: "value3",
+				}
+				result := webhook.EnsureEnvVarWithName(envVars, newEnvVar)
+				Expect(result).To(Equal(append(envVars, newEnvVar)))
+			})
+
+			It("should replace the existing EnvVar if it's not identical", func() {
+				existingEnvVar := corev1.EnvVar{
+					Name:  "envVar1",
+					Value: "value3",
+				}
+				result := webhook.EnsureEnvVarWithName(envVars, existingEnvVar)
+				Expect(result).To(Equal([]corev1.EnvVar{
+					{
+						Name:  "envVar1",
+						Value: "value3",
+					},
+					{
+						Name:  "envVar2",
+						Value: "value2",
+					},
+				}))
+			})
+
+			It("should do nothing to the existing EnvVar if it's identical", func() {
+				identicalEnvVar := envVars[0]
+				result := webhook.EnsureEnvVarWithName(envVars, identicalEnvVar)
+				Expect(result).To(Equal(envVars))
+			})
+		})
+
+		Describe("#EnsureVolumeMountWithName", func() {
+			var volumeMounts []corev1.VolumeMount
+
+			BeforeEach(func() {
+				volumeMounts = []corev1.VolumeMount{
+					{
+						Name:     "volumeMount1",
+						ReadOnly: true,
+					},
+					{
+						Name:     "volumeMount2",
+						ReadOnly: false,
+					},
+				}
+			})
+
+			It("should add a new VolumeMount if not present", func() {
+				newVolumeMount := corev1.VolumeMount{
+					Name:     "volumeMount3",
+					ReadOnly: true,
+				}
+				result := webhook.EnsureVolumeMountWithName(volumeMounts, newVolumeMount)
+				Expect(result).To(Equal(append(volumeMounts, newVolumeMount)))
+			})
+
+			It("should replace the existing VolumeMount if it's not identical", func() {
+				existingVolumeMount := corev1.VolumeMount{
+					Name:     "volumeMount1",
+					ReadOnly: false,
+				}
+				result := webhook.EnsureVolumeMountWithName(volumeMounts, existingVolumeMount)
+				Expect(result).To(Equal([]corev1.VolumeMount{
+					{
+						Name:     "volumeMount1",
+						ReadOnly: false,
+					},
+					{
+						Name:     "volumeMount2",
+						ReadOnly: false,
+					},
+				}))
+			})
+
+			It("should do nothing to the existing VolumeMount if it's identical", func() {
+				identicalVolumeMount := volumeMounts[0]
+				result := webhook.EnsureVolumeMountWithName(volumeMounts, identicalVolumeMount)
+				Expect(result).To(Equal(volumeMounts))
+			})
+		})
+
+		Describe("#EnsureVolumeWithName", func() {
 			var volumes []corev1.Volume
 
 			BeforeEach(func() {
@@ -87,7 +248,7 @@ var _ = Describe("Utils", func() {
 			})
 		})
 
-		Describe("EnsureContainerWithName", func() {
+		Describe("#EnsureContainerWithName", func() {
 			var containers []corev1.Container
 
 			BeforeEach(func() {
@@ -139,10 +300,12 @@ var _ = Describe("Utils", func() {
 			})
 		})
 
-		Describe("EnsureVPAContainerResourcePolicyWithName", func() {
-			var policies []vpaautoscalingv1.ContainerResourcePolicy
-			var modeAuto = vpaautoscalingv1.ContainerScalingModeAuto
-			var modeOff = vpaautoscalingv1.ContainerScalingModeOff
+		Describe("#EnsureVPAContainerResourcePolicyWithName", func() {
+			var (
+				policies []vpaautoscalingv1.ContainerResourcePolicy
+				modeAuto = vpaautoscalingv1.ContainerScalingModeAuto
+				modeOff  = vpaautoscalingv1.ContainerScalingModeOff
+			)
 
 			BeforeEach(func() {
 				policies = []vpaautoscalingv1.ContainerResourcePolicy{
@@ -191,21 +354,33 @@ var _ = Describe("Utils", func() {
 			})
 		})
 
-		Describe("EnsurePVCWithName", func() {
+		Describe("#EnsurePVCWithName", func() {
 			var pvcs []corev1.PersistentVolumeClaim
 
 			BeforeEach(func() {
 				pvcs = []corev1.PersistentVolumeClaim{
 					{
 						ObjectMeta: metav1.ObjectMeta{
-							Name:      "pvc1",
-							Namespace: "namespace1",
+							Name: "pvc1",
+						},
+						Spec: corev1.PersistentVolumeClaimSpec{
+							Resources: corev1.ResourceRequirements{
+								Requests: map[corev1.ResourceName]resource.Quantity{
+									"storage": resource.MustParse("10Gi"),
+								},
+							},
 						},
 					},
 					{
 						ObjectMeta: metav1.ObjectMeta{
-							Name:      "pvc2",
-							Namespace: "namespace2",
+							Name: "pvc2",
+						},
+						Spec: corev1.PersistentVolumeClaimSpec{
+							Resources: corev1.ResourceRequirements{
+								Requests: map[corev1.ResourceName]resource.Quantity{
+									"storage": resource.MustParse("20Gi"),
+								},
+							},
 						},
 					},
 				}
@@ -214,8 +389,14 @@ var _ = Describe("Utils", func() {
 			It("should add a new PersistentVolumeClaim if not present", func() {
 				newPVC := corev1.PersistentVolumeClaim{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "pvc3",
-						Namespace: "namespace3",
+						Name: "pvc3",
+					},
+					Spec: corev1.PersistentVolumeClaimSpec{
+						Resources: corev1.ResourceRequirements{
+							Requests: map[corev1.ResourceName]resource.Quantity{
+								"storage": resource.MustParse("30Gi"),
+							},
+						},
 					},
 				}
 				result := webhook.EnsurePVCWithName(pvcs, newPVC)
@@ -225,22 +406,40 @@ var _ = Describe("Utils", func() {
 			It("should replace the existing PersistentVolumeClaim if it's not identical", func() {
 				existingPVC := corev1.PersistentVolumeClaim{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "pvc1",
-						Namespace: "namespace3",
+						Name: "pvc1",
+					},
+					Spec: corev1.PersistentVolumeClaimSpec{
+						Resources: corev1.ResourceRequirements{
+							Requests: map[corev1.ResourceName]resource.Quantity{
+								"storage": resource.MustParse("30Gi"),
+							},
+						},
 					},
 				}
 				result := webhook.EnsurePVCWithName(pvcs, existingPVC)
 				Expect(result).To(Equal([]corev1.PersistentVolumeClaim{
 					{
 						ObjectMeta: metav1.ObjectMeta{
-							Name:      "pvc1",
-							Namespace: "namespace3",
+							Name: "pvc1",
+						},
+						Spec: corev1.PersistentVolumeClaimSpec{
+							Resources: corev1.ResourceRequirements{
+								Requests: map[corev1.ResourceName]resource.Quantity{
+									"storage": resource.MustParse("30Gi"),
+								},
+							},
 						},
 					},
 					{
 						ObjectMeta: metav1.ObjectMeta{
-							Name:      "pvc2",
-							Namespace: "namespace2",
+							Name: "pvc2",
+						},
+						Spec: corev1.PersistentVolumeClaimSpec{
+							Resources: corev1.ResourceRequirements{
+								Requests: map[corev1.ResourceName]resource.Quantity{
+									"storage": resource.MustParse("20Gi"),
+								},
+							},
 						},
 					},
 				}))
@@ -253,6 +452,7 @@ var _ = Describe("Utils", func() {
 			})
 		})
 
+<<<<<<< HEAD
 		Describe("#EnsureFileWithPath", func() {
 			var files []extensionsv1alpha1.File
 	
@@ -484,6 +684,9 @@ var _ = Describe("Utils", func() {
 		})
 
 		Describe("EnsureUnitOption", func() {
+=======
+		Describe("#EnsureUnitOption", func() {
+>>>>>>> ddddb7f5a (Addressing ialidzhikov's feedback)
 			var unitOptions []*unit.UnitOption
 
 			BeforeEach(func() {
@@ -528,7 +731,59 @@ var _ = Describe("Utils", func() {
 			})
 		})
 
-		Describe("EnsureAnnotationOrLabel", func() {
+		Describe("#EnsureFileWithPath", func() {
+			var (
+				files []extensionsv1alpha1.File
+			)
+
+			BeforeEach(func() {
+				files = []extensionsv1alpha1.File{
+					{
+						Path:        "path1",
+						Permissions: pointer.Int32(0644),
+					},
+					{
+						Path:        "path2",
+						Permissions: pointer.Int32(0644),
+					},
+				}
+			})
+
+			It("should add a new File if not present", func() {
+				newFile := extensionsv1alpha1.File{
+					Path:        "path3",
+					Permissions: pointer.Int32(0644),
+				}
+				result := webhook.EnsureFileWithPath(files, newFile)
+				Expect(result).To(Equal(append(files, newFile)))
+			})
+
+			It("should replace the existing File if it's not identical", func() {
+				existingFile := extensionsv1alpha1.File{
+					Path:        "path1",
+					Permissions: pointer.Int32(0400),
+				}
+				result := webhook.EnsureFileWithPath(files, existingFile)
+				Expect(result).To(Equal([]extensionsv1alpha1.File{
+					{
+						Path:        "path1",
+						Permissions: pointer.Int32(0400),
+					},
+					{
+						Path:        "path2",
+						Permissions: pointer.Int32(0644),
+					},
+				}))
+			})
+
+			It("should do nothing to the existing File if it's identical", func() {
+				identicalFile := files[0]
+				result := webhook.EnsureFileWithPath(files, identicalFile)
+				Expect(result).To(Equal(files))
+			})
+		})
+
+		Describe("#EnsureAnnotationOrLabel", func() {
 			var annotations map[string]string
 
 			BeforeEach(func() {
@@ -540,79 +795,106 @@ var _ = Describe("Utils", func() {
 
 			It("should ensure the specified annotation or label exists", func() {
 				result := webhook.EnsureAnnotationOrLabel(annotations, "annotation3", "value3")
-				Expect(len(result)).To(Equal(3))
-				Expect(result["annotation3"]).To(Equal("value3"))
+				Expect(result).To(Equal(map[string]string{
+					"annotation1": "value1",
+					"annotation2": "value2",
+					"annotation3": "value3",
+				}))
 			})
 
 			It("should overwrite the value of an existing annotation or label", func() {
 				result := webhook.EnsureAnnotationOrLabel(annotations, "annotation1", "newvalue1")
-				Expect(len(result)).To(Equal(2))
-				Expect(result["annotation1"]).To(Equal("newvalue1"))
+				Expect(result).To(Equal(map[string]string{
+					"annotation1": "newvalue1",
+					"annotation2": "value2",
+				}))
 			})
 
 			It("should create a new map if the input map is nil", func() {
-				var nilMap map[string]string
-				result := webhook.EnsureAnnotationOrLabel(nilMap, "annotation1", "value1")
-				Expect(len(result)).To(Equal(1))
-				Expect(result["annotation1"]).To(Equal("value1"))
-			})
-		})
-
-		Describe("EnsureStringWithPrefix", func() {
-			var flags []string
-
-			BeforeEach(func() {
-				flags = []string{
-					"--prefix1=key1=value1,key2=value2,key3=value3",
-					"--prefix2=key4=value4,key5=value5,key6=value6",
-					"--prefix1=key7=value7,key8=value8,key9=value9",
-				}
-			})
-
-			It("should replace all strings with a given prefix with prefix+value", func() {
-				result := webhook.EnsureStringWithPrefix(flags, "--prefix1=", "key7=value7")
-				Expect(result).To(Equal([]string{
-					"--prefix1=key7=value7",
-					"--prefix2=key4=value4,key5=value5,key6=value6",
-					"--prefix1=key7=value7",
+				result := webhook.EnsureAnnotationOrLabel(nil, "annotation1", "value1")
+				Expect(result).To(Equal(map[string]string{
+					"annotation1": "value1",
 				}))
-			})
-
-			It("should add a new flag with the specified prefix and value if no flag with the given prefix exists", func() {
-				result := webhook.EnsureStringWithPrefix(flags, "--prefix3=", "key8=value8")
-				Expect(result).To(Equal(append(flags, "--prefix3=key8=value8")))
-			})
-		})
-
-		Describe("EnsureStringWithPrefixContains", func() {
-			var flags []string
-
-			BeforeEach(func() {
-				flags = []string{
-					"--flag1=key1=value1,key2=value2,key3=value3",
-					"--flag2=key4=value4,key5=value5,key6=value6",
-					"--flag1=key7=value7,key8=value8,key9=value9",
-				}
-			})
-
-			It("should ensure the specified key-value pair is in all flags with a given prefix", func() {
-				result := webhook.EnsureStringWithPrefixContains(flags, "--flag1=", "key3=value3", ",")
-				Expect(result).To(Equal([]string{
-					"--flag1=key1=value1,key2=value2,key3=value3",
-					"--flag2=key4=value4,key5=value5,key6=value6",
-					"--flag1=key7=value7,key8=value8,key9=value9,key3=value3",
-				}))
-			})
-
-			It("should add a new flag with the specified key-value pair if no flag with the given prefix exists", func() {
-				result := webhook.EnsureStringWithPrefixContains(flags, "--flag3=", "key10=value10", ",")
-				Expect(result).To(Equal(append(flags, "--flag3=key10=value10")))
 			})
 		})
 	})
 
-	Describe("EnsureNo_", func() {
-		Describe("EnsureNoVolumeWithName", func() {
+	Describe("#EnsureNo*", func() {
+		Describe("#EnsureNoStringWithPrefix", func() {
+			var flags []string
+
+			BeforeEach(func() {
+				flags = []string{
+					"--prefix1-flag1=value1",
+					"--flag2=value2",
+					"--prefix1-flag3=value3",
+				}
+			})
+
+			It("should delete all strings with a given prefix", func() {
+				result := webhook.EnsureNoStringWithPrefix(flags, "--prefix1")
+				Expect(result).To(Equal([]string{"--flag2=value2"}))
+			})
+		})
+
+		Describe("#EnsureNoStringWithPrefixContains", func() {
+			var flags []string
+
+			BeforeEach(func() {
+				flags = []string{
+					"--flag1=key2=value2,key3=value3",
+					"--flag2=value1",
+					"--flag3=value3,value1",
+					"--flag1=key3=value3,key1=value1",
+				}
+			})
+
+			It("should delete the specified value from all strings with a given prefix", func() {
+				result := webhook.EnsureNoStringWithPrefixContains(flags, "--flag1=", "key3=value3", ",")
+				Expect(result).To(Equal([]string{
+					"--flag1=key2=value2",
+					"--flag2=value1",
+					"--flag3=value3,value1",
+					"--flag1=key1=value1",
+				}))
+			})
+		})
+
+		Describe("#EnsureNoEnvVarWithName", func() {
+			var envVars []corev1.EnvVar
+
+			BeforeEach(func() {
+				envVars = []corev1.EnvVar{
+					{Name: "envVar1"},
+					{Name: "envVar2"},
+					{Name: "envVar1"},
+				}
+			})
+
+			It("should delete all environment variables with a given name", func() {
+				result := webhook.EnsureNoEnvVarWithName(envVars, "envVar1")
+				Expect(result).To(Equal([]corev1.EnvVar{{Name: "envVar2"}}))
+			})
+		})
+
+		Describe("#EnsureNoVolumeMountWithName", func() {
+			var volumeMounts []corev1.VolumeMount
+
+			BeforeEach(func() {
+				volumeMounts = []corev1.VolumeMount{
+					{Name: "mount1"},
+					{Name: "mount2"},
+					{Name: "mount1"},
+				}
+			})
+
+			It("should delete all volume mounts with a given name", func() {
+				result := webhook.EnsureNoVolumeMountWithName(volumeMounts, "mount1")
+				Expect(result).To(Equal([]corev1.VolumeMount{{Name: "mount2"}}))
+			})
+		})
+
+		Describe("#EnsureNoVolumeWithName", func() {
 			var volumes []corev1.Volume
 
 			BeforeEach(func() {
@@ -649,41 +931,7 @@ var _ = Describe("Utils", func() {
 			})
 		})
 
-		Describe("EnsureNoVolumeMountWithName", func() {
-			var volumeMounts []corev1.VolumeMount
-
-			BeforeEach(func() {
-				volumeMounts = []corev1.VolumeMount{
-					{Name: "mount1"},
-					{Name: "mount2"},
-					{Name: "mount1"},
-				}
-			})
-
-			It("should delete all volume mounts with a given name", func() {
-				result := webhook.EnsureNoVolumeMountWithName(volumeMounts, "mount1")
-				Expect(result).To(Equal([]corev1.VolumeMount{{Name: "mount2"}}))
-			})
-		})
-
-		Describe("EnsureNoEnvVarWithName", func() {
-			var envVars []corev1.EnvVar
-
-			BeforeEach(func() {
-				envVars = []corev1.EnvVar{
-					{Name: "envVar1"},
-					{Name: "envVar2"},
-					{Name: "envVar1"},
-				}
-			})
-
-			It("should delete all environment variables with a given name", func() {
-				result := webhook.EnsureNoEnvVarWithName(envVars, "envVar1")
-				Expect(result).To(Equal([]corev1.EnvVar{{Name: "envVar2"}}))
-			})
-		})
-
-		Describe("EnsureNoContainerWithName", func() {
+		Describe("#EnsureNoContainerWithName", func() {
 			var containers []corev1.Container
 
 			BeforeEach(func() {
@@ -700,7 +948,7 @@ var _ = Describe("Utils", func() {
 			})
 		})
 
-		Describe("EnsureNoPVCWithName", func() {
+		Describe("#EnsureNoPVCWithName", func() {
 			var pvcs []corev1.PersistentVolumeClaim
 
 			BeforeEach(func() {
@@ -726,44 +974,6 @@ var _ = Describe("Utils", func() {
 			It("should delete all Persistent Volume Claims with a given name", func() {
 				result := webhook.EnsureNoPVCWithName(pvcs, "pvc1")
 				Expect(result).To(Equal([]corev1.PersistentVolumeClaim{{ObjectMeta: metav1.ObjectMeta{Name: "pvc2"}}}))
-			})
-		})
-
-		Describe("EnsureNoStringWithPrefix", func() {
-			var flags []string
-
-			BeforeEach(func() {
-				flags = []string{
-					"--prefix1=key1=value1,key2=value2,key3=value3",
-					"--prefix2=key4=value4,key5=value5,key6=value6",
-					"--prefix1=key7=value7,key8=value8,key9=value9",
-				}
-			})
-
-			It("should delete all flags with a given prefix", func() {
-				result := webhook.EnsureNoStringWithPrefix(flags, "--prefix1=")
-				Expect(result).To(Equal([]string{"--prefix2=key4=value4,key5=value5,key6=value6"}))
-			})
-		})
-
-		Describe("EnsureNoStringWithPrefixContains", func() {
-			var flags []string
-
-			BeforeEach(func() {
-				flags = []string{
-					"--prefix1=key1=value1,key2=value2,key3=value3",
-					"--prefix2=key4=value4,key5=value5,key6=value6",
-					"--prefix1=key7=value7,key8=value8,key9=value9",
-				}
-			})
-
-			It("should delete the specified key-value pair from all flags with a given prefix", func() {
-				result := webhook.EnsureNoStringWithPrefixContains(flags, "--prefix1=", "key2=value2", ",")
-				Expect(result).To(Equal([]string{
-					"--prefix1=key1=value1,key3=value3",
-					"--prefix2=key4=value4,key5=value5,key6=value6",
-					"--prefix1=key7=value7,key8=value8,key9=value9",
-				}))
 			})
 		})
 	})

--- a/extensions/pkg/webhook/utils_test.go
+++ b/extensions/pkg/webhook/utils_test.go
@@ -23,6 +23,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	vpaautoscalingv1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
 	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	"github.com/gardener/gardener/extensions/pkg/webhook"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
@@ -452,10 +453,9 @@ var _ = Describe("Utils", func() {
 			})
 		})
 
-<<<<<<< HEAD
 		Describe("#EnsureFileWithPath", func() {
 			var files []extensionsv1alpha1.File
-	
+
 			BeforeEach(func() {
 				files = []extensionsv1alpha1.File{
 					{
@@ -476,7 +476,7 @@ var _ = Describe("Utils", func() {
 					},
 				}
 			})
-	
+
 			It("should append file when file with such path does not exist", func() {
 				newFile := extensionsv1alpha1.File{
 					Path: "/baz.txt",
@@ -486,11 +486,11 @@ var _ = Describe("Utils", func() {
 						},
 					},
 				}
-	
+
 				actual := webhook.EnsureFileWithPath(files, newFile)
 				Expect(actual).To(Equal(append(files, newFile)))
 			})
-	
+
 			It("should update file when file with such path exists", func() {
 				newFile := extensionsv1alpha1.File{
 					Path: "/foo.txt",
@@ -500,7 +500,7 @@ var _ = Describe("Utils", func() {
 						},
 					},
 				}
-	
+
 				actual := webhook.EnsureFileWithPath(files, newFile)
 				Expect(actual).To(Equal([]extensionsv1alpha1.File{
 					{
@@ -521,18 +521,18 @@ var _ = Describe("Utils", func() {
 					},
 				}))
 			})
-	
+
 			It("should do nothing when the new file is exactly the same as the existing one", func() {
 				newFile := files[0]
-	
+
 				actual := webhook.EnsureFileWithPath(files, newFile)
 				Expect(actual).To(Equal(files))
 			})
 		})
-	
+
 		Describe("#EnsureUnitWithName", func() {
 			var units []extensionsv1alpha1.Unit
-	
+
 			BeforeEach(func() {
 				units = []extensionsv1alpha1.Unit{
 					{
@@ -545,23 +545,23 @@ var _ = Describe("Utils", func() {
 					},
 				}
 			})
-	
+
 			It("should append unit when unit with such name does not exist", func() {
 				newUnit := extensionsv1alpha1.Unit{
 					Name:    "baz.service",
 					Content: ptr.To("bar"),
 				}
-	
+
 				actual := webhook.EnsureUnitWithName(units, newUnit)
 				Expect(actual).To(Equal(append(units, newUnit)))
 			})
-	
+
 			It("should update unit when unit with such name exists", func() {
 				newUnit := extensionsv1alpha1.Unit{
 					Name:    "foo.service",
 					Content: ptr.To("baz"),
 				}
-	
+
 				actual := webhook.EnsureUnitWithName(units, newUnit)
 				Expect(actual).To(Equal([]extensionsv1alpha1.Unit{
 					{
@@ -574,406 +574,404 @@ var _ = Describe("Utils", func() {
 					},
 				}))
 			})
-	
+
 			It("should do nothing when the new unit is exactly the same as the existing one", func() {
 				newUnit := units[0]
-	
+
 				actual := webhook.EnsureUnitWithName(units, newUnit)
 				Expect(actual).To(Equal(units))
-	
+
 			})
 
-		Describe("EnsureVolumeMountWithName", func() {
-			var volumeMounts []corev1.VolumeMount
+			Describe("EnsureVolumeMountWithName", func() {
+				var volumeMounts []corev1.VolumeMount
 
-			BeforeEach(func() {
-				volumeMounts = []corev1.VolumeMount{
-					{
-						Name:     "volumeMount1",
+				BeforeEach(func() {
+					volumeMounts = []corev1.VolumeMount{
+						{
+							Name:     "volumeMount1",
+							ReadOnly: true,
+						},
+						{
+							Name:     "volumeMount2",
+							ReadOnly: false,
+						},
+					}
+				})
+
+				It("should add a new VolumeMount if not present", func() {
+					newVolumeMount := corev1.VolumeMount{
+						Name:     "volumeMount3",
 						ReadOnly: true,
-					},
-					{
-						Name:     "volumeMount2",
-						ReadOnly: false,
-					},
-				}
-			})
+					}
+					result := webhook.EnsureVolumeMountWithName(volumeMounts, newVolumeMount)
+					Expect(result).To(Equal(append(volumeMounts, newVolumeMount)))
+				})
 
-			It("should add a new VolumeMount if not present", func() {
-				newVolumeMount := corev1.VolumeMount{
-					Name:     "volumeMount3",
-					ReadOnly: true,
-				}
-				result := webhook.EnsureVolumeMountWithName(volumeMounts, newVolumeMount)
-				Expect(result).To(Equal(append(volumeMounts, newVolumeMount)))
-			})
-
-			It("should replace the existing VolumeMount if it's not identical", func() {
-				existingVolumeMount := corev1.VolumeMount{
-					Name:     "volumeMount1",
-					ReadOnly: false,
-				}
-				result := webhook.EnsureVolumeMountWithName(volumeMounts, existingVolumeMount)
-				Expect(result).To(Equal([]corev1.VolumeMount{
-					{
+				It("should replace the existing VolumeMount if it's not identical", func() {
+					existingVolumeMount := corev1.VolumeMount{
 						Name:     "volumeMount1",
 						ReadOnly: false,
-					},
-					{
-						Name:     "volumeMount2",
-						ReadOnly: false,
-					},
-				}))
+					}
+					result := webhook.EnsureVolumeMountWithName(volumeMounts, existingVolumeMount)
+					Expect(result).To(Equal([]corev1.VolumeMount{
+						{
+							Name:     "volumeMount1",
+							ReadOnly: false,
+						},
+						{
+							Name:     "volumeMount2",
+							ReadOnly: false,
+						},
+					}))
+				})
+
+				It("should do nothing to the existing VolumeMount if it's identical", func() {
+					identicalVolumeMount := volumeMounts[0]
+					result := webhook.EnsureVolumeMountWithName(volumeMounts, identicalVolumeMount)
+					Expect(result).To(Equal(volumeMounts))
+				})
 			})
 
-			It("should do nothing to the existing VolumeMount if it's identical", func() {
-				identicalVolumeMount := volumeMounts[0]
-				result := webhook.EnsureVolumeMountWithName(volumeMounts, identicalVolumeMount)
-				Expect(result).To(Equal(volumeMounts))
-			})
-		})
+			Describe("EnsureEnvVarWithName", func() {
+				var envVars []corev1.EnvVar
 
-		Describe("EnsureEnvVarWithName", func() {
-			var envVars []corev1.EnvVar
+				BeforeEach(func() {
+					envVars = []corev1.EnvVar{
+						{
+							Name:  "envVar1",
+							Value: "value1",
+						},
+						{
+							Name:  "envVar2",
+							Value: "value2",
+						},
+					}
+				})
 
-			BeforeEach(func() {
-				envVars = []corev1.EnvVar{
-					{
-						Name:  "envVar1",
-						Value: "value1",
-					},
-					{
-						Name:  "envVar2",
-						Value: "value2",
-					},
-				}
-			})
+				It("should add a new EnvVar if not present", func() {
+					newEnvVar := corev1.EnvVar{
+						Name:  "envVar3",
+						Value: "value3",
+					}
+					result := webhook.EnsureEnvVarWithName(envVars, newEnvVar)
+					Expect(result).To(Equal(append(envVars, newEnvVar)))
+				})
 
-			It("should add a new EnvVar if not present", func() {
-				newEnvVar := corev1.EnvVar{
-					Name:  "envVar3",
-					Value: "value3",
-				}
-				result := webhook.EnsureEnvVarWithName(envVars, newEnvVar)
-				Expect(result).To(Equal(append(envVars, newEnvVar)))
-			})
-
-			It("should replace the existing EnvVar if it's not identical", func() {
-				existingEnvVar := corev1.EnvVar{
-					Name:  "envVar1",
-					Value: "value3",
-				}
-				result := webhook.EnsureEnvVarWithName(envVars, existingEnvVar)
-				Expect(result).To(Equal([]corev1.EnvVar{
-					{
+				It("should replace the existing EnvVar if it's not identical", func() {
+					existingEnvVar := corev1.EnvVar{
 						Name:  "envVar1",
 						Value: "value3",
-					},
-					{
-						Name:  "envVar2",
-						Value: "value2",
-					},
-				}))
+					}
+					result := webhook.EnsureEnvVarWithName(envVars, existingEnvVar)
+					Expect(result).To(Equal([]corev1.EnvVar{
+						{
+							Name:  "envVar1",
+							Value: "value3",
+						},
+						{
+							Name:  "envVar2",
+							Value: "value2",
+						},
+					}))
+				})
+
+				It("should do nothing to the existing EnvVar if it's identical", func() {
+					identicalEnvVar := envVars[0]
+					result := webhook.EnsureEnvVarWithName(envVars, identicalEnvVar)
+					Expect(result).To(Equal(envVars))
+				})
 			})
 
-			It("should do nothing to the existing EnvVar if it's identical", func() {
-				identicalEnvVar := envVars[0]
-				result := webhook.EnsureEnvVarWithName(envVars, identicalEnvVar)
-				Expect(result).To(Equal(envVars))
-			})
-		})
+			Describe("EnsureUnitOption", func() {
+				var unitOptions []*unit.UnitOption
 
-		Describe("EnsureUnitOption", func() {
-=======
-		Describe("#EnsureUnitOption", func() {
->>>>>>> ddddb7f5a (Addressing ialidzhikov's feedback)
-			var unitOptions []*unit.UnitOption
+				BeforeEach(func() {
+					unitOptions = []*unit.UnitOption{
+						{
+							Section: "Unit",
+							Name:    "Description",
+							Value:   "Test Unit 1",
+						},
+						{
+							Section: "Service",
+							Name:    "ExecStart",
+							Value:   "/usr/bin/test1",
+						},
+					}
+				})
 
-			BeforeEach(func() {
-				unitOptions = []*unit.UnitOption{
-					{
+				It("should add a new UnitOption if not present", func() {
+					newOption := &unit.UnitOption{
+						Section: "Install",
+						Name:    "WantedBy",
+						Value:   "multi-user.target",
+					}
+					result := webhook.EnsureUnitOption(unitOptions, newOption)
+					Expect(result).To(Equal(append(unitOptions, newOption)))
+				})
+
+				It("should not replace the existing UnitOption if it's not identical but add it", func() {
+					existingOption := &unit.UnitOption{
 						Section: "Unit",
 						Name:    "Description",
-						Value:   "Test Unit 1",
-					},
-					{
-						Section: "Service",
-						Name:    "ExecStart",
-						Value:   "/usr/bin/test1",
-					},
-				}
+						Value:   "Test Unit 2",
+					}
+					result := webhook.EnsureUnitOption(unitOptions, existingOption)
+					Expect(result).To(Equal(append(unitOptions, existingOption)))
+				})
+
+				It("should do nothing to the existing UnitOption if it's identical", func() {
+					identicalOption := unitOptions[0]
+					result := webhook.EnsureUnitOption(unitOptions, identicalOption)
+					Expect(result).To(Equal(unitOptions))
+				})
 			})
 
-			It("should add a new UnitOption if not present", func() {
-				newOption := &unit.UnitOption{
-					Section: "Install",
-					Name:    "WantedBy",
-					Value:   "multi-user.target",
-				}
-				result := webhook.EnsureUnitOption(unitOptions, newOption)
-				Expect(result).To(Equal(append(unitOptions, newOption)))
-			})
+			Describe("#EnsureFileWithPath", func() {
+				var (
+					files []extensionsv1alpha1.File
+				)
 
-			It("should not replace the existing UnitOption if it's not identical but add it", func() {
-				existingOption := &unit.UnitOption{
-					Section: "Unit",
-					Name:    "Description",
-					Value:   "Test Unit 2",
-				}
-				result := webhook.EnsureUnitOption(unitOptions, existingOption)
-				Expect(result).To(Equal(append(unitOptions, existingOption)))
-			})
+				BeforeEach(func() {
+					files = []extensionsv1alpha1.File{
+						{
+							Path:        "path1",
+							Permissions: pointer.Int32(0644),
+						},
+						{
+							Path:        "path2",
+							Permissions: pointer.Int32(0644),
+						},
+					}
+				})
 
-			It("should do nothing to the existing UnitOption if it's identical", func() {
-				identicalOption := unitOptions[0]
-				result := webhook.EnsureUnitOption(unitOptions, identicalOption)
-				Expect(result).To(Equal(unitOptions))
-			})
-		})
-
-		Describe("#EnsureFileWithPath", func() {
-			var (
-				files []extensionsv1alpha1.File
-			)
-
-			BeforeEach(func() {
-				files = []extensionsv1alpha1.File{
-					{
-						Path:        "path1",
+				It("should add a new File if not present", func() {
+					newFile := extensionsv1alpha1.File{
+						Path:        "path3",
 						Permissions: pointer.Int32(0644),
-					},
-					{
-						Path:        "path2",
-						Permissions: pointer.Int32(0644),
-					},
-				}
-			})
+					}
+					result := webhook.EnsureFileWithPath(files, newFile)
+					Expect(result).To(Equal(append(files, newFile)))
+				})
 
-			It("should add a new File if not present", func() {
-				newFile := extensionsv1alpha1.File{
-					Path:        "path3",
-					Permissions: pointer.Int32(0644),
-				}
-				result := webhook.EnsureFileWithPath(files, newFile)
-				Expect(result).To(Equal(append(files, newFile)))
-			})
-
-			It("should replace the existing File if it's not identical", func() {
-				existingFile := extensionsv1alpha1.File{
-					Path:        "path1",
-					Permissions: pointer.Int32(0400),
-				}
-				result := webhook.EnsureFileWithPath(files, existingFile)
-				Expect(result).To(Equal([]extensionsv1alpha1.File{
-					{
+				It("should replace the existing File if it's not identical", func() {
+					existingFile := extensionsv1alpha1.File{
 						Path:        "path1",
 						Permissions: pointer.Int32(0400),
-					},
-					{
-						Path:        "path2",
-						Permissions: pointer.Int32(0644),
-					},
-				}))
-			})
-
-			It("should do nothing to the existing File if it's identical", func() {
-				identicalFile := files[0]
-				result := webhook.EnsureFileWithPath(files, identicalFile)
-				Expect(result).To(Equal(files))
-			})
-		})
-
-		Describe("#EnsureAnnotationOrLabel", func() {
-			var annotations map[string]string
-
-			BeforeEach(func() {
-				annotations = map[string]string{
-					"annotation1": "value1",
-					"annotation2": "value2",
-				}
-			})
-
-			It("should ensure the specified annotation or label exists", func() {
-				result := webhook.EnsureAnnotationOrLabel(annotations, "annotation3", "value3")
-				Expect(result).To(Equal(map[string]string{
-					"annotation1": "value1",
-					"annotation2": "value2",
-					"annotation3": "value3",
-				}))
-			})
-
-			It("should overwrite the value of an existing annotation or label", func() {
-				result := webhook.EnsureAnnotationOrLabel(annotations, "annotation1", "newvalue1")
-				Expect(result).To(Equal(map[string]string{
-					"annotation1": "newvalue1",
-					"annotation2": "value2",
-				}))
-			})
-
-			It("should create a new map if the input map is nil", func() {
-				result := webhook.EnsureAnnotationOrLabel(nil, "annotation1", "value1")
-				Expect(result).To(Equal(map[string]string{
-					"annotation1": "value1",
-				}))
-			})
-		})
-	})
-
-	Describe("#EnsureNo*", func() {
-		Describe("#EnsureNoStringWithPrefix", func() {
-			var flags []string
-
-			BeforeEach(func() {
-				flags = []string{
-					"--prefix1-flag1=value1",
-					"--flag2=value2",
-					"--prefix1-flag3=value3",
-				}
-			})
-
-			It("should delete all strings with a given prefix", func() {
-				result := webhook.EnsureNoStringWithPrefix(flags, "--prefix1")
-				Expect(result).To(Equal([]string{"--flag2=value2"}))
-			})
-		})
-
-		Describe("#EnsureNoStringWithPrefixContains", func() {
-			var flags []string
-
-			BeforeEach(func() {
-				flags = []string{
-					"--flag1=key2=value2,key3=value3",
-					"--flag2=value1",
-					"--flag3=value3,value1",
-					"--flag1=key3=value3,key1=value1",
-				}
-			})
-
-			It("should delete the specified value from all strings with a given prefix", func() {
-				result := webhook.EnsureNoStringWithPrefixContains(flags, "--flag1=", "key3=value3", ",")
-				Expect(result).To(Equal([]string{
-					"--flag1=key2=value2",
-					"--flag2=value1",
-					"--flag3=value3,value1",
-					"--flag1=key1=value1",
-				}))
-			})
-		})
-
-		Describe("#EnsureNoEnvVarWithName", func() {
-			var envVars []corev1.EnvVar
-
-			BeforeEach(func() {
-				envVars = []corev1.EnvVar{
-					{Name: "envVar1"},
-					{Name: "envVar2"},
-					{Name: "envVar1"},
-				}
-			})
-
-			It("should delete all environment variables with a given name", func() {
-				result := webhook.EnsureNoEnvVarWithName(envVars, "envVar1")
-				Expect(result).To(Equal([]corev1.EnvVar{{Name: "envVar2"}}))
-			})
-		})
-
-		Describe("#EnsureNoVolumeMountWithName", func() {
-			var volumeMounts []corev1.VolumeMount
-
-			BeforeEach(func() {
-				volumeMounts = []corev1.VolumeMount{
-					{Name: "mount1"},
-					{Name: "mount2"},
-					{Name: "mount1"},
-				}
-			})
-
-			It("should delete all volume mounts with a given name", func() {
-				result := webhook.EnsureNoVolumeMountWithName(volumeMounts, "mount1")
-				Expect(result).To(Equal([]corev1.VolumeMount{{Name: "mount2"}}))
-			})
-		})
-
-		Describe("#EnsureNoVolumeWithName", func() {
-			var volumes []corev1.Volume
-
-			BeforeEach(func() {
-				volumes = []corev1.Volume{
-					{
-						Name: "volume1",
-						VolumeSource: corev1.VolumeSource{
-							EmptyDir: &corev1.EmptyDirVolumeSource{},
+					}
+					result := webhook.EnsureFileWithPath(files, existingFile)
+					Expect(result).To(Equal([]extensionsv1alpha1.File{
+						{
+							Path:        "path1",
+							Permissions: pointer.Int32(0400),
 						},
-					},
-					{
+						{
+							Path:        "path2",
+							Permissions: pointer.Int32(0644),
+						},
+					}))
+				})
+
+				It("should do nothing to the existing File if it's identical", func() {
+					identicalFile := files[0]
+					result := webhook.EnsureFileWithPath(files, identicalFile)
+					Expect(result).To(Equal(files))
+				})
+			})
+
+			Describe("#EnsureAnnotationOrLabel", func() {
+				var annotations map[string]string
+
+				BeforeEach(func() {
+					annotations = map[string]string{
+						"annotation1": "value1",
+						"annotation2": "value2",
+					}
+				})
+
+				It("should ensure the specified annotation or label exists", func() {
+					result := webhook.EnsureAnnotationOrLabel(annotations, "annotation3", "value3")
+					Expect(result).To(Equal(map[string]string{
+						"annotation1": "value1",
+						"annotation2": "value2",
+						"annotation3": "value3",
+					}))
+				})
+
+				It("should overwrite the value of an existing annotation or label", func() {
+					result := webhook.EnsureAnnotationOrLabel(annotations, "annotation1", "newvalue1")
+					Expect(result).To(Equal(map[string]string{
+						"annotation1": "newvalue1",
+						"annotation2": "value2",
+					}))
+				})
+
+				It("should create a new map if the input map is nil", func() {
+					result := webhook.EnsureAnnotationOrLabel(nil, "annotation1", "value1")
+					Expect(result).To(Equal(map[string]string{
+						"annotation1": "value1",
+					}))
+				})
+			})
+		})
+
+		Describe("#EnsureNo*", func() {
+			Describe("#EnsureNoStringWithPrefix", func() {
+				var flags []string
+
+				BeforeEach(func() {
+					flags = []string{
+						"--prefix1-flag1=value1",
+						"--flag2=value2",
+						"--prefix1-flag3=value3",
+					}
+				})
+
+				It("should delete all strings with a given prefix", func() {
+					result := webhook.EnsureNoStringWithPrefix(flags, "--prefix1")
+					Expect(result).To(Equal([]string{"--flag2=value2"}))
+				})
+			})
+
+			Describe("#EnsureNoStringWithPrefixContains", func() {
+				var flags []string
+
+				BeforeEach(func() {
+					flags = []string{
+						"--flag1=key2=value2,key3=value3",
+						"--flag2=value1",
+						"--flag3=value3,value1",
+						"--flag1=key3=value3,key1=value1",
+					}
+				})
+
+				It("should delete the specified value from all strings with a given prefix", func() {
+					result := webhook.EnsureNoStringWithPrefixContains(flags, "--flag1=", "key3=value3", ",")
+					Expect(result).To(Equal([]string{
+						"--flag1=key2=value2",
+						"--flag2=value1",
+						"--flag3=value3,value1",
+						"--flag1=key1=value1",
+					}))
+				})
+			})
+
+			Describe("#EnsureNoEnvVarWithName", func() {
+				var envVars []corev1.EnvVar
+
+				BeforeEach(func() {
+					envVars = []corev1.EnvVar{
+						{Name: "envVar1"},
+						{Name: "envVar2"},
+						{Name: "envVar1"},
+					}
+				})
+
+				It("should delete all environment variables with a given name", func() {
+					result := webhook.EnsureNoEnvVarWithName(envVars, "envVar1")
+					Expect(result).To(Equal([]corev1.EnvVar{{Name: "envVar2"}}))
+				})
+			})
+
+			Describe("#EnsureNoVolumeMountWithName", func() {
+				var volumeMounts []corev1.VolumeMount
+
+				BeforeEach(func() {
+					volumeMounts = []corev1.VolumeMount{
+						{Name: "mount1"},
+						{Name: "mount2"},
+						{Name: "mount1"},
+					}
+				})
+
+				It("should delete all volume mounts with a given name", func() {
+					result := webhook.EnsureNoVolumeMountWithName(volumeMounts, "mount1")
+					Expect(result).To(Equal([]corev1.VolumeMount{{Name: "mount2"}}))
+				})
+			})
+
+			Describe("#EnsureNoVolumeWithName", func() {
+				var volumes []corev1.Volume
+
+				BeforeEach(func() {
+					volumes = []corev1.Volume{
+						{
+							Name: "volume1",
+							VolumeSource: corev1.VolumeSource{
+								EmptyDir: &corev1.EmptyDirVolumeSource{},
+							},
+						},
+						{
+							Name: "volume2",
+							VolumeSource: corev1.VolumeSource{
+								EmptyDir: &corev1.EmptyDirVolumeSource{},
+							},
+						},
+						{
+							Name: "volume1",
+							VolumeSource: corev1.VolumeSource{
+								EmptyDir: &corev1.EmptyDirVolumeSource{},
+							},
+						},
+					}
+				})
+
+				It("should delete all volumes with a given name", func() {
+					result := webhook.EnsureNoVolumeWithName(volumes, "volume1")
+					Expect(result).To(Equal([]corev1.Volume{{
 						Name: "volume2",
 						VolumeSource: corev1.VolumeSource{
 							EmptyDir: &corev1.EmptyDirVolumeSource{},
 						},
-					},
-					{
-						Name: "volume1",
-						VolumeSource: corev1.VolumeSource{
-							EmptyDir: &corev1.EmptyDirVolumeSource{},
+					}}))
+				})
+			})
+
+			Describe("#EnsureNoContainerWithName", func() {
+				var containers []corev1.Container
+
+				BeforeEach(func() {
+					containers = []corev1.Container{
+						{Name: "container1"},
+						{Name: "container2"},
+						{Name: "container1"},
+					}
+				})
+
+				It("should delete all containers with a given name", func() {
+					result := webhook.EnsureNoContainerWithName(containers, "container1")
+					Expect(result).To(Equal([]corev1.Container{{Name: "container2"}}))
+				})
+			})
+
+			Describe("#EnsureNoPVCWithName", func() {
+				var pvcs []corev1.PersistentVolumeClaim
+
+				BeforeEach(func() {
+					pvcs = []corev1.PersistentVolumeClaim{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "pvc1",
+							},
 						},
-					},
-				}
-			})
-
-			It("should delete all volumes with a given name", func() {
-				result := webhook.EnsureNoVolumeWithName(volumes, "volume1")
-				Expect(result).To(Equal([]corev1.Volume{{
-					Name: "volume2",
-					VolumeSource: corev1.VolumeSource{
-						EmptyDir: &corev1.EmptyDirVolumeSource{},
-					},
-				}}))
-			})
-		})
-
-		Describe("#EnsureNoContainerWithName", func() {
-			var containers []corev1.Container
-
-			BeforeEach(func() {
-				containers = []corev1.Container{
-					{Name: "container1"},
-					{Name: "container2"},
-					{Name: "container1"},
-				}
-			})
-
-			It("should delete all containers with a given name", func() {
-				result := webhook.EnsureNoContainerWithName(containers, "container1")
-				Expect(result).To(Equal([]corev1.Container{{Name: "container2"}}))
-			})
-		})
-
-		Describe("#EnsureNoPVCWithName", func() {
-			var pvcs []corev1.PersistentVolumeClaim
-
-			BeforeEach(func() {
-				pvcs = []corev1.PersistentVolumeClaim{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: "pvc1",
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "pvc2",
+							},
 						},
-					},
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: "pvc2",
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "pvc1",
+							},
 						},
-					},
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: "pvc1",
-						},
-					},
-				}
-			})
+					}
+				})
 
-			It("should delete all Persistent Volume Claims with a given name", func() {
-				result := webhook.EnsureNoPVCWithName(pvcs, "pvc1")
-				Expect(result).To(Equal([]corev1.PersistentVolumeClaim{{ObjectMeta: metav1.ObjectMeta{Name: "pvc2"}}}))
+				It("should delete all Persistent Volume Claims with a given name", func() {
+					result := webhook.EnsureNoPVCWithName(pvcs, "pvc1")
+					Expect(result).To(Equal([]corev1.PersistentVolumeClaim{{ObjectMeta: metav1.ObjectMeta{Name: "pvc2"}}}))
+				})
 			})
 		})
 	})

--- a/extensions/pkg/webhook/utils_test.go
+++ b/extensions/pkg/webhook/utils_test.go
@@ -452,6 +452,51 @@ var _ = Describe("Utils", func() {
 			})
 		})
 
+		Describe("#EnsureUnitOption", func() {
+			var unitOptions []*unit.UnitOption
+
+			BeforeEach(func() {
+				unitOptions = []*unit.UnitOption{
+					{
+						Section: "Unit",
+						Name:    "Description",
+						Value:   "Test Unit 1",
+					},
+					{
+						Section: "Service",
+						Name:    "ExecStart",
+						Value:   "/usr/bin/test1",
+					},
+				}
+			})
+
+			It("should add a new UnitOption if not present", func() {
+				newOption := &unit.UnitOption{
+					Section: "Install",
+					Name:    "WantedBy",
+					Value:   "multi-user.target",
+				}
+				result := webhook.EnsureUnitOption(unitOptions, newOption)
+				Expect(result).To(Equal(append(unitOptions, newOption)))
+			})
+
+			It("should not replace the existing UnitOption if it's not identical but add it", func() {
+				existingOption := &unit.UnitOption{
+					Section: "Unit",
+					Name:    "Description",
+					Value:   "Test Unit 2",
+				}
+				result := webhook.EnsureUnitOption(unitOptions, existingOption)
+				Expect(result).To(Equal(append(unitOptions, existingOption)))
+			})
+
+			It("should do nothing to the existing UnitOption if it's identical", func() {
+				identicalOption := unitOptions[0]
+				result := webhook.EnsureUnitOption(unitOptions, identicalOption)
+				Expect(result).To(Equal(unitOptions))
+			})
+		})
+
 		Describe("#EnsureFileWithPath", func() {
 			var files []extensionsv1alpha1.File
 
@@ -581,396 +626,199 @@ var _ = Describe("Utils", func() {
 				Expect(actual).To(Equal(units))
 
 			})
+		})
 
-			Describe("EnsureVolumeMountWithName", func() {
-				var volumeMounts []corev1.VolumeMount
+		Describe("#EnsureAnnotationOrLabel", func() {
+			var annotations map[string]string
 
-				BeforeEach(func() {
-					volumeMounts = []corev1.VolumeMount{
-						{
-							Name:     "volumeMount1",
-							ReadOnly: true,
-						},
-						{
-							Name:     "volumeMount2",
-							ReadOnly: false,
-						},
-					}
-				})
-
-				It("should add a new VolumeMount if not present", func() {
-					newVolumeMount := corev1.VolumeMount{
-						Name:     "volumeMount3",
-						ReadOnly: true,
-					}
-					result := webhook.EnsureVolumeMountWithName(volumeMounts, newVolumeMount)
-					Expect(result).To(Equal(append(volumeMounts, newVolumeMount)))
-				})
-
-				It("should replace the existing VolumeMount if it's not identical", func() {
-					existingVolumeMount := corev1.VolumeMount{
-						Name:     "volumeMount1",
-						ReadOnly: false,
-					}
-					result := webhook.EnsureVolumeMountWithName(volumeMounts, existingVolumeMount)
-					Expect(result).To(Equal([]corev1.VolumeMount{
-						{
-							Name:     "volumeMount1",
-							ReadOnly: false,
-						},
-						{
-							Name:     "volumeMount2",
-							ReadOnly: false,
-						},
-					}))
-				})
-
-				It("should do nothing to the existing VolumeMount if it's identical", func() {
-					identicalVolumeMount := volumeMounts[0]
-					result := webhook.EnsureVolumeMountWithName(volumeMounts, identicalVolumeMount)
-					Expect(result).To(Equal(volumeMounts))
-				})
+			BeforeEach(func() {
+				annotations = map[string]string{
+					"annotation1": "value1",
+					"annotation2": "value2",
+				}
 			})
 
-			Describe("EnsureEnvVarWithName", func() {
-				var envVars []corev1.EnvVar
-
-				BeforeEach(func() {
-					envVars = []corev1.EnvVar{
-						{
-							Name:  "envVar1",
-							Value: "value1",
-						},
-						{
-							Name:  "envVar2",
-							Value: "value2",
-						},
-					}
-				})
-
-				It("should add a new EnvVar if not present", func() {
-					newEnvVar := corev1.EnvVar{
-						Name:  "envVar3",
-						Value: "value3",
-					}
-					result := webhook.EnsureEnvVarWithName(envVars, newEnvVar)
-					Expect(result).To(Equal(append(envVars, newEnvVar)))
-				})
-
-				It("should replace the existing EnvVar if it's not identical", func() {
-					existingEnvVar := corev1.EnvVar{
-						Name:  "envVar1",
-						Value: "value3",
-					}
-					result := webhook.EnsureEnvVarWithName(envVars, existingEnvVar)
-					Expect(result).To(Equal([]corev1.EnvVar{
-						{
-							Name:  "envVar1",
-							Value: "value3",
-						},
-						{
-							Name:  "envVar2",
-							Value: "value2",
-						},
-					}))
-				})
-
-				It("should do nothing to the existing EnvVar if it's identical", func() {
-					identicalEnvVar := envVars[0]
-					result := webhook.EnsureEnvVarWithName(envVars, identicalEnvVar)
-					Expect(result).To(Equal(envVars))
-				})
+			It("should ensure the specified annotation or label exists", func() {
+				result := webhook.EnsureAnnotationOrLabel(annotations, "annotation3", "value3")
+				Expect(result).To(Equal(map[string]string{
+					"annotation1": "value1",
+					"annotation2": "value2",
+					"annotation3": "value3",
+				}))
 			})
 
-			Describe("EnsureUnitOption", func() {
-				var unitOptions []*unit.UnitOption
-
-				BeforeEach(func() {
-					unitOptions = []*unit.UnitOption{
-						{
-							Section: "Unit",
-							Name:    "Description",
-							Value:   "Test Unit 1",
-						},
-						{
-							Section: "Service",
-							Name:    "ExecStart",
-							Value:   "/usr/bin/test1",
-						},
-					}
-				})
-
-				It("should add a new UnitOption if not present", func() {
-					newOption := &unit.UnitOption{
-						Section: "Install",
-						Name:    "WantedBy",
-						Value:   "multi-user.target",
-					}
-					result := webhook.EnsureUnitOption(unitOptions, newOption)
-					Expect(result).To(Equal(append(unitOptions, newOption)))
-				})
-
-				It("should not replace the existing UnitOption if it's not identical but add it", func() {
-					existingOption := &unit.UnitOption{
-						Section: "Unit",
-						Name:    "Description",
-						Value:   "Test Unit 2",
-					}
-					result := webhook.EnsureUnitOption(unitOptions, existingOption)
-					Expect(result).To(Equal(append(unitOptions, existingOption)))
-				})
-
-				It("should do nothing to the existing UnitOption if it's identical", func() {
-					identicalOption := unitOptions[0]
-					result := webhook.EnsureUnitOption(unitOptions, identicalOption)
-					Expect(result).To(Equal(unitOptions))
-				})
+			It("should overwrite the value of an existing annotation or label", func() {
+				result := webhook.EnsureAnnotationOrLabel(annotations, "annotation1", "newvalue1")
+				Expect(result).To(Equal(map[string]string{
+					"annotation1": "newvalue1",
+					"annotation2": "value2",
+				}))
 			})
 
-			Describe("#EnsureFileWithPath", func() {
-				var (
-					files []extensionsv1alpha1.File
-				)
+			It("should create a new map if the input map is nil", func() {
+				result := webhook.EnsureAnnotationOrLabel(nil, "annotation1", "value1")
+				Expect(result).To(Equal(map[string]string{
+					"annotation1": "value1",
+				}))
+			})
+		})
+	})
 
-				BeforeEach(func() {
-					files = []extensionsv1alpha1.File{
-						{
-							Path:        "path1",
-							Permissions: ptr.To(int32(0644)),
-						},
-						{
-							Path:        "path2",
-							Permissions: ptr.To(int32(0644)),
-						},
-					}
-				})
+	Describe("#EnsureNo*", func() {
+		Describe("#EnsureNoStringWithPrefix", func() {
+			var flags []string
 
-				It("should add a new File if not present", func() {
-					newFile := extensionsv1alpha1.File{
-						Path:        "path3",
-						Permissions: ptr.To(int32(0644)),
-					}
-					result := webhook.EnsureFileWithPath(files, newFile)
-					Expect(result).To(Equal(append(files, newFile)))
-				})
-
-				It("should replace the existing File if it's not identical", func() {
-					existingFile := extensionsv1alpha1.File{
-						Path:        "path1",
-						Permissions: ptr.To(int32(0400)),
-					}
-					result := webhook.EnsureFileWithPath(files, existingFile)
-					Expect(result).To(Equal([]extensionsv1alpha1.File{
-						{
-							Path:        "path1",
-							Permissions: ptr.To(int32(0400)),
-						},
-						{
-							Path:        "path2",
-							Permissions: ptr.To(int32(0644)),
-						},
-					}))
-				})
-
-				It("should do nothing to the existing File if it's identical", func() {
-					identicalFile := files[0]
-					result := webhook.EnsureFileWithPath(files, identicalFile)
-					Expect(result).To(Equal(files))
-				})
+			BeforeEach(func() {
+				flags = []string{
+					"--prefix1-flag1=value1",
+					"--flag2=value2",
+					"--prefix1-flag3=value3",
+				}
 			})
 
-			Describe("#EnsureAnnotationOrLabel", func() {
-				var annotations map[string]string
-
-				BeforeEach(func() {
-					annotations = map[string]string{
-						"annotation1": "value1",
-						"annotation2": "value2",
-					}
-				})
-
-				It("should ensure the specified annotation or label exists", func() {
-					result := webhook.EnsureAnnotationOrLabel(annotations, "annotation3", "value3")
-					Expect(result).To(Equal(map[string]string{
-						"annotation1": "value1",
-						"annotation2": "value2",
-						"annotation3": "value3",
-					}))
-				})
-
-				It("should overwrite the value of an existing annotation or label", func() {
-					result := webhook.EnsureAnnotationOrLabel(annotations, "annotation1", "newvalue1")
-					Expect(result).To(Equal(map[string]string{
-						"annotation1": "newvalue1",
-						"annotation2": "value2",
-					}))
-				})
-
-				It("should create a new map if the input map is nil", func() {
-					result := webhook.EnsureAnnotationOrLabel(nil, "annotation1", "value1")
-					Expect(result).To(Equal(map[string]string{
-						"annotation1": "value1",
-					}))
-				})
+			It("should delete all strings with a given prefix", func() {
+				result := webhook.EnsureNoStringWithPrefix(flags, "--prefix1")
+				Expect(result).To(Equal([]string{"--flag2=value2"}))
 			})
 		})
 
-		Describe("#EnsureNo*", func() {
-			Describe("#EnsureNoStringWithPrefix", func() {
-				var flags []string
+		Describe("#EnsureNoStringWithPrefixContains", func() {
+			var flags []string
 
-				BeforeEach(func() {
-					flags = []string{
-						"--prefix1-flag1=value1",
-						"--flag2=value2",
-						"--prefix1-flag3=value3",
-					}
-				})
-
-				It("should delete all strings with a given prefix", func() {
-					result := webhook.EnsureNoStringWithPrefix(flags, "--prefix1")
-					Expect(result).To(Equal([]string{"--flag2=value2"}))
-				})
+			BeforeEach(func() {
+				flags = []string{
+					"--flag1=key2=value2,key3=value3",
+					"--flag2=value1",
+					"--flag3=value3,value1",
+					"--flag1=key3=value3,key1=value1",
+				}
 			})
 
-			Describe("#EnsureNoStringWithPrefixContains", func() {
-				var flags []string
+			It("should delete the specified value from all strings with a given prefix", func() {
+				result := webhook.EnsureNoStringWithPrefixContains(flags, "--flag1=", "key3=value3", ",")
+				Expect(result).To(Equal([]string{
+					"--flag1=key2=value2",
+					"--flag2=value1",
+					"--flag3=value3,value1",
+					"--flag1=key1=value1",
+				}))
+			})
+		})
 
-				BeforeEach(func() {
-					flags = []string{
-						"--flag1=key2=value2,key3=value3",
-						"--flag2=value1",
-						"--flag3=value3,value1",
-						"--flag1=key3=value3,key1=value1",
-					}
-				})
+		Describe("#EnsureNoEnvVarWithName", func() {
+			var envVars []corev1.EnvVar
 
-				It("should delete the specified value from all strings with a given prefix", func() {
-					result := webhook.EnsureNoStringWithPrefixContains(flags, "--flag1=", "key3=value3", ",")
-					Expect(result).To(Equal([]string{
-						"--flag1=key2=value2",
-						"--flag2=value1",
-						"--flag3=value3,value1",
-						"--flag1=key1=value1",
-					}))
-				})
+			BeforeEach(func() {
+				envVars = []corev1.EnvVar{
+					{Name: "envVar1"},
+					{Name: "envVar2"},
+					{Name: "envVar1"},
+				}
 			})
 
-			Describe("#EnsureNoEnvVarWithName", func() {
-				var envVars []corev1.EnvVar
+			It("should delete all environment variables with a given name", func() {
+				result := webhook.EnsureNoEnvVarWithName(envVars, "envVar1")
+				Expect(result).To(Equal([]corev1.EnvVar{{Name: "envVar2"}}))
+			})
+		})
 
-				BeforeEach(func() {
-					envVars = []corev1.EnvVar{
-						{Name: "envVar1"},
-						{Name: "envVar2"},
-						{Name: "envVar1"},
-					}
-				})
+		Describe("#EnsureNoVolumeMountWithName", func() {
+			var volumeMounts []corev1.VolumeMount
 
-				It("should delete all environment variables with a given name", func() {
-					result := webhook.EnsureNoEnvVarWithName(envVars, "envVar1")
-					Expect(result).To(Equal([]corev1.EnvVar{{Name: "envVar2"}}))
-				})
+			BeforeEach(func() {
+				volumeMounts = []corev1.VolumeMount{
+					{Name: "mount1"},
+					{Name: "mount2"},
+					{Name: "mount1"},
+				}
 			})
 
-			Describe("#EnsureNoVolumeMountWithName", func() {
-				var volumeMounts []corev1.VolumeMount
-
-				BeforeEach(func() {
-					volumeMounts = []corev1.VolumeMount{
-						{Name: "mount1"},
-						{Name: "mount2"},
-						{Name: "mount1"},
-					}
-				})
-
-				It("should delete all volume mounts with a given name", func() {
-					result := webhook.EnsureNoVolumeMountWithName(volumeMounts, "mount1")
-					Expect(result).To(Equal([]corev1.VolumeMount{{Name: "mount2"}}))
-				})
+			It("should delete all volume mounts with a given name", func() {
+				result := webhook.EnsureNoVolumeMountWithName(volumeMounts, "mount1")
+				Expect(result).To(Equal([]corev1.VolumeMount{{Name: "mount2"}}))
 			})
+		})
 
-			Describe("#EnsureNoVolumeWithName", func() {
-				var volumes []corev1.Volume
+		Describe("#EnsureNoVolumeWithName", func() {
+			var volumes []corev1.Volume
 
-				BeforeEach(func() {
-					volumes = []corev1.Volume{
-						{
-							Name: "volume1",
-							VolumeSource: corev1.VolumeSource{
-								EmptyDir: &corev1.EmptyDirVolumeSource{},
-							},
+			BeforeEach(func() {
+				volumes = []corev1.Volume{
+					{
+						Name: "volume1",
+						VolumeSource: corev1.VolumeSource{
+							EmptyDir: &corev1.EmptyDirVolumeSource{},
 						},
-						{
-							Name: "volume2",
-							VolumeSource: corev1.VolumeSource{
-								EmptyDir: &corev1.EmptyDirVolumeSource{},
-							},
-						},
-						{
-							Name: "volume1",
-							VolumeSource: corev1.VolumeSource{
-								EmptyDir: &corev1.EmptyDirVolumeSource{},
-							},
-						},
-					}
-				})
-
-				It("should delete all volumes with a given name", func() {
-					result := webhook.EnsureNoVolumeWithName(volumes, "volume1")
-					Expect(result).To(Equal([]corev1.Volume{{
+					},
+					{
 						Name: "volume2",
 						VolumeSource: corev1.VolumeSource{
 							EmptyDir: &corev1.EmptyDirVolumeSource{},
 						},
-					}}))
-				})
+					},
+					{
+						Name: "volume1",
+						VolumeSource: corev1.VolumeSource{
+							EmptyDir: &corev1.EmptyDirVolumeSource{},
+						},
+					},
+				}
 			})
 
-			Describe("#EnsureNoContainerWithName", func() {
-				var containers []corev1.Container
+			It("should delete all volumes with a given name", func() {
+				result := webhook.EnsureNoVolumeWithName(volumes, "volume1")
+				Expect(result).To(Equal([]corev1.Volume{{
+					Name: "volume2",
+					VolumeSource: corev1.VolumeSource{
+						EmptyDir: &corev1.EmptyDirVolumeSource{},
+					},
+				}}))
+			})
+		})
 
-				BeforeEach(func() {
-					containers = []corev1.Container{
-						{Name: "container1"},
-						{Name: "container2"},
-						{Name: "container1"},
-					}
-				})
+		Describe("#EnsureNoContainerWithName", func() {
+			var containers []corev1.Container
 
-				It("should delete all containers with a given name", func() {
-					result := webhook.EnsureNoContainerWithName(containers, "container1")
-					Expect(result).To(Equal([]corev1.Container{{Name: "container2"}}))
-				})
+			BeforeEach(func() {
+				containers = []corev1.Container{
+					{Name: "container1"},
+					{Name: "container2"},
+					{Name: "container1"},
+				}
 			})
 
-			Describe("#EnsureNoPVCWithName", func() {
-				var pvcs []corev1.PersistentVolumeClaim
+			It("should delete all containers with a given name", func() {
+				result := webhook.EnsureNoContainerWithName(containers, "container1")
+				Expect(result).To(Equal([]corev1.Container{{Name: "container2"}}))
+			})
+		})
 
-				BeforeEach(func() {
-					pvcs = []corev1.PersistentVolumeClaim{
-						{
-							ObjectMeta: metav1.ObjectMeta{
-								Name: "pvc1",
-							},
-						},
-						{
-							ObjectMeta: metav1.ObjectMeta{
-								Name: "pvc2",
-							},
-						},
-						{
-							ObjectMeta: metav1.ObjectMeta{
-								Name: "pvc1",
-							},
-						},
-					}
-				})
+		Describe("#EnsureNoPVCWithName", func() {
+			var pvcs []corev1.PersistentVolumeClaim
 
-				It("should delete all Persistent Volume Claims with a given name", func() {
-					result := webhook.EnsureNoPVCWithName(pvcs, "pvc1")
-					Expect(result).To(Equal([]corev1.PersistentVolumeClaim{{ObjectMeta: metav1.ObjectMeta{Name: "pvc2"}}}))
-				})
+			BeforeEach(func() {
+				pvcs = []corev1.PersistentVolumeClaim{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "pvc1",
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "pvc2",
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "pvc1",
+						},
+					},
+				}
+			})
+
+			It("should delete all Persistent Volume Claims with a given name", func() {
+				result := webhook.EnsureNoPVCWithName(pvcs, "pvc1")
+				Expect(result).To(Equal([]corev1.PersistentVolumeClaim{{ObjectMeta: metav1.ObjectMeta{Name: "pvc2"}}}))
 			})
 		})
 	})

--- a/extensions/pkg/webhook/utils_test.go
+++ b/extensions/pkg/webhook/utils_test.go
@@ -24,134 +24,747 @@ import (
 )
 
 var _ = Describe("Utils", func() {
+	Describe("Ensure_", func() {
+		Describe("EnsureVolumeWithName", func() {
+			var volumes []corev1.Volume
 
-	Describe("#EnsureFileWithPath", func() {
-		var files []extensionsv1alpha1.File
-
-		BeforeEach(func() {
-			files = []extensionsv1alpha1.File{
-				{
-					Path: "/foo.txt",
-					Content: extensionsv1alpha1.FileContent{
-						Inline: &extensionsv1alpha1.FileContentInline{
-							Data: "foo",
+			BeforeEach(func() {
+				volumes = []corev1.Volume{
+					{
+						Name: "volume1",
+						VolumeSource: corev1.VolumeSource{
+							EmptyDir: &corev1.EmptyDirVolumeSource{Medium: ""},
 						},
 					},
-				},
-				{
-					Path: "/bar.txt",
-					Content: extensionsv1alpha1.FileContent{
-						Inline: &extensionsv1alpha1.FileContentInline{
-							Data: "bar",
+					{
+						Name: "volume2",
+						VolumeSource: corev1.VolumeSource{
+							EmptyDir: &corev1.EmptyDirVolumeSource{},
 						},
 					},
-				},
-			}
+				}
+			})
+
+			It("should add a new Volume if not present", func() {
+				newVolume := corev1.Volume{
+					Name: "volume3",
+					VolumeSource: corev1.VolumeSource{
+						EmptyDir: &corev1.EmptyDirVolumeSource{},
+					},
+				}
+				result := webhook.EnsureVolumeWithName(volumes, newVolume)
+				Expect(result).To(Equal(append(volumes, newVolume)))
+			})
+
+			It("should replace the existing Volume if it's not identical", func() {
+				existingVolume := corev1.Volume{
+					Name: "volume1",
+					VolumeSource: corev1.VolumeSource{
+						EmptyDir: &corev1.EmptyDirVolumeSource{Medium: "Memory"},
+					},
+				}
+				result := webhook.EnsureVolumeWithName(volumes, existingVolume)
+				Expect(result).To(Equal([]corev1.Volume{
+					{
+						Name: "volume1",
+						VolumeSource: corev1.VolumeSource{
+							EmptyDir: &corev1.EmptyDirVolumeSource{Medium: "Memory"},
+						},
+					},
+					{
+						Name: "volume2",
+						VolumeSource: corev1.VolumeSource{
+							EmptyDir: &corev1.EmptyDirVolumeSource{},
+						},
+					},
+				}))
+			})
+
+			It("should do nothing to the existing Volume if it's identical", func() {
+				identicalVolume := volumes[0]
+				result := webhook.EnsureVolumeWithName(volumes, identicalVolume)
+				Expect(result).To(Equal(volumes))
+			})
 		})
 
-		It("should append file when file with such path does not exist", func() {
-			newFile := extensionsv1alpha1.File{
-				Path: "/baz.txt",
-				Content: extensionsv1alpha1.FileContent{
-					Inline: &extensionsv1alpha1.FileContentInline{
-						Data: "baz",
-					},
-				},
-			}
+		Describe("EnsureContainerWithName", func() {
+			var containers []corev1.Container
 
-			actual := webhook.EnsureFileWithPath(files, newFile)
-			Expect(actual).To(Equal(append(files, newFile)))
+			BeforeEach(func() {
+				containers = []corev1.Container{
+					{
+						Name:  "container1",
+						Image: "image1",
+					},
+					{
+						Name:  "container2",
+						Image: "image2",
+					},
+				}
+			})
+
+			It("should add a new Container if not present", func() {
+				newContainer := corev1.Container{
+					Name:  "container3",
+					Image: "image3",
+				}
+				result := webhook.EnsureContainerWithName(containers, newContainer)
+				Expect(result).To(Equal(append(containers, newContainer)))
+			})
+
+			It("should replace the existing Container if it's not identical", func() {
+				existingContainer := corev1.Container{
+					Name:  "container1",
+					Image: "image3",
+				}
+				result := webhook.EnsureContainerWithName(containers, existingContainer)
+				Expect(result).To(Equal(
+					[]corev1.Container{
+						{
+							Name:  "container1",
+							Image: "image3",
+						},
+						{
+							Name:  "container2",
+							Image: "image2",
+						},
+					},
+				))
+			})
+
+			It("should do nothing to the existing Container if it's identical", func() {
+				identicalContainer := containers[0]
+				result := webhook.EnsureContainerWithName(containers, identicalContainer)
+				Expect(result).To(Equal(containers))
+			})
 		})
 
-		It("should update file when file with such path exists", func() {
-			newFile := extensionsv1alpha1.File{
-				Path: "/foo.txt",
-				Content: extensionsv1alpha1.FileContent{
-					Inline: &extensionsv1alpha1.FileContentInline{
-						Data: "baz",
-					},
-				},
-			}
+		Describe("EnsureVPAContainerResourcePolicyWithName", func() {
+			var policies []vpaautoscalingv1.ContainerResourcePolicy
+			var modeAuto = vpaautoscalingv1.ContainerScalingModeAuto
+			var modeOff = vpaautoscalingv1.ContainerScalingModeOff
 
-			actual := webhook.EnsureFileWithPath(files, newFile)
-			Expect(actual).To(Equal([]extensionsv1alpha1.File{
-				{
+			BeforeEach(func() {
+				policies = []vpaautoscalingv1.ContainerResourcePolicy{
+					{
+						ContainerName: "container1",
+						Mode:          &modeAuto,
+					},
+					{
+						ContainerName: "container2",
+						Mode:          &modeOff,
+					},
+				}
+			})
+
+			It("should add a new ContainerResourcePolicy if not present", func() {
+				newPolicy := vpaautoscalingv1.ContainerResourcePolicy{
+					ContainerName: "container3",
+					Mode:          &modeAuto,
+				}
+				result := webhook.EnsureVPAContainerResourcePolicyWithName(policies, newPolicy)
+				Expect(result).To(Equal(append(policies, newPolicy)))
+			})
+
+			It("should replace the existing ContainerResourcePolicy if it's not identical", func() {
+				existingPolicy := vpaautoscalingv1.ContainerResourcePolicy{
+					ContainerName: "container1",
+					Mode:          &modeOff,
+				}
+				result := webhook.EnsureVPAContainerResourcePolicyWithName(policies, existingPolicy)
+				Expect(result).To(Equal([]vpaautoscalingv1.ContainerResourcePolicy{
+					{
+						ContainerName: "container1",
+						Mode:          &modeOff,
+					},
+					{
+						ContainerName: "container2",
+						Mode:          &modeOff,
+					},
+				}))
+			})
+
+			It("should do nothing to the existing ContainerResourcePolicy if it's identical", func() {
+				identicalPolicy := policies[0]
+				result := webhook.EnsureVPAContainerResourcePolicyWithName(policies, identicalPolicy)
+				Expect(result).To(Equal(policies))
+			})
+		})
+
+		Describe("EnsurePVCWithName", func() {
+			var pvcs []corev1.PersistentVolumeClaim
+
+			BeforeEach(func() {
+				pvcs = []corev1.PersistentVolumeClaim{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "pvc1",
+							Namespace: "namespace1",
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "pvc2",
+							Namespace: "namespace2",
+						},
+					},
+				}
+			})
+
+			It("should add a new PersistentVolumeClaim if not present", func() {
+				newPVC := corev1.PersistentVolumeClaim{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "pvc3",
+						Namespace: "namespace3",
+					},
+				}
+				result := webhook.EnsurePVCWithName(pvcs, newPVC)
+				Expect(result).To(Equal(append(pvcs, newPVC)))
+			})
+
+			It("should replace the existing PersistentVolumeClaim if it's not identical", func() {
+				existingPVC := corev1.PersistentVolumeClaim{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "pvc1",
+						Namespace: "namespace3",
+					},
+				}
+				result := webhook.EnsurePVCWithName(pvcs, existingPVC)
+				Expect(result).To(Equal([]corev1.PersistentVolumeClaim{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "pvc1",
+							Namespace: "namespace3",
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "pvc2",
+							Namespace: "namespace2",
+						},
+					},
+				}))
+			})
+
+			It("should do nothing to the existing PersistentVolumeClaim if it's identical", func() {
+				identicalPVC := pvcs[0]
+				result := webhook.EnsurePVCWithName(pvcs, identicalPVC)
+				Expect(result).To(Equal(pvcs))
+			})
+		})
+
+		Describe("#EnsureFileWithPath", func() {
+			var files []extensionsv1alpha1.File
+	
+			BeforeEach(func() {
+				files = []extensionsv1alpha1.File{
+					{
+						Path: "/foo.txt",
+						Content: extensionsv1alpha1.FileContent{
+							Inline: &extensionsv1alpha1.FileContentInline{
+								Data: "foo",
+							},
+						},
+					},
+					{
+						Path: "/bar.txt",
+						Content: extensionsv1alpha1.FileContent{
+							Inline: &extensionsv1alpha1.FileContentInline{
+								Data: "bar",
+							},
+						},
+					},
+				}
+			})
+	
+			It("should append file when file with such path does not exist", func() {
+				newFile := extensionsv1alpha1.File{
+					Path: "/baz.txt",
+					Content: extensionsv1alpha1.FileContent{
+						Inline: &extensionsv1alpha1.FileContentInline{
+							Data: "baz",
+						},
+					},
+				}
+	
+				actual := webhook.EnsureFileWithPath(files, newFile)
+				Expect(actual).To(Equal(append(files, newFile)))
+			})
+	
+			It("should update file when file with such path exists", func() {
+				newFile := extensionsv1alpha1.File{
 					Path: "/foo.txt",
 					Content: extensionsv1alpha1.FileContent{
 						Inline: &extensionsv1alpha1.FileContentInline{
 							Data: "baz",
 						},
 					},
-				},
-				{
-					Path: "/bar.txt",
-					Content: extensionsv1alpha1.FileContent{
-						Inline: &extensionsv1alpha1.FileContentInline{
-							Data: "bar",
+				}
+	
+				actual := webhook.EnsureFileWithPath(files, newFile)
+				Expect(actual).To(Equal([]extensionsv1alpha1.File{
+					{
+						Path: "/foo.txt",
+						Content: extensionsv1alpha1.FileContent{
+							Inline: &extensionsv1alpha1.FileContentInline{
+								Data: "baz",
+							},
 						},
 					},
-				},
-			}))
+					{
+						Path: "/bar.txt",
+						Content: extensionsv1alpha1.FileContent{
+							Inline: &extensionsv1alpha1.FileContentInline{
+								Data: "bar",
+							},
+						},
+					},
+				}))
+			})
+	
+			It("should do nothing when the new file is exactly the same as the existing one", func() {
+				newFile := files[0]
+	
+				actual := webhook.EnsureFileWithPath(files, newFile)
+				Expect(actual).To(Equal(files))
+			})
+		})
+	
+		Describe("#EnsureUnitWithName", func() {
+			var units []extensionsv1alpha1.Unit
+	
+			BeforeEach(func() {
+				units = []extensionsv1alpha1.Unit{
+					{
+						Name:    "foo.service",
+						Content: ptr.To("foo"),
+					},
+					{
+						Name:    "bar.service",
+						Content: ptr.To("bar"),
+					},
+				}
+			})
+	
+			It("should append unit when unit with such name does not exist", func() {
+				newUnit := extensionsv1alpha1.Unit{
+					Name:    "baz.service",
+					Content: ptr.To("bar"),
+				}
+	
+				actual := webhook.EnsureUnitWithName(units, newUnit)
+				Expect(actual).To(Equal(append(units, newUnit)))
+			})
+	
+			It("should update unit when unit with such name exists", func() {
+				newUnit := extensionsv1alpha1.Unit{
+					Name:    "foo.service",
+					Content: ptr.To("baz"),
+				}
+	
+				actual := webhook.EnsureUnitWithName(units, newUnit)
+				Expect(actual).To(Equal([]extensionsv1alpha1.Unit{
+					{
+						Name:    "foo.service",
+						Content: ptr.To("baz"),
+					},
+					{
+						Name:    "bar.service",
+						Content: ptr.To("bar"),
+					},
+				}))
+			})
+	
+			It("should do nothing when the new unit is exactly the same as the existing one", func() {
+				newUnit := units[0]
+	
+				actual := webhook.EnsureUnitWithName(units, newUnit)
+				Expect(actual).To(Equal(units))
+	
+			})
+
+		Describe("EnsureVolumeMountWithName", func() {
+			var volumeMounts []corev1.VolumeMount
+
+			BeforeEach(func() {
+				volumeMounts = []corev1.VolumeMount{
+					{
+						Name:     "volumeMount1",
+						ReadOnly: true,
+					},
+					{
+						Name:     "volumeMount2",
+						ReadOnly: false,
+					},
+				}
+			})
+
+			It("should add a new VolumeMount if not present", func() {
+				newVolumeMount := corev1.VolumeMount{
+					Name:     "volumeMount3",
+					ReadOnly: true,
+				}
+				result := webhook.EnsureVolumeMountWithName(volumeMounts, newVolumeMount)
+				Expect(result).To(Equal(append(volumeMounts, newVolumeMount)))
+			})
+
+			It("should replace the existing VolumeMount if it's not identical", func() {
+				existingVolumeMount := corev1.VolumeMount{
+					Name:     "volumeMount1",
+					ReadOnly: false,
+				}
+				result := webhook.EnsureVolumeMountWithName(volumeMounts, existingVolumeMount)
+				Expect(result).To(Equal([]corev1.VolumeMount{
+					{
+						Name:     "volumeMount1",
+						ReadOnly: false,
+					},
+					{
+						Name:     "volumeMount2",
+						ReadOnly: false,
+					},
+				}))
+			})
+
+			It("should do nothing to the existing VolumeMount if it's identical", func() {
+				identicalVolumeMount := volumeMounts[0]
+				result := webhook.EnsureVolumeMountWithName(volumeMounts, identicalVolumeMount)
+				Expect(result).To(Equal(volumeMounts))
+			})
 		})
 
-		It("should do nothing when the new file is exactly the same as the existing one", func() {
-			newFile := files[0]
+		Describe("EnsureEnvVarWithName", func() {
+			var envVars []corev1.EnvVar
 
-			actual := webhook.EnsureFileWithPath(files, newFile)
-			Expect(actual).To(Equal(files))
+			BeforeEach(func() {
+				envVars = []corev1.EnvVar{
+					{
+						Name:  "envVar1",
+						Value: "value1",
+					},
+					{
+						Name:  "envVar2",
+						Value: "value2",
+					},
+				}
+			})
+
+			It("should add a new EnvVar if not present", func() {
+				newEnvVar := corev1.EnvVar{
+					Name:  "envVar3",
+					Value: "value3",
+				}
+				result := webhook.EnsureEnvVarWithName(envVars, newEnvVar)
+				Expect(result).To(Equal(append(envVars, newEnvVar)))
+			})
+
+			It("should replace the existing EnvVar if it's not identical", func() {
+				existingEnvVar := corev1.EnvVar{
+					Name:  "envVar1",
+					Value: "value3",
+				}
+				result := webhook.EnsureEnvVarWithName(envVars, existingEnvVar)
+				Expect(result).To(Equal([]corev1.EnvVar{
+					{
+						Name:  "envVar1",
+						Value: "value3",
+					},
+					{
+						Name:  "envVar2",
+						Value: "value2",
+					},
+				}))
+			})
+
+			It("should do nothing to the existing EnvVar if it's identical", func() {
+				identicalEnvVar := envVars[0]
+				result := webhook.EnsureEnvVarWithName(envVars, identicalEnvVar)
+				Expect(result).To(Equal(envVars))
+			})
+		})
+
+		Describe("EnsureUnitOption", func() {
+			var unitOptions []*unit.UnitOption
+
+			BeforeEach(func() {
+				unitOptions = []*unit.UnitOption{
+					{
+						Section: "Unit",
+						Name:    "Description",
+						Value:   "Test Unit 1",
+					},
+					{
+						Section: "Service",
+						Name:    "ExecStart",
+						Value:   "/usr/bin/test1",
+					},
+				}
+			})
+
+			It("should add a new UnitOption if not present", func() {
+				newOption := &unit.UnitOption{
+					Section: "Install",
+					Name:    "WantedBy",
+					Value:   "multi-user.target",
+				}
+				result := webhook.EnsureUnitOption(unitOptions, newOption)
+				Expect(result).To(Equal(append(unitOptions, newOption)))
+			})
+
+			It("should not replace the existing UnitOption if it's not identical but add it", func() {
+				existingOption := &unit.UnitOption{
+					Section: "Unit",
+					Name:    "Description",
+					Value:   "Test Unit 2",
+				}
+				result := webhook.EnsureUnitOption(unitOptions, existingOption)
+				Expect(result).To(Equal(append(unitOptions, existingOption)))
+			})
+
+			It("should do nothing to the existing UnitOption if it's identical", func() {
+				identicalOption := unitOptions[0]
+				result := webhook.EnsureUnitOption(unitOptions, identicalOption)
+				Expect(result).To(Equal(unitOptions))
+			})
+		})
+
+		Describe("EnsureAnnotationOrLabel", func() {
+			var annotations map[string]string
+
+			BeforeEach(func() {
+				annotations = map[string]string{
+					"annotation1": "value1",
+					"annotation2": "value2",
+				}
+			})
+
+			It("should ensure the specified annotation or label exists", func() {
+				result := webhook.EnsureAnnotationOrLabel(annotations, "annotation3", "value3")
+				Expect(len(result)).To(Equal(3))
+				Expect(result["annotation3"]).To(Equal("value3"))
+			})
+
+			It("should overwrite the value of an existing annotation or label", func() {
+				result := webhook.EnsureAnnotationOrLabel(annotations, "annotation1", "newvalue1")
+				Expect(len(result)).To(Equal(2))
+				Expect(result["annotation1"]).To(Equal("newvalue1"))
+			})
+
+			It("should create a new map if the input map is nil", func() {
+				var nilMap map[string]string
+				result := webhook.EnsureAnnotationOrLabel(nilMap, "annotation1", "value1")
+				Expect(len(result)).To(Equal(1))
+				Expect(result["annotation1"]).To(Equal("value1"))
+			})
+		})
+
+		Describe("EnsureStringWithPrefix", func() {
+			var flags []string
+
+			BeforeEach(func() {
+				flags = []string{
+					"--prefix1=key1=value1,key2=value2,key3=value3",
+					"--prefix2=key4=value4,key5=value5,key6=value6",
+					"--prefix1=key7=value7,key8=value8,key9=value9",
+				}
+			})
+
+			It("should replace all strings with a given prefix with prefix+value", func() {
+				result := webhook.EnsureStringWithPrefix(flags, "--prefix1=", "key7=value7")
+				Expect(result).To(Equal([]string{
+					"--prefix1=key7=value7",
+					"--prefix2=key4=value4,key5=value5,key6=value6",
+					"--prefix1=key7=value7",
+				}))
+			})
+
+			It("should add a new flag with the specified prefix and value if no flag with the given prefix exists", func() {
+				result := webhook.EnsureStringWithPrefix(flags, "--prefix3=", "key8=value8")
+				Expect(result).To(Equal(append(flags, "--prefix3=key8=value8")))
+			})
+		})
+
+		Describe("EnsureStringWithPrefixContains", func() {
+			var flags []string
+
+			BeforeEach(func() {
+				flags = []string{
+					"--flag1=key1=value1,key2=value2,key3=value3",
+					"--flag2=key4=value4,key5=value5,key6=value6",
+					"--flag1=key7=value7,key8=value8,key9=value9",
+				}
+			})
+
+			It("should ensure the specified key-value pair is in all flags with a given prefix", func() {
+				result := webhook.EnsureStringWithPrefixContains(flags, "--flag1=", "key3=value3", ",")
+				Expect(result).To(Equal([]string{
+					"--flag1=key1=value1,key2=value2,key3=value3",
+					"--flag2=key4=value4,key5=value5,key6=value6",
+					"--flag1=key7=value7,key8=value8,key9=value9,key3=value3",
+				}))
+			})
+
+			It("should add a new flag with the specified key-value pair if no flag with the given prefix exists", func() {
+				result := webhook.EnsureStringWithPrefixContains(flags, "--flag3=", "key10=value10", ",")
+				Expect(result).To(Equal(append(flags, "--flag3=key10=value10")))
+			})
 		})
 	})
 
-	Describe("#EnsureUnitWithName", func() {
-		var units []extensionsv1alpha1.Unit
+	Describe("EnsureNo_", func() {
+		Describe("EnsureNoVolumeWithName", func() {
+			var volumes []corev1.Volume
 
-		BeforeEach(func() {
-			units = []extensionsv1alpha1.Unit{
-				{
-					Name:    "foo.service",
-					Content: ptr.To("foo"),
-				},
-				{
-					Name:    "bar.service",
-					Content: ptr.To("bar"),
-				},
-			}
+			BeforeEach(func() {
+				volumes = []corev1.Volume{
+					{
+						Name: "volume1",
+						VolumeSource: corev1.VolumeSource{
+							EmptyDir: &corev1.EmptyDirVolumeSource{},
+						},
+					},
+					{
+						Name: "volume2",
+						VolumeSource: corev1.VolumeSource{
+							EmptyDir: &corev1.EmptyDirVolumeSource{},
+						},
+					},
+					{
+						Name: "volume1",
+						VolumeSource: corev1.VolumeSource{
+							EmptyDir: &corev1.EmptyDirVolumeSource{},
+						},
+					},
+				}
+			})
+
+			It("should delete all volumes with a given name", func() {
+				result := webhook.EnsureNoVolumeWithName(volumes, "volume1")
+				Expect(result).To(Equal([]corev1.Volume{{
+					Name: "volume2",
+					VolumeSource: corev1.VolumeSource{
+						EmptyDir: &corev1.EmptyDirVolumeSource{},
+					},
+				}}))
+			})
 		})
 
-		It("should append unit when unit with such name does not exist", func() {
-			newUnit := extensionsv1alpha1.Unit{
-				Name:    "baz.service",
-				Content: ptr.To("bar"),
-			}
+		Describe("EnsureNoVolumeMountWithName", func() {
+			var volumeMounts []corev1.VolumeMount
 
-			actual := webhook.EnsureUnitWithName(units, newUnit)
-			Expect(actual).To(Equal(append(units, newUnit)))
+			BeforeEach(func() {
+				volumeMounts = []corev1.VolumeMount{
+					{Name: "mount1"},
+					{Name: "mount2"},
+					{Name: "mount1"},
+				}
+			})
+
+			It("should delete all volume mounts with a given name", func() {
+				result := webhook.EnsureNoVolumeMountWithName(volumeMounts, "mount1")
+				Expect(result).To(Equal([]corev1.VolumeMount{{Name: "mount2"}}))
+			})
 		})
 
-		It("should update unit when unit with such name exists", func() {
-			newUnit := extensionsv1alpha1.Unit{
-				Name:    "foo.service",
-				Content: ptr.To("baz"),
-			}
+		Describe("EnsureNoEnvVarWithName", func() {
+			var envVars []corev1.EnvVar
 
-			actual := webhook.EnsureUnitWithName(units, newUnit)
-			Expect(actual).To(Equal([]extensionsv1alpha1.Unit{
-				{
-					Name:    "foo.service",
-					Content: ptr.To("baz"),
-				},
-				{
-					Name:    "bar.service",
-					Content: ptr.To("bar"),
-				},
-			}))
+			BeforeEach(func() {
+				envVars = []corev1.EnvVar{
+					{Name: "envVar1"},
+					{Name: "envVar2"},
+					{Name: "envVar1"},
+				}
+			})
+
+			It("should delete all environment variables with a given name", func() {
+				result := webhook.EnsureNoEnvVarWithName(envVars, "envVar1")
+				Expect(result).To(Equal([]corev1.EnvVar{{Name: "envVar2"}}))
+			})
 		})
 
-		It("should do nothing when the new unit is exactly the same as the existing one", func() {
-			newUnit := units[0]
+		Describe("EnsureNoContainerWithName", func() {
+			var containers []corev1.Container
 
-			actual := webhook.EnsureUnitWithName(units, newUnit)
-			Expect(actual).To(Equal(units))
+			BeforeEach(func() {
+				containers = []corev1.Container{
+					{Name: "container1"},
+					{Name: "container2"},
+					{Name: "container1"},
+				}
+			})
+
+			It("should delete all containers with a given name", func() {
+				result := webhook.EnsureNoContainerWithName(containers, "container1")
+				Expect(result).To(Equal([]corev1.Container{{Name: "container2"}}))
+			})
+		})
+
+		Describe("EnsureNoPVCWithName", func() {
+			var pvcs []corev1.PersistentVolumeClaim
+
+			BeforeEach(func() {
+				pvcs = []corev1.PersistentVolumeClaim{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "pvc1",
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "pvc2",
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "pvc1",
+						},
+					},
+				}
+			})
+
+			It("should delete all Persistent Volume Claims with a given name", func() {
+				result := webhook.EnsureNoPVCWithName(pvcs, "pvc1")
+				Expect(result).To(Equal([]corev1.PersistentVolumeClaim{{ObjectMeta: metav1.ObjectMeta{Name: "pvc2"}}}))
+			})
+		})
+
+		Describe("EnsureNoStringWithPrefix", func() {
+			var flags []string
+
+			BeforeEach(func() {
+				flags = []string{
+					"--prefix1=key1=value1,key2=value2,key3=value3",
+					"--prefix2=key4=value4,key5=value5,key6=value6",
+					"--prefix1=key7=value7,key8=value8,key9=value9",
+				}
+			})
+
+			It("should delete all flags with a given prefix", func() {
+				result := webhook.EnsureNoStringWithPrefix(flags, "--prefix1=")
+				Expect(result).To(Equal([]string{"--prefix2=key4=value4,key5=value5,key6=value6"}))
+			})
+		})
+
+		Describe("EnsureNoStringWithPrefixContains", func() {
+			var flags []string
+
+			BeforeEach(func() {
+				flags = []string{
+					"--prefix1=key1=value1,key2=value2,key3=value3",
+					"--prefix2=key4=value4,key5=value5,key6=value6",
+					"--prefix1=key7=value7,key8=value8,key9=value9",
+				}
+			})
+
+			It("should delete the specified key-value pair from all flags with a given prefix", func() {
+				result := webhook.EnsureNoStringWithPrefixContains(flags, "--prefix1=", "key2=value2", ",")
+				Expect(result).To(Equal([]string{
+					"--prefix1=key1=value1,key3=value3",
+					"--prefix2=key4=value4,key5=value5,key6=value6",
+					"--prefix1=key7=value7,key8=value8,key9=value9",
+				}))
+			})
 		})
 	})
 })


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind enhancement

**What this PR does / why we need it**:
- `EnsureNo_`, `EnsureStringWithPrefix`, `EnsureStringWithPrefixContains` act on all matches
- rewrites utility functions from package `extensions/pkg/webhook` using `slices` library
- add test covering `Ensure_` functions

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener/issues/8296

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking dependency
There are several breaking changes in the `github.com/gardener/gardener/extensions/pkg/webhook` package:
- `EnsureNoStringWithPrefix`, `EnsureNoStringWithPrefixContains`, `EnsureNoEnvVarWithName`, `EnsureNoVolumeMountWithName`, `EnsureNoVolumeWithName`, `EnsureNoContainerWithName`, `EnsureNoPVCWithName` now delete all matching entries. Previously they were deleting only the first occurrence.
- `EnsureStringWithPrefix`, `EnsureStringWithPrefixContains` now act on all prefix matches.
- `StringIndex` is removed. instead, use `slices.Index`.
```
