### PR TITLE
Update Plutono config for targeting seed Prometheus

### DIFF
--- a/pkg/component/plutono/plutono.go
+++ b/pkg/component/plutono/plutono.go
@@ -366,7 +366,7 @@ datasources:
 		datasource += `- name: seed-prometheus
   type: prometheus
   access: proxy
-  url: http://seed-prometheus-web:80
+  url: http://prometheus-seed:80
   basicAuth: false
   version: 1
   editable: false
@@ -844,7 +844,7 @@ func (p *plutono) getPodLabels() map[string]string {
 			v1beta1constants.LabelRole:                                         v1beta1constants.LabelMonitoring,
 			"networking.gardener.cloud/to-seed-prometheus":                     v1beta1constants.LabelNetworkPolicyAllowed,
 			gardenerutils.NetworkPolicyLabel("aggregate-prometheus-web", 9090): v1beta1constants.LabelNetworkPolicyAllowed,
-			gardenerutils.NetworkPolicyLabel("seed-prometheus-web", 9090):      v1beta1constants.LabelNetworkPolicyAllowed,
+			gardenerutils.NetworkPolicyLabel("prometheus-seed", 9090):          v1beta1constants.LabelNetworkPolicyAllowed,
 		})
 	} else if p.values.ClusterType == component.ClusterTypeShoot {
 		labels = utils.MergeStringMaps(labels, map[string]string{

--- a/pkg/component/plutono/plutono_test.go
+++ b/pkg/component/plutono/plutono_test.go
@@ -211,7 +211,7 @@ metadata:
 					configMapData += `    - name: seed-prometheus
       type: prometheus
       access: proxy
-      url: http://seed-prometheus-web:80
+      url: http://prometheus-seed:80
       basicAuth: false
       version: 1
       editable: false
@@ -251,7 +251,7 @@ metadata:
   namespace: some-namespace
 `
 				} else {
-					configMap += `  name: plutono-datasources-27f1a6c5
+					configMap += `  name: plutono-datasources-cf9781ab
   namespace: some-namespace
 `
 				}
@@ -261,7 +261,7 @@ metadata:
 
 			deploymentYAMLFor = func(values Values, dashboardConfigMaps []string) *appsv1.Deployment {
 				providerConfigMap := "plutono-dashboard-providers-29d306e7"
-				dataSourceConfigMap := "plutono-datasources-27f1a6c5"
+				dataSourceConfigMap := "plutono-datasources-cf9781ab"
 				if values.ClusterType == comp.ClusterTypeShoot {
 					dataSourceConfigMap = "plutono-datasources-0fd41775"
 				}
@@ -578,7 +578,7 @@ status:
 
 				It("should successfully deploy all resources", func() {
 					Expect(string(managedResourceSecret.Data["configmap__some-namespace__plutono-dashboard-providers-29d306e7.yaml"])).To(Equal(providerConfigMapYAMLFor(values)))
-					Expect(string(managedResourceSecret.Data["configmap__some-namespace__plutono-datasources-27f1a6c5.yaml"])).To(Equal(dataSourceConfigMapYAMLFor(values)))
+					Expect(string(managedResourceSecret.Data["configmap__some-namespace__plutono-datasources-cf9781ab.yaml"])).To(Equal(dataSourceConfigMapYAMLFor(values)))
 					plutonoDashboardsConfigMap, err := getDashboardConfigMaps(ctx, c, namespace, "plutono-dashboards-[^-]{8}")
 					Expect(err).ToNot(HaveOccurred())
 					testDashboardConfigMap(ctx, c, types.NamespacedName{Namespace: namespace, Name: plutonoDashboardsConfigMap.Name}, 22)
@@ -844,7 +844,7 @@ func getPodLabels(values Values) map[string]string {
 			v1beta1constants.LabelRole:                                         v1beta1constants.LabelMonitoring,
 			"networking.gardener.cloud/to-seed-prometheus":                     v1beta1constants.LabelNetworkPolicyAllowed,
 			gardenerutils.NetworkPolicyLabel("aggregate-prometheus-web", 9090): v1beta1constants.LabelNetworkPolicyAllowed,
-			gardenerutils.NetworkPolicyLabel("seed-prometheus-web", 9090):      v1beta1constants.LabelNetworkPolicyAllowed,
+			gardenerutils.NetworkPolicyLabel("prometheus-seed", 9090):          v1beta1constants.LabelNetworkPolicyAllowed,
 		})
 	} else if values.ClusterType == comp.ClusterTypeShoot {
 		labels = utils.MergeStringMaps(labels, map[string]string{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind bug

**What this PR does / why we need it**:
After https://github.com/gardener/gardener/pull/9180, the service name for targeting the seed Prometheus is called `prometheus-seed` and no longer `seed-prometheus-web`.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/9065
Follow-up of https://github.com/gardener/gardener/pull/9180

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
