### PR TITLE
Bump up fluent-bit to v2.2.2

### DIFF
--- a/imagevector/images.yaml
+++ b/imagevector/images.yaml
@@ -402,7 +402,7 @@ images:
 - name: fluent-bit
   sourceRepository: github.com/fluent/fluent-operator
   repository: europe-docker.pkg.dev/gardener-project/releases/3rd/kubesphere/fluent-bit
-  tag: "v2.2.0"
+  tag: "v2.2.2"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:


### PR DESCRIPTION
/area logging
/kind enhancement

This PR brings latest released fluent-bit v2.2.2 version.
It upgrades from current version v2.2.0

Release notes:

- [v2.2.1](https://fluentbit.io/announcements/v2.2.1/)
- [v2.2.2](https://fluentbit.io/announcements/v2.2.2/)

```other operator
Fluent-bit is now upgraded to v2.2.2
```
