### PR TITLE
Enhance shoot validation error message

### DIFF
--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -2031,7 +2031,7 @@ func ValidateSystemComponentWorkers(workers []core.Worker, kubernetesVersion str
 	}
 
 	if !atLeastOnePoolWithAllowedSystemComponents {
-		allErrs = append(allErrs, field.Forbidden(fldPath, "at least one active worker pool with allowSystemComponents=true needed"))
+		allErrs = append(allErrs, field.Forbidden(fldPath, "at least one active (workers[i].maximum > 0) worker pool with systemComponents.allow=true needed"))
 	}
 
 	return allErrs

--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -5930,7 +5930,9 @@ var _ = Describe("Shoot Validation Tests", func() {
 			Entry("at least one worker pool min>0, max>0", zero, zero, one, one, BeEmpty()),
 			Entry("all worker pools min=max=0", zero, zero, zero, zero, ConsistOf(
 				PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type": Equal(field.ErrorTypeForbidden),
+					"Type":   Equal(field.ErrorTypeForbidden),
+					"Field":  Equal("workers"),
+					"Detail": ContainSubstring("at least one active (workers[i].maximum > 0) worker pool with systemComponents.allow=true needed"),
 				})),
 			)),
 		)
@@ -5961,7 +5963,9 @@ var _ = Describe("Shoot Validation Tests", func() {
 
 			Entry("all worker pools min=max=0", zero, zero, zero, zero, true, true, ConsistOf(
 				PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type": Equal(field.ErrorTypeForbidden),
+					"Type":   Equal(field.ErrorTypeForbidden),
+					"Field":  Equal("workers"),
+					"Detail": ContainSubstring("at least one active (workers[i].maximum > 0) worker pool with systemComponents.allow=true needed"),
 				})),
 			)),
 			Entry("at least one worker pool allows system components", zero, zero, one, one, true, true, BeEmpty()),


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind bug

**What this PR does / why we need it**:
This PR fixes issue #9030 and by enhancing the shoot validation error message and making it more explanatory.

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener/issues/9030

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
