### PR TITLE
Set correct labels to shoot prometheus vpa

### DIFF
--- a/pkg/component/monitoring/charts/seed-monitoring/charts/core/charts/prometheus/templates/prometheus-vpa.yaml
+++ b/pkg/component/monitoring/charts/seed-monitoring/charts/core/charts/prometheus/templates/prometheus-vpa.yaml
@@ -3,6 +3,9 @@ kind: VerticalPodAutoscaler
 metadata:
   name: prometheus-vpa
   namespace: {{ .Release.Namespace }}
+  labels:
+    app: prometheus
+    role: monitoring
 spec:
   targetRef:
     apiVersion: apps/v1


### PR DESCRIPTION
/area monitoring
/kind enhancement

This PR sets labels to shoot prometheu vpa, aligned with the statefulset.

```other operator
The `VerticalPodAutoscaler` object for the shoot Prometheus is now labeled with `app=prometheus,role=monitoring`, similar to the corresponding `StatefulSet`.
```
