### PR TITLE
Remove `allow-privileged-containers` flag from test definition

### DIFF
--- a/.test-defs/CreateShoot.yaml
+++ b/.test-defs/CreateShoot.yaml
@@ -35,7 +35,6 @@ spec:
     -networking-services=$NETWORKING_SERVICES
     -networking-nodes=$NETWORKING_NODES
     -start-hibernated=$START_HIBERNATED
-    -allow-privileged-containers=$ALLOW_PRIVILEGED_CONTAINERS
     -annotations=$SHOOT_ANNOTATIONS
     -control-plane-failure-tolerance=$CONTROL_PLANE_FAILURE_TOLERANCE
 #    -machine-image-name=$MACHINE_IMAGE


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind cleanup

**What this PR does / why we need it**:
Remove `allow-privileged-containers flag` from test definition.

Leftover from https://github.com/gardener/gardener/pull/8989

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @adenitiu 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
