### PR TITLE
Update the registry image to the AR one

### DIFF
--- a/example/gardener-local/registry/base/registry.yaml
+++ b/example/gardener-local/registry/base/registry.yaml
@@ -12,7 +12,7 @@ spec:
       automountServiceAccountToken: false
       containers:
       - name: registry
-        image: eu.gcr.io/gardener-project/3rd/registry:2.8.3
+        image: europe-docker.pkg.dev/gardener-project/releases/3rd/registry:2.8.3
         imagePullPolicy: IfNotPresent
         ports:
         - name: registry

--- a/example/provider-extensions/registry-seed/registry/registry.yaml
+++ b/example/provider-extensions/registry-seed/registry/registry.yaml
@@ -24,7 +24,7 @@ spec:
       automountServiceAccountToken: false
       containers:
       - name: registry
-        image: eu.gcr.io/gardener-project/3rd/registry:2.8.3
+        image: europe-docker.pkg.dev/gardener-project/releases/3rd/registry:2.8.3
         imagePullPolicy: IfNotPresent
         env:
         - name: REGISTRY_HTTP_TLS_CERTIFICATE


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind enhancement

**What this PR does / why we need it**:
With the migration to AR, the registry image is maintained under `europe-docker.pkg.dev/gardener-project/releases/3rd/registry`.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
