### PR TITLE
Add `renovate` image ref detection regex

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -31,6 +31,13 @@
         "https:\/\/raw\\.githubusercontent\\.com\/(?<depName>[^/]*\/[^/]*?)\/(?<currentValue>.*?)\/",
       ],
       "datasourceTemplate": "github-releases"
+    },
+    {
+      // Generic detection for cli argument image specifications.
+      "customType": "regex",
+      "fileMatch": ["^hack\/.+\\.sh$"],
+      "matchStrings": ["--image[=| ][\"|']?(?<depName>.*?):(?<currentValue>.*?)[\"|']?\\s"],
+      "datasourceTemplate": "docker"
     }
   ],
   "separateMinorPatch": true,
@@ -47,10 +54,17 @@
       "matchFileNames": ["hack\/tools\\.mk"]
     },
     {
-      // Only patch level updates for golang-test image. Minor and major versions are manually updated.
+      // Only patch level updates for golang-test image. Minor and major versions are updated manually.
       "matchDatasources": ["docker"],
       "matchUpdateTypes": ["major", "minor"],
       "matchFileNames": ["hack\/tools\/image\/variants\\.yaml"],
+      "enabled": false
+    },
+    {
+      // Only patch level updates for kindest/node image. Minor and major versions are updated manually.
+      "matchDatasources": ["docker"],
+      "matchUpdateTypes": ["major", "minor"],
+      "matchPackagePatterns": ["kindest\/node"],
       "enabled": false
     },
     {

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -19,7 +19,7 @@
       // Generic detection for pod-like image specifications.
       "customType": "regex",
       "fileMatch": ["^example\/.+\\.yaml$", "^hack\/.+\\.yaml$", "^\\.test-defs\/.+\\.yaml$"],
-      "matchStrings": ["image: (?<depName>.*?):(?<currentValue>.*?)\\s"],
+      "matchStrings": ["image: [\"|']?(?<depName>.*?):(?<currentValue>.*?)[\"|']?\\s"],
       "datasourceTemplate": "docker"
     },
     {

--- a/hack/kind-up.sh
+++ b/hack/kind-up.sh
@@ -190,9 +190,7 @@ if [[ "$IPFAMILY" == "ipv6" ]] && [[ "$MULTI_ZONAL" == "true" ]]; then
   ADDITIONAL_ARGS="$ADDITIONAL_ARGS --set gardener.seed.istio.listenAddresses={::1,::10,::11,::12}"
 fi
 
-
-# TODO(acumino): update to kindest/node:v1.29.0 once we have a solution for adding seed authorizer in provider-local setup
-# For details check https://github.com/gardener/gardener/issues/8871
+# Adjust version of kindest/node image according to the latest supported Kubernetes version in Gardener
 kind create cluster \
   --name "$CLUSTER_NAME" \
   --image "kindest/node:v1.29.0" \


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
This PR adds another customManager to `renovate` config which allows to update image refs in `--image` cli arguments.
The primary use case is updating the [kindest/node image](https://github.com/gardener/gardener/blob/bf7bd5ba0914524ca5a04252b4d4f23cc892047d/hack/kind-up.sh#L198). Only patch levels should be updated, because minor (and major) updates are part of the validation of a new Kubernetes version.

Some small improvements and cleanups related to the changes are part of this PR too.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
