### PR TITLE
Annotate `kube-apiserver` deployment after labeling the resources for encryption

### DIFF
--- a/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
@@ -413,7 +413,7 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 		rewriteResourcesAddLabel = g.Add(flow.Task{
 			Name: "Labeling resources after modification of encryption config or to encrypt them with new ETCD encryption key",
 			Fn: flow.TaskFn(func(ctx context.Context) error {
-				return secretsrotation.RewriteEncryptedDataAddLabel(ctx, o.Logger, o.ShootClientSet, o.SecretsManager, o.Shoot.ResourcesToEncrypt, o.Shoot.EncryptedResources, gardenerutils.DefaultGVKsForEncryption())
+				return secretsrotation.RewriteEncryptedDataAddLabel(ctx, o.Logger, o.SeedClientSet.Client(), o.ShootClientSet, o.SecretsManager, o.Shoot.SeedNamespace, v1beta1constants.DeploymentNameKubeAPIServer, o.Shoot.ResourcesToEncrypt, o.Shoot.EncryptedResources, gardenerutils.DefaultGVKsForEncryption())
 			}).RetryUntilTimeout(30*time.Second, 10*time.Minute),
 			SkipIf: v1beta1helper.GetShootETCDEncryptionKeyRotationPhase(o.Shoot.GetInfo().Status.Credentials) != gardencorev1beta1.RotationPreparing &&
 				apiequality.Semantic.DeepEqual(o.Shoot.ResourcesToEncrypt, o.Shoot.EncryptedResources),

--- a/pkg/operator/controller/garden/garden/reconciler_reconcile.go
+++ b/pkg/operator/controller/garden/garden/reconciler_reconcile.go
@@ -378,7 +378,7 @@ func (r *Reconciler) reconcile(
 		rewriteResourcesAddLabel = g.Add(flow.Task{
 			Name: "Labeling encrypted resources after modification of encryption config or to re-encrypt them with new ETCD encryption key",
 			Fn: flow.TaskFn(func(ctx context.Context) error {
-				return secretsrotation.RewriteEncryptedDataAddLabel(ctx, log, virtualClusterClientSet, secretsManager, resourcesToEncrypt, encryptedResources, defaultEncryptedGVKs)
+				return secretsrotation.RewriteEncryptedDataAddLabel(ctx, log, r.RuntimeClientSet.Client(), virtualClusterClientSet, secretsManager, r.GardenNamespace, namePrefix+v1beta1constants.DeploymentNameKubeAPIServer, resourcesToEncrypt, encryptedResources, defaultEncryptedGVKs)
 			}).RetryUntilTimeout(30*time.Second, 10*time.Minute),
 			SkipIf: helper.GetETCDEncryptionKeyRotationPhase(garden.Status.Credentials) != gardencorev1beta1.RotationPreparing &&
 				apiequality.Semantic.DeepEqual(resourcesToEncrypt, encryptedResources),

--- a/pkg/utils/gardener/secretsrotation/constants.go
+++ b/pkg/utils/gardener/secretsrotation/constants.go
@@ -20,7 +20,6 @@ const (
 
 	// AnnotationKeyResourcesLabeled is an annotation indicating the completion of labeling the resources with the credentials.gardener.cloud/key-name label
 	AnnotationKeyResourcesLabeled = "credentials.gardener.cloud/resources-labeled"
-
 	// AnnotationKeyEtcdSnapshotted is an annotation indicating that ETCD snapshot was completed
 	AnnotationKeyEtcdSnapshotted = "credentials.gardener.cloud/etcd-snapshotted"
 

--- a/pkg/utils/gardener/secretsrotation/constants.go
+++ b/pkg/utils/gardener/secretsrotation/constants.go
@@ -18,6 +18,9 @@ const (
 	// AnnotationKeyNewEncryptionKeyPopulated is an annotation indicating that the new ETCD encryption key was populated
 	AnnotationKeyNewEncryptionKeyPopulated = "credentials.gardener.cloud/new-encryption-key-populated"
 
+	// AnnotationKeyResourcesLabeled is an annotation indicating the completion of labeling the resources with the credentials.gardener.cloud/key-name label
+	AnnotationKeyResourcesLabeled = "credentials.gardener.cloud/resources-labeled"
+
 	// AnnotationKeyEtcdSnapshotted is an annotation indicating that ETCD snapshot was completed
 	AnnotationKeyEtcdSnapshotted = "credentials.gardener.cloud/etcd-snapshotted"
 

--- a/pkg/utils/gardener/secretsrotation/etcd.go
+++ b/pkg/utils/gardener/secretsrotation/etcd.go
@@ -49,12 +49,26 @@ import (
 func RewriteEncryptedDataAddLabel(
 	ctx context.Context,
 	log logr.Logger,
+	runtimeClient client.Client,
 	clientSet kubernetes.Interface,
 	secretsManager secretsmanager.Interface,
+	namespace string,
+	name string,
 	resourcesToEncrypt []string,
 	encryptedResources []string,
 	defaultGVKs []schema.GroupVersionKind,
 ) error {
+	// Check if we have to label the resources to rewrite the data.
+	meta := &metav1.PartialObjectMetadata{}
+	meta.SetGroupVersionKind(appsv1.SchemeGroupVersion.WithKind("Deployment"))
+	if err := runtimeClient.Get(ctx, kubernetesutils.Key(namespace, name), meta); err != nil {
+		return err
+	}
+
+	if metav1.HasAnnotation(meta.ObjectMeta, AnnotationKeyResourcesLabeled) {
+		return nil
+	}
+
 	encryptedGVKs, message, err := GetResourcesForRewrite(clientSet.Kubernetes().Discovery(), resourcesToEncrypt, encryptedResources, defaultGVKs)
 	if err != nil {
 		return err
@@ -65,7 +79,7 @@ func RewriteEncryptedDataAddLabel(
 		return fmt.Errorf("secret %q not found", v1beta1constants.SecretNameETCDEncryptionKey)
 	}
 
-	return rewriteEncryptedData(
+	if err := rewriteEncryptedData(
 		ctx,
 		log,
 		clientSet.Client(),
@@ -75,7 +89,16 @@ func RewriteEncryptedDataAddLabel(
 		},
 		message+" (Add label)",
 		encryptedGVKs...,
-	)
+	); err != nil {
+		return err
+	}
+
+	// If we have hit this point then we have labeled all the resources successfully. Now we can mark this step as "completed"
+	// (via an annotation) so that we do not start labeling the resources in a future reconciliation in case the flow fails in
+	// "Removing the label" and labels were only partially removed.
+	return PatchAPIServerDeploymentMeta(ctx, runtimeClient, namespace, name, func(meta *metav1.PartialObjectMetadata) {
+		metav1.SetMetaDataAnnotation(&meta.ObjectMeta, AnnotationKeyResourcesLabeled, "true")
+	})
 }
 
 // RewriteEncryptedDataRemoveLabel patches all encrypted data in all namespaces in the target clusters and removes the
@@ -114,6 +137,7 @@ func RewriteEncryptedDataRemoveLabel(
 
 	return PatchAPIServerDeploymentMeta(ctx, runtimeClient, namespace, name, func(meta *metav1.PartialObjectMetadata) {
 		delete(meta.Annotations, AnnotationKeyEtcdSnapshotted)
+		delete(meta.Annotations, AnnotationKeyResourcesLabeled)
 	})
 }
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane security
/kind bug

**What this PR does / why we need it**:
When the encryption configuration is modified, we label the resources in parallel so that they are rewritten in the ETCD, then snapshot ETCD and remove the label. But in case there are thousands of resources and the client is throttled during the removal of label step, in the next try these resources are again labeled and this results in a cycle.
This PR adds an annotation to the kube-apiserver deployment marking the completion of adding of labels so that we don't repeat this again in case the labels are partially removed from resources.

The task functions for a particular GVK is executed in parallel but sets of tasks for different GVKs are now run in sequence to prevent hitting the rate limit.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Introduced with https://github.com/gardener/gardener/pull/8842
/cc @rfranzke @timuthy as reviewers of the original PR

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
The `kube-apiserver` deployment is annotated to mark the completion of labeling the resources for encrytion so that this step is not repeated in case the "label removal" step fails and resources are partially without the label.
```
