### PR TITLE
Deflake `Renew gardenlet kubeconfig` e2e test

### DIFF
--- a/test/e2e/gardener/managedseed/create_rotate_delete.go
+++ b/test/e2e/gardener/managedseed/create_rotate_delete.go
@@ -43,6 +43,9 @@ import (
 	"github.com/gardener/gardener/test/utils/rotation"
 )
 
+// SeedName is the name of the managed seed used in this e2e test
+const SeedName = "e2e-managedseed"
+
 var parentCtx context.Context
 
 var _ = Describe("ManagedSeed Tests", Label("ManagedSeed", "default"), func() {
@@ -53,7 +56,7 @@ var _ = Describe("ManagedSeed Tests", Label("ManagedSeed", "default"), func() {
 	f := framework.NewShootCreationFramework(&framework.ShootCreationConfig{
 		GardenerConfig: e2e.DefaultGardenConfig("garden"),
 	})
-	f.Shoot = e2e.DefaultShoot("e2e-managedseed")
+	f.Shoot = e2e.DefaultShoot(SeedName)
 
 	It("Create Shoot, Create ManagedSeed, Delete ManagedSeed, Delete Shoot", func() {
 		By("Create Shoot")

--- a/test/e2e/gardener/seed/renew_gardenlet_kubeconfig.go
+++ b/test/e2e/gardener/seed/renew_gardenlet_kubeconfig.go
@@ -30,10 +30,18 @@ var _ = Describe("Seed Tests", Label("Seed", "default"), func() {
 		var seed *gardencorev1beta1.Seed
 
 		BeforeEach(func() {
-			// find the first seed, it doesn't matter which one (seed name differs between test scenarios, e.g., non-ha/ha)
+			// Find the first seed which is not "e2e-managedseed". Seed name differs between test scenarios, e.g., non-ha/ha.
+			// However, this test should not use "e2e-managedseed", because it is created and deleted in a separate e2e test.
+			// This e2e test already includes tests for the "Renew gardenlet kubeconfig" functionality. Additionally,
+			// it might be already gone before the kubeconfig was renewed.
 			seedList := &gardencorev1beta1.SeedList{}
-			Expect(testClient.List(ctx, seedList, client.Limit(1))).To(Succeed())
-			seed = seedList.Items[0].DeepCopy()
+			Expect(testClient.List(ctx, seedList)).To(Succeed())
+			for _, s := range seedList.Items {
+				if s.Name != "e2e-managedseed" {
+					seed = s.DeepCopy()
+					break
+				}
+			}
 			log.Info("Renewing gardenlet kubeconfig", "seedName", seed.Name)
 		})
 

--- a/test/e2e/gardener/seed/renew_gardenlet_kubeconfig.go
+++ b/test/e2e/gardener/seed/renew_gardenlet_kubeconfig.go
@@ -22,6 +22,7 @@ import (
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	"github.com/gardener/gardener/test/e2e/gardener/managedseed"
 	"github.com/gardener/gardener/test/utils/rotation"
 )
 
@@ -37,7 +38,7 @@ var _ = Describe("Seed Tests", Label("Seed", "default"), func() {
 			seedList := &gardencorev1beta1.SeedList{}
 			Expect(testClient.List(ctx, seedList)).To(Succeed())
 			for _, s := range seedList.Items {
-				if s.Name != "e2e-managedseed" {
+				if s.Name != managedseed.SeedName {
 					seed = s.DeepCopy()
 					break
 				}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind flake

**What this PR does / why we need it**:
`Renew gardenlet kubeconfig` e2e test is flaking when it runs on `e2e-managedseed`. I found two possible reasons for this behavior:
1. The same functionality is already tested in the managedseed e2e test ([ref](https://github.com/gardener/gardener/blob/e14f57ac4c652f2aefc0b2b90ef74e91e6ff05ac/test/e2e/gardener/managedseed/create_rotate_delete.go#L121-L146)) which might interfere with the `Renew gardenlet kubeconfig` e2e test.
2. `e2e-managedseed` seed is created and deleted in its e2e test. Thus, it can happen that the seed is deleted while `Renew gardenlet kubeconfig` e2e test is still running

This PR ensures that `Renew gardenlet kubeconfig` e2e test does not run on `e2e-managedseed` to avoid these potential side effects.

**Which issue(s) this PR fixes**:
Fixes #8954

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
4. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
