### PR TITLE
Extend health checks of `gardener-resource-manager` for new `VerticalPodAutoscaler` resources

### DIFF
--- a/pkg/resourcemanager/client/scheme.go
+++ b/pkg/resourcemanager/client/scheme.go
@@ -25,6 +25,7 @@ import (
 	apiextensionsinstall "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/install"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	vpaautoscalingv1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
 	kubernetesscheme "k8s.io/client-go/kubernetes/scheme"
 	apiregistrationinstall "k8s.io/kube-aggregator/pkg/apis/apiregistration/install"
 
@@ -57,6 +58,7 @@ func init() {
 			monitoringv1alpha1.AddToScheme,
 			monitoringv1beta1.AddToScheme,
 			monitoringv1.AddToScheme,
+			vpaautoscalingv1.AddToScheme,
 		)
 	)
 

--- a/pkg/resourcemanager/controller/health/utils/health_checker.go
+++ b/pkg/resourcemanager/controller/health/utils/health_checker.go
@@ -26,6 +26,7 @@ import (
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime"
+	vpaautoscalingv1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
@@ -92,6 +93,8 @@ func CheckHealth(obj client.Object) (bool, error) {
 		return true, health.CheckPrometheus(o)
 	case *monitoringv1.Alertmanager:
 		return true, health.CheckAlertmanager(o)
+	case *vpaautoscalingv1.VerticalPodAutoscaler:
+		return true, health.CheckVerticalPodAutoscaler(o)
 	}
 
 	return false, nil

--- a/pkg/resourcemanager/controller/health/utils/health_checker_test.go
+++ b/pkg/resourcemanager/controller/health/utils/health_checker_test.go
@@ -24,6 +24,7 @@ import (
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	vpaautoscalingv1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -505,6 +506,25 @@ var _ = Describe("CheckHealth", func() {
 				},
 				Spec:   monitoringv1.AlertmanagerSpec{Replicas: ptr.To(int32(2))},
 				Status: monitoringv1.AlertmanagerStatus{AvailableReplicas: 1},
+			}
+		})
+
+		testSuite()
+	})
+
+	Context("VerticalPodAutoscaler", func() {
+		BeforeEach(func() {
+			healthy = &vpaautoscalingv1.VerticalPodAutoscaler{}
+			unhealthy = &vpaautoscalingv1.VerticalPodAutoscaler{
+				Status: vpaautoscalingv1.VerticalPodAutoscalerStatus{Conditions: []vpaautoscalingv1.VerticalPodAutoscalerCondition{{Type: vpaautoscalingv1.ConfigUnsupported, Status: corev1.ConditionTrue}}},
+			}
+			unhealthyWithSkipHealthCheckAnnotation = &vpaautoscalingv1.VerticalPodAutoscaler{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						resourcesv1alpha1.SkipHealthCheck: "true",
+					},
+				},
+				Status: vpaautoscalingv1.VerticalPodAutoscalerStatus{Conditions: []vpaautoscalingv1.VerticalPodAutoscalerCondition{{Type: vpaautoscalingv1.ConfigUnsupported, Status: corev1.ConditionTrue}}},
 			}
 		})
 

--- a/pkg/utils/kubernetes/health/vpa.go
+++ b/pkg/utils/kubernetes/health/vpa.go
@@ -1,0 +1,34 @@
+// Copyright 2024 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package health
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	vpaautoscalingv1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
+)
+
+// CheckVerticalPodAutoscaler checks whether the given VPA is healthy.
+func CheckVerticalPodAutoscaler(vpa *vpaautoscalingv1.VerticalPodAutoscaler) error {
+	for _, condition := range vpa.Status.Conditions {
+		if condition.Type == vpaautoscalingv1.ConfigUnsupported {
+			if err := checkConditionState(string(condition.Type), string(corev1.ConditionFalse), string(condition.Status), condition.Reason, condition.Message); err != nil {
+				return err
+			}
+			break
+		}
+	}
+
+	return nil
+}

--- a/pkg/utils/kubernetes/health/vpa_test.go
+++ b/pkg/utils/kubernetes/health/vpa_test.go
@@ -1,0 +1,41 @@
+// Copyright 2024 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package health_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/types"
+	corev1 "k8s.io/api/core/v1"
+	vpaautoscalingv1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
+
+	"github.com/gardener/gardener/pkg/utils/kubernetes/health"
+)
+
+var _ = Describe("VPA", func() {
+	DescribeTable("CheckVerticalPodAutoscaler",
+		func(vpa *vpaautoscalingv1.VerticalPodAutoscaler, matcher types.GomegaMatcher) {
+			err := health.CheckVerticalPodAutoscaler(vpa)
+			Expect(err).To(matcher)
+		},
+		Entry("healthy", &vpaautoscalingv1.VerticalPodAutoscaler{}, BeNil()),
+		Entry("condition False", &vpaautoscalingv1.VerticalPodAutoscaler{
+			Status: vpaautoscalingv1.VerticalPodAutoscalerStatus{Conditions: []vpaautoscalingv1.VerticalPodAutoscalerCondition{{Type: vpaautoscalingv1.ConfigUnsupported, Status: corev1.ConditionFalse}}},
+		}, BeNil()),
+		Entry("condition True", &vpaautoscalingv1.VerticalPodAutoscaler{
+			Status: vpaautoscalingv1.VerticalPodAutoscalerStatus{Conditions: []vpaautoscalingv1.VerticalPodAutoscalerCondition{{Type: vpaautoscalingv1.ConfigUnsupported, Status: corev1.ConditionTrue}}},
+		}, MatchError(ContainSubstring(`condition "ConfigUnsupported" has invalid status True (expected False)`))),
+	)
+})


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity
/kind enhancement

**What this PR does / why we need it**:
`gardener-resource-manager`'s health check controller now checks whether `VerticalPodAutoscaler`s report the `ConfigUnsupported` condition.
- If the condition is `True` then they are considered unhealthy.
- If the condition is `False` or not present then they are considered healthy.

**Which issue(s) this PR fixes**:
Follow-up of https://github.com/gardener/gardener/pull/9188

**Special notes for your reviewer**:
FYI @voelzmo 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
`gardener-resource-manager`'s health check controller now checks whether `VerticalPodAutoscaler`s report the `ConfigUnsupported` condition.
```
