### PR TITLE
[node-agent] Disable and stop `gardener-node-init.service` when gardener-node-agent is active

### DIFF
--- a/pkg/nodeagent/controller/operatingsystemconfig/reconciler.go
+++ b/pkg/nodeagent/controller/operatingsystemconfig/reconciler.go
@@ -324,6 +324,12 @@ func (r *Reconciler) applyChangedUnits(ctx context.Context, log logr.Logger, uni
 			}
 		}
 
+		// TODO(rfranzke): Remove this when UseGardenerNodeAgent feature gate gets removed.
+		// Never enable `gardener-node-init.service` to avoid undesired restarts of `gardener-node-agent`
+		if unit.Name == nodeagentv1alpha1.InitUnitName {
+			unit.Enable = pointer.Bool(false)
+		}
+
 		if unit.Name == nodeagentv1alpha1.UnitName || pointer.BoolDeref(unit.Enable, true) {
 			if err := r.DBus.Enable(ctx, unit.Name); err != nil {
 				return fmt.Errorf("unable to enable unit %q: %w", unit.Name, err)
@@ -381,6 +387,12 @@ func (r *Reconciler) executeUnitCommands(ctx context.Context, log logr.Logger, n
 
 	for _, u := range units {
 		unit := u
+
+		// TODO(rfranzke): Remove this when UseGardenerNodeAgent feature gate gets removed.
+		// Never start `gardener-node-init.service` to avoid undesired restarts of `gardener-node-agent`
+		if unit.Name == nodeagentv1alpha1.InitUnitName {
+			unit.Enable = pointer.Bool(false)
+		}
 
 		if unit.Name == nodeagentv1alpha1.UnitName {
 			mustRestartGardenerNodeAgent = true


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind enhancement

**What this PR does / why we need it**:
At the moment `gardener-node-init.service` has to be added to OSC with purpose `reconcile` to support migration from `cloud-config-downloader` to `gardener-node-agent`.
However, once GNA is active this service can cause undesired restarts of `gardener-node-agent.service`. In a very unlikely case, this restart could prevent GNA from saving the updated OSC to disk.
Thus, this PR makes GNA disable and stop `gardener-node-init.service`. The code can be removed when we remove `UseGardenerNodeAgent` feature gate (and `gardener-node-init.service` from OSC with purpose reconcile)

**Which issue(s) this PR fixes**:
Part of #8023 

**Special notes for your reviewer**:
/cc @rfranzke 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
On node machines `gardener-node-init.service` is disabled and stopped when `gardener-node-agent` is active.
```
