### PR TITLE
Add Prometheus alert for nodes not ready on seeds

### DIFF
--- a/pkg/component/monitoring/charts/bootstrap/aggregate-prometheus-rules/seed.rules.yaml
+++ b/pkg/component/monitoring/charts/bootstrap/aggregate-prometheus-rules/seed.rules.yaml
@@ -14,3 +14,16 @@ groups:
       description: >
         Pod {{$labels.pod}} in namespace {{$labels.namespace}} was stuck
         in Pending state for more than 10 minutes.
+
+  - alert: NodeNotHealthy
+    expr: |
+      count_over_time((sum by (node) (kube_node_spec_taint{effect="NoSchedule", key!="ToBeDeletedByClusterAutoscaler", key!="node.gardener.cloud/critical-components-not-ready"}))[30m:]) > 5
+    for: 10m
+    labels:
+      severity: warning
+      type: seed
+      visibility: operator
+    annotations:
+      summary: A node is not healthy.
+      description: >
+        Node {{$labels.node}} in seed {{$labels.name}} in landscape {{$externalLabels.landscape}} is not healthy for over 10 min.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind enhancement

**What this PR does / why we need it**:
This PR adds a new alerting rule for nodes that are unhealthy / unschedulable for more than 10 mins, during a time window of 30 mins, ignoring actions taken by the ClusterAutoscaler or by a possible K8S upgrade activity.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/invite @istvanballok @rickardsjp

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Add Prometheus alert for unhealthy seed node.
```
