### PR TITLE
Bump observability components, plutono to 7.5.28, vali and valitail to v2.2.13

### DIFF
--- a/imagevector/images.yaml
+++ b/imagevector/images.yaml
@@ -238,7 +238,7 @@ images:
 - name: plutono
   sourceRepository: github.com/credativ/plutono
   repository: ghcr.io/credativ/plutono
-  tag: "v7.5.26"
+  tag: "v7.5.28"
   labels:
   - name: gardener.cloud/cve-categorisation
     value:
@@ -413,7 +413,7 @@ images:
 - name: vali
   sourceRepository: github.com/credativ/vali
   repository: ghcr.io/credativ/vali
-  tag: "v2.2.11"
+  tag: "v2.2.13"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:
@@ -465,7 +465,7 @@ images:
 - name: valitail
   sourceRepository: github.com/credativ/vali
   repository: ghcr.io/credativ/valitail
-  tag: "v2.2.11"
+  tag: "v2.2.13"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:


### PR DESCRIPTION
/area logging
/area monitoring

/kind enhancement

This PR brings the latest released versions of the observability componetns.

- Plutono is updated from [v7.5.26 to v7.5.28](https://github.com/credativ/plutono/compare/v7.5.26...v7.5.28)
- Vali (Valitail) are updated from [v2.2.11 to v2.2.13](https://github.com/credativ/vali/compare/v2.2.9...v2.2.11)

**Release note**:

```other operator
Plutono is updated to v7.5.28.
Vali and Valitail are updated to v2.2.13.
```
