### PR TITLE
`gardener-operator`: Allow project admins and viewers to create read-only kubeconfigs

### DIFF
--- a/pkg/component/gardensystem/virtual/virtual.go
+++ b/pkg/component/gardensystem/virtual/virtual.go
@@ -435,8 +435,11 @@ func (g *gardenSystem) computeResourcesData() (map[string][]byte, error) {
 				},
 				{
 					APIGroups: []string{gardencorev1beta1.GroupName},
-					Resources: []string{"shoots/adminkubeconfig"},
-					Verbs:     []string{"create"},
+					Resources: []string{
+						"shoots/adminkubeconfig",
+						"shoots/viewerkubeconfig",
+					},
+					Verbs: []string{"create"},
 				},
 			},
 		}
@@ -529,6 +532,11 @@ func (g *gardenSystem) computeResourcesData() (map[string][]byte, error) {
 						"rolebindings",
 					},
 					Verbs: []string{"get", "list", "watch"},
+				},
+				{
+					APIGroups: []string{gardencorev1beta1.GroupName},
+					Resources: []string{"shoots/viewerkubeconfig"},
+					Verbs:     []string{"create"},
 				},
 			},
 		}

--- a/pkg/component/gardensystem/virtual/virtual_test.go
+++ b/pkg/component/gardensystem/virtual/virtual_test.go
@@ -453,8 +453,11 @@ var _ = Describe("Virtual", func() {
 				},
 				{
 					APIGroups: []string{"core.gardener.cloud"},
-					Resources: []string{"shoots/adminkubeconfig"},
-					Verbs:     []string{"create"},
+					Resources: []string{
+						"shoots/adminkubeconfig",
+						"shoots/viewerkubeconfig",
+					},
+					Verbs: []string{"create"},
 				},
 			},
 		}
@@ -545,6 +548,11 @@ var _ = Describe("Virtual", func() {
 						"rolebindings",
 					},
 					Verbs: []string{"get", "list", "watch"},
+				},
+				{
+					APIGroups: []string{"core.gardener.cloud"},
+					Resources: []string{"shoots/viewerkubeconfig"},
+					Verbs:     []string{"create"},
 				},
 			},
 		}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area user-management
/kind bug

**What this PR does / why we need it**:
With https://github.com/gardener/gardener/pull/8870/commits/eb871ea9c63a1ff54cb555434c2c45335d67d9d7 (#8870) the gardener controlplane chart was adapted so that project admins and viewers were allowed to create read-only kubeconfigs. 

With this PR these permissions are added to the respective cluster roles that the `gardener-operator` deploys.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Fixed an issue which prevented project admins and viewers from creating read-only kubeconfigs (via the `shoots/viewerkubeconfig` subresource).
```
