### PR TITLE
[node-agent] Introduce `hostname-check` controller

### DIFF
--- a/cmd/gardener-node-agent/app/app.go
+++ b/cmd/gardener-node-agent/app/app.go
@@ -24,7 +24,6 @@ import (
 	"path/filepath"
 	goruntime "runtime"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -154,11 +153,10 @@ func run(ctx context.Context, cancel context.CancelFunc, log logr.Logger, cfg *c
 	}
 
 	log.Info("Fetching hostname")
-	hostName, err := os.Hostname()
+	hostName, err := nodeagent.GetHostName()
 	if err != nil {
 		return fmt.Errorf("failed fetching hostname: %w", err)
 	}
-	hostName = strings.ToLower(hostName)
 	log.Info("Fetched hostname", "hostname", hostName)
 
 	log.Info("Fetching name of node (if already registered)")

--- a/pkg/nodeagent/controller/add.go
+++ b/pkg/nodeagent/controller/add.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/gardener/gardener/pkg/nodeagent/apis/config"
 	"github.com/gardener/gardener/pkg/nodeagent/controller/healthcheck"
+	"github.com/gardener/gardener/pkg/nodeagent/controller/hostnamecheck"
 	"github.com/gardener/gardener/pkg/nodeagent/controller/lease"
 	"github.com/gardener/gardener/pkg/nodeagent/controller/node"
 	"github.com/gardener/gardener/pkg/nodeagent/controller/operatingsystemconfig"
@@ -61,7 +62,14 @@ func AddToManager(ctx context.Context, cancel context.CancelFunc, mgr manager.Ma
 	}
 
 	if err := (&healthcheck.Reconciler{}).AddToManager(mgr, nodePredicate); err != nil {
-		return fmt.Errorf("failed adding healthcheck controller: %w", err)
+		return fmt.Errorf("failed adding health-check controller: %w", err)
+	}
+
+	if err := (&hostnamecheck.Reconciler{
+		HostName:      hostName,
+		CancelContext: cancel,
+	}).AddToManager(mgr); err != nil {
+		return fmt.Errorf("failed adding hostname-check controller: %w", err)
 	}
 
 	return nil

--- a/pkg/nodeagent/controller/healthcheck/add.go
+++ b/pkg/nodeagent/controller/healthcheck/add.go
@@ -33,10 +33,12 @@ import (
 	"github.com/gardener/gardener/pkg/nodeagent/dbus"
 )
 
-// ControllerName is the name of this controller.
-const ControllerName = "healthcheck"
+const (
+	// ControllerName is the name of this controller.
+	ControllerName = "health-check"
 
-const defaultIntervalSeconds = 30
+	defaultIntervalSeconds = 30
+)
 
 // AddToManager adds Reconciler to the given manager.
 func (r *Reconciler) AddToManager(mgr manager.Manager, nodePredicate predicate.Predicate) error {

--- a/pkg/nodeagent/controller/hostnamecheck/add.go
+++ b/pkg/nodeagent/controller/hostnamecheck/add.go
@@ -1,0 +1,36 @@
+// Copyright 2024 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hostnamecheck
+
+import (
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	"github.com/gardener/gardener/pkg/controllerutils"
+)
+
+// ControllerName is the name of this controller.
+const ControllerName = "hostname-check"
+
+// AddToManager adds Reconciler to the given manager.
+func (r *Reconciler) AddToManager(mgr manager.Manager) error {
+	return builder.
+		ControllerManagedBy(mgr).
+		Named(ControllerName).
+		WithOptions(controller.Options{MaxConcurrentReconciles: 1}).
+		WatchesRawSource(controllerutils.EnqueueOnce, nil).
+		Complete(r)
+}

--- a/pkg/nodeagent/controller/hostnamecheck/hostnamecheck_suite_test.go
+++ b/pkg/nodeagent/controller/hostnamecheck/hostnamecheck_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright 2024 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hostnamecheck_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestHostNameCheck(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "NodeAgent Controller HostNameCheck Suite")
+}

--- a/pkg/nodeagent/controller/hostnamecheck/reconciler.go
+++ b/pkg/nodeagent/controller/hostnamecheck/reconciler.go
@@ -1,0 +1,53 @@
+// Copyright 2024 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hostnamecheck
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/gardener/gardener/pkg/nodeagent"
+)
+
+// Reconciler checks periodically whether the hostname changed. If yes, it calls the cancel func. This is required
+// because gardener-node-agent uses a label selector for kubernetes.io/hostname=<hostname> which no longer works in case
+// the hostname of the node has changed. Calling the cancel func leads to terminating (and eventually restarting) the
+// gardener-node-agent such that it can fetch the hostname again during start-up.
+type Reconciler struct {
+	CancelContext context.CancelFunc
+	HostName      string
+}
+
+// Reconcile checks periodically whether the hostname changed. If yes, it calls the cancel func.
+func (r *Reconciler) Reconcile(ctx context.Context, _ reconcile.Request) (reconcile.Result, error) {
+	log := logf.FromContext(ctx)
+
+	hostName, err := nodeagent.GetHostName()
+	if err != nil {
+		return reconcile.Result{}, fmt.Errorf("failed fetching hostname: %w", err)
+	}
+
+	if hostName != r.HostName {
+		log.Info("Hostname has changed, calling the cancel func to trigger a restart of gardener-node-agent", "from", r.HostName, "to", hostName)
+		r.CancelContext()
+		return reconcile.Result{}, nil
+	}
+
+	return reconcile.Result{RequeueAfter: 30 * time.Second}, nil
+}

--- a/pkg/nodeagent/controller/hostnamecheck/reconciler_test.go
+++ b/pkg/nodeagent/controller/hostnamecheck/reconciler_test.go
@@ -1,0 +1,70 @@
+// Copyright 2024 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hostnamecheck_test
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/gardener/gardener/pkg/nodeagent"
+	. "github.com/gardener/gardener/pkg/nodeagent/controller/hostnamecheck"
+)
+
+var _ = Describe("Reconciler", func() {
+	var (
+		ctx           = context.Background()
+		cancelContext cancel
+		reconciler    *Reconciler
+	)
+
+	BeforeEach(func() {
+		cancelContext = cancel{}
+		reconciler = &Reconciler{CancelContext: cancelContext.Cancel}
+	})
+
+	Describe("#Reconcile", func() {
+		It("should do nothing because hostname did not change", func() {
+			hostName, err := nodeagent.GetHostName()
+			Expect(err).NotTo(HaveOccurred())
+			reconciler.HostName = hostName
+
+			result, err := reconciler.Reconcile(ctx, reconcile.Request{})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal(reconcile.Result{RequeueAfter: 30 * time.Second}))
+			Expect(cancelContext.called).To(BeFalse())
+		})
+
+		It("should cancel the context because hostname changed", func() {
+			reconciler.HostName = "foobartest"
+
+			result, err := reconciler.Reconcile(ctx, reconcile.Request{})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal(reconcile.Result{}))
+			Expect(cancelContext.called).To(BeTrue())
+		})
+	})
+})
+
+type cancel struct {
+	called bool
+}
+
+func (c *cancel) Cancel() {
+	c.called = true
+}

--- a/pkg/nodeagent/hostname.go
+++ b/pkg/nodeagent/hostname.go
@@ -1,0 +1,33 @@
+// Copyright 2024 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nodeagent
+
+import (
+	"os"
+	"strings"
+)
+
+// Hostname is an alias for os.Hostname.
+// Exposed for testing.
+var Hostname = os.Hostname
+
+// GetHostName gets the hostname and converts it to lowercase.
+func GetHostName() (string, error) {
+	hostName, err := Hostname()
+	if err != nil {
+		return "", err
+	}
+	return strings.ToLower(hostName), nil
+}

--- a/pkg/nodeagent/hostname_test.go
+++ b/pkg/nodeagent/hostname_test.go
@@ -1,0 +1,38 @@
+// Copyright 2024 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nodeagent_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	. "github.com/gardener/gardener/pkg/nodeagent"
+	"github.com/gardener/gardener/pkg/utils/test"
+)
+
+var _ = Describe("HostName", func() {
+	Describe("#GetHostName", func() {
+		It("should convert the string to lower case", func() {
+			DeferCleanup(test.WithVar(&Hostname, func() (string, error) {
+				return "FoObAr", nil
+			}))
+
+			hostName, err := GetHostName()
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(hostName).To(Equal("foobar"))
+		})
+	})
+})

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -1156,6 +1156,7 @@ build:
             - pkg/nodeagent/bootstrap
             - pkg/nodeagent/controller
             - pkg/nodeagent/controller/healthcheck
+            - pkg/nodeagent/controller/hostnamecheck
             - pkg/nodeagent/controller/lease
             - pkg/nodeagent/controller/node
             - pkg/nodeagent/controller/operatingsystemconfig


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind bug

**What this PR does / why we need it**:
With this PR, a new `hostname-check` controller is introduced. It periodically (each `30s`) checks if the hostname of the node `gardener-node-agent` runs on has changed compared to what it has read during its start-up. If a change is detected, it calls the cancel function of the root context, leading to a termination and an eventual restart of the `gardener-node-agent` `systemd` unit.

Motivation: We have seen cases where  the hostname has changed for some nodes. Without this, `gardener-node-agent` will stuck forever in https://github.com/gardener/gardener/blob/76704c377f34cdbdf1b0d3986b243c8b67c66909/pkg/nodeagent/controller/operatingsystemconfig/reconciler.go#L155-L158 until it gets restarted. In addition, the hostname is used to compute a label selector predicate here: https://github.com/gardener/gardener/blob/76704c377f34cdbdf1b0d3986b243c8b67c66909/pkg/nodeagent/controller/add.go#L36-L39

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/8023
Follow-up of https://github.com/gardener/gardener/pull/9114

**Special notes for your reviewer**:
/cc @oliver-goetz @ialidzhikov 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
`gardener-node-agent` now terminates itself (leading to a restart of its `systemd` unit) in case it determines that the hostname of its node has changed.
```
