### PR TITLE
Consider errors from configValidator for ErrorCodes

### DIFF
--- a/extensions/pkg/controller/infrastructure/controller.go
+++ b/extensions/pkg/controller/infrastructure/controller.go
@@ -25,6 +25,7 @@ import (
 
 	extensionscontroller "github.com/gardener/gardener/extensions/pkg/controller"
 	extensionspredicate "github.com/gardener/gardener/extensions/pkg/predicate"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/controllerutils/mapper"
 )
@@ -57,6 +58,8 @@ type AddArgs struct {
 	// If the annotation is not ignored, the extension controller will only reconcile
 	// with a present operation annotation typically set during a reconcile (e.g in the maintenance time) by the Gardenlet
 	IgnoreOperationAnnotation bool
+	// KnownCodes is a map of known error codes and their respective error check functions.
+	KnownCodes map[gardencorev1beta1.ErrorCode]func(string) bool
 }
 
 // DefaultPredicates returns the default predicates for an infrastructure reconciler.
@@ -67,7 +70,7 @@ func DefaultPredicates(ctx context.Context, mgr manager.Manager, ignoreOperation
 // Add creates a new Infrastructure Controller and adds it to the Manager.
 // and Start it when the Manager is Started.
 func Add(ctx context.Context, mgr manager.Manager, args AddArgs) error {
-	args.ControllerOptions.Reconciler = NewReconciler(mgr, args.Actuator, args.ConfigValidator)
+	args.ControllerOptions.Reconciler = NewReconciler(mgr, args.Actuator, args.ConfigValidator, args.KnownCodes)
 	return add(ctx, mgr, args)
 }
 

--- a/extensions/pkg/controller/infrastructure/reconciler.go
+++ b/extensions/pkg/controller/infrastructure/reconciler.go
@@ -28,6 +28,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	extensionscontroller "github.com/gardener/gardener/extensions/pkg/controller"
+	"github.com/gardener/gardener/extensions/pkg/util"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
@@ -39,6 +40,7 @@ import (
 type reconciler struct {
 	actuator        Actuator
 	configValidator ConfigValidator
+	knownCodes      map[gardencorev1beta1.ErrorCode]func(string) bool
 
 	client        client.Client
 	reader        client.Reader
@@ -47,13 +49,14 @@ type reconciler struct {
 
 // NewReconciler creates a new reconcile.Reconciler that reconciles
 // infrastructure resources of Gardener's `extensions.gardener.cloud` API group.
-func NewReconciler(mgr manager.Manager, actuator Actuator, configValidator ConfigValidator) reconcile.Reconciler {
+func NewReconciler(mgr manager.Manager, actuator Actuator, configValidator ConfigValidator, knownCodes map[gardencorev1beta1.ErrorCode]func(string) bool) reconcile.Reconciler {
 	return reconcilerutils.OperationAnnotationWrapper(
 		mgr,
 		func() client.Object { return &extensionsv1alpha1.Infrastructure{} },
 		&reconciler{
 			actuator:        actuator,
 			configValidator: configValidator,
+			knownCodes:      knownCodes,
 			client:          mgr.GetClient(),
 			reader:          mgr.GetAPIReader(),
 			statusUpdater:   extensionscontroller.NewStatusUpdater(mgr.GetClient()),
@@ -271,6 +274,9 @@ func (r *reconciler) validateConfig(ctx context.Context, infrastructure *extensi
 
 	if allErrs := r.configValidator.Validate(ctx, infrastructure); len(allErrs) > 0 {
 		if filteredErrs := allErrs.Filter(field.NewErrorTypeMatcher(field.ErrorTypeInternal)); len(filteredErrs) < len(allErrs) {
+			if r.knownCodes != nil {
+				return util.DetermineError(allErrs.ToAggregate(), r.knownCodes)
+			}
 			return allErrs.ToAggregate()
 		}
 		return v1beta1helper.NewErrorWithCodes(allErrs.ToAggregate(), gardencorev1beta1.ErrorConfigurationProblem)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity
/kind enhancement

**What this PR does / why we need it**:
This PR allows errors from configValidator to be considered for ErrorCodes. So if a user-specific error occurs during config validation a proper error code can be assigned to it and ops people can ignore the affected clusters.

Related issue in extensions - 
- https://github.com/gardener/gardener-extension-provider-openstack/issues/605

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @ialidzhikov 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking developer
Function signature of infrastructure controller `NewReconciler` has changed from `NewReconciler(manager.Manager, Actuator, ConfigValidator)` to NewReconciler(manager.Manager, Actuator, ConfigValidator, map[gardencorev1beta1.ErrorCode]func(string) bool).
```
