### PR TITLE
Add support for migration of istio ingress namespaces.

### DIFF
--- a/pkg/gardenlet/controller/seed/seed/components.go
+++ b/pkg/gardenlet/controller/seed/seed/components.go
@@ -370,6 +370,47 @@ func (r *Reconciler) newIstio(ctx context.Context, seed *seedpkg.Seed, isGardenC
 		}
 	}
 
+	// Allow temporary creation of ingress gateway copy to easy migration
+
+	// Map all ingress gateway namespace names to the corresponding gateway values for easier access
+	namespaceToGatewayValues := map[string]istio.IngressGatewayValues{}
+	for _, values := range istioDeployer.GetValues().IngressGateway {
+		namespaceToGatewayValues[values.Namespace] = values
+	}
+
+	// Search for istio namespaces with an annotation to copy them and add them to the list with a different namespace
+	for _, label := range []string{"istio", v1beta1constants.LabelExposureClassHandlerName} {
+		namespaceList := &metav1.PartialObjectMetadataList{}
+		namespaceList.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("NamespaceList"))
+		if err := r.SeedClientSet.Client().List(ctx, namespaceList, client.HasLabels{label}); err != nil {
+			return nil, nil, "", err
+		}
+		for _, ns := range namespaceList.Items {
+			if targetNamespace, ok := ns.Annotations["alpha.istio-ingress.gardener.cloud/migrate-to"]; ok && targetNamespace != "" {
+				if gatewayValues, ok := namespaceToGatewayValues[ns.Name]; ok {
+					var zone *string
+					if len(gatewayValues.Zones) == 1 {
+						zone = ptr.To(gatewayValues.Zones[0])
+					}
+					if err := sharedcomponent.AddIstioIngressGateway(
+						ctx,
+						r.SeedClientSet.Client(),
+						istioDeployer,
+						targetNamespace,
+						gatewayValues.Annotations,
+						gatewayValues.Labels,
+						gatewayValues.ExternalTrafficPolicy,
+						nil,
+						zone,
+						seed.IsDualStack(),
+					); err != nil {
+						return nil, nil, "", err
+					}
+				}
+			}
+		}
+	}
+
 	return istioDeployer, labels, istioDeployer.GetValues().IngressGateway[0].Namespace, nil
 }
 

--- a/pkg/gardenlet/controller/seed/seed/components.go
+++ b/pkg/gardenlet/controller/seed/seed/components.go
@@ -370,6 +370,7 @@ func (r *Reconciler) newIstio(ctx context.Context, seed *seedpkg.Seed, isGardenC
 		}
 	}
 
+	// TODO(scheererj): Remove this after v1.95 has been released.
 	// Allow temporary creation of ingress gateway copy to easy migration
 
 	// Map all ingress gateway namespace names to the corresponding gateway values for easier access


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/area high-availability
/area ops-productivity
/kind enhancement

**What this PR does / why we need it**:
Add support for migration of istio ingress namespaces.

The single-zone istio ingress gateway namespaces include the zone name as part of their namespace name. Unfortunately, with some infrastructures there might be inconsistencies with regards to the zone naming leading to inconsistent istio namespace names. This is why it might be beneficial to copy an existing istio namespace to a target namespace with a proper name. This allows a slow migration process in the shoot maintenance windows and is decoupled from the seed reconciliation. As a follow-up step, seed operators may want to adapt the zones in the seed specification when all shoot clusters have migration. This will remove the no longer needed istio ingress gateway namespace, i.e. it will automatically clean up.

**Which issue(s) this PR fixes**:
None.

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Operators can create duplicate istio ingress gateways for migration if the zone names should be changed in the seed specification
```

/cc @dguendisch @rfranzke @kon-angelo 
