### PR TITLE
Fix VPA for seed prometheus

### DIFF
--- a/pkg/component/monitoring/charts/bootstrap/charts/monitoring/templates/prometheus-vpa.yaml
+++ b/pkg/component/monitoring/charts/bootstrap/charts/monitoring/templates/prometheus-vpa.yaml
@@ -7,13 +7,14 @@ metadata:
 spec:
   resourcePolicy:
     containerPolicies:
-    - containerName: '*'
-      minAllowed:
-        memory: 400Mi
-    - containerName: prometheus
-      maxAllowed:
-        cpu: "4"
-        memory: 28G
+      - containerName: prometheus-config-reloader
+        mode: "Off"
+      - containerName: "*"
+        controlledValues: RequestsOnly
+      - containerName: prometheus
+        maxAllowed:
+          cpu: "4"
+          memory: 28G
   targetRef:
     apiVersion: apps/v1
     kind: StatefulSet


### PR DESCRIPTION
/area monitoring
/kind bug

This PR removes the wildcard container name match from minAllowed 400M condition.
The correct way is demonstated at the [aggregate prometheus vpa](https://github.com/gardener/gardener/blob/99837c9b84dbe22b92ec0fa28cc95879d1d46584/pkg/component/monitoring/charts/seed-monitoring/charts/core/charts/prometheus/templates/prometheus-vpa.yaml#L25). The proposal here follows that approach

```bugfix operator
NONE
```
