### PR TITLE
Remove unnecessary spaces in license headers added via "hack/add-license-header.sh"

### DIFF
--- a/hack/add-license-header.sh
+++ b/hack/add-license-header.sh
@@ -23,7 +23,7 @@ echo "> Adding Apache License header to all go files where it is not present"
 
 temp_file=$(mktemp)
 trap "rm -f $temp_file" EXIT
-sed 's|^//||' hack/LICENSE_BOILERPLATE.txt > $temp_file
+sed 's|^// *||' hack/LICENSE_BOILERPLATE.txt > $temp_file
 
 addlicense \
   -f $temp_file \


### PR DESCRIPTION
**How to categorize this PR?**

/area compliance
/kind cleanup

**What this PR does / why we need it**:
If `hack/add-license-header.sh` adds a license to a *.go file, unnecessary spaces are added.
