### PR TITLE
Throw error if hostname is empty

### DIFF
--- a/cmd/gardener-node-agent/app/app.go
+++ b/cmd/gardener-node-agent/app/app.go
@@ -155,7 +155,7 @@ func run(ctx context.Context, cancel context.CancelFunc, log logr.Logger, cfg *c
 
 	log.Info("Fetching hostname")
 	hostName, err := os.Hostname()
-	if err != nil {
+	if err != nil || hostName == "" {
 		return fmt.Errorf("failed fetching hostname: %w", err)
 	}
 	hostName = strings.ToLower(hostName)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area os
/kind enhancement

**What this PR does / why we need it**:
There can be a scenario that for whatever reason `os.Hostname` can return an empty string, in this case, node-agent will keep on looping/stuck [here](https://github.com/gardener/gardener/blob/76704c377f34cdbdf1b0d3986b243c8b67c66909/pkg/nodeagent/controller/operatingsystemconfig/reconciler.go#L155-L158), because of not able to find node. The only solution is to manually restart the `node-agent` on the node. This PR returns an error at the start if `os.Hostname` returns an empty string to prevent the above scenario.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @rfranzke @ary1992 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
