### PR TITLE
Add IP Stack to `DNSRecord` resources

### DIFF
--- a/pkg/component/extensions/dnsrecord/dnsrecord.go
+++ b/pkg/component/extensions/dnsrecord/dnsrecord.go
@@ -32,6 +32,7 @@ import (
 	"github.com/gardener/gardener/pkg/component"
 	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/extensions"
+	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 )
 
 const (
@@ -85,6 +86,8 @@ type Values struct {
 	Values []string
 	// TTL is the time to live in seconds of the DNSRecord.
 	TTL *int64
+	// IPStack is the indication of the IP stack used for the DNSRecord. It can be ipv4, ipv6 or dual-stack.
+	IPStack string
 }
 
 // New creates a new instance that implements component.DeployMigrateWaiter.
@@ -149,6 +152,10 @@ func (d *dnsRecord) deploy(ctx context.Context, operation string) (extensionsv1a
 			d.isTimestampInvalidOrAfterLastUpdateTime() {
 			metav1.SetMetaDataAnnotation(&d.dnsRecord.ObjectMeta, v1beta1constants.GardenerOperation, operation)
 			metav1.SetMetaDataAnnotation(&d.dnsRecord.ObjectMeta, v1beta1constants.GardenerTimestamp, TimeNow().UTC().Format(time.RFC3339Nano))
+		}
+
+		if d.values.IPStack != "" {
+			metav1.SetMetaDataAnnotation(&d.dnsRecord.ObjectMeta, gardenerutils.AnnotationKeyIPStack, d.values.IPStack)
 		}
 
 		d.dnsRecord.Spec = extensionsv1alpha1.DNSRecordSpec{

--- a/pkg/gardenlet/controller/seed/seed/nginxingress.go
+++ b/pkg/gardenlet/controller/seed/seed/nginxingress.go
@@ -27,6 +27,7 @@ import (
 	"github.com/gardener/gardener/pkg/component/extensions/dnsrecord"
 	seedpkg "github.com/gardener/gardener/pkg/gardenlet/operation/seed"
 	"github.com/gardener/gardener/pkg/utils"
+	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 )
 
@@ -44,6 +45,7 @@ func (r *Reconciler) newIngressDNSRecord(ctx context.Context, log logr.Logger, s
 		DNSName:                      seed.GetIngressFQDN("*"),
 		RecordType:                   extensionsv1alpha1helper.GetDNSRecordType(loadBalancerAddress),
 		ReconcileOnlyOnChangeOrError: true,
+		IPStack:                      gardenerutils.GetIPStackForSeed(seed.GetInfo()),
 	}
 
 	if provider := seed.GetInfo().Spec.DNS.Provider; provider != nil {

--- a/pkg/gardenlet/operation/botanist/dnsrecord.go
+++ b/pkg/gardenlet/operation/botanist/dnsrecord.go
@@ -32,6 +32,7 @@ func (b *Botanist) DefaultExternalDNSRecord() extensionsdnsrecord.Interface {
 		Namespace:         b.Shoot.SeedNamespace,
 		TTL:               b.Config.Controllers.Shoot.DNSEntryTTLSeconds,
 		AnnotateOperation: controllerutils.HasTask(b.Shoot.GetInfo().Annotations, v1beta1constants.ShootTaskDeployDNSRecordExternal) || b.IsRestorePhase(),
+		IPStack:           gardenerutils.GetIPStackForShoot(b.Shoot.GetInfo()),
 	}
 
 	if b.NeedsExternalDNS() {
@@ -64,6 +65,7 @@ func (b *Botanist) DefaultInternalDNSRecord() extensionsdnsrecord.Interface {
 		AnnotateOperation: b.Shoot.GetInfo().DeletionTimestamp != nil ||
 			controllerutils.HasTask(b.Shoot.GetInfo().Annotations, v1beta1constants.ShootTaskDeployDNSRecordInternal) ||
 			b.IsRestorePhase(),
+		IPStack: gardenerutils.GetIPStackForShoot(b.Shoot.GetInfo()),
 	}
 
 	if b.NeedsInternalDNS() {

--- a/pkg/gardenlet/operation/botanist/dnsrecord_test.go
+++ b/pkg/gardenlet/operation/botanist/dnsrecord_test.go
@@ -202,6 +202,7 @@ var _ = Describe("dnsrecord", func() {
 				RecordType:        extensionsv1alpha1.DNSRecordTypeA,
 				Values:            []string{address},
 				AnnotateOperation: false,
+				IPStack:           "ipv4",
 			}))
 		})
 
@@ -312,6 +313,7 @@ var _ = Describe("dnsrecord", func() {
 				RecordType:        extensionsv1alpha1.DNSRecordTypeA,
 				Values:            []string{address},
 				AnnotateOperation: false,
+				IPStack:           "ipv4",
 			}))
 		})
 

--- a/pkg/gardenlet/operation/botanist/nginxingress.go
+++ b/pkg/gardenlet/operation/botanist/nginxingress.go
@@ -28,6 +28,7 @@ import (
 	sharedcomponent "github.com/gardener/gardener/pkg/component/shared"
 	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/utils"
+	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 )
 
 // DefaultNginxIngress returns a deployer for the nginxingress.
@@ -103,6 +104,7 @@ func (b *Botanist) DefaultIngressDNSRecord() extensionsdnsrecord.Interface {
 		Namespace:         b.Shoot.SeedNamespace,
 		TTL:               b.Config.Controllers.Shoot.DNSEntryTTLSeconds,
 		AnnotateOperation: controllerutils.HasTask(b.Shoot.GetInfo().Annotations, v1beta1constants.ShootTaskDeployDNSRecordIngress) || b.IsRestorePhase(),
+		IPStack:           gardenerutils.GetIPStackForShoot(b.Shoot.GetInfo()),
 	}
 
 	// Set component values even if the nginx-ingress addons is not enabled.

--- a/pkg/gardenlet/operation/botanist/nginxingress_test.go
+++ b/pkg/gardenlet/operation/botanist/nginxingress_test.go
@@ -233,6 +233,7 @@ var _ = Describe("NginxIngress", func() {
 				RecordType:        extensionsv1alpha1.DNSRecordTypeA,
 				Values:            []string{address},
 				AnnotateOperation: false,
+				IPStack:           "ipv4",
 			}))
 		})
 
@@ -279,6 +280,7 @@ var _ = Describe("NginxIngress", func() {
 				RecordType:        extensionsv1alpha1.DNSRecordTypeA,
 				Values:            []string{address},
 				AnnotateOperation: false,
+				IPStack:           "ipv4",
 			}))
 		})
 

--- a/pkg/utils/gardener/dns.go
+++ b/pkg/utils/gardener/dns.go
@@ -16,6 +16,7 @@ package gardener
 
 import (
 	"fmt"
+	"slices"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 )
@@ -123,9 +124,7 @@ func getIPStackForFamilies(ipFamilies []gardencorev1beta1.IPFamily) string {
 	if gardencorev1beta1.IsIPv6SingleStack(ipFamilies) {
 		return AnnotationValueIPStackIPv6
 	}
-	if len(ipFamilies) == 2 &&
-		((ipFamilies[0] == gardencorev1beta1.IPFamilyIPv4 && ipFamilies[1] == gardencorev1beta1.IPFamilyIPv6) ||
-			(ipFamilies[0] == gardencorev1beta1.IPFamilyIPv6 && ipFamilies[1] == gardencorev1beta1.IPFamilyIPv4)) {
+	if len(ipFamilies) == 2 && slices.Contains(ipFamilies, gardencorev1beta1.IPFamilyIPv4) && slices.Contains(ipFamilies, gardencorev1beta1.IPFamilyIPv6) {
 		return AnnotationValueIPStackIPDualStack
 	}
 	// Fall-back to IPv4 per default

--- a/pkg/utils/gardener/seed.go
+++ b/pkg/utils/gardener/seed.go
@@ -176,3 +176,9 @@ func RequiredExtensionsReady(ctx context.Context, gardenClient client.Client, se
 
 	return nil
 }
+
+// GetIPStackForSeed returns the value for the AnnotationKeyIPStack annotation based on the given seed.
+// It falls back to IPv4 if no IP families are available.
+func GetIPStackForSeed(seed *gardencorev1beta1.Seed) string {
+	return getIPStackForFamilies(seed.Spec.Networks.IPFamilies)
+}

--- a/pkg/utils/gardener/seed_test.go
+++ b/pkg/utils/gardener/seed_test.go
@@ -342,4 +342,16 @@ var _ = Describe("utils", func() {
 			})
 		})
 	})
+
+	DescribeTable("#GetIPStackForSeed",
+		func(seed *gardencorev1beta1.Seed, expectedResult string) {
+			Expect(GetIPStackForSeed(seed)).To(Equal(expectedResult))
+		},
+
+		Entry("default seed", &gardencorev1beta1.Seed{}, "ipv4"),
+		Entry("ipv4 seed", &gardencorev1beta1.Seed{Spec: gardencorev1beta1.SeedSpec{Networks: gardencorev1beta1.SeedNetworks{IPFamilies: []gardencorev1beta1.IPFamily{gardencorev1beta1.IPFamilyIPv4}}}}, "ipv4"),
+		Entry("ipv6 seed", &gardencorev1beta1.Seed{Spec: gardencorev1beta1.SeedSpec{Networks: gardencorev1beta1.SeedNetworks{IPFamilies: []gardencorev1beta1.IPFamily{gardencorev1beta1.IPFamilyIPv6}}}}, "ipv6"),
+		Entry("dual-stack seed (ipv4 preferred)", &gardencorev1beta1.Seed{Spec: gardencorev1beta1.SeedSpec{Networks: gardencorev1beta1.SeedNetworks{IPFamilies: []gardencorev1beta1.IPFamily{gardencorev1beta1.IPFamilyIPv4, gardencorev1beta1.IPFamilyIPv6}}}}, "dual-stack"),
+		Entry("dual-stack seed (ipv6 preferred)", &gardencorev1beta1.Seed{Spec: gardencorev1beta1.SeedSpec{Networks: gardencorev1beta1.SeedNetworks{IPFamilies: []gardencorev1beta1.IPFamily{gardencorev1beta1.IPFamilyIPv6, gardencorev1beta1.IPFamilyIPv4}}}}, "dual-stack"),
+	)
 })

--- a/pkg/utils/gardener/shoot.go
+++ b/pkg/utils/gardener/shoot.go
@@ -755,3 +755,13 @@ func DefaultGVKsForEncryption() []schema.GroupVersionKind {
 func DefaultResourcesForEncryption() sets.Set[string] {
 	return sets.New(corev1.Resource("secrets").String())
 }
+
+// GetIPStackForShoot returns the value for the AnnotationKeyIPStack annotation based on the given shoot.
+// It falls back to IPv4 if no IP families are available, e.g. in a workerless shoot cluster.
+func GetIPStackForShoot(shoot *gardencorev1beta1.Shoot) string {
+	var ipFamilies []gardencorev1beta1.IPFamily
+	if networking := shoot.Spec.Networking; networking != nil {
+		ipFamilies = networking.IPFamilies
+	}
+	return getIPStackForFamilies(ipFamilies)
+}

--- a/pkg/utils/gardener/shoot_test.go
+++ b/pkg/utils/gardener/shoot_test.go
@@ -1341,4 +1341,16 @@ var _ = Describe("Shoot", func() {
 			))
 		})
 	})
+
+	DescribeTable("#GetIPStackForShoot",
+		func(shoot *gardencorev1beta1.Shoot, expectedResult string) {
+			Expect(GetIPStackForShoot(shoot)).To(Equal(expectedResult))
+		},
+
+		Entry("default shoot", &gardencorev1beta1.Shoot{}, "ipv4"),
+		Entry("ipv4 shoot", &gardencorev1beta1.Shoot{Spec: gardencorev1beta1.ShootSpec{Networking: &gardencorev1beta1.Networking{IPFamilies: []gardencorev1beta1.IPFamily{gardencorev1beta1.IPFamilyIPv4}}}}, "ipv4"),
+		Entry("ipv6 shoot", &gardencorev1beta1.Shoot{Spec: gardencorev1beta1.ShootSpec{Networking: &gardencorev1beta1.Networking{IPFamilies: []gardencorev1beta1.IPFamily{gardencorev1beta1.IPFamilyIPv6}}}}, "ipv6"),
+		Entry("dual-stack shoot (ipv4 preferred)", &gardencorev1beta1.Shoot{Spec: gardencorev1beta1.ShootSpec{Networking: &gardencorev1beta1.Networking{IPFamilies: []gardencorev1beta1.IPFamily{gardencorev1beta1.IPFamilyIPv4, gardencorev1beta1.IPFamilyIPv6}}}}, "dual-stack"),
+		Entry("dual-stack shoot (ipv6 preferred)", &gardencorev1beta1.Shoot{Spec: gardencorev1beta1.ShootSpec{Networking: &gardencorev1beta1.Networking{IPFamilies: []gardencorev1beta1.IPFamily{gardencorev1beta1.IPFamilyIPv6, gardencorev1beta1.IPFamilyIPv4}}}}, "dual-stack"),
+	)
 })


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement

**What this PR does / why we need it**:
For some DNS providers it might be beneficial to know the IP stack of the actual DNS record, e.g. ipv4 for `A` records and ipv4 for `AAAA` records. This is especially true for `CNAME` records, which are an alias for another name. Some DNS providers allow shortcuts, i.e. other means to achieve the equivalent of a `CNAME` record, but need knowledge about the target record's type. For those scenarios, it can be helpful to have the target IP stack directly available at the DNS record so that the corresponding DNS provider can directly use the information instead of having to query DNS to resolve the `CNAME` record.
This pull requests adds an annotation to the DNS records depending on the `IPFamily` of the shoot/seed clusters. This allows DNS providers to act accordingly.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
`DNSRecord` resources for seed and shoot clusters now have an annotation indicating their target ip stack (`dns.gardener.cloud/ip-stack` set to either `ipv4`, `ipv6`, or `dual-stack`).
```

/cc @MartinWeindel 