### PR TITLE
Make ClientMap accessible

### DIFF
--- a/pkg/client/kubernetes/clientmap/alias.go
+++ b/pkg/client/kubernetes/clientmap/alias.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package internal
+package clientmap
 
 import (
 	"net"

--- a/pkg/client/kubernetes/clientmap/builder/garden_builder.go
+++ b/pkg/client/kubernetes/clientmap/builder/garden_builder.go
@@ -22,7 +22,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap"
-	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap/internal"
 )
 
 // GardenClientMapBuilder can build a ClientMap which can be used to
@@ -65,7 +64,7 @@ func (b *GardenClientMapBuilder) Build(log logr.Logger) (clientmap.ClientMap, er
 		return nil, fmt.Errorf("clientConnectionConfig is required but not set")
 	}
 
-	return internal.NewGardenClientMap(log, &internal.GardenClientSetFactory{
+	return clientmap.NewGardenClientMap(log, &clientmap.GardenClientSetFactory{
 		RuntimeClient:          b.runtimeClient,
 		ClientConnectionConfig: *b.clientConnectionConfig,
 		GardenNamespace:        b.gardenNamespace,

--- a/pkg/client/kubernetes/clientmap/builder/shoot_builder.go
+++ b/pkg/client/kubernetes/clientmap/builder/shoot_builder.go
@@ -22,7 +22,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap"
-	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap/internal"
 )
 
 // ShootClientMapBuilder can build a ClientMap which can be used to construct a ClientMap for requesting and storing
@@ -68,7 +67,7 @@ func (b *ShootClientMapBuilder) Build(log logr.Logger) (clientmap.ClientMap, err
 		return nil, fmt.Errorf("clientConnectionConfig is required but not set")
 	}
 
-	return internal.NewShootClientMap(log, &internal.ShootClientSetFactory{
+	return clientmap.NewShootClientMap(log, &clientmap.ShootClientSetFactory{
 		GardenClient:           b.gardenClient,
 		SeedClient:             b.seedClient,
 		ClientConnectionConfig: *b.clientConnectionConfig,

--- a/pkg/client/kubernetes/clientmap/clientmap_suite_test.go
+++ b/pkg/client/kubernetes/clientmap/clientmap_suite_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package internal_test
+package clientmap_test
 
 import (
 	"testing"
@@ -23,5 +23,5 @@ import (
 
 func TestClientmap(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Client Kubernetes ClientMap Internal Suite")
+	RunSpecs(t, "Client Kubernetes ClientMap Suite")
 }

--- a/pkg/client/kubernetes/clientmap/garden_clientmap.go
+++ b/pkg/client/kubernetes/clientmap/garden_clientmap.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package internal
+package clientmap
 
 import (
 	"context"
@@ -26,7 +26,6 @@ import (
 
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
-	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap"
 	operatorclient "github.com/gardener/gardener/pkg/operator/client"
 	"github.com/gardener/gardener/pkg/utils"
 	"github.com/gardener/gardener/pkg/utils/gardener/tokenrequest"
@@ -34,11 +33,11 @@ import (
 
 // gardenClientMap is a ClientMap for requesting and storing clients for virtual gardens.
 type gardenClientMap struct {
-	clientmap.ClientMap
+	ClientMap
 }
 
 // NewGardenClientMap creates a new gardenClientMap with the given factory.
-func NewGardenClientMap(log logr.Logger, factory *GardenClientSetFactory) clientmap.ClientMap {
+func NewGardenClientMap(log logr.Logger, factory *GardenClientSetFactory) ClientMap {
 	logger := log.WithValues("clientmap", "GardenClientMap")
 	factory.log = logger
 	return &gardenClientMap{
@@ -60,7 +59,7 @@ type GardenClientSetFactory struct {
 }
 
 // CalculateClientSetHash calculates a SHA256 hash of the kubeconfig in the 'gardener' secret in the Garden's Garden namespace.
-func (f *GardenClientSetFactory) CalculateClientSetHash(ctx context.Context, k clientmap.ClientSetKey) (string, error) {
+func (f *GardenClientSetFactory) CalculateClientSetHash(ctx context.Context, k ClientSetKey) (string, error) {
 	_, hash, err := f.getSecretAndComputeHash(ctx, k)
 	if err != nil {
 		return "", err
@@ -70,7 +69,7 @@ func (f *GardenClientSetFactory) CalculateClientSetHash(ctx context.Context, k c
 }
 
 // NewClientSet creates a new ClientSet for a Garden cluster.
-func (f *GardenClientSetFactory) NewClientSet(ctx context.Context, k clientmap.ClientSetKey) (kubernetes.Interface, string, error) {
+func (f *GardenClientSetFactory) NewClientSet(ctx context.Context, k ClientSetKey) (kubernetes.Interface, string, error) {
 	kubeconfigSecret, hash, err := f.getSecretAndComputeHash(ctx, k)
 	if err != nil {
 		return nil, "", err
@@ -98,7 +97,7 @@ func (f *GardenClientSetFactory) NewClientSet(ctx context.Context, k clientmap.C
 	return clientSet, hash, nil
 }
 
-func (f *GardenClientSetFactory) getSecretAndComputeHash(ctx context.Context, k clientmap.ClientSetKey) (*corev1.Secret, string, error) {
+func (f *GardenClientSetFactory) getSecretAndComputeHash(ctx context.Context, k ClientSetKey) (*corev1.Secret, string, error) {
 	_, ok := k.(GardenClientSetKey)
 	if !ok {
 		return nil, "", fmt.Errorf("unsupported ClientSetKey: expected %T got %T", GardenClientSetKey{}, k)
@@ -128,10 +127,10 @@ func (f *GardenClientSetFactory) secretName(gardenNamespace string) string {
 	return secretName
 }
 
-var _ clientmap.Invalidate = &GardenClientSetFactory{}
+var _ Invalidate = &GardenClientSetFactory{}
 
 // InvalidateClient invalidates information cached for the given ClientSetKey in the factory.
-func (f *GardenClientSetFactory) InvalidateClient(k clientmap.ClientSetKey) error {
+func (f *GardenClientSetFactory) InvalidateClient(k ClientSetKey) error {
 	_, ok := k.(GardenClientSetKey)
 	if !ok {
 		return fmt.Errorf("unsupported ClientSetKey: expected %T got %T", GardenClientSetKey{}, k)

--- a/pkg/client/kubernetes/clientmap/garden_clientmap_test.go
+++ b/pkg/client/kubernetes/clientmap/garden_clientmap_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package internal_test
+package clientmap_test
 
 import (
 	"context"
@@ -29,8 +29,7 @@ import (
 
 	operatorv1alpha1 "github.com/gardener/gardener/pkg/apis/operator/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
-	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap"
-	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap/internal"
+	. "github.com/gardener/gardener/pkg/client/kubernetes/clientmap"
 	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap/keys"
 	kubernetesfake "github.com/gardener/gardener/pkg/client/kubernetes/fake"
 	. "github.com/gardener/gardener/pkg/client/kubernetes/test"
@@ -44,9 +43,9 @@ var _ = Describe("GardenClientMap", func() {
 		ctrl              *gomock.Controller
 		mockRuntimeClient *mockclient.MockClient
 
-		cm                     clientmap.ClientMap
-		key                    clientmap.ClientSetKey
-		factory                *internal.GardenClientSetFactory
+		cm                     ClientMap
+		key                    ClientSetKey
+		factory                *GardenClientSetFactory
 		clientConnectionConfig componentbaseconfig.ClientConnectionConfiguration
 		clientOptions          client.Options
 
@@ -64,7 +63,7 @@ var _ = Describe("GardenClientMap", func() {
 			},
 		}
 
-		internal.LookupHost = func(host string) ([]string, error) {
+		LookupHost = func(host string) ([]string, error) {
 			Expect(host).To(Equal("virtual-garden-kube-apiserver.garden.svc.cluster.local"))
 			return []string{"10.0.1.1"}, nil
 		}
@@ -79,11 +78,11 @@ var _ = Describe("GardenClientMap", func() {
 			Burst:              43,
 		}
 		clientOptions = client.Options{Scheme: operatorclient.VirtualScheme}
-		factory = &internal.GardenClientSetFactory{
+		factory = &GardenClientSetFactory{
 			RuntimeClient:          mockRuntimeClient,
 			ClientConnectionConfig: clientConnectionConfig,
 		}
-		cm = internal.NewGardenClientMap(logr.Discard(), factory)
+		cm = NewGardenClientMap(logr.Discard(), factory)
 	})
 
 	AfterEach(func() {
@@ -104,11 +103,11 @@ var _ = Describe("GardenClientMap", func() {
 				DoAndReturn(func(ctx context.Context, key client.ObjectKey, obj client.Object, _ ...client.GetOption) error {
 					return nil
 				})
-			internal.LookupHost = func(host string) ([]string, error) {
+			LookupHost = func(host string) ([]string, error) {
 				return nil, fakeErr
 			}
 
-			internal.NewClientFromSecretObject = func(secret *corev1.Secret, fns ...kubernetes.ConfigFunc) (kubernetes.Interface, error) {
+			NewClientFromSecretObject = func(secret *corev1.Secret, fns ...kubernetes.ConfigFunc) (kubernetes.Interface, error) {
 				Expect(secret.Namespace).To(Equal("garden"))
 				Expect(secret.Name).To(Equal("gardener"))
 				return nil, fakeErr
@@ -132,11 +131,11 @@ var _ = Describe("GardenClientMap", func() {
 					}).DeepCopyInto(obj.(*corev1.Secret))
 					return nil
 				})
-			internal.LookupHost = func(host string) ([]string, error) {
+			LookupHost = func(host string) ([]string, error) {
 				return nil, fakeErr
 			}
 
-			internal.NewClientFromSecretObject = func(secret *corev1.Secret, fns ...kubernetes.ConfigFunc) (kubernetes.Interface, error) {
+			NewClientFromSecretObject = func(secret *corev1.Secret, fns ...kubernetes.ConfigFunc) (kubernetes.Interface, error) {
 				Expect(secret.Namespace).To(Equal("garden"))
 				Expect(secret.Name).To(Equal("gardener"))
 				return nil, fakeErr
@@ -155,7 +154,7 @@ var _ = Describe("GardenClientMap", func() {
 					return nil
 				})
 
-			internal.NewClientFromSecretObject = func(secret *corev1.Secret, fns ...kubernetes.ConfigFunc) (kubernetes.Interface, error) {
+			NewClientFromSecretObject = func(secret *corev1.Secret, fns ...kubernetes.ConfigFunc) (kubernetes.Interface, error) {
 				Expect(secret.Namespace).To(Equal("garden"))
 				Expect(secret.Name).To(Equal("gardener-internal"))
 				Expect(fns).To(ConsistOfConfigFuncs(
@@ -198,7 +197,7 @@ var _ = Describe("GardenClientMap", func() {
 					}),
 			)
 
-			internal.NewClientFromSecretObject = func(secret *corev1.Secret, fns ...kubernetes.ConfigFunc) (kubernetes.Interface, error) {
+			NewClientFromSecretObject = func(secret *corev1.Secret, fns ...kubernetes.ConfigFunc) (kubernetes.Interface, error) {
 				Expect(secret.Namespace).To(Equal("garden"))
 				Expect(secret.Name).To(Equal("gardener-internal"))
 				Expect(fns).To(ConsistOfConfigFuncs(
@@ -272,7 +271,7 @@ var _ = Describe("GardenClientMap", func() {
 			})
 
 			It("when out-of-cluster", func() {
-				internal.LookupHost = func(host string) ([]string, error) {
+				LookupHost = func(host string) ([]string, error) {
 					return nil, nil
 				}
 				test("gardener")

--- a/pkg/client/kubernetes/clientmap/keys/keys.go
+++ b/pkg/client/kubernetes/clientmap/keys/keys.go
@@ -18,19 +18,18 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	operatorv1alpha1 "github.com/gardener/gardener/pkg/apis/operator/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap"
-	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap/internal"
 )
 
 // ForGarden returns a key for retrieving a ClientSet for the given Shoot cluster.
 func ForGarden(garden *operatorv1alpha1.Garden) clientmap.ClientSetKey {
-	return internal.GardenClientSetKey{
+	return clientmap.GardenClientSetKey{
 		Name: garden.Name,
 	}
 }
 
 // ForShoot returns a key for retrieving a ClientSet for the given Shoot cluster.
 func ForShoot(shoot *gardencorev1beta1.Shoot) clientmap.ClientSetKey {
-	return internal.ShootClientSetKey{
+	return clientmap.ShootClientSetKey{
 		Namespace: shoot.Namespace,
 		Name:      shoot.Name,
 	}
@@ -39,7 +38,7 @@ func ForShoot(shoot *gardencorev1beta1.Shoot) clientmap.ClientSetKey {
 // ForShootWithNamespacedName returns a key for retrieving a ClientSet for the Shoot cluster with the given
 // namespace and name.
 func ForShootWithNamespacedName(namespace, name string) clientmap.ClientSetKey {
-	return internal.ShootClientSetKey{
+	return clientmap.ShootClientSetKey{
 		Namespace: namespace,
 		Name:      name,
 	}

--- a/pkg/client/kubernetes/clientmap/keys/keys_test.go
+++ b/pkg/client/kubernetes/clientmap/keys/keys_test.go
@@ -21,7 +21,7 @@ import (
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	operatorv1alpha1 "github.com/gardener/gardener/pkg/apis/operator/v1alpha1"
-	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap/internal"
+	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap"
 	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap/keys"
 )
 
@@ -32,7 +32,7 @@ var _ = Describe("Keys", func() {
 				Name: "inception",
 			},
 		}
-		key := keys.ForGarden(garden).(internal.GardenClientSetKey)
+		key := keys.ForGarden(garden).(clientmap.GardenClientSetKey)
 		Expect(key.Key()).To(Equal(garden.Name))
 		Expect(key.Name).To(Equal(garden.Name))
 	})
@@ -44,7 +44,7 @@ var _ = Describe("Keys", func() {
 				Namespace: "core",
 			},
 		}
-		key := keys.ForShoot(shoot).(internal.ShootClientSetKey)
+		key := keys.ForShoot(shoot).(clientmap.ShootClientSetKey)
 		Expect(key.Key()).To(Equal(shoot.Namespace + "/" + shoot.Name))
 		Expect(key.Namespace).To(Equal(shoot.Namespace))
 		Expect(key.Name).To(Equal(shoot.Name))
@@ -53,7 +53,7 @@ var _ = Describe("Keys", func() {
 	It("#ForShootWithNamespacedName", func() {
 		name := "inception"
 		namespace := "core"
-		key := keys.ForShootWithNamespacedName(namespace, name).(internal.ShootClientSetKey)
+		key := keys.ForShootWithNamespacedName(namespace, name).(clientmap.ShootClientSetKey)
 		Expect(key.Key()).To(Equal(namespace + "/" + name))
 		Expect(key.Namespace).To(Equal(namespace))
 		Expect(key.Name).To(Equal(name))

--- a/skaffold-operator.yaml
+++ b/skaffold-operator.yaml
@@ -55,7 +55,6 @@ build:
             - pkg/client/kubernetes/cache
             - pkg/client/kubernetes/clientmap
             - pkg/client/kubernetes/clientmap/builder
-            - pkg/client/kubernetes/clientmap/internal
             - pkg/client/kubernetes/clientmap/keys
             - pkg/component
             - pkg/component/apiserver

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -816,7 +816,6 @@ build:
             - pkg/client/kubernetes/cache
             - pkg/client/kubernetes/clientmap
             - pkg/client/kubernetes/clientmap/builder
-            - pkg/client/kubernetes/clientmap/internal
             - pkg/client/kubernetes/clientmap/keys
             - pkg/component
             - pkg/component/apiserver


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area open-source
/kind enhancement

**What this PR does / why we need it**:
This PR removes the `ClientMap` functionality from the `internal` package, so that it can be used in other projects as well.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
Gardener's `ClientMap` implementation was moved from an `internal` to the commonly accessible `clientmap` package.
```
