### PR TITLE
Allow authenticated users to read `kube-system/cluster-identity` `ConfigMap` resource

### DIFF
--- a/charts/gardener/controlplane/charts/application/templates/rbac-user.yaml
+++ b/charts/gardener/controlplane/charts/application/templates/rbac-user.yaml
@@ -290,6 +290,49 @@ subjects:
   kind: Group
   name: system:authenticated
 
+# Role with role binding allowing all authenticated users to read the kube-system/cluster-identity configmap
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: gardener.cloud:system:read-cluster-identity-configmap
+  namespace: kube-system
+  labels:
+    app: gardener
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  resourceNames:
+  - cluster-identity
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: gardener.cloud:system:read-cluster-identity-configmap
+  namespace: kube-system
+  labels:
+    app: gardener
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: gardener.cloud:system:read-cluster-identity-configmap
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:authenticated
+
 # Cluster role for allowing creation of projects.
 # IMPORTANT: You need to define a corresponding ClusterRoleBinding binding specific users/
 #            groups/serviceaccounts to this ClusterRole on your own.

--- a/pkg/component/gardensystem/virtual/virtual.go
+++ b/pkg/component/gardensystem/virtual/virtual.go
@@ -543,6 +543,34 @@ func (g *gardenSystem) computeResourcesData() (map[string][]byte, error) {
 				},
 			},
 		}
+		roleReadClusterIdentityConfigMap = &rbacv1.Role{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "gardener.cloud:system:read-cluster-identity-configmap",
+				Namespace: metav1.NamespaceSystem,
+			},
+			Rules: []rbacv1.PolicyRule{{
+				APIGroups:     []string{corev1.GroupName},
+				Resources:     []string{"configmaps"},
+				ResourceNames: []string{v1beta1constants.ClusterIdentity},
+				Verbs:         []string{"get", "list", "watch"},
+			}},
+		}
+		roleBindingReadClusterIdentityConfigMap = &rbacv1.RoleBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      roleReadClusterIdentityConfigMap.Name,
+				Namespace: metav1.NamespaceSystem,
+			},
+			RoleRef: rbacv1.RoleRef{
+				APIGroup: rbacv1.GroupName,
+				Kind:     "Role",
+				Name:     roleReadClusterIdentityConfigMap.Name,
+			},
+			Subjects: []rbacv1.Subject{{
+				APIGroup: rbacv1.GroupName,
+				Kind:     "Group",
+				Name:     user.AllAuthenticated,
+			}},
+		}
 	)
 
 	if err := registry.Add(
@@ -565,6 +593,8 @@ func (g *gardenSystem) computeResourcesData() (map[string][]byte, error) {
 		clusterRoleProjectServiceAccountManagerAggregated,
 		clusterRoleProjectViewer,
 		clusterRoleProjectViewerAggregated,
+		roleReadClusterIdentityConfigMap,
+		roleBindingReadClusterIdentityConfigMap,
 	); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind enhancement

**What this PR does / why we need it**:
End-users should be able to read the `cluster-identity` `ConfigMap` resource in the `kube-system` namespace.  This will enable them to to set up gardenlogin or gardenctl without having to [look up](https://github.com/gardener/dashboard/blob/master/docs/images/03-gardenlogin-info.png) the cluster-identity from the setup instructions within the gardener dashboard or having to workaround it as described [here](https://github.com/gardener/gardenctl-v2/blob/a8f4786de2ba2f90dde0c1148c6a1e3855994530/README.md?plain=1#L74-L81)


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other user
It is now possible to read the `cluster-identity` `ConfigMap` in the `kube-system` namespace of the Garden cluster
```
