### PR TITLE
Allow additional permissions for extensions in garden cluster defined via RBAC

### DIFF
--- a/docs/concepts/controller-manager.md
+++ b/docs/concepts/controller-manager.md
@@ -74,17 +74,29 @@ The controller then creates or updates the required `ControllerInstallation` obj
 It also deletes every existing `ControllerInstallation` whose referenced `ControllerRegistration` is not part of the required list.
 For example, if the shoots in the seed are no longer using the DNS provider `aws-route53`, then the controller proceeds to delete the respective `ControllerInstallation` object.
 
-#### ["ControllerRegistration Finalizer" Reconciler](../../pkg/controllermanager/controller/controllerregistration/controllerregistrationfinalizer)
+#### ["`ControllerRegistration` Finalizer" Reconciler](../../pkg/controllermanager/controller/controllerregistration/controllerregistrationfinalizer)
 
 This reconciliation loop watches the `ControllerRegistration` resource and adds finalizers to it when they are created.
 In case a deletion request comes in for the resource, i.e., if a `.metadata.deletionTimestamp` is set, it actively scans for a `ControllerInstallation` resource using this `ControllerRegistration`, and decides whether the deletion can be allowed.
 In case no related `ControllerInstallation` is present, it removes the finalizer and marks it for deletion.
 
-#### ["Seed Finalizer" Reconciler](../../pkg/controllermanager/controller/controllerregistration/seedfinalizer)
+#### ["`Seed` Finalizer" Reconciler](../../pkg/controllermanager/controller/controllerregistration/seedfinalizer)
 
 This loop also watches the `Seed` object and adds finalizers to it at creation.
 If a `.metadata.deletionTimestamp` is set for the seed, then the controller checks for existing `ControllerInstallation` objects which reference this seed.
 If no such objects exist, then it removes the finalizer and allows the deletion.
+
+#### ["Extension `ClusterRole`" Reconciler](../../pkg/controllermanager/controller/controllerregistration/extensionclusterrole)
+
+This reconciler watches two resources in the garden cluster:
+
+- `ClusterRole`s labeled with `authorization.extensions.gardener.cloud/additional-permissions=true`
+- `ServiceAccount`s in seed namespaces prefixed with `extension-`.
+
+Its core task is to maintain a `ClusterRoleBinding` resource referencing the respective `ClusterRole`.
+This gets bound to all `ServiceAccount`s in seed namespaces that belong to extensions enlisted in the `authorization.extensions.gardener.cloud/bind-to` annotation.
+
+You can read more about the purpose of this reconciler in [this document](../extensions/garden-api-access.md#additional-permissions).
 
 ### [`Event` Controller](../../pkg/controllermanager/controller/event)
 

--- a/docs/extensions/garden-api-access.md
+++ b/docs/extensions/garden-api-access.md
@@ -16,27 +16,6 @@ Accordingly, extensions running on the seed cluster didn't have access to the ga
 Starting from Gardener [`v1.74.0`](https://github.com/gardener/gardener/releases/v1.74.0), there is a new mechanism for components running on seed clusters to get access to the garden cluster.
 For this, `gardenlet` runs an instance of the [`TokenRequestor`](../concepts/gardenlet.md#tokenrequestor-controller) for requesting tokens that can be used to communicate with the garden cluster.
 
-## Manually Requesting a Token for the Garden Cluster
-
-Seed components that need to communicate with the garden cluster can request a token in the garden cluster by creating a garden access secret.
-This secret has to be labelled with `resources.gardener.cloud/purpose=token-requestor` and `resources.gardener.cloud/class=garden`, e.g.:
-
-```yaml
-apiVersion: v1
-kind: Secret
-metadata:
-  name: garden-access-example
-  namespace: example
-  labels:
-    resources.gardener.cloud/purpose: token-requestor
-    resources.gardener.cloud/class: garden
-  annotations:
-    serviceaccount.resources.gardener.cloud/name: example
-type: Opaque
-```
-
-This will instruct gardenlet to create a new `ServiceAccount` named `example` in its own `seed-<seed-name>` namespace in the garden cluster, request a token for it, and populate the token in the secret's data under the `token` key.
-
 ## Using Gardenlet-Managed Garden Access
 
 By default, extensions are equipped with secure access to the garden cluster using a dedicated `ServiceAccount` without requiring any additional action.
@@ -119,6 +98,27 @@ users:
   user:
     tokenFile: /var/run/secrets/gardener.cloud/garden/generic-kubeconfig/token
 ```
+
+## Manually Requesting a Token for the Garden Cluster
+
+Seed components that need to communicate with the garden cluster can request a token in the garden cluster by creating a garden access secret.
+This secret has to be labelled with `resources.gardener.cloud/purpose=token-requestor` and `resources.gardener.cloud/class=garden`, e.g.:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: garden-access-example
+  namespace: example
+  labels:
+    resources.gardener.cloud/purpose: token-requestor
+    resources.gardener.cloud/class: garden
+  annotations:
+    serviceaccount.resources.gardener.cloud/name: example
+type: Opaque
+```
+
+This will instruct gardenlet to create a new `ServiceAccount` named `example` in its own `seed-<seed-name>` namespace in the garden cluster, request a token for it, and populate the token in the secret's data under the `token` key.
 
 ## Permissions in the Garden Cluster
 

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -513,6 +513,13 @@ const (
 	// server).
 	LabelNetworkPolicyAccessTargetAPIServer = "networking.gardener.cloud/access-target-apiserver"
 
+	// LabelExtensionsAuthorizationBindTo is a constant for an annotation key on ClusterRoles in the garden cluster
+	// which can be used to describe which extensions are allowed to get bound to this ClusterRole.
+	LabelExtensionsAuthorizationBindTo = "authorization.extensions.gardener.cloud/bind-to"
+	// LabelExtensionsAuthorizationAdditionalPermissions is a constant for a label key on ClusterRoles in the garden
+	// cluster which can be used to describe that this ClusterRole contains additional permissions for extensions.
+	LabelExtensionsAuthorizationAdditionalPermissions = "authorization.extensions.gardener.cloud/additional-permissions"
+
 	// LabelApp is a constant for a label key.
 	LabelApp = "app"
 	// LabelRole is a constant for a label key.

--- a/pkg/controllermanager/controller/controllerregistration/add.go
+++ b/pkg/controllermanager/controller/controllerregistration/add.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/gardener/gardener/pkg/controllermanager/apis/config"
 	"github.com/gardener/gardener/pkg/controllermanager/controller/controllerregistration/controllerregistrationfinalizer"
+	"github.com/gardener/gardener/pkg/controllermanager/controller/controllerregistration/extensionclusterrole"
 	"github.com/gardener/gardener/pkg/controllermanager/controller/controllerregistration/seed"
 	"github.com/gardener/gardener/pkg/controllermanager/controller/controllerregistration/seedfinalizer"
 )
@@ -36,6 +37,10 @@ func AddToManager(ctx context.Context, mgr manager.Manager, cfg config.Controlle
 
 	if err := (&controllerregistrationfinalizer.Reconciler{}).AddToManager(mgr); err != nil {
 		return fmt.Errorf("failed adding ControllerRegistration finalizer reconciler: %w", err)
+	}
+
+	if err := (&extensionclusterrole.Reconciler{}).AddToManager(ctx, mgr); err != nil {
+		return fmt.Errorf("failed adding extension ClusterRole reconciler: %w", err)
 	}
 
 	if err := (&seedfinalizer.Reconciler{}).AddToManager(mgr); err != nil {

--- a/pkg/controllermanager/controller/controllerregistration/extensionclusterrole/add.go
+++ b/pkg/controllermanager/controller/controllerregistration/extensionclusterrole/add.go
@@ -1,0 +1,107 @@
+// Copyright 2024 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package extensionclusterrole
+
+import (
+	"context"
+	"strings"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	"github.com/gardener/gardener/pkg/controllerutils/mapper"
+	"github.com/gardener/gardener/pkg/utils"
+	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
+)
+
+// ControllerName is the name of this controller.
+const ControllerName = "controllerregistration-extension-clusterrole"
+
+var labelSelectorPredicate predicate.Predicate
+
+func init() {
+	var err error
+	labelSelectorPredicate, err = predicate.LabelSelectorPredicate(metav1.LabelSelector{
+		MatchExpressions: []metav1.LabelSelectorRequirement{{
+			Key:      v1beta1constants.LabelExtensionsAuthorizationAdditionalPermissions,
+			Operator: metav1.LabelSelectorOpIn,
+			Values:   []string{"true"},
+		}},
+	})
+	utilruntime.Must(err)
+}
+
+// AddToManager adds Reconciler to the given manager.
+func (r *Reconciler) AddToManager(ctx context.Context, mgr manager.Manager) error {
+	if r.Client == nil {
+		r.Client = mgr.GetClient()
+	}
+
+	clusterRole := &metav1.PartialObjectMetadata{}
+	clusterRole.SetGroupVersionKind(rbacv1.SchemeGroupVersion.WithKind("ClusterRole"))
+
+	c, err := builder.
+		ControllerManagedBy(mgr).
+		Named(ControllerName).
+		For(clusterRole, builder.WithPredicates(labelSelectorPredicate)).
+		WithOptions(controller.Options{MaxConcurrentReconciles: 5}).
+		Build(r)
+	if err != nil {
+		return err
+	}
+
+	serviceAccount := &metav1.PartialObjectMetadata{}
+	serviceAccount.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("ServiceAccount"))
+
+	return c.Watch(
+		source.Kind(mgr.GetCache(), serviceAccount),
+		mapper.EnqueueRequestsFrom(ctx, mgr.GetCache(), mapper.MapFunc(r.MapToAllClusterRoles), mapper.UpdateWithNew, c.GetLogger()),
+		r.ServiceAccountPredicate(),
+	)
+}
+
+// ServiceAccountPredicate returns true when the name of the ServiceAccount is prefixed with `extension-` and when its
+// namespace is prefixed with `seed-`.
+func (r *Reconciler) ServiceAccountPredicate() predicate.Predicate {
+	return predicate.NewPredicateFuncs(func(obj client.Object) bool {
+		return strings.HasPrefix(obj.GetName(), v1beta1constants.ExtensionGardenServiceAccountPrefix) &&
+			strings.HasPrefix(obj.GetNamespace(), gardenerutils.SeedNamespaceNamePrefix)
+	})
+}
+
+// MapToAllClusterRoles returns reconcile.Request objects for all ClusterRoles with a respective label.
+func (r *Reconciler) MapToAllClusterRoles(ctx context.Context, log logr.Logger, reader client.Reader, _ client.Object) []reconcile.Request {
+	clusterRoleList := &metav1.PartialObjectMetadataList{}
+	clusterRoleList.SetGroupVersionKind(rbacv1.SchemeGroupVersion.WithKind("ClusterRoleList"))
+	if err := reader.List(ctx, clusterRoleList, client.MatchingLabelsSelector{Selector: labels.NewSelector().Add(utils.MustNewRequirement(v1beta1constants.LabelExtensionsAuthorizationAdditionalPermissions, selection.In, "true"))}); err != nil {
+		log.Error(err, "Failed to list ClusterRoles")
+		return nil
+	}
+
+	return mapper.ObjectListToRequests(clusterRoleList)
+}

--- a/pkg/controllermanager/controller/controllerregistration/extensionclusterrole/add_test.go
+++ b/pkg/controllermanager/controller/controllerregistration/extensionclusterrole/add_test.go
@@ -1,0 +1,126 @@
+// Copyright 2024 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package extensionclusterrole_test
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	. "github.com/gardener/gardener/pkg/controllermanager/controller/controllerregistration/extensionclusterrole"
+)
+
+var _ = Describe("Add", func() {
+	var (
+		reconciler     *Reconciler
+		serviceAccount *corev1.ServiceAccount
+	)
+
+	BeforeEach(func() {
+		reconciler = &Reconciler{}
+		serviceAccount = &corev1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "seed-foo",
+				Name:      "extension-bar",
+			},
+		}
+	})
+
+	Describe("ServiceAccountPredicate", func() {
+		var p predicate.Predicate
+
+		BeforeEach(func() {
+			p = reconciler.ServiceAccountPredicate()
+		})
+
+		tests := func(f func(obj client.Object) bool) {
+			It("should return false because object is no Secret", func() {
+				Expect(f(&corev1.ConfigMap{})).To(BeFalse())
+			})
+
+			It("should return false because namespace is not prefixed with 'seed-'", func() {
+				serviceAccount.Namespace = "foo"
+				Expect(f(serviceAccount)).To(BeFalse())
+			})
+
+			It("should return false because name is not prefixed with 'extension-'", func() {
+				serviceAccount.Name = "bar"
+				Expect(f(serviceAccount)).To(BeFalse())
+			})
+
+			It("should return true because object matches all conditions", func() {
+				Expect(f(serviceAccount)).To(BeTrue())
+			})
+		}
+
+		Describe("#Create", func() {
+			tests(func(obj client.Object) bool { return p.Create(event.CreateEvent{Object: obj}) })
+		})
+
+		Describe("#Update", func() {
+			tests(func(obj client.Object) bool { return p.Update(event.UpdateEvent{ObjectNew: obj}) })
+		})
+
+		Describe("#Delete", func() {
+			tests(func(obj client.Object) bool { return p.Delete(event.DeleteEvent{Object: obj}) })
+		})
+
+		Describe("#Generic", func() {
+			tests(func(obj client.Object) bool { return p.Generic(event.GenericEvent{Object: obj}) })
+		})
+	})
+
+	Describe("#MapToAllClusterRoles", func() {
+		var (
+			ctx                                      = context.Background()
+			log                                      logr.Logger
+			fakeClient                               client.Client
+			clusterRole1, clusterRole2, clusterRole3 *rbacv1.ClusterRole
+		)
+
+		BeforeEach(func() {
+			log = logr.Discard()
+			fakeClient = fakeclient.NewClientBuilder().WithScheme(kubernetes.GardenScheme).Build()
+
+			clusterRole1 = &rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: "clusterRole1", Labels: map[string]string{v1beta1constants.LabelExtensionsAuthorizationAdditionalPermissions: "true"}}}
+			clusterRole2 = &rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: "clusterRole2", Labels: map[string]string{v1beta1constants.LabelExtensionsAuthorizationAdditionalPermissions: "true"}}}
+			clusterRole3 = &rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: "clusterRole3"}}
+
+			Expect(fakeClient.Create(ctx, clusterRole1)).To(Succeed())
+			Expect(fakeClient.Create(ctx, clusterRole2)).To(Succeed())
+			Expect(fakeClient.Create(ctx, clusterRole3)).To(Succeed())
+		})
+
+		It("should map to all seeds", func() {
+			Expect(reconciler.MapToAllClusterRoles(ctx, log, fakeClient, nil)).To(ConsistOf(
+				reconcile.Request{NamespacedName: types.NamespacedName{Name: clusterRole1.Name}},
+				reconcile.Request{NamespacedName: types.NamespacedName{Name: clusterRole2.Name}},
+			))
+		})
+	})
+})

--- a/pkg/controllermanager/controller/controllerregistration/extensionclusterrole/extensionclusterrole_suite_test.go
+++ b/pkg/controllermanager/controller/controllerregistration/extensionclusterrole/extensionclusterrole_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright 2024 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package extensionclusterrole_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestExtensionClusterRole(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "ControllerManager Controller ControllerRegistration ExtensionClusterRole Suite")
+}

--- a/pkg/controllermanager/controller/controllerregistration/extensionclusterrole/reconciler.go
+++ b/pkg/controllermanager/controller/controllerregistration/extensionclusterrole/reconciler.go
@@ -1,0 +1,126 @@
+// Copyright 2024 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package extensionclusterrole
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	"github.com/gardener/gardener/pkg/controllerutils"
+	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
+)
+
+// Reconciler reconciles ClusterRoles for additional extension permissions and creates ClusterRoleBindings for binding
+// extension service accounts to such ClusterRoles.
+type Reconciler struct {
+	Client client.Client
+}
+
+// Reconcile reconciles ControllerRegistrations.
+func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
+	log := logf.FromContext(ctx)
+
+	ctx, cancel := controllerutils.GetMainReconciliationContext(ctx, controllerutils.DefaultReconciliationTimeout)
+	defer cancel()
+
+	clusterRole := &metav1.PartialObjectMetadata{}
+	clusterRole.SetGroupVersionKind(rbacv1.SchemeGroupVersion.WithKind("ClusterRole"))
+	if err := r.Client.Get(ctx, request.NamespacedName, clusterRole); err != nil {
+		if apierrors.IsNotFound(err) {
+			log.V(1).Info("Object is gone, stop reconciling")
+			return reconcile.Result{}, nil
+		}
+		return reconcile.Result{}, fmt.Errorf("error retrieving object from store: %w", err)
+	}
+
+	if clusterRole.DeletionTimestamp != nil {
+		return reconcile.Result{}, nil
+	}
+
+	subjects, err := r.computeSubjects(ctx, clusterRole)
+	if err != nil {
+		return reconcile.Result{}, fmt.Errorf("failed computing subjects for ClusterRoleBinding: %w", err)
+	}
+
+	clusterRoleBinding := &rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: clusterRole.Name}}
+	_, err = controllerutils.GetAndCreateOrMergePatch(ctx, r.Client, clusterRoleBinding, func() error {
+		ownerReference := metav1.NewControllerRef(clusterRole, rbacv1.SchemeGroupVersion.WithKind("ClusterRole"))
+		ownerReference.BlockOwnerDeletion = pointer.Bool(false)
+		clusterRoleBinding.SetOwnerReferences(kubernetesutils.MergeOwnerReferences(clusterRoleBinding.GetOwnerReferences(), *ownerReference))
+
+		clusterRoleBinding.RoleRef = rbacv1.RoleRef{
+			APIGroup: rbacv1.SchemeGroupVersion.Group,
+			Kind:     "ClusterRole",
+			Name:     clusterRole.Name,
+		}
+		clusterRoleBinding.Subjects = subjects
+		return nil
+	})
+	return reconcile.Result{}, err
+}
+
+func (r *Reconciler) computeSubjects(ctx context.Context, clusterRole *metav1.PartialObjectMetadata) ([]rbacv1.Subject, error) {
+	extensionNames := strings.Split(clusterRole.Annotations[v1beta1constants.LabelExtensionsAuthorizationBindTo], ",")
+	if len(extensionNames) == 0 {
+		return nil, nil
+	}
+
+	seedNamespaceList := &metav1.PartialObjectMetadataList{}
+	seedNamespaceList.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("NamespaceList"))
+	if err := r.Client.List(ctx, seedNamespaceList, client.MatchingLabels{v1beta1constants.GardenRole: v1beta1constants.GardenRoleSeed}); err != nil {
+		return nil, fmt.Errorf("failed listing seed namespaces: %w", err)
+	}
+
+	// ensure stable order of subjects
+	kubernetesutils.ByName().Sort(seedNamespaceList)
+
+	var subjects []rbacv1.Subject
+
+	for _, namespace := range seedNamespaceList.Items {
+		serviceAccountList := &metav1.PartialObjectMetadataList{}
+		serviceAccountList.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("ServiceAccountList"))
+		if err := r.Client.List(ctx, serviceAccountList, client.InNamespace(namespace.Name)); err != nil {
+			return nil, fmt.Errorf("failed listing ServiceAccounts in namespace %s: %w", namespace.Name, err)
+		}
+
+		// ensure stable order of subjects
+		kubernetesutils.ByName().Sort(serviceAccountList)
+
+		for _, serviceAccount := range serviceAccountList.Items {
+			for _, extensionName := range extensionNames {
+				if strings.HasPrefix(serviceAccount.Name, v1beta1constants.ExtensionGardenServiceAccountPrefix+extensionName) {
+					subjects = append(subjects, rbacv1.Subject{
+						Kind:      rbacv1.ServiceAccountKind,
+						Name:      serviceAccount.Name,
+						Namespace: serviceAccount.Namespace,
+					})
+				}
+			}
+		}
+	}
+
+	return subjects, nil
+}

--- a/pkg/controllermanager/controller/seed/secrets/reconciler_test.go
+++ b/pkg/controllermanager/controller/seed/secrets/reconciler_test.go
@@ -85,6 +85,7 @@ var _ = Describe("Reconciler", func() {
 					OwnerReferences: []metav1.OwnerReference{
 						*metav1.NewControllerRef(seed, gardencorev1beta1.SchemeGroupVersion.WithKind("Seed")),
 					},
+					Labels: map[string]string{"gardener.cloud/role": "seed"},
 				},
 			}
 		})

--- a/skaffold-operator.yaml
+++ b/skaffold-operator.yaml
@@ -510,6 +510,7 @@ build:
             - pkg/controllermanager/controller/controllerdeployment
             - pkg/controllermanager/controller/controllerregistration
             - pkg/controllermanager/controller/controllerregistration/controllerregistrationfinalizer
+            - pkg/controllermanager/controller/controllerregistration/extensionclusterrole
             - pkg/controllermanager/controller/controllerregistration/seed
             - pkg/controllermanager/controller/controllerregistration/seedfinalizer
             - pkg/controllermanager/controller/event

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -252,6 +252,7 @@ build:
             - pkg/controllermanager/controller/controllerdeployment
             - pkg/controllermanager/controller/controllerregistration
             - pkg/controllermanager/controller/controllerregistration/controllerregistrationfinalizer
+            - pkg/controllermanager/controller/controllerregistration/extensionclusterrole
             - pkg/controllermanager/controller/controllerregistration/seed
             - pkg/controllermanager/controller/controllerregistration/seedfinalizer
             - pkg/controllermanager/controller/event

--- a/test/integration/controllermanager/controllerregistration/extensionclusterrole/extensionclusterrole_suite_test.go
+++ b/test/integration/controllermanager/controllerregistration/extensionclusterrole/extensionclusterrole_suite_test.go
@@ -1,0 +1,120 @@
+// Copyright 2024 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package extensionclusterrole_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/uuid"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+
+	"github.com/gardener/gardener/pkg/controllermanager/controller/controllerregistration/extensionclusterrole"
+	gardenerenvtest "github.com/gardener/gardener/pkg/envtest"
+	"github.com/gardener/gardener/pkg/logger"
+	gardenerutils "github.com/gardener/gardener/pkg/utils"
+	"github.com/gardener/gardener/test/utils/namespacefinalizer"
+)
+
+func TestExtensionClusterRole(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Test Integration ControllerManager ControllerRegistration ExtensionClusterRole Suite")
+}
+
+const testID = "extensionclusterrole-controller-test"
+
+var (
+	ctx = context.Background()
+	log logr.Logger
+
+	restConfig *rest.Config
+	testEnv    *gardenerenvtest.GardenerTestEnvironment
+	testClient client.Client
+
+	testRunID = "test-" + gardenerutils.ComputeSHA256Hex([]byte(uuid.NewUUID()))[:8]
+)
+
+var _ = BeforeSuite(func() {
+	logf.SetLogger(logger.MustNewZapLogger(logger.DebugLevel, logger.FormatJSON, zap.WriteTo(GinkgoWriter)))
+	log = logf.Log.WithName(testID)
+
+	By("Start test environment")
+	testEnv = &gardenerenvtest.GardenerTestEnvironment{
+		GardenerAPIServer: &gardenerenvtest.GardenerAPIServer{
+			Args: []string{"--disable-admission-plugins=DeletionConfirmation,ResourceReferenceManager,ExtensionValidator,ShootDNS,ShootQuotaValidator,ShootTolerationRestriction,ShootValidator,ControllerRegistrationResources"},
+		},
+	}
+
+	var err error
+	restConfig, err = testEnv.Start()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(restConfig).NotTo(BeNil())
+
+	DeferCleanup(func() {
+		By("Stop test environment")
+		Expect(testEnv.Stop()).To(Succeed())
+	})
+
+	By("Create test client")
+	testClient, err = client.New(restConfig, client.Options{})
+	Expect(err).NotTo(HaveOccurred())
+
+	By("Setup manager")
+	mgr, err := manager.New(restConfig, manager.Options{
+		Metrics: metricsserver.Options{BindAddress: "0"},
+		Cache: cache.Options{
+			ByObject: map[client.Object]cache.ByObject{
+				&corev1.Namespace{}: {
+					Label: labels.SelectorFromSet(labels.Set{testID: testRunID}),
+				},
+				&corev1.ServiceAccount{}: {
+					Label: labels.SelectorFromSet(labels.Set{testID: testRunID}),
+				},
+			},
+		},
+	})
+	Expect(err).NotTo(HaveOccurred())
+
+	By("Register controller")
+	Expect((&extensionclusterrole.Reconciler{}).AddToManager(ctx, mgr)).To(Succeed())
+
+	// The test waits for namespaces to be gone, so we need to finalize them as envtest doesn't run the namespace
+	// controller.
+	Expect((&namespacefinalizer.Reconciler{}).AddToManager(mgr)).To(Succeed())
+
+	By("Start manager")
+	mgrContext, mgrCancel := context.WithCancel(ctx)
+
+	go func() {
+		defer GinkgoRecover()
+		Expect(mgr.Start(mgrContext)).To(Succeed())
+	}()
+
+	DeferCleanup(func() {
+		By("Stop manager")
+		mgrCancel()
+	})
+})

--- a/test/integration/controllermanager/controllerregistration/extensionclusterrole/extensionclusterrole_test.go
+++ b/test/integration/controllermanager/controllerregistration/extensionclusterrole/extensionclusterrole_test.go
@@ -1,0 +1,373 @@
+// Copyright 2024 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package extensionclusterrole_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	. "github.com/gardener/gardener/pkg/utils/test/matchers"
+)
+
+var _ = Describe("ExtensionClusterRole controller tests", func() {
+	var (
+		seedNamespace1                *corev1.Namespace
+		serviceAccount1SeedNamespace2 *corev1.ServiceAccount
+		serviceAccount2SeedNamespace2 *corev1.ServiceAccount
+
+		seedNamespace2                *corev1.Namespace
+		serviceAccount1SeedNamespace1 *corev1.ServiceAccount
+		serviceAccount2SeedNamespace1 *corev1.ServiceAccount
+
+		nonSeedNamespace                *corev1.Namespace
+		serviceAccount1NonSeedNamespace *corev1.ServiceAccount
+
+		clusterRole        *rbacv1.ClusterRole
+		clusterRoleBinding *rbacv1.ClusterRoleBinding
+
+		extensionName = "provider-test"
+	)
+
+	BeforeEach(func() {
+		seedNamespace1 = &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   "seed-bar",
+				Labels: map[string]string{testID: testRunID, "gardener.cloud/role": "seed"},
+			},
+		}
+		serviceAccount1SeedNamespace1 = &corev1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "extension-" + extensionName,
+				Namespace: seedNamespace1.Name,
+				Labels:    map[string]string{testID: testRunID},
+			},
+		}
+		serviceAccount2SeedNamespace1 = &corev1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "extension-" + extensionName + "-foobar",
+				Namespace: seedNamespace1.Name,
+				Labels:    map[string]string{testID: testRunID},
+			},
+		}
+
+		By("Create Seed Namespace 1 and ServiceAccounts")
+		Expect(testClient.Create(ctx, seedNamespace1)).To(Succeed())
+		Expect(testClient.Create(ctx, serviceAccount1SeedNamespace1)).To(Succeed())
+		Expect(testClient.Create(ctx, serviceAccount2SeedNamespace1)).To(Succeed())
+
+		DeferCleanup(func() {
+			By("Delete ServiceAccounts and Seed Namespace 1")
+			Expect(testClient.Delete(ctx, serviceAccount1SeedNamespace1)).To(Or(Succeed(), BeNotFoundError()))
+			Expect(testClient.Delete(ctx, serviceAccount2SeedNamespace1)).To(Or(Succeed(), BeNotFoundError()))
+			Expect(testClient.Delete(ctx, seedNamespace1)).To(Or(Succeed(), BeNotFoundError()))
+
+			Eventually(func() error {
+				return testClient.Get(ctx, client.ObjectKeyFromObject(seedNamespace1), &corev1.Namespace{})
+			}).Should(BeNotFoundError())
+		})
+
+		seedNamespace2 = &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   "seed-foo",
+				Labels: map[string]string{testID: testRunID, "gardener.cloud/role": "seed"},
+			},
+		}
+		serviceAccount1SeedNamespace2 = &corev1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "extension-" + extensionName + "-hugo",
+				Namespace: seedNamespace2.Name,
+				Labels:    map[string]string{testID: testRunID},
+			},
+		}
+		serviceAccount2SeedNamespace2 = &corev1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "default",
+				Namespace: seedNamespace2.Name,
+				Labels:    map[string]string{testID: testRunID},
+			},
+		}
+
+		By("Create Seed Namespace 2 and ServiceAccounts")
+		Expect(testClient.Create(ctx, seedNamespace2)).To(Succeed())
+		Expect(testClient.Create(ctx, serviceAccount1SeedNamespace2)).To(Succeed())
+		Expect(testClient.Create(ctx, serviceAccount2SeedNamespace2)).To(Succeed())
+
+		DeferCleanup(func() {
+			By("Delete ServiceAccounts and Seed Namespace 2")
+			Expect(testClient.Delete(ctx, serviceAccount1SeedNamespace2)).To(Or(Succeed(), BeNotFoundError()))
+			Expect(testClient.Delete(ctx, serviceAccount2SeedNamespace2)).To(Or(Succeed(), BeNotFoundError()))
+			Expect(testClient.Delete(ctx, seedNamespace2)).To(Or(Succeed(), BeNotFoundError()))
+
+			Eventually(func() error {
+				return testClient.Get(ctx, client.ObjectKeyFromObject(seedNamespace2), &corev1.Namespace{})
+			}).Should(BeNotFoundError())
+		})
+
+		nonSeedNamespace = &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   "garden-foo",
+				Labels: map[string]string{testID: testRunID},
+			},
+		}
+		serviceAccount1NonSeedNamespace = &corev1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "extension-" + extensionName,
+				Namespace: nonSeedNamespace.Name,
+				Labels:    map[string]string{testID: testRunID},
+			},
+		}
+
+		By("Create non-Seed Namespace and ServiceAccount")
+		Expect(testClient.Create(ctx, nonSeedNamespace)).To(Succeed())
+		Expect(testClient.Create(ctx, serviceAccount1NonSeedNamespace)).To(Succeed())
+
+		DeferCleanup(func() {
+			By("Delete ServiceAccount and non-Seed Namespace")
+			Expect(testClient.Delete(ctx, serviceAccount1NonSeedNamespace)).To(Or(Succeed(), BeNotFoundError()))
+			Expect(testClient.Delete(ctx, nonSeedNamespace)).To(Or(Succeed(), BeNotFoundError()))
+
+			Eventually(func() error {
+				return testClient.Get(ctx, client.ObjectKeyFromObject(nonSeedNamespace), &corev1.Namespace{})
+			}).Should(BeNotFoundError())
+		})
+
+		clusterRole = &rbacv1.ClusterRole{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: testRunID,
+				Annotations: map[string]string{
+					"authorization.extensions.gardener.cloud/bind-to": extensionName,
+				},
+				Labels: map[string]string{
+					"authorization.extensions.gardener.cloud/additional-permissions": "true",
+					testID: testRunID,
+				},
+			},
+			Rules: []rbacv1.PolicyRule{{
+				APIGroups: []string{""},
+				Resources: []string{"pods"},
+				Verbs:     []string{"list"},
+			}},
+		}
+
+		By("Create ClusterRole")
+		Expect(testClient.Create(ctx, clusterRole)).To(Succeed())
+
+		DeferCleanup(func() {
+			By("Delete ClusterRole")
+			Expect(testClient.Delete(ctx, clusterRole)).To(Or(Succeed(), BeNotFoundError()))
+
+			Eventually(func() error {
+				return testClient.Get(ctx, client.ObjectKeyFromObject(clusterRole), &rbacv1.ClusterRole{})
+			}).Should(BeNotFoundError())
+		})
+
+		clusterRoleBinding = &rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: clusterRole.Name}}
+
+		DeferCleanup(func() {
+			By("Delete ClusterRoleBinding")
+			Expect(testClient.Delete(ctx, clusterRoleBinding)).To(Succeed())
+
+			Eventually(func() error {
+				return testClient.Get(ctx, client.ObjectKeyFromObject(clusterRoleBinding), &rbacv1.ClusterRoleBinding{})
+			}).Should(BeNotFoundError())
+		})
+	})
+
+	It("should create the expected ClusterRoleBinding", func() {
+		Eventually(func() error {
+			return testClient.Get(ctx, client.ObjectKeyFromObject(clusterRoleBinding), clusterRoleBinding)
+		}).Should(Succeed())
+
+		Expect(clusterRoleBinding.OwnerReferences).To(ConsistOf(metav1.OwnerReference{
+			APIVersion:         "rbac.authorization.k8s.io/v1",
+			Kind:               "ClusterRole",
+			Name:               clusterRole.Name,
+			UID:                clusterRole.UID,
+			Controller:         pointer.Bool(true),
+			BlockOwnerDeletion: pointer.Bool(false),
+		}))
+		Expect(clusterRoleBinding.RoleRef).To(Equal(rbacv1.RoleRef{
+			APIGroup: rbacv1.SchemeGroupVersion.Group,
+			Kind:     "ClusterRole",
+			Name:     clusterRole.Name,
+		}))
+		Expect(clusterRoleBinding.Subjects).To(HaveExactElements(
+			rbacv1.Subject{
+				Kind:      "ServiceAccount",
+				Name:      serviceAccount1SeedNamespace1.Name,
+				Namespace: seedNamespace1.Name,
+			},
+			rbacv1.Subject{
+				Kind:      "ServiceAccount",
+				Name:      serviceAccount2SeedNamespace1.Name,
+				Namespace: seedNamespace1.Name,
+			},
+			rbacv1.Subject{
+				Kind:      "ServiceAccount",
+				Name:      serviceAccount1SeedNamespace2.Name,
+				Namespace: seedNamespace2.Name,
+			},
+		))
+	})
+
+	When("a ServiceAccount is added or deleted", func() {
+		It("should adjust the subjects", func() {
+			serviceAccount3SeedNamespace1 := &corev1.ServiceAccount{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "extension-" + extensionName + "-new",
+					Namespace: seedNamespace1.Name,
+					Labels:    map[string]string{testID: testRunID},
+				},
+			}
+
+			By("Create ServiceAccount")
+			Expect(testClient.Create(ctx, serviceAccount3SeedNamespace1)).To(Succeed())
+			DeferCleanup(func() {
+				By("Delete ServiceAccount")
+				Expect(testClient.Delete(ctx, serviceAccount3SeedNamespace1)).To(Succeed())
+			})
+
+			Eventually(func(g Gomega) []rbacv1.Subject {
+				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(clusterRoleBinding), clusterRoleBinding)).To(Succeed())
+				return clusterRoleBinding.Subjects
+			}).Should(HaveExactElements(
+				rbacv1.Subject{
+					Kind:      "ServiceAccount",
+					Name:      serviceAccount1SeedNamespace1.Name,
+					Namespace: seedNamespace1.Name,
+				},
+				rbacv1.Subject{
+					Kind:      "ServiceAccount",
+					Name:      serviceAccount2SeedNamespace1.Name,
+					Namespace: seedNamespace1.Name,
+				},
+				rbacv1.Subject{
+					Kind:      "ServiceAccount",
+					Name:      serviceAccount3SeedNamespace1.Name,
+					Namespace: seedNamespace1.Name,
+				},
+				rbacv1.Subject{
+					Kind:      "ServiceAccount",
+					Name:      serviceAccount1SeedNamespace2.Name,
+					Namespace: seedNamespace2.Name,
+				},
+			))
+
+			By("Delete ServiceAccount")
+			Expect(testClient.Delete(ctx, serviceAccount1SeedNamespace1)).To(Succeed())
+
+			Eventually(func(g Gomega) []rbacv1.Subject {
+				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(clusterRoleBinding), clusterRoleBinding)).To(Succeed())
+				return clusterRoleBinding.Subjects
+			}).Should(HaveExactElements(
+				rbacv1.Subject{
+					Kind:      "ServiceAccount",
+					Name:      serviceAccount2SeedNamespace1.Name,
+					Namespace: seedNamespace1.Name,
+				},
+				rbacv1.Subject{
+					Kind:      "ServiceAccount",
+					Name:      serviceAccount3SeedNamespace1.Name,
+					Namespace: seedNamespace1.Name,
+				},
+				rbacv1.Subject{
+					Kind:      "ServiceAccount",
+					Name:      serviceAccount1SeedNamespace2.Name,
+					Namespace: seedNamespace2.Name,
+				},
+			))
+		})
+	})
+
+	When("the list of extension names is extended", func() {
+		It("should adjust the subjects", func() {
+			extensionName2 := "some-other-extension"
+
+			serviceAccount3SeedNamespace2 := &corev1.ServiceAccount{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "extension-" + extensionName2 + "-hb23b",
+					Namespace: seedNamespace2.Name,
+					Labels:    map[string]string{testID: testRunID},
+				},
+			}
+
+			By("Create ServiceAccount")
+			Expect(testClient.Create(ctx, serviceAccount3SeedNamespace2)).To(Succeed())
+			DeferCleanup(func() {
+				By("Delete ServiceAccount")
+				Expect(testClient.Delete(ctx, serviceAccount3SeedNamespace2)).To(Succeed())
+			})
+
+			By("Subjects should not change yet")
+			Consistently(func(g Gomega) []rbacv1.Subject {
+				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(clusterRoleBinding), clusterRoleBinding)).To(Succeed())
+				return clusterRoleBinding.Subjects
+			}).Should(HaveExactElements(
+				rbacv1.Subject{
+					Kind:      "ServiceAccount",
+					Name:      serviceAccount1SeedNamespace1.Name,
+					Namespace: seedNamespace1.Name,
+				},
+				rbacv1.Subject{
+					Kind:      "ServiceAccount",
+					Name:      serviceAccount2SeedNamespace1.Name,
+					Namespace: seedNamespace1.Name,
+				},
+				rbacv1.Subject{
+					Kind:      "ServiceAccount",
+					Name:      serviceAccount1SeedNamespace2.Name,
+					Namespace: seedNamespace2.Name,
+				},
+			))
+
+			By("Patch ClusterRole")
+			patch := client.MergeFrom(clusterRole.DeepCopy())
+			clusterRole.Annotations["authorization.extensions.gardener.cloud/bind-to"] = extensionName + "," + extensionName2
+			Expect(testClient.Patch(ctx, clusterRole, patch)).To(Succeed())
+
+			By("Subjects should include the service account of newly added extension")
+			Eventually(func(g Gomega) []rbacv1.Subject {
+				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(clusterRoleBinding), clusterRoleBinding)).To(Succeed())
+				return clusterRoleBinding.Subjects
+			}).Should(HaveExactElements(
+				rbacv1.Subject{
+					Kind:      "ServiceAccount",
+					Name:      serviceAccount1SeedNamespace1.Name,
+					Namespace: seedNamespace1.Name,
+				},
+				rbacv1.Subject{
+					Kind:      "ServiceAccount",
+					Name:      serviceAccount2SeedNamespace1.Name,
+					Namespace: seedNamespace1.Name,
+				},
+				rbacv1.Subject{
+					Kind:      "ServiceAccount",
+					Name:      serviceAccount1SeedNamespace2.Name,
+					Namespace: seedNamespace2.Name,
+				},
+				rbacv1.Subject{
+					Kind:      "ServiceAccount",
+					Name:      serviceAccount3SeedNamespace2.Name,
+					Namespace: seedNamespace2.Name,
+				},
+			))
+		})
+	})
+})

--- a/test/integration/controllermanager/controllerregistration/seed/seed_suite_test.go
+++ b/test/integration/controllermanager/controllerregistration/seed/seed_suite_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package controllerregistration_test
+package seed_test
 
 import (
 	"context"

--- a/test/integration/controllermanager/controllerregistration/seed/seed_test.go
+++ b/test/integration/controllermanager/controllerregistration/seed/seed_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package controllerregistration_test
+package seed_test
 
 import (
 	. "github.com/onsi/ginkgo/v2"

--- a/test/integration/controllermanager/seed/secrets/secrets_test.go
+++ b/test/integration/controllermanager/seed/secrets/secrets_test.go
@@ -125,6 +125,7 @@ var _ = Describe("Seed Secrets controller tests", func() {
 			g.Expect(namespace.OwnerReferences).To(HaveLen(1))
 			g.Expect(namespace.OwnerReferences[0].Kind).To(Equal("Seed"))
 			g.Expect(namespace.OwnerReferences[0].Name).To(Equal(seed.Name))
+			g.Expect(namespace.Labels).To(HaveKeyWithValue("gardener.cloud/role", "seed"))
 		}).Should(Succeed())
 
 		By("Expect relevant garden secrets to be synced to seed namespace")


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security usability
/kind enhancement

**What this PR does / why we need it**:
This PR adds a new controller part of `gardener-controller-manager` which watches `ClusterRole`s labeled with `authorization.extensions.gardener.cloud/additional-permissions=true`. It also watches `ServiceAccount`s in seed namespaces.

On reconciliation, the new controller creates a `ClusterRoleBinding` referencing the respective `ClusterRole`. The subjects are all `ServiceAccount`s related to extension sin seed namespaces - but only if the `ServiceAccount`s are prefixed with `extension-<name>` and `<name>` is present in the comma-separated list in the `authorization.extensions.gardener.cloud/bind-to=<name1>,<name2>` annotation.

**Which issue(s) this PR fixes**:
Fixes #8980

**Special notes for your reviewer**:
See https://github.com/gardener/gardener/issues/8980#issuecomment-1903837782

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
It is now possible to define additional permissions via RBAC for extensions access in the garden cluster. You can read all about it [here](https://github.com/gardener/gardener/tree/master/docs/extensions/garden-api-access.md#additional-permissions).
```
