### PR TITLE
Remove SAP news from documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,5 @@ Please find further resources about our project here:
 * [Our landing page gardener.cloud](https://gardener.cloud/)
 * ["Gardener Project Update" blog on kubernetes.io](https://kubernetes.io/blog/2019/12/02/gardener-project-update/).
 * ["Gardener, the Kubernetes Botanist" blog on kubernetes.io](https://kubernetes.io/blog/2018/05/17/gardener/)
-* [SAP news article about "Project Gardener"](https://news.sap.com/2018/11/hasso-plattner-founders-award-finalist-profile-project-gardener/)
 * ["Thinking Cloud Native" talk at EclipseCon 2018](https://www.youtube.com/watch?v=bfw22WPg99A)
 * [Blog - "Showcase of Gardener at OSCON 2018"](https://blogs.sap.com/2018/07/26/showcase-of-gardener-at-oscon/)


### PR DESCRIPTION
**How to categorize this PR?**
/area documentation
/kind cleanup

**What this PR does / why we need it**:
Adjusting a link inside the ReadMe which leads to a 404 page. This was a news from SAP about Gardener which apparently got removed.

**Release note**:
NONE
