### PR TITLE
[GEP-19] Extend health checks of `gardener-resource-manager` for new `Prometheus` and `Alertmanager` resources

### DIFF
--- a/pkg/resourcemanager/client/scheme.go
+++ b/pkg/resourcemanager/client/scheme.go
@@ -19,6 +19,9 @@ import (
 	hvpav1alpha1 "github.com/gardener/hvpa-controller/api/v1alpha1"
 	machinev1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
 	volumesnapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v4/apis/volumesnapshot/v1"
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	monitoringv1alpha1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1alpha1"
+	monitoringv1beta1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1beta1"
 	apiextensionsinstall "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/install"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -51,6 +54,9 @@ func init() {
 			kubernetesscheme.AddToScheme,
 			hvpav1alpha1.AddToScheme,
 			volumesnapshotv1.AddToScheme,
+			monitoringv1alpha1.AddToScheme,
+			monitoringv1beta1.AddToScheme,
+			monitoringv1.AddToScheme,
 		)
 	)
 

--- a/pkg/resourcemanager/controller/health/progressing/add.go
+++ b/pkg/resourcemanager/controller/health/progressing/add.go
@@ -18,6 +18,7 @@ import (
 	"context"
 
 	"github.com/go-logr/logr"
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -80,9 +81,11 @@ func (r *Reconciler) AddToManager(ctx context.Context, mgr manager.Manager, sour
 	}
 
 	for resource, obj := range map[string]client.Object{
-		"deployments":  &appsv1.Deployment{},
-		"statefulsets": &appsv1.StatefulSet{},
-		"daemonsets":   &appsv1.DaemonSet{},
+		"deployments":   &appsv1.Deployment{},
+		"statefulsets":  &appsv1.StatefulSet{},
+		"daemonsets":    &appsv1.DaemonSet{},
+		"prometheuses":  &monitoringv1.Prometheus{},
+		"alertmanagers": &monitoringv1.Alertmanager{},
 	} {
 		gvr := schema.GroupVersionResource{Group: appsv1.SchemeGroupVersion.Group, Version: appsv1.SchemeGroupVersion.Version, Resource: resource}
 

--- a/pkg/resourcemanager/controller/health/progressing/reconciler.go
+++ b/pkg/resourcemanager/controller/health/progressing/reconciler.go
@@ -106,7 +106,7 @@ func (r *Reconciler) reconcile(ctx context.Context, log logr.Logger, mr *resourc
 
 	for _, ref := range mr.Status.Resources {
 		// only resources in the apps/v1 and monitoring.coreos.com/v1 API groups are considered for Progressing condition
-		if !sets.New[string](appsv1.GroupName, monitoring.GroupName).Has(ref.GroupVersionKind().Group) {
+		if !sets.New(appsv1.GroupName, monitoring.GroupName).Has(ref.GroupVersionKind().Group) {
 			continue
 		}
 

--- a/pkg/resourcemanager/controller/health/utils/health_checker.go
+++ b/pkg/resourcemanager/controller/health/utils/health_checker.go
@@ -17,6 +17,7 @@ package utils
 import (
 	"context"
 
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -87,6 +88,10 @@ func CheckHealth(obj client.Object) (bool, error) {
 		return true, health.CheckService(o)
 	case *appsv1.StatefulSet:
 		return true, health.CheckStatefulSet(o)
+	case *monitoringv1.Prometheus:
+		return true, health.CheckPrometheus(o)
+	case *monitoringv1.Alertmanager:
+		return true, health.CheckAlertmanager(o)
 	}
 
 	return false, nil

--- a/pkg/resourcemanager/controller/health/utils/health_checker_test.go
+++ b/pkg/resourcemanager/controller/health/utils/health_checker_test.go
@@ -17,6 +17,7 @@ package utils_test
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -456,6 +457,54 @@ var _ = Describe("CheckHealth", func() {
 				},
 				Spec:   appsv1.StatefulSetSpec{Replicas: ptr.To(int32(2))},
 				Status: appsv1.StatefulSetStatus{ReadyReplicas: 1},
+			}
+		})
+
+		testSuite()
+	})
+
+	Context("Prometheus", func() {
+		BeforeEach(func() {
+			healthy = &monitoringv1.Prometheus{
+				Spec:   monitoringv1.PrometheusSpec{CommonPrometheusFields: monitoringv1.CommonPrometheusFields{Replicas: ptr.To(int32(1))}},
+				Status: monitoringv1.PrometheusStatus{Replicas: 1, AvailableReplicas: 1, Conditions: []monitoringv1.Condition{{Type: monitoringv1.Available, Status: monitoringv1.ConditionTrue}}},
+			}
+			unhealthy = &monitoringv1.Prometheus{
+				Spec:   monitoringv1.PrometheusSpec{CommonPrometheusFields: monitoringv1.CommonPrometheusFields{Replicas: ptr.To(int32(2))}},
+				Status: monitoringv1.PrometheusStatus{AvailableReplicas: 1},
+			}
+			unhealthyWithSkipHealthCheckAnnotation = &monitoringv1.Prometheus{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						resourcesv1alpha1.SkipHealthCheck: "true",
+					},
+				},
+				Spec:   monitoringv1.PrometheusSpec{CommonPrometheusFields: monitoringv1.CommonPrometheusFields{Replicas: ptr.To(int32(2))}},
+				Status: monitoringv1.PrometheusStatus{AvailableReplicas: 1},
+			}
+		})
+
+		testSuite()
+	})
+
+	Context("Alertmanager", func() {
+		BeforeEach(func() {
+			healthy = &monitoringv1.Alertmanager{
+				Spec:   monitoringv1.AlertmanagerSpec{Replicas: ptr.To(int32(1))},
+				Status: monitoringv1.AlertmanagerStatus{Replicas: 1, AvailableReplicas: 1, Conditions: []monitoringv1.Condition{{Type: monitoringv1.Available, Status: monitoringv1.ConditionTrue}}},
+			}
+			unhealthy = &monitoringv1.Alertmanager{
+				Spec:   monitoringv1.AlertmanagerSpec{Replicas: ptr.To(int32(2))},
+				Status: monitoringv1.AlertmanagerStatus{AvailableReplicas: 1},
+			}
+			unhealthyWithSkipHealthCheckAnnotation = &monitoringv1.Alertmanager{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						resourcesv1alpha1.SkipHealthCheck: "true",
+					},
+				},
+				Spec:   monitoringv1.AlertmanagerSpec{Replicas: ptr.To(int32(2))},
+				Status: monitoringv1.AlertmanagerStatus{AvailableReplicas: 1},
 			}
 		})
 

--- a/pkg/utils/kubernetes/health/monitoring.go
+++ b/pkg/utils/kubernetes/health/monitoring.go
@@ -1,0 +1,100 @@
+// Copyright 2024 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package health
+
+import (
+	"fmt"
+
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/ptr"
+)
+
+// CheckPrometheus checks whether the given Prometheus is healthy.
+func CheckPrometheus(prometheus *monitoringv1.Prometheus) error {
+	if err := checkMonitoringCondition(prometheus.Status.Conditions, monitoringv1.Available, prometheus.Generation); err != nil {
+		return err
+	}
+
+	if replicas := ptr.Deref(prometheus.Spec.Replicas, 1); prometheus.Status.AvailableReplicas < replicas {
+		return fmt.Errorf("not enough available replicas (%d/%d)", prometheus.Status.AvailableReplicas, replicas)
+	}
+	return nil
+}
+
+// IsPrometheusProgressing returns false if the Prometheus has been fully rolled out. Otherwise, it returns true along
+// with a reason, why the Prometheus is not considered to be fully rolled out.
+func IsPrometheusProgressing(prometheus *monitoringv1.Prometheus) (bool, string) {
+	if err := checkMonitoringCondition(prometheus.Status.Conditions, monitoringv1.Reconciled, prometheus.Generation); err != nil {
+		return true, err.Error()
+	}
+
+	desiredReplicas, updatedReplicas := ptr.Deref(prometheus.Spec.Replicas, 1), prometheus.Status.UpdatedReplicas
+
+	if updatedReplicas < desiredReplicas {
+		return true, fmt.Sprintf("%d of %d replica(s) have been updated", updatedReplicas, desiredReplicas)
+	}
+
+	return false, "Prometheus is fully rolled out"
+}
+
+// CheckAlertmanager checks whether the given Alertmanager is healthy.
+func CheckAlertmanager(alertManager *monitoringv1.Alertmanager) error {
+	if err := checkMonitoringCondition(alertManager.Status.Conditions, monitoringv1.Available, alertManager.Generation); err != nil {
+		return err
+	}
+
+	if replicas := ptr.Deref(alertManager.Spec.Replicas, 1); alertManager.Status.AvailableReplicas < replicas {
+		return fmt.Errorf("not enough available replicas (%d/%d)", alertManager.Status.AvailableReplicas, replicas)
+	}
+	return nil
+}
+
+// IsAlertmanagerProgressing returns false if the Alertmanager has been fully rolled out. Otherwise, it returns true along
+// with a reason, why the Alertmanager is not considered to be fully rolled out.
+func IsAlertmanagerProgressing(alertManager *monitoringv1.Alertmanager) (bool, string) {
+	if err := checkMonitoringCondition(alertManager.Status.Conditions, monitoringv1.Reconciled, alertManager.Generation); err != nil {
+		return true, err.Error()
+	}
+
+	desiredReplicas, updatedReplicas := ptr.Deref(alertManager.Spec.Replicas, 1), alertManager.Status.UpdatedReplicas
+
+	if updatedReplicas < desiredReplicas {
+		return true, fmt.Sprintf("%d of %d replica(s) have been updated", updatedReplicas, desiredReplicas)
+	}
+
+	return false, "Alertmanager is fully rolled out"
+}
+
+func getMonitoringCondition(conditions []monitoringv1.Condition, conditionType monitoringv1.ConditionType) *monitoringv1.Condition {
+	for _, condition := range conditions {
+		if condition.Type == conditionType {
+			return &condition
+		}
+	}
+	return nil
+}
+
+func checkMonitoringCondition(conditions []monitoringv1.Condition, conditionType monitoringv1.ConditionType, generation int64) error {
+	if condition := getMonitoringCondition(conditions, conditionType); condition == nil {
+		return fmt.Errorf("condition %q is missing", conditionType)
+	} else if condition.ObservedGeneration < generation {
+		return fmt.Errorf("observed generation outdated (%d/%d)", condition.ObservedGeneration, generation)
+	} else if err := checkConditionState(string(condition.Type), string(corev1.ConditionTrue), string(condition.Status), condition.Reason, condition.Message); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/utils/kubernetes/health/monitoring_test.go
+++ b/pkg/utils/kubernetes/health/monitoring_test.go
@@ -41,15 +41,15 @@ var _ = Describe("Monitoring", func() {
 		Entry("not observed at latest version", &monitoringv1.Prometheus{
 			ObjectMeta: metav1.ObjectMeta{Generation: 1},
 			Status:     monitoringv1.PrometheusStatus{Conditions: []monitoringv1.Condition{{Type: monitoringv1.Available, Status: monitoringv1.ConditionTrue}}},
-		}, HaveOccurred()),
-		Entry("condition missing", &monitoringv1.Prometheus{}, HaveOccurred()),
+		}, MatchError(ContainSubstring("observed generation outdated (0/1)"))),
+		Entry("condition missing", &monitoringv1.Prometheus{}, MatchError(ContainSubstring(`condition "Available" is missing`))),
 		Entry("condition False", &monitoringv1.Prometheus{
 			Status: monitoringv1.PrometheusStatus{Conditions: []monitoringv1.Condition{{Type: monitoringv1.Available, Status: monitoringv1.ConditionFalse}}},
-		}, HaveOccurred()),
+		}, MatchError(ContainSubstring(`condition "Available" has invalid status False (expected True)`))),
 		Entry("not enough ready replicas", &monitoringv1.Prometheus{
 			Spec:   monitoringv1.PrometheusSpec{CommonPrometheusFields: monitoringv1.CommonPrometheusFields{Replicas: ptr.To(int32(2))}},
 			Status: monitoringv1.PrometheusStatus{Replicas: 1, AvailableReplicas: 1, Conditions: []monitoringv1.Condition{{Type: monitoringv1.Available, Status: monitoringv1.ConditionTrue}}},
-		}, HaveOccurred()),
+		}, MatchError(ContainSubstring(`not enough available replicas (1/2)`))),
 	)
 
 	Describe("IsPrometheusProgressing", func() {
@@ -119,15 +119,15 @@ var _ = Describe("Monitoring", func() {
 		Entry("not observed at latest version", &monitoringv1.Alertmanager{
 			ObjectMeta: metav1.ObjectMeta{Generation: 1},
 			Status:     monitoringv1.AlertmanagerStatus{Conditions: []monitoringv1.Condition{{Type: monitoringv1.Available, Status: monitoringv1.ConditionTrue}}},
-		}, HaveOccurred()),
-		Entry("condition missing", &monitoringv1.Alertmanager{}, HaveOccurred()),
+		}, MatchError(ContainSubstring("observed generation outdated (0/1)"))),
+		Entry("condition missing", &monitoringv1.Alertmanager{}, MatchError(ContainSubstring(`condition "Available" is missing`))),
 		Entry("condition False", &monitoringv1.Alertmanager{
 			Status: monitoringv1.AlertmanagerStatus{Conditions: []monitoringv1.Condition{{Type: monitoringv1.Available, Status: monitoringv1.ConditionFalse}}},
-		}, HaveOccurred()),
+		}, MatchError(ContainSubstring(`condition "Available" has invalid status False (expected True)`))),
 		Entry("not enough ready replicas", &monitoringv1.Alertmanager{
 			Spec:   monitoringv1.AlertmanagerSpec{Replicas: ptr.To(int32(2))},
 			Status: monitoringv1.AlertmanagerStatus{Replicas: 1, AvailableReplicas: 1, Conditions: []monitoringv1.Condition{{Type: monitoringv1.Available, Status: monitoringv1.ConditionTrue}}},
-		}, HaveOccurred()),
+		}, MatchError(ContainSubstring(`not enough available replicas (1/2)`))),
 	)
 
 	Describe("IsAlertmanagerProgressing", func() {

--- a/pkg/utils/kubernetes/health/monitoring_test.go
+++ b/pkg/utils/kubernetes/health/monitoring_test.go
@@ -1,0 +1,184 @@
+// Copyright 2024 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package health_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/types"
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+
+	"github.com/gardener/gardener/pkg/utils/kubernetes/health"
+)
+
+var _ = Describe("Monitoring", func() {
+	DescribeTable("CheckPrometheus",
+		func(prometheus *monitoringv1.Prometheus, matcher types.GomegaMatcher) {
+			err := health.CheckPrometheus(prometheus)
+			Expect(err).To(matcher)
+		},
+		Entry("healthy", &monitoringv1.Prometheus{
+			Spec:   monitoringv1.PrometheusSpec{CommonPrometheusFields: monitoringv1.CommonPrometheusFields{Replicas: ptr.To(int32(1))}},
+			Status: monitoringv1.PrometheusStatus{Replicas: 1, AvailableReplicas: 1, Conditions: []monitoringv1.Condition{{Type: monitoringv1.Available, Status: monitoringv1.ConditionTrue}}},
+		}, BeNil()),
+		Entry("healthy with nil replicas", &monitoringv1.Prometheus{
+			Status: monitoringv1.PrometheusStatus{Replicas: 1, AvailableReplicas: 1, Conditions: []monitoringv1.Condition{{Type: monitoringv1.Available, Status: monitoringv1.ConditionTrue}}},
+		}, BeNil()),
+		Entry("not observed at latest version", &monitoringv1.Prometheus{
+			ObjectMeta: metav1.ObjectMeta{Generation: 1},
+			Status:     monitoringv1.PrometheusStatus{Conditions: []monitoringv1.Condition{{Type: monitoringv1.Available, Status: monitoringv1.ConditionTrue}}},
+		}, HaveOccurred()),
+		Entry("condition missing", &monitoringv1.Prometheus{}, HaveOccurred()),
+		Entry("condition False", &monitoringv1.Prometheus{
+			Status: monitoringv1.PrometheusStatus{Conditions: []monitoringv1.Condition{{Type: monitoringv1.Available, Status: monitoringv1.ConditionFalse}}},
+		}, HaveOccurred()),
+		Entry("not enough ready replicas", &monitoringv1.Prometheus{
+			Spec:   monitoringv1.PrometheusSpec{CommonPrometheusFields: monitoringv1.CommonPrometheusFields{Replicas: ptr.To(int32(2))}},
+			Status: monitoringv1.PrometheusStatus{Replicas: 1, AvailableReplicas: 1, Conditions: []monitoringv1.Condition{{Type: monitoringv1.Available, Status: monitoringv1.ConditionTrue}}},
+		}, HaveOccurred()),
+	)
+
+	Describe("IsPrometheusProgressing", func() {
+		var (
+			prometheus *monitoringv1.Prometheus
+		)
+
+		BeforeEach(func() {
+			prometheus = &monitoringv1.Prometheus{
+				ObjectMeta: metav1.ObjectMeta{
+					Generation: 42,
+				},
+				Spec: monitoringv1.PrometheusSpec{
+					CommonPrometheusFields: monitoringv1.CommonPrometheusFields{Replicas: ptr.To(int32(3))},
+				},
+				Status: monitoringv1.PrometheusStatus{
+					Conditions:      []monitoringv1.Condition{{Type: monitoringv1.Reconciled, Status: monitoringv1.ConditionTrue, ObservedGeneration: 42}},
+					UpdatedReplicas: 3,
+				},
+			}
+		})
+
+		It("should return false if it is fully rolled out", func() {
+			progressing, reason := health.IsPrometheusProgressing(prometheus)
+			Expect(progressing).To(BeFalse())
+			Expect(reason).To(Equal("Prometheus is fully rolled out"))
+		})
+
+		It("should return true if observedGeneration is outdated", func() {
+			prometheus.Status.Conditions[0].ObservedGeneration--
+
+			progressing, reason := health.IsPrometheusProgressing(prometheus)
+			Expect(progressing).To(BeTrue())
+			Expect(reason).To(Equal("observed generation outdated (41/42)"))
+		})
+
+		It("should return true if replicas still need to be updated", func() {
+			prometheus.Status.UpdatedReplicas--
+
+			progressing, reason := health.IsPrometheusProgressing(prometheus)
+			Expect(progressing).To(BeTrue())
+			Expect(reason).To(Equal("2 of 3 replica(s) have been updated"))
+		})
+
+		It("should return true if replica still needs to be updated (spec.replicas=null)", func() {
+			prometheus.Spec.Replicas = nil
+			prometheus.Status.UpdatedReplicas = 0
+
+			progressing, reason := health.IsPrometheusProgressing(prometheus)
+			Expect(progressing).To(BeTrue())
+			Expect(reason).To(Equal("0 of 1 replica(s) have been updated"))
+		})
+	})
+
+	DescribeTable("CheckAlertmanager",
+		func(alertManager *monitoringv1.Alertmanager, matcher types.GomegaMatcher) {
+			err := health.CheckAlertmanager(alertManager)
+			Expect(err).To(matcher)
+		},
+		Entry("healthy", &monitoringv1.Alertmanager{
+			Spec:   monitoringv1.AlertmanagerSpec{Replicas: ptr.To(int32(1))},
+			Status: monitoringv1.AlertmanagerStatus{Replicas: 1, AvailableReplicas: 1, Conditions: []monitoringv1.Condition{{Type: monitoringv1.Available, Status: monitoringv1.ConditionTrue}}},
+		}, BeNil()),
+		Entry("healthy with nil replicas", &monitoringv1.Alertmanager{
+			Status: monitoringv1.AlertmanagerStatus{Replicas: 1, AvailableReplicas: 1, Conditions: []monitoringv1.Condition{{Type: monitoringv1.Available, Status: monitoringv1.ConditionTrue}}},
+		}, BeNil()),
+		Entry("not observed at latest version", &monitoringv1.Alertmanager{
+			ObjectMeta: metav1.ObjectMeta{Generation: 1},
+			Status:     monitoringv1.AlertmanagerStatus{Conditions: []monitoringv1.Condition{{Type: monitoringv1.Available, Status: monitoringv1.ConditionTrue}}},
+		}, HaveOccurred()),
+		Entry("condition missing", &monitoringv1.Alertmanager{}, HaveOccurred()),
+		Entry("condition False", &monitoringv1.Alertmanager{
+			Status: monitoringv1.AlertmanagerStatus{Conditions: []monitoringv1.Condition{{Type: monitoringv1.Available, Status: monitoringv1.ConditionFalse}}},
+		}, HaveOccurred()),
+		Entry("not enough ready replicas", &monitoringv1.Alertmanager{
+			Spec:   monitoringv1.AlertmanagerSpec{Replicas: ptr.To(int32(2))},
+			Status: monitoringv1.AlertmanagerStatus{Replicas: 1, AvailableReplicas: 1, Conditions: []monitoringv1.Condition{{Type: monitoringv1.Available, Status: monitoringv1.ConditionTrue}}},
+		}, HaveOccurred()),
+	)
+
+	Describe("IsAlertmanagerProgressing", func() {
+		var (
+			alertManager *monitoringv1.Alertmanager
+		)
+
+		BeforeEach(func() {
+			alertManager = &monitoringv1.Alertmanager{
+				ObjectMeta: metav1.ObjectMeta{
+					Generation: 42,
+				},
+				Spec: monitoringv1.AlertmanagerSpec{
+					Replicas: ptr.To(int32(3)),
+				},
+				Status: monitoringv1.AlertmanagerStatus{
+					Conditions:      []monitoringv1.Condition{{Type: monitoringv1.Reconciled, Status: monitoringv1.ConditionTrue, ObservedGeneration: 42}},
+					UpdatedReplicas: 3,
+				},
+			}
+		})
+
+		It("should return false if it is fully rolled out", func() {
+			progressing, reason := health.IsAlertmanagerProgressing(alertManager)
+			Expect(progressing).To(BeFalse())
+			Expect(reason).To(Equal("Alertmanager is fully rolled out"))
+		})
+
+		It("should return true if observedGeneration is outdated", func() {
+			alertManager.Status.Conditions[0].ObservedGeneration--
+
+			progressing, reason := health.IsAlertmanagerProgressing(alertManager)
+			Expect(progressing).To(BeTrue())
+			Expect(reason).To(Equal("observed generation outdated (41/42)"))
+		})
+
+		It("should return true if replicas still need to be updated", func() {
+			alertManager.Status.UpdatedReplicas--
+
+			progressing, reason := health.IsAlertmanagerProgressing(alertManager)
+			Expect(progressing).To(BeTrue())
+			Expect(reason).To(Equal("2 of 3 replica(s) have been updated"))
+		})
+
+		It("should return true if replica still needs to be updated (spec.replicas=null)", func() {
+			alertManager.Spec.Replicas = nil
+			alertManager.Status.UpdatedReplicas = 0
+
+			progressing, reason := health.IsAlertmanagerProgressing(alertManager)
+			Expect(progressing).To(BeTrue())
+			Expect(reason).To(Equal("0 of 1 replica(s) have been updated"))
+		})
+	})
+})

--- a/test/integration/resourcemanager/health/health_suite_test.go
+++ b/test/integration/resourcemanager/health/health_suite_test.go
@@ -72,7 +72,11 @@ var _ = BeforeSuite(func() {
 	By("Start test environment")
 	testEnv = &envtest.Environment{
 		CRDInstallOptions: envtest.CRDInstallOptions{
-			Paths: []string{filepath.Join("..", "..", "..", "..", "example", "resource-manager", "10-crd-resources.gardener.cloud_managedresources.yaml")},
+			Paths: []string{
+				filepath.Join("..", "..", "..", "..", "example", "seed-crds", "10-crd-resources.gardener.cloud_managedresources.yaml"),
+				filepath.Join("..", "..", "..", "..", "example", "seed-crds", "10-crd-monitoring.coreos.com_alertmanagers.yaml"),
+				filepath.Join("..", "..", "..", "..", "example", "seed-crds", "10-crd-monitoring.coreos.com_prometheuses.yaml"),
+			},
 		},
 		ErrorIfCRDPathMissing: true,
 	}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring ops-productivity
/kind enhancement

**What this PR does / why we need it**:
Extend health and progressing checks of `gardener-resource-manager` for new `Prometheus` and `Alertmanager` resources.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/9065

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
`gardener-resource-manager` now considers the health and the progressing status for `Prometheus` and `Alertmanager` resources managed via `ManagedResource`s.
```
