### PR TITLE
Promote `UseGardenerNodeAgent` feature gate to beta

### DIFF
--- a/docs/deployment/feature_gates.md
+++ b/docs/deployment/feature_gates.md
@@ -31,7 +31,8 @@ The following tables are a summary of the feature gates that you can set on diff
 | MachineControllerManagerDeployment  | `true`  | `GA`    | `1.82` |        |
 | ShootForceDeletion                  | `false` | `Alpha` | `1.81` |        |
 | APIServerFastRollout                | `true`  | `Beta`  | `1.82` |        |
-| UseGardenerNodeAgent                | `false` | `Alpha` | `1.82` |        |
+| UseGardenerNodeAgent                | `false` | `Alpha` | `1.82` | `1.88` |
+| UseGardenerNodeAgent                | `true`  | `Beta`  | `1.89` |        |
 
 ## Feature Gates for Graduated or Deprecated Features
 

--- a/pkg/component/extensions/operatingsystemconfig/original/original_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/original_test.go
@@ -125,6 +125,7 @@ var _ = Describe("Original", func() {
 				"kubelet",
 				"sshd-ensurer",
 				"gardener-user",
+				"gardener-node-agent",
 			}))
 		})
 
@@ -144,6 +145,7 @@ var _ = Describe("Original", func() {
 				"kernel-config",
 				"kubelet",
 				"sshd-ensurer",
+				"gardener-node-agent",
 			}))
 		})
 

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -85,6 +85,7 @@ const (
 	// nodes.
 	// owner: @rfranzke @oliver-goetz
 	// alpha: v1.82.0
+	// beta: v1.89.0
 	UseGardenerNodeAgent featuregate.Feature = "UseGardenerNodeAgent"
 )
 
@@ -122,7 +123,7 @@ var AllFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	ShootForceDeletion:                 {Default: false, PreRelease: featuregate.Alpha},
 	MachineControllerManagerDeployment: {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
 	APIServerFastRollout:               {Default: true, PreRelease: featuregate.Beta},
-	UseGardenerNodeAgent:               {Default: false, PreRelease: featuregate.Alpha},
+	UseGardenerNodeAgent:               {Default: true, PreRelease: featuregate.Beta},
 }
 
 // GetFeatures returns a feature gate map with the respective specifications. Non-existing feature gates are ignored.

--- a/pkg/operation/botanist/operatingsystemconfig_test.go
+++ b/pkg/operation/botanist/operatingsystemconfig_test.go
@@ -314,6 +314,8 @@ var _ = Describe("operatingsystemconfig", func() {
 
 				kubernetesInterfaceShoot.EXPECT().Client().Return(kubernetesClientShoot).AnyTimes()
 				kubernetesInterfaceSeed.EXPECT().Client().Return(kubernetesClientSeed).AnyTimes()
+
+				DeferCleanup(test.WithFeatureGate(features.DefaultFeatureGate, features.UseGardenerNodeAgent, false))
 			})
 
 			type tableTestParams struct {

--- a/pkg/operation/botanist/worker_test.go
+++ b/pkg/operation/botanist/worker_test.go
@@ -304,7 +304,7 @@ var _ = Describe("Worker", func() {
 				Labels: map[string]string{"worker.gardener.cloud/kubernetes-version": "1.24.0"},
 			}}}},
 			map[string]metav1.ObjectMeta{"pool1": {
-				Name:        "cloud-config--c63c0",
+				Name:        "gardener-node-agent--c63c0",
 				Annotations: map[string]string{"checksum/data-script": "foo"},
 			}},
 			MatchError(ContainSubstring("hasn't been reported yet")),
@@ -316,7 +316,7 @@ var _ = Describe("Worker", func() {
 				Labels:      map[string]string{"worker.gardener.cloud/kubernetes-version": "1.24.0"},
 			}}}},
 			map[string]metav1.ObjectMeta{"pool1": {
-				Name:        "cloud-config--c63c0",
+				Name:        "gardener-node-agent--c63c0",
 				Annotations: map[string]string{"checksum/data-script": "foo"},
 			}},
 			MatchError(ContainSubstring("is outdated")),
@@ -331,7 +331,7 @@ var _ = Describe("Worker", func() {
 				Spec: corev1.NodeSpec{Taints: []corev1.Taint{{Key: "deployment.machine.sapcloud.io/prefer-no-schedule", Effect: corev1.TaintEffectPreferNoSchedule}}},
 			}}},
 			map[string]metav1.ObjectMeta{"pool1": {
-				Name:        "cloud-config--c63c0",
+				Name:        "gardener-node-agent--c63c0",
 				Annotations: map[string]string{"checksum/data-script": "foo"},
 			}},
 			BeNil(),
@@ -343,7 +343,7 @@ var _ = Describe("Worker", func() {
 				Labels:      map[string]string{"worker.gardener.cloud/kubernetes-version": "1.24.0"},
 			}}}},
 			map[string]metav1.ObjectMeta{"pool1": {
-				Name:        "cloud-config--c63c1",
+				Name:        "gardener-node-agent--c63c1",
 				Annotations: map[string]string{"checksum/data-script": "foo"},
 			}},
 			BeNil(),
@@ -362,11 +362,11 @@ var _ = Describe("Worker", func() {
 			},
 			map[string]metav1.ObjectMeta{
 				"pool1": {
-					Name:        "cloud-config--c63c0",
+					Name:        "gardener-node-agent--c63c0",
 					Annotations: map[string]string{"checksum/data-script": "uptodate1"},
 				},
 				"pool2": {
-					Name:        "cloud-config--5dcdf",
+					Name:        "gardener-node-agent--5dcdf",
 					Annotations: map[string]string{"checksum/data-script": "uptodate2"},
 				},
 			},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area open-source
/kind enhancement

**What this PR does / why we need it**:
Promote `UseGardenerNodeAgent` feature gate to beta and turn it on by default.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/8023

**Special notes for your reviewer**:
/cc @oliver-goetz 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
The `UseGardenerNodeAgent` feature gate has been promoted to beta and is now turned on by default. 
```
