### PR TITLE
Adapt `gardenlet` health checks to consider `gardener-node-agent`'s `Lease` object for the `EveryNodeReady` condition

### DIFF
--- a/cmd/gardener-node-agent/app/app.go
+++ b/cmd/gardener-node-agent/app/app.go
@@ -58,8 +58,8 @@ import (
 	nodeagentv1alpha1 "github.com/gardener/gardener/pkg/nodeagent/apis/config/v1alpha1"
 	"github.com/gardener/gardener/pkg/nodeagent/bootstrap"
 	"github.com/gardener/gardener/pkg/nodeagent/controller"
-	"github.com/gardener/gardener/pkg/nodeagent/controller/lease"
 	"github.com/gardener/gardener/pkg/nodeagent/dbus"
+	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 )
 
 // Name is a const for the name of this component.
@@ -169,7 +169,7 @@ func run(ctx context.Context, cancel context.CancelFunc, log logr.Logger, cfg *c
 	leaseCacheOptions := cache.ByObject{Namespaces: map[string]cache.Config{metav1.NamespaceSystem: {}}}
 	if nodeName != "" {
 		log.Info("Node already registered, found name", "nodeName", nodeName)
-		leaseCacheOptions.Field = fields.SelectorFromSet(fields.Set{metav1.ObjectNameField: lease.ObjectName(nodeName)})
+		leaseCacheOptions.Field = fields.SelectorFromSet(fields.Set{metav1.ObjectNameField: gardenerutils.NodeAgentLeaseName(nodeName)})
 	}
 
 	log.Info("Setting up manager")

--- a/pkg/gardenlet/controller/shoot/care/health_test.go
+++ b/pkg/gardenlet/controller/shoot/care/health_test.go
@@ -720,7 +720,6 @@ var _ = Describe("health check", func() {
 	})
 
 	Describe("#CheckingNodeAgentLease", func() {
-
 		var (
 			validLease = coordinationv1.Lease{
 				ObjectMeta: metav1.ObjectMeta{
@@ -760,8 +759,7 @@ var _ = Describe("health check", func() {
 				},
 			}
 
-			err := CheckNodeAgentLease(&nodeList, &leaseList, fakeClock)
-			Expect(err).To(expected)
+			Expect(CheckNodeAgentLeases(&nodeList, &leaseList, fakeClock)).To(expected)
 		},
 			Entry("should return nil if there is a matching lease for node", validLease, BeNil()),
 			Entry("should return Error that node agent is not running if no matching lease could be found for node", nil, MatchError(ContainSubstring("not running"))),

--- a/pkg/gardenlet/controller/shoot/care/health_test.go
+++ b/pkg/gardenlet/controller/shoot/care/health_test.go
@@ -741,6 +741,16 @@ var _ = Describe("health check", func() {
 				},
 			}
 
+			nonrelatedLease = coordinationv1.Lease{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "gardener-node-agent-node2",
+				},
+				Spec: coordinationv1.LeaseSpec{
+					RenewTime:            &metav1.MicroTime{Time: fakeClock.Now()},
+					LeaseDurationSeconds: pointer.Int32(40),
+				},
+			}
+
 			nodeList = corev1.NodeList{
 				Items: []corev1.Node{
 					{
@@ -762,7 +772,9 @@ var _ = Describe("health check", func() {
 			Expect(CheckNodeAgentLeases(&nodeList, &leaseList, fakeClock)).To(expected)
 		},
 			Entry("should return nil if there is a matching lease for node", validLease, BeNil()),
-			Entry("should return Error that node agent is not running if no matching lease could be found for node", nil, MatchError(ContainSubstring("not running"))),
+			// TODO(rfranzke): Remove this test-entry as soon as the UseGardenerNodeAgent feature gate gets removed.
+			Entry("should return nil if no leases are present", nil, BeNil()),
+			Entry("should return Error that node agent is not running if no matching lease could be found for node", nonrelatedLease, MatchError(ContainSubstring("not running"))),
 			Entry("should return Error that node agent stopped running if the lease for the node is not valid anymore", invalidLease, MatchError(ContainSubstring("stopped running"))),
 		)
 	})

--- a/pkg/nodeagent/controller/lease/reconciler.go
+++ b/pkg/nodeagent/controller/lease/reconciler.go
@@ -26,6 +26,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 )
 
 // Reconciler creates a lease in the kube-system namespace of the shoot.
@@ -48,7 +50,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 
 	lease := &coordinationv1.Lease{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      ObjectName(node.GetName()),
+			Name:      gardenerutils.NodeAgentLeaseName(node.GetName()),
 			Namespace: r.Namespace,
 		},
 	}
@@ -67,9 +69,4 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	})
 	log.V(1).Info("Heartbeat Lease", "lease", client.ObjectKeyFromObject(lease), "operation", op)
 	return reconcile.Result{RequeueAfter: time.Duration(r.LeaseDurationSeconds) * time.Second / 4}, err
-}
-
-// ObjectName returns the name of the Lease object based on the node name.
-func ObjectName(nodeName string) string {
-	return "gardener-node-agent-" + nodeName
 }

--- a/pkg/nodeagent/controller/lease/reconciler_test.go
+++ b/pkg/nodeagent/controller/lease/reconciler_test.go
@@ -18,13 +18,13 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	. "github.com/gardener/gardener/pkg/nodeagent/controller/lease"
+	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 )
 
 var _ = Describe("Reconciler", func() {
 	Describe("#ObjectName", func() {
 		It("should return the expected name", func() {
-			Expect(ObjectName("foo")).To(Equal("gardener-node-agent-foo"))
+			Expect(gardenerutils.NodeAgentLeaseName("foo")).To(Equal("gardener-node-agent-foo"))
 		})
 	})
 })

--- a/pkg/utils/gardener/machines.go
+++ b/pkg/utils/gardener/machines.go
@@ -36,6 +36,8 @@ const (
 	MachineSetKind = "MachineSet"
 	// MachineDeploymentKind is the kind of the owner reference of a machine deployment
 	MachineDeploymentKind = "MachineDeployment"
+	// NodeLeasePrefix describes the Prefix of the lease that this node is corresponding to
+	NodeLeasePrefix = "gardener-node-agent-"
 )
 
 // BuildOwnerToMachinesMap returns a map that associates `MachineSet` names to the given `machines`.
@@ -167,4 +169,9 @@ func WaitUntilMachineResourcesDeleted(ctx context.Context, log logr.Logger, read
 
 		return retryutils.Ok()
 	})
+}
+
+// NodeAgentLeaseName returns the name of the Lease object based on the node name.
+func NodeAgentLeaseName(nodeName string) string {
+	return NodeLeasePrefix + nodeName
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind enhancement

**What this PR does / why we need it**:
This PR adds a health check for the `gardener-node-agent`.
It checks for the lease that the `gardener-node-agent` writes into its shoot as a heartbeat.

**Which issue(s) this PR fixes**:
Part of #8023 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
The `gardener-node-agent` health is now being considered during the health check of a `Shoot` and incorporated into the `EveryNodeReady` condition.
```
