### PR TITLE
Remove `ConditionPathExists` from `valitail` systemd unit

### DIFF
--- a/pkg/component/extensions/operatingsystemconfig/original/components/valitail/config.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/valitail/config.go
@@ -147,9 +147,6 @@ Documentation=https://github.com/credativ/plutono`
 	if !features.DefaultFeatureGate.Enabled(features.UseGardenerNodeAgent) {
 		unitContent += `
 After=` + unitNameFetchToken
-	} else {
-		unitContent += `
-ConditionPathExists=` + PathAuthToken
 	}
 
 	unitContent += `

--- a/pkg/component/extensions/operatingsystemconfig/original/components/valitail/config_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/valitail/config_test.go
@@ -82,9 +82,6 @@ Documentation=https://github.com/credativ/plutono`
 					if !useGardenerNodeAgentEnabled {
 						unitContent += `
 After=valitail-fetch-token.service`
-					} else {
-						unitContent += `
-ConditionPathExists=/var/lib/valitail/auth-token`
 					}
 
 					unitContent += `
@@ -389,9 +386,6 @@ Documentation=https://github.com/credativ/plutono`
 					if !useGardenerNodeAgentEnabled {
 						unitContent += `
 After=valitail-fetch-token.service`
-					} else {
-						unitContent += `
-ConditionPathExists=/var/lib/valitail/auth-token`
 					}
 
 					unitContent += `


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity
/kind bug

**What this PR does / why we need it**:
`ConditionPathExists` in `valitail`s systemd unit prevents it from starting when `gardener-node-agent` is active.

`gardener-node-agent` creates the token file (`/var/lib/valitail/auth-token`) shortly after `valitail` was started. Because of that its start fails. Due to the nature of  `ConditionPathExists` it is not repeated.
```
systemd[1]: valitail.service - valitail daemon was skipped because of an unmet condition check (ConditionPathExists=/var/lib/valitail/auth-token).
```

This PR removes the `ConditionPathExists` from `valitail`s systemd unit. 
`valitail` is able to start without the token file and is logging errors in this case. When the token file is finally created, which should happen after only a few seconds, it recovers and starts its tail routines.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
A bug has been fixed which was preventing `valitail` systemd services on shoot workers from starting when the `UseGardenerNodeAgent` feature gate is enabled.
```
