### PR TITLE
Remove memory limits from Prometheis

### DIFF
--- a/pkg/component/monitoring/prometheus/prometheus.go
+++ b/pkg/component/monitoring/prometheus/prometheus.go
@@ -67,9 +67,6 @@ func (p *prometheus) prometheus(takeOverOldPV bool) *monitoringv1.Prometheus {
 						corev1.ResourceCPU:    resource.MustParse("300m"),
 						corev1.ResourceMemory: resource.MustParse("1000Mi"),
 					},
-					Limits: corev1.ResourceList{
-						corev1.ResourceMemory: resource.MustParse("2000Mi"),
-					},
 				},
 				ServiceAccountName: p.name(),
 				SecurityContext:    &corev1.PodSecurityContext{RunAsUser: ptr.To(int64(0))},

--- a/pkg/component/monitoring/prometheus/prometheus_test.go
+++ b/pkg/component/monitoring/prometheus/prometheus_test.go
@@ -226,9 +226,6 @@ honor_labels: true`
 							corev1.ResourceCPU:    resource.MustParse("300m"),
 							corev1.ResourceMemory: resource.MustParse("1000Mi"),
 						},
-						Limits: corev1.ResourceList{
-							corev1.ResourceMemory: resource.MustParse("2000Mi"),
-						},
 					},
 					ServiceAccountName: "prometheus-" + name,
 					SecurityContext:    &corev1.PodSecurityContext{RunAsUser: ptr.To(int64(0))},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area scalability
/kind bug

**What this PR does / why we need it**:
After https://github.com/gardener/gardener/pull/9192, the limits are no longer automatically scaled by VPA. Hence, they will always remain at their static `2000Mi` value, effectively causing Prometheis pods to run OOM.

To align the config with the shoot Prometheus, let's simply remove the memory limits: https://github.com/gardener/gardener/blob/55193c7184b6cc27fb5c4a86c45888e7f8eb7fcd/pkg/component/monitoring/charts/seed-monitoring/charts/core/charts/prometheus/templates/prometheus.yaml#L119-L122

**Which issue(s) this PR fixes**:
Follow-up of #9192

**Special notes for your reviewer**:
NONE

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
