### PR TITLE
Change ETCD VPA MaxAllowed memory value to 28Gb

### DIFF
--- a/pkg/component/etcd/etcd.go
+++ b/pkg/component/etcd/etcd.go
@@ -515,7 +515,7 @@ func (e *etcd) Deploy(ctx context.Context) error {
 									MinAllowed:    minAllowed,
 									MaxAllowed: corev1.ResourceList{
 										corev1.ResourceCPU:    resource.MustParse("4"),
-										corev1.ResourceMemory: resource.MustParse("30G"),
+										corev1.ResourceMemory: resource.MustParse("28G"),
 									},
 									ControlledValues: &controlledValues,
 								},

--- a/pkg/component/etcd/etcd_test.go
+++ b/pkg/component/etcd/etcd_test.go
@@ -452,7 +452,7 @@ var _ = Describe("Etcd", func() {
 											},
 											MaxAllowed: corev1.ResourceList{
 												corev1.ResourceCPU:    resource.MustParse("4"),
-												corev1.ResourceMemory: resource.MustParse("30G"),
+												corev1.ResourceMemory: resource.MustParse("28G"),
 											},
 											ControlledValues: &controlledValues,
 										},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area auto-scaling 
/area control-plane
/kind bug

**What this PR does / why we need it**:
This PR changes ETCD VPA MaxAllowed memory value to 28Gb, due to node Allocatable limitations available on certain infrastructures.
 
**Which issue(s) this PR fixes**:


**Special notes for your reviewer**:
/invite @voelzmo 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
