### PR TITLE
Update golang variants, add golang 1.22

### DIFF
--- a/hack/tools/image/variants.yaml
+++ b/hack/tools/image/variants.yaml
@@ -4,6 +4,8 @@
 # - https://github.com/gardener/ci-infra/blob/master/images/krte
 variants:
   "1.20":
-    image: golang:1.20.13-bookworm
+    image: golang:1.20.14-bookworm
   "1.21":
-    image: golang:1.21.6-bookworm
+    image: golang:1.21.7-bookworm
+  "1.22":
+    image: golang:1.22.0-bookworm


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind enhancement

**What this PR does / why we need it**:
This PR updates Go versions of golang-test image to the recent patch versions 1.21.7, 1.20.14 and the new 1.22.0.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
