### PR TITLE
Fix go toolchain for `golang-test` image

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gardener/gardener
 
-go 1.22
+go 1.22.0
 
 require (
 	github.com/Masterminds/semver/v3 v3.2.1

--- a/hack/tools/image/Dockerfile
+++ b/hack/tools/image/Dockerfile
@@ -13,6 +13,7 @@ RUN echo "Installing Packages ..." \
 FROM base as builder
 ARG GOPROXY=https://proxy.golang.org,direct
 ENV GOPROXY=$GOPROXY
+ENV GOTOOLCHAIN=auto
 WORKDIR /go/src/github.com/gardener/gardener
 COPY . .
 RUN make create-tools-bin

--- a/hack/tools/image/variants.yaml
+++ b/hack/tools/image/variants.yaml
@@ -3,8 +3,6 @@
 # - https://github.com/kubernetes/test-infra/blob/master/images/krte/Dockerfile
 # - https://github.com/gardener/ci-infra/blob/master/images/krte
 variants:
-  "1.20":
-    image: golang:1.20.14-bookworm
   "1.21":
     image: golang:1.21.7-bookworm
   "1.22":


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind bug

**What this PR does / why we need it**:
Since `Go 1.21` the toolchain is a separate package ([ref](https://go.dev/doc/toolchain)).
It now has to be specified with `go X.Y.Z` instead of `go X.Y` (see https://github.com/golang/go/issues/62278#issuecomment-1698829945) in `go.mod`. This currently breaks the build of `golang-test` image with Go 1.21 ([ref](https://prow.gardener.cloud/view/gs/gardener-prow/logs/post-gardener-build-golang-test-images/1758500160960204800)).

With this PR we start using the new format. Additionally, the env `GOTOOLCHAIN=auto` (default `local`) must be set when building `golang-test` image.
The new format is incompatible with Go 1.20. Thus, this version is removed. It is now deprecated anyway.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
