### PR TITLE
Copy alerting SMTP secret from garden to seed cluster

### DIFF
--- a/pkg/component/monitoring/alertmanager/component.go
+++ b/pkg/component/monitoring/alertmanager/component.go
@@ -88,6 +88,7 @@ func (a *alertManager) Deploy(ctx context.Context) error {
 		a.alertManager(takeOverExistingPV),
 		a.vpa(),
 		a.config(),
+		a.smtpSecret(),
 	)
 	if err != nil {
 		return err


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind bug

**What this PR does / why we need it**:
Copy alerting SMTP secret from garden to seed cluster. Without this, `prometheus-operator` will not be able to create the `StatefulSet`:

```
      message: 'provision alertmanager configuration: failed to initialize from global
        AlertmangerConfig: EmailConfig[0]: failed to get auth password: unable to
        get secret "<alerting-smtp-secret-name>": secrets "<alerting-smtp-secret-name>" not found'
```

This works in the local setup because the garden cluster is the seed cluster at the same time, and the secret is present "by accident".

**Which issue(s) this PR fixes**:
Part of #9065

Follow-up of https://github.com/gardener/gardener/pull/9159

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
