### PR TITLE
Bump up container images: fluent-bit to v2.2.0 and fluent-operator to v2.7.0

### DIFF
--- a/imagevector/images.yaml
+++ b/imagevector/images.yaml
@@ -363,7 +363,7 @@ images:
 - name: fluent-operator
   sourceRepository: github.com/fluent/fluent-operator
   repository: europe-docker.pkg.dev/gardener-project/releases/3rd/kubesphere/fluent-operator
-  tag: "v2.3.0"
+  tag: "v2.7.0"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:
@@ -380,7 +380,7 @@ images:
 - name: fluent-bit
   sourceRepository: github.com/fluent/fluent-operator
   repository: europe-docker.pkg.dev/gardener-project/releases/3rd/kubesphere/fluent-bit
-  tag: "v2.1.4"
+  tag: "v2.2.0"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:


### PR DESCRIPTION
/area logging
/kind enhancement

Thie PR brings the latest releases of fluent-operator and fluent-bit:

- fluent-operator [release notes v2.7.0](https://github.com/fluent/fluent-operator/releases/tag/v2.7.0)
- fluent-bit [release notes v2.2.0](https://fluentbit.io/announcements/v2.2.0/)

```other operator
The following images are updated:
- `europe-docker.pkg.dev/gardener-project/releases/3rd/kubesphere/fluent-operator`: v2.3.0 -> v2.7.0
- `europe-docker.pkg.dev/gardener-project/releases/3rd/kubesphere/fluent-bit`: v2.1.4 -> v2.2.0
```
