### PR TITLE
fix: avoid erroneously detecting images as components

### DIFF
--- a/hack/.ci/component_descriptor
+++ b/hack/.ci/component_descriptor
@@ -4,7 +4,7 @@
 #
 # COMPONENT_PREFIXES: Set the image prefix that should be used to
 #                     determine if an image is defined by another component.
-#                     Defaults to "europe-docker.pkg.dev/gardener-project"
+#                     Defaults to "europe-docker.pkg.dev/gardener-project/releases/gardener"
 #
 # COMPONENT_CLI_ARGS: Set all component-cli arguments.
 #                     This should be used with care as all defaults are overwritten.
@@ -55,7 +55,7 @@ fi
 if [[ ! -z "$image_vector_path" ]]; then
   # default environment variables
   if [[ -z "${COMPONENT_PREFIXES}" ]]; then
-    COMPONENT_PREFIXES="europe-docker.pkg.dev/gardener-project"
+    COMPONENT_PREFIXES="europe-docker.pkg.dev/gardener-project/releases/gardener"
   fi
 
   if [[ -z "${COMPONENT_CLI_ARGS}" ]]; then


### PR DESCRIPTION
When generating OCM Component-Descriptors using
`hack/.ci/component_descriptor`, contents from `imagevector/images.yaml` are evaluated to determine images built by the current component, as well as references to other components (mapped to repositories below the github.com/gardener organisation).

The latter are detected by interpreting the OCI Image reference. Which follow a naming convention:

- <prefix>/gardener/<image-name>: images built from sources from github.com/gardener/<name>
- <prefix>/<name != gardener>: other images (e.g. copied from other repositories)

Change component-name prefix to again only match images adhering to the above naming convention which are built from a gardener-source-repository. This change will fix [release/head-update-pipelines](https://concourse.ci.gardener.cloud/teams/gardener-tests/pipelines/gardener-master/jobs/master-head-update-job/builds/166)

**How to categorize this PR?**
/area delivery
/kind regression


**Release note**

This change will have no effect relevant for any downstream consumer of Gardener, therefore no release note.
