### PR TITLE
fix: also configure snapshots as component-prefix

### DIFF
--- a/hack/.ci/component_descriptor
+++ b/hack/.ci/component_descriptor
@@ -55,7 +55,7 @@ fi
 if [[ ! -z "$image_vector_path" ]]; then
   # default environment variables
   if [[ -z "${COMPONENT_PREFIXES}" ]]; then
-    COMPONENT_PREFIXES="europe-docker.pkg.dev/gardener-project/releases/gardener"
+    COMPONENT_PREFIXES="europe-docker.pkg.dev/gardener-project/releases/gardener,europe-docker.pkg.dev/gardener-project/snapshots/gardener"
   fi
 
   if [[ -z "${COMPONENT_CLI_ARGS}" ]]; then


### PR DESCRIPTION

**How to categorize this PR?**

/area delivery
/kind bug

**What this PR does / why we need it**:

`component-cli` heuristically assumes OCI Image References (registry + repository) of configured prefixes to actually be intended as cross-repository references to another component (/github-repository).

After splitting repositories into dedicated ones for releases and snapshots, this prefix also needs to be configured properly for snapshot-repositories so component-descriptors will be correctly generated also for non-release-builds.


**Which issue(s) this PR fixes**:
n/a

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix developer
Fix: add snapshots repository to default "component prefixes" to fix wrong values generated into Component Descriptors
```
