### PR TITLE
Remove catch-all containername matching from prometheus VPAs

### DIFF
--- a/pkg/component/monitoring/alertmanager/alertmanager_test.go
+++ b/pkg/component/monitoring/alertmanager/alertmanager_test.go
@@ -216,10 +216,6 @@ var _ = Describe("Prometheus", func() {
 				ResourcePolicy: &vpaautoscalingv1.PodResourcePolicy{
 					ContainerPolicies: []vpaautoscalingv1.ContainerResourcePolicy{
 						{
-							ContainerName:    "*",
-							ControlledValues: &vpaControlledValuesRequestsOnly,
-						},
-						{
 							ContainerName: "alertmanager",
 							MinAllowed: corev1.ResourceList{
 								corev1.ResourceMemory: resource.MustParse("20Mi"),
@@ -228,6 +224,7 @@ var _ = Describe("Prometheus", func() {
 								corev1.ResourceCPU:    resource.MustParse("500m"),
 								corev1.ResourceMemory: resource.MustParse("200Mi"),
 							},
+							ControlledValues: &vpaControlledValuesRequestsOnly,
 						},
 						{
 							ContainerName: "config-reloader",

--- a/pkg/component/monitoring/alertmanager/vpa.go
+++ b/pkg/component/monitoring/alertmanager/vpa.go
@@ -44,10 +44,6 @@ func (a *alertManager) vpa() *vpaautoscalingv1.VerticalPodAutoscaler {
 			ResourcePolicy: &vpaautoscalingv1.PodResourcePolicy{
 				ContainerPolicies: []vpaautoscalingv1.ContainerResourcePolicy{
 					{
-						ContainerName:    "*",
-						ControlledValues: &controlledValuesRequestsOnly,
-					},
-					{
 						ContainerName: "alertmanager",
 						MinAllowed: corev1.ResourceList{
 							corev1.ResourceMemory: resource.MustParse("20Mi"),
@@ -56,6 +52,7 @@ func (a *alertManager) vpa() *vpaautoscalingv1.VerticalPodAutoscaler {
 							corev1.ResourceCPU:    resource.MustParse("500m"),
 							corev1.ResourceMemory: resource.MustParse("200Mi"),
 						},
+						ControlledValues: &controlledValuesRequestsOnly,
 					},
 					{
 						ContainerName: "config-reloader",

--- a/pkg/component/monitoring/charts/seed-monitoring/charts/core/charts/prometheus/templates/prometheus-vpa.yaml
+++ b/pkg/component/monitoring/charts/seed-monitoring/charts/core/charts/prometheus/templates/prometheus-vpa.yaml
@@ -22,7 +22,7 @@ spec:
     # failed to write 2485760 to memory.limit_in_bytes in /sys/fs/cgroup/memory/kubepods/prometheus-config-reloader/memory.limit_in_bytes: device or resource busy
     # https://github.com/lxc/lxc/commit/6400238d08cdf1ca20d49bafb85f4e224348bf9d
     # https://github.com/helm/charts/issues/11447#issuecomment-464716379
+      controlledValues: RequestsOnly
     - containerName: prometheus-config-reloader
       mode: "Off"
-    - containerName: '*'
-      controlledValues: RequestsOnly
+

--- a/pkg/component/monitoring/prometheus/prometheus_test.go
+++ b/pkg/component/monitoring/prometheus/prometheus_test.go
@@ -278,10 +278,6 @@ honor_labels: true`
 				ResourcePolicy: &vpaautoscalingv1.PodResourcePolicy{
 					ContainerPolicies: []vpaautoscalingv1.ContainerResourcePolicy{
 						{
-							ContainerName:    "*",
-							ControlledValues: &vpaControlledValuesRequestsOnly,
-						},
-						{
 							ContainerName: "prometheus",
 							MinAllowed: corev1.ResourceList{
 								corev1.ResourceMemory: resource.MustParse("1000M"),
@@ -290,6 +286,7 @@ honor_labels: true`
 								corev1.ResourceCPU:    resource.MustParse("4"),
 								corev1.ResourceMemory: resource.MustParse("28G"),
 							},
+							ControlledValues: &vpaControlledValuesRequestsOnly,
 						},
 						{
 							ContainerName: "config-reloader",

--- a/pkg/component/monitoring/prometheus/vpa.go
+++ b/pkg/component/monitoring/prometheus/vpa.go
@@ -45,10 +45,6 @@ func (p *prometheus) vpa() *vpaautoscalingv1.VerticalPodAutoscaler {
 			ResourcePolicy: &vpaautoscalingv1.PodResourcePolicy{
 				ContainerPolicies: []vpaautoscalingv1.ContainerResourcePolicy{
 					{
-						ContainerName:    "*",
-						ControlledValues: &controlledValuesRequestsOnly,
-					},
-					{
 						ContainerName: "prometheus",
 						MinAllowed: ptr.Deref(p.values.VPAMinAllowed, corev1.ResourceList{
 							corev1.ResourceMemory: resource.MustParse("1000M"),
@@ -57,6 +53,7 @@ func (p *prometheus) vpa() *vpaautoscalingv1.VerticalPodAutoscaler {
 							corev1.ResourceCPU:    resource.MustParse("4"),
 							corev1.ResourceMemory: resource.MustParse("28G"),
 						},
+						ControlledValues: &controlledValuesRequestsOnly,
 					},
 					{
 						ContainerName: "config-reloader",


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area auto-scaling
/kind bug

**What this PR does / why we need it**:
Remove the `containerName: "*"` catch-all definition from the `containerPolicies` for the prometheus VPAs and move the configuration into the containers explicitly.

VPA doesn't actually merge these configurations: [as soon as you specify a `containerPolicy` for a specific container name, all configuration under `containerName: "*"` is ignored](https://github.com/kubernetes/autoscaler/blob/a3c8978e119f56a90a6f8406e76685c21cfecd51/vertical-pod-autoscaler/pkg/utils/vpa/api.go#L186-L201). This can lead to unwanted cases, for example here you could assume that VPA was configured to scale only `requests`, but not `limits` for the `prometheus` container, but this was _not_ the case. This configuration would only be set for all containers not explicitly mentioned in the `containerPolicies` section with their name.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
