### PR TITLE
pkg/utils/flow: refactor Parallel() to use ParallelN()

### DIFF
--- a/pkg/utils/flow/taskfn.go
+++ b/pkg/utils/flow/taskfn.go
@@ -146,34 +146,7 @@ func ParallelN(n int, fns ...TaskFn) TaskFn {
 
 // Parallel runs the given TaskFns in parallel, collecting their errors in a multierror.
 func Parallel(fns ...TaskFn) TaskFn {
-	return func(ctx context.Context) error {
-		var (
-			wg     sync.WaitGroup
-			errors = make(chan error)
-			result error
-		)
-
-		for _, fn := range fns {
-			t := fn
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
-				errors <- t(ctx)
-			}()
-		}
-
-		go func() {
-			defer close(errors)
-			wg.Wait()
-		}()
-
-		for err := range errors {
-			if err != nil {
-				result = multierror.Append(result, err)
-			}
-		}
-		return result
-	}
+	return ParallelN(len(fns), fns...)
 }
 
 // ParallelExitOnError runs the given TaskFns in parallel and stops execution as soon as one TaskFn returns an error.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind cleanup

**What this PR does / why we need it**:

This PR refactors `pkg/utils/flow:Parallel` to use `pkg/utils/flow:ParallelN` in order to remove some duplicate and redundant code.

**Which issue(s) this PR fixes**:

None

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
