### PR TITLE
Update containerd registry configuration docs

### DIFF
--- a/docs/usage/containerd-registry-configuration.md
+++ b/docs/usage/containerd-registry-configuration.md
@@ -71,4 +71,8 @@ This allows Shoot owners to use the [hosts directory pattern](https://github.com
 
 ### The registry-cache Extension
 
-[Configuring `containerd` registries for a Shoot](#configuring-containerd-registries-for-a-shoot) is not the recommended approach for configuring a pull through cache for a Shoot. There is a Gardener-native extension named [registry-cache](https://github.com/gardener/gardener-extension-registry-cache) that manages a pull through cache for a Shoot using the upstream [distribution/distribution](https://github.com/distribution/distribution) project.
+There is a Gardener-native extension named [registry-cache](https://github.com/gardener/gardener-extension-registry-cache) that supports:
+- Configuring containerd registry mirrors based on the above-described contract. The feature is added in [registry-cache@v0.6.0](https://github.com/gardener/gardener-extension-registry-cache/releases/tag/v0.6.0).
+- Running pull through cache(s) in the Shoot.
+
+For more details, see the [registry-cache documentation](https://github.com/gardener/gardener-extension-registry-cache/blob/main/README.md).


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind enhancement

**What this PR does / why we need it**:
The current contract described in `docs/usage/containerd-registry-configuration.md` is a contract that can be used by Shoot owners to add registry/mirror configuration.
So far adding such registry/mirror configuration as Shoot owner it is not a super nice experience as it requires running DaemonSet that adds the needed `hosts.toml` files.
In [`registry-cache@v0.6.0`](https://github.com/gardener/gardener-extension-registry-cache/releases/tag/v0.6.0) we added support for configuring containerd registry mirrors as an extension in the Shoot spec.
This PR updates the docs to list that feature of the registry-cache extension.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener-extension-registry-cache/issues/3

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
