### PR TITLE
Fix fetching CA bundle secret in DWD migration function

### DIFF
--- a/cmd/gardenlet/app/app.go
+++ b/cmd/gardenlet/app/app.go
@@ -502,17 +502,15 @@ func (g *garden) createNewDWDResources(ctx context.Context, seedClient client.Cl
 				return err
 			}
 
-			//Delete old DWD secrets
-			if err := kubernetesutils.DeleteObjects(ctx, seedClient, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: dwd.InternalProbeSecretName, Namespace: namespace.Name}}); err != nil {
-				return err
-			}
-
-			if err := kubernetesutils.DeleteObjects(ctx, seedClient, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: dwd.ExternalProbeSecretName, Namespace: namespace.Name}}); err != nil {
+			// Delete old DWD secrets
+			if err := kubernetesutils.DeleteObjects(ctx, seedClient,
+				&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: dwd.InternalProbeSecretName, Namespace: namespace.Name}},
+				&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: dwd.ExternalProbeSecretName, Namespace: namespace.Name}},
+			); err != nil {
 				return err
 			}
 
 			// Fetch and update the GRM configmap
-			grmConfigMap := &corev1.ConfigMap{}
 			var grmCMName string
 			var grmCMVolumeIndex int
 			for n, vol := range grmDeploy.Spec.Template.Spec.Volumes {
@@ -525,6 +523,8 @@ func (g *garden) createNewDWDResources(ctx context.Context, seedClient client.Cl
 			if len(grmCMName) == 0 {
 				return nil
 			}
+
+			grmConfigMap := &corev1.ConfigMap{}
 			if err := seedClient.Get(ctx, types.NamespacedName{Namespace: namespace.Name, Name: grmCMName}, grmConfigMap); err != nil {
 				if apierrors.IsNotFound(err) {
 					return nil


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind bug

**What this PR does / why we need it**:
Fix fetching CA bundle secret in DWD migration function. 

**Which issue(s) this PR fixes**:
Follow-up of https://github.com/gardener/gardener/pull/9072

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
