### PR TITLE
Move `observability-ingress{-users}` secret generation out of `plutono` component

### DIFF
--- a/pkg/component/observability/plutono/plutono.go
+++ b/pkg/component/observability/plutono/plutono.go
@@ -711,8 +711,7 @@ func (p *plutono) getIngress(ctx context.Context) (*networkingv1.Ingress, error)
 			Format:         secrets.BasicAuthFormatNormal,
 			Username:       "admin",
 			PasswordLength: 32,
-		}, secretsmanager.Persist(), secretsmanager.Rotate(secretsmanager.InPlace),
-		)
+		}, secretsmanager.Persist(), secretsmanager.Rotate(secretsmanager.InPlace))
 		if err != nil {
 			return nil, err
 		}
@@ -722,16 +721,9 @@ func (p *plutono) getIngress(ctx context.Context) (*networkingv1.Ingress, error)
 	}
 
 	if p.values.ClusterType == component.ClusterTypeShoot {
-		credentialsSecret, err := p.secretsManager.Generate(ctx, &secrets.BasicAuthSecretConfig{
-			Name:           v1beta1constants.SecretNameObservabilityIngressUsers,
-			Format:         secrets.BasicAuthFormatNormal,
-			Username:       "admin",
-			PasswordLength: 32,
-		}, secretsmanager.Persist(),
-			secretsmanager.Rotate(secretsmanager.InPlace),
-		)
-		if err != nil {
-			return nil, err
+		credentialsSecret, found := p.secretsManager.Get(v1beta1constants.SecretNameObservabilityIngressUsers)
+		if !found {
+			return nil, fmt.Errorf("secret %q not found", v1beta1constants.SecretNameObservabilityIngressUsers)
 		}
 
 		credentialsSecretName = credentialsSecret.Name

--- a/pkg/component/observability/plutono/plutono.go
+++ b/pkg/component/observability/plutono/plutono.go
@@ -706,14 +706,10 @@ func (p *plutono) getIngress(ctx context.Context) (*networkingv1.Ingress, error)
 
 	if p.values.IsGardenCluster {
 		pathType = networkingv1.PathTypeImplementationSpecific
-		credentialsSecret, err := p.secretsManager.Generate(ctx, &secrets.BasicAuthSecretConfig{
-			Name:           v1beta1constants.SecretNameObservabilityIngress,
-			Format:         secrets.BasicAuthFormatNormal,
-			Username:       "admin",
-			PasswordLength: 32,
-		}, secretsmanager.Persist(), secretsmanager.Rotate(secretsmanager.InPlace))
-		if err != nil {
-			return nil, err
+
+		credentialsSecret, found := p.secretsManager.Get(v1beta1constants.SecretNameObservabilityIngress)
+		if !found {
+			return nil, fmt.Errorf("secret %q not found", v1beta1constants.SecretNameObservabilityIngress)
 		}
 
 		credentialsSecretName = credentialsSecret.Name

--- a/pkg/component/observability/plutono/plutono_test.go
+++ b/pkg/component/observability/plutono/plutono_test.go
@@ -93,6 +93,7 @@ var _ = Describe("Plutono", func() {
 		}
 
 		By("Create secrets managed outside of this function for whose secretsmanager.Get() will be called")
+		Expect(c.Create(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "observability-ingress", Namespace: namespace}})).To(Succeed())
 		Expect(c.Create(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "observability-ingress-users", Namespace: namespace}})).To(Succeed())
 
 		// extensions dashboard
@@ -481,7 +482,7 @@ metadata:
 `
 					}
 				} else {
-					out += `    nginx.ingress.kubernetes.io/auth-secret: observability-ingress-0da36eb1
+					out += `    nginx.ingress.kubernetes.io/auth-secret: observability-ingress
     nginx.ingress.kubernetes.io/auth-type: basic
 `
 				}

--- a/pkg/component/observability/plutono/plutono_test.go
+++ b/pkg/component/observability/plutono/plutono_test.go
@@ -92,6 +92,9 @@ var _ = Describe("Plutono", func() {
 			},
 		}
 
+		By("Create secrets managed outside of this function for whose secretsmanager.Get() will be called")
+		Expect(c.Create(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "observability-ingress-users", Namespace: namespace}})).To(Succeed())
+
 		// extensions dashboard
 		filePath := filepath.Join("testdata", "configmap.yaml")
 		cm, err := os.ReadFile(filePath)
@@ -469,7 +472,7 @@ metadata:
 `
 				if !values.IsGardenCluster {
 					if values.ClusterType == comp.ClusterTypeShoot {
-						out += `    nginx.ingress.kubernetes.io/auth-secret: observability-ingress-users-f27eb0bf
+						out += `    nginx.ingress.kubernetes.io/auth-secret: observability-ingress-users
     nginx.ingress.kubernetes.io/auth-type: basic
 `
 					} else {

--- a/pkg/gardenlet/operation/operation.go
+++ b/pkg/gardenlet/operation/operation.go
@@ -411,8 +411,8 @@ func (o *Operation) IsShootMonitoringEnabled() bool {
 	return helper.IsMonitoringEnabled(o.Config) && o.Shoot.Purpose != gardencorev1beta1.ShootPurposeTesting
 }
 
-// WantsPlutono returns true if shoot is not of purpose testing and either shoot monitoring or vali is enabled.
-func (o *Operation) WantsPlutono() bool {
+// WantsObservabilityComponents returns true if shoot is not of purpose testing and either shoot monitoring or vali is enabled.
+func (o *Operation) WantsObservabilityComponents() bool {
 	return o.Shoot.Purpose != gardencorev1beta1.ShootPurposeTesting && (helper.IsMonitoringEnabled(o.Config) || helper.IsValiEnabled(o.Config))
 }
 

--- a/pkg/operator/controller/garden/garden/reconciler.go
+++ b/pkg/operator/controller/garden/garden/reconciler.go
@@ -352,6 +352,16 @@ func (r *Reconciler) cleanupGenericTokenKubeconfig(ctx context.Context, secretsM
 	return client.IgnoreNotFound(r.RuntimeClientSet.Client().Delete(ctx, secret))
 }
 
+func (r *Reconciler) generateObservabilityIngressPassword(ctx context.Context, secretsManager secretsmanager.Interface) error {
+	_, err := secretsManager.Generate(ctx, &secretsutils.BasicAuthSecretConfig{
+		Name:           v1beta1constants.SecretNameObservabilityIngress,
+		Format:         secretsutils.BasicAuthFormatNormal,
+		Username:       "admin",
+		PasswordLength: 32,
+	}, secretsmanager.Persist(), secretsmanager.Rotate(secretsmanager.InPlace))
+	return err
+}
+
 func startRotationCA(garden *operatorv1alpha1.Garden, now *metav1.Time) {
 	helper.MutateCARotation(garden, func(rotation *gardencorev1beta1.CARotation) {
 		rotation.Phase = gardencorev1beta1.RotationPreparing

--- a/pkg/operator/controller/garden/garden/reconciler_reconcile.go
+++ b/pkg/operator/controller/garden/garden/reconciler_reconcile.go
@@ -130,6 +130,12 @@ func (r *Reconciler) reconcile(
 				return r.generateGenericTokenKubeconfig(ctx, garden, secretsManager)
 			},
 		})
+		generateObservabilityIngressPassword = g.Add(flow.Task{
+			Name: "Generating observability ingress password",
+			Fn: func(ctx context.Context) error {
+				return r.generateObservabilityIngressPassword(ctx, secretsManager)
+			},
+		})
 		deployEtcdCRD = g.Add(flow.Task{
 			Name: "Deploying ETCD-related custom resource definitions",
 			Fn:   c.etcdCRD.Deploy,
@@ -217,6 +223,7 @@ func (r *Reconciler) reconcile(
 		})
 		syncPointSystemComponents = flow.NewTaskIDs(
 			generateGenericTokenKubeconfig,
+			generateObservabilityIngressPassword,
 			deployRuntimeSystemResources,
 			deployFluentCRD,
 			deployPrometheusCRD,


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
This secret is not directly related to `plutono` only but also to other components (`prometheus`, `alertmanager`, ...). Hence, it's better to generate it outside in a central place.

/cc @acumino 

**Which issue(s) this PR fixes**:
Related to #9065 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
