### PR TITLE
Upgrade node-problem-detector to `v0.8.15`

### DIFF
--- a/imagevector/images.yaml
+++ b/imagevector/images.yaml
@@ -352,7 +352,7 @@ images:
 - name: node-problem-detector
   sourceRepository: github.com/kubernetes/node-problem-detector
   repository: registry.k8s.io/node-problem-detector/node-problem-detector
-  tag: "v0.8.13"
+  tag: "v0.8.15"
 
 # Shoot optional addons
 - name: kubernetes-dashboard


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind enhancement

**What this PR does / why we need it**:
Upgrade NPD version to https://github.com/kubernetes/node-problem-detector/releases/tag/v0.8.15

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Works on both AMD and ARM ( cc @acumino )

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The `node-problem-detector` version has been updated from `v0.8.13` to `v0.8.15`.
```
