### PR TITLE
Change dnsLookupFamily to ALL in vpn seed envoy config.

### DIFF
--- a/pkg/component/vpnseedserver/vpn_seed_server.go
+++ b/pkg/component/vpnseedserver/vpn_seed_server.go
@@ -891,7 +891,7 @@ func (v *vpnSeedServer) getEnvoyConfig() string {
 	var (
 		listenAddress   = "0.0.0.0"
 		listenAddressV6 = "::"
-		dnsLookupFamily = "V4_PREFERRED"
+		dnsLookupFamily = "ALL"
 	)
 
 	return `static_resources:

--- a/pkg/component/vpnseedserver/vpn_seed_server_test.go
+++ b/pkg/component/vpnseedserver/vpn_seed_server_test.go
@@ -80,7 +80,7 @@ var _ = Describe("VpnSeedServer", func() {
 
 		listenAddress   = "0.0.0.0"
 		listenAddressV6 = "::"
-		dnsLookUpFamily = "V4_PREFERRED"
+		dnsLookUpFamily = "ALL"
 
 		expectedConfigMap *corev1.ConfigMap
 		expectedSecretDH  = &corev1.Secret{
@@ -793,7 +793,7 @@ var _ = Describe("VpnSeedServer", func() {
 					BeforeEach(func() {
 						listenAddress = "0.0.0.0"
 						listenAddressV6 = "::"
-						dnsLookUpFamily = "V4_PREFERRED"
+						dnsLookUpFamily = "ALL"
 						networkConfig := NetworkValues{
 							PodCIDR:     "2001:db8:1::/48",
 							ServiceCIDR: "2001:db8:3::/48",


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement

**What this PR does / why we need it**:
The envoy property `dnsLookupFamily` determines the address family for DNS lookups.
`V4_PREFERED` means, that a DNS lookup for the IPv4 address is made and if there is no result a lookup for IPv6 is made.
The meaning of `ALL` would be that both IPv4 and IPv6 lookups are made.
However, the property has the side effect, that with `IPV4_PREFERED` envoy tries to resolve IPv6 addresses as hostnames.
This results in unnecessary DNS queries.
The envoy proxy in the VPN seed server doesn't need to to do any DNS lookups. Unnecessary lookups for addresses as hostnames can prevented by setting  dnsLookupFamily to `ALL`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Change dnsLookupFamily to ALL in vpn seed envoy config, to prevent unnecessary DNS lookups.
```
