### PR TITLE
Fix VPA for Prometheis managed by `prometheus-operator`

### DIFF
--- a/pkg/component/monitoring/prometheus/prometheus.go
+++ b/pkg/component/monitoring/prometheus/prometheus.go
@@ -57,6 +57,7 @@ func (p *prometheus) prometheus(takeOverOldPV bool) *monitoringv1.Prometheus {
 				},
 				PriorityClassName: p.values.PriorityClassName,
 				Replicas:          ptr.To(int32(1)),
+				Shards:            ptr.To(int32(1)),
 				Image:             &p.values.Image,
 				ImagePullPolicy:   corev1.PullIfNotPresent,
 				Version:           p.values.Version,

--- a/pkg/component/monitoring/prometheus/prometheus_test.go
+++ b/pkg/component/monitoring/prometheus/prometheus_test.go
@@ -208,6 +208,7 @@ honor_labels: true`
 					},
 					PriorityClassName: priorityClassName,
 					Replicas:          ptr.To(int32(1)),
+					Shards:            ptr.To(int32(1)),
 					Image:             &image,
 					ImagePullPolicy:   corev1.PullIfNotPresent,
 					Version:           version,
@@ -259,9 +260,9 @@ honor_labels: true`
 			},
 			Spec: vpaautoscalingv1.VerticalPodAutoscalerSpec{
 				TargetRef: &autoscalingv1.CrossVersionObjectReference{
-					APIVersion: "apps/v1",
-					Kind:       "StatefulSet",
-					Name:       "prometheus-" + name,
+					APIVersion: "monitoring.coreos.com/v1",
+					Kind:       "Prometheus",
+					Name:       name,
 				},
 				UpdatePolicy: &vpaautoscalingv1.PodUpdatePolicy{
 					UpdateMode: &vpaUpdateMode,

--- a/pkg/component/monitoring/prometheus/vpa.go
+++ b/pkg/component/monitoring/prometheus/vpa.go
@@ -15,7 +15,7 @@
 package prometheus
 
 import (
-	appsv1 "k8s.io/api/apps/v1"
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -34,9 +34,9 @@ func (p *prometheus) vpa() *vpaautoscalingv1.VerticalPodAutoscaler {
 		},
 		Spec: vpaautoscalingv1.VerticalPodAutoscalerSpec{
 			TargetRef: &autoscalingv1.CrossVersionObjectReference{
-				APIVersion: appsv1.SchemeGroupVersion.String(),
-				Kind:       "StatefulSet",
-				Name:       p.name(),
+				APIVersion: monitoringv1.SchemeGroupVersion.String(),
+				Kind:       "Prometheus",
+				Name:       p.values.Name,
 			},
 			UpdatePolicy: &vpaautoscalingv1.PodUpdatePolicy{
 				UpdateMode: &updateMode,


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area scalability
/kind bug

**What this PR does / why we need it**:
Without this, VPA does not work and complains with

```yaml
  conditions:
  - lastTransitionTime: "2024-02-19T14:23:14Z"
    message: 'Error checking if target is a topmost well-known or scalable controller:
      Unhandled targetRef monitoring.coreos.com/v1 / Prometheus / cache, last error
      Internal error occurred: the spec replicas field ".spec.shards" does not exist'
    status: "True"
    type: ConfigUnsupported
```

This is the `prometheuses.monitoring.coreos.com/v1` CRD and the respective section defining the `scale` subresource:

```yaml
...
      scale:
        labelSelectorPath: .status.selector
        specReplicasPath: .spec.shards
        statusReplicasPath: .status.shards
```

We didn't set `.spec.shards`, however, for `GET`ting the `prometheuses/scale` resource (which VPA calls), it is required, see:

```
$ kubectl -n garden get prom cache --subresource=scale
Error from server (InternalError): Internal error occurred: the spec replicas field ".spec.shards" does not exist
```

Also, VPA wants the topmost owner to be the `.spec.targetRef`.

FYI @voelzmo 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
