### PR TITLE
Enhance error msg when trying to change `.spec.seedName` by patching a shoot

### DIFF
--- a/plugin/pkg/shoot/validator/admission.go
+++ b/plugin/pkg/shoot/validator/admission.go
@@ -40,6 +40,7 @@ import (
 	"k8s.io/apiserver/pkg/authorization/authorizer"
 	kubeinformers "k8s.io/client-go/informers"
 	kubecorev1listers "k8s.io/client-go/listers/core/v1"
+	"k8s.io/utils/pointer"
 	"k8s.io/utils/ptr"
 
 	"github.com/gardener/gardener/pkg/apis/core"
@@ -394,7 +395,9 @@ func (c *validationContext) validateScheduling(ctx context.Context, a admission.
 				}
 			}
 		} else if !reflect.DeepEqual(c.shoot.Spec.SeedName, c.oldShoot.Spec.SeedName) {
-			return admission.NewForbidden(a, fmt.Errorf("spec.seedName cannot be changed by patching the shoot, please use the shoots/binding subresource"))
+			oldSeedNameStr := pointer.StringDeref(c.oldShoot.Spec.SeedName, "nil")
+			seedNameStr := pointer.StringDeref(c.shoot.Spec.SeedName, "nil")
+			return admission.NewForbidden(a, fmt.Errorf("spec.seedName '%s' cannot be changed to '%s' by patching the shoot, please use the shoots/binding subresource", oldSeedNameStr, seedNameStr))
 		}
 	case admission.Delete:
 		return nil

--- a/plugin/pkg/shoot/validator/admission.go
+++ b/plugin/pkg/shoot/validator/admission.go
@@ -40,7 +40,6 @@ import (
 	"k8s.io/apiserver/pkg/authorization/authorizer"
 	kubeinformers "k8s.io/client-go/informers"
 	kubecorev1listers "k8s.io/client-go/listers/core/v1"
-	"k8s.io/utils/pointer"
 	"k8s.io/utils/ptr"
 
 	"github.com/gardener/gardener/pkg/apis/core"
@@ -395,8 +394,8 @@ func (c *validationContext) validateScheduling(ctx context.Context, a admission.
 				}
 			}
 		} else if !reflect.DeepEqual(c.shoot.Spec.SeedName, c.oldShoot.Spec.SeedName) {
-			oldSeedNameStr := pointer.StringDeref(c.oldShoot.Spec.SeedName, "nil")
-			seedNameStr := pointer.StringDeref(c.shoot.Spec.SeedName, "nil")
+			oldSeedNameStr := ptr.Deref(c.oldShoot.Spec.SeedName, "nil")
+			seedNameStr := ptr.Deref(c.shoot.Spec.SeedName, "nil")
 			return admission.NewForbidden(a, fmt.Errorf("spec.seedName '%s' cannot be changed to '%s' by patching the shoot, please use the shoots/binding subresource", oldSeedNameStr, seedNameStr))
 		}
 	case admission.Delete:

--- a/plugin/pkg/shoot/validator/admission.go
+++ b/plugin/pkg/shoot/validator/admission.go
@@ -381,11 +381,9 @@ func (c *validationContext) validateScheduling(ctx context.Context, a admission.
 			}
 		}
 	case admission.Update:
-		if a.GetSubresource() == "binding" {
-			if c.oldShoot.Spec.SeedName != nil && c.shoot.Spec.SeedName == nil {
-				return admission.NewForbidden(a, fmt.Errorf("spec.seedName cannot be set to nil"))
-			}
-
+		if c.oldShoot.Spec.SeedName != nil && c.shoot.Spec.SeedName == nil {
+			return admission.NewForbidden(a, fmt.Errorf("spec.seedName is already set to '%s' and cannot be changed to 'nil'", *c.oldShoot.Spec.SeedName))
+		} else if a.GetSubresource() == "binding" {
 			if shootIsBeingRescheduled {
 				newShootSpec := c.shoot.Spec
 				newShootSpec.SeedName = c.oldShoot.Spec.SeedName
@@ -394,9 +392,8 @@ func (c *validationContext) validateScheduling(ctx context.Context, a admission.
 				}
 			}
 		} else if !reflect.DeepEqual(c.shoot.Spec.SeedName, c.oldShoot.Spec.SeedName) {
-			oldSeedNameStr := ptr.Deref(c.oldShoot.Spec.SeedName, "nil")
-			seedNameStr := ptr.Deref(c.shoot.Spec.SeedName, "nil")
-			return admission.NewForbidden(a, fmt.Errorf("spec.seedName '%s' cannot be changed to '%s' by patching the shoot, please use the shoots/binding subresource", oldSeedNameStr, seedNameStr))
+			oldShootNameStr := ptr.Deref(c.oldShoot.Spec.SeedName, "nil")
+			return admission.NewForbidden(a, fmt.Errorf("spec.seedName '%s' cannot be changed to '%s' by patching the shoot, please use the shoots/binding subresource", oldShootNameStr, *c.shoot.Spec.SeedName))
 		}
 	case admission.Delete:
 		return nil

--- a/plugin/pkg/shoot/validator/admission_test.go
+++ b/plugin/pkg/shoot/validator/admission_test.go
@@ -761,7 +761,7 @@ var _ = Describe("validator", func() {
 				err := admissionHandler.Admit(ctx, attrs, nil)
 
 				Expect(err).To(BeForbiddenError())
-				Expect(err).To(MatchError(ContainSubstring("spec.seedName 'seed' cannot be changed to 'nil' by patching the shoot, please use the shoots/binding subresource")))
+				Expect(err).To(MatchError(ContainSubstring("spec.seedName is already set to 'seed' and cannot be changed to 'nil'")))
 			})
 
 			It("should not allow setting the seedName to nil on admission.Update even if the subresource is binding", func() {
@@ -771,7 +771,7 @@ var _ = Describe("validator", func() {
 				err := admissionHandler.Admit(ctx, attrs, nil)
 
 				Expect(err).To(BeForbiddenError())
-				Expect(err).To(MatchError(ContainSubstring("spec.seedName cannot be set to nil")))
+				Expect(err).To(MatchError(ContainSubstring("spec.seedName is already set to 'seed' and cannot be changed to 'nil'")))
 			})
 
 			It("should not allow setting seedName even if old seedName was nil on admission.Update if the subresource is not binding", func() {
@@ -4539,7 +4539,7 @@ var _ = Describe("validator", func() {
 					err := admissionHandler.Admit(context.TODO(), attrs, nil)
 
 					Expect(err).To(HaveOccurred())
-					Expect(err.Error()).To(ContainSubstring("spec.seedName cannot be set to nil"))
+					Expect(err.Error()).To(ContainSubstring("spec.seedName is already set to 'seed' and cannot be changed to 'nil'"))
 				})
 
 				It("should allow update of binding when shoot.spec.seedName is not nil", func() {

--- a/plugin/pkg/shoot/validator/admission_test.go
+++ b/plugin/pkg/shoot/validator/admission_test.go
@@ -741,7 +741,7 @@ var _ = Describe("validator", func() {
 				err := admissionHandler.Admit(ctx, attrs, nil)
 
 				Expect(err).To(BeForbiddenError())
-				Expect(err).To(MatchError(ContainSubstring("spec.seedName cannot be changed by patching the shoot, please use the shoots/binding subresource")))
+				Expect(err).To(MatchError(ContainSubstring("spec.seedName 'seed' cannot be changed to 'new-seed' by patching the shoot, please use the shoots/binding subresource")))
 			})
 
 			It("should not forbid changing the seedName on admission.Update if the subresource is binding", func() {
@@ -761,7 +761,7 @@ var _ = Describe("validator", func() {
 				err := admissionHandler.Admit(ctx, attrs, nil)
 
 				Expect(err).To(BeForbiddenError())
-				Expect(err).To(MatchError(ContainSubstring("spec.seedName cannot be changed by patching the shoot, please use the shoots/binding subresource")))
+				Expect(err).To(MatchError(ContainSubstring("spec.seedName 'seed' cannot be changed to 'nil' by patching the shoot, please use the shoots/binding subresource")))
 			})
 
 			It("should not allow setting the seedName to nil on admission.Update even if the subresource is binding", func() {
@@ -781,7 +781,7 @@ var _ = Describe("validator", func() {
 				err := admissionHandler.Admit(ctx, attrs, nil)
 
 				Expect(err).To(BeForbiddenError())
-				Expect(err).To(MatchError(ContainSubstring("spec.seedName cannot be changed by patching the shoot, please use the shoots/binding subresource")))
+				Expect(err).To(MatchError(ContainSubstring("spec.seedName 'nil' cannot be changed to 'seed' by patching the shoot, please use the shoots/binding subresource")))
 			})
 
 			It("should reject update of binding when shoot.spec.seedName is not nil and the binding has the same seedName", func() {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind enhancement

**What this PR does / why we need it**:
This PR enhances the validation error which is shown when trying to change a shoot's `.spec.seedName` without using the `shoots/binding` subresource. The new error message will also display the old and new `.spec.seedName`s to show that a change attempt was actually made. If one of the `.spec.seedName` fields are `nil` it will print 'nil' in the error message. You can check the following examples:
```
Error from server (Forbidden): error when replacing "example/provider-local/shoot.yaml": shoots.core.gardener.cloud "local" is forbidden: spec.seedName 'local' cannot be changed to 'nil' by patching the shoot, please use the shoots/binding subresource
```

```
Error from server (Forbidden): error when replacing "example/provider-local/shoot.yaml": shoots.core.gardener.cloud "local" is forbidden: spec.seedName 'local' cannot be changed to 'new-local' by patching the shoot, please use the shoots/binding subresource
```

**Which issue(s) this PR fixes**:
Fixes #9186 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other user
The validation error shown when a user tries to change the `.spec.seedName` field of a Shoot will now also display the old and new values to better indicate that a change was attempted.
```
