### PR TITLE
Promote `UseGardenerNodeAgent` feature gate to GA

### DIFF
--- a/docs/deployment/feature_gates.md
+++ b/docs/deployment/feature_gates.md
@@ -34,6 +34,7 @@ The following tables are a summary of the feature gates that you can set on diff
 | APIServerFastRollout               | `true`  | `GA`    | `1.90` |        |
 | UseGardenerNodeAgent               | `false` | `Alpha` | `1.82` | `1.88` |
 | UseGardenerNodeAgent               | `true`  | `Beta`  | `1.89` |        |
+| UseGardenerNodeAgent               | `true`  | `GA`    | `1.90` |        |
 
 ## Feature Gates for Graduated or Deprecated Features
 

--- a/pkg/component/extensions/operatingsystemconfig/downloader/downloader_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/downloader/downloader_test.go
@@ -181,19 +181,6 @@ subjects:
 `
 		})
 
-		It("should generate the expected RBAC resources when UseGardenerNodeAgent feature gate is off", func() {
-			DeferCleanup(test.WithFeatureGate(features.DefaultFeatureGate, features.UseGardenerNodeAgent, false))
-
-			data, err := GenerateRBACResourcesData([]string{secretName1, secretName2})
-			Expect(err).NotTo(HaveOccurred())
-			Expect(data).To(HaveLen(5))
-			Expect(string(data["role__kube-system__cloud-config-downloader.yaml"])).To(Equal(roleYAML))
-			Expect(string(data["rolebinding__kube-system__cloud-config-downloader.yaml"])).To(Equal(roleBindingYAML))
-			Expect(string(data["clusterrolebinding____system_node-bootstrapper.yaml"])).To(Equal(clusterRoleBindingNodeBootstrapperYAML))
-			Expect(string(data["clusterrolebinding____system_certificates.k8s.io_certificatesigningrequests_nodeclient.yaml"])).To(Equal(clusterRoleBindingNodeClientYAML))
-			Expect(string(data["clusterrolebinding____system_certificates.k8s.io_certificatesigningrequests_selfnodeclient.yaml"])).To(Equal(clusterRoleBindingSelfNodeClientYAML))
-		})
-
 		It("should generate the expected RBAC resources when UseGardenerNodeAgent feature gate is on", func() {
 			DeferCleanup(test.WithFeatureGate(features.DefaultFeatureGate, features.UseGardenerNodeAgent, true))
 

--- a/pkg/component/extensions/operatingsystemconfig/original/components/kubelet/component_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/kubelet/component_test.go
@@ -25,10 +25,8 @@ import (
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/original/components"
 	. "github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/original/components/kubelet"
-	"github.com/gardener/gardener/pkg/features"
 	"github.com/gardener/gardener/pkg/utils"
 	"github.com/gardener/gardener/pkg/utils/imagevector"
-	"github.com/gardener/gardener/pkg/utils/test"
 )
 
 var _ = Describe("Component", func() {
@@ -46,8 +44,7 @@ var _ = Describe("Component", func() {
 	})
 
 	DescribeTable("#Config",
-		func(kubernetesVersion string, kubeletConfig string, useGardenerNodeAgentEnabled bool, preferIPv6 bool) {
-			defer test.WithFeatureGate(features.DefaultFeatureGate, features.UseGardenerNodeAgent, useGardenerNodeAgentEnabled)()
+		func(kubernetesVersion string, kubeletConfig string, preferIPv6 bool) {
 
 			ctx.CRIName = extensionsv1alpha1.CRINameContainerD
 			ctx.KubernetesVersion = semver.MustParse(kubernetesVersion)
@@ -75,20 +72,10 @@ var _ = Describe("Component", func() {
 
 			Expect(err).NotTo(HaveOccurred())
 
-			if useGardenerNodeAgentEnabled {
-				Expect(units).To(ConsistOf(
-					kubeletUnit(cliFlags, useGardenerNodeAgentEnabled),
-				))
-				Expect(files).To(ConsistOf(kubeletFiles(ctx, kubeletConfig, kubeletCABundleBase64, useGardenerNodeAgentEnabled)))
-			} else {
-				Expect(units).To(ConsistOf(
-					kubeletUnit(cliFlags, useGardenerNodeAgentEnabled),
-					kubeletMonitorUnit(),
-				))
-				Expect(files).To(ConsistOf(
-					append(kubeletFiles(ctx, kubeletConfig, kubeletCABundleBase64, useGardenerNodeAgentEnabled), kubeletMonitorFiles()...),
-				))
-			}
+			Expect(units).To(ConsistOf(
+				kubeletUnit(cliFlags),
+			))
+			Expect(files).To(ConsistOf(kubeletFiles(ctx, kubeletConfig, kubeletCABundleBase64)))
 		},
 
 		Entry(
@@ -96,171 +83,23 @@ var _ = Describe("Component", func() {
 			"1.25.1",
 			kubeletConfig(false),
 			false,
-			false,
-		),
-		Entry(
-			"kubernetes 1.25 w/ node-agent",
-			"1.25.1",
-			kubeletConfig(false),
-			true,
-			false,
 		),
 		Entry(
 			"kubernetes 1.26",
 			"1.26.1",
 			kubeletConfig(true),
 			false,
-			false,
 		),
 		Entry(
-			"kubernetes 1.26 w/ node-agent",
+			"kubernetes 1.26 and preferIPv6",
 			"1.26.1",
 			kubeletConfig(true),
-			true,
-			false,
-		),
-		Entry(
-			"kubernetes 1.26 w/ node-agent and preferIPv6",
-			"1.26.1",
-			kubeletConfig(true),
-			true,
 			true,
 		),
 	)
 })
 
 const (
-	healthMonitorScript = `#!/bin/bash
-set -o nounset
-set -o pipefail
-
-function kubelet_monitoring {
-  echo "Wait for 2 minutes for kubelet to be functional"
-  sleep 120
-  local -r max_seconds=10
-  local output=""
-
-  function kubectl {
-    /opt/bin/kubectl --kubeconfig /var/lib/kubelet/kubeconfig-real "$@"
-  }
-
-  function restart_kubelet {
-    pkill -x "kubelet"
-  }
-
-  function patch_internal_ip {
-    echo "Updating Node object $2 with InternalIP $3."
-    curl \
-      -XPATCH \
-      -H "Content-Type: application/strategic-merge-patch+json" \
-      -H "Accept: application/json" \
-      "$1/api/v1/nodes/$2/status" \
-      --data "{\"status\":{\"addresses\":[{\"address\": \"$3\", \"type\":\"InternalIP\"}]}}" \
-      --cacert <(base64 -d <<< $(kubectl config view -o jsonpath={.clusters[0].cluster.certificate-authority-data} --raw)) \
-      --key /var/lib/kubelet/pki/kubelet-client-current.pem \
-      --cert /var/lib/kubelet/pki/kubelet-client-current.pem \
-    > /dev/null 2>&1
-  }
-
-  timeframe=600
-  toggle_threshold=5
-  count_kubelet_alternating_between_ready_and_not_ready_within_timeframe=0
-  time_kubelet_not_ready_first_occurrence=0
-  last_kubelet_ready_state="True"
-
-  while [ 1 ]; do
-    # Check whether the kubelet's /healthz endpoint reports unhealthiness
-    if ! output=$(curl -m $max_seconds -f -s -S http://127.0.0.1:10248/healthz 2>&1); then
-      echo $output
-      echo "Kubelet is unhealthy!"
-      restart_kubelet
-      sleep 60
-      continue
-    fi
-
-    node_name=
-    if [[ -s "/var/lib/kubelet/nodename" ]]; then
-      node_name="$(cat "/var/lib/kubelet/nodename")"
-    fi
-    if [[ -z "$node_name" ]]; then
-      echo "Node name is not known yet, waiting..."
-      sleep 20
-      continue
-    fi
-
-    node_object="$(kubectl get node "$node_name" -o json)"
-    node_status="$(echo $node_object | jq -r '.status')"
-    if [[ -z "$node_status" ]] || [[ "$node_status" == "null" ]]; then
-      echo "Node object for this hostname not found in the system, waiting."
-      sleep 20
-      count_kubelet_alternating_between_ready_and_not_ready_within_timeframe=0
-      time_kubelet_not_ready_first_occurrence=0
-      continue
-    fi
-
-    # Check whether the kubelet does report an InternalIP node address
-    node_ip_internal="$(echo $node_status | jq -r '.addresses[] | select(.type=="InternalIP") | .address')"
-    node_ip_external="$(echo $node_status | jq -r '.addresses[] | select(.type=="ExternalIP") | .address')"
-    if [[ -z "$node_ip_internal" ]] && [[ -z "$node_ip_external" ]]; then
-      echo "Kubelet has not reported an InternalIP nor an ExternalIP node address yet.";
-      if ! [[ -z ${K8S_NODE_IP_INTERNAL_LAST_SEEN+x} ]]; then
-        echo "Check if last seen InternalIP "$K8S_NODE_IP_INTERNAL_LAST_SEEN" can be used";
-        if ip address show | grep $K8S_NODE_IP_INTERNAL_LAST_SEEN > /dev/null; then
-          echo "Last seen InternalIP "$K8S_NODE_IP_INTERNAL_LAST_SEEN" is still up-to-date";
-          server="$(kubectl config view -o jsonpath={.clusters[0].cluster.server})"
-          if patch_internal_ip $server $node_name $K8S_NODE_IP_INTERNAL_LAST_SEEN; then
-            echo "Successfully updated Node object."
-            continue
-          else
-            echo "An error occurred while updating the Node object."
-          fi
-        fi
-      fi
-      echo "Updating Node object is not possible. Restarting Kubelet.";
-      restart_kubelet
-      sleep 20
-      continue
-    elif ! [[ -z "$node_ip_internal" ]]; then
-      export K8S_NODE_IP_INTERNAL_LAST_SEEN="$node_ip_internal"
-    fi
-
-    # Check whether kubelet ready status toggles between true and false and reboot VM if happened too often.
-    if status="$(echo $node_status | jq -r '.conditions[] | select(.type=="Ready") | .status')"; then
-      if [[ "$status" != "True" ]]; then
-        if [[ $time_kubelet_not_ready_first_occurrence == 0 ]]; then
-          time_kubelet_not_ready_first_occurrence=$(date +%s)
-          echo "Start tracking kubelet ready status toggles."
-        fi
-      else
-        if [[ $time_kubelet_not_ready_first_occurrence != 0 ]]; then
-          if [[ "$last_kubelet_ready_state" != "$status" ]]; then
-            count_kubelet_alternating_between_ready_and_not_ready_within_timeframe=$((count_kubelet_alternating_between_ready_and_not_ready_within_timeframe+1))
-            echo "count_kubelet_alternating_between_ready_and_not_ready_within_timeframe=$count_kubelet_alternating_between_ready_and_not_ready_within_timeframe"
-            if [[ $count_kubelet_alternating_between_ready_and_not_ready_within_timeframe -ge $toggle_threshold ]]; then
-              sudo reboot
-            fi
-          fi
-        fi
-      fi
-
-      if [[ $time_kubelet_not_ready_first_occurrence != 0 && $(($(date +%s)-$time_kubelet_not_ready_first_occurrence)) -ge $timeframe ]]; then
-        count_kubelet_alternating_between_ready_and_not_ready_within_timeframe=0
-        time_kubelet_not_ready_first_occurrence=0
-        echo "Resetting kubelet ready status toggle tracking."
-      fi
-
-      last_kubelet_ready_state="$status"
-    fi
-
-    sleep $SLEEP_SECONDS
-  done
-}
-
-SLEEP_SECONDS=10
-echo "Start health monitoring for kubelet"
-kubelet_monitoring
-`
-
 	pauseContainerImageRepo = "foo.io"
 	pauseContainerImageTag  = "v1.2.3"
 	hyperkubeImageRepo      = "hyperkube.io"
@@ -382,12 +221,8 @@ volumeStatsAggPeriod: 1m0s
 	return out
 }
 
-func kubeletUnit(cliFlags []string, useGardenerNodeAgentEnabled bool) extensionsv1alpha1.Unit {
+func kubeletUnit(cliFlags []string) extensionsv1alpha1.Unit {
 	var kubeletStartPre string
-	if !useGardenerNodeAgentEnabled {
-		kubeletStartPre = `
-ExecStartPre=` + PathScriptCopyKubernetesBinary + ` kubelet`
-	}
 
 	unit := extensionsv1alpha1.Unit{
 		Name:    "kubelet.service",
@@ -409,14 +244,12 @@ ExecStart=/opt/bin/kubelet \
 		FilePaths: []string{"/var/lib/kubelet/ca.crt", "/var/lib/kubelet/config/kubelet"},
 	}
 
-	if useGardenerNodeAgentEnabled {
-		unit.FilePaths = append(unit.FilePaths, "/opt/bin/kubelet")
-	}
+	unit.FilePaths = append(unit.FilePaths, "/opt/bin/kubelet")
 
 	return unit
 }
 
-func kubeletFiles(ctx components.Context, kubeletConfig, kubeletCABundleBase64 string, useGardenerNodeAgentEnabled bool) []extensionsv1alpha1.File {
+func kubeletFiles(ctx components.Context, kubeletConfig, kubeletCABundleBase64 string) []extensionsv1alpha1.File {
 	files := []extensionsv1alpha1.File{
 		{
 			Path:        "/var/lib/kubelet/ca.crt",
@@ -440,55 +273,16 @@ func kubeletFiles(ctx components.Context, kubeletConfig, kubeletCABundleBase64 s
 		},
 	}
 
-	if useGardenerNodeAgentEnabled {
-		files = append(files, extensionsv1alpha1.File{
-			Path:        "/opt/bin/kubelet",
-			Permissions: ptr.To(int32(0755)),
-			Content: extensionsv1alpha1.FileContent{
-				ImageRef: &extensionsv1alpha1.FileContentImageRef{
-					Image:           ctx.Images["hyperkube"].String(),
-					FilePathInImage: "/kubelet",
-				},
-			},
-		})
-	}
-
-	return files
-}
-
-func kubeletMonitorUnit() extensionsv1alpha1.Unit {
-	unit := extensionsv1alpha1.Unit{
-		Name:    "kubelet-monitor.service",
-		Command: ptr.To(extensionsv1alpha1.CommandStart),
-		Enable:  ptr.To(true),
-		Content: ptr.To(`[Unit]
-Description=Kubelet-monitor daemon
-After=kubelet.service
-[Install]
-WantedBy=multi-user.target
-[Service]
-Restart=always
-EnvironmentFile=/etc/environment
-ExecStartPre=` + PathScriptCopyKubernetesBinary + ` kubectl
-ExecStart=/opt/bin/health-monitor-kubelet`),
-	}
-
-	return unit
-}
-
-func kubeletMonitorFiles() []extensionsv1alpha1.File {
-	files := []extensionsv1alpha1.File{
-		{
-			Path:        "/opt/bin/health-monitor-kubelet",
-			Permissions: ptr.To(int32(0755)),
-			Content: extensionsv1alpha1.FileContent{
-				Inline: &extensionsv1alpha1.FileContentInline{
-					Encoding: "b64",
-					Data:     utils.EncodeBase64([]byte(healthMonitorScript)),
-				},
+	files = append(files, extensionsv1alpha1.File{
+		Path:        "/opt/bin/kubelet",
+		Permissions: ptr.To(int32(0755)),
+		Content: extensionsv1alpha1.FileContent{
+			ImageRef: &extensionsv1alpha1.FileContentImageRef{
+				Image:           ctx.Images["hyperkube"].String(),
+				FilePathInImage: "/kubelet",
 			},
 		},
-	}
+	})
 
 	return files
 }

--- a/pkg/component/extensions/operatingsystemconfig/original/components/valitail/config_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/valitail/config_test.go
@@ -15,18 +15,14 @@
 package valitail
 
 import (
-	"fmt"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"k8s.io/utils/ptr"
 
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/original/components"
-	"github.com/gardener/gardener/pkg/features"
 	"github.com/gardener/gardener/pkg/utils"
 	"github.com/gardener/gardener/pkg/utils/imagevector"
-	"github.com/gardener/gardener/pkg/utils/test"
 )
 
 var _ = Describe("Valitail", func() {
@@ -46,45 +42,27 @@ var _ = Describe("Valitail", func() {
 			valiIngress = "ingress.vali.testClusterDomain"
 		)
 
-		testConfig := func(useGardenerNodeAgentEnabled bool) {
-			Context(fmt.Sprintf("UseGardenerNodeAgent: %v", useGardenerNodeAgentEnabled), func() {
-				It("should return the expected units and files when shoot logging is enabled", func() {
-					defer test.WithFeatureGate(features.DefaultFeatureGate, features.UseGardenerNodeAgent, useGardenerNodeAgentEnabled)()
-					ctx := components.Context{
-						CABundle:      &cABundle,
-						ClusterDomain: clusterDomain,
-						Images: map[string]*imagevector.Image{
-							"valitail": valitailImage,
-						},
-						ValiIngress:     valiIngress,
-						ValitailEnabled: true,
-						APIServerURL:    apiServerURL,
-					}
+		testConfig := func() {
+			It("should return the expected units and files when shoot logging is enabled", func() {
+				ctx := components.Context{
+					CABundle:      &cABundle,
+					ClusterDomain: clusterDomain,
+					Images: map[string]*imagevector.Image{
+						"valitail": valitailImage,
+					},
+					ValiIngress:     valiIngress,
+					ValitailEnabled: true,
+					APIServerURL:    apiServerURL,
+				}
 
-					units, files, err := New().Config(ctx)
-					Expect(err).NotTo(HaveOccurred())
+				units, files, err := New().Config(ctx)
+				Expect(err).NotTo(HaveOccurred())
 
-					var (
-						afterUnit              = "gardener-node-agent.service"
-						valitailDaemonStartPre string
-					)
-
-					if !useGardenerNodeAgentEnabled {
-						afterUnit = "cloud-config-downloader.service"
-						valitailDaemonStartPre = `
-ExecStartPre=/usr/bin/docker run --rm -v /opt/bin:/opt/bin:rw --entrypoint /bin/sh ` + valitailRepository + ":" + valitailImageTag + " -c " + "\"cp /usr/bin/valitail /opt/bin\""
-					}
-
-					unitContent := `[Unit]
+				unitContent := `[Unit]
 Description=valitail daemon
 Documentation=https://github.com/credativ/plutono`
 
-					if !useGardenerNodeAgentEnabled {
-						unitContent += `
-After=valitail-fetch-token.service`
-					}
-
-					unitContent += `
+				unitContent += `
 [Install]
 WantedBy=multi-user.target
 [Service]
@@ -99,41 +77,23 @@ MemorySwapMax=0
 Restart=always
 RestartSec=5
 EnvironmentFile=/etc/environment
-ExecStartPre=/bin/sh -c "systemctl set-environment HOSTNAME=$(hostname | tr [:upper:] [:lower:])"` + valitailDaemonStartPre + `
+ExecStartPre=/bin/sh -c "systemctl set-environment HOSTNAME=$(hostname | tr [:upper:] [:lower:])"
 ExecStart=/opt/bin/valitail -config.file=` + PathConfig
 
-					valitailDaemonUnit := extensionsv1alpha1.Unit{
-						Name:    UnitName,
-						Command: ptr.To(extensionsv1alpha1.CommandStart),
-						Enable:  ptr.To(true),
-						Content: ptr.To(unitContent),
-					}
+				valitailDaemonUnit := extensionsv1alpha1.Unit{
+					Name:    UnitName,
+					Command: ptr.To(extensionsv1alpha1.CommandStart),
+					Enable:  ptr.To(true),
+					Content: ptr.To(unitContent),
+				}
 
-					valitailTokenFetchUnit := extensionsv1alpha1.Unit{
-						Name:    "valitail-fetch-token.service",
-						Command: ptr.To(extensionsv1alpha1.CommandStart),
-						Enable:  ptr.To(true),
-						Content: ptr.To(`[Unit]
-Description=valitail token fetcher
-After=` + afterUnit + `
-[Install]
-WantedBy=multi-user.target
-[Service]
-Restart=always
-RestartSec=300
-RuntimeMaxSec=120
-EnvironmentFile=/etc/environment
-ExecStart=/var/lib/valitail/scripts/fetch-token.sh`),
-						FilePaths: []string{"/var/lib/valitail/scripts/fetch-token.sh"},
-					}
-
-					valitailConfigFile := extensionsv1alpha1.File{
-						Path:        "/var/lib/valitail/config/config",
-						Permissions: ptr.To(int32(0644)),
-						Content: extensionsv1alpha1.FileContent{
-							Inline: &extensionsv1alpha1.FileContentInline{
-								Encoding: "b64",
-								Data: utils.EncodeBase64([]byte(`server:
+				valitailConfigFile := extensionsv1alpha1.File{
+					Path:        "/var/lib/valitail/config/config",
+					Permissions: ptr.To(int32(0644)),
+					Content: extensionsv1alpha1.FileContent{
+						Inline: &extensionsv1alpha1.FileContentInline{
+							Encoding: "b64",
+							Data: utils.EncodeBase64([]byte(`server:
   disable: true
   log_level: info
   http_listen_port: 3001
@@ -269,194 +229,83 @@ scrape_configs:
     replacement: 'shoot_system'
     target_label: origin
 `)),
-							},
 						},
-					}
+					},
+				}
 
-					valitailBinaryFile := extensionsv1alpha1.File{
-						Path:        "/opt/bin/valitail",
-						Permissions: ptr.To(int32(0755)),
-						Content: extensionsv1alpha1.FileContent{
-							ImageRef: &extensionsv1alpha1.FileContentImageRef{
-								Image:           ctx.Images["valitail"].String(),
-								FilePathInImage: "/usr/bin/valitail",
-							},
+				valitailBinaryFile := extensionsv1alpha1.File{
+					Path:        "/opt/bin/valitail",
+					Permissions: ptr.To(int32(0755)),
+					Content: extensionsv1alpha1.FileContent{
+						ImageRef: &extensionsv1alpha1.FileContentImageRef{
+							Image:           ctx.Images["valitail"].String(),
+							FilePathInImage: "/usr/bin/valitail",
 						},
-					}
+					},
+				}
 
-					valitailFetchTokenScriptFile := extensionsv1alpha1.File{
-						Path:        "/var/lib/valitail/scripts/fetch-token.sh",
-						Permissions: ptr.To(int32(0744)),
-						Content: extensionsv1alpha1.FileContent{
-							Inline: &extensionsv1alpha1.FileContentInline{
-								Encoding: "b64",
-								Data: utils.EncodeBase64([]byte(`#!/bin/bash
-
-set -o errexit
-set -o nounset
-set -o pipefail
-
-{
-if ! SECRET="$(wget \
-  -qO- \
-  --header         "Accept: application/yaml" \
-  --header         "Authorization: Bearer $(cat "/var/lib/cloud-config-downloader/credentials/token")" \
-  --ca-certificate "/var/lib/cloud-config-downloader/credentials/ca.crt" \
-  "$(cat "/var/lib/cloud-config-downloader/credentials/server")/api/v1/namespaces/kube-system/secrets/gardener-valitail")"; then
-
-  echo "Could not retrieve the valitail token secret"
-  exit 1
-fi
-
-echo "$SECRET" | sed -rn "s/  token: (.*)/\1/p" | base64 -d > "/var/lib/valitail/auth-token"
-
-exit $?
-}
-`)),
-							},
+				caBundleFile := extensionsv1alpha1.File{
+					Path:        "/var/lib/valitail/ca.crt",
+					Permissions: ptr.To(int32(0644)),
+					Content: extensionsv1alpha1.FileContent{
+						Inline: &extensionsv1alpha1.FileContentInline{
+							Encoding: "b64",
+							Data:     utils.EncodeBase64([]byte(cABundle)),
 						},
-					}
+					},
+				}
 
-					caBundleFile := extensionsv1alpha1.File{
-						Path:        "/var/lib/valitail/ca.crt",
-						Permissions: ptr.To(int32(0644)),
-						Content: extensionsv1alpha1.FileContent{
-							Inline: &extensionsv1alpha1.FileContentInline{
-								Encoding: "b64",
-								Data:     utils.EncodeBase64([]byte(cABundle)),
-							},
-						},
-					}
+				expectedFiles := []extensionsv1alpha1.File{valitailConfigFile, caBundleFile}
 
-					expectedFiles := []extensionsv1alpha1.File{valitailConfigFile, caBundleFile}
-					if !useGardenerNodeAgentEnabled {
-						expectedFiles = append(expectedFiles, valitailFetchTokenScriptFile)
-						valitailTokenFetchUnit.FilePaths = []string{"/var/lib/valitail/scripts/fetch-token.sh"}
-					}
+				valitailDaemonUnit.FilePaths = []string{
+					"/var/lib/valitail/config/config",
+					"/var/lib/valitail/ca.crt",
+				}
 
-					valitailDaemonUnit.FilePaths = []string{
-						"/var/lib/valitail/config/config",
-						"/var/lib/valitail/ca.crt",
-					}
+				expectedFiles = append(expectedFiles, valitailBinaryFile)
+				valitailDaemonUnit.FilePaths = append(valitailDaemonUnit.FilePaths, "/opt/bin/valitail")
 
-					if useGardenerNodeAgentEnabled {
-						expectedFiles = append(expectedFiles, valitailBinaryFile)
-						valitailDaemonUnit.FilePaths = append(valitailDaemonUnit.FilePaths, "/opt/bin/valitail")
-					}
+				expectedUnits := []extensionsv1alpha1.Unit{valitailDaemonUnit}
 
-					expectedUnits := []extensionsv1alpha1.Unit{valitailDaemonUnit}
-					if !useGardenerNodeAgentEnabled {
-						expectedUnits = append(expectedUnits, valitailTokenFetchUnit)
-					}
+				Expect(units).To(ConsistOf(expectedUnits))
+				Expect(files).To(ConsistOf(expectedFiles))
+			})
 
-					Expect(units).To(ConsistOf(expectedUnits))
-					Expect(files).To(ConsistOf(expectedFiles))
-				})
+			It("should return the expected units and files when shoot logging is not enabled", func() {
+				ctx := components.Context{
+					CABundle:      &cABundle,
+					ClusterDomain: clusterDomain,
+					Images: map[string]*imagevector.Image{
+						"valitail": valitailImage,
+					},
+					ValiIngress:     valiIngress,
+					ValitailEnabled: false,
+				}
 
-				It("should return the expected units and files when shoot logging is not enabled", func() {
-					defer test.WithFeatureGate(features.DefaultFeatureGate, features.UseGardenerNodeAgent, useGardenerNodeAgentEnabled)()
-					ctx := components.Context{
-						CABundle:      &cABundle,
-						ClusterDomain: clusterDomain,
-						Images: map[string]*imagevector.Image{
-							"valitail": valitailImage,
-						},
-						ValiIngress:     valiIngress,
-						ValitailEnabled: false,
-					}
+				units, files, err := New().Config(ctx)
+				Expect(err).NotTo(HaveOccurred())
 
-					units, files, err := New().Config(ctx)
-					Expect(err).NotTo(HaveOccurred())
+				Expect(units).To(BeEmpty())
+				Expect(files).To(BeEmpty())
+			})
 
-					if useGardenerNodeAgentEnabled {
-						Expect(units).To(BeEmpty())
-						Expect(files).To(BeEmpty())
-						return
-					}
+			It("should return error when vali ingress is not specified", func() {
+				ctx := components.Context{
+					CABundle:      &cABundle,
+					ClusterDomain: clusterDomain,
+					Images: map[string]*imagevector.Image{
+						"valitail": valitailImage,
+					},
+					ValitailEnabled: true,
+					ValiIngress:     "",
+				}
 
-					afterUnit := "cloud-config-downloader.service"
-					if useGardenerNodeAgentEnabled {
-						afterUnit = "gardener-node-agent.service"
-					}
-
-					unitContent := `[Unit]
-Description=valitail daemon
-Documentation=https://github.com/credativ/plutono`
-
-					if !useGardenerNodeAgentEnabled {
-						unitContent += `
-After=valitail-fetch-token.service`
-					}
-
-					unitContent += `
-[Install]
-WantedBy=multi-user.target
-[Service]
-CPUAccounting=yes
-MemoryAccounting=yes
-CPUQuota=3%
-CPUQuotaPeriodSec=1000ms
-MemoryMin=29M
-MemoryHigh=400M
-MemoryMax=800M
-MemorySwapMax=0
-Restart=always
-RestartSec=5
-EnvironmentFile=/etc/environment
-ExecStartPre=/bin/sh -c "systemctl set-environment HOSTNAME=$(hostname | tr [:upper:] [:lower:])"
-ExecStartPre=/bin/systemctl disable valitail.service
-ExecStart=/bin/sh -c "echo service valitail.service is removed!; while true; do sleep 86400; done"`
-
-					Expect(units).To(ConsistOf([]extensionsv1alpha1.Unit{
-						{
-							Name:    "valitail.service",
-							Command: ptr.To(extensionsv1alpha1.CommandStart),
-							Enable:  ptr.To(true),
-							Content: ptr.To(unitContent),
-						},
-						{
-							Name:    "valitail-fetch-token.service",
-							Command: ptr.To(extensionsv1alpha1.CommandStart),
-							Enable:  ptr.To(true),
-							Content: ptr.To(`[Unit]
-Description=valitail token fetcher
-After=` + afterUnit + `
-[Install]
-WantedBy=multi-user.target
-[Service]
-Restart=always
-RestartSec=300
-RuntimeMaxSec=120
-EnvironmentFile=/etc/environment
-ExecStartPre=/bin/systemctl disable valitail-fetch-token.service
-ExecStart=/bin/sh -c "rm -f /var/lib/valitail/auth-token; echo service valitail-fetch-token.service is removed!; while true; do sleep 86400; done"`),
-						},
-					}))
-					Expect(files).To(BeNil())
-				})
-
-				It("should return error when vali ingress is not specified", func() {
-					defer test.WithFeatureGate(features.DefaultFeatureGate, features.UseGardenerNodeAgent, useGardenerNodeAgentEnabled)()
-					ctx := components.Context{
-						CABundle:      &cABundle,
-						ClusterDomain: clusterDomain,
-						Images: map[string]*imagevector.Image{
-							"valitail": valitailImage,
-						},
-						ValitailEnabled: true,
-						ValiIngress:     "",
-					}
-
-					units, files, err := New().Config(ctx)
-					Expect(err).To(MatchError(ContainSubstring("vali ingress url is missing")))
-					Expect(units).To(BeNil())
-					Expect(files).To(BeNil())
-				})
+				units, files, err := New().Config(ctx)
+				Expect(err).To(MatchError(ContainSubstring("vali ingress url is missing")))
+				Expect(units).To(BeNil())
+				Expect(files).To(BeNil())
 			})
 		}
-		// Testing with feature gate UseGardenerNodeAgent: false
-		testConfig(false)
-		// Testing with feature gate UseGardenerNodeAgent: true
-		testConfig(true)
+		testConfig()
 	})
 })

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -87,6 +87,7 @@ const (
 	// owner: @rfranzke @oliver-goetz
 	// alpha: v1.82.0
 	// beta: v1.89.0
+	// GA: v1.90.0
 	UseGardenerNodeAgent featuregate.Feature = "UseGardenerNodeAgent"
 )
 
@@ -124,7 +125,7 @@ var AllFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	ShootForceDeletion:                 {Default: false, PreRelease: featuregate.Alpha},
 	MachineControllerManagerDeployment: {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
 	APIServerFastRollout:               {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
-	UseGardenerNodeAgent:               {Default: true, PreRelease: featuregate.Beta},
+	UseGardenerNodeAgent:               {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
 }
 
 // GetFeatures returns a feature gate map with the respective specifications. Non-existing feature gates are ignored.

--- a/pkg/operation/botanist/operatingsystemconfig_test.go
+++ b/pkg/operation/botanist/operatingsystemconfig_test.go
@@ -314,8 +314,11 @@ var _ = Describe("operatingsystemconfig", func() {
 
 				kubernetesInterfaceShoot.EXPECT().Client().Return(kubernetesClientShoot).AnyTimes()
 				kubernetesInterfaceSeed.EXPECT().Client().Return(kubernetesClientSeed).AnyTimes()
+			})
 
-				DeferCleanup(test.WithFeatureGate(features.DefaultFeatureGate, features.UseGardenerNodeAgent, false))
+			JustBeforeEach(func() {
+				worker1Key = operatingsystemconfig.LegacyKey(worker1Name, semver.MustParse(kubernetesVersion), nil)
+				worker2Key = operatingsystemconfig.LegacyKey(worker2Name, semver.MustParse(worker2KubernetesVersion), nil)
 			})
 
 			type tableTestParams struct {

--- a/pkg/operation/botanist/worker_test.go
+++ b/pkg/operation/botanist/worker_test.go
@@ -563,14 +563,6 @@ var _ = Describe("Worker", func() {
 			})
 		}
 
-		When("UseGardenerNodeAgent feature gate is disabled", func() {
-			BeforeEach(func() {
-				DeferCleanup(test.WithFeatureGate(features.DefaultFeatureGate, features.UseGardenerNodeAgent, false))
-			})
-
-			tests(name, cloudConfigSecretListOptions, "cloud-config", false)
-		})
-
 		When("UseGardenerNodeAgent feature gate is enabled", func() {
 			BeforeEach(func() {
 				DeferCleanup(test.WithFeatureGate(features.DefaultFeatureGate, features.UseGardenerNodeAgent, true))


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area open-source
/kind enhancement

**What this PR does / why we need it**:
Promote `UseGardenerNodeAgent` feature gate to GA and lock it to its default value (`true`).

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/8023

**Special notes for your reviewer**:
/cc @oliver-goetz 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
The `UseGardenerNodeAgent` feature gate has been promoted to GA. It was already enabled by default and can now no longer be turned off. The feature gate will be removed in a future release.
```
