### PR TITLE
[GEP-19] Delete `networkingv1.Ingress` instead of `networkingv1beta1.Ingress`

### DIFF
--- a/pkg/gardenlet/controller/seed/seed/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/seed/seed/reconciler_reconcile.go
@@ -26,7 +26,7 @@ import (
 	istiov1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	networkingv1beta1 "k8s.io/api/networking/v1beta1"
+	networkingv1 "k8s.io/api/networking/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -516,7 +516,7 @@ func (r *Reconciler) runReconcileSeedFlow(
 					&corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "aggregate-prometheus-web", Namespace: r.GardenNamespace}},
 					&corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "aggregate-prometheus", Namespace: r.GardenNamespace}},
 					&appsv1.StatefulSet{ObjectMeta: metav1.ObjectMeta{Name: "aggregate-prometheus", Namespace: r.GardenNamespace}},
-					&networkingv1beta1.Ingress{ObjectMeta: metav1.ObjectMeta{Name: "aggregate-prometheus", Namespace: r.GardenNamespace}},
+					&networkingv1.Ingress{ObjectMeta: metav1.ObjectMeta{Name: "aggregate-prometheus", Namespace: r.GardenNamespace}},
 					&rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: "aggregate-prometheus"}},
 					&hvpav1alpha1.Hvpa{ObjectMeta: metav1.ObjectMeta{Name: "aggregate-prometheus", Namespace: r.GardenNamespace}},
 					&vpaautoscalingv1.VerticalPodAutoscaler{ObjectMeta: metav1.ObjectMeta{Name: "aggregate-prometheus-vpa", Namespace: r.GardenNamespace}},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind bug

**What this PR does / why we need it**:
After https://github.com/gardener/gardener/pull/9200, the old `Ingress` related to `aggregate-prometheus` is not deleted on clusters that don't serve the `networking.k8s.io/v1beta1` API anymore. Actually, it was never intended to use this API but only `networking.k8s.io/v1`.  Thanks to the IDE! 

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/9065
Follow-up of https://github.com/gardener/gardener/pull/9200/commits/f7babdec1e01a7694805fc2087c6225e3af01e0c#diff-a3bc9d8bf428d542a1668556adcba0143538e5af8dad225753b26953049ceb18

**Special notes for your reviewer**:
/cc @ScheererJ @rickardsjp 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
