### PR TITLE
Remove the GA-ed `WorkerlessShoots` feature gate

### DIFF
--- a/docs/deployment/feature_gates.md
+++ b/docs/deployment/feature_gates.md
@@ -26,9 +26,6 @@ The following tables are a summary of the feature gates that you can set on diff
 | CoreDNSQueryRewriting               | `false` | `Alpha` | `1.55` |        |
 | IPv6SingleStack                     | `false` | `Alpha` | `1.63` |        |
 | MutableShootSpecNetworkingNodes     | `false` | `Alpha` | `1.64` |        |
-| WorkerlessShoots                    | `false` | `Alpha` | `1.70` | `1.78` |
-| WorkerlessShoots                    | `true`  | `Beta`  | `1.79` | `1.85` |
-| WorkerlessShoots                    | `true`  | `GA`    | `1.86` |        |
 | MachineControllerManagerDeployment  | `false` | `Alpha` | `1.73` |        |
 | MachineControllerManagerDeployment  | `true`  | `Beta`  | `1.81` | `1.81` |
 | MachineControllerManagerDeployment  | `true`  | `GA`    | `1.82` |        |
@@ -142,6 +139,10 @@ The following tables are a summary of the feature gates that you can set on diff
 | ContainerdRegistryHostsDir                   | `true`  | `Beta`       | `1.86` | `1.86` |
 | ContainerdRegistryHostsDir                   | `true`  | `GA`         | `1.87` | `1.87` |
 | ContainerdRegistryHostsDir                   | `true`  | `Removed`    | `1.88` |        |
+| WorkerlessShoots                             | `false` | `Alpha`      | `1.70` | `1.78` |
+| WorkerlessShoots                             | `true`  | `Beta`       | `1.79` | `1.85` |
+| WorkerlessShoots                             | `true`  | `GA`         | `1.86` |        |
+| WorkerlessShoots                             | `true`  | `Removed`    | `1.88` |        |
 
 ## Using a Feature
 
@@ -187,7 +188,6 @@ A *General Availability* (GA) feature is also referred to as a *stable* feature.
 | CoreDNSQueryRewriting              | `gardenlet`                       | Enables automatic DNS query rewriting in shoot cluster's CoreDNS to shortcut name resolution of fully qualified in-cluster and out-of-cluster names, which follow a user-defined pattern. Details can be found in [DNS Search Path Optimization](../usage/dns-search-path-optimization.md).                                                                                        |
 | IPv6SingleStack                    | `gardener-apiserver`, `gardenlet` | Allows creating seed and shoot clusters with [IPv6 single-stack networking](../usage/ipv6.md) enabled in their spec ([GEP-21](../proposals/21-ipv6-singlestack-local.md)). If enabled in gardenlet, the default behavior is unchanged, but setting `ipFamilies=[IPv6]` in the `seedConfig` is allowed. Only if the `ipFamilies` setting is changed, gardenlet behaves differently. |
 | MutableShootSpecNetworkingNodes    | `gardener-apiserver`              | Allows updating the field `spec.networking.nodes`. The validity of the values has to be checked in the provider extensions. Only enable this feature gate when your system runs provider extensions which have implemented the validation.                                                                                                                                         |
-| WorkerlessShoots                   | `gardener-apiserver`              | WorkerlessShoots allows creation of Shoot clusters with no worker pools.                                                                                                                                                                                                                                                                                                           |
 | MachineControllerManagerDeployment | `gardenlet`                       | Enables Gardener to take over the deployment of the machine-controller-manager. If enabled, all registered provider extensions must support injecting the provider-specific MCM sidecar container into the deployment via the `controlplane` webhook.                                                                                                                              |
 | ShootForceDeletion                 | `gardener-apiserver`              | Allows forceful deletion of Shoots by annotating them with the `confirmation.gardener.cloud/force-deletion` annotation.                                                                                                                                                                                                                                                            |
 | APIServerFastRollout               | `gardenlet`                       | Enables fast rollouts for Shoot kube-apiservers on the given Seed. When enabled, `maxSurge` for Shoot kube-apiserver deployments is set to 100%.                                                                                                                                                                                                                                   |

--- a/pkg/apiserver/features/features.go
+++ b/pkg/apiserver/features/features.go
@@ -26,6 +26,5 @@ func RegisterFeatureGates() {
 		features.IPv6SingleStack,
 		features.MutableShootSpecNetworkingNodes,
 		features.ShootForceDeletion,
-		features.WorkerlessShoots,
 	)))
 }

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -58,13 +58,6 @@ const (
 	// alpha: v1.64.0
 	MutableShootSpecNetworkingNodes featuregate.Feature = "MutableShootSpecNetworkingNodes"
 
-	// WorkerlessShoots allows creation of Shoot clusters with no worker pools.
-	// owner: @acumino @ary1992 @shafeeqes
-	// alpha: v1.70.0
-	// beta: v1.79.0
-	// GA: v1.86.0
-	WorkerlessShoots featuregate.Feature = "WorkerlessShoots"
-
 	// ShootForceDeletion allows force deletion of Shoots.
 	// See https://github.com/gardener/gardener/blob/master/docs/usage/shoot_operations.md#shoot-force-deletion for more details.
 	// owner: @acumino @ary1992 @shafeeqes
@@ -126,7 +119,6 @@ var AllFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	CoreDNSQueryRewriting:              {Default: false, PreRelease: featuregate.Alpha},
 	IPv6SingleStack:                    {Default: false, PreRelease: featuregate.Alpha},
 	MutableShootSpecNetworkingNodes:    {Default: false, PreRelease: featuregate.Alpha},
-	WorkerlessShoots:                   {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
 	ShootForceDeletion:                 {Default: false, PreRelease: featuregate.Alpha},
 	MachineControllerManagerDeployment: {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
 	APIServerFastRollout:               {Default: true, PreRelease: featuregate.Beta},

--- a/pkg/registry/core/shoot/strategy_test.go
+++ b/pkg/registry/core/shoot/strategy_test.go
@@ -61,7 +61,7 @@ var _ = Describe("Strategy", func() {
 			}
 		})
 
-		It("should allow an empty worker list if WorkerlessShoots featuregate is enabled", func() {
+		It("should allow an empty worker list", func() {
 			Expect(strategy.Validate(context.TODO(), shoot)).To(BeEmpty())
 		})
 	})


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind cleanup

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
The GA-ed `WorkerlessShoots` feature gate has been removed.
```
