### PR TITLE
Do no longer delete `prometheus-seed` `ClusterRoleBinding`

### DIFF
--- a/pkg/component/monitoring/prometheus/prometheus_test.go
+++ b/pkg/component/monitoring/prometheus/prometheus_test.go
@@ -170,6 +170,7 @@ honor_labels: true`
 					"role": "monitoring",
 					"name": name,
 				},
+				Annotations: map[string]string{"resources.gardener.cloud/delete-on-invalid-update": "true"},
 			},
 			RoleRef: rbacv1.RoleRef{
 				APIGroup: "rbac.authorization.k8s.io",

--- a/pkg/component/monitoring/prometheus/rbac.go
+++ b/pkg/component/monitoring/prometheus/rbac.go
@@ -17,13 +17,16 @@ package prometheus
 import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 )
 
 func (p *prometheus) clusterRoleBinding() *rbacv1.ClusterRoleBinding {
 	return &rbacv1.ClusterRoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:   p.name(),
-			Labels: p.getLabels(),
+			Name:        p.name(),
+			Labels:      p.getLabels(),
+			Annotations: map[string]string{resourcesv1alpha1.DeleteOnInvalidUpdate: "true"},
 		},
 		RoleRef: rbacv1.RoleRef{
 			APIGroup: rbacv1.GroupName,

--- a/pkg/gardenlet/controller/seed/seed/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/seed/seed/reconciler_reconcile.go
@@ -483,7 +483,6 @@ func (r *Reconciler) runReconcileSeedFlow(
 					&corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "prometheus-web", Namespace: r.GardenNamespace}},
 					&corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "prometheus", Namespace: r.GardenNamespace}},
 					&appsv1.StatefulSet{ObjectMeta: metav1.ObjectMeta{Name: "prometheus", Namespace: r.GardenNamespace}},
-					&rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: "prometheus-seed"}},
 					&hvpav1alpha1.Hvpa{ObjectMeta: metav1.ObjectMeta{Name: "prometheus", Namespace: r.GardenNamespace}},
 					&vpaautoscalingv1.VerticalPodAutoscaler{ObjectMeta: metav1.ObjectMeta{Name: "prometheus-vpa", Namespace: r.GardenNamespace}},
 				)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind bug

**What this PR does / why we need it**:
In previous versions of Gardener, the `prometheus-seed` `ClusterRoleBinding` was related to the cache Prometheus. As part of https://github.com/gardener/gardener/pull/9128, we introduced cleanup code that deletes this no longer required resource.

After https://github.com/gardener/gardener/pull/9180, the seed Prometheus component creates a `ClusterRoleBinding` with the same name (`prometheus-seed`), so let's remove it from the cleanup code again.

To be sure the `ClusterRoleBinding` can be updated for existing seeds, we annotate it with `resources.gardener.cloud/delete-on-invalid-update=true` (similar approach is already followed for other `ClusterRoleBinding`s).

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/9065
Follow-up of https://github.com/gardener/gardener/pull/9180

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
