### PR TITLE
Fix nil pointer panic

### DIFF
--- a/pkg/chartrenderer/default.go
+++ b/pkg/chartrenderer/default.go
@@ -167,13 +167,14 @@ func (c *RenderedChart) Manifest() []byte {
 func (c *RenderedChart) Files() map[string]map[string]string {
 	var files = make(map[string]map[string]string)
 	for _, manifest := range c.Manifests {
-		if _, ok := files[manifest.Name]; ok {
-			if resourceName := getResourceName(manifest); resourceName != "" {
-				files[manifest.Name][resourceName] = manifest.Content
-			}
+		resourceName := getResourceName(manifest)
+		if resourceName == "" {
 			continue
 		}
-		if resourceName := getResourceName(manifest); resourceName != "" {
+
+		if _, ok := files[manifest.Name]; ok {
+			files[manifest.Name][resourceName] = manifest.Content
+		} else {
 			files[manifest.Name] = map[string]string{resourceName: manifest.Content}
 		}
 	}

--- a/pkg/chartrenderer/default.go
+++ b/pkg/chartrenderer/default.go
@@ -168,10 +168,14 @@ func (c *RenderedChart) Files() map[string]map[string]string {
 	var files = make(map[string]map[string]string)
 	for _, manifest := range c.Manifests {
 		if _, ok := files[manifest.Name]; ok {
-			files[manifest.Name][strings.ToLower(manifest.Head.Kind+"/"+manifest.Head.Metadata.Name)] = manifest.Content
+			if resourceName := getResourceName(manifest); resourceName != "" {
+				files[manifest.Name][resourceName] = manifest.Content
+			}
 			continue
 		}
-		files[manifest.Name] = map[string]string{strings.ToLower(manifest.Head.Kind + "/" + manifest.Head.Metadata.Name): manifest.Content}
+		if resourceName := getResourceName(manifest); resourceName != "" {
+			files[manifest.Name] = map[string]string{resourceName: manifest.Content}
+		}
 	}
 	return files
 }
@@ -284,4 +288,11 @@ func loadEmbeddedFS(embeddedFS embed.FS, chartPath string) (*helmchart.Chart, er
 	}
 
 	return helmloader.LoadFiles(files)
+}
+
+func getResourceName(manifest releaseutil.Manifest) string {
+	if manifest.Head != nil && manifest.Head.Metadata != nil {
+		return strings.ToLower(manifest.Head.Kind + "/" + manifest.Head.Metadata.Name)
+	}
+	return ""
 }

--- a/pkg/chartrenderer/default_test.go
+++ b/pkg/chartrenderer/default_test.go
@@ -64,6 +64,20 @@ rules:
   - configmaps
   verbs:
   - create`
+
+	license = `# Copyright 2024 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.`
 )
 
 //go:embed testdata/alpine/*
@@ -113,7 +127,7 @@ var _ = Describe("ChartRenderer", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			actual := chart.FileContent("alpine-resources.yaml")
-			Expect(actual).To(Equal(testSecret + "\n---\n" + testClusterRole + "\n---\n" + alpinePod))
+			Expect(actual).To(Equal(testSecret + "\n---\n" + testClusterRole + "\n---\n" + alpinePod + "\n---\n" + license))
 
 			actual = chart.FileContent("secret.yaml")
 			Expect(actual).To(Equal(testSecret))

--- a/pkg/chartrenderer/testdata/alpine/templates/alpine-resources.yaml
+++ b/pkg/chartrenderer/testdata/alpine/templates/alpine-resources.yaml
@@ -1,3 +1,18 @@
+# Copyright 2024 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
 apiVersion: v1
 kind: Pod
 metadata:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area open-source
/kind enhancement

**What this PR does / why we need it**:
Follow up of - https://github.com/gardener/gardener/pull/8877

Some repos keep license information in charts example https://github.com/gardener/gardener-extension-shoot-networking-problemdetector/blob/main/charts/gardener-extension-shoot-networking-problemdetector/templates/configmap-imagevector-overwrite.yaml, so while rendering license is also considered as chart, but it create nil pointer panic as it doesn't have name and kind information.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @ialidzhikov 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
