### PR TITLE
Fix hanging of shoot force-deletion in case DNS records fails with invalid credentials

### DIFF
--- a/pkg/gardenlet/controller/shoot/shoot/cleaner.go
+++ b/pkg/gardenlet/controller/shoot/shoot/cleaner.go
@@ -45,7 +45,6 @@ var (
 	extensionKindToObjectList = map[string]client.ObjectList{
 		extensionsv1alpha1.ContainerRuntimeResource:      &extensionsv1alpha1.ContainerRuntimeList{},
 		extensionsv1alpha1.ControlPlaneResource:          &extensionsv1alpha1.ControlPlaneList{},
-		extensionsv1alpha1.DNSRecordResource:             &extensionsv1alpha1.DNSRecordList{},
 		extensionsv1alpha1.ExtensionResource:             &extensionsv1alpha1.ExtensionList{},
 		extensionsv1alpha1.InfrastructureResource:        &extensionsv1alpha1.InfrastructureList{},
 		extensionsv1alpha1.NetworkResource:               &extensionsv1alpha1.NetworkList{},

--- a/test/e2e/gardener/shoot/create_and_force_delete.go
+++ b/test/e2e/gardener/shoot/create_and_force_delete.go
@@ -44,7 +44,7 @@ var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
 			By("Wait for Shoot to be force-deleted")
 			ctx, cancel = context.WithTimeout(parentCtx, 10*time.Minute)
 			defer cancel()
-			Expect(f.ForceDeleteShootAndWaitForDeletion(ctx, f.Shoot)).To(Succeed())
+			Expect(f.ForceDeleteShootAndWaitForDeletion(ctx, f.Shoot, f.ShootFramework.SeedClient.Client())).To(Succeed())
 		})
 	}
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug

**What this PR does / why we need it**:
Shoot force deletion can get stuck for similar reasons as described in https://github.com/gardener/gardener/issues/5316, to fix this issue, DNSRecords are now deleted separately so that before deletion, the DNS secret is updated and its deletion doesn't hang.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
A bug causing shoot force-deletion to get stuck in case the secrets referred by the DNS Records are outdated is now fixed.
```
