### PR TITLE
[release-v1.87] Bump `nginx-ingress-controller` image to `v1.9.6`

### DIFF
--- a/imagevector/images.yaml
+++ b/imagevector/images.yaml
@@ -62,7 +62,7 @@ images:
 - name: nginx-ingress-controller
   sourceRepository: github.com/kubernetes/ingress-nginx
   repository: registry.k8s.io/ingress-nginx/controller-chroot
-  tag: "v1.9.5"
+  tag: "v1.9.6"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane open-source
/kind enhancement

**What this PR does / why we need it**:
- Bump `nginx-ingress-controller` image to `v1.9.6`.

https://github.com/kubernetes/ingress-nginx/releases/tag/controller-v1.9.6

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
Manual cherry-pick of https://github.com/gardener/gardener/pull/9124 in release-v1.87 branch

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
`nginx-ingress-controller` image is updated to `v1.9.6`.
```
