### PR TITLE
[release-v1.88] Allow `docker` CRI to be specified in the cloudprofile for one more version

### DIFF
--- a/example/provider-local/garden/base/cloudprofile.yaml
+++ b/example/provider-local/garden/base/cloudprofile.yaml
@@ -24,11 +24,11 @@ spec:
   machineImages:
   - name: local
     versions:
-    # TODO(shafeeqes): Remove this in gardener v1.89
-    - name: docker
     - version: 1.0.0
       cri:
       - name: containerd
+      # TODO(shafeeqes): Remove this in gardener v1.89
+      - name: docker
   providerConfig:
     apiVersion: local.provider.extensions.gardener.cloud/v1alpha1
     kind: CloudProfileConfig

--- a/example/provider-local/garden/base/cloudprofile.yaml
+++ b/example/provider-local/garden/base/cloudprofile.yaml
@@ -24,6 +24,8 @@ spec:
   machineImages:
   - name: local
     versions:
+    # TODO(shafeeqes): Remove this in gardener v1.89
+    - name: docker
     - version: 1.0.0
       cri:
       - name: containerd

--- a/pkg/apis/core/validation/cloudprofile.go
+++ b/pkg/apis/core/validation/cloudprofile.go
@@ -306,6 +306,13 @@ func validateContainerRuntimesInterfaces(cris []core.CRI, fldPath *field.Path) f
 		duplicateCRI.Insert(string(cri.Name))
 
 		if !availableWorkerCRINames.Has(string(cri.Name)) {
+			// TODO(shafeeqes): Remove this in gardener v1.89
+			{
+				if cri.Name == "docker" {
+					continue
+				}
+			}
+
 			allErrs = append(allErrs, field.NotSupported(criPath.Child("name"), string(cri.Name), sets.List(availableWorkerCRINames)))
 		}
 		allErrs = append(allErrs, validateContainerRuntimes(cri.ContainerRuntimes, criPath.Child("containerRuntimes"))...)

--- a/pkg/apis/core/validation/cloudprofile_test.go
+++ b/pkg/apis/core/validation/cloudprofile_test.go
@@ -754,9 +754,6 @@ var _ = Describe("CloudProfile Validation Tests ", func() {
 									{
 										Name: "invalid-cri-name",
 									},
-									{
-										Name: "docker",
-									},
 								},
 							},
 						},
@@ -772,6 +769,9 @@ var _ = Describe("CloudProfile Validation Tests ", func() {
 									{
 										Name: core.CRINameContainerD,
 									},
+									{
+										Name: "docker",
+									},
 								},
 							},
 						},
@@ -783,10 +783,6 @@ var _ = Describe("CloudProfile Validation Tests ", func() {
 				Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":   Equal(field.ErrorTypeNotSupported),
 					"Field":  Equal("spec.machineImages[0].versions[0].cri[0].name"),
-					"Detail": Equal("supported values: \"containerd\""),
-				})), PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":   Equal(field.ErrorTypeNotSupported),
-					"Field":  Equal("spec.machineImages[0].versions[0].cri[1].name"),
 					"Detail": Equal("supported values: \"containerd\""),
 				})),
 				))


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind enhancement

**What this PR does / why we need it**:
This PR relaxes the validation to allow docker CRI to be specified for one more version so that the migration is smooth.

Ref https://github.com/gardener/gardener/pull/9106#issuecomment-1929264290 and example failures: [1](https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/9128/pull-gardener-e2e-kind-upgrade/1755263797146161152), [2](https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/9128/pull-gardener-e2e-kind-ha-single-zone-upgrade/1755263796789645312)

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
