### PR TITLE
Add `extensionswebhook.EnsureUnitWithName` func to add unit to OSC units

### DIFF
--- a/extensions/pkg/webhook/utils.go
+++ b/extensions/pkg/webhook/utils.go
@@ -275,7 +275,18 @@ func EnsureFileWithPath(items []extensionsv1alpha1.File, item extensionsv1alpha1
 	if i := fileWithPathIndex(items, item.Path); i < 0 {
 		items = append(items, item)
 	} else if !reflect.DeepEqual(items[i], item) {
-		items = append(append(items[:i], item), items[i+1:]...)
+		items[i] = item
+	}
+	return items
+}
+
+// EnsureUnitWithName ensures that an unit with a name equal to the name of the given unit exists in the given slice
+// and is equal to the given unit.
+func EnsureUnitWithName(items []extensionsv1alpha1.Unit, item extensionsv1alpha1.Unit) []extensionsv1alpha1.Unit {
+	if i := unitWithNameIndex(items, item.Name); i < 0 {
+		items = append(items, item)
+	} else if !reflect.DeepEqual(items[i], item) {
+		items[i] = item
 	}
 	return items
 }

--- a/extensions/pkg/webhook/utils_test.go
+++ b/extensions/pkg/webhook/utils_test.go
@@ -1,0 +1,157 @@
+// Copyright 2024 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package webhook_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/utils/ptr"
+
+	"github.com/gardener/gardener/extensions/pkg/webhook"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+)
+
+var _ = Describe("Utils", func() {
+
+	Describe("#EnsureFileWithPath", func() {
+		var files []extensionsv1alpha1.File
+
+		BeforeEach(func() {
+			files = []extensionsv1alpha1.File{
+				{
+					Path: "/foo.txt",
+					Content: extensionsv1alpha1.FileContent{
+						Inline: &extensionsv1alpha1.FileContentInline{
+							Data: "foo",
+						},
+					},
+				},
+				{
+					Path: "/bar.txt",
+					Content: extensionsv1alpha1.FileContent{
+						Inline: &extensionsv1alpha1.FileContentInline{
+							Data: "bar",
+						},
+					},
+				},
+			}
+		})
+
+		It("should append file when file with such path does not exist", func() {
+			newFile := extensionsv1alpha1.File{
+				Path: "/baz.txt",
+				Content: extensionsv1alpha1.FileContent{
+					Inline: &extensionsv1alpha1.FileContentInline{
+						Data: "baz",
+					},
+				},
+			}
+
+			actual := webhook.EnsureFileWithPath(files, newFile)
+			Expect(actual).To(Equal(append(files, newFile)))
+		})
+
+		It("should update file when file with such path exists", func() {
+			newFile := extensionsv1alpha1.File{
+				Path: "/foo.txt",
+				Content: extensionsv1alpha1.FileContent{
+					Inline: &extensionsv1alpha1.FileContentInline{
+						Data: "baz",
+					},
+				},
+			}
+
+			actual := webhook.EnsureFileWithPath(files, newFile)
+			Expect(actual).To(Equal([]extensionsv1alpha1.File{
+				{
+					Path: "/foo.txt",
+					Content: extensionsv1alpha1.FileContent{
+						Inline: &extensionsv1alpha1.FileContentInline{
+							Data: "baz",
+						},
+					},
+				},
+				{
+					Path: "/bar.txt",
+					Content: extensionsv1alpha1.FileContent{
+						Inline: &extensionsv1alpha1.FileContentInline{
+							Data: "bar",
+						},
+					},
+				},
+			}))
+		})
+
+		It("should do nothing when the new file is exactly the same as the existing one", func() {
+			newFile := files[0]
+
+			actual := webhook.EnsureFileWithPath(files, newFile)
+			Expect(actual).To(Equal(files))
+		})
+	})
+
+	Describe("#EnsureUnitWithName", func() {
+		var units []extensionsv1alpha1.Unit
+
+		BeforeEach(func() {
+			units = []extensionsv1alpha1.Unit{
+				{
+					Name:    "foo.service",
+					Content: ptr.To("foo"),
+				},
+				{
+					Name:    "bar.service",
+					Content: ptr.To("bar"),
+				},
+			}
+		})
+
+		It("should append unit when unit with such name does not exist", func() {
+			newUnit := extensionsv1alpha1.Unit{
+				Name:    "baz.service",
+				Content: ptr.To("bar"),
+			}
+
+			actual := webhook.EnsureUnitWithName(units, newUnit)
+			Expect(actual).To(Equal(append(units, newUnit)))
+		})
+
+		It("should update unit when unit with such name exists", func() {
+			newUnit := extensionsv1alpha1.Unit{
+				Name:    "foo.service",
+				Content: ptr.To("baz"),
+			}
+
+			actual := webhook.EnsureUnitWithName(units, newUnit)
+			Expect(actual).To(Equal([]extensionsv1alpha1.Unit{
+				{
+					Name:    "foo.service",
+					Content: ptr.To("baz"),
+				},
+				{
+					Name:    "bar.service",
+					Content: ptr.To("bar"),
+				},
+			}))
+		})
+
+		It("should do nothing when the new unit is exactly the same as the existing one", func() {
+			newUnit := units[0]
+
+			actual := webhook.EnsureUnitWithName(units, newUnit)
+			Expect(actual).To(Equal(units))
+		})
+	})
+})

--- a/go.mod
+++ b/go.mod
@@ -67,7 +67,7 @@ require (
 	k8s.io/kubelet v0.28.3
 	k8s.io/metrics v0.28.3
 	k8s.io/pod-security-admission v0.28.3
-	k8s.io/utils v0.0.0-20231127182322-b307cd553661
+	k8s.io/utils v0.0.0-20240102154912-e7106e64919e
 	sigs.k8s.io/controller-runtime v0.16.3
 	sigs.k8s.io/controller-runtime/tools/setup-envtest v0.0.0-20231015215740-bf15e44028f9 // v0.16.3
 	sigs.k8s.io/controller-tools v0.13.0

--- a/go.sum
+++ b/go.sum
@@ -1616,8 +1616,8 @@ k8s.io/pod-security-admission v0.28.3/go.mod h1:qm+gZ8FdnxBgVVTZfSjlK/oeBosmvECB
 k8s.io/utils v0.0.0-20200324210504-a9aa75ae1b89/go.mod h1:sZAwmy6armz5eXlNoLmJcl4F1QuKu7sr+mFQ0byX7Ew=
 k8s.io/utils v0.0.0-20200729134348-d5654de09c73/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
 k8s.io/utils v0.0.0-20201110183641-67b214c5f920/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
-k8s.io/utils v0.0.0-20231127182322-b307cd553661 h1:FepOBzJ0GXm8t0su67ln2wAZjbQ6RxQGZDnzuLcrUTI=
-k8s.io/utils v0.0.0-20231127182322-b307cd553661/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
+k8s.io/utils v0.0.0-20240102154912-e7106e64919e h1:eQ/4ljkx21sObifjzXwlPKpdGLrCfRziVtos3ofG/sQ=
+k8s.io/utils v0.0.0-20240102154912-e7106e64919e/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind enhancement

**What this PR does / why we need it**:
Right now various extensions have different funcs for adding an unit to the OSC units. By adding, I mean "upsert" - insert if not present, update - if present.
The existing func `extensionswebhook.AppendUniqueUnit` does only insert but does not do update.
IMO, `extensionswebhook.AppendUniqueUnit` does not make much sense as we usually want "upsert" behaviour. I cannot thing of scenario where "insert only" behaviour is the desired one.

Examples of extensions having such func inline:
registry-cache: https://github.com/gardener/gardener-extension-registry-cache/blob/d701d3b4fcef53d8cb4a44281e4f9407e2723cba/pkg/webhook/operatingsystemconfig/ensurer.go#L154-L165
shoot-rsyslog-relp: https://github.com/gardener/gardener-extension-shoot-rsyslog-relp/blob/c09737d2ab8780c87463e5a685cc2ed89988a5e8/pkg/webhook/operatingsystemconfig/ensurer.go#L97-L99

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
There is now a new `github.com/gardener/gardener/extensions/pkg/webhook.EnsureUnitWithName` func that can be used to add/update unit to OperatingSystemConfig units.
```
