### PR TITLE
Fix leak of `extension-controlplane-shoot-webhooks` ManagedResource

### DIFF
--- a/extensions/pkg/controller/controlplane/genericactuator/actuator.go
+++ b/extensions/pkg/controller/controlplane/genericactuator/actuator.go
@@ -249,7 +249,7 @@ func (a *actuator) reconcileControlPlane(
 			return false, fmt.Errorf("expected *webhook.Configs, got %T", value)
 		}
 
-		if err := extensionsshootwebhook.ReconcileWebhookConfig(ctx, a.client, cp.Namespace, a.webhookServerNamespace, a.providerName, ShootWebhooksResourceName, *webhookConfig, cluster); err != nil {
+		if err := extensionsshootwebhook.ReconcileWebhookConfig(ctx, a.client, cp.Namespace, a.webhookServerNamespace, a.providerName, ShootWebhooksResourceName, *webhookConfig, cluster, true); err != nil {
 			return false, fmt.Errorf("could not reconcile shoot webhooks: %w", err)
 		}
 	}

--- a/extensions/pkg/webhook/shoot/webhook.go
+++ b/extensions/pkg/webhook/shoot/webhook.go
@@ -47,7 +47,7 @@ func ReconcileWebhookConfig(
 	managedResourceName string,
 	shootWebhookConfigs webhook.Configs,
 	cluster *controller.Cluster,
-	createOnUpdate bool,
+	createIfNotExists bool,
 ) error {
 	if cluster.Shoot == nil {
 		return fmt.Errorf("no shoot found in cluster resource")
@@ -70,7 +70,7 @@ func ReconcileWebhookConfig(
 		return err
 	}
 
-	if createOnUpdate {
+	if createIfNotExists {
 		err := managedresources.Create(ctx, c, shootNamespace, managedResourceName, nil, false, "", data, nil, nil, nil)
 		if err != nil {
 			return fmt.Errorf("could not create or update managed resource '%s/%s' containing shoot webhooks: %w", shootNamespace, managedResourceName, err)

--- a/extensions/pkg/webhook/shoot/webhook.go
+++ b/extensions/pkg/webhook/shoot/webhook.go
@@ -16,7 +16,6 @@ package shoot
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
@@ -120,15 +119,8 @@ func ReconcileWebhooksForAllNamespaces(
 				return err
 			}
 
-			if err := ReconcileWebhookConfig(ctx, c, namespaceName, extensionNamespace, extensionName, managedResourceName, *shootWebhookConfigs.DeepCopy(), cluster, false); err != nil {
-				statusErr := &apierrors.StatusError{}
-				if !errors.As(err, &statusErr) {
-					return err
-				}
-				// Ignore not found errors since the managed resource can be deleted in parallel during shoot deletion.
-				if apierrors.IsNotFound(err) {
-					return nil
-				}
+			// Ignore not found errors since the managed resource can be deleted in parallel during shoot deletion.
+			if err := ReconcileWebhookConfig(ctx, c, namespaceName, extensionNamespace, extensionName, managedResourceName, *shootWebhookConfigs.DeepCopy(), cluster, false); client.IgnoreNotFound(err) != nil {
 				return err
 			}
 			return nil

--- a/extensions/pkg/webhook/shoot/webhook_test.go
+++ b/extensions/pkg/webhook/shoot/webhook_test.go
@@ -91,7 +91,7 @@ webhooks:
 		})
 
 		It("should reconcile the shoot webhook config", func() {
-			Expect(ReconcileWebhookConfig(ctx, fakeClient, namespace, extensionNamespace, extensionName, managedResourceName, shootWebhookConfigs, cluster)).To(Succeed())
+			Expect(ReconcileWebhookConfig(ctx, fakeClient, namespace, extensionNamespace, extensionName, managedResourceName, shootWebhookConfigs, cluster, true)).To(Succeed())
 			expectWebhookConfigReconciliation(ctx, fakeClient, namespace, managedResourceName, shootWebhookConfigRaw)
 		})
 	})

--- a/pkg/utils/managedresources/builder/managedresources.go
+++ b/pkg/utils/managedresources/builder/managedresources.go
@@ -31,9 +31,9 @@ import (
 
 // ManagedResource is a structure managing a ManagedResource.
 type ManagedResource struct {
-	client         client.Client
-	createOnUpdate bool
-	resource       *resourcesv1alpha1.ManagedResource
+	client            client.Client
+	createIfNotExists bool
+	resource          *resourcesv1alpha1.ManagedResource
 
 	labels, annotations map[string]string
 }
@@ -41,15 +41,15 @@ type ManagedResource struct {
 // NewManagedResource creates a new builder for a ManagedResource.
 func NewManagedResource(client client.Client) *ManagedResource {
 	return &ManagedResource{
-		client:         client,
-		createOnUpdate: true,
-		resource:       &resourcesv1alpha1.ManagedResource{},
+		client:            client,
+		createIfNotExists: true,
+		resource:          &resourcesv1alpha1.ManagedResource{},
 	}
 }
 
-// CreateOnUpdate determines if the managed resources should be created if it does not exist.
-func (m *ManagedResource) CreateOnUpdate(create bool) *ManagedResource {
-	m.createOnUpdate = create
+// CreateIfNotExists determines if the managed resources should be created if it does not exist.
+func (m *ManagedResource) CreateIfNotExists(createIfNotExists bool) *ManagedResource {
+	m.createIfNotExists = createIfNotExists
 	return m
 }
 
@@ -146,7 +146,7 @@ func (m *ManagedResource) Reconcile(ctx context.Context) error {
 	}
 
 	if err := m.client.Get(ctx, client.ObjectKeyFromObject(resource), resource); err != nil {
-		if apierrors.IsNotFound(err) && m.createOnUpdate {
+		if apierrors.IsNotFound(err) && m.createIfNotExists {
 			// if the mr is not found just create it
 			mutateFn(resource)
 

--- a/pkg/utils/managedresources/builder/resourcemanager_test.go
+++ b/pkg/utils/managedresources/builder/resourcemanager_test.go
@@ -94,7 +94,7 @@ var _ = Describe("Resource Manager", func() {
 				WithKeyValues(data).
 				WithLabels(labels).
 				WithAnnotations(annotations).
-				CreateOnUpdate(false).
+				CreateIfNotExists(false).
 				Unique()
 
 			secretBuilder.AddLabels(map[string]string{"one": "two"})
@@ -248,7 +248,7 @@ var _ = Describe("Resource Manager", func() {
 			secret := NewSecret(fakeClient).
 				WithNamespacedName(namespace, name).
 				WithLabels(labels).
-				CreateOnUpdate(false)
+				CreateIfNotExists(false)
 
 			Expect(secret.Reconcile(ctx)).To(BeNotFoundError())
 
@@ -470,7 +470,7 @@ var _ = Describe("Resource Manager", func() {
 					WithNamespacedName(namespace, name).
 					WithLabels(labels).
 					WithAnnotations(annotations).
-					CreateOnUpdate(false).
+					CreateIfNotExists(false).
 					Reconcile(ctx),
 			).To(Succeed())
 
@@ -504,7 +504,7 @@ var _ = Describe("Resource Manager", func() {
 					WithNamespacedName(namespace, name).
 					WithLabels(labels).
 					WithAnnotations(annotations).
-					CreateOnUpdate(false).
+					CreateIfNotExists(false).
 					Reconcile(ctx),
 			).To(BeNotFoundError())
 

--- a/pkg/utils/managedresources/builder/resourcemanager_test.go
+++ b/pkg/utils/managedresources/builder/resourcemanager_test.go
@@ -30,11 +30,12 @@ import (
 	"github.com/gardener/gardener/pkg/resourcemanager/controller/garbagecollector/references"
 	"github.com/gardener/gardener/pkg/utils"
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
+	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 )
 
 var _ = Describe("Resource Manager", func() {
 	var (
-		ctx        = context.TODO()
+		ctx        = context.Background()
 		fakeClient client.Client
 	)
 
@@ -93,6 +94,7 @@ var _ = Describe("Resource Manager", func() {
 				WithKeyValues(data).
 				WithLabels(labels).
 				WithAnnotations(annotations).
+				CreateOnUpdate(false).
 				Unique()
 
 			secretBuilder.AddLabels(map[string]string{"one": "two"})
@@ -200,6 +202,57 @@ var _ = Describe("Resource Manager", func() {
 				Type:      corev1.SecretTypeOpaque,
 				Immutable: ptr.To(true),
 			}))
+		})
+
+		It("should update the secret if it exists", func() {
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					Namespace: namespace,
+				},
+				Data: map[string][]byte{
+					"foo": []byte("bar"),
+				},
+			}
+			Expect(fakeClient.Create(ctx, secret)).To(Succeed())
+
+			Expect(
+				NewSecret(fakeClient).
+					WithNamespacedName(namespace, name).
+					WithKeyValues(map[string][]byte{
+						"bar": []byte("foo"),
+					}).
+					Reconcile(ctx),
+			).To(Succeed())
+
+			Expect(fakeClient.Get(ctx, kubernetesutils.Key(namespace, name), secret)).To(Succeed())
+
+			Expect(secret).To(Equal(&corev1.Secret{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1",
+					Kind:       "Secret",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            name,
+					Namespace:       namespace,
+					ResourceVersion: "2",
+				},
+				Type: corev1.SecretTypeOpaque,
+				Data: map[string][]byte{
+					"bar": []byte("foo"),
+				},
+			}))
+		})
+
+		It("should fail to update the secret if it doesn't exist", func() {
+			secret := NewSecret(fakeClient).
+				WithNamespacedName(namespace, name).
+				WithLabels(labels).
+				CreateOnUpdate(false)
+
+			Expect(secret.Reconcile(ctx)).To(BeNotFoundError())
+
+			Expect(fakeClient.Get(ctx, kubernetesutils.Key(namespace, name), &corev1.Secret{})).To(BeNotFoundError())
 		})
 	})
 
@@ -394,6 +447,68 @@ var _ = Describe("Resource Manager", func() {
 					ResourceVersion: "2",
 				},
 			}))
+		})
+
+		It("should update the managed resource if it exists", func() {
+			var (
+				existingLabels      = map[string]string{"existing": "label"}
+				existingAnnotations = map[string]string{"existing": "annotation"}
+			)
+
+			mr := &resourcesv1alpha1.ManagedResource{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        name,
+					Namespace:   namespace,
+					Labels:      existingLabels,
+					Annotations: existingAnnotations,
+				},
+			}
+			Expect(fakeClient.Create(ctx, mr)).To(Succeed())
+
+			Expect(
+				NewManagedResource(fakeClient).
+					WithNamespacedName(namespace, name).
+					WithLabels(labels).
+					WithAnnotations(annotations).
+					CreateOnUpdate(false).
+					Reconcile(ctx),
+			).To(Succeed())
+
+			Expect(fakeClient.Get(ctx, kubernetesutils.Key(namespace, name), mr)).To(Succeed())
+
+			Expect(mr).To(Equal(&resourcesv1alpha1.ManagedResource{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "resources.gardener.cloud/v1alpha1",
+					Kind:       "ManagedResource",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            name,
+					Namespace:       namespace,
+					Labels:          utils.MergeStringMaps(existingLabels, labels),
+					Annotations:     utils.MergeStringMaps(existingAnnotations, annotations),
+					ResourceVersion: "2",
+				},
+			}))
+		})
+
+		It("should fail updating the managed resource if it doesn't exists", func() {
+			mr := &resourcesv1alpha1.ManagedResource{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					Namespace: namespace,
+				},
+			}
+
+			Expect(
+				NewManagedResource(fakeClient).
+					WithNamespacedName(namespace, name).
+					WithLabels(labels).
+					WithAnnotations(annotations).
+					CreateOnUpdate(false).
+					Reconcile(ctx),
+			).To(BeNotFoundError())
+
+			Expect(fakeClient.Get(ctx, kubernetesutils.Key(namespace, name), mr)).To(BeNotFoundError())
 		})
 	})
 })

--- a/pkg/utils/managedresources/builder/secrets.go
+++ b/pkg/utils/managedresources/builder/secrets.go
@@ -32,8 +32,8 @@ import (
 
 // Secret is a structure for managing a secret.
 type Secret struct {
-	client         client.Client
-	createOnUpdate bool
+	client            client.Client
+	createIfNotExists bool
 
 	keyValues map[string]string
 	secret    *corev1.Secret
@@ -42,17 +42,17 @@ type Secret struct {
 // NewSecret creates a new builder for a secret.
 func NewSecret(client client.Client) *Secret {
 	return &Secret{
-		client:         client,
-		createOnUpdate: true,
-		keyValues:      make(map[string]string),
-		secret:         &corev1.Secret{},
+		client:            client,
+		createIfNotExists: true,
+		keyValues:         make(map[string]string),
+		secret:            &corev1.Secret{},
 	}
 }
 
-// CreateOnUpdate determines if the secret should be created if it does not exist.
+// CreateIfNotExists determines if the secret should be created if it does not exist.
 // Immutable secrets are always created, regardless of this configuration.
-func (s *Secret) CreateOnUpdate(create bool) *Secret {
-	s.createOnUpdate = create
+func (s *Secret) CreateIfNotExists(createIfNotExists bool) *Secret {
+	s.createIfNotExists = createIfNotExists
 	return s
 }
 
@@ -125,7 +125,7 @@ func (s *Secret) Reconcile(ctx context.Context) error {
 		return nil
 	}
 
-	if s.createOnUpdate || ptr.Deref(s.secret.Immutable, false) {
+	if s.createIfNotExists || ptr.Deref(s.secret.Immutable, false) {
 		_, err := controllerutil.CreateOrUpdate(ctx, s.client, secret, mutate)
 		return err
 	}

--- a/pkg/utils/managedresources/managedresources.go
+++ b/pkg/utils/managedresources/managedresources.go
@@ -137,6 +137,27 @@ func CreateFromUnstructured(
 	return Create(ctx, client, namespace, name, nil, secretNameWithPrefix, class, dataMap, &keepObjects, injectedLabels, ptr.To(false))
 }
 
+// Update updates a managed resource and its secret with the given name, class, key, and data in the given namespace.
+func Update(
+	ctx context.Context,
+	client client.Client,
+	namespace, name string,
+	labels map[string]string,
+	secretNameWithPrefix bool,
+	class string,
+	data map[string][]byte,
+	keepObjects *bool,
+	injectedLabels map[string]string,
+	forceOverwriteAnnotations *bool,
+) error {
+	var (
+		secretName, secret = NewSecret(client, namespace, name, data, secretNameWithPrefix)
+		managedResource    = New(client, namespace, name, class, keepObjects, labels, injectedLabels, forceOverwriteAnnotations).WithSecretRef(secretName).CreateOnUpdate(false)
+	)
+
+	return deployManagedResource(ctx, secret, managedResource)
+}
+
 // Create creates a managed resource and its secret with the given name, class, key, and data in the given namespace.
 func Create(
 	ctx context.Context,

--- a/pkg/utils/managedresources/managedresources.go
+++ b/pkg/utils/managedresources/managedresources.go
@@ -152,7 +152,7 @@ func Update(
 ) error {
 	var (
 		secretName, secret = NewSecret(client, namespace, name, data, secretNameWithPrefix)
-		managedResource    = New(client, namespace, name, class, keepObjects, labels, injectedLabels, forceOverwriteAnnotations).WithSecretRef(secretName).CreateOnUpdate(false)
+		managedResource    = New(client, namespace, name, class, keepObjects, labels, injectedLabels, forceOverwriteAnnotations).WithSecretRef(secretName).CreateIfNotExists(false)
 	)
 
 	return deployManagedResource(ctx, secret, managedResource)

--- a/test/integration/extensions/webhook/certificates/certificates_test.go
+++ b/test/integration/extensions/webhook/certificates/certificates_test.go
@@ -77,10 +77,11 @@ var _ = Describe("Certificates tests", func() {
 		codec     = newCodec(kubernetes.SeedScheme, kubernetes.SeedCodec, kubernetes.SeedSerializer)
 		fakeClock *testclock.FakeClock
 
-		extensionName      string
-		extensionNamespace *corev1.Namespace
-		shootNamespace     *corev1.Namespace
-		cluster            *extensionsv1alpha1.Cluster
+		extensionName          string
+		extensionNamespace     *corev1.Namespace
+		shootNamespaceTemplate *corev1.Namespace
+		shootNamespace         *corev1.Namespace
+		cluster                *extensionsv1alpha1.Cluster
 
 		seedWebhook              admissionregistrationv1.MutatingWebhook
 		shootMutatingWebhook     admissionregistrationv1.MutatingWebhook
@@ -113,7 +114,7 @@ var _ = Describe("Certificates tests", func() {
 			Expect(testClient.Delete(ctx, extensionNamespace)).To(Or(Succeed(), BeNotFoundError()))
 		})
 
-		shootNamespace = &corev1.Namespace{
+		shootNamespaceTemplate = &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
 				GenerateName: "shoot--foo--",
 				Labels: utils.MergeStringMaps(shootNamespaceSelector, map[string]string{
@@ -121,6 +122,7 @@ var _ = Describe("Certificates tests", func() {
 				}),
 			},
 		}
+		shootNamespace = shootNamespaceTemplate.DeepCopy()
 		Expect(testClient.Create(ctx, shootNamespace)).To(Succeed())
 		log.Info("Created shoot Namespace for test", "namespaceName", shootNamespace.Name)
 
@@ -286,10 +288,15 @@ var _ = Describe("Certificates tests", func() {
 		})
 
 		Context("certificate rotation", func() {
+			var shootNamespace2 *corev1.Namespace
+
 			BeforeEach(func() {
+				shootNamespace2 = shootNamespaceTemplate.DeepCopy()
+				cluster2 := cluster.DeepCopy()
+
 				By("Prepare existing shoot webhook resources")
 				Expect(testClient.Create(ctx, cluster)).To(Succeed())
-				Expect(extensionsshootwebhook.ReconcileWebhookConfig(ctx, testClient, shootNamespace.Name, extensionNamespace.Name, extensionName, shootWebhookManagedResourceName, *shootWebhookConfig, &extensions.Cluster{Shoot: &gardencorev1beta1.Shoot{}})).To(Succeed())
+				Expect(extensionsshootwebhook.ReconcileWebhookConfig(ctx, testClient, shootNamespace.Name, extensionNamespace.Name, extensionName, shootWebhookManagedResourceName, *shootWebhookConfig, &extensions.Cluster{Shoot: &gardencorev1beta1.Shoot{}}, true)).To(Succeed())
 
 				DeferCleanup(func() {
 					Expect(testClient.Delete(ctx, cluster)).To(Or(Succeed(), BeNotFoundError()))
@@ -300,6 +307,18 @@ var _ = Describe("Certificates tests", func() {
 					&secretsutils.GenerateKey, secretsutils.FakeGenerateKey,
 					&secretsutils.Clock, fakeClock,
 				))
+
+				By("Prepare another shoot namespace that is incomplete", func() {
+					Expect(testClient.Create(ctx, shootNamespace2)).To(Succeed())
+
+					cluster2.Name = shootNamespace2.Name
+					Expect(testClient.Create(ctx, cluster2)).To(Succeed())
+
+					DeferCleanup(func() {
+						Expect(testClient.Delete(ctx, cluster2)).To(Or(Succeed(), BeNotFoundError()))
+						Expect(testClient.Delete(ctx, shootNamespace2)).To(Or(Succeed(), BeNotFoundError()))
+					})
+				})
 			})
 
 			It("should rotate the certificates and update the webhook configs", func() {
@@ -331,6 +350,10 @@ var _ = Describe("Certificates tests", func() {
 					g.Expect(getShootWebhookConfig(codec, shootWebhookConfig, shootNamespace.Name)).To(Succeed())
 					return shootWebhookConfig.MutatingWebhookConfig.Webhooks[0].ClientConfig.CABundle
 				}).Should(Not(BeEmpty()))
+
+				By("Verify managed resource in incomplete shoot namespace was not created", func() {
+					Expect(getShootWebhookConfig(codec, shootWebhookConfig, shootNamespace2.Name)).To(BeNotFoundError())
+				})
 
 				By("Read re-generated server certificate from disk")
 				Eventually(func(g Gomega) []byte {
@@ -478,7 +501,7 @@ var _ = Describe("Certificates tests", func() {
 			BeforeEach(func() {
 				By("Prepare existing shoot webhook resources")
 				Expect(testClient.Create(ctx, cluster)).To(Succeed())
-				Expect(extensionsshootwebhook.ReconcileWebhookConfig(ctx, testClient, shootNamespace.Name, extensionNamespace.Name, extensionName, shootWebhookManagedResourceName, *shootWebhookConfig, &extensions.Cluster{Shoot: &gardencorev1beta1.Shoot{}})).To(Succeed())
+				Expect(extensionsshootwebhook.ReconcileWebhookConfig(ctx, testClient, shootNamespace.Name, extensionNamespace.Name, extensionName, shootWebhookManagedResourceName, *shootWebhookConfig, &extensions.Cluster{Shoot: &gardencorev1beta1.Shoot{}}, true)).To(Succeed())
 
 				DeferCleanup(func() {
 					Expect(testClient.Delete(ctx, cluster)).To(Or(Succeed(), BeNotFoundError()))


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity
/area usability
/kind bug

**What this PR does / why we need it**:
This PR eliminates a race condition that led to a leaked managed resource `extension-controlplane-shoot-webhooks` during shoot deletion (see #8688 for more details).
Unlike before, the said `ManagedResource` is only updated when all shoot namespaces are reconciled. Creation won't happen anymore in this scope.

**Which issue(s) this PR fixes**:
Fixes #8688

**Special notes for your reviewer**:
/cc @Kostov6 @ialidzhikov

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix dependency
An issue was fixed that sometimes led to leaked `extension-controlplane-shoot-webhooks` which blocked the shoot deletion.
```
