### PR TITLE
Change image pattern in kyverno policy.

### DIFF
--- a/example/provider-extensions/kyverno-policies/gardener-image-pull-policy.yaml
+++ b/example/provider-extensions/kyverno-policies/gardener-image-pull-policy.yaml
@@ -22,6 +22,6 @@ spec:
       patchStrategicMerge:
         spec:
           containers:
-          - <(image): "*/eu_gcr_io_gardener-project_gardener*"
+          - <(image): "*/europe-docker_pkg_dev_gardener-project_releases_gardener*"
           imagePullSecrets:
           - name: gardener-images


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind bug

**What this PR does / why we need it**:
This PR fixes the kyverno policy which adds `imagePullSecrets` to the pods in `provider-extension` setup.
The change is required because we switched from GCR to artifact registry in PR #8968.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
