### PR TITLE
Remove redundant doc for autoscaling configuration

### DIFF
--- a/docs/usage/shoot_autoscaling.md
+++ b/docs/usage/shoot_autoscaling.md
@@ -17,24 +17,8 @@ Consequently, please refer to the [offical documentation](https://github.com/kub
 
 The `Shoot` API allows to configure a few flags of the `cluster-autoscaler`:
 
-The following flags are general options for `cluster-autoscaler`, and these values will be used for all worker groups except for those overwriting them:
-* `.spec.kubernetes.clusterAutoscaler.scaleDownDelayAfterAdd` defines how long after scale up that scale down evaluation resumes (default: `1h`).
-* `.spec.kubernetes.clusterAutoscaler.scaleDownDelayAfterDelete` defines how long after node deletion that scale down evaluation resumes (defaults to `ScanInterval`).
-* `.spec.kubernetes.clusterAutoscaler.scaleDownDelayAfterFailure` defines how long after scale down failure that scale down evaluation resumes (default: `3m`).
-* `.spec.kubernetes.clusterAutoscaler.scaleDownUnneededTime` defines how long a node should be unneeded before it is eligible for scale down (default: `30m`).
-* `.spec.kubernetes.clusterAutoscaler.scaleDownUtilizationThreshold` defines the threshold under which a node is being removed (default: `0.5`).
-* `.spec.kubernetes.clusterAutoscaler.scanInterval` defines how often cluster is reevaluated for scale up or down (default: `10s`). 
-* `.spec.kubernetes.clusterAutoscaler.ignoreTaints` specifies a list of taint keys to ignore in node templates when considering to scale a node group (default: `nil`). 
-* `.spec.kubernetes.clusterAutoscaler.newPodScaleUpDelay` specifies how long CA should ignore newly created pods before they have to be considered for scale-up.
-* `.spec.kubernetes.clusterAutoscaler.maxEmptyBulkDelete` specifies the maximum number of empty nodes that can be deleted at the same time (default: 10).
-
-The following flags allow some `cluster-autoscaler` flags to be set per worker pool. They are specified along with the worker and override any general value such as those specified in the flags above
+There are [general options for `cluster-autoscaler`](../api-reference/core.md#core.gardener.cloud/v1beta1.ClusterAutoscaler), and these values will be used for all worker groups except for those overwriting them. Additionally, there are some [`cluster-autoscaler` flags to be set per worker pool](../api-reference/core.md#core.gardener.cloud/v1beta1.ClusterAutoscalerOptions). They override any general value such as those specified in the general flags above.
 > Only some `cluster-autoscaler` flags can be configured per worker pool, and is limited by NodeGroupAutoscalingOptions of the upstream community Kubernetes repository. This list can be found [here](https://github.com/gardener/autoscaler/blob/machine-controller-manager-provider/cluster-autoscaler/config/autoscaling_options.go#L37-L55).
-* `.spec.provider.workers[].clusterAutoscaler.scaleDownUtilizationThreshold` defines the threshold under which a node is being removed
-* `.spec.provider.workers[].clusterAutoscaler.scaleDownGpuUtilizationThreshold` defines the threshold for gpu resources under which a node is being removed
-* `.spec.provider.workers[].clusterAutoscaler.scaleDownUnneededTime` defines how long a node should be unneeded before it is eligible for scale down
-* `.spec.provider.workers[].clusterAutoscaler.scaleDownUnreadyTime` defines how long an unready node should be unneeded before it is eligible for scale down.
-* `.spec.provider.workers[].clusterAutoscaler.maxNodeProvisionTime` defines how long cluster autoscaler should wait for a node to be provisioned.
 
 ## Vertical Pod Auto-Scaling
 
@@ -47,16 +31,7 @@ It will also be used for the vertical autoscaling of Gardener's system component
 
 You might want to refer to the [official documentation](https://github.com/kubernetes/autoscaler/blob/master/vertical-pod-autoscaler/README.md) for this component to get more information how to use it.
 
-The `Shoot` API allows to configure a few flags of the `vertical-pod-autoscaler`:
-
-* `.spec.kubernetes.verticalPodAutoscaler.evictAfterOOMThreshold` defines the threshold that will lead to pod eviction in case it OOMed in less than the given threshold since its start and if it has only one container (default: `10m0s`).
-* `.spec.kubernetes.verticalPodAutoscaler.evictionRateBurst` defines the burst of pods that can be evicted (default: `1`).
-* `.spec.kubernetes.verticalPodAutoscaler.evictionRateLimit` defines the number of pods that can be evicted per second. A rate limit set to 0 or -1 will disable the rate limiter (default: `-1`).
-* `.spec.kubernetes.verticalPodAutoscaler.evictionTolerance` defines the fraction of replica count that can be evicted for update in case more than one pod can be evicted (default: `0.5`).
-* `.spec.kubernetes.verticalPodAutoscaler.recommendationMarginFraction` is the fraction of usage added as the safety margin to the recommended request (default: `0.15`).
-* `.spec.kubernetes.verticalPodAutoscaler.updaterInterval` is the interval how often the updater should run (default: `1m0s`).
-* `.spec.kubernetes.verticalPodAutoscaler.recommenderInterval` is the interval how often metrics should be fetched (default: `1m0s`).
-* `.spec.kubernetes.verticalPodAutoscaler.targetCPUPercentile` is the usage percentile that will be used as a base for CPU target recommendation. Doesn't affect CPU lower bound, CPU upper bound nor memory recommendations. (default: `0.9`)
+The `Shoot` API allows to configure a few [flags of the `vertical-pod-autoscaler`](../api-reference/core.md#core.gardener.cloud/v1beta1.VerticalPodAutoscaler).
 
 ⚠️ Please note that if you disable the VPA again, then the related `CustomResourceDefinition`s will remain in your shoot cluster (although, nobody will act on them).
 This will also keep all existing `VerticalPodAutoscaler` objects in the system, including those that might be created by you. You can delete the `CustomResourceDefinition`s yourself using `kubectl delete crd` if you want to get rid of them.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area auto-scaling
/area documentation
/kind enhancement

**What this PR does / why we need it**:
Remove redundant API documentation for vertical-autoscaler and cluster-autoscaler parameters. In the end, those were just copy-pasted from the API docs that we generate anyways.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
