### PR TITLE
Fix Fallback Client scheme usage

### DIFF
--- a/pkg/client/kubernetes/client.go
+++ b/pkg/client/kubernetes/client.go
@@ -388,7 +388,7 @@ type FallbackClient struct {
 // Get retrieves an obj for a given object key from the Kubernetes Cluster.
 // `client.Reader` is used in case the kind of an object is configured in `KindToNamespaces` but the namespace isn't.
 func (d *FallbackClient) Get(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
-	gvk, err := apiutil.GVKForObject(obj, GardenScheme)
+	gvk, err := apiutil.GVKForObject(obj, d.Scheme())
 	if err != nil {
 		return err
 	}

--- a/pkg/extensions/customresources.go
+++ b/pkg/extensions/customresources.go
@@ -92,6 +92,7 @@ func WaitUntilObjectReadyWithHealthFunction(
 		healthFunc = health.And(health.ObjectHasAnnotationWithValue(v1beta1constants.GardenerTimestamp, expectedTimestamp), healthFunc)
 	}
 
+	var objectKind string
 	if err := retry.UntilTimeout(ctx, interval, timeout, func(ctx context.Context) (bool, error) {
 		retryCountUntilSevere++
 
@@ -100,6 +101,12 @@ func WaitUntilObjectReadyWithHealthFunction(
 				return retry.MinorError(err)
 			}
 			return retry.SevereError(err)
+		}
+
+		if objectKind == "" {
+			if objectKind = obj.GetObjectKind().GroupVersionKind().Kind; objectKind != "" {
+				log = log.WithValues("kind", objectKind)
+			}
 		}
 
 		if err := healthFunc(obj); err != nil {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/area open-source
/kind bug

**What this PR does / why we need it**:
Fallback Client should use the client's scheme instead of the Garden scheme statically. Potential issues has been disguised because Gardener disables caches when talking to the shoot APIs.

**Special notes for your reviewer**:
The `WaitUntilObjectReadyWithHealthFunction` was enhanced along the way to log the object's kind. Before, it was cumbersome to identify the object that was waited for if logs were spilled with `Object did not get ready yet` messages.

/cc @acumino 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
An issue with the `FallbackClient` was resolved. If used in external projects, the client threw scheme related errors belonging to GVKs that are not registered in the `GardenScheme`. 
```
```feature developer
The `WaitUntilObjectReadyWithHealthFunction` function was enhanced to log the object's kind.
```
