### PR TITLE
[SeedManagement] Clean up technical debt in defaulting code

### DIFF
--- a/pkg/apis/seedmanagement/v1alpha1/defaults_managedseed.go
+++ b/pkg/apis/seedmanagement/v1alpha1/defaults_managedseed.go
@@ -35,7 +35,7 @@ func addDefaultingFuncs(scheme *runtime.Scheme) error {
 // SetDefaults_ManagedSeed sets default values for ManagedSeed objects.
 func SetDefaults_ManagedSeed(obj *ManagedSeed) {
 	if obj.Spec.Gardenlet != nil {
-		setDefaultsGardenlet(obj.Spec.Gardenlet, obj.Name, obj.Namespace)
+		SetDefaults_Gardenlet(obj.Spec.Gardenlet, obj.Name, obj.Namespace)
 	}
 }
 
@@ -76,7 +76,8 @@ func SetDefaults_Image(obj *Image) {
 	}
 }
 
-func setDefaultsGardenlet(obj *Gardenlet, name, namespace string) {
+// SetDefaults_Gardenlet sets default values for Gardenlet.
+func SetDefaults_Gardenlet(obj *Gardenlet, name, namespace string) {
 	// Set deployment defaults
 	if obj.Deployment == nil {
 		obj.Deployment = &GardenletDeployment{}
@@ -101,7 +102,7 @@ func setDefaultsGardenlet(obj *Gardenlet, name, namespace string) {
 	}
 
 	// Set gardenlet config defaults
-	setDefaultsGardenletConfiguration(gardenletConfig, name, namespace)
+	SetDefaults_GardenletConfiguration(gardenletConfig, name, namespace)
 
 	// Set gardenlet config back to obj.Config
 	// Encoding back to bytes is not needed, it will be done by the custom conversion code
@@ -119,14 +120,15 @@ func setDefaultsGardenlet(obj *Gardenlet, name, namespace string) {
 	}
 }
 
-func setDefaultsGardenletConfiguration(obj *gardenletv1alpha1.GardenletConfiguration, name, namespace string) {
+// SetDefaults_GardenletConfiguration sets default values for GardenletConfiguration.
+func SetDefaults_GardenletConfiguration(obj *gardenletv1alpha1.GardenletConfiguration, name, namespace string) {
 	// Initialize resources
 	if obj.Resources == nil {
 		obj.Resources = &gardenletv1alpha1.ResourcesConfiguration{}
 	}
 
 	// Set resources defaults
-	setDefaultsResources(obj.Resources)
+	SetDefaults_Resources(obj.Resources)
 
 	// Initialize seed config
 	if obj.SeedConfig == nil {
@@ -134,10 +136,11 @@ func setDefaultsGardenletConfiguration(obj *gardenletv1alpha1.GardenletConfigura
 	}
 
 	// Set seed spec defaults
-	setDefaultsSeedSpec(&obj.SeedConfig.SeedTemplate.Spec, name, namespace)
+	SetDefaults_SeedSpec(&obj.SeedConfig.SeedTemplate.Spec, name, namespace)
 }
 
-func setDefaultsResources(obj *gardenletv1alpha1.ResourcesConfiguration) {
+// SetDefaults_Resources sets default values for ResourcesConfiguration.
+func SetDefaults_Resources(obj *gardenletv1alpha1.ResourcesConfiguration) {
 	if _, ok := obj.Capacity[gardencorev1beta1.ResourceShoots]; !ok {
 		if obj.Capacity == nil {
 			obj.Capacity = make(corev1.ResourceList)
@@ -146,7 +149,8 @@ func setDefaultsResources(obj *gardenletv1alpha1.ResourcesConfiguration) {
 	}
 }
 
-func setDefaultsSeedSpec(spec *gardencorev1beta1.SeedSpec, name, namespace string) {
+// SetDefaults_SeedSpec sets default values for SeedSpec.
+func SetDefaults_SeedSpec(spec *gardencorev1beta1.SeedSpec, name, namespace string) {
 	if spec.Backup != nil && spec.Backup.SecretRef == (corev1.SecretReference{}) {
 		spec.Backup.SecretRef = corev1.SecretReference{
 			Name:      fmt.Sprintf("backup-%s", name),

--- a/pkg/apis/seedmanagement/v1alpha1/defaults_managedseed.go
+++ b/pkg/apis/seedmanagement/v1alpha1/defaults_managedseed.go
@@ -28,10 +28,6 @@ import (
 	gardenletv1alpha1 "github.com/gardener/gardener/pkg/gardenlet/apis/config/v1alpha1"
 )
 
-func addDefaultingFuncs(scheme *runtime.Scheme) error {
-	return RegisterDefaults(scheme)
-}
-
 // SetDefaults_ManagedSeed sets default values for ManagedSeed objects.
 func SetDefaults_ManagedSeed(obj *ManagedSeed) {
 	if obj.Spec.Gardenlet != nil {

--- a/pkg/apis/seedmanagement/v1alpha1/defaults_managedseed.go
+++ b/pkg/apis/seedmanagement/v1alpha1/defaults_managedseed.go
@@ -31,7 +31,7 @@ import (
 // SetDefaults_ManagedSeed sets default values for ManagedSeed objects.
 func SetDefaults_ManagedSeed(obj *ManagedSeed) {
 	if obj.Spec.Gardenlet != nil {
-		SetDefaults_Gardenlet(obj.Spec.Gardenlet, obj.Name, obj.Namespace)
+		setDefaultsGardenlet(obj.Spec.Gardenlet, obj.Name, obj.Namespace)
 	}
 }
 
@@ -72,8 +72,7 @@ func SetDefaults_Image(obj *Image) {
 	}
 }
 
-// SetDefaults_Gardenlet sets default values for Gardenlet.
-func SetDefaults_Gardenlet(obj *Gardenlet, name, namespace string) {
+func setDefaultsGardenlet(obj *Gardenlet, name, namespace string) {
 	// Set deployment defaults
 	if obj.Deployment == nil {
 		obj.Deployment = &GardenletDeployment{}
@@ -98,7 +97,7 @@ func SetDefaults_Gardenlet(obj *Gardenlet, name, namespace string) {
 	}
 
 	// Set gardenlet config defaults
-	SetDefaults_GardenletConfiguration(gardenletConfig, name, namespace)
+	setDefaultsGardenletConfiguration(gardenletConfig, name, namespace)
 
 	// Set gardenlet config back to obj.Config
 	// Encoding back to bytes is not needed, it will be done by the custom conversion code
@@ -116,15 +115,14 @@ func SetDefaults_Gardenlet(obj *Gardenlet, name, namespace string) {
 	}
 }
 
-// SetDefaults_GardenletConfiguration sets default values for GardenletConfiguration.
-func SetDefaults_GardenletConfiguration(obj *gardenletv1alpha1.GardenletConfiguration, name, namespace string) {
+func setDefaultsGardenletConfiguration(obj *gardenletv1alpha1.GardenletConfiguration, name, namespace string) {
 	// Initialize resources
 	if obj.Resources == nil {
 		obj.Resources = &gardenletv1alpha1.ResourcesConfiguration{}
 	}
 
 	// Set resources defaults
-	SetDefaults_Resources(obj.Resources)
+	setDefaultsResources(obj.Resources)
 
 	// Initialize seed config
 	if obj.SeedConfig == nil {
@@ -132,11 +130,10 @@ func SetDefaults_GardenletConfiguration(obj *gardenletv1alpha1.GardenletConfigur
 	}
 
 	// Set seed spec defaults
-	SetDefaults_SeedSpec(&obj.SeedConfig.SeedTemplate.Spec, name, namespace)
+	setDefaultsSeedSpec(&obj.SeedConfig.SeedTemplate.Spec, name, namespace)
 }
 
-// SetDefaults_Resources sets default values for ResourcesConfiguration.
-func SetDefaults_Resources(obj *gardenletv1alpha1.ResourcesConfiguration) {
+func setDefaultsResources(obj *gardenletv1alpha1.ResourcesConfiguration) {
 	if _, ok := obj.Capacity[gardencorev1beta1.ResourceShoots]; !ok {
 		if obj.Capacity == nil {
 			obj.Capacity = make(corev1.ResourceList)
@@ -145,8 +142,7 @@ func SetDefaults_Resources(obj *gardenletv1alpha1.ResourcesConfiguration) {
 	}
 }
 
-// SetDefaults_SeedSpec sets default values for SeedSpec.
-func SetDefaults_SeedSpec(spec *gardencorev1beta1.SeedSpec, name, namespace string) {
+func setDefaultsSeedSpec(spec *gardencorev1beta1.SeedSpec, name, namespace string) {
 	if spec.Backup != nil && spec.Backup.SecretRef == (corev1.SecretReference{}) {
 		spec.Backup.SecretRef = corev1.SecretReference{
 			Name:      fmt.Sprintf("backup-%s", name),

--- a/pkg/apis/seedmanagement/v1alpha1/defaults_managedseed_test.go
+++ b/pkg/apis/seedmanagement/v1alpha1/defaults_managedseed_test.go
@@ -20,6 +20,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -48,42 +49,31 @@ var _ = Describe("Defaults", func() {
 		}
 	})
 
-	Describe("#SetDefaults_ManagedSeed", func() {
-		It("should default gardenlet deployment and configuration", func() {
+	Describe("ManagedSeed defaulting", func() {
+		It("should default gardenlet configuration", func() {
 			obj.Spec.Gardenlet = &Gardenlet{}
 
 			SetObjectDefaults_ManagedSeed(obj)
 
-			Expect(obj).To(Equal(&ManagedSeed{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      name,
-					Namespace: namespace,
-				},
-				Spec: ManagedSeedSpec{
-					Gardenlet: &Gardenlet{
-						Deployment: &GardenletDeployment{},
-						Config: runtime.RawExtension{
-							Object: &gardenletv1alpha1.GardenletConfiguration{
-								TypeMeta: metav1.TypeMeta{
-									APIVersion: gardenletv1alpha1.SchemeGroupVersion.String(),
-									Kind:       "GardenletConfiguration",
-								},
-								Resources: &gardenletv1alpha1.ResourcesConfiguration{
-									Capacity: corev1.ResourceList{
-										gardencorev1beta1.ResourceShoots: resource.MustParse("250"),
-									},
-								},
-								SeedConfig: &gardenletv1alpha1.SeedConfig{},
-							},
-						},
-						Bootstrap:       bootstrapPtr(BootstrapToken),
-						MergeWithParent: pointer.Bool(true),
+			Expect(obj.Spec.Gardenlet.Deployment).NotTo(BeNil())
+			Expect(obj.Spec.Gardenlet.Config).To(Equal(runtime.RawExtension{
+				Object: &gardenletv1alpha1.GardenletConfiguration{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: gardenletv1alpha1.SchemeGroupVersion.String(),
+						Kind:       "GardenletConfiguration",
 					},
-				},
-			}))
+					Resources: &gardenletv1alpha1.ResourcesConfiguration{
+						Capacity: corev1.ResourceList{
+							gardencorev1beta1.ResourceShoots: resource.MustParse("250"),
+						},
+					},
+					SeedConfig: &gardenletv1alpha1.SeedConfig{},
+				}}))
+			Expect(obj.Spec.Gardenlet.Bootstrap).To(PointTo(Equal(BootstrapToken)))
+			Expect(obj.Spec.Gardenlet.MergeWithParent).To(PointTo(Equal(true)))
 		})
 
-		It("should default gardenlet deployment, configuration, and backup secret reference if backup is specified", func() {
+		It("should default gardenlet configuration, and backup secret reference if backup is specified", func() {
 			obj.Spec.Gardenlet = &Gardenlet{
 				Config: runtime.RawExtension{
 					Raw: encode(&gardenletv1alpha1.GardenletConfiguration{
@@ -104,62 +94,129 @@ var _ = Describe("Defaults", func() {
 
 			SetObjectDefaults_ManagedSeed(obj)
 
-			Expect(obj).To(Equal(&ManagedSeed{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      name,
-					Namespace: namespace,
-				},
-				Spec: ManagedSeedSpec{
-					Gardenlet: &Gardenlet{
-						Deployment: &GardenletDeployment{},
-						Config: runtime.RawExtension{
-							Object: &gardenletv1alpha1.GardenletConfiguration{
-								TypeMeta: metav1.TypeMeta{
-									APIVersion: gardenletv1alpha1.SchemeGroupVersion.String(),
-									Kind:       "GardenletConfiguration",
-								},
-								Resources: &gardenletv1alpha1.ResourcesConfiguration{
-									Capacity: corev1.ResourceList{
-										gardencorev1beta1.ResourceShoots: resource.MustParse("250"),
-									},
-								},
-								SeedConfig: &gardenletv1alpha1.SeedConfig{
-									SeedTemplate: gardencorev1beta1.SeedTemplate{
-										Spec: gardencorev1beta1.SeedSpec{
-											Backup: &gardencorev1beta1.SeedBackup{
-												SecretRef: corev1.SecretReference{
-													Name:      fmt.Sprintf("backup-%s", name),
-													Namespace: namespace,
-												},
-											},
+			Expect(obj.Spec.Gardenlet.Config).To(Equal(
+				runtime.RawExtension{
+					Object: &gardenletv1alpha1.GardenletConfiguration{
+						TypeMeta: metav1.TypeMeta{
+							APIVersion: gardenletv1alpha1.SchemeGroupVersion.String(),
+							Kind:       "GardenletConfiguration",
+						},
+						Resources: &gardenletv1alpha1.ResourcesConfiguration{
+							Capacity: corev1.ResourceList{
+								gardencorev1beta1.ResourceShoots: resource.MustParse("250"),
+							},
+						},
+						SeedConfig: &gardenletv1alpha1.SeedConfig{
+							SeedTemplate: gardencorev1beta1.SeedTemplate{
+								Spec: gardencorev1beta1.SeedSpec{
+									Backup: &gardencorev1beta1.SeedBackup{
+										SecretRef: corev1.SecretReference{
+											Name:      fmt.Sprintf("backup-%s", name),
+											Namespace: namespace,
 										},
 									},
 								},
 							},
 						},
-						Bootstrap:       bootstrapPtr(BootstrapToken),
-						MergeWithParent: pointer.Bool(true),
 					},
 				},
-			}))
+			))
+		})
+
+		It("should not overwrite already set values for GardenletConfiguration", func() {
+			obj.Spec.Gardenlet = &Gardenlet{
+				Config: runtime.RawExtension{
+					Raw: encode(&gardenletv1alpha1.GardenletConfiguration{
+						TypeMeta: metav1.TypeMeta{
+							APIVersion: gardenletv1alpha1.SchemeGroupVersion.String(),
+							Kind:       "GardenletConfiguration",
+						},
+						Resources: &gardenletv1alpha1.ResourcesConfiguration{
+							Capacity: corev1.ResourceList{
+								gardencorev1beta1.ResourceShoots: resource.MustParse("300"),
+							},
+						},
+						SeedConfig: &gardenletv1alpha1.SeedConfig{
+							SeedTemplate: gardencorev1beta1.SeedTemplate{
+								Spec: gardencorev1beta1.SeedSpec{
+									Backup: &gardencorev1beta1.SeedBackup{
+										SecretRef: corev1.SecretReference{
+											Name:      "foo",
+											Namespace: "bar",
+										},
+									},
+								},
+							},
+						},
+					}),
+				},
+				Bootstrap:       bootstrapPtr(BootstrapServiceAccount),
+				MergeWithParent: pointer.Bool(false),
+			}
+
+			SetObjectDefaults_ManagedSeed(obj)
+
+			Expect(obj.Spec.Gardenlet.Config).To(Equal(
+				runtime.RawExtension{
+					Object: &gardenletv1alpha1.GardenletConfiguration{
+						TypeMeta: metav1.TypeMeta{
+							APIVersion: gardenletv1alpha1.SchemeGroupVersion.String(),
+							Kind:       "GardenletConfiguration",
+						},
+						Resources: &gardenletv1alpha1.ResourcesConfiguration{
+							Capacity: corev1.ResourceList{
+								gardencorev1beta1.ResourceShoots: resource.MustParse("300"),
+							},
+						},
+						SeedConfig: &gardenletv1alpha1.SeedConfig{
+							SeedTemplate: gardencorev1beta1.SeedTemplate{
+								Spec: gardencorev1beta1.SeedSpec{
+									Backup: &gardencorev1beta1.SeedBackup{
+										SecretRef: corev1.SecretReference{
+											Name:      "foo",
+											Namespace: "bar",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			))
+			Expect(obj.Spec.Gardenlet.Bootstrap).To(PointTo(Equal(BootstrapServiceAccount)))
+			Expect(obj.Spec.Gardenlet.MergeWithParent).To(PointTo(Equal(false)))
 		})
 	})
 
-	Describe("#SetDefaults_GardenletDeployment", func() {
-		It("should default replica count, revision history limit, image, and vpa", func() {
+	Describe("GardenletDeployment defaulting", func() {
+		It("should default GardenletDeployment field", func() {
 			obj.Spec.Gardenlet = &Gardenlet{}
 			SetObjectDefaults_ManagedSeed(obj)
 
-			Expect(obj.Spec.Gardenlet.Deployment).To(Equal(&GardenletDeployment{
-				ReplicaCount:         pointer.Int32(2),
-				RevisionHistoryLimit: pointer.Int32(2),
-				Image:                &Image{},
-				VPA:                  pointer.Bool(true),
-			}))
+			Expect(obj.Spec.Gardenlet.Deployment.ReplicaCount).To(Equal(pointer.Int32(2)))
+			Expect(obj.Spec.Gardenlet.Deployment.RevisionHistoryLimit).To(Equal(pointer.Int32(2)))
+			Expect(obj.Spec.Gardenlet.Deployment.Image).NotTo(BeNil())
+			Expect(obj.Spec.Gardenlet.Deployment.VPA).To(Equal(pointer.Bool(true)))
+		})
+
+		It("should not overwrite the already set values for GardenletDeployment field", func() {
+			obj.Spec.Gardenlet = &Gardenlet{
+				Deployment: &GardenletDeployment{
+					ReplicaCount:         pointer.Int32(3),
+					RevisionHistoryLimit: pointer.Int32(3),
+					VPA:                  pointer.Bool(false),
+				},
+			}
+			SetObjectDefaults_ManagedSeed(obj)
+
+			Expect(obj.Spec.Gardenlet.Deployment.ReplicaCount).To(Equal(pointer.Int32(3)))
+			Expect(obj.Spec.Gardenlet.Deployment.RevisionHistoryLimit).To(Equal(pointer.Int32(3)))
+			Expect(obj.Spec.Gardenlet.Deployment.Image).NotTo(BeNil())
+			Expect(obj.Spec.Gardenlet.Deployment.VPA).To(Equal(pointer.Bool(false)))
 		})
 	})
 
-	Describe("#SetDefaults_Image", func() {
+	Describe("Image defaulting", func() {
 		It("should default pull policy to IfNotPresent", func() {
 			obj.Spec.Gardenlet = &Gardenlet{}
 			SetObjectDefaults_ManagedSeed(obj)
@@ -180,6 +237,23 @@ var _ = Describe("Defaults", func() {
 			Expect(obj.Spec.Gardenlet.Deployment.Image).To(Equal(&Image{
 				Tag:        pointer.String("latest"),
 				PullPolicy: pullPolicyPtr(corev1.PullAlways),
+			}))
+		})
+
+		It("should not overwrite pull policy if tag is not latest", func() {
+			obj.Spec.Gardenlet = &Gardenlet{
+				Deployment: &GardenletDeployment{
+					Image: &Image{
+						Tag:        pointer.String("foo"),
+						PullPolicy: pullPolicyPtr(corev1.PullNever),
+					},
+				}}
+
+			SetObjectDefaults_ManagedSeed(obj)
+
+			Expect(obj.Spec.Gardenlet.Deployment.Image).To(Equal(&Image{
+				Tag:        pointer.String("foo"),
+				PullPolicy: pullPolicyPtr(corev1.PullNever),
 			}))
 		})
 	})

--- a/pkg/apis/seedmanagement/v1alpha1/defaults_managedseedset_test.go
+++ b/pkg/apis/seedmanagement/v1alpha1/defaults_managedseedset_test.go
@@ -29,7 +29,7 @@ var _ = Describe("Defaults", func() {
 		obj = &ManagedSeedSet{}
 	})
 
-	Describe("#SetDefaults_ManagedSeedSet", func() {
+	Describe("ManagedSeedSet defaulting", func() {
 		It("should default replicas to 1 and revisionHistoryLimit to 10", func() {
 			SetObjectDefaults_ManagedSeedSet(obj)
 
@@ -37,9 +37,21 @@ var _ = Describe("Defaults", func() {
 			Expect(obj.Spec.UpdateStrategy).NotTo(BeNil())
 			Expect(obj.Spec.RevisionHistoryLimit).To(Equal(pointer.Int32(10)))
 		})
+
+		It("should not overwrite the already set values for ManagedSeedSet spec", func() {
+			obj.Spec = ManagedSeedSetSpec{
+				Replicas:             pointer.Int32(5),
+				RevisionHistoryLimit: pointer.Int32(15),
+			}
+			SetObjectDefaults_ManagedSeedSet(obj)
+
+			Expect(obj.Spec.Replicas).To(Equal(pointer.Int32(5)))
+			Expect(obj.Spec.UpdateStrategy).NotTo(BeNil())
+			Expect(obj.Spec.RevisionHistoryLimit).To(Equal(pointer.Int32(15)))
+		})
 	})
 
-	Describe("#SetDefaults_UpdateStrategy", func() {
+	Describe("UpdateStrategy defaulting", func() {
 		It("should default type to RollingUpdate", func() {
 			obj.Spec.UpdateStrategy = &UpdateStrategy{}
 			SetObjectDefaults_ManagedSeedSet(obj)
@@ -48,9 +60,20 @@ var _ = Describe("Defaults", func() {
 				Type: updateStrategyTypePtr(RollingUpdateStrategyType),
 			}))
 		})
+
+		It("should not overwrite already set values for UpdateStrategy", func() {
+			obj.Spec.UpdateStrategy = &UpdateStrategy{
+				Type: updateStrategyTypePtr(UpdateStrategyType("foo")),
+			}
+			SetObjectDefaults_ManagedSeedSet(obj)
+
+			Expect(obj.Spec.UpdateStrategy).To(Equal(&UpdateStrategy{
+				Type: updateStrategyTypePtr(UpdateStrategyType("foo")),
+			}))
+		})
 	})
 
-	Describe("#SetDefaults_RollingUpdateStrategy", func() {
+	Describe("RollingUpdateStrategy defaulting", func() {
 		It("should default partition to 0", func() {
 			obj.Spec.UpdateStrategy = &UpdateStrategy{
 				RollingUpdate: &RollingUpdateStrategy{},
@@ -59,6 +82,19 @@ var _ = Describe("Defaults", func() {
 
 			Expect(obj.Spec.UpdateStrategy.RollingUpdate).To(Equal(&RollingUpdateStrategy{
 				Partition: pointer.Int32(0),
+			}))
+		})
+
+		It("should not overwrote the already set values for RollingUpdateStrategy", func() {
+			obj.Spec.UpdateStrategy = &UpdateStrategy{
+				RollingUpdate: &RollingUpdateStrategy{
+					Partition: pointer.Int32(1),
+				},
+			}
+			SetObjectDefaults_ManagedSeedSet(obj)
+
+			Expect(obj.Spec.UpdateStrategy.RollingUpdate).To(Equal(&RollingUpdateStrategy{
+				Partition: pointer.Int32(1),
 			}))
 		})
 	})

--- a/pkg/apis/seedmanagement/v1alpha1/defaults_managedseedset_test.go
+++ b/pkg/apis/seedmanagement/v1alpha1/defaults_managedseedset_test.go
@@ -23,53 +23,41 @@ import (
 )
 
 var _ = Describe("Defaults", func() {
+	var obj *ManagedSeedSet
+
+	BeforeEach(func() {
+		obj = &ManagedSeedSet{}
+	})
+
 	Describe("#SetDefaults_ManagedSeedSet", func() {
-		var obj *ManagedSeedSet
-
-		BeforeEach(func() {
-			obj = &ManagedSeedSet{}
-		})
-
 		It("should default replicas to 1 and revisionHistoryLimit to 10", func() {
-			SetDefaults_ManagedSeedSet(obj)
+			SetObjectDefaults_ManagedSeedSet(obj)
 
-			Expect(obj).To(Equal(&ManagedSeedSet{
-				Spec: ManagedSeedSetSpec{
-					Replicas:             pointer.Int32(1),
-					UpdateStrategy:       &UpdateStrategy{},
-					RevisionHistoryLimit: pointer.Int32(10),
-				},
-			}))
+			Expect(obj.Spec.Replicas).To(Equal(pointer.Int32(1)))
+			Expect(obj.Spec.UpdateStrategy).NotTo(BeNil())
+			Expect(obj.Spec.RevisionHistoryLimit).To(Equal(pointer.Int32(10)))
 		})
 	})
 
 	Describe("#SetDefaults_UpdateStrategy", func() {
-		var obj *UpdateStrategy
-
-		BeforeEach(func() {
-			obj = &UpdateStrategy{}
-		})
-
 		It("should default type to RollingUpdate", func() {
-			SetDefaults_UpdateStrategy(obj)
+			obj.Spec.UpdateStrategy = &UpdateStrategy{}
+			SetObjectDefaults_ManagedSeedSet(obj)
 
-			Expect(obj).To(Equal(&UpdateStrategy{
+			Expect(obj.Spec.UpdateStrategy).To(Equal(&UpdateStrategy{
 				Type: updateStrategyTypePtr(RollingUpdateStrategyType),
 			}))
 		})
 	})
 
 	Describe("#SetDefaults_RollingUpdateStrategy", func() {
-		var obj *RollingUpdateStrategy
-
-		BeforeEach(func() {
-			obj = &RollingUpdateStrategy{}
-		})
-
 		It("should default partition to 0", func() {
-			SetDefaults_RollingUpdateStrategy(obj)
+			obj.Spec.UpdateStrategy = &UpdateStrategy{
+				RollingUpdate: &RollingUpdateStrategy{},
+			}
+			SetObjectDefaults_ManagedSeedSet(obj)
 
-			Expect(obj).To(Equal(&RollingUpdateStrategy{
+			Expect(obj.Spec.UpdateStrategy.RollingUpdate).To(Equal(&RollingUpdateStrategy{
 				Partition: pointer.Int32(0),
 			}))
 		})

--- a/pkg/apis/seedmanagement/v1alpha1/register.go
+++ b/pkg/apis/seedmanagement/v1alpha1/register.go
@@ -55,3 +55,7 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 	metav1.AddToGroupVersion(scheme, SchemeGroupVersion)
 	return nil
 }
+
+func addDefaultingFuncs(scheme *runtime.Scheme) error {
+	return RegisterDefaults(scheme)
+}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area dev-productivity
  /area technical-debt
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind technical-debt

**What this PR does / why we need it**:
This PR cleans up technical debt in our API defaulting code according to https://github.com/gardener/gardener/issues/7312.
This PR tackles the following resources in the core API group:

- seedmanagement.gardener.cloud

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/7312

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
NONE
```
