### PR TITLE
Ignore dependency updates from `k8s.io/kube-openapi` because it depends on `k8s.io/apiserver`

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -72,6 +72,12 @@
       "enabled": false
     },
     {
+      // Ignore dependency updates from k8s.io/kube-openapi because it depends on k8s.io/apiserver.
+      "matchDatasources": ["go"],
+      "matchPackagePatterns": ["k8s\\.io\/kube-openapi"],
+      "enabled": false
+    },
+    {
       // Ignore paths which most likely create false positives.
       "matchFileNames": [
           "chart/**",


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
`k8s.io/apiserver` does not build with a different version of `k8s.io/kube-openapi` ([ref](https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/9262/pull-gardener-verify-image-build/1762320824057991168)).
Additionally, `k8s.io/kube-openapi` is reference by digest, so there is a large number of update PRs expected.
That's why will be ignored in `renovate` with this PR.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
