### PR TITLE
[gardenlet] Leverage server-side filtering for watches for `Shoot`s

### DIFF
--- a/cmd/gardenlet/app/app.go
+++ b/cmd/gardenlet/app/app.go
@@ -268,6 +268,9 @@ func (g *garden) Start(ctx context.Context) error {
 				&gardencorev1beta1.ControllerInstallation{}: {
 					Field: fields.SelectorFromSet(fields.Set{gardencore.SeedRefName: g.config.SeedConfig.SeedTemplate.Name}),
 				},
+				&gardencorev1beta1.Shoot{}: {
+					Label: labels.SelectorFromSet(labels.Set{v1beta1constants.LabelPrefixSeedName + g.config.SeedConfig.SeedTemplate.Name: "true"}),
+				},
 				&operationsv1alpha1.Bastion{}: {
 					Field: fields.SelectorFromSet(fields.Set{operations.BastionSeedName: g.config.SeedConfig.SeedTemplate.Name}),
 				},

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -435,6 +435,8 @@ const (
 
 	// LabelSecretBindingReference is used to identify secrets which are referred by a SecretBinding (not necessarily in the same namespace).
 	LabelSecretBindingReference = "reference.gardener.cloud/secretbinding"
+	// LabelPrefixSeedName is the prefix for the label key describing the name of a seed, e.g. seed.gardener.cloud/my-seed=true.
+	LabelPrefixSeedName = "seed.gardener.cloud/"
 
 	// LabelExtensionExtensionTypePrefix is used to prefix extension label for extension types.
 	LabelExtensionExtensionTypePrefix = "extensions.extensions.gardener.cloud/"

--- a/pkg/gardenlet/controller/shoot/care/add.go
+++ b/pkg/gardenlet/controller/shoot/care/add.go
@@ -34,7 +34,6 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	predicateutils "github.com/gardener/gardener/pkg/controllerutils/predicate"
 	"github.com/gardener/gardener/pkg/utils"
-	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 )
 
 // ControllerName is the name of this controller.
@@ -60,10 +59,7 @@ func (r *Reconciler) AddToManager(mgr manager.Manager, gardenCluster cluster.Clu
 		WatchesRawSource(
 			source.Kind(gardenCluster.GetCache(), &gardencorev1beta1.Shoot{}),
 			r.EventHandler(),
-			builder.WithPredicates(
-				predicateutils.SeedNamePredicate(r.SeedName, gardenerutils.GetShootSeedNames),
-				r.ShootPredicate(),
-			),
+			builder.WithPredicates(r.ShootPredicate()),
 		).
 		Complete(r)
 }

--- a/pkg/gardenlet/controller/shoot/shoot/add.go
+++ b/pkg/gardenlet/controller/shoot/shoot/add.go
@@ -32,9 +32,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
-	predicateutils "github.com/gardener/gardener/pkg/controllerutils/predicate"
 	"github.com/gardener/gardener/pkg/gardenlet/controller/shoot/shoot/helper"
-	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 )
 
 // ControllerName is the name of this controller.
@@ -69,7 +67,6 @@ func (r *Reconciler) AddToManager(mgr manager.Manager, gardenCluster cluster.Clu
 	return c.Watch(
 		source.Kind(gardenCluster.GetCache(), &gardencorev1beta1.Shoot{}),
 		r.EventHandler(c.GetLogger()),
-		predicateutils.SeedNamePredicate(r.Config.SeedConfig.Name, gardenerutils.GetShootSeedNames),
 		&predicate.GenerationChangedPredicate{},
 	)
 }

--- a/pkg/gardenlet/controller/shoot/state/add.go
+++ b/pkg/gardenlet/controller/shoot/state/add.go
@@ -18,7 +18,6 @@ import (
 	"k8s.io/utils/clock"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/cluster"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/event"
@@ -52,25 +51,9 @@ func (r *Reconciler) AddToManager(mgr manager.Manager, gardenCluster, seedCluste
 		WatchesRawSource(
 			source.Kind(gardenCluster.GetCache(), &gardencorev1beta1.Shoot{}),
 			&handler.EnqueueRequestForObject{},
-			builder.WithPredicates(
-				r.SeedNamePredicate(),
-				r.SeedNameChangedPredicate(),
-			),
+			builder.WithPredicates(r.SeedNameChangedPredicate()),
 		).
 		Complete(r)
-}
-
-// SeedNamePredicate returns a predicate which returns true for shoots whose seed name in the spec matches the seed name
-// the reconciler is configured with.
-func (r *Reconciler) SeedNamePredicate() predicate.Predicate {
-	return predicate.NewPredicateFuncs(func(obj client.Object) bool {
-		shoot, ok := obj.(*gardencorev1beta1.Shoot)
-		if !ok {
-			return false
-		}
-
-		return pointer.StringDeref(shoot.Spec.SeedName, "") == r.SeedName
-	})
 }
 
 // SeedNameChangedPredicate returns a predicate which returns true for all events except updates - here it only returns

--- a/pkg/gardenlet/controller/shoot/state/add_test.go
+++ b/pkg/gardenlet/controller/shoot/state/add_test.go
@@ -38,46 +38,6 @@ var _ = Describe("Add", func() {
 		shoot = &gardencorev1beta1.Shoot{}
 	})
 
-	Describe("#SeedNamePredicate", func() {
-		var p predicate.Predicate
-
-		BeforeEach(func() {
-			p = reconciler.SeedNamePredicate()
-		})
-
-		It("should return false because new object is no shoot", func() {
-			Expect(p.Create(event.CreateEvent{})).To(BeFalse())
-			Expect(p.Update(event.UpdateEvent{})).To(BeFalse())
-			Expect(p.Delete(event.DeleteEvent{})).To(BeFalse())
-			Expect(p.Generic(event.GenericEvent{})).To(BeFalse())
-		})
-
-		It("should return false because seed name is not set", func() {
-			Expect(p.Create(event.CreateEvent{Object: shoot})).To(BeFalse())
-			Expect(p.Update(event.UpdateEvent{ObjectNew: shoot})).To(BeFalse())
-			Expect(p.Delete(event.DeleteEvent{Object: shoot})).To(BeFalse())
-			Expect(p.Generic(event.GenericEvent{Object: shoot})).To(BeFalse())
-		})
-
-		It("should return false because seed name does not match", func() {
-			shoot.Spec.SeedName = pointer.String("some-seed")
-
-			Expect(p.Create(event.CreateEvent{Object: shoot})).To(BeFalse())
-			Expect(p.Update(event.UpdateEvent{ObjectNew: shoot})).To(BeFalse())
-			Expect(p.Delete(event.DeleteEvent{Object: shoot})).To(BeFalse())
-			Expect(p.Generic(event.GenericEvent{Object: shoot})).To(BeFalse())
-		})
-
-		It("should return true because seed name matches", func() {
-			shoot.Spec.SeedName = &seedName
-
-			Expect(p.Create(event.CreateEvent{Object: shoot})).To(BeTrue())
-			Expect(p.Update(event.UpdateEvent{ObjectNew: shoot})).To(BeTrue())
-			Expect(p.Delete(event.DeleteEvent{Object: shoot})).To(BeTrue())
-			Expect(p.Generic(event.GenericEvent{Object: shoot})).To(BeTrue())
-		})
-	})
-
 	Describe("#SeedNameChangedPredicate", func() {
 		var p predicate.Predicate
 

--- a/pkg/registry/core/backupentry/strategy.go
+++ b/pkg/registry/core/backupentry/strategy.go
@@ -33,6 +33,7 @@ import (
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	"github.com/gardener/gardener/pkg/apis/core/validation"
+	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 )
 
 type backupEntryStrategy struct {
@@ -109,7 +110,10 @@ func (backupEntryStrategy) Validate(_ context.Context, obj runtime.Object) field
 	return validation.ValidateBackupEntry(backupEntry)
 }
 
-func (backupEntryStrategy) Canonicalize(_ runtime.Object) {
+func (backupEntryStrategy) Canonicalize(obj runtime.Object) {
+	backupEntry := obj.(*core.BackupEntry)
+
+	gardenerutils.MaintainSeedNameLabels(backupEntry, backupEntry.Spec.SeedName, backupEntry.Status.SeedName)
 }
 
 func (backupEntryStrategy) AllowCreateOnUpdate() bool {

--- a/pkg/registry/core/shoot/strategy.go
+++ b/pkg/registry/core/shoot/strategy.go
@@ -36,6 +36,7 @@ import (
 	gardencorehelper "github.com/gardener/gardener/pkg/apis/core/helper"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/apis/core/validation"
+	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 	admissionpluginsvalidation "github.com/gardener/gardener/pkg/utils/validation/admissionplugins"
 )
 
@@ -171,10 +172,15 @@ func (shootStrategy) Validate(_ context.Context, obj runtime.Object) field.Error
 func (shootStrategy) Canonicalize(obj runtime.Object) {
 	shoot := obj.(*core.Shoot)
 
+	gardenerutils.MaintainSeedNameLabels(shoot, shoot.Spec.SeedName, shoot.Status.SeedName)
 	cleanupAdmissionPlugins(shoot)
 }
 
 func cleanupAdmissionPlugins(shoot *core.Shoot) {
+	if shoot.Spec.Kubernetes.KubeAPIServer == nil {
+		return
+	}
+
 	var (
 		admissionPlugins      []core.AdmissionPlugin
 		shootAdmissionPlugins = shoot.Spec.Kubernetes.KubeAPIServer.AdmissionPlugins

--- a/pkg/utils/gardener/identity.go
+++ b/pkg/utils/gardener/identity.go
@@ -22,8 +22,11 @@ import (
 	"strings"
 
 	"k8s.io/component-base/version"
+	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/utils"
 )
 
@@ -107,4 +110,29 @@ func extractID(line string) string {
 	id = strings.TrimPrefix(id, "docker-")
 
 	return id
+}
+
+// MaintainSeedNameLabels maintains the seed.gardener.cloud/<name>=true labels on the given object.
+func MaintainSeedNameLabels(obj client.Object, names ...*string) {
+	labels := obj.GetLabels()
+
+	for k := range labels {
+		if strings.HasPrefix(k, v1beta1constants.LabelPrefixSeedName) {
+			delete(labels, k)
+		}
+	}
+
+	for _, name := range names {
+		if pointer.StringDeref(name, "") == "" {
+			continue
+		}
+
+		if labels == nil {
+			labels = make(map[string]string)
+		}
+
+		labels[v1beta1constants.LabelPrefixSeedName+*name] = "true"
+	}
+
+	obj.SetLabels(labels)
 }

--- a/pkg/utils/gardener/identity_test.go
+++ b/pkg/utils/gardener/identity_test.go
@@ -1,0 +1,65 @@
+// Copyright 2024 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gardener_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	. "github.com/gardener/gardener/pkg/utils/gardener"
+)
+
+var _ = Describe("Identity", func() {
+	Describe("#MaintainSeedNameLabels", func() {
+		It("should maintain the labels", func() {
+			obj := &gardencorev1beta1.Shoot{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"seed.gardener.cloud/old-seed": "true"}},
+				Spec:       gardencorev1beta1.ShootSpec{SeedName: pointer.String("spec-seed")},
+				Status:     gardencorev1beta1.ShootStatus{SeedName: pointer.String("status-seed")},
+			}
+
+			MaintainSeedNameLabels(obj, obj.Spec.SeedName, obj.Status.SeedName)
+
+			Expect(obj.Labels).To(And(
+				HaveKeyWithValue("seed.gardener.cloud/spec-seed", "true"),
+				HaveKeyWithValue("seed.gardener.cloud/status-seed", "true"),
+			))
+		})
+
+		It("should maintain the labels when spec and status names are equal", func() {
+			obj := &gardencorev1beta1.Shoot{
+				Spec:   gardencorev1beta1.ShootSpec{SeedName: pointer.String("seed")},
+				Status: gardencorev1beta1.ShootStatus{SeedName: pointer.String("seed")},
+			}
+
+			MaintainSeedNameLabels(obj, obj.Spec.SeedName, obj.Status.SeedName)
+
+			Expect(obj.Labels).To(HaveKeyWithValue("seed.gardener.cloud/seed", "true"))
+		})
+
+		It("should maintain the labels when spec and status names are empty", func() {
+			obj := &gardencorev1beta1.Shoot{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"foo": "bar", "seed.gardener.cloud/old-seed": "true"}},
+			}
+
+			MaintainSeedNameLabels(obj, obj.Spec.SeedName, obj.Status.SeedName)
+
+			Expect(obj.Labels).To(Equal(map[string]string{"foo": "bar"}))
+		})
+	})
+})


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area scalability cost dev-productivity
/kind enhancement

**What this PR does / why we need it**:
`BackupEntry`s and `Shoot`s are now labelled with `seed.gardener.cloud/<seed-name>=true` where `<seed-name>` is the value of `.spec.seedName` or `.status.seedName`. This allows for server-side filtering when watching these resources by leveraging a label selector. `gardenlet` makes use of this such that it no longer filters client-side but only receives network traffic for resources belonging to its seed.
`BackupEntry`s and other resources are kept as they are as they
- do not cause a lot of network traffic
- are problematic when performing control plane migration

**Which issue(s) this PR fixes**:
Fixes #9074

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
`BackupEntry`s and `Shoot`s are now labelled with `seed.gardener.cloud/<seed-name>=true` where `<seed-name>` is the value of `.spec.seedName` or `.status.seedName`. This allows for server-side filtering when watching these resources by leveraging a label selector.
```
