### PR TITLE
Seed care controller incorporates health of `prometheus-cache` and `alertmanager-seed` `ManagedResource`s

### DIFF
--- a/pkg/gardenlet/controller/seed/care/health.go
+++ b/pkg/gardenlet/controller/seed/care/health.go
@@ -54,6 +54,7 @@ var requiredManagedResourcesSeed = sets.New(
 	seedsystem.ManagedResourceName,
 	vpa.ManagedResourceControlName,
 	prometheusoperator.ManagedResourceName,
+	"prometheus-cache",
 )
 
 // health contains information needed to execute health checks for a seed.
@@ -65,6 +66,7 @@ type health struct {
 	seedIsGarden        bool
 	loggingEnabled      bool
 	valiEnabled         bool
+	alertManagerEnabled bool
 	conditionThresholds map[gardencorev1beta1.ConditionType]time.Duration
 	healthChecker       *healthchecker.HealthChecker
 }
@@ -78,6 +80,7 @@ func NewHealth(
 	seedIsGarden bool,
 	loggingEnabled bool,
 	valiEnabled bool,
+	alertManagerEnabled bool,
 	conditionThresholds map[gardencorev1beta1.ConditionType]time.Duration,
 ) HealthCheck {
 	return &health{
@@ -88,6 +91,7 @@ func NewHealth(
 		seedIsGarden:        seedIsGarden,
 		loggingEnabled:      loggingEnabled,
 		valiEnabled:         valiEnabled,
+		alertManagerEnabled: alertManagerEnabled,
 		conditionThresholds: conditionThresholds,
 		healthChecker:       healthchecker.NewHealthChecker(seedClient, clock, conditionThresholds, seed.Status.LastOperation),
 	}
@@ -136,6 +140,9 @@ func (h *health) checkSystemComponents(
 	}
 	if h.valiEnabled {
 		managedResources = append(managedResources, vali.ManagedResourceNameRuntime)
+	}
+	if h.alertManagerEnabled {
+		managedResources = append(managedResources, "alertmanager-seed")
 	}
 
 	for _, name := range managedResources {

--- a/pkg/gardenlet/controller/seed/care/health_test.go
+++ b/pkg/gardenlet/controller/seed/care/health_test.go
@@ -60,6 +60,7 @@ var (
 		vpa.ManagedResourceControlName,
 		"istio",
 		prometheusoperator.ManagedResourceName,
+		"prometheus-cache",
 	}
 
 	optionalManagedResources = []string{
@@ -71,6 +72,7 @@ var (
 		fluentoperator.OperatorManagedResourceName,
 		fluentoperator.FluentBitManagedResourceName,
 		vali.ManagedResourceNameRuntime,
+		"alertmanager-seed",
 	}
 )
 
@@ -131,7 +133,7 @@ var _ = Describe("Seed health", func() {
 			})
 
 			It("should set SeedSystemComponentsHealthy condition to true", func() {
-				healthCheck := NewHealth(seed, c, fakeClock, nil, false, true, true, nil)
+				healthCheck := NewHealth(seed, c, fakeClock, nil, false, true, true, true, nil)
 				conditions := NewSeedConditions(fakeClock, gardencorev1beta1.SeedStatus{
 					Conditions: []gardencorev1beta1.Condition{seedSystemComponentsHealthyCondition},
 				})
@@ -154,7 +156,7 @@ var _ = Describe("Seed health", func() {
 			})
 
 			It("should set SeedSystemComponentsHealthy condition to true", func() {
-				healthCheck := NewHealth(seed, c, fakeClock, nil, true, false, false, nil)
+				healthCheck := NewHealth(seed, c, fakeClock, nil, true, false, false, false, nil)
 				conditions := NewSeedConditions(fakeClock, gardencorev1beta1.SeedStatus{
 					Conditions: []gardencorev1beta1.Condition{seedSystemComponentsHealthyCondition},
 				})
@@ -169,7 +171,7 @@ var _ = Describe("Seed health", func() {
 			var (
 				tests = func(reason, message string) {
 					It("should set SeedSystemComponentsHealthy condition to False if there is no Progressing threshold duration mapping", func() {
-						healthCheck := NewHealth(seed, c, fakeClock, nil, false, false, false, nil)
+						healthCheck := NewHealth(seed, c, fakeClock, nil, false, false, false, false, nil)
 						conditions := NewSeedConditions(fakeClock, gardencorev1beta1.SeedStatus{
 							Conditions: []gardencorev1beta1.Condition{seedSystemComponentsHealthyCondition},
 						})
@@ -184,7 +186,7 @@ var _ = Describe("Seed health", func() {
 						seedSystemComponentsHealthyCondition.Status = gardencorev1beta1.ConditionFalse
 						fakeClock.Step(30 * time.Second)
 
-						healthCheck := NewHealth(seed, c, fakeClock, nil, false, false, false, map[gardencorev1beta1.ConditionType]time.Duration{gardencorev1beta1.SeedSystemComponentsHealthy: time.Minute})
+						healthCheck := NewHealth(seed, c, fakeClock, nil, false, false, false, false, map[gardencorev1beta1.ConditionType]time.Duration{gardencorev1beta1.SeedSystemComponentsHealthy: time.Minute})
 						conditions := NewSeedConditions(fakeClock, gardencorev1beta1.SeedStatus{
 							Conditions: []gardencorev1beta1.Condition{seedSystemComponentsHealthyCondition},
 						})
@@ -199,7 +201,7 @@ var _ = Describe("Seed health", func() {
 						seedSystemComponentsHealthyCondition.Status = gardencorev1beta1.ConditionTrue
 						fakeClock.Step(30 * time.Second)
 
-						healthCheck := NewHealth(seed, c, fakeClock, nil, false, false, false, map[gardencorev1beta1.ConditionType]time.Duration{gardencorev1beta1.SeedSystemComponentsHealthy: time.Minute})
+						healthCheck := NewHealth(seed, c, fakeClock, nil, false, false, false, false, map[gardencorev1beta1.ConditionType]time.Duration{gardencorev1beta1.SeedSystemComponentsHealthy: time.Minute})
 						conditions := NewSeedConditions(fakeClock, gardencorev1beta1.SeedStatus{
 							Conditions: []gardencorev1beta1.Condition{seedSystemComponentsHealthyCondition},
 						})
@@ -214,7 +216,7 @@ var _ = Describe("Seed health", func() {
 						seedSystemComponentsHealthyCondition.Status = gardencorev1beta1.ConditionProgressing
 						fakeClock.Step(30 * time.Second)
 
-						healthCheck := NewHealth(seed, c, fakeClock, nil, false, false, false, map[gardencorev1beta1.ConditionType]time.Duration{gardencorev1beta1.SeedSystemComponentsHealthy: time.Minute})
+						healthCheck := NewHealth(seed, c, fakeClock, nil, false, false, false, false, map[gardencorev1beta1.ConditionType]time.Duration{gardencorev1beta1.SeedSystemComponentsHealthy: time.Minute})
 						conditions := NewSeedConditions(fakeClock, gardencorev1beta1.SeedStatus{
 							Conditions: []gardencorev1beta1.Condition{seedSystemComponentsHealthyCondition},
 						})
@@ -229,7 +231,7 @@ var _ = Describe("Seed health", func() {
 						seedSystemComponentsHealthyCondition.Status = gardencorev1beta1.ConditionProgressing
 						fakeClock.Step(90 * time.Second)
 
-						healthCheck := NewHealth(seed, c, fakeClock, nil, false, false, false, map[gardencorev1beta1.ConditionType]time.Duration{gardencorev1beta1.SeedSystemComponentsHealthy: time.Minute})
+						healthCheck := NewHealth(seed, c, fakeClock, nil, false, false, false, false, map[gardencorev1beta1.ConditionType]time.Duration{gardencorev1beta1.SeedSystemComponentsHealthy: time.Minute})
 						conditions := NewSeedConditions(fakeClock, gardencorev1beta1.SeedStatus{
 							Conditions: []gardencorev1beta1.Condition{seedSystemComponentsHealthyCondition},
 						})

--- a/pkg/gardenlet/controller/seed/care/reconciler_test.go
+++ b/pkg/gardenlet/controller/seed/care/reconciler_test.go
@@ -205,7 +205,7 @@ func (c resultingConditionFunc) Check(_ context.Context, conditions SeedConditio
 }
 
 func healthCheckFunc(fn resultingConditionFunc) NewHealthCheckFunc {
-	return func(*gardencorev1beta1.Seed, client.Client, clock.Clock, *string, bool, bool, bool, map[gardencorev1beta1.ConditionType]time.Duration) HealthCheck {
+	return func(*gardencorev1beta1.Seed, client.Client, clock.Clock, *string, bool, bool, bool, bool, map[gardencorev1beta1.ConditionType]time.Duration) HealthCheck {
 		return fn
 	}
 }

--- a/pkg/gardenlet/controller/seed/care/types.go
+++ b/pkg/gardenlet/controller/seed/care/types.go
@@ -22,19 +22,14 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
-	seedpkg "github.com/gardener/gardener/pkg/operation/seed"
 )
 
-var defaultNewSeedObjectFunc = func(ctx context.Context, seed *gardencorev1beta1.Seed) (*seedpkg.Seed, error) {
-	return seedpkg.NewBuilder().WithSeedObject(seed).Build(ctx)
-}
-
 // NewHealthCheckFunc is a function used to create a new instance for performing health checks.
-type NewHealthCheckFunc func(*gardencorev1beta1.Seed, client.Client, clock.Clock, *string, bool, bool, bool, map[gardencorev1beta1.ConditionType]time.Duration) HealthCheck
+type NewHealthCheckFunc func(*gardencorev1beta1.Seed, client.Client, clock.Clock, *string, bool, bool, bool, bool, map[gardencorev1beta1.ConditionType]time.Duration) HealthCheck
 
 // defaultNewHealthCheck is the default function to create a new instance for performing health checks.
-var defaultNewHealthCheck NewHealthCheckFunc = func(seed *gardencorev1beta1.Seed, client client.Client, clock clock.Clock, namespace *string, seedIsGarden bool, loggingEnabled, valiEnabled bool, conditionThresholds map[gardencorev1beta1.ConditionType]time.Duration) HealthCheck {
-	return NewHealth(seed, client, clock, namespace, seedIsGarden, loggingEnabled, valiEnabled, conditionThresholds)
+var defaultNewHealthCheck NewHealthCheckFunc = func(seed *gardencorev1beta1.Seed, client client.Client, clock clock.Clock, namespace *string, seedIsGarden bool, loggingEnabled, valiEnabled, alertManagerEnabled bool, conditionThresholds map[gardencorev1beta1.ConditionType]time.Duration) HealthCheck {
+	return NewHealth(seed, client, clock, namespace, seedIsGarden, loggingEnabled, valiEnabled, alertManagerEnabled, conditionThresholds)
 }
 
 // HealthCheck is an interface used to perform health checks.

--- a/test/integration/gardenlet/seed/care/care_suite_test.go
+++ b/test/integration/gardenlet/seed/care/care_suite_test.go
@@ -36,6 +36,7 @@ import (
 	gardenerenvtest "github.com/gardener/gardener/pkg/envtest"
 	"github.com/gardener/gardener/pkg/gardenlet/features"
 	"github.com/gardener/gardener/pkg/logger"
+	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 )
 
@@ -58,6 +59,7 @@ var (
 	testScheme    *runtime.Scheme
 	testRunID     string
 	testNamespace *corev1.Namespace
+	seedNamespace *corev1.Namespace
 	seedName      string
 )
 
@@ -115,5 +117,19 @@ var _ = BeforeSuite(func() {
 	DeferCleanup(func() {
 		By("Delete test Namespace")
 		Expect(testClient.Delete(ctx, testNamespace)).To(Or(Succeed(), BeNotFoundError()))
+	})
+
+	By("Create seed Namespace")
+	seedNamespace = &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: gardenerutils.ComputeGardenNamespace(seedName),
+		},
+	}
+	Expect(testClient.Create(ctx, seedNamespace)).To(Succeed())
+	log.Info("Created Namespace for seed", "namespaceName", seedNamespace.Name)
+
+	DeferCleanup(func() {
+		By("Delete seed Namespace")
+		Expect(testClient.Delete(ctx, seedNamespace)).To(Or(Succeed(), BeNotFoundError()))
 	})
 })


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity
/kind enhancement

**What this PR does / why we need it**:
Seed care controller incorporates health of `prometheus-cache` and `alertmanager-seed` `ManagedResource`s.

Follow-up of https://github.com/gardener/gardener/pull/9128 and https://github.com/gardener/gardener/pull/9159

**Which issue(s) this PR fixes**:
Part of #9065

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
