### PR TITLE
Align component management in seed controller with component management in garden controller

### DIFF
--- a/pkg/gardenlet/controller/seed/seed/add.go
+++ b/pkg/gardenlet/controller/seed/seed/add.go
@@ -17,6 +17,7 @@ package seed
 import (
 	"fmt"
 
+	"github.com/Masterminds/semver/v3"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/clock"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -40,6 +41,13 @@ const ControllerName = "seed"
 func (r *Reconciler) AddToManager(mgr manager.Manager, gardenCluster cluster.Cluster) error {
 	if r.GardenClient == nil {
 		r.GardenClient = gardenCluster.GetClient()
+	}
+	if r.SeedVersion == nil {
+		var err error
+		r.SeedVersion, err = semver.NewVersion(r.SeedClientSet.Version())
+		if err != nil {
+			return err
+		}
 	}
 	if r.Clock == nil {
 		r.Clock = clock.RealClock{}

--- a/pkg/gardenlet/controller/seed/seed/components.go
+++ b/pkg/gardenlet/controller/seed/seed/components.go
@@ -109,6 +109,7 @@ type components struct {
 
 	kubeAPIServerService component.Deployer
 	kubeAPIServerIngress component.Deployer
+	ingressDNSRecord     component.DeployWaiter
 
 	monitoring                    component.Deployer
 	fluentOperator                component.DeployWaiter
@@ -190,6 +191,10 @@ func (r *Reconciler) instantiateComponents(
 
 	c.kubeAPIServerService = r.newKubeAPIServerService(wildCardCertSecret)
 	c.kubeAPIServerIngress = r.newKubeAPIServerIngress(seed, wildCardCertSecret)
+	c.ingressDNSRecord, err = r.newIngressDNSRecord(ctx, log, seed, "")
+	if err != nil {
+		return
+	}
 
 	// observability components
 	c.fluentOperator, err = r.newFluentOperator()

--- a/pkg/gardenlet/controller/seed/seed/components.go
+++ b/pkg/gardenlet/controller/seed/seed/components.go
@@ -17,7 +17,6 @@ package seed
 import (
 	"context"
 
-	"github.com/Masterminds/semver/v3"
 	proberapi "github.com/gardener/dependency-watchdog/api/prober"
 	weederapi "github.com/gardener/dependency-watchdog/api/weeder"
 	hvpav1alpha1 "github.com/gardener/hvpa-controller/api/v1alpha1"
@@ -34,38 +33,45 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
-	"github.com/gardener/gardener/pkg/chartrenderer"
-	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/component"
 	"github.com/gardener/gardener/pkg/component/clusterautoscaler"
+	"github.com/gardener/gardener/pkg/component/clusteridentity"
 	"github.com/gardener/gardener/pkg/component/coredns"
 	"github.com/gardener/gardener/pkg/component/dependencywatchdog"
 	"github.com/gardener/gardener/pkg/component/etcd"
 	"github.com/gardener/gardener/pkg/component/extensions"
+	extensioncrds "github.com/gardener/gardener/pkg/component/extensions/crds"
 	"github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/downloader"
 	"github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/original/components/nodeagent"
+	"github.com/gardener/gardener/pkg/component/hvpa"
+	"github.com/gardener/gardener/pkg/component/istio"
 	"github.com/gardener/gardener/pkg/component/kubeapiserver"
 	kubeapiserverconstants "github.com/gardener/gardener/pkg/component/kubeapiserver/constants"
+	"github.com/gardener/gardener/pkg/component/kubeapiserverexposure"
 	"github.com/gardener/gardener/pkg/component/kubeproxy"
 	"github.com/gardener/gardener/pkg/component/kubernetesdashboard"
 	"github.com/gardener/gardener/pkg/component/kubescheduler"
 	"github.com/gardener/gardener/pkg/component/logging"
 	"github.com/gardener/gardener/pkg/component/logging/eventlogger"
+	"github.com/gardener/gardener/pkg/component/logging/fluentoperator"
 	"github.com/gardener/gardener/pkg/component/logging/fluentoperator/customresources"
 	"github.com/gardener/gardener/pkg/component/machinecontrollermanager"
 	"github.com/gardener/gardener/pkg/component/metricsserver"
 	"github.com/gardener/gardener/pkg/component/monitoring"
 	"github.com/gardener/gardener/pkg/component/monitoring/prometheus"
 	cacheprometheus "github.com/gardener/gardener/pkg/component/monitoring/prometheus/cache"
+	"github.com/gardener/gardener/pkg/component/monitoring/prometheusoperator"
 	"github.com/gardener/gardener/pkg/component/nodeexporter"
 	"github.com/gardener/gardener/pkg/component/nodeproblemdetector"
 	"github.com/gardener/gardener/pkg/component/plutono"
 	"github.com/gardener/gardener/pkg/component/seedsystem"
-	"github.com/gardener/gardener/pkg/component/shared"
+	sharedcomponent "github.com/gardener/gardener/pkg/component/shared"
+	"github.com/gardener/gardener/pkg/component/vpa"
 	"github.com/gardener/gardener/pkg/component/vpnauthzserver"
 	"github.com/gardener/gardener/pkg/component/vpnseedserver"
 	"github.com/gardener/gardener/pkg/component/vpnshoot"
-	"github.com/gardener/gardener/pkg/gardenlet/apis/config"
+	"github.com/gardener/gardener/pkg/features"
+	gardenlethelper "github.com/gardener/gardener/pkg/gardenlet/apis/config/helper"
 	seedpkg "github.com/gardener/gardener/pkg/operation/seed"
 	"github.com/gardener/gardener/pkg/utils"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
@@ -75,37 +81,202 @@ import (
 	"github.com/gardener/gardener/pkg/utils/timewindow"
 )
 
-func defaultIstio(
-	ctx context.Context,
-	seedClient client.Client,
-	chartRenderer chartrenderer.Interface,
-	seed *seedpkg.Seed,
-	conf *config.GardenletConfiguration,
-	isGardenCluster bool,
-) (
-	component.DeployWaiter,
-	map[string]string,
-	string,
-	error,
-) {
-	var (
-		seedObj = seed.GetInfo()
-		labels  = shared.GetIstioZoneLabels(conf.SNI.Ingress.Labels, nil)
-	)
+type components struct {
+	machineCRD    component.Deployer
+	extensionCRD  component.Deployer
+	etcdCRD       component.Deployer
+	istioCRD      component.Deployer
+	vpaCRD        component.Deployer
+	hvpaCRD       component.Deployer
+	fluentCRD     component.Deployer
+	prometheusCRD component.Deployer
 
-	istioDeployer, err := shared.NewIstio(
+	clusterIdentity          component.DeployWaiter
+	gardenerResourceManager  component.DeployWaiter
+	system                   component.DeployWaiter
+	istio                    component.DeployWaiter
+	istioDefaultLabels       map[string]string
+	istioDefaultNamespace    string
+	nginxIngressController   component.DeployWaiter
+	verticalPodAutoscaler    component.DeployWaiter
+	hvpaController           component.DeployWaiter
+	etcdDruid                component.DeployWaiter
+	clusterAutoscaler        component.DeployWaiter
+	machineControllerManager component.DeployWaiter
+	dwdWeeder                component.DeployWaiter
+	dwdProber                component.DeployWaiter
+	vpnAuthzServer           component.DeployWaiter
+
+	kubeAPIServerService component.Deployer
+	kubeAPIServerIngress component.Deployer
+
+	monitoring                    component.Deployer
+	fluentOperator                component.DeployWaiter
+	fluentBit                     component.DeployWaiter
+	fluentOperatorCustomResources component.DeployWaiter
+	plutono                       plutono.Interface
+	vali                          component.Deployer
+	kubeStateMetrics              component.DeployWaiter
+	prometheusOperator            component.DeployWaiter
+	cachePrometheus               component.DeployWaiter
+}
+
+func (r *Reconciler) instantiateComponents(
+	ctx context.Context,
+	log logr.Logger,
+	seed *seedpkg.Seed,
+	secretsManager secretsmanager.Interface,
+	seedIsGarden bool,
+	globalMonitoringSecretSeed *corev1.Secret,
+	alertingSMTPSecret *corev1.Secret,
+	wildCardCertSecret *corev1.Secret,
+) (
+	c components,
+	err error,
+) {
+	// crds
+	c.machineCRD = machinecontrollermanager.NewCRD(r.SeedClientSet.Client(), r.SeedClientSet.Applier())
+	c.extensionCRD = extensioncrds.NewCRD(r.SeedClientSet.Applier())
+	c.etcdCRD = etcd.NewCRD(r.SeedClientSet.Client(), r.SeedClientSet.Applier())
+	c.istioCRD = istio.NewCRD(r.SeedClientSet.ChartApplier())
+	c.vpaCRD = vpa.NewCRD(r.SeedClientSet.Applier(), nil)
+	c.hvpaCRD = hvpa.NewCRD(r.SeedClientSet.Applier())
+	if !hvpaEnabled() {
+		c.hvpaCRD = component.OpDestroy(c.hvpaCRD)
+	}
+	c.fluentCRD = fluentoperator.NewCRDs(r.SeedClientSet.Applier())
+	c.prometheusCRD = prometheusoperator.NewCRDs(r.SeedClientSet.Applier())
+
+	// seed system components
+	c.clusterIdentity = r.newClusterIdentity(seed.GetInfo())
+	c.gardenerResourceManager, err = r.newGardenerResourceManager(seed.GetInfo(), secretsManager)
+	if err != nil {
+		return
+	}
+	c.system, err = r.newSystem(seed.GetInfo())
+	if err != nil {
+		return
+	}
+	c.istio, c.istioDefaultLabels, c.istioDefaultNamespace, err = r.newIstio(ctx, seed, seedIsGarden)
+	if err != nil {
+		return
+	}
+	c.nginxIngressController, err = r.newNginxIngressController(seed, c.istioDefaultLabels)
+	if err != nil {
+		return
+	}
+	c.verticalPodAutoscaler, err = r.newVerticalPodAutoscaler(seed.GetInfo().Spec.Settings, secretsManager)
+	if err != nil {
+		return
+	}
+	c.hvpaController, err = r.newHVPA()
+	if err != nil {
+		return
+	}
+	c.etcdDruid, err = r.newEtcdDruid()
+	if err != nil {
+		return
+	}
+	c.clusterAutoscaler = r.newClusterAutoscaler()
+	c.machineControllerManager = r.newMachineControllerManager()
+	c.dwdWeeder, c.dwdProber, err = r.newDependencyWatchdogs(seed.GetInfo().Spec.Settings)
+	if err != nil {
+		return
+	}
+	c.vpnAuthzServer, err = r.newVPNAuthzServer()
+	if err != nil {
+		return
+	}
+
+	c.kubeAPIServerService = r.newKubeAPIServerService()
+	c.kubeAPIServerIngress = r.newKubeAPIServerIngress(seed, wildCardCertSecret)
+
+	// observability components
+	c.fluentOperator, err = r.newFluentOperator()
+	if err != nil {
+		return
+	}
+	c.fluentBit, err = r.newFluentBit()
+	if err != nil {
+		return
+	}
+	c.fluentOperatorCustomResources, err = r.newFluentCustomResources(seedIsGarden)
+	if err != nil {
+		return
+	}
+	c.vali, err = r.newVali(ctx)
+	if err != nil {
+		return
+	}
+	c.plutono, err = r.newPlutono(seed, secretsManager, globalMonitoringSecretSeed.Name, wildCardCertSecret)
+	if err != nil {
+		return
+	}
+	c.monitoring, err = r.newMonitoring(secretsManager, seed, alertingSMTPSecret, globalMonitoringSecretSeed, seed.GetIngressFQDN("p-seed"), wildCardCertSecret)
+	if err != nil {
+		return
+	}
+	c.kubeStateMetrics, err = r.newKubeStateMetrics()
+	if err != nil {
+		return
+	}
+	c.prometheusOperator, err = r.newPrometheusOperator()
+	if err != nil {
+		return
+	}
+	c.cachePrometheus, err = r.newCachePrometheus(log, seed)
+	if err != nil {
+		return
+	}
+
+	return c, nil
+}
+
+func (r *Reconciler) newGardenerResourceManager(seed *gardencorev1beta1.Seed, secretsManager secretsmanager.Interface) (component.DeployWaiter, error) {
+	var defaultNotReadyTolerationSeconds, defaultUnreachableTolerationSeconds *int64
+	if nodeToleration := r.Config.NodeToleration; nodeToleration != nil {
+		defaultNotReadyTolerationSeconds = nodeToleration.DefaultNotReadyTolerationSeconds
+		defaultUnreachableTolerationSeconds = nodeToleration.DefaultUnreachableTolerationSeconds
+	}
+
+	var additionalNetworkPolicyNamespaceSelectors []metav1.LabelSelector
+	if config := r.Config.Controllers.NetworkPolicy; config != nil {
+		additionalNetworkPolicyNamespaceSelectors = config.AdditionalNamespaceSelectors
+	}
+
+	return sharedcomponent.NewRuntimeGardenerResourceManager(
+		r.SeedClientSet.Client(),
+		r.GardenNamespace,
+		r.SeedVersion,
+		secretsManager,
+		r.Config.LogLevel, r.Config.LogFormat,
+		v1beta1constants.SecretNameCASeed,
+		v1beta1constants.PriorityClassNameSeedSystemCritical,
+		defaultNotReadyTolerationSeconds,
+		defaultUnreachableTolerationSeconds,
+		features.DefaultFeatureGate.Enabled(features.DefaultSeccompProfile),
+		v1beta1helper.SeedSettingTopologyAwareRoutingEnabled(seed.Spec.Settings),
+		additionalNetworkPolicyNamespaceSelectors,
+		seed.Spec.Provider.Zones,
+	)
+}
+
+func (r *Reconciler) newIstio(ctx context.Context, seed *seedpkg.Seed, isGardenCluster bool) (component.DeployWaiter, map[string]string, string, error) {
+	labels := sharedcomponent.GetIstioZoneLabels(r.Config.SNI.Ingress.Labels, nil)
+
+	istioDeployer, err := sharedcomponent.NewIstio(
 		ctx,
-		seedClient,
-		chartRenderer,
+		r.SeedClientSet.Client(),
+		r.SeedClientSet.ChartRenderer(),
 		"",
-		*conf.SNI.Ingress.Namespace,
+		*r.Config.SNI.Ingress.Namespace,
 		v1beta1constants.PriorityClassNameSeedSystemCritical,
 		!isGardenCluster,
 		labels,
 		gardenerutils.NetworkPolicyLabel(v1beta1constants.LabelNetworkPolicyShootNamespaceAlias+"-"+v1beta1constants.DeploymentNameKubeAPIServer, kubeapiserverconstants.Port),
 		seed.GetLoadBalancerServiceAnnotations(),
 		seed.GetLoadBalancerServiceExternalTrafficPolicy(),
-		conf.SNI.Ingress.ServiceExternalIP,
+		r.Config.SNI.Ingress.ServiceExternalIP,
 		[]corev1.ServicePort{
 			{Name: "proxy", Port: 8443, TargetPort: intstr.FromInt32(8443)},
 			{Name: "tcp", Port: 443, TargetPort: intstr.FromInt32(9443)},
@@ -113,7 +284,7 @@ func defaultIstio(
 		},
 		true,
 		true,
-		seedObj.Spec.Provider.Zones,
+		seed.GetInfo().Spec.Provider.Zones,
 		seed.IsDualStack(),
 	)
 	if err != nil {
@@ -121,15 +292,15 @@ func defaultIstio(
 	}
 
 	// Automatically create ingress gateways for single-zone control planes on multi-zonal seeds
-	if len(seedObj.Spec.Provider.Zones) > 1 {
-		for _, zone := range seedObj.Spec.Provider.Zones {
-			if err := shared.AddIstioIngressGateway(
+	if len(seed.GetInfo().Spec.Provider.Zones) > 1 {
+		for _, zone := range seed.GetInfo().Spec.Provider.Zones {
+			if err := sharedcomponent.AddIstioIngressGateway(
 				ctx,
-				seedClient,
+				r.SeedClientSet.Client(),
 				istioDeployer,
-				shared.GetIstioNamespaceForZone(*conf.SNI.Ingress.Namespace, zone),
+				sharedcomponent.GetIstioNamespaceForZone(*r.Config.SNI.Ingress.Namespace, zone),
 				seed.GetZonalLoadBalancerServiceAnnotations(zone),
-				shared.GetIstioZoneLabels(labels, &zone),
+				sharedcomponent.GetIstioZoneLabels(labels, &zone),
 				seed.GetZonalLoadBalancerServiceExternalTrafficPolicy(zone),
 				nil,
 				&zone,
@@ -141,15 +312,15 @@ func defaultIstio(
 	}
 
 	// Add for each ExposureClass handler in the config an own Ingress Gateway and Proxy Gateway.
-	for _, handler := range conf.ExposureClassHandlers {
-		if err := shared.AddIstioIngressGateway(
+	for _, handler := range r.Config.ExposureClassHandlers {
+		if err := sharedcomponent.AddIstioIngressGateway(
 			ctx,
-			seedClient,
+			r.SeedClientSet.Client(),
 			istioDeployer,
 			*handler.SNI.Ingress.Namespace,
 			// handler.LoadBalancerService.Annotations must put last to override non-exposure class related keys.
 			utils.MergeStringMaps(seed.GetLoadBalancerServiceAnnotations(), handler.LoadBalancerService.Annotations),
-			shared.GetIstioZoneLabels(gardenerutils.GetMandatoryExposureClassHandlerSNILabels(handler.SNI.Ingress.Labels, handler.Name), nil),
+			sharedcomponent.GetIstioZoneLabels(gardenerutils.GetMandatoryExposureClassHandlerSNILabels(handler.SNI.Ingress.Labels, handler.Name), nil),
 			seed.GetLoadBalancerServiceExternalTrafficPolicy(),
 			handler.SNI.Ingress.ServiceExternalIP,
 			nil,
@@ -159,16 +330,16 @@ func defaultIstio(
 		}
 
 		// Automatically create ingress gateways for single-zone control planes on multi-zonal seeds
-		if len(seedObj.Spec.Provider.Zones) > 1 {
-			for _, zone := range seedObj.Spec.Provider.Zones {
-				if err := shared.AddIstioIngressGateway(
+		if len(seed.GetInfo().Spec.Provider.Zones) > 1 {
+			for _, zone := range seed.GetInfo().Spec.Provider.Zones {
+				if err := sharedcomponent.AddIstioIngressGateway(
 					ctx,
-					seedClient,
+					r.SeedClientSet.Client(),
 					istioDeployer,
-					shared.GetIstioNamespaceForZone(*handler.SNI.Ingress.Namespace, zone),
+					sharedcomponent.GetIstioNamespaceForZone(*handler.SNI.Ingress.Namespace, zone),
 					// handler.LoadBalancerService.Annotations must put last to override non-exposure class related keys.
 					utils.MergeStringMaps(seed.GetZonalLoadBalancerServiceAnnotations(zone), handler.LoadBalancerService.Annotations),
-					shared.GetIstioZoneLabels(gardenerutils.GetMandatoryExposureClassHandlerSNILabels(handler.SNI.Ingress.Labels, handler.Name), &zone),
+					sharedcomponent.GetIstioZoneLabels(gardenerutils.GetMandatoryExposureClassHandlerSNILabels(handler.SNI.Ingress.Labels, handler.Name), &zone),
 					seed.GetZonalLoadBalancerServiceExternalTrafficPolicy(zone),
 					nil,
 					&zone,
@@ -183,28 +354,19 @@ func defaultIstio(
 	return istioDeployer, labels, istioDeployer.GetValues().IngressGateway[0].Namespace, nil
 }
 
-func defaultDependencyWatchdogs(
-	c client.Client,
-	seedVersion *semver.Version,
-	seedSettings *gardencorev1beta1.SeedSettings,
-	gardenNamespaceName string,
-) (
-	dwdWeeder component.DeployWaiter,
-	dwdProber component.DeployWaiter,
-	err error,
-) {
-	image, err := imagevector.ImageVector().FindImage(imagevector.ImageNameDependencyWatchdog, imagevectorutils.RuntimeVersion(seedVersion.String()), imagevectorutils.TargetVersion(seedVersion.String()))
+func (r *Reconciler) newDependencyWatchdogs(seedSettings *gardencorev1beta1.SeedSettings) (dwdWeeder component.DeployWaiter, dwdProber component.DeployWaiter, err error) {
+	image, err := imagevector.ImageVector().FindImage(imagevector.ImageNameDependencyWatchdog, imagevectorutils.RuntimeVersion(r.SeedVersion.String()), imagevectorutils.TargetVersion(r.SeedVersion.String()))
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var (
-		dwdWeederValues = dependencywatchdog.BootstrapperValues{Role: dependencywatchdog.RoleWeeder, Image: image.String(), KubernetesVersion: seedVersion}
-		dwdProberValues = dependencywatchdog.BootstrapperValues{Role: dependencywatchdog.RoleProber, Image: image.String(), KubernetesVersion: seedVersion}
+		dwdWeederValues = dependencywatchdog.BootstrapperValues{Role: dependencywatchdog.RoleWeeder, Image: image.String(), KubernetesVersion: r.SeedVersion}
+		dwdProberValues = dependencywatchdog.BootstrapperValues{Role: dependencywatchdog.RoleProber, Image: image.String(), KubernetesVersion: r.SeedVersion}
 	)
 
-	dwdWeeder = component.OpDestroyWithoutWait(dependencywatchdog.NewBootstrapper(c, gardenNamespaceName, dwdWeederValues))
-	dwdProber = component.OpDestroyWithoutWait(dependencywatchdog.NewBootstrapper(c, gardenNamespaceName, dwdProberValues))
+	dwdWeeder = component.OpDestroyWithoutWait(dependencywatchdog.NewBootstrapper(r.SeedClientSet.Client(), r.GardenNamespace, dwdWeederValues))
+	dwdProber = component.OpDestroyWithoutWait(dependencywatchdog.NewBootstrapper(r.SeedClientSet.Client(), r.GardenNamespace, dwdProberValues))
 
 	if v1beta1helper.SeedSettingDependencyWatchdogWeederEnabled(seedSettings) {
 		// Fetch component-specific dependency-watchdog configuration
@@ -232,7 +394,7 @@ func defaultDependencyWatchdogs(
 		}
 
 		dwdWeederValues.WeederConfig = dependencyWatchdogWeederConfiguration
-		dwdWeeder = dependencywatchdog.NewBootstrapper(c, gardenNamespaceName, dwdWeederValues)
+		dwdWeeder = dependencywatchdog.NewBootstrapper(r.SeedClientSet.Client(), r.GardenNamespace, dwdWeederValues)
 	}
 
 	if v1beta1helper.SeedSettingDependencyWatchdogProberEnabled(seedSettings) {
@@ -258,81 +420,57 @@ func defaultDependencyWatchdogs(
 		}
 
 		dwdProberValues.ProberConfig = dependencyWatchdogProberConfiguration
-		dwdProber = dependencywatchdog.NewBootstrapper(c, gardenNamespaceName, dwdProberValues)
+		dwdProber = dependencywatchdog.NewBootstrapper(r.SeedClientSet.Client(), r.GardenNamespace, dwdProberValues)
 	}
 
 	return
 }
 
-func defaultVPNAuthzServer(
-	c client.Client,
-	seedVersion *semver.Version,
-	gardenNamespaceName string,
-) (
-	component.DeployWaiter,
-	error,
-) {
-	image, err := imagevector.ImageVector().FindImage(imagevector.ImageNameExtAuthzServer, imagevectorutils.RuntimeVersion(seedVersion.String()), imagevectorutils.TargetVersion(seedVersion.String()))
+func (r *Reconciler) newVPNAuthzServer() (component.DeployWaiter, error) {
+	image, err := imagevector.ImageVector().FindImage(imagevector.ImageNameExtAuthzServer, imagevectorutils.RuntimeVersion(r.SeedVersion.String()), imagevectorutils.TargetVersion(r.SeedVersion.String()))
 	if err != nil {
 		return nil, err
 	}
 
 	return vpnauthzserver.New(
-		c,
-		gardenNamespaceName,
+		r.SeedClientSet.Client(),
+		r.GardenNamespace,
 		image.String(),
-		seedVersion,
+		r.SeedVersion,
 	), nil
 }
 
-func defaultSystem(
-	c client.Client,
-	seed *seedpkg.Seed,
-	gardenNamespaceName string,
-) (
-	component.DeployWaiter,
-	error,
-) {
+func (r *Reconciler) newSystem(seed *gardencorev1beta1.Seed) (component.DeployWaiter, error) {
 	image, err := imagevector.ImageVector().FindImage(imagevector.ImageNamePauseContainer)
 	if err != nil {
 		return nil, err
 	}
 
 	var replicasExcessCapacityReservation int32 = 2
-	if numberOfZones := len(seed.GetInfo().Spec.Provider.Zones); numberOfZones > 1 {
+	if numberOfZones := len(seed.Spec.Provider.Zones); numberOfZones > 1 {
 		replicasExcessCapacityReservation = int32(numberOfZones)
 	}
 
 	return seedsystem.New(
-		c,
-		gardenNamespaceName,
+		r.SeedClientSet.Client(),
+		r.GardenNamespace,
 		seedsystem.Values{
 			ReserveExcessCapacity: seedsystem.ReserveExcessCapacityValues{
-				Enabled:  v1beta1helper.SeedSettingExcessCapacityReservationEnabled(seed.GetInfo().Spec.Settings),
+				Enabled:  v1beta1helper.SeedSettingExcessCapacityReservationEnabled(seed.Spec.Settings),
 				Image:    image.String(),
 				Replicas: replicasExcessCapacityReservation,
-				Configs:  seed.GetInfo().Spec.Settings.ExcessCapacityReservation.Configs,
+				Configs:  seed.Spec.Settings.ExcessCapacityReservation.Configs,
 			},
 		},
 	), nil
 }
 
-func defaultVali(
-	ctx context.Context,
-	c client.Client,
-	loggingConfig *config.Logging,
-	gardenNamespaceName string,
-	isLoggingEnabled bool,
-	hvpaEnabled bool,
-) (
-	component.Deployer,
-	error,
-) {
+func (r *Reconciler) newVali(ctx context.Context) (component.Deployer, error) {
 	maintenanceBegin, maintenanceEnd := "220000-0000", "230000-0000"
 
-	if hvpaEnabled {
+	if hvpaEnabled() {
 		shootInfo := &corev1.ConfigMap{}
-		if err := c.Get(ctx, kubernetesutils.Key(metav1.NamespaceSystem, v1beta1constants.ConfigMapNameShootInfo), shootInfo); err != nil {
+		if err := r.SeedClientSet.Client().Get(ctx, kubernetesutils.Key(metav1.NamespaceSystem, v1beta1constants.ConfigMapNameShootInfo), shootInfo); err != nil {
 			if !apierrors.IsNotFound(err) {
 				return nil, err
 			}
@@ -353,13 +491,13 @@ func defaultVali(
 	}
 
 	var storage *resource.Quantity
-	if loggingConfig != nil && loggingConfig.Vali != nil && loggingConfig.Vali.Garden != nil {
-		storage = loggingConfig.Vali.Garden.Storage
+	if r.Config.Logging != nil && r.Config.Logging.Vali != nil && r.Config.Logging.Vali.Garden != nil {
+		storage = r.Config.Logging.Vali.Garden.Storage
 	}
 
-	deployer, err := shared.NewVali(
-		c,
-		gardenNamespaceName,
+	deployer, err := sharedcomponent.NewVali(
+		r.SeedClientSet.Client(),
+		r.GardenNamespace,
 		nil,
 		component.ClusterTypeSeed,
 		1,
@@ -367,7 +505,7 @@ func defaultVali(
 		v1beta1constants.PriorityClassNameSeedSystem600,
 		storage,
 		"",
-		hvpaEnabled,
+		hvpaEnabled(),
 		&hvpav1alpha1.MaintenanceTimeWindow{
 			Begin: maintenanceBegin,
 			End:   maintenanceEnd,
@@ -377,32 +515,27 @@ func defaultVali(
 		return nil, err
 	}
 
-	if !isLoggingEnabled {
+	if !gardenlethelper.IsLoggingEnabled(&r.Config) {
 		return component.OpDestroy(deployer), err
 	}
 
 	return deployer, err
 }
 
-func defaultPlutono(
-	c client.Client,
-	namespace string,
-	secretsManager secretsmanager.Interface,
-	ingressHot string,
-	authSecret string,
-	wildcardCertName *string,
-) (
-	plutono.Interface,
-	error,
-) {
-	return shared.NewPlutono(
-		c,
-		namespace,
+func (r *Reconciler) newPlutono(seed *seedpkg.Seed, secretsManager secretsmanager.Interface, authSecretName string, wildcardCertSecret *corev1.Secret) (plutono.Interface, error) {
+	var wildcardCertName *string
+	if wildcardCertSecret != nil {
+		wildcardCertName = ptr.To(wildcardCertSecret.GetName())
+	}
+
+	return sharedcomponent.NewPlutono(
+		r.SeedClientSet.Client(),
+		r.GardenNamespace,
 		secretsManager,
 		component.ClusterTypeSeed,
 		1,
-		authSecret,
-		ingressHot,
+		authSecretName,
+		seed.GetIngressFQDN("g-seed"),
 		v1beta1constants.PriorityClassNameSeedSystem600,
 		true,
 		false,
@@ -414,21 +547,7 @@ func defaultPlutono(
 	)
 }
 
-func defaultMonitoring(
-	c client.Client,
-	chartApplier kubernetes.ChartApplier,
-	secretsManager secretsmanager.Interface,
-	namespace string,
-	seed *seedpkg.Seed,
-	alertingSMTPSecret *corev1.Secret,
-	globalMonitoringSecret *corev1.Secret,
-	hvpaEnabled bool,
-	ingressHost string,
-	wildcardCertName *string,
-) (
-	component.Deployer,
-	error,
-) {
+func (r *Reconciler) newMonitoring(secretsManager secretsmanager.Interface, seed *seedpkg.Seed, alertingSMTPSecret *corev1.Secret, globalMonitoringSecret *corev1.Secret, ingressHost string, wildcardCertSecret *corev1.Secret) (component.Deployer, error) {
 	imageAlertmanager, err := imagevector.ImageVector().FindImage(imagevector.ImageNameAlertmanager)
 	if err != nil {
 		return nil, err
@@ -446,15 +565,20 @@ func defaultMonitoring(
 		return nil, err
 	}
 
+	var wildcardCertName *string
+	if wildcardCertSecret != nil {
+		wildcardCertName = ptr.To(wildcardCertSecret.GetName())
+	}
+
 	return monitoring.NewBootstrap(
-		c,
-		chartApplier,
+		r.SeedClientSet.Client(),
+		r.SeedClientSet.ChartApplier(),
 		secretsManager,
-		namespace,
+		r.GardenNamespace,
 		monitoring.ValuesBootstrap{
 			AlertingSMTPSecret:                 alertingSMTPSecret,
 			GlobalMonitoringSecret:             globalMonitoringSecret,
-			HVPAEnabled:                        hvpaEnabled,
+			HVPAEnabled:                        hvpaEnabled(),
 			ImageAlertmanager:                  imageAlertmanager.String(),
 			ImageAlpine:                        imageAlpine.String(),
 			ImageConfigmapReloader:             imageConfigmapReloader.String(),
@@ -469,15 +593,7 @@ func defaultMonitoring(
 	), nil
 }
 
-func defaultCachePrometheus(
-	log logr.Logger,
-	c client.Client,
-	namespace string,
-	seed *seedpkg.Seed,
-) (
-	component.DeployWaiter,
-	error,
-) {
+func (r *Reconciler) newCachePrometheus(log logr.Logger, seed *seedpkg.Seed) (component.DeployWaiter, error) {
 	imagePrometheus, err := imagevector.ImageVector().FindImage(imagevector.ImageNamePrometheus)
 	if err != nil {
 		return nil, err
@@ -487,7 +603,7 @@ func defaultCachePrometheus(
 		return nil, err
 	}
 
-	return prometheus.New(log, c, namespace, prometheus.Values{
+	return prometheus.New(log, r.SeedClientSet.Client(), r.GardenNamespace, prometheus.Values{
 		Name:              "cache",
 		Image:             imagePrometheus.String(),
 		Version:           ptr.Deref(imagePrometheus.Version, "v0.0.0"),
@@ -498,7 +614,7 @@ func defaultCachePrometheus(
 			ServiceMonitors:         cacheprometheus.CentralServiceMonitors(),
 			PrometheusRules:         cacheprometheus.CentralPrometheusRules(),
 		},
-		AdditionalResources: []client.Object{cacheprometheus.NetworkPolicyToNodeExporter(namespace)},
+		AdditionalResources: []client.Object{cacheprometheus.NetworkPolicyToNodeExporter(r.GardenNamespace)},
 		// TODO(rfranzke): Remove this after v1.92 has been released.
 		DataMigration: prometheus.DataMigration{
 			ImageAlpine:     imageAlpine.String(),
@@ -508,17 +624,7 @@ func defaultCachePrometheus(
 	}), nil
 }
 
-// getFluentBitInputsFilterAndParsers returns all fluent-bit inputs, filters and parsers for the seed
-func getFluentOperatorCustomResources(
-	c client.Client,
-	namespace string,
-	loggingEnabled bool,
-	seedIsGarden bool,
-	isEventLoggingEnabled bool,
-) (
-	deployer component.DeployWaiter,
-	err error,
-) {
+func (r *Reconciler) newFluentCustomResources(seedIsGarden bool) (deployer component.DeployWaiter, err error) {
 	centralLoggingConfigurations := []component.CentralLoggingConfiguration{
 		// seed system components
 		extensions.CentralLoggingConfiguration,
@@ -547,16 +653,141 @@ func getFluentOperatorCustomResources(
 	if !seedIsGarden {
 		centralLoggingConfigurations = append(centralLoggingConfigurations, logging.GardenCentralLoggingConfigurations...)
 	}
-	if isEventLoggingEnabled {
+	if gardenlethelper.IsEventLoggingEnabled(&r.Config) {
 		centralLoggingConfigurations = append(centralLoggingConfigurations, eventlogger.CentralLoggingConfiguration)
 	}
 
-	return shared.NewFluentOperatorCustomResources(
-		c,
-		namespace,
-		loggingEnabled,
+	return sharedcomponent.NewFluentOperatorCustomResources(
+		r.SeedClientSet.Client(),
+		r.GardenNamespace,
+		gardenlethelper.IsLoggingEnabled(&r.Config),
 		"",
 		centralLoggingConfigurations,
 		customresources.GetDynamicClusterOutput(map[string]string{v1beta1constants.LabelKeyCustomLoggingResource: v1beta1constants.LabelValueCustomLoggingResource}),
 	)
+}
+
+func (r *Reconciler) newVerticalPodAutoscaler(settings *gardencorev1beta1.SeedSettings, secretsManager secretsmanager.Interface) (component.DeployWaiter, error) {
+	return sharedcomponent.NewVerticalPodAutoscaler(
+		r.SeedClientSet.Client(),
+		r.GardenNamespace,
+		r.SeedVersion,
+		secretsManager,
+		vpaEnabled(settings),
+		v1beta1constants.SecretNameCASeed,
+		v1beta1constants.PriorityClassNameSeedSystem800,
+		v1beta1constants.PriorityClassNameSeedSystem700,
+		v1beta1constants.PriorityClassNameSeedSystem700,
+	)
+}
+
+func (r *Reconciler) newHVPA() (component.DeployWaiter, error) {
+	return sharedcomponent.NewHVPA(
+		r.SeedClientSet.Client(),
+		r.GardenNamespace,
+		hvpaEnabled(),
+		r.SeedVersion,
+		v1beta1constants.PriorityClassNameSeedSystem700,
+	)
+}
+
+func (r *Reconciler) newEtcdDruid() (component.DeployWaiter, error) {
+	return sharedcomponent.NewEtcdDruid(
+		r.SeedClientSet.Client(),
+		r.GardenNamespace,
+		r.SeedVersion,
+		r.ComponentImageVectors,
+		r.Config.ETCDConfig,
+		v1beta1constants.PriorityClassNameSeedSystem800,
+	)
+}
+
+func (r *Reconciler) newKubeStateMetrics() (component.DeployWaiter, error) {
+	return sharedcomponent.NewKubeStateMetrics(
+		r.SeedClientSet.Client(),
+		r.GardenNamespace,
+		r.SeedVersion,
+		v1beta1constants.PriorityClassNameSeedSystem600,
+	)
+}
+
+func (r *Reconciler) newPrometheusOperator() (component.DeployWaiter, error) {
+	return sharedcomponent.NewPrometheusOperator(
+		r.SeedClientSet.Client(),
+		r.GardenNamespace,
+		v1beta1constants.PriorityClassNameSeedSystem600,
+	)
+}
+
+func (r *Reconciler) newFluentOperator() (component.DeployWaiter, error) {
+	return sharedcomponent.NewFluentOperator(
+		r.SeedClientSet.Client(),
+		r.GardenNamespace,
+		gardenlethelper.IsLoggingEnabled(&r.Config),
+		v1beta1constants.PriorityClassNameSeedSystem600,
+	)
+}
+
+func (r *Reconciler) newFluentBit() (component.DeployWaiter, error) {
+	return sharedcomponent.NewFluentBit(
+		r.SeedClientSet.Client(),
+		r.GardenNamespace,
+		gardenlethelper.IsLoggingEnabled(&r.Config),
+		v1beta1constants.PriorityClassNameSeedSystem600,
+	)
+}
+
+func (r *Reconciler) newClusterAutoscaler() component.DeployWaiter {
+	return clusterautoscaler.NewBootstrapper(r.SeedClientSet.Client(), r.GardenNamespace)
+}
+
+func (r *Reconciler) newMachineControllerManager() component.DeployWaiter {
+	return machinecontrollermanager.NewBootstrapper(r.SeedClientSet.Client(), r.GardenNamespace)
+}
+
+func (r *Reconciler) newClusterIdentity(seed *gardencorev1beta1.Seed) component.DeployWaiter {
+	return clusteridentity.NewForSeed(r.SeedClientSet.Client(), r.GardenNamespace, *seed.Status.ClusterIdentity)
+}
+
+func (r *Reconciler) newNginxIngressController(seed *seedpkg.Seed, istioDefaultLabels map[string]string) (component.DeployWaiter, error) {
+	providerConfig, err := getConfig(seed.GetInfo())
+	if err != nil {
+		return nil, err
+	}
+
+	return sharedcomponent.NewNginxIngress(
+		r.SeedClientSet.Client(),
+		r.GardenNamespace,
+		r.GardenNamespace,
+		r.SeedVersion,
+		providerConfig,
+		seed.GetLoadBalancerServiceAnnotations(),
+		nil,
+		v1beta1constants.PriorityClassNameSeedSystem600,
+		true,
+		true,
+		component.ClusterTypeSeed,
+		"",
+		v1beta1constants.SeedNginxIngressClass,
+		[]string{seed.GetIngressFQDN("*")},
+		istioDefaultLabels,
+	)
+}
+
+func (r *Reconciler) newKubeAPIServerService() component.Deployer {
+	return kubeapiserverexposure.NewInternalNameService(r.SeedClientSet.Client(), r.GardenNamespace)
+}
+
+func (r *Reconciler) newKubeAPIServerIngress(seed *seedpkg.Seed, wildCardCertSecret *corev1.Secret) component.Deployer {
+	values := kubeapiserverexposure.IngressValues{}
+	if wildCardCertSecret != nil {
+		values = kubeapiserverexposure.IngressValues{
+			Host:             seed.GetIngressFQDN("api-seed"),
+			IngressClassName: ptr.To(v1beta1constants.SeedNginxIngressClass),
+			ServiceName:      v1beta1constants.DeploymentNameKubeAPIServer,
+			TLSSecretName:    &wildCardCertSecret.Name,
+		}
+	}
+
+	return kubeapiserverexposure.NewIngress(r.SeedClientSet.Client(), r.GardenNamespace, values)
 }

--- a/pkg/gardenlet/controller/seed/seed/components.go
+++ b/pkg/gardenlet/controller/seed/seed/components.go
@@ -208,7 +208,7 @@ func (r *Reconciler) instantiateComponents(
 	if err != nil {
 		return
 	}
-	c.plutono, err = r.newPlutono(seed, secretsManager, globalMonitoringSecretSeed.Name, wildCardCertSecret)
+	c.plutono, err = r.newPlutono(seed, secretsManager, globalMonitoringSecretSeed, wildCardCertSecret)
 	if err != nil {
 		return
 	}
@@ -522,10 +522,15 @@ func (r *Reconciler) newVali(ctx context.Context) (component.Deployer, error) {
 	return deployer, err
 }
 
-func (r *Reconciler) newPlutono(seed *seedpkg.Seed, secretsManager secretsmanager.Interface, authSecretName string, wildcardCertSecret *corev1.Secret) (plutono.Interface, error) {
+func (r *Reconciler) newPlutono(seed *seedpkg.Seed, secretsManager secretsmanager.Interface, authSecret, wildcardCertSecret *corev1.Secret) (plutono.Interface, error) {
 	var wildcardCertName *string
 	if wildcardCertSecret != nil {
 		wildcardCertName = ptr.To(wildcardCertSecret.GetName())
+	}
+
+	var authSecretName string
+	if authSecret != nil {
+		authSecretName = authSecret.Name
 	}
 
 	return sharedcomponent.NewPlutono(

--- a/pkg/gardenlet/controller/seed/seed/reconciler.go
+++ b/pkg/gardenlet/controller/seed/seed/reconciler.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/Masterminds/semver/v3"
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -34,6 +35,7 @@ import (
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/component"
+	"github.com/gardener/gardener/pkg/features"
 	"github.com/gardener/gardener/pkg/gardenlet/apis/config"
 	seedpkg "github.com/gardener/gardener/pkg/operation/seed"
 	"github.com/gardener/gardener/pkg/utils/flow"
@@ -47,6 +49,7 @@ import (
 type Reconciler struct {
 	GardenClient                         client.Client
 	SeedClientSet                        kubernetes.Interface
+	SeedVersion                          *semver.Version
 	Config                               config.GardenletConfiguration
 	Clock                                clock.Clock
 	Recorder                             record.EventRecorder
@@ -299,4 +302,12 @@ func destroyDNSResources(ctx context.Context, dnsRecord component.DeployMigrateW
 		return err
 	}
 	return dnsRecord.WaitCleanup(ctx)
+}
+
+func vpaEnabled(settings *gardencorev1beta1.SeedSettings) bool {
+	return settings == nil || settings.VerticalPodAutoscaler == nil || settings.VerticalPodAutoscaler.Enabled
+}
+
+func hvpaEnabled() bool {
+	return features.DefaultFeatureGate.Enabled(features.HVPA)
 }

--- a/pkg/gardenlet/controller/seed/seed/reconciler.go
+++ b/pkg/gardenlet/controller/seed/seed/reconciler.go
@@ -34,7 +34,6 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
-	"github.com/gardener/gardener/pkg/component"
 	"github.com/gardener/gardener/pkg/features"
 	"github.com/gardener/gardener/pkg/gardenlet/apis/config"
 	seedpkg "github.com/gardener/gardener/pkg/operation/seed"
@@ -277,31 +276,6 @@ func determineClusterIdentity(ctx context.Context, c client.Client) (string, err
 		return string(gardenNamespace.UID), nil
 	}
 	return clusterIdentity.Data[v1beta1constants.ClusterIdentity], nil
-}
-
-func getDNSProviderSecretData(ctx context.Context, gardenClient client.Client, seed *gardencorev1beta1.Seed) (map[string][]byte, error) {
-	if dnsConfig := seed.Spec.DNS; dnsConfig.Provider != nil {
-		secret, err := kubernetesutils.GetSecretByReference(ctx, gardenClient, &dnsConfig.Provider.SecretRef)
-		if err != nil {
-			return nil, err
-		}
-		return secret.Data, nil
-	}
-	return nil, nil
-}
-
-func deployDNSResources(ctx context.Context, dnsRecord component.DeployMigrateWaiter) error {
-	if err := dnsRecord.Deploy(ctx); err != nil {
-		return err
-	}
-	return dnsRecord.Wait(ctx)
-}
-
-func destroyDNSResources(ctx context.Context, dnsRecord component.DeployMigrateWaiter) error {
-	if err := dnsRecord.Destroy(ctx); err != nil {
-		return err
-	}
-	return dnsRecord.WaitCleanup(ctx)
 }
 
 func vpaEnabled(settings *gardencorev1beta1.SeedSettings) bool {

--- a/pkg/gardenlet/controller/seed/seed/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/seed/seed/reconciler_reconcile.go
@@ -164,11 +164,6 @@ func (r *Reconciler) runReconcileSeedFlow(
 		return err
 	}
 
-	kubernetesVersion, err := semver.NewVersion(r.SeedClientSet.Version())
-	if err != nil {
-		return err
-	}
-
 	var (
 		vpaEnabled     = seed.GetInfo().Spec.Settings == nil || seed.GetInfo().Spec.Settings.VerticalPodAutoscaler == nil || seed.GetInfo().Spec.Settings.VerticalPodAutoscaler.Enabled
 		hvpaEnabled    = features.DefaultFeatureGate.Enabled(features.HVPA)

--- a/pkg/gardenlet/controller/seed/seed/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/seed/seed/reconciler_reconcile.go
@@ -222,6 +222,11 @@ func (r *Reconciler) runReconcileSeedFlow(
 		return err
 	}
 
+	seedIsOriginOfClusterIdentity, err := clusteridentity.IsClusterIdentityEmptyOrFromOrigin(ctx, r.SeedClientSet.Client(), v1beta1constants.ClusterIdentityOriginSeed)
+	if err != nil {
+		return err
+	}
+
 	var (
 		g = flow.NewGraph("Seed reconciliation")
 
@@ -297,6 +302,21 @@ func (r *Reconciler) runReconcileSeedFlow(
 			},
 			Dependencies: flow.NewTaskIDs(deploySystemResources),
 		})
+		// Use the managed resource for cluster-identity only if there is no cluster-identity config map in kube-system namespace from a different origin than seed.
+		// This prevents gardenlet from deleting the config map accidentally on seed deletion when it was created by a different party (gardener-apiserver or shoot).
+		_ = g.Add(flow.Task{
+			Name:         "Deploying cluster-identity",
+			Fn:           c.clusterIdentity.Deploy,
+			Dependencies: flow.NewTaskIDs(waitUntilRequiredExtensionsReady),
+			SkipIf:       !seedIsOriginOfClusterIdentity,
+		})
+		_ = g.Add(flow.Task{
+			Name: "Cleaning up orphan ExposureClass handler resources",
+			Fn: func(ctx context.Context) error {
+				return cleanupOrphanExposureClassHandlerResources(ctx, log, r.SeedClientSet.Client(), r.Config.ExposureClassHandlers, seed.GetInfo().Spec.Provider.Zones)
+			},
+			Dependencies: flow.NewTaskIDs(waitUntilRequiredExtensionsReady),
+		})
 	)
 
 	if err := g.Compile().Run(ctx, flow.Opts{
@@ -307,15 +327,6 @@ func (r *Reconciler) runReconcileSeedFlow(
 	}
 
 	return secretsManager.Cleanup(ctx)
-
-	seedIsOriginOfClusterIdentity, err := clusteridentity.IsClusterIdentityEmptyOrFromOrigin(ctx, seedClient, v1beta1constants.ClusterIdentityOriginSeed)
-	if err != nil {
-		return err
-	}
-
-	if err := cleanupOrphanExposureClassHandlerResources(ctx, log, seedClient, r.Config.ExposureClassHandlers, seed.GetInfo().Spec.Provider.Zones); err != nil {
-		return err
-	}
 
 	// setup for flow graph
 	var dnsRecord component.DeployMigrateWaiter
@@ -433,15 +444,6 @@ func (r *Reconciler) runReconcileSeedFlow(
 			SkipIf: seed.GetInfo().Annotations[v1beta1constants.GardenerOperation] != v1beta1constants.GardenerOperationRenewKubeconfig,
 		})
 	)
-
-	// Use the managed resource for cluster-identity only if there is no cluster-identity config map in kube-system namespace from a different origin than seed.
-	// This prevents gardenlet from deleting the config map accidentally on seed deletion when it was created by a different party (gardener-apiserver or shoot).
-	if seedIsOriginOfClusterIdentity {
-		_ = g.Add(flow.Task{
-			Name: "Deploying cluster-identity",
-			Fn:   clusteridentity.NewForSeed(seedClient, r.GardenNamespace, *seed.GetInfo().Status.ClusterIdentity).Deploy,
-		})
-	}
 
 	// When the seed is the garden cluster then the following components are reconciled by the gardener-operator.
 	if !seedIsGarden {

--- a/pkg/operator/controller/garden/garden/reconciler_reconcile.go
+++ b/pkg/operator/controller/garden/garden/reconciler_reconcile.go
@@ -80,7 +80,7 @@ func (r *Reconciler) reconcile(
 		}
 	}
 
-	// create + label namespace
+	// create + label garden namespace
 	namespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: r.GardenNamespace}}
 	log.Info("Labeling and annotating namespace", "namespaceName", namespace.Name)
 	if _, err := controllerutils.CreateOrGetAndMergePatch(ctx, r.RuntimeClientSet.Client(), namespace, func() error {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind cleanup

**What this PR does / why we need it**:
The `Garden` controller uses a `component` structure https://github.com/gardener/gardener/blob/079171fe3c3867dc8fc9c76835b2b78999abd5de/pkg/operator/controller/garden/garden/components.go#L86-L125 and a clean initialisation function https://github.com/gardener/gardener/blob/079171fe3c3867dc8fc9c76835b2b78999abd5de/pkg/operator/controller/garden/garden/components.go#L127-L263

This PR aligns this approach with the component management in the seed controller.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
