### PR TITLE
Drop remaining usages of docker CRI

### DIFF
--- a/charts/gardener/operator/templates/customresouredefintion.yaml
+++ b/charts/gardener/operator/templates/customresouredefintion.yaml
@@ -1594,8 +1594,8 @@ spec:
                   acted on the Garden.
                 properties:
                   id:
-                    description: ID is the Docker container id of the Gardener which
-                      last acted on a resource.
+                    description: ID is the container id of the Gardener which last
+                      acted on a resource.
                     type: string
                   name:
                     description: Name is the hostname (pod name) of the Gardener which

--- a/docs/api-reference/core.md
+++ b/docs/api-reference/core.md
@@ -4653,7 +4653,7 @@ string
 </em>
 </td>
 <td>
-<p>ID is the Docker container id of the Gardener which last acted on a resource.</p>
+<p>ID is the container id of the Gardener which last acted on a resource.</p>
 </td>
 </tr>
 <tr>

--- a/docs/api-reference/core.md
+++ b/docs/api-reference/core.md
@@ -5725,7 +5725,9 @@ Kubernetes meta/v1.Duration
 <td>
 <em>(Optional)</em>
 <p>ImagePullProgressDeadline describes the time limit under which if no pulling progress is made, the image pulling will be cancelled.
-Default: 1m</p>
+Default: 1m
+Only relevant for docker CRI.</p>
+<p>Deprecated: This field is deprecated and will be removed in Gardener release v1.89.</p>
 </td>
 </tr>
 <tr>

--- a/docs/extensions/operatingsystemconfig.md
+++ b/docs/extensions/operatingsystemconfig.md
@@ -369,7 +369,7 @@ status:
 Once the `.status` indicates that the extension controller finished reconciling Gardener will continue with the next step of the shoot reconciliation flow.
 
 ## CRI Support
-Gardener supports specifying a Container Runtime Interface (CRI) configuration in the `OperatingSystemConfig` resource. If the `.spec.cri` section exists, then the `name` property is mandatory. The only supported values for `cri.name` at the moment are: `containerd` and `docker`, which uses the in-tree dockershim.
+Gardener supports specifying a Container Runtime Interface (CRI) configuration in the `OperatingSystemConfig` resource. If the `.spec.cri` section exists, then the `name` property is mandatory. The only supported value for `cri.name` at the moment is: `containerd`.
 For example:
 ```yaml
 ---

--- a/docs/usage/shoot_operations.md
+++ b/docs/usage/shoot_operations.md
@@ -41,10 +41,10 @@ Please consult [Credentials Rotation for Shoot Clusters](shoot_credentials_rotat
 
 It is possible to make Gardener restart particular systemd services on your shoot worker nodes if needed.
 The annotation is not set on the `Shoot` resource but directly on the `Node` object you want to target.
-For example, the following will restart both the `kubelet` and the `docker` services:
+For example, the following will restart both the `kubelet` and the `containerd` services:
 
 ```bash
-kubectl annotate node <node-name> worker.gardener.cloud/restart-systemd-services=kubelet,docker
+kubectl annotate node <node-name> worker.gardener.cloud/restart-systemd-services=kubelet,containerd
 ```
 
 It may take up to a minute until the service is restarted.

--- a/example/30-cloudprofile.yaml
+++ b/example/30-cloudprofile.yaml
@@ -32,8 +32,8 @@ spec:
     # architectures: # optional
     # - amd64
     # - arm64
-    # cri:
-    # - name: docker
+    # cri: # Even though gardener doesn't support docker CRI, gardener requires machine images to have the docker daemon installed. See https://github.com/gardener/gardener/issues/4673 for more information.
+    # - name: containerd    
     #   containerRuntimes:
     #   - type: gvisor
     # kubeletVersionConstraint: "< 1.26" # optional
@@ -41,7 +41,6 @@ spec:
     versions:
     - version: 18.04.201906170
     # cri:
-    # - name: docker
     # - name: containerd
     #   containerRuntimes:
     #   - type: gvisor

--- a/example/operator/10-crd-operator.gardener.cloud_gardens.yaml
+++ b/example/operator/10-crd-operator.gardener.cloud_gardens.yaml
@@ -1594,8 +1594,8 @@ spec:
                   acted on the Garden.
                 properties:
                   id:
-                    description: ID is the Docker container id of the Gardener which
-                      last acted on a resource.
+                    description: ID is the container id of the Gardener which last
+                      acted on a resource.
                     type: string
                   name:
                     description: Name is the hostname (pod name) of the Gardener which

--- a/example/provider-local/garden/base/cloudprofile.yaml
+++ b/example/provider-local/garden/base/cloudprofile.yaml
@@ -27,10 +27,6 @@ spec:
     - version: 1.0.0
       cri:
       - name: containerd
-      # provider-local image doesn't contain a full docker runtime but includes nerdctl imitating the docker CLI for fulfilling gardener's bootstrap needs:
-      # see https://github.com/gardener/machine-controller-manager-provider-local/blob/f2c93198c794afc4e8e742a26026584ecce9aadf/node/Dockerfile#L9-L20
-      # this can be removed as soon as https://github.com/gardener/gardener/issues/4673 is resolved
-      - name: docker
   providerConfig:
     apiVersion: local.provider.extensions.gardener.cloud/v1alpha1
     kind: CloudProfileConfig

--- a/extensions/pkg/controller/worker/machines.go
+++ b/extensions/pkg/controller/worker/machines.go
@@ -26,7 +26,6 @@ import (
 
 	extensionscontroller "github.com/gardener/gardener/extensions/pkg/controller"
 	"github.com/gardener/gardener/extensions/pkg/util"
-	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	"github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/utils"
@@ -132,7 +131,7 @@ func WorkerPoolHash(pool extensionsv1alpha1.WorkerPool, cluster *extensionscontr
 
 	for _, w := range cluster.Shoot.Spec.Provider.Workers {
 		if pool.Name == w.Name {
-			if w.CRI != nil && w.CRI.Name != gardencorev1beta1.CRINameDocker {
+			if w.CRI != nil {
 				data = append(data, string(w.CRI.Name))
 			}
 		}

--- a/extensions/pkg/controller/worker/machines_test.go
+++ b/extensions/pkg/controller/worker/machines_test.go
@@ -187,11 +187,6 @@ var _ = Describe("Machines", func() {
 				c.Shoot.Spec.Kubernetes.Version = "1.2.4"
 			})
 
-			It("when changing CRI configuration from `nil` to `docker`", func() {
-				c.Shoot.Spec.Provider = gardencorev1beta1.Provider{Workers: []gardencorev1beta1.Worker{
-					{Name: "test-worker", CRI: &gardencorev1beta1.CRI{Name: gardencorev1beta1.CRINameDocker}}}}
-			})
-
 			It("when disabling node local dns via specification", func() {
 				c.Shoot.Spec.SystemComponents = &gardencorev1beta1.SystemComponents{NodeLocalDNS: &gardencorev1beta1.NodeLocalDNS{Enabled: false}}
 			})

--- a/pkg/apis/core/types_common.go
+++ b/pkg/apis/core/types_common.go
@@ -117,7 +117,7 @@ type LastOperation struct {
 
 // Gardener holds the information about the Gardener.
 type Gardener struct {
-	// ID is the Docker container id of the Gardener which last acted on a Shoot cluster.
+	// ID is the container id of the Gardener which last acted on a Shoot cluster.
 	ID string
 	// Name is the hostname (pod name) of the Gardener which last acted on a Shoot cluster.
 	Name string

--- a/pkg/apis/core/types_shoot.go
+++ b/pkg/apis/core/types_shoot.go
@@ -863,8 +863,13 @@ type KubeletConfig struct {
 	MaxPods *int32
 	// PodPIDsLimit is the maximum number of process IDs per pod allowed by the kubelet.
 	PodPIDsLimit *int64
+	// TODO(shafeeqes): Remove this field in gardener v1.89
+
 	// ImagePullProgressDeadline describes the time limit under which if no pulling progress is made, the image pulling will be cancelled.
 	// Default: 1m
+	// Only relevant for docker CRI.
+	//
+	// Deprecated: This field is deprecated and will be removed in Gardener release v1.89.
 	ImagePullProgressDeadline *metav1.Duration
 	// FailSwapOn makes the Kubelet fail to start if swap is enabled on the node. (default true).
 	FailSwapOn *bool
@@ -1215,8 +1220,6 @@ type CRIName string
 const (
 	// CRINameContainerD is a constant for ContainerD CRI name.
 	CRINameContainerD CRIName = "containerd"
-	// CRINameDocker is a constant for Docker CRI name.
-	CRINameDocker CRIName = "docker"
 )
 
 // ContainerRuntime contains information about worker's available container runtime

--- a/pkg/apis/core/v1beta1/defaults_cloudprofile.go
+++ b/pkg/apis/core/v1beta1/defaults_cloudprofile.go
@@ -33,7 +33,7 @@ func SetDefaults_MachineImageVersion(obj *MachineImageVersion) {
 	if len(obj.CRI) == 0 {
 		obj.CRI = []CRI{
 			{
-				Name: CRINameDocker,
+				Name: CRINameContainerD,
 			},
 		}
 	}

--- a/pkg/apis/core/v1beta1/defaults_cloudprofile_test.go
+++ b/pkg/apis/core/v1beta1/defaults_cloudprofile_test.go
@@ -52,7 +52,7 @@ var _ = Describe("CloudProfile defaulting", func() {
 
 			machineImageVersion := obj.Spec.MachineImages[0].Versions[0]
 			Expect(machineImageVersion.CRI).To(ConsistOf(
-				CRI{Name: "docker"},
+				CRI{Name: "containerd"},
 			))
 			Expect(machineImageVersion.Architectures).To(ConsistOf(
 				"amd64",

--- a/pkg/apis/core/v1beta1/generated.proto
+++ b/pkg/apis/core/v1beta1/generated.proto
@@ -877,7 +877,7 @@ message FailureTolerance {
 
 // Gardener holds the information about the Gardener version that operated a resource.
 message Gardener {
-  // ID is the Docker container id of the Gardener which last acted on a resource.
+  // ID is the container id of the Gardener which last acted on a resource.
   optional string id = 1;
 
   // Name is the hostname (pod name) of the Gardener which last acted on a resource.

--- a/pkg/apis/core/v1beta1/generated.proto
+++ b/pkg/apis/core/v1beta1/generated.proto
@@ -1247,6 +1247,9 @@ message KubeletConfig {
   // ImagePullProgressDeadline describes the time limit under which if no pulling progress is made, the image pulling will be cancelled.
   // +optional
   // Default: 1m
+  // Only relevant for docker CRI.
+  //
+  // Deprecated: This field is deprecated and will be removed in Gardener release v1.89.
   optional k8s.io.apimachinery.pkg.apis.meta.v1.Duration imagePullProgressDeadline = 12;
 
   // FailSwapOn makes the Kubelet fail to start if swap is enabled on the node. (default true).

--- a/pkg/apis/core/v1beta1/types_common.go
+++ b/pkg/apis/core/v1beta1/types_common.go
@@ -119,7 +119,7 @@ type LastOperation struct {
 
 // Gardener holds the information about the Gardener version that operated a resource.
 type Gardener struct {
-	// ID is the Docker container id of the Gardener which last acted on a resource.
+	// ID is the container id of the Gardener which last acted on a resource.
 	ID string `json:"id" protobuf:"bytes,1,opt,name=id"`
 	// Name is the hostname (pod name) of the Gardener which last acted on a resource.
 	Name string `json:"name" protobuf:"bytes,2,opt,name=name"`

--- a/pkg/apis/core/v1beta1/types_shoot.go
+++ b/pkg/apis/core/v1beta1/types_shoot.go
@@ -1098,9 +1098,14 @@ type KubeletConfig struct {
 	// PodPIDsLimit is the maximum number of process IDs per pod allowed by the kubelet.
 	// +optional
 	PodPIDsLimit *int64 `json:"podPidsLimit,omitempty" protobuf:"varint,11,opt,name=podPidsLimit"`
+	// TODO(shafeeqes): Remove this field in gardener v1.89
+
 	// ImagePullProgressDeadline describes the time limit under which if no pulling progress is made, the image pulling will be cancelled.
 	// +optional
 	// Default: 1m
+	// Only relevant for docker CRI.
+	//
+	// Deprecated: This field is deprecated and will be removed in Gardener release v1.89.
 	ImagePullProgressDeadline *metav1.Duration `json:"imagePullProgressDeadline,omitempty" protobuf:"bytes,12,opt,name=imagePullProgressDeadline"`
 	// FailSwapOn makes the Kubelet fail to start if swap is enabled on the node. (default true).
 	// +optional
@@ -1550,8 +1555,6 @@ type CRIName string
 const (
 	// CRINameContainerD is a constant for ContainerD CRI name.
 	CRINameContainerD CRIName = "containerd"
-	// CRINameDocker is a constant for Docker CRI name.
-	CRINameDocker CRIName = "docker"
 )
 
 // ContainerRuntime contains information about worker's available container runtime

--- a/pkg/apis/core/validation/cloudprofile.go
+++ b/pkg/apis/core/validation/cloudprofile.go
@@ -306,7 +306,7 @@ func validateContainerRuntimesInterfaces(cris []core.CRI, fldPath *field.Path) f
 		duplicateCRI.Insert(string(cri.Name))
 
 		if !availableWorkerCRINames.Has(string(cri.Name)) {
-			allErrs = append(allErrs, field.NotSupported(criPath, cri, sets.List(availableWorkerCRINames)))
+			allErrs = append(allErrs, field.NotSupported(criPath.Child("name"), string(cri.Name), sets.List(availableWorkerCRINames)))
 		}
 		allErrs = append(allErrs, validateContainerRuntimes(cri.ContainerRuntimes, criPath.Child("containerRuntimes"))...)
 	}

--- a/pkg/apis/core/validation/cloudprofile.go
+++ b/pkg/apis/core/validation/cloudprofile.go
@@ -33,11 +33,6 @@ import (
 )
 
 var (
-	availableWorkerCRINamesForCloudProfile = sets.New(
-		string(core.CRINameDocker),
-		string(core.CRINameContainerD),
-	)
-
 	availableUpdateStrategiesForMachineImage = sets.New(
 		string(core.UpdateStrategyPatch),
 		string(core.UpdateStrategyMinor),
@@ -293,9 +288,10 @@ func validateMachineImages(machineImages []core.MachineImage, fldPath *field.Pat
 }
 
 func validateContainerRuntimesInterfaces(cris []core.CRI, fldPath *field.Path) field.ErrorList {
-	allErrs := field.ErrorList{}
-	duplicateCRI := sets.Set[string]{}
-	hasDocker := false
+	var (
+		allErrs      = field.ErrorList{}
+		duplicateCRI = sets.Set[string]{}
+	)
 
 	if len(cris) == 0 {
 		allErrs = append(allErrs, field.Required(fldPath, "must provide at least one supported container runtime"))
@@ -309,19 +305,10 @@ func validateContainerRuntimesInterfaces(cris []core.CRI, fldPath *field.Path) f
 		}
 		duplicateCRI.Insert(string(cri.Name))
 
-		if cri.Name == core.CRINameDocker {
-			hasDocker = true
-		}
-
-		if !availableWorkerCRINamesForCloudProfile.Has(string(cri.Name)) {
-			allErrs = append(allErrs, field.NotSupported(criPath, cri, sets.List(availableWorkerCRINamesForCloudProfile)))
+		if !availableWorkerCRINames.Has(string(cri.Name)) {
+			allErrs = append(allErrs, field.NotSupported(criPath, cri, sets.List(availableWorkerCRINames)))
 		}
 		allErrs = append(allErrs, validateContainerRuntimes(cri.ContainerRuntimes, criPath.Child("containerRuntimes"))...)
-	}
-
-	// TODO(shafeeqes): Remove this once https://github.com/gardener/gardener/issues/4673 is resolved.
-	if !hasDocker {
-		allErrs = append(allErrs, field.Invalid(fldPath, cris, "must provide docker as supported container runtime"))
 	}
 
 	return allErrs

--- a/pkg/apis/core/validation/cloudprofile_test.go
+++ b/pkg/apis/core/validation/cloudprofile_test.go
@@ -206,7 +206,7 @@ var _ = Describe("CloudProfile Validation Tests ", func() {
 										ExpirableVersion: core.ExpirableVersion{
 											Version: "1.2.3",
 										},
-										CRI: []core.CRI{{Name: "docker"}},
+										CRI: []core.CRI{{Name: "containerd"}},
 									},
 								},
 							},
@@ -412,7 +412,7 @@ var _ = Describe("CloudProfile Validation Tests ", func() {
 										Version:        "3.4.6",
 										Classification: &supportedClassification,
 									},
-									CRI: []core.CRI{{Name: "docker"}},
+									CRI: []core.CRI{{Name: "containerd"}},
 								},
 							},
 						},
@@ -424,7 +424,7 @@ var _ = Describe("CloudProfile Validation Tests ", func() {
 										Version:        "3.4.5",
 										Classification: &previewClassification,
 									},
-									CRI: []core.CRI{{Name: "docker"}},
+									CRI: []core.CRI{{Name: "containerd"}},
 								},
 							},
 						},
@@ -465,7 +465,7 @@ var _ = Describe("CloudProfile Validation Tests ", func() {
 										Version:        "3.4.6",
 										Classification: &supportedClassification,
 									},
-									CRI: []core.CRI{{Name: "docker"}},
+									CRI: []core.CRI{{Name: "containerd"}},
 								},
 							},
 							UpdateStrategy: &updateStrategy,
@@ -491,7 +491,7 @@ var _ = Describe("CloudProfile Validation Tests ", func() {
 										Version:        "3.4.6",
 										Classification: &supportedClassification,
 									},
-									CRI: []core.CRI{{Name: "docker"}},
+									CRI: []core.CRI{{Name: "containerd"}},
 								},
 							},
 							UpdateStrategy: &updateStrategy,
@@ -513,7 +513,7 @@ var _ = Describe("CloudProfile Validation Tests ", func() {
 										Version:        "0.1.2",
 										Classification: &supportedClassification,
 									},
-									CRI: []core.CRI{{Name: "docker"}},
+									CRI: []core.CRI{{Name: "containerd"}},
 								},
 							},
 						},
@@ -525,7 +525,7 @@ var _ = Describe("CloudProfile Validation Tests ", func() {
 										Version:        "a.b.c",
 										Classification: &supportedClassification,
 									},
-									CRI: []core.CRI{{Name: "docker"}},
+									CRI: []core.CRI{{Name: "containerd"}},
 								},
 							},
 						},
@@ -554,14 +554,14 @@ var _ = Describe("CloudProfile Validation Tests ", func() {
 										ExpirationDate: expirationDate,
 										Classification: &previewClassification,
 									},
-									CRI: []core.CRI{{Name: "docker"}},
+									CRI: []core.CRI{{Name: "containerd"}},
 								},
 								{
 									ExpirableVersion: core.ExpirableVersion{
 										Version:        "0.1.1",
 										Classification: &supportedClassification,
 									},
-									CRI: []core.CRI{{Name: "docker"}},
+									CRI: []core.CRI{{Name: "containerd"}},
 								},
 							},
 						},
@@ -574,7 +574,7 @@ var _ = Describe("CloudProfile Validation Tests ", func() {
 										ExpirationDate: expirationDate,
 										Classification: &supportedClassification,
 									},
-									CRI: []core.CRI{{Name: "docker"}},
+									CRI: []core.CRI{{Name: "containerd"}},
 								},
 							},
 						},
@@ -595,7 +595,7 @@ var _ = Describe("CloudProfile Validation Tests ", func() {
 										Version:        "0.1.2",
 										Classification: &classification,
 									},
-									CRI: []core.CRI{{Name: "docker"}},
+									CRI: []core.CRI{{Name: "containerd"}},
 								},
 							},
 						},
@@ -618,21 +618,21 @@ var _ = Describe("CloudProfile Validation Tests ", func() {
 									ExpirableVersion: core.ExpirableVersion{
 										Version: "0.1.2",
 									},
-									CRI:           []core.CRI{{Name: "docker"}},
+									CRI:           []core.CRI{{Name: "containerd"}},
 									Architectures: []string{"amd64", "arm64"},
 								},
 								{
 									ExpirableVersion: core.ExpirableVersion{
 										Version: "0.1.3",
 									},
-									CRI:           []core.CRI{{Name: "docker"}},
+									CRI:           []core.CRI{{Name: "containerd"}},
 									Architectures: []string{"amd64"},
 								},
 								{
 									ExpirableVersion: core.ExpirableVersion{
 										Version: "0.1.4",
 									},
-									CRI:           []core.CRI{{Name: "docker"}},
+									CRI:           []core.CRI{{Name: "containerd"}},
 									Architectures: []string{"arm64"},
 								},
 							},
@@ -652,7 +652,7 @@ var _ = Describe("CloudProfile Validation Tests ", func() {
 									ExpirableVersion: core.ExpirableVersion{
 										Version: "0.1.2",
 									},
-									CRI:           []core.CRI{{Name: "docker"}},
+									CRI:           []core.CRI{{Name: "containerd"}},
 									Architectures: []string{"foo"},
 								},
 							},
@@ -675,14 +675,14 @@ var _ = Describe("CloudProfile Validation Tests ", func() {
 									ExpirableVersion: core.ExpirableVersion{
 										Version: "0.1.2",
 									},
-									CRI:                      []core.CRI{{Name: "docker"}},
+									CRI:                      []core.CRI{{Name: "containerd"}},
 									KubeletVersionConstraint: ptr.To("< 1.26"),
 								},
 								{
 									ExpirableVersion: core.ExpirableVersion{
 										Version: "0.1.3",
 									},
-									CRI:                      []core.CRI{{Name: "docker"}},
+									CRI:                      []core.CRI{{Name: "containerd"}},
 									KubeletVersionConstraint: ptr.To(">= 1.26"),
 								},
 							},
@@ -702,14 +702,14 @@ var _ = Describe("CloudProfile Validation Tests ", func() {
 									ExpirableVersion: core.ExpirableVersion{
 										Version: "0.1.2",
 									},
-									CRI:                      []core.CRI{{Name: "docker"}},
+									CRI:                      []core.CRI{{Name: "containerd"}},
 									KubeletVersionConstraint: ptr.To(""),
 								},
 								{
 									ExpirableVersion: core.ExpirableVersion{
 										Version: "0.1.3",
 									},
-									CRI:                      []core.CRI{{Name: "docker"}},
+									CRI:                      []core.CRI{{Name: "containerd"}},
 									KubeletVersionConstraint: ptr.To("invalid-version"),
 								},
 							},
@@ -737,21 +737,6 @@ var _ = Describe("CloudProfile Validation Tests ", func() {
 
 				Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":  Equal(field.ErrorTypeRequired),
-					"Field": Equal("spec.machineImages[0].versions[0].cri"),
-				}))))
-			})
-
-			It("should forbid if docker container runtime interface not present", func() {
-				cloudProfile.Spec.MachineImages[0].Versions[0].CRI = []core.CRI{
-					{
-						Name: core.CRINameContainerD,
-					},
-				}
-
-				errorList := ValidateCloudProfile(cloudProfile)
-
-				Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":  Equal(field.ErrorTypeInvalid),
 					"Field": Equal("spec.machineImages[0].versions[0].cri"),
 				}))))
 			})
@@ -787,9 +772,6 @@ var _ = Describe("CloudProfile Validation Tests ", func() {
 									{
 										Name: core.CRINameContainerD,
 									},
-									{
-										Name: "docker",
-									},
 								},
 							},
 						},
@@ -801,7 +783,11 @@ var _ = Describe("CloudProfile Validation Tests ", func() {
 				Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":  Equal(field.ErrorTypeNotSupported),
 					"Field": Equal("spec.machineImages[0].versions[0].cri[0]"),
-				}))))
+				})), PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeNotSupported),
+					"Field": Equal("spec.machineImages[0].versions[0].cri[1]"),
+				})),
+				))
 			})
 
 			It("should forbid duplicated container runtime interface names", func() {
@@ -811,9 +797,6 @@ var _ = Describe("CloudProfile Validation Tests ", func() {
 					},
 					{
 						Name: core.CRINameContainerD,
-					},
-					{
-						Name: "docker",
 					},
 				}
 
@@ -837,9 +820,6 @@ var _ = Describe("CloudProfile Validation Tests ", func() {
 								Type: "cr1",
 							},
 						},
-					},
-					{
-						Name: "docker",
 					},
 				}
 
@@ -1061,7 +1041,7 @@ var _ = Describe("CloudProfile Validation Tests ", func() {
 										Version:        "1.2.3",
 										Classification: &supportedClassification,
 									},
-									CRI: []core.CRI{{Name: "docker"}},
+									CRI: []core.CRI{{Name: "containerd"}},
 								},
 							},
 						},
@@ -1112,7 +1092,7 @@ var _ = Describe("CloudProfile Validation Tests ", func() {
 							Version:        "2135.6.2",
 							Classification: &deprecatedClassification,
 						},
-						CRI: []core.CRI{{Name: "docker"}},
+						CRI: []core.CRI{{Name: "containerd"}},
 					},
 					{
 						ExpirableVersion: core.ExpirableVersion{
@@ -1120,7 +1100,7 @@ var _ = Describe("CloudProfile Validation Tests ", func() {
 							Classification: &deprecatedClassification,
 							ExpirationDate: dateInThePast,
 						},
-						CRI: []core.CRI{{Name: "docker"}},
+						CRI: []core.CRI{{Name: "containerd"}},
 					},
 					{
 						ExpirableVersion: core.ExpirableVersion{
@@ -1128,7 +1108,7 @@ var _ = Describe("CloudProfile Validation Tests ", func() {
 							Classification: &deprecatedClassification,
 							ExpirationDate: dateInThePast,
 						},
-						CRI: []core.CRI{{Name: "docker"}},
+						CRI: []core.CRI{{Name: "containerd"}},
 					},
 				}
 				cloudProfileNew.Spec.MachineImages[0].Versions = versions[0:1]

--- a/pkg/apis/core/validation/cloudprofile_test.go
+++ b/pkg/apis/core/validation/cloudprofile_test.go
@@ -781,11 +781,13 @@ var _ = Describe("CloudProfile Validation Tests ", func() {
 				errorList := ValidateCloudProfile(cloudProfile)
 
 				Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":  Equal(field.ErrorTypeNotSupported),
-					"Field": Equal("spec.machineImages[0].versions[0].cri[0]"),
+					"Type":   Equal(field.ErrorTypeNotSupported),
+					"Field":  Equal("spec.machineImages[0].versions[0].cri[0].name"),
+					"Detail": Equal("supported values: \"containerd\""),
 				})), PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":  Equal(field.ErrorTypeNotSupported),
-					"Field": Equal("spec.machineImages[0].versions[0].cri[1]"),
+					"Type":   Equal(field.ErrorTypeNotSupported),
+					"Field":  Equal("spec.machineImages[0].versions[0].cri[1].name"),
+					"Detail": Equal("supported values: \"containerd\""),
 				})),
 				))
 			})

--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -2179,7 +2179,7 @@ func ValidateCRI(CRI *core.CRI, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	if !availableWorkerCRINames.Has(string(CRI.Name)) {
-		allErrs = append(allErrs, field.NotSupported(fldPath.Child("name"), CRI.Name, sets.List(availableWorkerCRINames)))
+		allErrs = append(allErrs, field.NotSupported(fldPath.Child("name"), string(CRI.Name), sets.List(availableWorkerCRINames)))
 	}
 
 	if CRI.ContainerRuntimes != nil {

--- a/pkg/apis/extensions/v1alpha1/types_operatingsystemconfig.go
+++ b/pkg/apis/extensions/v1alpha1/types_operatingsystemconfig.go
@@ -273,8 +273,6 @@ type CRIName string
 const (
 	// CRINameContainerD is a constant for ContainerD CRI name
 	CRINameContainerD CRIName = "containerd"
-	// CRINameDocker is a constant for Docker CRI name
-	CRINameDocker CRIName = "docker"
 )
 
 // ContainerDRuntimeContainersBinFolder is the folder where Container Runtime binaries should be saved for ContainerD usage

--- a/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig.go
+++ b/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig.go
@@ -484,7 +484,7 @@ func (o *operatingSystemConfig) WorkerNameToOperatingSystemConfigsMap() map[stri
 }
 
 func (o *operatingSystemConfig) newDeployer(osc *extensionsv1alpha1.OperatingSystemConfig, worker gardencorev1beta1.Worker, purpose extensionsv1alpha1.OperatingSystemConfigPurpose) (deployer, error) {
-	criName := extensionsv1alpha1.CRINameDocker
+	criName := extensionsv1alpha1.CRINameContainerD
 	if worker.CRI != nil {
 		criName = extensionsv1alpha1.CRIName(worker.CRI.Name)
 	}
@@ -827,7 +827,7 @@ func key(prefix string, workerName string, kubernetesVersion *semver.Version, cr
 		criName                     gardencorev1beta1.CRIName
 	)
 
-	if criConfig != nil && criConfig.Name != gardencorev1beta1.CRINameDocker {
+	if criConfig != nil {
 		criName = criConfig.Name
 	}
 

--- a/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig_test.go
@@ -189,7 +189,7 @@ var _ = Describe("OperatingSystemConfig", func() {
 			expected := make([]*extensionsv1alpha1.OperatingSystemConfig, 0, 2*len(workers))
 			for _, worker := range workers {
 				var (
-					criName   = extensionsv1alpha1.CRINameDocker
+					criName   = extensionsv1alpha1.CRINameContainerD
 					criConfig *extensionsv1alpha1.CRIConfig
 				)
 
@@ -1081,14 +1081,8 @@ var _ = Describe("OperatingSystemConfig", func() {
 
 		It("is different for different worker.cri configurations", func() {
 			containerDKey := Key(workerName, semver.MustParse("1.2.3"), &gardencorev1beta1.CRI{Name: gardencorev1beta1.CRINameContainerD})
-			dockerKey := Key(workerName, semver.MustParse("1.2.3"), &gardencorev1beta1.CRI{Name: gardencorev1beta1.CRINameDocker})
-			Expect(containerDKey).NotTo(Equal(dockerKey))
-		})
-
-		It("is the same for `cri=nil` and `cri.name=docker`", func() {
-			dockerKey := Key(workerName, semver.MustParse("1.2.3"), &gardencorev1beta1.CRI{Name: gardencorev1beta1.CRINameDocker})
-			nilKey := Key(workerName, semver.MustParse("1.2.3"), nil)
-			Expect(dockerKey).To(Equal(nilKey))
+			otherKey := Key(workerName, semver.MustParse("1.2.3"), &gardencorev1beta1.CRI{Name: gardencorev1beta1.CRIName("other")})
+			Expect(containerDKey).NotTo(Equal(otherKey))
 		})
 	})
 
@@ -1108,14 +1102,8 @@ var _ = Describe("OperatingSystemConfig", func() {
 
 		It("is different for different worker.cri configurations", func() {
 			containerDKey := Key(workerName, semver.MustParse("1.2.3"), &gardencorev1beta1.CRI{Name: gardencorev1beta1.CRINameContainerD})
-			dockerKey := Key(workerName, semver.MustParse("1.2.3"), &gardencorev1beta1.CRI{Name: gardencorev1beta1.CRINameDocker})
-			Expect(containerDKey).NotTo(Equal(dockerKey))
-		})
-
-		It("is the same for `cri=nil` and `cri.name=docker`", func() {
-			dockerKey := Key(workerName, semver.MustParse("1.2.3"), &gardencorev1beta1.CRI{Name: gardencorev1beta1.CRINameDocker})
-			nilKey := Key(workerName, semver.MustParse("1.2.3"), nil)
-			Expect(dockerKey).To(Equal(nilKey))
+			otherKey := Key(workerName, semver.MustParse("1.2.3"), &gardencorev1beta1.CRI{Name: gardencorev1beta1.CRIName("other")})
+			Expect(containerDKey).NotTo(Equal(otherKey))
 		})
 	})
 })

--- a/pkg/component/extensions/operatingsystemconfig/original/components/kubelet.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/kubelet.go
@@ -23,20 +23,12 @@ import (
 )
 
 // ConfigurableKubeletCLIFlags is the set of configurable kubelet command line parameters.
-type ConfigurableKubeletCLIFlags struct {
-	ImagePullProgressDeadline *metav1.Duration
-}
+type ConfigurableKubeletCLIFlags struct{}
 
 // KubeletCLIFlagsFromCoreV1beta1KubeletConfig computes the ConfigurableKubeletCLIFlags based on the provided
 // gardencorev1beta1.KubeletConfig.
-func KubeletCLIFlagsFromCoreV1beta1KubeletConfig(kubeletConfig *gardencorev1beta1.KubeletConfig) ConfigurableKubeletCLIFlags {
-	var out ConfigurableKubeletCLIFlags
-
-	if kubeletConfig != nil {
-		out.ImagePullProgressDeadline = kubeletConfig.ImagePullProgressDeadline
-	}
-
-	return out
+func KubeletCLIFlagsFromCoreV1beta1KubeletConfig(_ *gardencorev1beta1.KubeletConfig) ConfigurableKubeletCLIFlags {
+	return ConfigurableKubeletCLIFlags{}
 }
 
 // ConfigurableKubeletConfigParameters is the set of configurable kubelet config parameters.

--- a/pkg/component/extensions/operatingsystemconfig/original/components/kubelet/cliflags.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/kubelet/cliflags.go
@@ -17,22 +17,19 @@ package kubelet
 import (
 	"fmt"
 	"slices"
-	"time"
 
 	"github.com/Masterminds/semver/v3"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/original/components"
 	"github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/original/components/containerd"
-	"github.com/gardener/gardener/pkg/utils/imagevector"
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	versionutils "github.com/gardener/gardener/pkg/utils/version"
 )
 
 // CLIFlags returns a list of kubelet CLI flags based on the provided parameters and for the provided Kubernetes version.
-func CLIFlags(kubernetesVersion *semver.Version, nodeLabels map[string]string, criName extensionsv1alpha1.CRIName, image *imagevector.Image, cliFlags components.ConfigurableKubeletCLIFlags, preferIPv6 bool) []string {
+func CLIFlags(kubernetesVersion *semver.Version, nodeLabels map[string]string, criName extensionsv1alpha1.CRIName, cliFlags components.ConfigurableKubeletCLIFlags, preferIPv6 bool) []string {
 	setCLIFlagsDefaults(&cliFlags)
 
 	var flags []string
@@ -53,15 +50,6 @@ func CLIFlags(kubernetesVersion *semver.Version, nodeLabels map[string]string, c
 		if versionutils.ConstraintK8sLess127.Check(kubernetesVersion) {
 			flags = append(flags, "--container-runtime=remote")
 		}
-	} else if criName == extensionsv1alpha1.CRINameDocker {
-		flags = append(flags,
-			"--network-plugin=cni",
-			"--cni-bin-dir=/opt/cni/bin/",
-			"--cni-conf-dir=/etc/cni/net.d/",
-			fmt.Sprintf("--image-pull-progress-deadline=%s", cliFlags.ImagePullProgressDeadline.Duration.String()))
-		if image != nil {
-			flags = append(flags, "--pod-infra-container-image="+image.String())
-		}
 	}
 
 	flags = append(flags, "--v=2")
@@ -73,10 +61,7 @@ func CLIFlags(kubernetesVersion *semver.Version, nodeLabels map[string]string, c
 	return flags
 }
 
-func setCLIFlagsDefaults(f *components.ConfigurableKubeletCLIFlags) {
-	if f.ImagePullProgressDeadline == nil {
-		f.ImagePullProgressDeadline = &metav1.Duration{Duration: time.Minute}
-	}
+func setCLIFlagsDefaults(_ *components.ConfigurableKubeletCLIFlags) {
 }
 
 func nodeLabelFlags(nodeLabels map[string]string) []string {

--- a/pkg/component/extensions/operatingsystemconfig/original/components/kubelet/cliflags_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/kubelet/cliflags_test.go
@@ -15,13 +15,10 @@
 package kubelet_test
 
 import (
-	"time"
-
 	"github.com/Masterminds/semver/v3"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	gomegatypes "github.com/onsi/gomega/types"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
@@ -51,36 +48,11 @@ var _ = Describe("CLIFlags", func() {
 				"worker.gardener.cloud/pool":                    "worker", // allowed
 				"containerruntime.worker.gardener.cloud/gvisor": "true",   // allowed
 			}
-			Expect(kubelet.CLIFlags(v, nodeLabels, criName, image, cliFlags, preferIPv6)).To(matcher)
+			Expect(kubelet.CLIFlags(v, nodeLabels, criName, cliFlags, preferIPv6)).To(matcher)
 		},
 
 		Entry(
-			"kubernetes 1.26 w/ docker, w/ imagePullProgressDeadline",
-			"1.26.6",
-			extensionsv1alpha1.CRINameDocker,
-			image,
-			components.ConfigurableKubeletCLIFlags{ImagePullProgressDeadline: &metav1.Duration{Duration: 2 * time.Minute}},
-			false,
-			ConsistOf(
-				"--bootstrap-kubeconfig=/var/lib/kubelet/kubeconfig-bootstrap",
-				"--config=/var/lib/kubelet/config/kubelet",
-				"--cni-bin-dir=/opt/cni/bin/",
-				"--cni-conf-dir=/etc/cni/net.d/",
-				"--image-pull-progress-deadline=2m0s",
-				"--kubeconfig=/var/lib/kubelet/kubeconfig-real",
-				"--node-labels=worker.gardener.cloud/kubernetes-version=1.26.6",
-				"--node-labels=containerruntime.worker.gardener.cloud/gvisor=true",
-				"--node-labels=kubernetes.io/arch=amd64",
-				"--node-labels=test=foo",
-				"--node-labels=test2=bar",
-				"--node-labels=worker.gardener.cloud/pool=worker",
-				"--network-plugin=cni",
-				"--pod-infra-container-image=foo.io/hyperkube:version",
-				"--v=2",
-			),
-		),
-		Entry(
-			"kubernetes 1.26 w/ containerd, w/o imagePullProgressDeadline",
+			"kubernetes 1.26 w/ containerd",
 			"1.26.6",
 			extensionsv1alpha1.CRINameContainerD,
 			image,
@@ -103,7 +75,7 @@ var _ = Describe("CLIFlags", func() {
 			),
 		),
 		Entry(
-			"kubernetes 1.27 w/ containerd, w/o imagePullProgressDeadline",
+			"kubernetes 1.27 w/ containerd",
 			"1.27.0",
 			extensionsv1alpha1.CRINameContainerD,
 			image,
@@ -125,7 +97,7 @@ var _ = Describe("CLIFlags", func() {
 			),
 		),
 		Entry(
-			"kubernetes 1.27 w/ containerd, w/o imagePullProgressDeadline",
+			"kubernetes 1.27 w/ containerd",
 			"1.27.0",
 			extensionsv1alpha1.CRINameContainerD,
 			image,

--- a/pkg/component/extensions/operatingsystemconfig/original/components/kubelet/cliflags_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/kubelet/cliflags_test.go
@@ -19,23 +19,15 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	gomegatypes "github.com/onsi/gomega/types"
-	"k8s.io/utils/ptr"
 
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/original/components"
 	"github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/original/components/kubelet"
-	"github.com/gardener/gardener/pkg/utils/imagevector"
 )
 
 var _ = Describe("CLIFlags", func() {
-	image := &imagevector.Image{
-		Name:       "hyperkube",
-		Repository: "foo.io/hyperkube",
-		Tag:        ptr.To("version"),
-	}
-
 	DescribeTable("#CLIFlags",
-		func(kubernetesVersion string, criName extensionsv1alpha1.CRIName, image *imagevector.Image, cliFlags components.ConfigurableKubeletCLIFlags, preferIPv6 bool, matcher gomegatypes.GomegaMatcher) {
+		func(kubernetesVersion string, criName extensionsv1alpha1.CRIName, cliFlags components.ConfigurableKubeletCLIFlags, preferIPv6 bool, matcher gomegatypes.GomegaMatcher) {
 			v := semver.MustParse(kubernetesVersion)
 			nodeLabels := map[string]string{
 				"test":  "foo",
@@ -55,7 +47,6 @@ var _ = Describe("CLIFlags", func() {
 			"kubernetes 1.26 w/ containerd",
 			"1.26.6",
 			extensionsv1alpha1.CRINameContainerD,
-			image,
 			components.ConfigurableKubeletCLIFlags{},
 			false,
 			ConsistOf(
@@ -78,7 +69,6 @@ var _ = Describe("CLIFlags", func() {
 			"kubernetes 1.27 w/ containerd",
 			"1.27.0",
 			extensionsv1alpha1.CRINameContainerD,
-			image,
 			components.ConfigurableKubeletCLIFlags{},
 			false,
 			ConsistOf(
@@ -97,10 +87,9 @@ var _ = Describe("CLIFlags", func() {
 			),
 		),
 		Entry(
-			"kubernetes 1.27 w/ containerd",
+			"kubernetes 1.27 w/ containerd w/ preferIPv6",
 			"1.27.0",
 			extensionsv1alpha1.CRINameContainerD,
-			image,
 			components.ConfigurableKubeletCLIFlags{},
 			true,
 			ConsistOf(

--- a/pkg/component/extensions/operatingsystemconfig/original/components/kubelet/component.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/kubelet/component.go
@@ -113,7 +113,7 @@ func (component) Config(ctx components.Context) ([]extensionsv1alpha1.Unit, []ex
 		return nil, nil, err
 	}
 
-	cliFlags := CLIFlags(ctx.KubernetesVersion, ctx.NodeLabels, ctx.CRIName, ctx.Images[imagevector.ImageNamePauseContainer], ctx.KubeletCLIFlags, ctx.PreferIPv6)
+	cliFlags := CLIFlags(ctx.KubernetesVersion, ctx.NodeLabels, ctx.CRIName, ctx.KubeletCLIFlags, ctx.PreferIPv6)
 
 	if !features.DefaultFeatureGate.Enabled(features.UseGardenerNodeAgent) {
 		kubeletStartPre = `

--- a/pkg/component/extensions/operatingsystemconfig/original/components/kubelet/component_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/kubelet/component_test.go
@@ -70,7 +70,7 @@ var _ = Describe("Component", func() {
 			}
 			ctx.PreferIPv6 = preferIPv6
 
-			cliFlags := CLIFlags(ctx.KubernetesVersion, ctx.NodeLabels, ctx.CRIName, ctx.Images["pause-container"], ctx.KubeletCLIFlags, ctx.PreferIPv6)
+			cliFlags := CLIFlags(ctx.KubernetesVersion, ctx.NodeLabels, ctx.CRIName, ctx.KubeletCLIFlags, ctx.PreferIPv6)
 			units, files, err := component.Config(ctx)
 
 			Expect(err).NotTo(HaveOccurred())

--- a/pkg/controllermanager/controller/shoot/maintenance/reconciler.go
+++ b/pkg/controllermanager/controller/shoot/maintenance/reconciler.go
@@ -620,7 +620,7 @@ func filterForArchitecture(machineImageFromCloudProfile *gardencorev1beta1.Machi
 
 func filterForCRI(machineImageFromCloudProfile *gardencorev1beta1.MachineImage, workerCRI *gardencorev1beta1.CRI) *gardencorev1beta1.MachineImage {
 	if workerCRI == nil {
-		return filterForCRI(machineImageFromCloudProfile, &gardencorev1beta1.CRI{Name: gardencorev1beta1.CRINameDocker})
+		return filterForCRI(machineImageFromCloudProfile, &gardencorev1beta1.CRI{Name: gardencorev1beta1.CRINameContainerD})
 	}
 
 	filteredMachineImages := gardencorev1beta1.MachineImage{

--- a/pkg/controllermanager/controller/shoot/maintenance/reconciler_test.go
+++ b/pkg/controllermanager/controller/shoot/maintenance/reconciler_test.go
@@ -863,6 +863,14 @@ var _ = Describe("Shoot Maintenance", func() {
 			})
 		})
 
+		It("should treat workers with `cri: nil` like `cri.name: containerd` and not update if `containerd` is not explicitly supported by the machine image", func() {
+			cloudProfile.Spec.MachineImages[0].Versions[1].CRI = []gardencorev1beta1.CRI{{Name: gardencorev1beta1.CRIName("other")}}
+
+			_, err := maintainMachineImages(log, shoot, cloudProfile)
+			Expect(err).NotTo(HaveOccurred())
+			assertWorkerMachineImageVersion(&shoot.Spec.Provider.Workers[0], "CoreOs", "1.0.0")
+		})
+
 		It("should determine that the shoot worker machine images must NOT to be maintained - ForceUpdate not required & MaintenanceAutoUpdate set to false", func() {
 			shoot.Spec.Maintenance.AutoUpdate.MachineImageVersion = ptr.To(false)
 

--- a/pkg/controllermanager/controller/shoot/maintenance/reconciler_test.go
+++ b/pkg/controllermanager/controller/shoot/maintenance/reconciler_test.go
@@ -88,7 +88,7 @@ var _ = Describe("Shoot Maintenance", func() {
 									ExpirableVersion: gardencorev1beta1.ExpirableVersion{
 										Version: shootCurrentImageVersion,
 									},
-									CRI:           []gardencorev1beta1.CRI{{Name: gardencorev1beta1.CRINameDocker}},
+									CRI:           []gardencorev1beta1.CRI{{Name: gardencorev1beta1.CRINameContainerD}},
 									Architectures: []string{"amd64"},
 								},
 								{
@@ -96,7 +96,7 @@ var _ = Describe("Shoot Maintenance", func() {
 										Version:        overallLatestVersion,
 										ExpirationDate: &expirationDateInTheFuture,
 									},
-									CRI:           []gardencorev1beta1.CRI{{Name: gardencorev1beta1.CRINameDocker}},
+									CRI:           []gardencorev1beta1.CRI{{Name: gardencorev1beta1.CRINameContainerD}},
 									Architectures: []string{"amd64"},
 								},
 							},
@@ -159,7 +159,7 @@ var _ = Describe("Shoot Maintenance", func() {
 						Version:        expectedVersion,
 						ExpirationDate: &expirationDateInTheFuture,
 					},
-					CRI:           []gardencorev1beta1.CRI{{Name: gardencorev1beta1.CRINameDocker}},
+					CRI:           []gardencorev1beta1.CRI{{Name: gardencorev1beta1.CRINameContainerD}},
 					Architectures: []string{"arm64"},
 				})
 
@@ -169,7 +169,7 @@ var _ = Describe("Shoot Maintenance", func() {
 						Version:        "1.7.1",
 						ExpirationDate: &expirationDateInTheFuture,
 					},
-					CRI:           []gardencorev1beta1.CRI{{Name: gardencorev1beta1.CRINameDocker}},
+					CRI:           []gardencorev1beta1.CRI{{Name: gardencorev1beta1.CRINameContainerD}},
 					Architectures: []string{"amd64"},
 				})
 
@@ -193,14 +193,14 @@ var _ = Describe("Shoot Maintenance", func() {
 							ExpirableVersion: gardencorev1beta1.ExpirableVersion{
 								Version: "1.0.0",
 							},
-							CRI:           []gardencorev1beta1.CRI{{Name: gardencorev1beta1.CRINameDocker}},
+							CRI:           []gardencorev1beta1.CRI{{Name: gardencorev1beta1.CRINameContainerD}},
 							Architectures: []string{"amd64"},
 						},
 						{
 							ExpirableVersion: gardencorev1beta1.ExpirableVersion{
 								Version: expectedVersionGLWorker,
 							},
-							CRI:           []gardencorev1beta1.CRI{{Name: gardencorev1beta1.CRINameDocker}},
+							CRI:           []gardencorev1beta1.CRI{{Name: gardencorev1beta1.CRINameContainerD}},
 							Architectures: []string{"amd64"},
 						},
 					},
@@ -233,7 +233,7 @@ var _ = Describe("Shoot Maintenance", func() {
 						Version: expectedVersion,
 					},
 					Architectures: []string{"amd64"},
-					CRI:           []gardencorev1beta1.CRI{{Name: gardencorev1beta1.CRINameDocker}},
+					CRI:           []gardencorev1beta1.CRI{{Name: gardencorev1beta1.CRINameContainerD}},
 				}
 
 				cloudProfile.Spec.MachineImages[0].Versions = append(cloudProfile.Spec.MachineImages[0].Versions, highestForMinor)
@@ -268,7 +268,7 @@ var _ = Describe("Shoot Maintenance", func() {
 									Version:        "1.1.1",
 									ExpirationDate: &expirationDateInTheFuture,
 								},
-								CRI:           []gardencorev1beta1.CRI{{Name: gardencorev1beta1.CRINameDocker}},
+								CRI:           []gardencorev1beta1.CRI{{Name: gardencorev1beta1.CRINameContainerD}},
 								Architectures: []string{"amd64"},
 							},
 							{
@@ -276,7 +276,7 @@ var _ = Describe("Shoot Maintenance", func() {
 									Version:        expectedVersion,
 									ExpirationDate: &expirationDateInTheFuture,
 								},
-								CRI:           []gardencorev1beta1.CRI{{Name: gardencorev1beta1.CRINameDocker}},
+								CRI:           []gardencorev1beta1.CRI{{Name: gardencorev1beta1.CRINameContainerD}},
 								Architectures: []string{"amd64"},
 							},
 						},
@@ -333,7 +333,7 @@ var _ = Describe("Shoot Maintenance", func() {
 						Version: expectedVersion,
 					},
 					Architectures: []string{"amd64"},
-					CRI:           []gardencorev1beta1.CRI{{Name: gardencorev1beta1.CRINameDocker}},
+					CRI:           []gardencorev1beta1.CRI{{Name: gardencorev1beta1.CRINameContainerD}},
 				}
 
 				versions := []gardencorev1beta1.MachineImageVersion{cloudProfile.Spec.MachineImages[0].Versions[0]}
@@ -366,7 +366,7 @@ var _ = Describe("Shoot Maintenance", func() {
 									Version:        "2.1.0",
 									ExpirationDate: &expirationDateInTheFuture,
 								},
-								CRI:           []gardencorev1beta1.CRI{{Name: gardencorev1beta1.CRINameDocker}},
+								CRI:           []gardencorev1beta1.CRI{{Name: gardencorev1beta1.CRINameContainerD}},
 								Architectures: []string{"amd64"},
 							},
 							{
@@ -374,7 +374,7 @@ var _ = Describe("Shoot Maintenance", func() {
 									Version:        expectedVersion,
 									ExpirationDate: &expirationDateInTheFuture,
 								},
-								CRI:           []gardencorev1beta1.CRI{{Name: gardencorev1beta1.CRINameDocker}},
+								CRI:           []gardencorev1beta1.CRI{{Name: gardencorev1beta1.CRINameContainerD}},
 								Architectures: []string{"amd64"},
 							},
 							{
@@ -382,7 +382,7 @@ var _ = Describe("Shoot Maintenance", func() {
 									Version:        "1.2.0",
 									ExpirationDate: &expirationDateInTheFuture,
 								},
-								CRI:           []gardencorev1beta1.CRI{{Name: gardencorev1beta1.CRINameDocker}},
+								CRI:           []gardencorev1beta1.CRI{{Name: gardencorev1beta1.CRINameContainerD}},
 								Architectures: []string{"amd64"},
 							},
 							{
@@ -390,7 +390,7 @@ var _ = Describe("Shoot Maintenance", func() {
 									Version:        shootCurrentImageVersion,
 									ExpirationDate: &expirationDateInThePast,
 								},
-								CRI:           []gardencorev1beta1.CRI{{Name: gardencorev1beta1.CRINameDocker}},
+								CRI:           []gardencorev1beta1.CRI{{Name: gardencorev1beta1.CRINameContainerD}},
 								Architectures: []string{"amd64"},
 							},
 						},
@@ -417,7 +417,7 @@ var _ = Describe("Shoot Maintenance", func() {
 									Version:        "1.3.1",
 									ExpirationDate: &expirationDateInTheFuture,
 								},
-								CRI:           []gardencorev1beta1.CRI{{Name: gardencorev1beta1.CRINameDocker}},
+								CRI:           []gardencorev1beta1.CRI{{Name: gardencorev1beta1.CRINameContainerD}},
 								Architectures: []string{"amd64"},
 							},
 							{
@@ -426,7 +426,7 @@ var _ = Describe("Shoot Maintenance", func() {
 									Version:        highestPatchNextMinor,
 									ExpirationDate: &expirationDateInTheFuture,
 								},
-								CRI:           []gardencorev1beta1.CRI{{Name: gardencorev1beta1.CRINameDocker}},
+								CRI:           []gardencorev1beta1.CRI{{Name: gardencorev1beta1.CRINameContainerD}},
 								Architectures: []string{"amd64"},
 							},
 							{
@@ -434,7 +434,7 @@ var _ = Describe("Shoot Maintenance", func() {
 									Version:        lowerPatchNextMinor,
 									ExpirationDate: &expirationDateInTheFuture,
 								},
-								CRI:           []gardencorev1beta1.CRI{{Name: gardencorev1beta1.CRINameDocker}},
+								CRI:           []gardencorev1beta1.CRI{{Name: gardencorev1beta1.CRINameContainerD}},
 								Architectures: []string{"amd64"},
 							},
 						},
@@ -458,7 +458,7 @@ var _ = Describe("Shoot Maintenance", func() {
 						Classification: &previewClassification,
 					},
 					Architectures: []string{"amd64"},
-					CRI:           []gardencorev1beta1.CRI{{Name: gardencorev1beta1.CRINameDocker}},
+					CRI:           []gardencorev1beta1.CRI{{Name: gardencorev1beta1.CRINameContainerD}},
 				}
 
 				// update to the latest patch version of the minor after the next minor (skip next minor)
@@ -467,7 +467,7 @@ var _ = Describe("Shoot Maintenance", func() {
 						Version: "1.4.1",
 					},
 					Architectures: []string{"amd64"},
-					CRI:           []gardencorev1beta1.CRI{{Name: gardencorev1beta1.CRINameDocker}},
+					CRI:           []gardencorev1beta1.CRI{{Name: gardencorev1beta1.CRINameContainerD}},
 				}
 
 				versions := []gardencorev1beta1.MachineImageVersion{cloudProfile.Spec.MachineImages[0].Versions[0]}
@@ -494,7 +494,7 @@ var _ = Describe("Shoot Maintenance", func() {
 						Classification: &previewClassification,
 					},
 					Architectures: []string{"amd64"},
-					CRI:           []gardencorev1beta1.CRI{{Name: gardencorev1beta1.CRINameDocker}},
+					CRI:           []gardencorev1beta1.CRI{{Name: gardencorev1beta1.CRINameContainerD}},
 				}
 				expiredPatchVersionNextMinor := gardencorev1beta1.MachineImageVersion{
 					ExpirableVersion: gardencorev1beta1.ExpirableVersion{
@@ -502,7 +502,7 @@ var _ = Describe("Shoot Maintenance", func() {
 						ExpirationDate: &expirationDateInThePast,
 					},
 					Architectures: []string{"amd64"},
-					CRI:           []gardencorev1beta1.CRI{{Name: gardencorev1beta1.CRINameDocker}},
+					CRI:           []gardencorev1beta1.CRI{{Name: gardencorev1beta1.CRINameContainerD}},
 				}
 
 				// do not update to the latest patch version of the minor after the next minor (no not skip next minor)
@@ -511,7 +511,7 @@ var _ = Describe("Shoot Maintenance", func() {
 						Version: "1.4.1",
 					},
 					Architectures: []string{"amd64"},
-					CRI:           []gardencorev1beta1.CRI{{Name: gardencorev1beta1.CRINameDocker}},
+					CRI:           []gardencorev1beta1.CRI{{Name: gardencorev1beta1.CRINameContainerD}},
 				}
 
 				versions := []gardencorev1beta1.MachineImageVersion{cloudProfile.Spec.MachineImages[0].Versions[0]}
@@ -540,7 +540,7 @@ var _ = Describe("Shoot Maintenance", func() {
 								ExpirableVersion: gardencorev1beta1.ExpirableVersion{
 									Version: highestVersionForMinor,
 								},
-								CRI:           []gardencorev1beta1.CRI{{Name: gardencorev1beta1.CRINameDocker}},
+								CRI:           []gardencorev1beta1.CRI{{Name: gardencorev1beta1.CRINameContainerD}},
 								Architectures: []string{"amd64"},
 							},
 							{
@@ -548,7 +548,7 @@ var _ = Describe("Shoot Maintenance", func() {
 									// highest version of next minor, but Shoot should not update, as current version is not expired.
 									Version: "1.2.0",
 								},
-								CRI:           []gardencorev1beta1.CRI{{Name: gardencorev1beta1.CRINameDocker}},
+								CRI:           []gardencorev1beta1.CRI{{Name: gardencorev1beta1.CRINameContainerD}},
 								Architectures: []string{"amd64"},
 							},
 						},
@@ -593,7 +593,7 @@ var _ = Describe("Shoot Maintenance", func() {
 									// Shoot's current version
 									Version: shootCurrentImageVersion,
 								},
-								CRI:           []gardencorev1beta1.CRI{{Name: gardencorev1beta1.CRINameDocker}},
+								CRI:           []gardencorev1beta1.CRI{{Name: gardencorev1beta1.CRINameContainerD}},
 								Architectures: []string{"amd64"},
 							},
 							{
@@ -601,14 +601,14 @@ var _ = Describe("Shoot Maintenance", func() {
 									// highest patch for Shoot's current minor
 									Version: highestPatchCurrentMinor,
 								},
-								CRI:           []gardencorev1beta1.CRI{{Name: gardencorev1beta1.CRINameDocker}},
+								CRI:           []gardencorev1beta1.CRI{{Name: gardencorev1beta1.CRINameContainerD}},
 								Architectures: []string{"amd64"},
 							},
 							{
 								ExpirableVersion: gardencorev1beta1.ExpirableVersion{
 									Version: highestVersionForCurrentMajor,
 								},
-								CRI:           []gardencorev1beta1.CRI{{Name: gardencorev1beta1.CRINameDocker}},
+								CRI:           []gardencorev1beta1.CRI{{Name: gardencorev1beta1.CRINameContainerD}},
 								Architectures: []string{"amd64"},
 							},
 							{
@@ -616,7 +616,7 @@ var _ = Describe("Shoot Maintenance", func() {
 									// highest version for next major. Don't update to this next major as need to update to latest version in major.
 									Version: "3.2.5",
 								},
-								CRI:           []gardencorev1beta1.CRI{{Name: gardencorev1beta1.CRINameDocker}},
+								CRI:           []gardencorev1beta1.CRI{{Name: gardencorev1beta1.CRINameContainerD}},
 								Architectures: []string{"amd64"},
 							},
 						},
@@ -642,7 +642,7 @@ var _ = Describe("Shoot Maintenance", func() {
 									// Shoot's current version
 									Version: shootCurrentImageVersion,
 								},
-								CRI:           []gardencorev1beta1.CRI{{Name: gardencorev1beta1.CRINameDocker}},
+								CRI:           []gardencorev1beta1.CRI{{Name: gardencorev1beta1.CRINameContainerD}},
 								Architectures: []string{"amd64"},
 							},
 							{
@@ -650,14 +650,14 @@ var _ = Describe("Shoot Maintenance", func() {
 									// intermediate minor (we skip over)
 									Version: "1.3.0",
 								},
-								CRI:           []gardencorev1beta1.CRI{{Name: gardencorev1beta1.CRINameDocker}},
+								CRI:           []gardencorev1beta1.CRI{{Name: gardencorev1beta1.CRINameContainerD}},
 								Architectures: []string{"amd64"},
 							},
 							{
 								ExpirableVersion: gardencorev1beta1.ExpirableVersion{
 									Version: highestVersionForCurrentMajor,
 								},
-								CRI:           []gardencorev1beta1.CRI{{Name: gardencorev1beta1.CRINameDocker}},
+								CRI:           []gardencorev1beta1.CRI{{Name: gardencorev1beta1.CRINameContainerD}},
 								Architectures: []string{"amd64"},
 							},
 							{
@@ -665,7 +665,7 @@ var _ = Describe("Shoot Maintenance", func() {
 									// highest version for next major. Don't update to this next major as need to update to latest version in major.
 									Version: "3.2.5",
 								},
-								CRI:           []gardencorev1beta1.CRI{{Name: gardencorev1beta1.CRINameDocker}},
+								CRI:           []gardencorev1beta1.CRI{{Name: gardencorev1beta1.CRINameContainerD}},
 								Architectures: []string{"amd64"},
 							},
 						},
@@ -692,7 +692,7 @@ var _ = Describe("Shoot Maintenance", func() {
 									Version:        shootCurrentImageVersion,
 									ExpirationDate: &expirationDateInThePast,
 								},
-								CRI:           []gardencorev1beta1.CRI{{Name: gardencorev1beta1.CRINameDocker}},
+								CRI:           []gardencorev1beta1.CRI{{Name: gardencorev1beta1.CRINameContainerD}},
 								Architectures: []string{"amd64"},
 							},
 							{
@@ -700,14 +700,14 @@ var _ = Describe("Shoot Maintenance", func() {
 									// intermediate minor (we skip over)
 									Version: "1.3.0",
 								},
-								CRI:           []gardencorev1beta1.CRI{{Name: gardencorev1beta1.CRINameDocker}},
+								CRI:           []gardencorev1beta1.CRI{{Name: gardencorev1beta1.CRINameContainerD}},
 								Architectures: []string{"amd64"},
 							},
 							{
 								ExpirableVersion: gardencorev1beta1.ExpirableVersion{
 									Version: highestVersionForCurrentMajor,
 								},
-								CRI:           []gardencorev1beta1.CRI{{Name: gardencorev1beta1.CRINameDocker}},
+								CRI:           []gardencorev1beta1.CRI{{Name: gardencorev1beta1.CRINameContainerD}},
 								Architectures: []string{"amd64"},
 							},
 							{
@@ -715,7 +715,7 @@ var _ = Describe("Shoot Maintenance", func() {
 									// highest version for next major. Don't update to this next major as need to update to latest version in major.
 									Version: "3.2.5",
 								},
-								CRI:           []gardencorev1beta1.CRI{{Name: gardencorev1beta1.CRINameDocker}},
+								CRI:           []gardencorev1beta1.CRI{{Name: gardencorev1beta1.CRINameContainerD}},
 								Architectures: []string{"amd64"},
 							},
 						},
@@ -744,21 +744,21 @@ var _ = Describe("Shoot Maintenance", func() {
 									Version:        latestVersionForCurrentMajor,
 									ExpirationDate: &expirationDateInThePast,
 								},
-								CRI:           []gardencorev1beta1.CRI{{Name: gardencorev1beta1.CRINameDocker}},
+								CRI:           []gardencorev1beta1.CRI{{Name: gardencorev1beta1.CRINameContainerD}},
 								Architectures: []string{"amd64"},
 							},
 							{
 								ExpirableVersion: gardencorev1beta1.ExpirableVersion{
 									Version: intermediateVersionNextMajor,
 								},
-								CRI:           []gardencorev1beta1.CRI{{Name: gardencorev1beta1.CRINameDocker}},
+								CRI:           []gardencorev1beta1.CRI{{Name: gardencorev1beta1.CRINameContainerD}},
 								Architectures: []string{"amd64"},
 							},
 							{
 								ExpirableVersion: gardencorev1beta1.ExpirableVersion{
 									Version: latestVersionNextMajor,
 								},
-								CRI:           []gardencorev1beta1.CRI{{Name: gardencorev1beta1.CRINameDocker}},
+								CRI:           []gardencorev1beta1.CRI{{Name: gardencorev1beta1.CRINameContainerD}},
 								Architectures: []string{"amd64"},
 							},
 						},
@@ -785,7 +785,7 @@ var _ = Describe("Shoot Maintenance", func() {
 						Classification: &previewClassification,
 					},
 					Architectures: []string{"amd64"},
-					CRI:           []gardencorev1beta1.CRI{{Name: gardencorev1beta1.CRINameDocker}},
+					CRI:           []gardencorev1beta1.CRI{{Name: gardencorev1beta1.CRINameContainerD}},
 				}
 
 				// update to the latest patch version of the major after the next major (skip next minor)
@@ -794,7 +794,7 @@ var _ = Describe("Shoot Maintenance", func() {
 						Version: "3.4.1",
 					},
 					Architectures: []string{"amd64"},
-					CRI:           []gardencorev1beta1.CRI{{Name: gardencorev1beta1.CRINameDocker}},
+					CRI:           []gardencorev1beta1.CRI{{Name: gardencorev1beta1.CRINameContainerD}},
 				}
 
 				versions := []gardencorev1beta1.MachineImageVersion{cloudProfile.Spec.MachineImages[0].Versions[0]}
@@ -840,7 +840,7 @@ var _ = Describe("Shoot Maintenance", func() {
 								ExpirableVersion: gardencorev1beta1.ExpirableVersion{
 									Version: highestVersionForMajor,
 								},
-								CRI:           []gardencorev1beta1.CRI{{Name: gardencorev1beta1.CRINameDocker}},
+								CRI:           []gardencorev1beta1.CRI{{Name: gardencorev1beta1.CRINameContainerD}},
 								Architectures: []string{"amd64"},
 							},
 							{
@@ -848,7 +848,7 @@ var _ = Describe("Shoot Maintenance", func() {
 									// highest version for next major. Don't update to this next major.
 									Version: "2.2.5",
 								},
-								CRI:           []gardencorev1beta1.CRI{{Name: gardencorev1beta1.CRINameDocker}},
+								CRI:           []gardencorev1beta1.CRI{{Name: gardencorev1beta1.CRINameContainerD}},
 								Architectures: []string{"amd64"},
 							},
 						},
@@ -863,14 +863,6 @@ var _ = Describe("Shoot Maintenance", func() {
 			})
 		})
 
-		It("should treat workers with `cri: nil` like `cri.name: docker` and not update if `docker` is not explicitly supported by the machine image", func() {
-			cloudProfile.Spec.MachineImages[0].Versions[1].CRI = []gardencorev1beta1.CRI{{Name: gardencorev1beta1.CRINameContainerD}}
-
-			_, err := maintainMachineImages(log, shoot, cloudProfile)
-			Expect(err).NotTo(HaveOccurred())
-			assertWorkerMachineImageVersion(&shoot.Spec.Provider.Workers[0], "CoreOs", "1.0.0")
-		})
-
 		It("should determine that the shoot worker machine images must NOT to be maintained - ForceUpdate not required & MaintenanceAutoUpdate set to false", func() {
 			shoot.Spec.Maintenance.AutoUpdate.MachineImageVersion = ptr.To(false)
 
@@ -882,7 +874,7 @@ var _ = Describe("Shoot Maintenance", func() {
 		})
 
 		It("should determine that the shoot worker machine images must NOT be maintained - found no machineImageVersion with matching CRI", func() {
-			cloudProfile.Spec.MachineImages[0].Versions[0].CRI = []gardencorev1beta1.CRI{{Name: gardencorev1beta1.CRINameContainerD}}
+			cloudProfile.Spec.MachineImages[0].Versions[1].CRI = []gardencorev1beta1.CRI{{Name: gardencorev1beta1.CRIName("other")}}
 			shoot.Spec.Provider.Workers[0].CRI = &gardencorev1beta1.CRI{Name: gardencorev1beta1.CRINameContainerD}
 
 			expected := shoot.Spec.Provider.Workers[0].Machine.Image.DeepCopy()
@@ -892,9 +884,9 @@ var _ = Describe("Shoot Maintenance", func() {
 		})
 
 		It("should determine that some shoot worker machine images must be not be maintained - MachineImageVersion doesn't support certain CRIs", func() {
-			// only the shoots current os image contains the containerd CRI (none of the other versions do) -> this worker pool must not be updated
-			cloudProfile.Spec.MachineImages[0].Versions[0].CRI = []gardencorev1beta1.CRI{{Name: gardencorev1beta1.CRINameContainerD}}
-			shoot.Spec.Provider.Workers[0].CRI = &gardencorev1beta1.CRI{Name: gardencorev1beta1.CRINameContainerD}
+			// only the shoots current os image contains the "other" CRI (none of the other versions do) -> this worker pool must not be updated
+			cloudProfile.Spec.MachineImages[0].Versions[0].CRI = []gardencorev1beta1.CRI{{Name: gardencorev1beta1.CRIName("other")}}
+			shoot.Spec.Provider.Workers[0].CRI = &gardencorev1beta1.CRI{Name: gardencorev1beta1.CRIName("other")}
 
 			// add another pool without CRI constraints -> should be updated via auto-update
 			shoot.Spec.Provider.Workers = append(shoot.Spec.Provider.Workers, gardencorev1beta1.Worker{Name: "worker-without-cri-config", Machine: gardencorev1beta1.Machine{Image: shootCurrentImage.DeepCopy(), Architecture: ptr.To("amd64")}})

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -4003,7 +4003,7 @@ func schema_pkg_apis_core_v1beta1_KubeletConfig(ref common.ReferenceCallback) co
 					},
 					"imagePullProgressDeadline": {
 						SchemaProps: spec.SchemaProps{
-							Description: "ImagePullProgressDeadline describes the time limit under which if no pulling progress is made, the image pulling will be cancelled. Default: 1m",
+							Description: "ImagePullProgressDeadline describes the time limit under which if no pulling progress is made, the image pulling will be cancelled. Default: 1m Only relevant for docker CRI.\n\nDeprecated: This field is deprecated and will be removed in Gardener release v1.89.",
 							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.Duration"),
 						},
 					},

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -3204,7 +3204,7 @@ func schema_pkg_apis_core_v1beta1_Gardener(ref common.ReferenceCallback) common.
 				Properties: map[string]spec.Schema{
 					"id": {
 						SchemaProps: spec.SchemaProps{
-							Description: "ID is the Docker container id of the Gardener which last acted on a resource.",
+							Description: "ID is the container id of the Gardener which last acted on a resource.",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",

--- a/test/integration/apiserver/admissionplugins/shootvalidator/shootvalidator_suite_test.go
+++ b/test/integration/apiserver/admissionplugins/shootvalidator/shootvalidator_suite_test.go
@@ -244,9 +244,6 @@ var _ = BeforeSuite(func() {
 							ExpirableVersion: gardencorev1beta1.ExpirableVersion{Version: "1.1.1"},
 							CRI: []gardencorev1beta1.CRI{
 								{
-									Name: gardencorev1beta1.CRINameDocker,
-								},
-								{
 									Name: gardencorev1beta1.CRINameContainerD,
 								},
 							},

--- a/test/integration/controllermanager/shoot/maintenance/maintenance_test.go
+++ b/test/integration/controllermanager/shoot/maintenance/maintenance_test.go
@@ -111,9 +111,6 @@ var _ = Describe("Shoot Maintenance controller tests", func() {
 								},
 								CRI: []gardencorev1beta1.CRI{
 									{
-										Name: gardencorev1beta1.CRINameDocker,
-									},
-									{
 										Name: gardencorev1beta1.CRINameContainerD,
 									},
 								},
@@ -126,9 +123,6 @@ var _ = Describe("Shoot Maintenance controller tests", func() {
 									Classification: &supportedClassification,
 								},
 								CRI: []gardencorev1beta1.CRI{
-									{
-										Name: gardencorev1beta1.CRINameDocker,
-									},
 									{
 										Name: gardencorev1beta1.CRINameContainerD,
 									},
@@ -143,9 +137,6 @@ var _ = Describe("Shoot Maintenance controller tests", func() {
 								},
 								CRI: []gardencorev1beta1.CRI{
 									{
-										Name: gardencorev1beta1.CRINameDocker,
-									},
-									{
 										Name: gardencorev1beta1.CRINameContainerD,
 									},
 								},
@@ -158,9 +149,6 @@ var _ = Describe("Shoot Maintenance controller tests", func() {
 									Classification: &supportedClassification,
 								},
 								CRI: []gardencorev1beta1.CRI{
-									{
-										Name: gardencorev1beta1.CRINameDocker,
-									},
 									{
 										Name: gardencorev1beta1.CRINameContainerD,
 									},
@@ -175,9 +163,6 @@ var _ = Describe("Shoot Maintenance controller tests", func() {
 								},
 								CRI: []gardencorev1beta1.CRI{
 									{
-										Name: gardencorev1beta1.CRINameDocker,
-									},
-									{
 										Name: gardencorev1beta1.CRINameContainerD,
 									},
 								},
@@ -191,9 +176,6 @@ var _ = Describe("Shoot Maintenance controller tests", func() {
 								},
 								CRI: []gardencorev1beta1.CRI{
 									{
-										Name: gardencorev1beta1.CRINameDocker,
-									},
-									{
 										Name: gardencorev1beta1.CRINameContainerD,
 									},
 								},
@@ -206,9 +188,6 @@ var _ = Describe("Shoot Maintenance controller tests", func() {
 									Classification: &supportedClassification,
 								},
 								CRI: []gardencorev1beta1.CRI{
-									{
-										Name: gardencorev1beta1.CRINameDocker,
-									},
 									{
 										Name: gardencorev1beta1.CRINameContainerD,
 									},
@@ -224,9 +203,6 @@ var _ = Describe("Shoot Maintenance controller tests", func() {
 								},
 								CRI: []gardencorev1beta1.CRI{
 									{
-										Name: gardencorev1beta1.CRINameDocker,
-									},
-									{
 										Name: gardencorev1beta1.CRINameContainerD,
 									},
 								},
@@ -241,9 +217,6 @@ var _ = Describe("Shoot Maintenance controller tests", func() {
 								},
 								CRI: []gardencorev1beta1.CRI{
 									{
-										Name: gardencorev1beta1.CRINameDocker,
-									},
-									{
 										Name: gardencorev1beta1.CRINameContainerD,
 									},
 								},
@@ -255,9 +228,6 @@ var _ = Describe("Shoot Maintenance controller tests", func() {
 									Classification: &deprecatedClassification,
 								},
 								CRI: []gardencorev1beta1.CRI{
-									{
-										Name: gardencorev1beta1.CRINameDocker,
-									},
 									{
 										Name: gardencorev1beta1.CRINameContainerD,
 									},
@@ -272,9 +242,6 @@ var _ = Describe("Shoot Maintenance controller tests", func() {
 								},
 								CRI: []gardencorev1beta1.CRI{
 									{
-										Name: gardencorev1beta1.CRINameDocker,
-									},
-									{
 										Name: gardencorev1beta1.CRINameContainerD,
 									},
 								},
@@ -288,9 +255,6 @@ var _ = Describe("Shoot Maintenance controller tests", func() {
 								},
 								CRI: []gardencorev1beta1.CRI{
 									{
-										Name: gardencorev1beta1.CRINameDocker,
-									},
-									{
 										Name: gardencorev1beta1.CRINameContainerD,
 									},
 								},
@@ -303,9 +267,6 @@ var _ = Describe("Shoot Maintenance controller tests", func() {
 								},
 								CRI: []gardencorev1beta1.CRI{
 									{
-										Name: gardencorev1beta1.CRINameDocker,
-									},
-									{
 										Name: gardencorev1beta1.CRINameContainerD,
 									},
 								},
@@ -317,9 +278,6 @@ var _ = Describe("Shoot Maintenance controller tests", func() {
 									Classification: &deprecatedClassification,
 								},
 								CRI: []gardencorev1beta1.CRI{
-									{
-										Name: gardencorev1beta1.CRINameDocker,
-									},
 									{
 										Name: gardencorev1beta1.CRINameContainerD,
 									},

--- a/test/integration/scheduler/shoot/shoot_test.go
+++ b/test/integration/scheduler/shoot/shoot_test.go
@@ -647,9 +647,6 @@ func createCloudProfile(providerType, region string) *gardencorev1beta1.CloudPro
 								{
 									Name: gardencorev1beta1.CRINameContainerD,
 								},
-								{
-									Name: gardencorev1beta1.CRINameDocker,
-								},
 							},
 						},
 					},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind cleanup

**What this PR does / why we need it**:
This PR drops the remaining usages of docker CRI from the codebase.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/4673

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
The `docker` CRI is no longer supported for machine images in the `CloudProfile`. Docker CRI was already not supported for `Shoot`s with Kubernetes versions `>= v1.23`, so adding this CRI is a no-op currently. Please remove all the usages of `docker` CRI from your `CloudProfile`s before upgrading to this version.
```
