### PR TITLE
Add `patch` cluster role permission to `dependency-watchdog-prober`

### DIFF
--- a/pkg/component/dependencywatchdog/bootstrap.go
+++ b/pkg/component/dependencywatchdog/bootstrap.go
@@ -329,7 +329,7 @@ func (b *bootstrapper) getClusterRolePolicyRules() []rbacv1.PolicyRule {
 			{
 				APIGroups: []string{"apps"},
 				Resources: []string{"deployments", "deployments/scale"},
-				Verbs:     []string{"get", "list", "watch", "update"},
+				Verbs:     []string{"get", "list", "watch", "update", "patch"},
 			},
 		}
 	}

--- a/pkg/component/dependencywatchdog/bootstrap_test.go
+++ b/pkg/component/dependencywatchdog/bootstrap_test.go
@@ -137,6 +137,7 @@ rules:`
   - list
   - watch
   - update
+  - patch
 `
 					}
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane 
/kind enhancement

**What this PR does / why we need it**:
This PR adds `patch` cluster role permission for `dependency-watchdog-prober` to allow patches to `deployments` and `deployments/status`.
This is needed to allow `dependency-watchdog` to be able to edit deployments for `MCM`, `CA` and `KCM`

**Which issue(s) this PR fixes**:
Fixes #9035 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Allow the `dependency-watchdog-prober` to patch `deployments` and `deployments/scale` resources.
```
