### PR TITLE
Reconcile extension `Backupbucket` and `Backupentry` if lastOperation is nil

### DIFF
--- a/pkg/gardenlet/controller/backupbucket/reconciler.go
+++ b/pkg/gardenlet/controller/backupbucket/reconciler.go
@@ -198,6 +198,9 @@ func (r *Reconciler) reconcileBackupBucket(
 	} else if extensionBackupBucket.Status.LastOperation == nil {
 		// if the extension did not record a lastOperation yet, record it as error in the backupbucket status
 		lastObservedError = fmt.Errorf("extension did not record a last operation yet")
+		if !metav1.HasAnnotation(extensionBackupBucket.ObjectMeta, v1beta1constants.GardenerOperation) {
+			mustReconcileExtensionBackupBucket = true
+		}
 	} else {
 		// check for errors, and if none are present, sync generated Secret to garden
 		lastOperationState := extensionBackupBucket.Status.LastOperation.State

--- a/pkg/gardenlet/controller/backupentry/reconciler.go
+++ b/pkg/gardenlet/controller/backupentry/reconciler.go
@@ -232,6 +232,9 @@ func (r *Reconciler) reconcileBackupEntry(
 	} else if extensionBackupEntry.Status.LastOperation == nil {
 		// if the extension did not record a lastOperation yet, record it as error in the backupentry status
 		lastObservedError = fmt.Errorf("extension did not record a last operation yet")
+		if !metav1.HasAnnotation(extensionBackupEntry.ObjectMeta, v1beta1constants.GardenerOperation) {
+			mustReconcileExtensionBackupEntry = true
+		}
 	} else {
 		// check for errors, and if none are present, reconciliation has succeeded
 		lastOperationState := extensionBackupEntry.Status.LastOperation.State
@@ -281,6 +284,7 @@ func (r *Reconciler) reconcileBackupEntry(
 			}
 		}
 	}
+
 	return reconcile.Result{}, nil
 }
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area backup
/kind bug

**What this PR does / why we need it**:
If for some reason, the extension is not reconciled yet by the extension, and the operation annotation is not present, we reconcile it during the retry of the garden object reconciliation.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
An issue causing the reconciliation of backupentries to be stuck when the extension fails to populate the status is now fixed.
```
