### PR TITLE
Delay removal of cleanup code in the extension library from 1.86 to 1.89

### DIFF
--- a/extensions/pkg/webhook/shoot/webhook.go
+++ b/extensions/pkg/webhook/shoot/webhook.go
@@ -51,7 +51,7 @@ func ReconcileWebhookConfig(
 		return fmt.Errorf("no shoot found in cluster resource")
 	}
 
-	// TODO(rfranzke): Remove this after Gardener v1.86 has been released.
+	// TODO(rfranzke): Remove this after Gardener v1.89 has been released.
 	{
 		if err := c.Delete(ctx, &networkingv1.NetworkPolicy{ObjectMeta: metav1.ObjectMeta{Namespace: shootNamespace, Name: "gardener-extension-" + extensionName}}); client.IgnoreNotFound(err) != nil {
 			return fmt.Errorf("could not delete old egress network policy for shoot webhooks in namespace '%s': %w", shootNamespace, err)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind cleanup

**What this PR does / why we need it**:
https://github.com/gardener/gardener/blame/70ade7496a49faf76c0a60b891ba913b8f8de3f0/extensions/pkg/webhook/shoot/webhook.go#L54-L62 was introduced in 1.82. However, there are several extensions right now that don't have a release with vendored gardener/gardener >= 1.82 so far: provider-{alicloud,gcp,openstack}. If we drop this cleanup code relatively soon, it might be the case that these extensions will never execute it.
Let's keep the cleanup code for a little bit more to make sure that every provider extension has a release with it.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
