### PR TITLE
Add container resource policies for HA VPN containers to hvpa resource of kube-apiserver.

### DIFF
--- a/pkg/component/kubeapiserver/deployment.go
+++ b/pkg/component/kubeapiserver/deployment.go
@@ -54,9 +54,10 @@ const (
 	secretNameHAVPNSeedClient        = "vpn-seed-client"
 
 	// ContainerNameKubeAPIServer is the name of the kube-apiserver container.
-	ContainerNameKubeAPIServer = "kube-apiserver"
-	containerNameVPNSeedClient = "vpn-client"
-	containerNameWatchdog      = "watchdog"
+	ContainerNameKubeAPIServer     = "kube-apiserver"
+	containerNameVPNPathController = "vpn-path-controller"
+	containerNameVPNSeedClient     = "vpn-client"
+	containerNameWatchdog          = "watchdog"
 
 	volumeNameAuthenticationWebhookKubeconfig = "authentication-webhook-kubeconfig"
 	volumeNameAuthorizationWebhookKubeconfig  = "authorization-webhook-kubeconfig"
@@ -869,7 +870,7 @@ func (k *kubeAPIServer) vpnSeedClientContainer(index int) *corev1.Container {
 
 func (k *kubeAPIServer) vpnSeedPathControllerContainer() *corev1.Container {
 	container := &corev1.Container{
-		Name:            "vpn-path-controller",
+		Name:            containerNameVPNPathController,
 		Image:           k.values.Images.VPNClient,
 		ImagePullPolicy: corev1.PullIfNotPresent,
 		Command:         []string{"/path-controller.sh"},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area auto-scaling
/area control-plane
/area networking
/area robustness
/kind enhancement

**What this PR does / why we need it**:

Add container resource policies for HA VPN containers to hvpa resource of kube-apiserver.

In the past, autoscaling of VPN side car containers was disabled in kube-apiserver. With the removal of the old VPN solution this code disappeared. The HA VPN solution did not influence the autoscaling of its containers in kube-apiserver. This can lead to situations where the memory resources are so restricted by VPA that even runc fails to start. Therefore, it is crucial to set minimum allowed values for memory so that the containers can always start.
This change achieves exactly that.

**Which issue(s) this PR fixes**:

None.

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The side car container of kube-apiserver for the HA VPN now have minimum memory resources that VPA will respect.
```
