### PR TITLE
Replace `Ingress` resources for `kube apiserver` with direct `Istio` exposure

### DIFF
--- a/pkg/component/kubernetes/apiserverexposure/ingress.go
+++ b/pkg/component/kubernetes/apiserverexposure/ingress.go
@@ -139,11 +139,13 @@ func (i *ingress) Deploy(ctx context.Context) error {
 		}
 	}
 
+	// TODO(scheererj): Drop this after v1.92
 	return kubernetesutils.DeleteObjects(ctx, i.client, i.emptyIngress())
 }
 
 func (i *ingress) Destroy(ctx context.Context) error {
 	objects := []client.Object{
+		// TODO(scheererj): Drop ingress after v1.92
 		i.emptyIngress(),
 		i.emptyDestinationRule(),
 		i.emptyGateway(),

--- a/pkg/component/kubernetes/apiserverexposure/ingress_test.go
+++ b/pkg/component/kubernetes/apiserverexposure/ingress_test.go
@@ -214,12 +214,16 @@ var _ = Describe("#Ingress", func() {
 
 	getDeployer := func(serviceNamespace string, tlsSecretName *string) component.Deployer {
 		return NewIngress(c, namespace, IngressValues{
-			Host:                         host,
-			IstioIngressGatewayLabels:    istioLabels,
-			IstioIngressGatewayNamespace: istioNamespace,
-			ServiceName:                  "foo",
-			ServiceNamespace:             serviceNamespace,
-			TLSSecretName:                tlsSecretName,
+			Host: host,
+			IstioIngressGatewayLabelsFunc: func() map[string]string {
+				return istioLabels
+			},
+			IstioIngressGatewayNamespaceFunc: func() string {
+				return istioNamespace
+			},
+			ServiceName:      "foo",
+			ServiceNamespace: serviceNamespace,
+			TLSSecretName:    tlsSecretName,
 		})
 	}
 

--- a/pkg/component/kubernetes/apiserverexposure/ingress_test.go
+++ b/pkg/component/kubernetes/apiserverexposure/ingress_test.go
@@ -19,15 +19,20 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+	istioapinetworkingv1beta1 "istio.io/api/networking/v1beta1"
+	istionetworkingv1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
+	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/gardener/gardener/pkg/component"
 	. "github.com/gardener/gardener/pkg/component/kubernetes/apiserverexposure"
+	comptest "github.com/gardener/gardener/pkg/component/test"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 )
 
@@ -36,113 +41,282 @@ var _ = Describe("#Ingress", func() {
 		ctx context.Context
 		c   client.Client
 
-		ingressObjKey        client.ObjectKey
-		ingressNamespace     string
-		ingressClass         string
-		pathType             networkingv1.PathType
-		expectedPassthrough  *networkingv1.Ingress
-		expectedHTTPSBackend *networkingv1.Ingress
+		objKey           client.ObjectKey
+		httpsDRKey       client.ObjectKey
+		istioLabels      map[string]string
+		istioNamespace   string
+		namespace        string
+		serviceNamespace string
+		host             string
+		sniHosts         []string
+		tlsSecret        string
+
+		expectedPassthroughGateway          *istionetworkingv1beta1.Gateway
+		expectedHTTPSBackendGateway         *istionetworkingv1beta1.Gateway
+		expectedPassthroughVirtualService   *istionetworkingv1beta1.VirtualService
+		expectedHTTPSBackendVirtualService  *istionetworkingv1beta1.VirtualService
+		expectedPassthroughDestinationRule  *istionetworkingv1beta1.DestinationRule
+		expectedHTTPSBackendDestinationRule *istionetworkingv1beta1.DestinationRule
 	)
 
 	BeforeEach(func() {
 		ctx = context.TODO()
 		s := runtime.NewScheme()
+		Expect(corev1.AddToScheme(s)).To(Succeed())
 		Expect(networkingv1.AddToScheme(s)).To(Succeed())
+		Expect(istionetworkingv1beta1.AddToScheme(s)).To(Succeed())
 		c = fake.NewClientBuilder().WithScheme(s).Build()
 
-		ingressNamespace = "bar"
-		ingressObjKey = client.ObjectKey{Name: "kube-apiserver", Namespace: ingressNamespace}
-		pathType = networkingv1.PathTypePrefix
-		ingressClass = "foo-bar-ingress"
+		istioLabels = map[string]string{"istio": "ingress"}
+		istioNamespace = "istio-foo"
+		namespace = "bar"
+		serviceNamespace = "services"
+		objKey = client.ObjectKey{Name: "kube-apiserver-ingress", Namespace: namespace}
+		httpsDRKey = client.ObjectKey{Name: objKey.Name, Namespace: serviceNamespace}
+		host = "foo.bar.example.com"
+		sniHosts = []string{host}
+		tlsSecret = "wildcard-tls-secret"
 
-		expected := &networkingv1.Ingress{
+		expectedGateway := &istionetworkingv1beta1.Gateway{
 			TypeMeta: metav1.TypeMeta{
-				APIVersion: networkingv1.SchemeGroupVersion.String(),
-				Kind:       "Ingress",
+				APIVersion: istionetworkingv1beta1.SchemeGroupVersion.String(),
+				Kind:       "Gateway",
 			},
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      ingressObjKey.Name,
-				Namespace: ingressObjKey.Namespace,
+				Name:      "kube-apiserver-ingress",
+				Namespace: namespace,
 				Labels: map[string]string{
 					"app":  "kubernetes",
 					"role": "apiserver",
 				},
 			},
-			Spec: networkingv1.IngressSpec{
-				IngressClassName: &ingressClass,
-				Rules: []networkingv1.IngressRule{
-					{
-						Host: "foo.bar.example.com",
-						IngressRuleValue: networkingv1.IngressRuleValue{
-							HTTP: &networkingv1.HTTPIngressRuleValue{
-								Paths: []networkingv1.HTTPIngressPath{
-									{
-										Backend: networkingv1.IngressBackend{
-											Service: &networkingv1.IngressServiceBackend{
-												Name: "foo",
-												Port: networkingv1.ServiceBackendPort{
-													Number: 443,
-												},
-											},
-										},
-										Path:     "/",
-										PathType: &pathType,
-									},
-								},
+			Spec: istioapinetworkingv1beta1.Gateway{
+				Selector: istioLabels,
+				Servers: []*istioapinetworkingv1beta1.Server{{
+					Hosts: sniHosts,
+					Port: &istioapinetworkingv1beta1.Port{
+						Number:   443,
+						Name:     "tls",
+						Protocol: "foo",
+					},
+					Tls: &istioapinetworkingv1beta1.ServerTLSSettings{},
+				}},
+			},
+		}
+
+		expectedPassthroughGateway = expectedGateway.DeepCopy()
+		expectedPassthroughGateway.Spec.Servers[0].Port.Protocol = "TLS"
+		expectedPassthroughGateway.Spec.Servers[0].Tls.Mode = istioapinetworkingv1beta1.ServerTLSSettings_PASSTHROUGH
+
+		expectedHTTPSBackendGateway = expectedGateway.DeepCopy()
+		expectedHTTPSBackendGateway.Spec.Servers[0].Port.Protocol = "HTTPS"
+		expectedHTTPSBackendGateway.Spec.Servers[0].Tls.Mode = istioapinetworkingv1beta1.ServerTLSSettings_SIMPLE
+		expectedHTTPSBackendGateway.Spec.Servers[0].Tls.CredentialName = tlsSecret
+
+		expectedVirtualService := &istionetworkingv1beta1.VirtualService{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: istionetworkingv1beta1.SchemeGroupVersion.String(),
+				Kind:       "VirtualService",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "kube-apiserver-ingress",
+				Namespace: namespace,
+				Labels: map[string]string{
+					"app":  "kubernetes",
+					"role": "apiserver",
+				},
+			},
+			Spec: istioapinetworkingv1beta1.VirtualService{
+				ExportTo: []string{"*"},
+				Hosts:    sniHosts,
+				Gateways: []string{"kube-apiserver-ingress"},
+				Tls: []*istioapinetworkingv1beta1.TLSRoute{{
+					Match: []*istioapinetworkingv1beta1.TLSMatchAttributes{{
+						Port:     443,
+						SniHosts: sniHosts,
+					}},
+					Route: []*istioapinetworkingv1beta1.RouteDestination{{
+						Destination: &istioapinetworkingv1beta1.Destination{
+							Host: "foo.bar.svc.cluster.local",
+							Port: &istioapinetworkingv1beta1.PortSelector{Number: 443},
+						},
+					}},
+				}},
+			},
+		}
+
+		expectedPassthroughVirtualService = expectedVirtualService.DeepCopy()
+
+		expectedHTTPSBackendVirtualService = expectedVirtualService.DeepCopy()
+		expectedHTTPSBackendVirtualService.Spec.Tls[0].Route[0].Destination.Host = "foo." + serviceNamespace + ".svc.cluster.local"
+		expectedHTTPSBackendVirtualService.Spec.Http = []*istioapinetworkingv1beta1.HTTPRoute{{
+			Match: []*istioapinetworkingv1beta1.HTTPMatchRequest{{
+				Uri: &istioapinetworkingv1beta1.StringMatch{
+					MatchType: &istioapinetworkingv1beta1.StringMatch_Prefix{Prefix: "/"},
+				},
+			}},
+			Route: []*istioapinetworkingv1beta1.HTTPRouteDestination{{
+				Destination: &istioapinetworkingv1beta1.Destination{
+					Host: "foo." + serviceNamespace + ".svc.cluster.local",
+					Port: &istioapinetworkingv1beta1.PortSelector{Number: 443},
+				},
+			}},
+		}}
+
+		expectedDestinationRule := &istionetworkingv1beta1.DestinationRule{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: istionetworkingv1beta1.SchemeGroupVersion.String(),
+				Kind:       "DestinationRule",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "kube-apiserver-ingress",
+				Namespace: namespace,
+				Labels: map[string]string{
+					"app":  "kubernetes",
+					"role": "apiserver",
+				},
+			},
+			Spec: istioapinetworkingv1beta1.DestinationRule{
+				ExportTo: []string{"*"},
+				Host:     "foo.bar.svc.cluster.local",
+				TrafficPolicy: &istioapinetworkingv1beta1.TrafficPolicy{
+					ConnectionPool: &istioapinetworkingv1beta1.ConnectionPoolSettings{
+						Tcp: &istioapinetworkingv1beta1.ConnectionPoolSettings_TCPSettings{
+							MaxConnections: 5000,
+							TcpKeepalive: &istioapinetworkingv1beta1.ConnectionPoolSettings_TCPSettings_TcpKeepalive{
+								Time:     &durationpb.Duration{Seconds: 7200},
+								Interval: &durationpb.Duration{Seconds: 75},
 							},
 						},
 					},
+					LoadBalancer: &istioapinetworkingv1beta1.LoadBalancerSettings{
+						LocalityLbSetting: &istioapinetworkingv1beta1.LocalityLoadBalancerSetting{
+							Enabled:          &wrapperspb.BoolValue{Value: true},
+							FailoverPriority: []string{corev1.LabelTopologyZone},
+						},
+					},
+					OutlierDetection: &istioapinetworkingv1beta1.OutlierDetection{
+						MinHealthPercent: 0,
+					},
+					Tls: &istioapinetworkingv1beta1.ClientTLSSettings{},
 				},
 			},
 		}
-		expectedPassthrough = expected.DeepCopy()
-		expectedPassthrough.SetAnnotations(map[string]string{"nginx.ingress.kubernetes.io/ssl-passthrough": "true"})
-		expectedPassthrough.Spec.TLS = []networkingv1.IngressTLS{{Hosts: []string{"foo.bar.example.com"}}}
 
-		expectedHTTPSBackend = expected.DeepCopy()
-		expectedHTTPSBackend.SetAnnotations(map[string]string{"nginx.ingress.kubernetes.io/backend-protocol": "HTTPS"})
-		expectedHTTPSBackend.Spec.TLS = []networkingv1.IngressTLS{{Hosts: []string{"foo.bar.example.com"}, SecretName: "foobar"}}
+		expectedPassthroughDestinationRule = expectedDestinationRule.DeepCopy()
+		expectedPassthroughDestinationRule.Spec.TrafficPolicy.Tls.Mode = istioapinetworkingv1beta1.ClientTLSSettings_DISABLE
+
+		expectedHTTPSBackendDestinationRule = expectedDestinationRule.DeepCopy()
+		expectedHTTPSBackendDestinationRule.Namespace = serviceNamespace
+		expectedHTTPSBackendDestinationRule.Spec.Host = "foo." + serviceNamespace + ".svc.cluster.local"
+		expectedHTTPSBackendDestinationRule.Spec.TrafficPolicy.Tls.Mode = istioapinetworkingv1beta1.ClientTLSSettings_SIMPLE
 	})
 
-	getDeployer := func(tlsSecretName *string) component.Deployer {
-		return NewIngress(c, ingressNamespace, IngressValues{
-			Host:             "foo.bar.example.com",
-			IngressClassName: &ingressClass,
-			ServiceName:      "foo",
-			TLSSecretName:    tlsSecretName,
+	getDeployer := func(serviceNamespace string, tlsSecretName *string) component.Deployer {
+		return NewIngress(c, namespace, IngressValues{
+			Host:                         host,
+			IstioIngressGatewayLabels:    istioLabels,
+			IstioIngressGatewayNamespace: istioNamespace,
+			ServiceName:                  "foo",
+			ServiceNamespace:             serviceNamespace,
+			TLSSecretName:                tlsSecretName,
 		})
 	}
 
 	Context("Deploy", func() {
-		It("should create the expected ingress object for ssl passthrough", func() {
-			Expect(getDeployer(nil).Deploy(ctx)).To(Succeed())
+		It("should create the expected resources for tls passthrough", func() {
+			Expect(getDeployer("", nil).Deploy(ctx)).To(Succeed())
 
-			actual := &networkingv1.Ingress{}
-			Expect(c.Get(ctx, ingressObjKey, actual)).To(Succeed())
-			Expect(actual.Annotations).To(DeepEqual(expectedPassthrough.Annotations))
-			Expect(actual.Labels).To(DeepEqual(expectedPassthrough.Labels))
-			Expect(actual.Spec).To(DeepEqual(expectedPassthrough.Spec))
+			actualGateway := &istionetworkingv1beta1.Gateway{}
+			Expect(c.Get(ctx, objKey, actualGateway)).To(Succeed())
+			Expect(actualGateway.Labels).To(DeepEqual(expectedPassthroughGateway.Labels))
+			Expect(actualGateway.Spec).To(BeComparableTo(expectedPassthroughGateway.Spec, comptest.CmpOptsForGateway()))
+
+			actualVirtualService := &istionetworkingv1beta1.VirtualService{}
+			Expect(c.Get(ctx, objKey, actualVirtualService)).To(Succeed())
+			Expect(actualVirtualService.Labels).To(DeepEqual(expectedPassthroughVirtualService.Labels))
+			Expect(actualVirtualService.Spec).To(BeComparableTo(expectedPassthroughVirtualService.Spec, comptest.CmpOptsForVirtualService()))
+
+			actualDestinationRule := &istionetworkingv1beta1.DestinationRule{}
+			Expect(c.Get(ctx, objKey, actualDestinationRule)).To(Succeed())
+			Expect(actualDestinationRule.Labels).To(DeepEqual(expectedPassthroughDestinationRule.Labels))
+			Expect(actualDestinationRule.Spec).To(BeComparableTo(expectedPassthroughDestinationRule.Spec, comptest.CmpOptsForDestinationRule()))
 		})
 
-		It("should create the expected ingress object for backend protocol HTTPS", func() {
-			Expect(getDeployer(ptr.To("foobar")).Deploy(ctx)).To(Succeed())
+		It("should create the expected resources for backend protocol HTTPS", func() {
+			Expect(c.Create(ctx, &corev1.Secret{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: corev1.SchemeGroupVersion.String(),
+					Kind:       "Secret",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      tlsSecret,
+					Namespace: "garden",
+					Labels:    map[string]string{"gardener.cloud/role": "controlplane-cert"},
+				}})).To(Succeed())
 
-			actual := &networkingv1.Ingress{}
-			Expect(c.Get(ctx, ingressObjKey, actual)).To(Succeed())
-			Expect(actual.Annotations).To(DeepEqual(expectedHTTPSBackend.Annotations))
-			Expect(actual.Labels).To(DeepEqual(expectedHTTPSBackend.Labels))
-			Expect(actual.Spec).To(DeepEqual(expectedHTTPSBackend.Spec))
+			Expect(getDeployer(serviceNamespace, &tlsSecret).Deploy(ctx)).To(Succeed())
+
+			actualGateway := &istionetworkingv1beta1.Gateway{}
+			Expect(c.Get(ctx, objKey, actualGateway)).To(Succeed())
+			Expect(actualGateway.Labels).To(DeepEqual(expectedHTTPSBackendGateway.Labels))
+			Expect(actualGateway.Spec).To(BeComparableTo(expectedHTTPSBackendGateway.Spec, comptest.CmpOptsForGateway()))
+
+			actualVirtualService := &istionetworkingv1beta1.VirtualService{}
+			Expect(c.Get(ctx, objKey, actualVirtualService)).To(Succeed())
+			Expect(actualVirtualService.Labels).To(DeepEqual(expectedHTTPSBackendVirtualService.Labels))
+			Expect(actualVirtualService.Spec).To(BeComparableTo(expectedHTTPSBackendVirtualService.Spec, comptest.CmpOptsForVirtualService()))
+
+			actualDestinationRule := &istionetworkingv1beta1.DestinationRule{}
+			Expect(c.Get(ctx, httpsDRKey, actualDestinationRule)).To(Succeed())
+			Expect(actualDestinationRule.Labels).To(DeepEqual(expectedHTTPSBackendDestinationRule.Labels))
+			Expect(actualDestinationRule.Spec).To(BeComparableTo(expectedHTTPSBackendDestinationRule.Spec, comptest.CmpOptsForDestinationRule()))
+
+			Expect(c.Get(ctx, client.ObjectKey{Name: tlsSecret, Namespace: istioNamespace}, &corev1.Secret{})).To(Succeed())
 		})
 	})
 
 	Context("Destroy", func() {
-		It("should delete the ingress object", func() {
-			Expect(c.Create(ctx, expectedPassthrough)).To(Succeed())
-			Expect(c.Get(ctx, ingressObjKey, &networkingv1.Ingress{})).To(Succeed())
+		It("should delete the resources for tls passthrough", func() {
+			Expect(c.Create(ctx, expectedPassthroughGateway)).To(Succeed())
+			Expect(c.Get(ctx, objKey, &istionetworkingv1beta1.Gateway{})).To(Succeed())
+			Expect(c.Create(ctx, expectedPassthroughVirtualService)).To(Succeed())
+			Expect(c.Get(ctx, objKey, &istionetworkingv1beta1.VirtualService{})).To(Succeed())
+			Expect(c.Create(ctx, expectedPassthroughDestinationRule)).To(Succeed())
+			Expect(c.Get(ctx, objKey, &istionetworkingv1beta1.DestinationRule{})).To(Succeed())
 
-			Expect(getDeployer(nil).Destroy(ctx)).To(Succeed())
+			Expect(getDeployer("", nil).Destroy(ctx)).To(Succeed())
 
-			Expect(c.Get(ctx, ingressObjKey, &networkingv1.Ingress{})).To(BeNotFoundError())
+			Expect(c.Get(ctx, objKey, &istionetworkingv1beta1.Gateway{})).To(BeNotFoundError())
+			Expect(c.Get(ctx, objKey, &istionetworkingv1beta1.VirtualService{})).To(BeNotFoundError())
+			Expect(c.Get(ctx, objKey, &istionetworkingv1beta1.DestinationRule{})).To(BeNotFoundError())
+		})
+
+		It("should delete the resources for backend protocol HTTPS", func() {
+			Expect(c.Create(ctx, expectedHTTPSBackendGateway)).To(Succeed())
+			Expect(c.Get(ctx, objKey, &istionetworkingv1beta1.Gateway{})).To(Succeed())
+			Expect(c.Create(ctx, expectedHTTPSBackendVirtualService)).To(Succeed())
+			Expect(c.Get(ctx, objKey, &istionetworkingv1beta1.VirtualService{})).To(Succeed())
+			Expect(c.Create(ctx, expectedHTTPSBackendDestinationRule)).To(Succeed())
+			Expect(c.Get(ctx, httpsDRKey, &istionetworkingv1beta1.DestinationRule{})).To(Succeed())
+			Expect(c.Create(ctx, &corev1.Secret{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: corev1.SchemeGroupVersion.String(),
+					Kind:       "Secret",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      tlsSecret,
+					Namespace: istioNamespace,
+				},
+			})).To(Succeed())
+			Expect(c.Get(ctx, client.ObjectKey{Name: tlsSecret, Namespace: istioNamespace}, &corev1.Secret{})).To(Succeed())
+
+			Expect(getDeployer(serviceNamespace, &tlsSecret).Destroy(ctx)).To(Succeed())
+
+			Expect(c.Get(ctx, objKey, &istionetworkingv1beta1.Gateway{})).To(BeNotFoundError())
+			Expect(c.Get(ctx, objKey, &istionetworkingv1beta1.VirtualService{})).To(BeNotFoundError())
+			Expect(c.Get(ctx, httpsDRKey, &istionetworkingv1beta1.DestinationRule{})).To(BeNotFoundError())
+			Expect(c.Get(ctx, client.ObjectKey{Name: tlsSecret, Namespace: istioNamespace}, &corev1.Secret{})).To(BeNotFoundError())
 		})
 	})
 })

--- a/pkg/component/kubernetes/apiserverexposure/ingress_test.go
+++ b/pkg/component/kubernetes/apiserverexposure/ingress_test.go
@@ -230,17 +230,17 @@ var _ = Describe("#Ingress", func() {
 			actualGateway := &istionetworkingv1beta1.Gateway{}
 			Expect(c.Get(ctx, objKey, actualGateway)).To(Succeed())
 			Expect(actualGateway.Labels).To(DeepEqual(expectedPassthroughGateway.Labels))
-			Expect(actualGateway.Spec).To(BeComparableTo(expectedPassthroughGateway.Spec, comptest.CmpOptsForGateway()))
+			Expect(&actualGateway.Spec).To(BeComparableTo(&expectedPassthroughGateway.Spec, comptest.CmpOptsForGateway()))
 
 			actualVirtualService := &istionetworkingv1beta1.VirtualService{}
 			Expect(c.Get(ctx, objKey, actualVirtualService)).To(Succeed())
 			Expect(actualVirtualService.Labels).To(DeepEqual(expectedPassthroughVirtualService.Labels))
-			Expect(actualVirtualService.Spec).To(BeComparableTo(expectedPassthroughVirtualService.Spec, comptest.CmpOptsForVirtualService()))
+			Expect(&actualVirtualService.Spec).To(BeComparableTo(&expectedPassthroughVirtualService.Spec, comptest.CmpOptsForVirtualService()))
 
 			actualDestinationRule := &istionetworkingv1beta1.DestinationRule{}
 			Expect(c.Get(ctx, objKey, actualDestinationRule)).To(Succeed())
 			Expect(actualDestinationRule.Labels).To(DeepEqual(expectedPassthroughDestinationRule.Labels))
-			Expect(actualDestinationRule.Spec).To(BeComparableTo(expectedPassthroughDestinationRule.Spec, comptest.CmpOptsForDestinationRule()))
+			Expect(&actualDestinationRule.Spec).To(BeComparableTo(&expectedPassthroughDestinationRule.Spec, comptest.CmpOptsForDestinationRule()))
 		})
 
 		It("should create the expected resources for backend protocol HTTPS", func() {
@@ -260,17 +260,17 @@ var _ = Describe("#Ingress", func() {
 			actualGateway := &istionetworkingv1beta1.Gateway{}
 			Expect(c.Get(ctx, objKey, actualGateway)).To(Succeed())
 			Expect(actualGateway.Labels).To(DeepEqual(expectedHTTPSBackendGateway.Labels))
-			Expect(actualGateway.Spec).To(BeComparableTo(expectedHTTPSBackendGateway.Spec, comptest.CmpOptsForGateway()))
+			Expect(&actualGateway.Spec).To(BeComparableTo(&expectedHTTPSBackendGateway.Spec, comptest.CmpOptsForGateway()))
 
 			actualVirtualService := &istionetworkingv1beta1.VirtualService{}
 			Expect(c.Get(ctx, objKey, actualVirtualService)).To(Succeed())
 			Expect(actualVirtualService.Labels).To(DeepEqual(expectedHTTPSBackendVirtualService.Labels))
-			Expect(actualVirtualService.Spec).To(BeComparableTo(expectedHTTPSBackendVirtualService.Spec, comptest.CmpOptsForVirtualService()))
+			Expect(&actualVirtualService.Spec).To(BeComparableTo(&expectedHTTPSBackendVirtualService.Spec, comptest.CmpOptsForVirtualService()))
 
 			actualDestinationRule := &istionetworkingv1beta1.DestinationRule{}
 			Expect(c.Get(ctx, httpsDRKey, actualDestinationRule)).To(Succeed())
 			Expect(actualDestinationRule.Labels).To(DeepEqual(expectedHTTPSBackendDestinationRule.Labels))
-			Expect(actualDestinationRule.Spec).To(BeComparableTo(expectedHTTPSBackendDestinationRule.Spec, comptest.CmpOptsForDestinationRule()))
+			Expect(&actualDestinationRule.Spec).To(BeComparableTo(&expectedHTTPSBackendDestinationRule.Spec, comptest.CmpOptsForDestinationRule()))
 
 			Expect(c.Get(ctx, client.ObjectKey{Name: tlsSecret, Namespace: istioNamespace}, &corev1.Secret{})).To(Succeed())
 		})

--- a/pkg/component/shared/istio.go
+++ b/pkg/component/shared/istio.go
@@ -91,6 +91,8 @@ func NewIstio(
 
 	policyLabels := commonIstioIngressNetworkPolicyLabels(vpnEnabled)
 	policyLabels[toKubeAPIServerPolicyLabel] = v1beta1constants.LabelNetworkPolicyAllowed
+	// In case the cluster's API server should be exposed via ingress domain for the dashboard terminal scenario,
+	// istio ingress gateway needs to be able to directly forward traffic to the runtime API server.
 	policyLabels[v1beta1constants.LabelNetworkPolicyToRuntimeAPIServer] = v1beta1constants.LabelNetworkPolicyAllowed
 
 	enforceSpreadAcrossHosts, err := ShouldEnforceSpreadAcrossHosts(ctx, cl, zones)

--- a/pkg/component/shared/istio.go
+++ b/pkg/component/shared/istio.go
@@ -91,6 +91,7 @@ func NewIstio(
 
 	policyLabels := commonIstioIngressNetworkPolicyLabels(vpnEnabled)
 	policyLabels[toKubeAPIServerPolicyLabel] = v1beta1constants.LabelNetworkPolicyAllowed
+	policyLabels[v1beta1constants.LabelNetworkPolicyToRuntimeAPIServer] = v1beta1constants.LabelNetworkPolicyAllowed
 
 	enforceSpreadAcrossHosts, err := ShouldEnforceSpreadAcrossHosts(ctx, cl, zones)
 	if err != nil {

--- a/pkg/component/shared/istio_test.go
+++ b/pkg/component/shared/istio_test.go
@@ -98,6 +98,7 @@ func checkIstio(istioDeploy istio.Interface, testValues istioTestValues) {
 
 	networkPolicyLabels := map[string]string{
 		"networking.gardener.cloud/to-dns":                                     "allowed",
+		"networking.gardener.cloud/to-runtime-apiserver":                       "allowed",
 		"networking.resources.gardener.cloud/to-istio-system-istiod-tcp-15012": "allowed",
 		testValues.kubeAPIServerPolicyLabel:                                    "allowed",
 	}

--- a/pkg/component/test/istiocomponent.go
+++ b/pkg/component/test/istiocomponent.go
@@ -56,6 +56,7 @@ func CmpOptsForGateway() cmp.Option {
 func CmpOptsForVirtualService() cmp.Option {
 	return cmpopts.IgnoreUnexported(
 		istioapinetworkingv1beta1.VirtualService{},
+		istioapinetworkingv1beta1.HTTPMatchRequest{},
 		istioapinetworkingv1beta1.HTTPRoute{},
 		istioapinetworkingv1beta1.HTTPRouteDestination{},
 		istioapinetworkingv1beta1.Destination{},
@@ -63,6 +64,7 @@ func CmpOptsForVirtualService() cmp.Option {
 		istioapinetworkingv1beta1.TLSRoute{},
 		istioapinetworkingv1beta1.TLSMatchAttributes{},
 		istioapinetworkingv1beta1.RouteDestination{},
+		istioapinetworkingv1beta1.StringMatch{},
 		istioapimetav1alpha1.IstioStatus{},
 	)
 }

--- a/pkg/controller/networkpolicy/reconciler.go
+++ b/pkg/controller/networkpolicy/reconciler.go
@@ -196,6 +196,7 @@ func (r *Reconciler) networkPolicyConfigs() []networkPolicyConfig {
 			namespaceSelectors: append([]labels.Selector{
 				labels.SelectorFromSet(labels.Set{corev1.LabelMetadataName: v1beta1constants.GardenNamespace}),
 				labels.SelectorFromSet(labels.Set{v1beta1constants.GardenRole: v1beta1constants.GardenRoleIstioSystem}),
+				labels.SelectorFromSet(labels.Set{v1beta1constants.GardenRole: v1beta1constants.GardenRoleIstioIngress}),
 				labels.SelectorFromSet(labels.Set{v1beta1constants.GardenRole: v1beta1constants.GardenRoleShoot}),
 				labels.SelectorFromSet(labels.Set{v1beta1constants.GardenRole: v1beta1constants.GardenRoleExtension}),
 			}, r.additionalNamespaceLabelSelectors...),

--- a/pkg/gardenlet/controller/seed/seed/components.go
+++ b/pkg/gardenlet/controller/seed/seed/components.go
@@ -855,12 +855,16 @@ func (r *Reconciler) newKubeAPIServerIngress(seed *seedpkg.Seed, wildCardCertSec
 	values := kubeapiserverexposure.IngressValues{ServiceNamespace: metav1.NamespaceDefault}
 	if wildCardCertSecret != nil {
 		values = kubeapiserverexposure.IngressValues{
-			Host:                         seed.GetIngressFQDN("api-seed"),
-			IstioIngressGatewayLabels:    istioDefaultLabels,
-			IstioIngressGatewayNamespace: istioDefaultNamespace,
-			ServiceName:                  "kubernetes",
-			ServiceNamespace:             metav1.NamespaceDefault,
-			TLSSecretName:                &wildCardCertSecret.Name,
+			Host: seed.GetIngressFQDN("api-seed"),
+			IstioIngressGatewayLabelsFunc: func() map[string]string {
+				return istioDefaultLabels
+			},
+			IstioIngressGatewayNamespaceFunc: func() string {
+				return istioDefaultNamespace
+			},
+			ServiceName:      "kubernetes",
+			ServiceNamespace: metav1.NamespaceDefault,
+			TLSSecretName:    &wildCardCertSecret.Name,
 		}
 	}
 

--- a/pkg/gardenlet/operation/botanist/kubeapiserverexposure.go
+++ b/pkg/gardenlet/operation/botanist/kubeapiserverexposure.go
@@ -113,10 +113,14 @@ func (b *Botanist) DefaultKubeAPIServerIngress() component.Deployer {
 		b.SeedClientSet.Client(),
 		b.Shoot.SeedNamespace,
 		kubeapiserverexposure.IngressValues{
-			ServiceName:                  v1beta1constants.DeploymentNameKubeAPIServer,
-			Host:                         b.ComputeKubeAPIServerHost(),
-			IstioIngressGatewayLabels:    b.IstioLabels(),
-			IstioIngressGatewayNamespace: b.IstioNamespace(),
+			ServiceName: v1beta1constants.DeploymentNameKubeAPIServer,
+			Host:        b.ComputeKubeAPIServerHost(),
+			IstioIngressGatewayLabelsFunc: func() map[string]string {
+				return b.IstioLabels()
+			},
+			IstioIngressGatewayNamespaceFunc: func() string {
+				return b.IstioNamespace()
+			},
 		})
 }
 

--- a/pkg/gardenlet/operation/botanist/kubeapiserverexposure.go
+++ b/pkg/gardenlet/operation/botanist/kubeapiserverexposure.go
@@ -17,7 +17,6 @@ package botanist
 import (
 	"context"
 
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
@@ -114,9 +113,10 @@ func (b *Botanist) DefaultKubeAPIServerIngress() component.Deployer {
 		b.SeedClientSet.Client(),
 		b.Shoot.SeedNamespace,
 		kubeapiserverexposure.IngressValues{
-			ServiceName:      v1beta1constants.DeploymentNameKubeAPIServer,
-			Host:             b.ComputeKubeAPIServerHost(),
-			IngressClassName: ptr.To(v1beta1constants.SeedNginxIngressClass),
+			ServiceName:                  v1beta1constants.DeploymentNameKubeAPIServer,
+			Host:                         b.ComputeKubeAPIServerHost(),
+			IstioIngressGatewayLabels:    b.IstioLabels(),
+			IstioIngressGatewayNamespace: b.IstioNamespace(),
 		})
 }
 

--- a/pkg/utils/istio/destinationrule.go
+++ b/pkg/utils/istio/destinationrule.go
@@ -24,6 +24,11 @@ import (
 
 // DestinationRuleWithLocalityPreference returns a function setting the given attributes to a destination rule object.
 func DestinationRuleWithLocalityPreference(destinationRule *istionetworkingv1beta1.DestinationRule, labels map[string]string, destinationHost string) func() error {
+	return DestinationRuleWithLocalityPreferenceAndTLS(destinationRule, labels, destinationHost, istioapinetworkingv1beta1.ClientTLSSettings_DISABLE)
+}
+
+// DestinationRuleWithLocalityPreferenceAndTLS returns a function setting the given attributes to a destination rule object.
+func DestinationRuleWithLocalityPreferenceAndTLS(destinationRule *istionetworkingv1beta1.DestinationRule, labels map[string]string, destinationHost string, tlsMode istioapinetworkingv1beta1.ClientTLSSettings_TLSmode) func() error {
 	return func() error {
 		destinationRule.Labels = labels
 		destinationRule.Spec = istioapinetworkingv1beta1.DestinationRule{
@@ -50,7 +55,7 @@ func DestinationRuleWithLocalityPreference(destinationRule *istionetworkingv1bet
 					MinHealthPercent: 0,
 				},
 				Tls: &istioapinetworkingv1beta1.ClientTLSSettings{
-					Mode: istioapinetworkingv1beta1.ClientTLSSettings_DISABLE,
+					Mode: tlsMode,
 				},
 			},
 		}

--- a/pkg/utils/istio/destinationrule_test.go
+++ b/pkg/utils/istio/destinationrule_test.go
@@ -17,6 +17,7 @@ package istio_test
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	istioapinetworkingv1beta1 "istio.io/api/networking/v1beta1"
 	istionetworkingv1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
 
 	. "github.com/gardener/gardener/pkg/utils/istio"
@@ -39,5 +40,24 @@ var _ = Describe("DestinationRule", func() {
 
 		Entry("Nil values", nil, ""),
 		Entry("Some values", map[string]string{"foo": "bar", "key": "value"}, "destination.namespace.svc.cluster.local"),
+	)
+
+	DescribeTable("#DestinationRuleWithLocalityPreferenceAndTLS", func(labels map[string]string, destinationHost string, tlsMode istioapinetworkingv1beta1.ClientTLSSettings_TLSmode) {
+		destinationRule := &istionetworkingv1beta1.DestinationRule{}
+
+		function := DestinationRuleWithLocalityPreferenceAndTLS(destinationRule, labels, destinationHost, tlsMode)
+
+		Expect(function).NotTo(BeNil())
+
+		err := function()
+
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(destinationRule.Labels).To(Equal(labels))
+		Expect(destinationRule.Spec.Host).To(Equal(destinationHost))
+		Expect(destinationRule.Spec.TrafficPolicy.Tls.Mode).To(Equal(tlsMode))
+	},
+
+		Entry("Nil values", nil, "", istioapinetworkingv1beta1.ClientTLSSettings_DISABLE),
+		Entry("Some values", map[string]string{"foo": "bar", "key": "value"}, "destination.namespace.svc.cluster.local", istioapinetworkingv1beta1.ClientTLSSettings_SIMPLE),
 	)
 })

--- a/pkg/utils/istio/gateway.go
+++ b/pkg/utils/istio/gateway.go
@@ -40,3 +40,26 @@ func GatewayWithTLSPassthrough(gateway *istionetworkingv1beta1.Gateway, labels m
 		return nil
 	}
 }
+
+// GatewayWithTLSTermination returns a function setting the given attributes to a gateway object.
+func GatewayWithTLSTermination(gateway *istionetworkingv1beta1.Gateway, labels map[string]string, istioLabels map[string]string, hosts []string, port uint32, tlsSecret string) func() error {
+	return func() error {
+		gateway.Labels = labels
+		gateway.Spec = istioapinetworkingv1beta1.Gateway{
+			Selector: istioLabels,
+			Servers: []*istioapinetworkingv1beta1.Server{{
+				Hosts: hosts,
+				Port: &istioapinetworkingv1beta1.Port{
+					Number:   port,
+					Name:     "tls",
+					Protocol: "HTTPS",
+				},
+				Tls: &istioapinetworkingv1beta1.ServerTLSSettings{
+					Mode:           istioapinetworkingv1beta1.ServerTLSSettings_SIMPLE,
+					CredentialName: tlsSecret,
+				},
+			}},
+		}
+		return nil
+	}
+}

--- a/pkg/utils/istio/gateway_test.go
+++ b/pkg/utils/istio/gateway_test.go
@@ -43,4 +43,26 @@ var _ = Describe("Gateway", func() {
 		Entry("Nil values", nil, nil, nil, uint32(0)),
 		Entry("Some values", map[string]string{"foo": "bar", "key": "value"}, map[string]string{"app": "istio", "istio": "gateway"}, []string{"host-1", "host-2"}, uint32(123456)),
 	)
+
+	DescribeTable("#GatewayWithTLSTermination", func(labels map[string]string, istioLabels map[string]string, hosts []string, port uint32, tlsSecret string) {
+		gateway := &istionetworkingv1beta1.Gateway{}
+
+		function := GatewayWithTLSTermination(gateway, labels, istioLabels, hosts, port, tlsSecret)
+
+		Expect(function).NotTo(BeNil())
+
+		err := function()
+
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(gateway.Labels).To(Equal(labels))
+		Expect(gateway.Spec.Selector).To(Equal(istioLabels))
+		Expect(len(gateway.Spec.Servers)).To(Equal(1))
+		Expect(gateway.Spec.Servers[0].Hosts).To(Equal(hosts))
+		Expect(gateway.Spec.Servers[0].Port.Number).To(Equal(port))
+		Expect(gateway.Spec.Servers[0].Tls.CredentialName).To(Equal(tlsSecret))
+	},
+
+		Entry("Nil values", nil, nil, nil, uint32(0), ""),
+		Entry("Some values", map[string]string{"foo": "bar", "key": "value"}, map[string]string{"app": "istio", "istio": "gateway"}, []string{"host-1", "host-2"}, uint32(123456), "my-secret"),
+	)
 })

--- a/pkg/utils/istio/gateway_test.go
+++ b/pkg/utils/istio/gateway_test.go
@@ -56,7 +56,7 @@ var _ = Describe("Gateway", func() {
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(gateway.Labels).To(Equal(labels))
 		Expect(gateway.Spec.Selector).To(Equal(istioLabels))
-		Expect(len(gateway.Spec.Servers)).To(Equal(1))
+		Expect(gateway.Spec.Servers).To(HaveLen(1))
 		Expect(gateway.Spec.Servers[0].Hosts).To(Equal(hosts))
 		Expect(gateway.Spec.Servers[0].Port.Number).To(Equal(port))
 		Expect(gateway.Spec.Servers[0].Tls.CredentialName).To(Equal(tlsSecret))

--- a/test/integration/gardenlet/networkpolicy/networkpolicy_test.go
+++ b/test/integration/gardenlet/networkpolicy/networkpolicy_test.go
@@ -388,6 +388,7 @@ var _ = Describe("NetworkPolicy controller tests", func() {
 			expectedNetworkPolicySpec: func(string) networkingv1.NetworkPolicySpec { return expectedNetworkPolicySpec },
 			inGardenNamespace:         true,
 			inIstioSystemNamespace:    true,
+			inIstioIngressNamespace:   true,
 			inShootNamespaces:         true,
 			inExtensionNamespaces:     true,
 			inCustomNamespace:         true,


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement

**What this PR does / why we need it**:
Replace ingress resources for `kube-apiserver` with direct istio exposure.

The terminal feature of the gardener dashboard requires kubernetes API servers to be reachable via an ingress domain due to cross-site restrictions in web browsers. In the past, this was handled via an ingress resource, exposed via nginx ingress controller. However, this led to `kube-apiserver` being exposed via multiple different endpoints, i.e. istio and nginx.

Now, that ingress resources are anyway (indirectly) exposed via istio, it makes a lot of sense to simply get rid of the additional hop for `kube-apiserver` as its exposure is very similar to the existing one (for shoot clusters).

The seed cluster API server was also exposed via ingress resource. However, this setup was more sophisticated as it used a service resource with `externalName` pointing to `kubernetes.default.svc.cluster.local`. Now, istio points directly to `kubernetes.default.svc.cluster.local` instead of using an additional service.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Seed clusters with a wildcard certificate no longer use `Ingress` resources to expose `kube-apiserver`. Instead, `Istio` resources are directly used now.
```
