### PR TITLE
🔎 Enable `unconvert` and `unparam` linters

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -18,6 +18,7 @@ linters:
   - revive
   - unused
   - unconvert
+  - unparam
   - importas
   - logcheck
   - ginkgolinter

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -17,6 +17,7 @@ linters:
   enable:
   - revive
   - unused
+  - unconvert
   - importas
   - logcheck
   - ginkgolinter

--- a/extensions/pkg/controller/healthcheck/message_util.go
+++ b/extensions/pkg/controller/healthcheck/message_util.go
@@ -23,24 +23,24 @@ import (
 // unsuccessful and pending checks
 func getUnsuccessfulDetailMessage(unsuccessfulChecks, progressingChecks int, details string) string {
 	if progressingChecks > 0 && unsuccessfulChecks > 0 {
-		return fmt.Sprintf("%d failing and %d progressing %s: %s", unsuccessfulChecks, progressingChecks, getSingularOrPlural("check", progressingChecks), details)
+		return fmt.Sprintf("%d failing and %d progressing %s: %s", unsuccessfulChecks, progressingChecks, getSingularOrPlural(progressingChecks), details)
 	}
 
 	return details
 }
 
 // getSingularOrPlural returns the given verb in either singular or plural
-func getSingularOrPlural(verb string, count int) string {
+func getSingularOrPlural(count int) string {
 	if count > 1 {
-		return fmt.Sprintf("%ss", verb)
+		return "checks"
 	}
-	return verb
+	return "check"
 }
 
 // appendUnsuccessfulChecksDetails appends a formatted detail message to the given string builder
 func (h *checkResultForConditionType) appendUnsuccessfulChecksDetails(details *strings.Builder) {
 	if len(h.unsuccessfulChecks) > 0 && (len(h.progressingChecks) != 0 || len(h.failedChecks) != 0) {
-		details.WriteString(fmt.Sprintf("Failed %s: ", getSingularOrPlural("check", len(h.unsuccessfulChecks))))
+		details.WriteString(fmt.Sprintf("Failed %s: ", getSingularOrPlural(len(h.unsuccessfulChecks))))
 	}
 
 	if len(h.unsuccessfulChecks) == 1 {
@@ -56,7 +56,7 @@ func (h *checkResultForConditionType) appendUnsuccessfulChecksDetails(details *s
 // appendProgressingChecksDetails appends a formatted detail message to the given string builder
 func (h *checkResultForConditionType) appendProgressingChecksDetails(details *strings.Builder) {
 	if len(h.progressingChecks) > 0 && (len(h.unsuccessfulChecks) != 0 || len(h.failedChecks) != 0) {
-		details.WriteString(fmt.Sprintf("Progressing %s: ", getSingularOrPlural("check", len(h.progressingChecks))))
+		details.WriteString(fmt.Sprintf("Progressing %s: ", getSingularOrPlural(len(h.progressingChecks))))
 	}
 
 	if len(h.progressingChecks) == 1 {
@@ -72,7 +72,7 @@ func (h *checkResultForConditionType) appendProgressingChecksDetails(details *st
 // appendFailedChecksDetails appends a formatted detail message to the given string builder
 func (h *checkResultForConditionType) appendFailedChecksDetails(details *strings.Builder) {
 	if len(h.failedChecks) > 0 && (len(h.unsuccessfulChecks) != 0 || len(h.progressingChecks) != 0) {
-		details.WriteString(fmt.Sprintf("Unable to execute %s: ", getSingularOrPlural("check", len(h.failedChecks))))
+		details.WriteString(fmt.Sprintf("Unable to execute %s: ", getSingularOrPlural(len(h.failedChecks))))
 	}
 
 	if len(h.failedChecks) == 1 {

--- a/extensions/pkg/controller/healthcheck/reconciler.go
+++ b/extensions/pkg/controller/healthcheck/reconciler.go
@@ -212,7 +212,7 @@ func extensionConditionCheckError(conditionBuilder v1beta1helper.ConditionBuilde
 	conditionBuilder.
 		WithStatus(gardencorev1beta1.ConditionUnknown).
 		WithReason(gardencorev1beta1.ConditionCheckError).
-		WithMessage(fmt.Sprintf("failed to execute %d health %s: %v", healthCheckResult.FailedChecks, getSingularOrPlural("check", healthCheckResult.FailedChecks), healthCheckResult.GetDetails()))
+		WithMessage(fmt.Sprintf("failed to execute %d health %s: %v", healthCheckResult.FailedChecks, getSingularOrPlural(healthCheckResult.FailedChecks), healthCheckResult.GetDetails()))
 	return condition{
 		builder:             conditionBuilder,
 		healthConditionType: healthConditionType,

--- a/extensions/pkg/webhook/cmd/factory_test.go
+++ b/extensions/pkg/webhook/cmd/factory_test.go
@@ -32,12 +32,14 @@ var _ = Describe("FactoryAggregator", func() {
 		wh1 = &extensionswebhook.Webhook{
 			Name: "webhook-1",
 		}
+		//nolint:unparam
 		whFactory1 = func(manager.Manager) (*extensionswebhook.Webhook, error) {
 			return wh1, nil
 		}
 		wh2 = &extensionswebhook.Webhook{
 			Name: "webhook-2",
 		}
+		//nolint:unparam
 		whFactory2 = func(manager.Manager) (*extensionswebhook.Webhook, error) {
 			return wh2, nil
 		}

--- a/extensions/pkg/webhook/network/network.go
+++ b/extensions/pkg/webhook/network/network.go
@@ -53,12 +53,6 @@ func New(mgr manager.Manager, args Args) (*extensionswebhook.Webhook, error) {
 		return nil, err
 	}
 
-	// Build namespace selector from the webhook kind and provider
-	namespaceSelector, err := buildSelector(args.NetworkProvider, args.CloudProvider)
-	if err != nil {
-		return nil, err
-	}
-
 	// Create webhook
 	var (
 		name = WebhookName
@@ -73,17 +67,17 @@ func New(mgr manager.Manager, args Args) (*extensionswebhook.Webhook, error) {
 		Target:            extensionswebhook.TargetSeed,
 		Path:              path,
 		Webhook:           &admission.Webhook{Handler: handler, RecoverPanic: true},
-		NamespaceSelector: namespaceSelector,
+		NamespaceSelector: buildSelector(args.NetworkProvider, args.CloudProvider),
 	}, nil
 }
 
 // buildSelector creates and returns a LabelSelector for the given webhook kind and provider.
-func buildSelector(networkProvider, cloudProvider string) (*metav1.LabelSelector, error) {
+func buildSelector(networkProvider, cloudProvider string) *metav1.LabelSelector {
 	// Create and return LabelSelector
 	return &metav1.LabelSelector{
 		MatchExpressions: []metav1.LabelSelectorRequirement{
 			{Key: v1beta1constants.LabelShootProvider, Operator: metav1.LabelSelectorOpIn, Values: []string{cloudProvider}},
 			{Key: v1beta1constants.LabelNetworkingProvider, Operator: metav1.LabelSelectorOpIn, Values: []string{networkProvider}},
 		},
-	}, nil
+	}
 }

--- a/extensions/pkg/webhook/shoot/shoot.go
+++ b/extensions/pkg/webhook/shoot/shoot.go
@@ -52,18 +52,12 @@ type Args struct {
 func New(mgr manager.Manager, args Args) (*extensionswebhook.Webhook, error) {
 	logger.Info("Creating webhook", "name", WebhookName)
 
-	// Build namespace selector from the webhook kind and provider
-	namespaceSelector, err := buildSelector()
-	if err != nil {
-		return nil, err
-	}
-
 	wh := &extensionswebhook.Webhook{
 		Name:              WebhookName,
 		Types:             args.Types,
 		Path:              WebhookName,
 		Target:            extensionswebhook.TargetShoot,
-		NamespaceSelector: namespaceSelector,
+		NamespaceSelector: buildSelector(),
 		FailurePolicy:     args.FailurePolicy,
 	}
 
@@ -91,11 +85,11 @@ func New(mgr manager.Manager, args Args) (*extensionswebhook.Webhook, error) {
 }
 
 // buildSelector creates and returns a LabelSelector for the given webhook kind and provider.
-func buildSelector() (*metav1.LabelSelector, error) {
+func buildSelector() *metav1.LabelSelector {
 	// Create and return LabelSelector
 	return &metav1.LabelSelector{
 		MatchExpressions: []metav1.LabelSelectorRequirement{
 			{Key: v1beta1constants.GardenerPurpose, Operator: metav1.LabelSelectorOpIn, Values: []string{metav1.NamespaceSystem}},
 		},
-	}, nil
+	}
 }

--- a/pkg/admissioncontroller/webhook/admission/namespacedeletion/handler_test.go
+++ b/pkg/admissioncontroller/webhook/admission/namespacedeletion/handler_test.go
@@ -81,7 +81,7 @@ var _ = Describe("handler", func() {
 		ctrl.Finish()
 	})
 
-	test := func(op admissionv1.Operation, matcher gomegatypes.GomegaMatcher) {
+	test := func(matcher gomegatypes.GomegaMatcher) {
 		ctx = admission.NewContextWithRequest(ctx, admission.Request{AdmissionRequest: admissionv1.AdmissionRequest{Name: namespaceName}})
 		warning, err := handler.ValidateDelete(ctx, nil)
 		Expect(warning).To(BeNil())
@@ -95,7 +95,7 @@ var _ = Describe("handler", func() {
 		})
 		mockClient.EXPECT().Get(gomock.Any(), kubernetesutils.Key(projectName), gomock.AssignableToTypeOf(&gardencorev1beta1.Project{})).Return(apierrors.NewNotFound(schema.GroupResource{}, ""))
 
-		test(admissionv1.Delete, Succeed())
+		test(Succeed())
 	})
 
 	It("should pass because namespace is not project related", func() {
@@ -104,13 +104,13 @@ var _ = Describe("handler", func() {
 			return nil
 		})
 
-		test(admissionv1.Delete, Succeed())
+		test(Succeed())
 	})
 
 	It("should fail because get namespace fails", func() {
 		mockClient.EXPECT().Get(gomock.Any(), kubernetesutils.Key(namespaceName), gomock.AssignableToTypeOf(&corev1.Namespace{})).Return(fmt.Errorf("fake"))
 
-		test(admissionv1.Delete, MatchError(ContainSubstring("fake")))
+		test(MatchError(ContainSubstring("fake")))
 	})
 
 	It("should fail because getting the projects fails", func() {
@@ -120,13 +120,13 @@ var _ = Describe("handler", func() {
 		})
 		mockClient.EXPECT().Get(gomock.Any(), kubernetesutils.Key(projectName), gomock.AssignableToTypeOf(&gardencorev1beta1.Project{})).Return(fmt.Errorf("fake"))
 
-		test(admissionv1.Delete, MatchError(ContainSubstring("fake")))
+		test(MatchError(ContainSubstring("fake")))
 	})
 
 	It("should pass because namespace is already gone", func() {
 		mockClient.EXPECT().Get(gomock.Any(), kubernetesutils.Key(namespaceName), gomock.AssignableToTypeOf(&corev1.Namespace{})).Return(apierrors.NewNotFound(schema.GroupResource{}, ""))
 
-		test(admissionv1.Delete, Succeed())
+		test(Succeed())
 	})
 
 	Context("related project available", func() {
@@ -141,7 +141,7 @@ var _ = Describe("handler", func() {
 			})
 			mockClient.EXPECT().Get(gomock.Any(), kubernetesutils.Key(projectName), gomock.AssignableToTypeOf(&gardencorev1beta1.Project{}))
 
-			test(admissionv1.Delete, Succeed())
+			test(Succeed())
 		})
 
 		It("should forbid namespace deletion because project is not marked for deletion", func() {
@@ -151,7 +151,7 @@ var _ = Describe("handler", func() {
 			})
 			mockClient.EXPECT().Get(gomock.Any(), kubernetesutils.Key(projectName), gomock.AssignableToTypeOf(&gardencorev1beta1.Project{}))
 
-			test(admissionv1.Delete, MatchError(ContainSubstring("direct deletion of namespace")))
+			test(MatchError(ContainSubstring("direct deletion of namespace")))
 		})
 
 		Context("related project marked for deletion ", func() {
@@ -175,7 +175,7 @@ var _ = Describe("handler", func() {
 					return fmt.Errorf("fake")
 				})
 
-				test(admissionv1.Delete, MatchError(ContainSubstring("fake")))
+				test(MatchError(ContainSubstring("fake")))
 			})
 
 			It("should pass because namespace is does not contain any shoots", func() {
@@ -183,7 +183,7 @@ var _ = Describe("handler", func() {
 					return nil
 				})
 
-				test(admissionv1.Delete, Succeed())
+				test(Succeed())
 			})
 
 			It("should forbid namespace deletion because it still contain shoots", func() {
@@ -192,7 +192,7 @@ var _ = Describe("handler", func() {
 					return nil
 				})
 
-				test(admissionv1.Delete, MatchError(ContainSubstring("still contains Shoots")))
+				test(MatchError(ContainSubstring("still contains Shoots")))
 			})
 		})
 	})

--- a/pkg/apis/core/v1beta1/helper/errors_test.go
+++ b/pkg/apis/core/v1beta1/helper/errors_test.go
@@ -61,7 +61,7 @@ var _ = Describe("errors", func() {
 		)
 
 		JustBeforeEach(func() {
-			formatFn = func(err []error) string {
+			formatFn = func([]error) string {
 				return strconv.Itoa(len(errs))
 			}
 			multiError = NewMultiErrorWithCodes(formatFn)

--- a/pkg/apis/core/validation/quota.go
+++ b/pkg/apis/core/validation/quota.go
@@ -56,7 +56,7 @@ func ValidateQuotaSpec(quotaSpec *core.QuotaSpec, fldPath *field.Path) field.Err
 	metricsFldPath := fldPath.Child("metrics")
 	for k, v := range quotaSpec.Metrics {
 		keyPath := metricsFldPath.Key(string(k))
-		if !isValidQuotaMetric(corev1.ResourceName(k)) {
+		if !isValidQuotaMetric(k) {
 			allErrs = append(allErrs, field.Invalid(keyPath, v.String(), fmt.Sprintf("%s is no supported quota metric", string(k))))
 		}
 		allErrs = append(allErrs, kubernetescorevalidation.ValidateResourceQuantityValue(k.String(), v, keyPath)...)

--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -1319,10 +1319,10 @@ func ValidateKubeAPIServer(kubeAPIServer *core.KubeAPIServerConfig, version stri
 	allErrs = append(allErrs, ValidateAPIServerLogging(kubeAPIServer.Logging, fldPath.Child("logging"))...)
 
 	if defaultNotReadyTolerationSeconds := kubeAPIServer.DefaultNotReadyTolerationSeconds; defaultNotReadyTolerationSeconds != nil {
-		allErrs = append(allErrs, apivalidation.ValidateNonnegativeField(int64(*defaultNotReadyTolerationSeconds), fldPath.Child("defaultNotReadyTolerationSeconds"))...)
+		allErrs = append(allErrs, apivalidation.ValidateNonnegativeField(*defaultNotReadyTolerationSeconds, fldPath.Child("defaultNotReadyTolerationSeconds"))...)
 	}
 	if defaultUnreachableTolerationSeconds := kubeAPIServer.DefaultUnreachableTolerationSeconds; defaultUnreachableTolerationSeconds != nil {
-		allErrs = append(allErrs, apivalidation.ValidateNonnegativeField(int64(*defaultUnreachableTolerationSeconds), fldPath.Child("defaultUnreachableTolerationSeconds"))...)
+		allErrs = append(allErrs, apivalidation.ValidateNonnegativeField(*defaultUnreachableTolerationSeconds, fldPath.Child("defaultUnreachableTolerationSeconds"))...)
 	}
 
 	allErrs = append(allErrs, validateEncryptionConfig(kubeAPIServer.EncryptionConfig, version, defaultEncryptedResources, fldPath)...)

--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -2020,7 +2020,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 						Default: ptr.To(int32(42)),
 					}, BeEmpty()),
 					Entry("invalid (default<0)", &core.WatchCacheSizes{
-						Default: ptr.To(int32(negativeSize)),
+						Default: ptr.To(negativeSize),
 					}, ConsistOf(
 						field.Invalid(field.NewPath("default"), int64(negativeSize), apivalidation.IsNegativeErrorMsg),
 					)),
@@ -2785,9 +2785,9 @@ var _ = Describe("Shoot Validation Tests", func() {
 			expanderMostPods                    = core.ClusterAutoscalerExpanderMostPods
 			expanderPriority                    = core.ClusterAutoscalerExpanderPriority
 			expanderRandom                      = core.ClusterAutoscalerExpanderRandom
-			expanderPriorityAndLeastWaste       = core.ExpanderMode(core.ClusterAutoscalerExpanderPriority + "," + core.ClusterAutoscalerExpanderLeastWaste)
-			invalidExpander                     = core.ExpanderMode(core.ClusterAutoscalerExpanderPriority + ", test-expander")
-			invalidMultipleExpanderString       = core.ExpanderMode(core.ClusterAutoscalerExpanderPriority + ", " + core.ClusterAutoscalerExpanderLeastWaste)
+			expanderPriorityAndLeastWaste       = core.ClusterAutoscalerExpanderPriority + "," + core.ClusterAutoscalerExpanderLeastWaste
+			invalidExpander                     = core.ClusterAutoscalerExpanderPriority + ", test-expander"
+			invalidMultipleExpanderString       = core.ClusterAutoscalerExpanderPriority + ", " + core.ClusterAutoscalerExpanderLeastWaste
 			ignoreTaintsUnique                  = []string{"taint-1", "taint-2"}
 			ignoreTaintsDuplicate               = []string{"taint-1", "taint-1"}
 			ignoreTaintsInvalid                 = []string{"taint 1", "taint-1"}

--- a/pkg/client/kubernetes/chartapplier_test.go
+++ b/pkg/client/kubernetes/chartapplier_test.go
@@ -173,7 +173,7 @@ var _ = Describe("chart applier", func() {
 				}
 				Expect(c.Create(ctx, existingCM)).To(Succeed(), "dummy configmap creation should succeed")
 
-				Expect(ca.DeleteFromEmbeddedFS(ctx, embeddedFS, chartPathV1, namespace, name)).To(Succeed())
+				Expect(ca.DeleteFromEmbeddedFS(ctx, embeddedFS, chartPath, namespace, name)).To(Succeed())
 
 				Expect(c.Get(ctx, client.ObjectKey{Name: configMapName, Namespace: namespace}, &corev1.ConfigMap{})).To(BeNotFoundError())
 			})

--- a/pkg/client/kubernetes/runtime_client.go
+++ b/pkg/client/kubernetes/runtime_client.go
@@ -40,19 +40,15 @@ const (
 // NewRuntimeCache creates a new cache.Cache with the given config and options. It can be used
 // for creating new controller-runtime clients with caches.
 func NewRuntimeCache(config *rest.Config, options cache.Options) (cache.Cache, error) {
-	if err := setCacheOptionsDefaults(&options); err != nil {
-		return nil, err
-	}
+	setCacheOptionsDefaults(&options)
 
 	return cache.New(config, options)
 }
 
-func setCacheOptionsDefaults(options *cache.Options) error {
+func setCacheOptionsDefaults(options *cache.Options) {
 	if options.SyncPeriod == nil {
 		options.SyncPeriod = ptr.To(defaultCacheSyncPeriod)
 	}
-
-	return nil
 }
 
 func setClientOptionsDefaults(config *rest.Config, options *client.Options) error {
@@ -78,9 +74,7 @@ func setClientOptionsDefaults(config *rest.Config, options *client.Options) erro
 // AggregatorCacheFunc returns a `cache.NewCacheFunc` which creates a cache that holds different cache implementations depending on the objects' GVKs.
 func AggregatorCacheFunc(newCache cache.NewCacheFunc, typeToNewCache map[client.Object]cache.NewCacheFunc, scheme *runtime.Scheme) cache.NewCacheFunc {
 	return func(config *rest.Config, options cache.Options) (cache.Cache, error) {
-		if err := setCacheOptionsDefaults(&options); err != nil {
-			return nil, err
-		}
+		setCacheOptionsDefaults(&options)
 
 		fallbackCache, err := newCache(config, options)
 		if err != nil {

--- a/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig_test.go
@@ -100,6 +100,7 @@ var _ = Describe("OperatingSystemConfig", func() {
 
 			ccdUnitContent = "ccd-unit-content"
 
+			//nolint:unparam
 			initConfigFn = func(worker gardencorev1beta1.Worker, nodeAgentImage string, config *nodeagentv1alpha1.NodeAgentConfiguration) ([]extensionsv1alpha1.Unit, []extensionsv1alpha1.File, error) {
 				return []extensionsv1alpha1.Unit{
 						{Name: worker.Name},
@@ -115,6 +116,7 @@ var _ = Describe("OperatingSystemConfig", func() {
 					},
 					nil
 			}
+			//nolint:unparam
 			downloaderConfigFn = func(cloudConfigUserDataSecretName, apiServerURL, clusterCASecretName string) ([]extensionsv1alpha1.Unit, []extensionsv1alpha1.File, error) {
 				return []extensionsv1alpha1.Unit{
 						{Name: cloudConfigUserDataSecretName},
@@ -129,6 +131,7 @@ var _ = Describe("OperatingSystemConfig", func() {
 					},
 					nil
 			}
+			//nolint:unparam
 			originalConfigFn = func(cctx components.Context) ([]extensionsv1alpha1.Unit, []extensionsv1alpha1.File, error) {
 				return []extensionsv1alpha1.Unit{
 						{Name: cctx.Key},

--- a/pkg/component/extensions/operatingsystemconfig/original/components/kubelet/component_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/kubelet/component_test.go
@@ -94,35 +94,35 @@ var _ = Describe("Component", func() {
 		Entry(
 			"kubernetes 1.25",
 			"1.25.1",
-			kubeletConfig(true, true, false),
+			kubeletConfig(false),
 			false,
 			false,
 		),
 		Entry(
 			"kubernetes 1.25 w/ node-agent",
 			"1.25.1",
-			kubeletConfig(true, true, false),
+			kubeletConfig(false),
 			true,
 			false,
 		),
 		Entry(
 			"kubernetes 1.26",
 			"1.26.1",
-			kubeletConfig(true, true, true),
+			kubeletConfig(true),
 			false,
 			false,
 		),
 		Entry(
 			"kubernetes 1.26 w/ node-agent",
 			"1.26.1",
-			kubeletConfig(true, true, true),
+			kubeletConfig(true),
 			true,
 			false,
 		),
 		Entry(
 			"kubernetes 1.26 w/ node-agent and preferIPv6",
 			"1.26.1",
-			kubeletConfig(true, true, true),
+			kubeletConfig(true),
 			true,
 			true,
 		),
@@ -268,8 +268,6 @@ kubelet_monitoring
 )
 
 func kubeletConfig(
-	rotateCertificates bool,
-	volumePluginDir bool,
 	k8sGreaterEqual126 bool,
 ) string {
 	streamingConnectionIdleTimeout := "4h0m0s"
@@ -368,28 +366,16 @@ protectKernelDefaults: true`
 registerWithTaints:
 - effect: NoSchedule
   key: node.gardener.cloud/critical-components-not-ready
-resolvConf: /etc/resolv.conf`
-
-	if rotateCertificates {
-		out += `
-rotateCertificates: true`
-	}
-
-	out += `
+resolvConf: /etc/resolv.conf
+rotateCertificates: true
 runtimeRequestTimeout: 2m0s
 serializeImagePulls: true
 serverTLSBootstrap: true
 shutdownGracePeriod: 0s
 shutdownGracePeriodCriticalPods: 0s
 streamingConnectionIdleTimeout: ` + streamingConnectionIdleTimeout + `
-syncFrequency: 1m0s`
-
-	if volumePluginDir {
-		out += `
-volumePluginDir: /var/lib/kubelet/volumeplugins`
-	}
-
-	out += `
+syncFrequency: 1m0s
+volumePluginDir: /var/lib/kubelet/volumeplugins
 volumeStatsAggPeriod: 1m0s
 `
 

--- a/pkg/component/logging/vali/vali.go
+++ b/pkg/component/logging/vali/vali.go
@@ -255,10 +255,7 @@ func (v *vali) Deploy(ctx context.Context) error {
 		}
 	}
 
-	valiConfigMap, err := v.getValiConfigMap()
-	if err != nil {
-		return err
-	}
+	valiConfigMap := v.getValiConfigMap()
 
 	resources = append(resources,
 		valiConfigMap,
@@ -567,7 +564,7 @@ func (v *vali) getService() *corev1.Service {
 	return service
 }
 
-func (v *vali) getValiConfigMap() (*corev1.ConfigMap, error) {
+func (v *vali) getValiConfigMap() *corev1.ConfigMap {
 	configMap := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "vali-config",
@@ -582,7 +579,7 @@ func (v *vali) getValiConfigMap() (*corev1.ConfigMap, error) {
 	}
 
 	utilruntime.Must(kubernetesutils.MakeUnique(configMap))
-	return configMap, nil
+	return configMap
 }
 
 func (v *vali) getTelegrafConfigMap() (*corev1.ConfigMap, error) {

--- a/pkg/component/logging/vali/vali_test.go
+++ b/pkg/component/logging/vali/vali_test.go
@@ -416,10 +416,12 @@ var _ = Describe("Vali", func() {
 			new80GiStorageQuantity  = resource.MustParse("80Gi")
 			valiPVCKey              = kubernetesutils.Key("garden", "vali-vali-0")
 			valiStatefulSetKey      = kubernetesutils.Key("garden", "vali")
-			funcGetValiPVC          = func(_ context.Context, _ types.NamespacedName, pvc *corev1.PersistentVolumeClaim, _ ...client.GetOption) error {
+			//nolint:unparam
+			funcGetValiPVC = func(_ context.Context, _ types.NamespacedName, pvc *corev1.PersistentVolumeClaim, _ ...client.GetOption) error {
 				*pvc = *valiPVC
 				return nil
 			}
+			//nolint:unparam
 			funcGetScaledToZeroValiStatefulset = func(_ context.Context, _ types.NamespacedName, sts *appsv1.StatefulSet, _ ...client.GetOption) error {
 				*sts = scaledToZeroValiStatefulset
 				return nil

--- a/pkg/component/vpnshoot/vpnshoot.go
+++ b/pkg/component/vpnshoot/vpnshoot.go
@@ -466,11 +466,7 @@ func (v *vpnShoot) computeResourcesData(secretCAVPN *corev1.Secret, secretsVPNSh
 	}
 
 	if v.values.HighAvailabilityEnabled {
-		pdb, err := v.podDisruptionBudget()
-		if err != nil {
-			return nil, err
-		}
-		objects = append(objects, pdb)
+		objects = append(objects, v.podDisruptionBudget())
 	}
 
 	objects = append(objects,
@@ -492,7 +488,7 @@ func (v *vpnShoot) computeResourcesData(secretCAVPN *corev1.Secret, secretsVPNSh
 	return registry.AddAllAndSerialize(objects...)
 }
 
-func (v *vpnShoot) podDisruptionBudget() (client.Object, error) {
+func (v *vpnShoot) podDisruptionBudget() client.Object {
 	pdb := &policyv1.PodDisruptionBudget{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      deploymentName,
@@ -507,7 +503,7 @@ func (v *vpnShoot) podDisruptionBudget() (client.Object, error) {
 
 	kubernetesutils.SetAlwaysAllowEviction(pdb, v.values.KubernetesVersion)
 
-	return pdb, nil
+	return pdb
 }
 
 func (v *vpnShoot) podTemplate(serviceAccount *corev1.ServiceAccount, secrets []vpnSecret, secretCA, secretTLSAuth *corev1.Secret) *corev1.PodTemplateSpec {

--- a/pkg/controllermanager/controller/seed/secrets/reconciler_test.go
+++ b/pkg/controllermanager/controller/seed/secrets/reconciler_test.go
@@ -132,9 +132,9 @@ var _ = Describe("Reconciler", func() {
 				corev1If.EXPECT().Secrets(gomock.Any()).Return(secretIf).AnyTimes()
 				corev1If.EXPECT().Namespaces().Return(namespaceIf).AnyTimes()
 
-				oldSecret = createSecret("existing", namespace.Name, "old", "role", []byte("data"))
-				addedSecret = createSecret("new", v1beta1constants.GardenNamespace, "foo", "role", []byte("bar"))
-				deletedSecret = createSecret("stale", namespace.Name, "foo", "role", []byte("bar"))
+				oldSecret = createSecret("existing", namespace.Name, "old", []byte("data"))
+				addedSecret = createSecret("new", v1beta1constants.GardenNamespace, "foo", []byte("bar"))
+				deletedSecret = createSecret("stale", namespace.Name, "foo", []byte("bar"))
 
 				cl.EXPECT().Get(gomock.Any(), kubernetesutils.Key(seed.Name), gomock.AssignableToTypeOf(&gardencorev1beta1.Seed{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.Seed, _ ...client.GetOption) error {
 					*obj = *seed
@@ -221,8 +221,8 @@ var _ = Describe("Reconciler", func() {
 				})
 
 				var (
-					secret1 = createSecret("1", v1beta1constants.GardenNamespace, "foo", "role", []byte("bar"))
-					secret2 = createSecret("2", v1beta1constants.GardenNamespace, "foo", "role", []byte("bar"))
+					secret1 = createSecret("1", v1beta1constants.GardenNamespace, "foo", []byte("bar"))
+					secret2 = createSecret("2", v1beta1constants.GardenNamespace, "foo", []byte("bar"))
 				)
 
 				cl.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&corev1.SecretList{}), client.InNamespace(v1beta1constants.GardenNamespace), labelSelector).DoAndReturn(func(ctx context.Context, list *corev1.SecretList, opts ...client.ListOption) error {
@@ -264,11 +264,11 @@ func copySecretWithNamespace(secret *corev1.Secret, namespace string) *corev1.Se
 	return s
 }
 
-func createSecret(name, namespace, key, role string, data []byte) *corev1.Secret {
+func createSecret(name, namespace, key string, data []byte) *corev1.Secret {
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Labels: map[string]string{
-				v1beta1constants.GardenRole: role,
+				v1beta1constants.GardenRole: "role",
 			},
 			Name:      name,
 			Namespace: namespace,

--- a/pkg/controllerutils/finalizers_test.go
+++ b/pkg/controllerutils/finalizers_test.go
@@ -57,8 +57,8 @@ var _ = Describe("Finalizers", func() {
 	})
 
 	Describe("RemoveFinalizers", func() {
-		test := func(description string, expectedPatchFinalizers string, existingFinalizers []string, finalizer string) {
-			It(description+fmt.Sprintf(" %v, %v", existingFinalizers, finalizer), func() {
+		test := func(expectedPatchFinalizers string, existingFinalizers []string, finalizer string) {
+			It(fmt.Sprintf("should succeed %v, %v", existingFinalizers, finalizer), func() {
 				obj.SetFinalizers(append(existingFinalizers[:0:0], existingFinalizers...))
 
 				mockWriter.EXPECT().Patch(ctx, obj, gomock.Any()).DoAndReturn(func(_ context.Context, o client.Object, patch client.Patch, opts ...client.PatchOption) error {
@@ -71,15 +71,15 @@ var _ = Describe("Finalizers", func() {
 			})
 		}
 
-		test("should succeed", ``, nil, "foo")
-		test("should succeed", ``, []string{"foo"}, "bar")
-		test("should succeed", `null`, []string{"foo"}, "foo")
-		test("should succeed", `["bar"]`, []string{"foo", "bar"}, "foo")
+		test(``, nil, "foo")
+		test(``, []string{"foo"}, "bar")
+		test(`null`, []string{"foo"}, "foo")
+		test(`["bar"]`, []string{"foo", "bar"}, "foo")
 	})
 
 	Describe("RemoveAllFinalizers", func() {
-		test := func(description string, expectedPatchFinalizers string, existingFinalizers []string) {
-			It(description+fmt.Sprintf(" %v", existingFinalizers), func() {
+		test := func(expectedPatchFinalizers string, existingFinalizers []string) {
+			It(fmt.Sprintf("should succeed %v", existingFinalizers), func() {
 				obj.SetFinalizers(append(existingFinalizers[:0:0], existingFinalizers...))
 
 				mockWriter.EXPECT().Patch(ctx, obj, gomock.Any()).DoAndReturn(func(_ context.Context, o client.Object, patch client.Patch, opts ...client.PatchOption) error {
@@ -92,9 +92,9 @@ var _ = Describe("Finalizers", func() {
 			})
 		}
 
-		test("should succeed", `{}`, nil)
-		test("should succeed", `{"metadata":{"finalizers":null}}`, []string{"foo"})
-		test("should succeed", `{"metadata":{"finalizers":null}}`, []string{"foo", "bar"})
+		test(`{}`, nil)
+		test(`{"metadata":{"finalizers":null}}`, []string{"foo"})
+		test(`{"metadata":{"finalizers":null}}`, []string{"foo", "bar"})
 	})
 })
 

--- a/pkg/gardenlet/controller/seed/seed/reconciler.go
+++ b/pkg/gardenlet/controller/seed/seed/reconciler.go
@@ -107,14 +107,14 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	}
 
 	if seed.DeletionTimestamp != nil {
-		if result, err := r.delete(ctx, log, seedObj, seedIsGarden); err != nil {
-			return result, r.updateStatusOperationError(ctx, seed, err, operationType)
+		if err := r.delete(ctx, log, seedObj, seedIsGarden); err != nil {
+			return reconcile.Result{}, r.updateStatusOperationError(ctx, seed, err, operationType)
 		}
 		return reconcile.Result{}, nil
 	}
 
-	if result, err := r.reconcile(ctx, log, seedObj, seedIsGarden); err != nil {
-		return result, r.updateStatusOperationError(ctx, seed, err, operationType)
+	if err := r.reconcile(ctx, log, seedObj, seedIsGarden); err != nil {
+		return reconcile.Result{}, r.updateStatusOperationError(ctx, seed, err, operationType)
 	}
 
 	return reconcile.Result{RequeueAfter: r.Config.Controllers.Seed.SyncPeriod.Duration}, r.updateStatusOperationSuccess(ctx, seed, operationType)

--- a/pkg/gardenlet/controller/seed/seed/reconciler_delete.go
+++ b/pkg/gardenlet/controller/seed/seed/reconciler_delete.go
@@ -28,7 +28,6 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
@@ -63,14 +62,11 @@ func (r *Reconciler) delete(
 	log logr.Logger,
 	seedObj *seedpkg.Seed,
 	seedIsGarden bool,
-) (
-	reconcile.Result,
-	error,
-) {
+) error {
 	seed := seedObj.GetInfo()
 
 	if !sets.New(seed.Finalizers...).Has(gardencorev1beta1.GardenerName) {
-		return reconcile.Result{}, nil
+		return nil
 	}
 
 	// Before deletion, it has to be ensured that no Shoots nor BackupBuckets depend on the Seed anymore.
@@ -79,51 +75,51 @@ func (r *Reconciler) delete(
 
 	associatedShoots, err := controllerutils.DetermineShootsAssociatedTo(ctx, r.GardenClient, seed)
 	if err != nil {
-		return reconcile.Result{}, err
+		return err
 	}
 
 	if len(associatedShoots) > 0 {
 		log.Info("Cannot delete Seed because the following Shoots are still referencing it", "shoots", associatedShoots)
 		r.Recorder.Event(seed, corev1.EventTypeNormal, v1beta1constants.EventResourceReferenced, fmt.Sprintf("%s Shoots=%v", parentLogMessage, associatedShoots))
 
-		return reconcile.Result{}, errors.New("seed still has references")
+		return errors.New("seed still has references")
 	}
 
 	if seed.Spec.Backup != nil {
 		backupBucket := &gardencorev1beta1.BackupBucket{ObjectMeta: metav1.ObjectMeta{Name: string(seed.UID)}}
 
 		if err := r.GardenClient.Delete(ctx, backupBucket); client.IgnoreNotFound(err) != nil {
-			return reconcile.Result{}, err
+			return err
 		}
 	}
 
 	associatedBackupBuckets, err := controllerutils.DetermineBackupBucketAssociations(ctx, r.GardenClient, seed.Name)
 	if err != nil {
-		return reconcile.Result{}, err
+		return err
 	}
 
 	if len(associatedBackupBuckets) > 0 {
 		log.Info("Cannot delete Seed because the following BackupBuckets are still referencing it", "backupBuckets", associatedBackupBuckets)
 		r.Recorder.Event(seed, corev1.EventTypeNormal, v1beta1constants.EventResourceReferenced, fmt.Sprintf("%s BackupBuckets=%v", parentLogMessage, associatedBackupBuckets))
 
-		return reconcile.Result{}, errors.New("seed still has references")
+		return errors.New("seed still has references")
 	}
 
 	log.Info("No Shoots or BackupBuckets are referencing the Seed, deletion accepted")
 
 	if err := r.runDeleteSeedFlow(ctx, log, seedObj, seedIsGarden); err != nil {
-		return reconcile.Result{}, err
+		return err
 	}
 
 	// Remove finalizer from Seed
 	if controllerutil.ContainsFinalizer(seed, gardencorev1beta1.GardenerName) {
 		log.Info("Removing finalizer")
 		if err := controllerutils.RemoveFinalizers(ctx, r.GardenClient, seed, gardencorev1beta1.GardenerName); err != nil {
-			return reconcile.Result{}, fmt.Errorf("failed to remove finalizer: %w", err)
+			return fmt.Errorf("failed to remove finalizer: %w", err)
 		}
 	}
 
-	return reconcile.Result{}, nil
+	return nil
 }
 
 func (r *Reconciler) runDeleteSeedFlow(

--- a/pkg/gardenlet/controller/shoot/care/health_test.go
+++ b/pkg/gardenlet/controller/shoot/care/health_test.go
@@ -378,7 +378,7 @@ var _ = Describe("health check", func() {
 				false,
 				kubernetesVersion,
 				[]corev1.Node{
-					newNode(nodeName, true, labels.Set{"worker.gardener.cloud/pool": workerPoolName1, "worker.gardener.cloud/kubernetes-version": kubernetesVersion.Original()}, map[string]string{"checksum/cloud-config-data": cloudConfigSecretChecksum1}, kubernetesVersion.Original()),
+					newNode(true, labels.Set{"worker.gardener.cloud/pool": workerPoolName1, "worker.gardener.cloud/kubernetes-version": kubernetesVersion.Original()}, map[string]string{"checksum/cloud-config-data": cloudConfigSecretChecksum1}, kubernetesVersion.Original()),
 				},
 				[]gardencorev1beta1.Worker{
 					{
@@ -394,7 +394,7 @@ var _ = Describe("health check", func() {
 				false,
 				kubernetesVersion,
 				[]corev1.Node{
-					newNode(nodeName, false, labels.Set{"worker.gardener.cloud/pool": workerPoolName1, "worker.gardener.cloud/kubernetes-version": kubernetesVersion.Original()}, nil, kubernetesVersion.Original()),
+					newNode(false, labels.Set{"worker.gardener.cloud/pool": workerPoolName1, "worker.gardener.cloud/kubernetes-version": kubernetesVersion.Original()}, nil, kubernetesVersion.Original()),
 				},
 				[]gardencorev1beta1.Worker{
 					{
@@ -444,7 +444,7 @@ var _ = Describe("health check", func() {
 				false,
 				kubernetesVersion,
 				[]corev1.Node{
-					newNode(nodeName, true, labels.Set{"worker.gardener.cloud/pool": workerPoolName1, "worker.gardener.cloud/kubernetes-version": kubernetesVersion.Original()}, nil, kubernetesVersion.Original()),
+					newNode(true, labels.Set{"worker.gardener.cloud/pool": workerPoolName1, "worker.gardener.cloud/kubernetes-version": kubernetesVersion.Original()}, nil, kubernetesVersion.Original()),
 				},
 				[]gardencorev1beta1.Worker{
 					{
@@ -465,7 +465,7 @@ var _ = Describe("health check", func() {
 				false,
 				kubernetesVersion,
 				[]corev1.Node{
-					newNode(nodeName, true, labels.Set{"worker.gardener.cloud/pool": workerPoolName2, "worker.gardener.cloud/kubernetes-version": kubernetesVersion.Original()}, nil, kubernetesVersion.Original()),
+					newNode(true, labels.Set{"worker.gardener.cloud/pool": workerPoolName2, "worker.gardener.cloud/kubernetes-version": kubernetesVersion.Original()}, nil, kubernetesVersion.Original()),
 				},
 				[]gardencorev1beta1.Worker{
 					{
@@ -486,7 +486,7 @@ var _ = Describe("health check", func() {
 				false,
 				getVersionPointer(kubernetesVersion.IncPatch()),
 				[]corev1.Node{
-					newNode(nodeName, true, labels.Set{"worker.gardener.cloud/pool": workerPoolName1, "worker.gardener.cloud/kubernetes-version": kubernetesVersion.Original()}, nil, kubernetesVersion.String()),
+					newNode(true, labels.Set{"worker.gardener.cloud/pool": workerPoolName1, "worker.gardener.cloud/kubernetes-version": kubernetesVersion.Original()}, nil, kubernetesVersion.String()),
 				},
 				[]gardencorev1beta1.Worker{
 					{
@@ -502,7 +502,7 @@ var _ = Describe("health check", func() {
 				false,
 				kubernetesVersion,
 				[]corev1.Node{
-					newNode(nodeName, true, labels.Set{"worker.gardener.cloud/pool": workerPoolName1, "worker.gardener.cloud/kubernetes-version": kubernetesVersion.Original()}, map[string]string{"checksum/cloud-config-data": cloudConfigSecretChecksum1}, kubernetesVersion.Original()),
+					newNode(true, labels.Set{"worker.gardener.cloud/pool": workerPoolName1, "worker.gardener.cloud/kubernetes-version": kubernetesVersion.Original()}, map[string]string{"checksum/cloud-config-data": cloudConfigSecretChecksum1}, kubernetesVersion.Original()),
 				},
 				[]gardencorev1beta1.Worker{
 					{
@@ -518,7 +518,7 @@ var _ = Describe("health check", func() {
 				false,
 				getVersionPointer(kubernetesVersion.IncMinor()),
 				[]corev1.Node{
-					newNode(nodeName, true, labels.Set{"worker.gardener.cloud/pool": workerPoolName1, "worker.gardener.cloud/kubernetes-version": kubernetesVersion.Original()}, nil, kubernetesVersion.Original()),
+					newNode(true, labels.Set{"worker.gardener.cloud/pool": workerPoolName1, "worker.gardener.cloud/kubernetes-version": kubernetesVersion.Original()}, nil, kubernetesVersion.Original()),
 				},
 				[]gardencorev1beta1.Worker{
 					{
@@ -537,7 +537,7 @@ var _ = Describe("health check", func() {
 				false,
 				getVersionPointer(kubernetesVersion.IncMinor()),
 				[]corev1.Node{
-					newNode(nodeName, true, labels.Set{"worker.gardener.cloud/pool": workerPoolName1, "worker.gardener.cloud/kubernetes-version": kubernetesVersion.Original()}, map[string]string{"checksum/cloud-config-data": cloudConfigSecretChecksum1}, kubernetesVersion.Original()),
+					newNode(true, labels.Set{"worker.gardener.cloud/pool": workerPoolName1, "worker.gardener.cloud/kubernetes-version": kubernetesVersion.Original()}, map[string]string{"checksum/cloud-config-data": cloudConfigSecretChecksum1}, kubernetesVersion.Original()),
 				},
 				[]gardencorev1beta1.Worker{
 					{
@@ -557,7 +557,7 @@ var _ = Describe("health check", func() {
 				false,
 				kubernetesVersion,
 				[]corev1.Node{
-					newNode(nodeName, true, labels.Set{"worker.gardener.cloud/pool": workerPoolName1, "worker.gardener.cloud/kubernetes-version": kubernetesVersion.Original()}, nil, kubernetesVersion.Original()),
+					newNode(true, labels.Set{"worker.gardener.cloud/pool": workerPoolName1, "worker.gardener.cloud/kubernetes-version": kubernetesVersion.Original()}, nil, kubernetesVersion.Original()),
 				},
 				[]gardencorev1beta1.Worker{
 					{
@@ -573,7 +573,7 @@ var _ = Describe("health check", func() {
 				false,
 				kubernetesVersion,
 				[]corev1.Node{
-					newNode(nodeName, true, labels.Set{"worker.gardener.cloud/pool": workerPoolName1, "worker.gardener.cloud/kubernetes-version": kubernetesVersion.Original()}, nil, kubernetesVersion.Original()),
+					newNode(true, labels.Set{"worker.gardener.cloud/pool": workerPoolName1, "worker.gardener.cloud/kubernetes-version": kubernetesVersion.Original()}, nil, kubernetesVersion.Original()),
 				},
 				[]gardencorev1beta1.Worker{
 					{
@@ -589,7 +589,7 @@ var _ = Describe("health check", func() {
 				false,
 				kubernetesVersion,
 				[]corev1.Node{
-					newNode(nodeName, true, labels.Set{"worker.gardener.cloud/pool": workerPoolName1, "worker.gardener.cloud/kubernetes-version": kubernetesVersion.Original()}, map[string]string{nodeagentv1alpha1.AnnotationKeyChecksumAppliedOperatingSystemConfig: "outdated"}, kubernetesVersion.Original()),
+					newNode(true, labels.Set{"worker.gardener.cloud/pool": workerPoolName1, "worker.gardener.cloud/kubernetes-version": kubernetesVersion.Original()}, map[string]string{nodeagentv1alpha1.AnnotationKeyChecksumAppliedOperatingSystemConfig: "outdated"}, kubernetesVersion.Original()),
 				},
 				[]gardencorev1beta1.Worker{
 					{
@@ -612,7 +612,7 @@ var _ = Describe("health check", func() {
 				true,
 				kubernetesVersion,
 				[]corev1.Node{
-					newNode(nodeName, true, labels.Set{"worker.gardener.cloud/pool": workerPoolName1, "worker.gardener.cloud/kubernetes-version": kubernetesVersion.Original()}, nil, kubernetesVersion.Original()),
+					newNode(true, labels.Set{"worker.gardener.cloud/pool": workerPoolName1, "worker.gardener.cloud/kubernetes-version": kubernetesVersion.Original()}, nil, kubernetesVersion.Original()),
 				},
 				[]gardencorev1beta1.Worker{
 					{
@@ -628,7 +628,7 @@ var _ = Describe("health check", func() {
 				true,
 				kubernetesVersion,
 				[]corev1.Node{
-					newNode(nodeName, true, labels.Set{"worker.gardener.cloud/pool": workerPoolName1, "worker.gardener.cloud/kubernetes-version": kubernetesVersion.Original()}, nil, kubernetesVersion.Original()),
+					newNode(true, labels.Set{"worker.gardener.cloud/pool": workerPoolName1, "worker.gardener.cloud/kubernetes-version": kubernetesVersion.Original()}, nil, kubernetesVersion.Original()),
 				},
 				[]gardencorev1beta1.Worker{
 					{
@@ -644,7 +644,7 @@ var _ = Describe("health check", func() {
 				true,
 				kubernetesVersion,
 				[]corev1.Node{
-					newNode(nodeName, true, labels.Set{"worker.gardener.cloud/pool": workerPoolName1, "worker.gardener.cloud/kubernetes-version": kubernetesVersion.Original()}, nil, kubernetesVersion.Original()),
+					newNode(true, labels.Set{"worker.gardener.cloud/pool": workerPoolName1, "worker.gardener.cloud/kubernetes-version": kubernetesVersion.Original()}, nil, kubernetesVersion.Original()),
 				},
 				[]gardencorev1beta1.Worker{
 					{
@@ -660,7 +660,7 @@ var _ = Describe("health check", func() {
 				true,
 				kubernetesVersion,
 				[]corev1.Node{
-					newNode(nodeName, true, labels.Set{"worker.gardener.cloud/pool": workerPoolName1, "worker.gardener.cloud/kubernetes-version": kubernetesVersion.Original()}, nil, kubernetesVersion.Original()),
+					newNode(true, labels.Set{"worker.gardener.cloud/pool": workerPoolName1, "worker.gardener.cloud/kubernetes-version": kubernetesVersion.Original()}, nil, kubernetesVersion.Original()),
 				},
 				[]gardencorev1beta1.Worker{
 					{
@@ -676,7 +676,7 @@ var _ = Describe("health check", func() {
 				true,
 				kubernetesVersion,
 				[]corev1.Node{
-					newNode(nodeName, true, labels.Set{"worker.gardener.cloud/pool": workerPoolName1, "worker.gardener.cloud/kubernetes-version": kubernetesVersion.Original()}, map[string]string{nodeagentv1alpha1.AnnotationKeyChecksumAppliedOperatingSystemConfig: "outdated"}, kubernetesVersion.Original()),
+					newNode(true, labels.Set{"worker.gardener.cloud/pool": workerPoolName1, "worker.gardener.cloud/kubernetes-version": kubernetesVersion.Original()}, map[string]string{nodeagentv1alpha1.AnnotationKeyChecksumAppliedOperatingSystemConfig: "outdated"}, kubernetesVersion.Original()),
 				},
 				[]gardencorev1beta1.Worker{
 					{
@@ -698,7 +698,7 @@ var _ = Describe("health check", func() {
 				true,
 				kubernetesVersion,
 				[]corev1.Node{
-					newNode(nodeName, true, labels.Set{"worker.gardener.cloud/pool": workerPoolName1, "worker.gardener.cloud/kubernetes-version": kubernetesVersion.Original()}, map[string]string{nodeagentv1alpha1.AnnotationKeyChecksumAppliedOperatingSystemConfig: "outdated"}, kubernetesVersion.Original()),
+					newNode(true, labels.Set{"worker.gardener.cloud/pool": workerPoolName1, "worker.gardener.cloud/kubernetes-version": kubernetesVersion.Original()}, map[string]string{nodeagentv1alpha1.AnnotationKeyChecksumAppliedOperatingSystemConfig: "outdated"}, kubernetesVersion.Original()),
 				},
 				[]gardencorev1beta1.Worker{
 					{
@@ -1027,10 +1027,10 @@ var _ = Describe("health check", func() {
 	})
 })
 
-func newNode(name string, healthy bool, labels labels.Set, annotations map[string]string, kubeletVersion string) corev1.Node {
+func newNode(healthy bool, labels labels.Set, annotations map[string]string, kubeletVersion string) corev1.Node {
 	node := corev1.Node{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        name,
+			Name:        "node1",
 			Labels:      labels,
 			Annotations: annotations,
 		},

--- a/pkg/gardenlet/controller/shoot/care/webhook_remediation_test.go
+++ b/pkg/gardenlet/controller/shoot/care/webhook_remediation_test.go
@@ -52,6 +52,7 @@ var _ = Describe("WebhookRemediation", func() {
 	BeforeEach(func() {
 		fakeClient = fakeclient.NewClientBuilder().WithScheme(kubernetes.ShootScheme).Build()
 		fakeKubernetesInterface = kubernetesfake.NewClientSetBuilder().WithClient(fakeClient).Build()
+		//nolint:unparam
 		shootClientInit = func() (kubernetes.Interface, bool, error) {
 			return fakeKubernetesInterface, true, nil
 		}

--- a/pkg/nodeagent/registry/containerd_extractor_test.go
+++ b/pkg/nodeagent/registry/containerd_extractor_test.go
@@ -121,12 +121,12 @@ func createFile(fakeFS afero.Fs, name, content string, permissions os.FileMode) 
 func checkFile(fakeFS afero.Fs, name, content string, permissions fs.FileMode) {
 	fileInfo, err := fakeFS.Stat(name)
 	ExpectWithOffset(1, err).ToNot(HaveOccurred())
-	ExpectWithOffset(1, fileInfo.Mode()).To(Equal(fs.FileMode(permissions)))
+	ExpectWithOffset(1, fileInfo.Mode()).To(Equal(permissions))
 	file, err := fakeFS.Open(name)
 	ExpectWithOffset(1, err).ToNot(HaveOccurred())
 	defer file.Close()
 	var fileContent []byte
 	_, err = file.Read(fileContent)
 	ExpectWithOffset(1, err).ToNot(HaveOccurred())
-	ExpectWithOffset(1, string(content)).To(Equal(content))
+	ExpectWithOffset(1, content).To(Equal(content))
 }

--- a/pkg/operation/botanist/secrets_test.go
+++ b/pkg/operation/botanist/secrets_test.go
@@ -236,31 +236,31 @@ var _ = Describe("Secrets", func() {
 								Name:   "ca",
 								Type:   "secret",
 								Labels: map[string]string{"managed-by": "secrets-manager", "manager-identity": fakesecretsmanager.ManagerIdentity},
-								Data:   runtime.RawExtension{Raw: rawData("data-for", "ca")},
+								Data:   runtime.RawExtension{Raw: rawData("ca")},
 							},
 							{
 								Name:   "ca-client",
 								Type:   "secret",
 								Labels: map[string]string{"managed-by": "secrets-manager", "manager-identity": fakesecretsmanager.ManagerIdentity},
-								Data:   runtime.RawExtension{Raw: rawData("data-for", "ca-client")},
+								Data:   runtime.RawExtension{Raw: rawData("ca-client")},
 							},
 							{
 								Name:   "ca-etcd",
 								Type:   "secret",
 								Labels: map[string]string{"managed-by": "secrets-manager", "manager-identity": fakesecretsmanager.ManagerIdentity},
-								Data:   runtime.RawExtension{Raw: rawData("data-for", "ca-etcd")},
+								Data:   runtime.RawExtension{Raw: rawData("ca-etcd")},
 							},
 							{
 								Name:   "non-ca-secret",
 								Type:   "secret",
 								Labels: map[string]string{"managed-by": "secrets-manager", "manager-identity": fakesecretsmanager.ManagerIdentity},
-								Data:   runtime.RawExtension{Raw: rawData("data-for", "non-ca-secret")},
+								Data:   runtime.RawExtension{Raw: rawData("non-ca-secret")},
 							},
 							{
 								Name:   "extension-foo-secret",
 								Type:   "secret",
 								Labels: map[string]string{"managed-by": "secrets-manager", "manager-identity": "extension-foo"},
-								Data:   runtime.RawExtension{Raw: rawData("data-for", "extension-foo-secret")},
+								Data:   runtime.RawExtension{Raw: rawData("extension-foo-secret")},
 							},
 							{
 								Name: "secret-without-labels",
@@ -326,6 +326,6 @@ func verifyCASecret(name string, secret *corev1.Secret, dataMatcher gomegatypes.
 	}
 }
 
-func rawData(key, value string) []byte {
-	return []byte(`{"` + key + `":"` + utils.EncodeBase64([]byte(value)) + `"}`)
+func rawData(value string) []byte {
+	return []byte(`{"data-for":"` + utils.EncodeBase64([]byte(value)) + `"}`)
 }

--- a/pkg/operator/controller/garden/care/health_test.go
+++ b/pkg/operator/controller/garden/care/health_test.go
@@ -188,10 +188,10 @@ var _ = Describe("Garden health", func() {
 					Expect(runtimeClient.Create(ctx, healthyManagedResource(name))).To(Succeed())
 				}
 				for _, name := range virtualGardenDeployments {
-					Expect(runtimeClient.Create(ctx, newDeployment(gardenNamespace, name, "controlplane", true))).To(Succeed())
+					Expect(runtimeClient.Create(ctx, newDeployment(gardenNamespace, name, true))).To(Succeed())
 				}
 				for _, name := range virtualGardenETCDs {
-					Expect(runtimeClient.Create(ctx, newEtcd(gardenNamespace, name, "controlplane", true, nil))).To(Succeed())
+					Expect(runtimeClient.Create(ctx, newEtcd(gardenNamespace, name, true))).To(Succeed())
 				}
 			})
 
@@ -227,10 +227,10 @@ var _ = Describe("Garden health", func() {
 					Expect(runtimeClient.Create(ctx, healthyManagedResource(name))).To(Succeed())
 				}
 				for _, name := range virtualGardenDeployments {
-					Expect(runtimeClient.Create(ctx, newDeployment(gardenNamespace, name, "controlplane", true))).To(Succeed())
+					Expect(runtimeClient.Create(ctx, newDeployment(gardenNamespace, name, true))).To(Succeed())
 				}
 				for _, name := range virtualGardenETCDs {
-					Expect(runtimeClient.Create(ctx, newEtcd(gardenNamespace, name, "controlplane", true, nil))).To(Succeed())
+					Expect(runtimeClient.Create(ctx, newEtcd(gardenNamespace, name, true))).To(Succeed())
 				}
 			})
 
@@ -265,10 +265,10 @@ var _ = Describe("Garden health", func() {
 					Expect(runtimeClient.Create(ctx, healthyManagedResource(name))).To(Succeed())
 				}
 				for _, name := range virtualGardenDeployments {
-					Expect(runtimeClient.Create(ctx, newDeployment(gardenNamespace, name, "controlplane", true))).To(Succeed())
+					Expect(runtimeClient.Create(ctx, newDeployment(gardenNamespace, name, true))).To(Succeed())
 				}
 				for _, name := range virtualGardenETCDs {
-					Expect(runtimeClient.Create(ctx, newEtcd(gardenNamespace, name, "controlplane", true, nil))).To(Succeed())
+					Expect(runtimeClient.Create(ctx, newEtcd(gardenNamespace, name, true))).To(Succeed())
 				}
 			})
 
@@ -426,10 +426,10 @@ var _ = Describe("Garden health", func() {
 			Context("when managed resources are not deployed", func() {
 				JustBeforeEach(func() {
 					for _, name := range virtualGardenDeployments {
-						Expect(runtimeClient.Create(ctx, newDeployment(gardenNamespace, name, "controlplane", true))).To(Succeed())
+						Expect(runtimeClient.Create(ctx, newDeployment(gardenNamespace, name, true))).To(Succeed())
 					}
 					for _, name := range virtualGardenETCDs {
-						Expect(runtimeClient.Create(ctx, newEtcd(gardenNamespace, name, "controlplane", true, nil))).To(Succeed())
+						Expect(runtimeClient.Create(ctx, newEtcd(gardenNamespace, name, true))).To(Succeed())
 					}
 				})
 
@@ -442,10 +442,10 @@ var _ = Describe("Garden health", func() {
 						Expect(runtimeClient.Create(ctx, notHealthyManagedResource(name))).To(Succeed())
 					}
 					for _, name := range virtualGardenDeployments {
-						Expect(runtimeClient.Create(ctx, newDeployment(gardenNamespace, name, "controlplane", true))).To(Succeed())
+						Expect(runtimeClient.Create(ctx, newDeployment(gardenNamespace, name, true))).To(Succeed())
 					}
 					for _, name := range virtualGardenETCDs {
-						Expect(runtimeClient.Create(ctx, newEtcd(gardenNamespace, name, "controlplane", true, nil))).To(Succeed())
+						Expect(runtimeClient.Create(ctx, newEtcd(gardenNamespace, name, true))).To(Succeed())
 					}
 				})
 
@@ -458,10 +458,10 @@ var _ = Describe("Garden health", func() {
 						Expect(runtimeClient.Create(ctx, notAppliedManagedResource(name))).To(Succeed())
 					}
 					for _, name := range virtualGardenDeployments {
-						Expect(runtimeClient.Create(ctx, newDeployment(gardenNamespace, name, "controlplane", true))).To(Succeed())
+						Expect(runtimeClient.Create(ctx, newDeployment(gardenNamespace, name, true))).To(Succeed())
 					}
 					for _, name := range virtualGardenETCDs {
-						Expect(runtimeClient.Create(ctx, newEtcd(gardenNamespace, name, "controlplane", true, nil))).To(Succeed())
+						Expect(runtimeClient.Create(ctx, newEtcd(gardenNamespace, name, true))).To(Succeed())
 					}
 				})
 
@@ -474,10 +474,10 @@ var _ = Describe("Garden health", func() {
 						Expect(runtimeClient.Create(ctx, progressingManagedResource(name))).To(Succeed())
 					}
 					for _, name := range virtualGardenDeployments {
-						Expect(runtimeClient.Create(ctx, newDeployment(gardenNamespace, name, "controlplane", true))).To(Succeed())
+						Expect(runtimeClient.Create(ctx, newDeployment(gardenNamespace, name, true))).To(Succeed())
 					}
 					for _, name := range virtualGardenETCDs {
-						Expect(runtimeClient.Create(ctx, newEtcd(gardenNamespace, name, "controlplane", true, nil))).To(Succeed())
+						Expect(runtimeClient.Create(ctx, newEtcd(gardenNamespace, name, true))).To(Succeed())
 					}
 				})
 
@@ -493,10 +493,10 @@ var _ = Describe("Garden health", func() {
 						))).To(Succeed())
 					}
 					for _, name := range virtualGardenDeployments {
-						Expect(runtimeClient.Create(ctx, newDeployment(gardenNamespace, name, "controlplane", true))).To(Succeed())
+						Expect(runtimeClient.Create(ctx, newDeployment(gardenNamespace, name, true))).To(Succeed())
 					}
 					for _, name := range virtualGardenETCDs {
-						Expect(runtimeClient.Create(ctx, newEtcd(gardenNamespace, name, "controlplane", true, nil))).To(Succeed())
+						Expect(runtimeClient.Create(ctx, newEtcd(gardenNamespace, name, true))).To(Succeed())
 					}
 				})
 
@@ -523,7 +523,7 @@ var _ = Describe("Garden health", func() {
 
 			It("should set VirtualComponentsHealthy conditions to false when the deployments are existing but unhealthy", func() {
 				for _, name := range virtualGardenDeployments {
-					Expect(runtimeClient.Create(ctx, newDeployment(gardenNamespace, name, "controlplane", false))).To(Succeed())
+					Expect(runtimeClient.Create(ctx, newDeployment(gardenNamespace, name, false))).To(Succeed())
 				}
 
 				updatedConditions := NewHealth(
@@ -545,7 +545,7 @@ var _ = Describe("Garden health", func() {
 		Context("when there are issues with ETCDs for virtual garden", func() {
 			JustBeforeEach(func() {
 				for _, name := range virtualGardenDeployments {
-					Expect(runtimeClient.Create(ctx, newDeployment(gardenNamespace, name, "controlplane", true))).To(Succeed())
+					Expect(runtimeClient.Create(ctx, newDeployment(gardenNamespace, name, true))).To(Succeed())
 				}
 			})
 
@@ -567,7 +567,7 @@ var _ = Describe("Garden health", func() {
 
 			It("should set VirtualComponentsHealthy conditions to false when the ETCDs are existing but unhealthy", func() {
 				for _, name := range virtualGardenETCDs {
-					Expect(runtimeClient.Create(ctx, newEtcd(gardenNamespace, name, "controlplane", false, nil))).To(Succeed())
+					Expect(runtimeClient.Create(ctx, newEtcd(gardenNamespace, name, false))).To(Succeed())
 				}
 
 				updatedConditions := NewHealth(
@@ -843,12 +843,12 @@ func roleLabels(role string) map[string]string {
 	return map[string]string{v1beta1constants.GardenRole: role}
 }
 
-func newDeployment(namespace, name, role string, healthy bool) *appsv1.Deployment {
+func newDeployment(namespace, name string, healthy bool) *appsv1.Deployment {
 	deployment := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
 			Name:      name,
-			Labels:    roleLabels(role),
+			Labels:    roleLabels("controlplane"),
 		},
 	}
 	if healthy {
@@ -860,20 +860,15 @@ func newDeployment(namespace, name, role string, healthy bool) *appsv1.Deploymen
 	return deployment
 }
 
-func newEtcd(namespace, name, role string, healthy bool, lastError *string) *druidv1alpha1.Etcd {
-	etcd := &druidv1alpha1.Etcd{
+func newEtcd(namespace, name string, healthy bool) *druidv1alpha1.Etcd {
+	return &druidv1alpha1.Etcd{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
 			Name:      name,
-			Labels:    roleLabels(role),
+			Labels:    roleLabels("controlplane"),
+		},
+		Status: druidv1alpha1.EtcdStatus{
+			Ready: ptr.To(healthy),
 		},
 	}
-	if healthy {
-		etcd.Status.Ready = ptr.To(true)
-	} else {
-		etcd.Status.Ready = ptr.To(false)
-		etcd.Status.LastError = lastError
-	}
-
-	return etcd
 }

--- a/pkg/resourcemanager/controller/garbagecollector/reconciler_test.go
+++ b/pkg/resourcemanager/controller/garbagecollector/reconciler_test.go
@@ -248,14 +248,14 @@ var _ = Describe("Collector", func() {
 				*labeledConfigMap4, *labeledConfigMap5, *labeledConfigMap6, *labeledConfigMap7, *labeledConfigMap8, *labeledConfigMap9,
 			))
 
-			Expect(c.Create(ctx, &appsv1.Deployment{ObjectMeta: objectMetaFor("deploy1", metav1.NamespaceDefault, labeledSecret1, labeledConfigMap1)})).To(Succeed())
-			Expect(c.Create(ctx, &appsv1.StatefulSet{ObjectMeta: objectMetaFor("sts1", metav1.NamespaceDefault, labeledSecret2, labeledConfigMap2)})).To(Succeed())
-			Expect(c.Create(ctx, &appsv1.DaemonSet{ObjectMeta: objectMetaFor("ds1", metav1.NamespaceDefault, labeledSecret3, labeledConfigMap3)})).To(Succeed())
-			Expect(c.Create(ctx, &batchv1.Job{ObjectMeta: objectMetaFor("job1", metav1.NamespaceDefault, labeledSecret4, labeledConfigMap4)})).To(Succeed())
-			Expect(c.Create(ctx, &batchv1beta1.CronJob{ObjectMeta: objectMetaFor("cronjob2", metav1.NamespaceDefault, labeledSecret5, labeledConfigMap5)})).To(Succeed())
-			Expect(c.Create(ctx, &corev1.Pod{ObjectMeta: objectMetaFor("pod1", metav1.NamespaceDefault, labeledSecret6, labeledConfigMap6)})).To(Succeed())
-			Expect(c.Create(ctx, &batchv1.CronJob{ObjectMeta: objectMetaFor("cronjob2", metav1.NamespaceDefault, labeledSecret7, labeledConfigMap7)})).To(Succeed())
-			Expect(c.Create(ctx, &resourcesv1alpha1.ManagedResource{ObjectMeta: objectMetaFor("mr1", metav1.NamespaceDefault, labeledSecret10)})).To(Succeed())
+			Expect(c.Create(ctx, &appsv1.Deployment{ObjectMeta: objectMetaFor("deploy1", labeledSecret1, labeledConfigMap1)})).To(Succeed())
+			Expect(c.Create(ctx, &appsv1.StatefulSet{ObjectMeta: objectMetaFor("sts1", labeledSecret2, labeledConfigMap2)})).To(Succeed())
+			Expect(c.Create(ctx, &appsv1.DaemonSet{ObjectMeta: objectMetaFor("ds1", labeledSecret3, labeledConfigMap3)})).To(Succeed())
+			Expect(c.Create(ctx, &batchv1.Job{ObjectMeta: objectMetaFor("job1", labeledSecret4, labeledConfigMap4)})).To(Succeed())
+			Expect(c.Create(ctx, &batchv1beta1.CronJob{ObjectMeta: objectMetaFor("cronjob2", labeledSecret5, labeledConfigMap5)})).To(Succeed())
+			Expect(c.Create(ctx, &corev1.Pod{ObjectMeta: objectMetaFor("pod1", labeledSecret6, labeledConfigMap6)})).To(Succeed())
+			Expect(c.Create(ctx, &batchv1.CronJob{ObjectMeta: objectMetaFor("cronjob2", labeledSecret7, labeledConfigMap7)})).To(Succeed())
+			Expect(c.Create(ctx, &resourcesv1alpha1.ManagedResource{ObjectMeta: objectMetaFor("mr1", labeledSecret10)})).To(Succeed())
 
 			_, err := gc.Reconcile(ctx, reconcile.Request{})
 			Expect(err).NotTo(HaveOccurred())
@@ -279,7 +279,7 @@ var _ = Describe("Collector", func() {
 	})
 })
 
-func objectMetaFor(name, namespace string, objs ...runtime.Object) metav1.ObjectMeta {
+func objectMetaFor(name string, objs ...runtime.Object) metav1.ObjectMeta {
 	annotations := make(map[string]string)
 
 	for _, obj := range objs {
@@ -297,7 +297,7 @@ func objectMetaFor(name, namespace string, objs ...runtime.Object) metav1.Object
 
 	return metav1.ObjectMeta{
 		Name:        name,
-		Namespace:   namespace,
+		Namespace:   metav1.NamespaceDefault,
 		Annotations: annotations,
 	}
 }

--- a/pkg/resourcemanager/webhook/crddeletionprotection/handler_test.go
+++ b/pkg/resourcemanager/webhook/crddeletionprotection/handler_test.go
@@ -333,13 +333,13 @@ var _ = Describe("handler", func() {
 
 func expectAllowed(response admission.Response, reason gomegatypes.GomegaMatcher, optionalDescription ...interface{}) {
 	Expect(response.Allowed).To(BeTrue(), optionalDescription...)
-	Expect(string(response.Result.Message)).To(reason, optionalDescription...)
+	Expect(response.Result.Message).To(reason, optionalDescription...)
 }
 
 func expectDenied(response admission.Response, reason gomegatypes.GomegaMatcher, optionalDescription ...interface{}) {
 	Expect(response.Allowed).To(BeFalse(), optionalDescription...)
 	Expect(response.Result.Code).To(BeEquivalentTo(http.StatusForbidden), optionalDescription...)
-	Expect(string(response.Result.Message)).To(reason, optionalDescription...)
+	Expect(response.Result.Message).To(reason, optionalDescription...)
 }
 
 func expectErrored(response admission.Response, code, err gomegatypes.GomegaMatcher, optionalDescription ...interface{}) {

--- a/pkg/utils/imagevector/imagevector.go
+++ b/pkg/utils/imagevector/imagevector.go
@@ -255,7 +255,7 @@ func checkVersionConstraint(constraint, version *string) (score int, ok bool, er
 	return score, true, nil
 }
 
-func checkArchitectureConstraint(source []string, desired *string) (score int, ok bool, err error) {
+func checkArchitectureConstraint(source []string, desired *string) (score int, ok bool) {
 	// if image doesn't have a architecture tag it is considered as multi arch image
 	// and if worker pool machine doesn't have architecture tag it is by default considered amd64 machine.
 	var sourceArch, desiredArch = []string{v1beta1constants.ArchitectureAMD64, v1beta1constants.ArchitectureARM64}, v1beta1constants.ArchitectureAMD64
@@ -268,11 +268,11 @@ func checkArchitectureConstraint(source []string, desired *string) (score int, o
 	}
 
 	if len(sourceArch) > 1 && slices.Contains(sourceArch, desiredArch) {
-		return 1, true, nil
+		return 1, true
 	}
 	if len(sourceArch) == 1 && slices.Contains(sourceArch, desiredArch) {
 		// prioritize equal constraints
-		return 2, true, nil
+		return 2, true
 	}
 
 	return
@@ -295,9 +295,9 @@ func match(source *ImageSource, name string, opts *FindOptions) (score int, ok b
 	}
 	score += targetScore
 
-	archScore, ok, err := checkArchitectureConstraint(source.Architectures, opts.Architecture)
-	if err != nil || !ok {
-		return 0, false, err
+	archScore, ok := checkArchitectureConstraint(source.Architectures, opts.Architecture)
+	if !ok {
+		return 0, false, nil
 	}
 	score += archScore
 

--- a/pkg/utils/kubernetes/health/checker/checker_test.go
+++ b/pkg/utils/kubernetes/health/checker/checker_test.go
@@ -85,7 +85,7 @@ var _ = Describe("HealthChecker", func() {
 				nil,
 				true,
 				false,
-				PointTo(beConditionWithStatusAndMsg(gardencorev1beta1.ConditionFalse, gardencorev1beta1.ManagedResourceMissingConditionError, ""))),
+				PointTo(beConditionWithFalseStatusReasonAndMsg(gardencorev1beta1.ManagedResourceMissingConditionError, ""))),
 			Entry("one true condition, one missing",
 				[]gardencorev1beta1.Condition{
 					{
@@ -95,7 +95,7 @@ var _ = Describe("HealthChecker", func() {
 				},
 				true,
 				false,
-				PointTo(beConditionWithStatusAndMsg(gardencorev1beta1.ConditionFalse, gardencorev1beta1.ManagedResourceMissingConditionError, string(resourcesv1alpha1.ResourcesHealthy)))),
+				PointTo(beConditionWithFalseStatusReasonAndMsg(gardencorev1beta1.ManagedResourceMissingConditionError, string(resourcesv1alpha1.ResourcesHealthy)))),
 			Entry("multiple true conditions",
 				[]gardencorev1beta1.Condition{
 					{
@@ -154,7 +154,7 @@ var _ = Describe("HealthChecker", func() {
 				},
 				true,
 				true,
-				PointTo(beConditionWithStatusAndMsg(gardencorev1beta1.ConditionFalse, gardencorev1beta1.ManagedResourceProgressingRolloutStuck, "ManagedResource  is progressing for more than 5m0s"))),
+				PointTo(beConditionWithFalseStatusReasonAndMsg(gardencorev1beta1.ManagedResourceProgressingRolloutStuck, "ManagedResource  is progressing for more than 5m0s"))),
 			Entry("one false condition ResourcesApplied",
 				[]gardencorev1beta1.Condition{
 					{
@@ -200,7 +200,7 @@ var _ = Describe("HealthChecker", func() {
 				},
 				true,
 				false,
-				PointTo(beConditionWithStatusAndMsg(gardencorev1beta1.ConditionFalse, "barFailed", "bar is unhealthy"))),
+				PointTo(beConditionWithFalseStatusReasonAndMsg("barFailed", "bar is unhealthy"))),
 			Entry("multiple false conditions with reason & message & ResourcesApplied condition is false",
 				[]gardencorev1beta1.Condition{
 					{
@@ -218,7 +218,7 @@ var _ = Describe("HealthChecker", func() {
 				},
 				true,
 				false,
-				PointTo(beConditionWithStatusAndMsg(gardencorev1beta1.ConditionFalse, "fooFailed", "foo is unhealthy"))),
+				PointTo(beConditionWithFalseStatusReasonAndMsg("fooFailed", "foo is unhealthy"))),
 			Entry("outdated managed resource",
 				[]gardencorev1beta1.Condition{
 					{
@@ -236,7 +236,7 @@ var _ = Describe("HealthChecker", func() {
 				},
 				false,
 				false,
-				PointTo(beConditionWithStatusAndMsg(gardencorev1beta1.ConditionFalse, gardencorev1beta1.OutdatedStatusError, "outdated"))),
+				PointTo(beConditionWithFalseStatusReasonAndMsg(gardencorev1beta1.OutdatedStatusError, "outdated"))),
 			Entry("unknown condition status with reason and message",
 				[]gardencorev1beta1.Condition{
 					{
@@ -252,7 +252,7 @@ var _ = Describe("HealthChecker", func() {
 				},
 				true,
 				false,
-				PointTo(beConditionWithStatusAndMsg(gardencorev1beta1.ConditionFalse, "Unknown", "bar is unknown"))),
+				PointTo(beConditionWithFalseStatusReasonAndMsg("Unknown", "bar is unknown"))),
 		)
 
 		var (
@@ -564,8 +564,8 @@ func beConditionWithStatus(status gardencorev1beta1.ConditionStatus) types.Gomeg
 	return WithStatus(status)
 }
 
-func beConditionWithStatusAndMsg(status gardencorev1beta1.ConditionStatus, reason, message string) types.GomegaMatcher {
-	return And(WithStatus(status), WithReason(reason), WithMessage(message))
+func beConditionWithFalseStatusReasonAndMsg(reason, message string) types.GomegaMatcher {
+	return And(WithStatus(gardencorev1beta1.ConditionFalse), WithReason(reason), WithMessage(message))
 }
 
 func beConditionWithMissingRequiredDeployment(deployments []*appsv1.Deployment) types.GomegaMatcher {

--- a/pkg/utils/validation/cidr/cidr_test.go
+++ b/pkg/utils/validation/cidr/cidr_test.go
@@ -402,7 +402,7 @@ var _ = Describe("cidr", func() {
 
 			It("should return an error if CIDRs overlap", func() {
 				cdr := NewCIDR("2001:0db8::/16", path)
-				badCIDR := string(validGardenCIDR)
+				badCIDR := validGardenCIDR
 				badPath := field.NewPath("bad")
 				other := NewCIDR(badCIDR, badPath)
 
@@ -520,13 +520,13 @@ var _ = Describe("cidr", func() {
 
 			It("should return no errors if cidr is subset", func() {
 				cdr := NewCIDR("2001:0db8::/32", path)
-				other := NewCIDR(string(validGardenCIDR), field.NewPath("other"))
+				other := NewCIDR(validGardenCIDR, field.NewPath("other"))
 				Expect(cdr.ValidateOverlap(other)).To(BeEmpty())
 			})
 
 			It("should return no errors if cidr is superset", func() {
 				cdr := NewCIDR(validGardenCIDR, path)
-				other := NewCIDR(string("2001:0db8::/32"), field.NewPath("other"))
+				other := NewCIDR("2001:0db8::/32", field.NewPath("other"))
 				Expect(cdr.ValidateOverlap(other)).To(BeEmpty())
 			})
 		})

--- a/pkg/utils/validation/cidr/helper_test.go
+++ b/pkg/utils/validation/cidr/helper_test.go
@@ -195,7 +195,7 @@ var _ = Describe("cidr", func() {
 		Describe("ValidateNotOverlap", func() {
 			It("should not be a subset", func() {
 				cdr := NewCIDR(validGardenCIDR, path)
-				other := NewCIDR(string("2.2.2.2/32"), path)
+				other := NewCIDR("2.2.2.2/32", path)
 
 				Expect(cdr.ValidateNotOverlap(other)).To(BeEmpty())
 			})
@@ -208,14 +208,14 @@ var _ = Describe("cidr", func() {
 
 			It("should ignore when parse error", func() {
 				cdr := NewCIDR(invalidGardenCIDR, path)
-				other := NewCIDR(string("2.2.2.2/32"), path)
+				other := NewCIDR("2.2.2.2/32", path)
 
 				Expect(cdr.ValidateNotOverlap(other)).To(BeEmpty())
 			})
 
 			It("should return a nil FieldPath", func() {
 				cdr := NewCIDR(validGardenCIDR, path)
-				badCIDR := string("10.0.0.1/32")
+				badCIDR := "10.0.0.1/32"
 				badPath := field.NewPath("bad")
 				other := NewCIDR(badCIDR, badPath)
 
@@ -301,7 +301,7 @@ var _ = Describe("cidr", func() {
 		Describe("ValidateSubset", func() {
 			It("should be a subset", func() {
 				cdr := NewCIDR(validGardenCIDR, path)
-				other := NewCIDR(string("10.0.0.1/32"), field.NewPath("other"))
+				other := NewCIDR("10.0.0.1/32", field.NewPath("other"))
 
 				Expect(cdr.ValidateSubset(other)).To(BeEmpty())
 			})
@@ -314,14 +314,14 @@ var _ = Describe("cidr", func() {
 
 			It("should ignore parse errors", func() {
 				cdr := NewCIDR(invalidGardenCIDR, path)
-				other := NewCIDR(string("10.0.0.1/32"), field.NewPath("other"))
+				other := NewCIDR("10.0.0.1/32", field.NewPath("other"))
 
 				Expect(cdr.ValidateSubset(other)).To(BeEmpty())
 			})
 
 			It("should not be a subset", func() {
 				cdr := NewCIDR(validGardenCIDR, path)
-				other := NewCIDR(string("10.0.0.1/32"), field.NewPath("bad"))
+				other := NewCIDR("10.0.0.1/32", field.NewPath("bad"))
 
 				Expect(other.ValidateSubset(cdr)).To(ConsistOfFields(Fields{
 					"Type":     Equal(field.ErrorTypeInvalid),
@@ -332,7 +332,7 @@ var _ = Describe("cidr", func() {
 			})
 
 			It("superset subnet should not be a subset", func() {
-				valid := NewCIDR(string("10.0.0.0/24"), field.NewPath("valid"))
+				valid := NewCIDR("10.0.0.0/24", field.NewPath("valid"))
 				other := NewCIDR(validGardenCIDR, path)
 
 				Expect(valid.ValidateSubset(other)).To(ConsistOfFields(Fields{
@@ -360,13 +360,13 @@ var _ = Describe("cidr", func() {
 
 			It("should return no errors if cidr is subset", func() {
 				cdr := NewCIDR(validGardenCIDR, path)
-				other := NewCIDR(string("10.5.0.0/16"), field.NewPath("other"))
+				other := NewCIDR("10.5.0.0/1", field.NewPath("other"))
 				Expect(cdr.ValidateOverlap(other)).To(BeEmpty())
 			})
 
 			It("should return no errors if cidr is superset", func() {
 				cdr := NewCIDR(validGardenCIDR, path)
-				other := NewCIDR(string("10.5.0.0/16"), field.NewPath("other"))
+				other := NewCIDR("10.5.0.0/16", field.NewPath("other"))
 				Expect(other.ValidateOverlap(cdr)).To(BeEmpty())
 			})
 		})
@@ -454,7 +454,7 @@ var _ = Describe("cidr", func() {
 		Describe("ValidateNotOverlap", func() {
 			It("should not be a subset", func() {
 				cdr := NewCIDR(validGardenCIDR, path)
-				other := NewCIDR(string("3001:0db8:85a3::1/128"), path)
+				other := NewCIDR("3001:0db8:85a3::1/128", path)
 
 				Expect(cdr.ValidateNotOverlap(other)).To(BeEmpty())
 			})
@@ -467,14 +467,14 @@ var _ = Describe("cidr", func() {
 
 			It("should ignore when parse error", func() {
 				cdr := NewCIDR(invalidGardenCIDR, path)
-				other := NewCIDR(string("3001:0db8:85a3::1/128"), path)
+				other := NewCIDR("3001:0db8:85a3::1/128", path)
 
 				Expect(cdr.ValidateNotOverlap(other)).To(BeEmpty())
 			})
 
 			It("should return a nil FieldPath", func() {
 				cdr := NewCIDR(validGardenCIDR, path)
-				badCIDR := string("2001:0db8:85a3::1/128")
+				badCIDR := "2001:0db8:85a3::1/128"
 				badPath := field.NewPath("bad")
 				other := NewCIDR(badCIDR, badPath)
 
@@ -488,7 +488,7 @@ var _ = Describe("cidr", func() {
 
 			It("should return an error if CIDRs overlap", func() {
 				cdr := NewCIDR("2001:0db8::/16", path)
-				badCIDR := string(validGardenCIDR)
+				badCIDR := validGardenCIDR
 				badPath := field.NewPath("bad")
 				other := NewCIDR(badCIDR, badPath)
 
@@ -547,7 +547,7 @@ var _ = Describe("cidr", func() {
 		Describe("ValidateSubset", func() {
 			It("should be a subset", func() {
 				cdr := NewCIDR(validGardenCIDR, path)
-				other := NewCIDR(string("2001:0db8:85a3::1/128"), field.NewPath("other"))
+				other := NewCIDR("2001:0db8:85a3::1/128", field.NewPath("other"))
 
 				Expect(cdr.ValidateSubset(other)).To(BeEmpty())
 			})
@@ -560,14 +560,14 @@ var _ = Describe("cidr", func() {
 
 			It("should ignore parse errors", func() {
 				cdr := NewCIDR(invalidGardenCIDR, path)
-				other := NewCIDR(string("2001:0db8:85a3::1/128"), field.NewPath("other"))
+				other := NewCIDR("2001:0db8:85a3::1/128", field.NewPath("other"))
 
 				Expect(cdr.ValidateSubset(other)).To(BeEmpty())
 			})
 
 			It("should not be a subset", func() {
 				cdr := NewCIDR(validGardenCIDR, path)
-				other := NewCIDR(string("2001:0db8:85a3::1/128"), field.NewPath("bad"))
+				other := NewCIDR("2001:0db8:85a3::1/128", field.NewPath("bad"))
 
 				Expect(other.ValidateSubset(cdr)).To(ConsistOfFields(Fields{
 					"Type":     Equal(field.ErrorTypeInvalid),
@@ -579,7 +579,7 @@ var _ = Describe("cidr", func() {
 
 			It("superset subnet should not be a subset", func() {
 				cdr := NewCIDR(validGardenCIDR, path)
-				other := NewCIDR(string("2001:0db8:85a3::/128"), field.NewPath("bad"))
+				other := NewCIDR("2001:0db8:85a3::/128", field.NewPath("bad"))
 
 				Expect(other.ValidateSubset(cdr)).To(ConsistOfFields(Fields{
 					"Type":     Equal(field.ErrorTypeInvalid),
@@ -606,13 +606,13 @@ var _ = Describe("cidr", func() {
 
 			It("should return no errors if cidr is subset", func() {
 				cdr := NewCIDR("2001:0db8::/32", path)
-				other := NewCIDR(string(validGardenCIDR), field.NewPath("other"))
+				other := NewCIDR(validGardenCIDR, field.NewPath("other"))
 				Expect(cdr.ValidateOverlap(other)).To(BeEmpty())
 			})
 
 			It("should return no errors if cidr is superset", func() {
 				cdr := NewCIDR(validGardenCIDR, path)
-				other := NewCIDR(string("2001:0db8::/32"), field.NewPath("other"))
+				other := NewCIDR("2001:0db8::/32", field.NewPath("other"))
 				Expect(cdr.ValidateOverlap(other)).To(BeEmpty())
 			})
 		})

--- a/plugin/pkg/shoot/managedseed/admission.go
+++ b/plugin/pkg/shoot/managedseed/admission.go
@@ -172,11 +172,7 @@ func (v *ManagedSeed) validateUpdate(ctx context.Context, a admission.Attributes
 		return apierrors.NewInternalError(fmt.Errorf("cannot extract the seed template: %w", err))
 	}
 
-	zoneValidationErrs, err := v.validateZoneRemovalFromShoot(field.NewPath("spec", "providers", "workers"), oldShoot, shoot, seedTemplate)
-	if err != nil {
-		return apierrors.NewInternalError(err)
-	}
-	allErrs = append(allErrs, zoneValidationErrs...)
+	allErrs = append(allErrs, v.validateZoneRemovalFromShoot(field.NewPath("spec", "providers", "workers"), oldShoot, shoot, seedTemplate)...)
 
 	if len(allErrs) > 0 {
 		return apierrors.NewInvalid(a.GetKind().GroupKind(), shoot.Name, allErrs)
@@ -187,7 +183,7 @@ func (v *ManagedSeed) validateUpdate(ctx context.Context, a admission.Attributes
 
 // validateZoneRemovalFromShoot returns an error if worker zones for the given shoot were changed
 // while they are still registered in the ManagedSeed.
-func (v *ManagedSeed) validateZoneRemovalFromShoot(fldPath *field.Path, oldShoot, newShoot *core.Shoot, seedTemplate *gardencorev1beta1.SeedTemplate) (field.ErrorList, error) {
+func (v *ManagedSeed) validateZoneRemovalFromShoot(fldPath *field.Path, oldShoot, newShoot *core.Shoot, seedTemplate *gardencorev1beta1.SeedTemplate) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	removedZones := gardencorehelper.GetAllZonesFromShoot(oldShoot).Difference(gardencorehelper.GetAllZonesFromShoot(newShoot))
@@ -199,7 +195,7 @@ func (v *ManagedSeed) validateZoneRemovalFromShoot(fldPath *field.Path, oldShoot
 		allErrs = append(allErrs, field.Forbidden(fldPath, "shoot worker zone(s) must not be removed as long as registered in managedseed"))
 	}
 
-	return allErrs, nil
+	return allErrs
 }
 
 func (v *ManagedSeed) validateDeleteCollection(ctx context.Context, a admission.Attributes) error {

--- a/test/integration/resourcemanager/health/health_test.go
+++ b/test/integration/resourcemanager/health/health_test.go
@@ -64,7 +64,7 @@ var _ = Describe("Health controller tests", func() {
 		JustBeforeEach(func() {
 			By("Set ManagedResource to be applied successfully")
 			patch := client.MergeFrom(managedResource.DeepCopy())
-			setCondition(managedResource, resourcesv1alpha1.ResourcesApplied, gardencorev1beta1.ConditionTrue)
+			setCondition(managedResource, gardencorev1beta1.ConditionTrue)
 			Expect(testClient.Status().Patch(ctx, managedResource, patch)).To(Succeed())
 		})
 
@@ -102,7 +102,7 @@ var _ = Describe("Health controller tests", func() {
 		JustBeforeEach(func() {
 			By("Set ManagedResource to be applied successfully")
 			patch := client.MergeFrom(managedResource.DeepCopy())
-			setCondition(managedResource, resourcesv1alpha1.ResourcesApplied, gardencorev1beta1.ConditionTrue)
+			setCondition(managedResource, gardencorev1beta1.ConditionTrue)
 			Expect(testClient.Status().Patch(ctx, managedResource, patch)).To(Succeed())
 		})
 
@@ -145,7 +145,7 @@ var _ = Describe("Health controller tests", func() {
 
 		It("does not touch ManagedResource if it is still being applied", func() {
 			patch := client.MergeFrom(managedResource.DeepCopy())
-			setCondition(managedResource, resourcesv1alpha1.ResourcesApplied, gardencorev1beta1.ConditionProgressing)
+			setCondition(managedResource, gardencorev1beta1.ConditionProgressing)
 			Expect(testClient.Status().Patch(ctx, managedResource, patch)).To(Succeed())
 
 			Consistently(func(g Gomega) []gardencorev1beta1.Condition {
@@ -159,7 +159,7 @@ var _ = Describe("Health controller tests", func() {
 
 		It("does not touch ManagedResource if it failed to be applied", func() {
 			patch := client.MergeFrom(managedResource.DeepCopy())
-			setCondition(managedResource, resourcesv1alpha1.ResourcesApplied, gardencorev1beta1.ConditionFalse)
+			setCondition(managedResource, gardencorev1beta1.ConditionFalse)
 			Expect(testClient.Status().Patch(ctx, managedResource, patch)).To(Succeed())
 
 			Consistently(func(g Gomega) []gardencorev1beta1.Condition {
@@ -176,7 +176,7 @@ var _ = Describe("Health controller tests", func() {
 		JustBeforeEach(func() {
 			By("Set ManagedResource to be applied successfully")
 			patch := client.MergeFrom(managedResource.DeepCopy())
-			setCondition(managedResource, resourcesv1alpha1.ResourcesApplied, gardencorev1beta1.ConditionTrue)
+			setCondition(managedResource, gardencorev1beta1.ConditionTrue)
 			Expect(testClient.Status().Patch(ctx, managedResource, patch)).To(Succeed())
 		})
 
@@ -320,7 +320,7 @@ var _ = Describe("Health controller tests", func() {
 		JustBeforeEach(func() {
 			By("Set ManagedResource to be applied successfully")
 			patch := client.MergeFrom(managedResource.DeepCopy())
-			setCondition(managedResource, resourcesv1alpha1.ResourcesApplied, gardencorev1beta1.ConditionTrue)
+			setCondition(managedResource, gardencorev1beta1.ConditionTrue)
 			Expect(testClient.Status().Patch(ctx, managedResource, patch)).To(Succeed())
 		})
 
@@ -557,9 +557,9 @@ var _ = Describe("Health controller tests", func() {
 	})
 })
 
-func setCondition(managedResource *resourcesv1alpha1.ManagedResource, conditionType gardencorev1beta1.ConditionType, status gardencorev1beta1.ConditionStatus) {
+func setCondition(managedResource *resourcesv1alpha1.ManagedResource, status gardencorev1beta1.ConditionStatus) {
 	managedResource.Status.Conditions = v1beta1helper.MergeConditions(managedResource.Status.Conditions, gardencorev1beta1.Condition{
-		Type:               conditionType,
+		Type:               resourcesv1alpha1.ResourcesApplied,
 		Status:             status,
 		LastUpdateTime:     metav1.Now(),
 		LastTransitionTime: metav1.Now(),

--- a/test/integration/resourcemanager/highavailabilityconfig/highavailabilityconfig_test.go
+++ b/test/integration/resourcemanager/highavailabilityconfig/highavailabilityconfig_test.go
@@ -760,13 +760,13 @@ var _ = Describe("HighAvailabilityConfig tests", func() {
 									Key:               "node.kubernetes.io/not-ready",
 									Operator:          "Exists",
 									Effect:            "NoExecute",
-									TolerationSeconds: ptr.To(int64(defaultNotReadyTolerationSeconds)),
+									TolerationSeconds: ptr.To(defaultNotReadyTolerationSeconds),
 								},
 								corev1.Toleration{
 									Key:               "node.kubernetes.io/unreachable",
 									Operator:          "Exists",
 									Effect:            "NoExecute",
-									TolerationSeconds: ptr.To(int64(defaultUnreachableTolerationSeconds)),
+									TolerationSeconds: ptr.To(defaultUnreachableTolerationSeconds),
 								},
 							))
 						})
@@ -810,13 +810,13 @@ var _ = Describe("HighAvailabilityConfig tests", func() {
 									Key:               "node.kubernetes.io/not-ready",
 									Operator:          "Exists",
 									Effect:            "NoExecute",
-									TolerationSeconds: ptr.To(int64(defaultNotReadyTolerationSeconds)),
+									TolerationSeconds: ptr.To(defaultNotReadyTolerationSeconds),
 								},
 								corev1.Toleration{
 									Key:               "node.kubernetes.io/unreachable",
 									Operator:          "Exists",
 									Effect:            "NoExecute",
-									TolerationSeconds: ptr.To(int64(defaultUnreachableTolerationSeconds)),
+									TolerationSeconds: ptr.To(defaultUnreachableTolerationSeconds),
 								},
 							)
 
@@ -850,7 +850,7 @@ var _ = Describe("HighAvailabilityConfig tests", func() {
 									Key:               "node.kubernetes.io/unreachable",
 									Operator:          "Exists",
 									Effect:            "NoExecute",
-									TolerationSeconds: ptr.To(int64(defaultUnreachableTolerationSeconds)),
+									TolerationSeconds: ptr.To(defaultUnreachableTolerationSeconds),
 								},
 							))
 						})
@@ -877,7 +877,7 @@ var _ = Describe("HighAvailabilityConfig tests", func() {
 									Operator:          "Exists",
 									Effect:            "NoExecute",
 									Value:             "",
-									TolerationSeconds: ptr.To(int64(defaultNotReadyTolerationSeconds)),
+									TolerationSeconds: ptr.To(defaultNotReadyTolerationSeconds),
 								},
 								corev1.Toleration{
 									Key:               "node.kubernetes.io/unreachable",

--- a/test/integration/scheduler/shoot/shoot_test.go
+++ b/test/integration/scheduler/shoot/shoot_test.go
@@ -44,9 +44,9 @@ var _ = Describe("Scheduler tests", func() {
 		})
 
 		It("should fail because no Seed in same region exist", func() {
-			cloudProfile := createCloudProfile(providerType, "other-region")
-			createSeed(providerType, "some-region", nil)
-			shoot := createShoot(providerType, cloudProfile.Name, "other-region", nil, ptr.To("somedns.example.com"), nil)
+			cloudProfile := createCloudProfile("other-region")
+			createSeed("some-region", nil)
+			shoot := createShoot(cloudProfile.Name, "other-region", nil, ptr.To("somedns.example.com"), nil)
 
 			Consistently(func() *string {
 				Expect(testClient.Get(ctx, client.ObjectKeyFromObject(shoot), shoot)).To(Succeed())
@@ -63,9 +63,9 @@ var _ = Describe("Scheduler tests", func() {
 		})
 
 		It("should fail because shoot doesn't configure the default scheduler", func() {
-			cloudProfile := createCloudProfile(providerType, "some-region")
-			_ = createSeed(providerType, "some-region", nil)
-			shoot := createShoot(providerType, cloudProfile.Name, "some-region", ptr.To("foo-scheduler"), ptr.To("somedns.example.com"), nil)
+			cloudProfile := createCloudProfile("some-region")
+			_ = createSeed("some-region", nil)
+			shoot := createShoot(cloudProfile.Name, "some-region", ptr.To("foo-scheduler"), ptr.To("somedns.example.com"), nil)
 
 			Consistently(func(g Gomega) {
 				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(shoot), shoot)).To(Succeed())
@@ -75,9 +75,9 @@ var _ = Describe("Scheduler tests", func() {
 		})
 
 		It("should pass because Seed and Shoot in the same region", func() {
-			cloudProfile := createCloudProfile(providerType, "some-region")
-			seed := createSeed(providerType, "some-region", nil)
-			shoot := createShoot(providerType, cloudProfile.Name, "some-region", nil, ptr.To("somedns.example.com"), nil)
+			cloudProfile := createCloudProfile("some-region")
+			seed := createSeed("some-region", nil)
+			shoot := createShoot(cloudProfile.Name, "some-region", nil, ptr.To("somedns.example.com"), nil)
 
 			Eventually(func(g Gomega) {
 				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(shoot), shoot)).To(Succeed())
@@ -87,9 +87,9 @@ var _ = Describe("Scheduler tests", func() {
 		})
 
 		It("should pass because there is a seed with < 3 zones for non-HA shoot", func() {
-			cloudProfile := createCloudProfile(providerType, "some-region")
-			seed := createSeed(providerType, "some-region", []string{"1"})
-			shoot := createShoot(providerType, cloudProfile.Name, "some-region", nil, ptr.To("somedns.example.com"), nil)
+			cloudProfile := createCloudProfile("some-region")
+			seed := createSeed("some-region", []string{"1"})
+			shoot := createShoot(cloudProfile.Name, "some-region", nil, ptr.To("somedns.example.com"), nil)
 
 			Eventually(func(g Gomega) {
 				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(shoot), shoot)).To(Succeed())
@@ -99,9 +99,9 @@ var _ = Describe("Scheduler tests", func() {
 		})
 
 		It("should pass because there is a seed with >= 3 zones for non-HA shoot", func() {
-			cloudProfile := createCloudProfile(providerType, "some-region")
-			seed := createSeed(providerType, "some-region", []string{"1", "2", "3"})
-			shoot := createShoot(providerType, cloudProfile.Name, "some-region", nil, ptr.To("somedns.example.com"), nil)
+			cloudProfile := createCloudProfile("some-region")
+			seed := createSeed("some-region", []string{"1", "2", "3"})
+			shoot := createShoot(cloudProfile.Name, "some-region", nil, ptr.To("somedns.example.com"), nil)
 
 			Eventually(func(g Gomega) {
 				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(shoot), shoot)).To(Succeed())
@@ -111,9 +111,9 @@ var _ = Describe("Scheduler tests", func() {
 		})
 
 		It("should pass because there is a seed with < 3 zones for shoot with failure tolerance type 'node'", func() {
-			cloudProfile := createCloudProfile(providerType, "some-region")
-			seed := createSeed(providerType, "some-region", []string{"1", "2"})
-			shoot := createShoot(providerType, cloudProfile.Name, "some-region", nil, ptr.To("somedns.example.com"), getControlPlaneWithType("node"))
+			cloudProfile := createCloudProfile("some-region")
+			seed := createSeed("some-region", []string{"1", "2"})
+			shoot := createShoot(cloudProfile.Name, "some-region", nil, ptr.To("somedns.example.com"), getControlPlaneWithType("node"))
 
 			Eventually(func(g Gomega) {
 				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(shoot), shoot)).To(Succeed())
@@ -123,9 +123,9 @@ var _ = Describe("Scheduler tests", func() {
 		})
 
 		It("should pass because there is a seed with >= 3 zones for shoot with failure tolerance type 'node'", func() {
-			cloudProfile := createCloudProfile(providerType, "some-region")
-			seed := createSeed(providerType, "some-region", []string{"1", "2", "3"})
-			shoot := createShoot(providerType, cloudProfile.Name, "some-region", nil, ptr.To("somedns.example.com"), getControlPlaneWithType("node"))
+			cloudProfile := createCloudProfile("some-region")
+			seed := createSeed("some-region", []string{"1", "2", "3"})
+			shoot := createShoot(cloudProfile.Name, "some-region", nil, ptr.To("somedns.example.com"), getControlPlaneWithType("node"))
 
 			Eventually(func(g Gomega) {
 				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(shoot), shoot)).To(Succeed())
@@ -135,9 +135,9 @@ var _ = Describe("Scheduler tests", func() {
 		})
 
 		It("should fail because there is no seed with >= 3 zones for shoot with failure tolerance type 'zone'", func() {
-			cloudProfile := createCloudProfile(providerType, "some-region")
-			_ = createSeed(providerType, "some-region", []string{"1", "2"})
-			shoot := createShoot(providerType, cloudProfile.Name, "some-region", nil, ptr.To("somedns.example.com"), getControlPlaneWithType("zone"))
+			cloudProfile := createCloudProfile("some-region")
+			_ = createSeed("some-region", []string{"1", "2"})
+			shoot := createShoot(cloudProfile.Name, "some-region", nil, ptr.To("somedns.example.com"), getControlPlaneWithType("zone"))
 
 			Consistently(func() *string {
 				Expect(testClient.Get(ctx, client.ObjectKeyFromObject(shoot), shoot)).To(Succeed())
@@ -154,9 +154,9 @@ var _ = Describe("Scheduler tests", func() {
 		})
 
 		It("should pass because there is a seed with >= 3 zones for shoot with failure tolerance type 'zone'", func() {
-			cloudProfile := createCloudProfile(providerType, "some-region")
-			seed := createSeed(providerType, "some-region", []string{"1", "2", "3"})
-			shoot := createShoot(providerType, cloudProfile.Name, "some-region", nil, ptr.To("somedns.example.com"), getControlPlaneWithType("zone"))
+			cloudProfile := createCloudProfile("some-region")
+			seed := createSeed("some-region", []string{"1", "2", "3"})
+			shoot := createShoot(cloudProfile.Name, "some-region", nil, ptr.To("somedns.example.com"), getControlPlaneWithType("zone"))
 
 			Eventually(func(g Gomega) {
 				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(shoot), shoot)).To(Succeed())
@@ -172,11 +172,11 @@ var _ = Describe("Scheduler tests", func() {
 		BeforeEach(func() {
 			createAndStartManager(&config.ShootSchedulerConfiguration{ConcurrentSyncs: 1, Strategy: config.MinimalDistance})
 
-			seedAPWest1 = createSeed(providerType, "ap-west-1", nil)
-			seedEUEast1 = createSeed(providerType, "eu-east-1", nil)
-			seedEUWest1 = createSeed(providerType, "eu-west-1", nil)
-			seedUSCentral2 = createSeed(providerType, "us-central-2", nil)
-			seedUSEast1 = createSeed(providerType, "us-east-1", nil)
+			seedAPWest1 = createSeed("ap-west-1", nil)
+			seedEUEast1 = createSeed("eu-east-1", nil)
+			seedEUWest1 = createSeed("eu-west-1", nil)
+			seedUSCentral2 = createSeed("us-central-2", nil)
+			seedUSEast1 = createSeed("us-east-1", nil)
 		})
 
 		Context("with region config", func() {
@@ -190,7 +190,7 @@ var _ = Describe("Scheduler tests", func() {
 			})
 
 			It("should successfully schedule to closest seed in the same region", func() {
-				cloudProfile := createCloudProfile(providerType, "eu-west-1")
+				cloudProfile := createCloudProfile("eu-west-1")
 
 				regionConfig := &corev1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{
@@ -220,7 +220,7 @@ us-central-2: 220`,
 					return testClient.Get(ctx, client.ObjectKeyFromObject(regionConfig), &corev1.ConfigMap{})
 				}).Should(Succeed())
 
-				shoot := createShoot(providerType, cloudProfile.Name, "eu-west-1", nil, ptr.To("somedns.example.com"), nil)
+				shoot := createShoot(cloudProfile.Name, "eu-west-1", nil, ptr.To("somedns.example.com"), nil)
 
 				Eventually(func(g Gomega) {
 					g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(shoot), shoot)).To(Succeed())
@@ -230,7 +230,7 @@ us-central-2: 220`,
 			})
 
 			It("should successfully schedule to closest seed in a different region", func() {
-				cloudProfile := createCloudProfile(providerType, "eu-west-1")
+				cloudProfile := createCloudProfile("eu-west-1")
 
 				regionConfig := &corev1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{
@@ -262,7 +262,7 @@ us-central-2: 220`,
 					return testClient.Get(ctx, client.ObjectKeyFromObject(regionConfig), &corev1.ConfigMap{})
 				}).Should(Succeed())
 
-				shoot := createShoot(providerType, cloudProfile.Name, "eu-west-1", nil, ptr.To("somedns.example.com"), nil)
+				shoot := createShoot(cloudProfile.Name, "eu-west-1", nil, ptr.To("somedns.example.com"), nil)
 
 				Eventually(func(g Gomega) {
 					g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(shoot), shoot)).To(Succeed())
@@ -272,7 +272,7 @@ us-central-2: 220`,
 			})
 
 			It("should successfully schedule to closest seed if multiple configs are found", func() {
-				cloudProfile := createCloudProfile(providerType, "eu-west-1")
+				cloudProfile := createCloudProfile("eu-west-1")
 
 				regionConfig1 := &corev1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{
@@ -329,7 +329,7 @@ us-central-2: 220`,
 					return configMapList.Items, nil
 				}).Should(HaveLen(2))
 
-				shoot := createShoot(providerType, cloudProfile.Name, "eu-west-1", nil, ptr.To("somedns.example.com"), nil)
+				shoot := createShoot(cloudProfile.Name, "eu-west-1", nil, ptr.To("somedns.example.com"), nil)
 
 				Eventually(func(g Gomega) {
 					g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(shoot), shoot)).To(Succeed())
@@ -339,7 +339,7 @@ us-central-2: 220`,
 			})
 
 			It("should fall back to Levenshtein minimal distance if shoot region is not configured", func() {
-				cloudProfile := createCloudProfile(providerType, "eu-west-1")
+				cloudProfile := createCloudProfile("eu-west-1")
 
 				regionConfig := &corev1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{
@@ -368,7 +368,7 @@ us-central-2: 220`,
 					return testClient.Get(ctx, client.ObjectKeyFromObject(regionConfig), &corev1.ConfigMap{})
 				}).Should(Succeed())
 
-				shoot := createShoot(providerType, cloudProfile.Name, "eu-west-1", nil, ptr.To("somedns.example.com"), nil)
+				shoot := createShoot(cloudProfile.Name, "eu-west-1", nil, ptr.To("somedns.example.com"), nil)
 
 				Eventually(func(g Gomega) {
 					g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(shoot), shoot)).To(Succeed())
@@ -380,7 +380,7 @@ us-central-2: 220`,
 			It("should fall back to Levenshtein minimal distance if seed regions are missing", func() {
 				Expect(testClient.Delete(ctx, seedEUWest1)).To(Succeed())
 
-				cloudProfile := createCloudProfile(providerType, "eu-west-1")
+				cloudProfile := createCloudProfile("eu-west-1")
 
 				regionConfig := &corev1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{
@@ -410,7 +410,7 @@ us-central-3: 220`,
 					return testClient.Get(ctx, client.ObjectKeyFromObject(regionConfig), &corev1.ConfigMap{})
 				}).Should(Succeed())
 
-				shoot := createShoot(providerType, cloudProfile.Name, "eu-west-1", nil, ptr.To("somedns.example.com"), nil)
+				shoot := createShoot(cloudProfile.Name, "eu-west-1", nil, ptr.To("somedns.example.com"), nil)
 
 				Eventually(func(g Gomega) {
 					g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(shoot), shoot)).To(Succeed())
@@ -420,7 +420,7 @@ us-central-3: 220`,
 			})
 
 			It("should fail to schedule to Seed if region config is not parseable", func() {
-				cloudProfile := createCloudProfile(providerType, "eu-west-1")
+				cloudProfile := createCloudProfile("eu-west-1")
 
 				regionConfig := &corev1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{
@@ -446,7 +446,7 @@ us-central-3: 220`,
 					return testClient.Get(ctx, client.ObjectKeyFromObject(regionConfig), &corev1.ConfigMap{})
 				}).Should(Succeed())
 
-				shoot := createShoot(providerType, cloudProfile.Name, "eu-west-1", nil, ptr.To("somedns.example.com"), nil)
+				shoot := createShoot(cloudProfile.Name, "eu-west-1", nil, ptr.To("somedns.example.com"), nil)
 
 				Consistently(func() *string {
 					Expect(testClient.Get(ctx, client.ObjectKeyFromObject(shoot), shoot)).To(Succeed())
@@ -465,9 +465,9 @@ us-central-3: 220`,
 
 		Context("fallback - without region config", func() {
 			It("should successfully schedule to Seed in region with minimal distance (prefer own region)", func() {
-				cloudProfile := createCloudProfile(providerType, "eu-west-1")
+				cloudProfile := createCloudProfile("eu-west-1")
 
-				shoot := createShoot(providerType, cloudProfile.Name, "eu-west-1", nil, ptr.To("somedns.example.com"), nil)
+				shoot := createShoot(cloudProfile.Name, "eu-west-1", nil, ptr.To("somedns.example.com"), nil)
 
 				Eventually(func(g Gomega) {
 					g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(shoot), shoot)).To(Succeed())
@@ -477,9 +477,9 @@ us-central-3: 220`,
 			})
 
 			It("should successfully schedule to Seed in region with minimal distance (prefer own zone)", func() {
-				cloudProfile := createCloudProfile(providerType, "eu-west-1")
+				cloudProfile := createCloudProfile("eu-west-1")
 
-				shoot := createShoot(providerType, cloudProfile.Name, "eu-west-1", nil, ptr.To("somedns.example.com"), nil)
+				shoot := createShoot(cloudProfile.Name, "eu-west-1", nil, ptr.To("somedns.example.com"), nil)
 
 				Eventually(func(g Gomega) {
 					g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(shoot), shoot)).To(Succeed())
@@ -489,9 +489,9 @@ us-central-3: 220`,
 			})
 
 			It("should successfully schedule to Seed in region with minimal distance (prefer same continent - multiple options)", func() {
-				cloudProfile := createCloudProfile(providerType, "eu-central-1")
+				cloudProfile := createCloudProfile("eu-central-1")
 
-				shoot := createShoot(providerType, cloudProfile.Name, "eu-central-1", nil, ptr.To("somedns.example.com"), nil)
+				shoot := createShoot(cloudProfile.Name, "eu-central-1", nil, ptr.To("somedns.example.com"), nil)
 
 				Eventually(func(g Gomega) {
 					g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(shoot), shoot)).To(Succeed())
@@ -501,9 +501,9 @@ us-central-3: 220`,
 			})
 
 			It("should successfully schedule to Seed minimal distance in different region", func() {
-				cloudProfile := createCloudProfile(providerType, "jp-west-1")
+				cloudProfile := createCloudProfile("jp-west-1")
 
-				shoot := createShoot(providerType, cloudProfile.Name, "jp-west-1", nil, ptr.To("somedns.example.com"), nil)
+				shoot := createShoot(cloudProfile.Name, "jp-west-1", nil, ptr.To("somedns.example.com"), nil)
 
 				Eventually(func(g Gomega) {
 					g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(shoot), shoot)).To(Succeed())
@@ -521,9 +521,9 @@ us-central-3: 220`,
 				seedUSCentral2.Spec.Provider.Zones = []string{"1", "2", "3"}
 				Expect(testClient.Patch(ctx, seedEUWest1, patch)).To(Succeed())
 
-				cloudProfile := createCloudProfile(providerType, "eu-east-1")
+				cloudProfile := createCloudProfile("eu-east-1")
 
-				shoot := createShoot(providerType, cloudProfile.Name, "eu-east-1", nil, ptr.To("somedns.example.com"), getControlPlaneWithType("zone"))
+				shoot := createShoot(cloudProfile.Name, "eu-east-1", nil, ptr.To("somedns.example.com"), getControlPlaneWithType("zone"))
 
 				Eventually(func(g Gomega) {
 					g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(shoot), shoot)).To(Succeed())
@@ -566,7 +566,7 @@ func createAndStartManager(config *config.ShootSchedulerConfiguration) {
 	})
 }
 
-func createSeed(providerType, region string, zones []string) *gardencorev1beta1.Seed {
+func createSeed(region string, zones []string) *gardencorev1beta1.Seed {
 	By("Create Seed")
 	seed := &gardencorev1beta1.Seed{
 		ObjectMeta: metav1.ObjectMeta{
@@ -574,7 +574,7 @@ func createSeed(providerType, region string, zones []string) *gardencorev1beta1.
 		},
 		Spec: gardencorev1beta1.SeedSpec{
 			Provider: gardencorev1beta1.SeedProvider{
-				Type:   providerType,
+				Type:   "provider-type",
 				Region: region,
 				Zones:  zones,
 			},
@@ -586,7 +586,7 @@ func createSeed(providerType, region string, zones []string) *gardencorev1beta1.
 			},
 			DNS: gardencorev1beta1.SeedDNS{
 				Provider: &gardencorev1beta1.SeedDNSProvider{
-					Type: providerType,
+					Type: "provider-type",
 					SecretRef: corev1.SecretReference{
 						Name:      "some-secret",
 						Namespace: "some-namespace",
@@ -627,7 +627,7 @@ func createSeed(providerType, region string, zones []string) *gardencorev1beta1.
 	return seed
 }
 
-func createCloudProfile(providerType, region string) *gardencorev1beta1.CloudProfile {
+func createCloudProfile(region string) *gardencorev1beta1.CloudProfile {
 	By("Create CloudProfile")
 	cloudProfile := &gardencorev1beta1.CloudProfile{
 		ObjectMeta: metav1.ObjectMeta{
@@ -654,7 +654,7 @@ func createCloudProfile(providerType, region string) *gardencorev1beta1.CloudPro
 			},
 			MachineTypes: []gardencorev1beta1.MachineType{{Name: "large"}},
 			Regions:      []gardencorev1beta1.Region{{Name: region}},
-			Type:         providerType,
+			Type:         "provider-type",
 		},
 	}
 	ExpectWithOffset(1, testClient.Create(ctx, cloudProfile)).To(Succeed())
@@ -668,7 +668,7 @@ func createCloudProfile(providerType, region string) *gardencorev1beta1.CloudPro
 	return cloudProfile
 }
 
-func createShoot(providerType, cloudProfile, region string, schedulerName, dnsDomain *string, controlPlane *gardencorev1beta1.ControlPlane) *gardencorev1beta1.Shoot {
+func createShoot(cloudProfile, region string, schedulerName, dnsDomain *string, controlPlane *gardencorev1beta1.ControlPlane) *gardencorev1beta1.Shoot {
 	By("Create Shoot")
 	shoot := &gardencorev1beta1.Shoot{
 		ObjectMeta: metav1.ObjectMeta{
@@ -680,7 +680,7 @@ func createShoot(providerType, cloudProfile, region string, schedulerName, dnsDo
 			CloudProfileName: cloudProfile,
 			Region:           region,
 			Provider: gardencorev1beta1.Provider{
-				Type: providerType,
+				Type: "provider-type",
 				Workers: []gardencorev1beta1.Worker{
 					{
 						Name:             "worker1",

--- a/test/testmachinery/shoots/logging/utils.go
+++ b/test/testmachinery/shoots/logging/utils.go
@@ -179,7 +179,7 @@ func getLoggingShootService(number int) *corev1.Service {
 			Namespace: fmt.Sprintf("%s%v", simulatedShootNamespacePrefix, number),
 		},
 		Spec: corev1.ServiceSpec{
-			Type:         corev1.ServiceType(corev1.ServiceTypeExternalName),
+			Type:         corev1.ServiceTypeExternalName,
 			ExternalName: "logging-shoot.garden.svc.cluster.local",
 		},
 	}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
This PR enables the `unconvert` and `unparam` linters to report superfluous
- type conversions
- function parameters

Note that I only focused on fixing the findings in this PR. There is probably potential to cleanup some of the code even more (or make it more concise), but that's beyond the scope I chose for this PR.

**Special notes for your reviewer**:
/cc @shafeeqes @acumino 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
