### PR TITLE
Reduce resource requests of istio ingress gateway and adapt autoscaling accordingly.

### DIFF
--- a/pkg/component/istio/charts/istio/istio-ingress/templates/autoscale.yaml
+++ b/pkg/component/istio/charts/istio/istio-ingress/templates/autoscale.yaml
@@ -20,3 +20,22 @@ spec:
       target:
         averageUtilization: 80
         type: Utilization
+  - type: Resource
+    resource:
+      name: memory
+      target:
+        averageUtilization: 80
+        type: Utilization
+  behavior:
+    scaleDown:
+      stabilizationWindowSeconds: 1800
+      policies:
+      - type: Pods
+        value: 1
+        periodSeconds: 1800
+    scaleUp:
+      stabilizationWindowSeconds: 60
+      policies:
+      - type: Pods
+        value: 1
+        periodSeconds: 60

--- a/pkg/component/istio/charts/istio/istio-ingress/templates/deployment.yaml
+++ b/pkg/component/istio/charts/istio/istio-ingress/templates/deployment.yaml
@@ -77,8 +77,8 @@ spec:
             timeoutSeconds: 1
           resources:
             requests:
-              cpu: 1000m
-              memory: 2Gi
+              cpu: 250m
+              memory: 1Gi
             limits:
               memory: 8Gi
           env:

--- a/pkg/component/istio/test_charts/ingress_autoscaler.yaml
+++ b/pkg/component/istio/test_charts/ingress_autoscaler.yaml
@@ -21,3 +21,22 @@ spec:
       target:
         averageUtilization: 80
         type: Utilization
+  - type: Resource
+    resource:
+      name: memory
+      target:
+        averageUtilization: 80
+        type: Utilization
+  behavior:
+    scaleDown:
+      stabilizationWindowSeconds: 1800
+      policies:
+      - type: Pods
+        value: 1
+        periodSeconds: 1800
+    scaleUp:
+      stabilizationWindowSeconds: 60
+      policies:
+      - type: Pods
+        value: 1
+        periodSeconds: 60

--- a/pkg/component/istio/test_charts/ingress_deployment.yaml
+++ b/pkg/component/istio/test_charts/ingress_deployment.yaml
@@ -74,8 +74,8 @@ spec:
             timeoutSeconds: 1
           resources:
             requests:
-              cpu: 1000m
-              memory: 2Gi
+              cpu: 250m
+              memory: 1Gi
             limits:
               memory: 8Gi
           env:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/area auto-scaling
/area cost
/kind enhancement

**What this PR does / why we need it**:
Reduce resource requests of istio ingress gateway and adapt autoscaling accordingly.

Due to the split of istio ingress gateways across zones in highly available seed setup, its resource requests are slightly oversized except for very large active seed clusters. To reduce the unnecessary resource waste this change reduces the resource requests to a quarter (cpu) and half (memory) respectively. The general assumption is that due to its priority the istio ingress gateway may be able to get additional cpu if available on the node. With regards to memory, the limit is left in place with the same value and again its priority may help not being out-of-memory killed. As an additional measure with regards to memory, the autoscaling is extended to also cover memory so that a scale-up can happen under memory pressure. In addition to that, the scale-up/-down behaviour is now explicitly specified with a fast scale-up and a slow scale-down.


**Which issue(s) this PR fixes**:
None.

**Special notes for your reviewer**:
For the istio ingress gateway spanning multiple zones, i.e. the default istio ingress gateway, the autoscaling is not optimal as it does not take zones into account. This means the deployment may scale up in a zone, which is not under pressure.
However, as we have not seen a lot of scale-up operations with regards to istio, this is left as a follow-up step. It might be a good idea to combine the single-zone istio ingress gateways to a virtual multi-zonal one and getting rid of the existing default one, but that requires more changes and may be done as a follow-up.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Resource requests of istio ingress gateway are reduced and its horizontal autoscaling behaviour specified in more detail, including scale-up under memory pressure
```
