### PR TITLE
Improved error reporting using `ERR_CLEANUP_CLUSTER_RESOURCES` when hibernating a cluster

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -73,6 +73,8 @@ require (
 	sigs.k8s.io/yaml v1.3.0
 )
 
+require github.com/pkg/errors v0.9.1
+
 require (
 	github.com/BurntSushi/toml v1.2.1 // indirect
 	github.com/Masterminds/goutils v1.1.1 // indirect
@@ -152,7 +154,6 @@ require (
 	github.com/opencontainers/selinux v1.10.1 // indirect
 	github.com/pelletier/go-toml v1.9.5 // indirect
 	github.com/pelletier/go-toml/v2 v2.0.8 // indirect
-	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/client_model v0.4.0 // indirect
 	github.com/prometheus/common v0.44.0 // indirect
 	github.com/prometheus/procfs v0.10.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -73,8 +73,6 @@ require (
 	sigs.k8s.io/yaml v1.3.0
 )
 
-require github.com/pkg/errors v0.9.1
-
 require (
 	github.com/BurntSushi/toml v1.2.1 // indirect
 	github.com/Masterminds/goutils v1.1.1 // indirect
@@ -154,6 +152,7 @@ require (
 	github.com/opencontainers/selinux v1.10.1 // indirect
 	github.com/pelletier/go-toml v1.9.5 // indirect
 	github.com/pelletier/go-toml/v2 v2.0.8 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/client_model v0.4.0 // indirect
 	github.com/prometheus/common v0.44.0 // indirect
 	github.com/prometheus/procfs v0.10.1 // indirect

--- a/pkg/operation/botanist/waiter.go
+++ b/pkg/operation/botanist/waiter.go
@@ -25,7 +25,9 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	"github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/retry"
 )
@@ -83,8 +85,13 @@ func (b *Botanist) WaitUntilNoPodRunning(ctx context.Context) error {
 		for _, pod := range podList.Items {
 			if pod.Status.Phase == corev1.PodRunning {
 				b.Logger.Info("Waiting until there are no running pods in the shoot cluster (at least one pod still exists)", "pod", client.ObjectKeyFromObject(&pod))
-				return retry.MinorError(fmt.Errorf("waiting until there are no running Pods in the shoot cluster... "+
-					"there is still at least one running Pod in the shoot cluster: %q", client.ObjectKeyFromObject(&pod).String()))
+
+				message := "waiting until there are no running Pods in the shoot cluster ... there is still at least one running Pod in the shoot cluster: %q"
+				if pod.Namespace == metav1.NamespaceSystem {
+					return retry.MinorError(fmt.Errorf(message, client.ObjectKeyFromObject(&pod).String()))
+				} else {
+					return retry.MinorError(helper.NewErrorWithCodes(fmt.Errorf(message, client.ObjectKeyFromObject(&pod).String()), gardencorev1beta1.ErrorCleanupClusterResources))
+				}
 			}
 		}
 

--- a/pkg/operation/botanist/waiter.go
+++ b/pkg/operation/botanist/waiter.go
@@ -89,11 +89,10 @@ func (b *Botanist) WaitUntilNoPodRunning(ctx context.Context) error {
 				message := "waiting until there are no running Pods in the shoot cluster, there is still at least one running Pod in the shoot cluster: %q"
 				if pod.Namespace == metav1.NamespaceSystem {
 					return retry.MinorError(fmt.Errorf(message, client.ObjectKeyFromObject(&pod).String()))
-				} else {
-					return retry.MinorError(helper.NewErrorWithCodes(fmt.Errorf(message,
-						client.ObjectKeyFromObject(&pod).String()),
-						gardencorev1beta1.ErrorCleanupClusterResources))
 				}
+				return retry.MinorError(helper.NewErrorWithCodes(fmt.Errorf(message,
+					client.ObjectKeyFromObject(&pod).String()),
+					gardencorev1beta1.ErrorCleanupClusterResources))
 			}
 		}
 

--- a/pkg/operation/botanist/waiter.go
+++ b/pkg/operation/botanist/waiter.go
@@ -86,11 +86,13 @@ func (b *Botanist) WaitUntilNoPodRunning(ctx context.Context) error {
 			if pod.Status.Phase == corev1.PodRunning {
 				b.Logger.Info("Waiting until there are no running pods in the shoot cluster (at least one pod still exists)", "pod", client.ObjectKeyFromObject(&pod))
 
-				message := "waiting until there are no running Pods in the shoot cluster ... there is still at least one running Pod in the shoot cluster: %q"
+				message := "waiting until there are no running Pods in the shoot cluster, there is still at least one running Pod in the shoot cluster: %q"
 				if pod.Namespace == metav1.NamespaceSystem {
 					return retry.MinorError(fmt.Errorf(message, client.ObjectKeyFromObject(&pod).String()))
 				} else {
-					return retry.MinorError(helper.NewErrorWithCodes(fmt.Errorf(message, client.ObjectKeyFromObject(&pod).String()), gardencorev1beta1.ErrorCleanupClusterResources))
+					return retry.MinorError(helper.NewErrorWithCodes(fmt.Errorf(message,
+						client.ObjectKeyFromObject(&pod).String()),
+						gardencorev1beta1.ErrorCleanupClusterResources))
 				}
 			}
 		}

--- a/pkg/operation/botanist/waiter_test.go
+++ b/pkg/operation/botanist/waiter_test.go
@@ -1,0 +1,117 @@
+// Copyright 2024 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package botanist_test
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	kubernetesfake "github.com/gardener/gardener/pkg/client/kubernetes/fake"
+	"github.com/gardener/gardener/pkg/operation"
+	. "github.com/gardener/gardener/pkg/operation/botanist"
+)
+
+var _ = Describe("Waiter", func() {
+	var (
+		botanist *Botanist
+
+		ctx = context.Background()
+	)
+
+	BeforeEach(func() {
+		shootClient := fakeclient.NewClientBuilder().WithScheme(kubernetes.ShootScheme).Build()
+		shootClientSet := kubernetesfake.NewClientSetBuilder().WithClient(shootClient).Build()
+
+		botanist = &Botanist{
+			Operation: &operation.Operation{
+				Logger:         logr.Discard(),
+				ShootClientSet: shootClientSet,
+			},
+		}
+	})
+
+	Describe("#WaitUntilNoPodRunning", func() {
+		var (
+			pod *corev1.Pod
+		)
+
+		BeforeEach(func() {
+			pod = &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "infinity-pod",
+				},
+			}
+		})
+
+		It("should return ok when no pod is found", func() {
+			Expect(botanist.WaitUntilNoPodRunning(ctx)).To(Succeed())
+		})
+
+		It("should return ok when no pod is running", func() {
+			ctxCanceled, cancel := context.WithCancel(ctx)
+			cancel()
+
+			pod.Status = corev1.PodStatus{Phase: corev1.PodFailed}
+
+			Expect(botanist.ShootClientSet.Client().Create(ctxCanceled, pod)).To(Succeed())
+
+			Expect(botanist.WaitUntilNoPodRunning(ctxCanceled)).To(Succeed())
+		})
+
+		It("should return an error when a pod is running in non system namespace", func() {
+			ctxCanceled, cancel := context.WithCancel(ctx)
+			cancel()
+
+			pod.Status = corev1.PodStatus{Phase: corev1.PodRunning}
+			pod.Namespace = "foo"
+
+			Expect(botanist.ShootClientSet.Client().Create(ctxCanceled, pod)).To(Succeed())
+
+			err := botanist.WaitUntilNoPodRunning(ctxCanceled)
+
+			var coder v1beta1helper.Coder
+			Expect(errors.As(err, &coder)).To(BeTrue())
+
+			Expect(coder.Codes()[0]).To(Equal(gardencorev1beta1.ErrorCleanupClusterResources))
+		})
+
+		It("should return an error when a pod is running in system namespace", func() {
+			ctxCanceled, cancel := context.WithCancel(ctx)
+			cancel()
+
+			pod.Status = corev1.PodStatus{Phase: corev1.PodRunning}
+			pod.Namespace = metav1.NamespaceSystem
+
+			Expect(botanist.ShootClientSet.Client().Create(ctxCanceled, pod)).To(Succeed())
+
+			err := botanist.WaitUntilNoPodRunning(ctxCanceled)
+
+			var coder v1beta1helper.Coder
+			Expect(errors.As(err, &coder)).To(BeFalse())
+
+			Expect(err).To(MatchError("retry failed with context canceled, last error: waiting until there are no running Pods in the shoot cluster ... there is still at least one running Pod in the shoot cluster: \"kube-system/infinity-pod\""))
+		})
+	})
+})

--- a/pkg/operation/botanist/waiter_test.go
+++ b/pkg/operation/botanist/waiter_test.go
@@ -16,11 +16,11 @@ package botanist_test
 
 import (
 	"context"
+	"errors"
 
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"

--- a/pkg/operation/botanist/waiter_test.go
+++ b/pkg/operation/botanist/waiter_test.go
@@ -111,7 +111,7 @@ var _ = Describe("Waiter", func() {
 			var coder v1beta1helper.Coder
 			Expect(errors.As(err, &coder)).To(BeFalse())
 
-			Expect(err).To(MatchError("retry failed with context canceled, last error: waiting until there are no running Pods in the shoot cluster ... there is still at least one running Pod in the shoot cluster: \"kube-system/infinity-pod\""))
+			Expect(err).To(MatchError("retry failed with context canceled, last error: waiting until there are no running Pods in the shoot cluster, there is still at least one running Pod in the shoot cluster: \"kube-system/infinity-pod\""))
 		})
 	})
 })


### PR DESCRIPTION
**How to categorize this PR?**
/area ops-productivity
/kind enhancement

**What this PR does / why we need it**:
Previously, when a pod was still running while gardener was waiting for all pods to be in a non running state, there was no distinction between a pod in system namespace and a pod in non system namespace. Now, different error messages will be returned depending on the namespace. This is especially useful when hibernating a cluster since the user will be provided with much better feedback about why his cluster refused to hibernate

**Which issue(s) this PR fixes**:
Fixes #8887 

**Special notes for your reviewer**:

**Release note**:
```feature operator
When hibernating a cluster, Gardener now assigns an error code `ERR_CLEANUP_CLUSTER_RESOURCES` to shoot clusters if (user) pods are still running in namespaces other than `kube-system`.
```
