### PR TITLE
[release-v1.86] [ci:component:github.com/gardener/etcd-druid:v0.21.0->v0.22.0]

### DIFF
--- a/imagevector/images.yaml
+++ b/imagevector/images.yaml
@@ -53,8 +53,8 @@ images:
         interacted with from other containers or other systems
 - name: etcd-druid
   sourceRepository: github.com/gardener/etcd-druid
-  repository: eu.gcr.io/gardener-project/gardener/etcd-druid
-  tag: "v0.21.0"
+  repository: europe-docker.pkg.dev/gardener-project/releases/gardener/etcd-druid
+  tag: "v0.22.0"
 - name: dependency-watchdog
   sourceRepository: github.com/gardener/dependency-watchdog
   repository: eu.gcr.io/gardener-project/gardener/dependency-watchdog


### PR DESCRIPTION
/kind enhancement

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator github.com/gardener/etcd-wrapper #16 @AleksandarSavchev
The `etcd` process now runs with umask set to `0077`, this way the files it creates have no permissions on `group` and `others` level.
```
```other operator github.com/gardener/etcd-druid #722 @renormalize
Documentation for the controllers of etcd-druid
```
```other operator github.com/gardener/etcd-druid #721 @anveshreddy18
Adds documentation for local setup of Etcd Druid
```
```improvement user github.com/gardener/etcd-backup-restore #691 @shreyas-s-rao
Add support for overriding storage API endpoint for provider GCS, by setting environment variable `GOOGLE_STORAGE_API_ENDPOINT`, with the value in the format `http[s]://host[:port]/storage/v1/`. ⚠️ Note: GCS storage API endpoint will not be overridden for `copy` subcommand, since backup buckets may reside in different regions.
```
```feature user github.com/gardener/etcd-druid #737 @shreyas-s-rao
Add support for overriding storage API endpoint for provider GCS, by adding new field `storageAPIEndpoint` in the GCP/GCS backup secret, with the value in the format `http[s]://host[:port]/storage/v1/`. ⚠️ Note: GCS storage API endpoint will not be overridden for `EtcdCopyBackupsTask`s, since backup buckets may reside in different regions.
```
```breaking operator github.com/gardener/etcd-backup-restore #688 @ccwienk
Change OCI Image Registry from GCR (`eu.gcr.io/gardener-project`) to Artifact-Registry (`europe-docker.pkg.dev/gardener-project/releases`). Users should update their references.
```
```other developer github.com/gardener/etcd-druid #727 @seshachalam-yv
Upgrade to go 1.21.4
```
```improvement operator github.com/gardener/etcd-backup-restore #670 @renormalize
Dynamic loading of IaaS credentials is now optimized to make use of file system information instead of calculating a hash of the credentials to detect changes.
```
```improvement operator github.com/gardener/etcd-backup-restore #685 @anveshreddy18
Add unit tests for chunk deletion
```
```breaking operator github.com/gardener/etcd-druid #744 @ishan16696
`EtcdWrapper` has progressed from the alpha stage to the beta stage, which now allows for its default usage in etcd-druid. If you prefer to continue using the etcd-custom-image, you can disable the EtcdWrapper by adjusting the feature flag.
```
```improvement operator github.com/gardener/etcd-backup-restore #703 @shreyas-s-rao
A regression in chunk deletion behavior for openstack provider has now been fixed.
```
