### PR TITLE
NodeNotHealthy prometheus alert

### DIFF
--- a/pkg/component/observability/monitoring/prometheus/aggregate/prometheusrules.go
+++ b/pkg/component/observability/monitoring/prometheus/aggregate/prometheusrules.go
@@ -66,14 +66,14 @@ func CentralPrometheusRules() []*monitoringv1.PrometheusRule {
 						{
 							Alert: "NodeNotHealthy",
 							Expr:  intstr.FromString(`count_over_time((sum by (node) (kube_node_spec_taint{effect="NoSchedule", key!="ToBeDeletedByClusterAutoscaler", key!="` + v1beta1constants.LabelNodeCriticalComponent + `"}))[30m:]) > 5`),
-							For:   ptr.To(monitoringv1.Duration("10m")),
+							For:   ptr.To(monitoringv1.Duration("0m")),
 							Labels: map[string]string{
 								"severity":   "warning",
 								"type":       "seed",
 								"visibility": "operator",
 							},
 							Annotations: map[string]string{
-								"description": "Node {{$labels.node}} in seed {{$labels.name}} in landscape {{$externalLabels.landscape}} is not healthy for over 10 min.",
+								"description": "Node {{$labels.node}} in landscape {{$externalLabels.landscape}} was not healthy for five scrapes in the past 30 mins.",
 								"summary":     "A node is not healthy.",
 							},
 						},

--- a/pkg/component/observability/monitoring/prometheus/aggregate/prometheusrules_test.go
+++ b/pkg/component/observability/monitoring/prometheus/aggregate/prometheusrules_test.go
@@ -58,14 +58,14 @@ var _ = Describe("PrometheusRules", func() {
 								{
 									Alert: "NodeNotHealthy",
 									Expr:  intstr.FromString(`count_over_time((sum by (node) (kube_node_spec_taint{effect="NoSchedule", key!="ToBeDeletedByClusterAutoscaler", key!="` + v1beta1constants.LabelNodeCriticalComponent + `"}))[30m:]) > 5`),
-									For:   ptr.To(monitoringv1.Duration("10m")),
+									For:   ptr.To(monitoringv1.Duration("0m")),
 									Labels: map[string]string{
 										"severity":   "warning",
 										"type":       "seed",
 										"visibility": "operator",
 									},
 									Annotations: map[string]string{
-										"description": "Node {{$labels.node}} in seed {{$labels.name}} in landscape {{$externalLabels.landscape}} is not healthy for over 10 min.",
+										"description": "Node {{$labels.node}} in landscape {{$externalLabels.landscape}} was not healthy for five scrapes in the past 30 mins.",
 										"summary":     "A node is not healthy.",
 									},
 								},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind bug

**What this PR does / why we need it**:
This PR removes the seed name mentioned in the alert and removes the wait time of 10m, as we would want to be notified immediately when a node fulfils the expression.
The expression checks a node is not healthy in a time-window of 30 mins, hence no need to wait for additional 10m.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @rickardsjp @istvanballok 
**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Enhance `NodeNotHealthy` Prometheus alert to fire immediately.
```
