### PR TITLE
Add zero line per default for tcp traffic per istio namespace in the ingress dashboard.

### DIFF
--- a/pkg/component/plutono/dashboards/seed/istio/istio-ingress-gateway-dashboard.json
+++ b/pkg/component/plutono/dashboards/seed/istio/istio-ingress-gateway-dashboard.json
@@ -671,7 +671,7 @@
       "lines": true,
       "linewidth": 1,
       "links": [],
-      "nullPointMode": "null",
+      "nullPointMode": "null as zero",
       "options": {
         "alertThreshold": true
       },
@@ -775,7 +775,7 @@
       "lines": true,
       "linewidth": 1,
       "links": [],
-      "nullPointMode": "null",
+      "nullPointMode": "null as zero",
       "options": {
         "alertThreshold": true
       },


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/area monitoring
/area ops-productivity
/kind cleanup

**What this PR does / why we need it**:
Add zero line per default for tcp traffic per istio namespace in the ingress dashboard.

Istio only reports traffic metrics when traffic for a given target actually took place. Therefore, istio ingress gateway namespaces without any shoot clusters using them might end up showing no lines in the istio ingress gateway dashboard. As this can be confusing, this change introduces a null line in case there are no values for the corresponding namespace.

**Which issue(s) this PR fixes**:
None.

**Special notes for your reviewer**:
Before:

![image](https://github.com/gardener/gardener/assets/30600170/3c3266e6-79dd-443f-bcc6-b84c998987e3)

After:

![image](https://github.com/gardener/gardener/assets/30600170/99ce8d93-4724-4703-86a4-3ccd1a951751)

(please disregard the heading change)

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Istio ingress gateway dashboard now always shows a graph for all istio namespaces even if no traffic was received in some of them.
```

/cc @MartinWeindel @axel7born 