### PR TITLE
Set Shoot K8s version for e2e tests to Kubernetes v1.29

### DIFF
--- a/example/gardener-local/kind/cluster/values.yaml
+++ b/example/gardener-local/kind/cluster/values.yaml
@@ -1,5 +1,4 @@
-# TODO(acumino): Update to 1.29.0 after support for 1.29 has been merged and released (after 1.87 has been released).
-image: kindest/node:v1.28.0
+image: kindest/node:v1.29.0
 
 gardener:
   apiserverRelay:

--- a/hack/kind-up.sh
+++ b/hack/kind-up.sh
@@ -190,9 +190,12 @@ if [[ "$IPFAMILY" == "ipv6" ]] && [[ "$MULTI_ZONAL" == "true" ]]; then
   ADDITIONAL_ARGS="$ADDITIONAL_ARGS --set gardener.seed.istio.listenAddresses={::1,::10,::11,::12}"
 fi
 
+
+# TODO(acumino): update to kindest/node:v1.29.0 once we have a solution for adding seed authorizer in provider-local setup
+# For details check https://github.com/gardener/gardener/issues/8871
 kind create cluster \
   --name "$CLUSTER_NAME" \
-  --image "kindest/node:v1.29.0" \
+  --image "kindest/node:v1.28.0" \
   --config <(helm template $CHART --values "$PATH_CLUSTER_VALUES" $ADDITIONAL_ARGS --set "gardener.repositoryRoot"=$(dirname "$0")/..)
 
 # adjust Kind's CRI default OCI runtime spec for new containers to include the cgroup namespace

--- a/hack/kind-up.sh
+++ b/hack/kind-up.sh
@@ -192,7 +192,7 @@ fi
 
 kind create cluster \
   --name "$CLUSTER_NAME" \
-  --image "kindest/node:v1.28.0" \
+  --image "kindest/node:v1.29.0" \
   --config <(helm template $CHART --values "$PATH_CLUSTER_VALUES" $ADDITIONAL_ARGS --set "gardener.repositoryRoot"=$(dirname "$0")/..)
 
 # adjust Kind's CRI default OCI runtime spec for new containers to include the cgroup namespace

--- a/test/e2e/gardener/common.go
+++ b/test/e2e/gardener/common.go
@@ -76,7 +76,7 @@ func DefaultShoot(name string) *gardencorev1beta1.Shoot {
 			SecretBindingName: pointer.String("local"),
 			CloudProfileName:  "local",
 			Kubernetes: gardencorev1beta1.Kubernetes{
-				Version:                     "1.28.2",
+				Version:                     "1.29.0",
 				EnableStaticTokenKubeconfig: pointer.Bool(false),
 				Kubelet: &gardencorev1beta1.KubeletConfig{
 					SerializeImagePulls: pointer.Bool(false),
@@ -128,7 +128,7 @@ func DefaultWorkerlessShoot(name string) *gardencorev1beta1.Shoot {
 			Region:           "local",
 			CloudProfileName: "local",
 			Kubernetes: gardencorev1beta1.Kubernetes{
-				Version:                     "1.28.2",
+				Version:                     "1.29.0",
 				EnableStaticTokenKubeconfig: pointer.Bool(false),
 				KubeAPIServer:               &gardencorev1beta1.KubeAPIServerConfig{},
 			},

--- a/test/e2e/gardener/shoot/create_update_delete.go
+++ b/test/e2e/gardener/shoot/create_update_delete.go
@@ -49,7 +49,7 @@ var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
 
 		// explicitly use one version below the latest supported minor version so that Kubernetes version update test can be
 		// performed
-		f.Shoot.Spec.Kubernetes.Version = "1.27.1"
+		f.Shoot.Spec.Kubernetes.Version = "1.28.2"
 
 		if !v1beta1helper.IsWorkerless(f.Shoot) {
 			// create two additional worker pools which explicitly specify the kubernetes version
@@ -58,7 +58,7 @@ var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
 			pool2.Name += "2"
 			pool2.Kubernetes = &gardencorev1beta1.WorkerKubernetes{Version: &f.Shoot.Spec.Kubernetes.Version}
 			pool3.Name += "3"
-			pool3.Kubernetes = &gardencorev1beta1.WorkerKubernetes{Version: pointer.String("1.26.0")}
+			pool3.Kubernetes = &gardencorev1beta1.WorkerKubernetes{Version: pointer.String("1.27.1")}
 			f.Shoot.Spec.Provider.Workers = append(f.Shoot.Spec.Provider.Workers, *pool2, *pool3)
 		}
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area open-source
/kind enhancement

**What this PR does / why we need it**:
Since PR https://github.com/gardener/gardener/pull/8976 Gardener supports Kubernetes v1.29.
As a follow-up, this PR updates e2e Kubernetes versions to v1.29.


**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/8871

**Special notes for your reviewer**:
`kindest/node` can't be upgraded to `1.29.0` because from `1.29` onwards kubeadm tries to create a clusterolebinding [ref](https://github.com/kubernetes/kubernetes/pull/121305) during the init phase of the cluster, since we use seedAuthorizer(authorization webhook) which is not yet started, leads to failure of cluster creation.
The only possible solution I see as of now is to disable `seedAuthorizer` in provider-local setup. Will follow up on that separately.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
