### PR TITLE
move network-problem-detector to observability

### DIFF
--- a/docs/extensions/healthcheck-library.md
+++ b/docs/extensions/healthcheck-library.md
@@ -39,7 +39,7 @@ health.DefaultRegisterExtensionForHealthCheck(
 This creates a health check controller that reconciles the `extensions.gardener.cloud/v1alpha1.Worker` resource with the spec.type 'aws'.
 Three health check functions are registered that are executed during reconciliation.
 Each health check is mapped to a single `HealthConditionType` that results in conditions with the same `condition.type` (see below).
-To contribute to the Shoot's health, the following conditions can be used: `SystemComponentsHealthy`, `EveryNodeReady`, `ControlPlaneHealthy`. In case of workerless `Shoot` the `EveryNodeReady` condition is not present, so it can't be used.
+To contribute to the Shoot's health, the following conditions can be used: `SystemComponentsHealthy`, `EveryNodeReady`, `ControlPlaneHealthy`, `ObservabilityComponentsHealthy`. In case of workerless `Shoot` the `EveryNodeReady` condition is not present, so it can't be used.
 
 The Gardener/Gardenlet checks each extension for conditions matching these types.
 However, extensions are free to choose any `HealthConditionType`.

--- a/docs/extensions/shoot-health-status-conditions.md
+++ b/docs/extensions/shoot-health-status-conditions.md
@@ -6,7 +6,7 @@ It categorizes its checks into five different types:
 * `APIServerAvailable`: This type indicates whether the shoot's kube-apiserver is available or not.
 * `ControlPlaneHealthy`: This type indicates whether the core components of the Shoot controlplane (ETCD, KAPI, KCM..) are healthy.
 * `EveryNodeReady`: This type indicates whether all `Node`s and all `Machine` objects report healthiness.
-* `ObservabilityComponentsHealthy`: This type indicates whether the  observability components of the Shoot control plane (Prometheus, Vali, Plutono..) and extension network-problem-detector are healthy.
+* `ObservabilityComponentsHealthy`: This type indicates whether the  observability components of the Shoot control plane (Prometheus, Vali, Plutono..) are healthy.
 * `SystemComponentsHealthy`: This type indicates whether all system components deployed to the `kube-system` namespace in the shoot do exist and are running fine.
 
 In case of workerless `Shoot`, `EveryNodeReady` condition is not present in the `Shoot`'s conditions since there are no nodes in the cluster.

--- a/docs/extensions/shoot-health-status-conditions.md
+++ b/docs/extensions/shoot-health-status-conditions.md
@@ -6,7 +6,7 @@ It categorizes its checks into five different types:
 * `APIServerAvailable`: This type indicates whether the shoot's kube-apiserver is available or not.
 * `ControlPlaneHealthy`: This type indicates whether the core components of the Shoot controlplane (ETCD, KAPI, KCM..) are healthy.
 * `EveryNodeReady`: This type indicates whether all `Node`s and all `Machine` objects report healthiness.
-* `ObservabilityComponentsHealthy`: This type indicates whether the  observability components of the Shoot control plane (Prometheus, Vali, Plutono..) are healthy.
+* `ObservabilityComponentsHealthy`: This type indicates whether the  observability components of the Shoot control plane (Prometheus, Vali, Plutono..) and extension network-problem-detector are healthy.
 * `SystemComponentsHealthy`: This type indicates whether all system components deployed to the `kube-system` namespace in the shoot do exist and are running fine.
 
 In case of workerless `Shoot`, `EveryNodeReady` condition is not present in the `Shoot`'s conditions since there are no nodes in the cluster.
@@ -21,7 +21,7 @@ Now that the extensions deploy resources into the cluster, especially resources 
 
 Every extension resource in Gardener's `extensions.gardener.cloud/v1alpha1` API group also has a `status.conditions[]` list (like the `Shoot`).
 Extension controllers can write conditions to the resource they are acting on and use a type that also exists in the shoot's conditions.
-One exception is that `APIServerAvailable` and `ObservabilityComponentsHealthy` can't be used, as Gardener clearly can identify the status of this condition and it doesn't make sense for extensions to try to contribute/modify it.
+One exception is that `APIServerAvailable` can't be used, as Gardener clearly can identify the status of this condition and it doesn't make sense for extensions to try to contribute/modify it.
 
 As an example for the `ControlPlane` controller, let's take a look at the following resource:
 

--- a/pkg/gardenlet/controller/shoot/care/health.go
+++ b/pkg/gardenlet/controller/shoot/care/health.go
@@ -162,7 +162,7 @@ func (h *Health) Check(
 				return nil
 			},
 			func(ctx context.Context) error {
-				newSystemComponents, err := h.checkSystemComponents(ctx, shootClient, conditions.systemComponentsHealthy, extensionConditionsSystemComponentsHealthy, healthCheckOutdatedThreshold)
+				newSystemComponents, err := h.checkSystemComponents(ctx, shootClient, conditions.systemComponentsHealthy)
 				conditions.systemComponentsHealthy = v1beta1helper.NewConditionOrError(h.clock, conditions.systemComponentsHealthy, newSystemComponents, err)
 				return nil
 			},
@@ -456,8 +456,6 @@ func (h *Health) checkSystemComponents(
 	ctx context.Context,
 	shootClient kubernetes.Interface,
 	condition gardencorev1beta1.Condition,
-	extensionConditions []healthchecker.ExtensionCondition,
-	healthCheckOutdatedThreshold *metav1.Duration,
 ) (
 	*gardencorev1beta1.Condition,
 	error,


### PR DESCRIPTION
**How to categorize this PR?**
The health check for extensions are conducted within condition `SystemComponentsHealthy`. 
For extension `network-problem-detector` which is a tool helps to diagnose and investigate shoot network problems. 
When `network-problem-detector` encounters an issue for some reason, it will set `SystemComponentsHealthy` to false. 
Actually this extension would not affect shoot functionality. 
To provide a more accurate representation of system health and reduce the frequency of `SystemComponentsUnHealthy` alert, this PR will add condition `ObservabilityComponentsHealthy`. Then it will allow extension register health check type  for `ShootObservabilityComponentsHealthy`



<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind enhancement

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**: 

```other operator
Add condition type `ObservabilityComponentsHealthy` for extension health check, it will allow extensions to register with this type. 
```
