### PR TITLE
[GEP-19] Set `replicas=1` for seed alertmanager

### DIFF
--- a/pkg/gardenlet/controller/seed/seed/components.go
+++ b/pkg/gardenlet/controller/seed/seed/components.go
@@ -682,6 +682,7 @@ func (r *Reconciler) newAlertmanager(log logr.Logger, seed *seedpkg.Seed, alerti
 		ClusterType:        component.ClusterTypeSeed,
 		PriorityClassName:  v1beta1constants.PriorityClassNameSeedSystem600,
 		StorageCapacity:    resource.MustParse(seed.GetValidVolumeSize("1Gi")),
+		Replicas:           1,
 		AlertingSMTPSecret: alertingSMTPSecret,
 	})
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind bug

**What this PR does / why we need it**:
After https://github.com/gardener/gardener/pull/9257, the seed alertmanager will always be deployed with 0 replicas because the seed controller does not explicitly set this field.

**Which issue(s) this PR fixes**:
Follow-up of https://github.com/gardener/gardener/pull/9257/commits/11dc78f7ef25072e474b93103cf7ed5f941ba11c#diff-0cc11d98580d91dba21a3bd4c309844de9e80091c46f4e7ce4324ecd9d0aba51
Part of https://github.com/gardener/gardener/issues/9065

**Special notes for your reviewer**:
/cc @ScheererJ 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
