### PR TITLE
Set vpa webhook `reinvocationPolicy: IfNeeded`

### DIFF
--- a/charts/gardener/gardenlet/templates/clusterrole-gardenlet.yaml
+++ b/charts/gardener/gardenlet/templates/clusterrole-gardenlet.yaml
@@ -111,16 +111,6 @@ rules:
   - patch
   - update
 - apiGroups:
-  - admissionregistration.k8s.io
-  resources:
-  - mutatingwebhookconfigurations
-  resourceNames:
-  - vpa-webhook-config-seed
-  verbs:
-  - get
-  - delete
-  - update
-- apiGroups:
   - apiextensions.k8s.io
   resources:
   - customresourcedefinitions

--- a/pkg/component/vpa/general.go
+++ b/pkg/component/vpa/general.go
@@ -187,7 +187,7 @@ func (v *vpa) reconcileGeneralMutatingWebhookConfiguration(mutatingWebhookConfig
 	var (
 		failurePolicy      = admissionregistrationv1.Ignore
 		matchPolicy        = admissionregistrationv1.Exact
-		reinvocationPolicy = admissionregistrationv1.NeverReinvocationPolicy
+		reinvocationPolicy = admissionregistrationv1.IfNeededReinvocationPolicy
 		sideEffects        = admissionregistrationv1.SideEffectClassNone
 		scope              = admissionregistrationv1.AllScopes
 

--- a/pkg/component/vpa/general.go
+++ b/pkg/component/vpa/general.go
@@ -211,6 +211,11 @@ func (v *vpa) reconcileGeneralMutatingWebhookConfiguration(mutatingWebhookConfig
 	}
 
 	metav1.SetMetaDataLabel(&mutatingWebhookConfiguration.ObjectMeta, v1beta1constants.LabelExcludeWebhookFromRemediation, "true")
+	metav1.SetMetaDataAnnotation(&mutatingWebhookConfiguration.ObjectMeta, v1beta1constants.GardenerDescription,
+		"The order in which MutatingWebhooks are called is determined alphabetically. This webhook's name "+
+			"intentionally starts with 'zzz', such that it is called after all other webhooks which inject "+
+			"containers. All containers injected by webhooks that are called _after_ the vpa webhook will not be "+
+			"under control of vpa.")
 	mutatingWebhookConfiguration.Webhooks = []admissionregistrationv1.MutatingWebhook{{
 		Name:                    "vpa.k8s.io",
 		AdmissionReviewVersions: []string{"v1"},

--- a/pkg/component/vpa/vpa.go
+++ b/pkg/component/vpa/vpa.go
@@ -244,10 +244,11 @@ func (v *vpa) emptyMutatingWebhookConfiguration() *admissionregistrationv1.Mutat
 		suffix = "target"
 	}
 
-	// This name intentionally starts with a 'v', such that the webhook is called after all other webhooks which inject
-	// containers. All containers injected by webhooks that are called _after_ the vpa webhook will not be under control
-	// of vpa.
-	return &admissionregistrationv1.MutatingWebhookConfiguration{ObjectMeta: metav1.ObjectMeta{Name: "vpa-webhook-config-" + suffix}}
+	// The order in which MutatingWebhooks are called is determined alphabetically. This webhook's name intentionally
+	// starts with 'zzz', such that it is called after all other webhooks which inject containers. All containers
+	// injected by webhooks that are called _after_ the vpa webhook will not be under control of vpa.
+	// See also the `gardener.cloud/description` annotation on the MutatingWebhook.
+	return &admissionregistrationv1.MutatingWebhookConfiguration{ObjectMeta: metav1.ObjectMeta{Name: "zzz-vpa-webhook-config-" + suffix}}
 }
 
 func (v *vpa) rbacNamePrefix() string {

--- a/pkg/component/vpa/vpa.go
+++ b/pkg/component/vpa/vpa.go
@@ -244,6 +244,9 @@ func (v *vpa) emptyMutatingWebhookConfiguration() *admissionregistrationv1.Mutat
 		suffix = "target"
 	}
 
+	// This name intentionally starts with a 'v', such that the webhook is called after all other webhooks which inject
+	// containers. All containers injected by webhooks that are called _after_ the vpa webhook will not be under control
+	// of vpa.
 	return &admissionregistrationv1.MutatingWebhookConfiguration{ObjectMeta: metav1.ObjectMeta{Name: "vpa-webhook-config-" + suffix}}
 }
 

--- a/pkg/component/vpa/vpa_test.go
+++ b/pkg/component/vpa/vpa_test.go
@@ -106,7 +106,7 @@ var _ = Describe("VPA", func() {
 
 		webhookFailurePolicy      = admissionregistrationv1.Ignore
 		webhookMatchPolicy        = admissionregistrationv1.Exact
-		webhookReinvocationPolicy = admissionregistrationv1.NeverReinvocationPolicy
+		webhookReinvocationPolicy = admissionregistrationv1.IfNeededReinvocationPolicy
 		webhookSideEffects        = admissionregistrationv1.SideEffectClassNone
 		webhookScope              = admissionregistrationv1.AllScopes
 

--- a/pkg/component/vpa/vpa_test.go
+++ b/pkg/component/vpa/vpa_test.go
@@ -41,6 +41,7 @@ import (
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	"github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/component"
@@ -1219,8 +1220,12 @@ var _ = Describe("VPA", func() {
 				Kind:       "MutatingWebhookConfiguration",
 			},
 			ObjectMeta: metav1.ObjectMeta{
-				Name:   "vpa-webhook-config-target",
+				Name:   "zzz-vpa-webhook-config-target",
 				Labels: map[string]string{"remediation.webhook.shoot.gardener.cloud/exclude": "true"},
+				Annotations: map[string]string{constants.GardenerDescription: "The order in which MutatingWebhooks are " +
+					"called is determined alphabetically. This webhook's name intentionally starts with 'zzz', such " +
+					"that it is called after all other webhooks which inject containers. All containers injected by " +
+					"webhooks that are called _after_ the vpa webhook will not be under control of vpa."},
 			},
 			Webhooks: []admissionregistrationv1.MutatingWebhook{{
 				Name:                    "vpa.k8s.io",
@@ -1398,7 +1403,7 @@ var _ = Describe("VPA", func() {
 					Expect(string(managedResourceSecret.Data["clusterrolebinding____gardener.cloud_vpa_source_actor.yaml"])).To(Equal(componenttest.Serialize(clusterRoleBindingGeneralActor)))
 					Expect(string(managedResourceSecret.Data["clusterrole____gardener.cloud_vpa_source_target-reader.yaml"])).To(Equal(componenttest.Serialize(clusterRoleGeneralTargetReader)))
 					Expect(string(managedResourceSecret.Data["clusterrolebinding____gardener.cloud_vpa_source_target-reader.yaml"])).To(Equal(componenttest.Serialize(clusterRoleBindingGeneralTargetReader)))
-					Expect(string(managedResourceSecret.Data["mutatingwebhookconfiguration____vpa-webhook-config-source.yaml"])).To(Equal(componenttest.Serialize(mutatingWebhookConfiguration)))
+					Expect(string(managedResourceSecret.Data["mutatingwebhookconfiguration____zzz-vpa-webhook-config-source.yaml"])).To(Equal(componenttest.Serialize(mutatingWebhookConfiguration)))
 				})
 
 				Context("Kubernetes versions < 1.26", func() {
@@ -1647,7 +1652,7 @@ var _ = Describe("VPA", func() {
 					Expect(string(managedResourceSecret.Data["clusterrolebinding____gardener.cloud_vpa_target_actor.yaml"])).To(Equal(componenttest.Serialize(clusterRoleBindingGeneralActor)))
 					Expect(string(managedResourceSecret.Data["clusterrole____gardener.cloud_vpa_target_target-reader.yaml"])).To(Equal(componenttest.Serialize(clusterRoleGeneralTargetReader)))
 					Expect(string(managedResourceSecret.Data["clusterrolebinding____gardener.cloud_vpa_target_target-reader.yaml"])).To(Equal(componenttest.Serialize(clusterRoleBindingGeneralTargetReader)))
-					Expect(string(managedResourceSecret.Data["mutatingwebhookconfiguration____vpa-webhook-config-target.yaml"])).To(Equal(componenttest.Serialize(mutatingWebhookConfiguration)))
+					Expect(string(managedResourceSecret.Data["mutatingwebhookconfiguration____zzz-vpa-webhook-config-target.yaml"])).To(Equal(componenttest.Serialize(mutatingWebhookConfiguration)))
 					Expect(managedResourceSecret.Data).To(HaveKey("crd-verticalpodautoscalercheckpoints.yaml"))
 					Expect(managedResourceSecret.Data).To(HaveKey("crd-verticalpodautoscalers.yaml"))
 				})

--- a/pkg/gardenlet/controller/managedseed/charttest/charttest.go
+++ b/pkg/gardenlet/controller/managedseed/charttest/charttest.go
@@ -226,12 +226,6 @@ func getGardenletClusterRole(labels map[string]string) *rbacv1.ClusterRole {
 				Verbs:     []string{"create", "delete", "deletecollection", "get", "list", "watch", "patch", "update"},
 			},
 			{
-				APIGroups:     []string{"admissionregistration.k8s.io"},
-				Resources:     []string{"mutatingwebhookconfigurations"},
-				ResourceNames: []string{"vpa-webhook-config-seed"},
-				Verbs:         []string{"get", "delete", "update"},
-			},
-			{
 				APIGroups: []string{"apiextensions.k8s.io"},
 				Resources: []string{"customresourcedefinitions"},
 				Verbs:     []string{"create", "get", "list", "watch", "patch", "update"},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area auto-scaling
/kind enhancement

**What this PR does / why we need it**:
Under normal circumstances, VPA is ignoring injected sidecar Containers. This is achieved by ensuring that the VPA admission-controller MutatingWebhook is called *before* all other webhooks which inject containers. The VPA admission-controller will [add an annotation `vpaObservedContainers`](https://github.com/kubernetes/autoscaler/blob/e29dff136fabc9ecf8b3efb03cd7fb847b7686d4/vertical-pod-autoscaler/pkg/admission-controller/main.go#L120) with a list of all Containers found in a Pod and later on only [apply recommendations to the Containers found in this annotation](https://github.com/kubernetes/autoscaler/blob/a3c8978e119f56a90a6f8406e76685c21cfecd51/vertical-pod-autoscaler/pkg/updater/priority/priority_processor.go#L54-L59). [This feature was introduced specifically to avoid endless eviction loops in the case where controllers injecting sidecar Containers are overwriting resources set by the VPA admission-controller](https://github.com/kubernetes/autoscaler/issues/5617#issuecomment-1539669433).

In gardener, however, we need the VPA admission-controller to be called *after* other webhooks inject containers, as we're e.g. [putting containers injected by the provider extensions under control of VPA.](https://github.com/gardener/gardener-extension-provider-aws/blob/d6a2cff76099350b9caa7e4f5784f3f7252902b7/pkg/webhook/controlplane/ensurer.go)

In this scenario, problems can arise if the injecting webhook specifies `reinvocationPolicy: IfNeeded` and unconditionally reconciles the `resources` section of the injected container. This way, it will overwrite the resources set by VPA, resulting in an endless eviction loop. This became visible after we introduced the [`app-oidc-controller`](https://github.com/gardener/oidc-apps-controller), which injects additional sidecar Containers and also adjusts their `resources`.

By setting vpa webhook `reinvocationPolicy: IfNeeded` for the VPA admission-controller webhook, we ensure that the VPA admission-controller is invoked last, making sure that the requests are set correctly also for injected Containers.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Set `reinvocationPolicy: IfNeeded` for VPA admission-controller webhook to ensure that webhooks injecting sidecar containers will not trigger and endless eviction loop.
```
