### PR TITLE
Enable `gardener-node-agent` in `provider-extensions` setup

### DIFF
--- a/docs/deployment/getting_started_locally_with_extensions.md
+++ b/docs/deployment/getting_started_locally_with_extensions.md
@@ -126,6 +126,27 @@ make gardener-extensions-down SEED_NAME=<seed-name>
 If it is not the last seed, this command will only remove the seed, but leave the local Gardener cluster and the other seeds untouched.
 To remove all seeds and to cleanup the local Gardener cluster, you have to run the command for each seed.
 
+### Rotate credentials of container image registry in a Seed
+
+There is a container image registry in each Seed cluster where Gardener images required for the Seed and the Shoot nodes are pushed to. This registry is password protected.
+The password is generated when the Seed is deployed via `make gardener-extensions-up`. Afterward, it is not rotated automatically.
+Otherwise, this could break the update of `gardener-node-agent`, because it might not be able to pull its own new image anymore
+This is no general issue of `gardener-node-agent`, but a limitation `provider-extensions` setup. Gardener does not support protected container images out of the box. The function was added for this scenario only.
+
+However, if you want to rotate the credentials for any reason, there are two options for it.
+- run `make gardener-extensions-up` (to ensure that your images are up-to-date)
+- `reconcile` all shoots on the seed where you want to rotate the registry password
+- run `kubectl delete secrets -n registry registry-password` on your seed cluster
+- run `make gardener-extensions-up`
+- `reconcile` the shoots again
+
+or
+- `reconcile` all shoots on the seed where you want to rotate the registry password
+- run `kubectl delete secrets -n registry registry-password` on your seed cluster
+- run `./example/provider-extensions/registry-seed/deploy-registry.sh <path to seed kubeconfig> <seed registry hostname>`
+- `reconcile` the shoots again
+
+
 ## Pause and Unpause the KinD Cluster
 
 The KinD cluster can be paused by stopping and keeping its docker container. This can be done by running:

--- a/example/gardener-local/gardenlet/values-provider-extensions.yaml
+++ b/example/gardener-local/gardenlet/values-provider-extensions.yaml
@@ -19,6 +19,3 @@ config:
         - name: gardenlet-bootstrap
           user:
             token: 07401d.f395accd246ae52d
-  featureGates:
-    # TODO(oliver-goetz): Remove this as soon as the local provider extensions setup supports this feature gate.
-    UseGardenerNodeAgent: false

--- a/example/provider-extensions/kyverno-policies/add-registry-to-osc.yaml
+++ b/example/provider-extensions/kyverno-policies/add-registry-to-osc.yaml
@@ -59,16 +59,16 @@ spec:
       patchesJson6902: |-
         - path: "/spec/files/0"
           op: add
-          value: {"content":{"inline":{"data":"{{config}}","encoding":"b64"}},"path":"/var/opt/docker/seed-registry-cache-config.yml","permissions":416}
+          value: {"content":{"inline":{"data":"{{config}}","encoding":"b64"}},"path":"/var/opt/docker/seed-registry-cache-config.yml","permissions":0640}
         - path: "/spec/files/1"
           op: add
-          value: {"content":{"inline":{"data":"{{hosts}}","encoding":"b64"}},"path":"/etc/containerd/certs.d/{{registryHost|base64_decode(@)}}/hosts.toml","permissions":416}
+          value: {"content":{"inline":{"data":"{{hosts}}","encoding":"b64"}},"path":"/etc/containerd/certs.d/{{registryHost|base64_decode(@)}}/hosts.toml","permissions":0640}
         - path: "/spec/files/2"
           op: add
-          value: {"content":{"inline":{"data":"{{startScript}}","encoding":"b64"}},"path":"/var/opt/docker/start-seed-registry-cache.sh","permissions":488}
+          value: {"content":{"inline":{"data":"{{startScript}}","encoding":"b64"}},"path":"/var/opt/docker/start-seed-registry-cache.sh","permissions":0750}
         - path: "/spec/files/3"
           op: add
-          value: {"content":{"inline":{"data":"{{stopScript}}","encoding":"b64"}},"path":"/var/opt/docker/stop-seed-registry-cache.sh","permissions":488}
+          value: {"content":{"inline":{"data":"{{stopScript}}","encoding":"b64"}},"path":"/var/opt/docker/stop-seed-registry-cache.sh","permissions":0750}
   - name: add-seed-registry-cache-dropin
     match:
       all:
@@ -145,7 +145,7 @@ spec:
         patchesJson6902: |-
           - path: "/spec/files/{{elementIndex}}"
             op: replace
-            value: {"content":{"inline":{"data":"{{base64_encode('{{replace_all('{{base64_decode(element.content.inline.data)}}','$tmp_dir/gardener-node-agent','$tmp_dir/ko-app/gardener-node-agent')}}')}}","encoding":"b64"}},"path":"/var/lib/gardener-node-agent/init.sh","permissions":493}
+            value: {"content":{"inline":{"data":"{{base64_encode('{{replace_all('{{base64_decode(element.content.inline.data)}}','$tmp_dir/gardener-node-agent','$tmp_dir/ko-app/gardener-node-agent')}}')}}","encoding":"b64"}},"path":"/var/lib/gardener-node-agent/init.sh","permissions":0755}
   - name: modify-gardener-node-agent-path
     match:
       all:
@@ -163,4 +163,4 @@ spec:
         patchesJson6902: |-
           - path: "/spec/files/{{elementIndex}}"
             op: replace
-            value: {"content":{"imageRef":{"filePathInImage":"/ko-app/gardener-node-agent","image":"{{element.content.imageRef.image}}"}},"path":"/opt/bin/gardener-node-agent","permissions":493}
+            value: {"content":{"imageRef":{"filePathInImage":"/ko-app/gardener-node-agent","image":"{{element.content.imageRef.image}}"}},"path":"/opt/bin/gardener-node-agent","permissions":0755}

--- a/example/provider-extensions/kyverno-policies/add-registry-to-osc.yaml
+++ b/example/provider-extensions/kyverno-policies/add-registry-to-osc.yaml
@@ -10,6 +10,8 @@ metadata:
       Locally built Gardener images are pushed to a container registry on the seed. One of those images is node-agent.
       The registry is password protected. This policy adds a registry-cache component to each node via OperatingSystemConfig.
       The registry-cache component allows pulling node-agent image during node bootstrapping and operation.
+      Additionally, these images are built with ko which uses a different non-configurable entrypoint.
+      Thus, the path of gardener-node-agent in OperatingSystemConfig needs to be modified accordingly.
 spec:
   rules:
   - name: add-registry-files-to-osc
@@ -126,3 +128,39 @@ spec:
           - path: "/spec/units/{{elementIndex}}/dropIns"
             op: add
             value: [{"name":"start-seed-registry-cache.conf","content":"{{startDropIn|base64_decode(@)}}"}]
+  - name: modify-gardener-node-init-path
+    match:
+      all:
+      - resources:
+          kinds:
+          - OperatingSystemConfig
+    mutate:
+      foreach:
+      - list: "request.object.spec.files[]"
+        preconditions:
+          all:
+          - key: "{{ element.path  || '' }}"
+            operator: Equals
+            value: "/var/lib/gardener-node-agent/init.sh"
+        patchesJson6902: |-
+          - path: "/spec/files/{{elementIndex}}"
+            op: replace
+            value: {"content":{"inline":{"data":"{{base64_encode('{{replace_all('{{base64_decode(element.content.inline.data)}}','$tmp_dir/gardener-node-agent','$tmp_dir/ko-app/gardener-node-agent')}}')}}","encoding":"b64"}},"path":"/var/lib/gardener-node-agent/init.sh","permissions":493}
+  - name: modify-gardener-node-agent-path
+    match:
+      all:
+      - resources:
+          kinds:
+          - OperatingSystemConfig
+    mutate:
+      foreach:
+      - list: "request.object.spec.files[]"
+        preconditions:
+          all:
+          - key: "{{ element.path  || '' }}"
+            operator: Equals
+            value: "/opt/bin/gardener-node-agent"
+        patchesJson6902: |-
+          - path: "/spec/files/{{elementIndex}}"
+            op: replace
+            value: {"content":{"imageRef":{"filePathInImage":"/ko-app/gardener-node-agent","image":"{{element.content.imageRef.image}}"}},"path":"/opt/bin/gardener-node-agent","permissions":493}

--- a/example/provider-extensions/kyverno-policies/add-registry-to-osc.yaml
+++ b/example/provider-extensions/kyverno-policies/add-registry-to-osc.yaml
@@ -1,0 +1,128 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: add-registry-to-osc
+  annotations:
+    policies.kyverno.io/title: Add registry to OperatingSystemConfig
+    policies.kyverno.io/category: Other
+    policies.kyverno.io/subject: OperatingSystemConfig
+    policies.kyverno.io/description: >-
+      Locally built Gardener images are pushed to a container registry on the seed. One of those images is node-agent.
+      The registry is password protected. This policy adds a registry-cache component to each node via OperatingSystemConfig.
+      The registry-cache component allows pulling node-agent image during node bootstrapping and operation.
+spec:
+  rules:
+  - name: add-registry-files-to-osc
+    match:
+      all:
+      - resources:
+          kinds:
+          - OperatingSystemConfig
+    context:
+    - name: registryHost
+      apiCall:
+        urlPath: "/api/v1/namespaces/registry/secrets/registry-cache-config"
+        jmesPath: 'data."registry-host"'
+    - name: config
+      apiCall:
+        urlPath: "/api/v1/namespaces/registry/secrets/registry-cache-config"
+        jmesPath: 'data."config.yml"'
+    - name: hosts
+      apiCall:
+        urlPath: "/api/v1/namespaces/registry/secrets/registry-cache-config"
+        jmesPath: 'data."hosts.toml"'
+    - name: startScript
+      apiCall:
+        urlPath: "/api/v1/namespaces/registry/secrets/registry-cache-config"
+        jmesPath: 'data."start-seed-registry-cache.sh"'
+    - name: stopScript
+      apiCall:
+        urlPath: "/api/v1/namespaces/registry/secrets/registry-cache-config"
+        jmesPath: 'data."stop-seed-registry-cache.sh"'
+    preconditions:
+      all:
+      - key: "{{ request.object.spec.files[0].path || '' }}"
+        operator: NotEquals
+        value: "/var/opt/docker/seed-registry-cache-config.yml"
+      - key: "{{ request.object.spec.files[1].path || '' }}"
+        operator: NotEquals
+        value: "/etc/containerd/certs.d/{{ registryHost | base64_decode(@) }}/hosts.toml"
+      - key: "{{ request.object.spec.files[2].path || '' }}"
+        operator: NotEquals
+        value: "/var/opt/docker/start-seed-registry-cache.sh"
+      - key: "{{ request.object.spec.files[3].path || '' }}"
+        operator: NotEquals
+        value: "/var/opt/docker/stop-seed-registry-cache.sh"
+    mutate:
+      patchesJson6902: |-
+        - path: "/spec/files/0"
+          op: add
+          value: {"content":{"inline":{"data":"{{config}}","encoding":"b64"}},"path":"/var/opt/docker/seed-registry-cache-config.yml","permissions":416}
+        - path: "/spec/files/1"
+          op: add
+          value: {"content":{"inline":{"data":"{{hosts}}","encoding":"b64"}},"path":"/etc/containerd/certs.d/{{registryHost|base64_decode(@)}}/hosts.toml","permissions":416}
+        - path: "/spec/files/2"
+          op: add
+          value: {"content":{"inline":{"data":"{{startScript}}","encoding":"b64"}},"path":"/var/opt/docker/start-seed-registry-cache.sh","permissions":488}
+        - path: "/spec/files/3"
+          op: add
+          value: {"content":{"inline":{"data":"{{stopScript}}","encoding":"b64"}},"path":"/var/opt/docker/stop-seed-registry-cache.sh","permissions":488}
+  - name: add-seed-registry-cache-dropin
+    match:
+      all:
+      - resources:
+          kinds:
+          - OperatingSystemConfig
+    context:
+    - name: registryHost
+      apiCall:
+        urlPath: "/api/v1/namespaces/registry/secrets/registry-cache-config"
+        jmesPath: 'data."registry-host"'
+    - name: startDropIn
+      apiCall:
+        urlPath: "/api/v1/namespaces/registry/secrets/registry-cache-config"
+        jmesPath: 'data."start-seed-registry-cache.conf"'
+    - name: stopDropIn
+      apiCall:
+        urlPath: "/api/v1/namespaces/registry/secrets/registry-cache-config"
+        jmesPath: 'data."stop-seed-registry-cache.conf"'
+    mutate:
+      foreach:
+      - list: "request.object.spec.units[]"
+        preconditions:
+          all:
+          - key: "{{ element.name  || '' }}"
+            operator: Equals
+            value: "gardener-node-agent.service"
+          - key: "{{ element.dropIns  || '' }}"
+            operator: Equals
+            value: ""
+        patchesJson6902: |-
+          - path: "/spec/units/{{elementIndex}}/dropIns"
+            op: add
+            value: [{"name":"start-seed-registry-cache.conf","content":"{{startDropIn|base64_decode(@)}}"},{"name":"stop-seed-registry-cache.conf","content":"{{stopDropIn|base64_decode(@)}}"}]
+          - path: "/spec/units/{{elementIndex}}/filePaths/-"
+            op: add
+            value: "/var/opt/docker/seed-registry-cache-config.yml"
+          - path: "/spec/units/{{elementIndex}}/filePaths/-"
+            op: add
+            value: "/etc/containerd/certs.d/{{registryHost|base64_decode(@)}}/hosts.toml"
+          - path: "/spec/units/{{elementIndex}}/filePaths/-"
+            op: add
+            value: "/var/opt/docker/start-seed-registry-cache.sh"
+          - path: "/spec/units/{{elementIndex}}/filePaths/-"
+            op: add
+            value: "/var/opt/docker/stop-seed-registry-cache.sh"
+      - list: "request.object.spec.units[]"
+        preconditions:
+          all:
+          - key: "{{ element.name  || '' }}"
+            operator: Equals
+            value: "gardener-node-init.service"
+          - key: "{{ element.dropIns  || '' }}"
+            operator: Equals
+            value: ""
+        patchesJson6902: |-
+          - path: "/spec/units/{{elementIndex}}/dropIns"
+            op: add
+            value: [{"name":"start-seed-registry-cache.conf","content":"{{startDropIn|base64_decode(@)}}"}]

--- a/example/provider-extensions/kyverno-policies/kustomization.yaml
+++ b/example/provider-extensions/kyverno-policies/kustomization.yaml
@@ -4,3 +4,4 @@ kind: Kustomization
 resources:
 - gardener-image-pull-policy.yaml
 - sync-gardener-secrets.yaml
+- add-registry-to-osc.yaml

--- a/example/provider-extensions/registry-seed/deploy-registry.sh
+++ b/example/provider-extensions/registry-seed/deploy-registry.sh
@@ -39,9 +39,15 @@ fi
 kubeconfig=$1
 registry=$2
 
-echo "Generating new password for container registry $registry"
+if kubectl --kubeconfig "$kubeconfig" get secrets -n registry registry-password; then
+  echo "Container registry password found in seed cluster"
+  password=$(kubectl --kubeconfig "$kubeconfig" get secrets -n registry registry-password -o yaml | yq -e .data.password | base64 -d)
+else
+  echo "Generating new password for container registry $registry"
+  password=$(openssl rand -base64 20)
+fi
+
 mkdir -p "$SCRIPT_DIR"/htpasswd
-password=$(openssl rand -base64 20)
 htpasswd -Bbn gardener "$password" > "$SCRIPT_DIR"/htpasswd/auth
 
 echo "Creating basic auth secret for registry"
@@ -49,6 +55,79 @@ kubectl --kubeconfig "$kubeconfig" --server-side=true apply -f "$SCRIPT_DIR"/loa
 kubectl create secret generic -n registry registry-htpasswd --from-file="$SCRIPT_DIR"/htpasswd/auth --dry-run=client -o yaml | \
   kubectl --kubeconfig "$kubeconfig" --server-side=true apply  -f -
 kubectl rollout restart statefulsets -n registry -l app=registry --kubeconfig "$kubeconfig"
+# TODO(oliver-goetz): contribute basic authentication support for registry to https://github.com/distribution/distribution and switch back to the official image afterwards
+kubectl --kubeconfig "$kubeconfig" apply -f - << EOF
+apiVersion: v1
+kind: Secret
+metadata:
+  name: registry-cache-config
+  namespace: registry
+type: Opaque
+stringData:
+  registry-host: $registry
+  config.yml: |
+    version: 0.1
+    log:
+      fields:
+        service: registry
+    storage:
+      delete:
+        enabled: true
+      cache:
+        blobdescriptor: inmemory
+      filesystem:
+        rootdirectory: /var/lib/registry
+    http:
+      addr: 127.0.0.1:5000
+      headers:
+        X-Content-Type-Options: [nosniff]
+    health:
+      storagedriver:
+        enabled: true
+        interval: 10s
+        threshold: 3
+    proxy:
+      remoteurl: https://$registry
+      username: gardener
+      password: '$password'
+  hosts.toml: |
+    server = "https://$registry"
+
+    [host."http://127.0.0.1:5000"]
+      capabilities = ["pull", "resolve"]
+  start-seed-registry-cache.conf: |
+    [Service]\n
+    ExecStartPre=bash /var/opt/docker/start-seed-registry-cache.sh\n
+  stop-seed-registry-cache.conf: |
+    [Service]\n
+    ExecStopPost=bash /var/opt/docker/stop-seed-registry-cache.sh\n
+  start-seed-registry-cache.sh: |
+    #!/usr/bin/env bash
+    if [[ "\$(/usr/bin/ctr task ls | grep seed-registry-cache | awk '{print \$3}')" == "RUNNING" ]]; then
+      echo "seed-registry-cache is already running"
+      exit 0
+    fi
+    if [[ "\$(/usr/bin/ctr container ls | grep seed-registry-cache | awk '{print \$1}')" == "seed-registry-cache" ]]; then
+      echo "removing old seed-registry-cache container"
+      /usr/bin/ctr task kill seed-registry-cache
+      /usr/bin/ctr task rm seed-registry-cache
+      /usr/bin/ctr container rm seed-registry-cache
+    fi
+    if [[ "\$(/usr/bin/ctr snapshot ls | grep seed-registry-cache | awk '{print \$1}')" == "seed-registry-cache" ]]; then
+      echo "removing old seed-registry-cache snapshot"
+      /usr/bin/ctr snapshot rm seed-registry-cache
+    fi
+    echo "Pulling registry-cache image"
+    /usr/bin/ctr image pull ghcr.io/oliver-goetz/distribution/registry:3.0.0-dev
+    echo "Starting registry-cache"
+    /usr/bin/ctr run --detach --mount type=bind,src=/var/opt/docker/seed-registry-cache-config.yml,dst=/etc/docker/registry/config.yml,options=rbind:ro --net-host ghcr.io/oliver-goetz/distribution/registry:3.0.0-dev seed-registry-cache
+  stop-seed-registry-cache.sh: |
+    #!/usr/bin/env bash
+    echo "stopping seed-registry-cache"
+    /usr/bin/ctr task kill seed-registry-cache
+    /usr/bin/ctr task rm seed-registry-cache
+    /usr/bin/ctr container rm seed-registry-cache
+EOF
 
 echo "Creating pull secret in garden namespace"
 kubectl apply -f "$SCRIPT_DIR"/../../00-namespace-garden.yaml --kubeconfig "$kubeconfig" --server-side=true
@@ -71,3 +150,7 @@ done
 
 echo "Run docker login for registry $registry"
 docker login "$registry" -u gardener -p "$password"
+
+echo "Saving password in seed cluster"
+kubectl create secret generic -n registry registry-password --from-literal=password="$password" --dry-run=client -o yaml | \
+  kubectl --kubeconfig "$kubeconfig" --server-side=true apply  -f -

--- a/pkg/component/extensions/operatingsystemconfig/nodeinit/nodeinit_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/nodeinit/nodeinit_test.go
@@ -132,7 +132,10 @@ set -o pipefail
 
 echo "> Prepare temporary directory for image pull and mount"
 tmp_dir="$(mktemp -d)"
-trap 'ctr images unmount "$tmp_dir" && rm -rf "$tmp_dir"' EXIT
+unmount() {
+  ctr images unmount "$tmp_dir" && rm -rf "$tmp_dir"
+}
+trap unmount EXIT
 
 echo "> Pull gardener-node-agent image and mount it to the temporary directory"
 ctr images pull  "` + image + `" --hosts-dir "/etc/containerd/certs.d"

--- a/pkg/component/extensions/operatingsystemconfig/nodeinit/templates/scripts/init.tpl.sh
+++ b/pkg/component/extensions/operatingsystemconfig/nodeinit/templates/scripts/init.tpl.sh
@@ -6,7 +6,10 @@ set -o pipefail
 
 echo "> Prepare temporary directory for image pull and mount"
 tmp_dir="$(mktemp -d)"
-trap 'ctr images unmount "$tmp_dir" && rm -rf "$tmp_dir"' EXIT
+unmount() {
+  ctr images unmount "$tmp_dir" && rm -rf "$tmp_dir"
+}
+trap unmount EXIT
 
 echo "> Pull gardener-node-agent image and mount it to the temporary directory"
 ctr images pull  "{{ .image }}" --hosts-dir "/etc/containerd/certs.d"


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
This PR enables `gardener-node-agent` in `provider-extensions` setup.

Previously, it was not active yet because the container registry on the seed is password protected and [ImageRef](https://github.com/gardener/gardener/blob/34646db9a84900fe64af4c4e219ed492ef7b88bb/pkg/apis/extensions/v1alpha1/types_operatingsystemconfig.go#L179-L181) `FileContent` supports public registries only.

As it is not an option to make this container registry public, there will be an `registry-cache` deployed on each node which is able to login into the registry on the seed.
This `registry-cache` is added to containerd configuration (`/etc/containerd/certs.d/...`) similar to how it is done in the [registry-cache-extension](https://github.com/gardener/gardener-extension-registry-cache). However, in the current case `registry-cache` is started as a container on the node via `ctr` because it needs to be available during bootstrapping of the node.
The configuration for the node is added to the `OperatingSystemConfig` using a `kyverno` policy. Kyverno was already deployed on the seed clusters of the `provider-extensions` setup before.

As an alternative solution [containerd registry credentials configuration](https://github.com/containerd/containerd/blob/main/docs/cri/registry.md#configure-registry-credentials) was considered too. However, this PR followed a different approach because:
- containerd registry credentials configuration only works for `cri` clients. This is not the case for `ctr` and the containerd client used by `gardener-node-agent`.
- containerd registry credentials configuration is deprecated.

With this PR the password of the container registry in the seed does not change on each `make gardener-extensions-up` anymore. Otherwise, the registry-caches on the nodes would not be able to pull the `node-agent` image anymore in this case.

**Which issue(s) this PR fixes**:
Part of #8023
Follow up to #8905

**Special notes for your reviewer**:
This PR uses a [custom built version](https://github.com/oliver-goetz/distribution/tree/enh/support-basic-auth) of registry implementation, because the [upstream repository](https://github.com/distribution/distribution) does not support basic auth (yet). However, there are only small changes required and I will try to contribute the function to the upstream repository.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
`gardener-node-agent` is now enabled in `provider-extensions` setup.
```
