### PR TITLE
Prevent excessive network traffic by avoiding unnecessary shoot updates in the `status.constraints[]` fields

### DIFF
--- a/pkg/gardenlet/controller/shoot/care/constraints.go
+++ b/pkg/gardenlet/controller/shoot/care/constraints.go
@@ -461,9 +461,9 @@ func (g ShootConstraints) ConstraintTypes() []gardencorev1beta1.ConditionType {
 // All constraints are retrieved from the given 'shoot' or newly initialized.
 func NewShootConstraints(clock clock.Clock, shoot *gardencorev1beta1.Shoot) ShootConstraints {
 	return ShootConstraints{
-		hibernationPossible:                   v1beta1helper.GetOrInitConditionWithClock(clock, shoot.Status.Conditions, gardencorev1beta1.ShootHibernationPossible),
-		maintenancePreconditionsSatisfied:     v1beta1helper.GetOrInitConditionWithClock(clock, shoot.Status.Conditions, gardencorev1beta1.ShootMaintenancePreconditionsSatisfied),
-		caCertificateValiditiesAcceptable:     v1beta1helper.GetOrInitConditionWithClock(clock, shoot.Status.Conditions, gardencorev1beta1.ShootCACertificateValiditiesAcceptable),
-		crdsWithProblematicConversionWebhooks: v1beta1helper.GetOrInitConditionWithClock(clock, shoot.Status.Conditions, gardencorev1beta1.ShootCRDsWithProblematicConversionWebhooks),
+		hibernationPossible:                   v1beta1helper.GetOrInitConditionWithClock(clock, shoot.Status.Constraints, gardencorev1beta1.ShootHibernationPossible),
+		maintenancePreconditionsSatisfied:     v1beta1helper.GetOrInitConditionWithClock(clock, shoot.Status.Constraints, gardencorev1beta1.ShootMaintenancePreconditionsSatisfied),
+		caCertificateValiditiesAcceptable:     v1beta1helper.GetOrInitConditionWithClock(clock, shoot.Status.Constraints, gardencorev1beta1.ShootCACertificateValiditiesAcceptable),
+		crdsWithProblematicConversionWebhooks: v1beta1helper.GetOrInitConditionWithClock(clock, shoot.Status.Constraints, gardencorev1beta1.ShootCRDsWithProblematicConversionWebhooks),
 	}
 }

--- a/pkg/gardenlet/controller/shoot/care/constraints_test.go
+++ b/pkg/gardenlet/controller/shoot/care/constraints_test.go
@@ -658,18 +658,19 @@ var _ = Describe("Constraints", func() {
 				))
 			})
 
-			It("should only initialize missing conditions", func() {
+			It("should only initialize missing constraints", func() {
+				hibernationPossibleConstraint := gardencorev1beta1.Condition{Type: "HibernationPossible"}
 				constraints := NewShootConstraints(clock, &gardencorev1beta1.Shoot{
 					Status: gardencorev1beta1.ShootStatus{
 						Constraints: []gardencorev1beta1.Condition{
-							{Type: "HibernationPossible"},
+							hibernationPossibleConstraint,
 							{Type: "Foo"},
 						},
 					},
 				})
 
 				Expect(constraints.ConvertToSlice()).To(ConsistOf(
-					OfType("HibernationPossible"),
+					hibernationPossibleConstraint,
 					beConditionWithStatusAndMsg("Unknown", "ConditionInitialized", "The condition has been initialized but its semantic check has not been performed yet."),
 					beConditionWithStatusAndMsg("Unknown", "ConditionInitialized", "The condition has been initialized but its semantic check has not been performed yet."),
 					beConditionWithStatusAndMsg("Unknown", "ConditionInitialized", "The condition has been initialized but its semantic check has not been performed yet."),


### PR DESCRIPTION
**How to categorize this PR?**

/area cost scalability
/kind regression

**What this PR does / why we need it**:

This PR addresses a regression introduced in #8387 within the [NewShootConstraints][] function. The issue arises during the initialization of the constraints, where the `Conditions` slice is mistakenly used in place of the `Constraints` slice for existing item lookup. This results in the [initialization][] of a new constraint during each iteration, and the subsequent [update][] of the constraint’s last update and transition timestamps in every iteration.

The proposed change ensures that the last update and transition timestamps remain untouched if there is no change in the constraint’s status, message, or reason attributes.

[NewShootConstraints]: https://github.com/gardener/gardener/pull/8387/files#diff-1b1bd39f63e5c946fdb7f1af543a068d31ee48c73d2e7732360bdc6e1d3ebd64R460-R469
[initialization]: https://github.com/gardener/gardener/blob/ec89ef1e820132303b3c9c7272849f274542eb87/pkg/apis/core/v1beta1/helper/condition.go#L61
[update]: https://github.com/gardener/gardener/blob/ec89ef1e820132303b3c9c7272849f274542eb87/pkg/apis/core/v1beta1/helper/condition_builder.go#L136-L144

**Which issue(s) this PR fixes**:

Currently, for each shoot, the `lastUpdateTime` and `lastTransitionTime` fields of the `HibernationPossible` and `MaintenancePreconditionsSatisfied` constraints in `status.constraints[]` are updated every minute. This frequent updating results in excessive egress network traffic, particularly between the `gardener-apiserver` in the `runtime-garden` cluster and the `gardenlet`s in the seeds, as the `gardenlet`s are currently monitoring the shoot resources at cluster scope (see [#9074][]). In Gardener installations with a large number of shoots and seeds, this unnecessary network traffic could have significant cost and scalability implications.

**Special notes for your reviewer**:

@timuthy @rfranzke @petersutter @dguendisch @mliepold

<details>
<summary>Detailed investigations</summary>

In larger Gardener installations, it has been observed that the `gardener-apiserver` in the `runtime-garden` cluster generates substantial network egress traffic. This traffic is primarily driven by cluster scope shoot watch responses, which could potentially impact cost and scalability.

While a single shoot resource is relatively small (a few tens of KB), the cumulative network egress traffic can become significant under certain conditions:

- When numerous clients request shoot watch events at cluster scope (refer to [#9074][])
- When there are frequent, potentially unnecessary changes to the shoot resources (the issue addressed in this PR)

[#9074]: https://github.com/gardener/gardener/issues/9074

To identify the property paths that frequently change within a stream of shoot watch events, I utilized the following `jq` program:

`library.jq`:

```jq
# pathValueMap converts a JSON object into a map with property paths as
# keys and the respective values as values.
def pathValueMap:
  . as $object |
  reduce paths(scalars) as $p ({};
    . + {($p | join(".")): $object | getpath($p)});

# diff/2 compares two pathValueMaps and returns the differences.
# For each property path that is present in only one of the objects,
# or that has a different value in the two objects,
# it returns an array of the values for the property path as key.
def diff($a; $b):
  reduce ($a + $b | keys[]) as $key ({};
    if $a[$key] != $b[$key]
    then . + {($key): [$a[$key], $b[$key]]} end);

# mergeDiffs accumulates an array of differences into a single object.
def mergeDiffs:
  reduce .[] as $item ({};
    . as $out |
    reduce ($item | keys[]) as $key ($out;
      if .[$key] != null and .[$key][-1] == $item[$key][0]
      then .[$key] += $item[$key][1:]
      else .[$key] += $item[$key] end));

# diff/0 compares an array of JSON objects pairwise and returns the accumulated differences.
def diff:
  map(pathValueMap) |
  . as $items |
  reduce range(length - 1) as $i ([];
    . + [diff($items[$i]; $items[$i + 1])]) |
  mergeDiffs;

# watchDiffs returns the differences of the watched Kubernetes resources.
# Usage: `jq -s 'include "library"; watchDiffs' shoots.jsonl | less -S`
def watchDiffs:
  group_by(.metadata.uid) |
  map({name: .[0].metadata | [.namespace, .name] | join("/"),
       diff:  diff | map_values({length: length, values: join(";")})});

# watchDiffStats returns the most frequently changed property paths.
# Usage: `jq -s -r 'include "library"; watchDiffStats' shoots.jsonl | column -t -R 1`
def watchDiffStats:
  group_by(.metadata.uid) |
  map(diff | map_values(length)) |
  reduce .[] as $item ({};
    reduce ($item | keys[]) as $key (.;
      .[$key] += $item[$key])) |
  to_entries | sort_by(.value * -1) |
  map("\(.value) \(.key)")[];
```

`library.jq.test`:

```jq
# jq --run-tests library.jq.test

include "library"; pathValueMap
{"a": {"b": 0, "c": [1]}}
{"a.b":0,"a.c.0":1}

include "library"; diff({"a": {"b": 0, "c": [1], "y": 4}} | pathValueMap; {"a": {"b": 2, "c": [3], "x": 5}} | pathValueMap)
null
{"a.b": [0, 2], "a.c.0": [1, 3], "a.x": [null, 5], "a.y": [4,null]}

include "library"; mergeDiffs
[{"a": [0, 1]}, {"a": [1, 2]}, {"a": [2, 0]}]
{"a": [0, 1, 2, 0]}

include "library"; diff
[{"a": {"b": 0, "c": [1], "y": 4}}, {"a": {"b": 2, "c": [3], "x": 5}}, {"a": {"b": 1, "c": [3], "z": 1, "y": 5}}]
{"a.b":[0,2,1],"a.c.0":[1,3],"a.x":[null,5,null],"a.y":[4,null,5],"a.z":[null,1]}
```

I captured the shoot changes over several minutes using the following command:

```bash
$ k get shoots -A -w -o json | jq --unbuffered -c '.' > shoots.jsonl
^C
```

Subsequently, I could identify the property paths that changed most frequently by comparing the different versions of each shoot.

```bash
$ jq -s -r 'include "library"; watchDiffStats' shoots.jsonl | column -t -R 1
30  metadata.resourceVersion
20  status.constraints.0.lastTransitionTime
20  status.constraints.0.lastUpdateTime
20  status.constraints.1.lastTransitionTime
20  status.constraints.1.lastUpdateTime
11  metadata.labels.shoot.gardener.cloud/status
 9  status.conditions.4.lastTransitionTime
 9  status.conditions.4.lastUpdateTime
 9  status.conditions.4.message
 9  status.conditions.4.reason
 9  status.conditions.4.status
 3  status.conditions.1.lastTransitionTime
 3  status.conditions.1.lastUpdateTime
 3  status.conditions.1.message
 3  status.conditions.1.reason
 3  status.conditions.1.status
```

The results indicated that the majority of changes were due to updates to the `status.constraints[].last{Update,Transition}Time` property paths. These updates were found to be unnecessary and have been addressed in this PR.

</details>

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
A regression is fixed that led to unnecessary and repetitive updates in the `status.constraints[].last{Update,Transition}Time` fields of the shoot. In larger Gardener installations, these superfluous updates could have resulted in significant excess network traffic, particularly between the `gardener-apiserver` and the `gardenlet`s in the seeds.
```
