### PR TITLE
[release-v1.86] [ci:component:github.com/gardener/etcd-druid:v0.21.0->v0.21.1]

### DIFF
--- a/imagevector/images.yaml
+++ b/imagevector/images.yaml
@@ -53,8 +53,8 @@ images:
         interacted with from other containers or other systems
 - name: etcd-druid
   sourceRepository: github.com/gardener/etcd-druid
-  repository: eu.gcr.io/gardener-project/gardener/etcd-druid
-  tag: "v0.21.0"
+  repository: europe-docker.pkg.dev/gardener-project/releases/gardener/etcd-druid
+  tag: "v0.21.1"
 - name: dependency-watchdog
   sourceRepository: github.com/gardener/dependency-watchdog
   repository: eu.gcr.io/gardener-project/gardener/dependency-watchdog


### PR DESCRIPTION
/kind enhancement

/invite @acumino @shafeeqes @ialidzhikov 

**Release note**:

```breaking operator github.com/gardener/etcd-druid #756 @shreyas-s-rao 
Change OCI Image Registry from GCR (`eu.gcr.io/gardener-project`) to Artifact-Registry (`europe-docker.pkg.dev/gardener-project/releases`). Users should update their references.
```

```breaking operator github.com/gardener/etcd-backup-restore #688 @ccwienk 
Change OCI Image Registry from GCR (`eu.gcr.io/gardener-project`) to Artifact-Registry (`europe-docker.pkg.dev/gardener-project/releases`). Users should update their references.
```

```improvement operator github.com/gardener/etcd-backup-restore #703 @shreyas-s-rao 
A regression in chunk deletion behavior for openstack provider has now been fixed.
```

```improvement operator github.com/gardener/etcd-backup-restore #685 @anveshreddy18
Add unit tests for chunk deletion
```

```improvement user github.com/gardener/etcd-backup-restore #691 @shreyas-s-rao 
Add support for overriding storage API endpoint for provider GCS, by setting environment variable `GOOGLE_STORAGE_API_ENDPOINT`, with the value in the format `http[s]://host[:port]/storage/v1/`. ⚠️ Note: GCS storage API endpoint will not be overridden for `copy` subcommand, since backup buckets may reside in different regions.
```

```improvement operator github.com/gardener/etcd-backup-restore #670 @renormalize 
Dynamic loading of IaaS credentials is now optimized to make use of file system information instead of calculating a hash of the credentials to detect changes.
```
