### PR TITLE
Allow to skip minor kubernetes versions for worker pool's kubernetes version upgrade

### DIFF
--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -661,8 +661,8 @@ func validateDNSUpdate(new, old *core.DNS, seedGotAssigned bool, fldPath *field.
 	return allErrs
 }
 
-// ValidateKubernetesVersionUpdate ensures that new version is newer than old version and does not skip one minor
-func ValidateKubernetesVersionUpdate(new, old string, isWorkerPoolKubernetesVersion bool, fldPath *field.Path) field.ErrorList {
+// ValidateKubernetesVersionUpdate ensures that new version is newer than old version and does not skip minor versions when not allowed
+func ValidateKubernetesVersionUpdate(new, old string, skipMinorVersionAllowed bool, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	if len(new) == 0 {
@@ -679,7 +679,7 @@ func ValidateKubernetesVersionUpdate(new, old string, isWorkerPoolKubernetesVers
 		allErrs = append(allErrs, field.Forbidden(fldPath, "kubernetes version downgrade is not supported"))
 	}
 
-	if !isWorkerPoolKubernetesVersion {
+	if !skipMinorVersionAllowed {
 		// Forbid Kubernetes version upgrade which skips a minor version
 		oldVersion, err := semver.NewVersion(old)
 		if err != nil {

--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -325,7 +325,7 @@ func ValidateShootSpecUpdate(newSpec, oldSpec *core.ShootSpec, newObjectMeta met
 	allErrs = append(allErrs, apivalidation.ValidateImmutableField(newSpec.ExposureClassName, oldSpec.ExposureClassName, fldPath.Child("exposureClassName"))...)
 
 	allErrs = append(allErrs, validateDNSUpdate(newSpec.DNS, oldSpec.DNS, newSpec.SeedName != nil, fldPath.Child("dns"))...)
-	allErrs = append(allErrs, ValidateKubernetesVersionUpdate(newSpec.Kubernetes.Version, oldSpec.Kubernetes.Version, fldPath.Child("kubernetes", "version"))...)
+	allErrs = append(allErrs, ValidateKubernetesVersionUpdate(newSpec.Kubernetes.Version, oldSpec.Kubernetes.Version, false, fldPath.Child("kubernetes", "version"))...)
 
 	allErrs = append(allErrs, validateKubeControllerManagerUpdate(newSpec.Kubernetes.KubeControllerManager, oldSpec.Kubernetes.KubeControllerManager, fldPath.Child("kubernetes", "kubeControllerManager"))...)
 
@@ -355,8 +355,8 @@ func ValidateShootSpecUpdate(newSpec, oldSpec *core.ShootSpec, newObjectMeta met
 			newKubernetesVersion = *newWorker.Kubernetes.Version
 		}
 
-		// worker kubernetes versions must not be downgraded and must not skip a minor
-		allErrs = append(allErrs, ValidateKubernetesVersionUpdate(newKubernetesVersion, oldKubernetesVersion, idxPath.Child("kubernetes", "version"))...)
+		// worker kubernetes versions must not be downgraded and but can skip minor versions
+		allErrs = append(allErrs, ValidateKubernetesVersionUpdate(newKubernetesVersion, oldKubernetesVersion, true, idxPath.Child("kubernetes", "version"))...)
 	}
 
 	allErrs = append(allErrs, validateNetworkingUpdate(newSpec.Networking, oldSpec.Networking, fldPath.Child("networking"))...)
@@ -662,7 +662,7 @@ func validateDNSUpdate(new, old *core.DNS, seedGotAssigned bool, fldPath *field.
 }
 
 // ValidateKubernetesVersionUpdate ensures that new version is newer than old version and does not skip one minor
-func ValidateKubernetesVersionUpdate(new, old string, fldPath *field.Path) field.ErrorList {
+func ValidateKubernetesVersionUpdate(new, old string, isWorkerPoolKubernetesVersion bool, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	if len(new) == 0 {
@@ -679,19 +679,21 @@ func ValidateKubernetesVersionUpdate(new, old string, fldPath *field.Path) field
 		allErrs = append(allErrs, field.Forbidden(fldPath, "kubernetes version downgrade is not supported"))
 	}
 
-	// Forbid Kubernetes version upgrade which skips a minor version
-	oldVersion, err := semver.NewVersion(old)
-	if err != nil {
-		allErrs = append(allErrs, field.Invalid(fldPath, old, err.Error()))
-	}
-	nextMinorVersion := oldVersion.IncMinor().IncMinor()
+	if !isWorkerPoolKubernetesVersion {
+		// Forbid Kubernetes version upgrade which skips a minor version
+		oldVersion, err := semver.NewVersion(old)
+		if err != nil {
+			allErrs = append(allErrs, field.Invalid(fldPath, old, err.Error()))
+		}
+		nextMinorVersion := oldVersion.IncMinor().IncMinor()
 
-	skippingMinorVersion, err := versionutils.CompareVersions(new, ">=", nextMinorVersion.String())
-	if err != nil {
-		allErrs = append(allErrs, field.Invalid(fldPath, new, err.Error()))
-	}
-	if skippingMinorVersion {
-		allErrs = append(allErrs, field.Forbidden(fldPath, "kubernetes version upgrade cannot skip a minor version"))
+		skippingMinorVersion, err := versionutils.CompareVersions(new, ">=", nextMinorVersion.String())
+		if err != nil {
+			allErrs = append(allErrs, field.Invalid(fldPath, new, err.Error()))
+		}
+		if skippingMinorVersion {
+			allErrs = append(allErrs, field.Forbidden(fldPath, "kubernetes version upgrade cannot skip a minor version"))
+		}
 	}
 
 	return allErrs

--- a/pkg/apis/operator/v1alpha1/validation/validation.go
+++ b/pkg/apis/operator/v1alpha1/validation/validation.go
@@ -137,7 +137,7 @@ func validateVirtualClusterUpdate(oldGarden, newGarden *operatorv1alpha1.Garden)
 		allErrs = append(allErrs, apivalidation.ValidateImmutableField(oldVirtualCluster.ControlPlane, newVirtualCluster.ControlPlane, fldPath.Child("controlPlane", "highAvailability"))...)
 	}
 
-	allErrs = append(allErrs, gardencorevalidation.ValidateKubernetesVersionUpdate(newVirtualCluster.Kubernetes.Version, oldVirtualCluster.Kubernetes.Version, fldPath.Child("kubernetes", "version"))...)
+	allErrs = append(allErrs, gardencorevalidation.ValidateKubernetesVersionUpdate(newVirtualCluster.Kubernetes.Version, oldVirtualCluster.Kubernetes.Version, false, fldPath.Child("kubernetes", "version"))...)
 	allErrs = append(allErrs, validateEncryptionConfigUpdate(oldGarden, newGarden)...)
 
 	return allErrs


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind enhancement

**What this PR does / why we need it**:
This PR relaxes the validation for worker pool kubernetes version upgrade to allow skipping minor versions.
See https://github.com/gardener/gardener/issues/9184 for detailed reasoning.

**Which issue(s) this PR fixes**:
Fixes #9184

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy user
It is now possible to skip a minor Kubernetes version for worker pool Kubernetes version upgrades as long as the version remains equal to or less than the control plane version.
```
