### PR TITLE
Downgrade `calico` to version `v3.27.0`

### DIFF
--- a/example/gardener-local/calico/base/kustomization.yaml
+++ b/example/gardener-local/calico/base/kustomization.yaml
@@ -2,7 +2,9 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-- https://raw.githubusercontent.com/projectcalico/calico/v3.27.2/manifests/calico.yaml
+# TODO(plkokanov): upgrade calico version after https://github.com/projectcalico/calico/issues/8541 is fixed.
+# We currently use 'v3.27.0' because this issue affects versions 'v3.27.1' and 'v3.27.2'.
+- https://raw.githubusercontent.com/projectcalico/calico/v3.27.0/manifests/calico.yaml
 
 images:
 - name: docker.io/calico/cni


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind bug

**What this PR does / why we need it**:
This PR downgrades the calico version used in the dev setup from `v3.27.2` to `v3.27.0` due to this issue https://github.com/gardener/gardener/issues/9261

More concretely, calico `v3.27.1` and `v3.27.2` have an issue where the `calico-node` pods cannot start on arm machines with the following error:
```
calico-node: error while loading shared libraries: libpcap.so.0.8: cannot open shared object file: No such file or directory
```

Calico was bumped to `v3.27.2` by renovate with this PR: https://github.com/gardener/gardener/pull/9241

**Which issue(s) this PR fixes**:
Fixes #9261 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
